### PR TITLE
chore(release): 0.9.45 - version bump with chart sync

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.3
-appVersion: "0.9.44"
+version: 0.1.4
+appVersion: "0.9.45"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.44
+      image: ghcr.io/libredb/libredb-studio:0.9.45
       platforms:
         - linux/amd64
   artifacthub.io/links: |
@@ -42,7 +42,7 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - Track app release 0.9.44 (appVersion bump; default image tag follows)
+    - Track app release 0.9.45 (appVersion bump; default image tag follows)
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -31,7 +31,7 @@ kubectl port-forward svc/libredb-libredb-studio 3000:80
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.3 \
+  --version 0.1.4 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123 \
   --set secrets.userPassword=MyUser123

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Release bump to 0.9.45.

First push intentionally contains ONLY the package.json bump, as a live validation of the #150 chart version sync guard: the required "Lint, Typecheck and Build" check must FAIL on the guard step. The follow-up commit runs bun run chart:bump (chart 0.1.4 / appVersion 0.9.45) and turns it green.

After merge: the GitHub release 0.9.45 will be published (npm, Docker, standalone artifacts), then helm-release re-dispatched once the 0.9.45 image exists (the merge-triggered run is expected to fail ct install on the not-yet-published image).