### PR TITLE
docs: refresh SQL_ALIAS_COMPLETION.md to current code locations

### DIFF
--- a/docs/SQL_ALIAS_COMPLETION.md
+++ b/docs/SQL_ALIAS_COMPLETION.md
@@ -60,6 +60,9 @@ src/lib/sql/
 ├── alias-extractor.ts   # Core alias extraction logic
 ├── types.ts             # TypeScript interfaces
 └── index.ts             # Module exports
+
+src/lib/editor/
+└── sql-completions.ts   # Monaco completion provider (consumes the alias extractor)
 ```
 
 ### Key Components
@@ -79,9 +82,11 @@ Lightweight regex-based SQL parser that extracts table aliases without external 
 4. Extracts CTE (WITH clause) aliases
 5. Returns a Map of alias → table name
 
-#### 2. Completion Provider (`src/components/QueryEditor.tsx`)
+#### 2. Completion Provider (`src/lib/editor/sql-completions.ts`)
 
-Monaco Editor completion provider that integrates with the alias extractor.
+Monaco Editor completion provider (`registerCompletionItemProvider('sql', …)`, triggered on `.` and
+space) that integrates with the alias extractor. Registered by the editor and hosted in
+`src/components/QueryEditor.tsx`.
 
 **Dot-triggered completion flow:**
 ```
@@ -184,7 +189,8 @@ interface AliasExtractionResult {
 
 | File | Description |
 |------|-------------|
-| `src/lib/sql/types.ts` | Type definitions |
-| `src/lib/sql/alias-extractor.ts` | Core parsing logic |
+| `src/lib/sql/alias-extractor.ts` | Core alias parsing logic (`extractAliases`, `resolveAlias`) |
+| `src/lib/sql/types.ts` | Type definitions (`TableAlias`, `AliasExtractionResult`) |
 | `src/lib/sql/index.ts` | Module exports |
-| `src/components/QueryEditor.tsx` | Monaco Editor integration |
+| `src/lib/editor/sql-completions.ts` | Monaco completion provider (dot/space-triggered; consumes the alias extractor) |
+| `src/components/QueryEditor.tsx` | Hosts the Monaco editor and registers the provider |


### PR DESCRIPTION
## Summary

`docs/SQL_ALIAS_COMPLETION.md` documents a **live, distinctive feature** (alias-aware SQL autocomplete) and is its **only** reference — so rather than archive it, this PR brings it up to date.

The completion provider was refactored out of `QueryEditor.tsx` into `src/lib/editor/sql-completions.ts` (which imports `extractAliases`/`resolveAlias` from `@/lib/sql` and registers `registerCompletionItemProvider('sql', …)`, triggered on `.`/space). The doc still pointed at the old location.

## Changes (docs-only)

- Module Structure: add `src/lib/editor/sql-completions.ts` (the consumer of the alias extractor).
- Key Components #2: completion provider is `src/lib/editor/sql-completions.ts`; `QueryEditor.tsx` now hosts the editor and registers the provider.
- Related Files: corrected to the real locations.

Core API (`extractAliases`/`resolveAlias`), types, and behaviour are unchanged and already accurate.

## Why keep (not archive)

The feature is live (`src/lib/sql/alias-extractor.ts` + `src/lib/editor/sql-completions.ts`), and this is its sole documentation. Archiving would leave working code undocumented — the opposite of "fewer but current, quality docs." It is also an editor/IDE feature, so it does **not** belong folded into `DATABASE_PROVIDERS.md` (a provider-architecture doc).