### PR TITLE
ci(docker): mirror image to Docker Hub alongside GHCR

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -69,18 +69,62 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
+      # Docker Hub is an optional secondary mirror for discoverability. It is
+      # only used when DOCKER_HUB_TOKEN is configured (so forks without the
+      # secret still build/push to GHCR cleanly).
+      - name: Check Docker Hub availability
+        id: dockerhub
+        env:
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+        run: |
+          if [ -n "$DOCKER_HUB_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ vars.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
       - name: Prepare image name (lowercase)
         id: image
         run: |
           IMAGE_NAME_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
           echo "name=${IMAGE_NAME_LOWER}" >> $GITHUB_OUTPUT
           echo "Image name (lowercase): ${IMAGE_NAME_LOWER}"
-      
+
+      # Build the list of target images. GHCR is always included; Docker Hub
+      # (docker.io/<DOCKER_HUB_USERNAME>/<repo>) is added only when enabled.
+      - name: Compose registry image list
+        id: images
+        env:
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          REPO_NAME: ${{ steps.image.outputs.name }}
+          DH_ENABLED: ${{ steps.dockerhub.outputs.enabled }}
+          DH_USERNAME: ${{ vars.DOCKER_HUB_USERNAME }}
+        run: |
+          IMAGES="$GHCR_IMAGE"
+          if [ "$DH_ENABLED" = "true" ] && [ -n "$DH_USERNAME" ]; then
+            SHORT_NAME="${REPO_NAME##*/}"
+            IMAGES="$(printf '%s\ndocker.io/%s/%s' "$IMAGES" "$DH_USERNAME" "$SHORT_NAME")"
+          fi
+          {
+            echo "list<<EOF"
+            printf '%s\n' "$IMAGES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Target images:"
+          printf '%s\n' "$IMAGES"
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          images: ${{ steps.images.outputs.list }}
           tags: |
             type=raw,value=${{ steps.extract-version.outputs.version }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}
@@ -108,7 +152,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.extract-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Registry:** ${{ env.REGISTRY }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Docker Hub mirror:** ${{ steps.dockerhub.outputs.enabled }}" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** ${{ steps.image.outputs.name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Tags:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Mirror the Docker image to **Docker Hub** (`docker.io/libredb/libredb-studio`) alongside the canonical GHCR image, in the same multi-arch buildx run.

## Why

- **GHCR stays canonical** — no pull rate limits (matters for the Helm/k8s audience), referenced by the Helm chart, CapRover template and docker-compose.
- **Docker Hub adds discoverability** — `docker pull libredb/libredb-studio`, Docker Desktop search, the default registry most users expect.

## How

- New optional steps: detect `DOCKER_HUB_TOKEN`, log in to Docker Hub, and add `docker.io/<DOCKER_HUB_USERNAME>/<repo>` to the metadata-action image list so the same tags (`<version>`, `latest`, `dev`, `sha-*`) push to both registries in one build.
- **Opt-in / fork-safe**: Docker Hub is only targeted when the `DOCKER_HUB_TOKEN` secret and `DOCKER_HUB_USERNAME` variable are present. Forks without them still build and push to GHCR cleanly.
- No untrusted input in `run:` steps (secrets/vars passed via `env:`).

## Verification

- `workflow_dispatch` test run on this branch: **ESLint, TypeScript, Check Docker Hub availability, Log in to Docker Hub, Compose image list, Extract metadata all green**; multi-arch build + push to both registries in progress. Docker Hub login succeeded with `DOCKER_HUB_USERNAME=libredb`.

## Follow-up (manual, one-time)

- Docker Hub auto-creates the repo as **private** on first push — set `libredb/libredb-studio` to **Public** in Docker Hub settings.
- Optional: apply for the **Docker-Sponsored Open Source** program to remove pull rate limits for the mirror; add cosign signing / provenance.
