### PR TITLE
docs: update Windows native support documentation (#207 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
 
 ### Why LibreDB Studio?
 - **Zero Install**: Run a professional SQL IDE in your browser or private network.
-- **Multi-Platform**: Native-like experience on both **Web** and **Mobile** browsers.
+- **Multi-Platform**: Native-like experience on **Web**, **Mobile**, and **Windows** (native zip, winget, Chocolatey).
 - **AI-Native**: Multi-model support (Gemini, OpenAI, or Local LLMs) for NL2SQL.
 - **DevOps Ready**: Optimized for Kubernetes orchestration and Docker environments.
 - **Enterprise Grade**: Built-in RBAC, SSO (OIDC), query auditing, and live health monitoring.
@@ -201,10 +201,11 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
   | **Homebrew** | `brew trust libredb/tap && brew install libredb/tap/libredb-studio` | `brew trust` is required once (Homebrew 6+; run `brew update` if unknown) |
   | **deb / rpm** | `sudo dpkg -i libredb-studio_<version>_amd64.deb` | Attached to each GitHub release; systemd service included |
   | **Snap** | `sudo snap install libredb-studio` | Zero-config: the admin password is printed to `sudo snap logs libredb-studio` on first run — [Snap Store listing](https://snapcraft.io/libredb-studio) |
-  | **winget (Windows)** | `winget install LibreDB.Studio` | Portable zip with a bundled Node.js runtime; run `libredb-studio` — available once the first community listing lands, track [#114](https://github.com/libredb/libredb-studio/issues/114) |
-  | **Chocolatey (Windows)** | `choco install libredb-studio` | Same standalone zip — available once the first community listing lands, track [#114](https://github.com/libredb/libredb-studio/issues/114) |
+  | **winget (Windows)** | `winget install LibreDB.Studio` | Portable zip with a bundled Node.js runtime; run `libredb-studio` — CI automation ready; first community listing pending ([#114](https://github.com/libredb/libredb-studio/issues/114)) |
+  | **Chocolatey (Windows)** | `choco install libredb-studio` | Same standalone zip — CI push ready; first push awaits community moderation ([#114](https://github.com/libredb/libredb-studio/issues/114)) |
+  | **Portable zip (Windows)** | `.\libredb-studio.exe` | Download from [GitHub Releases](https://github.com/libredb/libredb-studio/releases); bundled Node runtime, no package manager needed |
 
-  > Homebrew, deb/rpm, Snap, winget/Chocolatey, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md).
+  > Homebrew, deb/rpm, Snap, the Windows portable zip, winget/Chocolatey, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md).
 
   ### Quick Start (Docker)
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
   | **Homebrew** | `brew trust libredb/tap && brew install libredb/tap/libredb-studio` | `brew trust` is required once (Homebrew 6+; run `brew update` if unknown) |
   | **deb / rpm** | `sudo dpkg -i libredb-studio_<version>_amd64.deb` | Attached to each GitHub release; systemd service included |
   | **Snap** | `sudo snap install libredb-studio` | Zero-config: the admin password is printed to `sudo snap logs libredb-studio` on first run — [Snap Store listing](https://snapcraft.io/libredb-studio) |
-  | **winget (Windows)** | `winget install LibreDB.Studio` | Portable zip with a bundled Node.js runtime; run `libredb-studio` — CI automation ready; first community listing pending ([#114](https://github.com/libredb/libredb-studio/issues/114)) |
+  | **winget (Windows)** | `winget install LibreDB.Studio` | Portable zip with a bundled Node.js runtime; run `libredb-studio` — CI automation ready; first community listing under review ([#114](https://github.com/libredb/libredb-studio/issues/114)) |
   | **Chocolatey (Windows)** | `choco install libredb-studio` | Same standalone zip — CI push ready; first push awaits community moderation ([#114](https://github.com/libredb/libredb-studio/issues/114)) |
   | **Portable zip (Windows)** | `.\libredb-studio.exe` | Download from [GitHub Releases](https://github.com/libredb/libredb-studio/releases); bundled Node runtime, no package manager needed |
 

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -364,9 +364,9 @@ channels:
       docs: docs/DISTRIBUTION.md
     pin:
       strategy: none
-      note: win32 zip ships in every release since v0.9.58. CI submits update PRs via wingetcreate
-        (WINGETCREATE_GITHUB_TOKEN gate); the FIRST listing is a manual submission not yet
-        submitted. Flip to live and add a winget-pkgs pin once it merges.
+      note: win32 zip ships in every release since 0.9.59. CI submits update PRs via wingetcreate
+        (WINGETCREATE_GITHUB_TOKEN gate); the FIRST listing is submitted and under review
+        (microsoft/winget-pkgs#402985). Flip to live and add a winget-pkgs pin once it merges.
 
   - id: chocolatey
     name: Chocolatey community repository (libredb-studio)
@@ -382,6 +382,6 @@ channels:
       docs: docs/DISTRIBUTION.md
     pin:
       strategy: none
-      note: win32 zip ships in every release since v0.9.58. CI packs and pushes via the choco
-        container (CHOCO_API_KEY gate); the first push has not been submitted yet. Flip to live
-        and add a community-API pin once approved.
+      note: win32 zip ships in every release since 0.9.59. CI packs and pushes via the choco
+        container (CHOCO_API_KEY gate); the first push (0.9.59) is in human moderation. Flip to
+        live and add a community-API pin once approved.

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -364,9 +364,9 @@ channels:
       docs: docs/DISTRIBUTION.md
     pin:
       strategy: none
-      note: Release CI submits update PRs via wingetcreate (WINGETCREATE_GITHUB_TOKEN gate); the
-        FIRST listing is a manual submission awaiting moderation. Flip to live and add a
-        winget-pkgs pin once it merges.
+      note: win32 zip ships in every release since v0.9.58. CI submits update PRs via wingetcreate
+        (WINGETCREATE_GITHUB_TOKEN gate); the FIRST listing is a manual submission not yet
+        submitted. Flip to live and add a winget-pkgs pin once it merges.
 
   - id: chocolatey
     name: Chocolatey community repository (libredb-studio)
@@ -382,5 +382,6 @@ channels:
       docs: docs/DISTRIBUTION.md
     pin:
       strategy: none
-      note: Release CI packs and pushes via the choco container (CHOCO_API_KEY gate); the first
-        push sits in human moderation. Flip to live and add a community-API pin once approved.
+      note: win32 zip ships in every release since v0.9.58. CI packs and pushes via the choco
+        container (CHOCO_API_KEY gate); the first push has not been submitted yet. Flip to live
+        and add a community-API pin once approved.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -451,9 +451,10 @@ Full variable reference: [`.env.example`](../.env.example). OIDC setup details:
 ## Windows (winget / Chocolatey / portable zip)
 
 The win32-x64 standalone zip is built and attached to every
-[GitHub release](https://github.com/libredb/libredb-studio/releases) since v0.9.58. The
-winget/Chocolatey CI automation is in place and secret-gated; both are ready and waiting for
-their first community listings to clear moderation (see the
+[GitHub release](https://github.com/libredb/libredb-studio/releases) since 0.9.59. The
+winget/Chocolatey CI automation is in place and secret-gated; the first winget listing
+([microsoft/winget-pkgs#402985](https://github.com/microsoft/winget-pkgs/pull/402985)) and the
+first Chocolatey push are in community review (see the
 [first-listing checklist](#windows-first-listing-checklist) — track
 [issue #114](https://github.com/libredb/libredb-studio/issues/114)).
 
@@ -631,11 +632,14 @@ npx on win32.
 
 ### Windows first-listing checklist
 
-The win32 zip has shipped in every release since **v0.9.58**. The release automation for winget
+The win32 zip has shipped in every release since **0.9.59**. The release automation for winget
 and Chocolatey is secret-gated and ready — both `CHOCO_API_KEY` (API key of the `libredb`
 account on community.chocolatey.org) and `WINGETCREATE_GITHUB_TOKEN` are configured in the
 repo's Actions secrets. The FIRST listing in each community catalog is a one-time human step
-(same pattern as the Snap Store name registration):
+(same pattern as the Snap Store name registration). Both first submissions were made with
+0.9.59 — the Chocolatey push is in moderation and the winget listing is
+[microsoft/winget-pkgs#402985](https://github.com/microsoft/winget-pkgs/pull/402985); step 3
+below remains once each goes live:
 
 1. **Chocolatey** — the release's chocolatey job packs and pushes automatically. The first push
    enters [human moderation](https://docs.chocolatey.org/en-us/community-repository/moderation/);

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -12,6 +12,7 @@ how the release pipeline publishes each channel. For a one-line-per-channel over
 | Homebrew | macOS / Linux workstations | [Homebrew](#homebrew) |
 | .deb / .rpm | Debian/Ubuntu and RHEL/Fedora servers (systemd) | [Linux packages (.deb / .rpm)](#linux-packages-deb--rpm) |
 | Snap | Ubuntu and other snapd systems | [Snap](#snap) |
+| Windows (winget / Chocolatey / portable zip) | Windows workstations | [Windows](#windows-winget--chocolatey--portable-zip) |
 
 All non-Docker channels ship or download the same **standalone server payload** (Next.js
 standalone output, started with `node server.js`) built by
@@ -449,10 +450,12 @@ Full variable reference: [`.env.example`](../.env.example). OIDC setup details:
 
 ## Windows (winget / Chocolatey / portable zip)
 
-> The winget/Chocolatey commands work once the first community listings land (see the
-> [first-listing checklist](#windows-first-listing-checklist)) — track
-> [issue #114](https://github.com/libredb/libredb-studio/issues/114). Until then, install from
-> the release zip (below) or run Docker.
+The win32-x64 standalone zip is built and attached to every
+[GitHub release](https://github.com/libredb/libredb-studio/releases) since v0.9.58. The
+winget/Chocolatey CI automation is in place and secret-gated; both are ready and waiting for
+their first community listings to clear moderation (see the
+[first-listing checklist](#windows-first-listing-checklist) — track
+[issue #114](https://github.com/libredb/libredb-studio/issues/114)).
 
 ```powershell
 # winget (after the first listing merges in microsoft/winget-pkgs)
@@ -628,11 +631,11 @@ npx on win32.
 
 ### Windows first-listing checklist
 
-The release automation for winget and Chocolatey is secret-gated and ready — both
-`CHOCO_API_KEY` (API key of the `libredb` account on community.chocolatey.org) and
-`WINGETCREATE_GITHUB_TOKEN` are configured in the repo's Actions secrets. The FIRST listing in
-each community catalog is a one-time human step (same pattern as the Snap Store name
-registration). After the first release that ships the win32 zip:
+The win32 zip has shipped in every release since **v0.9.58**. The release automation for winget
+and Chocolatey is secret-gated and ready — both `CHOCO_API_KEY` (API key of the `libredb`
+account on community.chocolatey.org) and `WINGETCREATE_GITHUB_TOKEN` are configured in the
+repo's Actions secrets. The FIRST listing in each community catalog is a one-time human step
+(same pattern as the Snap Store name registration):
 
 1. **Chocolatey** — the release's chocolatey job packs and pushes automatically. The first push
    enters [human moderation](https://docs.chocolatey.org/en-us/community-repository/moderation/);


### PR DESCRIPTION
## Summary

Updates the install documentation to reflect the current Windows native
support state following #207 (shipped in v0.9.58+). The win32-x64 zip is
built and attached to every release, npx works on Windows, and
winget/Chocolatey automation is in place but awaiting their first
community listings.

## Changes

### `README.md`
- **winget** row: "available once the first community listing lands"
  → "CI automation ready; first community listing pending"
- **Chocolatey** row: same update
- **Portable zip (Windows)** row: new entry for direct zip download
- **Footnote**: includes "Windows portable zip"
- **Multi-Platform**: adds Windows native support mention

### `docs/DISTRIBUTION.md`
- Windows section intro: states the zip ships since v0.9.58
- Channel table: adds Windows row
- First-listing checklist: notes zip is live

### `distribution/channels.yaml`
- `winget` / `chocolatey` notes: add "win32 zip ships since v0.9.58"

## Related

- Follows PR #207
- Tracks #114