### PR TITLE
feat(distribution): channel inventory and drift checker (visibility matrix v1)

### DIFF
--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -1,0 +1,45 @@
+name: Distribution Check
+
+# Weekly visibility report: measures every distribution channel's pinned
+# version (distribution/channels.yaml) against package.json and writes the
+# drift table to the Job Summary. Warn-only by design - PaaS catalog drift is
+# routine and must never block anything; per-channel enforcement lives where
+# it is owned (e.g. the required chart:check gate for Helm).
+#
+# Deliberately NOT triggered on release: published - releases are published
+# by release-artifacts.yml under GITHUB_TOKEN, whose events never trigger
+# other workflows (see the explicit dispatch chain in that file). A weekly
+# cron plus manual dispatch covers the reporting need without joining the
+# release chain.
+on:
+  schedule:
+    - cron: "41 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: distribution-check
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check distribution channels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run distribution:check

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -38,5 +38,5 @@
       }
     }
   ],
-  "ignorePatterns": ["dist/**", ".next/**", "out/**", "build/**", "coverage/**", "node_modules/**", "snap-payload/**", "next-env.d.ts"]
+  "ignorePatterns": ["dist/**", ".next/**", "out/**", "build/**", "coverage/**", "node_modules/**", "snap-payload/**", ".claude/**", "next-env.d.ts"]
 }

--- a/README.md
+++ b/README.md
@@ -448,6 +448,11 @@ Deploy your own instance of LibreDB Studio with a single click on Koyeb, Render,
 
 ## Deployment (DevOps)
 
+> Maintainers: every distribution channel is inventoried in
+> [`distribution/channels.yaml`](distribution/channels.yaml); `bun run distribution:check`
+> reports version drift across all of them (see
+> [docs/DISTRIBUTION.md](docs/DISTRIBUTION.md#channel-inventory-and-drift-check)).
+
 ### Koyeb
 
 1. **Fork this repository**

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -1,0 +1,361 @@
+# Distribution channel inventory (the "visibility matrix").
+#
+# One entry per place users can obtain LibreDB Studio. Human-maintained:
+# scripts/distribution-check.mjs READS this file and reports drift against
+# package.json - it never writes version numbers into it. Schema, tier and
+# SLA definitions, and maintenance rules (including when to update
+# last_bump_pr) live in docs/DISTRIBUTION.md ("Channel inventory and drift
+# check").
+#
+# Field summary:
+#   id/name/status/tier/kind  identity; status: live | pending | deprecated
+#   update.method             ci_publish | commit | upstream_pr | manual_ui
+#   update.sla                every_release | minor_plus | major_only | on_demand
+#   links                     tracking_issue / first_pr / last_bump_pr (nullable
+#                             until the first post-listing bump) / catalog /
+#                             upstream_repo / docs
+#   pin.strategy              local_file | remote_file | none
+#   pin.extract               regex with ONE capture group; all matches in a
+#                             source must agree (ambiguity is reported, never
+#                             resolved to the first hit)
+
+channels:
+  # ---- Tier 0: core registries, published directly by release CI ----------
+
+  - id: github-release
+    name: GitHub Releases (standalone tarballs, deb/rpm, snap assets)
+    status: live
+    tier: 0
+    kind: release-assets
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      catalog: https://github.com/libredb/libredb-studio/releases
+      docs: docs/DISTRIBUTION.md
+    pin:
+      strategy: none
+      note: Assets are built from the tag by release-artifacts.yml; nothing to drift.
+
+  - id: docker-ghcr
+    name: Docker image (GHCR, canonical)
+    status: live
+    tier: 0
+    kind: container-image
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      catalog: https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio
+    pin:
+      strategy: none
+      note: Version and latest tags pushed by docker-build-push.yml on release.
+
+  - id: docker-hub-mirror
+    name: Docker Hub mirror (discoverability only)
+    status: live
+    tier: 0
+    kind: container-image
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      catalog: https://hub.docker.com/r/libredb/libredb-studio
+    pin:
+      strategy: none
+      note: Mirror of GHCR; immutable-tag rules must stay semver-only.
+
+  - id: npm
+    name: npm package @libredb/studio (library + npx launcher)
+    status: live
+    tier: 0
+    kind: package-registry
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/110
+      first_pr: https://github.com/libredb/libredb-studio/pull/122
+      catalog: https://www.npmjs.com/package/@libredb/studio
+    pin:
+      strategy: none
+      note: Published by npm-publish.yml; registry API probe is a phase-2 idea.
+
+  # ---- Tier 1: packaged formats owned by this repo, CI-published ----------
+
+  - id: helm
+    name: Helm chart (libredb.org repo + GHCR OCI + ArtifactHub)
+    status: live
+    tier: 1
+    kind: helm-chart
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/138
+      first_pr: https://github.com/libredb/libredb-studio/pull/44
+      catalog: https://artifacthub.io/packages/helm/libredb-studio/libredb-studio
+      docs: docs/HELM_CHART.md
+    pin:
+      strategy: local_file
+      files:
+        - charts/libredb-studio/Chart.yaml
+      extract: 'appVersion: "(\d+\.\d+\.\d+)"'
+      note: Enforcement lives in the required chart:check CI gate (#138); this row is visibility.
+
+  - id: homebrew
+    name: Homebrew tap (libredb/tap/libredb-studio)
+    status: live
+    tier: 1
+    kind: package-manager
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/111
+      first_pr: https://github.com/libredb/libredb-studio/pull/122
+      upstream_repo: https://github.com/libredb/homebrew-tap
+    pin:
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/libredb/homebrew-tap/main/Formula/libredb-studio.rb
+      extract: 'version "(\d+\.\d+\.\d+)"'
+      note: Confirms the release-CI tap push actually landed.
+
+  - id: snap
+    name: Snap Store (stable channel, amd64+arm64)
+    status: live
+    tier: 1
+    kind: package-manager
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/113
+      first_pr: https://github.com/libredb/libredb-studio/pull/177
+      catalog: https://snapcraft.io/libredb-studio
+    pin:
+      strategy: none
+      note: Store-published by the release-artifacts snap job; store API probe is a phase-2 idea.
+
+  - id: linux-deb-rpm
+    name: Linux .deb / .rpm packages (release assets)
+    status: live
+    tier: 1
+    kind: os-package
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/112
+      first_pr: https://github.com/libredb/libredb-studio/pull/122
+    pin:
+      strategy: none
+      note: Built by nfpm from the tag in release-artifacts.yml; nothing to drift.
+
+  # ---- Tier 2: LibreDB-owned copies and listings, bumped by hand ----------
+
+  - id: caprover-local
+    name: CapRover one-click template (in-repo source of truth)
+    status: live
+    tier: 2
+    kind: one-click-template
+    update:
+      method: commit
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/56
+      first_pr: https://github.com/libredb/libredb-studio/pull/57
+      docs: deploy/caprover/README.md
+    pin:
+      strategy: local_file
+      files:
+        - deploy/caprover/libredb-studio.yml
+      extract: "defaultValue: '(\\d+\\.\\d+\\.\\d+)'"
+
+  - id: caprover-mirror
+    name: CapRover 3rd-party repo (libredb.org/caprover-one-click-apps)
+    status: live
+    tier: 2
+    kind: one-click-template
+    update:
+      method: commit
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/56
+      catalog: https://libredb.org/caprover-one-click-apps
+      upstream_repo: https://github.com/libredb/caprover-one-click-apps
+    pin:
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/libredb/caprover-one-click-apps/main/public/v4/apps/libredb-studio.yml
+      extract: "defaultValue: '(\\d+\\.\\d+\\.\\d+)'"
+
+  - id: railway-template
+    name: Railway one-click template
+    status: live
+    tier: 2
+    kind: paas-template
+    update:
+      method: manual_ui
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/174
+      first_pr: https://github.com/libredb/libredb-studio/pull/67
+      catalog: https://railway.com/deploy/libredb-studio
+      docs: deploy/railway/PUBLISH.md
+    pin:
+      strategy: local_file
+      files:
+        - deploy/railway/template.json
+        - deploy/railway/README.md
+        - deploy/railway/PUBLISH.md
+      extract: 'libredb-studio:(\d+\.\d+\.\d+)'
+      note: The published template is edited in the Railway dashboard; these three files must move together.
+
+  - id: koyeb-deploy-button
+    name: Koyeb deploy button (repo README)
+    status: live
+    tier: 2
+    kind: deploy-button
+    update:
+      method: commit
+      sla: on_demand
+    links:
+      docs: deploy/koyeb/README.md
+    pin:
+      strategy: none
+      note: The button deploys ghcr.io latest by design; there is no version pin.
+
+  # ---- Tier 3: upstream community catalogs, bumped via PR -----------------
+
+  - id: caprover-official
+    name: CapRover official one-click apps
+    status: live
+    tier: 3
+    kind: one-click-template
+    update:
+      method: upstream_pr
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/56
+      first_pr: https://github.com/caprover/one-click-apps/pull/1303
+      upstream_repo: https://github.com/caprover/one-click-apps
+    pin:
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/caprover/one-click-apps/master/public/v4/apps/libredb-studio.yml
+      extract: "defaultValue: '(\\d+\\.\\d+\\.\\d+)'"
+
+  - id: dokploy
+    name: Dokploy template catalog
+    status: live
+    tier: 3
+    kind: paas-template
+    update:
+      method: upstream_pr
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/171
+      first_pr: https://github.com/Dokploy/templates/pull/931
+      catalog: https://templates.dokploy.com
+      upstream_repo: https://github.com/Dokploy/templates
+      docs: deploy/dokploy/README.md
+    pin:
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/Dokploy/templates/main/blueprints/libredb-studio/docker-compose.yml
+      extract: 'libredb-studio:(\d+\.\d+\.\d+)'
+      note: Bump from 0.9.27 to the current release is tracked in issue 175.
+
+  - id: cosmos
+    name: Cosmos servapp marketplace
+    status: live
+    tier: 3
+    kind: one-click-template
+    update:
+      method: upstream_pr
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/172
+      first_pr: https://github.com/azukaar/cosmos-servapps-official/pull/218
+      upstream_repo: https://github.com/azukaar/cosmos-servapps-official
+      docs: deploy/cosmos/README.md
+    pin:
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/azukaar/cosmos-servapps-official/master/servapps/LibreDB-Studio/cosmos-compose.json
+      extract: 'libredb-studio:(\d+\.\d+\.\d+)'
+
+  - id: kubero
+    name: Kubero template catalog
+    status: live
+    tier: 3
+    kind: paas-template
+    update:
+      method: upstream_pr
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/173
+      first_pr: https://github.com/kubero-dev/kubero/pull/754
+      catalog: https://www.kubero.dev/templates
+      upstream_repo: https://github.com/kubero-dev/kubero
+      docs: deploy/kubero/README.md
+    pin:
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/kubero-dev/kubero/main/services/libredb-studio/app.yaml
+      extract: 'ghcr\.io/libredb/libredb-studio\s+tag:\s*(\d+\.\d+\.\d+)'
+
+  # ---- Tier 4: partner and curated catalogs (not self-serve) --------------
+
+  - id: rancher-partner
+    name: Rancher Partner Charts
+    status: pending
+    tier: 4
+    kind: partner-catalog
+    update:
+      method: upstream_pr
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/166
+      first_pr: https://github.com/rancher/partner-charts/pull/1158
+      upstream_repo: https://github.com/rancher/partner-charts
+    pin:
+      strategy: none
+      note: Awaiting certification; pin strategy decided once the listing exists.
+
+  - id: koyeb-catalog
+    name: Koyeb One-Click Apps catalog (curated by Koyeb)
+    status: pending
+    tier: 4
+    kind: curated-catalog
+    update:
+      method: manual_ui
+      sla: on_demand
+    links:
+      catalog: https://www.koyeb.com/deploy
+      docs: deploy/koyeb/CATALOG_SUBMISSION.md
+    pin:
+      strategy: none
+
+  - id: digitalocean
+    name: DigitalOcean Marketplace
+    status: pending
+    tier: 4
+    kind: marketplace
+    update:
+      method: manual_ui
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/72
+    pin:
+      strategy: none
+
+  - id: winget
+    name: Windows distribution (winget / Chocolatey)
+    status: pending
+    tier: 4
+    kind: package-manager
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/114
+    pin:
+      strategy: none
+      note: Blocked on a Windows standalone payload.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -416,6 +416,51 @@ setups still publish the rest:
 | `SNAPCRAFT_STORE_CREDENTIALS` | The entire snap build/publish job (exported via `snapcraft export-login`) | Snap job skipped |
 | `DOCKER_HUB_TOKEN` (+ `DOCKER_HUB_USERNAME` variable) | The Docker Hub mirror push | GHCR-only publish |
 
+### Channel inventory and drift check
+
+[`distribution/channels.yaml`](../distribution/channels.yaml) is the machine-readable inventory
+of every distribution channel: identity, update policy, provenance links, and (where measurable)
+where its pinned version lives. `bun run distribution:check`
+([`scripts/distribution-check.mjs`](../scripts/distribution-check.mjs)) compares every live
+channel's pin against `package.json` and prints a markdown drift table; the weekly
+[`distribution-check.yml`](../.github/workflows/distribution-check.yml) workflow writes the same
+table to its Job Summary (cron + manual dispatch — deliberately not `release: published`, which
+GITHUB_TOKEN-published releases never fire). The checker only **reads** the inventory; bumping a
+pin or editing a channel entry is always a human commit.
+
+**Tiers** describe who controls publication:
+
+| Tier | Meaning | Examples |
+|---|---|---|
+| 0 | Core registries, published directly by release CI | GitHub Releases, GHCR, Docker Hub, npm |
+| 1 | Packaged formats owned by this repo, CI-published | Helm, Homebrew tap, Snap, .deb/.rpm |
+| 2 | LibreDB-owned copies and listings, bumped by hand | CapRover source/mirror, Railway, Koyeb button |
+| 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero |
+| 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DO, winget |
+
+**SLAs** (`update.sla`) state how quickly a channel is expected to follow a release:
+`every_release` (bumped as part of releasing), `minor_plus` (bumped for minor releases and
+above), `major_only`, `on_demand` (bumped when someone gets to it — the honest default for PaaS
+catalog templates).
+
+**Pin strategies:** `local_file` (version lives in files in this repo), `remote_file` (fetched
+from an upstream raw URL, best-effort — fetch failures degrade to UNKNOWN and never fail the
+run), `none` (nothing to measure, stated explicitly with a `note`). Measurable pins carry an
+`extract` regex with exactly one capture group; when a source yields multiple *different*
+matches the channel is reported instead of silently using the first hit.
+
+**Strict mode:** `bun run distribution:check --strict` exits non-zero only for `local_file`
+channels with `sla: every_release` that are drifted or unmeasurable. Remote catalogs and
+`on_demand` templates never gate, so strict is enableable today without first paying off
+historical PaaS drift. For the Helm chart the enforcement remains the required `chart:check` CI
+gate (#138) — the matrix row is visibility, not a second gate. `--json` emits the rows for
+scripting.
+
+**Adding a channel** = one new entry in `channels.yaml` (copy a neighbour of the same tier; the
+schema is validated on every run). Set `links.first_pr` to the PR that landed the listing, and
+update `links.last_bump_pr` whenever a version-bump PR for that channel merges — it is `null`
+until the first post-listing bump and is displayed, not auto-discovered.
+
 ### Manual steps still open
 
 - **Snap Store listing screenshots**: the description and icon ship with the snap

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,8 +6,10 @@ import tseslint from "typescript-eslint";
 const eslintConfig = defineConfig([
   ...nextCoreWebVitals,
   ...nextTypescript,
-  // snap-payload/ is the local snap-build scratch dir (see snap/snapcraft.yaml)
-  globalIgnores([".next/**", "out/**", "build/**", "dist/**", "snap-payload/**", "next-env.d.ts"]),
+  // snap-payload/ is the local snap-build scratch dir (see snap/snapcraft.yaml);
+  // .claude/ holds agent worktrees whose checkouts (and .next build output)
+  // must not be linted from this checkout
+  globalIgnores([".next/**", "out/**", "build/**", "dist/**", "snap-payload/**", ".claude/**", "next-env.d.ts"]),
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "warn",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "test:coverage-html": "bun run test:coverage && genhtml coverage/lcov.info --output-directory coverage/html && echo '\n Open coverage/html/index.html in your browser'",
     "knip": "knip",
     "chart:check": "node scripts/sync-chart-version.mjs --check",
-    "chart:bump": "node scripts/sync-chart-version.mjs --write"
+    "chart:bump": "node scripts/sync-chart-version.mjs --write",
+    "distribution:check": "node scripts/distribution-check.mjs"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Distribution visibility matrix checker.
+ *
+ * Reads the human-maintained channel inventory (distribution/channels.yaml),
+ * measures every live channel's pinned version against package.json, and
+ * prints a markdown drift table (also appended to GITHUB_STEP_SUMMARY when
+ * set). Warn-only by default so existing PaaS drift never breaks a release;
+ * `--strict` exits 1 only for owned local_file pins whose update SLA is
+ * every_release - remote catalogs are upstream-owned and never gate.
+ *
+ * The checker only ever READS channels.yaml; version bumps in pin files and
+ * inventory edits are human work (see docs/DISTRIBUTION.md). Mirrors the
+ * style of scripts/sync-chart-version.mjs; the pure functions below are unit
+ * tested in tests/unit/distribution-check.test.ts.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const CHANNELS_YAML = "distribution/channels.yaml";
+const STATUSES = ["live", "pending", "deprecated"];
+const STRATEGIES = ["local_file", "remote_file", "none"];
+const METHODS = ["ci_publish", "commit", "upstream_pr", "manual_ui"];
+const SLAS = ["every_release", "minor_plus", "major_only", "on_demand"];
+
+function countCaptureGroups(pattern) {
+  // Appending an empty alternative makes the regex match the empty string, so
+  // exec() always returns: array length - 1 == number of capture groups.
+  return new RegExp(`${pattern}|`).exec("").length - 1;
+}
+
+/**
+ * Parses and validates the inventory. Throws on structural problems (bad
+ * enum values, missing pin fields, duplicate ids) - a channel that cannot be
+ * measured on purpose must say so explicitly with `strategy: none`.
+ */
+export function parseChannels(yamlText) {
+  const doc = parseYaml(yamlText);
+  if (!doc || !Array.isArray(doc.channels)) {
+    throw new Error(`${CHANNELS_YAML}: top-level 'channels' list is missing`);
+  }
+  const seen = new Set();
+  for (const channel of doc.channels) {
+    const id = channel?.id;
+    if (typeof id !== "string" || id === "") {
+      throw new Error(`${CHANNELS_YAML}: every channel needs a non-empty string id`);
+    }
+    if (seen.has(id)) {
+      throw new Error(`${CHANNELS_YAML}: duplicate channel id '${id}'`);
+    }
+    seen.add(id);
+    if (!STATUSES.includes(channel.status)) {
+      throw new Error(`${CHANNELS_YAML}: ${id}: status must be one of ${STATUSES.join("|")}`);
+    }
+    if (!channel.update || !METHODS.includes(channel.update.method)) {
+      throw new Error(`${CHANNELS_YAML}: ${id}: update.method must be one of ${METHODS.join("|")}`);
+    }
+    if (!SLAS.includes(channel.update.sla)) {
+      throw new Error(`${CHANNELS_YAML}: ${id}: update.sla must be one of ${SLAS.join("|")}`);
+    }
+    const pin = channel.pin;
+    if (!pin || !STRATEGIES.includes(pin.strategy)) {
+      throw new Error(`${CHANNELS_YAML}: ${id}: pin.strategy must be one of ${STRATEGIES.join("|")}`);
+    }
+    if (pin.strategy === "local_file" && (!Array.isArray(pin.files) || pin.files.length === 0)) {
+      throw new Error(`${CHANNELS_YAML}: ${id}: local_file pin needs a non-empty 'files' list`);
+    }
+    if (pin.strategy === "remote_file" && typeof pin.url !== "string") {
+      throw new Error(`${CHANNELS_YAML}: ${id}: remote_file pin needs a 'url'`);
+    }
+    if (pin.strategy !== "none") {
+      if (typeof pin.extract !== "string" || countCaptureGroups(pin.extract) < 1) {
+        throw new Error(`${CHANNELS_YAML}: ${id}: pin.extract must be a regex with one capture group`);
+      }
+    }
+  }
+  return doc.channels;
+}
+
+/**
+ * Applies a channel's extract regex to one source. Multiple matches must
+ * agree - an ambiguous pin is reported, never silently resolved to the first
+ * occurrence (same rule as sync-chart-version's parseImageTag, #151).
+ */
+export function extractPin(content, extract, sourceLabel) {
+  const versions = [...content.matchAll(new RegExp(extract, "gm"))].map((m) => m[1]);
+  if (versions.length === 0) {
+    throw new Error(`${sourceLabel}: no version matched by the extract pattern`);
+  }
+  const unique = [...new Set(versions)];
+  if (unique.length > 1) {
+    throw new Error(`${sourceLabel}: extracted versions disagree (${unique.join(", ")})`);
+  }
+  return unique[0];
+}
+
+/**
+ * Builds one report row. `sources` maps every file path / url the channel
+ * pins to its text content, or null when unreadable (missing file, failed
+ * fetch) - fetching is the CLI's job so this stays pure and testable.
+ *
+ * Statuses: ok | drift | unknown (pin exists but is not measurable right
+ * now) | skip (pending/deprecated channel, or strategy none by design).
+ */
+export function evaluateChannel(channel, pkgVersion, sources) {
+  const row = {
+    id: channel.id,
+    name: channel.name ?? channel.id,
+    tier: channel.tier ?? "-",
+    channelStatus: channel.status,
+    strategy: channel.pin.strategy,
+    method: channel.update.method,
+    sla: channel.update.sla,
+    links: channel.links ?? {},
+    expected: pkgVersion,
+    observed: "-",
+    detail: channel.pin.note ?? "",
+  };
+  if (channel.status !== "live" || channel.pin.strategy === "none") {
+    return { ...row, status: "skip", expected: "-" };
+  }
+  const keys = channel.pin.strategy === "local_file" ? channel.pin.files : [channel.pin.url];
+  const problems = [];
+  const versions = [];
+  for (const key of keys) {
+    const content = sources[key];
+    if (content === null || content === undefined) {
+      problems.push(`${key}: unreadable`);
+      continue;
+    }
+    try {
+      versions.push({ key, version: extractPin(content, channel.pin.extract, key) });
+    } catch (error) {
+      problems.push(error.message);
+    }
+  }
+  if (problems.length > 0) {
+    return { ...row, status: "unknown", observed: "?", detail: problems.join("; ") };
+  }
+  const unique = [...new Set(versions.map((v) => v.version))];
+  if (unique.length > 1) {
+    const detail = versions.map((v) => `${v.key}=${v.version}`).join(", ");
+    return { ...row, status: "drift", observed: unique.join(", "), detail: `pin files disagree: ${detail}` };
+  }
+  const observed = unique[0];
+  return { ...row, status: observed === pkgVersion ? "ok" : "drift", observed };
+}
+
+/**
+ * Strict mode gates only what this repo owns and promises to bump on every
+ * release: local_file pins with sla every_release. Anything else (remote
+ * catalogs, on_demand PaaS templates) stays warn-only in v1, so strict can
+ * actually be enabled without first paying off historical PaaS drift.
+ */
+export function strictFailures(rows) {
+  return rows.filter(
+    (row) =>
+      row.strategy === "local_file" &&
+      row.sla === "every_release" &&
+      (row.status === "drift" || row.status === "unknown"),
+  );
+}
+
+/** Short display text for a provenance link: #56, Dokploy/templates#931, or the word link. */
+export function linkLabel(url) {
+  const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/(\d+)/);
+  if (!match) {
+    return "link";
+  }
+  const [, owner, repo, number] = match;
+  return owner === "libredb" && repo === "libredb-studio" ? `#${number}` : `${owner}/${repo}#${number}`;
+}
+
+function linkCell(url) {
+  return url ? `[${linkLabel(url)}](${url})` : "-";
+}
+
+/** Markdown drift table. Plain-text statuses only (house rule: no emoji). */
+export function renderTable(rows, pkgVersion) {
+  const lines = [
+    `## Distribution channels (expected version: ${pkgVersion})`,
+    "",
+    "| Status | Channel | Tier | Observed | Expected | SLA | Tracking | First PR | Last bump | Detail |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+  ];
+  for (const row of rows) {
+    lines.push(
+      `| ${row.status.toUpperCase()} | ${row.id} | ${row.tier} | ${row.observed} | ${row.expected} | ${row.sla} | ` +
+        `${linkCell(row.links.tracking_issue)} | ${linkCell(row.links.first_pr)} | ${linkCell(row.links.last_bump_pr)} | ` +
+        `${row.detail || "-"} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function fetchText(url, timeoutMs) {
+  const headers = {};
+  // raw.githubusercontent.com needs no auth for public repos; the token only
+  // helps api.github.com rate limits, so it is attached there and nowhere else.
+  if (url.startsWith("https://api.github.com/") && process.env.GITHUB_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs), headers });
+    if (!response.ok) {
+      return null;
+    }
+    return await response.text();
+  } catch {
+    return null;
+  }
+}
+
+async function main(argv) {
+  const strict = argv.includes("--strict");
+  const json = argv.includes("--json");
+  const rootIdx = argv.indexOf("--root");
+  const rootArg = rootIdx === -1 ? undefined : argv[rootIdx + 1];
+  if (rootIdx !== -1 && (rootArg === undefined || rootArg.startsWith("--"))) {
+    console.error("ERROR: --root requires a directory path");
+    process.exit(2);
+  }
+  const root = rootIdx === -1 ? process.cwd() : path.resolve(rootArg);
+  const timeoutMs = Number(process.env.DISTRIBUTION_CHECK_TIMEOUT_MS ?? 10_000);
+
+  const pkgVersion = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
+  const channels = parseChannels(fs.readFileSync(path.join(root, CHANNELS_YAML), "utf8"));
+
+  const sources = {};
+  const fetches = [];
+  for (const channel of channels) {
+    if (channel.status !== "live") {
+      continue;
+    }
+    if (channel.pin.strategy === "local_file") {
+      for (const file of channel.pin.files) {
+        try {
+          sources[file] = fs.readFileSync(path.join(root, file), "utf8");
+        } catch {
+          sources[file] = null;
+        }
+      }
+    } else if (channel.pin.strategy === "remote_file") {
+      const { url } = channel.pin;
+      fetches.push(fetchText(url, timeoutMs).then((content) => (sources[url] = content)));
+    }
+  }
+  await Promise.all(fetches);
+
+  const rows = channels.map((channel) => evaluateChannel(channel, pkgVersion, sources));
+  const table = renderTable(rows, pkgVersion);
+  if (json) {
+    console.log(JSON.stringify({ expected: pkgVersion, rows }, null, 2));
+  } else {
+    console.log(table);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${table}\n`);
+  }
+
+  const failures = strictFailures(rows);
+  if (strict && failures.length > 0) {
+    for (const row of failures) {
+      console.error(`ERROR: strict: ${row.id} is ${row.status} (observed ${row.observed}, expected ${pkgVersion})`);
+    }
+    process.exit(1);
+  }
+}
+
+// CLI entry only when executed directly (the unit test imports this module).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main(process.argv.slice(2));
+}

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -72,8 +72,10 @@ export function parseChannels(yamlText) {
       throw new Error(`${CHANNELS_YAML}: ${id}: remote_file pin needs a 'url'`);
     }
     if (pin.strategy !== "none") {
-      if (typeof pin.extract !== "string" || countCaptureGroups(pin.extract) < 1) {
-        throw new Error(`${CHANNELS_YAML}: ${id}: pin.extract must be a regex with one capture group`);
+      // Exactly one: extractPin reads m[1] only, so a second capture group
+      // would be measured or ignored silently. Use (?:...) for grouping.
+      if (typeof pin.extract !== "string" || countCaptureGroups(pin.extract) !== 1) {
+        throw new Error(`${CHANNELS_YAML}: ${id}: pin.extract must be a regex with exactly one capture group`);
       }
     }
   }

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Unit tests for the distribution visibility matrix checker
+ * (scripts/distribution-check.mjs, distribution/channels.yaml).
+ * The core functions (parseChannels, extractPin, evaluateChannel,
+ * strictFailures, renderTable, linkLabel) are pure; the CLI describe blocks
+ * run the real script as a subprocess against throwaway temp-dir fixtures,
+ * with remote pins served by a local Bun.serve instance - no real network.
+ */
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  evaluateChannel,
+  extractPin,
+  linkLabel,
+  parseChannels,
+  renderTable,
+  strictFailures,
+} from "../../scripts/distribution-check.mjs";
+
+function channelsYaml(rows: string): string {
+  return `channels:\n${rows}`;
+}
+
+const HELM_ROW = `  - id: helm
+    name: Helm chart
+    status: live
+    tier: 1
+    kind: chart
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/138
+    pin:
+      strategy: local_file
+      files:
+        - charts/libredb-studio/Chart.yaml
+      extract: 'appVersion: "(\\d+\\.\\d+\\.\\d+)"'
+`;
+
+const NONE_ROW = `  - id: npm
+    name: npm package
+    status: live
+    tier: 0
+    kind: package-registry
+    update:
+      method: ci_publish
+      sla: every_release
+    pin:
+      strategy: none
+      note: Published by npm-publish.yml on every release.
+`;
+
+describe("parseChannels", () => {
+  test("parses a valid inventory", () => {
+    const channels = parseChannels(channelsYaml(HELM_ROW + NONE_ROW));
+    expect(channels.length).toBe(2);
+    expect(channels[0].id).toBe("helm");
+    expect(channels[0].pin.files).toEqual(["charts/libredb-studio/Chart.yaml"]);
+    expect(channels[1].pin.strategy).toBe("none");
+  });
+
+  test("throws when the top-level channels list is missing", () => {
+    expect(() => parseChannels("foo: bar\n")).toThrow(/channels/);
+  });
+
+  test("throws on a duplicate id", () => {
+    expect(() => parseChannels(channelsYaml(HELM_ROW + HELM_ROW))).toThrow(/duplicate/i);
+  });
+
+  test("throws on an unknown pin strategy", () => {
+    const bad = HELM_ROW.replace("strategy: local_file", "strategy: registry_api");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/strategy/);
+  });
+
+  test("throws on an unknown status", () => {
+    const bad = HELM_ROW.replace("status: live", "status: shipped");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/status/);
+  });
+
+  test("throws when a local_file channel has no files", () => {
+    const bad = HELM_ROW.replace(/ {6}files:\n {8}- [^\n]+\n/, "");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/files/);
+  });
+
+  test("throws when a measurable pin has no extract capture group", () => {
+    const bad = HELM_ROW.replace("extract: 'appVersion: \"(\\d+\\.\\d+\\.\\d+)\"'", "extract: 'appVersion'");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/capture group/);
+  });
+
+  test("throws when a remote_file channel has no url", () => {
+    const bad = HELM_ROW.replace("strategy: local_file", "strategy: remote_file").replace(
+      / {6}files:\n {8}- [^\n]+\n/,
+      "",
+    );
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/url/);
+  });
+});
+
+describe("extractPin", () => {
+  test("extracts a single pinned version", () => {
+    expect(
+      extractPin("image: ghcr.io/libredb/libredb-studio:0.9.27\n", "libredb-studio:(\\d+\\.\\d+\\.\\d+)", "x"),
+    ).toBe("0.9.27");
+  });
+
+  test("agreeing duplicate matches collapse to one version", () => {
+    const content = "a: libredb-studio:0.9.22\nb: libredb-studio:0.9.22\n";
+    expect(extractPin(content, "libredb-studio:(\\d+\\.\\d+\\.\\d+)", "x")).toBe("0.9.22");
+  });
+
+  test("throws when nothing matches", () => {
+    expect(() => extractPin("no pins here", "libredb-studio:(\\d+\\.\\d+\\.\\d+)", "railway")).toThrow(/railway/);
+  });
+
+  test("throws when matches disagree instead of silently using the first", () => {
+    const content = "a: libredb-studio:0.9.22\nb: libredb-studio:0.9.27\n";
+    expect(() => extractPin(content, "libredb-studio:(\\d+\\.\\d+\\.\\d+)", "x")).toThrow(/disagree/);
+  });
+
+  test("extracts across lines (kubero repository/tag style)", () => {
+    const content = "    repository: ghcr.io/libredb/libredb-studio\n    tag: 0.9.27\n";
+    expect(extractPin(content, "ghcr\\.io/libredb/libredb-studio\\s+tag:\\s*(\\d+\\.\\d+\\.\\d+)", "kubero")).toBe(
+      "0.9.27",
+    );
+  });
+});
+
+function helmChannel() {
+  return parseChannels(channelsYaml(HELM_ROW))[0];
+}
+
+describe("evaluateChannel", () => {
+  const chartInSync = 'version: 0.1.13\nappVersion: "0.9.53"\n';
+  const chartBehind = 'version: 0.1.12\nappVersion: "0.9.44"\n';
+
+  test("a matching local pin is ok", () => {
+    const row = evaluateChannel(helmChannel(), "0.9.53", {
+      "charts/libredb-studio/Chart.yaml": chartInSync,
+    });
+    expect(row.status).toBe("ok");
+    expect(row.observed).toBe("0.9.53");
+    expect(row.expected).toBe("0.9.53");
+  });
+
+  test("a drifted local pin is drift", () => {
+    const row = evaluateChannel(helmChannel(), "0.9.53", {
+      "charts/libredb-studio/Chart.yaml": chartBehind,
+    });
+    expect(row.status).toBe("drift");
+    expect(row.observed).toBe("0.9.44");
+  });
+
+  test("files that disagree among themselves are drift and both versions are visible", () => {
+    const channel = parseChannels(
+      channelsYaml(
+        HELM_ROW.replace(/ {6}files:\n {8}- [^\n]+\n/, "      files:\n        - a.yaml\n        - b.yaml\n"),
+      ),
+    )[0];
+    const row = evaluateChannel(channel, "0.9.53", {
+      "a.yaml": 'appVersion: "0.9.53"\n',
+      "b.yaml": 'appVersion: "0.9.22"\n',
+    });
+    expect(row.status).toBe("drift");
+    expect(row.observed).toContain("0.9.53");
+    expect(row.observed).toContain("0.9.22");
+  });
+
+  test("an unreadable source is unknown, not a crash", () => {
+    const row = evaluateChannel(helmChannel(), "0.9.53", {
+      "charts/libredb-studio/Chart.yaml": null,
+    });
+    expect(row.status).toBe("unknown");
+    expect(row.detail).toContain("Chart.yaml");
+  });
+
+  test("a source where the extract regex finds nothing is unknown with a detail", () => {
+    const row = evaluateChannel(helmChannel(), "0.9.53", {
+      "charts/libredb-studio/Chart.yaml": "totally unrelated content",
+    });
+    expect(row.status).toBe("unknown");
+    expect(row.detail).toContain("no version");
+  });
+
+  test("a pin-less channel is skip", () => {
+    const channel = parseChannels(channelsYaml(NONE_ROW))[0];
+    const row = evaluateChannel(channel, "0.9.53", {});
+    expect(row.status).toBe("skip");
+    expect(row.observed).toBe("-");
+  });
+
+  test("a pending channel is skip even with a measurable pin", () => {
+    const channel = parseChannels(channelsYaml(HELM_ROW.replace("status: live", "status: pending")))[0];
+    const row = evaluateChannel(channel, "0.9.53", {});
+    expect(row.status).toBe("skip");
+  });
+});
+
+describe("strictFailures", () => {
+  function row(overrides: Record<string, unknown>) {
+    return {
+      id: "x",
+      status: "drift",
+      strategy: "local_file",
+      sla: "every_release",
+      ...overrides,
+    };
+  }
+
+  test("a drifted every_release local pin fails strict", () => {
+    expect(strictFailures([row({})]).length).toBe(1);
+  });
+
+  test("an unknown every_release local pin fails strict (owned file must be measurable)", () => {
+    expect(strictFailures([row({ status: "unknown" })]).length).toBe(1);
+  });
+
+  test("an on_demand local pin never fails strict", () => {
+    expect(strictFailures([row({ sla: "on_demand" })]).length).toBe(0);
+  });
+
+  test("remote pins never fail strict in v1", () => {
+    expect(strictFailures([row({ strategy: "remote_file" })]).length).toBe(0);
+  });
+
+  test("ok and skip rows never fail strict", () => {
+    expect(strictFailures([row({ status: "ok" }), row({ status: "skip" })]).length).toBe(0);
+  });
+});
+
+describe("linkLabel", () => {
+  test("shortens an issue in this repo to #N", () => {
+    expect(linkLabel("https://github.com/libredb/libredb-studio/issues/56")).toBe("#56");
+  });
+
+  test("keeps owner/repo for an upstream PR", () => {
+    expect(linkLabel("https://github.com/Dokploy/templates/pull/931")).toBe("Dokploy/templates#931");
+  });
+
+  test("falls back to the word link for a non-GitHub url", () => {
+    expect(linkLabel("https://templates.dokploy.com")).toBe("link");
+  });
+});
+
+describe("renderTable", () => {
+  test("renders one row per channel with plain-text statuses and links", () => {
+    const channels = parseChannels(channelsYaml(HELM_ROW + NONE_ROW));
+    const rows = [
+      evaluateChannel(channels[0], "0.9.53", {
+        "charts/libredb-studio/Chart.yaml": 'appVersion: "0.9.44"\n',
+      }),
+      evaluateChannel(channels[1], "0.9.53", {}),
+    ];
+    const table = renderTable(rows, "0.9.53");
+    expect(table).toContain("| DRIFT |");
+    expect(table).toContain("| SKIP |");
+    expect(table).toContain("helm");
+    expect(table).toContain("0.9.44");
+    expect(table).toContain("[#138](https://github.com/libredb/libredb-studio/issues/138)");
+    // No emoji, ever (house rule): the status column is plain text.
+    expect(table).not.toMatch(/[\u{1F300}-\u{1FAFF}✅❌⚠]/u);
+  });
+});
+
+const SCRIPT = join(import.meta.dir, "../../scripts/distribution-check.mjs");
+
+function writeFixture(root: string, pkgVersion: string, channels: string): void {
+  mkdirSync(join(root, "distribution"), { recursive: true });
+  writeFileSync(join(root, "package.json"), JSON.stringify({ version: pkgVersion }));
+  writeFileSync(join(root, "distribution/channels.yaml"), channels);
+}
+
+function runCheck(root: string, args: string[] = [], env: Record<string, string> = {}) {
+  return Bun.spawnSync(["node", SCRIPT, "--root", root, ...args], {
+    env: { ...process.env, GITHUB_STEP_SUMMARY: "", ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+describe("CLI (subprocess against temp fixtures)", () => {
+  const fixtureRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeFixture(pkgVersion: string, channels: string): string {
+    const root = mkdtempSync(join(tmpdir(), "dist-check-"));
+    fixtureRoots.push(root);
+    writeFixture(root, pkgVersion, channels);
+    return root;
+  }
+
+  function localRow(sla: string): string {
+    return `  - id: railway
+    name: Railway template
+    status: live
+    tier: 2
+    kind: paas-template
+    update:
+      method: manual_ui
+      sla: ${sla}
+    pin:
+      strategy: local_file
+      files:
+        - deploy/railway/template.json
+      extract: 'libredb-studio:(\\d+\\.\\d+\\.\\d+)'
+`;
+  }
+
+  function fixtureWithLocalPin(sla: string, pinned: string): string {
+    const root = makeFixture("0.9.53", channelsYaml(localRow(sla)));
+    mkdirSync(join(root, "deploy/railway"), { recursive: true });
+    writeFileSync(join(root, "deploy/railway/template.json"), `{"image": "ghcr.io/libredb/libredb-studio:${pinned}"}`);
+    return root;
+  }
+
+  test("drift is reported in the table but exits 0 by default (warn-only)", () => {
+    const root = fixtureWithLocalPin("on_demand", "0.9.22");
+    const result = runCheck(root);
+    expect(result.exitCode).toBe(0);
+    const stdout = result.stdout.toString();
+    expect(stdout).toContain("DRIFT");
+    expect(stdout).toContain("0.9.22");
+    expect(stdout).toContain("0.9.53");
+  });
+
+  test("--strict exits 1 when an every_release local pin drifts", () => {
+    const root = fixtureWithLocalPin("every_release", "0.9.22");
+    const result = runCheck(root, ["--strict"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("strict");
+  });
+
+  test("--strict exits 0 when only an on_demand local pin drifts", () => {
+    const root = fixtureWithLocalPin("on_demand", "0.9.22");
+    const result = runCheck(root, ["--strict"]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("--json emits machine-readable rows", () => {
+    const root = fixtureWithLocalPin("on_demand", "0.9.22");
+    const result = runCheck(root, ["--json"]);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout.toString());
+    expect(parsed.expected).toBe("0.9.53");
+    expect(parsed.rows.length).toBe(1);
+    expect(parsed.rows[0].status).toBe("drift");
+  });
+
+  test("the table is appended to GITHUB_STEP_SUMMARY when set", () => {
+    const root = fixtureWithLocalPin("on_demand", "0.9.22");
+    const summaryFile = join(root, "summary.md");
+    writeFileSync(summaryFile, "existing\n");
+    const result = runCheck(root, [], { GITHUB_STEP_SUMMARY: summaryFile });
+    expect(result.exitCode).toBe(0);
+    const summary = readFileSync(summaryFile, "utf8");
+    expect(summary).toContain("existing");
+    expect(summary).toContain("DRIFT");
+  });
+
+  test("a missing local pin file is unknown, not a crash", () => {
+    const root = makeFixture("0.9.53", channelsYaml(localRow("on_demand")));
+    const result = runCheck(root);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain("UNKNOWN");
+  });
+
+  test("--root with no value exits 2 with usage", () => {
+    const result = Bun.spawnSync(["node", SCRIPT, "--root"], { stdout: "pipe", stderr: "pipe" });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toContain("--root requires");
+  });
+});
+
+describe("CLI (remote pins against a local server)", () => {
+  const fixtureRoots: string[] = [];
+  const servers: Array<{ stop: () => void }> = [];
+
+  afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    for (const server of servers.splice(0)) server.stop();
+  });
+
+  function remoteFixture(url: string): string {
+    const root = mkdtempSync(join(tmpdir(), "dist-check-remote-"));
+    fixtureRoots.push(root);
+    const row = `  - id: dokploy
+    name: Dokploy template
+    status: live
+    tier: 3
+    kind: paas-template
+    update:
+      method: upstream_pr
+      sla: on_demand
+    pin:
+      strategy: remote_file
+      url: ${url}
+      extract: 'libredb-studio:(\\d+\\.\\d+\\.\\d+)'
+`;
+    writeFixture(root, "0.9.53", channelsYaml(row));
+    return root;
+  }
+
+  function serve(handler: (req: Request) => Response): string {
+    const server = Bun.serve({ port: 0, fetch: handler });
+    servers.push(server);
+    return `http://127.0.0.1:${server.port}/pin.yml`;
+  }
+
+  // Bun.spawnSync would block the event loop and deadlock against the
+  // in-process Bun.serve fixture, so the remote tests spawn asynchronously.
+  async function runCheckAsync(root: string) {
+    const proc = Bun.spawn(["node", SCRIPT, "--root", root], {
+      env: { ...process.env, GITHUB_STEP_SUMMARY: "", DISTRIBUTION_CHECK_TIMEOUT_MS: "3000" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("a reachable remote pin is compared like a local one", async () => {
+    const url = serve(() => new Response("image: ghcr.io/libredb/libredb-studio:0.9.27\n"));
+    const result = await runCheckAsync(remoteFixture(url));
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("DRIFT");
+    expect(result.stdout).toContain("0.9.27");
+  });
+
+  test("a failing remote fetch degrades to UNKNOWN and still exits 0", async () => {
+    const url = serve(() => new Response("boom", { status: 500 }));
+    const result = await runCheckAsync(remoteFixture(url));
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("UNKNOWN");
+  });
+
+  test("an unreachable host degrades to UNKNOWN and still exits 0", async () => {
+    // Port 1 is reserved and closed: connection refused, no timeout wait.
+    const result = await runCheckAsync(remoteFixture("http://127.0.0.1:1/pin.yml"));
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("UNKNOWN");
+  });
+});

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -90,6 +90,14 @@ describe("parseChannels", () => {
     expect(() => parseChannels(channelsYaml(bad))).toThrow(/capture group/);
   });
 
+  test("throws when a measurable pin has more than one capture group (extractPin reads only the first)", () => {
+    const bad = HELM_ROW.replace(
+      "extract: 'appVersion: \"(\\d+\\.\\d+\\.\\d+)\"'",
+      "extract: '(appVersion): \"(\\d+\\.\\d+\\.\\d+)\"'",
+    );
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/capture group/);
+  });
+
   test("throws when a remote_file channel has no url", () => {
     const bad = HELM_ROW.replace("strategy: local_file", "strategy: remote_file").replace(
       / {6}files:\n {8}- [^\n]+\n/,


### PR DESCRIPTION
## Summary

Distribution Visibility Matrix v1: a machine-readable inventory of every distribution channel plus a drift checker that reports each channel's pinned version against `package.json`. Visibility only - no auto-commits, no upstream PRs, nothing blocks a release.

- **`distribution/channels.yaml`** - 20 channels across tiers 0-4 (core registries, CI-published packages, LibreDB-owned listings, upstream catalogs, partner catalogs) with update method/SLA, provenance links (`tracking_issue` / `first_pr` / `last_bump_pr`), and a per-channel pin contract (`local_file` | `remote_file` | `none`, each measurable pin carrying a one-capture-group `extract` regex).
- **`scripts/distribution-check.mjs`** (`bun run distribution:check`) - compares every live pin, prints a markdown drift table (appended to `GITHUB_STEP_SUMMARY` when set), `--json` for scripting. Warn-only by default; `--strict` exits 1 only for owned `local_file` pins with `sla: every_release`, so strict is enableable today without first paying off historical PaaS drift. Remote fetches are best-effort with a timeout and degrade to UNKNOWN. Ambiguous pin matches are reported, never resolved to the first hit (same rule as `sync-chart-version`, #151).
- **`.github/workflows/distribution-check.yml`** - weekly cron + manual dispatch, publishes the table as the Job Summary. Deliberately **not** `release: published`: releases are published under `GITHUB_TOKEN`, whose events never trigger other workflows (the #155/#158 lesson); joining the release chain is not needed for a weekly report.
- **Docs** - new "Channel inventory and drift check" section in `docs/DISTRIBUTION.md` (tier/SLA definitions, strict semantics, how to add a channel, `last_bump_pr` maintenance) plus a maintainer pointer in the README deployment section.
- **Lint fix (separate commit)** - `eslint`/`oxlint` now ignore `.claude/**`: a live agent worktree carries its own `.next` build output that the root-level ignore does not cover, which broke `eslint .` repo-wide.

Current live output (the drift is real and expected - it is the point of the matrix):

| Status | Channel | Observed | Expected |
| --- | --- | --- | --- |
| OK | helm, homebrew | 0.9.53 | 0.9.53 |
| DRIFT | caprover-local / mirror / official | 0.9.14 | 0.9.53 |
| DRIFT | railway-template | 0.9.22 | 0.9.53 |
| DRIFT | dokploy (#175), cosmos, kubero | 0.9.27 | 0.9.53 |
| SKIP | tier-0 registries, snap, deb/rpm, pending channels | - | - |

## Out of scope (phase 2+)

Auto-committing pin bumps, draft PRs to upstream catalogs, auto-discovering `last_bump_pr`, registry/store API probes for tier-0/snap, blocking releases on PaaS drift.

## Test plan

- `tests/unit/distribution-check.test.ts`: 39 tests - schema validation, extraction (incl. multi-line Kubero style and disagree detection), evaluation statuses, strict gating semantics, table rendering (no emoji), plus CLI subprocess tests against temp fixtures and a local `Bun.serve` for the remote ok/500/unreachable paths (no real network).
- Live run verified: `bun run distribution:check` produces the table above; `--strict` exits 0 (helm in sync), `--json` parses.
- All six local gates green: format, lint, typecheck, knip, test, build.
