### PR TITLE
fix(npm): lower engines.node floor so bare npx resolves current releases (#130)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.42",
+  "version": "0.9.43",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -76,7 +76,7 @@
     "react-dom": "^19"
   },
   "engines": {
-    "node": ">=24.16.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "bun@1.3.14",
   "scripts": {


### PR DESCRIPTION
## Summary

- `engines.node` `>=24.16.0` -> `>=24.0.0` and version bump to 0.9.43.

npm's version picker avoids engine-incompatible versions for bare specs, so on Node 24.0-24.15 `npx @libredb/studio` silently resolved to the ancient 0.9.13 (which predates the `bin` field) and died with "could not determine executable to run". Reproduced live on Node v24.14.0. The old floor was the repo's dev-runtime pin, not a real API requirement: the launcher uses only stable Node 24 APIs, better-sqlite3 targets the Node 24 ABI line (identical across 24.x), and `node:sqlite` exists throughout 24.x.

Bundled/CI runtimes keep their exact pins on purpose (Dockerfile `node:24.16.0-trixie-slim`, `fetch-node.sh` 24.18.0, npm-publish CI 24.16.0, .nvmrc) - they ship or build a runtime rather than constrain the user's. Docs already say "Node 24+".

npm versions are immutable, so 0.9.42 cannot be repaired in place - this ships as 0.9.43.

Fixes #130

## Verification

- `bun run format` / `lint` / `typecheck` / `test` (486 pass, 0 fail) / `build` / `build:lib` / `attw` all green locally.