### PR TITLE
feat(runtime): tested Node 20.9 engines floor - launcher preflight, ABI guard, engine-matrix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Setup Node.js
+        # build-standalone-payload.sh aligns the better-sqlite3 binding to the
+        # ambient node (probe + npm rebuild). The payload must ship the Node 24
+        # ABI exactly like release-artifacts.yml does - without this, the
+        # runner's default node dictates the ABI and the matrix legs assert
+        # against a payload no release would ever ship.
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,69 @@ jobs:
           name: playwright-report
           path: playwright-report/
 
+  # The engines floor in package.json (>=20.9.0) is a tested claim: build the
+  # standalone payload once, then boot it through the npx launcher on every
+  # supported Node tier and assert the documented behaviour of each
+  # (scripts/engine-smoke.sh).
+  engine-payload:
+    name: Engine Smoke - Build Payload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build standalone payload
+        run: bash scripts/build-standalone-payload.sh dist-payload
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+
+      - name: Upload payload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: engine-smoke-payload
+          path: dist-payload/libredb-studio-standalone-*.tar.gz
+          retention-days: 1
+
+  engine-smoke:
+    name: Engine Smoke (Node ${{ matrix.node-version }})
+    needs: [engine-payload]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - node-version: "20.9"
+            tier: legacy20
+          - node-version: "22"
+            tier: node22
+          - node-version: "24"
+            tier: node24
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Download payload artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: engine-smoke-payload
+          path: dist-payload
+
+      - name: Run engine smoke (${{ matrix.tier }})
+        run: bash scripts/engine-smoke.sh dist-payload/libredb-studio-standalone-*.tar.gz ${{ matrix.tier }}
+
   helm-lint:
     name: Helm Chart Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/npx-engine-smoke.yml
+++ b/.github/workflows/npx-engine-smoke.yml
@@ -1,0 +1,67 @@
+# Post-release validation of the bare-npx experience against the LIVE npm
+# registry (issue #130 regression class): npm's version picker avoids
+# engine-incompatible versions for bare specs, so `npx @libredb/studio` must
+# resolve a runnable release on every supported Node tier - not fall back to
+# an ancient bin-less version. Run manually after a release (see the
+# first-release validation runbook in docs/DISTRIBUTION.md).
+name: npx Engine Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected-version:
+        description: "Version bare npx must resolve (empty = only assert a runnable server)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  npx-smoke:
+    name: bare npx on Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20.9", "22", "24"]
+    steps:
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run bare npx and assert resolution
+        env:
+          # Dispatch inputs are maintainer-provided, but validate anyway - the
+          # value ends up in log greps only after a strict semver check.
+          EXPECTED_VERSION: ${{ inputs.expected-version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$EXPECTED_VERSION" ] && ! printf '%s' "$EXPECTED_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid expected-version '$EXPECTED_VERSION' (plain semver or empty)" >&2
+            exit 1
+          fi
+          WORK=$(mktemp -d)
+          cd "$WORK"
+          echo "==> node $(node --version), bare: npx -y @libredb/studio"
+          npx -y @libredb/studio --port 3105 --host 127.0.0.1 > npx.log 2>&1 &
+          for _ in $(seq 1 150); do
+            curl -sf -o /dev/null http://127.0.0.1:3105/api/db/health && break
+            sleep 2
+          done
+          if ! curl -sf -o /dev/null http://127.0.0.1:3105/api/db/health; then
+            echo "FAIL: bare npx never served /api/db/health; log:" >&2
+            cat npx.log >&2
+            exit 1
+          fi
+          echo "PASS: health 200"
+          grep -F "Checksum verified" npx.log
+          RESOLVED=$(sed -n 's/^Starting LibreDB Studio \([0-9][0-9.]*\) .*/\1/p' npx.log | head -1)
+          echo "resolved version: ${RESOLVED:-unknown}"
+          if [ -n "$EXPECTED_VERSION" ] && [ "$RESOLVED" != "$EXPECTED_VERSION" ]; then
+            echo "FAIL: bare npx resolved '$RESOLVED', expected '$EXPECTED_VERSION'; log:" >&2
+            cat npx.log >&2
+            exit 1
+          fi
+          echo "==> OK"

--- a/.github/workflows/npx-engine-smoke.yml
+++ b/.github/workflows/npx-engine-smoke.yml
@@ -2,11 +2,18 @@
 # registry (issue #130 regression class): npm's version picker avoids
 # engine-incompatible versions for bare specs, so `npx @libredb/studio` must
 # resolve a runnable release on every supported Node tier - not fall back to
-# an ancient bin-less version. Run manually after a release (see the
-# first-release validation runbook in docs/DISTRIBUTION.md).
+# an ancient bin-less version.
+#
+# Runs automatically after a successful "NPM Publish" (the expected version is
+# read from the released commit's package.json, and the job waits for the
+# registry to serve it before asserting). Manual dispatch stays available for
+# re-runs; see the first-release validation runbook in docs/DISTRIBUTION.md.
 name: npx Engine Smoke
 
 on:
+  workflow_run:
+    workflows: ["NPM Publish"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       expected-version:
@@ -20,28 +27,68 @@ permissions:
 jobs:
   npx-smoke:
     name: bare npx on Node ${{ matrix.node-version }}
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node-version: ["20.9", "22", "24"]
     steps:
+      # On workflow_run this is the commit NPM Publish released from (our own
+      # release commit - never fork content), so its package.json version is
+      # exactly what the registry must serve.
+      - name: Checkout released commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Run bare npx and assert resolution
+      - name: Resolve expected version
+        id: expected
         env:
           # Dispatch inputs are maintainer-provided, but validate anyway - the
-          # value ends up in log greps only after a strict semver check.
-          EXPECTED_VERSION: ${{ inputs.expected-version }}
+          # value is only used after a strict semver check.
+          INPUT_VERSION: ${{ inputs.expected-version }}
         run: |
           set -euo pipefail
-          if [ -n "$EXPECTED_VERSION" ] && ! printf '%s' "$EXPECTED_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Invalid expected-version '$EXPECTED_VERSION' (plain semver or empty)" >&2
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            EXPECTED=$(node -p "require('./package.json').version")
+          else
+            EXPECTED="$INPUT_VERSION"
+          fi
+          if [ -n "$EXPECTED" ] && ! printf '%s' "$EXPECTED" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid expected version '$EXPECTED' (plain semver or empty)" >&2
             exit 1
           fi
+          echo "version=$EXPECTED" >> "$GITHUB_OUTPUT"
+          echo "expected version: ${EXPECTED:-<none - runnable-server assertion only>}"
+
+      - name: Wait for the registry to serve the expected version
+        if: steps.expected.outputs.version != ''
+        env:
+          EXPECTED_VERSION: ${{ steps.expected.outputs.version }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if npm view "@libredb/studio@${EXPECTED_VERSION}" version >/dev/null 2>&1; then
+              echo "registry serves ${EXPECTED_VERSION}"
+              exit 0
+            fi
+            echo "waiting for the registry to serve ${EXPECTED_VERSION} (attempt ${i}/30)"
+            sleep 20
+          done
+          echo "FAIL: registry never served ${EXPECTED_VERSION} within 10 minutes" >&2
+          exit 1
+
+      - name: Run bare npx and assert resolution
+        env:
+          EXPECTED_VERSION: ${{ steps.expected.outputs.version }}
+        run: |
+          set -euo pipefail
           WORK=$(mktemp -d)
           cd "$WORK"
           echo "==> node $(node --version), bare: npx -y @libredb/studio"

--- a/.github/workflows/npx-engine-smoke.yml
+++ b/.github/workflows/npx-engine-smoke.yml
@@ -5,9 +5,10 @@
 # an ancient bin-less version.
 #
 # Runs automatically after a successful "NPM Publish" (the expected version is
-# read from the released commit's package.json, and the job waits for the
-# registry to serve it before asserting). Manual dispatch stays available for
-# re-runs; see the first-release validation runbook in docs/DISTRIBUTION.md.
+# the release tag - workflow_run.head_branch - which the release guards pin to
+# package.json's version; the job waits for the registry to serve it before
+# asserting). Manual dispatch stays available for re-runs; see the
+# first-release validation runbook in docs/DISTRIBUTION.md.
 name: npx Engine Smoke
 
 on:
@@ -34,35 +35,39 @@ jobs:
       matrix:
         node-version: ["20.9", "22", "24"]
     steps:
-      # On workflow_run this is the commit NPM Publish released from (our own
-      # release commit - never fork content), so its package.json version is
-      # exactly what the registry must serve.
-      - name: Checkout released commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
 
+      # No checkout needed (and none wanted - a workflow_run checkout of
+      # head_sha is the pattern CodeQL rightly flags): on release-triggered
+      # NPM Publish runs, head_branch IS the release tag, and this repo's
+      # release guards enforce tag == package.json version. Anything that is
+      # not plain semver (e.g. a manually dispatched publish from a branch)
+      # falls back to the runnable-server-only assertion.
       - name: Resolve expected version
         id: expected
         env:
-          # Dispatch inputs are maintainer-provided, but validate anyway - the
-          # value is only used after a strict semver check.
+          # Both values are maintainer-provided (dispatch input / release
+          # tag), but validate anyway - they are only used after a strict
+          # semver check.
           INPUT_VERSION: ${{ inputs.expected-version }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            EXPECTED=$(node -p "require('./package.json').version")
+            EXPECTED="$RUN_HEAD_BRANCH"
           else
             EXPECTED="$INPUT_VERSION"
           fi
-          if [ -n "$EXPECTED" ] && ! printf '%s' "$EXPECTED" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Invalid expected version '$EXPECTED' (plain semver or empty)" >&2
-            exit 1
+          if ! printf '%s' "$EXPECTED" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$EXPECTED" ]; then
+              echo "Invalid expected-version '$EXPECTED' (plain semver or empty)" >&2
+              exit 1
+            fi
+            echo "'$EXPECTED' is not a release tag - asserting a runnable server only"
+            EXPECTED=""
           fi
           echo "version=$EXPECTED" >> "$GITHUB_OUTPUT"
           echo "expected version: ${EXPECTED:-<none - runnable-server assertion only>}"

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
   | :--- | :--- | :--- |
   | **Docker** | `docker run -d -p 3000:3000 ghcr.io/libredb/libredb-studio:latest` | Zero-config: the admin password is printed to the log on first run |
   | **Helm (Kubernetes)** | `helm install libredb oci://ghcr.io/libredb/charts/libredb-studio` | Requires `secrets.jwtSecret` / `secrets.adminPassword` (strict mode by default) |
-  | **npx** | `npx @libredb/studio` | Linux/macOS, Node 24+; downloads the release server tarball |
+  | **npx** | `npx @libredb/studio` | Linux/macOS, Node 20.9+ (Node 24 LTS recommended); downloads the release server tarball |
   | **Homebrew** | `brew trust libredb/tap && brew install libredb/tap/libredb-studio` | `brew trust` is required once for third-party taps |
   | **deb / rpm** | `sudo dpkg -i libredb-studio_<version>_amd64.deb` | Attached to each GitHub release; systemd service included |
   | **Snap** | `sudo snap install libredb-studio` | From the next release, once Snap Store publishing goes live |

--- a/bin/lib/launcher-utils.mjs
+++ b/bin/lib/launcher-utils.mjs
@@ -124,6 +124,67 @@ export function sha256File(filePath) {
 }
 
 /**
+ * Runtime tiers for the payload (Next.js standalone server):
+ * - Next.js 16 itself needs Node >= 20.9 - below that the server cannot run.
+ * - node:sqlite (SQLite database connections) exists unflagged from 22.13.
+ * - The bundled better-sqlite3 binding (server-side SQLite storage,
+ *   STORAGE_PROVIDER=sqlite) targets the Node 24 ABI line.
+ * Node 24 LTS is the fully supported runtime; older tiers run with the
+ * degradations spelled out by assessNodeRuntime so users see them up front.
+ */
+const MINIMUM_NODE = { major: 20, minor: 9 };
+
+/**
+ * Assess a Node.js runtime version (process.versions.node shape, e.g.
+ * "22.13.0") against the payload's requirements. Pure and injectable for
+ * unit tests - never reads process state itself.
+ *
+ * @param {string} version
+ * @returns {{ action: "fail" | "warn" | "ok", message: string | null }}
+ */
+export function assessNodeRuntime(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) {
+    return {
+      action: "fail",
+      message: `LibreDB Studio launcher could not parse the Node.js version ${JSON.stringify(version)}. Node.js ${MINIMUM_NODE.major}.${MINIMUM_NODE.minor}+ is required (Node 24 LTS recommended).`,
+    };
+  }
+  const [major, minor] = [Number(match[1]), Number(match[2])];
+
+  if (major < MINIMUM_NODE.major || (major === MINIMUM_NODE.major && minor < MINIMUM_NODE.minor)) {
+    return {
+      action: "fail",
+      message: [
+        `LibreDB Studio requires Node.js ${MINIMUM_NODE.major}.${MINIMUM_NODE.minor} or newer; this is Node ${version}.`,
+        "Install Node 24 LTS (https://nodejs.org) or run Studio with Docker:",
+        "  docker run -p 3000:3000 ghcr.io/libredb/libredb-studio:latest",
+      ].join("\n"),
+    };
+  }
+  if (major < 22 || (major === 22 && minor < 13)) {
+    return {
+      action: "warn",
+      message:
+        `Node ${version}: SQLite features are unavailable on this runtime - ` +
+        "SQLite database connections need the built-in node:sqlite module (Node 22.13+) and " +
+        "server-side SQLite storage (STORAGE_PROVIDER=sqlite) needs Node 24. " +
+        "Everything else works; use Node 24 LTS for full functionality.",
+    };
+  }
+  if (major < 24) {
+    return {
+      action: "warn",
+      message:
+        `Node ${version}: server-side SQLite storage (STORAGE_PROVIDER=sqlite) needs Node 24 - ` +
+        "the bundled native module targets the Node 24 ABI. Everything else works " +
+        "(node:sqlite may print a one-time ExperimentalWarning); use Node 24 LTS for full functionality.",
+    };
+  }
+  return { action: "ok", message: null };
+}
+
+/**
  * Parse launcher CLI arguments. Returns { help, port, host, archive,
  * verifyCache }; port/host stay null when not given (the server then falls
  * back to $PORT / 3000 and the launcher's loopback default). Throws

--- a/bin/studio.js
+++ b/bin/studio.js
@@ -208,6 +208,8 @@ async function preparePayload(cacheDir, payloadDir) {
         "The corrupted download was deleted - run the command again.",
     );
   }
+  // Log-line contract: "Checksum verified" is asserted verbatim by the
+  // post-release npx-engine-smoke workflow - keep the wording stable.
   console.log("Checksum verified");
   extract(tarballPath, payloadDir);
 }
@@ -227,6 +229,8 @@ function startServer(payloadDir, port, host) {
   if (host !== null) env.HOSTNAME = host;
   if (!env.HOSTNAME) env.HOSTNAME = "127.0.0.1";
   if (!env.NODE_ENV) env.NODE_ENV = "production";
+  // Log-line contract: npx-engine-smoke.yml parses the resolved version from
+  // "Starting LibreDB Studio <version> " - keep the prefix stable.
   console.log(`Starting LibreDB Studio ${pkg.version} on http://${env.HOSTNAME}:${env.PORT || "3000"}`);
   const child = spawn(process.execPath, ["server.js"], { cwd: payloadDir, env, stdio: "inherit" });
   child.on("error", (error) => fail(`Could not start server.js: ${error.message}`));

--- a/bin/studio.js
+++ b/bin/studio.js
@@ -23,6 +23,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import {
   artifactName,
+  assessNodeRuntime,
   LauncherUsageError,
   parseLauncherArgs,
   parseSha256Sums,
@@ -262,6 +263,12 @@ async function main() {
       ].join("\n"),
     );
   }
+
+  // Refuse runtimes the payload cannot run on and surface degraded tiers
+  // up front, before any download happens (see assessNodeRuntime).
+  const runtime = assessNodeRuntime(process.versions.node);
+  if (runtime.action === "fail") fail(runtime.message);
+  if (runtime.action === "warn") console.warn(runtime.message);
 
   const cacheDir = resolveCacheDir(pkg.version, os.homedir());
   const archive = args.archive || process.env.LIBREDB_STUDIO_ARCHIVE || null;

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -348,10 +348,11 @@ release. Right after publishing it:
    retired `macos-13` or paid `-large` labels blindly), `.deb`/`.rpm` uploaded with `.sha256`
    sidecars, `SHA256SUMS` complete, tap push and snap jobs behaving per their secrets.
 2. `npx @libredb/studio@<version>` on a clean machine: download + checksum + first-run banner +
-   login. Then dispatch the `npx Engine Smoke` workflow (`npx-engine-smoke.yml`) with the
-   released version: it runs **bare** `npx @libredb/studio` on Node 20.9/22/24 against the live
-   registry and asserts each tier resolves a runnable release (the #130 regression class -
-   npm's picker avoids engine-incompatible versions for bare specs).
+   login. The `npx Engine Smoke` workflow (`npx-engine-smoke.yml`) runs automatically after a
+   successful NPM Publish: it waits for the registry to serve the released version, then runs
+   **bare** `npx @libredb/studio` on Node 20.9/22/24 and asserts each tier resolves exactly that
+   release (the #130 regression class - npm's picker avoids engine-incompatible versions for
+   bare specs). Check that it went green; dispatch it manually to re-run.
 3. `brew tap libredb/tap && brew install libredb-studio && brew services start libredb-studio`.
 4. Download the `.deb` on Debian/Ubuntu: `dpkg -i`, `systemctl start libredb-studio`, health 200
    on `127.0.0.1:3000`; verify the arm64 package on an arm64 machine (the CI smoke covers amd64

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -169,7 +169,18 @@ chart architecture: [`docs/HELM_CHART.md`](HELM_CHART.md).
 
 ## npx
 
-Requires Node.js 24+ on Linux or macOS (x64 / arm64). The npm package stays a pure library for
+Requires Node.js 20.9+ on Linux or macOS (x64 / arm64); **Node 24 LTS is the recommended,
+fully supported runtime**. The launcher checks the runtime up front and spells out what an
+older Node cannot do (`scripts/engine-smoke.sh` tests every tier in CI):
+
+| Node | Support |
+|---|---|
+| 24+ (recommended) | Everything works |
+| 22.13 - 23.x | Works; server-side SQLite storage (`STORAGE_PROVIDER=sqlite`) needs Node 24 (the bundled better-sqlite3 binding targets the Node 24 ABI) and fails with a clear error. `node:sqlite` may print a one-time ExperimentalWarning. |
+| 20.9 - 22.12 | Works, minus all SQLite features: SQLite database connections need the built-in `node:sqlite` (unflagged from Node 22.13). |
+| < 20.9 | Refused with a clear error (Next.js 16 floor) - bare `npx` may also fall back to an ancient, bin-less package version here; those versions are npm-deprecated with pointers. |
+
+The npm package stays a pure library for
 libredb-platform; the launcher downloads the matching standalone tarball from the GitHub
 release, verifies it against the `SHA256SUMS` release asset, caches it under
 `~/.libredb-studio/<version>/`, and starts `node server.js`:
@@ -337,7 +348,10 @@ release. Right after publishing it:
    retired `macos-13` or paid `-large` labels blindly), `.deb`/`.rpm` uploaded with `.sha256`
    sidecars, `SHA256SUMS` complete, tap push and snap jobs behaving per their secrets.
 2. `npx @libredb/studio@<version>` on a clean machine: download + checksum + first-run banner +
-   login.
+   login. Then dispatch the `npx Engine Smoke` workflow (`npx-engine-smoke.yml`) with the
+   released version: it runs **bare** `npx @libredb/studio` on Node 20.9/22/24 against the live
+   registry and asserts each tier resolves a runnable release (the #130 regression class -
+   npm's picker avoids engine-incompatible versions for bare specs).
 3. `brew tap libredb/tap && brew install libredb-studio && brew services start libredb-studio`.
 4. Download the `.deb` on Debian/Ubuntu: `dpkg -i`, `systemctl start libredb-studio`, health 200
    on `127.0.0.1:3000`; verify the arm64 package on an arm64 machine (the CI smoke covers amd64

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -67,7 +67,7 @@ SQLite driver by runtime:
 | Runtime | Driver | Notes |
 |---------|--------|-------|
 | Bun (`typeof Bun !== "undefined"`) | `bun:sqlite` | Bun built-in |
-| Node | `node:sqlite` (`DatabaseSync`) | Node built-in, stable for the package's Node >= 24 target |
+| Node | `node:sqlite` (`DatabaseSync`) | Node built-in: unflagged from 22.13, stable on the recommended Node 24 LTS |
 
 - **Override:** set `LIBREDB_SQLITE_DRIVER=bun|node` to force a driver (used by the integration
   tests for determinism); any other value falls back to runtime detection.
@@ -371,9 +371,10 @@ not apply to SQLite ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
 
 - **Server-local file only.** No network protocol; a hosted/SaaS user cannot reach a SQLite file on
   their own machine. SQLite-as-target suits self-hosted / local-dev / edge and zero-config trials.
-- **Bun or Node >= 24 runtime required.** The provider needs a built-in SQLite driver
-  (`bun:sqlite` or `node:sqlite`); on a runtime with neither, `connect()` throws a
-  `DatabaseConfigError`. See [Runtime & driver selection](#runtime--driver-selection).
+- **Bun or Node 22.13+ runtime required** (Node 24 LTS recommended). The provider needs a built-in
+  SQLite driver (`bun:sqlite` or `node:sqlite`); on a runtime with neither (e.g. Node < 22.13
+  without the experimental flag), `connect()` throws a `DatabaseConfigError` with guidance.
+  See [Runtime & driver selection](#runtime--driver-selection).
 - **No transactions / cancellation / pooling.** Single embedded handle; the transaction and cancel
   API routes don't apply.
 - **No `EXPLAIN`.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -76,7 +76,7 @@
     "react-dom": "^19"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=20.9.0"
   },
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/scripts/engine-smoke.sh
+++ b/scripts/engine-smoke.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Engine-matrix smoke: boot the standalone payload through the npx launcher
+# (bin/studio.js --archive) on the CURRENT `node` and assert the runtime tier
+# behaves as documented. This is what makes the package.json engines floor
+# (>=20.9.0) a tested claim instead of a hope:
+#
+#   tier legacy20 (Node 20.9 - 22.12): server + login + embedded sample work;
+#     launcher warns that all SQLite features are unavailable; a sqlite
+#     connection fails with the node:sqlite guidance error.
+#   tier node22 (Node 22.13 - 23.x): sqlite connections work (node:sqlite);
+#     launcher warns about server-side SQLite storage; STORAGE_PROVIDER=sqlite
+#     fails with the better-sqlite3 Node-24-ABI guard message.
+#   tier node24 (Node >= 24): no launcher warning; everything works,
+#     including STORAGE_PROVIDER=sqlite.
+#
+# Usage: scripts/engine-smoke.sh <payload-tarball> <legacy20|node22|node24>
+#   PORT (default 3105) and PORT+1 must be free.
+#
+# Used by the engine-smoke job in .github/workflows/ci.yml; runs locally too
+# (e.g. inside `docker run node:20.9` with the repo and tarball mounted).
+# ==============================================================================
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <payload-tarball> <legacy20|node22|node24>" >&2
+  exit 1
+fi
+
+TARBALL=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+TIER=$2
+case "$TIER" in legacy20 | node22 | node24) ;; *)
+  echo "Unknown tier '$TIER' (expected legacy20|node22|node24)" >&2
+  exit 1
+  ;;
+esac
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+PORT=${PORT:-3105}
+STORAGE_PORT=$((PORT + 1))
+BASE="http://127.0.0.1:${PORT}"
+STORAGE_BASE="http://127.0.0.1:${STORAGE_PORT}"
+
+WORK=$(mktemp -d)
+SERVER_PID=""
+STORAGE_SERVER_PID=""
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  [ -n "$STORAGE_SERVER_PID" ] && kill "$STORAGE_SERVER_PID" 2>/dev/null || true
+  wait 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "==> engine-smoke: node $(node --version), tier ${TIER}"
+
+FAILURES=0
+check() { # check <description> <haystack> <needle>
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    echo "PASS: $1"
+  else
+    echo "FAIL: $1 - expected to find '$3' in:" >&2
+    printf '%s\n' "$2" | head -8 >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+check_absent() { # check_absent <description> <haystack> <needle>
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    echo "FAIL: $1 - did not expect '$3' in:" >&2
+    printf '%s\n' "$2" | head -8 >&2
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "PASS: $1"
+  fi
+}
+
+# Isolate the launcher cache and force the zero-config path: HOME points into
+# the temp dir and no auth/storage env leaks in from the CI job environment.
+LAUNCH_ENV=(env -u JWT_SECRET -u ADMIN_PASSWORD -u USER_PASSWORD -u AUTH_BOOTSTRAP -u STORAGE_PROVIDER -u STORAGE_SQLITE_PATH -u HOSTNAME "HOME=$WORK")
+
+start_server() { # start_server <log> <port> [extra env KEY=VALUE...]
+  local log=$1 port=$2
+  shift 2
+  "${LAUNCH_ENV[@]}" "$@" node "$ROOT_DIR/bin/studio.js" --archive "$TARBALL" --port "$port" --host 127.0.0.1 >"$log" 2>&1 &
+}
+
+wait_health() { # wait_health <base-url> <log>
+  for _ in $(seq 1 90); do
+    if curl -sf -o /dev/null "$1/api/db/health"; then return 0; fi
+    sleep 1
+  done
+  echo "FAIL: server on $1 never became healthy; log:" >&2
+  cat "$2" >&2
+  exit 1
+}
+
+login() { # login <base-url> <password> <cookie-jar> -> body
+  curl -s -c "$3" -X POST "$1/api/auth/login" -H "Content-Type: application/json" \
+    -d "{\"email\":\"admin@libredb.org\",\"password\":\"$2\"}"
+}
+
+# ------------------------------------------------------------------------------
+# Server 1: zero-config boot, login, embedded sample, sqlite connection tier.
+# ------------------------------------------------------------------------------
+LOG="$WORK/studio.log"
+start_server "$LOG" "$PORT"
+SERVER_PID=$!
+wait_health "$BASE" "$LOG"
+echo "PASS: health 200 on Node $(node --version)"
+
+PASSWORD=$(sed -n 's/^ Password: //p' "$LOG" | head -1)
+if [ -z "$PASSWORD" ]; then
+  echo "FAIL: no zero-config password banner in the launcher log:" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+LOGIN_BODY=$(login "$BASE" "$PASSWORD" "$WORK/cookies.txt")
+check "zero-config login succeeds" "$LOGIN_BODY" '"success":true'
+
+SAMPLE_BODY=$(curl -s -b "$WORK/cookies.txt" -X POST "$BASE/api/db/query" -H "Content-Type: application/json" \
+  -d '{"connectionId":"seed:libredb-embedded-sample","sql":"prefix users:"}')
+check "embedded sample query returns seeded rows" "$SAMPLE_BODY" "Ada"
+
+SQLITE_BODY=$(curl -s -b "$WORK/cookies.txt" -X POST "$BASE/api/db/query" -H "Content-Type: application/json" \
+  -d "{\"connection\":{\"id\":\"engine-smoke\",\"type\":\"sqlite\",\"name\":\"engine-smoke\",\"database\":\"$WORK/smoke.db\"},\"sql\":\"SELECT 41+1 AS a\"}")
+LAUNCHER_LOG=$(cat "$LOG")
+
+case "$TIER" in
+  legacy20)
+    check "launcher warns that SQLite features are unavailable" "$LAUNCHER_LOG" "SQLite features are unavailable"
+    check "sqlite connection fails with node:sqlite guidance" "$SQLITE_BODY" "node:sqlite"
+    check_absent "sqlite query returns no rows" "$SQLITE_BODY" '"a":42'
+    ;;
+  node22)
+    check "launcher warns about server-side SQLite storage only" "$LAUNCHER_LOG" "server-side SQLite storage"
+    check_absent "launcher does not claim SQLite features are unavailable" "$LAUNCHER_LOG" "SQLite features are unavailable"
+    check "sqlite connection works via node:sqlite" "$SQLITE_BODY" '"a":42'
+    ;;
+  node24)
+    check_absent "launcher prints no runtime warning" "$LAUNCHER_LOG" "SQLite features are unavailable"
+    check_absent "launcher prints no storage warning" "$LAUNCHER_LOG" "server-side SQLite storage"
+    check "sqlite connection works" "$SQLITE_BODY" '"a":42'
+    ;;
+esac
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+SERVER_PID=""
+
+# ------------------------------------------------------------------------------
+# Server 2: STORAGE_PROVIDER=sqlite exercises the bundled better-sqlite3
+# binding (Node 24 ABI) - the guard must translate the ABI mismatch on older
+# runtimes into the actionable message from src/lib/storage/providers/sqlite.ts.
+# ------------------------------------------------------------------------------
+LOG2="$WORK/studio-storage.log"
+start_server "$LOG2" "$STORAGE_PORT" env "STORAGE_PROVIDER=sqlite" "STORAGE_SQLITE_PATH=$WORK/storage.db"
+STORAGE_SERVER_PID=$!
+wait_health "$STORAGE_BASE" "$LOG2"
+
+# --archive re-extracts the payload, so this boot generated fresh credentials.
+PASSWORD2=$(sed -n 's/^ Password: //p' "$LOG2" | head -1)
+login "$STORAGE_BASE" "$PASSWORD2" "$WORK/cookies2.txt" >/dev/null
+STORAGE_BODY=$(curl -s -b "$WORK/cookies2.txt" -X PUT "$STORAGE_BASE/api/storage/connections" \
+  -H "Content-Type: application/json" -d '{"data":[]}')
+
+if [ "$TIER" = "node24" ]; then
+  check "server-side SQLite storage works" "$STORAGE_BODY" '"ok":true'
+else
+  check "storage guard explains the Node 24 ABI requirement" "$STORAGE_BODY" "requires Node.js 24+"
+  check "storage guard suggests alternatives" "$STORAGE_BODY" "STORAGE_PROVIDER=postgres"
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "==> engine-smoke FAILED (${FAILURES} assertion(s)) for tier ${TIER}" >&2
+  exit 1
+fi
+echo "==> engine-smoke OK for tier ${TIER} on node $(node --version)"

--- a/scripts/engine-smoke.sh
+++ b/scripts/engine-smoke.sh
@@ -157,7 +157,11 @@ start_server "$LOG2" "$STORAGE_PORT" env "STORAGE_PROVIDER=sqlite" "STORAGE_SQLI
 STORAGE_SERVER_PID=$!
 wait_health "$STORAGE_BASE" "$LOG2"
 
-# --archive re-extracts the payload, so this boot generated fresh credentials.
+# --archive re-extracts the payload per boot, wiping payload data, so this
+# boot generated FRESH credentials (issue #132 tracks that wipe). If #132
+# changes --archive to preserve payload data, reuse $PASSWORD here instead -
+# the banner parse below would come up empty and abort with a confusing
+# "no zero-config password banner".
 PASSWORD2=$(sed -n 's/^ Password: //p' "$LOG2" | head -1)
 login "$STORAGE_BASE" "$PASSWORD2" "$WORK/cookies2.txt" >/dev/null
 STORAGE_BODY=$(curl -s -b "$WORK/cookies2.txt" -X PUT "$STORAGE_BASE/api/storage/connections" \

--- a/src/lib/db/providers/sql/sqlite-driver.ts
+++ b/src/lib/db/providers/sql/sqlite-driver.ts
@@ -6,10 +6,11 @@
  * (npx / brew / deb installs running `node server.js`):
  *
  * - Bun runtime  -> `bun:sqlite` (Bun built-in)
- * - Node runtime -> `node:sqlite` (Node built-in, stable for the package's
- *   Node >= 24 target; `better-sqlite3` is not used here because Bun refuses
- *   to load it at all and its native binding must match the installing
- *   runtime's ABI, while `node:sqlite` needs no native dependency)
+ * - Node runtime -> `node:sqlite` (Node built-in: unflagged from 22.13,
+ *   stable on the recommended Node 24 LTS; `better-sqlite3` is not used here
+ *   because Bun refuses to load it at all and its native binding must match
+ *   the installing runtime's ABI, while `node:sqlite` needs no native
+ *   dependency)
  *
  * Set LIBREDB_SQLITE_DRIVER=bun|node to force a driver (deterministic tests).
  * Both drivers load lazily via dynamic import, so neither is required unless
@@ -157,7 +158,7 @@ export async function loadSQLiteDriver(): Promise<SQLiteConstructor> {
       `SQLite driver "${name}" is not available in this environment: ` +
         `${error instanceof Error ? error.message : String(error)}. ` +
         'The "bun" driver requires the Bun runtime (bun:sqlite); ' +
-        'the "node" driver requires Node.js with the built-in node:sqlite module (Node >= 24).',
+        'the "node" driver requires Node.js with the built-in node:sqlite module (Node 22.13+; Node 24 LTS recommended).',
       "sqlite",
     );
     driverLoadErrors.set(name, loadError);

--- a/src/lib/storage/providers/sqlite.ts
+++ b/src/lib/storage/providers/sqlite.ts
@@ -18,14 +18,16 @@ let Database: any;
  * (release CI / Docker build). Loading it under an older Node fails with an
  * ABI mismatch that reads like an installation bug - translate it into an
  * actionable message instead.
+ *
+ * Only the NODE_MODULE_VERSION text (emitted by Node's module-register
+ * check) is treated as an ABI mismatch. A bare ERR_DLOPEN_FAILED is NOT
+ * enough: missing shared libraries, a libc mismatch, or a corrupted file
+ * also surface as ERR_DLOPEN_FAILED - on any Node version - and must keep
+ * their original error rather than a misleading "requires Node 24" claim.
  */
 function isNodeAbiMismatch(error: unknown): boolean {
-  const code = (error as { code?: string })?.code;
   const message = error instanceof Error ? error.message : String(error);
-  return (
-    code === "ERR_DLOPEN_FAILED" ||
-    /NODE_MODULE_VERSION|was compiled against a different Node\.js version/i.test(message)
-  );
+  return /NODE_MODULE_VERSION|was compiled against a different Node\.js version/i.test(message);
 }
 
 export class SQLiteStorageProvider implements ServerStorageProvider {

--- a/src/lib/storage/providers/sqlite.ts
+++ b/src/lib/storage/providers/sqlite.ts
@@ -13,6 +13,21 @@ import { DEFAULT_STORAGE_SQLITE_PATH } from "@/lib/data-dir";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let Database: any;
 
+/**
+ * better-sqlite3 ships a native binding compiled against the Node 24 ABI
+ * (release CI / Docker build). Loading it under an older Node fails with an
+ * ABI mismatch that reads like an installation bug - translate it into an
+ * actionable message instead.
+ */
+function isNodeAbiMismatch(error: unknown): boolean {
+  const code = (error as { code?: string })?.code;
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    code === "ERR_DLOPEN_FAILED" ||
+    /NODE_MODULE_VERSION|was compiled against a different Node\.js version/i.test(message)
+  );
+}
+
 export class SQLiteStorageProvider implements ServerStorageProvider {
   private db: BetterSqlite3.Database | null = null;
   private dbPath: string;
@@ -54,6 +69,14 @@ export class SQLiteStorageProvider implements ServerStorageProvider {
       `);
     } catch (error) {
       logger.error("SQLite storage initialization failed", error, { provider: "sqlite", path: this.dbPath });
+      if (isNodeAbiMismatch(error)) {
+        throw new Error(
+          `Server-side SQLite storage (STORAGE_PROVIDER=sqlite) requires Node.js 24+: the bundled better-sqlite3 native module targets the Node 24 ABI and cannot load on Node ${process.versions.node}. ` +
+            "Run the server under Node 24 LTS, or use STORAGE_PROVIDER=postgres or STORAGE_PROVIDER=local instead. " +
+            `Underlying error: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
       throw error;
     }
   }

--- a/tests/unit/launcher-utils.test.ts
+++ b/tests/unit/launcher-utils.test.ts
@@ -9,6 +9,7 @@ import * as path from "path";
 import {
   artifactName,
   assertReleaseVersion,
+  assessNodeRuntime,
   LauncherUsageError,
   parseLauncherArgs,
   parseSha256Sums,
@@ -196,5 +197,59 @@ describe("parseLauncherArgs", () => {
   test("rejects unknown arguments", () => {
     expect(() => parseLauncherArgs(["--verbose"])).toThrow(LauncherUsageError);
     expect(() => parseLauncherArgs(["serve"])).toThrow(LauncherUsageError);
+  });
+});
+
+describe("assessNodeRuntime", () => {
+  test.each(["18.19.0", "20.0.0", "20.8.9"])("fails below the 20.9 floor (%s)", (version) => {
+    const result = assessNodeRuntime(version);
+    expect(result.action).toBe("fail");
+    expect(result.message).toContain("requires Node.js 20.9 or newer");
+    expect(result.message).toContain(version);
+    expect(result.message).toContain("docker run");
+  });
+
+  test.each([
+    "20.9.0",
+    "20.19.5",
+    "21.7.3",
+    "22.0.0",
+    "22.5.0",
+    "22.12.0",
+  ])("warns that all SQLite features are unavailable on %s (no unflagged node:sqlite)", (version) => {
+    const result = assessNodeRuntime(version);
+    expect(result.action).toBe("warn");
+    expect(result.message).toContain("SQLite features are unavailable");
+    expect(result.message).toContain("node:sqlite");
+    expect(result.message).toContain("Node 24");
+  });
+
+  test.each([
+    "22.13.0",
+    "22.23.1",
+    "23.4.0",
+  ])("warns only about server-side SQLite storage on %s (node:sqlite present, better-sqlite3 ABI mismatch)", (version) => {
+    const result = assessNodeRuntime(version);
+    expect(result.action).toBe("warn");
+    expect(result.message).toContain("STORAGE_PROVIDER=sqlite");
+    expect(result.message).toContain("Node 24 ABI");
+    expect(result.message).not.toContain("SQLite features are unavailable");
+  });
+
+  test.each(["24.0.0", "24.14.0", "25.1.0", "26.0.0"])("is silent on the fully supported %s", (version) => {
+    const result = assessNodeRuntime(version);
+    expect(result.action).toBe("ok");
+    expect(result.message).toBeNull();
+  });
+
+  test("handles prerelease-style version strings by their numeric prefix", () => {
+    expect(assessNodeRuntime("24.0.0-nightly202512").action).toBe("ok");
+    expect(assessNodeRuntime("20.8.0-rc.1").action).toBe("fail");
+  });
+
+  test("fails loudly on an unparsable version string", () => {
+    const result = assessNodeRuntime("weird");
+    expect(result.action).toBe("fail");
+    expect(result.message).toContain("could not parse");
   });
 });

--- a/tests/unit/launcher-utils.test.ts
+++ b/tests/unit/launcher-utils.test.ts
@@ -252,4 +252,21 @@ describe("assessNodeRuntime", () => {
     expect(result.action).toBe("fail");
     expect(result.message).toContain("could not parse");
   });
+
+  test("fails closed on two-component version strings (process.versions.node is always three)", () => {
+    expect(assessNodeRuntime("22.13").action).toBe("fail");
+  });
+
+  test("fail boundary matches the package.json engines floor (single source of truth)", () => {
+    // MINIMUM_NODE in launcher-utils.mjs and engines.node in package.json
+    // state the same floor in two places; this pins them together so bumping
+    // one without the other fails a test instead of shipping a drift.
+    const pkg = JSON.parse(fs.readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
+    const match = /^>=(\d+)\.(\d+)\.(\d+)$/.exec(pkg.engines.node);
+    expect(match).not.toBeNull();
+    const [major, minor, patch] = [Number(match![1]), Number(match![2]), Number(match![3])];
+    expect(assessNodeRuntime(`${major}.${minor}.${patch}`).action).not.toBe("fail");
+    const justBelow = minor > 0 ? `${major}.${minor - 1}.999` : `${major - 1}.999.999`;
+    expect(assessNodeRuntime(justBelow).action).toBe("fail");
+  });
 });

--- a/tests/unit/lib/storage/providers/sqlite.test.ts
+++ b/tests/unit/lib/storage/providers/sqlite.test.ts
@@ -267,12 +267,22 @@ describe("SQLiteStorageProvider", () => {
       );
     });
 
-    test("translates ERR_DLOPEN_FAILED by error code even without the ABI text", async () => {
-      const dlopenError = new Error("could not load the native binding") as Error & { code?: string };
+    test("does NOT claim an ABI mismatch for non-ABI dlopen failures (libc mismatch, missing libs)", async () => {
+      // Realistic loader text for a glibc/musl mismatch: ERR_DLOPEN_FAILED and
+      // the better_sqlite3.node path, but no NODE_MODULE_VERSION - the original
+      // error must pass through untouched instead of a misleading Node-24 claim.
+      const dlopenError = new Error(
+        "libstdc++.so.6: cannot open shared object file: No such file or directory (required by /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node)",
+      ) as Error & { code?: string };
       dlopenError.code = "ERR_DLOPEN_FAILED";
       constructorError = dlopenError;
       const freshProvider = new SQLiteStorageProvider(":memory:");
-      await expect(freshProvider.initialize()).rejects.toThrow(/requires Node\.js 24\+/);
+      const error = await freshProvider.initialize().then(
+        () => null,
+        (e: unknown) => e as Error,
+      );
+      expect(error).toBe(dlopenError);
+      expect(error?.message).not.toContain("requires Node.js 24+");
     });
 
     test("keeps the friendly error's cause chained to the original", async () => {

--- a/tests/unit/lib/storage/providers/sqlite.test.ts
+++ b/tests/unit/lib/storage/providers/sqlite.test.ts
@@ -21,8 +21,15 @@ const mockDbInstance = {
   transaction: mock((fn: () => void) => fn),
 };
 
+// When set, the mocked better-sqlite3 constructor throws this error - used to
+// exercise the Node-ABI-mismatch guard in initialize().
+let constructorError: Error | null = null;
+
 mock.module("better-sqlite3", () => ({
-  default: mock(() => mockDbInstance),
+  default: mock(() => {
+    if (constructorError) throw constructorError;
+    return mockDbInstance;
+  }),
 }));
 
 // Mock fs and path for directory creation
@@ -243,5 +250,46 @@ describe("SQLiteStorageProvider", () => {
   test("ensureDb throws when not initialized", async () => {
     const freshProvider = new SQLiteStorageProvider(":memory:");
     await expect(freshProvider.getAllData("test@test.com")).rejects.toThrow("not initialized");
+  });
+
+  describe("Node ABI mismatch guard", () => {
+    afterEach(() => {
+      constructorError = null;
+    });
+
+    test("translates a NODE_MODULE_VERSION mismatch into an actionable message", async () => {
+      constructorError = new Error(
+        "The module 'better_sqlite3.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 137. This version of Node.js requires NODE_MODULE_VERSION 127.",
+      );
+      const freshProvider = new SQLiteStorageProvider(":memory:");
+      await expect(freshProvider.initialize()).rejects.toThrow(
+        /requires Node\.js 24\+[\s\S]*STORAGE_PROVIDER=postgres/,
+      );
+    });
+
+    test("translates ERR_DLOPEN_FAILED by error code even without the ABI text", async () => {
+      const dlopenError = new Error("could not load the native binding") as Error & { code?: string };
+      dlopenError.code = "ERR_DLOPEN_FAILED";
+      constructorError = dlopenError;
+      const freshProvider = new SQLiteStorageProvider(":memory:");
+      await expect(freshProvider.initialize()).rejects.toThrow(/requires Node\.js 24\+/);
+    });
+
+    test("keeps the friendly error's cause chained to the original", async () => {
+      constructorError = new Error("was compiled against a different Node.js version using NODE_MODULE_VERSION 137");
+      const freshProvider = new SQLiteStorageProvider(":memory:");
+      const error = await freshProvider.initialize().then(
+        () => null,
+        (e: unknown) => e as Error,
+      );
+      expect(error).not.toBeNull();
+      expect(error?.cause).toBe(constructorError);
+    });
+
+    test("rethrows unrelated initialization errors untouched", async () => {
+      constructorError = new Error("disk I/O error");
+      const freshProvider = new SQLiteStorageProvider(":memory:");
+      await expect(freshProvider.initialize()).rejects.toThrow("disk I/O error");
+    });
   });
 });


### PR DESCRIPTION
## Problem

npm's version picker avoids engine-incompatible versions for **bare** specs. With `engines.node >=24.0.0`, every Node 20/22 user running bare `npx @libredb/studio` silently resolves the ancient bin-less 0.9.13 and dies with "could not determine executable to run" - the #130 failure class, still live for the pre-24 population (Node 22 is maintenance LTS until April 2027). npm-deprecating the old versions helped `npm install` users but npm 10's npx flow does not surface deprecation messages (verified empirically).

## Approach: support the honest floor instead of excluding it

`engines.node` `>=24.0.0` -> `>=20.9.0` (Next.js 16's own floor) + version bump to 0.9.44, backed by three guards so the widened floor is a **tested claim**, not a hope:

1. **Launcher preflight** (`assessNodeRuntime`, pure + unit-tested): refuses `< 20.9` with clear guidance before any download; warns `20.9-22.12` that all SQLite features are unavailable (no unflagged `node:sqlite`); warns `22.13-23.x` that server-side SQLite storage needs Node 24; silent on 24+.
2. **Storage ABI guard**: the bundled better-sqlite3 binding targets the Node 24 ABI; `STORAGE_PROVIDER=sqlite` on an older Node now fails with an actionable message (Node 24 requirement + `STORAGE_PROVIDER=postgres`/`local` alternatives, original error chained as `cause`) instead of a raw `NODE_MODULE_VERSION` dump.
3. **Engine-matrix CI** (`scripts/engine-smoke.sh`): builds the standalone payload once, then boots it through the npx launcher on Node **20.9 / 22 / 24** and asserts each tier's documented behaviour - health, zero-config login, embedded sample query, `node:sqlite` availability, preflight warning text, and the ABI guard.

Plus `npx-engine-smoke.yml` (workflow_dispatch): post-release **bare**-npx check against the live registry on all three tiers (wired into the DISTRIBUTION.md runbook), docs support matrix, and the sqlite provider doc/message sync (node:sqlite is unflagged from 22.13, not only 24).

Node 24 users see zero behaviour change (preflight is silent, guard never fires, bundled runtimes untouched); the library consumer only gets a relaxed range.

## Verification

- Local gates: format / lint / typecheck / test (0 fail; +11 new tests) / build / build:lib / attw / knip - all green.
- Local engine matrix with the exact CI script in containers:
  - `node:20.9` (v20.9.0, tier legacy20): 8/8 PASS - boots, login, sample query; sqlite connection fails with node:sqlite guidance; ABI guard message on storage.
  - `node:22` (v22.23.1, tier node22): 8/8 PASS - sqlite connections work via node:sqlite; storage guard fires with the Node 24 message.
  - `node:24` (v24.18.0, tier node24): 7/7 PASS - no warnings, everything works including `STORAGE_PROVIDER=sqlite`.
  - `node:18`: launcher refuses cleanly ("requires Node.js 20.9 or newer", exit 1) before any download.

Context: #130, follow-up to the 0.9.43 channel-validation run on epic #108.

## Related issues (none closed by this PR)

- #130 (closed by 0.9.43) - this PR closes the same failure class for the Node 20/22 population that engines >=24 left behind.
- #132 - not fixed here; the engine-smoke script leans on the same payload re-extraction behaviour (`--archive` re-extracts per boot, hence fresh credentials per server) and documents it inline. The wipe-on-reextract defect remains open.
- #127 - the smoke creates sqlite connections via the API because the connection form does not offer sqlite yet; once #127 lands, pre-24 UI users will see exactly the driver guidance this PR improves (node:sqlite from 22.13, Node 24 recommended).
- #124 - the new engine-payload CI job builds the standalone payload on every PR; trimming the payload will make that job (and the matrix legs) proportionally faster.
