### PR TITLE
fix(ci): chart releases must not masquerade as product releases

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -31,6 +31,9 @@ env:
 
 jobs:
   build-and-push:
+    # Product releases only: chart releases (libredb-studio-<chart-version>)
+    # are published by helm-release.yml and must not feed this pipeline.
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'libredb-studio-')
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -82,6 +82,9 @@ jobs:
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           skip_existing: true
+          # Chart releases (tag libredb-studio-<chart-version>) must never take
+          # the repo's Latest marker away from product releases (bare semver).
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,9 @@ permissions:
 
 jobs:
   validate:
+    # Product releases only: chart releases (libredb-studio-<chart-version>)
+    # are published by helm-release.yml and must not reach npm.
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'libredb-studio-')
     name: Validate
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -32,6 +32,9 @@ permissions:
 
 jobs:
   guard:
+    # Product releases only: chart releases (libredb-studio-<chart-version>)
+    # are published by helm-release.yml and must not feed this pipeline.
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'libredb-studio-')
     name: Validate release version
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
The Helm chart release for 0.1.1 (first chart-releaser run, triggered by the #122 merge) created GitHub release `libredb-studio-0.1.1` and took the repo's **Latest** marker from the 0.9.41 product release (already restored manually: `gh release edit 0.9.41 --latest`).

Verified blast radius before fixing: **no release-triggered workflow ran** for the chart release (chart-releaser publishes with `GITHUB_TOKEN`, whose events do not trigger workflows), so npm still has 0.9.41, GHCR tags are intact, and no standalone artifacts were produced. Artifact Hub showing chart 0.1.1 is correct and intended.

Fixes:
- `helm-release.yml`: `mark_as_latest: false` on chart-releaser
- `docker-build-push.yml`, `release-artifacts.yml`, `npm-publish.yml`: release-triggered jobs skip `libredb-studio-*` tags explicitly (defense in depth for a future PAT switch)