### PR TITLE
fix(release): move the latest Docker tag through the chain dispatch

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -18,6 +18,11 @@ on:
         description: 'Version tag (e.g., 0.9.41 - no v prefix)'
         required: true
         type: string
+      publish_latest:
+        description: 'Also move the latest tag to this version (set by the release chain; leave false for backfills of old versions)'
+        required: false
+        default: false
+        type: boolean
 
 # Cancel an in-progress build when a newer commit is pushed to the same ref,
 # so rapid pushes to a feature/fix branch don't stack multi-arch builds.
@@ -157,7 +162,12 @@ jobs:
           images: ${{ steps.images.outputs.list }}
           tags: |
             type=raw,value=${{ steps.extract-version.outputs.version }},enable=${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            # latest moves on a real release event, or on the release chain's
+            # dispatch (publish_latest=true, pinned to the release tag ref).
+            # A plain manual dispatch (backfilling an old version) must never
+            # move latest - the 0.9.46 chain shipped with latest stuck on the
+            # previous release because dispatch could not move it at all.
+            type=raw,value=latest,enable=${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest == true) }}
             type=raw,value=main,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
             type=sha,prefix=sha-

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -97,8 +97,8 @@ jobs:
         # Immutable releases (issue #154) freeze assets at publish time, so the
         # chart .tgz must be attached while the release is still a draft and
         # the release published only afterwards. chart-releaser's own upload
-        # (create published release, then attach asset) would 422; it now runs
-        # index-only in the next step.
+        # (create published release, then attach asset) would 422; the repo
+        # index is pushed manually in the next step.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -147,6 +147,9 @@ jobs:
           tag=$(basename "$asset_path" .tgz)
           pages_dir="${RUNNER_TEMP}/gh-pages"
           rm -rf "$pages_dir"
+          # Explicit fetch: keeps this step working even if the checkout
+          # configuration ever stops fetching all branches.
+          git fetch origin "refs/heads/gh-pages:refs/remotes/origin/gh-pages"
           git worktree add "$pages_dir" origin/gh-pages
           helm repo index .cr-release-packages \
             --url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}" \

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -16,10 +16,10 @@ name: Release Artifacts
 # fail with HTTP 422 (the 0.9.45 incident). So this workflow triggers on the
 # TAG push (not on release publish), attaches every asset to a DRAFT release,
 # verifies the full asset set, and publishes the release as its LAST step.
-# `release: published` then fires exactly once with all assets in place, which
-# is what triggers npm-publish and docker-build-push. A hand-written draft
-# release for the tag is reused if one exists; otherwise a draft is created
-# with generated notes.
+# Because that publish runs under GITHUB_TOKEN it fires no `release:published`
+# triggers; npm-publish and docker-build-push are chained explicitly by the
+# final dispatch step instead. A hand-written draft release for the tag is
+# reused if one exists; otherwise a draft is created with generated notes.
 
 on:
   push:
@@ -529,7 +529,10 @@ jobs:
         # GITHUB_TOKEN do not trigger other workflows (the 0.9.46 release
         # published without npm/Docker firing). workflow_dispatch API calls
         # are NOT subject to that restriction, so chain the downstream
-        # channels explicitly. Their own guards re-validate the version.
+        # channels explicitly. Version safety comes from this workflow's
+        # guard job (TAG validated against package.json at the tagged
+        # commit) plus the --ref pinning below - docker trusts its version
+        # input and npm derives the version from the ref's package.json.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -544,5 +547,6 @@ jobs:
           # case on a tag ref. Empty input = publish the package.json
           # version at the tag, which is the released version by definition.
           gh workflow run npm-publish.yml --ref "refs/tags/$TAG"
-          gh workflow run docker-build-push.yml --ref "refs/tags/$TAG" -f "version=$TAG"
+          gh workflow run docker-build-push.yml --ref "refs/tags/$TAG" \
+            -f "version=$TAG" -f "publish_latest=true"
           echo "Dispatched npm-publish and docker-build-push for '$TAG'."


### PR DESCRIPTION
Post-merge review notes on #158 (external GPT-5.5 agent + Copilot), verified and applied before the 0.9.47 validation release.

## Important (verified live): ghcr latest stuck on the previous release

docker-build-push.yml gated the latest tag on `github.event_name == 'release'`. The draft-first flow publishes with GITHUB_TOKEN and chains Docker via workflow_dispatch, so 0.9.46 published its version tag but latest silently stayed behind (digest-verified against ghcr before this fix). Fix: a `publish_latest` boolean dispatch input; the release chain passes `publish_latest=true` with the dispatch already pinned to `refs/tags/<version>`. A plain manual dispatch (backfilling an old version) still cannot move latest.

The stale latest self-heals with the 0.9.47 release cut right after this merge.

## Review-note cleanups

- release-artifacts.yml comments no longer claim `release: published` triggers npm/Docker (it cannot, GITHUB_TOKEN); the version-safety comment now credits the guard job + --ref pinning rather than "downstream re-validation" (Copilot: docker trusts its version input).
- helm-release.yml: explicit `git fetch origin gh-pages` before the worktree add. The Copilot claim that `origin/gh-pages` would be missing is refuted by evidence (the job checks out with fetch-depth: 0 and the 0.1.5 run log shows the branch fetched), but the explicit fetch makes the step independent of checkout configuration.
- helm-release.yml index-step comment updated (chart-releaser is gone from that path; the index is pushed manually).

## Deferred (from the notes, tracked in #154 discussion)

- Post-condition checks that `gh workflow run` actually created runs: the command is fail-fast on API errors; run-creation polling adds complexity for little signal. Revisit if a dispatch ever silently no-ops.
- Verifying the pushed index contains the new entry: the index is generated locally from the package (the entry is there by construction) and the daily helm-index-check verifies the served side within a day.

## Verification

- actionlint: clean apart from the pre-existing SC2024 in the untouched deb smoke step.
- Live validation: 0.9.47 will be cut immediately after merge; the acceptance criterion is the full chain running green with zero manual intervention and ghcr latest digest == 0.9.47 digest.