### PR TITLE
test(coverage): reach 100% - authority-universe lcov merge + DataCharts interaction tests

### DIFF
--- a/scripts/merge-lcov.mjs
+++ b/scripts/merge-lcov.mjs
@@ -96,45 +96,93 @@ function mergeRecords(inputRecords) {
   const byFile = new Map();
 
   for (const record of inputRecords) {
-    const existing = byFile.get(record.sf) || {
-      sf: record.sf,
-      functions: new Map(),
-      functionHits: new Map(),
-      lines: new Map(),
-      branches: new Map(),
-    };
+    const group = byFile.get(record.sf);
+    if (group) {
+      group.push(record);
+    } else {
+      byFile.set(record.sf, [record]);
+    }
+  }
 
+  return [...byFile.entries()]
+    .map(([sf, records]) => mergeFileRecords(sf, records))
+    .sort((a, b) => a.sf.localeCompare(b.sf));
+}
+
+/**
+ * bun's per-process lcov granularity is per-FUNCTION (V8 semantics): functions
+ * that executed get a precise executable-line map, while functions that never
+ * ran in that process are reported as coarse whole-span blocks whose DA set
+ * also includes type annotations, JSX text lines, and other non-executable
+ * lines. A process that loads a module without exercising it (a mocked-away
+ * child, a transitive import) therefore emits extra zero-hit lines that no
+ * exercising process considers coverable, and a naive per-line union surfaces
+ * them as phantom uncovered lines (observed: 41 phantom lines across
+ * DataCharts/MaskingSettings/VisualExplain before this rule existed).
+ *
+ * Merge rule: the record with the most EXECUTED lines is the authority for
+ * which lines are coverable (its map is the finest available); per-line hit
+ * counts still take the max across ALL records, so coverage contributed by
+ * secondary processes (e.g. the mobile-drawer group for a component whose
+ * main group renders desktop) is preserved.
+ */
+function mergeFileRecords(sf, records) {
+  const hitLineCount = (record) => [...record.lines.values()].filter((hits) => hits > 0).length;
+  let authority = records[0];
+  for (const record of records) {
+    const a = hitLineCount(authority);
+    const b = hitLineCount(record);
+    // Tie-break on the smaller line map: with equal executed lines the finer
+    // (more-exercised) map claims fewer lines as coverable.
+    if (b > a || (b === a && record.lines.size < authority.lines.size)) {
+      authority = record;
+    }
+  }
+
+  const merged = {
+    sf,
+    functions: new Map(),
+    functionHits: new Map(),
+    lines: new Map(),
+    branches: new Map(),
+  };
+
+  for (const lineNo of authority.lines.keys()) {
+    let best = 0;
+    for (const record of records) {
+      const hits = record.lines.get(lineNo);
+      if (hits !== undefined && hits > best) {
+        best = hits;
+      }
+    }
+    merged.lines.set(lineNo, best);
+  }
+
+  for (const record of records) {
     for (const [fnName, fnLine] of record.functions.entries()) {
-      if (!existing.functions.has(fnName)) {
-        existing.functions.set(fnName, fnLine);
+      if (!merged.functions.has(fnName)) {
+        merged.functions.set(fnName, fnLine);
       }
     }
 
     for (const [fnName, hits] of record.functionHits.entries()) {
-      const prevHits = existing.functionHits.get(fnName) || 0;
-      existing.functionHits.set(fnName, Math.max(prevHits, hits));
-    }
-
-    for (const [lineNo, hits] of record.lines.entries()) {
-      const prevHits = existing.lines.get(lineNo) || 0;
-      existing.lines.set(lineNo, Math.max(prevHits, hits));
+      const prevHits = merged.functionHits.get(fnName) || 0;
+      merged.functionHits.set(fnName, Math.max(prevHits, hits));
     }
 
     for (const [key, taken] of record.branches.entries()) {
-      const prevTaken = existing.branches.has(key) ? existing.branches.get(key) : -1;
+      const prevTaken = merged.branches.has(key) ? merged.branches.get(key) : -1;
       if (prevTaken === -1 && taken !== -1) {
-        existing.branches.set(key, taken);
+        merged.branches.set(key, taken);
       } else if (prevTaken !== -1 && taken === -1) {
-        existing.branches.set(key, prevTaken);
+        merged.branches.set(key, prevTaken);
       } else {
-        existing.branches.set(key, Math.max(prevTaken, taken));
+        merged.branches.set(key, Math.max(prevTaken, taken));
       }
     }
-
-    byFile.set(record.sf, existing);
   }
 
-  return [...byFile.values()].sort((a, b) => a.sf.localeCompare(b.sf));
+  return merged;
 }
 
 /**

--- a/tests/components/DataCharts.test.tsx
+++ b/tests/components/DataCharts.test.tsx
@@ -31,7 +31,25 @@ mock.module("recharts", () => ({
   YAxis: () => null,
   ZAxis: () => null,
   CartesianGrid: () => null,
-  Tooltip: () => null,
+  // Recharts only renders tooltip content on hover, which happy-dom cannot
+  // trigger. Render the `content` element directly with an active payload
+  // (plus an inactive clone) so CustomTooltip executes in this group.
+  Tooltip: ({ content }: { content?: React.ReactElement }) =>
+    React.isValidElement(content)
+      ? React.createElement(
+          "div",
+          { "data-testid": "mock-tooltip" },
+          React.cloneElement(content as React.ReactElement<Record<string, unknown>>, {
+            active: true,
+            payload: [{ name: "tooltip_series", value: 1234567, color: "#8884d8" }],
+            label: "tooltip_label",
+          }),
+          React.cloneElement(content as React.ReactElement<Record<string, unknown>>, {
+            active: false,
+            payload: [],
+          }),
+        )
+      : null,
   Legend: () => null,
   PolarAngleAxis: () => null,
 }));
@@ -72,10 +90,11 @@ mock.module("@/components/ui/dropdown-menu", () => ({
     React.createElement("div", { "data-testid": "dropdown-trigger", ...props }, children as React.ReactNode),
   DropdownMenuContent: ({ children }: { children: React.ReactNode }) =>
     React.createElement("div", { "data-testid": "dropdown-content" }, children),
-  DropdownMenuItem: ({ children, onClick, className }: Record<string, unknown>) =>
+  // Saved-chart items use Radix's onSelect instead of onClick — honor both.
+  DropdownMenuItem: ({ children, onClick, onSelect, className }: Record<string, unknown>) =>
     React.createElement(
       "div",
-      { role: "menuitem", onClick: onClick as () => void, className },
+      { role: "menuitem", onClick: (onClick ?? onSelect) as () => void, className },
       children as React.ReactNode,
     ),
 }));
@@ -109,15 +128,33 @@ mock.module("@/lib/storage", () => ({
   },
 }));
 
+// Context lets each mocked SelectItem invoke its own Select's onValueChange on
+// click, so tests can drive value changes without Radix pointer machinery.
+const SelectChangeContext = React.createContext<((v: string) => void) | undefined>(undefined);
+
 mock.module("@/components/ui/select", () => ({
-  Select: ({ children, value }: Record<string, unknown>) =>
-    React.createElement("div", { "data-testid": "select", "data-value": value }, children as React.ReactNode),
+  Select: ({ children, value, onValueChange }: Record<string, unknown>) =>
+    React.createElement(
+      SelectChangeContext.Provider,
+      { value: onValueChange as ((v: string) => void) | undefined },
+      React.createElement("div", { "data-testid": "select", "data-value": value }, children as React.ReactNode),
+    ),
   SelectTrigger: ({ children, className }: Record<string, unknown>) =>
     React.createElement("div", { "data-testid": "select-trigger", className }, children as React.ReactNode),
   SelectContent: ({ children }: { children: React.ReactNode }) =>
     React.createElement("div", { "data-testid": "select-content" }, children),
-  SelectItem: ({ children, value }: Record<string, unknown>) =>
-    React.createElement("div", { "data-testid": `select-item-${value}`, role: "option" }, children as React.ReactNode),
+  SelectItem: ({ children, value }: Record<string, unknown>) => {
+    const onValueChange = React.useContext(SelectChangeContext);
+    return React.createElement(
+      "div",
+      {
+        "data-testid": `select-item-${value}`,
+        role: "option",
+        onClick: () => onValueChange?.(value as string),
+      },
+      children as React.ReactNode,
+    );
+  },
   SelectValue: ({ placeholder }: Record<string, unknown>) =>
     React.createElement("span", { "data-testid": "select-value" }, placeholder as string),
 }));
@@ -807,5 +844,91 @@ describe("DataCharts", () => {
     expect(hashIcons.length).toBeGreaterThan(0);
     expect(calendarIcons.length).toBeGreaterThan(0);
     expect(typeIcons.length).toBeGreaterThan(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Tooltip content, aggregation paths, saved-chart load, SVG export
+  // -----------------------------------------------------------------------
+
+  test("custom tooltip renders label and formatted payload entries when active", () => {
+    const { container } = render(React.createElement(DataCharts, { result: mockNumericResult }));
+    // The recharts Tooltip mock renders CustomTooltip once active (with a
+    // payload) and once inactive (which must render nothing).
+    expect(container.textContent).toContain("tooltip_label");
+    expect(container.textContent).toContain("tooltip_series");
+    expect(container.textContent).toContain("1.2M");
+  });
+
+  test("selecting an aggregation feeds chart data through aggregateData", () => {
+    const { getByTestId, container } = render(React.createElement(DataCharts, { result: mockNumericResult }));
+    fireEvent.click(getByTestId("select-item-sum"));
+    expect(container.querySelector('[data-value="sum"]')).not.toBeNull();
+  });
+
+  test("selecting a date grouping without aggregation groups chart data", () => {
+    const { getByTestId, container } = render(React.createElement(DataCharts, { result: mockNumericResult }));
+    fireEvent.click(getByTestId("select-item-month"));
+    expect(container.querySelector('[data-value="month"]')).not.toBeNull();
+  });
+
+  test("clicking an already-selected Y-axis field deselects it", () => {
+    const { getAllByRole, queryByText } = render(React.createElement(DataCharts, { result: mockNumericResult }));
+    // revenue is auto-selected as the first numeric field
+    expect(queryByText("Select fields")).toBeNull();
+    const revenueItem = getAllByRole("menuitem").find((i) => i.textContent?.includes("revenue"));
+    expect(revenueItem).toBeDefined();
+    fireEvent.click(revenueItem!);
+    expect(queryByText("Select fields")).not.toBeNull();
+  });
+
+  test("loading a saved chart applies its stored configuration", () => {
+    localStorage.setItem(
+      "libredb_saved_charts",
+      JSON.stringify([
+        {
+          id: "chart-1",
+          name: "Saved revenue by category",
+          chartType: "bar",
+          xAxis: "category",
+          yAxis: ["revenue"],
+          aggregation: "sum",
+          dateGrouping: "",
+        },
+      ]),
+    );
+    const { getAllByRole, queryByText, container } = render(
+      React.createElement(DataCharts, { result: mockNumericResult }),
+    );
+    expect(queryByText(/Saved \(1\)/)).not.toBeNull();
+
+    const savedItem = getAllByRole("menuitem").find((i) => i.textContent?.includes("Saved revenue by category"));
+    expect(savedItem).toBeDefined();
+    fireEvent.click(savedItem!);
+
+    // loadSavedChart applied the stored aggregation
+    expect(container.querySelector('[data-value="sum"]')).not.toBeNull();
+  });
+
+  test("exports the chart as SVG by serializing the rendered svg element", async () => {
+    const linkClick = mock(() => {});
+    const originalClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = linkClick as unknown as typeof HTMLAnchorElement.prototype.click;
+
+    try {
+      const { queryByText, container } = render(React.createElement(DataCharts, { result: mockNumericResult }));
+      // The recharts mock renders no real <svg>, so provide one inside the
+      // chart area for exportChart's querySelector to find.
+      const chartArea = container.querySelector(".flex-1.p-4");
+      expect(chartArea).not.toBeNull();
+      chartArea!.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
+
+      fireEvent.click(queryByText("Export as SVG")!);
+
+      await waitFor(() => {
+        expect(linkClick).toHaveBeenCalled();
+      });
+    } finally {
+      HTMLAnchorElement.prototype.click = originalClick;
+    }
   });
 });

--- a/tests/unit/merge-lcov.test.ts
+++ b/tests/unit/merge-lcov.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Exercise the CLI end-to-end on synthetic fixtures. SF paths point at files
+// that do not exist on disk so stripNonExecutableLines leaves the records
+// untouched and assertions stay deterministic.
+const SCRIPT = path.resolve(import.meta.dir, "../../scripts/merge-lcov.mjs");
+const workDir = mkdtempSync(path.join(tmpdir(), "merge-lcov-test-"));
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function runMerge(name: string, inputs: string[]): Map<string, Map<number, number>> {
+  const inputPaths = inputs.map((content, i) => {
+    const p = path.join(workDir, `${name}-in-${i}.info`);
+    writeFileSync(p, content);
+    return p;
+  });
+  const outPath = path.join(workDir, `${name}-out.info`);
+  const result = Bun.spawnSync(["node", SCRIPT, ...inputPaths, outPath]);
+  expect(result.exitCode).toBe(0);
+
+  const records = new Map<string, Map<number, number>>();
+  let current: Map<number, number> | null = null;
+  for (const line of readFileSync(outPath, "utf8").split("\n")) {
+    if (line.startsWith("SF:")) {
+      current = new Map();
+      records.set(line.slice(3), current);
+    } else if (line.startsWith("DA:") && current) {
+      const [ln, hits] = line.slice(3).split(",").map(Number);
+      current.set(ln, hits);
+    }
+  }
+  return records;
+}
+
+function lcov(sf: string, lines: Array<[number, number]>): string {
+  const da = lines.map(([ln, hits]) => `DA:${ln},${hits}`).join("\n");
+  const lh = lines.filter(([, hits]) => hits > 0).length;
+  return `SF:${sf}\nFNF:1\nFNH:0\n${da}\nLF:${lines.length}\nLH:${lh}\nend_of_record\n`;
+}
+
+describe("merge-lcov authority-universe rule", () => {
+  test("drops zero-hit lines that only a coarse load-only record claims", () => {
+    // Exercised record: fine map, 2 hit lines, 2 real gaps.
+    const fine = lcov("src/virtual/widget.tsx", [
+      [1, 5],
+      [10, 3],
+      [20, 0],
+      [30, 0],
+    ]);
+    // Load-only record: coarse map with extra never-coverable lines 15/25.
+    const coarse = lcov("src/virtual/widget.tsx", [
+      [1, 2],
+      [15, 0],
+      [20, 0],
+      [25, 0],
+      [30, 0],
+    ]);
+
+    const merged = runMerge("phantom", [fine, coarse]).get("src/virtual/widget.tsx")!;
+    expect([...merged.keys()].sort((a, b) => a - b)).toEqual([1, 10, 20, 30]);
+    expect(merged.get(20)).toBe(0);
+    expect(merged.get(30)).toBe(0);
+  });
+
+  test("keeps per-line max from secondary exercised records inside the authority universe", () => {
+    // Desktop group: authority (3 hit lines), mobile branch at line 40 unexecuted.
+    const desktop = lcov("src/virtual/modal.tsx", [
+      [1, 9],
+      [10, 4],
+      [20, 2],
+      [40, 0],
+    ]);
+    // Mobile group: fewer hit lines overall, but it covers the drawer line 40.
+    const mobile = lcov("src/virtual/modal.tsx", [
+      [1, 3],
+      [40, 7],
+    ]);
+
+    const merged = runMerge("secondary", [desktop, mobile]).get("src/virtual/modal.tsx")!;
+    expect(merged.get(40)).toBe(7);
+    expect(merged.get(10)).toBe(4);
+  });
+
+  test("keeps single-record files untouched even when barely executed", () => {
+    // The orphan file appears in only one input; the other input covers an
+    // unrelated file, so no authority competition exists for the orphan.
+    const loadOnly = lcov("src/virtual/orphan.ts", [
+      [1, 1],
+      [5, 0],
+      [9, 0],
+    ]);
+    const unrelated = lcov("src/virtual/other.ts", [[1, 4]]);
+
+    const merged = runMerge("single", [loadOnly, unrelated]).get("src/virtual/orphan.ts")!;
+    expect([...merged.keys()].sort((a, b) => a - b)).toEqual([1, 5, 9]);
+    expect(merged.get(5)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Final wave of the coverage push (follow-up to #192/#195). Merged local line coverage reaches **100% (25571/25571 lines, 208/208 files)**. No production source changes - the wave splits into a measurement fix and real test work.

### Part 1: 41 of the 74 remaining lines were phantoms (measurement fix)

Classifying every remaining uncovered line against the per-group lcov inputs showed:

| File | Merged misses | Real | Phantom |
|---|---|---|---|
| DataCharts.tsx | 50 | 33 | 17 |
| MaskingSettings.tsx | 15 | 0 | 15 |
| VisualExplain.tsx | 9 | 0 | 9 |

Root cause: bun's lcov granularity is per-function (V8 semantics). Functions that executed get a precise executable-line map; functions that never ran in a process are reported as coarse whole-span blocks whose DA sets include type annotations and JSX text lines. A process that loads a module without exercising it (a mocked-away child, a transitive import) therefore claims lines as coverable that no exercising process does - e.g. BottomPanel's group loads the real DataCharts (886-line map, 30 hits) even though it mocks it, while DataCharts' own group has the fine 759-line map. The old per-line union in merge-lcov.mjs surfaced the difference as permanently-uncovered lines.

**Fix (scripts/merge-lcov.mjs):** per file, the record with the most executed lines is the authority for *which* lines are coverable; per-line hit counts still take the max across all records, so secondary exercised groups (e.g. ConnectionModal's mobile-drawer group) keep contributing coverage. Single-record files are untouched. Covered by a new fixture-driven CLI test (tests/unit/merge-lcov.test.ts, 3 cases: phantom drop, secondary-record max, single-record passthrough).

MaskingSettings and VisualExplain turned out to be fully covered by their existing tests; the merge fix alone takes them to 100%.

### Part 2: DataCharts' 33 genuinely uncovered lines (test-side only)

All closed via mock upgrades + 6 new tests in the component's own isolated group:

- **CustomTooltip (221-230):** real recharts renders tooltip content only on hover, which happy-dom cannot produce. The recharts Tooltip mock now renders the `content` element with an active payload and an inactive clone, executing both branches.
- **Aggregation + date grouping (422-426, 432-436):** the select mock now passes onValueChange through a React context to clickable SelectItems, driving Radix-free value changes.
- **Saved-chart load (472-476):** the dropdown mock honors Radix's `onSelect` (previously only `onClick`, which is why deletion was covered but loading was unreachable).
- **SVG export (523-530):** an svg element injected into the chart area lets exportChart's querySelector/XMLSerializer path run; anchor click is stubbed like the existing PNG test.
- **Y-axis deselection (538):** clicking the auto-selected numeric field.

## Verification

All six local gates pass: format, lint, typecheck, knip, test (20 component groups + core), build. Full `test:coverage` confirms 25571/25571 lines and 208/208 files at 100%; re-merging the previous run's untouched group inputs with the new rule alone reproduced exactly the predicted 99.87% intermediate (phantoms gone, real gaps intact), validating the rule against real data before the new tests landed.