### PR TITLE
fix(a11y): resolve jsx-a11y warnings in app components (#100, a11y 1/2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ docs/summaries/
 
 # Maintainer loop runtime artifacts (not source)
 .loop/
+.tokens

--- a/e2e/tab-management.spec.ts
+++ b/e2e/tab-management.spec.ts
@@ -9,56 +9,46 @@ test.describe("Tab Management", () => {
     await page.getByRole("button", { name: "Sign In" }).click();
     await page.waitForURL("/");
     // Wait for studio to fully load
-    await expect(page.locator("text=Query 1").first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("tab", { name: "Query 1" })).toBeVisible({ timeout: 10000 });
   });
 
   test("default tab exists with name Query 1", async ({ page }) => {
-    await expect(page.locator("text=Query 1").first()).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Query 1" })).toBeVisible();
   });
 
   test("can add a new tab", async ({ page }) => {
-    // The tab bar's plus icon is a sibling of the "Query 1" tab div
-    // Navigate from Query 1 text → its parent tab div → the parent tab bar → find the direct child SVG plus
-    const query1Parent = page.locator("text=Query 1").first().locator("..");
-    const tabBar = query1Parent.locator("..");
-    const tabPlusIcon = tabBar.locator(":scope > svg").first();
-    await tabPlusIcon.click();
+    await page.getByRole("button", { name: "New tab" }).click();
 
     // New tab "Query 2" should appear
-    await expect(page.locator("text=Query 2")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("tab", { name: "Query 2" })).toBeVisible({ timeout: 5000 });
   });
 
   test("can switch between tabs", async ({ page }) => {
-    // Add a second tab using the same strategy
-    const query1Parent = page.locator("text=Query 1").first().locator("..");
-    const tabBar = query1Parent.locator("..");
-    const tabPlusIcon = tabBar.locator(":scope > svg").first();
-    await tabPlusIcon.click();
-    await expect(page.locator("text=Query 2")).toBeVisible({ timeout: 5000 });
+    // Add a second tab; the new tab becomes the active one
+    await page.getByRole("button", { name: "New tab" }).click();
+    const queryTab1 = page.getByRole("tab", { name: "Query 1" });
+    const queryTab2 = page.getByRole("tab", { name: "Query 2" });
+    await expect(queryTab2).toBeVisible({ timeout: 5000 });
+    await expect(queryTab2).toHaveAttribute("aria-selected", "true");
 
     // Click on Query 1 to switch back
-    await page.locator("text=Query 1").first().click();
-    await page.waitForTimeout(300);
+    await queryTab1.click();
+    await expect(queryTab1).toHaveAttribute("aria-selected", "true");
+    await expect(queryTab2).toHaveAttribute("aria-selected", "false");
   });
 
   test("can close a tab when multiple exist", async ({ page }) => {
     // Add a second tab
-    const query1Parent = page.locator("text=Query 1").first().locator("..");
-    const tabBar = query1Parent.locator("..");
-    const tabPlusIcon = tabBar.locator(":scope > svg").first();
-    await tabPlusIcon.click();
-    await expect(page.locator("text=Query 2")).toBeVisible({ timeout: 5000 });
+    await page.getByRole("button", { name: "New tab" }).click();
+    await expect(page.getByRole("tab", { name: "Query 2" })).toBeVisible({ timeout: 5000 });
 
-    // Close Query 2 — the X icon is inside the Query 2 tab div
-    // Hover the tab to reveal the X icon, then click
-    const query2Parent = page.locator("text=Query 2").first().locator("..");
-    await query2Parent.hover();
-    const closeIcon = query2Parent.locator("svg").last();
-    await closeIcon.click();
+    // Hover the tab to reveal its close button, then click it
+    await page.getByRole("tab", { name: "Query 2" }).hover();
+    await page.getByRole("button", { name: "Close Query 2" }).click();
 
     // Query 2 should no longer exist
-    await expect(page.locator("text=Query 2")).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole("tab", { name: "Query 2" })).not.toBeVisible({ timeout: 3000 });
     // Query 1 should still exist
-    await expect(page.locator("text=Query 1").first()).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Query 1" })).toBeVisible();
   });
 });

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -162,6 +162,7 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
             href="https://libredb.org"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="LibreDB Studio website"
             className="flex flex-col items-center gap-4 lg:hidden group"
           >
             <div className="relative">

--- a/src/components/DataImportModal.tsx
+++ b/src/components/DataImportModal.tsx
@@ -306,11 +306,12 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
           {/* Step 1: Upload */}
           {step === "upload" && (
             <div className="p-4">
-              <div
+              <button
+                type="button"
                 onDrop={handleDrop}
                 onDragOver={handleDragOver}
                 onClick={() => fileInputRef.current?.click()}
-                className="border-2 border-dashed border-white/10 rounded-xl p-12 text-center cursor-pointer hover:border-blue-500/30 hover:bg-blue-500/5 transition-all"
+                className="w-full border-2 border-dashed border-white/10 rounded-xl p-12 text-center cursor-pointer hover:border-blue-500/30 hover:bg-blue-500/5 transition-all"
               >
                 <Upload strokeWidth={1.5} className="w-10 h-10 text-zinc-600 mx-auto mb-4" />
                 <p className="text-xs text-zinc-400 mb-1">Drop a file here or click to browse</p>
@@ -325,7 +326,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                     <span className="text-xs">JSON</span>
                   </div>
                 </div>
-              </div>
+              </button>
               <input
                 ref={fileInputRef}
                 type="file"
@@ -428,7 +429,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
             <div className="p-4 space-y-4">
               {/* Target Table */}
               <div className="space-y-2">
-                <label className="text-xs text-zinc-400 font-medium">Target Table</label>
+                <span className="text-xs text-zinc-400 font-medium">Target Table</span>
                 <div className="flex items-center gap-2">
                   <button
                     className={cn(
@@ -459,8 +460,11 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
 
               {createNewTable ? (
                 <div>
-                  <label className="text-xs text-zinc-400">New Table Name</label>
+                  <label htmlFor="import-new-table-name" className="text-xs text-zinc-400">
+                    New Table Name
+                  </label>
                   <Input
+                    id="import-new-table-name"
                     value={newTableName}
                     onChange={(e) => setNewTableName(e.target.value)}
                     placeholder="imported_data"
@@ -469,8 +473,11 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                 </div>
               ) : (
                 <div>
-                  <label className="text-xs text-zinc-400">Select Table</label>
+                  <label htmlFor="import-target-table" className="text-xs text-zinc-400">
+                    Select Table
+                  </label>
                   <select
+                    id="import-target-table"
                     value={targetTable}
                     onChange={(e) => setTargetTable(e.target.value)}
                     className="w-full mt-1 bg-[#111] border border-white/10 rounded-md px-3 py-2 text-xs text-zinc-300 outline-none focus:border-blue-500/40"
@@ -487,7 +494,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
 
               {/* Column Mapping */}
               <div className="space-y-2">
-                <label className="text-xs text-zinc-400 font-medium">Column Mapping</label>
+                <span className="text-xs text-zinc-400 font-medium">Column Mapping</span>
                 <div className="border border-white/5 rounded-lg overflow-hidden">
                   <div className="bg-[#0d0d0d] grid grid-cols-[1fr,auto,1fr] gap-2 px-3 py-1.5 text-xs text-zinc-500 border-b border-white/5">
                     <span>Source Column</span>

--- a/src/components/DataImportModal.tsx
+++ b/src/components/DataImportModal.tsx
@@ -510,6 +510,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                         <span className="text-xs text-zinc-300 font-mono truncate">{header}</span>
                         <ArrowRight strokeWidth={1.5} className="w-3 h-3 text-zinc-600" />
                         <Input
+                          aria-label={`Target column for ${header}`}
                           value={columnMapping[header] || ""}
                           onChange={(e) => setColumnMapping((prev) => ({ ...prev, [header]: e.target.value }))}
                           className="h-7 text-xs bg-[#111] border-white/10"

--- a/src/components/MaskingSettings.tsx
+++ b/src/components/MaskingSettings.tsx
@@ -191,6 +191,7 @@ export function MaskingSettings() {
                   <label htmlFor="masking-admin-can-toggle" className="flex items-center gap-2 text-xs text-zinc-400">
                     <Switch
                       id="masking-admin-can-toggle"
+                      aria-label="Admin can toggle"
                       checked={config.roleSettings.admin.canToggle}
                       onCheckedChange={(v) => updateRoleSetting("admin", "canToggle", v)}
                     />
@@ -199,6 +200,7 @@ export function MaskingSettings() {
                   <label htmlFor="masking-admin-can-reveal" className="flex items-center gap-2 text-xs text-zinc-400">
                     <Switch
                       id="masking-admin-can-reveal"
+                      aria-label="Admin can reveal"
                       checked={config.roleSettings.admin.canReveal}
                       onCheckedChange={(v) => updateRoleSetting("admin", "canReveal", v)}
                     />
@@ -217,6 +219,7 @@ export function MaskingSettings() {
                   <label htmlFor="masking-user-can-toggle" className="flex items-center gap-2 text-xs text-zinc-400">
                     <Switch
                       id="masking-user-can-toggle"
+                      aria-label="User can toggle"
                       checked={config.roleSettings.user.canToggle}
                       onCheckedChange={(v) => updateRoleSetting("user", "canToggle", v)}
                     />
@@ -225,6 +228,7 @@ export function MaskingSettings() {
                   <label htmlFor="masking-user-can-reveal" className="flex items-center gap-2 text-xs text-zinc-400">
                     <Switch
                       id="masking-user-can-reveal"
+                      aria-label="User can reveal"
                       checked={config.roleSettings.user.canReveal}
                       onCheckedChange={(v) => updateRoleSetting("user", "canReveal", v)}
                     />

--- a/src/components/MaskingSettings.tsx
+++ b/src/components/MaskingSettings.tsx
@@ -188,15 +188,17 @@ export function MaskingSettings() {
                   </Badge>
                 </div>
                 <div className="flex items-center gap-6">
-                  <label className="flex items-center gap-2 text-xs text-zinc-400">
+                  <label htmlFor="masking-admin-can-toggle" className="flex items-center gap-2 text-xs text-zinc-400">
                     <Switch
+                      id="masking-admin-can-toggle"
                       checked={config.roleSettings.admin.canToggle}
                       onCheckedChange={(v) => updateRoleSetting("admin", "canToggle", v)}
                     />
                     Can toggle
                   </label>
-                  <label className="flex items-center gap-2 text-xs text-zinc-400">
+                  <label htmlFor="masking-admin-can-reveal" className="flex items-center gap-2 text-xs text-zinc-400">
                     <Switch
+                      id="masking-admin-can-reveal"
                       checked={config.roleSettings.admin.canReveal}
                       onCheckedChange={(v) => updateRoleSetting("admin", "canReveal", v)}
                     />
@@ -212,15 +214,17 @@ export function MaskingSettings() {
                   </Badge>
                 </div>
                 <div className="flex items-center gap-6">
-                  <label className="flex items-center gap-2 text-xs text-zinc-400">
+                  <label htmlFor="masking-user-can-toggle" className="flex items-center gap-2 text-xs text-zinc-400">
                     <Switch
+                      id="masking-user-can-toggle"
                       checked={config.roleSettings.user.canToggle}
                       onCheckedChange={(v) => updateRoleSetting("user", "canToggle", v)}
                     />
                     Can toggle
                   </label>
-                  <label className="flex items-center gap-2 text-xs text-zinc-400">
+                  <label htmlFor="masking-user-can-reveal" className="flex items-center gap-2 text-xs text-zinc-400">
                     <Switch
+                      id="masking-user-can-reveal"
                       checked={config.roleSettings.user.canReveal}
                       onCheckedChange={(v) => updateRoleSetting("user", "canReveal", v)}
                     />
@@ -332,13 +336,22 @@ export function MaskingSettings() {
           </DialogHeader>
           <div className="space-y-4 py-4">
             <div className="space-y-2">
-              <label className="text-xs font-medium text-zinc-300">Name</label>
-              <Input value={editName} onChange={(e) => setEditName(e.target.value)} placeholder="Pattern name" />
+              <label htmlFor="masking-pattern-name" className="text-xs font-medium text-zinc-300">
+                Name
+              </label>
+              <Input
+                id="masking-pattern-name"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                placeholder="Pattern name"
+              />
             </div>
             <div className="space-y-2">
-              <label className="text-xs font-medium text-zinc-300">Mask Type</label>
+              <label htmlFor="masking-mask-type" className="text-xs font-medium text-zinc-300">
+                Mask Type
+              </label>
               <Select value={editMaskType} onValueChange={(v) => setEditMaskType(v as MaskType)}>
-                <SelectTrigger>
+                <SelectTrigger id="masking-mask-type">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -352,8 +365,11 @@ export function MaskingSettings() {
             </div>
             {editMaskType === "custom" && (
               <div className="space-y-2">
-                <label className="text-xs font-medium text-zinc-300">Custom Mask String</label>
+                <label htmlFor="masking-custom-mask" className="text-xs font-medium text-zinc-300">
+                  Custom Mask String
+                </label>
                 <Input
+                  id="masking-custom-mask"
                   value={editCustomMask}
                   onChange={(e) => setEditCustomMask(e.target.value)}
                   placeholder="e.g. ***"
@@ -361,8 +377,11 @@ export function MaskingSettings() {
               </div>
             )}
             <div className="space-y-2">
-              <label className="text-xs font-medium text-zinc-300">Column Patterns (one per line)</label>
+              <label htmlFor="masking-column-patterns" className="text-xs font-medium text-zinc-300">
+                Column Patterns (one per line)
+              </label>
               <textarea
+                id="masking-column-patterns"
                 className="w-full h-32 bg-[#0a0a0a] border border-white/10 rounded-md px-3 py-2 text-xs font-mono text-zinc-200 focus:outline-none focus:ring-1 focus:ring-purple-500/50 resize-none"
                 value={editColumnPatterns}
                 onChange={(e) => setEditColumnPatterns(e.target.value)}

--- a/src/components/QueryHistory.tsx
+++ b/src/components/QueryHistory.tsx
@@ -299,7 +299,9 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                       />
                     </div>
                   </th>
-                  <th className="px-4 py-3 w-20"></th>
+                  <th className="px-4 py-3 w-20">
+                    <span className="sr-only">Actions</span>
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/5">
@@ -322,6 +324,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                         )}
                       </div>
                     </td>
+                    {/* oxlint-disable-next-line jsx-a11y/control-has-associated-label -- cell text is dynamic; oxlint cannot see expressions through the wrapper div */}
                     <td className="px-4 py-4 whitespace-nowrap">
                       <div className="flex flex-col">
                         <span className="text-zinc-200 font-medium">
@@ -332,6 +335,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                         </span>
                       </div>
                     </td>
+                    {/* oxlint-disable-next-line jsx-a11y/control-has-associated-label -- cell text is dynamic; oxlint cannot see expressions through the wrapper div */}
                     <td className="px-4 py-4 whitespace-nowrap">
                       <div className="flex flex-col gap-1">
                         <div className="flex items-center gap-1.5 text-zinc-300">

--- a/src/components/ResultsGrid.tsx
+++ b/src/components/ResultsGrid.tsx
@@ -186,8 +186,9 @@ export function ResultsGrid({
         const isSensitive = effectiveMaskingEnabled && sensitiveColumns.has(field);
         return (
           <div className="flex items-center gap-1 select-none group/header w-full">
-            <div
-              className="flex items-center gap-1 cursor-pointer flex-1 min-w-0"
+            <button
+              type="button"
+              className="flex items-center gap-1 cursor-pointer flex-1 min-w-0 text-left"
               onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
             >
               <span className="truncate">{field}</span>
@@ -201,7 +202,7 @@ export function ResultsGrid({
                 {column.getIsSorted() === "desc" && <ArrowDown strokeWidth={1.5} className="w-3 h-3" />}
                 {!column.getIsSorted() && <ArrowUpDown strokeWidth={1.5} className="w-3 h-3" />}
               </div>
-            </div>
+            </button>
             <button
               className={cn(
                 "shrink-0 p-0.5 rounded transition-colors",
@@ -219,6 +220,7 @@ export function ResultsGrid({
             </button>
             {activeFilterCol === field && (
               <div
+                role="presentation"
                 className="absolute top-full left-0 mt-1 z-30 bg-[#111] border border-white/10 rounded-lg shadow-xl p-2 w-48"
                 onClick={(e) => e.stopPropagation()}
               >
@@ -262,7 +264,7 @@ export function ResultsGrid({
 
         if (isEditing) {
           return (
-            <div className="flex items-center gap-1 w-full" onClick={(e) => e.stopPropagation()}>
+            <div role="presentation" className="flex items-center gap-1 w-full" onClick={(e) => e.stopPropagation()}>
               <input
                 autoFocus
                 className="w-full bg-zinc-800 border border-blue-500 rounded px-1 py-0.5 text-zinc-100 outline-none"
@@ -504,7 +506,8 @@ export function ResultsGrid({
             {mobileTableVirtualizer.getVirtualItems().map((virtualRow) => {
               const row = result.rows[virtualRow.index];
               return (
-                <div
+                <button
+                  type="button"
                   key={virtualRow.index}
                   style={{
                     position: "absolute",
@@ -514,7 +517,7 @@ export function ResultsGrid({
                     height: `${virtualRow.size}px`,
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
-                  className="flex hover:bg-blue-500/[0.03] transition-colors border-b border-white/5 cursor-pointer"
+                  className="flex hover:bg-blue-500/[0.03] transition-colors border-b border-white/5 cursor-pointer text-left"
                   onClick={() => setSelectedRow({ row, index: virtualRow.index })}
                 >
                   {result.fields.map((field, idx) => {
@@ -539,7 +542,7 @@ export function ResultsGrid({
                       </div>
                     );
                   })}
-                </div>
+                </button>
               );
             })}
           </div>
@@ -559,6 +562,7 @@ export function ResultsGrid({
                   {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
 
                   <div
+                    aria-hidden="true"
                     onMouseDown={header.getResizeHandler()}
                     onTouchStart={header.getResizeHandler()}
                     className={cn(

--- a/src/components/ResultsGrid.tsx
+++ b/src/components/ResultsGrid.tsx
@@ -188,6 +188,9 @@ export function ResultsGrid({
           <div className="flex items-center gap-1 select-none group/header w-full">
             <button
               type="button"
+              aria-label={`${field}${
+                column.getIsSorted() ? `, sorted ${column.getIsSorted() === "asc" ? "ascending" : "descending"}` : ""
+              }`}
               className="flex items-center gap-1 cursor-pointer flex-1 min-w-0 text-left"
               onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
             >

--- a/src/components/SavedQueries.tsx
+++ b/src/components/SavedQueries.tsx
@@ -68,23 +68,36 @@ export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: 
             {filteredQueries.map((q) => (
               <div
                 key={q.id}
-                className="bg-[#0a0a0a] p-4 hover:bg-white/[0.02] transition-colors group cursor-pointer"
-                onClick={() => onSelectQuery(q.query)}
+                className="relative bg-[#0a0a0a] p-4 hover:bg-white/[0.02] transition-colors group cursor-pointer"
               >
                 <div className="flex items-start justify-between mb-2">
                   <div>
-                    <h4 className="text-xs font-medium text-blue-400 mb-1 group-hover:text-blue-300 transition-colors">
-                      {q.name}
+                    <h4 className="text-xs font-medium mb-1">
+                      {/* Stretched-link pattern: the button's ::after overlay makes the
+                          whole card clickable while nested action buttons stay above it */}
+                      <button
+                        type="button"
+                        className="text-blue-400 group-hover:text-blue-300 transition-colors cursor-pointer text-left after:absolute after:inset-0"
+                        onClick={() => onSelectQuery(q.query)}
+                      >
+                        {q.name}
+                      </button>
                     </h4>
                     {q.description && <p className="text-xs text-zinc-500 line-clamp-1">{q.description}</p>}
                   </div>
-                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <Button variant="ghost" size="icon" className="h-6 w-6 text-zinc-500 hover:text-white">
+                  <div className="relative z-10 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Edit ${q.name}`}
+                      className="h-6 w-6 text-zinc-500 hover:text-white"
+                    >
                       <Edit3 strokeWidth={1.5} className="w-3 h-3" />
                     </Button>
                     <Button
                       variant="ghost"
                       size="icon"
+                      aria-label={`Delete ${q.name}`}
                       className="h-6 w-6 text-zinc-500 hover:text-red-400"
                       onClick={(e) => handleDelete(q.id, e)}
                     >

--- a/src/components/SavedQueries.tsx
+++ b/src/components/SavedQueries.tsx
@@ -85,12 +85,13 @@ export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: 
                     </h4>
                     {q.description && <p className="text-xs text-zinc-500 line-clamp-1">{q.description}</p>}
                   </div>
-                  <div className="relative z-10 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="relative z-10 flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity">
                     <Button
                       variant="ghost"
                       size="icon"
                       aria-label={`Edit ${q.name}`}
                       className="h-6 w-6 text-zinc-500 hover:text-white"
+                      onClick={() => onSelectQuery(q.query)}
                     >
                       <Edit3 strokeWidth={1.5} className="w-3 h-3" />
                     </Button>

--- a/src/components/SnapshotTimeline.tsx
+++ b/src/components/SnapshotTimeline.tsx
@@ -16,8 +16,10 @@ interface SnapshotTimelineProps {
 // multi-line JSX text and attribute tails are otherwise unattributable.
 const EMPTY_MESSAGE = "No snapshots taken yet. Take a snapshot to start tracking schema changes.";
 const NODE_CLASS = "relative flex flex-col items-center min-w-[100px] cursor-pointer group";
+// w-6 h-6 keeps a 24x24 minimum hit target: the control sits on top of the
+// stretched selection overlay, so a near miss must not select the snapshot.
 const DELETE_BUTTON_CLASS =
-  "absolute -top-2 -right-1 z-20 p-0.5 text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity";
+  "absolute -top-3 -right-2 z-20 w-6 h-6 flex items-center justify-center text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity";
 
 export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTimelineProps) {
   const [selected, setSelected] = useState<string[]>([]);

--- a/src/components/SnapshotTimeline.tsx
+++ b/src/components/SnapshotTimeline.tsx
@@ -17,7 +17,7 @@ interface SnapshotTimelineProps {
 const EMPTY_MESSAGE = "No snapshots taken yet. Take a snapshot to start tracking schema changes.";
 const NODE_CLASS = "relative flex flex-col items-center min-w-[100px] cursor-pointer group";
 const DELETE_BUTTON_CLASS =
-  "absolute -top-2 -right-1 p-0.5 text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity";
+  "absolute -top-2 -right-1 z-20 p-0.5 text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity";
 
 export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTimelineProps) {
   const [selected, setSelected] = useState<string[]>([]);
@@ -77,19 +77,20 @@ export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTim
                   "w-3.5 h-3.5 rounded-full border-2 z-10 transition-all",
                   isSelected
                     ? "bg-blue-500 border-blue-400 scale-125"
-                    : "bg-[#0d0d0d] border-white/20 hover:border-white/40",
+                    : "bg-[#0d0d0d] border-white/20 group-hover:border-white/40",
                 )}
               />
 
               {idx < sorted.length - 1 && <div className="absolute top-[7px] left-[50%] w-full h-[2px] bg-white/10" />}
 
               {/* Stretched-link pattern: the button's ::after overlay makes the
-                  whole node clickable; the delete button below paints above it */}
+                  whole node clickable. after:z-10 lifts it above the z-10 dot
+                  flex item; the z-20 delete button stays on top. */}
               <button
                 type="button"
                 aria-pressed={isSelected}
                 onClick={() => handleClick(snapshot.id)}
-                className={cn(labelClass, "cursor-pointer after:absolute after:inset-0")}
+                className={cn(labelClass, "cursor-pointer after:absolute after:inset-0 after:z-10")}
               >
                 <div className="text-xs font-medium truncate max-w-[90px]">
                   {snapshot.label || snapshot.connectionName}

--- a/src/components/SnapshotTimeline.tsx
+++ b/src/components/SnapshotTimeline.tsx
@@ -87,6 +87,7 @@ export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTim
                   whole node clickable; the delete button below paints above it */}
               <button
                 type="button"
+                aria-pressed={isSelected}
                 onClick={() => handleClick(snapshot.id)}
                 className={cn(labelClass, "cursor-pointer after:absolute after:inset-0")}
               >

--- a/src/components/SnapshotTimeline.tsx
+++ b/src/components/SnapshotTimeline.tsx
@@ -69,25 +69,9 @@ export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTim
             e.stopPropagation();
             onDelete(snapshot.id);
           };
-          const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-            // Ignore keydown bubbling from the nested delete button so its
-            // native Enter/Space activation is not hijacked into selection.
-            if (e.target !== e.currentTarget) return;
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              handleClick(snapshot.id);
-            }
-          };
 
           return (
-            <div
-              key={snapshot.id}
-              className={NODE_CLASS}
-              role="button"
-              tabIndex={0}
-              onClick={() => handleClick(snapshot.id)}
-              onKeyDown={handleKeyDown}
-            >
+            <div key={snapshot.id} className={NODE_CLASS}>
               <div
                 className={cn(
                   "w-3.5 h-3.5 rounded-full border-2 z-10 transition-all",
@@ -99,7 +83,13 @@ export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTim
 
               {idx < sorted.length - 1 && <div className="absolute top-[7px] left-[50%] w-full h-[2px] bg-white/10" />}
 
-              <div className={labelClass}>
+              {/* Stretched-link pattern: the button's ::after overlay makes the
+                  whole node clickable; the delete button below paints above it */}
+              <button
+                type="button"
+                onClick={() => handleClick(snapshot.id)}
+                className={cn(labelClass, "cursor-pointer after:absolute after:inset-0")}
+              >
                 <div className="text-xs font-medium truncate max-w-[90px]">
                   {snapshot.label || snapshot.connectionName}
                 </div>
@@ -109,9 +99,13 @@ export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTim
                 <Badge variant="secondary" className="text-[0.625rem] mt-1">
                   {snapshot.schema.length} tables
                 </Badge>
-              </div>
+              </button>
 
-              <button onClick={handleDelete} className={DELETE_BUTTON_CLASS}>
+              <button
+                onClick={handleDelete}
+                aria-label={`Delete ${snapshot.label || snapshot.connectionName}`}
+                className={DELETE_BUTTON_CLASS}
+              >
                 <Trash2 strokeWidth={1.5} className="w-2.5 h-2.5" />
               </button>
             </div>

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -242,7 +242,10 @@ const PlanNode = ({ node, depth = 0, maxTime }: { node: ExplainPlanNode; depth?:
         type="button"
         aria-expanded={expanded}
         className={cn(
-          "w-full text-left group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5",
+          // display:flex makes the button block-level with auto width, so the
+          // depth margin is deducted from the available width (w-full would
+          // overflow by depth * 20px)
+          "text-left group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5",
           depth === 0 && "bg-white/[0.02]",
         )}
         onClick={() => setExpanded(!expanded)}
@@ -400,7 +403,7 @@ const TreeNodeView = ({ node, depth = 0 }: { node: ExplainTreeNode; depth?: numb
       {hasChildren ? (
         <button
           type="button"
-          className="w-full text-left group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5"
+          className="text-left group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5"
           onClick={toggle}
           aria-expanded={expanded}
           style={{ marginLeft: depth * 20 }}

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -238,9 +238,11 @@ const PlanNode = ({ node, depth = 0, maxTime }: { node: ExplainPlanNode; depth?:
   return (
     <div className="relative">
       {/* Node */}
-      <div
+      <button
+        type="button"
+        aria-expanded={expanded}
         className={cn(
-          "group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5",
+          "w-full text-left group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5",
           depth === 0 && "bg-white/[0.02]",
         )}
         onClick={() => setExpanded(!expanded)}
@@ -294,7 +296,7 @@ const PlanNode = ({ node, depth = 0, maxTime }: { node: ExplainPlanNode; depth?:
             />
           </div>
         </div>
-      </div>
+      </button>
 
       {/* Details on expand */}
       {expanded && (
@@ -352,12 +354,6 @@ const TreeNodeView = ({ node, depth = 0 }: { node: ExplainTreeNode; depth?: numb
       metrics.estCost !== undefined);
 
   const toggle = () => setExpanded((prev) => !prev);
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key !== "Enter" && e.key !== " ") return;
-    // prevent Space from scrolling the panel
-    if (e.key === " ") e.preventDefault();
-    toggle();
-  };
 
   const rowContent = (
     <>
@@ -400,19 +396,17 @@ const TreeNodeView = ({ node, depth = 0 }: { node: ExplainTreeNode; depth?: numb
 
   return (
     <div className="relative">
-      {/* Expandable rows are keyboard-accessible buttons; leaves are plain divs */}
+      {/* Expandable rows are native buttons; leaves are plain divs */}
       {hasChildren ? (
-        <div
-          className="group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5"
+        <button
+          type="button"
+          className="w-full text-left group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all cursor-pointer hover:bg-white/5"
           onClick={toggle}
-          onKeyDown={handleKeyDown}
-          role="button"
-          tabIndex={0}
           aria-expanded={expanded}
           style={{ marginLeft: depth * 20 }}
         >
           {rowContent}
-        </div>
+        </button>
       ) : (
         <div
           className="group flex items-center gap-2 py-1.5 px-2 rounded-lg transition-all"

--- a/src/components/results-grid/ResultCard.tsx
+++ b/src/components/results-grid/ResultCard.tsx
@@ -42,9 +42,10 @@ export function ResultCard({
   const previewFields = fields.filter((f) => f !== primaryColumn && f !== idColumn).slice(0, 4);
 
   return (
-    <div
+    <button
+      type="button"
       onClick={onSelect}
-      className="bg-[#0d0d0d] border border-white/5 rounded-xl p-4 active:scale-[0.98] transition-all cursor-pointer hover:border-white/10 hover:bg-[#111]"
+      className="w-full text-left bg-[#0d0d0d] border border-white/5 rounded-xl p-4 active:scale-[0.98] transition-all cursor-pointer hover:border-white/10 hover:bg-[#111]"
     >
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2 flex-1 min-w-0">
@@ -89,6 +90,6 @@ export function ResultCard({
           </p>
         )}
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/components/schema-explorer/TableItem.tsx
+++ b/src/components/schema-explorer/TableItem.tsx
@@ -139,14 +139,14 @@ export const TableItem = React.memo(function TableItem({
         <ContextMenuTrigger asChild>
           <div
             className={cn(
-              "flex items-center gap-1.5 px-2 py-1.5 rounded-md transition-all",
+              "flex items-center gap-1.5 px-2 rounded-md transition-all",
               isExpanded ? "bg-accent/50" : "hover:bg-accent/30",
             )}
           >
             <button
               type="button"
               aria-expanded={isExpanded}
-              className="flex items-center gap-1.5 flex-1 min-w-0 cursor-pointer text-left"
+              className="flex items-center gap-1.5 flex-1 min-w-0 py-1.5 cursor-pointer text-left"
               onClick={onToggle}
             >
               <motion.div animate={{ rotate: isExpanded ? 90 : 0 }} transition={{ duration: 0.2 }} className="shrink-0">

--- a/src/components/schema-explorer/TableItem.tsx
+++ b/src/components/schema-explorer/TableItem.tsx
@@ -139,30 +139,36 @@ export const TableItem = React.memo(function TableItem({
         <ContextMenuTrigger asChild>
           <div
             className={cn(
-              "flex items-center gap-1.5 px-2 py-1.5 rounded-md cursor-pointer transition-all",
+              "flex items-center gap-1.5 px-2 py-1.5 rounded-md transition-all",
               isExpanded ? "bg-accent/50" : "hover:bg-accent/30",
             )}
-            onClick={onToggle}
           >
-            <motion.div animate={{ rotate: isExpanded ? 90 : 0 }} transition={{ duration: 0.2 }} className="shrink-0">
-              <ChevronRight strokeWidth={1.5} className="w-3.5 h-3.5 text-muted-foreground" />
-            </motion.div>
-
-            <TableIcon
-              className={cn(
-                "w-3.5 h-3.5 shrink-0 transition-colors",
-                isExpanded ? "text-blue-400" : "text-muted-foreground group-hover:text-foreground",
-              )}
-            />
-
-            <span
-              className={cn(
-                "truncate min-w-0 flex-1 text-xs font-medium transition-colors",
-                isExpanded ? "text-foreground" : "text-muted-foreground group-hover:text-foreground",
-              )}
+            <button
+              type="button"
+              aria-expanded={isExpanded}
+              className="flex items-center gap-1.5 flex-1 min-w-0 cursor-pointer text-left"
+              onClick={onToggle}
             >
-              {table.name}
-            </span>
+              <motion.div animate={{ rotate: isExpanded ? 90 : 0 }} transition={{ duration: 0.2 }} className="shrink-0">
+                <ChevronRight strokeWidth={1.5} className="w-3.5 h-3.5 text-muted-foreground" />
+              </motion.div>
+
+              <TableIcon
+                className={cn(
+                  "w-3.5 h-3.5 shrink-0 transition-colors",
+                  isExpanded ? "text-blue-400" : "text-muted-foreground group-hover:text-foreground",
+                )}
+              />
+
+              <span
+                className={cn(
+                  "truncate min-w-0 flex-1 text-xs font-medium transition-colors",
+                  isExpanded ? "text-foreground" : "text-muted-foreground group-hover:text-foreground",
+                )}
+              >
+                {table.name}
+              </span>
+            </button>
 
             <div className="shrink-0 relative w-8 h-6 flex items-center justify-center">
               {table.rowCount !== undefined && (

--- a/src/components/studio/StudioTabBar.tsx
+++ b/src/components/studio/StudioTabBar.tsx
@@ -79,6 +79,7 @@ export function StudioTabBar({
               )}
               <input
                 autoFocus
+                aria-label={`Rename ${tab.name}`}
                 value={editingTabName}
                 onChange={(e) => onSetEditingTabName(e.target.value)}
                 onBlur={() => {
@@ -131,7 +132,15 @@ export function StudioTabBar({
               type="button"
               aria-label={`Close ${tab.name}`}
               className="ml-auto opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-white shrink-0 cursor-pointer"
-              onClick={(e) => onCloseTab(tab.id, e)}
+              onClick={(e) => {
+                // Closing removes this button from the DOM; without an explicit
+                // handoff, keyboard focus falls back to the document body.
+                const tablist = e.currentTarget.closest('[role="tablist"]') as HTMLElement | null;
+                onCloseTab(tab.id, e);
+                setTimeout(() => {
+                  tablist?.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="true"]')?.focus();
+                }, 0);
+              }}
             >
               <X strokeWidth={1.5} className="w-3 h-3" />
             </button>

--- a/src/components/studio/StudioTabBar.tsx
+++ b/src/components/studio/StudioTabBar.tsx
@@ -30,30 +30,39 @@ export function StudioTabBar({
   onCloseTab,
   onAddTab,
 }: StudioTabBarProps) {
+  // Roving tabindex (WAI-ARIA tabs pattern): arrows/Home/End move activation,
+  // and focus follows the newly activated tab.
+  const activateTabAt = (index: number, e: React.KeyboardEvent) => {
+    const target = tabs[(index + tabs.length) % tabs.length];
+    onSetActiveTabId(target.id);
+    e.currentTarget
+      .closest('[role="tablist"]')
+      ?.querySelector<HTMLButtonElement>(`[role="tab"][data-tab-id="${target.id}"]`)
+      ?.focus();
+  };
+
+  const handleTabKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (e.key === "ArrowRight") activateTabAt(index + 1, e);
+    else if (e.key === "ArrowLeft") activateTabAt(index - 1, e);
+    else if (e.key === "Home") activateTabAt(0, e);
+    else if (e.key === "End") activateTabAt(tabs.length - 1, e);
+    else return;
+    e.preventDefault();
+  };
+
   return (
     <div
       role="tablist"
       aria-label="Editor tabs"
       className="hidden md:flex h-10 bg-[#0d0d0d] border-b border-white/5 items-center px-2 gap-1 overflow-x-auto no-scrollbar"
     >
-      {tabs.map((tab) => (
+      {tabs.map((tab, index) => (
+        // Non-semantic wrapper: role="tab" lives on the name button below so
+        // the rename input and close button are siblings, not tab descendants
+        // (a tab must not contain focusable controls, and the close button's
+        // label would otherwise contaminate the tab's accessible name).
         <div
           key={tab.id}
-          role="tab"
-          aria-selected={activeTabId === tab.id}
-          tabIndex={0}
-          onClick={() => onSetActiveTabId(tab.id)}
-          onKeyDown={(e) => {
-            if (e.target !== e.currentTarget) return;
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              onSetActiveTabId(tab.id);
-            }
-          }}
-          onDoubleClick={() => {
-            onSetEditingTabId(tab.id);
-            onSetEditingTabName(tab.name);
-          }}
           className={cn(
             "h-8 flex items-center px-3 gap-2 rounded-t-md transition-all cursor-pointer min-w-[120px] max-w-[200px] group relative border-t-2",
             activeTabId === tab.id
@@ -61,43 +70,67 @@ export function StudioTabBar({
               : "text-zinc-500 hover:bg-white/5 border-transparent",
           )}
         >
-          {tab.type === "sql" ? (
-            <Hash strokeWidth={1.5} className="w-3 h-3" />
-          ) : (
-            <FileJson strokeWidth={1.5} className="w-3 h-3" />
-          )}
           {editingTabId === tab.id ? (
-            <input
-              autoFocus
-              value={editingTabName}
-              onChange={(e) => onSetEditingTabName(e.target.value)}
-              onBlur={() => {
-                if (editingTabName.trim()) {
-                  onSetTabs((prev) => prev.map((t) => (t.id === tab.id ? { ...t, name: editingTabName.trim() } : t)));
-                }
-                onSetEditingTabId(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
+            <>
+              {tab.type === "sql" ? (
+                <Hash strokeWidth={1.5} className="w-3 h-3" />
+              ) : (
+                <FileJson strokeWidth={1.5} className="w-3 h-3" />
+              )}
+              <input
+                autoFocus
+                value={editingTabName}
+                onChange={(e) => onSetEditingTabName(e.target.value)}
+                onBlur={() => {
                   if (editingTabName.trim()) {
                     onSetTabs((prev) => prev.map((t) => (t.id === tab.id ? { ...t, name: editingTabName.trim() } : t)));
                   }
                   onSetEditingTabId(null);
-                } else if (e.key === "Escape") {
-                  onSetEditingTabId(null);
-                }
-              }}
-              onClick={(e) => e.stopPropagation()}
-              className="text-xs font-medium bg-transparent border-b border-blue-500 outline-none w-full text-zinc-100"
-            />
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    if (editingTabName.trim()) {
+                      onSetTabs((prev) =>
+                        prev.map((t) => (t.id === tab.id ? { ...t, name: editingTabName.trim() } : t)),
+                      );
+                    }
+                    onSetEditingTabId(null);
+                  } else if (e.key === "Escape") {
+                    onSetEditingTabId(null);
+                  }
+                }}
+                onClick={(e) => e.stopPropagation()}
+                className="text-xs font-medium bg-transparent border-b border-blue-500 outline-none w-full text-zinc-100"
+              />
+            </>
           ) : (
-            <span className="text-xs truncate font-medium">{tab.name}</span>
+            <button
+              type="button"
+              role="tab"
+              data-tab-id={tab.id}
+              aria-selected={activeTabId === tab.id}
+              tabIndex={activeTabId === tab.id ? 0 : -1}
+              onClick={() => onSetActiveTabId(tab.id)}
+              onKeyDown={(e) => handleTabKeyDown(e, index)}
+              onDoubleClick={() => {
+                onSetEditingTabId(tab.id);
+                onSetEditingTabName(tab.name);
+              }}
+              className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
+            >
+              {tab.type === "sql" ? (
+                <Hash strokeWidth={1.5} className="w-3 h-3" />
+              ) : (
+                <FileJson strokeWidth={1.5} className="w-3 h-3" />
+              )}
+              <span className="text-xs truncate font-medium">{tab.name}</span>
+            </button>
           )}
           {tabs.length > 1 && (
             <button
               type="button"
               aria-label={`Close ${tab.name}`}
-              className="ml-auto opacity-0 group-hover:opacity-100 hover:text-white shrink-0 cursor-pointer"
+              className="ml-auto opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-white shrink-0 cursor-pointer"
               onClick={(e) => onCloseTab(tab.id, e)}
             >
               <X strokeWidth={1.5} className="w-3 h-3" />

--- a/src/components/studio/StudioTabBar.tsx
+++ b/src/components/studio/StudioTabBar.tsx
@@ -31,11 +31,25 @@ export function StudioTabBar({
   onAddTab,
 }: StudioTabBarProps) {
   return (
-    <div className="hidden md:flex h-10 bg-[#0d0d0d] border-b border-white/5 items-center px-2 gap-1 overflow-x-auto no-scrollbar">
+    <div
+      role="tablist"
+      aria-label="Editor tabs"
+      className="hidden md:flex h-10 bg-[#0d0d0d] border-b border-white/5 items-center px-2 gap-1 overflow-x-auto no-scrollbar"
+    >
       {tabs.map((tab) => (
         <div
           key={tab.id}
+          role="tab"
+          aria-selected={activeTabId === tab.id}
+          tabIndex={0}
           onClick={() => onSetActiveTabId(tab.id)}
+          onKeyDown={(e) => {
+            if (e.target !== e.currentTarget) return;
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onSetActiveTabId(tab.id);
+            }
+          }}
           onDoubleClick={() => {
             onSetEditingTabId(tab.id);
             onSetEditingTabName(tab.name);
@@ -80,19 +94,25 @@ export function StudioTabBar({
             <span className="text-xs truncate font-medium">{tab.name}</span>
           )}
           {tabs.length > 1 && (
-            <X
-              strokeWidth={1.5}
-              className="w-3 h-3 ml-auto opacity-0 group-hover:opacity-100 hover:text-white shrink-0"
+            <button
+              type="button"
+              aria-label={`Close ${tab.name}`}
+              className="ml-auto opacity-0 group-hover:opacity-100 hover:text-white shrink-0 cursor-pointer"
               onClick={(e) => onCloseTab(tab.id, e)}
-            />
+            >
+              <X strokeWidth={1.5} className="w-3 h-3" />
+            </button>
           )}
         </div>
       ))}
-      <Plus
-        strokeWidth={1.5}
-        className="w-3.5 h-3.5 text-zinc-500 cursor-pointer hover:text-white mx-2"
+      <button
+        type="button"
+        aria-label="New tab"
+        className="text-zinc-500 cursor-pointer hover:text-white mx-2"
         onClick={onAddTab}
-      />
+      >
+        <Plus strokeWidth={1.5} className="w-3.5 h-3.5" />
+      </button>
     </div>
   );
 }

--- a/src/components/studio/StudioTabBar.tsx
+++ b/src/components/studio/StudioTabBar.tsx
@@ -89,16 +89,17 @@ export function StudioTabBar({
                   onSetEditingTabId(null);
                 }}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    if (editingTabName.trim()) {
-                      onSetTabs((prev) =>
-                        prev.map((t) => (t.id === tab.id ? { ...t, name: editingTabName.trim() } : t)),
-                      );
-                    }
-                    onSetEditingTabId(null);
-                  } else if (e.key === "Escape") {
-                    onSetEditingTabId(null);
+                  if (e.key !== "Enter" && e.key !== "Escape") return;
+                  if (e.key === "Enter" && editingTabName.trim()) {
+                    onSetTabs((prev) => prev.map((t) => (t.id === tab.id ? { ...t, name: editingTabName.trim() } : t)));
                   }
+                  // The input unmounts with the state update; hand focus back to
+                  // the restored tab button instead of the document body.
+                  const tablist = e.currentTarget.closest('[role="tablist"]') as HTMLElement | null;
+                  onSetEditingTabId(null);
+                  setTimeout(() => {
+                    tablist?.querySelector<HTMLButtonElement>(`[role="tab"][data-tab-id="${tab.id}"]`)?.focus();
+                  }, 0);
                 }}
                 onClick={(e) => e.stopPropagation()}
                 className="text-xs font-medium bg-transparent border-b border-blue-500 outline-none w-full text-zinc-100"
@@ -117,7 +118,7 @@ export function StudioTabBar({
                 onSetEditingTabId(tab.id);
                 onSetEditingTabName(tab.name);
               }}
-              className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
+              className="flex items-center gap-2 flex-1 min-w-0 h-full text-left cursor-pointer"
             >
               {tab.type === "sql" ? (
                 <Hash strokeWidth={1.5} className="w-3 h-3" />

--- a/tests/components/DataImportModal.test.tsx
+++ b/tests/components/DataImportModal.test.tsx
@@ -767,4 +767,28 @@ describe("DataImportModal", () => {
 
     expect(baseElement.querySelector("select")).not.toBeNull();
   });
+
+  // ── A11y semantics (#100) ──────────────────────────────────────────────────
+
+  describe("a11y semantics", () => {
+    test("upload dropzone is an accessible button", () => {
+      const { baseElement } = render(<DataImportModal isOpen onClose={noop} onImport={noop} tables={sampleTables} />);
+      expect(within(baseElement).getByRole("button", { name: /Drop a file here/ })).not.toBeNull();
+    });
+
+    test("configure fields are reachable by their labels", () => {
+      const { baseElement } = render(<DataImportModal isOpen onClose={noop} onImport={noop} tables={sampleTables} />);
+      act(() => {
+        simulateFileUpload(baseElement, "name,age\nAlice,30", "data.csv");
+      });
+      act(() => {
+        fireEvent.click(within(baseElement).getByText("Configure Import"));
+      });
+      expect(within(baseElement).getByLabelText("Select Table")).not.toBeNull();
+      act(() => {
+        fireEvent.click(within(baseElement).getByText("New Table"));
+      });
+      expect(within(baseElement).getByLabelText("New Table Name")).not.toBeNull();
+    });
+  });
 });

--- a/tests/components/DataImportModal.test.tsx
+++ b/tests/components/DataImportModal.test.tsx
@@ -790,5 +790,17 @@ describe("DataImportModal", () => {
       });
       expect(within(baseElement).getByLabelText("New Table Name")).not.toBeNull();
     });
+
+    test("column-mapping inputs are named after their source column", () => {
+      const { baseElement } = render(<DataImportModal isOpen onClose={noop} onImport={noop} tables={sampleTables} />);
+      act(() => {
+        simulateFileUpload(baseElement, "name,age\nAlice,30", "data.csv");
+      });
+      act(() => {
+        fireEvent.click(within(baseElement).getByText("Configure Import"));
+      });
+      expect(within(baseElement).getByLabelText("Target column for name")).not.toBeNull();
+      expect(within(baseElement).getByLabelText("Target column for age")).not.toBeNull();
+    });
   });
 });

--- a/tests/components/MaskingSettings.test.tsx
+++ b/tests/components/MaskingSettings.test.tsx
@@ -549,10 +549,12 @@ describe("MaskingSettings", () => {
   // ── A11y semantics (#100): labels are programmatically associated ───────
 
   describe("a11y semantics", () => {
-    test("role switches are labelled Can toggle / Can reveal", () => {
-      const { getAllByLabelText } = render(<MaskingSettings />);
-      expect(getAllByLabelText("Can toggle").length).toBe(2);
-      expect(getAllByLabelText("Can reveal").length).toBe(2);
+    test("role switches carry distinct role-qualified accessible names", () => {
+      const { getByLabelText } = render(<MaskingSettings />);
+      expect(getByLabelText("Admin can toggle")).not.toBeNull();
+      expect(getByLabelText("Admin can reveal")).not.toBeNull();
+      expect(getByLabelText("User can toggle")).not.toBeNull();
+      expect(getByLabelText("User can reveal")).not.toBeNull();
     });
 
     test("pattern dialog fields are reachable by their labels", () => {

--- a/tests/components/MaskingSettings.test.tsx
+++ b/tests/components/MaskingSettings.test.tsx
@@ -545,4 +545,26 @@ describe("MaskingSettings", () => {
     // Email is enabled, should show preview
     expect(text).toContain("j***@example.com");
   });
+
+  // ── A11y semantics (#100): labels are programmatically associated ───────
+
+  describe("a11y semantics", () => {
+    test("role switches are labelled Can toggle / Can reveal", () => {
+      const { getAllByLabelText } = render(<MaskingSettings />);
+      expect(getAllByLabelText("Can toggle").length).toBe(2);
+      expect(getAllByLabelText("Can reveal").length).toBe(2);
+    });
+
+    test("pattern dialog fields are reachable by their labels", () => {
+      const { container, baseElement } = render(<MaskingSettings />);
+      const addBtn = within(container).getByText("Add Pattern");
+      act(() => {
+        fireEvent.click(addBtn);
+      });
+      const body = within(baseElement);
+      expect(body.getByLabelText("Name")).not.toBeNull();
+      expect(body.getByLabelText("Mask Type")).not.toBeNull();
+      expect(body.getByLabelText("Column Patterns (one per line)")).not.toBeNull();
+    });
+  });
 });

--- a/tests/components/QueryHistory.test.tsx
+++ b/tests/components/QueryHistory.test.tsx
@@ -83,6 +83,14 @@ describe("QueryHistory", () => {
     expect(view.queryByText("DROP TABLE bad")).not.toBeNull();
   });
 
+  // ── A11y semantics (#100) ─────────────────────────────────────────────────
+
+  test("actions column header has an accessible name", () => {
+    const props = createDefaultProps();
+    const { container } = render(<QueryHistory {...props} />);
+    expect(within(container).getByRole("columnheader", { name: "Actions" })).not.toBeNull();
+  });
+
   // ── Status icons ──────────────────────────────────────────────────────────
 
   test("shows success and error status indicators", () => {

--- a/tests/components/ResultsGrid.test.tsx
+++ b/tests/components/ResultsGrid.test.tsx
@@ -881,4 +881,32 @@ describe("ResultsGrid", () => {
       expect(revealButton).toBeNull();
     });
   });
+
+  // ── A11y semantics (#100): keyboard-reachable interactive elements ────────
+
+  describe("a11y semantics", () => {
+    test("column sort headers are buttons named after the field", () => {
+      const { getAllByRole } = render(React.createElement(ResultsGrid, { result: mockResult }));
+      const sortButtons = getAllByRole("button", { name: "name" });
+      expect(sortButtons.length).toBeGreaterThan(0);
+      fireEvent.click(sortButtons[0]);
+    });
+
+    test("mobile rows are buttons that open the row detail sheet", () => {
+      const { getAllByRole, queryByTestId } = render(React.createElement(ResultsGrid, { result: mockResult }));
+      const rowButtons = getAllByRole("button", { name: /Alice/ });
+      expect(rowButtons.length).toBeGreaterThan(0);
+      fireEvent.click(rowButtons[0]);
+      expect(queryByTestId("row-detail-sheet")).not.toBeNull();
+    });
+
+    test("column resize handles are hidden from assistive technology", () => {
+      const { container } = render(React.createElement(ResultsGrid, { result: mockResult }));
+      const handles = container.querySelectorAll(".cursor-col-resize");
+      expect(handles.length).toBeGreaterThan(0);
+      for (const handle of handles) {
+        expect(handle.getAttribute("aria-hidden")).toBe("true");
+      }
+    });
+  });
 });

--- a/tests/components/ResultsGrid.test.tsx
+++ b/tests/components/ResultsGrid.test.tsx
@@ -892,6 +892,15 @@ describe("ResultsGrid", () => {
       fireEvent.click(sortButtons[0]);
     });
 
+    test("sort buttons expose the current sort direction in their accessible name", () => {
+      const { getAllByRole } = render(React.createElement(ResultsGrid, { result: mockResult }));
+      fireEvent.click(getAllByRole("button", { name: "name" })[0]);
+      const ascending = getAllByRole("button", { name: "name, sorted ascending" });
+      expect(ascending.length).toBeGreaterThan(0);
+      fireEvent.click(ascending[0]);
+      expect(getAllByRole("button", { name: "name, sorted descending" }).length).toBeGreaterThan(0);
+    });
+
     test("mobile rows are buttons that open the row detail sheet", () => {
       const { getAllByRole, queryByTestId } = render(React.createElement(ResultsGrid, { result: mockResult }));
       const rowButtons = getAllByRole("button", { name: /Alice/ });

--- a/tests/components/SavedQueries.test.tsx
+++ b/tests/components/SavedQueries.test.tsx
@@ -65,6 +65,21 @@ describe("SavedQueries", () => {
     expect(onSelectQuery).toHaveBeenCalledWith("SELECT * FROM users WHERE active = true");
   });
 
+  test("edit button loads the query for editing", () => {
+    const onSelectQuery = mock(() => {});
+    const { getByRole } = render(<SavedQueries onSelectQuery={onSelectQuery} />);
+    fireEvent.click(getByRole("button", { name: "Edit Active Users" }));
+    expect(onSelectQuery).toHaveBeenCalledTimes(1);
+    expect(onSelectQuery).toHaveBeenCalledWith("SELECT * FROM users WHERE active = true");
+  });
+
+  test("card actions are revealed on keyboard focus and non-hover devices", () => {
+    const { getByRole } = render(<SavedQueries onSelectQuery={mock(() => {})} />);
+    const actions = getByRole("button", { name: "Delete Active Users" }).parentElement!;
+    expect(actions.className).toContain("focus-within:opacity-100");
+    expect(actions.className).toContain("[@media(hover:none)]:opacity-100");
+  });
+
   test("delete button removes query after confirm", () => {
     const originalConfirm = globalThis.confirm;
     globalThis.confirm = mock(() => true) as unknown as typeof confirm;

--- a/tests/components/SavedQueries.test.tsx
+++ b/tests/components/SavedQueries.test.tsx
@@ -55,21 +55,28 @@ describe("SavedQueries", () => {
     expect(queryByText("Get active users")).not.toBeNull();
   });
 
+  // ── A11y semantics (#100) ─────────────────────────────────────────────────
+
+  test("query card is loaded via a button named after the query", () => {
+    const onSelectQuery = mock(() => {});
+    const { getByRole } = render(<SavedQueries onSelectQuery={onSelectQuery} />);
+    fireEvent.click(getByRole("button", { name: "Active Users" }));
+    expect(onSelectQuery).toHaveBeenCalledTimes(1);
+    expect(onSelectQuery).toHaveBeenCalledWith("SELECT * FROM users WHERE active = true");
+  });
+
   test("delete button removes query after confirm", () => {
     const originalConfirm = globalThis.confirm;
     globalThis.confirm = mock(() => true) as unknown as typeof confirm;
     try {
       const onSelectQuery = mock(() => {});
-      const { container, queryByText } = render(<SavedQueries onSelectQuery={onSelectQuery} />);
+      const { getByRole, queryByText } = render(<SavedQueries onSelectQuery={onSelectQuery} />);
       expect(queryByText("Active Users")).not.toBeNull();
 
       // After deletion, storage returns an empty list
       mockGetSavedQueries.mockImplementation(() => []);
 
-      // Buttons per card: [0] edit, [1] delete
-      const deleteButton = container.querySelectorAll("button")[1];
-      expect(deleteButton).not.toBeNull();
-      fireEvent.click(deleteButton!);
+      fireEvent.click(getByRole("button", { name: "Delete Active Users" }));
 
       expect(mockDeleteSavedQuery).toHaveBeenCalledTimes(1);
       expect(mockDeleteSavedQuery).toHaveBeenCalledWith("q1");
@@ -86,10 +93,9 @@ describe("SavedQueries", () => {
     const originalConfirm = globalThis.confirm;
     globalThis.confirm = mock(() => false) as unknown as typeof confirm;
     try {
-      const { container, queryByText } = render(<SavedQueries onSelectQuery={mock(() => {})} />);
+      const { getByRole, queryByText } = render(<SavedQueries onSelectQuery={mock(() => {})} />);
 
-      const deleteButton = container.querySelectorAll("button")[1];
-      fireEvent.click(deleteButton!);
+      fireEvent.click(getByRole("button", { name: "Delete Active Users" }));
 
       expect(mockDeleteSavedQuery).not.toHaveBeenCalled();
       expect(queryByText("Active Users")).not.toBeNull();

--- a/tests/components/SnapshotTimeline.test.tsx
+++ b/tests/components/SnapshotTimeline.test.tsx
@@ -81,6 +81,9 @@ describe("SnapshotTimeline", () => {
     expect(del.className).toContain("z-20");
     expect(del.className).toContain("focus-visible:opacity-100");
     expect(del.className).toContain("[@media(hover:none)]:opacity-100");
+    // 24x24 minimum hit target: near misses must not fall through to select
+    expect(del.className).toContain("w-6");
+    expect(del.className).toContain("h-6");
   });
 
   test("selection state is exposed via aria-pressed", () => {

--- a/tests/components/SnapshotTimeline.test.tsx
+++ b/tests/components/SnapshotTimeline.test.tsx
@@ -69,6 +69,18 @@ describe("SnapshotTimeline", () => {
     expect(before[0].tagName).toBe("BUTTON");
   });
 
+  test("selection state is exposed via aria-pressed", () => {
+    const { getAllByRole } = render(
+      <SnapshotTimeline snapshots={snapshots} onCompare={mock(() => {})} onDelete={mock(() => {})} />,
+    );
+    const node = getAllByRole("button", { name: /^Before migration/ })[0];
+    expect(node.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(node);
+    expect(node.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(node);
+    expect(node.getAttribute("aria-pressed")).toBe("false");
+  });
+
   test("delete buttons carry the snapshot label in their accessible name", () => {
     const onDelete = mock((id: string) => {
       void id;

--- a/tests/components/SnapshotTimeline.test.tsx
+++ b/tests/components/SnapshotTimeline.test.tsx
@@ -58,6 +58,29 @@ describe("SnapshotTimeline", () => {
     expect(queryByText("3 tables")).not.toBeNull();
   });
 
+  // ── A11y semantics (#100) ─────────────────────────────────────────────────
+
+  test("snapshot nodes are native buttons named by their label", () => {
+    const { getAllByRole } = render(
+      <SnapshotTimeline snapshots={snapshots} onCompare={mock(() => {})} onDelete={mock(() => {})} />,
+    );
+    const before = getAllByRole("button", { name: /^Before migration/ });
+    expect(before.length).toBe(1);
+    expect(before[0].tagName).toBe("BUTTON");
+  });
+
+  test("delete buttons carry the snapshot label in their accessible name", () => {
+    const onDelete = mock((id: string) => {
+      void id;
+    });
+    const { getByRole } = render(
+      <SnapshotTimeline snapshots={snapshots} onCompare={mock(() => {})} onDelete={onDelete} />,
+    );
+    fireEvent.click(getByRole("button", { name: "Delete Before migration" }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith("s1");
+  });
+
   test("selecting two snapshots triggers onCompare", () => {
     const onCompare = mock((a: string, b: string) => {
       void a;
@@ -79,34 +102,22 @@ describe("SnapshotTimeline", () => {
     const { getAllByRole } = render(
       <SnapshotTimeline snapshots={snapshots} onCompare={onCompare} onDelete={mock(() => {})} />,
     );
-    const nodes = getAllByRole("button").filter((el) => el.tagName === "DIV");
-    fireEvent.keyDown(nodes[0]!, { key: "Enter" });
-    fireEvent.keyDown(nodes[1]!, { key: " " });
+    // Node buttons are native <button> elements: Enter/Space activation is
+    // browser behavior, so activation is exercised via click semantics.
+    const nodes = getAllByRole("button", { name: /^(Before|After) migration/ });
+    fireEvent.click(nodes[0]!);
+    fireEvent.click(nodes[1]!);
     expect(onCompare).toHaveBeenCalledTimes(1);
   });
 
-  test("keydown on the nested delete button does not select the node", () => {
+  test("clicking the delete button does not select the node", () => {
     const onCompare = mock(() => {});
-    const { container, getAllByRole } = render(
+    const { getByRole, getAllByRole } = render(
       <SnapshotTimeline snapshots={snapshots} onCompare={onCompare} onDelete={mock(() => {})} />,
     );
-    const nodes = getAllByRole("button").filter((el) => el.tagName === "DIV");
-    const deleteButton = container.querySelector("button")!;
-    // Enter on the delete button bubbles to the node but must be ignored
-    fireEvent.keyDown(deleteButton, { key: "Enter" });
-    fireEvent.keyDown(nodes[1]!, { key: "Enter" });
-    // Only the second keydown selected a node, so no compare pair exists
-    expect(onCompare).toHaveBeenCalledTimes(0);
-  });
-
-  test("other keys do not select a snapshot", () => {
-    const onCompare = mock(() => {});
-    const { getAllByRole } = render(
-      <SnapshotTimeline snapshots={snapshots} onCompare={onCompare} onDelete={mock(() => {})} />,
-    );
-    const nodes = getAllByRole("button").filter((el) => el.tagName === "DIV");
-    fireEvent.keyDown(nodes[0]!, { key: "Tab" });
-    fireEvent.keyDown(nodes[1]!, { key: "Escape" });
+    fireEvent.click(getByRole("button", { name: "Delete Before migration" }));
+    fireEvent.click(getAllByRole("button", { name: /After migration/ })[0]!);
+    // Delete must not count as a selection, so no compare pair exists
     expect(onCompare).toHaveBeenCalledTimes(0);
   });
 
@@ -114,11 +125,10 @@ describe("SnapshotTimeline", () => {
     const onDelete = mock((id: string) => {
       void id;
     });
-    const { container } = render(
+    const { getByRole } = render(
       <SnapshotTimeline snapshots={snapshots} onCompare={mock(() => {})} onDelete={onDelete} />,
     );
-    const deleteButtons = container.querySelectorAll("button");
-    fireEvent.click(deleteButtons[0]!);
+    fireEvent.click(getByRole("button", { name: "Delete Before migration" }));
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
 
@@ -285,12 +295,11 @@ describe("SnapshotTimeline", () => {
   test("delete button stopPropagation prevents selection change", () => {
     const onCompare = mock(() => {});
     const onDelete = mock(() => {});
-    const { container, queryByText } = render(
+    const { getByRole, queryByText } = render(
       <SnapshotTimeline snapshots={snapshots} onCompare={onCompare} onDelete={onDelete} />,
     );
     // Click delete on first snapshot — should NOT trigger selection due to stopPropagation
-    const deleteButtons = container.querySelectorAll("button");
-    fireEvent.click(deleteButtons[0]!);
+    fireEvent.click(getByRole("button", { name: "Delete Before migration" }));
     // onDelete should fire
     expect(onDelete).toHaveBeenCalledTimes(1);
     // Now select both snapshots — if delete had leaked a selection, we'd need only 1 more click
@@ -318,15 +327,13 @@ describe("SnapshotTimeline", () => {
     const onDelete = mock((id: string) => {
       void id;
     });
-    const { container } = render(
+    const { getByRole } = render(
       <SnapshotTimeline snapshots={snapshots} onCompare={mock(() => {})} onDelete={onDelete} />,
     );
-    const deleteButtons = container.querySelectorAll("button");
     // Snapshots are sorted by createdAt ascending: s1 (2026-01-10), s2 (2026-01-15)
-    // First delete button corresponds to s1, second to s2
-    fireEvent.click(deleteButtons[0]!);
+    fireEvent.click(getByRole("button", { name: "Delete Before migration" }));
     expect(onDelete).toHaveBeenCalledWith("s1");
-    fireEvent.click(deleteButtons[1]!);
+    fireEvent.click(getByRole("button", { name: "Delete After migration" }));
     expect(onDelete).toHaveBeenCalledWith("s2");
     expect(onDelete).toHaveBeenCalledTimes(2);
   });

--- a/tests/components/SnapshotTimeline.test.tsx
+++ b/tests/components/SnapshotTimeline.test.tsx
@@ -69,6 +69,20 @@ describe("SnapshotTimeline", () => {
     expect(before[0].tagName).toBe("BUTTON");
   });
 
+  test("the select overlay layers above the timeline dot and below delete", () => {
+    const { getAllByRole, getByRole } = render(
+      <SnapshotTimeline snapshots={snapshots} onCompare={mock(() => {})} onDelete={mock(() => {})} />,
+    );
+    // The dot is a z-10 flex item; the overlay must stack above it or clicks
+    // on the dot never reach the button (and delete must stay on top).
+    const node = getAllByRole("button", { name: /^Before migration/ })[0];
+    expect(node.className).toContain("after:z-10");
+    const del = getByRole("button", { name: "Delete Before migration" });
+    expect(del.className).toContain("z-20");
+    expect(del.className).toContain("focus-visible:opacity-100");
+    expect(del.className).toContain("[@media(hover:none)]:opacity-100");
+  });
+
   test("selection state is exposed via aria-pressed", () => {
     const { getAllByRole } = render(
       <SnapshotTimeline snapshots={snapshots} onCompare={mock(() => {})} onDelete={mock(() => {})} />,

--- a/tests/components/VisualExplain.test.tsx
+++ b/tests/components/VisualExplain.test.tsx
@@ -165,6 +165,20 @@ describe("VisualExplain", () => {
     expect(queryByText("cost")).not.toBeNull();
   });
 
+  // -----------------------------------------------------------------------
+  // A11y semantics (#100)
+  // -----------------------------------------------------------------------
+
+  test("plan node rows are native buttons with expansion state", () => {
+    const { getAllByRole } = render(<VisualExplain plan={samplePlan} />);
+    const nodeButtons = getAllByRole("button", { name: /Seq Scan/ });
+    expect(nodeButtons.length).toBeGreaterThan(0);
+    expect(nodeButtons[0].tagName).toBe("BUTTON");
+    expect(nodeButtons[0].getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(nodeButtons[0]);
+    expect(nodeButtons[0].getAttribute("aria-expanded")).toBe("false");
+  });
+
   test("displays formatted execution time", () => {
     const { queryAllByText } = render(<VisualExplain plan={samplePlan} />);
     // 42.50ms appears in header + insights + plan node
@@ -942,34 +956,29 @@ describe("tree render model (sqlite-queryplan)", () => {
     expect(queryByText(/0 rows/)).toBeNull();
   });
 
-  test("parent tree rows are keyboard-accessible; leaf rows are non-interactive", () => {
+  test("parent tree rows are native buttons; leaf rows are non-interactive", () => {
     const { getByText, queryByText } = render(
       <VisualExplain plan={TREE_INPUT} query="SELECT 1" databaseType="sqlite" />,
     );
 
-    // "SCAN employee" has a child, so its row must be a focusable button
-    const parentRow = getByText("SCAN employee").closest('[role="button"]') as HTMLElement | null;
+    // "SCAN employee" has a child, so its row must be a native button
+    // (Enter/Space activation is browser behavior on <button>)
+    const parentRow = getByText("SCAN employee").closest("button") as HTMLElement | null;
     expect(parentRow).not.toBeNull();
-    expect(parentRow!.getAttribute("tabindex")).toBe("0");
     expect(parentRow!.getAttribute("aria-expanded")).toBe("true");
 
-    // Enter collapses the children
-    parentRow!.focus();
-    fireEvent.keyDown(parentRow!, { key: "Enter" });
+    // Activation collapses the children
+    fireEvent.click(parentRow!);
     expect(queryByText("USING INDEX idx_dept")).toBeNull();
     expect(parentRow!.getAttribute("aria-expanded")).toBe("false");
 
-    // Space expands them again
-    fireEvent.keyDown(parentRow!, { key: " " });
-    expect(queryByText("USING INDEX idx_dept")).not.toBeNull();
-
-    // any other key does nothing
-    fireEvent.keyDown(parentRow!, { key: "a" });
+    // Activation expands them again
+    fireEvent.click(parentRow!);
     expect(queryByText("USING INDEX idx_dept")).not.toBeNull();
 
     // the leaf row (no children) is a plain non-interactive div
     const leafRow = getByText("USING INDEX idx_dept").parentElement!.parentElement!;
-    expect(leafRow.getAttribute("role")).toBeNull();
+    expect(leafRow.tagName).not.toBe("BUTTON");
     expect(leafRow.getAttribute("tabindex")).toBeNull();
     expect(leafRow.className).not.toContain("cursor-pointer");
   });

--- a/tests/components/results-grid/ResultCard.test.tsx
+++ b/tests/components/results-grid/ResultCard.test.tsx
@@ -61,6 +61,26 @@ describe("results-grid/ResultCard", () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
+  // ── A11y semantics (#100) ─────────────────────────────────────────────────
+
+  test("card is a native button reachable by its primary value", () => {
+    const onSelect = mock(() => {});
+    const { getByRole } = render(
+      <ResultCard
+        row={{ id: 1, name: "Bob" }}
+        fields={["id", "name"]}
+        primaryColumn="name"
+        idColumn="id"
+        index={0}
+        onSelect={onSelect}
+      />,
+    );
+    const card = getByRole("button", { name: /Bob/ });
+    expect(card.tagName).toBe("BUTTON");
+    fireEvent.click(card);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
   test("masks primary and preview sensitive values", () => {
     const sensitiveColumns = new Map<string, unknown>([
       ["name", { type: "email" }],

--- a/tests/components/schema-explorer/TableItem.test.tsx
+++ b/tests/components/schema-explorer/TableItem.test.tsx
@@ -468,4 +468,24 @@ describe("TableItem", () => {
     expect(queryAllByText("Analyze Table").length).toBe(0);
     expect(queryAllByText("Vacuum Table").length).toBe(0);
   });
+
+  // ── A11y semantics (#100) ─────────────────────────────────────────────────
+
+  describe("a11y semantics", () => {
+    test("expand toggle is a button named after the table with aria-expanded", () => {
+      const onToggle = mock(() => {});
+      const { getByRole } = render(<TableItem table={largeTable} isExpanded={false} onToggle={onToggle} isAdmin />);
+      const toggle = getByRole("button", { name: "users" });
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(toggle);
+      expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    test("expanded state is reflected on the toggle button", () => {
+      const { getByRole } = render(
+        <TableItem table={largeTable} isExpanded={true} onToggle={mock(() => {})} isAdmin />,
+      );
+      expect(getByRole("button", { name: "users" }).getAttribute("aria-expanded")).toBe("true");
+    });
+  });
 });

--- a/tests/components/schema-explorer/TableItem.test.tsx
+++ b/tests/components/schema-explorer/TableItem.test.tsx
@@ -487,5 +487,14 @@ describe("TableItem", () => {
       );
       expect(getByRole("button", { name: "users" }).getAttribute("aria-expanded")).toBe("true");
     });
+
+    test("the toggle button owns the row's vertical padding (full-height hit target)", () => {
+      const { getByRole } = render(
+        <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin />,
+      );
+      const toggle = getByRole("button", { name: "users" });
+      expect(toggle.className).toContain("py-1.5");
+      expect(toggle.parentElement?.className).not.toContain("py-1.5");
+    });
   });
 });

--- a/tests/components/studio/StudioTabBar.test.tsx
+++ b/tests/components/studio/StudioTabBar.test.tsx
@@ -386,6 +386,24 @@ describe("StudioTabBar", () => {
       expect(getByLabelText("Rename Query 1")).not.toBeNull();
     });
 
+    test("tab buttons fill the wrapper height so the whole visible tab is clickable", () => {
+      const props = createDefaultProps();
+      const { getAllByRole } = render(<StudioTabBar {...props} />);
+      for (const tab of getAllByRole("tab")) {
+        expect(tab.className).toContain("h-full");
+      }
+    });
+
+    test("committing a rename with Enter restores focus to the tab", async () => {
+      const props = createDefaultProps({ editingTabId: "tab-1", editingTabName: "Renamed" });
+      const { getByLabelText, rerender } = render(<StudioTabBar {...props} />);
+      fireEvent.keyDown(getByLabelText("Rename Query 1"), { key: "Enter" });
+      // The parent clears editing state in response; simulate that re-render
+      rerender(<StudioTabBar {...createDefaultProps({ activeTabId: "tab-1" })} />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(document.activeElement?.getAttribute("data-tab-id")).toBe("tab-1");
+    });
+
     test("closing a tab moves focus back to the selected tab", async () => {
       const onCloseTab = mock(() => {});
       const props = createDefaultProps({ activeTabId: "tab-1", onCloseTab });

--- a/tests/components/studio/StudioTabBar.test.tsx
+++ b/tests/components/studio/StudioTabBar.test.tsx
@@ -109,11 +109,8 @@ describe("StudioTabBar", () => {
   test("plus button fires onAddTab", () => {
     const onAddTab = mock(() => {});
     const props = createDefaultProps({ onAddTab });
-    const { container } = render(<StudioTabBar {...props} />);
-    const svgElements = container.querySelectorAll("svg");
-    const plusIcon = Array.from(svgElements).find((el) => el.getAttribute("class")?.includes("cursor-pointer"));
-    expect(plusIcon).not.toBeNull();
-    fireEvent.click(plusIcon!);
+    const { getByRole } = render(<StudioTabBar {...props} />);
+    fireEvent.click(getByRole("button", { name: "New tab" }));
     expect(onAddTab).toHaveBeenCalledTimes(1);
   });
 
@@ -122,19 +119,18 @@ describe("StudioTabBar", () => {
   test("close button fires onCloseTab when multiple tabs", () => {
     const onCloseTab = mock(() => {});
     const props = createDefaultProps({ onCloseTab });
-    const { container } = render(<StudioTabBar {...props} />);
-    const closeIcons = container.querySelectorAll('svg[class*="ml-auto"]');
-    expect(closeIcons.length).toBeGreaterThan(0);
-    fireEvent.click(closeIcons[0]);
+    const { getAllByRole } = render(<StudioTabBar {...props} />);
+    const closeButtons = getAllByRole("button", { name: /^Close / });
+    expect(closeButtons.length).toBeGreaterThan(0);
+    fireEvent.click(closeButtons[0]);
     expect(onCloseTab).toHaveBeenCalledTimes(1);
   });
 
   test("close button hidden when only one tab", () => {
     const singleTab = createTab({ id: "tab-1", name: "Query 1" });
     const props = createDefaultProps({ tabs: [singleTab], activeTabId: "tab-1" });
-    const { container } = render(<StudioTabBar {...props} />);
-    const closeIcons = container.querySelectorAll('svg[class*="ml-auto"]');
-    expect(closeIcons.length).toBe(0);
+    const { queryAllByRole } = render(<StudioTabBar {...props} />);
+    expect(queryAllByRole("button", { name: /^Close / }).length).toBe(0);
   });
 
   // ── Double-click → rename mode ────────────────────────────────────────
@@ -328,5 +324,37 @@ describe("StudioTabBar", () => {
     expect(capturedFn).not.toBeNull();
     const result = capturedFn!([tab1]);
     expect(result[0].name).toBe("Blur Name");
+  });
+
+  // ── A11y semantics (#100) ─────────────────────────────────────────────
+
+  describe("a11y semantics", () => {
+    test("tabs expose the tab role with aria-selected state", () => {
+      const props = createDefaultProps({ activeTabId: "tab-1" });
+      const { getAllByRole } = render(<StudioTabBar {...props} />);
+      const tabs = getAllByRole("tab");
+      expect(tabs.length).toBe(2);
+      expect(tabs[0].getAttribute("aria-selected")).toBe("true");
+      expect(tabs[1].getAttribute("aria-selected")).toBe("false");
+    });
+
+    test("Enter and Space activate a tab from the keyboard", () => {
+      const onSetActiveTabId = mock(() => {});
+      const props = createDefaultProps({ onSetActiveTabId });
+      const { getAllByRole } = render(<StudioTabBar {...props} />);
+      const tabs = getAllByRole("tab");
+      fireEvent.keyDown(tabs[1], { key: "Enter" });
+      expect(onSetActiveTabId).toHaveBeenCalledWith("tab-2");
+      fireEvent.keyDown(tabs[0], { key: " " });
+      expect(onSetActiveTabId).toHaveBeenCalledWith("tab-1");
+    });
+
+    test("close buttons carry the tab name in their accessible name", () => {
+      const onCloseTab = mock(() => {});
+      const props = createDefaultProps({ onCloseTab });
+      const { getByRole } = render(<StudioTabBar {...props} />);
+      fireEvent.click(getByRole("button", { name: "Close Query 2" }));
+      expect(onCloseTab).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/tests/components/studio/StudioTabBar.test.tsx
+++ b/tests/components/studio/StudioTabBar.test.tsx
@@ -379,5 +379,23 @@ describe("StudioTabBar", () => {
       fireEvent.click(close);
       expect(onCloseTab).toHaveBeenCalledTimes(1);
     });
+
+    test("rename input carries an accessible name identifying the tab", () => {
+      const props = createDefaultProps({ editingTabId: "tab-1", editingTabName: "Query 1" });
+      const { getByLabelText } = render(<StudioTabBar {...props} />);
+      expect(getByLabelText("Rename Query 1")).not.toBeNull();
+    });
+
+    test("closing a tab moves focus back to the selected tab", async () => {
+      const onCloseTab = mock(() => {});
+      const props = createDefaultProps({ activeTabId: "tab-1", onCloseTab });
+      const { getByRole, rerender } = render(<StudioTabBar {...props} />);
+      fireEvent.click(getByRole("button", { name: "Close Query 2" }));
+      // The parent removes the tab in response; simulate that re-render
+      const tab1 = createTab({ id: "tab-1", name: "Query 1" });
+      rerender(<StudioTabBar {...createDefaultProps({ tabs: [tab1], activeTabId: "tab-1", onCloseTab })} />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(document.activeElement?.getAttribute("data-tab-id")).toBe("tab-1");
+    });
   });
 });

--- a/tests/components/studio/StudioTabBar.test.tsx
+++ b/tests/components/studio/StudioTabBar.test.tsx
@@ -97,9 +97,8 @@ describe("StudioTabBar", () => {
   test("click on tab fires onSetActiveTabId with tab id", () => {
     const onSetActiveTabId = mock(() => {});
     const props = createDefaultProps({ onSetActiveTabId });
-    const { container } = render(<StudioTabBar {...props} />);
-    const tabElements = container.querySelectorAll('[class*="border-t-2"]');
-    fireEvent.click(tabElements[1]!);
+    const { getAllByRole } = render(<StudioTabBar {...props} />);
+    fireEvent.click(getAllByRole("tab")[1]);
     expect(onSetActiveTabId).toHaveBeenCalledTimes(1);
     expect(onSetActiveTabId).toHaveBeenCalledWith("tab-2");
   });
@@ -139,9 +138,8 @@ describe("StudioTabBar", () => {
     const onSetEditingTabId = mock(() => {});
     const onSetEditingTabName = mock(() => {});
     const props = createDefaultProps({ onSetEditingTabId, onSetEditingTabName });
-    const { container } = render(<StudioTabBar {...props} />);
-    const tabElements = container.querySelectorAll('[class*="border-t-2"]');
-    fireEvent.doubleClick(tabElements[0]!);
+    const { getAllByRole } = render(<StudioTabBar {...props} />);
+    fireEvent.doubleClick(getAllByRole("tab")[0]);
     expect(onSetEditingTabId).toHaveBeenCalledTimes(1);
     expect(onSetEditingTabId).toHaveBeenCalledWith("tab-1");
     expect(onSetEditingTabName).toHaveBeenCalledTimes(1);
@@ -338,22 +336,47 @@ describe("StudioTabBar", () => {
       expect(tabs[1].getAttribute("aria-selected")).toBe("false");
     });
 
-    test("Enter and Space activate a tab from the keyboard", () => {
-      const onSetActiveTabId = mock(() => {});
-      const props = createDefaultProps({ onSetActiveTabId });
+    test("tablist uses a roving tabindex: only the active tab is in tab order", () => {
+      const props = createDefaultProps({ activeTabId: "tab-1" });
       const { getAllByRole } = render(<StudioTabBar {...props} />);
       const tabs = getAllByRole("tab");
-      fireEvent.keyDown(tabs[1], { key: "Enter" });
+      expect(tabs[0].getAttribute("tabindex")).toBe("0");
+      expect(tabs[1].getAttribute("tabindex")).toBe("-1");
+    });
+
+    test("arrow keys, Home and End move activation between tabs", () => {
+      const onSetActiveTabId = mock(() => {});
+      const props = createDefaultProps({ activeTabId: "tab-1", onSetActiveTabId });
+      const { getAllByRole } = render(<StudioTabBar {...props} />);
+      const tabs = getAllByRole("tab");
+      fireEvent.keyDown(tabs[0], { key: "ArrowRight" });
       expect(onSetActiveTabId).toHaveBeenCalledWith("tab-2");
-      fireEvent.keyDown(tabs[0], { key: " " });
+      fireEvent.keyDown(tabs[1], { key: "ArrowLeft" });
+      expect(onSetActiveTabId).toHaveBeenCalledWith("tab-1");
+      fireEvent.keyDown(tabs[0], { key: "End" });
+      expect(onSetActiveTabId).toHaveBeenCalledWith("tab-2");
+      fireEvent.keyDown(tabs[1], { key: "Home" });
       expect(onSetActiveTabId).toHaveBeenCalledWith("tab-1");
     });
 
-    test("close buttons carry the tab name in their accessible name", () => {
+    test("the tab accessible name is not contaminated by nested controls", () => {
+      const props = createDefaultProps();
+      const { getAllByRole } = render(<StudioTabBar {...props} />);
+      // Exact accessible-name match: fails if the close button's label leaks in
+      expect(getAllByRole("tab", { name: "Query 1" }).length).toBe(1);
+      expect(getAllByRole("tab", { name: "Query 2" }).length).toBe(1);
+      // The close control must not be a descendant of the tab element
+      const tab = getAllByRole("tab", { name: "Query 2" })[0];
+      expect(tab.querySelector("button")).toBeNull();
+    });
+
+    test("close buttons carry the tab name and stay visible on keyboard focus", () => {
       const onCloseTab = mock(() => {});
       const props = createDefaultProps({ onCloseTab });
       const { getByRole } = render(<StudioTabBar {...props} />);
-      fireEvent.click(getByRole("button", { name: "Close Query 2" }));
+      const close = getByRole("button", { name: "Close Query 2" });
+      expect(close.className).toContain("focus-visible:opacity-100");
+      fireEvent.click(close);
       expect(onCloseTab).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
Part 1 of 2 for the accessibility pass in #100 (section 1). Clears all 39 jsx-a11y warnings in app code; the follow-up PR handles the vendored `ui/*` override, the `no-autofocus` policy, and the promotion of the rules from `warn` to `error`.

## Patterns applied

- **Native buttons** where the interactive element contains no nested controls: ResultsGrid sort headers and mobile rows, VisualExplain plan/tree rows (with `aria-expanded`), ResultCard, the DataImportModal dropzone. Keyboard activation becomes browser behavior instead of hand-rolled keydown handlers (two of which this PR deletes).
- **Stretched-link overlay** (`after:absolute after:inset-0`) where a clickable card contains nested action buttons and therefore cannot itself be a button: SavedQueries cards, SnapshotTimeline nodes. The accessible name comes from the visible title; action buttons paint above the overlay.
- **Composite tab semantics** for StudioTabBar: `role="tablist"` / `role="tab"` + `aria-selected` + Enter/Space activation; the close X and the new-tab plus icon become real labelled buttons (previously unfocusable SVGs).
- **Inner toggle button** for the schema-explorer TableItem row (the row hosts a nested dropdown trigger, so the toggle moves onto a button wrapping chevron + icon + name, with `aria-expanded`).
- **Label association** via `htmlFor`/`id` in MaskingSettings (4 Switch rows + 4 dialog fields) and DataImportModal (table select, new-table name); pure group captions become spans.
- **Accessible names** for icon-only controls: SavedQueries edit/delete, SnapshotTimeline delete, QueryHistory's empty actions `th` (sr-only text), the login-page brand link.
- **Honest exemptions**: stop-propagation-only wrappers get `role="presentation"`; the mouse-only column-resize handle gets `aria-hidden`; two oxlint `control-has-associated-label` false positives on `td` cells with dynamic text behind wrapper divs are suppressed inline with a written reason (verified with a minimal reproduction: oxlint cannot see expression content through a nested div).

`role="button"` was deliberately NOT used anywhere: it trips `prefer-tag-over-role`, which is exactly what the two pre-existing `role="button"` sites (SnapshotTimeline, VisualExplain) were flagged for - both are now real buttons.

## Testing (TDD)

Every behavior change landed test-first: 16 new a11y-semantics tests (failing before the fix) assert roles, accessible names, `aria-selected`/`aria-expanded` state, and that activation fires the same callbacks as clicking. Brittle positional selectors in existing tests (`querySelectorAll("button")[1]`, svg class matching) were replaced with role/name queries where the call shape intentionally changed.

## Warning counts

jsx-a11y: 58 before, 19 after - all remaining are vendored `ui/*` (13) plus `no-autofocus` (6), both handled by the follow-up config PR per the agreed policy.

## Verification

All local gates pass: `format` / `lint` / `typecheck` / `knip` / `test` (20 groups) / `build` / `build:lib`, plus `test:coverage && coverage:check` (100.00%, 25801/25801 lines).
