### PR TITLE
chore(release): 0.9.50 - chart 0.1.9 / appVersion 0.9.50 (bun run chart:bump)

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.8
-appVersion: "0.9.49"
+version: 0.1.9
+appVersion: "0.9.50"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.49
+      image: ghcr.io/libredb/libredb-studio:0.9.50
       platforms:
         - linux/amd64
         - linux/arm64
@@ -43,7 +43,7 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - Track app release 0.9.49 (appVersion bump; default image tag follows)
+    - Track app release 0.9.50 (appVersion bump; default image tag follows)
     - Default install is now zero-config: with no values set, first-run admin credentials are generated and printed to the pod log (config.authBootstrap default changed from "off" to ""); set config.authBootstrap=off for strict fail-closed installs
     - Secret keys and env entries for JWT_SECRET, ADMIN_PASSWORD, USER_EMAIL and USER_PASSWORD are rendered only when their values are set (or an existingSecret is used), so pods no longer reference missing Secret keys
     - Strict mode now requires only secrets.jwtSecret and secrets.adminPassword; secrets.userPassword is optional in all modes (the non-admin account is an optional app feature and is never generated)

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.8 \
+  --version 0.1.9 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.49",
+  "version": "0.9.50",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Release bump for 0.9.50.

- package.json: 0.9.49 -> 0.9.50
- Chart.yaml: version 0.1.8 -> 0.1.9, appVersion 0.9.50, image tag annotation, changes entry
- chart README: --version example synced

Chart 0.1.9 is the first published chart version carrying the zero-config
default-install changes from #165 (Rancher partner-charts requirement,
tracked in #166).

Verified locally: chart:check in sync, helm lint --strict clean, format,
lint, typecheck, test (18/18 groups), build.