### PR TITLE
docs(deploy): add Kubero deployment guide and README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,15 @@ The app runs the prebuilt `ghcr.io/libredb/libredb-studio` image. As with Railwa
 
 ### Kubero
 
-LibreDB Studio is listed in the official [Kubero template catalog](https://www.kubero.dev/templates) (a self-hosted "Heroku alternative for Kubernetes"). From your Kubero dashboard, browse **Templates**, search **LibreDB Studio**, fill in the credentials / `JWT_SECRET`, and deploy. The template runs the prebuilt `ghcr.io/libredb/libredb-studio` image with SQLite persistence on a 5Gi volume at `/app/data`. See [`deploy/kubero/`](deploy/kubero/) for install and post-install details. As with Railway and CapRover, Docker-image templates require a manual version bump on each release.
+LibreDB Studio is listed in the official
+[Kubero template catalog](https://www.kubero.dev/templates) (a self-hosted
+"Heroku alternative for Kubernetes"). From your Kubero dashboard, browse
+**Templates**, search **LibreDB Studio**, fill in the credentials / `JWT_SECRET`,
+and deploy. The template runs the prebuilt `ghcr.io/libredb/libredb-studio` image
+with SQLite persistence on a 5Gi volume at `/app/data`. See
+[`deploy/kubero/`](deploy/kubero/) for install and post-install details. As with
+Railway and CapRover, Docker-image templates require a manual version bump on
+each release.
 
 ### Render (Recommended for cloud deployment)
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,10 @@ LibreDB Studio is published in the official [CapRover One-Click Apps](https://gi
 
 The app runs the prebuilt `ghcr.io/libredb/libredb-studio` image. As with Railway, Docker-image templates require a manual version bump on each release.
 
+### Kubero
+
+LibreDB Studio is published in the official [Kubero](https://www.kubero.dev) template catalog (a self-hosted "Heroku alternative for Kubernetes"). From your Kubero dashboard, browse **Templates**, search **LibreDB Studio**, fill in the credentials / `JWT_SECRET`, and deploy. The template runs the prebuilt `ghcr.io/libredb/libredb-studio` image with SQLite persistence on a 5Gi volume at `/app/data`. See [`deploy/kubero/`](deploy/kubero/) for install and post-install details. As with Railway and CapRover, Docker-image templates require a manual version bump on each release.
+
 ### Render (Recommended for cloud deployment)
 
 LibreDB Studio includes a `render.yaml` Blueprint for one-click deployment:

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Deploy your own instance of LibreDB Studio with a single click on Koyeb, Render,
 
 ## Deployment (DevOps)
 
-### Koyeb (Recommended for cloud deployment)
+### Koyeb
 
 1. **Fork this repository**
 2. **Connect to Koyeb**: [app.koyeb.com](https://app.koyeb.com) → New → Blueprint
@@ -429,7 +429,7 @@ The app runs the prebuilt `ghcr.io/libredb/libredb-studio` image. As with Railwa
 
 ### Kubero
 
-LibreDB Studio is published in the official [Kubero](https://www.kubero.dev) template catalog (a self-hosted "Heroku alternative for Kubernetes"). From your Kubero dashboard, browse **Templates**, search **LibreDB Studio**, fill in the credentials / `JWT_SECRET`, and deploy. The template runs the prebuilt `ghcr.io/libredb/libredb-studio` image with SQLite persistence on a 5Gi volume at `/app/data`. See [`deploy/kubero/`](deploy/kubero/) for install and post-install details. As with Railway and CapRover, Docker-image templates require a manual version bump on each release.
+LibreDB Studio is listed in the official [Kubero template catalog](https://www.kubero.dev/templates) (a self-hosted "Heroku alternative for Kubernetes"). From your Kubero dashboard, browse **Templates**, search **LibreDB Studio**, fill in the credentials / `JWT_SECRET`, and deploy. The template runs the prebuilt `ghcr.io/libredb/libredb-studio` image with SQLite persistence on a 5Gi volume at `/app/data`. See [`deploy/kubero/`](deploy/kubero/) for install and post-install details. As with Railway and CapRover, Docker-image templates require a manual version bump on each release.
 
 ### Render (Recommended for cloud deployment)
 

--- a/deploy/kubero/README.md
+++ b/deploy/kubero/README.md
@@ -4,7 +4,8 @@
 "Heroku alternative for Kubernetes" — that deploys 12-factor apps onto a cluster
 from a built-in template catalog.
 
-LibreDB Studio is published in the official Kubero template catalog
+LibreDB Studio is listed in the official
+[Kubero template catalog](https://www.kubero.dev/templates)
 (merged in [kubero-dev/kubero#754](https://github.com/kubero-dev/kubero/pull/754)).
 The canonical template lives in the Kubero repo at
 [`services/libredb-studio/app.yaml`](https://github.com/kubero-dev/kubero/blob/main/services/libredb-studio/app.yaml)

--- a/deploy/kubero/README.md
+++ b/deploy/kubero/README.md
@@ -14,8 +14,9 @@ source of truth.
 
 ## Install
 
-From a running Kubero instance (install Kubero itself with
-`curl -L https://get.kubero.dev | bash`):
+From a running Kubero instance (see the
+[Kubero install docs](https://docs.kubero.dev/docs/Getting-Started/Installation/)
+to set one up):
 
 1. **Open your Kubero dashboard** → create or pick a pipeline/app, then browse
    **Templates**.

--- a/deploy/kubero/README.md
+++ b/deploy/kubero/README.md
@@ -1,0 +1,74 @@
+# LibreDB Studio on Kubero
+
+[Kubero](https://www.kubero.dev) is a self-hosted, open-source PaaS — a
+"Heroku alternative for Kubernetes" — that deploys 12-factor apps onto a cluster
+from a built-in template catalog.
+
+LibreDB Studio is published in the official Kubero template catalog
+(merged in [kubero-dev/kubero#754](https://github.com/kubero-dev/kubero/pull/754)).
+The canonical template lives in the Kubero repo at
+[`services/libredb-studio/app.yaml`](https://github.com/kubero-dev/kubero/blob/main/services/libredb-studio/app.yaml)
+as a `KuberoApp` custom resource; this folder is a documentation mirror, not the
+source of truth.
+
+## Install
+
+From a running Kubero instance (install Kubero itself with
+`curl -L https://get.kubero.dev | bash`):
+
+1. **Open your Kubero dashboard** → create or pick a pipeline/app, then browse
+   **Templates**.
+2. **Search** for **LibreDB Studio**.
+3. **Fill in the variables** — admin/user credentials, a strong `JWT_SECRET`
+   (32+ chars), and any optional AI/storage settings.
+4. **Deploy.**
+
+## What the template does
+
+- Runs the prebuilt `ghcr.io/libredb/libredb-studio` image (pinned tag, never
+  `:latest`) with the `docker` deployment strategy on container HTTP port `3000`.
+- Persists saved connections & settings with **SQLite** (`STORAGE_PROVIDER=sqlite`)
+  on a `5Gi` ReadWriteOnce volume mounted at `/app/data`, surviving restarts and
+  redeploys — no external database required.
+- Ships configurable `ADMIN_EMAIL` / `ADMIN_PASSWORD`, `USER_EMAIL` /
+  `USER_PASSWORD`, and `JWT_SECRET` env vars. The catalog defaults are
+  placeholders — set real values before deploying.
+
+## First login
+
+After deploy, open the app's public URL and log in:
+
+- **Admin** (full access incl. maintenance tools): `admin@libredb.org` + your
+  `ADMIN_PASSWORD`.
+- **User** (query execution only): `user@libredb.org` + your `USER_PASSWORD`.
+
+## Environment variables
+
+See the [main README environment table](../../README.md#environment-variables)
+for the full list. Minimum required for a working Kubero deploy:
+
+| Variable | Notes |
+|----------|-------|
+| `JWT_SECRET` | 32+ chars, set your own |
+| `ADMIN_EMAIL` / `ADMIN_PASSWORD` | admin login |
+| `USER_EMAIL` / `USER_PASSWORD` | standard user login |
+| `STORAGE_PROVIDER` | `sqlite` (default here); `postgres` for an external backend |
+
+## Post-install options
+
+Add these variables on the app to extend the deployment:
+
+- **SSO / OIDC** — `NEXT_PUBLIC_AUTH_PROVIDER=oidc`, `OIDC_ISSUER`,
+  `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ROLE_CLAIM`, `OIDC_ADMIN_ROLES`.
+- **PostgreSQL storage backend** (multi-node) — `STORAGE_PROVIDER=postgres`,
+  `STORAGE_POSTGRES_URL=...`.
+- **AI** — `LLM_PROVIDER` (`gemini` | `openai` | `ollama` | `custom`),
+  `LLM_API_KEY`, `LLM_MODEL`, `LLM_API_URL`.
+
+## Version bumps
+
+The catalog template pins a specific image tag. On each release, bump the tag in
+the Kubero repo's `services/libredb-studio/app.yaml` (same manual-bump caveat as
+the Railway and CapRover Docker-image templates).
+
+More details and docs: https://github.com/libredb/libredb-studio

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.33",
+  "version": "0.9.34",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

LibreDB Studio is now available in the official **Kubero** template catalog (a self-hosted "Heroku alternative for Kubernetes"), merged in [kubero-dev/kubero#754](https://github.com/kubero-dev/kubero/pull/754).

This PR documents that on our side, mirroring how the other PaaS targets (CapRover, Railway, Koyeb) are documented.

## Changes

- **`deploy/kubero/README.md`** (new) — install steps from the Kubero template catalog, what the template does (prebuilt GHCR image, port 3000, 5Gi SQLite volume at `/app/data`), first-login, env vars, OIDC/Postgres/AI post-install options, and the manual version-bump caveat shared by the Docker-image templates.
- **`README.md`** — adds a `### Kubero` subsection under **Deployment (DevOps)**, linking to `deploy/kubero/`.

The canonical template (a `KuberoApp` CR) lives in the Kubero repo at `services/libredb-studio/app.yaml`; this folder is a documentation mirror, not the source of truth.

## Notes

- Docs-only change. No code, deps, or build config touched. `bun run format` passes clean.
- Kubero has no external one-click deploy button (apps install from within a running Kubero instance's catalog), so it is intentionally placed under Deployment (DevOps) alongside CapRover, not in the one-click button row.