### PR TITLE
ci(npm-publish): trigger on release published, not v* tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,12 @@
 name: NPM Publish
 
+# Publish when a GitHub Release is published, regardless of the tag's naming
+# (the project uses plain "0.9.x" tags now, but older ones were "v0.9.x" — a
+# tag-name filter kept missing the plain ones). The release commit's
+# package.json is the version source. workflow_dispatch remains a manual fallback.
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Problem

`npm-publish.yml` only triggered on `push: tags: ['v*']`, but the release tag convention switched to plain `0.9.x` (e.g. `0.9.30`, `0.9.32`, `0.9.36`). Plain tags don't match `v*`, so recent releases never auto-published to npm — each needed a manual `workflow_dispatch`.

## Fix

Trigger on the GitHub **release `published`** event instead of a tag-name filter. This is independent of whether the tag is `v0.9.x` or `0.9.x`, so it can't drift from the tag convention again. The tag-push trigger is dropped (avoids double-firing, since creating a release also creates a tag); `workflow_dispatch` stays as a manual fallback.

The job body is unchanged and already compatible:
- Version comes from the release commit's `package.json` (no tag/ref parsing).
- `Set version` / `dry_run` steps are gated on `inputs.*`, which are empty on a release event, so a published release runs a normal publish with the package.json version.

## Note

This only affects **future** releases. `0.9.36` is already published (its release event predates this change), so it still needs a one-time manual `workflow_dispatch` to reach npm.