### PR TITLE
chore: bump version to 0.9.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Patch bump for the distribution-channels release: the first release that ships standalone tarballs (4 platforms + SHA256SUMS), .deb/.rpm packages, and the automated Homebrew formula push, plus zero-config follow-ups, the dual-runtime SQLite driver, Helm strict bootstrap, and the docs truth pass (all merged via #122 and #128).