### PR TITLE
fix(release): dispatch npx engine smoke explicitly after npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -118,3 +118,32 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Registry:** https://www.npmjs.com/package/@libredb/studio" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Install:** \`npm install @libredb/studio@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  dispatch-smoke:
+    # npx-engine-smoke listens for this workflow's completion via
+    # workflow_run, but that event never fires when THIS run was itself
+    # dispatched with GITHUB_TOKEN (the release chain path) - the 0.9.48
+    # chain published npm cleanly and the smoke silently never ran. Dispatch
+    # it explicitly; workflow_dispatch API calls are not subject to the
+    # GITHUB_TOKEN event restriction. The workflow_run trigger stays for
+    # PAT/manual runs; if both paths fire for the same publish the second
+    # smoke run is a harmless duplicate (read-only npx install checks).
+    name: Dispatch npx engine smoke
+    needs: publish
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Dispatch npx-engine-smoke with the published version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          gh workflow run npx-engine-smoke.yml -f "expected-version=$VERSION"
+          echo "Dispatched npx-engine-smoke expecting ${VERSION}."


### PR DESCRIPTION
Found by the 0.9.48 hands-off validation run - the last silent gap in the release chain.

## Problem

npx-engine-smoke triggers on the NPM Publish workflow_run completion. When NPM Publish is dispatched by the release chain (GITHUB_TOKEN), its completion event is attributed to GITHUB_TOKEN and fires no workflow_run - so 0.9.48 published to npm cleanly and the smoke silently never ran. (The PR #158 assumption that workflow_run "fires for dispatched runs too" was based on the 0.9.46 recovery, which used a user PAT via gh CLI, not GITHUB_TOKEN.)

## Fix

A dispatch-smoke job (needs: publish, skipped on dry runs, job-scoped actions:write) dispatches npx-engine-smoke.yml explicitly with the published version from package.json - the same GITHUB_TOKEN-restriction workaround already used for the npm/docker/helm chain edges. The workflow_run trigger stays for PAT/manual publishes; if both paths fire, the duplicate smoke is a harmless read-only npx check.

## Verification

- actionlint clean (pre-existing SC2129 style hint in the untouched Summary step aside).
- The smoke for 0.9.48 itself was dispatched manually with expected-version=0.9.48 and is running.
- Live validation: 0.9.49 will be cut after merge; acceptance is the complete chain green with zero manual intervention, npx smoke included.