### PR TITLE
fix(build): self-host Geist fonts so next build works offline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "elkjs": "^0.11.0",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.23.24",
+        "geist": "^1.7.2",
         "input-otp": "^1.4.2",
         "ioredis": "^5.9.2",
         "jose": "^6.1.3",
@@ -1225,6 +1226,8 @@
     "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
+
+    "geist": ["geist@1.7.2", "", { "peerDependencies": { "next": ">=13.2.0" } }, "sha512-Gu5lDFa3pLRyoBlBPf0QIFHVdWAnpco7fS1bJm41jyLPFoguBgiubseUN2oLXMgqZ7uxAxDoXcHMhCY/fOTTgg=="],
 
     "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "elkjs": "^0.11.0",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.23.24",
+    "geist": "^1.7.2",
     "input-otp": "^1.4.2",
     "ioredis": "^5.9.2",
     "jose": "^6.1.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,14 @@
+import { GeistMono } from "geist/font/mono";
+// Self-hosted Geist (the `geist` package wraps next/font/local around the woff2
+// files it ships). next/font/google would fetch fonts.googleapis.com at BUILD
+// time, so `next build` failed in offline or egress-restricted environments;
+// the rendered output is identical since Next self-hosts either way. The CSS
+// variable names must stay --font-geist-sans/mono: globals.css maps them to
+// --font-sans/--font-mono.
+import { GeistSans } from "geist/font/sans";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
-
-const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
-const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "LibreDB Studio | Universal Database Editor",
@@ -32,7 +36,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         suppressHydrationWarning
-        className={`${geistSans.variable} ${geistMono.variable} antialiased dark font-sans`}
+        className={`${GeistSans.variable} ${GeistMono.variable} antialiased dark font-sans`}
       >
         {children}
         <Toaster position="bottom-right" theme="dark" />

--- a/tests/components/RootLayout.test.tsx
+++ b/tests/components/RootLayout.test.tsx
@@ -3,10 +3,13 @@ import { mock } from "bun:test";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 
-// Mock next/font/google
-mock.module("next/font/google", () => ({
-  Geist: () => ({ variable: "mock-geist-sans", className: "mock-geist-sans" }),
-  Geist_Mono: () => ({ variable: "mock-geist-mono", className: "mock-geist-mono" }),
+// Mock the self-hosted geist fonts (they wrap next/font/local, which only
+// resolves inside a Next build)
+mock.module("geist/font/sans", () => ({
+  GeistSans: { variable: "mock-geist-sans", className: "mock-geist-sans" },
+}));
+mock.module("geist/font/mono", () => ({
+  GeistMono: { variable: "mock-geist-mono", className: "mock-geist-mono" },
 }));
 
 // Mock @/components/ui/sonner directly to avoid sonner/next-themes/lucide-react chain


### PR DESCRIPTION
`next/font/google` fetches `fonts.googleapis.com` **at build time**, so `next build` fails wherever egress to Google is unavailable - air-gapped or proxied Docker builds, restricted CI runners, offline dev - with:

```
next/font: error: Failed to fetch `Geist` from Google Fonts.
```

Fix: use Vercel's `geist` package (v1.7.2, SIL OFL), which wraps `next/font/local` around the woff2 files it ships, so the fonts resolve from `node_modules`.

Why this is a no-op for users and for platform:

- Rendered output is unchanged - Next already self-hosted the fetched fonts into `.next`, so no runtime request ever went to Google.
- The package keeps the same `--font-geist-sans` / `--font-geist-mono` variable names that `src/app/globals.css` maps to `--font-sans` / `--font-mono`, so no CSS change.
- `src/app/layout.tsx` is not a `tsup` entry (`index`, `providers`, `types`, `components`, `workspace`), so the `@libredb/studio` package and the platform embedding are untouched.

Test-first: `tests/components/RootLayout.test.tsx` now mocks `geist/font/sans` / `geist/font/mono` (they wrap `next/font/local`, which only resolves inside a Next build). That mock swap fails against the old `next/font/google` import, then passes with the new one.

Verified locally, all six gates: `format`, `lint` (0 errors), `typecheck`, `knip`, `test` (all layers, 0 fail), `build` - the build now completes **with no network access to Google Fonts**, which is the actual regression test. Coverage gate: 25871/25871 lines (100.00%).