### PR TITLE
feat(deploy): fly.io launch config, docs and channel inventory entry (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Deploy your own instance of LibreDB Studio with a single click on Koyeb, Render,
 >
 > **Koyeb:** set a strong `JWT_SECRET` and credentials before deploying (Koyeb cannot auto-generate secrets). The button uses `STORAGE_PROVIDER=local` — connection metadata lives in the browser, which suits Koyeb's ephemeral filesystem. For persistence across redeploys, switch to `STORAGE_PROVIDER=postgres` and point `STORAGE_POSTGRES_URL` at a Koyeb managed Postgres or Neon database. See [`deploy/koyeb/`](deploy/koyeb/).
 >
-> **Fly.io:** the repo ships a ready [`fly.toml`](fly.toml) — clone, `fly launch --copy-config`, set your secrets, deploy. Steps in [`docs/FLY.md`](docs/FLY.md).
+> **Fly.io:** the repo ships a ready [`fly.toml`](fly.toml) — full steps (app name, volume, secrets) in [`docs/FLY.md`](docs/FLY.md).
 >
 > **Cosmos:** install in one click from the [Cosmos](https://cosmos-cloud.io) Marketplace — search for **LibreDB Studio**. Cosmos auto-generates secrets, provisions a persistent SQLite volume, and serves the app behind its SmartShield reverse proxy. See [`deploy/cosmos/`](deploy/cosmos/).
 

--- a/README.md
+++ b/README.md
@@ -412,10 +412,13 @@ Deploy your own instance of LibreDB Studio with a single click on Koyeb, Render,
  [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/libredb/libredb-studio)  
  [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/libredb-studio?referralCode=libredb&utm_medium=integration&utm_source=template&utm_campaign=generic)  
  [![Deploy on CapRover](https://img.shields.io/badge/Deploy%20on-CapRover-2474ed?style=for-the-badge&logo=docker&logoColor=white)](https://github.com/caprover/one-click-apps/blob/master/public/v4/apps/libredb-studio.yml)  
+ [![Deploy on Fly.io](https://img.shields.io/badge/Deploy%20on-Fly.io-24175B?style=for-the-badge&logo=flydotio&logoColor=white)](docs/FLY.md)  
 
 > **CapRover:** open your CapRover dashboard → **Apps → One-Click Apps/Databases**, search for **LibreDB Studio**, and deploy.
 >
 > **Koyeb:** set a strong `JWT_SECRET` and credentials before deploying (Koyeb cannot auto-generate secrets). The button uses `STORAGE_PROVIDER=local` — connection metadata lives in the browser, which suits Koyeb's ephemeral filesystem. For persistence across redeploys, switch to `STORAGE_PROVIDER=postgres` and point `STORAGE_POSTGRES_URL` at a Koyeb managed Postgres or Neon database. See [`deploy/koyeb/`](deploy/koyeb/).
+>
+> **Fly.io:** the repo ships a ready [`fly.toml`](fly.toml) — clone, `fly launch --copy-config`, set your secrets, deploy. Steps in [`docs/FLY.md`](docs/FLY.md).
 >
 > **Cosmos:** install in one click from the [Cosmos](https://cosmos-cloud.io) Marketplace — search for **LibreDB Studio**. Cosmos auto-generates secrets, provisions a persistent SQLite volume, and serves the app behind its SmartShield reverse proxy. See [`deploy/cosmos/`](deploy/cosmos/).
 

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -239,6 +239,7 @@ channels:
       sla: on_demand
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/218
+      first_pr: https://github.com/libredb/libredb-studio/pull/219
       docs: docs/FLY.md
     pin:
       strategy: local_file

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -229,6 +229,24 @@ channels:
       strategy: none
       note: The button deploys ghcr.io latest by design; there is no version pin.
 
+  - id: fly-io
+    name: Fly.io launch config (repo fly.toml)
+    status: live
+    tier: 2
+    kind: paas-template
+    update:
+      method: commit
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/218
+      docs: docs/FLY.md
+    pin:
+      strategy: local_file
+      files:
+        - fly.toml
+      extract: 'libredb-studio:(\d+\.\d+\.\d+)'
+      note: Users deploy straight from the repo file; bump the tag here on release when convenient.
+
   # ---- Tier 3: upstream community catalogs, bumped via PR -----------------
 
   - id: caprover-official

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -683,7 +683,7 @@ pin or editing a channel entry is always a human commit.
 |---|---|---|
 | 0 | Core registries, published directly by release CI | GitHub Releases, GHCR, Docker Hub, npm |
 | 1 | Packaged formats owned by this repo, CI-published | Helm, Homebrew tap, Snap, .deb/.rpm |
-| 2 | LibreDB-owned copies and listings, bumped by hand | CapRover source/mirror, Railway, Koyeb button |
+| 2 | LibreDB-owned copies and listings, bumped by hand | CapRover source/mirror, Railway, Koyeb button, Fly.io config |
 | 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero |
 | 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DO, winget |
 

--- a/docs/FLY.md
+++ b/docs/FLY.md
@@ -1,0 +1,51 @@
+# LibreDB Studio on Fly.io
+
+Fly.io does not have a template gallery, so this repo ships a ready
+[`fly.toml`](../fly.toml) instead. It runs the prebuilt
+`ghcr.io/libredb/libredb-studio` image with a persistent volume at
+`/app/data` and a health check on `/api/db/health`.
+
+## Deploy
+
+You need [flyctl](https://fly.io/docs/flyctl/install/) and a Fly.io account.
+
+```bash
+git clone https://github.com/libredb/libredb-studio
+cd libredb-studio
+
+# Creates the app from the bundled fly.toml. Pick your own app name and
+# region when prompted. --no-deploy because secrets are not set yet.
+fly launch --copy-config --no-deploy
+
+# Persistent storage for saved connections and settings (1 GB is plenty).
+# Use the same region you picked above.
+fly volumes create libredb_data --size 1
+
+# Required credentials. Generate a strong JWT secret, choose your own
+# passwords.
+fly secrets set \
+  JWT_SECRET=$(openssl rand -hex 32) \
+  ADMIN_EMAIL=admin@libredb.org \
+  ADMIN_PASSWORD=change-me \
+  USER_EMAIL=user@libredb.org \
+  USER_PASSWORD=change-me-too
+
+fly deploy
+fly apps open
+```
+
+Log in with the admin credentials you set above.
+
+## Notes
+
+- The app state lives in SQLite on the mounted volume, so run a single
+  machine. Do not `fly scale count 2` — two writers on one SQLite file
+  will corrupt it. For multi-instance setups switch to
+  `STORAGE_PROVIDER=postgres` and set `STORAGE_POSTGRES_URL`.
+- `auto_stop_machines` is enabled: the machine stops when idle and wakes
+  on the next request. First request after idle takes a few seconds.
+- To update, bump the image tag in `fly.toml` to the latest release and
+  run `fly deploy` again.
+- Optional features (AI assistance, OIDC login) are configured the same
+  way as everywhere else — set the extra env vars with `fly secrets set`.
+  See the [README](../README.md#configuration) for the list.

--- a/docs/FLY.md
+++ b/docs/FLY.md
@@ -13,13 +13,14 @@ You need [flyctl](https://fly.io/docs/flyctl/install/) and a Fly.io account.
 git clone https://github.com/libredb/libredb-studio
 cd libredb-studio
 
-# Creates the app from the bundled fly.toml. Pick your own app name and
-# region when prompted. --no-deploy because secrets are not set yet.
-fly launch --copy-config --no-deploy
+# Creates the app from the bundled fly.toml. --copy-config uses the file
+# as-is without prompting, so pass your own app name and region explicitly.
+# --no-deploy because secrets and the volume are not set up yet.
+fly launch --copy-config --no-deploy --name my-libredb --region ams
 
 # Persistent storage for saved connections and settings (1 GB is plenty).
-# Use the same region you picked above.
-fly volumes create libredb_data --size 1
+# Use the SAME region you passed above - volumes are region-bound.
+fly volumes create libredb_data --size 1 --region ams
 
 # Required credentials. Generate a strong JWT secret, choose your own
 # passwords.
@@ -39,8 +40,10 @@ Log in with the admin credentials you set above.
 ## Notes
 
 - The app state lives in SQLite on the mounted volume, so run a single
-  machine. Do not `fly scale count 2` — two writers on one SQLite file
-  will corrupt it. For multi-instance setups switch to
+  machine. A Fly volume attaches to one machine at a time: `fly scale
+  count 2` either fails for lack of a second volume or, with an extra
+  volume, gives the second machine its own empty database (divergent
+  state). For multi-instance setups switch to
   `STORAGE_PROVIDER=postgres` and set `STORAGE_POSTGRES_URL`.
 - `auto_stop_machines` is enabled: the machine stops when idle and wakes
   on the next request. First request after idle takes a few seconds.

--- a/docs/FLY.md
+++ b/docs/FLY.md
@@ -22,14 +22,17 @@ fly launch --copy-config --no-deploy --name my-libredb --region ams
 # Use the SAME region you passed above - volumes are region-bound.
 fly volumes create libredb_data --size 1 --region ams
 
-# Required credentials. Generate a strong JWT secret, choose your own
-# passwords.
+# Required credentials. Everything is generated - note the two passwords
+# printed below, you will log in with them.
+ADMIN_PASSWORD=$(openssl rand -base64 15)
+USER_PASSWORD=$(openssl rand -base64 15)
+echo "admin: $ADMIN_PASSWORD  user: $USER_PASSWORD"
 fly secrets set \
   JWT_SECRET=$(openssl rand -hex 32) \
   ADMIN_EMAIL=admin@libredb.org \
-  ADMIN_PASSWORD=change-me \
+  ADMIN_PASSWORD="$ADMIN_PASSWORD" \
   USER_EMAIL=user@libredb.org \
-  USER_PASSWORD=change-me-too
+  USER_PASSWORD="$USER_PASSWORD"
 
 fly deploy
 fly apps open

--- a/fly.toml
+++ b/fly.toml
@@ -14,7 +14,7 @@ primary_region = 'ams'
   NEXT_PUBLIC_AUTH_PROVIDER = 'local'
   NODE_ENV = 'production'
   PORT = '3000'
-  STORAGE_PROVIDER = 'local'
+  STORAGE_PROVIDER = 'sqlite'
   STORAGE_SQLITE_PATH = '/app/data/libredb-storage.db'
 
 [mounts]

--- a/fly.toml
+++ b/fly.toml
@@ -1,38 +1,39 @@
-# fly.toml app configuration file generated for libredb-studio on 2026-03-04T03:50:40+03:00
+# Run LibreDB Studio on Fly.io from the prebuilt image.
+# Setup steps: docs/FLY.md
 #
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
+# Credentials are NOT set here on purpose - put them in Fly secrets
+# (see docs/FLY.md), never in a committed file.
 
 app = 'libredb-studio'
 primary_region = 'ams'
 
 [build]
-  image = 'ghcr.io/libredb/libredb-studio:latest'
+  image = 'ghcr.io/libredb/libredb-studio:0.9.59'
 
 [env]
   NEXT_PUBLIC_AUTH_PROVIDER = 'local'
   NODE_ENV = 'production'
   PORT = '3000'
   STORAGE_PROVIDER = 'local'
-  ADMIN_EMAIL = 'admin@libredb.org'
-  ADMIN_PASSWORD = 'LibreDB.2026'
-  USER_EMAIL = 'user@libredb.org'
-  USER_PASSWORD = 'LibreDB.2026'
-  JWT_SECRET = 'LibreDB.2026'
+  STORAGE_SQLITE_PATH = '/app/data/libredb-storage.db'
 
+[mounts]
+  source = 'libredb_data'
+  destination = '/app/data'
 
 [http_service]
   internal_port = 3000
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
+  # SQLite on a single volume: keep this at one machine, don't scale out.
   min_machines_running = 0
   processes = ['app']
 
   [[http_service.checks]]
     interval = '30s'
     timeout = '5s'
-    grace_period = '10s'
+    grace_period = '20s'
     method = 'GET'
     path = '/api/db/health'
 
@@ -40,4 +41,3 @@ primary_region = 'ams'
   memory = '512mb'
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 512


### PR DESCRIPTION
## Description

Reworks the Fly.io deployment path. A `fly.toml` generated back in March was already sitting at the repo root with hard-coded credentials (including `JWT_SECRET`), no persistent volume, a floating `:latest` tag — and no mention of it anywhere in the docs or README.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue

Closes #218

## Changes Made

- `fly.toml`: drop the committed credentials (they now go through `fly secrets`, see docs), pin the image to `0.9.59`, mount a volume at `/app/data`, add a single-machine note (SQLite)
- `docs/FLY.md`: step-by-step deploy guide
- `README.md`: Fly.io badge and note in the One-Click Deploy section
- `distribution/channels.yaml` + `docs/DISTRIBUTION.md`: `fly-io` channel entry (tier 2) so the weekly drift check covers it

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

Local checks: `fly.toml` parses (tomllib), `node scripts/distribution-check.mjs` reports `fly-io | OK | 0.9.59`. Not tested with a real `fly launch` yet — needs a Fly.io account, tracked in the #218 checklist.

### Test Environment
- **LibreDB Studio Version**: 0.9.59
- **Browser**: n/a (config/docs only)
- **OS**: macOS 15
- **Node.js/Bun Version**: node 24 (drift check script)
- **Database Type**: n/a
