### PR TITLE
fix(helm): bump chart to 0.1.2 / appVersion 0.9.43

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.1
-appVersion: "0.9.41"
+version: 0.1.2
+appVersion: "0.9.43"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.8.10
+      image: ghcr.io/libredb/libredb-studio:0.9.43
       platforms:
         - linux/amd64
   artifacthub.io/links: |
@@ -42,7 +42,7 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - Expose AUTH_BOOTSTRAP via config.authBootstrap (chart default: off, strict mode)
+    - Track app release 0.9.43 (appVersion bump; default image tag follows)
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -31,7 +31,7 @@ kubectl port-forward svc/libredb-libredb-studio 3000:80
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.1 \
+  --version 0.1.2 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123 \
   --set secrets.userPassword=MyUser123


### PR DESCRIPTION
## Summary

The published chart (0.1.1) still carries `appVersion: 0.9.41` - the default image tag - so a brand-new Helm user installs 0.9.41 while every other channel ships 0.9.43 (found in the epic #108 acceptance run; validation required `--set image.tag=0.9.43`).

- Chart `version` 0.1.1 -> 0.1.2, `appVersion` 0.9.41 -> 0.9.43
- Refreshes the stale `artifacthub.io/images` reference (0.8.10) and the chart README's pinned `--version` example
- `artifacthub.io/changes` updated for this release

Merging publishes chart 0.1.2 via the helm-release workflow (chart releases stay un-Latest per #128 guards). The durable fix - bumping appVersion automatically on each product release - stays tracked in #138.

## Verification

- `helm lint charts/libredb-studio --strict` -> 1 chart(s) linted, 0 failed
- `bun run format` clean