### PR TITLE
fix(helm): run the chart release only after its image exists (gate + dispatch)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -44,8 +44,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # Required by the helm-release dispatch step (release context only).
-      actions: write
     outputs:
       version: ${{ steps.extract-version.outputs.version }}
       image: ${{ steps.meta.outputs.tags }}
@@ -189,23 +187,6 @@ jobs:
             ADMIN_PASSWORD_BUILD=build
             USER_PASSWORD_BUILD=build
 
-      - name: Dispatch Helm chart release
-        # The chart deploys this image by default, so helm-release runs only
-        # AFTER a successful image publish: the version-bump merge's own
-        # helm-release run ends as a no-op at its image gate, and this
-        # dispatch re-triggers it now that the image exists. Release context
-        # only - main/dev branch builds must not publish charts. If this
-        # build fails, no dispatch happens and the chart correctly stays
-        # unpublished.
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest == true)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          gh workflow run helm-release.yml --ref main
-          echo "Dispatched helm-release."
-
       - name: Generate build summary
         run: |
           echo "## 🚀 Docker Build Summary" >> $GITHUB_STEP_SUMMARY
@@ -220,3 +201,31 @@ jobs:
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+
+  dispatch-helm-release:
+    # The chart deploys the image this run just published, so helm-release
+    # runs only AFTER a successful publish: the version-bump merge's own
+    # helm-release run ends as a no-op at its image gate, and this dispatch
+    # re-triggers it now that the image exists. Release context only -
+    # main/dev branch builds must not publish charts - and a failed build
+    # dispatches nothing, so the chart correctly stays unpublished. Separate
+    # job so actions:write is never granted to ordinary branch builds, and
+    # the dispatch targets THIS run's ref so the chart is released from the
+    # same commit as the image (a main dispatch could pick up a newer,
+    # not-yet-built chart).
+    name: Dispatch Helm chart release
+    needs: build-and-push
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest == true)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch helm-release on this ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          gh workflow run helm-release.yml --ref "$REF"
+          echo "Dispatched helm-release on ${REF}."

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -44,6 +44,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Required by the helm-release dispatch step (release context only).
+      actions: write
     outputs:
       version: ${{ steps.extract-version.outputs.version }}
       image: ${{ steps.meta.outputs.tags }}
@@ -186,6 +188,23 @@ jobs:
             JWT_SECRET_BUILD=build-time-placeholder-secret-32ch
             ADMIN_PASSWORD_BUILD=build
             USER_PASSWORD_BUILD=build
+
+      - name: Dispatch Helm chart release
+        # The chart deploys this image by default, so helm-release runs only
+        # AFTER a successful image publish: the version-bump merge's own
+        # helm-release run ends as a no-op at its image gate, and this
+        # dispatch re-triggers it now that the image exists. Release context
+        # only - main/dev branch builds must not publish charts. If this
+        # build fails, no dispatch happens and the chart correctly stays
+        # unpublished.
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest == true)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh workflow run helm-release.yml --ref main
+          echo "Dispatched helm-release."
 
       - name: Generate build summary
         run: |

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -167,6 +167,9 @@ jobs:
             # A plain manual dispatch (backfilling an old version) must never
             # move latest - the 0.9.46 chain shipped with latest stuck on the
             # previous release because dispatch could not move it at all.
+            # Keep this "release context" condition in step with the
+            # dispatch-helm-release job's if: below - if they drift, the
+            # chart dispatch and the latest tag disagree on what a release is.
             type=raw,value=latest,enable=${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest == true) }}
             type=raw,value=main,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
@@ -212,7 +215,9 @@ jobs:
     # job so actions:write is never granted to ordinary branch builds, and
     # the dispatch targets THIS run's ref so the chart is released from the
     # same commit as the image (a main dispatch could pick up a newer,
-    # not-yet-built chart).
+    # not-yet-built chart). The if: below is the same "release context"
+    # condition as the latest-tag enable in the metadata step above - keep
+    # the two in step.
     name: Dispatch Helm chart release
     needs: build-and-push
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest == true)

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -36,7 +36,12 @@ jobs:
     # an image that a failed Docker run will never produce.
     name: Image gate
     runs-on: ubuntu-latest
-    # The gate only reads Chart.yaml and queries a public registry; do not
+    # A registry query is near-instant; never let a network hang hold a
+    # runner.
+    timeout-minutes: 5
+    # The gate only reads Chart.yaml and queries the registry anonymously -
+    # this relies on the GHCR package being PUBLIC (if visibility ever
+    # changes, this step fails loudly and needs a registry login). Do not
     # inherit the workflow-level write scopes.
     permissions:
       contents: read
@@ -53,6 +58,10 @@ jobs:
         run: |
           set -euo pipefail
           app_version=$(grep '^appVersion:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
+          if [ -z "$app_version" ]; then
+            echo "::error::could not read appVersion from charts/libredb-studio/Chart.yaml"
+            exit 1
+          fi
           image="ghcr.io/libredb/libredb-studio:${app_version}"
           if inspect_out=$(docker manifest inspect "$image" 2>&1); then
             echo "proceed=true" >> "$GITHUB_OUTPUT"
@@ -64,7 +73,9 @@ jobs:
           # loudly: treating it as "missing" would green-no-op a chart-only
           # release that nothing ever re-dispatches - a silent never-publish.
           if ! grep -qiE "manifest unknown|not found|no such manifest" <<< "$inspect_out"; then
-            echo "::error::could not query GHCR for ${image} - failing instead of deferring. Inspect output: ${inspect_out}"
+            # Collapse newlines: a multi-line message breaks the ::error::
+            # annotation format (the full output is in the step log anyway).
+            echo "::error::could not query GHCR for ${image} - failing instead of deferring. Inspect output: ${inspect_out//$'\n'/ }"
             exit 1
           fi
           echo "proceed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -72,7 +72,10 @@ jobs:
           # inspect failure (registry outage, DNS, auth, CLI) must fail
           # loudly: treating it as "missing" would green-no-op a chart-only
           # release that nothing ever re-dispatches - a silent never-publish.
-          if ! grep -qiE "manifest unknown|not found|no such manifest" <<< "$inspect_out"; then
+          # Every alternative requires manifest context: a bare "not found"
+          # would also match unrelated failures (e.g. "docker: command not
+          # found") and wrongly defer instead of failing loudly.
+          if ! grep -qiE "manifest unknown|no such manifest|manifest for .+ not found" <<< "$inspect_out"; then
             # Collapse newlines: a multi-line message breaks the ::error::
             # annotation format (the full output is in the step log anyway).
             echo "::error::could not query GHCR for ${image} - failing instead of deferring. Inspect output: ${inspect_out//$'\n'/ }"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -36,6 +36,10 @@ jobs:
     # an image that a failed Docker run will never produce.
     name: Image gate
     runs-on: ubuntu-latest
+    # The gate only reads Chart.yaml and queries a public registry; do not
+    # inherit the workflow-level write scopes.
+    permissions:
+      contents: read
     outputs:
       proceed: ${{ steps.gate.outputs.proceed }}
     steps:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -23,7 +23,54 @@ permissions:
   pages: write
 
 jobs:
+  preflight:
+    # Image gate: the chart deploys ghcr.io/libredb/libredb-studio:<appVersion>
+    # by default, so nothing here may run (or publish) before that image
+    # exists. A version-bump merge fires this workflow ~25-35 minutes before
+    # the release chain has built the image; in that case the push-triggered
+    # run ends here as a green no-op and docker-build-push dispatches this
+    # workflow again after it publishes the version tag (and never dispatches
+    # it when the build failed - a failed image makes every downstream job
+    # pointless). Chart-only releases pass instantly: their appVersion image
+    # is already published. No polling by design: a wait would burn 45 min on
+    # an image that a failed Docker run will never produce.
+    name: Image gate
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check the appVersion image exists on GHCR
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          app_version=$(grep '^appVersion:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
+          image="ghcr.io/libredb/libredb-studio:${app_version}"
+          if docker manifest inspect "$image" >/dev/null 2>&1; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "OK: ${image} is published - proceeding."
+            exit 0
+          fi
+          echo "proceed=false" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "::error::${image} is not published. A dispatched run expects the image to exist - check docker-build-push for this version, then re-dispatch."
+            exit 1
+          fi
+          echo "::notice::${image} is not published yet - ending as a no-op. docker-build-push re-dispatches this workflow after it pushes the version tag (release chain), so no action is needed unless that build failed."
+          {
+            echo "## Helm release deferred"
+            echo ""
+            echo "\`${image}\` is not on GHCR yet. This push-triggered run is a no-op;"
+            echo "the release chain re-dispatches helm-release after the image is published."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   lint-test:
+    needs: preflight
+    if: needs.preflight.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,32 +96,6 @@ jobs:
 
       - name: Run chart-testing lint
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --charts charts/libredb-studio
-
-      - name: Wait for the appVersion image on GHCR
-        # A version-bump merge triggers this workflow BEFORE the release
-        # chain has built the new image (tag push -> artifacts -> publish ->
-        # docker dispatch takes ~25-35 min), so ct install used to fail with
-        # ImagePullBackOff and the chart could even publish before its image
-        # existed (user-facing ImagePullBackOff window). Wait for the image
-        # instead: chart-only releases (appVersion unchanged, image already
-        # published) pass through instantly; release merges wait here until
-        # docker-build-push pushes the tag, then everything proceeds with no
-        # manual re-dispatch.
-        run: |
-          set -euo pipefail
-          app_version=$(grep '^appVersion:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
-          image="ghcr.io/libredb/libredb-studio:${app_version}"
-          echo "Waiting for ${image} (up to 45 minutes)..."
-          deadline=$((SECONDS + 45 * 60))
-          until docker manifest inspect "$image" >/dev/null 2>&1; do
-            if ((SECONDS >= deadline)); then
-              echo "::error::${image} did not appear within 45 minutes. If the release chain failed, fix it and re-run this workflow; ct install and the chart publish both need the image."
-              exit 1
-            fi
-            echo "$(date -u +%H:%M:%S) not there yet, retrying in 60s..."
-            sleep 60
-          done
-          echo "Image ${image} is available."
 
       - name: Create Kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -50,6 +50,32 @@ jobs:
       - name: Run chart-testing lint
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --charts charts/libredb-studio
 
+      - name: Wait for the appVersion image on GHCR
+        # A version-bump merge triggers this workflow BEFORE the release
+        # chain has built the new image (tag push -> artifacts -> publish ->
+        # docker dispatch takes ~25-35 min), so ct install used to fail with
+        # ImagePullBackOff and the chart could even publish before its image
+        # existed (user-facing ImagePullBackOff window). Wait for the image
+        # instead: chart-only releases (appVersion unchanged, image already
+        # published) pass through instantly; release merges wait here until
+        # docker-build-push pushes the tag, then everything proceeds with no
+        # manual re-dispatch.
+        run: |
+          set -euo pipefail
+          app_version=$(grep '^appVersion:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
+          image="ghcr.io/libredb/libredb-studio:${app_version}"
+          echo "Waiting for ${image} (up to 45 minutes)..."
+          deadline=$((SECONDS + 45 * 60))
+          until docker manifest inspect "$image" >/dev/null 2>&1; do
+            if ((SECONDS >= deadline)); then
+              echo "::error::${image} did not appear within 45 minutes. If the release chain failed, fix it and re-run this workflow; ct install and the chart publish both need the image."
+              exit 1
+            fi
+            echo "$(date -u +%H:%M:%S) not there yet, retrying in 60s..."
+            sleep 60
+          done
+          echo "Image ${image} is available."
+
       - name: Create Kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -54,10 +54,18 @@ jobs:
           set -euo pipefail
           app_version=$(grep '^appVersion:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
           image="ghcr.io/libredb/libredb-studio:${app_version}"
-          if docker manifest inspect "$image" >/dev/null 2>&1; then
+          if inspect_out=$(docker manifest inspect "$image" 2>&1); then
             echo "proceed=true" >> "$GITHUB_OUTPUT"
             echo "OK: ${image} is published - proceeding."
             exit 0
+          fi
+          # Only a genuinely missing tag may defer the release. Any other
+          # inspect failure (registry outage, DNS, auth, CLI) must fail
+          # loudly: treating it as "missing" would green-no-op a chart-only
+          # release that nothing ever re-dispatches - a silent never-publish.
+          if ! grep -qiE "manifest unknown|not found|no such manifest" <<< "$inspect_out"; then
+            echo "::error::could not query GHCR for ${image} - failing instead of deferring. Inspect output: ${inspect_out}"
+            exit 1
           fi
           echo "proceed=false" >> "$GITHUB_OUTPUT"
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -57,6 +57,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
+          # grep/awk on purpose (matching the description: extraction in the
+          # release job below): yq is not preinstalled and this job stays
+          # lean - do not "improve" this into a yq dependency.
           app_version=$(grep '^appVersion:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
           if [ -z "$app_version" ]; then
             echo "::error::could not read appVersion from charts/libredb-studio/Chart.yaml"

--- a/docs/HELM_CHART.md
+++ b/docs/HELM_CHART.md
@@ -191,12 +191,26 @@ When `seedConnections.enabled=true`, the chart provisions a set of pre-defined d
 
 ## Release Pipeline
 
+The chart never releases before the image it deploys exists (#161), and the
+whole flow is compatible with the repository's immutable-releases policy
+(draft-first, #154/#155/#158). For a product release, `docker-build-push.yml`
+dispatches `helm-release.yml` on the release tag ref after the image publish
+succeeds.
+
 ```
-Push to main (charts/** changed)
-  │
+Push to main (charts/** changed)   OR   dispatched by docker-build-push
+  │                                     after a successful image publish
   ▼
 ┌─────────────────────────────────────────┐
 │  helm-release.yml                       │
+│                                         │
+│  Job 0: preflight (image gate)          │
+│    ghcr image <appVersion> published?   │
+│    ├── yes → proceed                    │
+│    ├── no + push event → green no-op    │
+│    │   (the release chain re-dispatches │
+│    │    after the image is published)   │
+│    └── no + dispatch → fail fast        │
 │                                         │
 │  Job 1: lint-test                       │
 │    ├── ct lint (chart-testing)          │
@@ -205,9 +219,10 @@ Push to main (charts/** changed)
 │                                         │
 │  Job 2: release-github-pages            │
 │    ├── helm dependency build            │
-│    └── chart-releaser-action            │
-│        ├── GitHub Release (tag + .tgz)  │
-│        └── gh-pages index.yaml update   │
+│    ├── draft release + .tgz upload,     │
+│    │   publish last (immutable-safe)    │
+│    └── helm repo index --merge → push   │
+│        gh-pages index.yaml              │
 │                                         │
 │  Job 3: release-oci                     │
 │    ├── helm dependency build            │
@@ -218,6 +233,11 @@ Push to main (charts/** changed)
   ▼
 ArtifactHub auto-scan (~30 min)
 ```
+
+Do not manually dispatch `helm-release.yml` for a new appVersion before its
+image is on GHCR - the gate fails fast by design. A failed image build
+dispatches nothing, so the chart correctly stays unpublished. The gate
+queries GHCR anonymously and relies on the image package being public.
 
 ### Version Management
 

--- a/docs/HELM_CHART.md
+++ b/docs/HELM_CHART.md
@@ -194,8 +194,10 @@ When `seedConnections.enabled=true`, the chart provisions a set of pre-defined d
 The chart never releases before the image it deploys exists (#161), and the
 whole flow is compatible with the repository's immutable-releases policy
 (draft-first, #154/#155/#158). For a product release, `docker-build-push.yml`
-dispatches `helm-release.yml` on the release tag ref after the image publish
-succeeds.
+dispatches `helm-release.yml` **on the release tag ref** after the image
+publish succeeds - the chart is deliberately published from the tag's
+snapshot (the same commit as the image), not from main HEAD; a chart-only
+fix merged in between publishes separately via its own `charts/**` push run.
 
 ```
 Push to main (charts/** changed)   OR   dispatched by docker-build-push


### PR DESCRIPTION
Closes the last manual step in the release chain (the #154 ordering note, bitten again by 0.9.47's merge-triggered run).

## Problem

A version-bump merge touches charts/**, so helm-release fires immediately - but the appVersion image only exists ~25-35 minutes later. ct install fails with ImagePullBackOff on every release merge (0.9.45/0.9.46/0.9.47) and needs a manual re-dispatch; worse, a green run would publish the chart BEFORE its image, giving fresh installs an ImagePullBackOff window.

## Design (reworked after review)

The first commit here polled GHCR for up to 45 minutes. Review pushback (correct): a poll waits blindly on an image that a FAILED Docker build will never produce - wasted runner time and an opaque timeout instead of a clear cause, and if Docker is red there is no point running the chart pipeline at all. Reworked to state the dependency explicitly:

- **helm-release / preflight (image gate)**: instant check that ghcr.io/libredb/libredb-studio:<appVersion> exists. Present -> full pipeline. Missing on a push event -> the run ends as a green no-op with a notice and step summary (the release chain re-triggers it); missing on workflow_dispatch -> fail fast with an actionable message. Chart-only releases pass the gate instantly (their image is long published).
- **docker-build-push -> helm-release dispatch**: after a successful image push in release context only (release event, or the chain's publish_latest dispatch), docker-build-push dispatches helm-release. main/dev branch builds never dispatch it; a failed image build dispatches nothing, so the chart correctly stays unpublished.

This mirrors the existing release-artifacts -> npm/docker chaining pattern (one explicit dispatch edge, no new patterns), keeps inter-workflow coupling minimal, and removes both the recurring red run and the chart-before-image publish window.

## Verification

- actionlint clean on both files (pre-existing SC2086/SC2024 infos in untouched steps aside).
- Live validation: once the 0.9.47 image lands, docker's dispatch step is exercised by re-dispatching docker-build-push? No - this PR merges after 0.9.47's docker run; the gate is validated by dispatching helm-release for chart 0.1.6 (image present -> proceeds), and the full chain (gate no-op -> docker dispatch -> gated helm run) is validated hands-off with the next release.