### PR TITLE
feat(libredb): upgrade @libredb/libredb to 0.2.2 with error-code mapping

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "libredb-studio",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
-        "@libredb/libredb": "0.1.3",
+        "@libredb/libredb": "^0.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -362,7 +362,7 @@
 
     "@js-joda/core": ["@js-joda/core@5.7.0", "", {}, "sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg=="],
 
-    "@libredb/libredb": ["@libredb/libredb@0.1.3", "", { "bin": { "libredb": "dist/cli/main.js" } }, "sha512-TuQRLz+sEIx0YJSvT9tiin4yehpqdG1kalPgVtnGhw78JmgUsLryS3/sbNMI2X3sTxE+8Gel7CvUim6s2azYDQ=="],
+    "@libredb/libredb": ["@libredb/libredb@0.2.2", "", { "bin": { "libredb": "dist/cli/main.js" } }, "sha512-x/7Bc42njLHcG2BCwGHX/UA5wmKG82NkVBlYXj7C4TNy+9LpXKQGZRzhgfORv+wlxMG7WQP4sDEqiM2rZymZUg=="],
 
     "@loaderkit/resolve": ["@loaderkit/resolve@1.0.6", "", { "dependencies": { "@braidai/lang": "^1.0.0" } }, "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg=="],
 

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -11,7 +11,7 @@
 | **Status** | Implemented & shipped |
 | **Database type id** | `libredb` |
 | **Family** | Embedded / Key-Value (`src/lib/db/providers/embedded/`) |
-| **Driver** | `@libredb/libredb` (lazy dynamic import) |
+| **Driver** | `@libredb/libredb` `^0.2.2` (lazy dynamic import) |
 | **Query language** | `json` (small command grammar — NOT SQL) |
 | **Default port** | None (embedded in-process, no network) |
 | **Connection pooling** | None — single in-process file handle |
@@ -252,6 +252,32 @@ file does not exist at `connect()` time, the `@libredb/libredb` package will cre
 ordered-KV store). If the path is missing entirely, `connect()` throws `DatabaseConfigError`
 before attempting to open anything.
 
+### 4.2.1 On-disk format, locking, and version compatibility (0.2.x)
+
+Since `@libredb/libredb` 0.2.0 the driver hardens the file boundary; the provider surfaces each
+condition as a clear `ConnectionError` (see [§10](#10-error-handling)):
+
+- **`LRDB` header.** New databases begin with an 8-byte magic/version header. Files written by
+  0.1.x (headerless) keep opening through a legacy read path — upgrading Studio does not require
+  migrating existing files.
+- **Foreign files are refused untouched.** Opening a file that is not a LibreDB database throws
+  `NOT_A_DATABASE` and leaves the file byte-for-byte intact (0.1.x silently truncated it to zero).
+  A file written by a newer format version is refused as `UNSUPPORTED_VERSION`, also untouched.
+- **Exclusive per-file lock.** `open()` takes an exclusive `<path>.lock` sidecar (pid/host/nonce).
+  A second writer — another Studio connection to the same file, an external process, or the
+  `libredb` CLI — fails loudly with `LOCKED` instead of silently diverging. The lock is released
+  on `disconnect()`; locks from verifiably dead holders are reclaimed automatically. To *read* a
+  file a live writer holds, external tooling can use the package's `readonlyFileSystem` (no lock,
+  no writes).
+- **Provider cache interaction.** Studio caches a connected provider per connection id and evicts
+  it after 30 minutes idle — the lock is held that whole time. To edit the same file with external
+  tooling, disconnect the Studio connection first (or wait for eviction); otherwise the external
+  writer gets `LOCKED`.
+
+> **DOWNGRADE WARNING:** a file written by `@libredb/libredb` 0.2.x must never be opened by 0.1.3
+> or older. The old recovery cannot parse the header, classifies the whole file as a torn tail,
+> and silently truncates it to zero bytes. Back up before any downgrade.
+
 ### 4.3 Sample connection (standalone mode)
 
 On the first startup of a **standalone** Studio instance (i.e. not embedded inside
@@ -480,6 +506,24 @@ The provider raises the shared error classes from
 
 All `QueryError`s carry the `QUERY_ERROR` API code and surface to the client as `400 Bad Request`.
 
+### 10.1 Kernel error codes (`LibreDbError.code`)
+
+Since 0.2.0, every failure the `@libredb/libredb` kernel throws is a `LibreDbError` carrying a
+stable `code` — the part a caller may branch on (messages are free to change between releases).
+The provider maps the open-time codes to user-actionable `ConnectionError` messages in
+`describeOpenError()`:
+
+| Kernel code | When | Studio surfaces it as |
+|-------------|------|----------------------|
+| `LOCKED` | Another writer holds the file's exclusive lock | `ConnectionError` — *"already open by another process ... close the other writer"* |
+| `NOT_A_DATABASE` | The file at the path is not a LibreDB database | `ConnectionError` — *"not a LibreDB database ... left untouched"* |
+| `UNSUPPORTED_VERSION` | The file was written by a newer format version | `ConnectionError` — *"written by a newer version of LibreDB ... upgrade @libredb/libredb"* |
+| `CORRUPT_WAL` | Mid-log corruption; the kernel refuses to destroy data | `ConnectionError` — *"write-ahead log is corrupt mid-file"* + kernel detail |
+| `INVALID_ARGUMENT` (query-time) | Bad user input the lenses reject — e.g. a lone-surrogate (malformed UTF-16) key or value | `QueryError` with the kernel message (→ `400 Bad Request`) |
+| any other code (`CLOSED`, `FAILED`, ...) | Storage/durability conditions | Rethrown untouched so the meaning survives to the caller |
+
+The mapping branches on `error.code` via `instanceof lib.LibreDbError` — never on message text.
+
 ---
 
 ## 11. Testing
@@ -511,6 +555,14 @@ document collection (`doc()`) alongside the raw kv keys, then asserts: (a) `getS
 its real declared columns with the primary key marked (the relational signal); (c) the document
 collection shows the generic `id`/`document` columns (the document signal); and (d) raw kv
 namespaces still group as `key`/`value` pseudo-tables.
+
+A **0.2.x error mapping & locking** suite covers the hardened file boundary: a second open of a
+live-locked file is a clear `ConnectionError` (`LOCKED`); `connect()` takes the exclusive
+`<path>.lock` and `disconnect()` releases it; a non-LibreDB file is refused (`NOT_A_DATABASE`)
+and left byte-for-byte untouched with no lock held; a newer-format file is refused
+(`UNSUPPORTED_VERSION`); and a malformed UTF-16 (lone surrogate) `put` value surfaces as a
+`QueryError` without poisoning the open handle. Test temp-file cleanup removes the `.lock`
+sidecars alongside the database files.
 
 ### 11.3 Run it
 
@@ -570,8 +622,10 @@ await provider.query('put session:abc token123');
 await provider.query('put note "hello world"');
 // -> { rows: [{ changed: 1 }], ... }
 
-// Write a JSON value (stored as-is; read back pretty-printed)
-await provider.query('put user:3 {"name":"Grace","age":45}');
+// Write a JSON value — wrap it in single quotes. The tokenizer treats bare
+// double quotes as token quoting (Redis-style) and would strip them, storing
+// invalid JSON; the single-quote wrapper preserves them verbatim.
+await provider.query('put user:3 \'{"name":"Grace","age":45}\'');
 // get user:3 -> value: '{\n  "name": "Grace",\n  "age": 45\n}'
 
 // Delete a key

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
-    "@libredb/libredb": "^0.1.3",
+    "@libredb/libredb": "^0.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/src/lib/db/providers/embedded/libredb.ts
+++ b/src/lib/db/providers/embedded/libredb.ts
@@ -175,11 +175,33 @@ export class LibreDBProvider extends BaseDatabaseProvider {
       this.setConnected(true);
     } catch (error) {
       this.setError(error instanceof Error ? error : new Error(String(error)));
-      throw new ConnectionError(
-        `Failed to open LibreDB file: ${error instanceof Error ? error.message : String(error)}`,
-        "libredb",
-      );
+      throw new ConnectionError(this.describeOpenError(lib, error), "libredb");
     }
+  }
+
+  /**
+   * Map a 0.2.x kernel open() failure to a user-actionable message. The kernel's
+   * `LibreDbError.code` is its stable contract (messages may be reworded between
+   * releases), so branch on the code, never on message text. Codes that cannot
+   * occur at open time (CLOSED, NESTED_TRANSACTION, ...) fall through to the
+   * generic wrapper together with non-kernel errors.
+   */
+  private describeOpenError(lib: LibreDBModule, error: unknown): string {
+    if (error instanceof lib.LibreDbError) {
+      switch (error.code) {
+        case "LOCKED":
+          return "LibreDB file is already open by another process (exclusive lock). Close the other writer, or wait for its lock to be released.";
+        case "NOT_A_DATABASE":
+          return "The file is not a LibreDB database. It was left untouched — check the path.";
+        case "UNSUPPORTED_VERSION":
+          return "The file was written by a newer version of LibreDB than this Studio supports. Upgrade the @libredb/libredb package.";
+        case "CORRUPT_WAL":
+          return `The LibreDB write-ahead log is corrupt mid-file; refusing to open so no data is destroyed. (${error.message})`;
+        default:
+          break; // open-time codes only; anything else keeps the kernel message below
+      }
+    }
+    return `Failed to open LibreDB file: ${error instanceof Error ? error.message : String(error)}`;
   }
 
   public async disconnect(): Promise<void> {
@@ -337,8 +359,23 @@ export class LibreDBProvider extends BaseDatabaseProvider {
     }
     const parts = this.tokenize(line);
     if (parts.length === 0) throw new QueryError("Empty command", "libredb");
-    const kv = this.kv!;
     const verb = parts[0].toLowerCase();
+    try {
+      return this.dispatchCommand(verb, parts);
+    } catch (error) {
+      // A kernel INVALID_ARGUMENT is bad user input (e.g. a lone-surrogate key or
+      // value the lenses reject), so present it as a QueryError. Every other
+      // kernel code (CLOSED, FAILED, ...) is a storage/durability condition and
+      // is rethrown untouched so its meaning survives to the caller.
+      if (error instanceof libredbModule!.LibreDbError && error.code === "INVALID_ARGUMENT") {
+        throw new QueryError(error.message, "libredb", line);
+      }
+      throw error;
+    }
+  }
+
+  private dispatchCommand(verb: string, parts: string[]): Omit<QueryResult, "executionTime"> {
+    const kv = this.kv!;
 
     switch (verb) {
       case "get": {

--- a/src/lib/seed/libredb-sample.ts
+++ b/src/lib/seed/libredb-sample.ts
@@ -42,7 +42,13 @@ export async function seedSampleFile(filePath: string): Promise<void> {
   // file. The rename publishes one complete file (last writer wins; both seeds are
   // identical), and stays on one filesystem since the temp is in the same dir.
   const tempPath = `${filePath}.${process.pid}.seeding`;
-  fs.rmSync(tempPath, { force: true }); // discard any stale temp from a crashed boot
+  // Discard any stale temp from a crashed boot — including its exclusive-lock
+  // sidecar (`<temp>.lock`, since @libredb/libredb 0.2.x). The temp name is
+  // per-pid, and in Docker a restarted process often reuses the same pid, so a
+  // crashed boot's lock would read as a LIVE holder and open() would refuse
+  // with LOCKED forever. We have not opened the temp yet, so on entry any lock
+  // on it is stale by construction and safe to clear.
+  removeSeedingTemp(tempPath);
 
   const { open, kv, doc, table } = await import("@libredb/libredb");
   try {
@@ -73,13 +79,19 @@ export async function seedSampleFile(filePath: string): Promise<void> {
       // overwrites, but Windows throws if the destination exists — treat a
       // present destination as success (the sample is seeded), and only rethrow
       // if filePath still does not exist.
-      fs.rmSync(tempPath, { force: true });
+      removeSeedingTemp(tempPath);
       if (!fs.existsSync(filePath)) throw renameError;
     }
   } catch (error) {
-    fs.rmSync(tempPath, { force: true }); // never leave a partial temp behind
+    removeSeedingTemp(tempPath); // never leave a partial temp (or its lock) behind
     throw error;
   }
+}
+
+/** Remove a seeding temp file and its 0.2.x exclusive-lock sidecar, if present. */
+function removeSeedingTemp(tempPath: string): void {
+  fs.rmSync(tempPath, { force: true });
+  fs.rmSync(`${tempPath}.lock`, { force: true });
 }
 
 /** The built-in editable seed connection descriptor (managed:false). */

--- a/tests/integration/db/libredb-provider.test.ts
+++ b/tests/integration/db/libredb-provider.test.ts
@@ -418,7 +418,10 @@ describe("LibreDBProvider — 0.2.x error mapping & locking", () => {
   });
 
   test("a non-LibreDB file is refused (NOT_A_DATABASE) and left byte-for-byte untouched", async () => {
-    const foreign = path.join(os.tmpdir(), `libredb-foreign-${Math.random().toString(36).slice(2)}.libredb`);
+    // mkdtempSync atomically creates a unique 0700 dir — the secure-temp pattern
+    // (avoids the predictable-name race CodeQL flags for os.tmpdir + Math.random).
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "libredb-foreign-"));
+    const foreign = path.join(dir, "foreign.libredb");
     const bytes = Buffer.from("definitely not a libredb database; long enough to pass the header probe\n");
     fs.writeFileSync(foreign, bytes);
     try {
@@ -434,12 +437,14 @@ describe("LibreDBProvider — 0.2.x error mapping & locking", () => {
       // A refused open must not keep holding the exclusive lock.
       expect(fs.existsSync(`${foreign}.lock`)).toBe(false);
     } finally {
-      rmDbFile(foreign);
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
   test("a file written by a newer format version is refused (UNSUPPORTED_VERSION)", async () => {
-    const future = path.join(os.tmpdir(), `libredb-future-${Math.random().toString(36).slice(2)}.libredb`);
+    // Secure-temp pattern (mkdtempSync), same as the foreign-file test above.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "libredb-future-"));
+    const future = path.join(dir, "future.libredb");
     // "LRDB" magic + big-endian format version 99 — a valid header from the future.
     fs.writeFileSync(future, Buffer.from([0x4c, 0x52, 0x44, 0x42, 0x00, 0x63, 0x00, 0x00]));
     try {
@@ -451,7 +456,7 @@ describe("LibreDBProvider — 0.2.x error mapping & locking", () => {
       expect(error).toBeInstanceOf(ConnectionError);
       expect((error as Error).message).toMatch(/newer version of LibreDB/i);
     } finally {
-      rmDbFile(future);
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 

--- a/tests/integration/db/libredb-provider.test.ts
+++ b/tests/integration/db/libredb-provider.test.ts
@@ -6,11 +6,23 @@
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { LibreDBProvider } from "@/lib/db/providers/embedded/libredb";
+import { ConnectionError, QueryError } from "@/lib/db/errors";
 import type { DatabaseConnection } from "@/lib/types";
 import { open, kv, doc, table } from "@libredb/libredb";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+
+/** Remove a database file AND its 0.2.x exclusive-lock sidecar (`<path>.lock`). */
+function rmDbFile(file: string): void {
+  for (const f of [file, `${file}.lock`]) {
+    try {
+      fs.unlinkSync(f);
+    } catch {
+      /* ignore */
+    }
+  }
+}
 
 let tmpFile: string;
 
@@ -66,11 +78,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  try {
-    fs.unlinkSync(tmpFile);
-  } catch {
-    /* ignore */
-  }
+  rmDbFile(tmpFile);
 });
 
 describe("LibreDBProvider — lifecycle & metadata", () => {
@@ -144,11 +152,7 @@ describe("LibreDBProvider — catalog-aware schema", () => {
   });
 
   afterEach(() => {
-    try {
-      fs.unlinkSync(catalogFile);
-    } catch {
-      /* ignore */
-    }
+    rmDbFile(catalogFile);
   });
 
   test("a bare key is NOT catalog-upgraded even if its name matches a namespace", async () => {
@@ -174,11 +178,7 @@ describe("LibreDBProvider — catalog-aware schema", () => {
       // ...but the bare key stays raw key/value, not upgraded.
       expect(bareGroup?.columns.map((c) => c.name)).toEqual(["key", "value"]);
     } finally {
-      try {
-        fs.unlinkSync(file);
-      } catch {
-        /* ignore */
-      }
+      rmDbFile(file);
     }
   });
 
@@ -388,6 +388,84 @@ describe("LibreDBProvider — query commands", () => {
     const provider = new LibreDBProvider(makeConn(tmpFile));
     await provider.connect();
     await expect(provider.query("# just a note\n\n")).rejects.toThrow(/only comments|no command/i);
+    await provider.disconnect();
+  });
+});
+
+describe("LibreDBProvider — 0.2.x error mapping & locking", () => {
+  test("a second open of a live-locked file is a clear ConnectionError (LOCKED)", async () => {
+    const writer = open({ path: tmpFile }); // holds the exclusive <path>.lock
+    try {
+      const provider = new LibreDBProvider(makeConn(tmpFile));
+      const error = await provider.connect().then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(ConnectionError);
+      expect((error as Error).message).toMatch(/already open by another process/i);
+      expect(provider.isConnected()).toBe(false);
+    } finally {
+      writer.close();
+    }
+  });
+
+  test("connect() takes the exclusive lock; disconnect() releases it (.lock removed)", async () => {
+    const provider = new LibreDBProvider(makeConn(tmpFile));
+    await provider.connect();
+    expect(fs.existsSync(`${tmpFile}.lock`)).toBe(true);
+    await provider.disconnect();
+    expect(fs.existsSync(`${tmpFile}.lock`)).toBe(false);
+  });
+
+  test("a non-LibreDB file is refused (NOT_A_DATABASE) and left byte-for-byte untouched", async () => {
+    const foreign = path.join(os.tmpdir(), `libredb-foreign-${Math.random().toString(36).slice(2)}.libredb`);
+    const bytes = Buffer.from("definitely not a libredb database; long enough to pass the header probe\n");
+    fs.writeFileSync(foreign, bytes);
+    try {
+      const provider = new LibreDBProvider(makeConn(foreign));
+      const error = await provider.connect().then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(ConnectionError);
+      expect((error as Error).message).toMatch(/not a LibreDB database/i);
+      // The refusal must not mutate the file (0.1.x used to truncate it to zero).
+      expect(fs.readFileSync(foreign).equals(bytes)).toBe(true);
+      // A refused open must not keep holding the exclusive lock.
+      expect(fs.existsSync(`${foreign}.lock`)).toBe(false);
+    } finally {
+      rmDbFile(foreign);
+    }
+  });
+
+  test("a file written by a newer format version is refused (UNSUPPORTED_VERSION)", async () => {
+    const future = path.join(os.tmpdir(), `libredb-future-${Math.random().toString(36).slice(2)}.libredb`);
+    // "LRDB" magic + big-endian format version 99 — a valid header from the future.
+    fs.writeFileSync(future, Buffer.from([0x4c, 0x52, 0x44, 0x42, 0x00, 0x63, 0x00, 0x00]));
+    try {
+      const provider = new LibreDBProvider(makeConn(future));
+      const error = await provider.connect().then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(ConnectionError);
+      expect((error as Error).message).toMatch(/newer version of LibreDB/i);
+    } finally {
+      rmDbFile(future);
+    }
+  });
+
+  test("a malformed UTF-16 put value (lone surrogate) is a QueryError, and the connection survives", async () => {
+    const provider = new LibreDBProvider(makeConn(tmpFile));
+    await provider.connect();
+    const error = await provider.query("put broken \uD800").then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(QueryError);
+    expect((error as Error).message).toMatch(/utf-16|surrogate/i);
+    // The invalid write must not poison the open handle.
+    expect((await provider.query("get user:1")).rowCount).toBe(1);
     await provider.disconnect();
   });
 });

--- a/tests/integration/seed/libredb-sample.test.ts
+++ b/tests/integration/seed/libredb-sample.test.ts
@@ -65,6 +65,35 @@ describe("libredb-sample", () => {
     db.close();
   });
 
+  test("seedSampleFile: survives a stale temp + lock left by a crashed boot with the same pid", async () => {
+    // A boot that crashed mid-seed leaves `<file>.<pid>.seeding` AND (since
+    // @libredb/libredb 0.2.x) its exclusive-lock sidecar. In Docker a restarted
+    // process often reuses the SAME pid (pid 1), so the stale lock reads as a
+    // LIVE holder and open() would refuse with LOCKED forever. The temp name is
+    // per-pid, so on entry any existing lock on it is necessarily stale and the
+    // seeder must clear it.
+    const file = tmpPath();
+    const tempPath = `${file}.${process.pid}.seeding`;
+    fs.writeFileSync(tempPath, "partial junk from a crashed seed");
+    fs.writeFileSync(`${tempPath}.lock`, `libredb-lock\n${process.pid}\n${os.hostname()}\ndeadbeef\n`);
+
+    await seedSampleFile(file);
+
+    expect(fs.existsSync(file)).toBe(true);
+    expect(fs.existsSync(tempPath)).toBe(false);
+    expect(fs.existsSync(`${tempPath}.lock`)).toBe(false);
+    const db = open({ path: file });
+    expect(catalog(db).get("users")?.kind).toBe("relational");
+    db.close();
+  });
+
+  test("seedSampleFile: leaves no lock sidecar next to the published sample", async () => {
+    const file = tmpPath();
+    await seedSampleFile(file);
+    expect(fs.existsSync(`${file}.lock`)).toBe(false);
+    expect(fs.existsSync(`${file}.${process.pid}.seeding.lock`)).toBe(false);
+  });
+
   test("seedSampleFile: idempotent — does not modify an existing file", async () => {
     const file = tmpPath();
     await seedSampleFile(file);


### PR DESCRIPTION
## Summary

Upgrades the embedded LibreDB driver from 0.1.3 to 0.2.2 and aligns the Studio provider boundary with the 0.2.x hardening wave (LRDB header, exclusive per-file lock, stable LibreDbError codes). Provider tri-sync maintained: code, docs, and tests updated together.

### Provider (src/lib/db/providers/embedded/libredb.ts)
- Map open-time `LibreDbError` codes to user-actionable `ConnectionError` messages, branching on the stable `code` field, never on message text:
  - `LOCKED` -> "already open by another process (exclusive lock)"
  - `NOT_A_DATABASE` -> "not a LibreDB database ... left untouched"
  - `UNSUPPORTED_VERSION` -> "written by a newer version of LibreDB"
  - `CORRUPT_WAL` -> "write-ahead log is corrupt mid-file" + kernel detail
- Query-time `INVALID_ARGUMENT` (e.g. lone-surrogate keys/values) normalizes to `QueryError` (400); storage/durability codes rethrow untouched so their meaning survives.

### Seed (src/lib/seed/libredb-sample.ts)
- Clear the stale `.seeding` temp AND its `.lock` sidecar on entry. The temp name is per-pid and Docker restarts often reuse pid 1, so a crashed boot's lock read as a live holder and made seeding fail with `LOCKED` forever (reproduced in a test before the fix).

### Tests (integration)
- New "0.2.x error mapping & locking" suite: live-lock second-open refusal, lock acquire/release across connect/disconnect, foreign-file refusal with byte-for-byte preservation, newer-format refusal, malformed UTF-16 rejection that keeps the handle usable.
- Seed suite: crashed-boot stale temp+lock survival, no lock sidecar left next to the published sample.
- Temp cleanup removes `.lock` sidecars everywhere.

### Docs (docs/providers/libredb.md)
- New section on 0.2.x format, locking, and version compatibility, including the downgrade warning (0.2.x files must never be opened by <=0.1.3 - old recovery silently truncates them).
- Error-code mapping table (`LibreDbError.code` -> Studio error).
- Fixed the JSON `put` example: bare double quotes are consumed by the Redis-style tokenizer, so JSON values must be wrapped in single quotes.

## Runtime verification (production build, real app)

- Legacy (headerless 0.1.x) `sample.libredb` opens through the 0.2.2 legacy read path; catalog-aware schema renders all three lenses.
- Fresh boot re-seeds the sample with the new `LRDB` v1 header; no temp/lock leftovers.
- All five verbs, quoted values, JSON pretty-print, comment cheatsheets exercised via API and UI (schema tree, Scan Keys, Generate Command, results grid) with zero console errors.
- Lock lifecycle verified end-to-end: Studio holds `<path>.lock` while connected, external CLI writer fails loudly with LOCKED, disconnect releases the lock.
- All three new ConnectionError mappings observed through the live API (junk file, future-version file, held lock).

## Verification

- bun run format / lint / typecheck / test / build: all green
- bun run build:lib + attw (node16 CJS/ESM, bundler): green