### PR TITLE
ci(npm): per-file test isolation in publish gate + bump to 0.9.19

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,7 +42,10 @@ jobs:
         run: bun run typecheck
 
       - name: Test
-        run: bun run test
+        # Per-file process isolation (run-core.sh) — bun's mock.module() is
+        # process-wide, so the single-process `bun run test` is load-order flaky
+        # here. This mirrors the reliable path ci.yml uses via test:coverage.
+        run: bun run test:ci
 
       - name: Build
         run: bun run build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "bun test tests/unit tests/api tests/integration && bun test tests/hooks && bun run test:components",
+    "test:ci": "bash tests/run-core.sh && bun run test:components",
     "test:unit": "bun test tests/unit",
     "test:integration": "bun test tests/integration",
     "test:hooks": "bun test tests/hooks",


### PR DESCRIPTION
## Problem
The `v0.9.18` tag triggered **NPM Publish**, but its **Validate** job failed: 88 unrelated tests across oidc/auth/audit/etc. failed in a single run. The publish job was correctly skipped, so nothing bad was published — but `@libredb/studio@0.9.18` never made it to npm.

Root cause: `npm-publish.yml` ran `bun run test`, whose first batch `bun test tests/unit tests/api tests/integration` runs in **one** bun process. `bun`'s `mock.module()` is process-wide, so a file that mocks a shared module poisons every other file by load order. The very same commit is green on `ci.yml` because CI uses the **isolated** `test:coverage` path (`tests/run-core.sh`, one process per file). The publish gate was using the known-flaky path.

## Fix
- Add `test:ci` = `bash tests/run-core.sh && bun run test:components` — per-file process isolation (unit/api/integration/hooks) + isolated components, **without** the coverage-merge overhead.
- Point the publish Validate `Test` step at `bun run test:ci`.

## Verification
- ✅ `bun run test:ci` locally: run-core.sh green, then components `486 pass / 0 fail / All 18 groups passed!`

After merge, npm@0.9.18 will be published via `workflow_dispatch` (version=0.9.18).
