### PR TITLE
fix(logger): use a constant console format string on the stack-trace path (#100)

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -82,7 +82,9 @@ function log(level: LogLevel, message: string, error?: unknown, context?: LogCon
     if (errInfo.stack) {
       // Stack traces contain intentional newlines — sanitize control chars only
       const safeStack = errInfo.stack.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
-      console.error(full, "\n", safeStack);
+      // Constant format string: %s/%d in user-controlled text must never be
+      // interpreted as format specifiers (CodeQL js/tainted-format-string)
+      console.error("%s\n%s", full, safeStack);
     } else {
       console.error(full);
     }

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -63,7 +63,7 @@ describe("logger", () => {
     const err = new TypeError("something broke");
     logger.error("failure", err);
     expect(errorSpy).toHaveBeenCalledTimes(1);
-    // Stack path uses a constant format string; the line is the first argument
+    // Stack path call shape is ("%s\n%s", line, stack): the log line is at index 1
     const line = errorSpy.mock.calls[0][1] as string;
     expect(line).toContain("[ERROR]");
     expect(line).toContain("failure");
@@ -163,7 +163,7 @@ describe("logger", () => {
   test("error extraction: Error name and message appear in output", () => {
     const err = new RangeError("out of bounds");
     logger.error("bad range", err);
-    // Stack path uses a constant format string; the line is the first argument
+    // Stack path call shape is ("%s\n%s", line, stack): the log line is at index 1
     const line = errorSpy.mock.calls[0][1] as string;
     expect(line).toContain("RangeError");
     expect(line).toContain("out of bounds");

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -63,7 +63,8 @@ describe("logger", () => {
     const err = new TypeError("something broke");
     logger.error("failure", err);
     expect(errorSpy).toHaveBeenCalledTimes(1);
-    const line = errorSpy.mock.calls[0][0] as string;
+    // Stack path uses a constant format string; the line is the first argument
+    const line = errorSpy.mock.calls[0][1] as string;
     expect(line).toContain("[ERROR]");
     expect(line).toContain("failure");
     expect(line).toContain("TypeError");
@@ -162,7 +163,8 @@ describe("logger", () => {
   test("error extraction: Error name and message appear in output", () => {
     const err = new RangeError("out of bounds");
     logger.error("bad range", err);
-    const line = errorSpy.mock.calls[0][0] as string;
+    // Stack path uses a constant format string; the line is the first argument
+    const line = errorSpy.mock.calls[0][1] as string;
     expect(line).toContain("RangeError");
     expect(line).toContain("out of bounds");
   });
@@ -194,5 +196,22 @@ describe("logger", () => {
     logger.error("null error", null);
     const line = errorSpy.mock.calls[0][0] as string;
     expect(line).not.toContain(" | ");
+  });
+
+  // ─── Format-string safety (CodeQL js/tainted-format-string) ──────────────
+
+  test("stack-trace path keeps user text out of the console format-string position", () => {
+    const err = new TypeError("boom with %s and %d specifiers");
+    logger.error("user-controlled %s message", err);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const call = errorSpy.mock.calls[0];
+    // First argument must be a constant format string; the log line and the
+    // stack are passed as arguments so %s/%d in user text is never interpreted.
+    expect(call[0]).toBe("%s\n%s");
+    const line = call[1] as string;
+    expect(line).toContain("[ERROR]");
+    expect(line).toContain("user-controlled %s message");
+    expect(line).toContain("TypeError");
+    expect(call[2] as string).toContain("boom with %s and %d specifiers");
   });
 });


### PR DESCRIPTION
Part of the CodeQL triage tracked in #100 (section 2).

## Problem

CodeQL `js/tainted-format-string` (alert 82, high): on the stack-trace path, `logger.ts` passed the log line as the first argument of `console.error(full, "\n", safeStack)`. The line is sanitized against log injection (CR/LF and control chars stripped), but it still contains user-controlled text (message, context values, error message), and the first argument of a multi-argument `console.*` call is a format string. A `%s`/`%d` inside a user-supplied message or error text would be interpreted as a format specifier and consume the stack argument, corrupting the log record.

## Fix

Pass a constant format string instead:

```ts
console.error("%s\n%s", full, safeStack);
```

User text now only ever appears as a formatting argument, never in the format-string position. Output is unchanged apart from no longer being reformattable by user input (verified against a real, unmocked run: `%s`/`%d` stay literal, the stack prints on its own line).

## Triage context (rest of the 13 open alerts)

This was the only alert of the 13 needing a code change. The other 12 were dismissed with written justifications, per the checklist in #100:

- 5x `js/log-injection` (logger.ts:96/99/102, factory.ts:58, base-provider.ts:261) - false positive: every value passes through an inline sanitizer stripping CR/LF and control chars immediately before the sink; CodeQL does not model the custom sanitizer.
- 1x `js/log-injection` (logger.ts:85) - by design: the stack-trace argument is intentionally multi-line; control chars are stripped and stacks are only printed outside production.
- 4x `js/sql-injection` (mssql.ts, mongodb.ts x3) - by design: Studio is a database IDE; these lines execute the user's own query/operation against their own configured connection (MSSQL via `request.query` with optional `request.input` bind parameters, MongoDB via the official driver's structured API).
- 2x `js/path-injection` (sqlite.ts:176-177) - by design: the SQLite path is user-configured, trusted server-side input (documented in `docs/providers/sqlite.md`); NUL bytes are rejected and the path resolved; parent-dir creation is intentional first-run behavior.

## Testing (TDD)

- New failing test first: `stack-trace path keeps user text out of the console format-string position` - asserts the constant `"%s\n%s"` first argument and that user text (including literal `%s`/`%d`) lands in the arguments.
- Two existing tests that read the log line from the first argument were updated to read it from the second (the call shape intentionally changed).

## Verification

All local gates pass: `format` / `lint` / `typecheck` / `knip` / `test` (20 groups) / `build`, plus `test:coverage && coverage:check` (100.00%, 25753/25753 lines).
