### PR TITLE
fix(editor): let Monaco flex containers shrink with the viewport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,10 @@ seed-connections.yaml
 
 .playwright-mcp/
 
+# Playwright run artifacts
+/test-results/
+/playwright-report/
+
 npmjs-token
 
 .npmrc

--- a/e2e/editor-layout.spec.ts
+++ b/e2e/editor-layout.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+
+// Regression test for #94: the flex chain around Monaco lacked min-height:0,
+// so after a viewport shrink the editor kept its stale larger height,
+// overflowed the panel clip, and the tail of the document could never be
+// scrolled into view (the scrollbar hit bottom while lines stayed hidden).
+
+type MonacoEditorHandle = {
+  setValue: (value: string) => void;
+  setScrollTop: (top: number) => void;
+  getScrollHeight: () => number;
+};
+
+type MonacoWindow = {
+  monaco?: { editor: { getEditors: () => MonacoEditorHandle[] } };
+};
+
+test.describe("Editor layout", () => {
+  test("editor shrinks with the viewport and stays inside its panel", async ({ page }) => {
+    await page.goto("/login");
+    await page.locator('input[type="email"]').fill("user@libredb.org");
+    await page.locator('input[type="password"]').fill("test-user");
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await page.waitForURL("/");
+    await expect(page.locator(".monaco-editor").first()).toBeVisible({ timeout: 15000 });
+    await page.waitForFunction(() => ((window as unknown as MonacoWindow).monaco?.editor.getEditors().length ?? 0) > 0);
+
+    // A document long enough to need vertical scrolling at any panel size
+    await page.evaluate(() => {
+      const lines = [];
+      for (let i = 1; i <= 60; i++) lines.push(`SELECT ${i} AS col FROM users WHERE id = ${i};`);
+      const monaco = (window as unknown as MonacoWindow).monaco;
+      if (!monaco) throw new Error("monaco not loaded");
+      monaco.editor.getEditors()[0].setValue(lines.join("\n"));
+    });
+
+    // Lay the editor out large first, then shrink: growth always relayouts,
+    // it is the shrink path that used to deadlock.
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await page.waitForTimeout(500);
+    await page.setViewportSize({ width: 950, height: 600 });
+
+    // Scrolled to the very end, the editor's bottom edge must sit inside its
+    // clipping panel; any positive overhang means hidden, unreachable lines.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const monaco = (window as unknown as MonacoWindow).monaco;
+            if (!monaco) throw new Error("monaco not loaded");
+            const ed = monaco.editor.getEditors()[0];
+            ed.setScrollTop(ed.getScrollHeight());
+            const monacoEl = document.querySelector(".monaco-editor");
+            const panel = monacoEl?.closest('[data-slot="resizable-panel"]');
+            if (!monacoEl || !panel) throw new Error("editor or panel not found");
+            return Math.round(monacoEl.getBoundingClientRect().bottom - panel.getBoundingClientRect().bottom);
+          }),
+        { timeout: 5000 },
+      )
+      .toBeLessThanOrEqual(1);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// Override with E2E_PORT when localhost:3000 is occupied by another instance.
+const port = Number(process.env.E2E_PORT ?? 3000);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -8,7 +11,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? "html" : "list",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: `http://localhost:${port}`,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
@@ -20,10 +23,11 @@ export default defineConfig({
   ],
   webServer: {
     command: "bun run build && bun start",
-    url: "http://localhost:3000",
+    url: `http://localhost:${port}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     env: {
+      PORT: String(port),
       JWT_SECRET: "test-jwt-secret-for-e2e-tests-32ch",
       ADMIN_EMAIL: "admin@libredb.org",
       ADMIN_PASSWORD: "test-admin",

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -113,11 +113,9 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
 
     // Line numbers toggle state (persisted in localStorage)
     const [showLineNumbers, setShowLineNumbers] = useState<boolean>(() => {
-      if (typeof window !== "undefined") {
-        const saved = localStorage.getItem("editor-line-numbers");
-        return saved !== null ? saved === "true" : true; // default: true
-      }
-      return true;
+      if (typeof window === "undefined") return true;
+      const saved = localStorage.getItem("editor-line-numbers");
+      return saved !== null ? saved === "true" : true; // default: true
     });
 
     // Track last synced value to detect external changes
@@ -697,8 +695,7 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
           )}
         </AnimatePresence>
 
-        {/* min-h-0 lets this flex item shrink below Monaco's rendered height;
-            without it the editor can grow but never shrink (issue #94) */}
+        {/* min-h-0: the flex item must shrink below Monaco's rendered height, else the editor can never shrink (#94) */}
         <div className="flex-1 relative min-h-0">
           <Editor
             height="100%"

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -697,7 +697,9 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
           )}
         </AnimatePresence>
 
-        <div className="flex-1 relative">
+        {/* min-h-0 lets this flex item shrink below Monaco's rendered height;
+            without it the editor can grow but never shrink (issue #94) */}
+        <div className="flex-1 relative min-h-0">
           <Editor
             height="100%"
             language={language}

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -454,7 +454,7 @@ export default function Studio() {
                           onImport={() => setIsImportModalOpen(true)}
                         />
 
-                        <div className="flex-1 relative">
+                        <div className="flex-1 relative min-h-0">
                           <QueryEditor
                             ref={queryEditorRef}
                             value={tabMgr.currentTab.query}

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -422,7 +422,7 @@ export function StudioWorkspace({
                           onImport={features.dataImport ? () => setIsImportModalOpen(true) : noop}
                         />
 
-                        <div className="flex-1 relative">
+                        <div className="flex-1 relative min-h-0">
                           <QueryEditor
                             ref={queryEditorRef}
                             value={tabMgr.currentTab.query}

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
-import { Sidebar, ConnectionsList } from "@/components/sidebar";
-// MobileNav excluded in embedded mode — platform provides its own navigation
-import { SchemaExplorer } from "@/components/schema-explorer";
+import { Sidebar } from "@/components/sidebar";
+// MobileNav and mobile tab panels excluded in embedded mode — platform provides its own navigation
 import { QueryEditor, QueryEditorRef } from "@/components/QueryEditor";
 import { DataImportModal } from "@/components/DataImportModal";
 import { QuerySafetyDialog } from "@/components/QuerySafetyDialog";
@@ -13,7 +12,6 @@ import { TestDataGenerator } from "@/components/TestDataGenerator";
 import { SchemaDiagram } from "@/components/SchemaDiagram";
 import { SaveQueryModal } from "@/components/SaveQueryModal";
 import { StudioTabBar, QueryToolbar, BottomPanel } from "@/components/studio/index";
-import type { DatabaseConnection } from "@/lib/types";
 import type { MaskingConfig } from "@/lib/data-masking";
 import { useToast } from "@/hooks/use-toast";
 import { useTabManager } from "@/hooks/use-tab-manager";
@@ -91,7 +89,7 @@ function useStudioTheme() {
     };
   }, []);
 }
-import { AlertTriangle, Database } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { AnimatePresence } from "framer-motion";
 import {
@@ -171,7 +169,6 @@ export function StudioWorkspace({
   const [showDiagram, setShowDiagram] = useState(false);
   const [isSaveQueryModalOpen, setIsSaveQueryModalOpen] = useState(false);
   const [savedKey, setSavedKey] = useState(0);
-  const [activeMobileTab, setActiveMobileTab] = useState<"database" | "schema" | "editor">("editor");
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [isNL2SQLOpen, setIsNL2SQLOpen] = useState(false);
   const [profilerTable, setProfilerTable] = useState<string | null>(null);
@@ -344,62 +341,8 @@ export function StudioWorkspace({
                 </AnimatePresence>
               )}
 
-              {/* Mobile: Database Tab */}
-              {activeMobileTab === "database" && (
-                <div className="md:hidden h-full bg-[#080808] overflow-auto p-4">
-                  <div className="mb-4 flex items-center justify-between">
-                    <h2 className="text-xs font-medium text-zinc-300">Connections</h2>
-                  </div>
-                  <ConnectionsList
-                    connections={conn.connections}
-                    activeConnection={conn.activeConnection}
-                    onSelectConnection={(c: DatabaseConnection) => {
-                      conn.setActiveConnection(c);
-                      setActiveMobileTab("editor");
-                    }}
-                    onDeleteConnection={noop}
-                    onAddConnection={noop}
-                  />
-                </div>
-              )}
-
-              {/* Mobile: Schema Tab */}
-              {activeMobileTab === "schema" && (
-                <div className="md:hidden h-full bg-[#080808] overflow-auto p-4">
-                  {conn.activeConnection ? (
-                    <SchemaExplorer
-                      schema={conn.schema}
-                      isLoadingSchema={conn.isLoadingSchema}
-                      onTableClick={(tableName: string) => {
-                        onTableClick(tableName);
-                        setActiveMobileTab("editor");
-                      }}
-                      onGenerateSelect={(tableName: string) => {
-                        tabMgr.handleGenerateSelect(tableName);
-                        setActiveMobileTab("editor");
-                      }}
-                      onCreateTableClick={undefined}
-                      isAdmin={false}
-                      onOpenMaintenance={noop}
-                      databaseType={conn.activeConnection?.type}
-                      metadata={null}
-                      onProfileTable={features.codeGenerator ? (name: string) => setProfilerTable(name) : undefined}
-                      onGenerateCode={features.codeGenerator ? (name: string) => setCodeGenTable(name) : undefined}
-                      onGenerateTestData={
-                        features.testDataGenerator ? (name: string) => setTestDataTable(name) : undefined
-                      }
-                    />
-                  ) : (
-                    <div className="flex flex-col items-center justify-center h-full text-zinc-500">
-                      <Database strokeWidth={1.5} className="w-12 h-12 mb-4 opacity-30" />
-                      <p className="text-xs">Select a connection first</p>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {/* Desktop & Mobile Editor Tab */}
-              <div className={cn("h-full", activeMobileTab !== "editor" && "hidden md:block")}>
+              {/* Editor area — no mobile database/schema tab panels in embedded mode (no MobileNav to switch to them) */}
+              <div className="h-full">
                 <div className="h-full">
                   <ResizablePanelGroup id="workspace-editor" direction="vertical">
                     <ResizablePanel defaultSize={40} minSize={20}>

--- a/tests/components/QueryEditor.test.tsx
+++ b/tests/components/QueryEditor.test.tsx
@@ -1774,6 +1774,24 @@ describe("QueryEditor", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  test("ref format is a no-op for languages without a formatter (e.g. libredb)", () => {
+    const onChange = mock(() => {});
+    const editorRef = React.createRef<import("@/components/QueryEditor").QueryEditorRef>();
+    const { queryByTestId } = render(
+      React.createElement(QueryEditor, {
+        ...createDefaultProps({ onChange, value: "USE db1", language: "libredb" }),
+        ref: editorRef,
+      }),
+    );
+    act(() => {
+      editorRef.current?.format();
+    });
+    // handleFormat hits the else branch and returns without touching the editor
+    const editor = queryByTestId("mock-monaco-editor") as HTMLTextAreaElement;
+    expect(editor.value).toBe("USE db1");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   // -----------------------------------------------------------------------
   // Branch coverage: onChange optional chaining (false path)
   // -----------------------------------------------------------------------

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -2,7 +2,9 @@ import "../setup-dom";
 import "../helpers/mock-sonner";
 import { mockRouterPush } from "../helpers/mock-navigation";
 
-import { mock } from "bun:test";
+import { describe, test, expect, afterEach, beforeEach, mock } from "bun:test";
+import { render, cleanup, act, fireEvent } from "@testing-library/react";
+import React from "react";
 import { setupMonacoMock, setupRechartssMock, setupXYFlowMock, setupFramerMotionMock } from "../helpers/mock-monaco";
 
 // Setup heavy library mocks before any component imports
@@ -20,6 +22,10 @@ let capturedSaveQueryModalProps: Record<string, unknown> = {};
 let capturedCommandPaletteProps: Record<string, unknown> = {};
 let capturedSafetyDialogProps: Record<string, unknown> = {};
 let capturedMobileHeaderProps: Record<string, unknown> = {};
+let capturedSchemaExplorerProps: Record<string, unknown> = {};
+let capturedConnectionsListProps: Record<string, unknown> = {};
+let capturedQueryEditorProps: Record<string, unknown> = {};
+let capturedMobileNavProps: Record<string, unknown> = {};
 
 // ---- Trackable mock functions (shared across mocks + assertions) ----
 
@@ -33,6 +39,7 @@ const mockFetchSchema = mock(() => {});
 // Tab Manager
 const mockSetTabs = mock(() => {});
 const mockUpdateCurrentTab = mock(() => {});
+const mockUpdateTabById = mock(() => {});
 const mockHandleTableClick = mock(() => {});
 const mockHandleGenerateSelect = mock(() => {});
 // Transaction Control
@@ -135,6 +142,7 @@ mock.module("@/hooks/use-tab-manager", () => ({
     addTab: mock(() => {}),
     closeTab: mock(() => {}),
     updateCurrentTab: mockUpdateCurrentTab,
+    updateTabById: mockUpdateTabById,
     handleTableClick: mockHandleTableClick,
     handleGenerateSelect: mockHandleGenerateSelect,
     ...tabMgrOverride,
@@ -189,6 +197,16 @@ mock.module("@/hooks/use-toast", () => ({
   })),
 }));
 
+mock.module("@/hooks/use-storage-sync", () => ({
+  useStorageSync: mock(() => ({
+    isServerMode: false,
+    isSyncing: false,
+    isReady: true,
+    lastSyncedAt: null,
+    syncError: null,
+  })),
+}));
+
 // ---- Mock utility modules ----
 
 mock.module("@/lib/storage", () => ({
@@ -227,19 +245,28 @@ mock.module("@/components/sidebar", () => {
       capturedSidebarProps = props;
       return React.createElement("div", { "data-testid": "sidebar" }, "Sidebar");
     },
-    ConnectionsList: () => React.createElement("div", { "data-testid": "connections-list" }, "ConnectionsList"),
+    ConnectionsList: (props: Record<string, unknown>) => {
+      capturedConnectionsListProps = props;
+      return React.createElement("div", { "data-testid": "connections-list" }, "ConnectionsList");
+    },
   };
 });
 
 mock.module("@/components/MobileNav", () => ({
-  MobileNav: () => null,
+  MobileNav: (props: Record<string, unknown>) => {
+    capturedMobileNavProps = props;
+    return null;
+  },
 }));
 
 mock.module("@/components/schema-explorer", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require("react");
   return {
-    SchemaExplorer: () => React.createElement("div", { "data-testid": "schema-explorer" }, "SchemaExplorer"),
+    SchemaExplorer: (props: Record<string, unknown>) => {
+      capturedSchemaExplorerProps = props;
+      return React.createElement("div", { "data-testid": "schema-explorer" }, "SchemaExplorer");
+    },
   };
 });
 
@@ -255,9 +282,10 @@ mock.module("@/components/ConnectionModal", () => ({
 mock.module("@/components/QueryEditor", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require("react");
-  const QueryEditor = React.forwardRef((props: Record<string, unknown>, ref: unknown) =>
-    React.createElement("div", { "data-testid": "query-editor", ref }, "QueryEditor"),
-  );
+  const QueryEditor = React.forwardRef((props: Record<string, unknown>, ref: unknown) => {
+    capturedQueryEditorProps = props;
+    return React.createElement("div", { "data-testid": "query-editor", ref }, "QueryEditor");
+  });
   QueryEditor.displayName = "QueryEditor";
   return { QueryEditor, QueryEditorRef: {} };
 });
@@ -378,13 +406,13 @@ mock.module("@/components/ui/resizable", () => {
   };
 });
 
-// ---- Now import bun:test, testing-library, and the component ----
+// ---- Load the component under test AFTER all mock.module registrations ----
+// A static import would be hoisted and evaluate the real module tree (QueryEditor,
+// sidebar, schema-explorer, BottomPanel, monaco, ...) before the mocks apply,
+// poisoning coverage with zero-hit phantom lines for modules that never execute.
+// The dynamic import resolves against the mock registry instead.
 
-import { describe, test, expect, afterEach, beforeEach } from "bun:test";
-import { render, cleanup, act } from "@testing-library/react";
-import React from "react";
-
-import Studio from "@/components/Studio";
+const { default: Studio } = await import("@/components/Studio");
 
 // =============================================================================
 // Test data
@@ -426,6 +454,10 @@ describe("Studio", () => {
     capturedCommandPaletteProps = {};
     capturedSafetyDialogProps = {};
     capturedMobileHeaderProps = {};
+    capturedSchemaExplorerProps = {};
+    capturedConnectionsListProps = {};
+    capturedQueryEditorProps = {};
+    capturedMobileNavProps = {};
 
     // Reset overrides
     connMgrOverride = {};
@@ -442,6 +474,7 @@ describe("Studio", () => {
     mockFetchSchema.mockClear();
     mockSetTabs.mockClear();
     mockUpdateCurrentTab.mockClear();
+    mockUpdateTabById.mockClear();
     mockHandleTableClick.mockClear();
     mockHandleGenerateSelect.mockClear();
     mockResetTransactionState.mockClear();
@@ -1039,5 +1072,164 @@ describe("Studio", () => {
     // we just verify the callback is properly wired.
     expect(fn).toBeDefined();
     expect(typeof fn).toBe("function");
+  });
+
+  // --- Connection-change effect: setTabs updater ---
+  test("connection-change effect retypes existing tabs via setTabs updater", () => {
+    connMgrOverride = { activeConnection: pgConn };
+    render(<Studio />);
+    expect(mockSetTabs).toHaveBeenCalled();
+    const updater = (mockSetTabs.mock.calls[0] as unknown[])[0] as (prev: unknown[]) => Array<{ type: string }>;
+    const result = updater([
+      { id: "tab-1", name: "Query 1", query: "SELECT 1", result: null, isExecuting: false, type: "mongodb" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("sql");
+  });
+
+  // --- exportResults sql-ddl type mapping ---
+  test("exportResults sql-ddl maps boolean and date sample values", async () => {
+    tabMgrOverride = {
+      currentTab: {
+        id: "tab-1",
+        name: "Users",
+        query: "SELECT 1",
+        result: {
+          rows: [{ active: true, created: new Date("2026-01-01T00:00:00Z") }],
+          fields: ["active", "created"],
+          rowCount: 1,
+          executionTime: 5,
+        },
+        isExecuting: false,
+        type: "sql",
+      },
+    };
+    render(<Studio />);
+    const exportFn = capturedBottomPanelProps.onExportResults as (format: string) => void;
+    act(() => exportFn("sql-ddl"));
+    expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
+    const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
+    const content = await blob.text();
+    expect(content).toContain("active BOOLEAN");
+    expect(content).toContain("created TIMESTAMP");
+  });
+
+  // --- Mobile: database tab ---
+  test("mobile database tab lists connections and selecting one returns to editor", () => {
+    connMgrOverride = { connections: [pgConn] };
+    const { queryByTestId } = render(<Studio />);
+    expect(queryByTestId("connections-list")).toBeNull();
+    const onTabChange = capturedMobileNavProps.onTabChange as (tab: string) => void;
+    act(() => onTabChange("database"));
+    expect(queryByTestId("connections-list")).not.toBeNull();
+    const addFn = capturedConnectionsListProps.onAddConnection as () => void;
+    act(() => addFn());
+    expect(capturedConnectionModalProps.isOpen).toBe(true);
+    const selectFn = capturedConnectionsListProps.onSelectConnection as (c: unknown) => void;
+    act(() => selectFn(pgConn));
+    expect(mockSetActiveConnection).toHaveBeenCalledWith(pgConn);
+    expect(queryByTestId("connections-list")).toBeNull();
+  });
+
+  test("mobile database tab Add button opens connection modal", () => {
+    const { getByText, queryByTestId } = render(<Studio />);
+    const onTabChange = capturedMobileNavProps.onTabChange as (tab: string) => void;
+    act(() => onTabChange("database"));
+    fireEvent.click(getByText(/Add/));
+    expect(queryByTestId("connection-modal")).not.toBeNull();
+  });
+
+  // --- Mobile: schema tab ---
+  test("mobile schema tab shows empty state without a connection", () => {
+    const { queryByTestId, getByText } = render(<Studio />);
+    const onTabChange = capturedMobileNavProps.onTabChange as (tab: string) => void;
+    act(() => onTabChange("schema"));
+    expect(queryByTestId("schema-explorer")).toBeNull();
+    expect(getByText("Select a connection first")).not.toBeNull();
+  });
+
+  test("mobile schema tab table click returns to editor", () => {
+    connMgrOverride = { activeConnection: pgConn, connections: [pgConn] };
+    const { queryByTestId } = render(<Studio />);
+    const onTabChange = capturedMobileNavProps.onTabChange as (tab: string) => void;
+    act(() => onTabChange("schema"));
+    expect(queryByTestId("schema-explorer")).not.toBeNull();
+    const tableClick = capturedSchemaExplorerProps.onTableClick as (name: string) => void;
+    act(() => tableClick("users"));
+    expect(mockHandleTableClick).toHaveBeenCalledWith("users", mockExecuteQuery);
+    expect(queryByTestId("schema-explorer")).toBeNull();
+  });
+
+  test("mobile schema tab generate select returns to editor", () => {
+    connMgrOverride = { activeConnection: pgConn };
+    const { queryByTestId } = render(<Studio />);
+    act(() => (capturedMobileNavProps.onTabChange as (tab: string) => void)("schema"));
+    const genFn = capturedSchemaExplorerProps.onGenerateSelect as (name: string) => void;
+    act(() => genFn("users"));
+    expect(mockHandleGenerateSelect).toHaveBeenCalledWith("users");
+    expect(queryByTestId("schema-explorer")).toBeNull();
+  });
+
+  test("mobile schema tab table tool callbacks open modals and maintenance", () => {
+    connMgrOverride = { activeConnection: pgConn };
+    const { queryByTestId } = render(<Studio />);
+    act(() => (capturedMobileNavProps.onTabChange as (tab: string) => void)("schema"));
+    act(() => (capturedSchemaExplorerProps.onCreateTableClick as () => void)());
+    expect(queryByTestId("createtablemodal")).not.toBeNull();
+    act(() => (capturedSchemaExplorerProps.onProfileTable as (n: string) => void)("users"));
+    expect(queryByTestId("dataprofiler")).not.toBeNull();
+    act(() => (capturedSchemaExplorerProps.onGenerateCode as (n: string) => void)("users"));
+    expect(queryByTestId("codegenerator")).not.toBeNull();
+    act(() => (capturedSchemaExplorerProps.onGenerateTestData as (n: string) => void)("users"));
+    expect(queryByTestId("testdatagenerator")).not.toBeNull();
+    act(() => (capturedSchemaExplorerProps.onOpenMaintenance as () => void)());
+    expect(mockRouterPush).toHaveBeenCalledWith("/admin?tab=operations");
+  });
+
+  // --- QueryToolbar execution/transaction callbacks ---
+  test("QueryToolbar onExecuteQuery delegates to executeQuery", () => {
+    render(<Studio />);
+    const fn = capturedQueryToolbarProps.onExecuteQuery as () => void;
+    act(() => fn());
+    expect(mockExecuteQuery).toHaveBeenCalled();
+  });
+
+  test("QueryToolbar onCancelQuery delegates to cancelQuery", () => {
+    render(<Studio />);
+    const fn = capturedQueryToolbarProps.onCancelQuery as () => void;
+    act(() => fn());
+    expect(mockCancelQuery).toHaveBeenCalled();
+  });
+
+  test("QueryToolbar transaction callbacks delegate to handleTransaction", () => {
+    render(<Studio />);
+    act(() => (capturedQueryToolbarProps.onBeginTransaction as () => void)());
+    expect(mockHandleTransaction).toHaveBeenCalledWith("begin");
+    act(() => (capturedQueryToolbarProps.onCommitTransaction as () => void)());
+    expect(mockHandleTransaction).toHaveBeenCalledWith("commit");
+    act(() => (capturedQueryToolbarProps.onRollbackTransaction as () => void)());
+    expect(mockHandleTransaction).toHaveBeenCalledWith("rollback");
+  });
+
+  test("QueryToolbar onTogglePlayground toggles playground mode", () => {
+    render(<Studio />);
+    const fn = capturedQueryToolbarProps.onTogglePlayground as () => void;
+    act(() => fn());
+    expect(mockSetPlaygroundMode).toHaveBeenCalledWith(true);
+  });
+
+  // --- QueryEditor callbacks ---
+  test("QueryEditor onContentChange updates the owning tab by id", () => {
+    render(<Studio />);
+    const fn = capturedQueryEditorProps.onContentChange as (val: string) => void;
+    act(() => fn("SELECT 2"));
+    expect(mockUpdateTabById).toHaveBeenCalledWith("tab-1", { query: "SELECT 2" });
+  });
+
+  test("QueryEditor onExplain executes explain query", () => {
+    render(<Studio />);
+    const fn = capturedQueryEditorProps.onExplain as () => void;
+    act(() => fn());
+    expect(mockExecuteQuery).toHaveBeenCalledWith(undefined, undefined, true);
   });
 });

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -1,0 +1,836 @@
+import "../setup-dom";
+
+import { mock } from "bun:test";
+import { setupFramerMotionMock } from "../helpers/mock-monaco";
+
+// Setup heavy library mocks before the component is imported
+setupFramerMotionMock();
+
+// ---- Module-level prop capture for child components ----
+let capturedSidebarProps: Record<string, unknown> = {};
+let capturedTabBarProps: Record<string, unknown> = {};
+let capturedQueryToolbarProps: Record<string, unknown> = {};
+let capturedQueryEditorProps: Record<string, unknown> = {};
+let capturedBottomPanelProps: Record<string, unknown> = {};
+let capturedSaveQueryModalProps: Record<string, unknown> = {};
+let capturedDataImportModalProps: Record<string, unknown> = {};
+let capturedSafetyDialogProps: Record<string, unknown> = {};
+let capturedSchemaDiagramProps: Record<string, unknown> = {};
+let capturedDataProfilerProps: Record<string, unknown> = {};
+let capturedCodeGeneratorProps: Record<string, unknown> = {};
+let capturedTestDataGeneratorProps: Record<string, unknown> = {};
+
+// ---- Trackable mock functions (shared across mocks + assertions) ----
+
+// Connection adapter
+const mockSetConnections = mock(() => {});
+const mockSetActiveConnection = mock(() => {});
+const mockSetSchema = mock(() => {});
+const mockFetchSchema = mock(() => {});
+// Tab manager
+const mockSetTabs = mock(() => {});
+const mockUpdateCurrentTab = mock(() => {});
+const mockUpdateTabById = mock(() => {});
+const mockHandleTableClick = mock(() => {});
+const mockHandleGenerateSelect = mock(() => {});
+// Query adapter
+const mockExecuteQuery = mock(() => {});
+const mockForceExecuteQuery = mock(() => {});
+const mockCancelQuery = mock(() => {});
+const mockSetSafetyCheckQuery = mock(() => {});
+const mockSetBottomPanelMode = mock(() => {});
+const mockHandleUnlimitedQuery = mock(() => {});
+const mockHandleLoadMore = mock(() => {});
+const mockSetUnlimitedWarningOpen = mock(() => {});
+// Toast
+const mockToast = mock((_args?: unknown) => {});
+// URL (for export tests)
+const mockCreateObjectURL = mock((_blob?: unknown) => "blob:mock-url");
+const mockRevokeObjectURL = mock(() => {});
+
+// ---- Hook override objects (spread into mock returns per-test) ----
+let connAdapterOverride: Record<string, unknown> = {};
+let tabMgrOverride: Record<string, unknown> = {};
+let queryAdapterOverride: Record<string, unknown> = {};
+
+// ---- Shared test data used inside mock factories ----
+
+const dbConn = {
+  id: "c1",
+  name: "TestPG",
+  type: "postgres" as const,
+  createdAt: new Date("2026-01-01"),
+  managed: true,
+};
+
+const baseTab = {
+  id: "tab-1",
+  name: "Query 1",
+  query: "SELECT 1",
+  result: null,
+  isExecuting: false,
+  type: "sql" as const,
+};
+
+const usersTable = { name: "users", columns: [{ name: "id", type: "integer" }] };
+
+// ---- Mock the workspace adapter hooks ----
+
+mock.module("@/workspace/hooks/use-connection-adapter", () => ({
+  useConnectionAdapter: mock(() => ({
+    connections: [dbConn],
+    setConnections: mockSetConnections,
+    activeConnection: dbConn,
+    setActiveConnection: mockSetActiveConnection,
+    schema: [usersTable],
+    setSchema: mockSetSchema,
+    isLoadingSchema: false,
+    connectionPulse: null,
+    fetchSchema: mockFetchSchema,
+    tableNames: ["users"],
+    schemaContext: JSON.stringify([usersTable]),
+    ...connAdapterOverride,
+  })),
+}));
+
+mock.module("@/workspace/hooks/use-query-adapter", () => ({
+  useQueryAdapter: mock(() => ({
+    executeQuery: mockExecuteQuery,
+    forceExecuteQuery: mockForceExecuteQuery,
+    cancelQuery: mockCancelQuery,
+    handleLoadMore: mockHandleLoadMore,
+    handleUnlimitedQuery: mockHandleUnlimitedQuery,
+    safetyCheckQuery: null,
+    setSafetyCheckQuery: mockSetSafetyCheckQuery,
+    unlimitedWarningOpen: false,
+    setUnlimitedWarningOpen: mockSetUnlimitedWarningOpen,
+    pendingUnlimitedQuery: null,
+    setPendingUnlimitedQuery: mock(() => {}),
+    historyKey: 0,
+    bottomPanelMode: "results",
+    setBottomPanelMode: mockSetBottomPanelMode,
+    ...queryAdapterOverride,
+  })),
+}));
+
+// ---- Mock shared studio hooks ----
+
+mock.module("@/hooks/use-tab-manager", () => ({
+  useTabManager: mock(() => ({
+    tabs: [baseTab],
+    activeTabId: "tab-1",
+    currentTab: baseTab,
+    setTabs: mockSetTabs,
+    setActiveTabId: mock(() => {}),
+    editingTabId: null,
+    editingTabName: "",
+    setEditingTabId: mock(() => {}),
+    setEditingTabName: mock(() => {}),
+    addTab: mock(() => {}),
+    closeTab: mock(() => {}),
+    updateCurrentTab: mockUpdateCurrentTab,
+    updateTabById: mockUpdateTabById,
+    handleTableClick: mockHandleTableClick,
+    handleGenerateSelect: mockHandleGenerateSelect,
+    ...tabMgrOverride,
+  })),
+}));
+
+mock.module("@/hooks/use-toast", () => ({
+  useToast: mock(() => ({
+    toast: mockToast,
+  })),
+}));
+
+// ---- Mock child components ----
+
+mock.module("@/components/sidebar", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  return {
+    Sidebar: (props: Record<string, unknown>) => {
+      capturedSidebarProps = props;
+      return React.createElement("div", { "data-testid": "sidebar" }, "Sidebar");
+    },
+    ConnectionsList: () => React.createElement("div", { "data-testid": "connections-list" }, "ConnectionsList"),
+  };
+});
+
+mock.module("@/components/QueryEditor", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  const QueryEditor = React.forwardRef((props: Record<string, unknown>, ref: unknown) => {
+    capturedQueryEditorProps = props;
+    return React.createElement("div", { "data-testid": "query-editor", ref }, "QueryEditor");
+  });
+  QueryEditor.displayName = "QueryEditor";
+  return { QueryEditor, QueryEditorRef: {} };
+});
+
+// Mock the studio sub-components barrel (same rationale as Studio.test.tsx:
+// StudioWorkspace imports from '@/components/studio/index').
+mock.module("@/components/studio/index", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  return {
+    StudioMobileHeader: () => null,
+    StudioDesktopHeader: () => null,
+    StudioTabBar: (props: Record<string, unknown>) => {
+      capturedTabBarProps = props;
+      return React.createElement("div", { "data-testid": "tab-bar" }, "TabBar");
+    },
+    QueryToolbar: (props: Record<string, unknown>) => {
+      capturedQueryToolbarProps = props;
+      return React.createElement("div", { "data-testid": "query-toolbar" }, "QueryToolbar");
+    },
+    BottomPanel: (props: Record<string, unknown>) => {
+      capturedBottomPanelProps = props;
+      return React.createElement("div", { "data-testid": "bottom-panel" }, "BottomPanel");
+    },
+    BottomPanelMode: {},
+  };
+});
+
+mock.module("@/components/SchemaDiagram", () => ({
+  SchemaDiagram: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require("react");
+    capturedSchemaDiagramProps = props;
+    return React.createElement("div", { "data-testid": "schemadiagram" }, "SchemaDiagram");
+  },
+}));
+
+mock.module("@/components/SaveQueryModal", () => ({
+  SaveQueryModal: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require("react");
+    capturedSaveQueryModalProps = props;
+    return props.isOpen ? React.createElement("div", { "data-testid": "savequerymodal" }, "SaveQueryModal") : null;
+  },
+}));
+
+mock.module("@/components/DataImportModal", () => ({
+  DataImportModal: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require("react");
+    capturedDataImportModalProps = props;
+    return props.isOpen ? React.createElement("div", { "data-testid": "dataimportmodal" }, "DataImportModal") : null;
+  },
+}));
+
+mock.module("@/components/QuerySafetyDialog", () => ({
+  QuerySafetyDialog: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require("react");
+    capturedSafetyDialogProps = props;
+    return props.isOpen
+      ? React.createElement("div", { "data-testid": "querysafetydialog" }, "QuerySafetyDialog")
+      : null;
+  },
+  isDangerousQuery: mock(() => false),
+}));
+
+mock.module("@/components/DataProfiler", () => ({
+  DataProfiler: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require("react");
+    capturedDataProfilerProps = props;
+    return props.isOpen ? React.createElement("div", { "data-testid": "dataprofiler" }, "DataProfiler") : null;
+  },
+}));
+
+mock.module("@/components/CodeGenerator", () => ({
+  CodeGenerator: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require("react");
+    capturedCodeGeneratorProps = props;
+    return props.isOpen ? React.createElement("div", { "data-testid": "codegenerator" }, "CodeGenerator") : null;
+  },
+}));
+
+mock.module("@/components/TestDataGenerator", () => ({
+  TestDataGenerator: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const React = require("react");
+    capturedTestDataGeneratorProps = props;
+    return props.isOpen
+      ? React.createElement("div", { "data-testid": "testdatagenerator" }, "TestDataGenerator")
+      : null;
+  },
+}));
+
+mock.module("@/components/ui/resizable", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  return {
+    ResizablePanelGroup: ({ children }: Record<string, unknown>) =>
+      React.createElement("div", { "data-testid": "resizable-group" }, children),
+    ResizablePanel: ({ children }: Record<string, unknown>) =>
+      React.createElement("div", { "data-testid": "resizable-panel" }, children),
+    ResizableHandle: () => React.createElement("div", { "data-testid": "resizable-handle" }),
+  };
+});
+
+// ---- Now import bun:test, testing-library, and the component ----
+// StudioWorkspace is loaded via dynamic import AFTER all mock.module calls so
+// that no real heavy child module evaluates in this process.
+
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { render, cleanup, act } from "@testing-library/react";
+import React from "react";
+import type { SavedQueryInput, StudioWorkspaceProps } from "@/workspace/types";
+
+const { StudioWorkspace } = await import("@/workspace/StudioWorkspace");
+
+// =============================================================================
+// Test data + helpers
+// =============================================================================
+
+const workspaceConnections = [{ id: "c1", name: "TestPG", type: "postgres" as const }];
+
+const exportResult = {
+  rows: [
+    { id: 1, name: "Alice", ratio: 0.5, active: true, created: new Date("2026-01-01"), deleted: null },
+    { id: 2, name: "Bob's", ratio: 2, active: false, created: new Date("2026-01-02"), deleted: "yes" },
+  ],
+  fields: ["id", "name", "ratio", "active", "created", "deleted"],
+  rowCount: 2,
+  executionTime: 5,
+};
+
+const mockOnQueryExecute = mock(async () => ({ rows: [], fields: [], rowCount: 0, executionTime: 1 }));
+const mockOnSchemaFetch = mock(async () => []);
+const mockOnSaveQuery = mock(async (_query: SavedQueryInput) => {});
+
+function renderWorkspace(props: Partial<StudioWorkspaceProps> = {}) {
+  return render(
+    <StudioWorkspace
+      connections={workspaceConnections}
+      onQueryExecute={mockOnQueryExecute}
+      onSchemaFetch={mockOnSchemaFetch}
+      onSaveQuery={mockOnSaveQuery}
+      {...props}
+    />,
+  );
+}
+
+const ALL_FEATURES_OFF = {
+  ai: false,
+  charts: false,
+  codeGenerator: false,
+  testDataGenerator: false,
+  schemaDiagram: false,
+  dataImport: false,
+  inlineEditing: false,
+  transactions: false,
+  connectionManagement: false,
+  dataMasking: false,
+};
+
+// =============================================================================
+// StudioWorkspace Tests
+// =============================================================================
+
+describe("StudioWorkspace", () => {
+  beforeEach(() => {
+    // Reset prop captures
+    capturedSidebarProps = {};
+    capturedTabBarProps = {};
+    capturedQueryToolbarProps = {};
+    capturedQueryEditorProps = {};
+    capturedBottomPanelProps = {};
+    capturedSaveQueryModalProps = {};
+    capturedDataImportModalProps = {};
+    capturedSafetyDialogProps = {};
+    capturedSchemaDiagramProps = {};
+    capturedDataProfilerProps = {};
+    capturedCodeGeneratorProps = {};
+    capturedTestDataGeneratorProps = {};
+
+    // Reset overrides
+    connAdapterOverride = {};
+    tabMgrOverride = {};
+    queryAdapterOverride = {};
+
+    // Clear trackable mocks
+    mockSetConnections.mockClear();
+    mockSetActiveConnection.mockClear();
+    mockSetSchema.mockClear();
+    mockFetchSchema.mockClear();
+    mockSetTabs.mockClear();
+    mockUpdateCurrentTab.mockClear();
+    mockUpdateTabById.mockClear();
+    mockHandleTableClick.mockClear();
+    mockHandleGenerateSelect.mockClear();
+    mockExecuteQuery.mockClear();
+    mockForceExecuteQuery.mockClear();
+    mockCancelQuery.mockClear();
+    mockSetSafetyCheckQuery.mockClear();
+    mockSetBottomPanelMode.mockClear();
+    mockHandleUnlimitedQuery.mockClear();
+    mockHandleLoadMore.mockClear();
+    mockSetUnlimitedWarningOpen.mockClear();
+    mockToast.mockClear();
+    mockCreateObjectURL.mockClear();
+    mockRevokeObjectURL.mockClear();
+    mockOnQueryExecute.mockClear();
+    mockOnSchemaFetch.mockClear();
+    mockOnSaveQuery.mockClear();
+
+    // URL mocks (may not exist in happy-dom)
+    globalThis.URL.createObjectURL = mockCreateObjectURL as unknown as typeof URL.createObjectURL;
+    globalThis.URL.revokeObjectURL = mockRevokeObjectURL as unknown as typeof URL.revokeObjectURL;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // =========================================================================
+  // Rendering
+  // =========================================================================
+
+  test("renders shell with sidebar, tab bar, toolbar, editor and bottom panel", () => {
+    const { getByTestId, queryByTestId } = renderWorkspace();
+    expect(getByTestId("sidebar").textContent).toBe("Sidebar");
+    expect(getByTestId("tab-bar").textContent).toBe("TabBar");
+    expect(capturedTabBarProps.activeTabId).toBe("tab-1");
+    expect(getByTestId("query-toolbar").textContent).toBe("QueryToolbar");
+    expect(getByTestId("query-editor").textContent).toBe("QueryEditor");
+    expect(getByTestId("bottom-panel").textContent).toBe("BottomPanel");
+    // Overlays and modals hidden by default
+    expect(queryByTestId("schemadiagram")).toBeNull();
+    expect(queryByTestId("savequerymodal")).toBeNull();
+    expect(queryByTestId("dataimportmodal")).toBeNull();
+    expect(queryByTestId("querysafetydialog")).toBeNull();
+    expect(queryByTestId("dataprofiler")).toBeNull();
+    expect(queryByTestId("codegenerator")).toBeNull();
+    expect(queryByTestId("testdatagenerator")).toBeNull();
+  });
+
+  test("applies data-studio-workspace attribute and custom className", () => {
+    const { container } = renderWorkspace({ className: "my-custom-class" });
+    const root = container.querySelector("[data-studio-workspace]");
+    expect(root).not.toBeNull();
+    expect(root?.className).toContain("my-custom-class");
+  });
+
+  test("multiple rerenders do not crash", () => {
+    const { container, rerender } = renderWorkspace();
+    rerender(
+      <StudioWorkspace
+        connections={workspaceConnections}
+        onQueryExecute={mockOnQueryExecute}
+        onSchemaFetch={mockOnSchemaFetch}
+      />,
+    );
+    rerender(
+      <StudioWorkspace connections={[]} onQueryExecute={mockOnQueryExecute} onSchemaFetch={mockOnSchemaFetch} />,
+    );
+    expect(container.innerHTML.length).toBeGreaterThan(0);
+  });
+
+  // =========================================================================
+  // Scoped theme injection (useStudioTheme)
+  // =========================================================================
+
+  test("injects scoped theme style on mount and removes it on unmount", () => {
+    expect(document.getElementById("studio-workspace-theme")).toBeNull();
+    const { unmount } = renderWorkspace();
+    const style = document.getElementById("studio-workspace-theme");
+    expect(style).not.toBeNull();
+    expect(style?.textContent).toContain("[data-studio-workspace]");
+    expect(style?.textContent).toContain("--background: #09090b");
+    unmount();
+    expect(document.getElementById("studio-workspace-theme")).toBeNull();
+  });
+
+  test("does not duplicate theme style when one already exists", () => {
+    const existing = document.createElement("style");
+    existing.id = "studio-workspace-theme";
+    document.head.appendChild(existing);
+    const { unmount } = renderWorkspace();
+    expect(document.querySelectorAll("#studio-workspace-theme").length).toBe(1);
+    unmount();
+    // Effect early-returned, so no cleanup was registered and the pre-existing style survives
+    expect(document.getElementById("studio-workspace-theme")).not.toBeNull();
+    existing.remove();
+  });
+
+  // =========================================================================
+  // Connection-change effect
+  // =========================================================================
+
+  test("fetches schema when an active connection exists", () => {
+    renderWorkspace();
+    expect(mockFetchSchema).toHaveBeenCalledWith(dbConn);
+    expect(mockSetSchema).not.toHaveBeenCalled();
+  });
+
+  test("clears schema when there is no active connection", () => {
+    connAdapterOverride = { activeConnection: null, connections: [], schema: [], tableNames: [], schemaContext: "[]" };
+    renderWorkspace({ connections: [] });
+    expect(mockFetchSchema).not.toHaveBeenCalled();
+    expect(mockSetSchema).toHaveBeenCalledWith([]);
+  });
+
+  // =========================================================================
+  // handleSaveQuery
+  // =========================================================================
+
+  test("handleSaveQuery delegates to onSaveQuery and shows success toast", async () => {
+    renderWorkspace();
+    const onSave = capturedSaveQueryModalProps.onSave as (n: string, d: string, t: string[]) => Promise<void>;
+    await act(async () => {
+      await onSave("My Query", "A test query", ["tag1"]);
+    });
+    expect(mockOnSaveQuery).toHaveBeenCalledTimes(1);
+    const saved = mockOnSaveQuery.mock.calls[0][0];
+    expect(saved.name).toBe("My Query");
+    expect(saved.query).toBe("SELECT 1");
+    expect(saved.description).toBe("A test query");
+    expect(saved.connectionType).toBe("postgres");
+    expect(saved.tags).toEqual(["tag1"]);
+    expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ title: "Query Saved" }));
+  });
+
+  test("handleSaveQuery shows destructive toast when onSaveQuery rejects", async () => {
+    mockOnSaveQuery.mockImplementationOnce(() => Promise.reject(new Error("save exploded")));
+    renderWorkspace();
+    const onSave = capturedSaveQueryModalProps.onSave as (n: string, d: string, t: string[]) => Promise<void>;
+    await act(async () => {
+      await onSave("Broken", "", []);
+    });
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Save Failed",
+        description: "save exploded",
+        variant: "destructive",
+      }),
+    );
+  });
+
+  test("handleSaveQuery returns early without an active connection", async () => {
+    connAdapterOverride = { activeConnection: null };
+    renderWorkspace();
+    const onSave = capturedSaveQueryModalProps.onSave as (n: string, d: string, t: string[]) => Promise<void>;
+    await act(async () => {
+      await onSave("Noop", "", []);
+    });
+    expect(mockOnSaveQuery).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  test("SaveQueryModal opens via toolbar and closes via onClose", () => {
+    const { queryByTestId } = renderWorkspace();
+    expect(queryByTestId("savequerymodal")).toBeNull();
+    act(() => (capturedQueryToolbarProps.onSaveQuery as () => void)());
+    expect(queryByTestId("savequerymodal")).not.toBeNull();
+    act(() => (capturedSaveQueryModalProps.onClose as () => void)());
+    expect(queryByTestId("savequerymodal")).toBeNull();
+  });
+
+  test("without onSaveQuery prop the modal never renders and toolbar save is a noop", () => {
+    const { queryByTestId } = renderWorkspace({ onSaveQuery: undefined });
+    act(() => (capturedQueryToolbarProps.onSaveQuery as () => void)());
+    expect(queryByTestId("savequerymodal")).toBeNull();
+  });
+
+  // =========================================================================
+  // exportResults
+  // =========================================================================
+
+  function withExportResult() {
+    tabMgrOverride = {
+      currentTab: { ...baseTab, name: "Query: users", result: exportResult },
+      tabs: [{ ...baseTab, name: "Query: users", result: exportResult }],
+    };
+  }
+
+  test("exportResults csv creates a text/csv blob", async () => {
+    withExportResult();
+    renderWorkspace();
+    act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("csv"));
+    expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
+    expect(mockRevokeObjectURL).toHaveBeenCalledTimes(1);
+    const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/csv");
+    const text = await blob.text();
+    expect(text).toContain("id,name,ratio,active,created,deleted");
+    expect(text).toContain('"Alice"');
+  });
+
+  test("exportResults json creates an application/json blob", async () => {
+    withExportResult();
+    renderWorkspace();
+    act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("json"));
+    const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toContain("application/json");
+    const text = await blob.text();
+    expect(text).toContain('"name": "Alice"');
+  });
+
+  test("exportResults sql-insert escapes values and emits NULL", async () => {
+    withExportResult();
+    renderWorkspace();
+    act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("sql-insert"));
+    const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/sql");
+    const text = await blob.text();
+    expect(text).toContain("INSERT INTO users");
+    expect(text).toContain("NULL");
+    expect(text).toContain("'Bob''s'");
+    expect(text).toContain("true");
+  });
+
+  test("exportResults sql-ddl infers column types from the first row", async () => {
+    withExportResult();
+    renderWorkspace();
+    act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("sql-ddl"));
+    const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/sql");
+    const text = await blob.text();
+    expect(text).toContain("CREATE TABLE users");
+    expect(text).toContain("id INTEGER");
+    expect(text).toContain("ratio NUMERIC");
+    expect(text).toContain("active BOOLEAN");
+    expect(text).toContain("created TIMESTAMP");
+    expect(text).toContain("name TEXT");
+  });
+
+  test("exportResults does nothing without a result", () => {
+    renderWorkspace();
+    act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("csv"));
+    expect(mockCreateObjectURL).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Sidebar callbacks
+  // =========================================================================
+
+  test("onTableClick delegates to handleTableClick with executeQuery", () => {
+    renderWorkspace();
+    act(() => (capturedSidebarProps.onTableClick as (n: string) => void)("users"));
+    expect(mockHandleTableClick).toHaveBeenCalledWith("users", mockExecuteQuery);
+  });
+
+  test("sidebar noop callbacks and references are wired", () => {
+    renderWorkspace();
+    expect(capturedSidebarProps.onSelectConnection).toBe(mockSetActiveConnection);
+    expect(capturedSidebarProps.onGenerateSelect).toBe(mockHandleGenerateSelect);
+    expect(capturedSidebarProps.isAdmin).toBe(false);
+    // noop callbacks do not throw
+    act(() => (capturedSidebarProps.onDeleteConnection as () => void)());
+    act(() => (capturedSidebarProps.onEditConnection as () => void)());
+    act(() => (capturedSidebarProps.onAddConnection as () => void)());
+    act(() => (capturedSidebarProps.onOpenMaintenance as () => void)());
+  });
+
+  test("onShowDiagram opens the schema diagram and onClose closes it", () => {
+    const { queryByTestId } = renderWorkspace();
+    expect(queryByTestId("schemadiagram")).toBeNull();
+    act(() => (capturedSidebarProps.onShowDiagram as () => void)());
+    expect(queryByTestId("schemadiagram")).not.toBeNull();
+    act(() => (capturedSchemaDiagramProps.onClose as () => void)());
+    expect(queryByTestId("schemadiagram")).toBeNull();
+  });
+
+  test("onProfileTable opens the data profiler with the matching schema", () => {
+    const { queryByTestId } = renderWorkspace();
+    act(() => (capturedSidebarProps.onProfileTable as (n: string) => void)("users"));
+    expect(queryByTestId("dataprofiler")).not.toBeNull();
+    expect(capturedDataProfilerProps.tableName).toBe("users");
+    expect(capturedDataProfilerProps.tableSchema).toEqual(usersTable);
+    act(() => (capturedDataProfilerProps.onClose as () => void)());
+    expect(queryByTestId("dataprofiler")).toBeNull();
+  });
+
+  test("onGenerateCode opens the code generator", () => {
+    const { queryByTestId } = renderWorkspace();
+    act(() => (capturedSidebarProps.onGenerateCode as (n: string) => void)("users"));
+    expect(queryByTestId("codegenerator")).not.toBeNull();
+    act(() => (capturedCodeGeneratorProps.onClose as () => void)());
+    expect(queryByTestId("codegenerator")).toBeNull();
+  });
+
+  test("onGenerateTestData opens the test data generator which can execute queries", () => {
+    const { queryByTestId } = renderWorkspace();
+    act(() => (capturedSidebarProps.onGenerateTestData as (n: string) => void)("users"));
+    expect(queryByTestId("testdatagenerator")).not.toBeNull();
+    act(() => (capturedTestDataGeneratorProps.onExecuteQuery as (q: string) => void)("INSERT INTO users VALUES (1)"));
+    expect(mockExecuteQuery).toHaveBeenCalledWith("INSERT INTO users VALUES (1)");
+    act(() => (capturedTestDataGeneratorProps.onClose as () => void)());
+    expect(queryByTestId("testdatagenerator")).toBeNull();
+  });
+
+  // =========================================================================
+  // Feature flags
+  // =========================================================================
+
+  test("disabled features remove optional callbacks and modals", () => {
+    const { queryByTestId } = renderWorkspace({ features: ALL_FEATURES_OFF, onSaveQuery: undefined });
+    expect(capturedSidebarProps.onShowDiagram).toBeUndefined();
+    expect(capturedSidebarProps.onProfileTable).toBeUndefined();
+    expect(capturedSidebarProps.onGenerateCode).toBeUndefined();
+    expect(capturedSidebarProps.onGenerateTestData).toBeUndefined();
+    expect(capturedBottomPanelProps.isNL2SQLOpen).toBe(false);
+    // Import and save become noops
+    act(() => (capturedQueryToolbarProps.onImport as () => void)());
+    expect(queryByTestId("dataimportmodal")).toBeNull();
+    act(() => (capturedQueryToolbarProps.onSaveQuery as () => void)());
+    expect(queryByTestId("savequerymodal")).toBeNull();
+    // NL2SQL setter is a noop
+    act(() => (capturedBottomPanelProps.onSetIsNL2SQLOpen as (v: boolean) => void)(true));
+    expect(capturedBottomPanelProps.isNL2SQLOpen).toBe(false);
+  });
+
+  test("features.ai enables the NL2SQL open state round-trip", () => {
+    renderWorkspace({ features: { ai: true } });
+    expect(capturedBottomPanelProps.isNL2SQLOpen).toBe(false);
+    act(() => (capturedBottomPanelProps.onSetIsNL2SQLOpen as (v: boolean) => void)(true));
+    expect(capturedBottomPanelProps.isNL2SQLOpen).toBe(true);
+  });
+
+  // =========================================================================
+  // QueryToolbar callbacks
+  // =========================================================================
+
+  test("toolbar onExecuteQuery triggers executeQuery", () => {
+    renderWorkspace();
+    act(() => (capturedQueryToolbarProps.onExecuteQuery as () => void)());
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(1);
+    expect(capturedQueryToolbarProps.onCancelQuery).toBe(mockCancelQuery);
+    // Transaction and playground callbacks are noops in embedded mode
+    act(() => (capturedQueryToolbarProps.onBeginTransaction as () => void)());
+    act(() => (capturedQueryToolbarProps.onCommitTransaction as () => void)());
+    act(() => (capturedQueryToolbarProps.onRollbackTransaction as () => void)());
+    act(() => (capturedQueryToolbarProps.onTogglePlayground as () => void)());
+    act(() => (capturedQueryToolbarProps.onToggleEditing as () => void)());
+  });
+
+  test("toolbar onImport opens the import modal which delegates and closes", () => {
+    const { queryByTestId } = renderWorkspace();
+    expect(queryByTestId("dataimportmodal")).toBeNull();
+    act(() => (capturedQueryToolbarProps.onImport as () => void)());
+    expect(queryByTestId("dataimportmodal")).not.toBeNull();
+    act(() => (capturedDataImportModalProps.onImport as (sql: string) => void)("INSERT INTO t VALUES (1)"));
+    expect(mockExecuteQuery).toHaveBeenCalledWith("INSERT INTO t VALUES (1)");
+    act(() => (capturedDataImportModalProps.onClose as () => void)());
+    expect(queryByTestId("dataimportmodal")).toBeNull();
+  });
+
+  // =========================================================================
+  // QueryEditor
+  // =========================================================================
+
+  test("onContentChange updates the current tab by id", () => {
+    renderWorkspace();
+    act(() => (capturedQueryEditorProps.onContentChange as (v: string) => void)("SELECT 2"));
+    expect(mockUpdateTabById).toHaveBeenCalledWith("tab-1", { query: "SELECT 2" });
+  });
+
+  test("editor language defaults to sql", () => {
+    renderWorkspace();
+    expect(capturedQueryEditorProps.language).toBe("sql");
+    expect(capturedQueryEditorProps.tables).toEqual(["users"]);
+  });
+
+  test("editor language is libredb for libredb tabs", () => {
+    tabMgrOverride = { currentTab: { ...baseTab, type: "libredb" } };
+    renderWorkspace();
+    expect(capturedQueryEditorProps.language).toBe("libredb");
+  });
+
+  test("editor language is json for mongodb tabs", () => {
+    tabMgrOverride = { currentTab: { ...baseTab, type: "mongodb" } };
+    renderWorkspace();
+    expect(capturedQueryEditorProps.language).toBe("json");
+  });
+
+  // =========================================================================
+  // BottomPanel callbacks
+  // =========================================================================
+
+  test("bottom panel onExecuteQuery and onLoadQuery delegate", () => {
+    renderWorkspace();
+    act(() => (capturedBottomPanelProps.onExecuteQuery as (q: string) => void)("SELECT 5"));
+    expect(mockExecuteQuery).toHaveBeenCalledWith("SELECT 5");
+    act(() => (capturedBottomPanelProps.onLoadQuery as (q: string) => void)("SELECT 6"));
+    expect(mockUpdateCurrentTab).toHaveBeenCalledWith({ query: "SELECT 6" });
+    expect(capturedBottomPanelProps.onSetMode).toBe(mockSetBottomPanelMode);
+    // No-op editing callbacks do not throw
+    act(() => (capturedBottomPanelProps.onCellChange as () => void)());
+    act(() => (capturedBottomPanelProps.onApplyChanges as () => void)());
+    act(() => (capturedBottomPanelProps.onDiscardChanges as () => void)());
+  });
+
+  test("onLoadMore is undefined without pagination and wired when hasMore", () => {
+    renderWorkspace();
+    expect(capturedBottomPanelProps.onLoadMore).toBeUndefined();
+    cleanup();
+    tabMgrOverride = {
+      currentTab: {
+        ...baseTab,
+        result: {
+          ...exportResult,
+          pagination: { limit: 500, offset: 0, hasMore: true, totalReturned: 2, wasLimited: true },
+        },
+      },
+    };
+    renderWorkspace();
+    expect(capturedBottomPanelProps.onLoadMore).toBe(mockHandleLoadMore);
+  });
+
+  test("passes the current user role to the bottom panel", () => {
+    renderWorkspace({ currentUser: { id: "u1", name: "Admin", role: "admin" } });
+    expect(capturedBottomPanelProps.userRole).toBe("admin");
+    expect(capturedBottomPanelProps.maskingEnabled).toBe(false);
+  });
+
+  // =========================================================================
+  // QuerySafetyDialog
+  // =========================================================================
+
+  test("safety dialog renders when a query is under review and proceeds", () => {
+    queryAdapterOverride = { safetyCheckQuery: "DROP TABLE users" };
+    const { queryByTestId } = renderWorkspace();
+    expect(queryByTestId("querysafetydialog")).not.toBeNull();
+    expect(capturedSafetyDialogProps.query).toBe("DROP TABLE users");
+    act(() => (capturedSafetyDialogProps.onProceed as () => void)());
+    expect(mockForceExecuteQuery).toHaveBeenCalledWith("DROP TABLE users");
+    act(() => (capturedSafetyDialogProps.onClose as () => void)());
+    expect(mockSetSafetyCheckQuery).toHaveBeenCalledWith(null);
+  });
+
+  test("safety dialog onProceed is a no-op without a pending query", () => {
+    renderWorkspace();
+    expect(capturedSafetyDialogProps.query).toBe("");
+    act(() => (capturedSafetyDialogProps.onProceed as () => void)());
+    expect(mockForceExecuteQuery).not.toHaveBeenCalled();
+  });
+
+  test("onAnalyzeSafety returns the embedded high-risk stub", async () => {
+    renderWorkspace();
+    const analyze = capturedSafetyDialogProps.onAnalyzeSafety as () => Promise<{
+      riskLevel: string;
+      warnings: { type: string }[];
+      recommendation: string;
+    }>;
+    const result = await analyze();
+    expect(result.riskLevel).toBe("high");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].type).toBe("destructive");
+    expect(result.recommendation).toContain("Review this query");
+  });
+
+  // =========================================================================
+  // Unlimited query warning dialog
+  // =========================================================================
+
+  test("unlimited warning dialog renders when open", () => {
+    queryAdapterOverride = { unlimitedWarningOpen: true };
+    const { baseElement } = renderWorkspace();
+    expect(baseElement.textContent).toContain("Load all results?");
+    expect(baseElement.textContent).toContain("Load All");
+  });
+});

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -24,7 +24,7 @@ set -e
 
 PASS=0
 FAIL=0
-TOTAL_GROUPS=18
+TOTAL_GROUPS=19
 EXTRA_BUN_ARGS=("$@")
 GROUP_INDEX=0
 COVERAGE_MODE=0
@@ -181,6 +181,13 @@ run_group "Group 15/16: Remaining components" \
   tests/components/monitoring/QueriesTab.test.tsx \
   tests/components/monitoring/PerformanceTab.test.tsx \
   tests/components/monitoring/OverviewTab.test.tsx
+
+# Group 17: StudioWorkspace (isolated — mocks the same child families as Studio:
+#           sidebar, QueryEditor, studio/index, SchemaDiagram, DataProfiler,
+#           CodeGenerator, TestDataGenerator, SaveQueryModal, DataImportModal,
+#           QuerySafetyDialog, plus the workspace adapter hooks)
+run_group "Group 17: StudioWorkspace" \
+  tests/components/StudioWorkspace.test.tsx
 
 # Summary
 echo ""


### PR DESCRIPTION
## Summary

Fixes #94.

After shrinking the browser window (or restoring from maximized), the query editor could no longer scroll to the end of the document: the scrollbar hit bottom while 20-30 lines of SQL stayed hidden below the visible area. Long lines were also unreachable because Monaco's horizontal scrollbar lived in the same clipped region.

## Root cause

Flex items default to `min-height: auto`, which forbids them from shrinking below their content's minimum size. Monaco writes its measured size as inline pixel styles into its own DOM, so after any layout it acts as rigid content. On viewport shrink this deadlocks:

1. The panel and its `h-full` wrapper shrink correctly.
2. The `flex-1` wrapper around the editor refuses to shrink below Monaco's stale pixel height (`min-height: auto`).
3. Monaco's `automaticLayout` ResizeObserver watches that wrapper, which never actually shrank, so it never fires and the stale height persists.

Growth always relayouts fine (min-height is only a floor), which is why the bug appeared only after a grow-then-shrink cycle and looked intermittent. Measured live: the editor overflowed its clipping panel by 76-120px, and `getVisibleRanges()` reported lines as visible that were physically clipped.

The horizontal counterpart (`min-w-0`) was already present in `Studio.tsx`; the vertical twin was missing.

## Fix

Add `min-h-0` to the editor flex chain:

- `QueryEditor.tsx` inner wrapper - the one that actually breaks the deadlock (min-content propagates outward); ships in the npm package, so embedded mode is fixed too
- `Studio.tsx` / `StudioWorkspace.tsx` outer wrappers - defense in depth

## Tests

- New Playwright regression test (`e2e/editor-layout.spec.ts`): loads a 60-line document, grows the viewport, shrinks it, and asserts the editor's bottom edge stays inside its clipping panel. Fails with a 120px overhang without the fix; passes with it.
- `playwright.config.ts` now honors `E2E_PORT` for local runs when port 3000 is occupied (CI unchanged).
- Playwright run artifacts added to `.gitignore`.

## Verification

- All six local gates pass: format, lint, typecheck, knip, test (502), build
- `build:lib` + `attw` pass (platform-facing component touched)
- Full E2E suite: 34/34
- Manual browser verification on the production build: two grow-shrink cycles (1600x900 -> 950x600 -> 1600x900 -> 820x520); layout chain stays consistent, zero clipping, line 60/60 reachable at every size