### PR TITLE
chore(ci): drop dead release/* conditions from docker image tagging

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -133,9 +133,9 @@ jobs:
         with:
           images: ${{ steps.images.outputs.list }}
           tags: |
-            type=raw,value=${{ steps.extract-version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ steps.extract-version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=dev,enable=${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') }}
+            type=raw,value=dev,enable=${{ github.ref != 'refs/heads/main' }}
             type=sha,prefix=sha-
 
       - name: Build and push Docker image

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Follow-up to the trunk-based migration (#90). `release/*` branches were deleted, so the `release/*` clauses in the docker image-tag rules were dead (always-true/false). Removed them; behavior is identical:
- `main` -> version + `latest` tags
- feature branches -> `dev` rolling image tag

Pure CI-config change, no app code touched.