### PR TITLE
fix(operator): add CSV description annotation for the OperatorHub card

### DIFF
--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -22,7 +22,9 @@ metadata:
     capabilities: Basic Install
     categories: Database, Developer Tools
     containerImage: ghcr.io/libredb/libredb-studio-operator:0.9.59
-    createdAt: "2026-07-20T00:42:55Z"
+    createdAt: "2026-07-20T09:40:28Z"
+    description: Open-source web-based SQL IDE for PostgreSQL, MySQL, Oracle, SQL
+      Server, SQLite, MongoDB and Redis, with AI-powered query assistance.
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/libredb/libredb-studio

--- a/operator/config/manifests/bases/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/libredb-studio-operator.clusterserviceversion.yaml
@@ -6,6 +6,8 @@ metadata:
     capabilities: Basic Install
     categories: Database, Developer Tools
     containerImage: ghcr.io/libredb/libredb-studio-operator:0.0.0
+    description: Open-source web-based SQL IDE for PostgreSQL, MySQL, Oracle, SQL
+      Server, SQLite, MongoDB and Redis, with AI-powered query assistance.
     repository: https://github.com/libredb/libredb-studio
     support: LibreDB
   labels:


### PR DESCRIPTION
Adds `metadata.annotations.description` to the operator CSV — the short card description shown on OperatorHub.io and the OpenShift console. The community-operators-prod static test (`check_required_fields`) flagged its absence as a warning on the #152 submissions (k8s-operatorhub/community-operators#8794, redhat-openshift-ecosystem/community-operators-prod#10497).

Source base CSV updated and the OLM bundle regenerated (`make -C operator bundle`); the two catalog submissions are refreshed from this bundle after merge. No chart or app-code change.

Refs #152.