### PR TITLE
feat(loop): generic milestone operation - archive rotation, unattended pipeline, gate single-sourcing

### DIFF
--- a/e2e/functional-smoke.spec.ts
+++ b/e2e/functional-smoke.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Functional smoke: the product's reason to exist, end to end - boot the real
+ * app, log in, create a PostgreSQL connection through the real connection
+ * modal, run a SQL query, and see the rows in the results grid. This is the
+ * invariant no change may break (the maintainer loop runs it as the last step
+ * before declaring a milestone complete; CI runs it with the regular E2E job).
+ *
+ * The spec manages its own throwaway PostgreSQL container. Without a Docker
+ * daemon the spec SKIPS (annotated) - fine for a dev machine; the loop's
+ * close-out wrapper (loop/scripts/functional-smoke.sh) hard-fails on missing
+ * Docker instead, so the loop can never pass this gate vacuously.
+ */
+import { execFileSync } from "node:child_process";
+import { expect, test } from "@playwright/test";
+
+const PG_CONTAINER = "libredb-functional-smoke-pg";
+const PG_PORT = 54329;
+const PG_PASSWORD = "smoke-pg-password";
+
+function docker(args: string[]): string {
+  return execFileSync("docker", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function dockerAvailable(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function startSeededPostgres(): Promise<void> {
+  try {
+    docker(["rm", "-f", PG_CONTAINER]);
+  } catch {
+    // no stale container - fine
+  }
+  docker([
+    "run",
+    "-d",
+    "--rm",
+    "--name",
+    PG_CONTAINER,
+    "-e",
+    `POSTGRES_PASSWORD=${PG_PASSWORD}`,
+    "-p",
+    `127.0.0.1:${PG_PORT}:5432`,
+    "postgres:16-alpine",
+  ]);
+  // Readiness is proven by the seed itself succeeding, not by pg_isready:
+  // the official image's init sequence starts a TEMPORARY server (which
+  // pg_isready happily reports ready) and then restarts - a seed racing that
+  // gap fails with "socket ... failed". Retrying the real operation is the
+  // only honest readiness check.
+  const seedSql =
+    "CREATE TABLE smoke_items (id int PRIMARY KEY, name text NOT NULL);" +
+    " INSERT INTO smoke_items VALUES (1, 'smoke_row_one'), (2, 'smoke_row_two');";
+  let seeded = false;
+  let lastError: unknown;
+  for (let i = 0; i < 60 && !seeded; i++) {
+    try {
+      docker(["exec", PG_CONTAINER, "psql", "-U", "postgres", "-d", "postgres", "-c", seedSql]);
+      seeded = true;
+    } catch (err) {
+      lastError = err;
+      await sleep(1000);
+    }
+  }
+  if (!seeded) throw new Error(`postgres did not accept the seed within 60s: ${lastError}`);
+}
+
+test.describe("Functional smoke: connect to PostgreSQL and run a query", () => {
+  test.skip(!dockerAvailable(), "Docker daemon not available - postgres smoke skipped");
+  test.describe.configure({ mode: "serial" });
+
+  test.afterAll(() => {
+    try {
+      docker(["rm", "-f", PG_CONTAINER]);
+    } catch {
+      // already gone
+    }
+  });
+
+  test("login -> create connection via the modal -> run SQL -> rows render", async ({ page }) => {
+    test.setTimeout(180_000); // includes a possible postgres image pull
+    await startSeededPostgres();
+
+    // Login (user role: lands directly on the studio).
+    await page.goto("/login");
+    await page.locator('input[type="email"]').fill("user@libredb.org");
+    await page.locator('input[type="password"]').fill("test-user");
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await page.waitForURL("/");
+    await expect(page.locator("text=Query 1").first()).toBeVisible({ timeout: 15_000 });
+
+    // Open the connection modal (last button in the sidebar header row).
+    const sidebarButtons = page.locator("text=LibreDB Studio").locator("..").locator("..").locator("button");
+    await sidebarButtons.last().click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Fill the real form: PostgreSQL type, host/port/user/password/database.
+    await dialog.locator("text=PostgreSQL").first().click();
+    await dialog.locator("#name").fill("Smoke PG");
+    await dialog.locator("#host").fill("127.0.0.1");
+    await dialog.locator("#port").fill(String(PG_PORT));
+    await dialog.locator("#user").fill("postgres");
+    await dialog.locator("#password").fill(PG_PASSWORD);
+    await dialog.locator("#database").fill("postgres");
+    await dialog.getByRole("button", { name: "Establish Connection" }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 15_000 });
+
+    // The new connection appears and is selected; its health is proven by the
+    // query below, not by a status badge (the header renders hidden responsive
+    // duplicates of the status text, which makes badge assertions brittle).
+    await expect(page.locator("text=Smoke PG").first()).toBeVisible({ timeout: 15_000 });
+
+    // Run a real query through the editor.
+    await expect(page.locator(".monaco-editor").first()).toBeVisible({ timeout: 15_000 });
+    await page.evaluate(() => {
+      const monaco = (window as unknown as { monaco?: { editor: { getEditors(): { setValue(v: string): void }[] } } })
+        .monaco;
+      if (!monaco) throw new Error("monaco global not found");
+      monaco.editor.getEditors()[0].setValue("SELECT id, name FROM smoke_items ORDER BY id");
+    });
+    await page.getByRole("button", { name: "RUN" }).click();
+
+    // The seeded rows render in the results grid.
+    await expect(page.locator("text=smoke_row_one").first()).toBeVisible({ timeout: 20_000 });
+    await expect(page.locator("text=smoke_row_two").first()).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/loop/HANDOFF.md
+++ b/loop/HANDOFF.md
@@ -3,60 +3,48 @@
 > Orientation only — not authoritative. Authoritative state is
 > `loop/IMPLEMENTATION_PLAN.md` + `loop/PROGRESS.md` + git log.
 
-## Current milestone
+## Current state
 
-Maintainer Sweep 2 — the first fully autonomous milestone (triage → planning → build over the
-open public issue tracker), on branch `loop/maintainer-sweep-2`. Queue: the 7 issues labeled
-`loop:queued` at planning time — #126, #125, #136, #151, #45, #124, #96 — each with a
-sanitized spec in `loop/TRIAGE.md`. Definition of done: `loop/ACCEPTANCE.md` (sentinel
-`LIBREDB-STUDIO-SWEEP-2-DONE`).
+No milestone is open. The last completed one — Maintainer Sweep 2, the first fully autonomous
+run (triage → planning → build over the open public issue tracker) — shipped in PR #178,
+released as 0.9.53 (chart 0.1.13), and its 7 queued issues (#45, #96, #124, #125, #126, #136,
+#151) are closed. Its working-set files still sit in `loop/` until the next milestone opens;
+`new-milestone.sh` will archive them to `loop/archive/sweep-2/` at that moment.
 
-## Status
+## How to run the next milestone (generic operation)
 
-COMPLETE. As of 2026-07-12, all three stages of the first fully autonomous milestone ran on
-this branch:
+```bash
+git checkout main && git pull
+git checkout -b loop/<name>          # dedicated branch, e.g. loop/sweep-3
+./loop/scripts/new-milestone.sh <name>   # archive previous state, reset files, set TRIAGE mode
+git add -A loop && git commit -m "chore(loop): open milestone <name>"
+./loop/scripts/pipeline.sh           # unattended: triage -> planning -> build
+# then, always human: review the branch, push, open the PR (base main)
+```
 
-- Triage: 15 issues across three batches (commits `3c78105`, `26fb92f`, `ca7cc05`) —
-  7 queued, 1 needs-info (#94), 4 escalated to moderator (#40, #123, #127, #167),
-  3 not-for-loop (#100, #108, #170).
-- Planning: 7 queued issues → 8 build tasks (#96 pre-split), commit `3b5472d`.
-- Build: all 8 tasks done, one commit each, every one with RED evidence and a fresh-context
-  `loop-reviewer` verdict of PASS or PASS WITH NOTES (details per entry in
-  `loop/PROGRESS.md`):
-  - #126 `01873b9` — Oracle/MSSQL `supportsExplain: false` + docs tri-sync
-  - #125 `f334137` — sqlite path guard rejects NUL only; dead traversal branch removed
-  - #136 `586b3b5` — render-level test pins the minimal two-secret install
-  - #151 `b751399` — chart:check merge-base comparison + shared predicate + polish
-  - #45 `496c191` — chart hardening (schema coverage, jwtSecret length, PDB zero-value and
-    exclusivity, no HPA with sqlite); chart 0.1.11 → 0.1.12
-  - #124 `e26dcf9` — deny-list prune of the standalone payload (105M → 32M locally)
-  - #96a `c2de170` — registry-based value renderers behind `formatCellValue`
-  - #96b `7a7f7e4` — pretty-printed json-kind values in the row detail sheet
-- Close-out: every `loop/ACCEPTANCE.md` criterion re-verified against actual repo state; the
-  full gate re-run fresh and green (format, lint, typecheck, all 18 test groups, build, plus
-  `helm lint --strict` and `bun run chart:check`); `.loop/COMPLETE` created.
-- All 7 queued issues remain OPEN by design — a human closes them at PR merge.
+- `pipeline.sh` never pushes; publishing is the human trust gate.
+- Planning mode writes both `IMPLEMENTATION_PLAN.md` and `ACCEPTANCE.md` from the
+  `loop:queued` queue (a human may instead pre-list issues in `ACCEPTANCE.md` before running).
+- The gate is `./loop/scripts/gate.sh` — the single mirror of root `CLAUDE.md`'s mandatory
+  pre-commit verification (currently format · lint · typecheck · knip · test · build). When
+  CLAUDE.md's gate changes, update `gate.sh`; prompts reference the script, not the commands.
+- Issues labeled `loop:needs-info` / `loop:needs-moderator-action` are never picked up; only a
+  human removing the label changes that.
 
-## Human gates outstanding
+## Human gates outstanding (as of 2026-07-13)
 
 - #94 (`loop:needs-info`) — awaiting the reporter's answer (question posted as issue comment
-  4949538647); only a human removing the label makes it pickable. Reported as an open gap at
-  close-out, NOT part of this milestone.
-- Moderator queue (`loop:needs-moderator-action`): #40 (ER-diagram export needs a new runtime
-  dependency decision), #123 (release signing/SLSA — privileged pipeline), #127 (expose
-  sqlite in the connection form — trust-model product call), #167 (helm-release republish
-  guard — workflow edit), plus pre-existing #175, #166, #152, #114, #72. Build mode must not
-  touch any of these.
-- Final human gate: review the branch (8 task commits + close-out), push, open the PR
-  (base `main`) — the loop never pushes. The PR bumps chart content (#45), and the chart
-  version bump (0.1.12) is already in the same commit per the charts/** repo rule.
-- Human-follow-up flags collected during the build (details in the matching
-  `loop/PROGRESS.md` entries): the embedded libredb provider carries the same dead traversal
-  branch #125 removed from sqlite; the Dockerfile runner stage still copies the untrimmed
-  standalone output (#124's prune covers only the payload script); a real `npmjs-token` file
-  sits at this dev machine's repo root (credential hygiene — move it off the repo root);
-  deployment.yaml's pre-existing zero-config guard message is slightly stale for the
-  sqlite+autoscaling case (#45); RowDetailSheet's pre-existing `Eye` icon lacks
-  `strokeWidth={1.5}` (#96b).
-- Next milestone: start with triage mode (`LOOP_PROMPT_FILE="loop/PROMPT-TRIAGE.md"`), new
-  sentinel in `loop/config/loop.env`, and remove the stale `.loop/COMPLETE` before running.
+  4949538647).
+- Moderator queue (`loop:needs-moderator-action`): #123 (release signing/SLSA — privileged
+  pipeline), #127 (expose sqlite in the connection form — trust-model product call), #167
+  (helm-release republish guard — workflow edit), plus pre-existing #175, #166, #152, #114,
+  #72. (#40 was resolved by a human directly in PR #180.)
+- Not-for-the-loop tracking issues needing a human split before they can be queued: #100,
+  #108, #170 (see `loop/TRIAGE.md`).
+- Human-follow-up flags collected during Sweep 2 (details in the matching `loop/PROGRESS.md`
+  entries; archived with the milestone): the embedded libredb provider carries the same dead
+  traversal branch #125 removed from sqlite; the Dockerfile runner stage still copies the
+  untrimmed standalone output (#124's prune covers only the payload script); a real
+  `npmjs-token` file sits at this dev machine's repo root (credential hygiene); the
+  deployment.yaml zero-config guard message is slightly stale for the sqlite+autoscaling case
+  (#45); RowDetailSheet's pre-existing `Eye` icon lacks `strokeWidth={1.5}` (#96b).

--- a/loop/LOOP-ENGINEERING.md
+++ b/loop/LOOP-ENGINEERING.md
@@ -138,12 +138,12 @@ The fully autonomous pipeline chains them: **triage** (until `.loop/COMPLETE`) �
 with a human review + push at the very end. Humans can veto between stages by editing labels or
 `TRIAGE.md` — the loop always re-derives state from files.
 
-Generic operation (see `HANDOFF.md` for the runbook): `scripts/new-milestone.sh <name>`
-archives the previous milestone's working set (PROGRESS log, consumed TRIAGE specs,
-ACCEPTANCE, PLAN → `loop/archive/<prev>/`) and resets state; `scripts/pipeline.sh` then runs
-all three stages unattended, enforcing the stage contracts (triage/build must produce the
-marker; planning must NOT). The archive rotation is what keeps per-iteration reading cost
-bounded — PROGRESS.md holds the current milestone only.
+Generic operation (see `HANDOFF.md` for the runbook): `./loop/scripts/new-milestone.sh <name>`
+(from the repo root) archives the previous milestone's working set (PROGRESS log, consumed
+TRIAGE specs, ACCEPTANCE, PLAN → `loop/archive/<prev>/`) and resets state;
+`./loop/scripts/pipeline.sh` then runs all three stages unattended, enforcing the stage
+contracts (triage/build must produce the marker; planning must NOT). The archive rotation is
+what keeps per-iteration reading cost bounded — PROGRESS.md holds the current milestone only.
 
 Planning is cheap and regenerable. Prefer regenerating the plan over letting the build circle.
 

--- a/loop/LOOP-ENGINEERING.md
+++ b/loop/LOOP-ENGINEERING.md
@@ -110,11 +110,12 @@ rules — maintainer accounts can be compromised too.
 | `.claude/agents/loop-reviewer.md`, `loop-judge.md` | Fresh-context review/judge subagents used by build iterations. | Human |
 | `CLAUDE.md` (repo root) | Conventions, project map, build/test, the mandatory gate. Not duplicated here. | Human (pre-existing) |
 | Linked GitHub issue (per task) | Frozen per-task spec — the *what* and *why* for the one task in progress. | Human (pre-existing, external) |
-| `loop/IMPLEMENTATION_PLAN.md` | Prioritized task checklist. **Disposable.** | Loop + human |
-| `loop/PROGRESS.md` | Lab notebook: done, failed, decisions, limitations. | Loop |
+| `loop/IMPLEMENTATION_PLAN.md` | Prioritized task checklist. **Disposable.** | Loop (planning) |
+| `loop/PROGRESS.md` | Lab notebook, CURRENT milestone only. | Loop |
 | `loop/HANDOFF.md` | Cross-session baton. Orientation only — not authoritative state. | Human / loop at close |
-| `loop/ACCEPTANCE.md` | Current milestone definition of done. | Human |
-| `loop/config/loop.env` | Runner configuration (agent cmd, gate, sentinel). | Human |
+| `loop/ACCEPTANCE.md` | Current milestone definition of done. | Loop (planning, autonomous path) or human |
+| `loop/archive/<milestone>/` | Frozen history: previous PROGRESS logs, consumed TRIAGE specs, closed ACCEPTANCE/PLAN. | `new-milestone.sh` |
+| `loop/config/loop.env` | Runner configuration (agent cmd, gate, sentinel). | `new-milestone.sh` + human |
 
 **Authoritative state during a build:** `IMPLEMENTATION_PLAN.md` (ticks) + `PROGRESS.md` + git history — not `HANDOFF.md` prose.
 
@@ -136,6 +137,13 @@ The fully autonomous pipeline chains them: **triage** (until `.loop/COMPLETE`) �
 (one iteration) → **building** (until `.loop/COMPLETE`), each on the same dedicated branch,
 with a human review + push at the very end. Humans can veto between stages by editing labels or
 `TRIAGE.md` — the loop always re-derives state from files.
+
+Generic operation (see `HANDOFF.md` for the runbook): `scripts/new-milestone.sh <name>`
+archives the previous milestone's working set (PROGRESS log, consumed TRIAGE specs,
+ACCEPTANCE, PLAN → `loop/archive/<prev>/`) and resets state; `scripts/pipeline.sh` then runs
+all three stages unattended, enforcing the stage contracts (triage/build must produce the
+marker; planning must NOT). The archive rotation is what keeps per-iteration reading cost
+bounded — PROGRESS.md holds the current milestone only.
 
 Planning is cheap and regenerable. Prefer regenerating the plan over letting the build circle.
 

--- a/loop/PROMPT-PLANNING.md
+++ b/loop/PROMPT-PLANNING.md
@@ -53,9 +53,10 @@ When `loop/ACCEPTANCE.md` is the stub, REWRITE it for this milestone:
   "Acceptance bar (testable)" section in `loop/TRIAGE.md` (which remains the authoritative
   detailed bar — say so in the header). Never weaken a spec's bar while summarizing.
 - Quality (standard, verbatim intent): built test-first with RED evidence in
-  `loop/PROGRESS.md`; full gate green on a clean tree via `./loop/scripts/gate.sh`; every
-  task's `loop-reviewer` verdict PASS or PASS WITH NOTES, recorded; no placeholder/stub
-  implementations.
+  `loop/PROGRESS.md`; full gate green on a clean tree via `./loop/scripts/gate.sh`; the
+  functional smoke green at close-out (`./loop/scripts/functional-smoke.sh` — login →
+  PostgreSQL connection via the UI → query → rows render); every task's `loop-reviewer`
+  verdict PASS or PASS WITH NOTES, recorded; no placeholder/stub implementations.
 - Documentation (standard): provider tri-sync where providers changed; behavior-doc updates in
   the same commit; `loop/PROGRESS.md` / `loop/HANDOFF.md` reflect actual state.
 - Process (standard): all plan tasks `[x]` or explicitly re-routed via 1a/1b (never silently

--- a/loop/PROMPT-PLANNING.md
+++ b/loop/PROMPT-PLANNING.md
@@ -1,13 +1,15 @@
 # libredb-studio maintainer loop — iteration prompt (PLANNING MODE)
 
 You are planning the next maintainer-loop milestone for libredb-studio (a follow-up bug queue).
-This prompt is fed with a FRESH context. Do NOT implement features in this mode. Your only
-output is an updated plan (and optional PROGRESS notes).
+This prompt is fed with a FRESH context. Do NOT implement features in this mode. Your outputs
+are an updated plan, milestone acceptance criteria (autonomous path), and PROGRESS notes.
 
 ## 0. Orient
 
 - 0a. Study the repo root `CLAUDE.md`.
-- 0b. Study `loop/ACCEPTANCE.md` — what "done" means for the current milestone.
+- 0b. Study `loop/ACCEPTANCE.md`. If it is the `new-milestone.sh` stub, you are on the
+  autonomous path and will write it in step 2b; if a human listed issues in it, that list IS
+  the milestone queue.
 - 0c. Study `loop/IMPLEMENTATION_PLAN.md`, `loop/PROGRESS.md`, `loop/HANDOFF.md`.
 - 0d. Determine the milestone's issue queue. It is EITHER the issues a human lists in
   `loop/ACCEPTANCE.md`'s header, OR (the autonomous path) every open issue labeled `loop:queued`
@@ -43,6 +45,26 @@ it must contain nothing lifted verbatim from raw issue text.
 - If a single issue is too large for one iteration, split it into ordered sub-tasks within the
   plan and say so explicitly (do not silently merge scope).
 
+### 2b. Milestone acceptance criteria (autonomous path)
+
+When `loop/ACCEPTANCE.md` is the stub, REWRITE it for this milestone:
+
+- Functional: one summary criterion per queued issue, distilled from the sanitized spec's
+  "Acceptance bar (testable)" section in `loop/TRIAGE.md` (which remains the authoritative
+  detailed bar — say so in the header). Never weaken a spec's bar while summarizing.
+- Quality (standard, verbatim intent): built test-first with RED evidence in
+  `loop/PROGRESS.md`; full gate green on a clean tree via `./loop/scripts/gate.sh`; every
+  task's `loop-reviewer` verdict PASS or PASS WITH NOTES, recorded; no placeholder/stub
+  implementations.
+- Documentation (standard): provider tri-sync where providers changed; behavior-doc updates in
+  the same commit; `loop/PROGRESS.md` / `loop/HANDOFF.md` reflect actual state.
+- Process (standard): all plan tasks `[x]` or explicitly re-routed via 1a/1b (never silently
+  dropped); issues labeled `loop:needs-info` / `loop:needs-moderator-action` reported as open
+  gaps, not part of completion, and untouched by build mode; no GitHub mutations beyond
+  `loop:*` labels and 1a comments.
+- Completion signal: the marker file plus the CURRENT `LOOP_COMPLETION_SENTINEL` from
+  `loop/config/loop.env` (read it — do not guess or reuse a previous milestone's sentinel).
+
 ## 3. Validate the plan
 
 - Every issue in the milestone queue (human-listed or `loop:queued`) maps to at least one task.
@@ -52,9 +74,10 @@ it must contain nothing lifted verbatim from raw issue text.
 
 ## 4. Commit and stop
 
-- Commit only the plan (and PROGRESS/HANDOFF updates if needed):
-  `docs(plan): refresh IMPLEMENTATION_PLAN for <milestone name>`
-- Do NOT create `.loop/COMPLETE` in planning mode.
+- Commit the plan, the acceptance criteria (when 2b applied), and PROGRESS/HANDOFF updates
+  together: `docs(plan): plan milestone <name> (<issue numbers>)`
+- Do NOT create `.loop/COMPLETE` in planning mode — the pipeline treats that as a contract
+  violation and aborts.
 - End the iteration.
 
 ## 999. Guardrails

--- a/loop/PROMPT.md
+++ b/loop/PROMPT.md
@@ -13,7 +13,9 @@ Re-derive state by reading.
 - 0b. Study `loop/LOOP-ENGINEERING.md` (operating discipline) and `loop/ACCEPTANCE.md`
   (this milestone's definition of done).
 - 0c. Study `loop/IMPLEMENTATION_PLAN.md` (the task list) and `loop/PROGRESS.md` (what was
-  done, what failed and why, what is waiting on a human).
+  done, what failed and why, what is waiting on a human). PROGRESS.md covers only the CURRENT
+  milestone; earlier milestones live under `loop/archive/` — consult them only when a task
+  genuinely needs that history.
 - 0d. Study the existing source and tests relevant to the chosen task. Do NOT assume
   something is unimplemented or broken a certain way — verify by reading before deciding.
 - 0e. For the task you are about to pick, the acceptance bar is maintainer-loop-authored text:
@@ -106,7 +108,9 @@ A human removing the label is the only way the task becomes pickable again.
 
 ## 3. Validate, then commit
 
-- Run the full gate: `bun run format && bun run lint && bun run typecheck && bun run test && bun run build`
+- Run the full gate: `./loop/scripts/gate.sh` — it mirrors the root `CLAUDE.md`'s mandatory
+  pre-commit verification and is the single source of truth for the gate's steps; never
+  reorder, skip, or reimplement them inline.
 - If anything fails, fix it. Never weaken, skip, or delete a test to make the gate pass.
 - Exception — broken gate infrastructure unrelated to your task: fold the MINIMAL repair into
   this iteration, record it in `loop/PROGRESS.md`.

--- a/loop/PROMPT.md
+++ b/loop/PROMPT.md
@@ -135,6 +135,16 @@ A human removing the label is the only way the task becomes pickable again.
 
 - Only if every criterion in `loop/ACCEPTANCE.md` is met and the full gate is green on a clean
   tree:
+  - Functional smoke (mandatory, LAST gate): run `./loop/scripts/functional-smoke.sh` — it
+    boots the built app, creates a real PostgreSQL connection through the UI, runs a SQL
+    query, and asserts the rows render. This pins the one invariant no milestone may break:
+    login → connect → query → results.
+    - If it FAILS: the milestone is NOT complete. Record the failure in `loop/PROGRESS.md`,
+      identify the breaking task by walking this milestone's one-task-one-commit history
+      (each commit's gate was green, so the breakage is in an interaction — test task
+      commits against the smoke as needed), and fix it as a regular task in a following
+      iteration (test-first; the smoke spec itself is a test under 999b — never weaken it
+      to pass). Do not create the marker this iteration.
   - Update `loop/HANDOFF.md` with actual state.
   - Create the marker file: `mkdir -p .loop && touch .loop/COMPLETE`.
   - Print the milestone's completion sentinel (`LOOP_COMPLETION_SENTINEL` in

--- a/loop/config/loop.env
+++ b/loop/config/loop.env
@@ -1,7 +1,7 @@
 # Loop runner configuration — libredb-studio maintainer loop.
 # Milestone-specific fields (sentinel, prompt mode) are rotated by
-# scripts/new-milestone.sh; scripts/pipeline.sh overrides LOOP_PROMPT_FILE
-# per stage without touching this file.
+# loop/scripts/new-milestone.sh; loop/scripts/pipeline.sh overrides
+# LOOP_PROMPT_FILE per stage without touching this file.
 
 # --- identity ---
 LOOP_PROJECT_NAME="libredb-studio maintainer loop"

--- a/loop/config/loop.env
+++ b/loop/config/loop.env
@@ -1,11 +1,14 @@
-# Loop runner configuration — libredb-studio maintainer loop, Maintainer Sweep 2
-# (first fully autonomous milestone: triage -> planning -> build over the open issue tracker)
+# Loop runner configuration — libredb-studio maintainer loop.
+# Milestone-specific fields (sentinel, prompt mode) are rotated by
+# scripts/new-milestone.sh; scripts/pipeline.sh overrides LOOP_PROMPT_FILE
+# per stage without touching this file.
 
 # --- identity ---
 LOOP_PROJECT_NAME="libredb-studio maintainer loop"
 
 # --- prompt (three modes; see loop/LOOP-ENGINEERING.md) ---
-# Stage 3 of Sweep 2: BUILD (triage + planning completed 2026-07-12; 7 tasks planned).
+# Set by new-milestone.sh (TRIAGE) and overridden per stage by pipeline.sh;
+# edit by hand only when driving a single mode directly via loop.sh.
 LOOP_PROMPT_FILE="loop/PROMPT.md"
 # Triage mode:
 #   LOOP_PROMPT_FILE="loop/PROMPT-TRIAGE.md"

--- a/loop/scripts/functional-smoke.sh
+++ b/loop/scripts/functional-smoke.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Functional smoke - the maintainer loop's LAST gate before a milestone may
+# complete: boot the real app, create a PostgreSQL connection through the real
+# UI, run a SQL query, assert the rows render (e2e/functional-smoke.spec.ts).
+#
+# The mechanical gate (gate.sh) proves the pieces work; this proves the
+# PRODUCT still works: no milestone's combined changes may break
+# login -> connect -> query -> results.
+#
+# Runs the spec via playwright.smoke.config.ts (port 3105, never reuses an
+# existing server - a locally installed Snap daemon shadows port 3000).
+# Unlike the spec's own CI behavior (skip without Docker), this wrapper
+# HARD-FAILS when Docker is unavailable: the loop must never pass this gate
+# vacuously.
+#
+# Usage: loop/scripts/functional-smoke.sh
+# ==============================================================================
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "=== functional smoke: preflight ==="
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker daemon is not available - the functional smoke cannot run." >&2
+  echo "The loop must not complete a milestone without this gate; fix Docker first." >&2
+  exit 1
+fi
+
+# The smoke config boots `bun start` without building (the gate has usually
+# just built); make sure a build exists for direct/manual invocations.
+if [ ! -f .next/BUILD_ID ]; then
+  echo "=== functional smoke: no build found, building ==="
+  bun run build
+fi
+
+# No-op when the browser is already cached.
+bunx playwright install chromium
+
+echo "=== functional smoke: run ==="
+bunx playwright test --config=playwright.smoke.config.ts
+
+echo "=== functional smoke: GREEN ==="

--- a/loop/scripts/gate.sh
+++ b/loop/scripts/gate.sh
@@ -17,6 +17,9 @@ bun run lint
 echo "=== gate: typecheck ==="
 bun run typecheck
 
+echo "=== gate: knip ==="
+bun run knip
+
 echo "=== gate: test ==="
 bun run test
 

--- a/loop/scripts/new-milestone.sh
+++ b/loop/scripts/new-milestone.sh
@@ -122,11 +122,13 @@ cat > "$LOOP_DIR/IMPLEMENTATION_PLAN.md" << EOF
 > milestone queue. Build mode must not run against this stub.
 EOF
 
-# --- loop.env: new sentinel, triage mode -------------------------------------
-sed -i \
+# --- loop.env: new sentinel, triage mode (tmp+mv, consistent with the file
+# --- rewrites above and portable across GNU/BSD sed) --------------------------
+sed \
   -e "s|^LOOP_COMPLETION_SENTINEL=.*|LOOP_COMPLETION_SENTINEL=\"$SENTINEL\"|" \
   -e "s|^LOOP_PROMPT_FILE=.*|LOOP_PROMPT_FILE=\"loop/PROMPT-TRIAGE.md\"|" \
-  "$ENV_FILE"
+  "$ENV_FILE" > "$ENV_FILE.tmp"
+mv "$ENV_FILE.tmp" "$ENV_FILE"
 
 rm -f "$ROOT/.loop/COMPLETE"
 

--- a/loop/scripts/new-milestone.sh
+++ b/loop/scripts/new-milestone.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Open a new maintainer-loop milestone.
+#
+# Archives the previous milestone's working-set content (the fresh-context
+# loop re-reads PROGRESS.md every iteration, so an ever-growing log would
+# re-introduce the context rot the loop exists to avoid) and resets the loop
+# state files for a fresh queue:
+#
+#   loop/archive/<prev>/PROGRESS.md   <- the previous "## Log" entries
+#   loop/archive/<prev>/TRIAGE.md     <- the previous "## Queue" specs
+#   loop/archive/<prev>/ACCEPTANCE.md <- the previous milestone criteria
+#   loop/archive/<prev>/IMPLEMENTATION_PLAN.md
+#
+#   loop/PROGRESS.md   -> entry-anatomy template + empty log + archive pointer
+#   loop/TRIAGE.md     -> spec format + empty queue; "Not for the loop" is
+#                         PRESERVED (it is the anti-re-triage memory)
+#   loop/ACCEPTANCE.md -> stub; planning mode writes the real criteria
+#   loop/IMPLEMENTATION_PLAN.md -> stub; planning mode writes the task list
+#   loop/config/loop.env -> new sentinel, prompt set to TRIAGE mode
+#   .loop/COMPLETE     -> removed
+#
+# Mutates files only - review the diff and commit; this script never commits
+# and never touches git state.
+#
+# Usage: new-milestone.sh <milestone-name> [root-dir]
+#   milestone-name: kebab-case, e.g. sweep-3
+#   root-dir: repo root override (used by the unit tests; defaults to the
+#             repository this script lives in)
+# ==============================================================================
+
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <milestone-name> [root-dir]" >&2
+  exit 1
+fi
+
+NAME=$1
+ROOT="${2:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+LOOP_DIR="$ROOT/loop"
+ENV_FILE="$LOOP_DIR/config/loop.env"
+
+if ! printf '%s' "$NAME" | grep -Eq '^[a-z0-9][a-z0-9-]*$'; then
+  echo "Milestone name must be kebab-case (got: '$NAME')" >&2
+  exit 1
+fi
+
+for f in "$LOOP_DIR/PROGRESS.md" "$LOOP_DIR/TRIAGE.md" "$LOOP_DIR/ACCEPTANCE.md" \
+  "$LOOP_DIR/IMPLEMENTATION_PLAN.md" "$ENV_FILE"; do
+  if [ ! -f "$f" ]; then
+    echo "Missing loop state file: $f" >&2
+    exit 1
+  fi
+done
+
+# The previous milestone's name comes from its completion sentinel.
+PREV=$(sed -n 's/^LOOP_COMPLETION_SENTINEL="LIBREDB-STUDIO-\(.*\)-DONE"$/\1/p' "$ENV_FILE" |
+  tr '[:upper:]' '[:lower:]')
+PREV="${PREV:-previous}"
+
+if [ "$PREV" = "$NAME" ]; then
+  echo "Milestone '$NAME' is already the current one (sentinel matches) - pick a new name" >&2
+  exit 1
+fi
+
+ARCHIVE="$LOOP_DIR/archive/$PREV"
+if [ -e "$ARCHIVE" ]; then
+  echo "Archive already exists: $ARCHIVE - refusing to overwrite history" >&2
+  exit 1
+fi
+mkdir -p "$ARCHIVE"
+
+# --- PROGRESS.md: archive everything from "## Log" on; keep the template ----
+awk '/^## Log$/{found=1} found{print}' "$LOOP_DIR/PROGRESS.md" > "$ARCHIVE/PROGRESS.md"
+awk '/^## Log$/{exit} {print}' "$LOOP_DIR/PROGRESS.md" > "$LOOP_DIR/PROGRESS.md.tmp"
+cat >> "$LOOP_DIR/PROGRESS.md.tmp" << EOF
+## Log
+
+> Earlier milestones are archived under \`loop/archive/\` (one directory per
+> milestone). Consult them only when a task genuinely needs that history.
+
+### $(date -u +%Y-%m-%d) — Milestone $NAME opened (human)
+
+- State reset by \`loop/scripts/new-milestone.sh $NAME\`; previous milestone
+  ($PREV) archived to \`loop/archive/$PREV/\`.
+- Next: triage mode over the untriaged open issues.
+EOF
+mv "$LOOP_DIR/PROGRESS.md.tmp" "$LOOP_DIR/PROGRESS.md"
+
+# --- TRIAGE.md: archive the Queue; preserve "Not for the loop" --------------
+awk '/^## Queue$/{found=1} found && /^## Not for the loop$/{exit} found{print}' \
+  "$LOOP_DIR/TRIAGE.md" > "$ARCHIVE/TRIAGE.md"
+{
+  awk '/^## Queue$/{exit} {print}' "$LOOP_DIR/TRIAGE.md"
+  printf '## Queue\n\n(empty — populated by triage mode; previous queue archived to loop/archive/%s/)\n\n' "$PREV"
+  awk '/^## Not for the loop$/{found=1} found{print}' "$LOOP_DIR/TRIAGE.md"
+} > "$LOOP_DIR/TRIAGE.md.tmp"
+mv "$LOOP_DIR/TRIAGE.md.tmp" "$LOOP_DIR/TRIAGE.md"
+
+# --- ACCEPTANCE.md / IMPLEMENTATION_PLAN.md: archive whole, write stubs -----
+mv "$LOOP_DIR/ACCEPTANCE.md" "$ARCHIVE/ACCEPTANCE.md"
+SENTINEL="LIBREDB-STUDIO-$(printf '%s' "$NAME" | tr '[:lower:]' '[:upper:]')-DONE"
+cat > "$LOOP_DIR/ACCEPTANCE.md" << EOF
+# Acceptance Criteria — Milestone $NAME
+
+> STUB: planning mode (\`loop/PROMPT-PLANNING.md\`) rewrites this file from the
+> \`loop:queued\` queue and \`loop/TRIAGE.md\` sanitized specs — one functional
+> criterion per queued issue plus the standard Quality / Documentation /
+> Process sections. A human may instead list issues here by hand before
+> planning runs (the human-listed path).
+>
+> The completion sentinel for this milestone is \`$SENTINEL\`;
+> the marker file \`.loop/COMPLETE\` remains the only authoritative signal.
+EOF
+
+mv "$LOOP_DIR/IMPLEMENTATION_PLAN.md" "$ARCHIVE/IMPLEMENTATION_PLAN.md"
+cat > "$LOOP_DIR/IMPLEMENTATION_PLAN.md" << EOF
+# Implementation Plan — Milestone $NAME
+
+> STUB: planning mode (\`loop/PROMPT-PLANNING.md\`) rewrites this file from the
+> milestone queue. Build mode must not run against this stub.
+EOF
+
+# --- loop.env: new sentinel, triage mode -------------------------------------
+sed -i \
+  -e "s|^LOOP_COMPLETION_SENTINEL=.*|LOOP_COMPLETION_SENTINEL=\"$SENTINEL\"|" \
+  -e "s|^LOOP_PROMPT_FILE=.*|LOOP_PROMPT_FILE=\"loop/PROMPT-TRIAGE.md\"|" \
+  "$ENV_FILE"
+
+rm -f "$ROOT/.loop/COMPLETE"
+
+cat << EOF
+Milestone '$NAME' opened (previous: '$PREV', archived to loop/archive/$PREV/).
+Sentinel: $SENTINEL | mode: TRIAGE | stale completion marker removed.
+
+Next steps:
+  1. Review the diff and commit it (this script never commits).
+  2. Run the full pipeline unattended:  ./loop/scripts/pipeline.sh
+  3. When it finishes: review the branch, push, open the PR (always human).
+EOF

--- a/loop/scripts/pipeline.sh
+++ b/loop/scripts/pipeline.sh
@@ -56,7 +56,7 @@ fi
 stage() {
   local label=$1 prompt=$2 max=$3 expectation=$4
   local stage_env code
-  stage_env=$(mktemp)
+  stage_env=$(mktemp "${TMPDIR:-/tmp}/loop-stage-env.XXXXXX")
   printf 'source "%s"\nLOOP_PROMPT_FILE="%s"\n' "$BASE_ENV" "$prompt" > "$stage_env"
 
   echo

--- a/loop/scripts/pipeline.sh
+++ b/loop/scripts/pipeline.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Run one full maintainer-loop milestone unattended:
+#
+#   TRIAGE  (loop/PROMPT-TRIAGE.md,   until .loop/COMPLETE)  ->
+#   PLANNING (loop/PROMPT-PLANNING.md, exactly one iteration) ->
+#   BUILD   (loop/PROMPT.md,          until .loop/COMPLETE)
+#
+# Each stage drives loop/scripts/loop.sh with a stage-specific prompt override;
+# loop/config/loop.env stays untouched. Publishing (push / PR / merge) remains
+# a HUMAN step by design - this script never pushes.
+#
+# Usage: pipeline.sh [TRIAGE_MAX] [BUILD_MAX]
+#   TRIAGE_MAX: max triage iterations (default 8 - covers 35+ issues at 5/batch)
+#   BUILD_MAX:  max build iterations  (default 20)
+#
+# Exit codes: 0 all stages complete; 1 a stage failed or hit its iteration cap
+# (inspect loop/PROGRESS.md and .loop/logs/); the planning-contract violation
+# (planning created the completion marker) also exits 1.
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TRIAGE_MAX="${1:-8}"
+BUILD_MAX="${2:-20}"
+BASE_ENV="${LOOP_ENV_FILE:-$ROOT/loop/config/loop.env}"
+MARKER="$ROOT/.loop/COMPLETE"
+
+if [ ! -f "$BASE_ENV" ]; then
+  echo "Loop env file not found: $BASE_ENV" >&2
+  exit 1
+fi
+
+# Refuse to run over uncommitted work or on a protected branch - the loop's
+# containment model is a clean tree on a dedicated branch (LOOP-ENGINEERING §7).
+if git -C "$ROOT" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+  if [ -n "$(git -C "$ROOT" status --porcelain)" ]; then
+    echo "Working tree is not clean - commit or stash before running the pipeline" >&2
+    exit 1
+  fi
+  branch="$(git -C "$ROOT" branch --show-current)"
+  if [ "$branch" = "main" ]; then
+    echo "Refusing to run on 'main' - create a dedicated loop branch first" >&2
+    exit 1
+  fi
+fi
+
+# stage <label> <prompt-file> <max-iterations> <expectation>
+#   expectation "marker":    loop.sh must exit 0 (completion marker found)
+#   expectation "no-marker": a single planning iteration; exit 1 (cap reached,
+#                            no marker) is the NORMAL outcome, a marker is a
+#                            contract violation (planning must never complete)
+stage() {
+  local label=$1 prompt=$2 max=$3 expectation=$4
+  local stage_env code
+  stage_env=$(mktemp)
+  printf 'source "%s"\nLOOP_PROMPT_FILE="%s"\n' "$BASE_ENV" "$prompt" > "$stage_env"
+
+  echo
+  echo "=== pipeline stage: $label ($prompt, up to $max iterations) ==="
+  set +e
+  LOOP_ENV_FILE="$stage_env" "$SCRIPT_DIR/loop.sh" "$max"
+  code=$?
+  set -e
+  rm -f "$stage_env"
+
+  case "$expectation" in
+    marker)
+      if [ "$code" -ne 0 ]; then
+        echo "PIPELINE STOP: $label stage failed (loop.sh exit $code) - inspect loop/PROGRESS.md and .loop/logs/" >&2
+        exit 1
+      fi
+      rm -f "$MARKER" # consumed; the next stage must earn its own
+      ;;
+    no-marker)
+      if [ "$code" -eq 0 ]; then
+        echo "PIPELINE STOP: $label created the completion marker - planning must never complete a milestone; inspect loop/PROGRESS.md" >&2
+        exit 1
+      fi
+      if [ "$code" -ne 1 ]; then
+        echo "PIPELINE STOP: $label stage failed (loop.sh exit $code)" >&2
+        exit 1
+      fi
+      ;;
+  esac
+  echo "=== pipeline stage: $label DONE ==="
+}
+
+stage "TRIAGE" "loop/PROMPT-TRIAGE.md" "$TRIAGE_MAX" marker
+stage "PLANNING" "loop/PROMPT-PLANNING.md" 1 no-marker
+stage "BUILD" "loop/PROMPT.md" "$BUILD_MAX" marker
+
+echo
+echo "=== pipeline COMPLETE: triage, planning and build all finished ==="
+echo "Next (human): review the branch (git log / loop/PROGRESS.md), push, open the PR."

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Dedicated config for the functional smoke (e2e/functional-smoke.spec.ts)
+ * when run OUTSIDE the regular E2E suite - i.e. by the maintainer loop's
+ * close-out gate (loop/scripts/functional-smoke.sh) or by hand on a dev
+ * machine. It differs from playwright.config.ts in exactly two ways, both
+ * lessons from real incidents:
+ *
+ * - port 3105 with reuseExistingServer disabled: a locally installed
+ *   libredb-studio Snap daemon occupies 127.0.0.1:3000, and reusing it would
+ *   silently run the smoke against the wrong server with the wrong
+ *   credentials (the 0.9.53 E2E incident).
+ * - `bun start` only (no build): the loop's gate has just built; rebuilding
+ *   here would double the close-out cost. loop/scripts/functional-smoke.sh
+ *   guarantees .next exists before invoking this config.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/functional-smoke.spec.ts",
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 0,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3105",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "bun start",
+    url: "http://localhost:3105",
+    reuseExistingServer: false,
+    timeout: 120_000,
+    env: {
+      PORT: "3105",
+      HOSTNAME: "127.0.0.1",
+      JWT_SECRET: "test-jwt-secret-for-e2e-tests-32ch",
+      ADMIN_EMAIL: "admin@libredb.org",
+      ADMIN_PASSWORD: "test-admin",
+      USER_EMAIL: "user@libredb.org",
+      USER_PASSWORD: "test-user",
+    },
+  },
+});

--- a/tests/unit/loop-scripts.test.ts
+++ b/tests/unit/loop-scripts.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for the maintainer-loop lifecycle scripts:
+ *
+ * - scripts under loop/scripts/: new-milestone.sh (archive rotation + state
+ *   reset - the guard against PROGRESS.md/TRIAGE.md growing without bound and
+ *   re-introducing context rot) and pipeline.sh (unattended
+ *   triage -> planning -> build sequencing with its stage contracts).
+ *
+ * Both are exercised as real subprocesses against throwaway fixture roots,
+ * per the packaging-test convention. The pipeline fixture stubs the agent
+ * command (loop.sh's generic-agent path) so no real model runs.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "../..");
+const NEW_MILESTONE = join(REPO_ROOT, "loop/scripts/new-milestone.sh");
+const LOOP_SH = join(REPO_ROOT, "loop/scripts/loop.sh");
+const PIPELINE_SH = join(REPO_ROOT, "loop/scripts/pipeline.sh");
+
+const fixtureRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function write(root: string, rel: string, content: string): void {
+  mkdirSync(dirname(join(root, rel)), { recursive: true });
+  writeFileSync(join(root, rel), content);
+}
+
+function read(root: string, rel: string): string {
+  return readFileSync(join(root, rel), "utf8");
+}
+
+function run(cmd: string[], cwd?: string) {
+  return Bun.spawnSync(cmd, { cwd, stdout: "pipe", stderr: "pipe" });
+}
+
+// --- new-milestone.sh --------------------------------------------------------
+
+function makeMilestoneFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "loop-milestone-"));
+  fixtureRoots.push(root);
+  write(
+    root,
+    "loop/PROGRESS.md",
+    [
+      "# Progress Log (lab notebook)",
+      "",
+      "## Entry anatomy (follow this shape)",
+      "",
+      "- rules about entries",
+      "",
+      "## Log",
+      "",
+      "### 2026-07-11 — old entry A (DONE)",
+      "",
+      "- did a thing",
+      "",
+      "### 2026-07-12 — old entry B (DONE)",
+      "",
+      "- did another thing",
+      "",
+    ].join("\n"),
+  );
+  write(
+    root,
+    "loop/TRIAGE.md",
+    [
+      "# Triage register",
+      "",
+      "## Spec format",
+      "",
+      "(the format)",
+      "",
+      "## Queue",
+      "",
+      "### #45 — an old consumed spec (QUEUED 2026-07-12)",
+      "",
+      "- Acceptance bar: something",
+      "",
+      "## Not for the loop",
+      "",
+      "- #100 — tracking issue, human splits it",
+      "- #108 — epic, human-owned",
+      "",
+    ].join("\n"),
+  );
+  write(root, "loop/ACCEPTANCE.md", "# Acceptance Criteria — Maintainer Sweep 2\n\n- [x] everything\n");
+  write(root, "loop/IMPLEMENTATION_PLAN.md", "# Implementation Plan — Maintainer Sweep 2\n\n- [x] all tasks\n");
+  write(
+    root,
+    "loop/config/loop.env",
+    [
+      'LOOP_PROMPT_FILE="loop/PROMPT.md"',
+      'LOOP_COMPLETION_SENTINEL="LIBREDB-STUDIO-SWEEP-2-DONE"',
+      "LOOP_MAX_ITERATIONS=20",
+      "",
+    ].join("\n"),
+  );
+  write(root, ".loop/COMPLETE", "");
+  return root;
+}
+
+describe("loop/scripts/new-milestone.sh", () => {
+  test("archives the previous milestone and resets the working set", () => {
+    const root = makeMilestoneFixture();
+    const result = run(["bash", NEW_MILESTONE, "sweep-3", root]);
+    expect(result.exitCode).toBe(0);
+
+    // Previous milestone name derived from the sentinel; whole set archived.
+    expect(read(root, "loop/archive/sweep-2/PROGRESS.md")).toContain("old entry B");
+    expect(read(root, "loop/archive/sweep-2/TRIAGE.md")).toContain("old consumed spec");
+    expect(read(root, "loop/archive/sweep-2/ACCEPTANCE.md")).toContain("Maintainer Sweep 2");
+    expect(read(root, "loop/archive/sweep-2/IMPLEMENTATION_PLAN.md")).toContain("all tasks");
+
+    // PROGRESS keeps the template, drops the old entries, points at the archive.
+    const progress = read(root, "loop/PROGRESS.md");
+    expect(progress).toContain("Entry anatomy");
+    expect(progress).not.toContain("old entry A");
+    expect(progress).toContain("loop/archive/");
+    expect(progress).toContain("Milestone sweep-3 opened");
+
+    // TRIAGE queue emptied; the anti-re-triage memory is preserved verbatim.
+    const triage = read(root, "loop/TRIAGE.md");
+    expect(triage).toContain("## Spec format");
+    expect(triage).not.toContain("old consumed spec");
+    expect(triage).toContain("- #100 — tracking issue, human splits it");
+    expect(triage).toContain("- #108 — epic, human-owned");
+
+    // Stubs direct planning mode; env rotated to triage with the new sentinel.
+    expect(read(root, "loop/ACCEPTANCE.md")).toContain("STUB");
+    expect(read(root, "loop/IMPLEMENTATION_PLAN.md")).toContain("STUB");
+    const env = read(root, "loop/config/loop.env");
+    expect(env).toContain('LOOP_COMPLETION_SENTINEL="LIBREDB-STUDIO-SWEEP-3-DONE"');
+    expect(env).toContain('LOOP_PROMPT_FILE="loop/PROMPT-TRIAGE.md"');
+
+    // Stale completion marker is gone.
+    expect(existsSync(join(root, ".loop/COMPLETE"))).toBe(false);
+  });
+
+  test("rejects a non-kebab-case milestone name", () => {
+    const root = makeMilestoneFixture();
+    const result = run(["bash", NEW_MILESTONE, "Sweep_3", root]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("kebab-case");
+  });
+
+  test("refuses to reopen the current milestone name", () => {
+    const root = makeMilestoneFixture();
+    const result = run(["bash", NEW_MILESTONE, "sweep-2", root]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("already the current one");
+  });
+
+  test("refuses to overwrite an existing archive", () => {
+    const root = makeMilestoneFixture();
+    mkdirSync(join(root, "loop/archive/sweep-2"), { recursive: true });
+    const result = run(["bash", NEW_MILESTONE, "sweep-3", root]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("refusing to overwrite");
+  });
+});
+
+// --- pipeline.sh --------------------------------------------------------------
+
+/**
+ * Pipeline fixture: a tiny git repo with the REAL loop.sh + pipeline.sh, mode
+ * prompts whose text identifies the stage, and a stub agent that emulates the
+ * per-mode contract (triage/build create the completion marker, planning does
+ * not - unless the planning-completes.flag violation fixture is planted).
+ */
+function makePipelineFixture({ planningViolation = false } = {}): string {
+  const root = mkdtempSync(join(tmpdir(), "loop-pipeline-"));
+  fixtureRoots.push(root);
+
+  write(root, "loop/scripts/loop.sh", readFileSync(LOOP_SH, "utf8"));
+  write(root, "loop/scripts/pipeline.sh", readFileSync(PIPELINE_SH, "utf8"));
+  write(root, "loop/PROMPT-TRIAGE.md", "TRIAGE MODE prompt\n");
+  write(root, "loop/PROMPT-PLANNING.md", "PLANNING MODE prompt\n");
+  write(root, "loop/PROMPT.md", "BUILD MODE prompt\n");
+  write(
+    root,
+    "stub-agent.sh",
+    [
+      "#!/usr/bin/env bash",
+      "set -eu",
+      "mkdir -p .loop",
+      'printf "%s\\n" "$1" >> .loop/stub.log',
+      'case "$1" in',
+      "  *TRIAGE*) touch .loop/COMPLETE ;;",
+      "  *PLANNING*) if [ -f planning-completes.flag ]; then touch .loop/COMPLETE; fi ;;",
+      "  *BUILD*) touch .loop/COMPLETE ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  write(
+    root,
+    "loop/config/loop.env",
+    [
+      'LOOP_PROMPT_FILE="loop/PROMPT.md"',
+      'LOOP_COMPLETION_SENTINEL="FIXTURE-DONE"',
+      `LOOP_AGENT_CMD="${join(root, "stub-agent.sh")}"`,
+      'LOOP_AGENT_ARGS=""',
+      'LOOP_DISALLOWED_TOOLS=""',
+      "LOOP_MAX_TRANSIENT=1",
+      "",
+    ].join("\n"),
+  );
+  write(root, ".gitignore", ".loop/\n");
+  if (planningViolation) {
+    write(root, "planning-completes.flag", "");
+  }
+  chmodSync(join(root, "stub-agent.sh"), 0o755);
+  chmodSync(join(root, "loop/scripts/loop.sh"), 0o755);
+  chmodSync(join(root, "loop/scripts/pipeline.sh"), 0o755);
+
+  for (const cmd of [
+    ["git", "init", "--quiet", "--initial-branch=main"],
+    ["git", "-c", "user.email=t@t", "-c", "user.name=t", "add", "-A"],
+    ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--quiet", "-m", "fixture"],
+    ["git", "checkout", "--quiet", "-b", "loop/fixture-run"],
+  ]) {
+    const r = run(cmd, root);
+    if (r.exitCode !== 0) throw new Error(`fixture git setup failed: ${cmd.join(" ")}: ${r.stderr.toString()}`);
+  }
+  return root;
+}
+
+describe("loop/scripts/pipeline.sh", () => {
+  test("runs triage, planning and build in order and exits 0", () => {
+    const root = makePipelineFixture();
+    const result = run(["bash", join(root, "loop/scripts/pipeline.sh"), "3", "3"], root);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain("pipeline COMPLETE");
+
+    const stages = read(root, ".loop/stub.log").trim().split("\n");
+    expect(stages[0]).toContain("TRIAGE");
+    expect(stages[1]).toContain("PLANNING");
+    expect(stages[stages.length - 1]).toContain("BUILD");
+  });
+
+  test("aborts when planning creates the completion marker (contract violation)", () => {
+    const root = makePipelineFixture({ planningViolation: true });
+    const result = run(["bash", join(root, "loop/scripts/pipeline.sh"), "3", "3"], root);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("planning must never complete");
+    // Build never ran.
+    expect(read(root, ".loop/stub.log")).not.toContain("BUILD");
+  });
+
+  test("refuses a dirty working tree", () => {
+    const root = makePipelineFixture();
+    write(root, "uncommitted.txt", "dirty");
+    const result = run(["bash", join(root, "loop/scripts/pipeline.sh")], root);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("not clean");
+  });
+
+  test("refuses to run on main", () => {
+    const root = makePipelineFixture();
+    run(["git", "checkout", "--quiet", "main"], root);
+    const result = run(["bash", join(root, "loop/scripts/pipeline.sh")], root);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("dedicated loop branch");
+  });
+});


### PR DESCRIPTION
## Summary

Makes the maintainer loop generically re-runnable over any future issue queue. Previously a new milestone took ~6 manual steps plus an operator driving the triage -> planning -> build stage transitions, PROGRESS.md/TRIAGE.md grew without bound (each fresh-context iteration re-reads them, re-introducing context rot), and ACCEPTANCE.md was hand-authored. The whole lifecycle is now:

```bash
git checkout -b loop/<name> main
./loop/scripts/new-milestone.sh <name>
git add -A loop && git commit -m "chore(loop): open milestone <name>"
./loop/scripts/pipeline.sh        # unattended: triage -> planning -> build
# human: review branch, push, open PR
```

- **new-milestone.sh** - archives the previous milestone's working set (PROGRESS log, consumed TRIAGE specs, ACCEPTANCE, PLAN) to `loop/archive/<prev>/`, preserves the anti-re-triage "Not for the loop" memory verbatim, writes planning-mode stubs, rotates the completion sentinel, sets TRIAGE mode, removes a stale `.loop/COMPLETE`. Mutates files only; never commits.
- **pipeline.sh** - drives all three stages via per-stage prompt overrides (loop.env untouched), enforcing the stage contracts: triage/build must produce the completion marker, planning must NOT (a marker from planning aborts the pipeline). Refuses a dirty tree and the `main` branch; never pushes - publishing stays the human trust gate.
- **PROMPT-PLANNING.md** - the autonomous path now also rewrites ACCEPTANCE.md from the queue's sanitized specs (one functional criterion per issue + the standard Quality/Documentation/Process sections + the current sentinel read from loop.env), removing the last hand-authored input.
- **Gate single-sourcing** - root CLAUDE.md's mandatory gate grew to six commands (knip added) while the loop's gate.sh and PROMPT.md still carried the old five: exactly the drift class this repo fights. gate.sh gains the knip step and PROMPT.md now invokes `./loop/scripts/gate.sh` instead of hardcoding commands.
- HANDOFF.md carries the new runbook; LOOP-ENGINEERING.md documents the archive layer and generic operation.

## Test plan

- [x] 8 new unit tests (`tests/unit/loop-scripts.test.ts`) run both scripts as real subprocesses against fixture roots: archive rotation + template preservation, anti-re-triage memory preservation, kebab-case/name-reuse/archive-overwrite guards, stage ordering via a stub agent in a fixture git repo, planning-contract violation abort, dirty-tree and main-branch refusals
- [x] Smoke run of new-milestone.sh against copies of the REAL loop files (24 log entries archived, memory preserved, env rotated)
- [x] Full six-command gate green locally (format, lint, typecheck, knip, test, build)