### PR TITLE
fix(test): isolate core coverage runs to stop mock.module contamination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,8 @@ helm dependency build charts/libredb-studio
 The project uses ESLint 9 for linting and `bun:test` for testing with `@testing-library/react` + `happy-dom` for component tests and Playwright for E2E tests.
 
 > **Important**: Always use `bun run test` instead of bare `bun test`. Component tests require isolated execution groups (handled by `tests/run-components.sh`) to prevent `mock.module()` cross-contamination between test files.
+>
+> **Coverage isolation**: `bun`'s `mock.module()` is process-wide, so a test file that mocks a shared module (e.g. `@/lib/db/factory`, `@/lib/oidc`, the audit module) poisons any other file that imports the real module if they share a process — yielding nondeterministic failures like `clearProviderCache is not a function` or `Export named 'removeProvider' not found`. It passes locally by load-order luck but fails in CI. For this reason `test:coverage:core` runs every core test file in its **own `bun` process** via `tests/run-core.sh` (each writing to `coverage/core/file-N`), and `test:coverage` merges all the per-file lcov reports. Do NOT collapse this back into a single `bun test tests/unit tests/api tests/integration` invocation.
 
 ## Platform Integration Rules (npm package @libredb/studio)
 

--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
     "test:components": "bash tests/run-components.sh",
     "test:components:coverage": "bash tests/run-components.sh --coverage --coverage-reporter=lcov --coverage-dir=coverage/components",
     "test:e2e": "bunx playwright test",
-    "test:coverage:core": "bun test --coverage --coverage-reporter=lcov --coverage-reporter=text --coverage-dir=coverage/core tests/unit tests/api tests/integration && bun test --coverage --coverage-reporter=lcov --coverage-reporter=text --coverage-dir=coverage/hooks tests/hooks",
-    "test:coverage": "rm -rf coverage && bun run test:coverage:core && bun run test:components:coverage && node scripts/merge-lcov.mjs coverage/core/lcov.info coverage/hooks/lcov.info coverage/components/lcov.info coverage/lcov.info",
+    "test:coverage:core": "bash tests/run-core.sh --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
+    "test:coverage": "rm -rf coverage && bun run test:coverage:core && bun run test:components:coverage && node scripts/merge-lcov.mjs coverage/core/file-*/lcov.info coverage/components/lcov.info coverage/lcov.info",
     "test:coverage-html": "bun run test:coverage && genhtml coverage/lcov.info --output-directory coverage/html && echo '\n Open coverage/html/index.html in your browser'"
   },
   "dependencies": {

--- a/tests/run-core.sh
+++ b/tests/run-core.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Core test runner with PER-FILE mock isolation.
+#
+# bun's mock.module() is process-wide: when one test file mocks a shared module
+# (e.g. @/lib/db/factory, @/lib/oidc, the audit module) the mock leaks into every
+# other file that runs in the same bun process. A file that imports the real
+# export then sees the partial mock — producing nondeterministic failures such as
+# "clearProviderCache is not a function" or "Export named 'removeProvider' not
+# found", depending purely on file load order. This passes locally and fails in
+# CI (different order).
+#
+# Running each core test file in its OWN bun process makes cross-file
+# contamination structurally impossible. This mirrors tests/run-components.sh,
+# which isolates the component tests for the same reason. It is slower than a
+# single invocation, but correctness beats speed for the coverage gate.
+#
+# Usage: bash tests/run-core.sh [extra bun test args]
+#   When --coverage-dir=DIR is passed, each file writes to DIR/file-N so the
+#   per-file lcov reports can be merged afterwards.
+
+set -uo pipefail
+
+EXTRA_BUN_ARGS=()
+COVERAGE_BASE_DIR=""
+for arg in "$@"; do
+  if [[ "$arg" == --coverage-dir=* ]]; then
+    COVERAGE_BASE_DIR="${arg#--coverage-dir=}"
+  else
+    EXTRA_BUN_ARGS+=("$arg")
+  fi
+done
+
+# Deterministic, sorted list of every core test file.
+mapfile -t FILES < <(find tests/unit tests/api tests/integration tests/hooks \
+  -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | sort)
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "run-core.sh: no core test files found" >&2
+  exit 1
+fi
+
+TOTAL="${#FILES[@]}"
+PASS=0
+FAIL=0
+FAILED_FILES=()
+INDEX=0
+
+for file in "${FILES[@]}"; do
+  INDEX=$((INDEX + 1))
+  RUN_ARGS=("${EXTRA_BUN_ARGS[@]}")
+  if [ -n "$COVERAGE_BASE_DIR" ]; then
+    RUN_ARGS+=("--coverage-dir=${COVERAGE_BASE_DIR}/file-${INDEX}")
+  fi
+
+  echo "=== [${INDEX}/${TOTAL}] ${file} ==="
+  if bun test "${RUN_ARGS[@]}" "$file"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_FILES+=("$file")
+  fi
+done
+
+echo ""
+echo "========================================"
+if [ "$FAIL" -eq 0 ]; then
+  echo "All ${TOTAL} core test files passed!"
+else
+  echo "${FAIL}/${TOTAL} core test files FAILED:"
+  for f in "${FAILED_FILES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Problem

The CI **"Run merged test coverage (core + components)"** step has failed on `main` since ~June with nondeterministic failures — `clearProviderCache is not a function`, `Export named 'removeProvider' not found`, `resolveConnection` not enforcing access control, plus OIDC / `AuditRingBuffer` / auth failures (~88 fails + 2 module-load errors). It passes with `bun run test` and passes locally under `bun run test:coverage`; only CI's file order exposes it, which made it look like a coverage drop. It isn't.

## Root cause

`bun`'s `mock.module()` is **process-wide**. `test:coverage:core` ran `tests/unit tests/api tests/integration` in a single `bun` process. Several `tests/api` files mock shared modules and never restore them — `@/lib/db/factory` (`profile`, `pool-stats`, `disconnect`, `test-connection`, `schema-snapshot`), `@/lib/oidc` (`oidc-login`, `oidc-callback`, `logout`), the audit module (`maintenance`, `audit`). When such a file runs **before** a file that imports the real export, the importer gets the partial mock. Local load order happens to be safe; CI's isn't.

(An intermediate per-directory split fixed `tests/unit` but the identical contamination then surfaced *inside* `tests/api` — e.g. `profile.test.ts`'s partial factory mock breaking `disconnect.test.ts`'s route import of `removeProvider`. So directory isolation isn't enough.)

## Fix

Run **every core test file in its own `bun` process** via `tests/run-core.sh` (mirrors the existing `tests/run-components.sh`), then merge the per-file lcov reports in `test:coverage`. No file shares a process with any other, so cross-file `mock.module()` contamination is structurally impossible.

- `tests/run-core.sh` — new per-file isolated runner (writes `coverage/core/file-N`).
- `package.json` — `test:coverage:core` calls the runner; `test:coverage` merges `coverage/core/file-*/lcov.info` + components.
- `CLAUDE.md` — documents why the isolation must stay.

No source or test code changed — only the coverage-runner wiring.

## Verification

- Locally: all **112** core test files pass isolated; `merge-lcov.mjs` merges all 112 per-file reports + components cleanly.
- The failure was **not locally reproducible** (identical bun revision/deps/command/env all pass locally because of load order), so **CI on this PR is the real verifier** — a green "Unit & Integration Tests" check is the proof.
