### PR TITLE
ci(docker): latest+version on main, dev on feat/fix branches

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,12 +5,20 @@ on:
     branches:
       - main
       - 'release/v*'
+      - 'feat/**'
+      - 'fix/**'
   workflow_dispatch:
     inputs:
       version:
         description: 'Version tag (e.g., v0.5.5)'
         required: true
         type: string
+
+# Cancel an in-progress build when a newer commit is pushed to the same ref,
+# so rapid pushes to a feature/fix branch don't stack multi-arch builds.
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -126,9 +134,9 @@ jobs:
         with:
           images: ${{ steps.images.outputs.list }}
           tags: |
-            type=raw,value=${{ steps.extract-version.outputs.version }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ steps.extract-version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') }}
             type=sha,prefix=sha-
 
       - name: Build and push Docker image


### PR DESCRIPTION
Adjusts Docker tag policy and triggers per request.

**Tagging**
| Ref | Tags pushed (to GHCR + Docker Hub) |
|-----|-----|
| `main` | `<version>`, `latest`, `sha-*` |
| `release/v*` | `<version>`, `sha-*` |
| `feat/**`, `fix/**` | `dev`, `sha-*` |

The version tag is intentionally **not** pushed from feat/fix branches so a branch build can never overwrite a released version. `concurrency` (cancel-in-progress per ref) prevents stacked multi-arch builds on rapid branch pushes.

**Cost note:** every push to a `feat/**` or `fix/**` branch now triggers a ~25-min multi-arch build. If that's too much, we can narrow it (e.g. amd64-only for `dev`, or build only on PRs).