### PR TITLE
docs(distribution): add the required brew trust step; drop stale availability phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
   | **Docker** | `docker run -d -p 3000:3000 ghcr.io/libredb/libredb-studio:latest` | Zero-config: the admin password is printed to the log on first run |
   | **Helm (Kubernetes)** | `helm install libredb oci://ghcr.io/libredb/charts/libredb-studio` | Requires `secrets.jwtSecret` / `secrets.adminPassword` (strict mode by default) |
   | **npx** | `npx @libredb/studio` | Linux/macOS, Node 24+; downloads the release server tarball |
-  | **Homebrew** | `brew install libredb/tap/libredb-studio` | From the next release |
-  | **deb / rpm** | `sudo dpkg -i libredb-studio_<version>_amd64.deb` | From the next release; systemd service included |
+  | **Homebrew** | `brew trust libredb/tap && brew install libredb/tap/libredb-studio` | `brew trust` is required once for third-party taps |
+  | **deb / rpm** | `sudo dpkg -i libredb-studio_<version>_amd64.deb` | Attached to each GitHub release; systemd service included |
   | **Snap** | `sudo snap install libredb-studio` | From the next release, once Snap Store publishing goes live |
 
-  > Homebrew, deb/rpm, Snap, and the npx launcher consume standalone artifacts that are attached to GitHub releases from the next release onward. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md).
+  > Homebrew, deb/rpm, Snap, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md).
 
   ### Quick Start (Docker)
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -204,10 +204,13 @@ cached `SHA256SUMS` and re-extracts the payload.
 
 ## Homebrew
 
-Available from the next release onward (the formula is rendered and pushed to
+The formula tracks the latest release (it is rendered and pushed to
 [`libredb/homebrew-tap`](https://github.com/libredb/homebrew-tap) by release CI):
 
 ```bash
+# One-time: Homebrew's untrusted-tap policy requires trusting third-party taps
+brew trust libredb/tap
+
 brew install libredb/tap/libredb-studio
 
 # Foreground (first run prints the generated admin password to the terminal)
@@ -231,7 +234,7 @@ brew services start libredb-studio
 ## Linux packages (.deb / .rpm)
 
 Native packages for Debian/Ubuntu and RHEL/Fedora (amd64/x86_64 and arm64/aarch64) are attached
-to every GitHub release from the next release onward. They bundle the standalone server together
+to every GitHub release. They bundle the standalone server together
 with a private, checksum-verified Node.js runtime under `/usr/lib/libredb-studio` — nothing else
 to install — and register a hardened systemd service:
 


### PR DESCRIPTION
## Summary

- Homebrew install instructions now include the one-time `brew trust libredb/tap` step. Current Homebrew's untrusted-tap policy hard-fails `brew install` from an untrusted third-party tap; reproduced in a clean `homebrew/brew` container during the 0.9.43 channel-validation run (epic #108):

  `Error: Refusing to load formula libredb/tap/libredb-studio from untrusted tap libredb/tap.`

- Drops the stale "from the next release onward" phrasing in README and docs/DISTRIBUTION.md - Homebrew, deb/rpm and the standalone artifacts have shipped with every release since 0.9.42.

Fixes #139

## Verification

Docs-only. `bun run format` clean; full brew-channel validation evidence in the epic #108 acceptance comment.