### PR TITLE
chore(ci): adopt trunk-based flow, retire dev branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "dev", "main" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "dev", "main" ]
+    branches: [ "main" ]
   schedule:
     - cron: '20 6 * * 5'
 

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'release/v*'
       - 'feat/**'
       - 'fix/**'
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Web-based SQL IDE for cloud-native teams: PostgreSQL, MySQL, SQLite, Oracle, SQL
 
 ## Branching & PRs
 
-> **Feature/work branches target `dev`, NOT `main`.** Open every PR with base `dev` (`gh pr create --base dev`). `main` is release-only, updated via a deliberate `dev` → `main` promotion. Branch off `dev` for new work.
+> **Trunk-based: feature/work branches target `main` directly; releases are git tags.** Branch off `main` for new work and open every PR with base `main` (`gh pr create --base main`). `main` is the single protected integration trunk — PRs are required and the `Lint, Typecheck and Build` check must pass before merge. Cut a release by tagging `main` (`vX.Y.Z`), which triggers the npm publish workflow. There is no `dev` branch and no long-lived `release/*` branches.
 
 ## GitHub
 


### PR DESCRIPTION
## Summary
Migrate from `feature -> dev -> main -> release/*` (GitFlow-lite) to trunk-based `feature -> main -> tag`. The `dev` branch and `release/*` branches caused divergence/conflicts and were redundant: releases are already tag-driven (`npm-publish` on `v*`) and `main` is already protected (PR required + `Lint, Typecheck and Build` must pass).

## Changes
- **codeql.yml**: trigger on `main` only (drop `dev`).
- **docker-build-push.yml**: drop dead `release/v*` trigger (release branches deleted).
- **CLAUDE.md**: document the trunk-based model.

## Context
- 13 `release/*` branches deleted (every tip was already reachable from `main`; zero unique commits).
- `main` and `dev` trees are byte-identical after #89; the apparent 33-commit gap is a squash-merge ancestry artifact, not content. `dev` will be deleted after this merges.

## Verification
`bun run lint` (0 errors) - `typecheck` (clean) - `build` (ok) - `test` (486 pass / 0 fail).