### PR TITLE
Fix silent helm-release failure: add concurrency guard and asset verification

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -100,9 +100,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Read the chart version robustly: split on the first colon and strip
-          # surrounding whitespace and quotes, so a quoted or padded value still parses.
-          version=$(awk -F':' '/^version:/ { gsub(/[[:space:]"'\'']/, "", $2); print $2; exit }' charts/libredb-studio/Chart.yaml)
+          # Read the chart version robustly: take the value after "version:",
+          # then strip whitespace and surrounding quotes. The tr set is in double
+          # quotes so the single quote inside it needs no awkward escaping.
+          version=$(awk -F': *' '/^version:/{print $2; exit}' charts/libredb-studio/Chart.yaml | tr -d " \t\r\"'")
+          if [ -z "${version}" ]; then
+            echo "::error::could not extract chart version from charts/libredb-studio/Chart.yaml"
+            exit 1
+          fi
           tag="libredb-studio-${version}"
           echo "Verifying GitHub Release asset for tag: ${tag}"
           # The Release/asset can lag behind chart-releaser via the API (eventual

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,6 +7,13 @@ on:
       - "charts/**"
   workflow_dispatch:
 
+# Prevent overlapping runs from racing on the shared gh-pages index/release
+# state. See #146: back-to-back pushes to charts/** triggered overlapping
+# runs, and chart-releaser silently produced a release with a missing asset.
+concurrency:
+  group: helm-release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   packages: write
@@ -87,6 +94,21 @@ jobs:
           mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Verify chart release asset was published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version=$(grep '^version:' charts/libredb-studio/Chart.yaml | awk '{print $2}')
+          tag="libredb-studio-${version}"
+          echo "Verifying GitHub Release for tag: ${tag}"
+          asset_count=$(gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets | length' 2>/dev/null || echo "0")
+          if [ "${asset_count}" -lt 1 ]; then
+            echo "::error::chart-releaser did not publish a release asset for '${tag}'. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
+            exit 1
+          fi
+          echo "OK: ${tag} has ${asset_count} asset(s)."
 
   release-oci:
     needs: lint-test

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,9 +7,12 @@ on:
       - "charts/**"
   workflow_dispatch:
 
-# Prevent overlapping runs from racing on the shared gh-pages index/release
-# state. See #146: back-to-back pushes to charts/** triggered overlapping
-# runs, and chart-releaser silently produced a release with a missing asset.
+# Serialize helm-release runs: overlapping runs would race on the shared
+# gh-pages index/release state, so queue them instead. Defense-in-depth -
+# the #146 incident itself turned out to be a post-publish release deletion
+# (the run created the release and asset successfully; the runs were hours
+# apart), not a workflow race, but rapid successive charts/** pushes should
+# still never be able to overlap here.
 concurrency:
   group: helm-release
   cancel-in-progress: false

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -100,15 +100,25 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          version=$(grep '^version:' charts/libredb-studio/Chart.yaml | awk '{print $2}')
+          # Read the chart version robustly: split on the first colon and strip
+          # surrounding whitespace and quotes, so a quoted or padded value still parses.
+          version=$(awk -F':' '/^version:/ { gsub(/[[:space:]"'\'']/, "", $2); print $2; exit }' charts/libredb-studio/Chart.yaml)
           tag="libredb-studio-${version}"
-          echo "Verifying GitHub Release for tag: ${tag}"
-          asset_count=$(gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets | length' 2>/dev/null || echo "0")
-          if [ "${asset_count}" -lt 1 ]; then
-            echo "::error::chart-releaser did not publish a release asset for '${tag}'. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
-            exit 1
-          fi
-          echo "OK: ${tag} has ${asset_count} asset(s)."
+          echo "Verifying GitHub Release asset for tag: ${tag}"
+          # The Release/asset can lag behind chart-releaser via the API (eventual
+          # consistency), so retry with backoff before treating it as a real failure.
+          asset_count=0
+          for attempt in 1 2 3 4 5; do
+            asset_count=$(gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets | length' 2>/dev/null || echo "0")
+            if [ "${asset_count}" -ge 1 ]; then
+              echo "OK: ${tag} has ${asset_count} asset(s) (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: no asset visible yet for ${tag}, retrying..."
+            sleep $((attempt * 10))
+          done
+          echo "::error::chart-releaser did not publish a release asset for '${tag}' after retries. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
+          exit 1
 
   release-oci:
     needs: lint-test

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -117,7 +117,11 @@ jobs:
           # The Release/asset can also lag behind chart-releaser via the API
           # (eventual consistency), so retry with backoff before failing.
           for attempt in 1 2 3 4 5; do
-            asset_names=$(gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets[].name' 2>/dev/null || echo "")
+            # Do not suppress stderr: if gh fails for a real reason (permissions,
+            # rate limiting) we want it visible in the log. The `|| echo ""`
+            # keeps the step from exiting under `set -e` when the tag/release is
+            # simply not visible yet, so the retry loop can proceed.
+            asset_names=$(gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets[].name' || echo "")
             if printf '%s\n' "${asset_names}" | grep -qx "${expected_asset}"; then
               echo "OK: ${tag} has asset ${expected_asset} (attempt ${attempt})."
               exit 0

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -104,7 +104,10 @@ jobs:
           # itself, instead of parsing the version out of Chart.yaml. `helm
           # package` names the file <chart-name>-<version>.tgz from the chart
           # metadata, so there is no version-string parsing to get wrong.
+          # Use a clean directory so a leftover .tgz can never make the glob
+          # below match more than one file.
           pkg_dir="${RUNNER_TEMP}/verify-pkg"
+          rm -rf "${pkg_dir}"
           mkdir -p "${pkg_dir}"
           helm package charts/libredb-studio -d "${pkg_dir}" >/dev/null
           asset=$(basename "${pkg_dir}"/*.tgz)
@@ -115,16 +118,20 @@ jobs:
           # missing is exactly the failure mode in #146. The Release/asset can
           # also lag behind chart-releaser via the API (eventual consistency),
           # so retry with backoff. stderr is left visible so a genuine failure
-          # (permissions, rate limiting) surfaces in the log.
-          for attempt in 1 2 3 4 5; do
-            if gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets[].name' | grep -qx "${asset}"; then
+          # (permissions, rate limiting) surfaces in the log. grep -F matches the
+          # asset name literally so the dots are not treated as regex wildcards.
+          attempts=5
+          for ((attempt = 1; attempt <= attempts; attempt++)); do
+            if gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets[].name' | grep -Fqx "${asset}"; then
               echo "OK: ${tag} has asset ${asset} (attempt ${attempt})."
               exit 0
             fi
-            echo "Attempt ${attempt}: ${asset} not visible yet on ${tag}, retrying..."
-            sleep $((attempt * 10))
+            if ((attempt < attempts)); then
+              echo "Attempt ${attempt}/${attempts}: ${asset} not visible yet on ${tag}, retrying..."
+              sleep $((attempt * 10))
+            fi
           done
-          echo "::error::chart-releaser did not publish '${asset}' on release '${tag}' after retries. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
+          echo "::error::chart-releaser did not publish '${asset}' on release '${tag}' after ${attempts} attempts. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
           exit 1
 
   release-oci:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -100,36 +100,30 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Read the chart version robustly: take the value after "version:",
-          # then strip whitespace and surrounding quotes. The tr set is in double
-          # quotes so the single quote inside it needs no awkward escaping.
-          version=$(awk -F': *' '/^version:/{print $2; exit}' charts/libredb-studio/Chart.yaml | tr -d " \t\r\"'")
-          if [ -z "${version}" ]; then
-            echo "::error::could not extract chart version from charts/libredb-studio/Chart.yaml"
-            exit 1
-          fi
-          tag="libredb-studio-${version}"
-          expected_asset="libredb-studio-${version}.tgz"
-          echo "Verifying GitHub Release asset '${expected_asset}' for tag: ${tag}"
+          # Derive the exact release tag and asset name from the packaged chart
+          # itself, instead of parsing the version out of Chart.yaml. `helm
+          # package` names the file <chart-name>-<version>.tgz from the chart
+          # metadata, so there is no version-string parsing to get wrong.
+          pkg_dir="${RUNNER_TEMP}/verify-pkg"
+          helm package charts/libredb-studio -d "${pkg_dir}" >/dev/null
+          asset=$(basename "${pkg_dir}"/*.tgz)
+          tag="${asset%.tgz}"
+          echo "Verifying release '${tag}' has asset '${asset}'"
           # Check for the specific chart package (.tgz), not just any asset: a
-          # release could carry an unrelated asset while the chart package is
-          # missing, which is exactly the failure mode in #146.
-          # The Release/asset can also lag behind chart-releaser via the API
-          # (eventual consistency), so retry with backoff before failing.
+          # release carrying some unrelated asset while the chart package is
+          # missing is exactly the failure mode in #146. The Release/asset can
+          # also lag behind chart-releaser via the API (eventual consistency),
+          # so retry with backoff. stderr is left visible so a genuine failure
+          # (permissions, rate limiting) surfaces in the log.
           for attempt in 1 2 3 4 5; do
-            # Do not suppress stderr: if gh fails for a real reason (permissions,
-            # rate limiting) we want it visible in the log. The `|| echo ""`
-            # keeps the step from exiting under `set -e` when the tag/release is
-            # simply not visible yet, so the retry loop can proceed.
-            asset_names=$(gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets[].name' || echo "")
-            if printf '%s\n' "${asset_names}" | grep -qx "${expected_asset}"; then
-              echo "OK: ${tag} has asset ${expected_asset} (attempt ${attempt})."
+            if gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets[].name' | grep -qx "${asset}"; then
+              echo "OK: ${tag} has asset ${asset} (attempt ${attempt})."
               exit 0
             fi
-            echo "Attempt ${attempt}: ${expected_asset} not visible yet for ${tag}, retrying..."
+            echo "Attempt ${attempt}: ${asset} not visible yet on ${tag}, retrying..."
             sleep $((attempt * 10))
           done
-          echo "::error::chart-releaser did not publish '${expected_asset}' on release '${tag}' after retries. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
+          echo "::error::chart-releaser did not publish '${asset}' on release '${tag}' after retries. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
           exit 1
 
   release-oci:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -105,6 +105,7 @@ jobs:
           # package` names the file <chart-name>-<version>.tgz from the chart
           # metadata, so there is no version-string parsing to get wrong.
           pkg_dir="${RUNNER_TEMP}/verify-pkg"
+          mkdir -p "${pkg_dir}"
           helm package charts/libredb-studio -d "${pkg_dir}" >/dev/null
           asset=$(basename "${pkg_dir}"/*.tgz)
           tag="${asset%.tgz}"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -109,20 +109,23 @@ jobs:
             exit 1
           fi
           tag="libredb-studio-${version}"
-          echo "Verifying GitHub Release asset for tag: ${tag}"
-          # The Release/asset can lag behind chart-releaser via the API (eventual
-          # consistency), so retry with backoff before treating it as a real failure.
-          asset_count=0
+          expected_asset="libredb-studio-${version}.tgz"
+          echo "Verifying GitHub Release asset '${expected_asset}' for tag: ${tag}"
+          # Check for the specific chart package (.tgz), not just any asset: a
+          # release could carry an unrelated asset while the chart package is
+          # missing, which is exactly the failure mode in #146.
+          # The Release/asset can also lag behind chart-releaser via the API
+          # (eventual consistency), so retry with backoff before failing.
           for attempt in 1 2 3 4 5; do
-            asset_count=$(gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets | length' 2>/dev/null || echo "0")
-            if [ "${asset_count}" -ge 1 ]; then
-              echo "OK: ${tag} has ${asset_count} asset(s) (attempt ${attempt})."
+            asset_names=$(gh api "repos/${{ github.repository }}/releases/tags/${tag}" --jq '.assets[].name' 2>/dev/null || echo "")
+            if printf '%s\n' "${asset_names}" | grep -qx "${expected_asset}"; then
+              echo "OK: ${tag} has asset ${expected_asset} (attempt ${attempt})."
               exit 0
             fi
-            echo "Attempt ${attempt}: no asset visible yet for ${tag}, retrying..."
+            echo "Attempt ${attempt}: ${expected_asset} not visible yet for ${tag}, retrying..."
             sleep $((attempt * 10))
           done
-          echo "::error::chart-releaser did not publish a release asset for '${tag}' after retries. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
+          echo "::error::chart-releaser did not publish '${expected_asset}' on release '${tag}' after retries. The gh-pages index may now point to a broken download URL. See #146 for the same failure mode."
           exit 1
 
   release-oci:


### PR DESCRIPTION
Fixes #146

## Problem

Chart version `0.1.3` has a git tag and an `index.yaml` entry, but no
GitHub Release / `.tgz` asset was ever created for it. The workflow run
that produced this reported `success` on every job, so the failure was
silent. See #146 for the full investigation (evidence, log excerpts,
timing of the three back-to-back releases that likely raced each other).

## Changes

1. Add a top-level `concurrency` group (`helm-release`) so that
   overlapping `helm-release.yml` runs triggered by rapid successive
   pushes to `charts/**` cannot race on the shared `gh-pages`
   index/release state.
2. Add a verification step right after `chart-releaser-action` that
   checks the GitHub Release for the just-packaged chart version actually
   has at least one asset attached, and fails the job loudly if not,
   instead of silently continuing to update `index.yaml` with a broken
   download URL.

## Scope

This PR only hardens the workflow so the silent failure cannot happen
again. It intentionally does not touch the existing broken `0.1.3`.

We are not patching `0.1.3` in place -- the plan is to fix forward: once
this workflow fix is merged, bump the chart version and cut a new release
(e.g. `0.1.4`) so `index.yaml` points to a valid, freshly published
version, and clean up the stale `0.1.3` entry/tag. That release step is
separate from this workflow change.