### PR TITLE
chore(railway): bump template image to 0.9.59

### DIFF
--- a/deploy/railway/PUBLISH.md
+++ b/deploy/railway/PUBLISH.md
@@ -13,7 +13,7 @@ values to enter are in [`template.json`](./template.json).
 
 - In the editor, click **+ New** (top-right), or open the command palette
   (`⌘K` / `Ctrl+K`) → **+ New Service** → **Docker Image**.
-- Image: `ghcr.io/libredb/libredb-studio:0.9.22` (pinned — never `:latest`).
+- Image: `ghcr.io/libredb/libredb-studio:0.9.59` (pinned — never `:latest`).
 - Rename the service to `libredb-studio`.
 
 ## 3. Variables

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -31,7 +31,7 @@ Or browse the Railway template marketplace and search **LibreDB Studio**.
 ## Deploy (manual — works today, before publishing)
 
 Railway dashboard → **New Project**, then in the project view click **+ New → Docker Image** →
-enter `ghcr.io/libredb/libredb-studio:0.9.22`, then configure the service to
+enter `ghcr.io/libredb/libredb-studio:0.9.59`, then configure the service to
 match [`template.json`](./template.json):
 
 - **Networking:** enable a public domain, target port `3000`.

--- a/deploy/railway/template.json
+++ b/deploy/railway/template.json
@@ -8,7 +8,7 @@
       "name": "libredb-studio",
       "icon": "https://raw.githubusercontent.com/libredb/libredb-studio/main/deploy/railway/libredb-studio.png",
       "source": {
-        "image": "ghcr.io/libredb/libredb-studio:0.9.22"
+        "image": "ghcr.io/libredb/libredb-studio:0.9.59"
       },
       "networking": {
         "public": true,


### PR DESCRIPTION
The Railway template files still pin `0.9.22`. Current release is `0.9.59`.

This updates the three files that hold the pin (`template.json`, `README.md`, `PUBLISH.md`), as documented in `distribution/channels.yaml`. The published template is edited in the Railway dashboard and is not auto-updated by Railway, so the dashboard image tag is updated in the same pass.

Closes #225
