### PR TITLE
fix(snap): stage the hidden .next dir explicitly so the daemon can boot (#113)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -38,5 +38,5 @@
       }
     }
   ],
-  "ignorePatterns": ["dist/**", ".next/**", "out/**", "build/**", "coverage/**", "node_modules/**", "next-env.d.ts"]
+  "ignorePatterns": ["dist/**", ".next/**", "out/**", "build/**", "coverage/**", "node_modules/**", "snap-payload/**", "next-env.d.ts"]
 }

--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.10
-appVersion: "0.9.51"
+version: 0.1.11
+appVersion: "0.9.52"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.51
+      image: ghcr.io/libredb/libredb-studio:0.9.52
       platforms:
         - linux/amd64
         - linux/arm64
@@ -43,7 +43,7 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - Track app release 0.9.51 (appVersion bump; default image tag follows)
+    - Track app release 0.9.52 (appVersion bump; default image tag follows)
     - Default install is now zero-config: with no values set, first-run admin credentials are generated and printed to the pod log (config.authBootstrap default changed from "off" to ""); set config.authBootstrap=off for strict fail-closed installs
     - Secret keys and env entries for JWT_SECRET, ADMIN_PASSWORD, USER_EMAIL and USER_PASSWORD are rendered only when their values are set (or an existingSecret is used), so pods no longer reference missing Secret keys
     - Strict mode now requires only secrets.jwtSecret and secrets.adminPassword; secrets.userPassword is optional in all modes (the non-admin account is an optional app feature and is never generated)

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.10 \
+  --version 0.1.11 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,8 @@ import tseslint from "typescript-eslint";
 const eslintConfig = defineConfig([
   ...nextCoreWebVitals,
   ...nextTypescript,
-  globalIgnores([".next/**", "out/**", "build/**", "dist/**", "next-env.d.ts"]),
+  // snap-payload/ is the local snap-build scratch dir (see snap/snapcraft.yaml)
+  globalIgnores([".next/**", "out/**", "build/**", "dist/**", "snap-payload/**", "next-env.d.ts"]),
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "warn",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,8 +11,14 @@
 # Local build (from the repo root, needs snapcraft + LXD):
 #   bash scripts/build-standalone-payload.sh dist
 #   mkdir -p snap-payload
-#   tar -xzf dist/libredb-studio-standalone-<version>-linux-<arch>.tar.gz -C snap-payload
+#   tar -xzf dist/libredb-studio-standalone-<version>-linux-<arch>.tar.gz -C snap-payload --strip-components=1
 #   snapcraft
+# When rebuilding after refreshing snap-payload/, run `snapcraft clean payload`
+# first: the payload part has no `source:` key, so snapcraft cannot detect the
+# changed payload and reuses the cached build (stale version and content).
+# Also delete stale scratch (snap-payload/, *.snap, old dist tarballs) BEFORE
+# rebuilding the payload: the Next.js file tracer sweeps the repo root, so
+# leftovers from a previous iteration end up inside the new payload.
 #
 # Confinement limits (strict): the snap holds only the network and
 # network-bind interfaces, so TCP database connections are the supported
@@ -21,6 +27,7 @@
 # arbitrary host sockets. Server-side SQLite storage lives under $SNAP_DATA.
 # ==============================================================================
 name: libredb-studio
+title: LibreDB Studio
 base: core24
 # Version is adopted from the payload part, which reads package.json at
 # build time (craftctl set version=...).
@@ -44,6 +51,7 @@ icon: public/logo.svg
 license: MIT
 website: https://github.com/libredb/libredb-studio
 source-code: https://github.com/libredb/libredb-studio
+contact: https://github.com/libredb/libredb-studio/issues
 issues: https://github.com/libredb/libredb-studio/issues
 grade: stable
 confinement: strict
@@ -99,7 +107,7 @@ parts:
         echo "snap-payload/server.js not found - build the payload first:" >&2
         echo "  bash scripts/build-standalone-payload.sh dist" >&2
         echo "  mkdir -p snap-payload" >&2
-        echo "  tar -xzf dist/libredb-studio-standalone-<version>-linux-<arch>.tar.gz -C snap-payload" >&2
+        echo "  tar -xzf dist/libredb-studio-standalone-<version>-linux-<arch>.tar.gz -C snap-payload --strip-components=1" >&2
         exit 1
       fi
       cp -R "$PAYLOAD_SRC/." "$CRAFT_PART_INSTALL/"
@@ -119,6 +127,17 @@ parts:
       # Snap version = package.json version. Native builds only (see
       # platforms), so the just-fetched node binary is runnable here.
       craftctl set version="$("$CRAFT_PART_INSTALL/node/bin/node" -p "require('$CRAFT_PROJECT_DIR/package.json').version")"
+    # Snapcraft filesets: the default '*' glob does NOT match hidden files,
+    # which silently drops .next (the Next.js production build) between
+    # install -> stage -> prime and leaves the daemon crash-looping on
+    # "Could not find a production build in the './.next' directory".
+    # List .next explicitly in BOTH filesets (each defaults to '*' on its own).
+    stage:
+      - "*"
+      - .next
+    prime:
+      - "*"
+      - .next
 
   launcher:
     plugin: dump


### PR DESCRIPTION
## Problem

The first local snap validation for #113 (per the docs/DISTRIBUTION.md runbook) produced a daemon that crash-looped on:

```
Error: Could not find a production build in the './.next' directory.
```

Root cause: snapcraft's default stage/prime fileset is `*`, a glob that does not match hidden files. The `.next` production build was silently dropped between install -> stage -> prime (verified inside the build container: `parts/payload/install` had `.next`, `prime/` did not). The release CI snap job uses the same snapcraft.yaml, so the first Store publish would have shipped a broken snap.

## Fix

- `snap/snapcraft.yaml`: list `.next` explicitly in both the `stage` and `prime` filesets (each defaults to `*` on its own).
- Document two local-rebuild gotchas in the header: `snapcraft clean payload` is required after refreshing `snap-payload/` (the part has no `source:` key, so snapcraft reuses the cached build), and stale scratch (`snap-payload/`, `*.snap`, old dist tarballs) must be deleted before rebuilding the payload (the Next.js file tracer sweeps the repo root into the payload).
- Fix the missing `--strip-components=1` in the header's local-build instructions (the release tarball is rooted under `libredb-studio-<version>/`).
- Add the `title` / `contact` metadata fields the snapcraft linter flags.
- `eslint.config.mjs`, `.oxlintrc.json`: ignore `snap-payload/**` so lint passes while the local scratch dir exists.
- `charts/`: `chart:bump` to 0.1.11 / appVersion 0.9.52 (package.json was bumped to 0.9.52 on main without the chart sync; the required check enforces the match).

## Validation

Local runbook execution on Linux Mint 22.1 (snapcraft 9.0.1, LXD):

- `snap install --dangerous` of the fixed snap: daemon active, `/api/db/health` 200, `/` -> `/login` 307, browser login with the first-run generated credentials works.
- `unsquashfs -l`: 764 `.next` entries in the fixed snap (0 before).
- Restart: bootstrap credentials reused from `$SNAP_DATA/auth-bootstrap.json`, no regenerated banner.

Part of #113.