### PR TITLE
docs(distribution): brew trust needs Homebrew 6+ - note the brew update fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
   | **Docker** | `docker run -d -p 3000:3000 ghcr.io/libredb/libredb-studio:latest` | Zero-config: the admin password is printed to the log on first run |
   | **Helm (Kubernetes)** | `helm install libredb oci://ghcr.io/libredb/charts/libredb-studio` | Requires `secrets.jwtSecret` / `secrets.adminPassword` (strict mode by default) |
   | **npx** | `npx @libredb/studio` | Linux/macOS, Node 20.9+ (Node 24 LTS recommended); downloads the release server tarball |
-  | **Homebrew** | `brew trust libredb/tap && brew install libredb/tap/libredb-studio` | `brew trust` is required once for third-party taps |
+  | **Homebrew** | `brew trust libredb/tap && brew install libredb/tap/libredb-studio` | `brew trust` is required once (Homebrew 6+; run `brew update` if unknown) |
   | **deb / rpm** | `sudo dpkg -i libredb-studio_<version>_amd64.deb` | Attached to each GitHub release; systemd service included |
   | **Snap** | `sudo snap install libredb-studio` | From the next release, once Snap Store publishing goes live |
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -219,7 +219,10 @@ The formula tracks the latest release (it is rendered and pushed to
 [`libredb/homebrew-tap`](https://github.com/libredb/homebrew-tap) by release CI):
 
 ```bash
-# One-time: Homebrew's untrusted-tap policy requires trusting third-party taps
+# One-time: Homebrew's untrusted-tap policy requires trusting third-party
+# taps. `brew trust` needs Homebrew 6+ - if it prints "Unknown command",
+# run `brew update` first (pre-6 Homebrew installs the tap without a trust
+# step, but the command below would stop the chain).
 brew trust libredb/tap
 
 brew install libredb/tap/libredb-studio


### PR DESCRIPTION
On pre-6 Homebrew (homebrew/brew image at 4.6.20), `brew trust` is an unknown command, so the documented `brew trust libredb/tap && brew install ...` chain short-circuited before installing - even though pre-trust-policy brew installs the tap formula without any trust step. After `brew update` (Homebrew 6.0.6) the flow works as written. Found in the 0.9.44 local channel validation (evidence on #144).

Docs-only: README install row + DISTRIBUTION.md Homebrew snippet now note the Homebrew 6+ requirement and the `brew update` fallback.

Fixes #144