### PR TITLE
feat(chart): CI-enforced chart/app version sync guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Chart version sync guard (issue #138)
+        # Runs inside the required "Lint, Typecheck and Build" check on
+        # purpose: a separate job would be advisory-only without a branch
+        # protection change. actions/checkout is shallow and single-ref, so
+        # fetch main explicitly for the base comparison (appVersion changed
+        # => chart version must change too and must not be a released tag).
+        run: |
+          git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+          bun run chart:check
+
       - name: Check formatting (Biome)
         run: bun run format
 
@@ -217,21 +227,6 @@ jobs:
 
       - name: Lint Helm chart
         run: helm lint charts/libredb-studio --strict
-
-      - name: Verify appVersion is valid
-        run: |
-          APP_VERSION=$(node -e "console.log(require('./package.json').version)")
-          CHART_APP_VERSION=$(grep '^appVersion:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
-          echo "package.json=$APP_VERSION, Chart appVersion=$CHART_APP_VERSION"
-          if [ "$(printf '%s\n' "$CHART_APP_VERSION" "$APP_VERSION" | sort -V | head -1)" != "$CHART_APP_VERSION" ]; then
-            echo "ERROR: Chart appVersion ($CHART_APP_VERSION) is ahead of package.json ($APP_VERSION)"
-            exit 1
-          fi
-          if [ "$APP_VERSION" != "$CHART_APP_VERSION" ]; then
-            echo "INFO: Chart appVersion ($CHART_APP_VERSION) is behind package.json ($APP_VERSION). Update Chart.yaml appVersion on next chart release."
-          else
-            echo "OK: versions in sync"
-          fi
 
   sonarcloud:
     name: SonarCloud Analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,13 @@ jobs:
         # protection change. actions/checkout is shallow and single-ref, so
         # fetch main explicitly for the base comparison (appVersion changed
         # => chart version must change too and must not be a released tag).
+        # Strict mode makes unavailable git state a failure in CI rather than
+        # a skipped check.
         run: |
           git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
           bun run chart:check
+        env:
+          CHART_SYNC_STRICT: "1"
 
       - name: Check formatting (Biome)
         run: bun run format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@ Web-based SQL IDE for cloud-native teams: PostgreSQL, MySQL, SQLite, Oracle, SQL
 
 ## Branching & PRs
 
-> **Trunk-based: feature/work branches target `main` directly; releases are git tags.** Branch off `main` for new work and open every PR with base `main` (`gh pr create --base main`). `main` is the single protected integration trunk — PRs are required and the `Lint, Typecheck and Build` check must pass before merge. Cut a release by tagging `main` (`vX.Y.Z`), which triggers the npm publish workflow. There is no `dev` branch and no long-lived `release/*` branches.
+> **Trunk-based: feature/work branches target `main` directly; releases are git tags.** Branch off `main` for new work and open every PR with base `main` (`gh pr create --base main`). `main` is the single protected integration trunk — PRs are required and the `Lint, Typecheck and Build` check must pass before merge. Cut a release by tagging `main` (`vX.Y.Z`), which triggers the npm publish workflow. There is no `dev` branch and no long-lived `release/*` branches. A PR that bumps the
+> `package.json` version must also run `bun run chart:bump` and commit the result — the
+> required CI check enforces `Chart.yaml appVersion` == `package.json` version (#138).
 
 ## GitHub
 

--- a/docs/HELM_CHART.md
+++ b/docs/HELM_CHART.md
@@ -290,4 +290,4 @@ helm install libredb libredb/libredb-studio \
 
 1. **SQLite + Multi-Replica**: SQLite is single-writer. `storageProvider=sqlite` with `replicaCount > 1` will cause write conflicts. Use `postgres` for multi-replica.
 2. **ISR Cache**: Next.js ISR cache is per-pod (emptyDir). Session-based app, so no impact.
-3. **Chart appVersion**: Set manually in `Chart.yaml`; CI fails only if it is *ahead* of `package.json` (being behind is tolerated). It is not auto-bumped.
+3. **Chart appVersion**: Not auto-bumped - a version-bump PR must run `bun run chart:bump`; the CI sync guard blocks the merge until `appVersion` equals `package.json` (see Version Management above).

--- a/docs/HELM_CHART.md
+++ b/docs/HELM_CHART.md
@@ -221,9 +221,33 @@ ArtifactHub auto-scan (~30 min)
 
 ### Version Management
 
-- `Chart.yaml version` (e.g., `0.1.0`): Chart version, bumped for chart-only changes
-- `Chart.yaml appVersion`: The app image version this chart deploys; set manually in `Chart.yaml`
-- CI guard (`ci.yml`, "Verify appVersion is valid"): the build **fails if `appVersion` is _ahead_ of `package.json`**. When `appVersion` is _behind_, CI emits an info notice ("update on next chart release") but does **not** fail — the chart version is bumped independently of the app version.
+- `Chart.yaml version` (e.g., `0.1.4`): the chart's own SemVer. Chart-only fixes bump it
+  alone; `bun run chart:bump` bumps its patch when tracking an app release.
+- `Chart.yaml appVersion`: the app image version this chart deploys. **Always equals
+  `package.json` version — enforced in CI.**
+- Guard: `scripts/sync-chart-version.mjs` runs as `bun run chart:check` inside the required
+  `Lint, Typecheck and Build` check (`ci.yml`), so a PR that bumps `package.json` cannot
+  merge until `bun run chart:bump` is run and committed (issue #138). The guard also fails
+  when `appVersion` changes without a chart `version` bump (chart-releaser's
+  `skip_existing` would silently publish nothing) or when the new chart version was
+  already released, and it keeps the `artifacthub.io/images` tag and the README
+  `--version` example in step. The `artifacthub.io/changes` line is written by
+  `chart:bump` but deliberately not checked, so hand-written changelog entries for
+  chart-only releases never trip the guard.
+
+#### Versioning policy: version and appVersion stay independent (researched 2026-07)
+
+Lockstep (`version` == `appVersion`, the cert-manager model) was considered and rejected:
+it only works when chart-only releases never happen. This chart still has an active
+chart-only backlog, and under lockstep each such fix would either wait for the next
+product release or force an artificial one through the full distribution pipeline (npm,
+Docker, brew, deb/rpm, snap) — irreversible now that immutable releases are enabled.
+SemVer prerelease suffixes are not an escape hatch (they sort *below* the version they
+suffix and Helm hides prereleases by default), and kubernetes-sigs/kueue abandoned
+lockstep for the same reasons (kueue#3971). Consumers still see the app version
+everywhere it matters: the `APP VERSION` column in `helm search repo`, ArtifactHub, and
+the `artifacthub.io/images` annotation. Revisit lockstep if the chart reaches 1.0 and
+chart-only churn drops.
 
 ## Deployment Examples
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,9 @@
     "test:coverage:core": "bash tests/run-core.sh --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
     "test:coverage": "rm -rf coverage && bun run test:coverage:core && bun run test:components:coverage && node scripts/merge-lcov.mjs coverage/core/file-*/lcov.info coverage/components/lcov.info coverage/lcov.info",
     "test:coverage-html": "bun run test:coverage && genhtml coverage/lcov.info --output-directory coverage/html && echo '\n Open coverage/html/index.html in your browser'",
-    "knip": "knip"
+    "knip": "knip",
+    "chart:check": "node scripts/sync-chart-version.mjs --check",
+    "chart:bump": "node scripts/sync-chart-version.mjs --write"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/scripts/sync-chart-version.mjs
+++ b/scripts/sync-chart-version.mjs
@@ -11,6 +11,11 @@
  * tested in tests/unit/sync-chart-version.test.ts.
  */
 
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 const CHART_YAML = "charts/libredb-studio/Chart.yaml";
 const CHART_README = "charts/libredb-studio/README.md";
 
@@ -110,4 +115,77 @@ export function applyBump({ pkgVersion, chartYaml, readme }) {
     );
   const newReadme = readme.replace(/--version\s+\S+/, `--version ${newVersion}`);
   return { chartYaml: newChartYaml, readme: newReadme, changed: true, version: newVersion, appVersion: pkgVersion };
+}
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+/** main's Chart.yaml, or null when origin/main is not resolvable (shallow local clone). */
+function readBaseChart(root) {
+  try {
+    return parseChart(git(root, ["show", `origin/main:${CHART_YAML}`]));
+  } catch {
+    return null;
+  }
+}
+
+/** true/false from origin, or null (skip + warn) when the remote is unreachable. */
+function chartTagExistsOnOrigin(root, version) {
+  try {
+    return git(root, ["ls-remote", "--tags", "origin", `refs/tags/libredb-studio-${version}`]) !== "";
+  } catch {
+    console.warn("WARN: could not query origin tags (offline?) - skipping the released-version check");
+    return null;
+  }
+}
+
+function main(argv) {
+  const mode = argv.includes("--write") ? "write" : argv.includes("--check") ? "check" : null;
+  const rootIdx = argv.indexOf("--root");
+  const root = rootIdx === -1 ? process.cwd() : path.resolve(argv[rootIdx + 1]);
+  if (!mode) {
+    console.error("Usage: node scripts/sync-chart-version.mjs --check|--write [--root <dir>]");
+    process.exit(2);
+  }
+
+  const pkgVersion = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
+  const chartPath = path.join(root, CHART_YAML);
+  const readmePath = path.join(root, CHART_README);
+  const chartYaml = fs.readFileSync(chartPath, "utf8");
+  const readme = fs.readFileSync(readmePath, "utf8");
+
+  if (mode === "check") {
+    const { version, appVersion } = parseChart(chartYaml);
+    const baseChart = readBaseChart(root);
+    let chartTagExists = null;
+    if (baseChart && baseChart.appVersion !== appVersion && baseChart.version !== version) {
+      chartTagExists = chartTagExistsOnOrigin(root, version);
+    }
+    const violations = checkSync({ pkgVersion, chartYaml, readme, baseChart, chartTagExists });
+    if (violations.length > 0) {
+      for (const violation of violations) console.error(`ERROR: ${violation}`);
+      console.error("\nFix: run 'bun run chart:bump', review the diff, and commit it in this PR.");
+      process.exit(1);
+    }
+    if (!baseChart) {
+      console.warn("WARN: origin/main not resolvable - base-comparison checks skipped");
+    }
+    console.log(`OK: chart ${version} / appVersion ${appVersion} in sync with package.json ${pkgVersion}`);
+    return;
+  }
+
+  const result = applyBump({ pkgVersion, chartYaml, readme });
+  if (!result.changed) {
+    console.log(`OK: already in sync (chart ${result.version} / appVersion ${result.appVersion}) - nothing to write`);
+    return;
+  }
+  fs.writeFileSync(chartPath, result.chartYaml);
+  fs.writeFileSync(readmePath, result.readme);
+  console.log(`Bumped chart to ${result.version} / appVersion ${result.appVersion} - review the diff and commit.`);
+}
+
+// CLI entry only when executed directly (the unit test imports this module).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2));
 }

--- a/scripts/sync-chart-version.mjs
+++ b/scripts/sync-chart-version.mjs
@@ -51,6 +51,15 @@ export function bumpPatch(version) {
  * Returns violation messages (empty = in sync). baseChart is main's parsed
  * Chart.yaml or null when unavailable; chartTagExists is true/false, or null
  * when origin tags could not be queried (check skipped, CLI prints a warning).
+ *
+ * @param {{
+ *   pkgVersion: string,
+ *   chartYaml: string,
+ *   readme: string,
+ *   baseChart?: { version: string, appVersion: string } | null,
+ *   chartTagExists?: boolean | null,
+ * }} input
+ * @returns {string[]}
  */
 export function checkSync({ pkgVersion, chartYaml, readme, baseChart = null, chartTagExists = null }) {
   const violations = [];

--- a/scripts/sync-chart-version.mjs
+++ b/scripts/sync-chart-version.mjs
@@ -144,6 +144,7 @@ function main(argv) {
   const mode = argv.includes("--write") ? "write" : argv.includes("--check") ? "check" : null;
   const rootIdx = argv.indexOf("--root");
   const root = rootIdx === -1 ? process.cwd() : path.resolve(argv[rootIdx + 1]);
+  const strict = /^(1|true)$/i.test(process.env.CHART_SYNC_STRICT ?? "");
   if (!mode) {
     console.error("Usage: node scripts/sync-chart-version.mjs --check|--write [--root <dir>]");
     process.exit(2);
@@ -158,9 +159,22 @@ function main(argv) {
   if (mode === "check") {
     const { version, appVersion } = parseChart(chartYaml);
     const baseChart = readBaseChart(root);
+    if (!baseChart && strict) {
+      console.error(
+        "ERROR: origin/main not resolvable and CHART_SYNC_STRICT is set - refusing to skip base-comparison checks",
+      );
+      process.exit(1);
+    }
     let chartTagExists = null;
-    if (baseChart && baseChart.appVersion !== appVersion && baseChart.version !== version) {
+    const tagQueryNeeded = Boolean(baseChart && baseChart.appVersion !== appVersion && baseChart.version !== version);
+    if (tagQueryNeeded) {
       chartTagExists = chartTagExistsOnOrigin(root, version);
+      if (chartTagExists === null && strict) {
+        console.error(
+          "ERROR: could not query origin tags and CHART_SYNC_STRICT is set - refusing to skip the released-version check",
+        );
+        process.exit(1);
+      }
     }
     const violations = checkSync({ pkgVersion, chartYaml, readme, baseChart, chartTagExists });
     if (violations.length > 0) {

--- a/scripts/sync-chart-version.mjs
+++ b/scripts/sync-chart-version.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Chart version sync guard (issue #138).
+ *
+ * Enforces the invariant that the Helm chart always deploys the app version
+ * in package.json: appVersion == package.json version, the artifacthub image
+ * tag matches appVersion, and the chart README example matches the chart
+ * version. `--check` (bun run chart:check) validates and is wired into the
+ * required lint-and-build CI job; `--write` (bun run chart:bump) applies the
+ * canonical bump. Both modes share the pure functions below, which are unit
+ * tested in tests/unit/sync-chart-version.test.ts.
+ */
+
+const CHART_YAML = "charts/libredb-studio/Chart.yaml";
+const CHART_README = "charts/libredb-studio/README.md";
+
+export function parseChart(chartYaml) {
+  const version = chartYaml.match(/^version:\s*(\S+)\s*$/m)?.[1];
+  const appVersion = chartYaml.match(/^appVersion:\s*"?([^"\s]+)"?\s*$/m)?.[1];
+  if (!version || !appVersion) {
+    throw new Error(`${CHART_YAML}: could not parse version/appVersion`);
+  }
+  return { version, appVersion };
+}
+
+export function parseImageTag(chartYaml) {
+  const tag = chartYaml.match(/image:\s*ghcr\.io\/libredb\/libredb-studio:(\S+)/)?.[1];
+  if (!tag) {
+    throw new Error(`${CHART_YAML}: could not find the artifacthub.io/images image tag`);
+  }
+  return tag;
+}
+
+export function parseReadmeVersion(readme) {
+  const version = readme.match(/--version\s+(\S+)/)?.[1];
+  if (!version) {
+    throw new Error(`${CHART_README}: could not find a --version example`);
+  }
+  return version;
+}
+
+export function bumpPatch(version) {
+  const m = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) {
+    throw new Error(`cannot patch-bump non-x.y.z chart version '${version}' - bump it by hand`);
+  }
+  return `${m[1]}.${m[2]}.${Number(m[3]) + 1}`;
+}
+
+/**
+ * Returns violation messages (empty = in sync). baseChart is main's parsed
+ * Chart.yaml or null when unavailable; chartTagExists is true/false, or null
+ * when origin tags could not be queried (check skipped, CLI prints a warning).
+ */
+export function checkSync({ pkgVersion, chartYaml, readme, baseChart = null, chartTagExists = null }) {
+  const violations = [];
+  const { version, appVersion } = parseChart(chartYaml);
+  if (appVersion !== pkgVersion) {
+    violations.push(`${CHART_YAML}: appVersion '${appVersion}' does not equal package.json version '${pkgVersion}'`);
+  }
+  const imageTag = parseImageTag(chartYaml);
+  if (imageTag !== appVersion) {
+    violations.push(`${CHART_YAML}: artifacthub.io/images tag '${imageTag}' does not equal appVersion '${appVersion}'`);
+  }
+  const readmeVersion = parseReadmeVersion(readme);
+  if (readmeVersion !== version) {
+    violations.push(`${CHART_README}: --version example '${readmeVersion}' does not equal chart version '${version}'`);
+  }
+  if (baseChart && baseChart.appVersion !== appVersion) {
+    if (baseChart.version === version) {
+      violations.push(
+        `${CHART_YAML}: appVersion changed (${baseChart.appVersion} -> ${appVersion}) but chart version is still ` +
+          `'${version}' - chart-releaser (skip_existing) would silently publish nothing`,
+      );
+    } else if (chartTagExists === true) {
+      violations.push(
+        `${CHART_YAML}: chart version '${version}' is already released (tag libredb-studio-${version} exists) - ` +
+          `bump to an unreleased version`,
+      );
+    }
+  }
+  return violations;
+}
+
+/** Applies the canonical bump; returns changed=false (inputs untouched) when already in sync. */
+export function applyBump({ pkgVersion, chartYaml, readme }) {
+  const { version, appVersion } = parseChart(chartYaml);
+  const inSync =
+    appVersion === pkgVersion && parseImageTag(chartYaml) === pkgVersion && parseReadmeVersion(readme) === version;
+  if (inSync) {
+    return { chartYaml, readme, changed: false, version, appVersion };
+  }
+  const newVersion = appVersion === pkgVersion ? version : bumpPatch(version);
+  const newChartYaml = chartYaml
+    .replace(/^version:\s*\S+\s*$/m, `version: ${newVersion}`)
+    .replace(/^appVersion:\s*.*$/m, `appVersion: "${pkgVersion}"`)
+    .replace(/(image:\s*ghcr\.io\/libredb\/libredb-studio:)\S+/, `$1${pkgVersion}`)
+    .replace(
+      /- Track app release .*/,
+      `- Track app release ${pkgVersion} (appVersion bump; default image tag follows)`,
+    );
+  const newReadme = readme.replace(/--version\s+\S+/, `--version ${newVersion}`);
+  return { chartYaml: newChartYaml, readme: newReadme, changed: true, version: newVersion, appVersion: pkgVersion };
+}

--- a/scripts/sync-chart-version.mjs
+++ b/scripts/sync-chart-version.mjs
@@ -105,14 +105,16 @@ export function applyBump({ pkgVersion, chartYaml, readme }) {
     return { chartYaml, readme, changed: false, version, appVersion };
   }
   const newVersion = appVersion === pkgVersion ? version : bumpPatch(version);
-  const newChartYaml = chartYaml
+  let newChartYaml = chartYaml
     .replace(/^version:\s*\S+\s*$/m, `version: ${newVersion}`)
     .replace(/^appVersion:\s*.*$/m, `appVersion: "${pkgVersion}"`)
-    .replace(/(image:\s*ghcr\.io\/libredb\/libredb-studio:)\S+/, `$1${pkgVersion}`)
-    .replace(
+    .replace(/(image:\s*ghcr\.io\/libredb\/libredb-studio:)\S+/, `$1${pkgVersion}`);
+  if (appVersion !== pkgVersion) {
+    newChartYaml = newChartYaml.replace(
       /- Track app release .*/,
       `- Track app release ${pkgVersion} (appVersion bump; default image tag follows)`,
     );
+  }
   const newReadme = readme.replace(/--version\s+\S+/, `--version ${newVersion}`);
   return { chartYaml: newChartYaml, readme: newReadme, changed: true, version: newVersion, appVersion: pkgVersion };
 }
@@ -141,14 +143,21 @@ function chartTagExistsOnOrigin(root, version) {
 }
 
 function main(argv) {
-  const mode = argv.includes("--write") ? "write" : argv.includes("--check") ? "check" : null;
-  const rootIdx = argv.indexOf("--root");
-  const root = rootIdx === -1 ? process.cwd() : path.resolve(argv[rootIdx + 1]);
-  const strict = /^(1|true)$/i.test(process.env.CHART_SYNC_STRICT ?? "");
-  if (!mode) {
+  const hasCheck = argv.includes("--check");
+  const hasWrite = argv.includes("--write");
+  if (hasCheck === hasWrite) {
     console.error("Usage: node scripts/sync-chart-version.mjs --check|--write [--root <dir>]");
     process.exit(2);
   }
+  const mode = hasWrite ? "write" : "check";
+  const rootIdx = argv.indexOf("--root");
+  const rootArg = rootIdx === -1 ? undefined : argv[rootIdx + 1];
+  if (rootIdx !== -1 && (rootArg === undefined || rootArg.startsWith("--"))) {
+    console.error("ERROR: --root requires a directory path");
+    process.exit(2);
+  }
+  const root = rootIdx === -1 ? process.cwd() : path.resolve(rootArg);
+  const strict = /^(1|true)$/i.test(process.env.CHART_SYNC_STRICT ?? "");
 
   const pkgVersion = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
   const chartPath = path.join(root, CHART_YAML);

--- a/tests/unit/sync-chart-version.test.ts
+++ b/tests/unit/sync-chart-version.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for the chart version sync guard
+ * (scripts/sync-chart-version.mjs, issue #138). Pure string checks - no git,
+ * no network, no filesystem writes.
+ */
+import { describe, expect, test } from "bun:test";
+import { applyBump, bumpPatch, checkSync, parseChart } from "../../scripts/sync-chart-version.mjs";
+
+function chartYaml({
+  version = "0.1.3",
+  appVersion = "0.9.44",
+  imageTag = appVersion,
+}: {
+  version?: string;
+  appVersion?: string;
+  imageTag?: string;
+} = {}): string {
+  return `apiVersion: v2
+name: libredb-studio
+description: Web-based SQL IDE for cloud-native teams
+type: application
+version: ${version}
+appVersion: "${appVersion}"
+kubeVersion: ">=1.26.0-0"
+annotations:
+  artifacthub.io/images: |
+    - name: libredb-studio
+      image: ghcr.io/libredb/libredb-studio:${imageTag}
+      platforms:
+        - linux/amd64
+  artifacthub.io/changes: |
+    - Track app release ${appVersion} (appVersion bump; default image tag follows)
+dependencies:
+  - name: postgresql
+    version: "16.x.x"
+`;
+}
+
+function readme(version = "0.1.3"): string {
+  return `# libredb-studio chart
+
+\`\`\`bash
+helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \\
+  --version ${version} \\
+  --set secrets.jwtSecret=$(openssl rand -base64 32)
+\`\`\`
+`;
+}
+
+describe("parseChart", () => {
+  test("parses version and quoted appVersion", () => {
+    expect(parseChart(chartYaml())).toEqual({ version: "0.1.3", appVersion: "0.9.44" });
+  });
+
+  test("throws when version is missing", () => {
+    expect(() => parseChart("apiVersion: v2\nname: x\n")).toThrow(/version/);
+  });
+});
+
+describe("bumpPatch", () => {
+  test("bumps the patch segment", () => {
+    expect(bumpPatch("0.1.3")).toBe("0.1.4");
+  });
+
+  test("throws on a prerelease version", () => {
+    expect(() => bumpPatch("0.1.3-rc.1")).toThrow(/patch-bump/);
+  });
+});
+
+describe("checkSync", () => {
+  test("in-sync tree produces no violations", () => {
+    expect(checkSync({ pkgVersion: "0.9.44", chartYaml: chartYaml(), readme: readme() })).toEqual([]);
+  });
+
+  test("appVersion behind package.json is a violation", () => {
+    const violations = checkSync({ pkgVersion: "0.9.45", chartYaml: chartYaml(), readme: readme() });
+    expect(violations.some((v) => v.includes("appVersion") && v.includes("0.9.45"))).toBe(true);
+  });
+
+  test("appVersion ahead of package.json is a violation", () => {
+    const violations = checkSync({ pkgVersion: "0.9.43", chartYaml: chartYaml(), readme: readme() });
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test("artifacthub image tag drift is a violation", () => {
+    const violations = checkSync({
+      pkgVersion: "0.9.44",
+      chartYaml: chartYaml({ imageTag: "0.9.43" }),
+      readme: readme(),
+    });
+    expect(violations.some((v) => v.includes("artifacthub.io/images"))).toBe(true);
+  });
+
+  test("README --version drift is a violation", () => {
+    const violations = checkSync({ pkgVersion: "0.9.44", chartYaml: chartYaml(), readme: readme("0.1.2") });
+    expect(violations.some((v) => v.includes("README"))).toBe(true);
+  });
+
+  test("appVersion changed without a chart version bump is a violation", () => {
+    const violations = checkSync({
+      pkgVersion: "0.9.45",
+      chartYaml: chartYaml({ version: "0.1.3", appVersion: "0.9.45" }),
+      readme: readme("0.1.3"),
+      baseChart: { version: "0.1.3", appVersion: "0.9.44" },
+    });
+    expect(violations.some((v) => v.includes("chart-releaser"))).toBe(true);
+  });
+
+  test("reusing an already-released chart version is a violation", () => {
+    const violations = checkSync({
+      pkgVersion: "0.9.45",
+      chartYaml: chartYaml({ version: "0.1.2", appVersion: "0.9.45" }),
+      readme: readme("0.1.2"),
+      baseChart: { version: "0.1.3", appVersion: "0.9.44" },
+      chartTagExists: true,
+    });
+    expect(violations.some((v) => v.includes("already released"))).toBe(true);
+  });
+
+  test("unknown tag state (offline) skips the released-version check", () => {
+    const violations = checkSync({
+      pkgVersion: "0.9.45",
+      chartYaml: chartYaml({ version: "0.1.4", appVersion: "0.9.45" }),
+      readme: readme("0.1.4"),
+      baseChart: { version: "0.1.3", appVersion: "0.9.44" },
+      chartTagExists: null,
+    });
+    expect(violations).toEqual([]);
+  });
+});
+
+describe("applyBump", () => {
+  test("round-trip: a behind tree becomes check-clean", () => {
+    const result = applyBump({ pkgVersion: "0.9.45", chartYaml: chartYaml(), readme: readme() });
+    expect(result.changed).toBe(true);
+    expect(result.version).toBe("0.1.4");
+    expect(result.appVersion).toBe("0.9.45");
+    expect(result.chartYaml).toContain('appVersion: "0.9.45"');
+    expect(result.chartYaml).toContain("image: ghcr.io/libredb/libredb-studio:0.9.45");
+    expect(result.chartYaml).toContain("- Track app release 0.9.45 (appVersion bump; default image tag follows)");
+    expect(result.readme).toContain("--version 0.1.4");
+    expect(checkSync({ pkgVersion: "0.9.45", chartYaml: result.chartYaml, readme: result.readme })).toEqual([]);
+  });
+
+  test("in-sync tree is untouched (idempotent)", () => {
+    const result = applyBump({ pkgVersion: "0.9.44", chartYaml: chartYaml(), readme: readme() });
+    expect(result.changed).toBe(false);
+    expect(result.chartYaml).toBe(chartYaml());
+    expect(result.readme).toBe(readme());
+  });
+});

--- a/tests/unit/sync-chart-version.test.ts
+++ b/tests/unit/sync-chart-version.test.ts
@@ -4,6 +4,9 @@
  * no network, no filesystem writes.
  */
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { applyBump, bumpPatch, checkSync, parseChart } from "../../scripts/sync-chart-version.mjs";
 
 function chartYaml({
@@ -147,5 +150,50 @@ describe("applyBump", () => {
     expect(result.changed).toBe(false);
     expect(result.chartYaml).toBe(chartYaml());
     expect(result.readme).toBe(readme());
+  });
+});
+
+describe("CLI (--check via subprocess)", () => {
+  const SCRIPT = join(import.meta.dir, "../../scripts/sync-chart-version.mjs");
+
+  function makeFixture(pkgVersion: string, chart: string, readmeText: string): string {
+    const root = mkdtempSync(join(tmpdir(), "chart-sync-"));
+    mkdirSync(join(root, "charts/libredb-studio"), { recursive: true });
+    writeFileSync(join(root, "package.json"), JSON.stringify({ version: pkgVersion }));
+    writeFileSync(join(root, "charts/libredb-studio/Chart.yaml"), chart);
+    writeFileSync(join(root, "charts/libredb-studio/README.md"), readmeText);
+    return root;
+  }
+
+  function runCheck(root: string, env: Record<string, string> = {}) {
+    return Bun.spawnSync(["node", SCRIPT, "--check", "--root", root], {
+      env: { ...process.env, CHART_SYNC_STRICT: "", ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  test("in-sync fixture passes without git (warn + skip base checks)", () => {
+    const root = makeFixture("0.9.44", chartYaml(), readme());
+    const result = runCheck(root);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr.toString()).toContain("base-comparison checks skipped");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("violation exits 1 with the chart:bump hint", () => {
+    const root = makeFixture("0.9.99", chartYaml(), readme());
+    const result = runCheck(root);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("bun run chart:bump");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("strict mode fails when origin/main is not resolvable", () => {
+    const root = makeFixture("0.9.44", chartYaml(), readme());
+    const result = runCheck(root, { CHART_SYNC_STRICT: "1" });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("CHART_SYNC_STRICT");
+    rmSync(root, { recursive: true, force: true });
   });
 });

--- a/tests/unit/sync-chart-version.test.ts
+++ b/tests/unit/sync-chart-version.test.ts
@@ -1,9 +1,11 @@
 /**
  * Unit tests for the chart version sync guard
- * (scripts/sync-chart-version.mjs, issue #138). Pure string checks - no git,
- * no network, no filesystem writes.
+ * (scripts/sync-chart-version.mjs, issue #138). The core functions
+ * (parseChart, bumpPatch, checkSync, applyBump) are pure string checks. The
+ * CLI describe block runs the real script as a subprocess against
+ * throwaway temp-dir fixtures - no git, no network.
  */
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -151,13 +153,30 @@ describe("applyBump", () => {
     expect(result.chartYaml).toBe(chartYaml());
     expect(result.readme).toBe(readme());
   });
+
+  test("hand-written changes line is preserved when only the image tag drifted", () => {
+    const custom = chartYaml({ imageTag: "0.9.43" }).replace(
+      /- Track app release .*/,
+      "- Hand-written chart-only changelog entry",
+    );
+    const result = applyBump({ pkgVersion: "0.9.44", chartYaml: custom, readme: readme() });
+    expect(result.changed).toBe(true);
+    expect(result.chartYaml).toContain("image: ghcr.io/libredb/libredb-studio:0.9.44");
+    expect(result.chartYaml).toContain("- Hand-written chart-only changelog entry");
+  });
 });
 
 describe("CLI (--check via subprocess)", () => {
   const SCRIPT = join(import.meta.dir, "../../scripts/sync-chart-version.mjs");
+  const fixtureRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
 
   function makeFixture(pkgVersion: string, chart: string, readmeText: string): string {
     const root = mkdtempSync(join(tmpdir(), "chart-sync-"));
+    fixtureRoots.push(root);
     mkdirSync(join(root, "charts/libredb-studio"), { recursive: true });
     writeFileSync(join(root, "package.json"), JSON.stringify({ version: pkgVersion }));
     writeFileSync(join(root, "charts/libredb-studio/Chart.yaml"), chart);
@@ -178,7 +197,6 @@ describe("CLI (--check via subprocess)", () => {
     const result = runCheck(root);
     expect(result.exitCode).toBe(0);
     expect(result.stderr.toString()).toContain("base-comparison checks skipped");
-    rmSync(root, { recursive: true, force: true });
   });
 
   test("violation exits 1 with the chart:bump hint", () => {
@@ -186,7 +204,6 @@ describe("CLI (--check via subprocess)", () => {
     const result = runCheck(root);
     expect(result.exitCode).toBe(1);
     expect(result.stderr.toString()).toContain("bun run chart:bump");
-    rmSync(root, { recursive: true, force: true });
   });
 
   test("strict mode fails when origin/main is not resolvable", () => {
@@ -194,6 +211,26 @@ describe("CLI (--check via subprocess)", () => {
     const result = runCheck(root, { CHART_SYNC_STRICT: "1" });
     expect(result.exitCode).toBe(1);
     expect(result.stderr.toString()).toContain("CHART_SYNC_STRICT");
-    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("--check and --write together exits 2 with usage", () => {
+    const root = makeFixture("0.9.44", chartYaml(), readme());
+    const result = Bun.spawnSync(["node", SCRIPT, "--check", "--write", "--root", root], {
+      env: { ...process.env, CHART_SYNC_STRICT: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toContain("Usage:");
+  });
+
+  test("--root with no value exits 2 with the --root error", () => {
+    const result = Bun.spawnSync(["node", SCRIPT, "--check", "--root"], {
+      env: { ...process.env, CHART_SYNC_STRICT: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toContain("--root requires");
   });
 });


### PR DESCRIPTION
Closes #138 (durable part; the immediate bumps shipped in #141/#143).

## Problem

Nothing kept charts/libredb-studio/Chart.yaml appVersion in step with package.json, so
after a product release the Helm channel silently installed an old image until someone
bumped the chart by hand. The existing CI step only failed when appVersion was AHEAD of
package.json, and it lived in the helm-lint job, which is not part of the required status
check - even that weak rule could not block a merge.

## Solution

CI-enforced invariant instead of post-release automation (no bot, no PAT, no auto-merge):

- scripts/sync-chart-version.mjs - pure, unit-tested check/bump logic with two modes:
  bun run chart:check (validate) and bun run chart:bump (apply the canonical bump:
  appVersion, chart patch version, artifacthub images tag + changes line, README
  --version example).
- The check runs inside the required "Lint, Typecheck and Build" job, so a PR bumping
  package.json cannot merge without the chart bump. It also catches the silent variant:
  appVersion changed without a chart version bump (chart-releaser skip_existing would
  publish nothing) or reusing an already-released chart version.
- The old weak "Verify appVersion is valid" step is removed; the rule has one
  implementation.
- docs/HELM_CHART.md documents the guard and the researched decision to keep chart
  version and appVersion independent rather than lockstep (cert-manager-style lockstep
  blocks chart-only fixes; kueue#3971 abandoned it for the same reason).

## Verification

- 14 unit tests (parse, every violation class, round-trip, idempotence).
- CLI smoke-tested on the real tree: in-sync pass, forced 0.9.99 mismatch fails with the
  fix hint, chart:bump round-trips to green, no-op when in sync.
- actionlint clean on ci.yml; format/lint/typecheck/full test/build all pass locally at
  the branch tip; knip clean.