### PR TITLE
refactor(explain): capability-driven explain strategy registry (#194, 1/5)

### DIFF
--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -295,6 +295,7 @@ validates that the target parses as an integer connection id.
 |------------|-------|
 | `queryLanguage` | `sql` |
 | `supportsExplain` | `true` |
+| `explainFormat` | `mysql-json` |
 | `supportsExternalQueryLimiting` | `true` (from base) |
 | `supportsCreateTable` | `true` (from base) |
 | `supportsMaintenance` | `true` |

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -369,6 +369,7 @@ Overrides the SQL base defaults:
 |------------|-------|
 | `queryLanguage` | `sql` |
 | `supportsExplain` | `true` |
+| `explainFormat` | `postgres-json` |
 | `supportsExternalQueryLimiting` | `true` |
 | `supportsCreateTable` | `true` |
 | `supportsMaintenance` | `true` |

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -11,6 +11,7 @@ import { isMultiStatement } from "@/lib/sql/statement-splitter";
 import { shouldRefreshSchema } from "@/lib/query-generators";
 import { ApiErrorCode } from "@/lib/api/error-codes";
 import { logger } from "@/lib/logger";
+import { getExplainStrategy } from "@/lib/explain";
 import { buildConnectionPayload } from "./use-connection-payload";
 
 export interface QueryExecutionOptions {
@@ -141,15 +142,7 @@ export function useQueryExecution({
         return;
       }
 
-      // Build EXPLAIN query for PostgreSQL/MySQL
-      const buildExplainQuery = (sql: string, dbType: string): string | null => {
-        // Only for SELECT queries
-        if (!/^\s*SELECT\b/i.test(sql.trim())) return null;
-
-        if (dbType === "postgres") return `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${sql}`;
-        if (dbType === "mysql") return `EXPLAIN FORMAT=JSON ${sql}`;
-        return null;
-      };
+      const explainStrategy = getExplainStrategy(metadata?.capabilities.explainFormat);
 
       const startTime = Date.now();
       // Set up abort controller for query cancellation
@@ -173,10 +166,10 @@ export function useQueryExecution({
           }
         }
 
-        // If isExplain mode, run EXPLAIN query instead
+        // If isExplain mode, run the dialect's EXPLAIN query instead
         let queryToRun = queryToExecute;
-        if (isExplain && activeConnection.type) {
-          const explainSql = buildExplainQuery(queryToExecute, activeConnection.type);
+        if (isExplain && explainStrategy) {
+          const explainSql = explainStrategy.buildSql(queryToExecute, "analyze");
           if (explainSql) {
             queryToRun = explainSql;
           }
@@ -213,8 +206,8 @@ export function useQueryExecution({
 
         // Run EXPLAIN in background for non-explain queries (SELECT only)
         let explainPromise: Promise<Response> | null = null;
-        if (!isExplain && !isLoadMore && activeConnection.type) {
-          const explainSql = buildExplainQuery(queryToExecute, activeConnection.type);
+        if (!isExplain && !isLoadMore && explainStrategy) {
+          const explainSql = explainStrategy.buildSql(queryToExecute, "estimate");
           if (explainSql) {
             explainPromise = fetch("/api/db/query", {
               method: "POST",
@@ -312,15 +305,14 @@ export function useQueryExecution({
         // Process EXPLAIN results (from background or direct)
         let explainPlanData = null;
         if (isExplain) {
-          // Direct EXPLAIN query - parse result
-          explainPlanData = resultData.rows?.[0]?.["QUERY PLAN"] || resultData.rows;
-        } else if (explainPromise) {
+          explainPlanData = explainStrategy ? explainStrategy.extractPlan(resultData) : null;
+        } else if (explainPromise && explainStrategy) {
           // Background EXPLAIN - don't block, update async
           explainPromise
             .then(async (explainRes) => {
               if (explainRes.ok) {
                 const explainData = await explainRes.json();
-                const plan = explainData.rows?.[0]?.["QUERY PLAN"] || explainData.rows;
+                const plan = explainStrategy.extractPlan(explainData);
                 setTabs((prev) => prev.map((t) => (t.id === targetTabId ? { ...t, explainPlan: plan } : t)));
               }
             })

--- a/src/lib/db/providers/sql/mysql.ts
+++ b/src/lib/db/providers/sql/mysql.ts
@@ -269,6 +269,7 @@ export class MySQLProvider extends SQLBaseProvider {
       ...super.getCapabilities(),
       defaultPort: 3306,
       supportsExplain: true,
+      explainFormat: "mysql-json",
       supportsConnectionString: true,
       maintenanceOperations: ["analyze", "optimize", "check", "kill"],
     };

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -531,6 +531,7 @@ export class PostgresProvider extends SQLBaseProvider {
       ...super.getCapabilities(),
       defaultPort: 5432,
       supportsExplain: true,
+      explainFormat: "postgres-json",
       supportsConnectionString: true,
       maintenanceOperations: ["vacuum", "analyze", "reindex", "kill"],
     };

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -85,6 +85,13 @@ export interface MaintenanceResult {
 // Provider Capabilities & Labels
 // ============================================================================
 
+/**
+ * Dialect discriminant for client-side EXPLAIN handling (issue #194).
+ * Each id selects one strategy module in `src/lib/explain`. Extended per
+ * provider as explain support lands (sqlite-queryplan arrives with #194 PR-3).
+ */
+export type ExplainFormat = "postgres-json" | "mysql-json";
+
 export interface ProviderCapabilities {
   queryLanguage: "sql" | "json";
   /**
@@ -96,6 +103,11 @@ export interface ProviderCapabilities {
    */
   queryDialect?: "libredb";
   supportsExplain: boolean;
+  /**
+   * Present iff supportsExplain is true (enforced by provider tests).
+   * Undefined = no explain support; the UI hides the Explain button and tab.
+   */
+  explainFormat?: ExplainFormat;
   supportsExternalQueryLimiting: boolean;
   supportsCreateTable: boolean;
   supportsMaintenance: boolean;

--- a/src/lib/explain/index.ts
+++ b/src/lib/explain/index.ts
@@ -1,0 +1,17 @@
+import type { ExplainFormat } from "@/lib/db/types";
+import type { ExplainStrategy } from "./types";
+import { postgresJsonStrategy } from "./postgres-json";
+import { mysqlJsonStrategy } from "./mysql-json";
+
+export type { ExplainMode, ExplainStrategy } from "./types";
+
+// Exhaustive by construction: adding an ExplainFormat member without a
+// registry entry is a compile error.
+const registry: Record<ExplainFormat, ExplainStrategy> = {
+  "postgres-json": postgresJsonStrategy,
+  "mysql-json": mysqlJsonStrategy,
+};
+
+export function getExplainStrategy(format: ExplainFormat | undefined): ExplainStrategy | null {
+  return format ? registry[format] : null;
+}

--- a/src/lib/explain/mysql-json.ts
+++ b/src/lib/explain/mysql-json.ts
@@ -1,0 +1,16 @@
+import type { ExplainStrategy } from "./types";
+
+const SELECT_ONLY = /^\s*SELECT\b/i;
+
+export const mysqlJsonStrategy: ExplainStrategy = {
+  format: "mysql-json",
+  buildSql(sql) {
+    if (!SELECT_ONLY.test(sql.trim())) return null;
+    return `EXPLAIN FORMAT=JSON ${sql}`;
+  },
+  // Legacy extraction preserved on purpose (bug B4): MySQL output has an
+  // "EXPLAIN" column, not "QUERY PLAN"; the real parser lands in #194 PR-4.
+  extractPlan(result) {
+    return result.rows?.[0]?.["QUERY PLAN"] || result.rows;
+  },
+};

--- a/src/lib/explain/postgres-json.ts
+++ b/src/lib/explain/postgres-json.ts
@@ -1,0 +1,14 @@
+import type { ExplainStrategy } from "./types";
+
+const SELECT_ONLY = /^\s*SELECT\b/i;
+
+export const postgresJsonStrategy: ExplainStrategy = {
+  format: "postgres-json",
+  buildSql(sql) {
+    if (!SELECT_ONLY.test(sql.trim())) return null;
+    return `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${sql}`;
+  },
+  extractPlan(result) {
+    return result.rows?.[0]?.["QUERY PLAN"] || result.rows;
+  },
+};

--- a/src/lib/explain/types.ts
+++ b/src/lib/explain/types.ts
@@ -1,0 +1,16 @@
+import type { ExplainFormat } from "@/lib/db/types";
+
+export type ExplainMode = "estimate" | "analyze";
+
+/**
+ * One strategy per ExplainFormat (registered in ./index.ts). Strategies are
+ * pure and per-dialect-isolated: a change for one dialect must never touch
+ * another dialect's file.
+ */
+export interface ExplainStrategy {
+  readonly format: ExplainFormat;
+  /** Dialect EXPLAIN SQL for a SELECT statement, or null when not explainable. */
+  buildSql(sql: string, mode: ExplainMode): string | null;
+  /** Maps a raw /api/db/query result to the value stored on QueryTab.explainPlan. Never throws. */
+  extractPlan(result: { rows?: Array<Record<string, unknown>> }): unknown;
+}

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -37,6 +37,7 @@ const mockMetadata: ProviderMetadata = {
   capabilities: {
     queryLanguage: "sql" as const,
     supportsExplain: true,
+    explainFormat: "postgres-json" as const,
     supportsExternalQueryLimiting: true,
     supportsCreateTable: true,
     supportsMaintenance: true,
@@ -989,7 +990,11 @@ describe("useQueryExecution", () => {
       },
     });
     const mysqlConnection = { ...mockConnection, type: "mysql" as const };
-    const params = createDefaultParams({ activeConnection: mysqlConnection });
+    const mysqlMetadata: ProviderMetadata = {
+      ...mockMetadata,
+      capabilities: { ...mockMetadata.capabilities, explainFormat: "mysql-json" as const },
+    };
+    const params = createDefaultParams({ activeConnection: mysqlConnection, metadata: mysqlMetadata });
 
     const { result } = renderHook(() => useQueryExecution(params));
 
@@ -1101,10 +1106,41 @@ describe("useQueryExecution", () => {
     });
 
     // Should proceed to execute (no toast about unsupported)
+    expect(mockToastError).not.toHaveBeenCalled();
     const queryCall = fetchMock.mock.calls.find(
       (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
     );
     expect(queryCall).toBeDefined();
+    // Metadata is the sole source of dialect knowledge now — without it, no
+    // EXPLAIN SQL is built (no more falling back to connection.type).
+    const body = JSON.parse(queryCall![1]!.body as string);
+    expect(body.sql).not.toContain("EXPLAIN");
+  });
+
+  // ── no EXPLAIN without explainFormat, even if supportsExplain is true ──
+
+  test("no EXPLAIN built when metadata lacks explainFormat even if supportsExplain is true", async () => {
+    const fetchMock = mockGlobalFetch({
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
+    const noFormatMetadata: ProviderMetadata = {
+      ...mockMetadata,
+      capabilities: { ...mockMetadata.capabilities, supportsExplain: true, explainFormat: undefined },
+    };
+    const params = createDefaultParams({ metadata: noFormatMetadata });
+
+    const { result } = renderHook(() => useQueryExecution(params));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT 1", undefined, true);
+    });
+
+    const queryCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
+    );
+    expect(queryCall).toBeDefined();
+    const body = JSON.parse(queryCall![1]!.body as string);
+    expect(body.sql).toBe("SELECT 1");
   });
 
   // ── handleLoadMore uses result.rows.length when currentOffset undefined ─
@@ -1258,7 +1294,11 @@ describe("useQueryExecution", () => {
       "/api/db/query": { ok: true, json: mockQueryResult },
     });
     const mssqlConnection = { ...mockConnection, type: "mssql" as const };
-    const params = createDefaultParams({ activeConnection: mssqlConnection });
+    const mssqlMetadata: ProviderMetadata = {
+      ...mockMetadata,
+      capabilities: { ...mockMetadata.capabilities, explainFormat: undefined },
+    };
+    const params = createDefaultParams({ activeConnection: mssqlConnection, metadata: mssqlMetadata });
 
     const { result } = renderHook(() => useQueryExecution(params));
 
@@ -1266,7 +1306,7 @@ describe("useQueryExecution", () => {
       await result.current.executeQuery("SELECT * FROM users");
     });
 
-    // Only the main query — no EXPLAIN is built for mssql
+    // Only the main query — no EXPLAIN is built when metadata carries no explainFormat
     const queryCalls = fetchMock.mock.calls.filter(
       (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
     );

--- a/tests/integration/db/libredb-provider.test.ts
+++ b/tests/integration/db/libredb-provider.test.ts
@@ -115,6 +115,8 @@ describe("LibreDBProvider — lifecycle & metadata", () => {
     expect(caps.queryDialect).toBe("libredb");
     expect(caps.supportsCreateTable).toBe(false);
     expect(caps.supportsExplain).toBe(false);
+    expect(caps.explainFormat).toBeUndefined();
+    expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
     expect(caps.defaultPort).toBeNull();
   });
 

--- a/tests/integration/db/mongodb-provider.test.ts
+++ b/tests/integration/db/mongodb-provider.test.ts
@@ -288,6 +288,8 @@ describe("MongoDBProvider", () => {
       expect(caps.supportsCreateTable).toBe(false);
       expect(caps.supportsConnectionString).toBe(true);
       expect(caps.supportsMaintenance).toBe(true);
+      expect(caps.explainFormat).toBeUndefined();
+      expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
     });
   });
 

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -532,6 +532,8 @@ describe("MSSQLProvider", () => {
       // the UI's EXPLAIN builder has no SET SHOWPLAN_* flow, so advertising the capability
       // made the Explain action silently run the unmodified query.
       expect(caps.supportsExplain).toBe(false);
+      expect(caps.explainFormat).toBeUndefined();
+      expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
       expect(caps.supportsConnectionString).toBe(true);
     });
   });

--- a/tests/integration/db/mysql-provider.test.ts
+++ b/tests/integration/db/mysql-provider.test.ts
@@ -436,6 +436,8 @@ describe("MySQLProvider", () => {
       expect(caps.defaultPort).toBe(3306);
       expect(caps.queryLanguage).toBe("sql");
       expect(caps.supportsExplain).toBe(true);
+      expect(caps.explainFormat).toBe("mysql-json");
+      expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
       expect(caps.supportsConnectionString).toBe(true);
       expect(caps.maintenanceOperations).toContain("analyze");
       expect(caps.maintenanceOperations).toContain("optimize");

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -525,6 +525,8 @@ describe("OracleProvider", () => {
       // the UI's EXPLAIN builder has no EXPLAIN PLAN FOR / DBMS_XPLAN flow, so advertising
       // the capability made the Explain action silently run the unmodified query.
       expect(caps.supportsExplain).toBe(false);
+      expect(caps.explainFormat).toBeUndefined();
+      expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
       expect(caps.supportsConnectionString).toBe(true);
     });
   });

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -1677,6 +1677,8 @@ describe("PostgresProvider", () => {
       expect(caps.defaultPort).toBe(5432);
       expect(caps.queryLanguage).toBe("sql");
       expect(caps.supportsExplain).toBe(true);
+      expect(caps.explainFormat).toBe("postgres-json");
+      expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
       expect(caps.supportsConnectionString).toBe(true);
       expect(caps.maintenanceOperations).toContain("vacuum");
       expect(caps.maintenanceOperations).toContain("analyze");

--- a/tests/integration/db/redis-provider.test.ts
+++ b/tests/integration/db/redis-provider.test.ts
@@ -191,6 +191,8 @@ describe("RedisProvider", () => {
       expect(caps.supportsConnectionString).toBe(false);
       expect(caps.supportsCreateTable).toBe(false);
       expect(caps.supportsMaintenance).toBe(true);
+      expect(caps.explainFormat).toBeUndefined();
+      expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
     });
   });
 

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -247,6 +247,8 @@ describe("SQLiteProvider", () => {
       expect(caps.defaultPort).toBeNull();
       expect(caps.queryLanguage).toBe("sql");
       expect(caps.supportsExplain).toBe(false);
+      expect(caps.explainFormat).toBeUndefined();
+      expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
       expect(caps.supportsConnectionString).toBe(false);
       expect(caps.maintenanceOperations).toContain("vacuum");
       expect(caps.maintenanceOperations).toContain("analyze");

--- a/tests/unit/lib/explain/mysql-json.test.ts
+++ b/tests/unit/lib/explain/mysql-json.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "bun:test";
+import { mysqlJsonStrategy } from "@/lib/explain/mysql-json";
+
+describe("mysqlJsonStrategy", () => {
+  test("format id", () => {
+    expect(mysqlJsonStrategy.format).toBe("mysql-json");
+  });
+
+  test("buildSql wraps SELECT with FORMAT=JSON explain in both modes", () => {
+    expect(mysqlJsonStrategy.buildSql("SELECT * FROM t", "analyze")).toBe("EXPLAIN FORMAT=JSON SELECT * FROM t");
+    expect(mysqlJsonStrategy.buildSql("SELECT * FROM t", "estimate")).toBe("EXPLAIN FORMAT=JSON SELECT * FROM t");
+  });
+
+  test("buildSql returns null for non-SELECT", () => {
+    expect(mysqlJsonStrategy.buildSql("SHOW TABLES", "analyze")).toBeNull();
+  });
+
+  // Byte-for-byte legacy behavior: MySQL rows have no "QUERY PLAN" column, so
+  // this falls back to raw rows (known bug B4, fixed in PR-4 with a real
+  // query_block parser). Locked here so PR-4 shows an intentional diff.
+  test("extractPlan falls back to raw rows for real MySQL output", () => {
+    const rows = [{ EXPLAIN: '{"query_block":{}}' }];
+    expect(mysqlJsonStrategy.extractPlan({ rows })).toEqual(rows);
+  });
+});

--- a/tests/unit/lib/explain/postgres-json.test.ts
+++ b/tests/unit/lib/explain/postgres-json.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "bun:test";
+import { postgresJsonStrategy } from "@/lib/explain/postgres-json";
+
+describe("postgresJsonStrategy", () => {
+  test("format id", () => {
+    expect(postgresJsonStrategy.format).toBe("postgres-json");
+  });
+
+  test("buildSql wraps SELECT with ANALYZE JSON explain", () => {
+    expect(postgresJsonStrategy.buildSql("SELECT * FROM users", "analyze")).toBe(
+      "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT * FROM users",
+    );
+  });
+
+  test("buildSql is case-insensitive and whitespace-tolerant", () => {
+    expect(postgresJsonStrategy.buildSql("  select 1", "analyze")).toBe(
+      "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)   select 1",
+    );
+  });
+
+  // PR-1 preserves current behavior: estimate mode also runs ANALYZE.
+  // PR-5 (#194 B5) will make estimate return plain EXPLAIN (FORMAT JSON).
+  test("buildSql estimate mode currently matches analyze mode", () => {
+    expect(postgresJsonStrategy.buildSql("SELECT 1", "estimate")).toBe(
+      postgresJsonStrategy.buildSql("SELECT 1", "analyze"),
+    );
+  });
+
+  test("buildSql returns null for non-SELECT", () => {
+    expect(postgresJsonStrategy.buildSql("UPDATE users SET a = 1", "analyze")).toBeNull();
+    expect(postgresJsonStrategy.buildSql("EXPLAIN SELECT 1", "analyze")).toBeNull();
+  });
+
+  test("extractPlan prefers the QUERY PLAN column", () => {
+    const plan = [{ Plan: { "Node Type": "Seq Scan" } }];
+    expect(postgresJsonStrategy.extractPlan({ rows: [{ "QUERY PLAN": plan }] })).toEqual(plan);
+  });
+
+  test("extractPlan falls back to raw rows", () => {
+    const rows = [{ id: 1 }];
+    expect(postgresJsonStrategy.extractPlan({ rows })).toEqual(rows);
+    expect(postgresJsonStrategy.extractPlan({})).toBeUndefined();
+  });
+});

--- a/tests/unit/lib/explain/registry.test.ts
+++ b/tests/unit/lib/explain/registry.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from "bun:test";
+import { getExplainStrategy } from "@/lib/explain";
+
+describe("getExplainStrategy", () => {
+  test("resolves postgres-json", () => {
+    expect(getExplainStrategy("postgres-json")?.format).toBe("postgres-json");
+  });
+
+  test("resolves mysql-json", () => {
+    expect(getExplainStrategy("mysql-json")?.format).toBe("mysql-json");
+  });
+
+  test("returns null for undefined (provider without explain support)", () => {
+    expect(getExplainStrategy(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Part 1 of 5 for #194. Pure refactor: all dialect-specific EXPLAIN knowledge moves out of `src/hooks/use-query-execution.ts` into a capability-driven strategy registry. No user-visible behavior changes (one unreachable edge disclosed below).

### What changed

- `ProviderCapabilities` gains an optional, JSON-serializable `explainFormat?: "postgres-json" | "mysql-json"` discriminant (same pattern as `queryDialect`). Postgres and MySQL declare theirs; all eight provider integration tests now assert the invariant `supportsExplain === (explainFormat !== undefined)`.
- New `src/lib/explain/` module — one file per dialect format:
  - `types.ts` — `ExplainStrategy` contract (`buildSql(sql, mode)`, `extractPlan(result)`), `ExplainMode = "estimate" | "analyze"`
  - `postgres-json.ts`, `mysql-json.ts` — SQL templates and result extraction moved byte-for-byte from the hook
  - `index.ts` — exhaustiveness-checked registry; adding a format id without a strategy fails typecheck
- The hook now resolves a strategy from `metadata.capabilities.explainFormat` (mirroring how `schemaRefreshPattern` is consumed) and contains zero dialect literals: `grep -n "postgres\|mysql\|QUERY PLAN" src/hooks/use-query-execution.ts` returns nothing.

### Disclosed edge-behavior change (intentional, approved in design)

When provider metadata is unavailable (`metadata === null` or no `explainFormat`), the old code still built EXPLAIN SQL from `connection.type`; the new code builds none — capability metadata is the single source of truth. Scope of reachability:

- The explain **button** path is unreachable in this state (every explain affordance is gated on `metadata?.capabilities.supportsExplain`).
- The background **pre-warm** on a plain Run IS reachable in this state, in two windows: the race before `/api/db/provider-meta` resolves, and metadata fetch failure (where `useProviderMetadata` does not retry for the same connection). There the old behavior fired a connection-type-guessed `EXPLAIN (ANALYZE, ...)` pre-warm; the new behavior fires none. Accepted as benign-to-beneficial: in exactly that degraded state the old code double-executed the SELECT via ANALYZE (bug B5), and the Explain tab simply shows its empty state until metadata is available.

Tests updated accordingly, and the no-fallback rule is locked by a dedicated test.

### Deliberately preserved (tracked follow-ups in the #194 series)

- B4: MySQL `extractPlan` keeps today's broken `"QUERY PLAN"` lookup (real `query_block` parser lands in PR 4/5 of the series).
- B5: Postgres background pre-warm still uses `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` (estimate-mode pre-warm lands in PR 5/5).
- The call sites already pass semantically correct modes ("estimate" for pre-warm, "analyze" for direct), so the PR-5 change is confined to `postgres-json.ts`.

### Why

`buildExplainQuery`'s `if (dbType === "postgres")` chain violated the project rule "no dbType checks outside provider classes" and made SQLite/others unimplementable without growing the hook. With the registry, adding a dialect = one capability id + one strategy file + one registry line; existing dialect files stay untouched.

### Verification

All six local gates (`format`, `lint`, `typecheck`, `knip`, `test`, `build`) plus `test:coverage` + `coverage:check` (100% line coverage) plus `build:lib` + `attw` pass at the branch tip.

Refs #194 (part 1/5)
