### PR TITLE
fix(auth): remove hardcoded default password (SonarCloud)

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -10,28 +10,29 @@ interface AuthUser {
 }
 
 function getAuthUsers(): AuthUser[] {
-  const adminEmail = process.env.ADMIN_EMAIL;
+  const adminEmail = process.env.ADMIN_EMAIL || 'admin@libredb.org';
   const adminPassword = process.env.ADMIN_PASSWORD;
-  const userEmail = process.env.USER_EMAIL;
+  const userEmail = process.env.USER_EMAIL || 'user@libredb.org';
   const userPassword = process.env.USER_PASSWORD;
 
-  if (process.env.NODE_ENV === 'production') {
-    if (!adminEmail || !adminPassword || !userEmail || !userPassword) {
-      throw new Error(
-        'ADMIN_EMAIL, ADMIN_PASSWORD, USER_EMAIL, and USER_PASSWORD environment variables are required in production'
-      );
-    }
+  // Passwords MUST come from the environment in every environment. Never fall
+  // back to a hardcoded default — a baked-in password would be a publicly known
+  // credential on any deployment that forgets to set ADMIN_PASSWORD/USER_PASSWORD.
+  if (!adminPassword || !userPassword) {
+    throw new Error(
+      'ADMIN_PASSWORD and USER_PASSWORD environment variables are required'
+    );
   }
 
   return [
     {
-      email: adminEmail || 'admin@libredb.org',
-      password: adminPassword || 'LibreDB.2026',
+      email: adminEmail,
+      password: adminPassword,
       role: 'admin',
     },
     {
-      email: userEmail || 'user@libredb.org',
-      password: userPassword || 'LibreDB.2026',
+      email: userEmail,
+      password: userPassword,
       role: 'user',
     },
   ];

--- a/tests/api/auth/login.test.ts
+++ b/tests/api/auth/login.test.ts
@@ -146,11 +146,9 @@ describe('POST /api/auth/login', () => {
     expect(mockLogin).toHaveBeenCalledWith('user', 'user@libredb.org');
   });
 
-  test('returns 500 when production env vars are missing', async () => {
-    const origNodeEnv = process.env.NODE_ENV;
-    const origAdminEmail = process.env.ADMIN_EMAIL;
-    (process.env as Record<string, string>).NODE_ENV = 'production';
-    delete process.env.ADMIN_EMAIL;
+  test('returns 500 when required password env vars are missing', async () => {
+    const origAdminPassword = process.env.ADMIN_PASSWORD;
+    delete process.env.ADMIN_PASSWORD;
 
     const req = createMockRequest('/api/auth/login', {
       method: 'POST',
@@ -164,7 +162,6 @@ describe('POST /api/auth/login', () => {
     expect(data.code).toBe('INTERNAL_ERROR');
     expect(data.statusCode).toBe(500);
 
-    (process.env as Record<string, string>).NODE_ENV = origNodeEnv!;
-    process.env.ADMIN_EMAIL = origAdminEmail!;
+    process.env.ADMIN_PASSWORD = origAdminPassword!;
   });
 });


### PR DESCRIPTION
## Problem
SonarCloud flags a **hardcoded credential** in `src/app/api/auth/login/route.ts`:
```ts
password: adminPassword || 'LibreDB.2026',
password: userPassword  || 'LibreDB.2026',
```
Production already required the env vars, but the baked-in default meant any **non-production** deployment that forgot to set `ADMIN_PASSWORD`/`USER_PASSWORD` would silently accept a **publicly known** password.

## Fix
- `ADMIN_PASSWORD` and `USER_PASSWORD` are now required in **every** environment — the route throws → 500 if absent. No password literal remains in source.
- Email values keep a non-sensitive default (`admin@libredb.org`/`user@libredb.org`) — SonarCloud does not flag those and they aren't secrets.
- Tests already inject the env via `tests/setup.ts`; updated the 'missing env vars' test to assert the new universal password requirement.

Verified locally: typecheck, lint, `login.test.ts` (10/0) and `LoginPage.test.tsx` (10/0) green.

## Note on remaining `LibreDB.2026` occurrences
- **Tests** (`tests/setup.ts`, `login.test.ts`, `LoginPage.test.tsx`): test fixtures, not real secrets.
- **Docs** (`README.md`, `DOCKERHUB.md`, `docs/releases`): the **intentional public demo** credential for app.libredb.org.

These are best handled by marking the SonarCloud Hotspots as *Safe/Acknowledged*. Happy to genericize the test credential too if preferred.