### PR TITLE
docs: add provider tri-sync invariant to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,18 @@ charts/
    - **Document:** MongoDB (extends `BaseDatabaseProvider`)
    - **Key-Value:** Redis (extends `BaseDatabaseProvider`)
 
+   > **⚠️ Providers are the lifeblood of this project. Keep the three artifacts in lockstep:**
+   > **code ↔ docs ↔ tests.** For every provider there is a 1:1 triad, keyed by the canonical
+   > **type-id** (`postgres`, `mysql`, `sqlite`, `oracle`, `mssql`, `mongodb`, `redis`):
+   > - **Code:** `src/lib/db/providers/<family>/<type-id>.ts`
+   > - **Docs:** `docs/providers/<type-id>.md` (filename = type-id; official name only in the title/prose)
+   > - **Tests:** `tests/integration/db/<type-id>-provider.test.ts`
+   >
+   > **Any change to one side MUST sync the others in the same PR.** Change the code → update the
+   > doc and tests to match. Touch the doc → verify it still reflects the code (every `file:line`
+   > citation, every behaviour). The doc must mirror the code, and the code must mirror what the doc
+   > promises — they are never allowed to drift.
+
 2. **LLM Abstraction:** `src/lib/llm/` module provides Strategy Pattern for AI providers (Gemini, OpenAI, Ollama, Custom)
 
 3. **Authentication Flow:** Supports two modes controlled by `NEXT_PUBLIC_AUTH_PROVIDER`:


### PR DESCRIPTION
## Summary

Documents a core project rule in `CLAUDE.md`: **providers are the lifeblood of libredb-studio, and their code, docs, and tests must stay in lockstep.**

For every database provider there is a 1:1 triad, keyed by the canonical **type-id**:

- **Code:** `src/lib/db/providers/<family>/<type-id>.ts`
- **Docs:** `docs/providers/<type-id>.md`
- **Tests:** `tests/integration/db/<type-id>-provider.test.ts`

**A change to any one side must sync the other two in the same PR** — the doc mirrors the code (every `file:line` citation and behaviour), the code mirrors what the doc promises, and tests cover the behaviour. They are never allowed to drift.

Added as a callout under **Architecture → Key Patterns → Database Abstraction** so it is loaded into context every session.

## Notes

- Docs-only (`CLAUDE.md`), no code/test changes.
- Complements the per-provider reference docs under `docs/providers/` (Redis #75, PostgreSQL #76).