### PR TITLE
feat(explain): SQLite EXPLAIN QUERY PLAN end-to-end (#194, 3/5)

### DIFF
--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -95,7 +95,7 @@ everything that assumes a server. Read this as a **diff against the [PostgreSQL 
 | Pooling | `pg.Pool` | none (one `Database` handle) |
 | Transactions API | begin/commit/rollback + auto-rollback | **none exposed** |
 | Cancellation | `pg_cancel_backend` | **none** |
-| `EXPLAIN` | `true` | **`false`** |
+| `EXPLAIN` | `true` | `true` (EXPLAIN QUERY PLAN) |
 | Connection string | `true` | `false` (path accepted in the field, but flagged unsupported) |
 | Schema scope | many schemas | single (`main`) |
 | Monitoring | rich `pg_stat_*` | minimal (PRAGMAs + file stats; many fields `N/A`/estimated) |
@@ -236,7 +236,7 @@ Homebrew). Each channel is browser-verified by
 `query(sql, params?)` — positional params via the driver's `all()`/`run()`. There is no
 `prepareQuery()` override, so the inherited base injects a `LIMIT` into bare `SELECT`s
 (`DEFAULT_QUERY_LIMIT = 500`). No transactions, no cancellation ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
-`EXPLAIN` is **not** supported (`supportsExplain: false`) — the UI hides the Explain action.
+`EXPLAIN QUERY PLAN` is supported (`supportsExplain: true`, `explainFormat: "sqlite-queryplan"`) — the UI renders the plan as a tree; SQLite reports no per-node cost or timing metrics, so none are shown.
 
 ---
 
@@ -293,12 +293,13 @@ Minimal by nature — SQLite keeps almost no server-style runtime statistics.
 
 ## 9. Capabilities & labels
 
-### `getCapabilities()` ([sqlite.ts:53](../../src/lib/db/providers/sql/sqlite.ts))
+### `getCapabilities()` ([sqlite.ts:133](../../src/lib/db/providers/sql/sqlite.ts))
 
 | Capability | Value |
 |------------|-------|
 | `queryLanguage` | `sql` |
-| `supportsExplain` | **`false`** |
+| `supportsExplain` | `true` |
+| `explainFormat` | `"sqlite-queryplan"` |
 | `supportsExternalQueryLimiting` | `true` (from base) |
 | `supportsCreateTable` | `true` (from base) |
 | `supportsMaintenance` | `true` |
@@ -406,7 +407,8 @@ not apply to SQLite ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
   See [Runtime & driver selection](#runtime--driver-selection).
 - **No transactions / cancellation / pooling.** Single embedded handle; the transaction and cancel
   API routes don't apply.
-- **No `EXPLAIN`.**
+- **No EXPLAIN plan metrics.** `EXPLAIN QUERY PLAN` returns step descriptions only — SQLite does not
+  report per-node cost, row estimates, or timing data.
 - **Estimated/absent monitoring:** per-table size is `rows × 100 bytes` (a rough estimate); index
   `scans` is always `0`; cache-hit ratio is a fixed estimate; slow queries are unavailable.
 - **`:memory:` is ephemeral** — data is lost on disconnect; intended for trials/tests.

--- a/e2e/explain-sqlite.spec.ts
+++ b/e2e/explain-sqlite.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * SQLite EXPLAIN QUERY PLAN, end to end: the zero-config "Sample (Employees)"
+ * SQLite connection now has a working Explain tab (dead through PR-2,
+ * undeliverable before PR-3 wired up sqlite-queryplan). Run a SELECT, open
+ * Explain, and see a metric-less tree whose node labels come straight from
+ * SQLite's EXPLAIN QUERY PLAN `detail` column - always SCAN or SEARCH for
+ * table access. Tree plans have no "insights" tab (its heuristics key off
+ * postgres-only fields - Actual Rows, Total Cost, buffer stats - the sqlite
+ * dialect never produces), so its absence is asserted too.
+ *
+ * Login/seed-appearance conventions match embedded-samples.spec.ts: the
+ * SQLite sample seeds asynchronously after boot and the client polls for up
+ * to 30s, so give it the full window plus slack before calling it missing.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+const SAMPLE_APPEAR_TIMEOUT = 45_000;
+
+async function loginAsUser(page: Page): Promise<void> {
+  await page.goto("/login");
+  await page.locator('input[type="email"]').fill("user@libredb.org");
+  await page.locator('input[type="password"]').fill("test-user");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  await page.waitForURL("/");
+  await expect(page.locator("text=Query 1").first()).toBeVisible({ timeout: 15_000 });
+}
+
+async function runQuery(page: Page, sql: string): Promise<void> {
+  await expect(page.locator(".monaco-editor").first()).toBeVisible({ timeout: 15_000 });
+  await page.waitForFunction(
+    () =>
+      ((window as unknown as { monaco?: { editor: { getEditors(): unknown[] } } }).monaco?.editor.getEditors().length ??
+        0) > 0,
+  );
+  await page.evaluate((query) => {
+    const monaco = (window as unknown as { monaco?: { editor: { getEditors(): { setValue(v: string): void }[] } } })
+      .monaco;
+    if (!monaco) throw new Error("monaco global not found");
+    monaco.editor.getEditors()[0].setValue(query);
+  }, sql);
+  await page.getByRole("button", { name: "RUN" }).click();
+}
+
+test.describe("SQLite EXPLAIN QUERY PLAN", () => {
+  // Worst-case chain: login (15s) + async-seed appearance (45s) + monaco
+  // (15s) + results grid (20s) + background explain pre-warm (20s) exceeds
+  // Playwright's default 30s test budget, as in embedded-samples.spec.ts.
+  test.describe.configure({ timeout: 120_000 });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsUser(page);
+  });
+
+  test("Explain tab renders a SCAN/SEARCH tree and hides the insights tab", async ({ page }) => {
+    const sample = page.locator("text=Sample (Employees)").first();
+    await expect(sample).toBeVisible({ timeout: SAMPLE_APPEAR_TIMEOUT });
+    await sample.click();
+
+    // Absent through PR-2 - now visible because sqlite declares explainFormat.
+    // data-testid disambiguates from QueryEditor's own "Explain" toolbar
+    // button (direct EXPLAIN ANALYZE run), which renders the same text.
+    const explainTab = page.getByTestId("bottom-panel-tab-explain");
+    await expect(explainTab).toBeVisible({ timeout: 15_000 });
+
+    await runQuery(page, "SELECT * FROM employee LIMIT 10");
+    // Results grid confirms the query landed before we go looking at its plan.
+    // "10 rows" (StatsBar / BottomPanel toolbar) rather than a column header:
+    // ResultsGrid virtualizes columns, so a header cell can resolve but report
+    // not-visible depending on horizontal scroll/measurement state.
+    await expect(page.locator("text=10 rows").first()).toBeVisible({ timeout: 20_000 });
+
+    await explainTab.click();
+
+    // The background EXPLAIN QUERY PLAN pre-warm resolves into the tagged
+    // tree model; node labels are SQLite's own `detail` column verbatim.
+    await expect(page.getByText(/SCAN|SEARCH/).first()).toBeVisible({ timeout: 20_000 });
+
+    // Tree plans render tree/raw/ai only - no insights tab (postgres-only heuristics).
+    await expect(page.getByRole("button", { name: "insights", exact: true })).toHaveCount(0);
+  });
+});

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -21,14 +21,15 @@ import {
   Sparkles,
   Play,
   Loader2,
+  ListTree,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { ExplainPlanNode, ExplainPlanResult } from "@/lib/explain/types";
+import type { ExplainPlanNode, ExplainPlanResult, ExplainPlanInput, ExplainTreeNode } from "@/lib/explain/types";
 
 export type { ExplainPlanResult } from "@/lib/explain/types";
 
 interface VisualExplainProps {
-  plan: ExplainPlanResult[] | null | undefined;
+  plan: ExplainPlanResult[] | ExplainPlanInput | null | undefined;
   query?: string;
   schemaContext?: string;
   databaseType?: string;
@@ -330,6 +331,69 @@ const PlanNode = ({ node, depth = 0, maxTime }: { node: ExplainPlanNode; depth?:
   );
 };
 
+function countTreeNodes(node: ExplainTreeNode): number {
+  return 1 + node.children.reduce((sum, child) => sum + countTreeNodes(child), 0);
+}
+
+// Generic tree renderer for dialects with no postgres-shaped cost/timing fields
+// (e.g. SQLite's EXPLAIN QUERY PLAN). Mirrors PlanNode's indent/border/expand
+// conventions but only shows metric badges when the node actually carries them
+// — never fabricates "0 rows" / "0μs" for metric-less plans.
+const TreeNodeView = ({ node, depth = 0 }: { node: ExplainTreeNode; depth?: number }) => {
+  const [expanded, setExpanded] = useState(depth < 2);
+  const children = node.children;
+  const metrics = node.metrics;
+  const hasMetrics = metrics !== undefined && (metrics.actualRows !== undefined || metrics.actualTimeMs !== undefined);
+
+  return (
+    <div className="relative">
+      {/* Node */}
+      <div
+        className="group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5"
+        onClick={() => setExpanded(!expanded)}
+        style={{ marginLeft: depth * 20 }}
+      >
+        {/* Expand icon */}
+        {children.length > 0 && (
+          <ChevronRight className={cn("w-3 h-3 text-zinc-600 transition-transform", expanded && "rotate-90")} />
+        )}
+        {children.length === 0 && <div className="w-3" />}
+
+        {/* Icon */}
+        <div className="p-1 rounded bg-white/5">
+          <ListTree strokeWidth={1.5} className="w-3 h-3 text-zinc-400" />
+        </div>
+
+        {/* Label */}
+        <div className="flex-1 min-w-0">
+          <span className="text-xs font-medium text-zinc-200 truncate">{node.label}</span>
+        </div>
+
+        {/* Metric badges — only when the node actually carries metrics */}
+        {hasMetrics && (
+          <div className="flex items-center gap-4 text-xs font-mono">
+            {metrics!.actualRows !== undefined && (
+              <span className="text-zinc-500 w-16 text-right">{formatNumber(metrics!.actualRows)} rows</span>
+            )}
+            {metrics!.actualTimeMs !== undefined && (
+              <span className="text-zinc-400 w-16 text-right">{formatTime(metrics!.actualTimeMs)}</span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Children */}
+      {expanded && children.length > 0 && (
+        <div className="ml-8 pl-4 border-l border-white/5" style={{ marginLeft: depth * 20 + 32 }}>
+          {children.map((child, idx) => (
+            <TreeNodeView key={idx} node={child} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 // ============================================================================
 // AI Explain Tab Component
 // ============================================================================
@@ -341,7 +405,7 @@ function AIExplainTab({
   databaseType,
   onLoadQuery,
 }: {
-  plan: ExplainPlanResult[];
+  plan: unknown;
   query?: string;
   schemaContext?: string;
   databaseType?: string;
@@ -609,15 +673,28 @@ function AIExplainTab({
 // ============================================================================
 
 export function VisualExplain({ plan, query, schemaContext, databaseType, onLoadQuery }: VisualExplainProps) {
-  const [activeTab, setActiveTab] = useState<"insights" | "tree" | "raw" | "ai">("insights");
-
-  const analysis = useMemo(() => {
-    if (!plan || !Array.isArray(plan) || plan.length === 0) return null;
-    return analyzePlan(plan);
+  // Normalize once: array (legacy) / tagged input / null|undefined -> ExplainPlanInput | null.
+  // Non-empty legacy arrays are wrapped as postgres-json so the rest of the component only
+  // ever deals with the tagged model; this reproduces the old empty-state guards exactly.
+  const input: ExplainPlanInput | null = useMemo(() => {
+    if (!plan) return null;
+    if (Array.isArray(plan)) return plan.length > 0 ? { kind: "postgres-json", plan } : null;
+    return typeof plan === "object" && "kind" in plan ? plan : null;
   }, [plan]);
 
+  const postgresPlan = input !== null && input.kind === "postgres-json" ? input.plan : null;
+
+  const [activeTab, setActiveTab] = useState<"insights" | "tree" | "raw" | "ai">(
+    input !== null && input.kind === "tree" ? "tree" : "insights",
+  );
+
+  const analysis = useMemo(() => {
+    if (!postgresPlan) return null;
+    return analyzePlan(postgresPlan);
+  }, [postgresPlan]);
+
   // Empty state
-  if (!plan || !Array.isArray(plan) || plan.length === 0) {
+  if (input === null) {
     return (
       <div className="h-full flex flex-col items-center justify-center text-zinc-500 bg-[#080808] p-12 text-center">
         <div className="w-12 h-12 rounded-xl bg-white/5 flex items-center justify-center mb-4">
@@ -631,7 +708,10 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
     );
   }
 
-  const rootPlan = plan[0]?.Plan;
+  const rootPlan = postgresPlan?.[0]?.Plan;
+  // No "insights" for tree plans — analyzePlan's heuristics key off postgres-only fields
+  // (Actual Rows, Total Cost, buffer stats) that sqlite-queryplan and friends never produce.
+  const tabs = input.kind === "tree" ? (["tree", "raw", "ai"] as const) : (["insights", "ai", "tree", "raw"] as const);
 
   return (
     <div className="h-full flex flex-col bg-[#080808]">
@@ -639,27 +719,35 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
       <div className="px-4 py-3 border-b border-white/5 bg-[#0a0a0a]">
         <div className="flex items-center justify-between">
           {/* Quick stats */}
-          <div className="flex items-center gap-6">
+          {input.kind === "tree" ? (
             <div className="flex items-center gap-2">
-              <Clock strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
-              <span className="text-xs font-medium text-zinc-200">{formatTime(analysis?.executionTime || 0)}</span>
-              <span className="text-xs text-zinc-600">execution</span>
+              <Layers strokeWidth={1.5} className="w-3 h-3 text-zinc-500" />
+              <span className="text-xs font-medium text-zinc-200">{countTreeNodes(input.root)}</span>
+              <span className="text-xs text-zinc-600">nodes</span>
             </div>
-            <div className="flex items-center gap-2">
-              <TrendingUp className="w-3 h-3 text-zinc-500" />
-              <span className="text-xs font-medium text-zinc-400">{formatNumber(analysis?.totalRows || 0)}</span>
-              <span className="text-xs text-zinc-600">rows</span>
+          ) : (
+            <div className="flex items-center gap-6">
+              <div className="flex items-center gap-2">
+                <Clock strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
+                <span className="text-xs font-medium text-zinc-200">{formatTime(analysis?.executionTime || 0)}</span>
+                <span className="text-xs text-zinc-600">execution</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <TrendingUp className="w-3 h-3 text-zinc-500" />
+                <span className="text-xs font-medium text-zinc-400">{formatNumber(analysis?.totalRows || 0)}</span>
+                <span className="text-xs text-zinc-600">rows</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <HardDrive strokeWidth={1.5} className="w-3 h-3 text-zinc-500" />
+                <span className="text-xs font-medium text-zinc-400">{formatNumber(analysis?.totalCost || 0)}</span>
+                <span className="text-xs text-zinc-600">cost</span>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <HardDrive strokeWidth={1.5} className="w-3 h-3 text-zinc-500" />
-              <span className="text-xs font-medium text-zinc-400">{formatNumber(analysis?.totalCost || 0)}</span>
-              <span className="text-xs text-zinc-600">cost</span>
-            </div>
-          </div>
+          )}
 
           {/* Tabs */}
           <div className="flex items-center gap-1 bg-white/5 rounded-lg p-0.5">
-            {(["insights", "ai", "tree", "raw"] as const).map((tab) => (
+            {tabs.map((tab) => (
               <button
                 key={tab}
                 onClick={() => setActiveTab(tab)}
@@ -687,7 +775,7 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
       <div className="flex-1 overflow-auto">
         {activeTab === "ai" && (
           <AIExplainTab
-            plan={plan}
+            plan={input.kind === "tree" ? input.raw : postgresPlan}
             query={query}
             schemaContext={schemaContext}
             databaseType={databaseType}
@@ -790,7 +878,10 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
         {activeTab === "tree" && (
           <div className="p-4">
             <div className="rounded-lg border border-white/5 bg-white/[0.01] p-2">
-              {rootPlan && analysis && <PlanNode node={rootPlan} maxTime={analysis.executionTime || 1} />}
+              {input.kind === "tree" && <TreeNodeView node={input.root} />}
+              {input.kind !== "tree" && rootPlan && analysis && (
+                <PlanNode node={rootPlan} maxTime={analysis.executionTime || 1} />
+              )}
             </div>
           </div>
         )}
@@ -798,7 +889,7 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
         {activeTab === "raw" && (
           <div className="p-4">
             <pre className="text-xs font-mono text-zinc-400 bg-white/[0.02] rounded-lg p-4 overflow-auto border border-white/5">
-              {JSON.stringify(plan, null, 2)}
+              {JSON.stringify(input.kind === "tree" ? input.raw : postgresPlan, null, 2)}
             </pre>
           </div>
         )}

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState, useCallback, useRef } from "react";
+import React, { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import {
   Zap,
   Search,
@@ -343,7 +343,12 @@ const TreeNodeView = ({ node, depth = 0 }: { node: ExplainTreeNode; depth?: numb
   const [expanded, setExpanded] = useState(depth < 2);
   const children = node.children;
   const metrics = node.metrics;
-  const hasMetrics = metrics !== undefined && (metrics.actualRows !== undefined || metrics.actualTimeMs !== undefined);
+  const hasMetrics =
+    metrics !== undefined &&
+    (metrics.actualRows !== undefined ||
+      metrics.actualTimeMs !== undefined ||
+      metrics.estRows !== undefined ||
+      metrics.estCost !== undefined);
 
   return (
     <div className="relative">
@@ -375,8 +380,14 @@ const TreeNodeView = ({ node, depth = 0 }: { node: ExplainTreeNode; depth?: numb
             {metrics!.actualRows !== undefined && (
               <span className="text-zinc-500 w-16 text-right">{formatNumber(metrics!.actualRows)} rows</span>
             )}
+            {metrics!.estRows !== undefined && (
+              <span className="text-zinc-500 w-16 text-right">~{formatNumber(metrics!.estRows)} rows</span>
+            )}
             {metrics!.actualTimeMs !== undefined && (
               <span className="text-zinc-400 w-16 text-right">{formatTime(metrics!.actualTimeMs)}</span>
+            )}
+            {metrics!.estCost !== undefined && (
+              <span className="text-zinc-400 w-16 text-right">cost {formatNumber(metrics!.estCost)}</span>
             )}
           </div>
         )}
@@ -672,6 +683,14 @@ function AIExplainTab({
 // Main Component
 // ============================================================================
 
+type ExplainTab = "insights" | "tree" | "raw" | "ai";
+
+// First entry is the kind's default tab. No "insights" for tree plans —
+// analyzePlan's heuristics key off postgres-only fields (Actual Rows, Total
+// Cost, buffer stats) that sqlite-queryplan and friends never produce.
+const TREE_TABS = ["tree", "raw", "ai"] as const;
+const POSTGRES_TABS = ["insights", "ai", "tree", "raw"] as const;
+
 export function VisualExplain({ plan, query, schemaContext, databaseType, onLoadQuery }: VisualExplainProps) {
   // Normalize once: array (legacy) / tagged input / null|undefined -> ExplainPlanInput | null.
   // Non-empty legacy arrays are wrapped as postgres-json so the rest of the component only
@@ -683,10 +702,21 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
   }, [plan]);
 
   const postgresPlan = input !== null && input.kind === "postgres-json" ? input.plan : null;
+  const kind = input === null ? null : input.kind;
 
-  const [activeTab, setActiveTab] = useState<"insights" | "tree" | "raw" | "ai">(
-    input !== null && input.kind === "tree" ? "tree" : "insights",
-  );
+  const [activeTab, setActiveTab] = useState<ExplainTab>(kind === "tree" ? "tree" : "insights");
+
+  // BottomPanel keeps a single VisualExplain mounted across query-tab/connection
+  // switches, so the plan kind can change without a remount. Resync the active tab
+  // when it does: a stale tab that is unavailable for the new kind ("insights" on a
+  // tree plan) would otherwise leave the content panel blank.
+  useEffect(() => {
+    if (kind === null) return;
+    setActiveTab((current) => {
+      const available: readonly ExplainTab[] = kind === "tree" ? TREE_TABS : POSTGRES_TABS;
+      return available.includes(current) ? current : available[0];
+    });
+  }, [kind]);
 
   const analysis = useMemo(() => {
     if (!postgresPlan) return null;
@@ -709,9 +739,7 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
   }
 
   const rootPlan = postgresPlan?.[0]?.Plan;
-  // No "insights" for tree plans — analyzePlan's heuristics key off postgres-only fields
-  // (Actual Rows, Total Cost, buffer stats) that sqlite-queryplan and friends never produce.
-  const tabs = input.kind === "tree" ? (["tree", "raw", "ai"] as const) : (["insights", "ai", "tree", "raw"] as const);
+  const tabs = input.kind === "tree" ? TREE_TABS : POSTGRES_TABS;
 
   return (
     <div className="h-full flex flex-col bg-[#080808]">

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -23,28 +23,9 @@ import {
   Loader2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { ExplainPlanNode, ExplainPlanResult } from "@/lib/explain/types";
 
-type ExplainPlanNode = {
-  Plan?: ExplainPlanNode;
-  "Node Type"?: string;
-  "Actual Rows"?: number;
-  "Plan Rows"?: number;
-  "Actual Total Time"?: number;
-  "Total Cost"?: number;
-  "Shared Hit Blocks"?: number;
-  "Shared Read Blocks"?: number;
-  "Relation Name"?: string;
-  "Actual Loops"?: number;
-  Filter?: string;
-  "Index Name"?: string;
-  Plans?: ExplainPlanNode[];
-};
-
-export type ExplainPlanResult = {
-  Plan?: ExplainPlanNode;
-  "Execution Time"?: number;
-  "Planning Time"?: number;
-};
+export type { ExplainPlanResult } from "@/lib/explain/types";
 
 interface VisualExplainProps {
   plan: ExplainPlanResult[] | null | undefined;

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -342,6 +342,7 @@ function countTreeNodes(node: ExplainTreeNode): number {
 const TreeNodeView = ({ node, depth = 0 }: { node: ExplainTreeNode; depth?: number }) => {
   const [expanded, setExpanded] = useState(depth < 2);
   const children = node.children;
+  const hasChildren = children.length > 0;
   const metrics = node.metrics;
   const hasMetrics =
     metrics !== undefined &&
@@ -350,51 +351,79 @@ const TreeNodeView = ({ node, depth = 0 }: { node: ExplainTreeNode; depth?: numb
       metrics.estRows !== undefined ||
       metrics.estCost !== undefined);
 
-  return (
-    <div className="relative">
-      {/* Node */}
-      <div
-        className="group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5"
-        onClick={() => setExpanded(!expanded)}
-        style={{ marginLeft: depth * 20 }}
-      >
-        {/* Expand icon */}
-        {children.length > 0 && (
-          <ChevronRight className={cn("w-3 h-3 text-zinc-600 transition-transform", expanded && "rotate-90")} />
-        )}
-        {children.length === 0 && <div className="w-3" />}
+  const toggle = () => setExpanded((prev) => !prev);
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    // prevent Space from scrolling the panel
+    if (e.key === " ") e.preventDefault();
+    toggle();
+  };
 
-        {/* Icon */}
-        <div className="p-1 rounded bg-white/5">
-          <ListTree strokeWidth={1.5} className="w-3 h-3 text-zinc-400" />
-        </div>
+  const rowContent = (
+    <>
+      {/* Expand icon */}
+      {hasChildren ? (
+        <ChevronRight className={cn("w-3 h-3 text-zinc-600 transition-transform", expanded && "rotate-90")} />
+      ) : (
+        <div className="w-3" />
+      )}
 
-        {/* Label */}
-        <div className="flex-1 min-w-0">
-          <span className="text-xs font-medium text-zinc-200 truncate">{node.label}</span>
-        </div>
-
-        {/* Metric badges — only when the node actually carries metrics */}
-        {hasMetrics && (
-          <div className="flex items-center gap-4 text-xs font-mono">
-            {metrics!.actualRows !== undefined && (
-              <span className="text-zinc-500 w-16 text-right">{formatNumber(metrics!.actualRows)} rows</span>
-            )}
-            {metrics!.estRows !== undefined && (
-              <span className="text-zinc-500 w-16 text-right">~{formatNumber(metrics!.estRows)} rows</span>
-            )}
-            {metrics!.actualTimeMs !== undefined && (
-              <span className="text-zinc-400 w-16 text-right">{formatTime(metrics!.actualTimeMs)}</span>
-            )}
-            {metrics!.estCost !== undefined && (
-              <span className="text-zinc-400 w-16 text-right">cost {formatNumber(metrics!.estCost)}</span>
-            )}
-          </div>
-        )}
+      {/* Icon */}
+      <div className="p-1 rounded bg-white/5">
+        <ListTree strokeWidth={1.5} className="w-3 h-3 text-zinc-400" />
       </div>
 
+      {/* Label */}
+      <div className="flex-1 min-w-0">
+        <span className="text-xs font-medium text-zinc-200 truncate">{node.label}</span>
+      </div>
+
+      {/* Metric badges — only when the node actually carries metrics */}
+      {hasMetrics && (
+        <div className="flex items-center gap-4 text-xs font-mono">
+          {metrics!.actualRows !== undefined && (
+            <span className="text-zinc-500 w-16 text-right">{formatNumber(metrics!.actualRows)} rows</span>
+          )}
+          {metrics!.estRows !== undefined && (
+            <span className="text-zinc-500 w-16 text-right">~{formatNumber(metrics!.estRows)} rows</span>
+          )}
+          {metrics!.actualTimeMs !== undefined && (
+            <span className="text-zinc-400 w-16 text-right">{formatTime(metrics!.actualTimeMs)}</span>
+          )}
+          {metrics!.estCost !== undefined && (
+            <span className="text-zinc-400 w-16 text-right">cost {formatNumber(metrics!.estCost)}</span>
+          )}
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <div className="relative">
+      {/* Expandable rows are keyboard-accessible buttons; leaves are plain divs */}
+      {hasChildren ? (
+        <div
+          className="group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5"
+          onClick={toggle}
+          onKeyDown={handleKeyDown}
+          role="button"
+          tabIndex={0}
+          aria-expanded={expanded}
+          style={{ marginLeft: depth * 20 }}
+        >
+          {rowContent}
+        </div>
+      ) : (
+        <div
+          className="group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all"
+          style={{ marginLeft: depth * 20 }}
+        >
+          {rowContent}
+        </div>
+      )}
+
       {/* Children */}
-      {expanded && children.length > 0 && (
+      {expanded && hasChildren && (
         <div className="ml-8 pl-4 border-l border-white/5" style={{ marginLeft: depth * 20 + 32 }}>
           {children.map((child, idx) => (
             <TreeNodeView key={idx} node={child} depth={depth + 1} />
@@ -427,6 +456,19 @@ function AIExplainTab({
   const [error, setError] = useState<string | null>(null);
   const [hasRun, setHasRun] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+
+  // A mounted panel can switch plans without remounting (BottomPanel keeps one
+  // VisualExplain alive across query-tab switches and the AI tab exists for every
+  // plan kind): drop the previous plan's analysis and abort any in-flight stream
+  // so the old response never bleeds into the new plan.
+  useEffect(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setHasRun(false);
+    setAiResponse("");
+    setError(null);
+    setIsLoading(false);
+  }, [plan, query]);
 
   const analyzeWithAI = useCallback(async () => {
     if (!query && !plan) return;
@@ -698,7 +740,10 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
   const input: ExplainPlanInput | null = useMemo(() => {
     if (!plan) return null;
     if (Array.isArray(plan)) return plan.length > 0 ? { kind: "postgres-json", plan } : null;
-    return typeof plan === "object" && "kind" in plan ? plan : null;
+    if (typeof plan !== "object" || !("kind" in plan)) return null;
+    // A tagged-but-empty postgres plan is as empty as a legacy [] — same empty state.
+    if (plan.kind === "postgres-json" && plan.plan.length === 0) return null;
+    return plan;
   }, [plan]);
 
   const postgresPlan = input !== null && input.kind === "postgres-json" ? input.plan : null;

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import type { DatabaseConnection, QueryTab, TableSchema, QueryResult } from "@/lib/types";
 import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
 import type { MaskingConfig } from "@/lib/data-masking";
@@ -160,6 +160,8 @@ export function BottomPanel({
   isLoadingMore,
   onExportResults,
 }: BottomPanelProps) {
+  const explainInput = useMemo(() => resolveExplainPlan(currentTab.explainPlan), [currentTab.explainPlan]);
+
   const tabs: { key: BottomPanelMode; label: string; icon: React.ReactNode; activeClass: string }[] = [
     {
       key: "results",
@@ -345,7 +347,7 @@ export function BottomPanel({
           <ChartDashboardLazy result={currentTab.result} />
         ) : mode === "explain" ? (
           <VisualExplain
-            plan={resolveExplainPlan(currentTab.explainPlan)}
+            plan={explainInput}
             query={currentTab.query}
             schemaContext={schemaContext}
             databaseType={activeConnection?.type}

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -240,6 +240,7 @@ export function BottomPanel({
           {visibleTabs.map((tab) => (
             <button
               key={tab.key}
+              data-testid={tab.key === "explain" ? "bottom-panel-tab-explain" : undefined}
               onClick={() => {
                 onSetMode(tab.key);
                 if (tab.key === "nl2sql") onSetIsNL2SQLOpen(true);

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -10,11 +10,12 @@ import { NL2SQLPanel } from "@/components/NL2SQLPanel";
 import { AIAutopilotPanel } from "@/components/AIAutopilotPanel";
 import { PivotTable } from "@/components/PivotTable";
 import { DatabaseDocs } from "@/components/DatabaseDocs";
-import { VisualExplain, type ExplainPlanResult } from "@/components/VisualExplain";
+import { VisualExplain } from "@/components/VisualExplain";
 import { QueryHistory } from "@/components/QueryHistory";
 import { SavedQueries } from "@/components/SavedQueries";
 import { DataCharts } from "@/components/DataCharts";
 import { SchemaDiff } from "@/components/SchemaDiff";
+import { resolveExplainPlan } from "@/lib/explain";
 import { cn } from "@/lib/utils";
 import {
   BarChart3,
@@ -344,7 +345,7 @@ export function BottomPanel({
           <ChartDashboardLazy result={currentTab.result} />
         ) : mode === "explain" ? (
           <VisualExplain
-            plan={currentTab.explainPlan as ExplainPlanResult[] | null | undefined}
+            plan={resolveExplainPlan(currentTab.explainPlan)}
             query={currentTab.query}
             schemaContext={schemaContext}
             databaseType={activeConnection?.type}

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -314,14 +314,16 @@ export function useQueryExecution({
         // Process EXPLAIN results (from background or direct)
         let explainPlanData = null;
         if (isExplain) {
-          explainPlanData = explainStrategy ? explainStrategy.extractPlan(resultData) : null;
+          explainPlanData = explainStrategy
+            ? { format: explainStrategy.format, raw: explainStrategy.extractPlan(resultData) }
+            : null;
         } else if (explainPromise && explainStrategy) {
           // Background EXPLAIN - don't block, update async
           explainPromise
             .then(async (explainRes) => {
               if (explainRes.ok) {
                 const explainData = await explainRes.json();
-                const plan = explainStrategy.extractPlan(explainData);
+                const plan = { format: explainStrategy.format, raw: explainStrategy.extractPlan(explainData) };
                 setTabs((prev) => prev.map((t) => (t.id === targetTabId ? { ...t, explainPlan: plan } : t)));
               }
             })

--- a/src/lib/db/providers/sql/sqlite.ts
+++ b/src/lib/db/providers/sql/sqlite.ts
@@ -134,7 +134,8 @@ export class SQLiteProvider extends SQLBaseProvider {
     return {
       ...super.getCapabilities(),
       defaultPort: null,
-      supportsExplain: false,
+      supportsExplain: true,
+      explainFormat: "sqlite-queryplan",
       supportsConnectionString: false,
       maintenanceOperations: ["vacuum", "analyze", "reindex", "check"],
     };

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -88,9 +88,9 @@ export interface MaintenanceResult {
 /**
  * Dialect discriminant for client-side EXPLAIN handling (issue #194).
  * Each id selects one strategy module in `src/lib/explain`. Extended per
- * provider as explain support lands (sqlite-queryplan arrives with #194 PR-3).
+ * provider as explain support lands.
  */
-export type ExplainFormat = "postgres-json" | "mysql-json";
+export type ExplainFormat = "postgres-json" | "mysql-json" | "sqlite-queryplan";
 
 export interface ProviderCapabilities {
   queryLanguage: "sql" | "json";

--- a/src/lib/explain/index.ts
+++ b/src/lib/explain/index.ts
@@ -1,9 +1,10 @@
 import type { ExplainFormat } from "@/lib/db/types";
-import type { ExplainStrategy } from "./types";
+import type { ExplainPlanInput, ExplainStrategy, StoredExplainPlan } from "./types";
 import { postgresJsonStrategy } from "./postgres-json";
 import { mysqlJsonStrategy } from "./mysql-json";
 
 export type { ExplainMode, ExplainStrategy } from "./types";
+export type { ExplainPlanInput, ExplainTreeNode, StoredExplainPlan } from "./types";
 
 // Exhaustive by construction: adding an ExplainFormat member without a
 // registry entry is a compile error.
@@ -14,4 +15,17 @@ const registry: Record<ExplainFormat, ExplainStrategy> = {
 
 export function getExplainStrategy(format: ExplainFormat | undefined): ExplainStrategy | null {
   return format ? registry[format] : null;
+}
+
+function isStoredExplainPlan(value: unknown): value is StoredExplainPlan {
+  if (typeof value !== "object" || value === null || !("raw" in value)) return false;
+  const format = (value as { format?: unknown }).format;
+  return typeof format === "string" && format in registry;
+}
+
+/** Render boundary: QueryTab.explainPlan (unknown) -> tagged render model. Tolerates legacy raw postgres arrays. */
+export function resolveExplainPlan(value: unknown): ExplainPlanInput | null {
+  if (isStoredExplainPlan(value)) return registry[value.format].toRenderModel(value.raw);
+  if (Array.isArray(value)) return postgresJsonStrategy.toRenderModel(value);
+  return null;
 }

--- a/src/lib/explain/index.ts
+++ b/src/lib/explain/index.ts
@@ -2,6 +2,7 @@ import type { ExplainFormat } from "@/lib/db/types";
 import type { ExplainPlanInput, ExplainStrategy, StoredExplainPlan } from "./types";
 import { postgresJsonStrategy } from "./postgres-json";
 import { mysqlJsonStrategy } from "./mysql-json";
+import { sqliteQueryplanStrategy } from "./sqlite-queryplan";
 
 export type { ExplainMode, ExplainStrategy } from "./types";
 export type { ExplainPlanInput, ExplainTreeNode, StoredExplainPlan } from "./types";
@@ -11,6 +12,7 @@ export type { ExplainPlanInput, ExplainTreeNode, StoredExplainPlan } from "./typ
 const registry: Record<ExplainFormat, ExplainStrategy> = {
   "postgres-json": postgresJsonStrategy,
   "mysql-json": mysqlJsonStrategy,
+  "sqlite-queryplan": sqliteQueryplanStrategy,
 };
 
 export function getExplainStrategy(format: ExplainFormat | undefined): ExplainStrategy | null {

--- a/src/lib/explain/index.ts
+++ b/src/lib/explain/index.ts
@@ -22,7 +22,7 @@ export function getExplainStrategy(format: ExplainFormat | undefined): ExplainSt
 function isStoredExplainPlan(value: unknown): value is StoredExplainPlan {
   if (typeof value !== "object" || value === null || !("raw" in value)) return false;
   const format = (value as { format?: unknown }).format;
-  return typeof format === "string" && format in registry;
+  return typeof format === "string" && Object.hasOwn(registry, format);
 }
 
 /** Render boundary: QueryTab.explainPlan (unknown) -> tagged render model. Tolerates legacy raw postgres arrays. */

--- a/src/lib/explain/mysql-json.ts
+++ b/src/lib/explain/mysql-json.ts
@@ -1,4 +1,4 @@
-import type { ExplainStrategy } from "./types";
+import type { ExplainPlanResult, ExplainStrategy } from "./types";
 
 const SELECT_ONLY = /^\s*SELECT\b/i;
 
@@ -12,5 +12,10 @@ export const mysqlJsonStrategy: ExplainStrategy = {
   // "EXPLAIN" column, not "QUERY PLAN"; the real parser lands in #194 PR-4.
   extractPlan(result) {
     return result.rows?.[0]?.["QUERY PLAN"] || result.rows;
+  },
+  // B4 passthrough: renders exactly like today's cast until the real query_block parser lands in #194 PR-4.
+  toRenderModel(raw) {
+    if (!Array.isArray(raw) || raw.length === 0) return null;
+    return { kind: "postgres-json", plan: raw as ExplainPlanResult[] };
   },
 };

--- a/src/lib/explain/postgres-json.ts
+++ b/src/lib/explain/postgres-json.ts
@@ -1,4 +1,4 @@
-import type { ExplainStrategy } from "./types";
+import type { ExplainPlanResult, ExplainStrategy } from "./types";
 
 const SELECT_ONLY = /^\s*SELECT\b/i;
 
@@ -10,5 +10,9 @@ export const postgresJsonStrategy: ExplainStrategy = {
   },
   extractPlan(result) {
     return result.rows?.[0]?.["QUERY PLAN"] || result.rows;
+  },
+  toRenderModel(raw) {
+    if (!Array.isArray(raw) || raw.length === 0) return null;
+    return { kind: "postgres-json", plan: raw as ExplainPlanResult[] };
   },
 };

--- a/src/lib/explain/sqlite-queryplan.ts
+++ b/src/lib/explain/sqlite-queryplan.ts
@@ -1,0 +1,59 @@
+import type { ExplainStrategy, ExplainTreeNode } from "./types";
+
+const SELECT_ONLY = /^\s*SELECT\b/i;
+
+interface QueryPlanRow {
+  id: number;
+  parent: number;
+  detail: string;
+}
+
+function isQueryPlanRow(row: unknown): row is QueryPlanRow {
+  return (
+    typeof row === "object" &&
+    row !== null &&
+    typeof (row as QueryPlanRow).id === "number" &&
+    typeof (row as QueryPlanRow).parent === "number" &&
+    typeof (row as QueryPlanRow).detail === "string"
+  );
+}
+
+export const sqliteQueryplanStrategy: ExplainStrategy = {
+  format: "sqlite-queryplan",
+  // EXPLAIN QUERY PLAN (not bare EXPLAIN, which dumps VDBE opcodes) and it
+  // never executes the statement, so estimate and analyze are identical.
+  buildSql(sql) {
+    if (!SELECT_ONLY.test(sql.trim())) return null;
+    return `EXPLAIN QUERY PLAN ${sql}`;
+  },
+  extractPlan(result) {
+    return result.rows;
+  },
+  toRenderModel(raw) {
+    if (!Array.isArray(raw) || raw.length === 0 || !raw.every(isQueryPlanRow)) return null;
+    const nodes = new Map<number, ExplainTreeNode>();
+    for (const row of raw) {
+      nodes.set(row.id, { label: row.detail, children: [] });
+    }
+    const root: ExplainTreeNode = { label: "Query Plan", children: [] };
+    const attached = new Set<number>();
+    for (const row of raw) {
+      const node = nodes.get(row.id);
+      if (!node || attached.has(row.id)) continue;
+      const parent = row.parent !== row.id ? nodes.get(row.parent) : undefined;
+      // Cycle/orphan guard: anything without a resolvable acyclic parent hangs off the root.
+      if (parent && !isAncestor(node, parent)) {
+        parent.children.push(node);
+      } else {
+        root.children.push(node);
+      }
+      attached.add(row.id);
+    }
+    return { kind: "tree", root, raw };
+  },
+};
+
+function isAncestor(candidate: ExplainTreeNode, of: ExplainTreeNode): boolean {
+  if (candidate === of) return true;
+  return candidate.children.some((child) => isAncestor(child, of));
+}

--- a/src/lib/explain/types.ts
+++ b/src/lib/explain/types.ts
@@ -2,6 +2,44 @@ import type { ExplainFormat } from "@/lib/db/types";
 
 export type ExplainMode = "estimate" | "analyze";
 
+export type ExplainPlanNode = {
+  Plan?: ExplainPlanNode;
+  "Node Type"?: string;
+  "Actual Rows"?: number;
+  "Plan Rows"?: number;
+  "Actual Total Time"?: number;
+  "Total Cost"?: number;
+  "Shared Hit Blocks"?: number;
+  "Shared Read Blocks"?: number;
+  "Relation Name"?: string;
+  "Actual Loops"?: number;
+  Filter?: string;
+  "Index Name"?: string;
+  Plans?: ExplainPlanNode[];
+};
+
+export type ExplainPlanResult = {
+  Plan?: ExplainPlanNode;
+  "Execution Time"?: number;
+  "Planning Time"?: number;
+};
+
+export interface ExplainTreeNode {
+  label: string;
+  detail?: string;
+  metrics?: { estRows?: number; estCost?: number; actualRows?: number; actualTimeMs?: number };
+  children: ExplainTreeNode[];
+}
+
+export type ExplainPlanInput =
+  | { kind: "postgres-json"; plan: ExplainPlanResult[] }
+  | { kind: "tree"; root: ExplainTreeNode; raw: unknown };
+
+export interface StoredExplainPlan {
+  format: ExplainFormat;
+  raw: unknown;
+}
+
 /**
  * One strategy per ExplainFormat (registered in ./index.ts). Strategies are
  * pure and per-dialect-isolated: a change for one dialect must never touch
@@ -13,4 +51,6 @@ export interface ExplainStrategy {
   buildSql(sql: string, mode: ExplainMode): string | null;
   /** Maps a raw /api/db/query result to the value stored on QueryTab.explainPlan. Never throws. */
   extractPlan(result: { rows?: Array<Record<string, unknown>> }): unknown;
+  /** Maps the stored raw value to the VisualExplain render model. Never throws; null on foreign shapes. */
+  toRenderModel(raw: unknown): ExplainPlanInput | null;
 }

--- a/tests/components/VisualExplain.test.tsx
+++ b/tests/components/VisualExplain.test.tsx
@@ -904,4 +904,36 @@ describe("tree render model (sqlite-queryplan)", () => {
     expect(queryByText("execution")).toBeNull();
     expect(queryByText("cost")).toBeNull();
   });
+
+  test("resyncs the active tab when the mounted instance's plan kind changes", () => {
+    // BottomPanel keeps one VisualExplain mounted across query-tab/connection switches,
+    // so the SAME instance can flip from a postgres plan to a tree plan without unmounting.
+    const { rerender, getByText, queryByText } = render(<VisualExplain plan={samplePlan} query="SELECT 1" />);
+    // postgres kind defaults to the insights tab
+    expect(queryByText("Performance Issues")).not.toBeNull();
+
+    rerender(<VisualExplain plan={TREE_INPUT} query="SELECT 1" databaseType="sqlite" />);
+
+    // insights is unavailable for tree plans and the tree content must actually be
+    // visible — a stale "insights" activeTab would leave a blank content panel.
+    expect(queryByText("insights")).toBeNull();
+    expect(getByText("SCAN employee")).toBeTruthy();
+    expect(getByText("USING INDEX idx_dept")).toBeTruthy();
+  });
+
+  test("renders estimate badges for estimate-only metrics", () => {
+    const estimateTree = {
+      kind: "tree" as const,
+      root: {
+        label: "Query Plan",
+        children: [{ label: "SCAN employee", metrics: { estRows: 1200, estCost: 7 }, children: [] }],
+      },
+      raw: [],
+    };
+    const { getByText, queryByText } = render(<VisualExplain plan={estimateTree} />);
+    expect(getByText("~1.2K rows")).toBeTruthy();
+    expect(getByText("cost 7")).toBeTruthy();
+    // no fabricated actuals for an estimate-only node
+    expect(queryByText(/0 rows/)).toBeNull();
+  });
 });

--- a/tests/components/VisualExplain.test.tsx
+++ b/tests/components/VisualExplain.test.tsx
@@ -824,7 +824,12 @@ describe("VisualExplain", () => {
 // ============================================================================
 
 describe("tree render model (sqlite-queryplan)", () => {
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
   afterEach(() => {
+    globalThis.fetch = originalFetch;
     cleanup();
   });
 
@@ -935,5 +940,72 @@ describe("tree render model (sqlite-queryplan)", () => {
     expect(getByText("cost 7")).toBeTruthy();
     // no fabricated actuals for an estimate-only node
     expect(queryByText(/0 rows/)).toBeNull();
+  });
+
+  test("parent tree rows are keyboard-accessible; leaf rows are non-interactive", () => {
+    const { getByText, queryByText } = render(
+      <VisualExplain plan={TREE_INPUT} query="SELECT 1" databaseType="sqlite" />,
+    );
+
+    // "SCAN employee" has a child, so its row must be a focusable button
+    const parentRow = getByText("SCAN employee").closest('[role="button"]') as HTMLElement | null;
+    expect(parentRow).not.toBeNull();
+    expect(parentRow!.getAttribute("tabindex")).toBe("0");
+    expect(parentRow!.getAttribute("aria-expanded")).toBe("true");
+
+    // Enter collapses the children
+    parentRow!.focus();
+    fireEvent.keyDown(parentRow!, { key: "Enter" });
+    expect(queryByText("USING INDEX idx_dept")).toBeNull();
+    expect(parentRow!.getAttribute("aria-expanded")).toBe("false");
+
+    // Space expands them again
+    fireEvent.keyDown(parentRow!, { key: " " });
+    expect(queryByText("USING INDEX idx_dept")).not.toBeNull();
+
+    // any other key does nothing
+    fireEvent.keyDown(parentRow!, { key: "a" });
+    expect(queryByText("USING INDEX idx_dept")).not.toBeNull();
+
+    // the leaf row (no children) is a plain non-interactive div
+    const leafRow = getByText("USING INDEX idx_dept").parentElement!.parentElement!;
+    expect(leafRow.getAttribute("role")).toBeNull();
+    expect(leafRow.getAttribute("tabindex")).toBeNull();
+    expect(leafRow.className).not.toContain("cursor-pointer");
+  });
+
+  test("AI tab clears the previous plan's analysis when the plan changes", async () => {
+    const user = userEvent.setup();
+    globalThis.fetch = mockFetchStream("## Old Analysis\nPostgres plan details.") as unknown as typeof fetch;
+    const abortSpy = spyOn(AbortController.prototype, "abort");
+
+    try {
+      const { queryByText, rerender } = render(
+        <VisualExplain plan={samplePlan} query="SELECT * FROM users" databaseType="postgres" />,
+      );
+      fireEvent.click(queryByText("AI Explain")!);
+      await user.click(queryByText("Analyze with AI")!);
+      await waitFor(() => {
+        expect(queryByText("Old Analysis")).not.toBeNull();
+      });
+
+      // same mounted instance switches plans while the AI tab stays active
+      rerender(<VisualExplain plan={TREE_INPUT} query="SELECT 1" databaseType="sqlite" />);
+
+      await waitFor(() => {
+        // the previous plan's response is gone and the tab is back to its initial state
+        expect(queryByText("Old Analysis")).toBeNull();
+        expect(queryByText("AI Query Analysis")).not.toBeNull();
+        // the previous request's controller was aborted
+        expect(abortSpy).toHaveBeenCalled();
+      });
+    } finally {
+      abortSpy.mockRestore();
+    }
+  });
+
+  test("tagged postgres-json input with an empty plan falls back to the empty state", () => {
+    const { getByText } = render(<VisualExplain plan={{ kind: "postgres-json", plan: [] }} />);
+    expect(getByText("No execution plan")).toBeTruthy();
   });
 });

--- a/tests/components/VisualExplain.test.tsx
+++ b/tests/components/VisualExplain.test.tsx
@@ -818,3 +818,90 @@ describe("VisualExplain", () => {
     expect(chevrons.length).toBe(0);
   });
 });
+
+// ============================================================================
+// Tree render model (sqlite-queryplan and other tagged-tree strategies)
+// ============================================================================
+
+describe("tree render model (sqlite-queryplan)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const TREE_INPUT = {
+    kind: "tree" as const,
+    root: {
+      label: "Query Plan",
+      children: [{ label: "SCAN employee", children: [{ label: "USING INDEX idx_dept", children: [] }] }],
+    },
+    raw: [{ id: 3, parent: 0, notused: 0, detail: "SCAN employee" }],
+  };
+
+  test("renders the tree labels without fabricated metric badges", () => {
+    const { getByText, queryByText } = render(
+      <VisualExplain plan={TREE_INPUT} query="SELECT 1" databaseType="sqlite" />,
+    );
+    expect(getByText("SCAN employee")).toBeTruthy();
+    expect(getByText("USING INDEX idx_dept")).toBeTruthy();
+    expect(queryByText(/0 rows/)).toBeNull();
+  });
+
+  test("hides the insights tab for metric-less plans and defaults to tree", () => {
+    const { queryByText } = render(<VisualExplain plan={TREE_INPUT} query="SELECT 1" databaseType="sqlite" />);
+    expect(queryByText("insights")).toBeNull();
+  });
+
+  test("raw tab stringifies the raw rows", () => {
+    // switch to the raw tab per the file's existing tab-click helper, then:
+    const { getByText, queryByText } = render(
+      <VisualExplain plan={TREE_INPUT} query="SELECT 1" databaseType="sqlite" />,
+    );
+    fireEvent.click(queryByText("raw")!);
+    expect(getByText(/"detail": "SCAN employee"/)).toBeTruthy();
+  });
+
+  test("legacy array prop still renders the postgres pipeline", () => {
+    // reuse the file's existing postgres plan fixture through the UNCHANGED array prop
+    // and assert the insights tab is present — proves the widening is additive.
+    const { queryByText } = render(<VisualExplain plan={samplePlan} />);
+    expect(queryByText("insights")).not.toBeNull();
+  });
+
+  test("empty tree input falls back to the empty state", () => {
+    const { getByText } = render(<VisualExplain plan={null} query="" />);
+    expect(getByText("No execution plan")).toBeTruthy();
+  });
+
+  test("renders metric badges only for nodes that carry them", () => {
+    const treeWithMetrics = {
+      kind: "tree" as const,
+      root: {
+        label: "Query Plan",
+        children: [
+          {
+            label: "SCAN employee",
+            metrics: { actualRows: 42, actualTimeMs: 3.5 },
+            children: [],
+          },
+        ],
+      },
+      raw: [],
+    };
+    const { getByText, queryByText } = render(<VisualExplain plan={treeWithMetrics} />);
+    expect(getByText(/42 rows/)).toBeTruthy();
+    expect(getByText("3.50ms")).toBeTruthy();
+    // The root node itself carries no metrics, so it must not fabricate a badge.
+    expect(queryByText(/0 rows/)).toBeNull();
+  });
+
+  test("tree header shows a node count instead of postgres stat chips", () => {
+    const { getByText, queryByText } = render(
+      <VisualExplain plan={TREE_INPUT} query="SELECT 1" databaseType="sqlite" />,
+    );
+    // 3 nodes total: root + "SCAN employee" + "USING INDEX idx_dept"
+    expect(getByText("3")).toBeTruthy();
+    expect(getByText("nodes")).toBeTruthy();
+    expect(queryByText("execution")).toBeNull();
+    expect(queryByText("cost")).toBeNull();
+  });
+});

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -1366,6 +1366,40 @@ describe("useQueryExecution", () => {
     expect(body.sql).not.toContain("EXPLAIN");
   });
 
+  // ── background EXPLAIN stores a format-tagged wrapper ──────────────────
+
+  test("background EXPLAIN stores a format-tagged { format, raw } wrapper on the tab", async () => {
+    mockGlobalFetch({
+      "/api/db/query": {
+        ok: true,
+        json: { rows: [{ "QUERY PLAN": { plan: "Seq Scan" } }], fields: ["QUERY PLAN"], rowCount: 1, executionTime: 5 },
+      },
+    });
+
+    const snapshots: QueryTab[][] = [];
+    const setTabsMock = mock((fn: unknown) => {
+      if (typeof fn === "function") {
+        snapshots.push(fn([createTab()]));
+      }
+    });
+
+    const params = createDefaultParams({ setTabs: setTabsMock });
+
+    const { result } = renderHook(() => useQueryExecution(params));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT * FROM users");
+    });
+
+    // Let the fire-and-forget background EXPLAIN promise's .then() resolve
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    const tabWithPlan = snapshots.map((snapshot) => snapshot[0]).find((t) => t.explainPlan);
+    expect(tabWithPlan?.explainPlan).toEqual({ format: "postgres-json", raw: { plan: "Seq Scan" } });
+  });
+
   // ── setTabs updaters preserve non-target tabs ──────────────────────────
 
   test("QUERY_CANCELLED updater preserves non-target tabs", async () => {

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -246,8 +246,8 @@ describe("SQLiteProvider", () => {
 
       expect(caps.defaultPort).toBeNull();
       expect(caps.queryLanguage).toBe("sql");
-      expect(caps.supportsExplain).toBe(false);
-      expect(caps.explainFormat).toBeUndefined();
+      expect(caps.supportsExplain).toBe(true);
+      expect(caps.explainFormat).toBe("sqlite-queryplan");
       expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
       expect(caps.supportsConnectionString).toBe(false);
       expect(caps.maintenanceOperations).toContain("vacuum");

--- a/tests/unit/lib/explain/render-model.test.ts
+++ b/tests/unit/lib/explain/render-model.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test";
+import { resolveExplainPlan } from "@/lib/explain";
+import { postgresJsonStrategy } from "@/lib/explain/postgres-json";
+import { mysqlJsonStrategy } from "@/lib/explain/mysql-json";
+
+const PG_PLAN = [{ Plan: { "Node Type": "Seq Scan" } }];
+
+describe("toRenderModel", () => {
+  test("postgres-json wraps a non-empty array", () => {
+    expect(postgresJsonStrategy.toRenderModel(PG_PLAN)).toEqual({ kind: "postgres-json", plan: PG_PLAN });
+  });
+
+  test("postgres-json rejects foreign shapes", () => {
+    expect(postgresJsonStrategy.toRenderModel(null)).toBeNull();
+    expect(postgresJsonStrategy.toRenderModel({})).toBeNull();
+    expect(postgresJsonStrategy.toRenderModel([])).toBeNull();
+  });
+
+  // B4: deliberate legacy passthrough so MySQL renders exactly as today until PR-4.
+  test("mysql-json passes arrays through as postgres-json kind", () => {
+    const rows: Record<string, unknown>[] = [{ EXPLAIN: '{"query_block":{}}' }];
+    expect(mysqlJsonStrategy.toRenderModel(rows)).toEqual({ kind: "postgres-json", plan: rows });
+  });
+});
+
+describe("resolveExplainPlan", () => {
+  test("dispatches a stored wrapper through its format's strategy", () => {
+    expect(resolveExplainPlan({ format: "postgres-json", raw: PG_PLAN })).toEqual({
+      kind: "postgres-json",
+      plan: PG_PLAN,
+    });
+  });
+
+  test("tolerates legacy pre-wrapper tab state (raw postgres array)", () => {
+    expect(resolveExplainPlan(PG_PLAN)).toEqual({ kind: "postgres-json", plan: PG_PLAN });
+  });
+
+  test("returns null for null, garbage, and unknown formats", () => {
+    expect(resolveExplainPlan(null)).toBeNull();
+    expect(resolveExplainPlan(undefined)).toBeNull();
+    expect(resolveExplainPlan("nope")).toBeNull();
+    expect(resolveExplainPlan({ format: "not-a-format", raw: [] })).toBeNull();
+    expect(resolveExplainPlan({ format: "postgres-json" })).toBeNull();
+  });
+});

--- a/tests/unit/lib/explain/render-model.test.ts
+++ b/tests/unit/lib/explain/render-model.test.ts
@@ -42,4 +42,9 @@ describe("resolveExplainPlan", () => {
     expect(resolveExplainPlan({ format: "not-a-format", raw: [] })).toBeNull();
     expect(resolveExplainPlan({ format: "postgres-json" })).toBeNull();
   });
+
+  test("rejects prototype-chain keys masquerading as formats", () => {
+    expect(resolveExplainPlan({ format: "toString", raw: [] })).toBeNull();
+    expect(resolveExplainPlan({ format: "constructor", raw: [] })).toBeNull();
+  });
 });

--- a/tests/unit/lib/explain/sqlite-queryplan.test.ts
+++ b/tests/unit/lib/explain/sqlite-queryplan.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "bun:test";
+import { sqliteQueryplanStrategy } from "@/lib/explain/sqlite-queryplan";
+import type { ExplainTreeNode } from "@/lib/explain/types";
+
+const ROWS = [
+  { id: 3, parent: 0, notused: 0, detail: "SCAN employee" },
+  { id: 8, parent: 3, notused: 0, detail: "USING INDEX idx_dept" },
+  { id: 12, parent: 0, notused: 0, detail: "USE TEMP B-TREE FOR ORDER BY" },
+];
+
+describe("sqliteQueryplanStrategy", () => {
+  test("format id", () => {
+    expect(sqliteQueryplanStrategy.format).toBe("sqlite-queryplan");
+  });
+
+  test("buildSql wraps SELECT identically in both modes (EXPLAIN QUERY PLAN never executes)", () => {
+    expect(sqliteQueryplanStrategy.buildSql("SELECT * FROM employee", "estimate")).toBe(
+      "EXPLAIN QUERY PLAN SELECT * FROM employee",
+    );
+    expect(sqliteQueryplanStrategy.buildSql("SELECT * FROM employee", "analyze")).toBe(
+      "EXPLAIN QUERY PLAN SELECT * FROM employee",
+    );
+  });
+
+  test("buildSql returns null for non-SELECT", () => {
+    expect(sqliteQueryplanStrategy.buildSql("PRAGMA table_info(t)", "estimate")).toBeNull();
+    expect(sqliteQueryplanStrategy.buildSql("EXPLAIN QUERY PLAN SELECT 1", "estimate")).toBeNull();
+  });
+
+  test("extractPlan stores the raw rows", () => {
+    expect(sqliteQueryplanStrategy.extractPlan({ rows: ROWS })).toEqual(ROWS);
+    expect(sqliteQueryplanStrategy.extractPlan({})).toBeUndefined();
+  });
+
+  test("toRenderModel builds a parent-pointer tree under a synthetic root", () => {
+    const model = sqliteQueryplanStrategy.toRenderModel(ROWS);
+    expect(model?.kind).toBe("tree");
+    const root = (model as { root: ExplainTreeNode }).root;
+    expect(root.label).toBe("Query Plan");
+    expect(root.children.map((c) => c.label)).toEqual(["SCAN employee", "USE TEMP B-TREE FOR ORDER BY"]);
+    expect(root.children[0].children[0].label).toBe("USING INDEX idx_dept");
+    expect(root.children[0].children[0].metrics).toBeUndefined();
+  });
+
+  test("toRenderModel attaches orphaned parents to the root and survives cycles", () => {
+    const orphan = [{ id: 5, parent: 99, notused: 0, detail: "ORPHAN" }];
+    expect(sqliteQueryplanStrategy.toRenderModel(orphan)?.kind).toBe("tree");
+    const cyc = [
+      { id: 1, parent: 2, notused: 0, detail: "A" },
+      { id: 2, parent: 1, notused: 0, detail: "B" },
+    ];
+    const model = sqliteQueryplanStrategy.toRenderModel(cyc);
+    expect(model?.kind).toBe("tree"); // must terminate, not recurse forever
+  });
+
+  test("toRenderModel rejects foreign shapes", () => {
+    expect(sqliteQueryplanStrategy.toRenderModel(null)).toBeNull();
+    expect(sqliteQueryplanStrategy.toRenderModel([])).toBeNull();
+    expect(sqliteQueryplanStrategy.toRenderModel([{ nope: 1 }])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Part 3 of 5 for #194: SQLite connections get a working Explain — `EXPLAIN QUERY PLAN` end-to-end, rendered as a metric-honest tree. This resolves the SQLite half of the issue (the LibreDB half needs its own design and stays out of this series).

### What changed

- **Tagged render model** (`src/lib/explain/`): strategies gain `toRenderModel(raw)` producing `ExplainPlanInput` — `{ kind: "postgres-json", plan }` for the existing pipeline, `{ kind: "tree", root, raw }` for metric-less dialects. A single boundary, `resolveExplainPlan`, converts whatever is stored on the tab into the render model; it also tolerates legacy raw postgres arrays defensively (in-memory values and external prop callers — persisted tab restore drops `explainPlan` by design, see `use-tab-manager.ts`, so no localStorage migration is involved). `ExplainPlanNode`/`ExplainPlanResult` types moved to `src/lib/explain/types.ts` (re-exported from `VisualExplain` for compatibility).
- **sqlite-queryplan strategy**: `EXPLAIN QUERY PLAN <sql>` (never bare `EXPLAIN`, which dumps VDBE opcodes; it never executes the statement, so the background pre-warm is free). Its `{id, parent, notused, detail}` rows become a tree via parent pointers — cycle-guarded, orphan-tolerant, never throws. Extending the `ExplainFormat` union without a registry entry fails typecheck (the designed extension mechanism, exercised in this PR).
- **VisualExplain**: the `plan` prop widens additively (`ExplainPlanResult[] | ExplainPlanInput`) — array callers are pixel-identical. Tree plans render with tabs `tree | raw | AI` (no insights: its heuristics key off Postgres fields; nothing is fabricated), a node-count header instead of zeroed stat chips, badges only when a node actually carries metrics, and the active tab resyncs if a mounted instance's plan kind changes. BottomPanel consumes plans exclusively through a memoized `resolveExplainPlan`.
- **Hook**: stored explain plans become `{ format, raw }` wrappers (reader is legacy-tolerant, so old persisted state keeps rendering).
- **Provider triad** (same commit): `sqlite.ts` declares `supportsExplain: true` + `explainFormat: "sqlite-queryplan"`; `tests/integration/db/sqlite-provider.test.ts` flips; `docs/providers/sqlite.md` updates all four explain mentions.
- **E2E**: new Playwright spec on the zero-config SQLite sample — Explain tab visible, SELECT produces a `/SCAN|SEARCH/` tree node, no insights tab. Adds `data-testid="bottom-panel-tab-explain"`.

### npm surface

Additive only: `VisualExplain`'s `plan` prop union widens; no exported type is removed or narrowed; `build:lib` + `attw` (node16 CJS/ESM + bundler) green. Embedded platform workspace behavior unchanged (`metadata={null}` keeps the tab hidden there).

### Release note

SQLite connections now have a working Explain tab and button, rendering `EXPLAIN QUERY PLAN` as a tree. SQLite reports no per-node cost/timing, so no metrics are shown (the insights view is deliberately unavailable for such plans).

### Verification

All six local gates + `test:coverage`/`coverage:check` (100.00%, 25723/25723 lines) + `build:lib` + `attw` + full Playwright suite (38/38) green at the branch tip; independently re-verified by the whole-branch review. Manually verified against the running app: the SQLite sample shows the Explain tab, a SELECT pre-warms the plan, and the panel renders "Query Plan -> SCAN employee" with tabs tree/raw/AI and a 2-node count.

### Deferred (tracked)

- B4 (MySQL query_block parser) — part 4; the mysql strategy's passthrough is comment-marked and test-locked.
- B5 (Postgres EXPLAIN ANALYZE double execution) — part 5.
- Explain-affordance hardening follow-ups: #200 (Monaco context-menu staleness) and the newly filed non-SELECT direct-explain fallthrough issue.

Refs #194 (part 3/5)
