### PR TITLE
fix(release): bump version to 0.9.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Patch bump 0.9.27 -> 0.9.28. End-to-end dry-run of the new trunk-based flow (feature -> main -> tag).

Local verify: lint (0 errors), typecheck (clean), test (0 fail), build (ok).