### PR TITLE
fix: use Node.js build stage to resolve ARM64 Docker segfault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,31 +3,24 @@
 # Optimized for Render, Railway, Fly.io, and Kubernetes
 # ==============================================================================
 
-# use the official Bun image (full version, not slim)
-# see all versions at https://hub.docker.com/r/oven/bun/tags
-# Reference: https://bun.com/docs/guides/ecosystem/docker
-FROM oven/bun:1 AS base
+# Bun for fast dependency installation, Node.js for build
+# Bun's JIT compiler segfaults under QEMU emulation (ARM64 cross-build),
+# so we use Node.js for the Next.js build step.
+FROM oven/bun:1 AS deps
 WORKDIR /usr/src/app
-
-# Install dependencies only when needed
-FROM base AS deps
 RUN apt-get update && apt-get install -y python3 make g++ --no-install-recommends && rm -rf /var/lib/apt/lists/*
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
-# Rebuild the source code only when needed
-FROM base AS builder
+# Build with Node.js to avoid Bun/QEMU segfaults on ARM64
+FROM node:20-slim AS builder
+WORKDIR /usr/src/app
 COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY . .
 
-# Next.js collects completely anonymous education data about general usage.
-# Learn more here: https://nextjs.org/telemetry
 ENV NEXT_TELEMETRY_DISABLED=1
-
-# Enable standalone output for Docker builds
 ENV DOCKER_BUILD=true
 
-# Build-time environment variables (replaced at runtime)
 ARG JWT_SECRET_BUILD="build-time-placeholder-secret-32ch"
 ARG ADMIN_PASSWORD_BUILD="build"
 ARG USER_PASSWORD_BUILD="build"
@@ -35,7 +28,7 @@ ENV JWT_SECRET=$JWT_SECRET_BUILD
 ENV ADMIN_PASSWORD=$ADMIN_PASSWORD_BUILD
 ENV USER_PASSWORD=$USER_PASSWORD_BUILD
 
-RUN bun run build
+RUN npx next build
 
 # Production image - use Node.js slim for lower memory footprint
 FROM node:20-slim AS runner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libredb-studio",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Switch Docker builder stage from Bun to Node.js to fix QEMU segfault during ARM64 cross-builds
- Keep Bun for dependency installation (fast, QEMU-compatible)
- Fixes the failed Docker build after #48 merged

## Problem

After #48 added `linux/arm64` platform support, the Docker build crashes with:

```
panic: Segmentation fault at address 0x15350
error: script "build" was terminated by signal SIGTRAP
```

Bun's JIT compiler is incompatible with QEMU's ARM64 CPU emulation used by GitHub Actions runners (x86) for cross-platform builds.

## Solution

Use Node.js (`node:20-slim`) for the builder stage where `next build` runs, while keeping Bun for the dependency installation stage where it works fine under QEMU.

## Test plan

- [x] `bun run lint` — passed (0 errors)
- [x] `bun run typecheck` — passed
- [x] `bun run build` (`npx next build`) — passed
- [ ] Verify ARM64 Docker build succeeds in CI after merge
