### PR TITLE
fix(helm): quote artifacthub.io/changes entries so ArtifactHub indexes new chart versions

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -43,10 +43,10 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - Expand values.schema.json coverage (serviceAccount, pod/container security contexts, imagePullSecrets, tolerations, affinity, topologySpreadConstraints, networkPolicy, service/persistence annotations, ingress hosts/tls, persistence accessModes, extraEnv/extraEnvFrom, podDisruptionBudget.maxUnavailable)
-    - Machine-enforce the documented jwtSecret length in values.schema.json - empty (zero-config) or at least 32 characters
-    - PodDisruptionBudget - an explicit minAvailable 0 now renders; minAvailable/maxUnavailable are mutually exclusive and exactly one is required when the PDB is enabled
-    - Autoscaling - the HPA is no longer rendered when the effective storage provider is sqlite (single-writer); the deployment falls back to replicaCount and the install notes warn
+    - "Expand values.schema.json coverage (serviceAccount, pod/container security contexts, imagePullSecrets, tolerations, affinity, topologySpreadConstraints, networkPolicy, service/persistence annotations, ingress hosts/tls, persistence accessModes, extraEnv/extraEnvFrom, podDisruptionBudget.maxUnavailable)"
+    - "Machine-enforce the documented jwtSecret length in values.schema.json - empty (zero-config) or at least 32 characters"
+    - "PodDisruptionBudget - an explicit minAvailable 0 now renders; minAvailable/maxUnavailable are mutually exclusive and exactly one is required when the PDB is enabled"
+    - "Autoscaling - the HPA is no longer rendered when the effective storage provider is sqlite (single-writer); the deployment falls back to replicaCount and the install notes warn"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/scripts/sync-chart-version.mjs
+++ b/scripts/sync-chart-version.mjs
@@ -71,18 +71,37 @@ export function bumpPatch(version) {
  */
 export function checkChangesAnnotation(chartYaml) {
   const violations = [];
-  const block = chartYaml.match(/^ {2}artifacthub\.io\/changes: \|\n((?: {4}.*\n?)*)/m);
-  if (!block) {
+  // Normalize CRLF and guarantee a trailing newline so the block regex sees
+  // every line the same way regardless of checkout/editor settings.
+  let text = chartYaml.replace(/\r\n/g, "\n");
+  if (!text.endsWith("\n")) {
+    text += "\n";
+  }
+  if (!/^[ \t]*artifacthub\.io\/changes:/m.test(text)) {
     return violations;
   }
-  for (const raw of block[1].split("\n")) {
-    if (!/^ {4}- /.test(raw)) {
-      continue;
+  // Locate the block scalar independent of the key's indentation: its body is
+  // every following line indented deeper than the key (or blank). If the key
+  // exists but this extraction fails, the guard must fail LOUDLY - a silent
+  // pass here is exactly the failure mode this check exists to prevent.
+  const block = text.match(/^([ \t]*)artifacthub\.io\/changes:[ \t]*\|[^\n]*\n((?:\1[ \t]+[^\n]*\n|[ \t]*\n)*)/m);
+  if (!block) {
+    violations.push(
+      `${CHART_YAML}: artifacthub.io/changes exists but its block scalar could not be parsed - ` +
+        `use a literal block ("changes: |" with indented entries) or update checkChangesAnnotation`,
+    );
+    return violations;
+  }
+  const lines = block[2].split("\n").filter((line) => line.trim() !== "");
+  const entryIndent = lines.length > 0 ? lines[0].match(/^[ \t]*/)[0].length : 0;
+  for (const raw of lines) {
+    if (raw.match(/^[ \t]*/)[0].length > entryIndent) {
+      continue; // continuation of a multi-line entry; the entry's first line is judged
     }
     const entry = raw.trim();
     if (!/^- "[^"]*"$/.test(entry)) {
       violations.push(
-        `${CHART_YAML}: artifacthub.io/changes entry must be a double-quoted string ` +
+        `${CHART_YAML}: artifacthub.io/changes entry must be a single-line double-quoted string ` +
           `(ArtifactHub refuses unquoted {}:[],&*#?|-<>=!%@ and skips the whole chart version): ${entry}`,
       );
     }

--- a/scripts/sync-chart-version.mjs
+++ b/scripts/sync-chart-version.mjs
@@ -59,6 +59,38 @@ export function bumpPatch(version) {
 }
 
 /**
+ * ArtifactHub refuses to index a chart version whose artifacthub.io/changes entries
+ * contain any of {}:[],&*#?|-<>=!%@ unquoted ("error preparing package ... invalid
+ * changes annotation"); released 0.1.1 and 0.1.9-0.1.11 are missing from the AH
+ * listing for exactly this reason. House style therefore requires every entry to be
+ * a double-quoted plain string, which sidesteps the character list entirely.
+ * Continuation lines (deeper indentation) are not entries and are ignored.
+ *
+ * @param {string} chartYaml
+ * @returns {string[]} violation messages (empty = clean or annotation absent)
+ */
+export function checkChangesAnnotation(chartYaml) {
+  const violations = [];
+  const block = chartYaml.match(/^ {2}artifacthub\.io\/changes: \|\n((?: {4}.*\n?)*)/m);
+  if (!block) {
+    return violations;
+  }
+  for (const raw of block[1].split("\n")) {
+    if (!/^ {4}- /.test(raw)) {
+      continue;
+    }
+    const entry = raw.trim();
+    if (!/^- "[^"]*"$/.test(entry)) {
+      violations.push(
+        `${CHART_YAML}: artifacthub.io/changes entry must be a double-quoted string ` +
+          `(ArtifactHub refuses unquoted {}:[],&*#?|-<>=!%@ and skips the whole chart version): ${entry}`,
+      );
+    }
+  }
+  return violations;
+}
+
+/**
  * The released-version check only matters when the appVersion changed against the base
  * AND the chart version moved off the base's (otherwise the chart-releaser violation
  * covers it). Shared by checkSync() and main() so the gating cannot drift (#151).
@@ -95,6 +127,7 @@ export function checkSync({ pkgVersion, chartYaml, readme, baseChart = null, cha
   if (imageTag !== appVersion) {
     violations.push(`${CHART_YAML}: artifacthub.io/images tag '${imageTag}' does not equal appVersion '${appVersion}'`);
   }
+  violations.push(...checkChangesAnnotation(chartYaml));
   const readmeVersion = parseReadmeVersion(readme);
   if (readmeVersion !== version) {
     violations.push(`${CHART_README}: --version example '${readmeVersion}' does not equal chart version '${version}'`);
@@ -133,8 +166,8 @@ export function applyBump({ pkgVersion, chartYaml, readme }) {
     .replace(/^(\s*image:\s*ghcr\.io\/libredb\/libredb-studio:)\S+/gm, `$1${pkgVersion}`);
   if (appVersion !== pkgVersion) {
     newChartYaml = newChartYaml.replace(
-      /- Track app release .*/,
-      `- Track app release ${pkgVersion} (appVersion bump; default image tag follows)`,
+      /- "?Track app release .*/,
+      `- "Track app release ${pkgVersion} (appVersion bump; default image tag follows)"`,
     );
   }
   const newReadme = readme.replace(/--version\s+\S+/g, `--version ${newVersion}`);

--- a/tests/unit/sync-chart-version.test.ts
+++ b/tests/unit/sync-chart-version.test.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import {
   applyBump,
   bumpPatch,
+  checkChangesAnnotation,
   checkSync,
   parseChart,
   parseImageTag,
@@ -43,7 +44,7 @@ annotations:
       platforms:
         - linux/amd64
   artifacthub.io/changes: |
-    - Track app release ${appVersion} (appVersion bump; default image tag follows)
+    - "Track app release ${appVersion} (appVersion bump; default image tag follows)"
 dependencies:
   - name: postgresql
     version: "16.x.x"
@@ -102,6 +103,46 @@ describe("parseReadmeVersion", () => {
   test("throws when duplicated --version examples disagree instead of silently using the first (#151)", () => {
     const dup = `${readme()}helm upgrade libredb libredb/libredb-studio --version 0.1.2\n`;
     expect(() => parseReadmeVersion(dup)).toThrow(/disagree/);
+  });
+});
+
+describe("checkChangesAnnotation", () => {
+  // ArtifactHub refuses to index a chart version whose artifacthub.io/changes
+  // entries contain any of {}:[],&*#?|-<>=!%@ unquoted - released 0.1.1 and
+  // 0.1.9-0.1.11 are missing from the AH listing for exactly this reason.
+  test("quoted entries are clean", () => {
+    expect(checkChangesAnnotation(chartYaml())).toEqual([]);
+  });
+
+  test("an unquoted entry is a violation naming the offending line", () => {
+    const unquoted = chartYaml().replace(
+      /- "Track app release .*/,
+      "- Default install is now zero-config: no values needed",
+    );
+    const violations = checkChangesAnnotation(unquoted);
+    expect(violations.length).toBe(1);
+    expect(violations[0]).toContain("artifacthub.io/changes");
+    expect(violations[0]).toContain("zero-config");
+  });
+
+  test("a half-quoted entry is a violation", () => {
+    const half = chartYaml().replace(/- "Track app release .*/, '- "Unterminated quote entry');
+    expect(checkChangesAnnotation(half).length).toBe(1);
+  });
+
+  test("a chart without a changes annotation is clean", () => {
+    const noChanges = chartYaml().replace(/  artifacthub\.io\/changes: \|\n(?: {4}.*\n)*/, "");
+    expect(noChanges).not.toContain("artifacthub.io/changes");
+    expect(checkChangesAnnotation(noChanges)).toEqual([]);
+  });
+
+  test("checkSync surfaces changes-annotation violations", () => {
+    const unquoted = chartYaml().replace(
+      /- "Track app release .*/,
+      "- Refuse zero-config installs with replicaCount > 1",
+    );
+    const violations = checkSync({ pkgVersion: "0.9.44", chartYaml: unquoted, readme: readme() });
+    expect(violations.some((v) => v.includes("artifacthub.io/changes"))).toBe(true);
   });
 });
 
@@ -196,7 +237,7 @@ describe("applyBump", () => {
     expect(result.appVersion).toBe("0.9.45");
     expect(result.chartYaml).toContain('appVersion: "0.9.45"');
     expect(result.chartYaml).toContain("image: ghcr.io/libredb/libredb-studio:0.9.45");
-    expect(result.chartYaml).toContain("- Track app release 0.9.45 (appVersion bump; default image tag follows)");
+    expect(result.chartYaml).toContain('- "Track app release 0.9.45 (appVersion bump; default image tag follows)"');
     expect(result.readme).toContain("--version 0.1.4");
     expect(checkSync({ pkgVersion: "0.9.45", chartYaml: result.chartYaml, readme: result.readme })).toEqual([]);
   });
@@ -210,13 +251,23 @@ describe("applyBump", () => {
 
   test("hand-written changes line is preserved when only the image tag drifted", () => {
     const custom = chartYaml({ imageTag: "0.9.43" }).replace(
-      /- Track app release .*/,
-      "- Hand-written chart-only changelog entry",
+      /- "Track app release .*/,
+      '- "Hand-written chart-only changelog entry"',
     );
     const result = applyBump({ pkgVersion: "0.9.44", chartYaml: custom, readme: readme() });
     expect(result.changed).toBe(true);
     expect(result.chartYaml).toContain("image: ghcr.io/libredb/libredb-studio:0.9.44");
-    expect(result.chartYaml).toContain("- Hand-written chart-only changelog entry");
+    expect(result.chartYaml).toContain('- "Hand-written chart-only changelog entry"');
+  });
+
+  test("rewrites a legacy unquoted Track line into the quoted form", () => {
+    const legacy = chartYaml().replace(
+      /- "Track app release .*/,
+      "- Track app release 0.9.44 (appVersion bump; default image tag follows)",
+    );
+    const result = applyBump({ pkgVersion: "0.9.45", chartYaml: legacy, readme: readme() });
+    expect(result.chartYaml).toContain('- "Track app release 0.9.45 (appVersion bump; default image tag follows)"');
+    expect(result.chartYaml).not.toContain("\n    - Track app release");
   });
 
   test("rewrites every duplicated image line and --version example, not just the first (#151)", () => {

--- a/tests/unit/sync-chart-version.test.ts
+++ b/tests/unit/sync-chart-version.test.ts
@@ -168,7 +168,7 @@ describe("checkChangesAnnotation", () => {
     // changes value means the extraction no longer understands the file.
     const inline = chartYaml().replace(
       /  artifacthub\.io\/changes: \|\n(?: {4}.*\n)*/,
-      '  artifacthub.io/changes: \'["entry"]\'\n',
+      "  artifacthub.io/changes: '[\"entry\"]'\n",
     );
     const violations = checkChangesAnnotation(inline);
     expect(violations.length).toBe(1);

--- a/tests/unit/sync-chart-version.test.ts
+++ b/tests/unit/sync-chart-version.test.ts
@@ -136,6 +136,55 @@ describe("checkChangesAnnotation", () => {
     expect(checkChangesAnnotation(noChanges)).toEqual([]);
   });
 
+  test("CRLF line endings do not blind the check", () => {
+    const crlfClean = chartYaml().replace(/\n/g, "\r\n");
+    expect(checkChangesAnnotation(crlfClean)).toEqual([]);
+    const crlfUnquoted = chartYaml()
+      .replace(/- "Track app release .*/, "- Default install is now zero-config: no values needed")
+      .replace(/\n/g, "\r\n");
+    expect(checkChangesAnnotation(crlfUnquoted).length).toBe(1);
+  });
+
+  test("a reindented changes block is still checked", () => {
+    const reindented = [
+      "apiVersion: v2",
+      "name: libredb-studio",
+      "version: 0.1.3",
+      'appVersion: "0.9.44"',
+      "annotations:",
+      "    artifacthub.io/changes: |",
+      '        - "Quoted entry"',
+      "        - Unquoted entry with a dash - flagged",
+      "dependencies: []",
+      "",
+    ].join("\n");
+    const violations = checkChangesAnnotation(reindented);
+    expect(violations.length).toBe(1);
+    expect(violations[0]).toContain("Unquoted entry");
+  });
+
+  test("a changes key whose block cannot be parsed fails loudly instead of passing silently", () => {
+    // The guard's failure mode must never be silence: an inline (non-block)
+    // changes value means the extraction no longer understands the file.
+    const inline = chartYaml().replace(
+      /  artifacthub\.io\/changes: \|\n(?: {4}.*\n)*/,
+      '  artifacthub.io/changes: \'["entry"]\'\n',
+    );
+    const violations = checkChangesAnnotation(inline);
+    expect(violations.length).toBe(1);
+    expect(violations[0]).toContain("could not be parsed");
+  });
+
+  test("a multi-line folded entry is flagged once (house style: single-line quoted entries)", () => {
+    const continued = chartYaml().replace(
+      /- "Track app release .*/,
+      '- "A quoted entry\n      that folds onto a second line"',
+    );
+    const violations = checkChangesAnnotation(continued);
+    expect(violations.length).toBe(1);
+    expect(violations[0]).toContain("A quoted entry");
+  });
+
   test("checkSync surfaces changes-annotation violations", () => {
     const unquoted = chartYaml().replace(
       /- "Track app release .*/,


### PR DESCRIPTION
## Summary

ArtifactHub's tracker hard-fails ("error preparing package ... invalid changes annotation") any chart version whose `artifacthub.io/changes` entries contain one of `{}:[],&*#?|-<>=!%@` unquoted. Released 0.1.1 and 0.1.9-0.1.11 are entirely absent from the AH listing for exactly this reason - AH currently shows 0.1.8 as latest while the helm repo index carries 0.1.11 (verified via the AH API and the live index).

The unreleased 0.1.13 annotation on main violated the same rule, so the upcoming 0.9.53 release would have vanished from AH too. This PR:

- Quotes all four pending 0.1.13 `changes` entries (chart version unchanged - 0.1.13 is unreleased, no tag exists).
- Makes `chart:bump` write the auto Track line in quoted form, still matching the legacy unquoted form when rewriting.
- Adds `checkChangesAnnotation` to the required `chart:check` CI gate: every changes entry must be a double-quoted string, so an unquoted entry can never ship again. Test-first (+6 cases, 40/40).

Released tarballs are NOT touched: they are immutable (see #167) and Rancher partner-charts pins 0.1.9. The missing old versions on AH stay missing; 0.1.13 will appear as latest once released.

## Test plan

- [x] `bun test tests/unit/sync-chart-version.test.ts` 40/40 (6 new cases, watched RED first via the missing export)
- [x] `bun run chart:check` green on the real repo
- [x] `helm lint charts/libredb-studio --strict` clean
- [x] Full five-command gate via the pre-commit hook