### PR TITLE
fix(deps): upgrade @libredb/libredb to 0.1.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "libredb-studio",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
-        "@libredb/libredb": "^0.0.3",
+        "@libredb/libredb": "0.1.3",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -362,7 +362,7 @@
 
     "@js-joda/core": ["@js-joda/core@5.7.0", "", {}, "sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg=="],
 
-    "@libredb/libredb": ["@libredb/libredb@0.0.3", "", {}, "sha512-bZ4/VW4e1QBdnhlgpiyt1YjW617zhUTdtdDhtYrI0UBnubHv8x8X2i2otKKgbw0bg2I8Izr/xRl5sk8gaErUyw=="],
+    "@libredb/libredb": ["@libredb/libredb@0.1.3", "", { "bin": { "libredb": "dist/cli/main.js" } }, "sha512-TuQRLz+sEIx0YJSvT9tiin4yehpqdG1kalPgVtnGhw78JmgUsLryS3/sbNMI2X3sTxE+8Gel7CvUim6s2azYDQ=="],
 
     "@loaderkit/resolve": ["@loaderkit/resolve@1.0.6", "", { "dependencies": { "@braidai/lang": "^1.0.0" } }, "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
-    "@libredb/libredb": "^0.0.3",
+    "@libredb/libredb": "^0.1.3",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",


### PR DESCRIPTION
## Summary

Bumps the embedded LibreDB provider package **\`@libredb/libredb\` 0.0.3 → 0.1.3** and patch-bumps Studio to **0.9.37**.

The 0.1.3 release moves \`node:fs\` out of the kernel into a runtime adapter and adds a browser/OPFS entry point. Studio only consumes the Node entry, whose default behavior is unchanged, so **no code changes are required**. The public API surface used by the provider and seed (\`open\`, \`kv\`, \`doc\`, \`table\`, \`catalog\`, \`isReservedKey\`, \`version\` and the exported types) is identical.

## Verification

- \`typecheck\` clean
- Full test suite: **486 tests pass** (incl. \`libredb-provider\` integration + seed tests that exercise the runtime API)
- \`build\`, \`build:lib\`, \`attw\` all green
- Playwright E2E: **32/32 pass**
- Manual live-UI E2E: created a new LibreDB connection via the provider dialog and ran a full CRUD cycle (\`put\` insert, \`get\`, \`put\` update, \`delete\`, \`get\` empty) successfully

## Release

Patch release **0.9.37**.