### PR TITLE
Improve query preview display in SaveQueryModal with better text wrap…

### DIFF
--- a/src/components/SaveQueryModal.tsx
+++ b/src/components/SaveQueryModal.tsx
@@ -81,8 +81,8 @@ export function SaveQueryModal({ isOpen, onClose, onSave, defaultQuery }: SaveQu
           </div>
           <div className="mt-2">
             <Label className="text-xs font-bold uppercase tracking-widest text-zinc-500 mb-2 block">Preview</Label>
-            <div className="bg-[#050505] p-3 rounded-md border border-white/5 max-h-[100px] overflow-hidden">
-              <pre className="text-[10px] font-mono text-zinc-500 italic truncate">
+            <div className="bg-[#050505] p-3 rounded-md border border-white/5 max-h-[100px] overflow-y-auto">
+              <pre className="text-[10px] font-mono text-zinc-500 italic whitespace-pre-wrap break-words">
                 {defaultQuery}
               </pre>
             </div>


### PR DESCRIPTION
## Description
Fixes the Save Query modal preview so long AI-generated SQL doesn’t force the dialog to stretch. The preview panel now wraps and scrolls text within a fixed height, keeping the surrounding text inputs at their intended size. (@/src/components/SaveQueryModal.tsx#74-88)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Related Issue
Closes #

## Changes Made
- Replaced the preview container’s `overflow-hidden` with `overflow-y-auto` so lengthy SQL can scroll without enlarging the modal.
- Updated the `<pre>` styling to use `whitespace-pre-wrap break-words`, preserving formatting while preventing horizontal overflow.
- Ensured the rest of the modal layout stays unchanged, so the Name/Description fields no longer expand when the preview contains long text.

## Testing
- [x] I have tested this locally
- [ ] All existing tests pass
- [ ] I have added/updated tests

### Test Environment
- **LibreDB Studio Version**:
- **Browser**: Brave,Arc
- **OS**: Mac os
- **Node.js/Bun Version**:
- **Database Type**:

## Screenshots (if applicable)

<img width="3456" height="1948" alt="image" src="https://github.com/user-attachments/assets/91e61644-ea46-46a5-b19f-e8ca2460d924" />


## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
None.