### PR TITLE
fix(chocolatey): address 0.9.59 moderation guidelines in the nuspec template

### DIFF
--- a/packaging/chocolatey/libredb-studio.nuspec.tmpl
+++ b/packaging/chocolatey/libredb-studio.nuspec.tmpl
@@ -15,7 +15,10 @@
     <owners>libredb</owners>
     <title>LibreDB Studio</title>
     <authors>LibreDB</authors>
-    <projectUrl>https://github.com/libredb/libredb-studio</projectUrl>
+    <!-- projectUrl (product page) deliberately differs from projectSourceUrl
+         (source code) - duplicate URLs are a moderation guideline flag
+         (CPMR0041, raised on the 0.9.59 review). -->
+    <projectUrl>https://libredb.org</projectUrl>
     <!-- jsDelivr CDN (raw.githubusercontent.com is a moderation rejection,
          CPMR0076), pinned to the immutable release tag. -->
     <iconUrl>https://cdn.jsdelivr.net/gh/libredb/libredb-studio@{{VERSION}}/public/logo.svg</iconUrl>
@@ -37,7 +40,7 @@ This package installs the standalone server together with a bundled, private Nod
 libredb-studio
 ```
 
-Then open http://127.0.0.1:3000. The first run prints generated admin credentials to the terminal (zero-config bootstrap). The server binds to 127.0.0.1 by default; set `LIBREDB_BIND=0.0.0.0` to expose it on the network. Server-side state is stored under `%LOCALAPPDATA%\LibreDB\Studio`.
+Then browse to `localhost:3000`. The first run prints generated admin credentials to the terminal (zero-config bootstrap). The server binds to the loopback interface by default; set `LIBREDB_BIND=0.0.0.0` to expose it on the network. Server-side state is stored under `%LOCALAPPDATA%\LibreDB\Studio`.
 
 ### Configuration
 


### PR DESCRIPTION
The first Chocolatey submission (0.9.59) passed automated validation with **no Requirements flagged**; the validator raised two Guideline-level items to fix for future releases:

- **Potentially invalid URL in the description**: the usage text linked `http://127.0.0.1:3000`, which the validator cannot resolve. Now written as plain `localhost:3000` (code-formatted, no scheme).
- **projectUrl duplicated projectSourceUrl** (CPMR0041): `projectUrl` now points at the product page (https://libredb.org); `projectSourceUrl` keeps the GitHub repository.

The remaining Note (owners matches authors) needs no change: the maintainer IS the software author - the reviewer confirms this manually, and it is the expected shape for a vendor-owned package.

No repush of 0.9.59: Guidelines do not hold up approval, and a same-version repush would restart the automated checks. These fixes ship with the next release's rendered nuspec.

Template-only change; `tests/unit/render-windows-packaging.test.ts` covers the rendering.