### PR TITLE
fix(sql): quote schema-qualified table names per-segment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/src/app/api/db/profile/route.ts
+++ b/src/app/api/db/profile/route.ts
@@ -3,7 +3,7 @@ import { getOrCreateProvider } from '@/lib/db/factory';
 import { createErrorResponse } from '@/lib/api/errors';
 import { resolveConnection } from '@/lib/seed/resolve-connection';
 import { getSession } from '@/lib/auth';
-import { quoteIdentifier } from '@/lib/query-generators';
+import { quoteIdentifier, quoteQualifiedName } from '@/lib/query-generators';
 
 export async function POST(req: NextRequest) {
   try {
@@ -71,7 +71,7 @@ export async function POST(req: NextRequest) {
       }
 
       // Quote the table once for the target dialect (mixed-case / special names)
-      const safeTable = quoteIdentifier(tableName, capabilities);
+      const safeTable = quoteQualifiedName(tableName, capabilities);
 
       // Get total row count
       const countResult = await provider.query(`SELECT COUNT(*) as total FROM ${safeTable}`);

--- a/src/lib/query-generators.ts
+++ b/src/lib/query-generators.ts
@@ -35,6 +35,22 @@ export function quoteIdentifier(name: string, capabilities: ProviderCapabilities
   return /^[a-z_][a-z0-9_$]*$/.test(name) ? name : `"${name.replaceAll('"', '""')}"`;
 }
 
+/**
+ * Quote a possibly schema-qualified name (e.g. `employees.department`) by quoting
+ * each dotted segment independently. Quoting the whole string as one identifier
+ * (`"employees.department"`) would make the database look for a single relation
+ * literally named with a dot, which fails. Each segment is still quoted only when
+ * needed, so `employees.department` stays unquoted and `public.Order` becomes
+ * `public."Order"`.
+ */
+export function quoteQualifiedName(name: string, capabilities: ProviderCapabilities): string {
+  if (capabilities.queryLanguage === 'json') return name;
+  return name
+    .split('.')
+    .map((part) => quoteIdentifier(part, capabilities))
+    .join('.');
+}
+
 export function generateTableQuery(tableName: string, capabilities: ProviderCapabilities): string {
   if (capabilities.queryLanguage === 'json') {
     return JSON.stringify(
@@ -43,7 +59,7 @@ export function generateTableQuery(tableName: string, capabilities: ProviderCapa
       2
     );
   }
-  const table = quoteIdentifier(tableName, capabilities);
+  const table = quoteQualifiedName(tableName, capabilities);
   // Oracle
   if (capabilities.defaultPort === 1521) {
     return `SELECT * FROM ${table} FETCH FIRST 50 ROWS ONLY;`;
@@ -79,7 +95,7 @@ export function generateSelectQuery(
       2
     );
   }
-  const table = quoteIdentifier(tableName, capabilities);
+  const table = quoteQualifiedName(tableName, capabilities);
   const cols = columns.map((c) => `  ${quoteIdentifier(c.name, capabilities)}`).join(',\n') || '  *';
   // Oracle
   if (capabilities.defaultPort === 1521) {

--- a/tests/unit/lib/query-generators.test.ts
+++ b/tests/unit/lib/query-generators.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { generateTableQuery, generateSelectQuery, shouldRefreshSchema, quoteIdentifier } from '@/lib/query-generators';
+import { generateTableQuery, generateSelectQuery, shouldRefreshSchema, quoteIdentifier, quoteQualifiedName } from '@/lib/query-generators';
 import type { ProviderCapabilities } from '@/lib/db/types';
 import type { ColumnSchema } from '@/lib/types';
 
@@ -151,6 +151,24 @@ describe('quoteIdentifier', () => {
   test('generateTableQuery quotes a mixed-case Postgres table', () => {
     expect(generateTableQuery('Customer', makeCaps({ defaultPort: 5432 })))
       .toBe('SELECT * FROM "Customer" LIMIT 50;');
+  });
+
+  test('schema-qualified names are quoted per-segment, not as one identifier', () => {
+    // lowercase schema.table → no quotes (Postgres)
+    expect(quoteQualifiedName('employees.department', makeCaps({ defaultPort: 5432 })))
+      .toBe('employees.department');
+    // mixed-case table in a schema → only the table segment is quoted
+    expect(quoteQualifiedName('public.Order', makeCaps({ defaultPort: 5432 })))
+      .toBe('public."Order"');
+    // bare name (no dot) is unchanged
+    expect(quoteQualifiedName('Customer', makeCaps({ defaultPort: 5432 })))
+      .toBe('"Customer"');
+  });
+
+  test('generateTableQuery on a schema-qualified table does NOT wrap the dot (regression)', () => {
+    // Was producing the broken `"employees.department"`; must be `employees.department`.
+    expect(generateTableQuery('employees.department', makeCaps({ defaultPort: 5432 })))
+      .toBe('SELECT * FROM employees.department LIMIT 50;');
   });
 
   test('generateSelectQuery quotes mixed-case table and columns (Postgres)', () => {


### PR DESCRIPTION
## Problem

Sidebar **"select top 100"** on a schema-qualified table produced a broken query:

```sql
SELECT * FROM "employees.department" LIMIT 50;   -- ❌ relation does not exist
```

The dialect-aware `quoteIdentifier` (added to support mixed-case names) treated the whole `schema.table` string as one identifier, so the dot got wrapped inside the quotes. Postgres then looks for a single relation literally named `employees.department`, which fails.

## Fix

Add `quoteQualifiedName()`: split on `.`, quote **each segment** only-when-needed, rejoin.

- `employees.department` → `employees.department` (lowercase, stays unquoted) ✅
- `public.Order` → `public."Order"` (only the mixed-case segment quoted)
- `Customer` (no dot) → `"Customer"` (unchanged)

Used for **table names** in the query generators (`generateTableQuery`, `generateSelectQuery`) and the data profiler. Column names still use single-identifier `quoteIdentifier`.

## Verification

- Reproduced and fixed against a real **Neon Postgres** database (`employees` schema): the old `"employees.department"` fails; the new `employees.department` returns rows.
- New unit tests cover per-segment quoting and the schema-qualified regression.
- lint, typecheck, knip, full `test:coverage` (18/18 groups) all pass.
