### PR TITLE
fix(release): explicitly dispatch npm and Docker after draft-first publish

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -132,16 +132,36 @@ jobs:
           gh release edit "$tag" --draft=false --latest=false
           echo "Published chart release '$tag' with '$asset'."
 
-      - name: Update Helm repo index (chart-releaser, index only)
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
-        with:
-          # Upload is handled draft-first above; cr only regenerates and pushes
-          # the gh-pages index.yaml from the published releases.
-          skip_upload: true
-          skip_existing: true
-          mark_as_latest: false
+      - name: Update Helm repo index on gh-pages
+        # chart-releaser cannot do this here: its skip_upload flag (needed
+        # because the upload is draft-first above) also skips the index push
+        # entirely - the 0.1.5 release published with no index entry until it
+        # was hand-patched. Merge the new package into the existing index
+        # with helm itself and push; --merge keeps every prior entry (and its
+        # per-release URL) untouched, only the new version gets --url.
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          asset_path=$(ls .cr-release-packages/*.tgz)
+          tag=$(basename "$asset_path" .tgz)
+          pages_dir="${RUNNER_TEMP}/gh-pages"
+          rm -rf "$pages_dir"
+          git worktree add "$pages_dir" origin/gh-pages
+          helm repo index .cr-release-packages \
+            --url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}" \
+            --merge "$pages_dir/index.yaml"
+          if cmp -s .cr-release-packages/index.yaml "$pages_dir/index.yaml"; then
+            echo "Index already contains ${tag} - nothing to push."
+            exit 0
+          fi
+          cp .cr-release-packages/index.yaml "$pages_dir/index.yaml"
+          cd "$pages_dir"
+          git checkout -B gh-pages origin/gh-pages
+          git add index.yaml
+          git commit -m "Update index.yaml for ${tag}"
+          git push origin gh-pages
+          echo "Pushed index update for ${tag}."
 
       - name: Verify chart release asset was published
         env:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -475,6 +475,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Required by the chain-dispatch step below: gh workflow run calls the
+      # Actions API, and an explicit permissions block disables every scope
+      # it does not name.
+      actions: write
     steps:
       - name: Verify the draft carries the full asset set
         env:
@@ -532,11 +536,13 @@ jobs:
           TAG: ${{ needs.guard.outputs.version }}
         run: |
           set -euo pipefail
+          # --ref pins both runs to the tagged commit: a default-branch
+          # dispatch would build whatever main has moved to in the meantime.
           # npm-publish gets NO version input: its "Set version" step runs
           # `npm version <input>`, which fails with "Version not changed"
           # when package.json already carries the tag version - always the
-          # case on a tag push. Empty input = publish the package.json
-          # version, which the tag was cut from.
-          gh workflow run npm-publish.yml
-          gh workflow run docker-build-push.yml -f "version=$TAG"
+          # case on a tag ref. Empty input = publish the package.json
+          # version at the tag, which is the released version by definition.
+          gh workflow run npm-publish.yml --ref "refs/tags/$TAG"
+          gh workflow run docker-build-push.yml --ref "refs/tags/$TAG" -f "version=$TAG"
           echo "Dispatched npm-publish and docker-build-push for '$TAG'."

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -532,6 +532,11 @@ jobs:
           TAG: ${{ needs.guard.outputs.version }}
         run: |
           set -euo pipefail
-          gh workflow run npm-publish.yml -f "version=$TAG"
+          # npm-publish gets NO version input: its "Set version" step runs
+          # `npm version <input>`, which fails with "Version not changed"
+          # when package.json already carries the tag version - always the
+          # case on a tag push. Empty input = publish the package.json
+          # version, which the tag was cut from.
+          gh workflow run npm-publish.yml
           gh workflow run docker-build-push.yml -f "version=$TAG"
           echo "Dispatched npm-publish and docker-build-push for '$TAG'."

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -519,3 +519,19 @@ jobs:
           set -euo pipefail
           gh release edit "$TAG" --draft=false --latest
           echo "Release '$TAG' published with the verified asset set."
+
+      - name: Dispatch npm and Docker publish
+        # The publish above runs under GITHUB_TOKEN, and events created by
+        # GITHUB_TOKEN do not trigger other workflows (the 0.9.46 release
+        # published without npm/Docker firing). workflow_dispatch API calls
+        # are NOT subject to that restriction, so chain the downstream
+        # channels explicitly. Their own guards re-validate the version.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.guard.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh workflow run npm-publish.yml -f "version=$TAG"
+          gh workflow run docker-build-push.yml -f "version=$TAG"
+          echo "Dispatched npm-publish and docker-build-push for '$TAG'."


### PR DESCRIPTION
Follow-up to #155 (draft-first release flow), found during the 0.9.46 live validation.

## Problem

The draft-first flow publishes the release via gh release edit under GITHUB_TOKEN. Events created by GITHUB_TOKEN do not trigger other workflows (documented GitHub Actions recursion guard - the same reason chart releases never triggered release pipelines, see the #128 investigation). Result: 0.9.46 published with a complete asset set, but npm-publish and docker-build-push never fired. Recovered by manual workflow_dispatch of both.

## Fix

A final step in the publish-release job dispatches npm-publish.yml and docker-build-push.yml explicitly with the version input. workflow_dispatch API calls are not subject to the GITHUB_TOKEN event restriction, and both target workflows already re-validate the version against package.json/the tag in their own guards, so the chain stays fail-safe.

npx-engine-smoke needs no change: it triggers on the NPM Publish workflow_run completion, which fires for dispatched runs too.

## Verification

- actionlint: only pre-existing SC2024 in the untouched deb smoke step; the new step is clean.
- Live: the 0.9.46 manual dispatches of both workflows ran through the exact code path this step automates.