### PR TITLE
chore(release): bump version to 0.9.56 (chart 0.1.16)

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.15
-appVersion: "0.9.55"
+version: 0.1.16
+appVersion: "0.9.56"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.55
+      image: ghcr.io/libredb/libredb-studio:0.9.56
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.15 \
+  --version 0.1.16 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.55",
+  "version": "0.9.56",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Patch release prep for 0.9.56. Contents since 0.9.55: the #194 explain-architecture series parts 1-3 (#198 capability-driven explain strategy registry, #199 Explain button/tab honesty fixes, #202 SQLite EXPLAIN QUERY PLAN end-to-end). chart:bump included per the CI-enforced appVersion sync rule (#138). Local pre-release validation completed on main: all six gates + coverage 100.00% + build:lib/attw, and channel E2E green for tarball, npx, docker (image built and run locally), deb, and rpm (nfpm 2.47.0 CI parity); snap validation in progress on the local machine.