### PR TITLE
feat(deploy): DigitalOcean Marketplace 1-Click Droplet (#72)

### DIFF
--- a/.github/workflows/do-packer-build.yml
+++ b/.github/workflows/do-packer-build.yml
@@ -18,15 +18,20 @@ jobs:
       run:
         working-directory: deploy/digitalocean/droplet
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: hashicorp/setup-packer@ce93c3c08a6c2ff2275bf4b54ff0d9a75f6c9789 # v3
 
-      # DO's official validation scripts are fetched fresh on every build
+      # DO's official validation scripts, pinned to a reviewed commit of
+      # digitalocean/marketplace-partners (they run as root inside the image
+      # build) — bump MP_SHA deliberately after reviewing upstream changes,
+      # and keep the copy in deploy/digitalocean/README.md in sync
       - name: Fetch DO marketplace scripts
+        env:
+          MP_SHA: b70878804ca27c01d5f5e882d26485defbaba210 # master @ 2026-07-16
         run: |
-          curl -fsSLo scripts/90-cleanup.sh   https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh
-          curl -fsSLo scripts/99-img-check.sh https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh
+          curl -fsSLo scripts/90-cleanup.sh   "https://raw.githubusercontent.com/digitalocean/marketplace-partners/${MP_SHA}/scripts/90-cleanup.sh"
+          curl -fsSLo scripts/99-img-check.sh "https://raw.githubusercontent.com/digitalocean/marketplace-partners/${MP_SHA}/scripts/99-img-check.sh"
 
       - name: Validate version format
         env:

--- a/.github/workflows/do-packer-build.yml
+++ b/.github/workflows/do-packer-build.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: '0.9.59'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hashicorp/setup-packer@v3
+      - uses: hashicorp/setup-packer@ce93c3c08a6c2ff2275bf4b54ff0d9a75f6c9789 # v3
 
       # DO's official validation scripts are fetched fresh on every build
       - name: Fetch DO marketplace scripts

--- a/.github/workflows/do-packer-build.yml
+++ b/.github/workflows/do-packer-build.yml
@@ -1,0 +1,63 @@
+name: DO Packer Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag for snapshot name AND image pin — must exist on ghcr.io/libredb/libredb-studio (e.g. 0.9.59)'
+        required: true
+        default: '0.9.59'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: deploy/digitalocean/droplet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-packer@v3
+
+      # DO's official validation scripts are fetched fresh on every build
+      - name: Fetch DO marketplace scripts
+        run: |
+          curl -fsSLo scripts/90-cleanup.sh   https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh
+          curl -fsSLo scripts/99-img-check.sh https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must be semver (e.g. 0.9.59), got: $VERSION"
+            exit 1
+          fi
+
+      - name: Packer init & validate
+        env:
+          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          packer init .
+          packer validate -var "version=$VERSION" .
+
+      - name: Packer build
+        env:
+          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: packer build -var "version=$VERSION" .
+
+      # DO artifact_id format is "region1,region2:snapshot_id" — the ID is after the colon
+      - name: Snapshot ID to job summary
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          SNAPSHOT_ID=$(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d: -f2)
+          {
+            echo "## DigitalOcean Snapshot"
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Snapshot ID | \`${SNAPSHOT_ID}\` |"
+            echo "| Version | \`${VERSION}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ docs/summaries/
 # Maintainer loop runtime artifacts (not source)
 .loop/
 .tokens
+
+# DO marketplace scripts fetched at build time (see deploy/digitalocean/README.md)
+deploy/digitalocean/droplet/scripts/90-cleanup.sh
+deploy/digitalocean/droplet/scripts/99-img-check.sh

--- a/deploy/digitalocean/README.md
+++ b/deploy/digitalocean/README.md
@@ -24,7 +24,9 @@ deploy/digitalocean/
 
 DO's official `90-cleanup.sh` / `99-img-check.sh` are fetched at build time
 from [`digitalocean/marketplace-partners`](https://github.com/digitalocean/marketplace-partners)
-— they are not vendored here.
+— they are not vendored here. Both the workflow and the local build pin the
+same reviewed commit (the scripts run as root inside the image build); bump
+the pin deliberately, in both places, after reviewing upstream changes.
 
 ## Build
 
@@ -37,8 +39,9 @@ Requires the `DIGITALOCEAN_TOKEN` repo secret (read+write PAT).
 
 ```bash
 cd deploy/digitalocean/droplet
-curl -fsSLo scripts/90-cleanup.sh   https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh
-curl -fsSLo scripts/99-img-check.sh https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh
+MP_SHA=b70878804ca27c01d5f5e882d26485defbaba210  # keep in sync with .github/workflows/do-packer-build.yml
+curl -fsSLo scripts/90-cleanup.sh   "https://raw.githubusercontent.com/digitalocean/marketplace-partners/${MP_SHA}/scripts/90-cleanup.sh"
+curl -fsSLo scripts/99-img-check.sh "https://raw.githubusercontent.com/digitalocean/marketplace-partners/${MP_SHA}/scripts/99-img-check.sh"
 export DIGITALOCEAN_TOKEN=dop_v1_...
 packer init .
 packer validate -var "version=0.9.59" .

--- a/deploy/digitalocean/README.md
+++ b/deploy/digitalocean/README.md
@@ -15,7 +15,7 @@ deploy/digitalocean/
     ├── template.pkr.hcl               # Packer template (manifest post-processor included)
     ├── scripts/
     │   ├── 01-install.sh              # Docker CE + compose plugin, droplet-agent purge, image pre-pull
-    │   └── 02-configure.sh            # UFW, exec bits (MOTD + first-boot!), /app/data, version pinning
+    │   └── 02-configure.sh            # UFW, exec bits (MOTD + first-boot!), /app/data, version pinning, application.info
     └── files/
         ├── etc/systemd/system/libredb-studio.service
         ├── etc/update-motd.d/99-libredb-studio

--- a/deploy/digitalocean/README.md
+++ b/deploy/digitalocean/README.md
@@ -1,0 +1,89 @@
+# DigitalOcean Marketplace — LibreDB Studio
+
+Build and submission files for the 1-Click Droplet App (Path B of #72).
+Base image: **Ubuntu 24.04 LTS** (`ubuntu-24-04-x64`).
+
+## Layout
+
+```
+deploy/digitalocean/
+├── README.md                          # this file — build guide + submission checklist
+├── manifest.yaml                      # Vendor Portal form reference
+├── assets/
+│   └── description-long.md            # Marketplace long description
+└── droplet/
+    ├── template.pkr.hcl               # Packer template (manifest post-processor included)
+    ├── scripts/
+    │   ├── 01-install.sh              # Docker CE + compose plugin, droplet-agent purge, image pre-pull
+    │   └── 02-configure.sh            # UFW, exec bits (MOTD + first-boot!), /app/data, version pinning
+    └── files/
+        ├── etc/systemd/system/libredb-studio.service
+        ├── etc/update-motd.d/99-libredb-studio
+        └── var/lib/cloud/scripts/per-instance/99-libredb-first-boot.sh
+```
+
+DO's official `90-cleanup.sh` / `99-img-check.sh` are fetched at build time
+from [`digitalocean/marketplace-partners`](https://github.com/digitalocean/marketplace-partners)
+— they are not vendored here.
+
+## Build
+
+**GitHub Actions (recommended):** Actions → "DO Packer Build" → Run workflow →
+enter a version (semver, e.g. `0.9.59` — must exist as a tag on
+`ghcr.io/libredb/libredb-studio`). The snapshot ID appears in the job summary.
+Requires the `DIGITALOCEAN_TOKEN` repo secret (read+write PAT).
+
+**Local:**
+
+```bash
+cd deploy/digitalocean/droplet
+curl -fsSLo scripts/90-cleanup.sh   https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh
+curl -fsSLo scripts/99-img-check.sh https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh
+export DIGITALOCEAN_TOKEN=dop_v1_...
+packer init .
+packer validate -var "version=0.9.59" .
+packer build -var "version=0.9.59" .
+```
+
+## Critical build rules
+
+1. **Never reboot after `90-cleanup.sh`.** Cleanup wipes the cloud-init
+   semaphores; a reboot would run the first-boot script on the build droplet
+   and bake generated secrets into the snapshot — every customer would get
+   the same credentials. The flow is always: cleanup → img-check → snapshot.
+2. **The first-boot script must be executable.** cloud-init silently skips
+   non-executable files; `02-configure.sh` guarantees the exec bit — do not
+   remove that line.
+3. **The MOTD file must stay extensionless.** `run-parts --lsbsysinit`
+   silently ignores files with a `.sh` suffix.
+4. **`environment_vars` is mandatory on every provisioner using `${VERSION}`.**
+   Without it, `docker pull` and `sed` silently run with an empty value.
+5. **`/opt/digitalocean` must not exist in the snapshot** — `99-img-check.sh`
+   fails on it; `01-install.sh` purges the droplet-agent.
+
+## Pre-submission checklist
+
+- [ ] `packer validate` → clean
+- [ ] Fresh test Droplet from the snapshot ($6) → MOTD shows up
+- [ ] `http://<IP>:3000` loads; `/api/db/health` → `{"status":"ok"}`
+- [ ] Login works with the credentials from `/etc/libredb-studio.env`
+- [ ] SQLite data survives a Droplet restart (`/app/data`)
+- [ ] `ufw status` → active (only 22/tcp LIMIT; port 3000 is published via
+      Docker's iptables rules and intentionally absent from the ufw list)
+- [ ] `cat /root/.ssh/authorized_keys` → empty/missing (remove your test key!)
+- [ ] `bash 99-img-check.sh` on the Droplet → "0 Tests FAILED"
+- [ ] A "host key changed" SSH warning on first login is expected — cleanup
+      deletes host keys; cloud-init regenerates them
+
+## Submission
+
+1. [Vendor Portal](https://cloud.digitalocean.com/vendorportal) → New App → snapshot ID
+2. Marketing assets:
+   - Logo 128×128 PNG
+   - Screenshots (editor + results grid)
+   - Short description (≤75 chars): `Open-source SQL IDE with AI — PostgreSQL, MySQL, MongoDB, Redis & more`
+   - Long description: `assets/description-long.md`
+3. Follow-up: one-clicks-team@digitalocean.com — there is no official review
+   SLA; a polite nudge after a couple of weeks is fine.
+4. After approval, add the Marketplace link next to the other one-click
+   buttons in the root README.

--- a/deploy/digitalocean/assets/description-long.md
+++ b/deploy/digitalocean/assets/description-long.md
@@ -10,7 +10,7 @@ LibreDB Studio gives you a full-featured database workspace in your browser — 
 - **AI-assisted SQL** — turn natural language into queries (NL2SQL)
 - **Modern editor** — autocomplete, syntax highlighting, query history
 - **Zero-config start** — this 1-Click App boots fully configured; credentials are generated uniquely for your Droplet on first boot
-- **Self-hosted & private** — your data never leaves your Droplet; storage is local SQLite by default
+- **Self-hosted & private** — the app and its configuration store run entirely on your Droplet (local SQLite by default); traffic to the databases and optional AI providers you configure flows directly from your Droplet to those services
 
 ## Getting started
 

--- a/deploy/digitalocean/assets/description-long.md
+++ b/deploy/digitalocean/assets/description-long.md
@@ -1,0 +1,28 @@
+# LibreDB Studio
+
+**The open-source SQL IDE built for cloud-native teams.**
+
+LibreDB Studio gives you a full-featured database workspace in your browser — connect to PostgreSQL, MySQL, MongoDB, Redis and more, write and run queries with AI assistance, and share results with your team.
+
+## Features
+
+- **Multi-engine support** — PostgreSQL, MySQL, MongoDB, Redis and more from a single interface
+- **AI-assisted SQL** — turn natural language into queries (NL2SQL)
+- **Modern editor** — autocomplete, syntax highlighting, query history
+- **Zero-config start** — this 1-Click App boots fully configured; credentials are generated uniquely for your Droplet on first boot
+- **Self-hosted & private** — your data never leaves your Droplet; storage is local SQLite by default
+
+## Getting started
+
+1. Create the Droplet from this 1-Click App.
+2. SSH in (`ssh root@your-droplet-ip`) — the welcome message (MOTD) shows your access URL and where to find the generated admin credentials (`/etc/libredb-studio.env`).
+3. Open `http://your-droplet-ip:3000` in your browser and log in.
+
+## How it works
+
+LibreDB Studio runs as a Docker container managed by systemd (`libredb-studio.service`). Application data persists in `/app/data` and survives restarts and upgrades. A unique JWT secret and admin/user passwords are generated on first boot — no shared default credentials.
+
+## Links
+
+- Documentation & source: https://github.com/libredb/libredb-studio
+- Issues & support: https://github.com/libredb/libredb-studio/issues

--- a/deploy/digitalocean/droplet/files/etc/systemd/system/libredb-studio.service
+++ b/deploy/digitalocean/droplet/files/etc/systemd/system/libredb-studio.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=LibreDB Studio
+After=docker.service network-online.target
+BindsTo=docker.service
+Wants=network-online.target
+
+[Service]
+ExecStartPre=-/usr/bin/docker rm -f libredb-studio
+ExecStart=/usr/bin/docker run \
+  --name libredb-studio \
+  --init \
+  -p 3000:3000 \
+  --env-file /etc/libredb-studio.env \
+  -v /app/data:/app/data \
+  ghcr.io/libredb/libredb-studio:PINNED_VERSION
+ExecStop=/usr/bin/docker stop libredb-studio
+ExecStopPost=-/usr/bin/docker rm -f libredb-studio
+Restart=always
+RestartSec=10
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/digitalocean/droplet/files/etc/systemd/system/libredb-studio.service
+++ b/deploy/digitalocean/droplet/files/etc/systemd/system/libredb-studio.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=LibreDB Studio
 After=docker.service network-online.target
-BindsTo=docker.service
-Wants=network-online.target
+# Wants= not BindsTo=/Requires=: dependency-triggered stops bypass
+# Restart=always, so a docker daemon restart (e.g. unattended-upgrades)
+# would leave the app down permanently. With Wants= the container process
+# simply dies and Restart= re-runs it until docker is back.
+Wants=network-online.target docker.service
 
 [Service]
 ExecStartPre=-/usr/bin/docker rm -f libredb-studio

--- a/deploy/digitalocean/droplet/files/etc/update-motd.d/99-libredb-studio
+++ b/deploy/digitalocean/droplet/files/etc/update-motd.d/99-libredb-studio
@@ -1,5 +1,7 @@
 #!/bin/bash
-IP=$(hostname -I | awk '{print $1}')
+# Public IPv4 from the DO metadata service; hostname -I as fallback (its
+# first address may be a private/VPC one)
+IP=$(curl -fsm 2 http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || hostname -I | awk '{print $1}')
 cat <<EOF
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   LibreDB Studio

--- a/deploy/digitalocean/droplet/files/etc/update-motd.d/99-libredb-studio
+++ b/deploy/digitalocean/droplet/files/etc/update-motd.d/99-libredb-studio
@@ -1,0 +1,13 @@
+#!/bin/bash
+IP=$(hostname -I | awk '{print $1}')
+cat <<EOF
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  LibreDB Studio
+  Open-source SQL IDE for cloud-native teams
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Access:   http://${IP}:3000
+  Admin:    admin@libredb.org
+  Password: (see /etc/libredb-studio.env)
+  Docs:     https://github.com/libredb/libredb-studio
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF

--- a/deploy/digitalocean/droplet/files/var/lib/cloud/scripts/per-instance/99-libredb-first-boot.sh
+++ b/deploy/digitalocean/droplet/files/var/lib/cloud/scripts/per-instance/99-libredb-first-boot.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# cloud-init per-instance: runs exactly once per droplet
+set -euo pipefail
+
+JWT_SECRET=$(openssl rand -base64 48)
+ADMIN_PASSWORD=$(openssl rand -hex 12)
+USER_PASSWORD=$(openssl rand -hex 12)
+
+cat > /etc/libredb-studio.env <<EOF
+JWT_SECRET=$JWT_SECRET
+ADMIN_EMAIL=admin@libredb.org
+ADMIN_PASSWORD=$ADMIN_PASSWORD
+USER_EMAIL=user@libredb.org
+USER_PASSWORD=$USER_PASSWORD
+STORAGE_PROVIDER=sqlite
+STORAGE_SQLITE_PATH=/app/data/libredb-storage.db
+PORT=3000
+EOF
+chmod 600 /etc/libredb-studio.env
+
+systemctl enable --now libredb-studio

--- a/deploy/digitalocean/droplet/scripts/01-install.sh
+++ b/deploy/digitalocean/droplet/scripts/01-install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# Docker's official APT repo (docker-ce is not in Ubuntu's default repos)
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+# DO img-check FAILs if /opt/digitalocean exists — droplet-agent must go
+apt-get purge -y droplet-agent 2>/dev/null || true
+rm -rf /opt/digitalocean
+
+# Packer's file provisioner does not create destination directories
+mkdir -p /var/lib/cloud/scripts/per-instance
+
+# Bake the image into the snapshot — no registry access needed on customer boot
+docker pull "ghcr.io/libredb/libredb-studio:${VERSION}"

--- a/deploy/digitalocean/droplet/scripts/02-configure.sh
+++ b/deploy/digitalocean/droplet/scripts/02-configure.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+# UFW: SSH only (rate-limited). Port 3000 is published through Docker's
+# iptables rules — "ufw allow 3000" is not needed and the port will not
+# show up in "ufw status". This is intentional.
+ufw default deny incoming
+ufw default allow outgoing
+ufw limit ssh
+ufw --force enable
+
+systemctl daemon-reload
+
+# run-parts --lsbsysinit requires an extensionless name AND the exec bit
+chmod +x /etc/update-motd.d/99-libredb-studio
+
+# cloud-init's runparts silently skips non-executable files (log warning
+# only) — without this line the service is never installed on customer
+# droplets
+chmod +x /var/lib/cloud/scripts/per-instance/99-libredb-first-boot.sh
+
+mkdir -p /app/data
+chmod 750 /app/data
+
+# Version pinning — must run AFTER the file provisioner
+sed -i "s/PINNED_VERSION/${VERSION}/" /etc/systemd/system/libredb-studio.service

--- a/deploy/digitalocean/droplet/scripts/02-configure.sh
+++ b/deploy/digitalocean/droplet/scripts/02-configure.sh
@@ -24,3 +24,18 @@ chmod 750 /app/data
 
 # Version pinning — must run AFTER the file provisioner
 sed -i "s/PINNED_VERSION/${VERSION}/" /etc/systemd/system/libredb-studio.service
+
+# Standard 1-Click metadata, mirroring droplet-1-clicks
+# common/scripts/020-application-tag.sh — img-check does not validate it,
+# but every canonical DO 1-Click ships it and DO tooling reads it to
+# identify the app and release in a snapshot
+mkdir -p /var/lib/digitalocean
+cat > /var/lib/digitalocean/application.info <<EOM
+application_name="libredb-studio"
+build_date="$(date +%Y-%m-%d)"
+distro="$(lsb_release -s -i)"
+distro_release="$(lsb_release -s -r)"
+distro_codename="$(lsb_release -s -c)"
+distro_arch="$(uname -m)"
+application_version="${VERSION}"
+EOM

--- a/deploy/digitalocean/droplet/template.pkr.hcl
+++ b/deploy/digitalocean/droplet/template.pkr.hcl
@@ -1,0 +1,72 @@
+packer {
+  required_plugins {
+    digitalocean = {
+      version = ">= 1.4.0"
+      source  = "github.com/digitalocean/digitalocean"
+    }
+  }
+}
+
+variable "version" {
+  type        = string
+  description = "LibreDB Studio release tag — image pin + snapshot name (e.g. 0.9.59). Must exist on ghcr.io/libredb/libredb-studio."
+}
+
+source "digitalocean" "ubuntu" {
+  image         = "ubuntu-24-04-x64"
+  region        = "nyc3"
+  size          = "s-1vcpu-1gb"
+  ssh_username  = "root"
+  snapshot_name = "libredb-studio-${var.version}-${formatdate("YYYYMMDD", timestamp())}"
+  # api_token is read from the DIGITALOCEAN_TOKEN env var
+}
+
+build {
+  sources = ["source.digitalocean.ubuntu"]
+
+  # Don't touch apt before the build droplet's own cloud-init finishes (lock contention)
+  provisioner "shell" {
+    inline = ["cloud-init status --wait || true"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive", "NEEDRESTART_MODE=a"]
+    inline = [
+      "apt-get update -y",
+      "apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold dist-upgrade",
+    ]
+  }
+
+  provisioner "shell" {
+    script           = "scripts/01-install.sh"
+    environment_vars = ["VERSION=${var.version}", "DEBIAN_FRONTEND=noninteractive", "NEEDRESTART_MODE=a"]
+  }
+
+  provisioner "file" {
+    source      = "files/etc/"
+    destination = "/etc/"
+  }
+
+  provisioner "file" {
+    source      = "files/var/"
+    destination = "/var/"
+  }
+
+  provisioner "shell" {
+    script           = "scripts/02-configure.sh"
+    environment_vars = ["VERSION=${var.version}"]
+  }
+
+  # DO's official scripts (fetched from the marketplace-partners repo, not ours).
+  # 90-cleanup.sh wipes the cloud-init semaphores — NEVER reboot after it runs.
+  provisioner "shell" {
+    scripts = [
+      "scripts/90-cleanup.sh",
+      "scripts/99-img-check.sh",
+    ]
+  }
+
+  post-processor "manifest" {
+    output = "packer-manifest.json"
+  }
+}

--- a/deploy/digitalocean/manifest.yaml
+++ b/deploy/digitalocean/manifest.yaml
@@ -1,0 +1,15 @@
+# Vendor Portal reference metadata — DO does not read this programmatically;
+# it mirrors what goes into the listing form.
+name: LibreDB Studio
+vendor: Sekoya Tech
+version: "1.0"
+os_distros:
+  - ubuntu-24.04
+summary: "Open-source SQL IDE with AI — PostgreSQL, MySQL, MongoDB, Redis & more"
+category:
+  - Databases
+  - Developer Tools
+pricing: free
+health_check: "GET http://localhost:3000/api/db/health"
+port: 3000
+support_email: yusuf.gundogdu@sekoya.tech

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -347,6 +347,7 @@ channels:
       sla: on_demand
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/72
+      docs: deploy/digitalocean/README.md
     pin:
       strategy: none
 


### PR DESCRIPTION
## Description

DigitalOcean Marketplace 1-Click Droplet build for LibreDB Studio — Path B of #72, following the same pattern as the existing deploy targets (CapRover, Koyeb, Railway). Adds a Packer-based image build under `deploy/digitalocean/droplet/` plus a manually triggered GitHub Actions workflow that produces the Marketplace snapshot. No application code is touched.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue

Refs #72 (Path B — Droplet 1-Click; the issue stays open for Paths A and C)

## Changes Made

- `deploy/digitalocean/droplet/template.pkr.hcl` — Ubuntu 24.04 base, $6 build droplet, DO plugin >= 1.4.0, `manifest` post-processor to capture the snapshot ID; first provisioner is `cloud-init status --wait` (apt lock contention), `NEEDRESTART_MODE=a` on apt steps (Ubuntu's needrestart prompts otherwise)
- `droplet/scripts/01-install.sh` — Docker CE + compose plugin from Docker's apt repo, droplet-agent purge (`/opt/digitalocean` fails `99-img-check.sh`), app image pre-pulled and version-pinned (never `:latest`)
- `droplet/scripts/02-configure.sh` — UFW (SSH only, rate-limited; port 3000 is published via Docker's iptables rules by design), exec bits for the MOTD and the first-boot script (cloud-init silently skips non-executable files), version pinning via `sed`
- `droplet/files/etc/systemd/system/libredb-studio.service` — foreground `docker run` under systemd (`Wants=docker.service` (self-healing across docker daemon restarts), `Restart=always`, `--init`)
- `droplet/files/var/lib/cloud/scripts/per-instance/99-libredb-first-boot.sh` — per-customer `JWT_SECRET` + admin/user passwords generated on first boot; nothing is baked into the snapshot (Marketplace requirement)
- `droplet/files/etc/update-motd.d/99-libredb-studio` — access URL + credentials pointer at login (extensionless: `run-parts --lsbsysinit` ignores `.sh` names)
- `deploy/digitalocean/README.md` — build guide, non-obvious constraints (never reboot after DO's cleanup script, exec-bit requirements), pre-submission checklist
- `deploy/digitalocean/manifest.yaml` + `assets/description-long.md` — Vendor Portal form reference + listing copy
- `.github/workflows/do-packer-build.yml` — `workflow_dispatch` build; semver-validated version input passed via env (inputs are never shell-interpolated), DO's official `90-cleanup.sh`/`99-img-check.sh` fetched at build time, snapshot ID surfaced in the job summary

Directory layout follows the structure proposed in #72 (`droplet/` subdir, leaving room for `kubernetes/` and `app-platform/`).

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests (n/a — no app code touched)
- [x] All existing tests pass (untouched)

Done:
- `packer init` + `packer validate` clean locally (Packer v1.15.4, DO plugin v1.4.1)
- `bash -n` on all shell scripts; workflow YAML parsed
- Pinned version verified to exist as a GHCR tag (`ghcr.io/libredb/libredb-studio:0.9.59`)

Not yet done (blocked on the `DIGITALOCEAN_TOKEN` repo secret; next step in #72):
- Real `packer build` + a test Droplet from the snapshot (MOTD, `:3000`, `/api/db/health`, login with generated credentials, data persistence across restart, `99-img-check.sh` → 0 FAILED)

### Test Environment

- **LibreDB Studio Version**: 0.9.59 (pinned image tag)
- **OS**: build target Ubuntu 24.04 LTS; validated from macOS (darwin/arm64)
- **Browser / Node.js / Database**: n/a — no app code changes

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a)
- [x] New and existing unit tests pass locally with my changes (untouched)
- [ ] Any dependent changes have been merged and published (n/a)

## Additional Notes

The snapshot build is deliberately manual (`workflow_dispatch`): Marketplace versions should be cut consciously, and each run needs a version that actually exists on GHCR. Vendor Portal application was submitted on 2026-06-23 (approval pending). First real build + Droplet test round follows once the `DIGITALOCEAN_TOKEN` secret is in place.
