### PR TITLE
feat(auth): zero-config first run - bootstrap JWT_SECRET and ADMIN_PASSWORD (#109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,16 @@ USER_PASSWORD=your_secure_user_password
 JWT_SECRET=your_32_character_random_string_here
 
 # ============================================
+# ZERO-CONFIG BOOTSTRAP (Optional)
+# ============================================
+# When JWT_SECRET and/or ADMIN_PASSWORD are NOT set, the server generates the
+# missing values on first start, persists them to <data dir>/auth-bootstrap.json
+# (file mode 0600), and prints the admin password ONCE to stdout. Explicit env
+# vars always win. Set to "off" to disable bootstrap and require explicit
+# configuration (strict mode: missing vars surface as a clear login error).
+# AUTH_BOOTSTRAP=on
+
+# ============================================
 # AUTHENTICATION PROVIDER
 # ============================================
 # "local" (default) = email/password login (ADMIN_EMAIL/ADMIN_PASSWORD, USER_EMAIL/USER_PASSWORD)

--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,11 @@
 # ============================================
 
 # ============================================
-# AUTHENTICATION (Required)
+# AUTHENTICATION (Required when AUTH_BOOTSTRAP=off)
 # ============================================
-# Admin credentials (full access + maintenance tools) — ADMIN_PASSWORD is required.
+# Admin credentials (full access + maintenance tools) — ADMIN_PASSWORD is
+# required only when AUTH_BOOTSTRAP=off; otherwise it is auto-generated on
+# first start (see ZERO-CONFIG BOOTSTRAP section below).
 ADMIN_EMAIL=admin@libredb.org
 ADMIN_PASSWORD=your_secure_admin_password
 
@@ -34,8 +36,10 @@ JWT_SECRET=your_32_character_random_string_here
 # When JWT_SECRET and/or ADMIN_PASSWORD are NOT set, the server generates the
 # missing values on first start, persists them to <data dir>/auth-bootstrap.json
 # (file mode 0600), and prints the admin password ONCE to stdout. Explicit env
-# vars always win. Set to "off" to disable bootstrap and require explicit
-# configuration (strict mode: missing vars surface as a clear login error).
+# vars always win. In OIDC mode (NEXT_PUBLIC_AUTH_PROVIDER=oidc) only the JWT
+# secret is generated — a password is never generated. Set to "off" to disable
+# bootstrap and require explicit configuration (strict mode: missing vars
+# surface as a clear login error).
 # AUTH_BOOTSTRAP=on
 
 # ============================================

--- a/.env.example
+++ b/.env.example
@@ -37,9 +37,10 @@ JWT_SECRET=your_32_character_random_string_here
 # missing values on first start, persists them to <data dir>/auth-bootstrap.json
 # (file mode 0600), and prints the admin password ONCE to stdout. Explicit env
 # vars always win. In OIDC mode (NEXT_PUBLIC_AUTH_PROVIDER=oidc) only the JWT
-# secret is generated — a password is never generated. Set to "off" to disable
-# bootstrap and require explicit configuration (strict mode: missing vars
-# surface as a clear login error).
+# secret is generated — a password is never generated. Set to "off" (or
+# "false"/"0", case-insensitive) to disable bootstrap and require explicit
+# configuration (strict mode: missing vars surface as a clear login error).
+# Unrecognized values warn and leave bootstrap on.
 # AUTH_BOOTSTRAP=on
 
 # ============================================

--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ docker run -d \
 
   > **Tip**: Add `-e LLM_PROVIDER=gemini -e LLM_API_KEY=your_key -e LLM_MODEL=gemini-2.5-flash` to enable AI features.
 
+  ### Zero-config first run
+
+  Starting the server without `JWT_SECRET` / `ADMIN_PASSWORD` works out of the box:
+  the missing values are generated on first start, stored in `<data dir>/auth-bootstrap.json`
+  (file mode 0600), and the admin password is printed once to the server log. Explicitly
+  set environment variables always take precedence. Set `AUTH_BOOTSTRAP=off` to require
+  explicit configuration instead (recommended for production deployments).
+
   ### Prerequisites
   - [Bun](https://bun.sh/) (Recommended) or Node.js 24+
   - A target database to query (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, or Redis)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ docker run -d \
 
   Open [http://localhost:3000](http://localhost:3000) and login with `admin@libredb.org` / `LibreDB.2026`.
 
-  > **Auth env vars (local provider):** `ADMIN_PASSWORD` is only required when `AUTH_BOOTSTRAP=off`; otherwise it is generated on first start (see [Zero-config first run](#zero-config-first-run) below). `USER_EMAIL` / `USER_PASSWORD` are optional; omit them to run admin-only (no default user password is ever assumed). `ADMIN_EMAIL` defaults to `admin@libredb.org`. Using OIDC (`NEXT_PUBLIC_AUTH_PROVIDER=oidc`)? None of these are needed.
+  > **Auth env vars (local provider):** `ADMIN_PASSWORD` and `JWT_SECRET` are only required when `AUTH_BOOTSTRAP=off`; otherwise both are generated on first start (see [Zero-config first run](#zero-config-first-run) below). `USER_EMAIL` / `USER_PASSWORD` are optional; omit them to run admin-only (no default user password is ever assumed). `ADMIN_EMAIL` defaults to `admin@libredb.org`. Using OIDC (`NEXT_PUBLIC_AUTH_PROVIDER=oidc`)? None of these are needed.
 
   > **Tip**: Add `-e LLM_PROVIDER=gemini -e LLM_API_KEY=your_key -e LLM_MODEL=gemini-2.5-flash` to enable AI features.
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ docker run -d \
 
   Open [http://localhost:3000](http://localhost:3000) and login with `admin@libredb.org` / `LibreDB.2026`.
 
-  > **Auth env vars (local provider):** `ADMIN_PASSWORD` is required — without it the login screen shows a clear "server not configured" message instead of letting you in. `USER_EMAIL` / `USER_PASSWORD` are optional; omit them to run admin-only (no default user password is ever assumed). `ADMIN_EMAIL` defaults to `admin@libredb.org`. Using OIDC (`NEXT_PUBLIC_AUTH_PROVIDER=oidc`)? None of these are needed.
+  > **Auth env vars (local provider):** `ADMIN_PASSWORD` is only required when `AUTH_BOOTSTRAP=off`; otherwise it is generated on first start (see [Zero-config first run](#zero-config-first-run) below). `USER_EMAIL` / `USER_PASSWORD` are optional; omit them to run admin-only (no default user password is ever assumed). `ADMIN_EMAIL` defaults to `admin@libredb.org`. Using OIDC (`NEXT_PUBLIC_AUTH_PROVIDER=oidc`)? None of these are needed.
 
   > **Tip**: Add `-e LLM_PROVIDER=gemini -e LLM_API_KEY=your_key -e LLM_MODEL=gemini-2.5-flash` to enable AI features.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,12 +1,18 @@
 /**
  * Next.js boot hook. register() runs once per server worker, ONLY when this app
  * boots its own Next.js server (never when @libredb/studio is imported by
- * libredb-platform). On standalone boot, seed the embedded sample .libredb file
- * if enabled. A failure here must never break boot.
+ * libredb-platform). On standalone boot, bootstrap missing auth env (#109) and
+ * seed the embedded sample .libredb file if enabled. A failure here must never
+ * break boot.
  */
 export async function register(): Promise<void> {
   // Node.js server runtime only (skip the edge runtime).
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  // Zero-config first run (#109): fill missing auth env from the persisted
+  // bootstrap file BEFORE anything reads process.env secrets. Fail-open inside.
+  const { bootstrapAuth } = await import("@/lib/auth-bootstrap");
+  bootstrapAuth();
 
   const { isSampleEnabled, resolveSamplePath, seedSampleFile } = await import("@/lib/seed/libredb-sample");
   if (!isSampleEnabled()) return;

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -45,6 +45,9 @@ function readBootstrapFile(filePath: string): BootstrapFile {
   } catch {
     // Unreadable state: keep the evidence, regenerate. Sessions signed with a
     // lost secret become invalid; that is logged by the caller's banner path.
+    // Windows rename throws if the destination exists (see seedSampleFile), so
+    // clear any older .bak first — the newest evidence wins.
+    fs.rmSync(`${filePath}.bak`, { force: true });
     fs.renameSync(filePath, `${filePath}.bak`);
     console.warn(`LibreDB Studio: corrupt ${filePath} moved to .bak; regenerating credentials`);
     return {};
@@ -57,7 +60,21 @@ function writeBootstrapFile(filePath: string, data: BootstrapFile): void {
   // (same pattern as seedSampleFile in libredb-sample.ts).
   const tempPath = `${filePath}.${process.pid}.tmp`;
   fs.writeFileSync(tempPath, JSON.stringify(data, null, 2), { mode: 0o600 });
-  fs.renameSync(tempPath, filePath);
+  try {
+    fs.renameSync(tempPath, filePath);
+  } catch (renameError) {
+    // POSIX rename overwrites, but Windows throws if the destination exists
+    // (see seedSampleFile). Unlike the sample, a present destination is NOT
+    // success here — this write may carry a newly generated field — so drop
+    // the old file and retry once; on failure never leave a partial temp.
+    try {
+      fs.rmSync(filePath, { force: true });
+      fs.renameSync(tempPath, filePath);
+    } catch {
+      fs.rmSync(tempPath, { force: true });
+      throw renameError;
+    }
+  }
 }
 
 function printFirstRunBanner(filePath: string, adminPassword: string): void {

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -25,7 +25,23 @@ export function resolveBootstrapPath(): string {
 function readBootstrapFile(filePath: string): BootstrapFile {
   if (!fs.existsSync(filePath)) return {};
   try {
-    return JSON.parse(fs.readFileSync(filePath, "utf8")) as BootstrapFile;
+    const parsed: unknown = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    // Wrong-shape JSON (null, an array, a primitive) must be rejected here, in
+    // the same try block as JSON.parse, so the catch below treats it exactly
+    // like a corrupt file: rename to .bak and regenerate. Without this check,
+    // `null` throws later on property access (permanent fail-open) and `[]`
+    // silently drops assigned fields on write (new credentials every boot).
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("bootstrap file does not contain a JSON object");
+    }
+    const { jwtSecret, adminPassword } = parsed as BootstrapFile;
+    if (jwtSecret !== undefined && typeof jwtSecret !== "string") {
+      throw new Error("bootstrap file jwtSecret is not a string");
+    }
+    if (adminPassword !== undefined && typeof adminPassword !== "string") {
+      throw new Error("bootstrap file adminPassword is not a string");
+    }
+    return parsed as BootstrapFile;
   } catch {
     // Unreadable state: keep the evidence, regenerate. Sessions signed with a
     // lost secret become invalid; that is logged by the caller's banner path.

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -42,6 +42,8 @@ export function bootstrapAuth(): void {
   const needSecret = !process.env.JWT_SECRET;
   const needPassword = !process.env.ADMIN_PASSWORD && process.env.NEXT_PUBLIC_AUTH_PROVIDER !== "oidc";
 
+  if (!needSecret && !needPassword) return;
+
   const filePath = resolveBootstrapPath();
   const stored = readBootstrapFile(filePath);
   let generated = false;

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -18,6 +18,24 @@ interface BootstrapFile {
   createdAt?: string;
 }
 
+/**
+ * Zero-config bootstrap is on unless AUTH_BOOTSTRAP opts out: "off", "false",
+ * or "0", case-insensitive ("false"/"0" match the LIBREDB_EMBEDDED_SAMPLE
+ * convention). Any other non-empty, non-affirmative value is treated as a
+ * misconfiguration: warn and stay on, so a typo never silently flips the
+ * security posture in either direction.
+ */
+export function isBootstrapEnabled(): boolean {
+  const raw = process.env.AUTH_BOOTSTRAP;
+  if (!raw) return true;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "off" || normalized === "false" || normalized === "0") return false;
+  if (normalized !== "on" && normalized !== "true" && normalized !== "1") {
+    console.warn(`LibreDB Studio: unrecognized AUTH_BOOTSTRAP value "${raw}"; bootstrap stays on (use "off" to disable)`);
+  }
+  return true;
+}
+
 export function resolveBootstrapPath(): string {
   // Resolve to an absolute path so the banner and log lines name a location
   // the operator can copy verbatim (the data dir default is CWD-relative).
@@ -104,7 +122,7 @@ function printFirstRunBanner(filePath: string, adminPassword: string): void {
 }
 
 export function bootstrapAuth(): void {
-  if (process.env.AUTH_BOOTSTRAP === "off") return;
+  if (!isBootstrapEnabled()) return;
 
   const needSecret = !process.env.JWT_SECRET;
   const needPassword = !process.env.ADMIN_PASSWORD && process.env.NEXT_PUBLIC_AUTH_PROVIDER !== "oidc";

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -19,7 +19,9 @@ interface BootstrapFile {
 }
 
 export function resolveBootstrapPath(): string {
-  return path.join(getDataDir(), BOOTSTRAP_FILE_NAME);
+  // Resolve to an absolute path so the banner and log lines name a location
+  // the operator can copy verbatim (the data dir default is CWD-relative).
+  return path.resolve(getDataDir(), BOOTSTRAP_FILE_NAME);
 }
 
 function readBootstrapFile(filePath: string): BootstrapFile {

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -1,0 +1,64 @@
+/**
+ * Zero-config first run (#109): when auth env vars are absent, generate
+ * credentials once, persist them in the data directory, and inject them into
+ * process.env BEFORE any secret reader runs (auth.ts, proxy.ts, oidc.ts,
+ * local-auth.ts all read process.env lazily). Called from instrumentation.ts.
+ * Explicitly set env vars always win; only missing fields are generated.
+ */
+import { randomBytes } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import { getDataDir } from "@/lib/data-dir";
+
+export const BOOTSTRAP_FILE_NAME = "auth-bootstrap.json";
+
+interface BootstrapFile {
+  jwtSecret?: string;
+  adminPassword?: string;
+  createdAt?: string;
+}
+
+export function resolveBootstrapPath(): string {
+  return path.join(getDataDir(), BOOTSTRAP_FILE_NAME);
+}
+
+function readBootstrapFile(filePath: string): BootstrapFile {
+  if (!fs.existsSync(filePath)) return {};
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as BootstrapFile;
+}
+
+function writeBootstrapFile(filePath: string, data: BootstrapFile): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  // Temp + atomic rename so a crash never leaves a partial credentials file
+  // (same pattern as seedSampleFile in libredb-sample.ts).
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  fs.renameSync(tempPath, filePath);
+}
+
+export function bootstrapAuth(): void {
+  const needSecret = !process.env.JWT_SECRET;
+  const needPassword = !process.env.ADMIN_PASSWORD;
+  if (!needSecret && !needPassword) return;
+
+  const filePath = resolveBootstrapPath();
+  const stored = readBootstrapFile(filePath);
+  let generated = false;
+
+  if (needSecret && !stored.jwtSecret) {
+    stored.jwtSecret = randomBytes(48).toString("base64");
+    generated = true;
+  }
+  if (needPassword && !stored.adminPassword) {
+    stored.adminPassword = randomBytes(12).toString("base64url");
+    generated = true;
+  }
+
+  if (generated) {
+    stored.createdAt = stored.createdAt || new Date().toISOString();
+    writeBootstrapFile(filePath, stored);
+  }
+
+  if (needSecret && stored.jwtSecret) process.env.JWT_SECRET = stored.jwtSecret;
+  if (needPassword && stored.adminPassword) process.env.ADMIN_PASSWORD = stored.adminPassword;
+}

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -24,7 +24,15 @@ export function resolveBootstrapPath(): string {
 
 function readBootstrapFile(filePath: string): BootstrapFile {
   if (!fs.existsSync(filePath)) return {};
-  return JSON.parse(fs.readFileSync(filePath, "utf8")) as BootstrapFile;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as BootstrapFile;
+  } catch {
+    // Unreadable state: keep the evidence, regenerate. Sessions signed with a
+    // lost secret become invalid; that is logged by the caller's banner path.
+    fs.renameSync(filePath, `${filePath}.bak`);
+    console.warn(`LibreDB Studio: corrupt ${filePath} moved to .bak; regenerating credentials`);
+    return {};
+  }
 }
 
 function writeBootstrapFile(filePath: string, data: BootstrapFile): void {
@@ -36,32 +44,57 @@ function writeBootstrapFile(filePath: string, data: BootstrapFile): void {
   fs.renameSync(tempPath, filePath);
 }
 
+function printFirstRunBanner(filePath: string, adminPassword: string): void {
+  const adminEmail = process.env.ADMIN_EMAIL || "admin@libredb.org"; // mirrors local-auth.ts default
+  console.log(
+    [
+      "",
+      "============================================================",
+      " LibreDB Studio first run: generated admin credentials",
+      ` Email:    ${adminEmail}`,
+      ` Password: ${adminPassword}`,
+      ` Stored in ${filePath} (delete the file to regenerate)`,
+      "============================================================",
+      "",
+    ].join("\n"),
+  );
+}
+
 export function bootstrapAuth(): void {
   if (process.env.AUTH_BOOTSTRAP === "off") return;
 
   const needSecret = !process.env.JWT_SECRET;
   const needPassword = !process.env.ADMIN_PASSWORD && process.env.NEXT_PUBLIC_AUTH_PROVIDER !== "oidc";
-
   if (!needSecret && !needPassword) return;
 
-  const filePath = resolveBootstrapPath();
-  const stored = readBootstrapFile(filePath);
-  let generated = false;
+  try {
+    const filePath = resolveBootstrapPath();
+    const stored = readBootstrapFile(filePath);
+    let secretGenerated = false;
+    let passwordGenerated = false;
 
-  if (needSecret && !stored.jwtSecret) {
-    stored.jwtSecret = randomBytes(48).toString("base64");
-    generated = true;
-  }
-  if (needPassword && !stored.adminPassword) {
-    stored.adminPassword = randomBytes(12).toString("base64url");
-    generated = true;
-  }
+    if (needSecret && !stored.jwtSecret) {
+      stored.jwtSecret = randomBytes(48).toString("base64");
+      secretGenerated = true;
+    }
+    if (needPassword && !stored.adminPassword) {
+      stored.adminPassword = randomBytes(12).toString("base64url");
+      passwordGenerated = true;
+    }
 
-  if (generated) {
-    stored.createdAt = stored.createdAt || new Date().toISOString();
-    writeBootstrapFile(filePath, stored);
-  }
+    if (secretGenerated || passwordGenerated) {
+      stored.createdAt = stored.createdAt || new Date().toISOString();
+      writeBootstrapFile(filePath, stored); // throws on read-only fs -> fail open below
+    }
 
-  if (needSecret && stored.jwtSecret) process.env.JWT_SECRET = stored.jwtSecret;
-  if (needPassword && stored.adminPassword) process.env.ADMIN_PASSWORD = stored.adminPassword;
+    if (needSecret && stored.jwtSecret) process.env.JWT_SECRET = stored.jwtSecret;
+    if (needPassword && stored.adminPassword) {
+      process.env.ADMIN_PASSWORD = stored.adminPassword;
+      if (passwordGenerated) printFirstRunBanner(filePath, stored.adminPassword);
+      else console.log(`LibreDB Studio: using generated admin credentials from ${filePath}`);
+    }
+  } catch (error) {
+    // Fail open: leave env untouched so login surfaces the clear 503 (PR #106).
+    console.warn(`LibreDB Studio: auth bootstrap skipped (${error instanceof Error ? error.message : String(error)})`);
+  }
 }

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -37,9 +37,10 @@ function writeBootstrapFile(filePath: string, data: BootstrapFile): void {
 }
 
 export function bootstrapAuth(): void {
+  if (process.env.AUTH_BOOTSTRAP === "off") return;
+
   const needSecret = !process.env.JWT_SECRET;
-  const needPassword = !process.env.ADMIN_PASSWORD;
-  if (!needSecret && !needPassword) return;
+  const needPassword = !process.env.ADMIN_PASSWORD && process.env.NEXT_PUBLIC_AUTH_PROVIDER !== "oidc";
 
   const filePath = resolveBootstrapPath();
   const stored = readBootstrapFile(filePath);

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -31,7 +31,9 @@ export function isBootstrapEnabled(): boolean {
   const normalized = raw.trim().toLowerCase();
   if (normalized === "off" || normalized === "false" || normalized === "0") return false;
   if (normalized !== "on" && normalized !== "true" && normalized !== "1") {
-    console.warn(`LibreDB Studio: unrecognized AUTH_BOOTSTRAP value "${raw}"; bootstrap stays on (use "off" to disable)`);
+    console.warn(
+      `LibreDB Studio: unrecognized AUTH_BOOTSTRAP value "${raw}"; bootstrap stays on (use "off" to disable)`,
+    );
   }
   return true;
 }

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -37,8 +37,11 @@ function readBootstrapFile(filePath: string): BootstrapFile {
       throw new Error("bootstrap file does not contain a JSON object");
     }
     const { jwtSecret, adminPassword } = parsed as BootstrapFile;
-    if (jwtSecret !== undefined && typeof jwtSecret !== "string") {
-      throw new Error("bootstrap file jwtSecret is not a string");
+    // Mirror the >= 32 chars minimum enforced by auth.ts getJwtSecret(): a
+    // hand-edited short secret must regenerate here instead of being injected
+    // and wedging every login on a misleading "JWT_SECRET too short" 503.
+    if (jwtSecret !== undefined && (typeof jwtSecret !== "string" || jwtSecret.length < 32)) {
+      throw new Error("bootstrap file jwtSecret is not a string of at least 32 chars");
     }
     if (adminPassword !== undefined && typeof adminPassword !== "string") {
       throw new Error("bootstrap file adminPassword is not a string");
@@ -64,17 +67,16 @@ function writeBootstrapFile(filePath: string, data: BootstrapFile): void {
   fs.writeFileSync(tempPath, JSON.stringify(data, null, 2), { mode: 0o600 });
   try {
     fs.renameSync(tempPath, filePath);
-  } catch (renameError) {
+  } catch {
     // POSIX rename overwrites, but Windows throws if the destination exists
-    // (see seedSampleFile). Unlike the sample, a present destination is NOT
-    // success here — this write may carry a newly generated field — so drop
-    // the old file and retry once; on failure never leave a partial temp.
+    // (see seedSampleFile). Fall back to copy-over instead of delete-and-retry
+    // so a failure here can never destroy the only copy of the credentials
+    // file; a torn copy is repaired by the corrupt-file recovery on next boot.
     try {
-      fs.rmSync(filePath, { force: true });
-      fs.renameSync(tempPath, filePath);
-    } catch {
+      fs.copyFileSync(tempPath, filePath);
+      fs.chmodSync(filePath, 0o600); // copyFileSync does not carry the temp's mode
+    } finally {
       fs.rmSync(tempPath, { force: true });
-      throw renameError;
     }
   }
 }

--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -74,7 +74,13 @@ function writeBootstrapFile(filePath: string, data: BootstrapFile): void {
     // file; a torn copy is repaired by the corrupt-file recovery on next boot.
     try {
       fs.copyFileSync(tempPath, filePath);
-      fs.chmodSync(filePath, 0o600); // copyFileSync does not carry the temp's mode
+      try {
+        fs.chmodSync(filePath, 0o600); // copyFileSync does not carry the temp's mode
+      } catch {
+        // Best-effort hardening: the credentials were written successfully, so
+        // an unsupported/failed chmod must not abort bootstrap. Warn instead.
+        console.warn(`LibreDB Studio: could not restrict permissions on ${filePath}`);
+      }
     } finally {
       fs.rmSync(tempPath, { force: true });
     }

--- a/src/lib/data-dir.ts
+++ b/src/lib/data-dir.ts
@@ -1,0 +1,13 @@
+/**
+ * Server-side data directory resolution. The data dir is wherever the SQLite
+ * storage DB lives (writable in Docker as /app/data); the sample .libredb file
+ * and generated auth credentials live alongside it. Launchers (npx/brew/deb)
+ * point STORAGE_SQLITE_PATH at a platform-appropriate location.
+ */
+import * as path from "path";
+
+export const DEFAULT_STORAGE_SQLITE_PATH = "./data/libredb-storage.db";
+
+export function getDataDir(): string {
+  return path.dirname(process.env.STORAGE_SQLITE_PATH || DEFAULT_STORAGE_SQLITE_PATH);
+}

--- a/src/lib/seed/libredb-sample.ts
+++ b/src/lib/seed/libredb-sample.ts
@@ -9,6 +9,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { ManagedConnection } from "./types";
+import { getDataDir } from "@/lib/data-dir";
 
 export const SAMPLE_SEED_ID = "libredb-embedded-sample";
 
@@ -22,8 +23,7 @@ export function isSampleEnabled(): boolean {
 export function resolveSamplePath(): string {
   const override = process.env.LIBREDB_EMBEDDED_SAMPLE_PATH;
   if (override) return override;
-  const storageDb = process.env.STORAGE_SQLITE_PATH || "./data/libredb-storage.db";
-  return path.join(path.dirname(storageDb), "sample.libredb");
+  return path.join(getDataDir(), "sample.libredb");
 }
 
 /**

--- a/src/lib/storage/providers/sqlite.ts
+++ b/src/lib/storage/providers/sqlite.ts
@@ -8,6 +8,7 @@ import type { ServerStorageProvider, StorageCollection, StorageData } from "../t
 import { STORAGE_COLLECTIONS } from "../types";
 import type BetterSqlite3 from "better-sqlite3";
 import { logger } from "@/lib/logger";
+import { DEFAULT_STORAGE_SQLITE_PATH } from "@/lib/data-dir";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let Database: any;
@@ -17,7 +18,7 @@ export class SQLiteStorageProvider implements ServerStorageProvider {
   private dbPath: string;
 
   constructor(dbPath?: string) {
-    this.dbPath = dbPath || process.env.STORAGE_SQLITE_PATH || "./data/libredb-storage.db";
+    this.dbPath = dbPath || process.env.STORAGE_SQLITE_PATH || DEFAULT_STORAGE_SQLITE_PATH;
   }
 
   async initialize(): Promise<void> {

--- a/tests/unit/instrumentation.test.ts
+++ b/tests/unit/instrumentation.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { register } from "@/instrumentation";
+import { logger } from "@/lib/logger";
+
+const ENV_KEYS = [
+  "NEXT_RUNTIME",
+  "LIBREDB_EMBEDDED_SAMPLE",
+  "LIBREDB_EMBEDDED_SAMPLE_PATH",
+  "STORAGE_SQLITE_PATH",
+  "JWT_SECRET",
+  "ADMIN_PASSWORD",
+  "AUTH_BOOTSTRAP",
+] as const;
+
+describe("instrumentation register()", () => {
+  let orig: Record<string, string | undefined>;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    orig = {};
+    for (const key of ENV_KEYS) {
+      orig[key] = process.env[key];
+      delete process.env[key];
+    }
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "instrumentation-"));
+    process.env.STORAGE_SQLITE_PATH = path.join(tmpDir, "libredb-storage.db");
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (orig[key] === undefined) delete process.env[key];
+      else process.env[key] = orig[key];
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("does nothing outside the nodejs runtime", async () => {
+    process.env.NEXT_RUNTIME = "edge";
+
+    await register();
+
+    expect(process.env.JWT_SECRET).toBeUndefined();
+    expect(fs.readdirSync(tmpDir)).toHaveLength(0);
+  });
+
+  test("runs auth bootstrap, then returns early when the sample is disabled", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.LIBREDB_EMBEDDED_SAMPLE = "false";
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await register();
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    expect(fs.existsSync(path.join(tmpDir, "auth-bootstrap.json"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "sample.libredb"))).toBe(false);
+  });
+
+  test("seeds the sample file on a nodejs boot", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.AUTH_BOOTSTRAP = "off";
+    process.env.LIBREDB_EMBEDDED_SAMPLE_PATH = path.join(tmpDir, "sample.libredb");
+
+    await register();
+
+    expect(fs.existsSync(path.join(tmpDir, "sample.libredb"))).toBe(true);
+    expect(fs.statSync(path.join(tmpDir, "sample.libredb")).size).toBeGreaterThan(0);
+  });
+
+  test("logs a warning and keeps boot alive when seeding fails", async () => {
+    if (process.platform === "win32" || process.getuid?.() === 0) return; // perms not enforceable
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.AUTH_BOOTSTRAP = "off";
+    const lockedDir = path.join(tmpDir, "locked");
+    fs.mkdirSync(lockedDir);
+    fs.chmodSync(lockedDir, 0o500);
+    process.env.LIBREDB_EMBEDDED_SAMPLE_PATH = path.join(lockedDir, "sample.libredb");
+    const warn = spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      await expect(register()).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalled();
+      expect(String(warn.mock.calls[0]?.[0])).toContain("seeding skipped");
+    } finally {
+      warn.mockRestore();
+      fs.chmodSync(lockedDir, 0o700);
+    }
+  });
+});

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -118,4 +118,14 @@ describe("auth-bootstrap bootstrapAuth()", () => {
     expect(stored.jwtSecret).toBeDefined();
     expect(stored.adminPassword).toBeUndefined();
   });
+
+  test("does not read the bootstrap file at all when both env vars are set", () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(resolveBootstrapPath(), "{not json");
+    process.env.JWT_SECRET = "an-explicit-secret-of-32-characters!";
+    process.env.ADMIN_PASSWORD = "explicit-password";
+
+    expect(() => bootstrapAuth()).not.toThrow();
+    expect(fs.readFileSync(resolveBootstrapPath(), "utf8")).toBe("{not json");
+  });
 });

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -72,8 +72,8 @@ describe("auth-bootstrap bootstrapAuth()", () => {
     delete process.env.ADMIN_PASSWORD;
     bootstrapAuth();
 
-    expect(process.env.JWT_SECRET).toBe(firstSecret!);
-    expect(process.env.ADMIN_PASSWORD).toBe(firstPassword!);
+    expect(process.env.JWT_SECRET!).toBe(firstSecret!);
+    expect(process.env.ADMIN_PASSWORD!).toBe(firstPassword!);
   });
 
   test("generates only the missing field and leaves set env untouched", () => {

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -221,4 +221,117 @@ describe("auth-bootstrap bootstrapAuth()", () => {
     expect(fs.readFileSync(`${resolveBootstrapPath()}.bak`, "utf8")).toBe("{not json");
     expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
   });
+
+  test("recovers when the file contains primitive JSON", () => {
+    fs.writeFileSync(resolveBootstrapPath(), "42");
+
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(fs.existsSync(`${resolveBootstrapPath()}.bak`)).toBe(true);
+    expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
+  });
+
+  test("recovers when jwtSecret is not a string", () => {
+    fs.writeFileSync(resolveBootstrapPath(), JSON.stringify({ jwtSecret: 12345 }));
+
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(fs.existsSync(`${resolveBootstrapPath()}.bak`)).toBe(true);
+  });
+
+  test("recovers when adminPassword is not a string", () => {
+    fs.writeFileSync(resolveBootstrapPath(), JSON.stringify({ adminPassword: false }));
+
+    bootstrapAuth();
+
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    expect(fs.existsSync(`${resolveBootstrapPath()}.bak`)).toBe(true);
+  });
+
+  test("generates only the password when JWT_SECRET is set, bannering the custom admin email", () => {
+    process.env.JWT_SECRET = "an-explicit-secret-of-32-characters!";
+    process.env.ADMIN_EMAIL = "ops@example.org";
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      bootstrapAuth();
+
+      expect(process.env.JWT_SECRET).toBe("an-explicit-secret-of-32-characters!");
+      expect(process.env.ADMIN_PASSWORD).toBeDefined();
+      const stored = readStored();
+      expect(stored.adminPassword).toBe(process.env.ADMIN_PASSWORD!);
+      expect(stored.jwtSecret).toBeUndefined();
+      const output = log.mock.calls.flat().join("\n");
+      expect(output).toContain("ops@example.org");
+      expect(output).toContain(process.env.ADMIN_PASSWORD!);
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test("adds the missing password to a jwtSecret-only file, reusing secret and createdAt", () => {
+    const existingSecret = "persisted-secret-that-is-32-chars-x";
+    fs.writeFileSync(
+      resolveBootstrapPath(),
+      JSON.stringify({ jwtSecret: existingSecret, createdAt: "2026-01-01T00:00:00.000Z" }),
+    );
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      bootstrapAuth();
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(process.env.JWT_SECRET).toBe(existingSecret);
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    const stored = readStored();
+    expect(stored.jwtSecret).toBe(existingSecret);
+    expect(stored.adminPassword).toBe(process.env.ADMIN_PASSWORD!);
+    expect(stored.createdAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("write falls back to copy-over when rename fails, keeping mode 600 and no temp", () => {
+    const renameSpy = spyOn(fs, "renameSync").mockImplementation(() => {
+      throw new Error("EPERM: simulated Windows rename failure");
+    });
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      bootstrapAuth();
+    } finally {
+      renameSpy.mockRestore();
+      log.mockRestore();
+    }
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(resolveBootstrapPath()).mode & 0o777).toBe(0o600);
+    }
+    expect(fs.readdirSync(tmpDir).filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
+
+  test("fails open when both rename and copy fail, leaving no temp behind", () => {
+    const renameSpy = spyOn(fs, "renameSync").mockImplementation(() => {
+      throw new Error("EPERM: simulated rename failure");
+    });
+    const copySpy = spyOn(fs, "copyFileSync").mockImplementation(() => {
+      // A non-Error throw also exercises the String(error) logging branch.
+      throw "simulated non-Error copy failure";
+    });
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() => bootstrapAuth()).not.toThrow();
+      expect(warn.mock.calls.flat().join("\n")).toContain("auth bootstrap skipped");
+    } finally {
+      renameSpy.mockRestore();
+      copySpy.mockRestore();
+      warn.mockRestore();
+    }
+
+    expect(process.env.JWT_SECRET).toBeUndefined();
+    expect(process.env.ADMIN_PASSWORD).toBeUndefined();
+    expect(fs.existsSync(resolveBootstrapPath())).toBe(false);
+    expect(fs.readdirSync(tmpDir).filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
 });

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { bootstrapAuth, resolveBootstrapPath, BOOTSTRAP_FILE_NAME } from "@/lib/auth-bootstrap";
+import { bootstrapAuth, isBootstrapEnabled, resolveBootstrapPath, BOOTSTRAP_FILE_NAME } from "@/lib/auth-bootstrap";
 
 const ENV_KEYS = [
   "JWT_SECRET",
@@ -105,6 +105,40 @@ describe("auth-bootstrap bootstrapAuth()", () => {
     expect(process.env.JWT_SECRET).toBeUndefined();
     expect(process.env.ADMIN_PASSWORD).toBeUndefined();
     expect(fs.existsSync(resolveBootstrapPath())).toBe(false);
+  });
+
+  test.each(["off", "OFF", " Off ", "false", "FALSE", "0"])(
+    "isBootstrapEnabled() treats %j as opt-out",
+    (value) => {
+      process.env.AUTH_BOOTSTRAP = value;
+      expect(isBootstrapEnabled()).toBe(false);
+    },
+  );
+
+  test.each([undefined, "", "on", "ON", "true", "1"])(
+    "isBootstrapEnabled() stays on for %j without warning",
+    (value) => {
+      if (value === undefined) delete process.env.AUTH_BOOTSTRAP;
+      else process.env.AUTH_BOOTSTRAP = value;
+      const warn = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(isBootstrapEnabled()).toBe(true);
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
+
+  test("isBootstrapEnabled() warns on an unrecognized value and stays on", () => {
+    process.env.AUTH_BOOTSTRAP = "offf";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(isBootstrapEnabled()).toBe(true);
+      expect(warn.mock.calls.flat().join("\n")).toContain('unrecognized AUTH_BOOTSTRAP value "offf"');
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   test("OIDC mode bootstraps the JWT secret but never a password", () => {

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -96,4 +96,26 @@ describe("auth-bootstrap bootstrapAuth()", () => {
 
     expect(fs.existsSync(resolveBootstrapPath())).toBe(false);
   });
+
+  test("AUTH_BOOTSTRAP=off disables bootstrap entirely (strict PR #106 behavior)", () => {
+    process.env.AUTH_BOOTSTRAP = "off";
+
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBeUndefined();
+    expect(process.env.ADMIN_PASSWORD).toBeUndefined();
+    expect(fs.existsSync(resolveBootstrapPath())).toBe(false);
+  });
+
+  test("OIDC mode bootstraps the JWT secret but never a password", () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "oidc";
+
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.ADMIN_PASSWORD).toBeUndefined();
+    const stored = readStored();
+    expect(stored.jwtSecret).toBeDefined();
+    expect(stored.adminPassword).toBeUndefined();
+  });
 });

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -198,4 +198,16 @@ describe("auth-bootstrap bootstrapAuth()", () => {
       log.mockRestore();
     }
   });
+
+  test("corrupt-file recovery still works when a stale .bak already exists", () => {
+    fs.writeFileSync(resolveBootstrapPath(), "{not json");
+    fs.writeFileSync(`${resolveBootstrapPath()}.bak`, "older evidence");
+
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    expect(fs.readFileSync(`${resolveBootstrapPath()}.bak`, "utf8")).toBe("{not json");
+    expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
+  });
 });

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -199,6 +199,17 @@ describe("auth-bootstrap bootstrapAuth()", () => {
     }
   });
 
+  test("regenerates when the stored jwtSecret is shorter than the 32-char minimum", () => {
+    fs.writeFileSync(resolveBootstrapPath(), JSON.stringify({ jwtSecret: "short" }));
+
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.JWT_SECRET!.length).toBeGreaterThanOrEqual(32);
+    expect(fs.existsSync(`${resolveBootstrapPath()}.bak`)).toBe(true);
+    expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
+  });
+
   test("corrupt-file recovery still works when a stale .bak already exists", () => {
     fs.writeFileSync(resolveBootstrapPath(), "{not json");
     fs.writeFileSync(`${resolveBootstrapPath()}.bak`, "older evidence");

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -311,6 +311,31 @@ describe("auth-bootstrap bootstrapAuth()", () => {
     expect(fs.readdirSync(tmpDir).filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
   });
 
+  test("still injects when the post-copy chmod fails (best-effort hardening)", () => {
+    const renameSpy = spyOn(fs, "renameSync").mockImplementation(() => {
+      throw new Error("EPERM: simulated rename failure");
+    });
+    const chmodSpy = spyOn(fs, "chmodSync").mockImplementation(() => {
+      throw new Error("ENOSYS: simulated unsupported chmod");
+    });
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      bootstrapAuth();
+      expect(warn.mock.calls.flat().join("\n")).toContain("could not restrict permissions");
+    } finally {
+      renameSpy.mockRestore();
+      chmodSpy.mockRestore();
+      log.mockRestore();
+      warn.mockRestore();
+    }
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
+    expect(fs.readdirSync(tmpDir).filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
+
   test("fails open when both rename and copy fail, leaving no temp behind", () => {
     const renameSpy = spyOn(fs, "renameSync").mockImplementation(() => {
       throw new Error("EPERM: simulated rename failure");

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { bootstrapAuth, resolveBootstrapPath, BOOTSTRAP_FILE_NAME } from "@/lib/auth-bootstrap";
+
+const ENV_KEYS = [
+  "JWT_SECRET",
+  "ADMIN_PASSWORD",
+  "ADMIN_EMAIL",
+  "NEXT_PUBLIC_AUTH_PROVIDER",
+  "AUTH_BOOTSTRAP",
+  "STORAGE_SQLITE_PATH",
+] as const;
+
+describe("auth-bootstrap bootstrapAuth()", () => {
+  let orig: Record<string, string | undefined>;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    orig = {};
+    for (const key of ENV_KEYS) {
+      orig[key] = process.env[key];
+      delete process.env[key];
+    }
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "auth-bootstrap-"));
+    process.env.STORAGE_SQLITE_PATH = path.join(tmpDir, "libredb-storage.db");
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (orig[key] === undefined) delete process.env[key];
+      else process.env[key] = orig[key];
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function readStored(): { jwtSecret?: string; adminPassword?: string; createdAt?: string } {
+    return JSON.parse(fs.readFileSync(resolveBootstrapPath(), "utf8"));
+  }
+
+  test("generates, persists, and injects JWT_SECRET and ADMIN_PASSWORD when both are unset", () => {
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.JWT_SECRET!.length).toBeGreaterThanOrEqual(32);
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    expect(process.env.ADMIN_PASSWORD!.length).toBeGreaterThanOrEqual(16);
+
+    const stored = readStored();
+    expect(stored.jwtSecret).toBe(process.env.JWT_SECRET!);
+    expect(stored.adminPassword).toBe(process.env.ADMIN_PASSWORD!);
+    expect(stored.createdAt).toBeDefined();
+  });
+
+  test("resolveBootstrapPath() lives in the data dir", () => {
+    expect(resolveBootstrapPath()).toBe(path.join(tmpDir, BOOTSTRAP_FILE_NAME));
+  });
+
+  test("persists with owner-only file mode", () => {
+    if (process.platform === "win32") return; // chmod is a no-op on Windows
+    bootstrapAuth();
+    expect(fs.statSync(resolveBootstrapPath()).mode & 0o777).toBe(0o600);
+  });
+
+  test("reuses persisted credentials across restarts instead of regenerating", () => {
+    bootstrapAuth();
+    const firstSecret = process.env.JWT_SECRET;
+    const firstPassword = process.env.ADMIN_PASSWORD;
+
+    delete process.env.JWT_SECRET;
+    delete process.env.ADMIN_PASSWORD;
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBe(firstSecret!);
+    expect(process.env.ADMIN_PASSWORD).toBe(firstPassword!);
+  });
+
+  test("generates only the missing field and leaves set env untouched", () => {
+    process.env.ADMIN_PASSWORD = "explicit-password";
+
+    bootstrapAuth();
+
+    expect(process.env.ADMIN_PASSWORD).toBe("explicit-password");
+    expect(process.env.JWT_SECRET).toBeDefined();
+    const stored = readStored();
+    expect(stored.jwtSecret).toBeDefined();
+    expect(stored.adminPassword).toBeUndefined();
+  });
+
+  test("does nothing when both env vars are set", () => {
+    process.env.JWT_SECRET = "an-explicit-secret-of-32-characters!";
+    process.env.ADMIN_PASSWORD = "explicit-password";
+
+    bootstrapAuth();
+
+    expect(fs.existsSync(resolveBootstrapPath())).toBe(false);
+  });
+});

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -141,6 +141,30 @@ describe("auth-bootstrap bootstrapAuth()", () => {
     expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
   });
 
+  test("recovers from a bootstrap file containing JSON null by renaming it to .bak and regenerating", () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(resolveBootstrapPath(), "null");
+
+    expect(() => bootstrapAuth()).not.toThrow();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    expect(fs.existsSync(`${resolveBootstrapPath()}.bak`)).toBe(true);
+    expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
+  });
+
+  test("recovers from a bootstrap file containing a JSON array by renaming it to .bak and regenerating", () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(resolveBootstrapPath(), "[]");
+
+    expect(() => bootstrapAuth()).not.toThrow();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    expect(fs.existsSync(`${resolveBootstrapPath()}.bak`)).toBe(true);
+    expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
+  });
+
   test("fails open when the data dir is not writable: no throw, no injection", () => {
     if (process.platform === "win32" || process.getuid?.() === 0) return; // perms not enforceable
     fs.mkdirSync(tmpDir, { recursive: true });

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -127,5 +127,51 @@ describe("auth-bootstrap bootstrapAuth()", () => {
 
     expect(() => bootstrapAuth()).not.toThrow();
     expect(fs.readFileSync(resolveBootstrapPath(), "utf8")).toBe("{not json");
+  });
+
+  test("recovers from a corrupt bootstrap file by renaming it to .bak and regenerating", () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(resolveBootstrapPath(), "{not json");
+
+    bootstrapAuth();
+
+    expect(process.env.JWT_SECRET).toBeDefined();
+    expect(process.env.ADMIN_PASSWORD).toBeDefined();
+    expect(fs.existsSync(`${resolveBootstrapPath()}.bak`)).toBe(true);
+    expect(readStored().jwtSecret).toBe(process.env.JWT_SECRET!);
+  });
+
+  test("fails open when the data dir is not writable: no throw, no injection", () => {
+    if (process.platform === "win32" || process.getuid?.() === 0) return; // perms not enforceable
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.chmodSync(tmpDir, 0o500);
+    try {
+      expect(() => bootstrapAuth()).not.toThrow();
+      expect(process.env.JWT_SECRET).toBeUndefined();
+      expect(process.env.ADMIN_PASSWORD).toBeUndefined();
+    } finally {
+      fs.chmodSync(tmpDir, 0o700);
+    }
+  });
+
+  test("prints the password in a banner on generation, but not on reuse", () => {
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      bootstrapAuth();
+      const password = process.env.ADMIN_PASSWORD!;
+      const firstRunOutput = log.mock.calls.flat().join("\n");
+      expect(firstRunOutput).toContain(password);
+      expect(firstRunOutput).not.toContain(process.env.JWT_SECRET!);
+
+      log.mockClear();
+      delete process.env.JWT_SECRET;
+      delete process.env.ADMIN_PASSWORD;
+      bootstrapAuth();
+      const reuseOutput = log.mock.calls.flat().join("\n");
+      expect(reuseOutput).not.toContain(password);
+      expect(reuseOutput).toContain(resolveBootstrapPath());
+    } finally {
+      log.mockRestore();
+    }
   });
 });

--- a/tests/unit/lib/auth-bootstrap.test.ts
+++ b/tests/unit/lib/auth-bootstrap.test.ts
@@ -107,28 +107,29 @@ describe("auth-bootstrap bootstrapAuth()", () => {
     expect(fs.existsSync(resolveBootstrapPath())).toBe(false);
   });
 
-  test.each(["off", "OFF", " Off ", "false", "FALSE", "0"])(
-    "isBootstrapEnabled() treats %j as opt-out",
-    (value) => {
-      process.env.AUTH_BOOTSTRAP = value;
-      expect(isBootstrapEnabled()).toBe(false);
-    },
-  );
+  test.each(["off", "OFF", " Off ", "false", "FALSE", "0"])("isBootstrapEnabled() treats %j as opt-out", (value) => {
+    process.env.AUTH_BOOTSTRAP = value;
+    expect(isBootstrapEnabled()).toBe(false);
+  });
 
-  test.each([undefined, "", "on", "ON", "true", "1"])(
-    "isBootstrapEnabled() stays on for %j without warning",
-    (value) => {
-      if (value === undefined) delete process.env.AUTH_BOOTSTRAP;
-      else process.env.AUTH_BOOTSTRAP = value;
-      const warn = spyOn(console, "warn").mockImplementation(() => {});
-      try {
-        expect(isBootstrapEnabled()).toBe(true);
-        expect(warn).not.toHaveBeenCalled();
-      } finally {
-        warn.mockRestore();
-      }
-    },
-  );
+  test.each([
+    undefined,
+    "",
+    "on",
+    "ON",
+    "true",
+    "1",
+  ])("isBootstrapEnabled() stays on for %j without warning", (value) => {
+    if (value === undefined) delete process.env.AUTH_BOOTSTRAP;
+    else process.env.AUTH_BOOTSTRAP = value;
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(isBootstrapEnabled()).toBe(true);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
 
   test("isBootstrapEnabled() warns on an unrecognized value and stays on", () => {
     process.env.AUTH_BOOTSTRAP = "offf";

--- a/tests/unit/lib/data-dir.test.ts
+++ b/tests/unit/lib/data-dir.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import * as path from "path";
+import { DEFAULT_STORAGE_SQLITE_PATH, getDataDir } from "@/lib/data-dir";
+
+describe("data-dir getDataDir()", () => {
+  let origStoragePath: string | undefined;
+
+  beforeEach(() => {
+    origStoragePath = process.env.STORAGE_SQLITE_PATH;
+  });
+
+  afterEach(() => {
+    if (origStoragePath === undefined) delete process.env.STORAGE_SQLITE_PATH;
+    else process.env.STORAGE_SQLITE_PATH = origStoragePath;
+  });
+
+  test("defaults to the directory of the default SQLite storage path", () => {
+    delete process.env.STORAGE_SQLITE_PATH;
+    expect(getDataDir()).toBe(path.dirname(DEFAULT_STORAGE_SQLITE_PATH));
+  });
+
+  test("derives the data dir from STORAGE_SQLITE_PATH when set", () => {
+    process.env.STORAGE_SQLITE_PATH = "/var/lib/libredb/storage.db";
+    expect(getDataDir()).toBe("/var/lib/libredb");
+  });
+
+  test("treats an empty STORAGE_SQLITE_PATH as unset", () => {
+    process.env.STORAGE_SQLITE_PATH = "";
+    expect(getDataDir()).toBe(path.dirname(DEFAULT_STORAGE_SQLITE_PATH));
+  });
+});


### PR DESCRIPTION
Closes #109. Part of epic #108 (distribution channels beyond Docker).

## What

Starting the server with no auth env vars now works out of the box. When `JWT_SECRET` and/or `ADMIN_PASSWORD` are absent, the boot hook generates the missing values, persists them to `<data dir>/auth-bootstrap.json` (mode 0600, atomic temp+rename write), injects them into `process.env` before any secret reader runs, and prints the admin password once to the server log. This is the prerequisite for every native distribution channel in #108 (npx, Homebrew, deb/rpm, Snap, winget, desktop): `brew install` users cannot be asked to preconfigure env vars the way Docker users are.

## How

- `src/lib/data-dir.ts` (new): centralizes the data-dir rule previously duplicated in `sqlite.ts` and `libredb-sample.ts`; behavior unchanged.
- `src/lib/auth-bootstrap.ts` (new): load-or-generate with `crypto.randomBytes` (384-bit secret, 96-bit password); explicit env vars always win and only missing fields are generated.
- `src/instrumentation.ts`: calls `bootstrapAuth()` after the `NEXT_RUNTIME` guard, before sample seeding — all existing secret readers (`auth.ts`, `proxy.ts`, `oidc.ts`, `local-auth.ts`) are untouched and keep reading `process.env` lazily.
- `AUTH_BOOTSTRAP=off` restores the strict PR #106 behavior exactly (no file access, missing env surfaces as a clear 503 at login) — recommended for production.
- OIDC mode (`NEXT_PUBLIC_AUTH_PROVIDER=oidc`) bootstraps only the JWT secret (needed for state encryption), never a password.
- Fail-open: any bootstrap error (read-only fs, corrupt file) is caught and logged; the app degrades to the strict behavior instead of failing boot. Corrupt or wrong-shape JSON (including `null`/`[]`) is moved to `.bak` and regenerated.
- The JWT secret is never printed; the password prints only on fresh generation (a test asserts the banner does not contain the secret).

Docker/Helm are unaffected operationally (no image or chart changes; explicit env keeps working as before), and the npm package surface (`@libredb/studio`) is untouched — `instrumentation.ts` is app-level only.

## Testing

- 17 new unit tests (14 for `auth-bootstrap` against the real filesystem via per-test `mkdtempSync` dirs, 3 for `data-dir`); all existing auth tests pass unchanged.
- Full local gates green: format, lint, typecheck, `bun run test` (486 tests, 18 groups), build.
- End-to-end zero-env smoke: production server booted with no auth env, banner printed, credentials file created with mode 600, and a real login with the generated password returned `{"success":true,"role":"admin"}`.

## Follow-ups filed

- #116 multi-process race guard on the bootstrap file
- #117 normalize `AUTH_BOOTSTRAP` opt-out values — pulled into this PR (f127277); closes on merge
- #118 Helm: expose and document `AUTH_BOOTSTRAP`
- #119 consolidate the three JWT-secret readers into a central config module

