### PR TITLE
fix(explain): dead Explain button and dishonest Explain tab (#194, 2/5)

### DIFF
--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -340,34 +340,32 @@ export function BottomPanel({
           <SchemaDiff schema={schema} connection={activeConnection} />
         ) : mode === "dashboard" ? (
           <ChartDashboardLazy result={currentTab.result} />
+        ) : mode === "explain" ? (
+          <VisualExplain
+            plan={currentTab.explainPlan as ExplainPlanResult[] | null | undefined}
+            query={currentTab.query}
+            schemaContext={schemaContext}
+            databaseType={activeConnection?.type}
+            onLoadQuery={(q) => {
+              onLoadQuery(q);
+              onSetMode("results");
+            }}
+          />
         ) : currentTab.result ? (
-          mode === "explain" ? (
-            <VisualExplain
-              plan={currentTab.explainPlan as ExplainPlanResult[] | null | undefined}
-              query={currentTab.query}
-              schemaContext={schemaContext}
-              databaseType={activeConnection?.type}
-              onLoadQuery={(q) => {
-                onLoadQuery(q);
-                onSetMode("results");
-              }}
-            />
-          ) : (
-            <ResultsGrid
-              result={currentTab.result}
-              onLoadMore={onLoadMore}
-              isLoadingMore={isLoadingMore}
-              maskingEnabled={maskingEnabled}
-              onToggleMasking={onToggleMasking}
-              userRole={userRole}
-              maskingConfig={maskingConfig}
-              editingEnabled={editingEnabled}
-              pendingChanges={pendingChanges}
-              onCellChange={onCellChange}
-              onApplyChanges={onApplyChanges}
-              onDiscardChanges={onDiscardChanges}
-            />
-          )
+          <ResultsGrid
+            result={currentTab.result}
+            onLoadMore={onLoadMore}
+            isLoadingMore={isLoadingMore}
+            maskingEnabled={maskingEnabled}
+            onToggleMasking={onToggleMasking}
+            userRole={userRole}
+            maskingConfig={maskingConfig}
+            editingEnabled={editingEnabled}
+            pendingChanges={pendingChanges}
+            onCellChange={onCellChange}
+            onApplyChanges={onApplyChanges}
+            onDiscardChanges={onDiscardChanges}
+          />
         ) : (
           <div className="h-full flex flex-col items-center justify-center opacity-20 bg-[#0a0a0a]">
             <Terminal strokeWidth={1.5} className="w-12 h-12 mb-4" />

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -228,11 +228,13 @@ export function BottomPanel({
     },
   ];
 
+  const visibleTabs = metadata?.capabilities.explainFormat ? tabs : tabs.filter((tab) => tab.key !== "explain");
+
   return (
     <div className="h-full flex flex-col bg-[#080808]">
       <div className="h-9 bg-[#0a0a0a] border-b border-white/5 flex items-center justify-between px-2">
         <div className="flex items-center h-full gap-1">
-          {tabs.map((tab) => (
+          {visibleTabs.map((tab) => (
             <button
               key={tab.key}
               onClick={() => {

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -70,10 +70,11 @@ export function useQueryExecution({
     | "dashboard"
   >("results");
 
-  // Capability honesty: if the active provider loses explain support (e.g. the
+  // Capability honesty: if the active provider has no explainFormat (e.g. the
   // user switched connections), never leave the panel stuck on a hidden tab.
+  // Keyed on explainFormat to match the BottomPanel tab filter and getExplainStrategy.
   useEffect(() => {
-    if (bottomPanelMode === "explain" && metadata && !metadata.capabilities.supportsExplain) {
+    if (bottomPanelMode === "explain" && metadata && !metadata.capabilities.explainFormat) {
       setBottomPanelMode("results");
     }
   }, [bottomPanelMode, metadata]);

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -70,6 +70,14 @@ export function useQueryExecution({
     | "dashboard"
   >("results");
 
+  // Capability honesty: if the active provider loses explain support (e.g. the
+  // user switched connections), never leave the panel stuck on a hidden tab.
+  useEffect(() => {
+    if (bottomPanelMode === "explain" && metadata && !metadata.capabilities.supportsExplain) {
+      setBottomPanelMode("results");
+    }
+  }, [bottomPanelMode, metadata]);
+
   const { toast } = useToast();
 
   // Unified executeQuery — handles both normal and force (skipSafety) execution

--- a/tests/components/studio/BottomPanel.test.tsx
+++ b/tests/components/studio/BottomPanel.test.tsx
@@ -368,16 +368,17 @@ describe("BottomPanel", () => {
     expect(queryByTestId("schemadiff")).not.toBeNull();
   });
 
-  test('Explain tab renders VisualExplain when mode="explain" and result exists', () => {
+  test('Explain tab renders VisualExplain when mode="explain" even with result=null (real explain-run shape)', () => {
     const props = createDefaultProps({
       mode: "explain",
       currentTab: {
         id: "tab-1",
         name: "Q",
         query: "SELECT 1",
-        result: { rows: [{ id: 1 }], fields: ["id"], rowCount: 1, executionTime: 10 },
+        result: null, // executeQuery(isExplain=true) always nulls result (bug B1 regression guard)
         isExecuting: false,
         type: "sql" as const,
+        explainPlan: [{ Plan: { "Node Type": "Seq Scan" } }],
       },
     });
     const { queryByTestId } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);

--- a/tests/components/studio/BottomPanel.test.tsx
+++ b/tests/components/studio/BottomPanel.test.tsx
@@ -238,7 +238,9 @@ describe("BottomPanel", () => {
   });
 
   test("renders tab buttons for all modes", () => {
-    const props = createDefaultProps();
+    const props = createDefaultProps({
+      metadata: { capabilities: { explainFormat: "postgres-json", supportsExplain: true } },
+    });
     const { getByText } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
 
     const expectedLabels = [
@@ -258,6 +260,20 @@ describe("BottomPanel", () => {
       const btn = getByText(label);
       expect(btn).not.toBeNull();
     }
+  });
+
+  test("Explain tab is hidden when provider metadata lacks explainFormat", () => {
+    const props = createDefaultProps(); // metadata: null
+    const { queryByText } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
+    expect(queryByText("Explain")).toBeNull();
+  });
+
+  test("Explain tab is visible when provider declares explainFormat", () => {
+    const props = createDefaultProps({
+      metadata: { capabilities: { explainFormat: "postgres-json", supportsExplain: true } },
+    });
+    const { getByText } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
+    expect(getByText("Explain")).not.toBeNull();
   });
 
   test('Results tab is active by default when mode="results"', () => {

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -477,6 +477,33 @@ describe("useQueryExecution", () => {
     expect(result.current.bottomPanelMode).toBe("saved");
   });
 
+  // ── bottomPanelMode resets when the connection loses explain support ───────
+  // useProviderMetadata creates a fresh metadata object per fetch and never
+  // refetches for the same connection id — reference change IS the
+  // connection-switch signal this effect relies on.
+
+  test("bottomPanelMode resets from explain when metadata loses explain support", async () => {
+    mockGlobalFetch({});
+    const params = createDefaultParams();
+    const unsupported = {
+      ...mockMetadata,
+      capabilities: { ...mockMetadata.capabilities, supportsExplain: false, explainFormat: undefined },
+    };
+
+    const { result, rerender } = renderHook(({ metadata }) => useQueryExecution({ ...params, metadata }), {
+      initialProps: { metadata: mockMetadata as ProviderMetadata },
+    });
+
+    act(() => {
+      result.current.setBottomPanelMode("explain");
+    });
+    expect(result.current.bottomPanelMode).toBe("explain");
+
+    rerender({ metadata: unsupported });
+
+    await waitFor(() => expect(result.current.bottomPanelMode).toBe("results"));
+  });
+
   // ── executeQuery sets explain panel mode for explain queries ────────────────
 
   test("executeQuery sets explain panel mode for explain queries", async () => {

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -504,6 +504,30 @@ describe("useQueryExecution", () => {
     await waitFor(() => expect(result.current.bottomPanelMode).toBe("results"));
   });
 
+  test("bottomPanelMode resets from explain when metadata lacks explainFormat even if supportsExplain is true", async () => {
+    mockGlobalFetch({});
+    const params = createDefaultParams();
+    // Divergent state (reachable via custom metadata in embedded mode): the tab
+    // filter and getExplainStrategy key on explainFormat, so the reset must too.
+    const noFormat = {
+      ...mockMetadata,
+      capabilities: { ...mockMetadata.capabilities, supportsExplain: true, explainFormat: undefined },
+    };
+
+    const { result, rerender } = renderHook(({ metadata }) => useQueryExecution({ ...params, metadata }), {
+      initialProps: { metadata: mockMetadata as ProviderMetadata },
+    });
+
+    act(() => {
+      result.current.setBottomPanelMode("explain");
+    });
+    expect(result.current.bottomPanelMode).toBe("explain");
+
+    rerender({ metadata: noFormat });
+
+    await waitFor(() => expect(result.current.bottomPanelMode).toBe("results"));
+  });
+
   // ── executeQuery sets explain panel mode for explain queries ────────────────
 
   test("executeQuery sets explain panel mode for explain queries", async () => {


### PR DESCRIPTION
## Summary

Part 2 of 5 for #194. Three UI-honesty fixes for the Explain feature, each landed test-first against the real bug.

### Fixes

1. **Dead Explain button (B1).** The `mode === "explain"` render branch in `BottomPanel.tsx` was nested inside a `currentTab.result ?` gate, while every explain run sets `result: null` — so the Explain button never displayed a plan for ANY provider. The branch is hoisted out of the gate (JSX props byte-identical, only the ternary nesting changes). The old test passed only because its fixture stubbed a non-null `result` under `mode: "explain"` — a state the real flow never produces; it is replaced by a regression test using the real shape (`result: null` + populated `explainPlan`).
2. **Dishonest Explain tab (B3, the visible half of #194).** The tab list now filters on `metadata?.capabilities.explainFormat`: providers without explain support no longer show a permanently-empty Explain tab.
3. **Stale panel mode.** A `useEffect` in `useQueryExecution` resets `bottomPanelMode` from `"explain"` to `"results"` when the active provider's metadata says explain is unsupported, so switching connections can no longer strand the user on a hidden view. Guarded against transient `metadata === null` (loading) so it never fights the normal flow.

### Release note (consumer-visible change)

The Explain tab is no longer rendered for connections whose provider does not declare explain support — today that means it disappears for **Oracle, SQL Server, MongoDB, Redis, and LibreDB** connections (it was always non-functional there), and in the **embedded platform workspace** (`@libredb/studio` — `StudioWorkspace` passes `metadata={null}`). Postgres and MySQL keep the tab; SQLite gains working explain support in part 3 of this series.

npm public API surface is unchanged: `BottomPanel` is not exported; `BottomPanelProps` and all `src/exports/*` entries are untouched (verified with `build:lib` + `attw`).

### Verification

- All six local gates + `test:coverage`/`coverage:check` (100.00%, 25598/25598 lines) + `build:lib` + `attw` green at the branch tip.
- Manually verified against the running app: LibreDB and SQLite sample connections show no Explain tab or button; a live PostgreSQL connection shows both, the background pre-warm fills the Explain tab after RUN, and the Explain button now renders a fresh plan (first time the button path works); switching from the Explain view to a SQLite connection resets the panel to Results.

### Follow-up filed from the whole-branch review

The Monaco context-menu "Explain Plan" action in `QueryEditor.tsx` is registered once in `onMount` behind `if (onExplain)` and captures that render's closure — it can be missing for a supporting provider (metadata race at mount) or stale after a connection switch. Pre-existing, outside this diff's scope; tracked as a separate issue in the #194 series.

Refs #194 (part 2/5)
