### PR TITLE
chore(release): 0.9.48

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.6
-appVersion: "0.9.47"
+version: 0.1.7
+appVersion: "0.9.48"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.47
+      image: ghcr.io/libredb/libredb-studio:0.9.48
       platforms:
         - linux/amd64
   artifacthub.io/links: |
@@ -42,7 +42,7 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - Track app release 0.9.47 (appVersion bump; default image tag follows)
+    - Track app release 0.9.48 (appVersion bump; default image tag follows)
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -31,7 +31,7 @@ kubectl port-forward svc/libredb-libredb-studio 3000:80
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.6 \
+  --version 0.1.7 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123 \
   --set secrets.userPassword=MyUser123

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Version bump to 0.9.48 with the chart sync guard satisfied in the same commit (chart 0.1.7 / appVersion 0.9.48 via bun run chart:bump).

This is the full hands-off validation release for the automated chain (#155, #158, #159, #161). Acceptance: after merge + tag push, ZERO manual intervention - the merge's helm-release run must end as a green no-op at the image gate, and the chain (draft, 13 assets, verify, publish, npm, Docker with latest, docker-dispatched helm release with automatic index push, npx smoke) must run green end to end.