### PR TITLE
docs(loop): clarify SCENARIOS authority and the CI smoke path (review follow-up)

### DIFF
--- a/loop/README.md
+++ b/loop/README.md
@@ -43,7 +43,9 @@ Full runbook and current status: [`HANDOFF.md`](./HANDOFF.md).
    `CLAUDE.md` (format · lint · typecheck · knip · test · build), per task, before every commit.
 2. **Functional** — `scripts/functional-smoke.sh`: boot the built app, create a real
    PostgreSQL connection through the UI, run a SQL query, assert the rows render. Mandatory
-   before a milestone may complete; also runs in CI's E2E job.
+   before a milestone may complete. (CI covers the same flow by running the underlying spec,
+   `e2e/functional-smoke.spec.ts`, inside the regular Playwright E2E job — not this wrapper;
+   the wrapper additionally hard-fails when Docker is missing, the spec skips.)
 
 ## Trust model in one paragraph
 

--- a/loop/SCENARIOS.md
+++ b/loop/SCENARIOS.md
@@ -4,9 +4,11 @@
 > every class of input it can meet — successful runs, failures, skips, bugs, fixes, features,
 > tasks, questions, missing information, moderator escalations, scams, and prompt injection.
 >
-> This document mirrors the implemented system (`PROMPT-TRIAGE.md`, `PROMPT-PLANNING.md`,
-> `PROMPT.md`, the 999-series guardrails, `scripts/*.sh`). If the mechanisms change, this file
-> changes in the same PR — the code mirrors the doc and the doc mirrors the code.
+> This document is DESCRIPTIVE, not authoritative: agent behavior is defined exclusively by
+> the prompts (`PROMPT-TRIAGE.md`, `PROMPT-PLANNING.md`, `PROMPT.md`, their 999-series
+> guardrails) and the runner scripts (`scripts/*.sh`) — on any conflict, those win and this
+> file is the bug. The sync obligation still holds: when the mechanisms change, this
+> catalogue is updated in the same PR so it never drifts into fiction.
 > Use cases marked **precedent** actually happened (Sweep 1: issues #132–#137; Sweep 2:
 > #45/#96/#124/#125/#126/#136/#151 plus routing decisions on #40/#94/#100/#108/#123/#127/#167/#170).
 > Use cases marked **synthetic** are designed-for but have not occurred live yet.


### PR DESCRIPTION
Two clarity fixes from the Copilot review of #184, both real:

- SCENARIOS.md now states explicitly that it is descriptive, not authoritative - prompts and runner scripts win on any conflict (the same-PR sync obligation stays). Removes the tension between the doc's mirror language and the folder's agents-follow-prompts-only rule.
- README.md no longer implies CI runs scripts/functional-smoke.sh: CI runs the underlying e2e/functional-smoke.spec.ts inside the regular Playwright E2E job, and the two have different missing-Docker semantics (wrapper hard-fails, spec skips).

Docs-only; full gate green via the pre-commit hook.