### PR TITLE
ci(npm): pin oven-sh/setup-bun to a SHA (CodeQL #76/#77)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.9"
 
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.9"
 


### PR DESCRIPTION
Pins both `oven-sh/setup-bun@v2` steps in `npm-publish.yml` to the commit SHA already used across `ci.yml` and `docker-build-push.yml` (`0c5077e… # v2`).

Resolves CodeQL **actions/unpinned-tag** alerts **#76** and **#77**.

`actions/checkout` / `actions/setup-node` are first-party GitHub actions and are not flagged by the rule, so they're left as-is.