### PR TITLE
feat(windows): win32-x64 standalone zip, winget and Chocolatey automation, npx win32 support (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,25 @@ jobs:
       - name: Run linters (oxlint + ESLint)
         run: bun run lint
 
+      # The Windows launcher (issue #114) is dependency-free Go whose pure
+      # logic tests run on any OS. Gate it here, not only in the release
+      # workflow: windows-package is a hard release gate, so a launcher
+      # regression discovered first at tag time would block the release.
+      - name: Setup Go (Windows launcher toolchain)
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: packaging/windows/launcher/go.mod
+          # Dependency-free module (no go.sum) - caching would only warn.
+          cache: false
+
+      - name: Vet and test the Windows launcher (Go)
+        run: |
+          cd packaging/windows/launcher
+          gofmt -l . | tee /tmp/gofmt.out
+          test ! -s /tmp/gofmt.out
+          go vet ./...
+          go test ./...
+
       - name: Run TypeScript type check
         run: bun run typecheck
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -263,6 +263,14 @@ jobs:
           "${SYSTEMROOT:-${SystemRoot:-C:\\Windows}}/System32/tar.exe" -xf "dist/libredb-studio-standalone-${VERSION}-win32-x64.zip" -C "$SMOKE_DIR"
           test -f "$SMOKE_DIR/libredb-studio.exe"
           test -f "$SMOKE_DIR/node/node.exe"
+          # Issue #114 constraint: the drivers must load on Windows with the
+          # BUNDLED runtime - the health route never imports them, so probe
+          # explicitly before booting. better-sqlite3 is the native binding
+          # (the real prebuild risk); oracledb ships as a traced standalone
+          # node_modules package. mssql cannot be probed this way by design:
+          # Next bundles it (pure-JS tedious, no Windows prebuild risk) into
+          # the server chunks instead of node_modules.
+          (cd "$SMOKE_DIR" && ./node/node.exe -e "require('better-sqlite3')(':memory:').close(); require('oracledb'); console.log('db driver probe ok')")
           # Zero-config boot through the launcher: storage defaults under
           # %LOCALAPPDATA%\LibreDB\Studio, bind defaults to loopback, and
           # the first run must print generated admin credentials.
@@ -854,6 +862,17 @@ jobs:
           if gh api "repos/microsoft/winget-pkgs/contents/manifests/l/LibreDB/Studio/${VERSION}" --jq '.[0].name' >/dev/null 2>&1; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "::notice::winget already carries LibreDB.Studio ${VERSION} - nothing to submit"
+            exit 0
+          fi
+          # The Contents API only reflects MERGED manifests, and wingetcreate
+          # has no duplicate detection of its own - a rerun while this
+          # version's update PR is still open must not submit a second one.
+          OPEN_PRS=$(gh api -X GET search/issues \
+            -f q="repo:microsoft/winget-pkgs is:pr is:open in:title LibreDB.Studio ${VERSION}" \
+            --jq '.total_count' 2>/dev/null || echo 0)
+          if [ "$OPEN_PRS" != "0" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::an open winget-pkgs PR for LibreDB.Studio ${VERSION} already exists - skipping a duplicate submission"
             exit 0
           fi
           echo "enabled=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -23,8 +23,8 @@ name: Release Artifacts
 # verifies the full asset set, and publishes the release as its LAST step.
 # Because that publish runs under GITHUB_TOKEN it fires no `release:published`
 # triggers; npm-publish and docker-build-push are chained explicitly by the
-# final dispatch step instead. A hand-written draft release for the tag is
-# reused if one exists; otherwise a draft is created with generated notes.
+# dispatch-downstream job instead. A hand-written draft release for the tag
+# is reused if one exists; otherwise a draft is created with generated notes.
 
 on:
   push:
@@ -685,10 +685,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # Required by the chain-dispatch step below: gh workflow run calls the
-      # Actions API, and an explicit permissions block disables every scope
-      # it does not name.
-      actions: write
     steps:
       - name: Verify the draft carries the full asset set
         env:
@@ -735,15 +731,27 @@ jobs:
           gh release edit "$TAG" --draft=false --latest
           echo "Release '$TAG' published with the verified asset set."
 
+  dispatch-downstream:
+    # The publish above runs under GITHUB_TOKEN, and events created by
+    # GITHUB_TOKEN do not trigger other workflows (the 0.9.46 release
+    # published without npm/Docker firing). workflow_dispatch API calls
+    # are NOT subject to that restriction, so chain the downstream
+    # channels explicitly. A SIBLING job (not a publish-release step) on
+    # purpose: the chocolatey and winget jobs below need only "the release
+    # is published", and a transient dispatch failure here must not skip
+    # them. Version safety comes from the guard job (TAG validated against
+    # package.json at the tagged commit) plus the --ref pinning below -
+    # docker trusts its version input and npm derives the version from the
+    # ref's package.json.
+    name: Dispatch npm and Docker publish
+    needs: [guard, publish-release]
+    runs-on: ubuntu-latest
+    permissions:
+      # gh workflow run calls the Actions API, and an explicit permissions
+      # block disables every scope it does not name.
+      actions: write
+    steps:
       - name: Dispatch npm and Docker publish
-        # The publish above runs under GITHUB_TOKEN, and events created by
-        # GITHUB_TOKEN do not trigger other workflows (the 0.9.46 release
-        # published without npm/Docker firing). workflow_dispatch API calls
-        # are NOT subject to that restriction, so chain the downstream
-        # channels explicitly. Version safety comes from this workflow's
-        # guard job (TAG validated against package.json at the tagged
-        # commit) plus the --ref pinning below - docker trusts its version
-        # input and npm derives the version from the ref's package.json.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -816,9 +824,11 @@ jobs:
           VERSION: ${{ needs.guard.outputs.version }}
         run: |
           # The image's `choco` wrapper already runs the Mono build with
-          # --allow-unofficial; do not pass it again.
+          # --allow-unofficial; do not pass it again. Pinned by immutable
+          # digest (the tag is readability only): a mutable latest-linux
+          # would hand CHOCO_API_KEY to whatever the tag points at.
           docker run --rm -v "$PWD/pkg/choco:/wd" -w /wd -e CHOCO_API_KEY -e VERSION \
-            chocolatey/choco:latest-linux sh -c '
+            chocolatey/choco:v2.7.3-linux@sha256:ae878c6e550ed7bd0adfb958f2f54b3aadab585d6a9386ad9e23a1aae06bee3d sh -c '
               set -eu
               choco pack
               choco push "libredb-studio.${VERSION}.nupkg" \
@@ -886,7 +896,18 @@ jobs:
           WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGETCREATE_GITHUB_TOKEN }}
           VERSION: ${{ needs.guard.outputs.version }}
         run: |
-          Invoke-WebRequest -Uri 'https://aka.ms/wingetcreate/latest' -OutFile wingetcreate.exe
+          # Pinned wingetcreate release, checksum-verified before execution:
+          # the aka.ms/latest redirect is mutable, and this process holds the
+          # classic PAT in its environment. Update the version and sha256
+          # together (digest from the GitHub release asset).
+          $wingetcreateVersion = 'v1.12.8.0'
+          $wingetcreateSha256 = '8bd738851b524885410112678e3771b341c5c716de60fbbecb88ab0a363ed85d'
+          Invoke-WebRequest -Uri "https://github.com/microsoft/winget-create/releases/download/$wingetcreateVersion/wingetcreate.exe" -OutFile wingetcreate.exe
+          $actual = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $wingetcreateSha256) {
+            Write-Error "wingetcreate.exe sha256 mismatch: expected $wingetcreateSha256, got $actual"
+            exit 1
+          }
           $url = "https://github.com/libredb/libredb-studio/releases/download/$env:VERSION/libredb-studio-standalone-$env:VERSION-win32-x64.zip"
           .\wingetcreate.exe update LibreDB.Studio --version $env:VERSION --urls "$url|x64" --submit
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -10,6 +10,11 @@ name: Release Artifacts
 # it to libredb/homebrew-tap when TAP_GITHUB_TOKEN is configured (issue #111).
 # The snap job builds the server snap from the linux tarballs and publishes it
 # to the Snap Store when SNAPCRAFT_STORE_CREDENTIALS is configured (issue #113).
+# The windows-package job builds the win32-x64 standalone zip (bundled Node
+# runtime + Go launcher exe, issue #114); after the release is published the
+# chocolatey job pushes the package to the Chocolatey community repository
+# when CHOCO_API_KEY is configured, and the winget job submits an update PR
+# to microsoft/winget-pkgs when WINGETCREATE_GITHUB_TOKEN is configured.
 #
 # DRAFT-FIRST FLOW (issue #154): the repository uses immutable releases, which
 # freeze a release's assets the moment it is published - post-publish uploads
@@ -173,9 +178,144 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  windows-package:
+    name: Build win32-x64 standalone zip
+    # Builds the Windows release artifact (issue #114): the standalone
+    # payload (built natively on windows-latest), the pinned Node runtime
+    # (packaging/windows/fetch-node.sh), and the Go launcher
+    # (packaging/windows/launcher) assembled into ONE flat zip - the
+    # artifact winget and Chocolatey install and the npx launcher downloads
+    # on win32. Smoke: the final zip is extracted fresh and booted through
+    # libredb-studio.exe (the exact end-user path).
+    #
+    # DELIBERATELY a hard release gate: publish needs this job, exactly like
+    # the POSIX build matrix - the win32 zip is a core artifact on the
+    # publish-release required-assets list (#114), not an optional channel
+    # like snap. A failure here blocks the whole release train by design;
+    # a release without its Windows artifact would strand winget/Chocolatey
+    # (their manifests point at this exact asset) and npx on win32.
+    needs: guard
+    runs-on: windows-latest
+    defaults:
+      run:
+        # Git Bash: keeps the packaging scripts single-source with the POSIX
+        # jobs. Anything needing the System32 bsdtar addresses it absolutely
+        # (Git Bash's own tar is GNU tar, which cannot read zip).
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Setup Go (launcher toolchain)
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: packaging/windows/launcher/go.mod
+          # The launcher is dependency-free (no go.sum) - module caching
+          # would only emit restore warnings.
+          cache: false
+
+      - name: Vet and test the launcher
+        run: |
+          cd packaging/windows/launcher
+          gofmt -l . | tee /tmp/gofmt.out
+          test ! -s /tmp/gofmt.out
+          go vet ./...
+          go test ./...
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build the standalone payload zip
+        run: bash scripts/build-standalone-payload.sh dist
+
+      - name: Bundle the Node runtime and launcher, re-pack the zip
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          ZIP="dist/libredb-studio-standalone-${VERSION}-win32-x64.zip"
+          STAGING="$RUNNER_TEMP/win-payload"
+          mkdir -p "$STAGING"
+          # Env-var casing differs between shells (SystemRoot vs SYSTEMROOT);
+          # cover both before falling back to the canonical location.
+          "${SYSTEMROOT:-${SystemRoot:-C:\\Windows}}/System32/tar.exe" -xf "$ZIP" -C "$STAGING"
+          bash packaging/windows/fetch-node.sh "$STAGING"
+          (cd packaging/windows/launcher && \
+            CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
+            go build -trimpath -ldflags="-s -w" -o "$STAGING/libredb-studio.exe" .)
+          bash scripts/lib/pack-standalone-zip.sh "$STAGING" "$ZIP"
+
+      - name: Smoke test the final zip via libredb-studio.exe
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          SMOKE_DIR="$RUNNER_TEMP/win-smoke"
+          mkdir -p "$SMOKE_DIR"
+          "${SYSTEMROOT:-${SystemRoot:-C:\\Windows}}/System32/tar.exe" -xf "dist/libredb-studio-standalone-${VERSION}-win32-x64.zip" -C "$SMOKE_DIR"
+          test -f "$SMOKE_DIR/libredb-studio.exe"
+          test -f "$SMOKE_DIR/node/node.exe"
+          # Zero-config boot through the launcher: storage defaults under
+          # %LOCALAPPDATA%\LibreDB\Studio, bind defaults to loopback, and
+          # the first run must print generated admin credentials.
+          PORT=3900
+          # exec pins $! to the launcher itself (same pattern as the POSIX
+          # smoke in scripts/build-standalone-payload.sh), not a wrapper
+          # subshell.
+          (cd "$SMOKE_DIR" && PORT="$PORT" exec ./libredb-studio.exe) > /tmp/win-smoke.log 2>&1 &
+          LAUNCHER_PID=$!
+          HEALTHY=false
+          for _ in $(seq 1 60); do
+            if ! kill -0 "$LAUNCHER_PID" 2>/dev/null; then break; fi
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/api/db/health" || true)
+            if [ "$CODE" = "200" ]; then HEALTHY=true; break; fi
+            sleep 2
+          done
+          if [ "$HEALTHY" != "true" ]; then
+            echo "Smoke test FAILED: /api/db/health did not return 200" >&2
+            cat /tmp/win-smoke.log >&2 || true
+            exit 1
+          fi
+          grep -q "first run: generated admin credentials" /tmp/win-smoke.log
+          # The embedded SQLite sample seeds asynchronously into the storage
+          # directory (the launcher's %LOCALAPPDATA% default) - its absence
+          # means the zip shipped without seed-assets/.
+          SAMPLE_SEEDED=false
+          for _ in $(seq 1 30); do
+            if [ -f "${LOCALAPPDATA}/LibreDB/Studio/sample-employees.db" ]; then SAMPLE_SEEDED=true; break; fi
+            sleep 1
+          done
+          if [ "$SAMPLE_SEEDED" != "true" ]; then
+            echo "Smoke test FAILED: embedded SQLite sample was not seeded within 30s" >&2
+            cat /tmp/win-smoke.log >&2 || true
+            exit 1
+          fi
+          echo "Smoke: launcher booted, /api/db/health returned 200, first-run banner printed, sample seeded"
+          # Tear the whole tree down (launcher exe + its node.exe child) so
+          # nothing holds files open while the artifact uploads; the doubled
+          # slashes stop Git Bash's path mangling of taskkill's /flags.
+          taskkill //F //T //IM libredb-studio.exe 2>/dev/null || true
+          kill "$LAUNCHER_PID" 2>/dev/null || true
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: standalone-win32-x64
+          path: dist/libredb-studio-standalone-*-win32-x64.zip
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: Attach artifacts to release
-    needs: [guard, build, draft]
+    needs: [guard, build, windows-package, draft]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -185,7 +325,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Download all tarballs
+      - name: Download all standalone archives
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: standalone-*
@@ -193,9 +333,11 @@ jobs:
           path: dist
 
       - name: Generate SHA256SUMS
+        # Covers the POSIX tarballs AND the win32 zip: winget, Chocolatey,
+        # and the npx launcher all verify against this one checksum file.
         run: |
           cd dist
-          sha256sum libredb-studio-standalone-*.tar.gz > SHA256SUMS
+          sha256sum libredb-studio-standalone-*.tar.gz libredb-studio-standalone-*.zip > SHA256SUMS
           cat SHA256SUMS
 
       - name: Upload artifacts to GitHub release
@@ -203,7 +345,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.guard.outputs.version }}
         run: |
-          gh release upload "$TAG" dist/libredb-studio-standalone-*.tar.gz dist/SHA256SUMS \
+          gh release upload "$TAG" dist/libredb-studio-standalone-*.tar.gz \
+            dist/libredb-studio-standalone-*.zip dist/SHA256SUMS \
             --clobber --repo "$GITHUB_REPOSITORY"
 
       # The Homebrew tap update is optional: it only runs when TAP_GITHUB_TOKEN
@@ -557,6 +700,7 @@ jobs:
             "libredb-studio-standalone-${TAG}-linux-arm64.tar.gz" \
             "libredb-studio-standalone-${TAG}-darwin-x64.tar.gz" \
             "libredb-studio-standalone-${TAG}-darwin-arm64.tar.gz" \
+            "libredb-studio-standalone-${TAG}-win32-x64.zip" \
             "SHA256SUMS" \
             "libredb-studio_${TAG}_amd64.deb" \
             "libredb-studio_${TAG}_amd64.deb.sha256" \
@@ -609,3 +753,121 @@ jobs:
           gh workflow run docker-build-push.yml --ref "refs/tags/$TAG" \
             -f "version=$TAG" -f "publish_latest=true"
           echo "Dispatched npm-publish and docker-build-push for '$TAG'."
+
+  chocolatey:
+    name: Push Chocolatey package
+    # Renders the Chocolatey package from packaging/chocolatey/ templates and
+    # pushes it to the community repository (issue #114). Runs strictly AFTER
+    # the release is published: chocolateyinstall.ps1 downloads the zip from
+    # the release URL, which only becomes public at publish time (draft
+    # assets are not downloadable). Gated on CHOCO_API_KEY with the same
+    # pattern as the snap job; the first push enters human moderation - see
+    # docs/DISTRIBUTION.md ("Windows").
+    needs: [guard, publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Chocolatey availability
+        id: choco
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+        run: |
+          if [ -n "$CHOCO_API_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CHOCO_API_KEY is not configured - skipping the Chocolatey publish"
+          fi
+
+      - name: Checkout code
+        if: steps.choco.outputs.enabled == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download SHA256SUMS from the published release
+        if: steps.choco.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.guard.outputs.version }}
+        run: gh release download "$TAG" --pattern SHA256SUMS --dir dist --repo "$GITHUB_REPOSITORY"
+
+      - name: Render the package from templates
+        if: steps.choco.outputs.enabled == 'true'
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          node scripts/render-windows-packaging.mjs \
+            packaging/chocolatey/libredb-studio.nuspec.tmpl \
+            dist/SHA256SUMS "$VERSION" pkg/choco/libredb-studio.nuspec
+          node scripts/render-windows-packaging.mjs \
+            packaging/chocolatey/tools/chocolateyinstall.ps1.tmpl \
+            dist/SHA256SUMS "$VERSION" pkg/choco/tools/chocolateyinstall.ps1
+
+      - name: Pack and push with the official choco container
+        if: steps.choco.outputs.enabled == 'true'
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          # The image's `choco` wrapper already runs the Mono build with
+          # --allow-unofficial; do not pass it again.
+          docker run --rm -v "$PWD/pkg/choco:/wd" -w /wd -e CHOCO_API_KEY -e VERSION \
+            chocolatey/choco:latest-linux sh -c '
+              set -eu
+              choco pack
+              choco push "libredb-studio.${VERSION}.nupkg" \
+                --source https://push.chocolatey.org/ --api-key="$CHOCO_API_KEY"
+            '
+
+  winget:
+    name: Submit winget update PR
+    # Submits a version-update PR to microsoft/winget-pkgs (issue #114) via
+    # wingetcreate, strictly AFTER the release is published - the winget
+    # validation pipeline downloads InstallerUrl, which only becomes public
+    # at publish time. Gated on WINGETCREATE_GITHUB_TOKEN (classic PAT with
+    # public_repo scope; wingetcreate does not support fine-grained PATs).
+    # Skips cleanly when the package has no listing yet (the FIRST
+    # submission is manual, see docs/DISTRIBUTION.md) or when this version
+    # is already in the community repo (wingetcreate has no duplicate-PR
+    # detection of its own).
+    needs: [guard, publish-release]
+    runs-on: windows-latest
+    steps:
+      - name: Check winget submission availability
+        id: winget
+        shell: bash
+        env:
+          WINGETCREATE_GITHUB_TOKEN: ${{ secrets.WINGETCREATE_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          if [ -z "$WINGETCREATE_GITHUB_TOKEN" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::WINGETCREATE_GITHUB_TOKEN is not configured - skipping the winget submission"
+            exit 0
+          fi
+          # wingetcreate update cannot create a first listing; it exits with
+          # a generic failure when the id is unknown, so pre-check instead.
+          if ! gh api "repos/microsoft/winget-pkgs/contents/manifests/l/LibreDB/Studio" --jq '.[0].name' >/dev/null 2>&1; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::LibreDB.Studio is not listed in microsoft/winget-pkgs yet - submit the first manifest manually (docs/DISTRIBUTION.md, Windows first-listing checklist)"
+            exit 0
+          fi
+          if gh api "repos/microsoft/winget-pkgs/contents/manifests/l/LibreDB/Studio/${VERSION}" --jq '.[0].name' >/dev/null 2>&1; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::winget already carries LibreDB.Studio ${VERSION} - nothing to submit"
+            exit 0
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Submit the update PR with wingetcreate
+        if: steps.winget.outputs.enabled == 'true'
+        shell: pwsh
+        env:
+          # Official CI pattern: wingetcreate reads the token from
+          # WINGET_CREATE_GITHUB_TOKEN, keeping it off the command line.
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGETCREATE_GITHUB_TOKEN }}
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          Invoke-WebRequest -Uri 'https://aka.ms/wingetcreate/latest' -OutFile wingetcreate.exe
+          $url = "https://github.com/libredb/libredb-studio/releases/download/$env:VERSION/libredb-studio-standalone-$env:VERSION-win32-x64.zip"
+          .\wingetcreate.exe update LibreDB.Studio --version $env:VERSION --urls "$url|x64" --submit
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/README.md
+++ b/README.md
@@ -197,12 +197,14 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
   | :--- | :--- | :--- |
   | **Docker** | `docker run -d -p 3000:3000 ghcr.io/libredb/libredb-studio:latest` | Zero-config: the admin password is printed to the log on first run |
   | **Helm (Kubernetes)** | `helm install libredb oci://ghcr.io/libredb/charts/libredb-studio` | Zero-config: first-run admin credentials are printed to the pod log |
-  | **npx** | `npx @libredb/studio` | Linux/macOS, Node 20.9+ (Node 24 LTS recommended); downloads the release server tarball |
+  | **npx** | `npx @libredb/studio` | Linux/macOS/Windows, Node 20.9+ (Node 24 LTS recommended); downloads the release server archive |
   | **Homebrew** | `brew trust libredb/tap && brew install libredb/tap/libredb-studio` | `brew trust` is required once (Homebrew 6+; run `brew update` if unknown) |
   | **deb / rpm** | `sudo dpkg -i libredb-studio_<version>_amd64.deb` | Attached to each GitHub release; systemd service included |
   | **Snap** | `sudo snap install libredb-studio` | Zero-config: the admin password is printed to `sudo snap logs libredb-studio` on first run — [Snap Store listing](https://snapcraft.io/libredb-studio) |
+  | **winget (Windows)** | `winget install LibreDB.Studio` | Portable zip with a bundled Node.js runtime; run `libredb-studio` — available once the first community listing lands, track [#114](https://github.com/libredb/libredb-studio/issues/114) |
+  | **Chocolatey (Windows)** | `choco install libredb-studio` | Same standalone zip — available once the first community listing lands, track [#114](https://github.com/libredb/libredb-studio/issues/114) |
 
-  > Homebrew, deb/rpm, Snap, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md).
+  > Homebrew, deb/rpm, Snap, winget/Chocolatey, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md).
 
   ### Quick Start (Docker)
 

--- a/bin/lib/launcher-utils.mjs
+++ b/bin/lib/launcher-utils.mjs
@@ -11,13 +11,21 @@ import { createReadStream, existsSync, renameSync, rmSync } from "node:fs";
 import * as path from "node:path";
 
 /**
- * Platform/arch pairs the release workflow builds standalone tarballs for
- * (must mirror the matrix in .github/workflows/release-artifacts.yml).
+ * Platform/arch pairs the release workflow builds standalone payloads for
+ * (must mirror the build jobs in .github/workflows/release-artifacts.yml).
  */
 const SUPPORTED_TARGETS = {
   linux: ["x64", "arm64"],
   darwin: ["x64", "arm64"],
+  win32: ["x64"],
 };
+
+/**
+ * Archive extension per platform: POSIX targets ship .tar.gz; Windows ships
+ * a .zip (issue #114) because winget's InstallerType is zip and Windows has
+ * no gzip/tar toolchain guarantee outside the System32 bsdtar.
+ */
+const ARCHIVE_EXTENSION = { linux: ".tar.gz", darwin: ".tar.gz", win32: ".zip" };
 
 /** Thrown for user-facing CLI mistakes; the entry prints the message plus usage. */
 export class LauncherUsageError extends Error {}
@@ -47,7 +55,7 @@ export function assertReleaseVersion(version) {
 /**
  * Map a Node process.platform/process.arch pair to the release artifact name.
  * The naming must mirror scripts/build-standalone-payload.sh:
- * libredb-studio-standalone-<version>-<os>-<arch>.tar.gz
+ * libredb-studio-standalone-<version>-<os>-<arch>.tar.gz (.zip on win32).
  * Throws for targets the release workflow does not build.
  *
  * @param {string} version
@@ -61,10 +69,10 @@ export function artifactName(version, platform, arch) {
   if (!archs || !archs.includes(arch)) {
     throw new Error(
       `No standalone artifact is published for ${platform}-${arch}. ` +
-        "Supported targets: linux-x64, linux-arm64, darwin-x64, darwin-arm64.",
+        "Supported targets: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64.",
     );
   }
-  return `libredb-studio-standalone-${version}-${platform}-${arch}.tar.gz`;
+  return `libredb-studio-standalone-${version}-${platform}-${arch}${ARCHIVE_EXTENSION[platform]}`;
 }
 
 /**
@@ -146,20 +154,53 @@ export function preservePayloadData(payloadDir, stagingDir) {
 }
 
 /**
- * Extract a tarball into destDir via the system `tar`. Release tarballs are
- * packed under a top-level libredb-studio-<version>/ root (issue #133,
- * scripts/lib/pack-standalone-tarball.sh) instead of a tarbomb, so every
- * entry is unwrapped one path component - the payload (server.js, etc.)
- * lands directly in destDir, matching every caller's expectation.
+ * Build the archive extraction command for extractArchive. Pure so the
+ * per-format/per-platform branches are unit-testable on any host:
+ * - .tar.gz: system `tar`, stripping the top-level libredb-studio-<version>/
+ *   root the tarballs are packed under (issue #133,
+ *   scripts/lib/pack-standalone-tarball.sh).
+ * - .zip (the win32-x64 payload, issue #114): flat by design - winget's
+ *   NestedInstallerFiles.RelativeFilePath must stay stable across versions,
+ *   so there is no versioned root and nothing to strip. On Windows the
+ *   command is the absolute System32 bsdtar (reads zip natively): a bare
+ *   `tar` could resolve to Git Bash's GNU tar, which cannot read zip. On
+ *   macOS the system tar IS bsdtar, so plain `tar -xf` handles zip there.
+ *   On linux GNU tar cannot read zip at all, so a zip --archive is refused
+ *   with a clear error instead of a cryptic tar failure (npx on linux only
+ *   ever downloads the .tar.gz artifact).
  *
- * @param {string} tarballPath
+ * @param {string} archivePath
+ * @param {string} destDir
+ * @param {string} platform value of process.platform
+ * @param {Record<string, string | undefined>} env process.env shape
+ * @returns {{ command: string, args: string[] }}
+ */
+export function extractionCommand(archivePath, destDir, platform, env) {
+  if (archivePath.toLowerCase().endsWith(".zip")) {
+    if (platform !== "win32" && platform !== "darwin") {
+      throw new Error(
+        `zip archives cannot be extracted on ${platform} (GNU tar has no zip support) - ` +
+          "use the .tar.gz artifact instead (the zip is the win32 artifact)",
+      );
+    }
+    const command = platform === "win32" ? `${env.SystemRoot || "C:\\Windows"}\\System32\\tar.exe` : "tar";
+    return { command, args: ["-xf", archivePath, "-C", destDir] };
+  }
+  return { command: "tar", args: ["-xzf", archivePath, "-C", destDir, "--strip-components=1"] };
+}
+
+/**
+ * Extract a release archive (tarball or win32 zip) into destDir - the
+ * payload (server.js, etc.) lands directly in destDir on every platform
+ * (see extractionCommand for the per-format layout contract).
+ *
+ * @param {string} archivePath
  * @param {string} destDir
  * @returns {{ status: number | null, error: Error | null }}
  */
-export function extractTarball(tarballPath, destDir) {
-  const result = spawnSync("tar", ["-xzf", tarballPath, "-C", destDir, "--strip-components=1"], {
-    stdio: "inherit",
-  });
+export function extractArchive(archivePath, destDir) {
+  const { command, args } = extractionCommand(archivePath, destDir, process.platform, process.env);
+  const result = spawnSync(command, args, { stdio: "inherit" });
   return { status: result.status, error: result.error ?? null };
 }
 

--- a/bin/studio.js
+++ b/bin/studio.js
@@ -24,7 +24,7 @@ import { pipeline } from "node:stream/promises";
 import {
   artifactName,
   assessNodeRuntime,
-  extractTarball,
+  extractArchive,
   LauncherUsageError,
   parseLauncherArgs,
   parseSha256Sums,
@@ -41,21 +41,21 @@ const USAGE = `LibreDB Studio ${pkg.version} launcher
 Usage: npx @libredb/studio [options]
 
 Starts the LibreDB Studio standalone server. On first run the launcher
-downloads the release tarball for this platform from GitHub Releases,
-verifies its SHA256 checksum, and caches it in ~/.libredb-studio/${pkg.version}/.
-Later runs start straight from the cache.
+downloads the release archive for this platform (tar.gz; zip on Windows)
+from GitHub Releases, verifies its SHA256 checksum, and caches it in
+~/.libredb-studio/${pkg.version}/. Later runs start straight from the cache.
 
 Options:
   --port <n>        Port to listen on (default: $PORT or 3000)
   --host <addr>     Address to bind (default: $HOSTNAME or 127.0.0.1;
                     use --host 0.0.0.0 to expose on the network)
-  --archive <path>  Start from a local standalone tarball instead of
+  --archive <path>  Start from a local standalone archive instead of
                     downloading (env: LIBREDB_STUDIO_ARCHIVE). WARNING:
                     local archives skip checksum verification unless
-                    --archive-sha256 is given - only use tarballs you
+                    --archive-sha256 is given - only use archives you
                     built or obtained from a trusted source.
   --archive-sha256 <hex>
-                    Expected sha256 of the --archive tarball; mismatch
+                    Expected sha256 of the --archive file; mismatch
                     refuses to start
   --verify-cache    Re-verify the cached tarball checksum and re-extract
                     the payload before starting
@@ -163,24 +163,26 @@ async function download(url, destination) {
 }
 
 /**
- * Unpack a payload tarball into payloadDir (atomic: staging dir then rename).
- * `tar` exists on all supported POSIX platforms (linux, darwin). The tarball
- * is packed under a top-level libredb-studio-<version>/ root (issue #133),
- * which extractTarball strips. A previous payload's data/ dir (generated
+ * Unpack a payload archive into payloadDir (atomic: staging dir then rename).
+ * `tar` exists on all supported platforms: GNU/bsd tar on linux and darwin,
+ * the System32 bsdtar on win32 (which also reads the flat win32 .zip -
+ * see extractionCommand in lib/launcher-utils.mjs, issue #114). Tarballs
+ * are packed under a top-level libredb-studio-<version>/ root (issue #133),
+ * which extractArchive strips. A previous payload's data/ dir (generated
  * credentials, SQLite storage) is preserved across the swap - see
  * preservePayloadData (issue #132).
  *
- * @param {string} tarballPath
+ * @param {string} archivePath
  * @param {string} payloadDir
  */
-function extract(tarballPath, payloadDir) {
+function extract(archivePath, payloadDir) {
   console.log(`Unpacking into ${payloadDir}`);
   const staging = `${payloadDir}.extracting`;
   fs.rmSync(staging, { recursive: true, force: true });
   fs.mkdirSync(staging, { recursive: true });
-  const { status, error } = extractTarball(tarballPath, staging);
+  const { status, error } = extractArchive(archivePath, staging);
   if (error) fail(`Could not run tar: ${error.message}`);
-  if (status !== 0) fail(`tar exited with code ${status} while unpacking ${tarballPath}`);
+  if (status !== 0) fail(`tar exited with code ${status} while unpacking ${archivePath}`);
   preservePayloadData(payloadDir, staging);
   fs.rmSync(payloadDir, { recursive: true, force: true });
   fs.renameSync(staging, payloadDir);
@@ -264,17 +266,6 @@ async function main() {
     return;
   }
 
-  if (process.platform === "win32") {
-    fail(
-      [
-        "LibreDB Studio standalone tarballs are not available for Windows yet.",
-        "Run Studio with Docker instead:",
-        "  docker run -p 3000:3000 ghcr.io/libredb/libredb-studio:latest",
-        "Native Windows support is tracked in https://github.com/libredb/libredb-studio/issues/114",
-      ].join("\n"),
-    );
-  }
-
   // Refuse runtimes the payload cannot run on and surface degraded tiers
   // up front, before any download happens (see assessNodeRuntime).
   const runtime = assessNodeRuntime(process.versions.node);
@@ -314,7 +305,7 @@ async function main() {
   }
 
   if (!fs.existsSync(path.join(payloadDir, "server.js"))) {
-    fail(`Payload in ${payloadDir} has no server.js - not a LibreDB Studio standalone tarball`);
+    fail(`Payload in ${payloadDir} has no server.js - not a LibreDB Studio standalone archive`);
   }
   startServer(payloadDir, args.port, args.host);
 }

--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.16
-appVersion: "0.9.56"
+version: 0.1.17
+appVersion: "0.9.57"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.56
+      image: ghcr.io/libredb/libredb-studio:0.9.57
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.16 \
+  --version 0.1.17 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -351,7 +351,7 @@ channels:
       strategy: none
 
   - id: winget
-    name: Windows distribution (winget / Chocolatey)
+    name: winget community repository (LibreDB.Studio)
     status: pending
     tier: 4
     kind: package-manager
@@ -360,6 +360,27 @@ channels:
       sla: every_release
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/114
+      upstream_repo: https://github.com/microsoft/winget-pkgs
+      docs: docs/DISTRIBUTION.md
     pin:
       strategy: none
-      note: Blocked on a Windows standalone payload.
+      note: Release CI submits update PRs via wingetcreate (WINGETCREATE_GITHUB_TOKEN gate); the
+        FIRST listing is a manual submission awaiting moderation. Flip to live and add a
+        winget-pkgs pin once it merges.
+
+  - id: chocolatey
+    name: Chocolatey community repository (libredb-studio)
+    status: pending
+    tier: 4
+    kind: package-manager
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/114
+      catalog: https://community.chocolatey.org/packages/libredb-studio
+      docs: docs/DISTRIBUTION.md
+    pin:
+      strategy: none
+      note: Release CI packs and pushes via the choco container (CHOCO_API_KEY gate); the first
+        push sits in human moderation. Flip to live and add a community-API pin once approved.

--- a/docs/DESKTOP_WRAPPER_SPIKE.md
+++ b/docs/DESKTOP_WRAPPER_SPIKE.md
@@ -118,10 +118,9 @@ Per-OS native-module notes:
 - **Node runtime is bundled per platform**, pinned and checksum-verified against the official
   `SHASUMS256.txt` — the mechanism already implemented in `packaging/linux/fetch-node.sh`
   (Node 24.18.0); extend the same script pattern to darwin and win32 dist tarballs.
-- **Windows gap:** there is no Windows standalone tarball today (`bin/studio.js` points Windows
-  users to Docker and issue #114). The wrapper's Windows target therefore depends on adding a
-  `win32-x64` payload build to `release-artifacts.yml` first — this is the shared prerequisite
-  with winget/Chocolatey (#114, option 2 of which explicitly anticipates the wrapper installer).
+- **Windows gap (closed by #114):** `release-artifacts.yml` now builds the `win32-x64`
+  standalone zip (bundled Node runtime + Go launcher, `packaging/windows/`), and `bin/studio.js`
+  runs it via npx on Windows — the wrapper's Windows target can consume that payload directly.
 - **macOS:** everything inside the .app bundle (Node binary included) must be signed and
   notarized together; unsigned nested binaries fail Gatekeeper on first launch.
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -489,7 +489,8 @@ Download `libredb-studio-standalone-<version>-win32-x64.zip` and `SHA256SUMS` fr
 # Verify (compare against the SHA256SUMS line for the zip)
 Get-FileHash .\libredb-studio-standalone-<version>-win32-x64.zip -Algorithm SHA256
 
-# Extract (Explorer "Extract All...", or:)
+# Extract (Explorer "Extract All...", or - tar -C needs the directory to exist:)
+mkdir libredb-studio
 tar -xf .\libredb-studio-standalone-<version>-win32-x64.zip -C libredb-studio
 
 # Run from the extracted directory

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -87,13 +87,14 @@ Release tags carry **no `v` prefix** (tag `0.9.41` == package.json version). Eac
 | Artifact | Name | Targets |
 |---|---|---|
 | Standalone server tarball | `libredb-studio-standalone-<version>-<os>-<arch>.tar.gz` | `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64` |
-| Checksums | `SHA256SUMS` | covers all tarballs |
+| Standalone server zip (Windows) | `libredb-studio-standalone-<version>-win32-x64.zip` | `win32-x64` (bundled Node runtime + `libredb-studio.exe` launcher) |
+| Checksums | `SHA256SUMS` | covers all standalone tarballs and the win32 zip |
 | Debian package | `libredb-studio_<version>_<arch>.deb` (+ `.sha256` sidecar) | `amd64`, `arm64` |
 | RPM package | `libredb-studio-<version>.<arch>.rpm` (+ `.sha256` sidecar) | `x86_64`, `aarch64` |
 | Snap | `libredb-studio_<version>_<arch>.snap` | `amd64`, `arm64` (also published to the Snap Store) |
 
-`SHA256SUMS` covers the standalone tarballs; each `.deb`/`.rpm` ships its own per-file
-`<artifact>.sha256` sidecar instead (the packages are built in a separate job).
+`SHA256SUMS` covers the standalone tarballs and the win32 zip; each `.deb`/`.rpm` ships its own
+per-file `<artifact>.sha256` sidecar instead (the packages are built in a separate job).
 
 Standalone tarball entries are rooted under a top-level `libredb-studio-<version>/` directory
 (not a tarbomb) - extract with `tar --strip-components=1` (`tar xzf <artifact>
@@ -101,6 +102,13 @@ Standalone tarball entries are rooted under a top-level `libredb-studio-<version
 `scripts/build-standalone-payload.sh`'s own `--smoke` self-test all do; Homebrew strips the single
 top-level directory automatically for its main `url`/`sha256` download, so the formula needs no
 extra flag.
+
+The **win32 zip is deliberately FLAT** (entries at the archive root, no versioned wrapper
+directory - `scripts/lib/pack-standalone-zip.sh`): winget resolves the manifest's
+`NestedInstallerFiles.RelativeFilePath` against the zip root and `wingetcreate update` never
+rewrites that path, so it must stay `libredb-studio.exe` across releases; Chocolatey likewise
+unzips straight into its package tools directory. Windows Explorer's "Extract All" already
+defaults to a folder named after the zip, so manual extraction stays tidy.
 
 The payload contains only the runtime (`server.js`, `package.json`, `.next`, `node_modules`,
 `public`, an empty `data/`, plus `LICENSE`/`README.md`): Next.js output file tracing sweeps the
@@ -113,9 +121,6 @@ repo root (CI release checkouts are clean; published artifacts are unaffected).
 
 Download URL pattern:
 `https://github.com/libredb/libredb-studio/releases/download/<version>/<artifact>`.
-
-There is no Windows standalone artifact yet — Windows users should run Docker; native Windows
-packaging is tracked in [issue #114](https://github.com/libredb/libredb-studio/issues/114).
 
 ## Docker
 
@@ -197,8 +202,8 @@ chart architecture: [`docs/HELM_CHART.md`](HELM_CHART.md).
 
 ## npx
 
-Requires Node.js 20.9+ on Linux or macOS (x64 / arm64); **Node 24 LTS is the recommended,
-fully supported runtime**. The launcher checks the runtime up front and spells out what an
+Requires Node.js 20.9+ on Linux, macOS (x64 / arm64), or Windows (x64); **Node 24 LTS is the
+recommended, fully supported runtime**. The launcher checks the runtime up front and spells out what an
 older Node cannot do (`scripts/engine-smoke.sh` tests every tier in CI):
 
 | Node | Support |
@@ -209,9 +214,9 @@ older Node cannot do (`scripts/engine-smoke.sh` tests every tier in CI):
 | < 20.9 | Refused with a clear error (Next.js 16 floor) - bare `npx` may also fall back to an ancient, bin-less package version here; those versions are npm-deprecated with pointers. |
 
 The npm package stays a pure library for
-libredb-platform; the launcher downloads the matching standalone tarball from the GitHub
-release, verifies it against the `SHA256SUMS` release asset, caches it under
-`~/.libredb-studio/<version>/`, and starts `node server.js`:
+libredb-platform; the launcher downloads the matching standalone archive (tar.gz; the flat zip
+on Windows) from the GitHub release, verifies it against the `SHA256SUMS` release asset, caches
+it under `~/.libredb-studio/<version>/`, and starts `node server.js`:
 
 ```bash
 npx @libredb/studio                # first run downloads + verifies, then starts
@@ -239,7 +244,8 @@ rebuilt archive never invalidates a previously printed admin password.
   instead of downloading — useful for testing a tarball built with
   `scripts/build-standalone-payload.sh` (checksum verification is skipped and the archive is
   re-extracted on every run).
-- On Windows the launcher exits with a pointer to Docker
+- On Windows the launcher downloads the win32 zip and extracts it with the built-in
+  `System32\tar.exe` (bsdtar); see [Windows](#windows-winget--chocolatey--portable-zip)
   ([issue #114](https://github.com/libredb/libredb-studio/issues/114)).
 - Versions released before the standalone tarballs existed have no artifacts; the launcher
   detects this (HTTP 404) and suggests `npx @libredb/studio@latest`.
@@ -441,9 +447,65 @@ to server-side Postgres, uncomment the `STORAGE_PROVIDER` / `STORAGE_POSTGRES_UR
 Full variable reference: [`.env.example`](../.env.example). OIDC setup details:
 [`docs/OIDC.md`](OIDC.md). Storage providers: [`docs/STORAGE.md`](STORAGE.md).
 
+## Windows (winget / Chocolatey / portable zip)
+
+> The winget/Chocolatey commands work once the first community listings land (see the
+> [first-listing checklist](#windows-first-listing-checklist)) — track
+> [issue #114](https://github.com/libredb/libredb-studio/issues/114). Until then, install from
+> the release zip (below) or run Docker.
+
+```powershell
+# winget (after the first listing merges in microsoft/winget-pkgs)
+winget install LibreDB.Studio
+
+# Chocolatey (after the first push clears community moderation)
+choco install libredb-studio
+
+# Then, from any terminal - first run prints the generated admin credentials
+libredb-studio
+```
+
+Open http://127.0.0.1:3000 and log in with the printed credentials. Both packages install the
+same standalone zip: the server payload, a bundled private Node.js runtime (`node\node.exe`),
+and the `libredb-studio.exe` launcher — nothing else to install.
+
+The launcher mirrors the Linux packages' contract:
+
+- **Local-first bind (issue #134):** the server binds `127.0.0.1` regardless of any inherited
+  `HOSTNAME`; set `LIBREDB_BIND=0.0.0.0` to expose it on the network.
+- **State:** server-side SQLite storage and generated first-run credentials live under
+  `%LOCALAPPDATA%\LibreDB\Studio\` (created on first run) unless `STORAGE_SQLITE_PATH` is set,
+  so upgrades and reinstalls never wipe state.
+- **Configuration:** environment variables only — the same set as Docker and the Linux packages
+  (`PORT`, `LIBREDB_BIND`, `JWT_SECRET`, `ADMIN_PASSWORD`, `LLM_*`, `OIDC_*`, `STORAGE_*`, ...).
+  See [Configuration](#configuration) above and [`.env.example`](../.env.example).
+
+### Portable zip (no package manager)
+
+Download `libredb-studio-standalone-<version>-win32-x64.zip` and `SHA256SUMS` from the
+[release](https://github.com/libredb/libredb-studio/releases), verify, extract, run:
+
+```powershell
+# Verify (compare against the SHA256SUMS line for the zip)
+Get-FileHash .\libredb-studio-standalone-<version>-win32-x64.zip -Algorithm SHA256
+
+# Extract (Explorer "Extract All...", or:)
+tar -xf .\libredb-studio-standalone-<version>-win32-x64.zip -C libredb-studio
+
+# Run from the extracted directory
+cd libredb-studio
+.\libredb-studio.exe
+```
+
+The zip is flat by design (see [Release artifact naming](#release-artifact-naming)). `npx
+@libredb/studio` also works on Windows (Node 20.9+): it downloads this zip, verifies it against
+`SHA256SUMS`, and runs the payload with your own Node runtime.
+
 ## Building a standalone payload locally
 
-The single source of truth for the release tarballs also works locally (Linux and macOS):
+The single source of truth for the release archives also works locally (Linux and macOS; on
+Windows it runs under Git Bash and produces the flat zip — the release job then adds the
+bundled Node runtime and launcher, see [`packaging/windows/README.md`](../packaging/windows/README.md)):
 
 ```bash
 bun install
@@ -463,10 +525,13 @@ Release publishing is driven by two workflows, both triggered on `release: publi
 - [`docker-build-push.yml`](../.github/workflows/docker-build-push.yml) — GHCR image
   (version + `latest` tags) and the Docker Hub mirror.
 - [`release-artifacts.yml`](../.github/workflows/release-artifacts.yml) — standalone tarballs +
-  `SHA256SUMS`, `.deb`/`.rpm` (nfpm, [`packaging/linux/`](../packaging/linux)), the Homebrew
-  formula ([`packaging/homebrew/`](../packaging/homebrew) rendered by
-  [`scripts/render-homebrew-formula.mjs`](../scripts/render-homebrew-formula.mjs)), and the snap
-  ([`snap/snapcraft.yaml`](../snap/snapcraft.yaml)).
+  the win32 zip + `SHA256SUMS`, `.deb`/`.rpm` (nfpm, [`packaging/linux/`](../packaging/linux)),
+  the Homebrew formula ([`packaging/homebrew/`](../packaging/homebrew) rendered by
+  [`scripts/render-homebrew-formula.mjs`](../scripts/render-homebrew-formula.mjs)), the snap
+  ([`snap/snapcraft.yaml`](../snap/snapcraft.yaml)), and — after the release publishes — the
+  Chocolatey push and winget update PR ([`packaging/chocolatey/`](../packaging/chocolatey) and
+  [`packaging/winget/`](../packaging/winget) rendered by
+  [`scripts/render-windows-packaging.mjs`](../scripts/render-windows-packaging.mjs)).
 - The npm package (`@libredb/studio`, which carries the npx launcher `bin/studio.js`) is
   published by the separate npm-publish workflow, also on `release: published`.
 
@@ -547,6 +612,50 @@ setups still publish the rest:
 | `TAP_GITHUB_TOKEN` | Rendering and pushing the Homebrew formula to `libredb/homebrew-tap` (needs write access to that repo) | Tap update skipped; tarballs still attach to the release |
 | `SNAPCRAFT_STORE_CREDENTIALS` | The entire snap build/publish job (exported via `snapcraft export-login`) | Snap job skipped |
 | `DOCKER_HUB_TOKEN` (+ `DOCKER_HUB_USERNAME` variable) | The Docker Hub mirror push | GHCR-only publish |
+| `CHOCO_API_KEY` | The chocolatey job: `choco pack` + `choco push` to `https://push.chocolatey.org/` (API key of the `libredb` community account) | Chocolatey publish skipped; the win32 zip still attaches to the release |
+| `WINGETCREATE_GITHUB_TOKEN` | The winget job: `wingetcreate update --submit` PRs to `microsoft/winget-pkgs`. Classic PAT with `public_repo` scope — wingetcreate does not support fine-grained PATs | winget submission skipped |
+
+The chocolatey and winget jobs run strictly **after** `publish-release`: both channels download
+the zip from the release URL, which is public only once the release is published. A failure
+there never blocks the release itself (same trust model as the npm/Docker dispatch chain).
+
+By contrast, the `windows-package` job (which builds the win32 zip) **is a hard release gate**,
+exactly like the POSIX build matrix: the zip is on the publish-release required-assets list, so
+a Windows build failure blocks the whole release train by design — a release without its
+Windows artifact would strand winget/Chocolatey (their manifests point at that exact asset) and
+npx on win32.
+
+### Windows first-listing checklist
+
+The release automation for winget and Chocolatey is secret-gated and ready — both
+`CHOCO_API_KEY` (API key of the `libredb` account on community.chocolatey.org) and
+`WINGETCREATE_GITHUB_TOKEN` are configured in the repo's Actions secrets. The FIRST listing in
+each community catalog is a one-time human step (same pattern as the Snap Store name
+registration). After the first release that ships the win32 zip:
+
+1. **Chocolatey** — the release's chocolatey job packs and pushes automatically. The first push
+   enters [human moderation](https://docs.chocolatey.org/en-us/community-repository/moderation/);
+   while a version sits in the moderation queue, pushing further versions can be rejected —
+   if a release-time push fails during that window, re-run the job after approval.
+2. **winget** — the first manifest cannot be submitted by `wingetcreate update` (the package id
+   does not exist yet; the release job detects this and skips with a notice). Render the
+   manifests locally from the release's `SHA256SUMS` and submit once by hand:
+
+   ```bash
+   gh release download <version> --pattern SHA256SUMS --dir dist
+   for t in packaging/winget/*.tmpl; do
+     out="manifests/l/LibreDB/Studio/<version>/$(basename "${t%.tmpl}")"
+     node scripts/render-windows-packaging.mjs "$t" dist/SHA256SUMS <version> "$out"
+   done
+   wingetcreate submit --token <classic-PAT> manifests/l/LibreDB/Studio/<version>
+   ```
+
+   (or open the PR against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
+   manually; sign the Microsoft CLA on that first PR). Once it merges, later releases submit
+   update PRs automatically.
+3. After each catalog goes live: flip its `distribution/channels.yaml` entry to `status: live`,
+   set `links.first_pr`, and add a measurable pin (winget-pkgs raw manifest / Chocolatey
+   community API).
 
 ### Channel inventory and drift check
 
@@ -602,8 +711,11 @@ until the first post-listing bump and is displayed, not auto-discovered.
 - **Website install docs**: the libredb-website documentation must be updated with the new
   channels (npx, Homebrew, .deb/.rpm, Snap) — a cross-repo step and part of issue #111's
   "README and website docs" acceptance criterion (and implicitly of #110/#112/#113).
-- **Windows**: no standalone payload / installer yet; winget/Chocolatey and the `win32-x64`
-  tarball are tracked in [issue #114](https://github.com/libredb/libredb-studio/issues/114).
+- **Windows first listings**: the `win32-x64` zip, launcher, winget/Chocolatey release
+  automation, and both gating secrets are in place; the one-time first submissions to both
+  community catalogs follow the
+  [Windows first-listing checklist](#windows-first-listing-checklist) —
+  tracked in [issue #114](https://github.com/libredb/libredb-studio/issues/114).
 - **Desktop app**: a native desktop wrapper (Tauri v2 sidecar; unlocks AppImage, Flathub, .dmg,
   Microsoft Store, brew cask) has a go recommendation —
   see [`docs/DESKTOP_WRAPPER_SPIKE.md`](DESKTOP_WRAPPER_SPIKE.md).
@@ -613,9 +725,10 @@ until the first post-listing bump and is displayed, not auto-discovered.
 Deviations and partial deliveries to record on the tracking issues when closing them, so the
 record matches the implementation:
 
-- **#110 (npx)**: the "Works on Linux, macOS, and Windows" acceptance criterion is NOT delivered
-  for Windows — the launcher exits on `win32` with a Docker pointer. Amend/re-scope that
-  criterion to [#114](https://github.com/libredb/libredb-studio/issues/114) before closing.
+- **#110 (npx)**: the "Works on Linux, macOS, and Windows" acceptance criterion was initially
+  NOT delivered for Windows (the launcher exited on `win32` with a Docker pointer); the win32
+  path shipped with [#114](https://github.com/libredb/libredb-studio/issues/114) — the npx
+  launcher now downloads the win32 zip and runs it with the user's Node runtime.
 - **#111 (Homebrew)**: the website half of "Install instructions added to README and website
   docs" is a cross-repo step (see Manual steps above).
 - **#113 (Snap)**: closed after the 0.9.52 live validation (store publish from release CI,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.56",
+  "version": "0.9.57",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packaging/chocolatey/libredb-studio.nuspec.tmpl
+++ b/packaging/chocolatey/libredb-studio.nuspec.tmpl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Chocolatey community package template for LibreDB Studio (issue #114).
+  Rendered by scripts/render-windows-packaging.mjs; packed and pushed by the
+  chocolatey job in .github/workflows/release-artifacts.yml. The payload zip
+  is NOT embedded: tools/chocolateyinstall.ps1 downloads it from the GitHub
+  release and verifies the pinned sha256 (moderation-friendly - the nupkg
+  stays small).
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>libredb-studio</id>
+    <version>{{VERSION}}</version>
+    <packageSourceUrl>https://github.com/libredb/libredb-studio/tree/main/packaging/chocolatey</packageSourceUrl>
+    <owners>libredb</owners>
+    <title>LibreDB Studio</title>
+    <authors>LibreDB</authors>
+    <projectUrl>https://github.com/libredb/libredb-studio</projectUrl>
+    <!-- jsDelivr CDN (raw.githubusercontent.com is a moderation rejection,
+         CPMR0076), pinned to the immutable release tag. -->
+    <iconUrl>https://cdn.jsdelivr.net/gh/libredb/libredb-studio@{{VERSION}}/public/logo.svg</iconUrl>
+    <licenseUrl>https://github.com/libredb/libredb-studio/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/libredb/libredb-studio</projectSourceUrl>
+    <docsUrl>https://github.com/libredb/libredb-studio/blob/main/docs/DISTRIBUTION.md</docsUrl>
+    <bugTrackerUrl>https://github.com/libredb/libredb-studio/issues</bugTrackerUrl>
+    <tags>libredb-studio database sql ide editor postgres postgresql mysql sqlite oracle mssql mongodb redis</tags>
+    <summary>Web-based SQL IDE for PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis.</summary>
+    <description><![CDATA[
+LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis, and ships a Monaco-powered editor with AI query assistance, schema browsing, ER diagrams, charts, and import/export tooling.
+
+This package installs the standalone server together with a bundled, private Node.js runtime - nothing else to install.
+
+### Usage
+
+```
+libredb-studio
+```
+
+Then open http://127.0.0.1:3000. The first run prints generated admin credentials to the terminal (zero-config bootstrap). The server binds to 127.0.0.1 by default; set `LIBREDB_BIND=0.0.0.0` to expose it on the network. Server-side state is stored under `%LOCALAPPDATA%\LibreDB\Studio`.
+
+### Configuration
+
+All configuration is environment-variable driven (same variables as the Docker image and the Linux packages) - see the [Distribution & Install Guide](https://github.com/libredb/libredb-studio/blob/main/docs/DISTRIBUTION.md).
+]]></description>
+    <releaseNotes>https://github.com/libredb/libredb-studio/releases/tag/{{VERSION}}</releaseNotes>
+  </metadata>
+  <files>
+    <!-- Forward slashes on purpose: this nuspec is packed by the Mono choco
+         build inside the Linux container (release-artifacts.yml). -->
+    <file src="tools/**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1.tmpl
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1.tmpl
@@ -1,0 +1,25 @@
+# Chocolatey install script template for LibreDB Studio (issue #114).
+# Rendered by scripts/render-windows-packaging.mjs: {{VERSION}} and
+# {{SHA256_WIN32_X64}} come from the GitHub release and its SHA256SUMS.
+#
+# Downloads the win32-x64 standalone zip from the GitHub release (the nupkg
+# does not embed the multi-hundred-MB payload) and unzips it into the
+# package tools directory. The zip is flat (server.js, node\node.exe,
+# libredb-studio.exe at the root - scripts/lib/pack-standalone-zip.sh), so
+# the launcher lands directly in $toolsDir and Chocolatey shims it onto
+# PATH automatically.
+$ErrorActionPreference = 'Stop'
+$toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
+
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  unzipLocation  = $toolsDir
+  url64bit       = 'https://github.com/libredb/libredb-studio/releases/download/{{VERSION}}/libredb-studio-standalone-{{VERSION}}-win32-x64.zip'
+  checksum64     = '{{SHA256_WIN32_X64}}'
+  checksumType64 = 'sha256'
+}
+Install-ChocolateyZipPackage @packageArgs
+
+# Shim ONLY libredb-studio.exe: node.exe is the bundled private runtime, not
+# a user-facing CLI - the .ignore sidecar tells shimgen to skip it.
+New-Item -ItemType File -Force -Path (Join-Path $toolsDir 'node\node.exe.ignore') | Out-Null

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,36 @@
+# Windows packaging (issue #114)
+
+Everything that turns the standalone payload into the `win32-x64` release zip
+installed by winget, Chocolatey, and the npx launcher. The Linux siblings live
+in [`packaging/linux/`](../linux).
+
+| Piece | Purpose |
+|---|---|
+| [`launcher/`](launcher) | Go source of `libredb-studio.exe` — resolves its own directory, applies the local-first defaults (`HOSTNAME`/`LIBREDB_BIND`, `STORAGE_SQLITE_PATH` under `%LOCALAPPDATA%\LibreDB\Studio`), and runs the bundled `node\node.exe` against `server.js` |
+| [`fetch-node.sh`](fetch-node.sh) | Downloads the pinned Node runtime zip from nodejs.org, verifies the in-repo sha256, installs only `node.exe` into the payload |
+| [`../winget/`](../winget) | winget manifest templates (`LibreDB.Studio`), rendered by [`scripts/render-windows-packaging.mjs`](../../scripts/render-windows-packaging.mjs) |
+| [`../chocolatey/`](../chocolatey) | Chocolatey package templates (`libredb-studio`), rendered by the same script |
+
+The release flow (`.github/workflows/release-artifacts.yml`, `windows-package`
+job) builds the payload natively on `windows-latest`, bundles Node and the
+launcher, re-packs the FLAT zip (`scripts/lib/pack-standalone-zip.sh` — flat so
+winget's `NestedInstallerFiles.RelativeFilePath` stays stable across releases),
+and smoke-boots `libredb-studio.exe` before anything is attached to the
+release. After the release publishes, the `chocolatey` and `winget` jobs push
+the community-catalog updates (secret-gated; see `docs/DISTRIBUTION.md`,
+"Windows first-listing checklist").
+
+## Working on the launcher (any OS)
+
+The launcher is dependency-free Go with its pure logic unit-tested
+host-agnostically — no Windows box needed:
+
+```bash
+cd packaging/windows/launcher
+gofmt -l .          # formatting (must print nothing)
+go vet ./...
+go test ./...
+GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o libredb-studio.exe .
+```
+
+The same commands run in the `windows-package` release job before every build.

--- a/packaging/windows/fetch-node.sh
+++ b/packaging/windows/fetch-node.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Bundle the pinned Node.js runtime into a win32 standalone payload
+# (issue #114) - the Windows sibling of packaging/linux/fetch-node.sh.
+#
+# Downloads the official nodejs.org dist zip for NODE_VERSION (win-x64),
+# verifies it against the sha256 pinned in this script, and installs ONLY
+# node.exe into <payload-dir>/node/node.exe - the private runtime the
+# packaged launcher (libredb-studio.exe) starts. Nothing else from the Node
+# distribution (npm, corepack, headers, docs) is shipped.
+#
+# Runs in Git Bash on the windows-latest release runner; zip extraction uses
+# the System32 bsdtar there (Git Bash's own tar is GNU tar, which cannot
+# read zip) and falls back to `unzip` for local non-Windows dry runs.
+#
+# Usage: packaging/windows/fetch-node.sh <payload-dir>
+# ==============================================================================
+
+set -euo pipefail
+
+# Pinned Node LTS (Krypton). Keep in lockstep with packaging/linux/fetch-node.sh
+# (same NODE_VERSION) and bump BOTH scripts' pins together.
+NODE_VERSION="24.18.0"
+
+# sha256 of the official node-v${NODE_VERSION}-win-x64.zip, from
+# https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt. Pinned in-repo so
+# a compromised download origin cannot serve a tampered archive together
+# with a matching checksum file.
+NODE_SHA256_WIN_X64="0ae68406b42d7725661da979b1403ec9926da205c6770827f33aac9d8f26e821"
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <payload-dir>" >&2
+  exit 1
+fi
+
+PAYLOAD_DIR="$1"
+if [ ! -d "$PAYLOAD_DIR" ]; then
+  echo "Payload directory not found: $PAYLOAD_DIR" >&2
+  exit 1
+fi
+PAYLOAD_DIR=$(cd "$PAYLOAD_DIR" && pwd)
+
+DIST="node-v${NODE_VERSION}-win-x64"
+BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}"
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "==> Downloading ${DIST}.zip"
+curl -fsSL --retry 3 -o "$WORK_DIR/${DIST}.zip" "${BASE_URL}/${DIST}.zip"
+
+echo "==> Verifying against the pinned sha256"
+(
+  cd "$WORK_DIR"
+  echo "${NODE_SHA256_WIN_X64}  ${DIST}.zip" | sha256sum -c -
+)
+
+# The official win-x64 zip keeps node.exe directly under the top-level
+# ${DIST}/ folder (no bin/ subdirectory, unlike the POSIX tarballs).
+# Env-var casing differs between shells (SystemRoot vs SYSTEMROOT), so probe
+# for the System32 bsdtar by path and fall back to `unzip` (present in Git
+# Bash and on Linux dev machines).
+echo "==> Extracting node.exe into ${PAYLOAD_DIR}/node/node.exe"
+WINTAR="${SYSTEMROOT:-${SystemRoot:-C:\\Windows}}/System32/tar.exe"
+if [ -x "$WINTAR" ]; then
+  "$WINTAR" -xf "$WORK_DIR/${DIST}.zip" -C "$WORK_DIR" "${DIST}/node.exe"
+else
+  unzip -q -o "$WORK_DIR/${DIST}.zip" "${DIST}/node.exe" -d "$WORK_DIR"
+fi
+mkdir -p "$PAYLOAD_DIR/node"
+install -m 0755 "$WORK_DIR/${DIST}/node.exe" "$PAYLOAD_DIR/node/node.exe"
+
+echo "==> Done: $("$PAYLOAD_DIR/node/node.exe" --version 2>/dev/null || echo "(cross-platform: not runnable on this host)")"

--- a/packaging/windows/launcher/go.mod
+++ b/packaging/windows/launcher/go.mod
@@ -1,0 +1,3 @@
+module github.com/libredb/libredb-studio/packaging/windows/launcher
+
+go 1.25

--- a/packaging/windows/launcher/launch.go
+++ b/packaging/windows/launcher/launch.go
@@ -1,0 +1,95 @@
+// Pure helpers for the Windows launcher (main.go) - the win32 sibling of
+// packaging/linux/libredb-studio. Everything here is host-agnostic (built
+// with filepath so the same assertions hold under `go test` on any OS) and
+// covered by launch_test.go; main.go stays a thin composition.
+package main
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// launchPaths are the payload files the launcher composes, resolved
+// relative to the directory of the real executable (the zip root).
+type launchPaths struct {
+	Node   string // bundled private runtime: <exeDir>/node/node.exe
+	Server string // standalone Next.js server: <exeDir>/server.js
+}
+
+// resolveLaunchPaths maps the launcher's directory to the payload layout
+// packed by scripts/lib/pack-standalone-zip.sh (flat zip, issue #114).
+func resolveLaunchPaths(exeDir string) launchPaths {
+	return launchPaths{
+		Node:   filepath.Join(exeDir, "node", "node.exe"),
+		Server: filepath.Join(exeDir, "server.js"),
+	}
+}
+
+// envValue looks up a key in a "key=value" environ slice. Windows
+// environment keys are case-insensitive, so the match is too - a user's
+// `set storage_sqlite_path=...` must count as "already set".
+func envValue(environ []string, key string) (string, bool) {
+	for _, entry := range environ {
+		if eq := strings.IndexByte(entry, '='); eq > 0 && strings.EqualFold(entry[:eq], key) {
+			return entry[eq+1:], true
+		}
+	}
+	return "", false
+}
+
+// defaultStoragePath is the zero-config server-side SQLite location:
+// <localAppData>\LibreDB\Studio\libredb-storage.db. Returns "" when
+// localAppData is unknown - the caller then leaves STORAGE_SQLITE_PATH
+// unset and the server falls back to its relative ./data default.
+func defaultStoragePath(localAppData string) string {
+	if localAppData == "" {
+		return ""
+	}
+	return filepath.Join(localAppData, "LibreDB", "Studio", "libredb-storage.db")
+}
+
+// resolveLocalAppData returns %LOCALAPPDATA%, falling back to the
+// conventional <%USERPROFILE%>\AppData\Local when only USERPROFILE is set
+// (os.UserCacheDir has no such fallback and just errors), or "" when
+// neither is available.
+func resolveLocalAppData(environ []string) string {
+	if value, ok := envValue(environ, "LOCALAPPDATA"); ok && value != "" {
+		return value
+	}
+	if profile, ok := envValue(environ, "USERPROFILE"); ok && profile != "" {
+		return filepath.Join(profile, "AppData", "Local")
+	}
+	return ""
+}
+
+// launcherEnv builds the child environment. Appended entries win over
+// inherited duplicates (os/exec: "only the last value in the slice for each
+// duplicate key is used", case-insensitively deduped on Windows):
+//   - HOSTNAME is ALWAYS overridden to LIBREDB_BIND or loopback - the
+//     local-first bind contract of packaging/linux/libredb-studio (issue
+//     #134): an inherited HOSTNAME (e.g. a container hostname) must never
+//     silently become the server's bind address.
+//   - STORAGE_SQLITE_PATH defaults under LOCALAPPDATA when unset, so the
+//     zero-config first run can persist generated credentials outside the
+//     (potentially read-only or replaced-on-upgrade) install directory.
+//   - NODE_ENV defaults to production (parity with the npx launcher).
+func launcherEnv(environ []string) []string {
+	env := append([]string(nil), environ...)
+
+	bind := "127.0.0.1"
+	if value, ok := envValue(environ, "LIBREDB_BIND"); ok && value != "" {
+		bind = value
+	}
+	env = append(env, "HOSTNAME="+bind)
+
+	if _, ok := envValue(environ, "STORAGE_SQLITE_PATH"); !ok {
+		if storage := defaultStoragePath(resolveLocalAppData(environ)); storage != "" {
+			env = append(env, "STORAGE_SQLITE_PATH="+storage)
+		}
+	}
+
+	if _, ok := envValue(environ, "NODE_ENV"); !ok {
+		env = append(env, "NODE_ENV=production")
+	}
+	return env
+}

--- a/packaging/windows/launcher/launch.go
+++ b/packaging/windows/launcher/launch.go
@@ -25,16 +25,19 @@ func resolveLaunchPaths(exeDir string) launchPaths {
 	}
 }
 
-// envValue looks up a key in a "key=value" environ slice. Windows
-// environment keys are case-insensitive, so the match is too - a user's
-// `set storage_sqlite_path=...` must count as "already set".
+// envValue looks up a key in a "key=value" environ slice and returns the
+// LAST match - the value os/exec hands to the child under its
+// duplicate-key rule. Windows environment keys are case-insensitive, so
+// the match is too - a user's `set storage_sqlite_path=...` must count as
+// "already set".
 func envValue(environ []string, key string) (string, bool) {
+	value, found := "", false
 	for _, entry := range environ {
 		if eq := strings.IndexByte(entry, '='); eq > 0 && strings.EqualFold(entry[:eq], key) {
-			return entry[eq+1:], true
+			value, found = entry[eq+1:], true
 		}
 	}
-	return "", false
+	return value, found
 }
 
 // defaultStoragePath is the zero-config server-side SQLite location:
@@ -82,13 +85,16 @@ func launcherEnv(environ []string) []string {
 	}
 	env = append(env, "HOSTNAME="+bind)
 
-	if _, ok := envValue(environ, "STORAGE_SQLITE_PATH"); !ok {
+	// An inherited-but-EMPTY value counts as unset (parity with the Linux
+	// wrapper's ${VAR:-} handling): the server treats "" as absent and would
+	// otherwise fall back to ./data inside the install tree.
+	if value, ok := envValue(environ, "STORAGE_SQLITE_PATH"); !ok || value == "" {
 		if storage := defaultStoragePath(resolveLocalAppData(environ)); storage != "" {
 			env = append(env, "STORAGE_SQLITE_PATH="+storage)
 		}
 	}
 
-	if _, ok := envValue(environ, "NODE_ENV"); !ok {
+	if value, ok := envValue(environ, "NODE_ENV"); !ok || value == "" {
 		env = append(env, "NODE_ENV=production")
 	}
 	return env

--- a/packaging/windows/launcher/launch_test.go
+++ b/packaging/windows/launcher/launch_test.go
@@ -1,0 +1,136 @@
+// Unit tests for the pure launcher helpers (launch.go). Host-agnostic:
+// expectations are built with filepath.Join, so `go test ./...` passes on
+// linux CI runners and on Windows alike.
+package main
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestResolveLaunchPaths(t *testing.T) {
+	paths := resolveLaunchPaths(filepath.Join("C:", "pkg"))
+	if want := filepath.Join("C:", "pkg", "node", "node.exe"); paths.Node != want {
+		t.Errorf("Node = %q, want %q", paths.Node, want)
+	}
+	if want := filepath.Join("C:", "pkg", "server.js"); paths.Server != want {
+		t.Errorf("Server = %q, want %q", paths.Server, want)
+	}
+}
+
+func TestEnvValueIsCaseInsensitive(t *testing.T) {
+	environ := []string{"storage_sqlite_path=D:\\data\\s.db", "FOO=bar"}
+	value, ok := envValue(environ, "STORAGE_SQLITE_PATH")
+	if !ok || value != "D:\\data\\s.db" {
+		t.Errorf("envValue = %q, %v; want the case-insensitive match", value, ok)
+	}
+	if _, ok := envValue(environ, "MISSING"); ok {
+		t.Error("envValue found a key that is not set")
+	}
+	// A bare "=..." entry (cmd.exe drive-cwd entries look like "=C:=...")
+	// must never match.
+	if _, ok := envValue([]string{"=C:=C:\\x"}, ""); ok {
+		t.Error("envValue matched an empty key")
+	}
+}
+
+func TestLauncherEnvBindsLoopbackByDefault(t *testing.T) {
+	env := launcherEnv([]string{"HOSTNAME=container-1234", "LOCALAPPDATA=" + filepath.Join("C:", "Users", "u", "AppData", "Local")})
+	// The override is appended AFTER the inherited entries, so it wins the
+	// os/exec last-duplicate-wins rule.
+	last := lastValue(t, env, "HOSTNAME")
+	if last != "127.0.0.1" {
+		t.Errorf("HOSTNAME override = %q, want 127.0.0.1 (an inherited HOSTNAME must never leak into the bind address)", last)
+	}
+}
+
+func TestLauncherEnvHonoursLibredbBind(t *testing.T) {
+	env := launcherEnv([]string{"LIBREDB_BIND=0.0.0.0"})
+	if last := lastValue(t, env, "HOSTNAME"); last != "0.0.0.0" {
+		t.Errorf("HOSTNAME = %q, want the LIBREDB_BIND opt-in 0.0.0.0", last)
+	}
+}
+
+func TestLauncherEnvDefaultsStorageUnderLocalAppData(t *testing.T) {
+	localAppData := filepath.Join("C:", "Users", "u", "AppData", "Local")
+	env := launcherEnv([]string{"LOCALAPPDATA=" + localAppData})
+	want := filepath.Join(localAppData, "LibreDB", "Studio", "libredb-storage.db")
+	if last := lastValue(t, env, "STORAGE_SQLITE_PATH"); last != want {
+		t.Errorf("STORAGE_SQLITE_PATH = %q, want %q", last, want)
+	}
+}
+
+func TestLauncherEnvKeepsPresetStoragePath(t *testing.T) {
+	env := launcherEnv([]string{"STORAGE_SQLITE_PATH=D:\\custom\\s.db", "LOCALAPPDATA=C:\\lad"})
+	if count := countKey(env, "STORAGE_SQLITE_PATH"); count != 1 {
+		t.Errorf("STORAGE_SQLITE_PATH appears %d times, want the single preset entry", count)
+	}
+}
+
+func TestLauncherEnvFallsBackToUserProfile(t *testing.T) {
+	profile := filepath.Join("C:", "Users", "u")
+	env := launcherEnv([]string{"USERPROFILE=" + profile})
+	want := filepath.Join(profile, "AppData", "Local", "LibreDB", "Studio", "libredb-storage.db")
+	if last := lastValue(t, env, "STORAGE_SQLITE_PATH"); last != want {
+		t.Errorf("STORAGE_SQLITE_PATH = %q, want the USERPROFILE-derived %q", last, want)
+	}
+}
+
+func TestLauncherEnvSkipsStorageWhenUnresolvable(t *testing.T) {
+	env := launcherEnv([]string{"PATH=x"})
+	if count := countKey(env, "STORAGE_SQLITE_PATH"); count != 0 {
+		t.Error("STORAGE_SQLITE_PATH must stay unset when no LOCALAPPDATA/USERPROFILE exists (server falls back to ./data)")
+	}
+}
+
+func TestLauncherEnvDefaultsNodeEnv(t *testing.T) {
+	if last := lastValue(t, launcherEnv(nil), "NODE_ENV"); last != "production" {
+		t.Errorf("NODE_ENV = %q, want production", last)
+	}
+	env := launcherEnv([]string{"NODE_ENV=development"})
+	if count := countKey(env, "NODE_ENV"); count != 1 {
+		t.Error("a preset NODE_ENV must not be overridden")
+	}
+}
+
+func TestLauncherEnvPreservesInheritedEntries(t *testing.T) {
+	env := launcherEnv([]string{"JWT_SECRET=abc", "PORT=3900"})
+	if !slices.Contains(env, "JWT_SECRET=abc") || !slices.Contains(env, "PORT=3900") {
+		t.Error("inherited environment entries must pass through untouched")
+	}
+}
+
+func TestDefaultStoragePathEmptyInput(t *testing.T) {
+	if got := defaultStoragePath(""); got != "" {
+		t.Errorf("defaultStoragePath(\"\") = %q, want \"\"", got)
+	}
+}
+
+// lastValue returns the value of the LAST entry for key - the one os/exec
+// hands to the child under its duplicate-key rule.
+func lastValue(t *testing.T, environ []string, key string) string {
+	t.Helper()
+	value := ""
+	found := false
+	for _, entry := range environ {
+		if len(entry) > len(key)+1 && entry[:len(key)] == key && entry[len(key)] == '=' {
+			value = entry[len(key)+1:]
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no %s entry in %v", key, environ)
+	}
+	return value
+}
+
+func countKey(environ []string, key string) int {
+	count := 0
+	for _, entry := range environ {
+		if len(entry) > len(key)+1 && entry[:len(key)] == key && entry[len(key)] == '=' {
+			count++
+		}
+	}
+	return count
+}

--- a/packaging/windows/launcher/launch_test.go
+++ b/packaging/windows/launcher/launch_test.go
@@ -33,6 +33,10 @@ func TestEnvValueIsCaseInsensitive(t *testing.T) {
 	if _, ok := envValue([]string{"=C:=C:\\x"}, ""); ok {
 		t.Error("envValue matched an empty key")
 	}
+	// Duplicate keys: the LAST entry wins, matching os/exec's rule.
+	if value, _ := envValue([]string{"FOO=first", "FOO=second"}, "FOO"); value != "second" {
+		t.Errorf("envValue duplicate = %q, want the last entry", value)
+	}
 }
 
 func TestLauncherEnvBindsLoopbackByDefault(t *testing.T) {
@@ -65,6 +69,21 @@ func TestLauncherEnvKeepsPresetStoragePath(t *testing.T) {
 	env := launcherEnv([]string{"STORAGE_SQLITE_PATH=D:\\custom\\s.db", "LOCALAPPDATA=C:\\lad"})
 	if count := countKey(env, "STORAGE_SQLITE_PATH"); count != 1 {
 		t.Errorf("STORAGE_SQLITE_PATH appears %d times, want the single preset entry", count)
+	}
+}
+
+func TestLauncherEnvTreatsEmptyPresetsAsUnset(t *testing.T) {
+	// Parity with packaging/linux/libredb-studio's ${VAR:-} handling: an
+	// inherited-but-empty value must not suppress the zero-config defaults
+	// (the server would fall back to ./data inside the install tree).
+	localAppData := filepath.Join("C:", "Users", "u", "AppData", "Local")
+	env := launcherEnv([]string{"STORAGE_SQLITE_PATH=", "NODE_ENV=", "LOCALAPPDATA=" + localAppData})
+	wantStorage := filepath.Join(localAppData, "LibreDB", "Studio", "libredb-storage.db")
+	if last := lastValue(t, env, "STORAGE_SQLITE_PATH"); last != wantStorage {
+		t.Errorf("STORAGE_SQLITE_PATH = %q, want the default %q despite the empty preset", last, wantStorage)
+	}
+	if last := lastValue(t, env, "NODE_ENV"); last != "production" {
+		t.Errorf("NODE_ENV = %q, want production despite the empty preset", last)
 	}
 }
 

--- a/packaging/windows/launcher/main.go
+++ b/packaging/windows/launcher/main.go
@@ -1,0 +1,88 @@
+// libredb-studio.exe - the Windows launcher shipped at the root of the
+// win32-x64 standalone zip (issue #114), installed by winget (portable) and
+// Chocolatey. The win32 sibling of packaging/linux/libredb-studio: it execs
+// the bundled private Node runtime against the standalone server payload
+// sitting next to the executable, with the same local-first defaults.
+//
+// Go (CGO_ENABLED=0, cross-compiled from any OS) so Linux/macOS
+// contributors can rebuild the shim without a Windows box; see
+// packaging/windows/README.md.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+)
+
+func main() {
+	exe, err := os.Executable()
+	if err != nil {
+		fatal(fmt.Sprintf("could not resolve the launcher path: %v", err))
+	}
+	// winget's portable install exposes the exe through an NTFS symlink in
+	// its Links folder; the payload (node/, server.js) sits next to the REAL
+	// binary. EvalSymlinks is a no-op when there is no symlink, so resolve
+	// unconditionally.
+	if resolved, evalErr := filepath.EvalSymlinks(exe); evalErr == nil {
+		exe = resolved
+	}
+	exeDir := filepath.Dir(exe)
+
+	paths := resolveLaunchPaths(exeDir)
+	for _, required := range []string{paths.Node, paths.Server} {
+		if _, statErr := os.Stat(required); statErr != nil {
+			fatal(fmt.Sprintf(
+				"%s not found - libredb-studio.exe must stay at the root of the extracted LibreDB Studio zip (next to node\\ and server.js)",
+				required,
+			))
+		}
+	}
+
+	env := launcherEnv(os.Environ())
+	// The default storage path's parent directories may not exist yet
+	// (fresh %LOCALAPPDATA%); the server expects the directory to be there
+	// (the deb/Homebrew packages pre-create theirs the same way).
+	if _, preset := envValue(os.Environ(), "STORAGE_SQLITE_PATH"); !preset {
+		if storage, ok := envValue(env, "STORAGE_SQLITE_PATH"); ok {
+			if mkdirErr := os.MkdirAll(filepath.Dir(storage), 0o755); mkdirErr != nil {
+				fatal(fmt.Sprintf("could not create the storage directory for %s: %v", storage, mkdirErr))
+			}
+		}
+	}
+
+	cmd := exec.Command(paths.Node, append([]string{paths.Server}, os.Args[1:]...)...)
+	cmd.Dir = exeDir
+	cmd.Env = env
+	// os/exec defaults nil stdio to the null device, NOT the parent console.
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	// Ctrl+C / Ctrl+Break reach the child directly (same console process
+	// group); the launcher only has to outlive it to report the real exit
+	// code instead of dying to its own default interrupt handling. os/signal
+	// documents this suppression explicitly for Notify on Windows ("the
+	// program will not exit"), so Notify-and-drain is the doc-sanctioned
+	// form; the channel must be buffered (Notify sends non-blocking).
+	interrupts := make(chan os.Signal, 1)
+	signal.Notify(interrupts, os.Interrupt)
+	go func() {
+		for range interrupts {
+		}
+	}()
+
+	if runErr := cmd.Run(); runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			os.Exit(exitErr.ProcessState.ExitCode())
+		}
+		fatal(fmt.Sprintf("could not start %s: %v", paths.Node, runErr))
+	}
+}
+
+func fatal(message string) {
+	fmt.Fprintln(os.Stderr, "libredb-studio launcher: "+message)
+	os.Exit(1)
+}

--- a/packaging/windows/launcher/main.go
+++ b/packaging/windows/launcher/main.go
@@ -45,8 +45,9 @@ func main() {
 	env := launcherEnv(os.Environ())
 	// The default storage path's parent directories may not exist yet
 	// (fresh %LOCALAPPDATA%); the server expects the directory to be there
-	// (the deb/Homebrew packages pre-create theirs the same way).
-	if _, preset := envValue(os.Environ(), "STORAGE_SQLITE_PATH"); !preset {
+	// (the deb/Homebrew packages pre-create theirs the same way). An empty
+	// preset counts as unset, mirroring launcherEnv.
+	if value, preset := envValue(os.Environ(), "STORAGE_SQLITE_PATH"); !preset || value == "" {
 		if storage, ok := envValue(env, "STORAGE_SQLITE_PATH"); ok {
 			if mkdirErr := os.MkdirAll(filepath.Dir(storage), 0o755); mkdirErr != nil {
 				fatal(fmt.Sprintf("could not create the storage directory for %s: %v", storage, mkdirErr))

--- a/packaging/winget/LibreDB.Studio.installer.yaml.tmpl
+++ b/packaging/winget/LibreDB.Studio.installer.yaml.tmpl
@@ -1,0 +1,27 @@
+# Installer manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs from the release SHA256SUMS.
+#
+# InstallerType zip + NestedInstallerType portable needs winget client 1.5+.
+# The zip is FLAT (scripts/lib/pack-standalone-zip.sh), so RelativeFilePath
+# is stable across releases - `wingetcreate update` carries the
+# NestedInstallerFiles list forward by exact-path match.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "{{VERSION}}"
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: libredb-studio.exe
+    PortableCommandAlias: libredb-studio
+Commands:
+  - libredb-studio
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/libredb/libredb-studio/releases/download/{{VERSION}}/libredb-studio-standalone-{{VERSION}}-win32-x64.zip
+    InstallerSha256: {{SHA256_WIN32_X64}}
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl
+++ b/packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl
@@ -1,0 +1,43 @@
+# Default-locale manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs with the release version.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "{{VERSION}}"
+PackageLocale: en-US
+Publisher: LibreDB
+PublisherUrl: https://libredb.org
+PublisherSupportUrl: https://github.com/libredb/libredb-studio/issues
+PackageName: LibreDB Studio
+PackageUrl: https://github.com/libredb/libredb-studio
+License: MIT
+LicenseUrl: https://github.com/libredb/libredb-studio/blob/main/LICENSE
+Copyright: Copyright (c) 2025 LibreDB
+ShortDescription: Web-based SQL IDE for PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis with AI query assistance.
+Description: |-
+  LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams.
+  It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and
+  Redis, and ships a Monaco-powered editor with AI query assistance, schema
+  browsing, ER diagrams, charts, and import/export tooling. This package
+  installs the standalone server with a bundled Node.js runtime; run
+  `libredb-studio` and open http://127.0.0.1:3000 - the first run prints
+  generated admin credentials to the terminal (zero-config bootstrap).
+Moniker: libredb-studio
+Tags:
+  - database
+  - db
+  - ide
+  - mongodb
+  - mysql
+  - oracle
+  - postgres
+  - postgresql
+  - redis
+  - sql
+  - sqlite
+ReleaseNotesUrl: https://github.com/libredb/libredb-studio/releases/tag/{{VERSION}}
+Documentations:
+  - DocumentLabel: Distribution & Install Guide
+    DocumentUrl: https://github.com/libredb/libredb-studio/blob/main/docs/DISTRIBUTION.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/packaging/winget/LibreDB.Studio.yaml.tmpl
+++ b/packaging/winget/LibreDB.Studio.yaml.tmpl
@@ -1,0 +1,10 @@
+# Version manifest template for the winget community repository
+# (microsoft/winget-pkgs), issue #114. Rendered by
+# scripts/render-windows-packaging.mjs with the release version; see
+# docs/DISTRIBUTION.md ("Windows") for the first-listing flow.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: LibreDB.Studio
+PackageVersion: "{{VERSION}}"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/build-standalone-payload.sh
+++ b/scripts/build-standalone-payload.sh
@@ -18,11 +18,15 @@
 #
 # Usage: scripts/build-standalone-payload.sh <output-dir> [--smoke]
 #
-#   <output-dir>  where the tarball is written:
+#   <output-dir>  where the archive is written:
 #                 libredb-studio-standalone-<version>-<os>-<arch>.tar.gz
-#                 Entries are rooted under a top-level libredb-studio-<version>/
-#                 directory (issue #133) - extract with --strip-components=1
-#                 (see scripts/lib/pack-standalone-tarball.sh).
+#                 (.zip on win32, issue #114).
+#                 Tarball entries are rooted under a top-level
+#                 libredb-studio-<version>/ directory (issue #133) - extract
+#                 with --strip-components=1 (scripts/lib/pack-standalone-tarball.sh).
+#                 The win32 zip is FLAT (no versioned root) so winget's
+#                 NestedInstallerFiles paths stay stable across versions
+#                 (scripts/lib/pack-standalone-zip.sh).
 #   --smoke       after packing, extract the tarball to a temp dir, boot
 #                 `node server.js` on a random port with a temp
 #                 STORAGE_SQLITE_PATH and require GET /api/db/health to
@@ -57,8 +61,9 @@ VERSION=$(node -p "require('./package.json').version")
 case "$(node -p 'process.platform')" in
   linux) OS=linux ;;
   darwin) OS=darwin ;;
+  win32) OS=win32 ;;
   *)
-    echo "Unsupported platform '$(node -p 'process.platform')' (expected linux or darwin)" >&2
+    echo "Unsupported platform '$(node -p 'process.platform')' (expected linux, darwin, or win32)" >&2
     exit 1
     ;;
 esac
@@ -72,7 +77,20 @@ case "$(node -p 'process.arch')" in
     ;;
 esac
 
-TARBALL="libredb-studio-standalone-${VERSION}-${OS}-${ARCH}.tar.gz"
+if [ "$OS" = "win32" ] && [ "$ARCH" != "x64" ]; then
+  echo "Unsupported Windows architecture '$ARCH' (only win32-x64 is released, issue #114)" >&2
+  exit 1
+fi
+
+# POSIX targets ship a tar.gz rooted under libredb-studio-<version>/ (issue
+# #133); win32 ships a FLAT .zip (issue #114) - winget extracts it in place
+# and NestedInstallerFiles.RelativeFilePath must stay stable across versions,
+# so the zip has no versioned root directory.
+if [ "$OS" = "win32" ]; then
+  ARCHIVE="libredb-studio-standalone-${VERSION}-${OS}-${ARCH}.zip"
+else
+  ARCHIVE="libredb-studio-standalone-${VERSION}-${OS}-${ARCH}.tar.gz"
+fi
 
 STAGE_DIR=$(mktemp -d)
 SERVER_PID=""
@@ -170,11 +188,16 @@ fi
 rm -rf "$PAYLOAD_DIR/seed-assets"
 cp -R seed-assets "$PAYLOAD_DIR/seed-assets"
 
-echo "==> Packing $TARBALL"
-# Wraps PAYLOAD_DIR in a top-level libredb-studio-<version>/ root instead of
-# a tarbomb (issue #133); consumers extract with --strip-components=1.
-"$ROOT_DIR/scripts/lib/pack-standalone-tarball.sh" "$PAYLOAD_DIR" "$VERSION" "$OUT_DIR/$TARBALL"
-echo "==> Wrote $OUT_DIR/$TARBALL ($(du -h "$OUT_DIR/$TARBALL" | cut -f1))"
+echo "==> Packing $ARCHIVE"
+if [ "$OS" = "win32" ]; then
+  # Flat zip (issue #114): entries at the archive root, no versioned wrapper.
+  "$ROOT_DIR/scripts/lib/pack-standalone-zip.sh" "$PAYLOAD_DIR" "$OUT_DIR/$ARCHIVE"
+else
+  # Wraps PAYLOAD_DIR in a top-level libredb-studio-<version>/ root instead of
+  # a tarbomb (issue #133); consumers extract with --strip-components=1.
+  "$ROOT_DIR/scripts/lib/pack-standalone-tarball.sh" "$PAYLOAD_DIR" "$VERSION" "$OUT_DIR/$ARCHIVE"
+fi
+echo "==> Wrote $OUT_DIR/$ARCHIVE ($(du -h "$OUT_DIR/$ARCHIVE" | cut -f1))"
 
 # ------------------------------------------------------------------------------
 # Smoke test: extract the tarball we just produced (not the staging dir), boot
@@ -184,10 +207,23 @@ if [ "$RUN_SMOKE" = "true" ]; then
   SMOKE_DIR="$STAGE_DIR/smoke"
   STORAGE_DIR="$STAGE_DIR/storage"
   mkdir -p "$SMOKE_DIR" "$STORAGE_DIR"
-  tar -xzf "$OUT_DIR/$TARBALL" -C "$SMOKE_DIR" --strip-components=1
+  # The native node.exe on Windows cannot resolve Git Bash's POSIX-style
+  # mktemp paths (/tmp/... would land on the current drive root), so every
+  # path handed to node goes through cygpath there; NODE_STORAGE_DIR stays
+  # the plain POSIX path everywhere else.
+  NODE_STORAGE_DIR="$STORAGE_DIR"
+  if [ "$OS" = "win32" ]; then
+    NODE_STORAGE_DIR="$(cygpath -w "$STORAGE_DIR")"
+    # Flat zip: nothing to strip. Use the System32 bsdtar explicitly - it
+    # reads zip natively, while Git Bash's own `tar` is GNU tar (no zip).
+    # Env-var casing differs between shells (SystemRoot vs SYSTEMROOT).
+    "${SYSTEMROOT:-${SystemRoot:-C:\\Windows}}/System32/tar.exe" -xf "$OUT_DIR/$ARCHIVE" -C "$SMOKE_DIR"
+  else
+    tar -xzf "$OUT_DIR/$ARCHIVE" -C "$SMOKE_DIR" --strip-components=1
+  fi
 
   echo "==> Smoke: better-sqlite3 native binding loads"
-  (cd "$SMOKE_DIR" && node -e "const db = require('better-sqlite3')('$STORAGE_DIR/probe.db'); db.exec('CREATE TABLE t (id INTEGER)'); db.close();")
+  (cd "$SMOKE_DIR" && NODE_PROBE_DB="$NODE_STORAGE_DIR/probe.db" node -e "const db = require('better-sqlite3')(process.env.NODE_PROBE_DB); db.exec('CREATE TABLE t (id INTEGER)'); db.close();")
 
   PORT=$(( (RANDOM % 20000) + 20001 ))
   echo "==> Smoke: booting node server.js on port $PORT"
@@ -198,7 +234,7 @@ if [ "$RUN_SMOKE" = "true" ]; then
       HOSTNAME=127.0.0.1 \
       PORT="$PORT" \
       STORAGE_PROVIDER=sqlite \
-      STORAGE_SQLITE_PATH="$STORAGE_DIR/storage.db" \
+      STORAGE_SQLITE_PATH="$NODE_STORAGE_DIR/storage.db" \
       node server.js
   ) >"$STAGE_DIR/server.log" 2>&1 &
   SERVER_PID=$!
@@ -247,4 +283,4 @@ if [ "$RUN_SMOKE" = "true" ]; then
   echo "==> Smoke: embedded SQLite sample seeded"
 fi
 
-echo "==> Done: $OUT_DIR/$TARBALL"
+echo "==> Done: $OUT_DIR/$ARCHIVE"

--- a/scripts/lib/pack-standalone-zip.sh
+++ b/scripts/lib/pack-standalone-zip.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Pack an assembled standalone payload directory into a FLAT zip for the
+# win32-x64 release artifact (issue #114).
+#
+# Flat means entries sit at the archive root (server.js, .next/, node/,
+# libredb-studio.exe, ...) with NO libredb-studio-<version>/ wrapper - the
+# opposite of the POSIX tarball layout (issue #133). Two consumers force
+# this:
+#   - winget extracts the zip in place and resolves
+#     NestedInstallerFiles.RelativeFilePath against the zip root; a
+#     versioned wrapper directory would change that path on every release
+#     (wingetcreate update does not rewrite RelativeFilePath).
+#   - Chocolatey's Install-ChocolateyZipPackage unzips into the package
+#     tools dir, where the launcher exe must land at a stable depth for
+#     shimming.
+# Windows Explorer's "Extract All" already defaults to a directory named
+# after the zip, so a flat archive is not a zipbomb hazard for manual users.
+#
+# Packs with 7-Zip (preinstalled on the windows-latest runner image), then
+# asserts the resulting layout is really flat and complete - a zip missing
+# server.js or .next/ must fail here, not at install time.
+#
+# Usage: pack-standalone-zip.sh <payload-dir> <output-zip>
+# ==============================================================================
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <payload-dir> <output-zip>" >&2
+  exit 1
+fi
+
+PAYLOAD_DIR=$1
+OUT_ZIP=$2
+
+if [ ! -d "$PAYLOAD_DIR" ]; then
+  echo "Payload dir not found: $PAYLOAD_DIR" >&2
+  exit 1
+fi
+
+# Resolve the output path against the caller's cwd before any cd.
+OUT_PARENT=$(cd "$(dirname "$OUT_ZIP")" && pwd)
+OUT_ZIP="$OUT_PARENT/$(basename "$OUT_ZIP")"
+
+# 7z is on PATH on the windows-latest runner image; fall back to the
+# canonical install location for local Git Bash setups that skip PATH.
+SEVENZIP=$(command -v 7z || true)
+if [ -z "$SEVENZIP" ] && [ -x "/c/Program Files/7-Zip/7z.exe" ]; then
+  SEVENZIP="/c/Program Files/7-Zip/7z.exe"
+fi
+if [ -z "$SEVENZIP" ]; then
+  echo "7z not found - the win32 zip is packed with 7-Zip (preinstalled on windows-latest)" >&2
+  exit 1
+fi
+
+rm -f "$OUT_ZIP"
+# `7z a <zip> .` from inside the payload adds its CONTENTS at the archive
+# root (no wrapper directory) and includes dot-named entries like .next -
+# unlike a shell glob, which would skip them.
+(cd "$PAYLOAD_DIR" && "$SEVENZIP" a -tzip -bd -bso0 "$OUT_ZIP" .)
+
+# Layout assertions: required roots present, and present AT the root (7z
+# lists paths with backslashes on Windows, so match both separators).
+LISTING=$("$SEVENZIP" l -ba -slt "$OUT_ZIP" | sed -n 's/^Path = //p')
+for required in "server.js" ".next" "package.json"; do
+  if ! printf '%s\n' "$LISTING" | grep -qx "$required"; then
+    echo "Packed zip is missing required root entry '$required' - refusing to ship it" >&2
+    exit 1
+  fi
+done
+if printf '%s\n' "$LISTING" | grep -qE '^libredb-studio-[0-9]'; then
+  echo "Packed zip has a versioned wrapper directory - the win32 zip must be flat (issue #114)" >&2
+  exit 1
+fi
+
+echo "==> Packed flat zip $OUT_ZIP"

--- a/scripts/lib/pack-standalone-zip.sh
+++ b/scripts/lib/pack-standalone-zip.sh
@@ -61,8 +61,10 @@ rm -f "$OUT_ZIP"
 (cd "$PAYLOAD_DIR" && "$SEVENZIP" a -tzip -bd -bso0 "$OUT_ZIP" .)
 
 # Layout assertions: required roots present, and present AT the root (7z
-# lists paths with backslashes on Windows, so match both separators).
-LISTING=$("$SEVENZIP" l -ba -slt "$OUT_ZIP" | sed -n 's/^Path = //p')
+# lists paths with backslashes on Windows, so match both separators; the
+# native 7z.exe also emits CRLF line endings, so strip \r or the anchored
+# grep below would reject every entry on the Windows runner).
+LISTING=$("$SEVENZIP" l -ba -slt "$OUT_ZIP" | sed -n 's/^Path = //p' | tr -d '\r')
 for required in "server.js" ".next" "package.json"; do
   if ! printf '%s\n' "$LISTING" | grep -qx "$required"; then
     echo "Packed zip is missing required root entry '$required' - refusing to ship it" >&2

--- a/scripts/lib/pack-standalone-zip.sh
+++ b/scripts/lib/pack-standalone-zip.sh
@@ -66,7 +66,9 @@ rm -f "$OUT_ZIP"
 # grep below would reject every entry on the Windows runner).
 LISTING=$("$SEVENZIP" l -ba -slt "$OUT_ZIP" | sed -n 's/^Path = //p' | tr -d '\r')
 for required in "server.js" ".next" "package.json"; do
-  if ! printf '%s\n' "$LISTING" | grep -qx "$required"; then
+  # -F: fixed-string match - a regex match would let the dots in these
+  # names match any character (serverXjs must not satisfy server.js).
+  if ! printf '%s\n' "$LISTING" | grep -qxF "$required"; then
     echo "Packed zip is missing required root entry '$required' - refusing to ship it" >&2
     exit 1
   fi

--- a/scripts/render-windows-packaging.mjs
+++ b/scripts/render-windows-packaging.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Render a Windows packaging template (issue #114) - the win32 sibling of
+ * scripts/render-homebrew-formula.mjs, shared by the winget manifests
+ * (packaging/winget/*.tmpl) and the Chocolatey package
+ * (packaging/chocolatey/**.tmpl).
+ *
+ * Fills {{VERSION}} and {{SHA256_WIN32_X64}} (the win32-x64 zip digest)
+ * from the SHA256SUMS file the release workflow attaches to the GitHub
+ * release. Fails loudly when the digest is missing or a placeholder would
+ * survive rendering - a half-rendered manifest must never reach a package
+ * repository.
+ *
+ * Usage: node scripts/render-windows-packaging.mjs <template> <sums> <version> <output>
+ *
+ * Pure rendering logic is exported and unit tested in
+ * tests/unit/render-windows-packaging.test.ts (no network access).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { artifactName, parseSha256Sums } from "../bin/lib/launcher-utils.mjs";
+
+/** Same semver shape the release workflow guard enforces (no v prefix). */
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-.][0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+
+/**
+ * Render a winget/Chocolatey template into a concrete package file.
+ *
+ * @param {string} template raw template text
+ * @param {string} sumsText SHA256SUMS content (sha256sum output format)
+ * @param {string} version release version, no v prefix (e.g. "0.9.41")
+ * @returns {string} the rendered file
+ */
+export function renderWindowsPackagingTemplate(template, sumsText, version) {
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error(`Version '${version}' is not a valid semver (no v prefix)`);
+  }
+
+  const sums = parseSha256Sums(sumsText);
+  const zipName = artifactName(version, "win32", "x64");
+  const digest = sums.get(zipName);
+  if (!digest) {
+    throw new Error(`SHA256SUMS has no entry for ${zipName}`);
+  }
+
+  const rendered = template.replaceAll("{{VERSION}}", version).replaceAll("{{SHA256_WIN32_X64}}", digest);
+
+  // Any surviving marker (known or misspelled) means a broken package file.
+  const leftover = /\{\{[^}\n]*\}\}/.exec(rendered) ?? (rendered.includes("{{") ? ["{{"] : null);
+  if (leftover) {
+    throw new Error(`Unfilled placeholder ${leftover[0]} in rendered template`);
+  }
+
+  return rendered;
+}
+
+function main(argv) {
+  const [templatePath, sumsPath, version, outputPath] = argv;
+  if (!templatePath || !sumsPath || !version || !outputPath) {
+    console.error("Usage: node scripts/render-windows-packaging.mjs <template> <sums> <version> <output>");
+    process.exit(1);
+  }
+
+  const template = fs.readFileSync(templatePath, "utf8");
+  const sumsText = fs.readFileSync(sumsPath, "utf8");
+  const rendered = renderWindowsPackagingTemplate(template, sumsText, version);
+
+  fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+  fs.writeFileSync(outputPath, rendered);
+  console.log(`Rendered ${outputPath} for version ${version}`);
+}
+
+// CLI entry only when executed directly (the unit test imports this module).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2));
+}

--- a/scripts/render-windows-packaging.mjs
+++ b/scripts/render-windows-packaging.mjs
@@ -46,8 +46,12 @@ export function renderWindowsPackagingTemplate(template, sumsText, version) {
 
   const rendered = template.replaceAll("{{VERSION}}", version).replaceAll("{{SHA256_WIN32_X64}}", digest);
 
-  // Any surviving marker (known or misspelled) means a broken package file.
-  const leftover = /\{\{[^}\n]*\}\}/.exec(rendered) ?? (rendered.includes("{{") ? ["{{"] : null);
+  // Any surviving marker (known, misspelled, or a stray half - e.g. a
+  // typoed {VERSION}} leaving a bare "}}") means a broken package file.
+  const leftover =
+    /\{\{[^}\n]*\}\}/.exec(rendered) ??
+    (rendered.includes("{{") ? ["{{"] : null) ??
+    (rendered.includes("}}") ? ["}}"] : null);
   if (leftover) {
     throw new Error(`Unfilled placeholder ${leftover[0]} in rendered template`);
   }

--- a/tests/unit/launcher-utils.test.ts
+++ b/tests/unit/launcher-utils.test.ts
@@ -10,7 +10,8 @@ import {
   artifactName,
   assertReleaseVersion,
   assessNodeRuntime,
-  extractTarball,
+  extractArchive,
+  extractionCommand,
   LauncherUsageError,
   parseLauncherArgs,
   parseSha256Sums,
@@ -34,10 +35,57 @@ describe("artifactName", () => {
     expect(artifactName("1.0.0", "darwin", "arm64")).toBe("libredb-studio-standalone-1.0.0-darwin-arm64.tar.gz");
   });
 
+  test("maps win32-x64 to the release zip name (issue #114)", () => {
+    // Windows ships a .zip (winget InstallerType zip; bsdtar-extractable),
+    // not a .tar.gz - the extension is part of the artifact contract.
+    expect(artifactName("0.9.41", "win32", "x64")).toBe("libredb-studio-standalone-0.9.41-win32-x64.zip");
+  });
+
   test("throws for targets the release workflow does not build", () => {
-    expect(() => artifactName("0.9.41", "win32", "x64")).toThrow(/win32-x64/);
+    expect(() => artifactName("0.9.41", "win32", "arm64")).toThrow(/win32-arm64/);
     expect(() => artifactName("0.9.41", "linux", "ia32")).toThrow(/linux-ia32/);
     expect(() => artifactName("0.9.41", "freebsd", "arm64")).toThrow(/Supported targets/);
+    expect(() => artifactName("0.9.41", "freebsd", "arm64")).toThrow(/win32-x64/);
+  });
+});
+
+describe("extractionCommand", () => {
+  test("builds the strip-one-root tar command for .tar.gz archives", () => {
+    expect(extractionCommand("/tmp/payload.tar.gz", "/tmp/dest", "linux", {})).toEqual({
+      command: "tar",
+      args: ["-xzf", "/tmp/payload.tar.gz", "-C", "/tmp/dest", "--strip-components=1"],
+    });
+  });
+
+  test("uses the System32 bsdtar for .zip archives on win32 (Git Bash GNU tar cannot read zip)", () => {
+    // The win32 zip is flat (no versioned root - winget's RelativeFilePath
+    // must stay stable across versions), so no --strip-components here.
+    expect(extractionCommand("C:\\cache\\payload.zip", "C:\\cache\\dest", "win32", { SystemRoot: "D:\\Win" })).toEqual({
+      command: "D:\\Win\\System32\\tar.exe",
+      args: ["-xf", "C:\\cache\\payload.zip", "-C", "C:\\cache\\dest"],
+    });
+  });
+
+  test("falls back to C:\\Windows when SystemRoot is unset", () => {
+    expect(extractionCommand("a.zip", "dest", "win32", {}).command).toBe("C:\\Windows\\System32\\tar.exe");
+  });
+
+  test("uses plain tar for .zip archives on macOS (the system tar is bsdtar and reads zip natively)", () => {
+    expect(extractionCommand("/tmp/payload.zip", "/tmp/dest", "darwin", {})).toEqual({
+      command: "tar",
+      args: ["-xf", "/tmp/payload.zip", "-C", "/tmp/dest"],
+    });
+  });
+
+  test("refuses .zip archives on linux (GNU tar cannot read zip - fail loudly, not cryptically)", () => {
+    expect(() => extractionCommand("/tmp/payload.zip", "/tmp/dest", "linux", {})).toThrow(
+      /zip archives cannot be extracted on linux/,
+    );
+    expect(() => extractionCommand("/tmp/payload.zip", "/tmp/dest", "linux", {})).toThrow(/tar\.gz/);
+  });
+
+  test("is case-insensitive on the .zip extension", () => {
+    expect(extractionCommand("/tmp/PAYLOAD.ZIP", "/tmp/dest", "darwin", {}).args[0]).toBe("-xf");
   });
 });
 
@@ -330,12 +378,14 @@ describe("preservePayloadData", () => {
   });
 });
 
-describe("extractTarball", () => {
+describe("extractArchive", () => {
   // Release tarballs are packed with a top-level libredb-studio-<version>/
   // root (issue #133, scripts/lib/pack-standalone-tarball.sh) instead of a
-  // tarbomb; extractTarball must strip that one path component so the
+  // tarbomb; extractArchive must strip that one path component so the
   // payload (server.js, etc.) lands directly in destDir, matching every
-  // caller's expectation (e.g. `payloadDir/server.js`).
+  // caller's expectation (e.g. `payloadDir/server.js`). Windows .zip
+  // archives are flat by design (issue #114) and take the zip branch of
+  // extractionCommand, covered above.
   function buildFixtureTarball(rootName: string): string {
     const sourceDir = fs.mkdtempSync(path.join(tempDir, "extract-src-"));
     const versionedRoot = path.join(sourceDir, rootName);
@@ -356,7 +406,7 @@ describe("extractTarball", () => {
     const tarballPath = buildFixtureTarball("libredb-studio-9.9.9");
     const destDir = fs.mkdtempSync(path.join(tempDir, "extract-dest-"));
 
-    const { status, error } = extractTarball(tarballPath, destDir);
+    const { status, error } = extractArchive(tarballPath, destDir);
 
     expect(error).toBeNull();
     expect(status).toBe(0);

--- a/tests/unit/packaging-standalone-zip.test.ts
+++ b/tests/unit/packaging-standalone-zip.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the win32 flat-zip packer (issue #114):
+ * scripts/lib/pack-standalone-zip.sh must produce a zip whose entries sit at
+ * the archive root (server.js, .next/, ...) with NO libredb-studio-<version>/
+ * wrapper - winget resolves NestedInstallerFiles.RelativeFilePath against the
+ * zip root and `wingetcreate update` never rewrites that path, so a versioned
+ * wrapper would break every subsequent release. Exercises the real script as
+ * a subprocess against a small fixture payload (mirrors
+ * packaging-standalone-tarball.test.ts; 7z is preinstalled on the CI runners).
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(import.meta.dir, "../../scripts/lib/pack-standalone-zip.sh");
+
+function listZipEntries(zipPath: string): string[] {
+  const list = Bun.spawnSync(["7z", "l", "-ba", "-slt", zipPath], { stdout: "pipe", stderr: "pipe" });
+  expect(list.exitCode).toBe(0);
+  return list.stdout
+    .toString()
+    .split("\n")
+    .filter((line) => line.startsWith("Path = "))
+    .map((line) => line.slice("Path = ".length).trim())
+    .filter(Boolean);
+}
+
+describe("scripts/lib/pack-standalone-zip.sh (#114)", () => {
+  const fixtureRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeFixturePayload(): { root: string; payloadDir: string; zip: string } {
+    const root = mkdtempSync(join(tmpdir(), "pack-standalone-zip-"));
+    fixtureRoots.push(root);
+    const payloadDir = join(root, "payload");
+    mkdirSync(join(payloadDir, ".next"), { recursive: true });
+    mkdirSync(join(payloadDir, "data"), { recursive: true });
+    writeFileSync(join(payloadDir, "server.js"), "// stub");
+    writeFileSync(join(payloadDir, "package.json"), "{}");
+    writeFileSync(join(payloadDir, ".next", "BUILD_ID"), "stub-build");
+    return { root, payloadDir, zip: join(root, "out.zip") };
+  }
+
+  test("packs the payload contents FLAT at the archive root, including dot-directories", () => {
+    const { payloadDir, zip } = makeFixturePayload();
+
+    const run = Bun.spawnSync(["bash", SCRIPT, payloadDir, zip], { stdout: "pipe", stderr: "pipe" });
+    expect(run.stderr.toString()).toBe("");
+    expect(run.exitCode).toBe(0);
+
+    const entries = listZipEntries(zip).map((entry) => entry.replaceAll("\\", "/"));
+    expect(entries).toContain("server.js");
+    expect(entries).toContain("package.json");
+    expect(entries).toContain(".next");
+    expect(entries).toContain(".next/BUILD_ID");
+    // Flat contract: nothing may hide under a versioned wrapper root.
+    for (const entry of entries) {
+      expect(entry.startsWith("libredb-studio-")).toBe(false);
+      expect(entry.startsWith("payload/")).toBe(false);
+    }
+  });
+
+  test("overwrites a stale zip at the output path", () => {
+    const { payloadDir, zip } = makeFixturePayload();
+    writeFileSync(zip, "not a zip");
+
+    const run = Bun.spawnSync(["bash", SCRIPT, payloadDir, zip], { stdout: "pipe", stderr: "pipe" });
+    expect(run.exitCode).toBe(0);
+    expect(listZipEntries(zip)).toContain("server.js");
+  });
+
+  test("refuses a payload missing a required root entry (server.js)", () => {
+    const { payloadDir, zip } = makeFixturePayload();
+    rmSync(join(payloadDir, "server.js"));
+
+    const run = Bun.spawnSync(["bash", SCRIPT, payloadDir, zip], { stdout: "pipe", stderr: "pipe" });
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr.toString()).toContain("server.js");
+  });
+
+  test("fails loudly for a missing payload directory", () => {
+    const { root, zip } = makeFixturePayload();
+
+    const run = Bun.spawnSync(["bash", SCRIPT, join(root, "nope"), zip], { stdout: "pipe", stderr: "pipe" });
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr.toString()).toContain("Payload dir not found");
+  });
+
+  test("rejects wrong usage", () => {
+    const run = Bun.spawnSync(["bash", SCRIPT, "only-one-arg"], { stdout: "pipe", stderr: "pipe" });
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr.toString()).toContain("Usage:");
+  });
+});

--- a/tests/unit/packaging-standalone-zip.test.ts
+++ b/tests/unit/packaging-standalone-zip.test.ts
@@ -82,6 +82,16 @@ describe("scripts/lib/pack-standalone-zip.sh (#114)", () => {
     expect(run.stderr.toString()).toContain("server.js");
   });
 
+  test("matches required entries as fixed strings, not regexes (serverXjs must not satisfy server.js)", () => {
+    const { payloadDir, zip } = makeFixturePayload();
+    rmSync(join(payloadDir, "server.js"));
+    writeFileSync(join(payloadDir, "serverXjs"), "// imposter");
+
+    const run = Bun.spawnSync(["bash", SCRIPT, payloadDir, zip], { stdout: "pipe", stderr: "pipe" });
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr.toString()).toContain("server.js");
+  });
+
   test("fails loudly for a missing payload directory", () => {
     const { root, zip } = makeFixturePayload();
 

--- a/tests/unit/render-windows-packaging.test.ts
+++ b/tests/unit/render-windows-packaging.test.ts
@@ -96,4 +96,13 @@ describe("renderWindowsPackagingTemplate", () => {
       /Unfilled placeholder/,
     );
   });
+
+  test("throws on a stray closing marker (a typoed {VERSION}} must fail closed, not ship)", () => {
+    expect(() => renderWindowsPackagingTemplate("{VERSION}} stray", fixtureSums(), VERSION)).toThrow(
+      /Unfilled placeholder/,
+    );
+    expect(() => renderWindowsPackagingTemplate("{{VERSION}} tail }}", fixtureSums(), VERSION)).toThrow(
+      /Unfilled placeholder/,
+    );
+  });
 });

--- a/tests/unit/render-windows-packaging.test.ts
+++ b/tests/unit/render-windows-packaging.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the Windows packaging template renderer
+ * (scripts/render-windows-packaging.mjs, issue #114). Renders the real
+ * winget and Chocolatey templates against a fixture SHA256SUMS - pure
+ * string work, no network (mirrors render-homebrew-formula.test.ts).
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { renderWindowsPackagingTemplate } from "../../scripts/render-windows-packaging.mjs";
+
+const VERSION = "0.9.41";
+const ZIP_DIGEST = "a".repeat(64);
+
+const TEMPLATES = [
+  "packaging/winget/LibreDB.Studio.yaml.tmpl",
+  "packaging/winget/LibreDB.Studio.installer.yaml.tmpl",
+  "packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl",
+  "packaging/chocolatey/libredb-studio.nuspec.tmpl",
+  "packaging/chocolatey/tools/chocolateyinstall.ps1.tmpl",
+].map((relative) => path.join(__dirname, "../..", relative));
+
+function readTemplate(templatePath: string): string {
+  return fs.readFileSync(templatePath, "utf8");
+}
+
+function fixtureSums(version = VERSION, digest = ZIP_DIGEST): string {
+  return (
+    `${"1".repeat(64)}  libredb-studio-standalone-${version}-linux-x64.tar.gz\n` +
+    `${digest}  libredb-studio-standalone-${version}-win32-x64.zip\n`
+  );
+}
+
+describe("renderWindowsPackagingTemplate", () => {
+  test("fills the version and win32 zip digest", () => {
+    const rendered = renderWindowsPackagingTemplate(
+      "id {{VERSION}} sha {{SHA256_WIN32_X64}} again {{VERSION}}",
+      fixtureSums(),
+      VERSION,
+    );
+    expect(rendered).toBe(`id ${VERSION} sha ${ZIP_DIGEST} again ${VERSION}`);
+  });
+
+  test.each(TEMPLATES)("renders %s without leftover placeholders", (templatePath) => {
+    const rendered = renderWindowsPackagingTemplate(readTemplate(templatePath), fixtureSums(), VERSION);
+    expect(rendered).not.toContain("{{");
+    expect(rendered).not.toContain("}}");
+    expect(rendered).toContain(VERSION);
+  });
+
+  test("the winget installer manifest carries the release zip URL and digest", () => {
+    const template = readTemplate(TEMPLATES[1]);
+    const rendered = renderWindowsPackagingTemplate(template, fixtureSums(), VERSION);
+    expect(rendered).toContain(
+      `https://github.com/libredb/libredb-studio/releases/download/${VERSION}/` +
+        `libredb-studio-standalone-${VERSION}-win32-x64.zip`,
+    );
+    expect(rendered).toContain(`InstallerSha256: ${ZIP_DIGEST}`);
+    expect(rendered).toContain("RelativeFilePath: libredb-studio.exe");
+  });
+
+  test("the Chocolatey install script pins the checksum", () => {
+    const template = readTemplate(TEMPLATES[4]);
+    const rendered = renderWindowsPackagingTemplate(template, fixtureSums(), VERSION);
+    expect(rendered).toContain(ZIP_DIGEST);
+    expect(rendered).toContain("sha256");
+  });
+
+  test("throws when the win32 zip digest is missing from SHA256SUMS", () => {
+    const sums = `${"1".repeat(64)}  libredb-studio-standalone-${VERSION}-linux-x64.tar.gz\n`;
+    expect(() => renderWindowsPackagingTemplate("{{SHA256_WIN32_X64}}", sums, VERSION)).toThrow(
+      /SHA256SUMS has no entry for libredb-studio-standalone-0\.9\.41-win32-x64\.zip/,
+    );
+  });
+
+  test("throws when the SHA256SUMS entries are for a different version", () => {
+    expect(() => renderWindowsPackagingTemplate("{{SHA256_WIN32_X64}}", fixtureSums("0.9.40"), VERSION)).toThrow(
+      /SHA256SUMS has no entry/,
+    );
+  });
+
+  test("rejects invalid or v-prefixed versions", () => {
+    for (const version of ["v0.9.41", "0.9", "0.9.41; rm -rf /", ""]) {
+      expect(() => renderWindowsPackagingTemplate("{{VERSION}}", fixtureSums(), version)).toThrow(/not a valid semver/);
+    }
+  });
+
+  test("throws when a placeholder survives rendering", () => {
+    expect(() =>
+      renderWindowsPackagingTemplate("{{VERSION}} {{NOT_A_KNOWN_PLACEHOLDER}}", fixtureSums(), VERSION),
+    ).toThrow(/Unfilled placeholder \{\{NOT_A_KNOWN_PLACEHOLDER\}\}/);
+  });
+
+  test("throws on a stray opening marker without a closing brace", () => {
+    expect(() => renderWindowsPackagingTemplate("{{VERSION}} stray {{", fixtureSums(), VERSION)).toThrow(
+      /Unfilled placeholder/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #114 (engineering scope; first community listings follow the checklist below).

## What this delivers

Native Windows distribution end to end: a `win32-x64` standalone zip built in release CI, a Go launcher (`libredb-studio.exe`), winget (`LibreDB.Studio`) and Chocolatey (`libredb-studio`) automation, and npx launcher support on Windows.

### Release artifact: flat win32 zip

- `windows-package` job (windows-latest): builds the payload natively, bundles the pinned Node 24.18.0 runtime (`packaging/windows/fetch-node.sh`, sha256 pinned in-repo like the Linux sibling), cross-checks/builds the Go launcher, packs a **flat** zip (`scripts/lib/pack-standalone-zip.sh`), and smoke-boots the final zip through `libredb-studio.exe` (health 200 + first-run credentials banner + embedded sample seeded) before anything reaches the release.
- Flat by design: winget resolves `NestedInstallerFiles.RelativeFilePath` against the zip root and `wingetcreate update` never rewrites it, so `libredb-studio.exe` must stay at the root across releases.
- `SHA256SUMS` now covers the zip; the zip is on the publish-release required-assets list.

### Launcher (`packaging/windows/launcher`, Go)

Windows sibling of `packaging/linux/libredb-studio`, cross-compilable from any OS (CGO_ENABLED=0):

- Local-first bind (#134 parity): `HOSTNAME` is always overridden to `LIBREDB_BIND` or `127.0.0.1`.
- Zero-config state: `STORAGE_SQLITE_PATH` defaults under `%LOCALAPPDATA%\LibreDB\Studio\` (created on first run), so upgrades never wipe credentials/storage.
- Resolves the real exe dir through `filepath.EvalSymlinks` (winget portable installs expose a symlink in its Links folder), forwards stdio/argv/exit code, and lets console Ctrl+C reach the child directly.
- Pure helpers unit-tested host-agnostically (`go test` runs on the linux CI too); `gofmt`/`go vet`/`go test` gate the release build.

### winget + Chocolatey automation (post-publish, secret-gated)

Both jobs run strictly after `publish-release` - the catalogs download the zip from the release URL, which is public only once published. Failures never block the release (same trust model as the npm/Docker dispatch chain).

- `chocolatey` job (gated on `CHOCO_API_KEY` - configured): renders `packaging/chocolatey/` templates via `scripts/render-windows-packaging.mjs`, packs and pushes with the official `chocolatey/choco:latest-linux` container. Remote-zip install script (`Install-ChocolateyZipPackage` + pinned sha256); `node.exe` gets a shim-ignore sidecar so only `libredb-studio` lands on PATH.
- `winget` job (gated on `WINGETCREATE_GITHUB_TOKEN`, classic PAT `public_repo` - configured): pre-checks the package/version in microsoft/winget-pkgs via the Contents API (first listing is manual; until it merges the job skips with a notice, and duplicate submissions skip cleanly), then `wingetcreate update --submit` with the token passed via the official `WINGET_CREATE_GITHUB_TOKEN` env var.
- `packaging/winget/` manifest templates (schema 1.12.0, zip + nested portable) power the one-time first submission (`wingetcreate submit`) and keep the manifest reviewable in-repo.

### npx on Windows

- `bin/lib/launcher-utils.mjs`: `win32-x64` joins `SUPPORTED_TARGETS`; `artifactName` returns the `.zip` name on win32; new pure `extractionCommand` picks the System32 bsdtar for zips (Git Bash's GNU tar cannot read zip) with no strip (flat zip) - `extractTarball` became format-aware `extractArchive`.
- `bin/studio.js`: the win32 early-exit is gone; download/verify/extract/run now works on Windows with the user's Node runtime.

### Docs / inventory

- `docs/DISTRIBUTION.md`: Windows section (winget/choco/portable zip, storage location, `LIBREDB_BIND`), artifact-naming updates, secrets table (`CHOCO_API_KEY`, `WINGETCREATE_GITHUB_TOKEN`), and a "Windows first-listing checklist" for the one-time manual submissions.
- `distribution/channels.yaml`: `winget` and `chocolatey` entries (tier 4, `pending` until the first listings merge, then flip to `live` with measurable pins).
- README install matrix: winget/Chocolatey rows (marked as in moderation) and npx now listed for Windows.
- `packaging/windows/README.md`: layout and local launcher workflow.

## Tests (TDD, 100% line coverage maintained)

- `tests/unit/launcher-utils.test.ts`: win32 artifact naming, extraction-command branches (bsdtar path, SystemRoot fallback, case-insensitive extension), archive extraction.
- `tests/unit/packaging-standalone-zip.test.ts`: real `pack-standalone-zip.sh` subprocess tests - flat layout, dot-directories included, wrapper-root rejection, missing-entry refusal.
- `tests/unit/render-windows-packaging.test.ts`: renders all five real templates, digest/version injection, missing-digest and leftover-placeholder failure modes.
- `packaging/windows/launcher/launch_test.go`: bind override, storage defaulting (LOCALAPPDATA/USERPROFILE fallback/skip), preset preservation, env passthrough.
- Coverage gate: `coverage:check` at 100.00% (25838/25838 lines).

## Outside this PR (human/catalog steps)

First `microsoft/winget-pkgs` submission (+ Microsoft CLA) and first Chocolatey moderation pass - documented in the first-listing checklist; automation takes over from the second release onward.

## Version

Bumps `package.json` to **0.9.57** and the chart to **0.1.17** (`bun run chart:bump`, per the required chart-sync gate, #138). The `windows-package` job is a hard release gate by design - the win32 zip is a core required asset like the POSIX tarballs (documented in DISTRIBUTION.md); flagging this explicitly for review since it widens the release train's blast radius to Windows-runner health.

## Adversarial review

A 14-agent review workflow (6 dimensions, refute-style verification) ran over the full diff: 8 findings, 7 confirmed and all fixed in this PR - stale npx/Windows docs, premature "in moderation" wording, missing cd in the zip snippet, a clear error for zip archives on Linux GNU tar, MSYS-path conversion in the win32 smoke (`cygpath`), doc-sanctioned Ctrl+C suppression in the launcher (Notify-and-drain instead of `signal.Ignore`, whose Windows behavior is not guaranteed), and explicit documentation of the hard-gate trade-off plus `exec` PID-pinning in the smoke.

## Verification

- All six local gates pass: `format`, `lint`, `typecheck`, `knip`, `test`, `build` (+ `test:coverage` && `coverage:check`, `build:lib` + `attw`).
- Go launcher: `gofmt`/`go vet`/`go test` clean; behavior verified end-to-end against a stub runtime (bind override, storage dir creation, argv passthrough, exit-code propagation) and cross-compiled to windows/amd64.
- Rendered winget manifests parse as valid YAML with the expected `ManifestType`s; `distribution:check` validates the new inventory entries.
