### PR TITLE
feat(auth): add AUTH_COOKIE_SECURE to allow login over HTTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,23 @@ JWT_SECRET=your_32_character_random_string_here
 # AUTH_BOOTSTRAP=on
 
 # ============================================
+# COOKIE SECURITY (Optional)
+# ============================================
+# The Secure flag on the auth cookies (auth-token and the OIDC state cookie).
+# Unset (default): on in production, off otherwise, with one exception - a
+# request that arrived on a loopback host over plain http never gets it, so the
+# desktop shell can keep a session (issue #232).
+# Set to "false" ("off"/"0") when the browser itself reaches the app over plain
+# HTTP on a host that is not loopback - a LAN or home-server deployment such as
+# umbrelOS. The browser would otherwise reject the cookie and login would
+# silently bounce back to /login. The session cookie then travels in cleartext,
+# so keep it to trusted networks. TLS terminated at an ingress or load balancer
+# does NOT need this: the browser still speaks HTTPS and accepts the flag.
+# Set to "true" ("on"/"1") to force the flag on. Unrecognized values warn and
+# leave the default in place.
+# AUTH_COOKIE_SECURE=false
+
+# ============================================
 # AUTHENTICATION PROVIDER
 # ============================================
 # "local" (default) = email/password login (ADMIN_EMAIL/ADMIN_PASSWORD, USER_EMAIL/USER_PASSWORD)

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -132,6 +132,7 @@ A ready-to-use, fully-commented compose file is in the repo: [`docker-compose.ex
 | `USER_EMAIL` | ✅ | Standard user email (default `user@libredb.org`) |
 | `USER_PASSWORD` | ✅ | Standard user password |
 | `JWT_SECRET` | ✅ | JWT signing secret (min 32 chars) |
+| `AUTH_COOKIE_SECURE` | ❌ | `false` drops the `Secure` flag from auth cookies (browser reaches the app over plain HTTP, e.g. LAN/home server) |
 | `NEXT_PUBLIC_AUTH_PROVIDER` | ❌ | `local` (default) or `oidc` |
 | `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` | ❌ | OIDC SSO (required when `oidc`) |
 | `OIDC_ROLE_CLAIM` / `OIDC_ADMIN_ROLES` / `OIDC_SCOPE` | ❌ | OIDC role mapping & scope |

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Deploy your own instance of LibreDB Studio with a single click on DigitalOcean, 
 | `USER_PASSWORD` | ❌ | Optional; the lower-privilege user account exists only when set |
 | `JWT_SECRET` | ❌ | JWT secret (min 32 chars); auto-generated on first run unless `AUTH_BOOTSTRAP=off` |
 | `AUTH_BOOTSTRAP` | ❌ | `off` disables zero-config generation (strict mode; recommended for production) |
+| `AUTH_COOKIE_SECURE` | ❌ | `false` drops the `Secure` flag from auth cookies — needed only when the browser reaches the app over plain HTTP (LAN/home server); not for TLS terminated at an ingress |
 | `NEXT_PUBLIC_AUTH_PROVIDER` | ❌ | `local` (default) or `oidc` for SSO |
 | `OIDC_ISSUER` | ❌ | OIDC issuer URL (required when `oidc`) |
 | `OIDC_CLIENT_ID` | ❌ | OIDC client ID (required when `oidc`) |

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -630,13 +630,20 @@ export async function login(role: Role, username?: string) {
   const cookieStore = await cookies();
   cookieStore.set('auth-token', token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure: await shouldMarkCookieSecure(),
     sameSite: 'lax',
     maxAge: 86400,     // 24 hours
     path: '/',
   });
 }
 ```
+
+`shouldMarkCookieSecure()` also decides the flag on the `oidc-state` cookie, so both cookies of the flow always agree. It resolves in this order:
+
+1. `AUTH_COOKIE_SECURE` when set (`on`/`true`/`1` vs `off`/`false`/`0`) — the operator's explicit answer, needed when the browser itself reaches the app over plain HTTP on a non-loopback host (LAN or home server). TLS terminated at an ingress does not need it: the browser still speaks HTTPS.
+2. Off outside production.
+3. Off for a request that arrived on a loopback host over plain HTTP — WebKitGTK's cookie store discards a `Secure` cookie delivered over HTTP, which would break the desktop shell (issue #232). A proxy that forwarded HTTPS to loopback still gets the flag, via `x-forwarded-proto`.
+4. On otherwise.
 
 The optional `username` parameter was added for OIDC — local login passes the email, while the OIDC callback resolves it through a fallback chain: `claims.email || claims.preferred_username || claims.sub || role` (so a username is always set regardless of which claims the provider returns).
 

--- a/src/app/api/auth/oidc/login/route.ts
+++ b/src/app/api/auth/oidc/login/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getOIDCConfig, discoverProvider, generateAuthUrl, encryptState, getPublicOrigin } from "@/lib/oidc";
+import { shouldMarkCookieSecure } from "@/lib/auth";
 import { logger } from "@/lib/logger";
 
 export async function GET(request: Request) {
@@ -13,12 +14,14 @@ export async function GET(request: Request) {
 
     const { url, state } = await generateAuthUrl(config, redirectUri, oidcConfig.scope);
 
-    // Store PKCE state in signed cookie
+    // Store PKCE state in signed cookie. The Secure flag follows the same rule
+    // as the session cookie: a state cookie the browser drops takes the PKCE
+    // verifier with it, and the callback fails on a missing state.
     const stateCookie = await encryptState(state);
     const cookieStore = await cookies();
     cookieStore.set("oidc-state", stateCookie, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
+      secure: await shouldMarkCookieSecure(),
       sameSite: "lax",
       maxAge: 300, // 5 minutes
       path: "/",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -57,6 +57,47 @@ export async function getSession() {
 /** Hosts whose traffic never leaves the machine (port is stripped before the check). */
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
+const COOKIE_SECURE_OFF = new Set(["off", "false", "0"]);
+const COOKIE_SECURE_ON = new Set(["on", "true", "1"]);
+
+// Hoisted to module scope on one line: bun's line coverage under-counts the
+// continuation lines of a wrapped string, which then reads as uncovered code.
+const COOKIE_SECURE_DISABLED_MESSAGE =
+  "AUTH_COOKIE_SECURE=false: auth cookies drop the Secure flag and travel in cleartext; keep this to trusted networks";
+
+// Weakening the session cookie deserves a line in the log, but shouldMarkCookieSecure()
+// runs on every login, so the notice is latched to fire once per process.
+let cookieSecurityWarned = false;
+
+/** Test seam: clears the warn-once latch so each case observes a fresh process. */
+export function resetCookieSecurityWarning(): void {
+  cookieSecurityWarned = false;
+}
+
+function warnOnce(message: string): void {
+  if (cookieSecurityWarned) return;
+  cookieSecurityWarned = true;
+  logger.warn(message, { route: "auth" });
+}
+
+/**
+ * The operator's explicit AUTH_COOKIE_SECURE answer, or undefined to let the
+ * environment decide. Spellings follow AUTH_BOOTSTRAP ("off"/"false"/"0" and
+ * "on"/"true"/"1", trimmed, case-insensitive); anything else warns and falls
+ * through to the default, so a typo never silently flips the security posture.
+ */
+function readCookieSecureOverride(): boolean | undefined {
+  const raw = process.env.AUTH_COOKIE_SECURE;
+  const normalized = raw?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (COOKIE_SECURE_OFF.has(normalized)) return false;
+  if (COOKIE_SECURE_ON.has(normalized)) return true;
+  // Single-line message: bun's line coverage under-counts the continuation
+  // lines of a wrapped call, which then reads as uncovered new code.
+  warnOnce(`Unrecognized AUTH_COOKIE_SECURE value "${raw}"; keeping the default (use "false" for plain HTTP)`);
+  return undefined;
+}
+
 function isLoopbackHost(host: string | null): boolean {
   if (!host) return false;
   // Strip the port, then the brackets of an IPv6 literal ("[::1]:3000" -> "::1").
@@ -68,9 +109,18 @@ function isLoopbackHost(host: string | null): boolean {
 }
 
 /**
- * Whether the session cookie should carry the Secure flag.
+ * Whether an auth cookie should carry the Secure flag.
  *
- * Secure in production, as before, with one exception: a request that arrived on
+ * AUTH_COOKIE_SECURE wins whenever it is set. It is needed when the browser's
+ * own connection is plain http on a host that is not loopback - a LAN or
+ * home-server deployment such as umbrelOS (getumbrel/umbrel-apps#5847), where
+ * the browser rejects the Secure cookie and login silently loops. Only the
+ * operator can state that: no request-scoped signal proves it, and
+ * x-forwarded-proto is attacker-supplied, so trusting it to *drop* the flag
+ * would be a downgrade vector. Note that TLS terminated at an ingress does not
+ * need this - the browser still speaks https, so it accepts a Secure cookie.
+ *
+ * Otherwise: Secure in production, with one exception: a request that arrived on
  * a loopback host over plain http. Marking that cookie Secure protects nothing
  * (the traffic never leaves the machine) and actively breaks the desktop shell,
  * because libsoup - the cookie store behind WebKitGTK - discards a Secure cookie
@@ -78,7 +128,12 @@ function isLoopbackHost(host: string | null): boolean {
  * localhost (issue #232). A proxy that terminated TLS and forwarded to loopback
  * still gets Secure, via x-forwarded-proto.
  */
-async function shouldMarkCookieSecure(): Promise<boolean> {
+export async function shouldMarkCookieSecure(): Promise<boolean> {
+  const override = readCookieSecureOverride();
+  if (override === false && process.env.NODE_ENV === "production") {
+    warnOnce(COOKIE_SECURE_DISABLED_MESSAGE);
+  }
+  if (override !== undefined) return override;
   if (process.env.NODE_ENV !== "production") return false;
   try {
     const headerStore = await headers();

--- a/tests/api/auth/oidc-login.test.ts
+++ b/tests/api/auth/oidc-login.test.ts
@@ -93,6 +93,27 @@ describe("GET /api/auth/oidc/login", () => {
     expect(options!.maxAge).toBe(300);
   });
 
+  // The state cookie has to follow the same Secure rule as the session cookie.
+  // If the browser drops it - plain http with a Secure flag - the PKCE verifier
+  // is gone by the time the provider redirects back, and the callback fails on
+  // a missing state instead of logging the user in.
+  test("applies the shared Secure rule to the oidc-state cookie", async () => {
+    for (const [override, expected] of [
+      ["true", true],
+      ["false", false],
+    ] as const) {
+      process.env.AUTH_COOKIE_SECURE = override;
+      mockCookieSet.mockClear();
+      try {
+        await GET(new Request("http://localhost:3000/api/auth/oidc/login"));
+      } finally {
+        delete process.env.AUTH_COOKIE_SECURE;
+      }
+      const [, , options] = mockCookieSet.mock.calls[0];
+      expect(options!.secure).toBe(expected);
+    }
+  });
+
   test("uses correct redirect URI based on request origin", async () => {
     const req = new Request("https://app.example.com/api/auth/oidc/login");
     await GET(req);

--- a/tests/unit/lib/auth.test.ts
+++ b/tests/unit/lib/auth.test.ts
@@ -1,5 +1,6 @@
-import { describe, test, expect, mock, beforeEach, spyOn } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
 import * as jose from "jose";
+import { logger } from "@/lib/logger";
 
 // ============================================================================
 // Mock State — only mock next/headers (cookies), NOT jose
@@ -39,7 +40,7 @@ mock.module("next/headers", () => ({
 // Import module under test (after mocks)
 // ============================================================================
 
-const { signJWT, verifyJWT, getSession, login, logout } = await import("@/lib/auth");
+const { signJWT, verifyJWT, getSession, login, logout, resetCookieSecurityWarning } = await import("@/lib/auth");
 
 // ============================================================================
 // Tests — use real jose sign/verify with JWT_SECRET from tests/setup.ts
@@ -223,6 +224,106 @@ describe("auth", () => {
           setNodeEnv(previous);
         }
         expect((mockSetCalls[0].opts as { secure: boolean }).secure).toBe(true);
+      });
+
+      // AUTH_COOKIE_SECURE is the escape hatch for a deployment that terminates
+      // TLS upstream and forwards plain http to the app on a host that is not
+      // loopback (umbrelOS: getumbrel/umbrel-apps#5847). The loopback exception
+      // above cannot cover that - the browser reaches the app on umbrel.local -
+      // so the operator has to declare it.
+      describe("AUTH_COOKIE_SECURE override", () => {
+        const setOverride = (value: string | undefined) => {
+          if (value === undefined) delete process.env.AUTH_COOKIE_SECURE;
+          else process.env.AUTH_COOKIE_SECURE = value;
+        };
+
+        afterEach(() => {
+          setOverride(undefined);
+          resetCookieSecurityWarning();
+        });
+
+        test("turns the flag off for a public host in production", async () => {
+          setOverride("false");
+          expect(await asProduction("studio.example.com")).toBe(false);
+        });
+
+        test("forces the flag on outside production", async () => {
+          setOverride("true");
+          mockRequestHeaders.host = "studio.example.com";
+          await login("admin", "admin");
+          expect((mockSetCalls[0].opts as { secure: boolean }).secure).toBe(true);
+        });
+
+        test("forces the flag on for loopback, overruling the desktop-shell exception", async () => {
+          setOverride("true");
+          expect(await asProduction("localhost:3000")).toBe(true);
+        });
+
+        // Same spellings AUTH_BOOTSTRAP accepts: a typo must never be the reason
+        // an operator thinks they turned the flag off while it is still on.
+        test("accepts the AUTH_BOOTSTRAP spellings, trimmed and case-insensitive", async () => {
+          for (const off of ["false", "0", "off", " FALSE "]) {
+            setOverride(off);
+            mockSetCalls = [];
+            expect(await asProduction("studio.example.com")).toBe(false);
+          }
+          for (const on of ["true", "1", "on", " TRUE "]) {
+            setOverride(on);
+            mockSetCalls = [];
+            expect(await asProduction("127.0.0.1:41234")).toBe(true);
+          }
+        });
+
+        test("warns and keeps the default when the value is unrecognized", async () => {
+          const warn = spyOn(logger, "warn").mockImplementation(() => {});
+          setOverride("yes-please");
+          try {
+            expect(await asProduction("studio.example.com")).toBe(true);
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(warn.mock.calls[0][0]).toContain("AUTH_COOKIE_SECURE");
+          } finally {
+            warn.mockRestore();
+          }
+        });
+
+        test("treats a blank value as unset, without warning", async () => {
+          const warn = spyOn(logger, "warn").mockImplementation(() => {});
+          setOverride("   ");
+          try {
+            expect(await asProduction("studio.example.com")).toBe(true);
+            expect(warn).not.toHaveBeenCalled();
+          } finally {
+            warn.mockRestore();
+          }
+        });
+
+        // Relaxing the flag in production is a deliberate weakening of the
+        // session cookie: it belongs in the log, once, not on every login.
+        test("warns once when it disables the flag in production", async () => {
+          const warn = spyOn(logger, "warn").mockImplementation(() => {});
+          setOverride("false");
+          try {
+            await asProduction("studio.example.com");
+            mockSetCalls = [];
+            await asProduction("studio.example.com");
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(warn.mock.calls[0][0]).toContain("AUTH_COOKIE_SECURE");
+          } finally {
+            warn.mockRestore();
+          }
+        });
+
+        test("stays quiet when it disables the flag outside production", async () => {
+          const warn = spyOn(logger, "warn").mockImplementation(() => {});
+          setOverride("false");
+          try {
+            await login("admin", "admin");
+            expect((mockSetCalls[0].opts as { secure: boolean }).secure).toBe(false);
+            expect(warn).not.toHaveBeenCalled();
+          } finally {
+            warn.mockRestore();
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
Adds an `AUTH_COOKIE_SECURE` env var that controls the `Secure` flag on the auth
cookies (`auth-token` and the OIDC `oidc-state` cookie). Left unset it behaves
exactly as before. Set it to `false` to keep the flag off, or `true` to force it on.

The reason is the umbrelOS package review in getumbrel/umbrel-apps#5847. umbrelOS
serves the app over plain HTTP on the LAN (`http://umbrel.local`), so the browser
rejects a Secure cookie: the login request goes through but the cookie never
comes back and you land on `/login` again. A fresh install on arm64 with umbrelOS
1.7.4 could not stay logged in. Setting `AUTH_COOKIE_SECURE=false` fixes that,
and existing HTTPS deployments are unaffected because the default does not change.

To be precise about when this flag is needed: it is the **browser's own
connection** being plain HTTP that breaks login. TLS terminated at an ingress or
load balancer does *not* need it — the browser still speaks HTTPS and accepts the
flag, and the internal HTTP hop is invisible to it.

## Resolution order

The override folds into `shouldMarkCookieSecure()`, which already carried the
loopback exception added for the desktop shell in #232, so there is one rule for
both auth cookies:

1. `AUTH_COOKIE_SECURE` when set — the operator's explicit answer. No
   request-scoped signal can replace it: `x-forwarded-proto` is attacker-supplied,
   so trusting it to *drop* the flag would be a downgrade vector.
2. Off outside production.
3. Off for a request that arrived on a loopback host over plain HTTP (#232 —
   WebKitGTK's cookie store discards such a cookie, breaking the desktop shell).
   A proxy that forwarded HTTPS to loopback still gets the flag.
4. On otherwise.

## Review changes

- Rebased onto `main`. The branch predated #232/#235, and the original patch
  replaced `shouldMarkCookieSecure()` with a separate helper, which would have
  reverted the desktop-shell fix.
- The `oidc-state` cookie now follows the same rule. It read `NODE_ENV` directly,
  which left the OIDC flow broken in the desktop shell for the same reason a
  dropped state cookie loses the PKCE verifier and the callback fails on a
  missing state.
- Values follow the `AUTH_BOOTSTRAP` convention (`on`/`true`/`1` and
  `off`/`false`/`0`, trimmed, case-insensitive). Strict `=== "false"` parsing
  would have let `AUTH_COOKIE_SECURE=0` silently leave the flag on, reproducing
  the exact login loop the operator was trying to fix. Unrecognized values warn
  and keep the default.
- Disabling the flag in production logs a warning once, so a deliberate
  weakening of the session cookie leaves a trace.
- Documented in `.env.example`, `README.md`, `DOCKERHUB.md` and `docs/OIDC.md`
  (whose snippet was also stale since #232).

## Tests

`tests/unit/lib/auth.test.ts` covers the override in both directions, the
override overruling the loopback exception, every accepted spelling, the
unrecognized-value warning, a blank value treated as unset, and the warn-once
latch. `tests/api/auth/oidc-login.test.ts` asserts the shared rule on the
`oidc-state` cookie. Merged line coverage stays at 100% (25912/25912).
