### PR TITLE
feat(ci): daily Helm index-vs-assets consistency check

### DIFF
--- a/.github/workflows/helm-index-check.yml
+++ b/.github/workflows/helm-index-check.yml
@@ -1,0 +1,115 @@
+name: Helm Index Consistency Check
+
+# Daily consistency check between the published Helm repo index and the
+# release assets it points to (follow-up to #146/#148). The publish-time
+# verification in helm-release.yml only catches failures during the release
+# run; the #146 incident was a post-publish release deletion, and the 0.1.3
+# restore additionally showed that a silently failed Pages deployment can
+# leave the live index stale (wrong digest) while the gh-pages source is
+# correct. Checking the *served* index against the *actual* assets catches
+# every variant of that drift within a day.
+on:
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: helm-index-check
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      INDEX_URL: https://libredb.org/libredb-studio/index.yaml
+    steps:
+      - name: Check every index entry against its release asset
+        run: |
+          set -euo pipefail
+          # Cache-bust with the run id: the index is served through the GitHub
+          # Pages CDN, and a cached response is exactly the kind of staleness
+          # this check exists to detect at the origin, not to be fooled by.
+          curl -fsSL --retry 3 "${INDEX_URL}?cb=${GITHUB_RUN_ID}" -o index.yaml
+
+          failures=0
+          checked=0
+          report="${RUNNER_TEMP}/report.md"
+          : > "${report}"
+          # One line per chart version: name, version, digest, download URL.
+          # Download the real asset and compare sha256 with the index digest -
+          # a HEAD 200 alone would have missed the stale-digest half of the
+          # 0.1.3 incident.
+          while IFS=$'\t' read -r name version digest url; do
+            checked=$((checked + 1))
+            entry="${name}-${version}"
+            # The index is our own content, but its values still land in a
+            # filesystem path - keep the filename to a safe character set.
+            asset="${RUNNER_TEMP}/$(printf '%s' "${entry}" | tr -c 'A-Za-z0-9._-' '_').tgz"
+            if ! curl -fsSL --retry 3 -o "${asset}" "${url}"; then
+              echo "::error::${entry}: download failed: ${url}"
+              echo "- \`${entry}\`: download failed: ${url}" >> "${report}"
+              failures=$((failures + 1))
+              continue
+            fi
+            actual=$(sha256sum "${asset}" | cut -d' ' -f1)
+            if [ "${actual}" != "${digest}" ]; then
+              echo "::error::${entry}: digest mismatch (index ${digest}, asset ${actual})"
+              echo "- \`${entry}\`: digest mismatch (index \`${digest}\`, asset \`${actual}\`)" >> "${report}"
+              failures=$((failures + 1))
+            else
+              echo "OK: ${entry} (${digest})"
+            fi
+          done < <(yq -r '.entries[][] | [.name, .version, .digest, .urls[0]] | @tsv' index.yaml)
+
+          # An empty or unparseable index must fail too: zero entries means
+          # every helm install is already broken, not that there is no work.
+          if [ "${checked}" -eq 0 ]; then
+            echo "::error::no entries parsed from ${INDEX_URL} - index is empty or malformed"
+            echo "- no entries parsed from ${INDEX_URL} - index is empty or malformed" >> "${report}"
+            failures=$((failures + 1))
+          fi
+
+          echo "Checked ${checked} entries, ${failures} failures."
+          {
+            echo "## Helm index consistency check"
+            echo ""
+            echo "Checked ${checked} entries, ${failures} failures."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          if [ "${failures}" -gt 0 ]; then
+            cat "${report}" >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+
+      - name: Open or update tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          title="Helm index consistency check failed"
+          body="${RUNNER_TEMP}/issue-body.md"
+          {
+            echo "The daily index-vs-assets check (#148) found the published Helm repo index out of sync with the release assets it points to. \`helm install\` may be failing for affected versions right now."
+            echo ""
+            if [ -s "${RUNNER_TEMP}/report.md" ]; then
+              cat "${RUNNER_TEMP}/report.md"
+            else
+              echo "- the check failed before producing a report (fetch or parse error); see the run log"
+            fi
+            echo ""
+            echo "Run: ${GITHUB_SERVER_URL}/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}"
+          } > "${body}"
+          # One open tracking issue at a time: comment on it while the
+          # breakage persists instead of opening a duplicate per day.
+          existing=$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file "${body}"
+            echo "Commented on existing issue #${existing}."
+          else
+            gh issue create --title "${title}" --body-file "${body}"
+          fi


### PR DESCRIPTION
Closes #148.

## Problem

The publish-time verification added in #147 only catches failures during the release run itself. Two failure modes remain invisible to it:

- post-publish release deletion (the actual #146 incident) - every helm install of the affected version fails until someone notices manually
- a silently failed pages-build-deployment (seen during the 0.1.3 restore) - the gh-pages source is correct, but the served index.yaml keeps stale content such as a wrong digest

## Solution

A daily scheduled workflow (plus workflow_dispatch) that checks the published state end to end, from the consumer's point of view:

1. Fetches the live https://libredb.org/libredb-studio/index.yaml (cache-busted, so CDN staleness at the origin is detected rather than masked)
2. For every index entry, downloads the referenced chart asset and verifies it is reachable AND its sha256 matches the digest recorded in the index (a HEAD 200 alone would have missed the stale-digest half of the 0.1.3 incident)
3. Treats an empty or unparseable index as a failure - zero entries means every helm install is already broken
4. On failure, opens a tracking issue (or comments on the existing open one, so persistent breakage does not spawn one issue per day) and fails the run

## Verification

- Green path: check logic run locally against the live index - all 4 entries (0.1.0-0.1.3) pass
- Red paths tested locally: digest mismatch, deleted/renamed asset (404), and empty index all detected with exit 1
- The yq extraction expression verified against both yq dialects (mikefarah v4.53.3, as preinstalled on ubuntu-latest runners, and python-yq)
- actionlint (with shellcheck) passes; triggers are schedule/dispatch only, no event-controlled input reaches run blocks

After merge I will workflow_dispatch it once to confirm a green end-to-end run.