### PR TITLE
chore(release): 0.9.61 - AUTH_COOKIE_SECURE for plain-HTTP deployments

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.21
-appVersion: "0.9.60"
+version: 0.1.22
+appVersion: "0.9.61"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.60
+      image: ghcr.io/libredb/libredb-studio:0.9.61
       platforms:
         - linux/amd64
         - linux/arm64
@@ -43,9 +43,8 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "OpenShift compatibility - global.compatibility.openshift.adaptSecurityContext (auto/force/disabled, default auto) drops the fixed runAsUser/runAsGroup/fsGroup so pods pass the restricted-v2 SCC; the Bitnami postgresql subchart honours the same value"
-    - "PostgreSQL subchart - default image redirected to docker.io/bitnamilegacy/postgresql after the Bitnami catalog freeze removed the pinned tag from docker.io/bitnami; global.security.allowInsecureImages is set accordingly"
-    - "seedConnections.enabled without inline config or an existing ConfigMap now fails the render instead of shipping a Deployment that mounts a ConfigMap that does not exist"
+    - "Application updated to 0.9.61 - AUTH_COOKIE_SECURE controls the Secure flag on the auth cookies, so a deployment the browser reaches over plain HTTP can hold a session; set it via extraEnv"
+    - "No chart template changes - the rendered manifests are identical to 0.1.21"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.21 \
+  --version 0.1.22 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -21,8 +21,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Database, Developer Tools
-    containerImage: ghcr.io/libredb/libredb-studio-operator:0.9.60
-    createdAt: "2026-07-28T22:14:00Z"
+    containerImage: ghcr.io/libredb/libredb-studio-operator:0.9.61
+    createdAt: "2026-07-29T00:22:21Z"
     description: Open-source web-based SQL IDE for PostgreSQL, MySQL, Oracle, SQL
       Server, SQLite, MongoDB and Redis, with AI-powered query assistance.
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: libredb-studio-operator.v0.9.60
+  name: libredb-studio-operator.v0.9.61
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -255,7 +255,7 @@ spec:
                 - --leader-elect
                 - --leader-election-id=libredb-studio-operator
                 - --health-probe-bind-address=:8081
-                image: ghcr.io/libredb/libredb-studio-operator:0.9.60
+                image: ghcr.io/libredb/libredb-studio-operator:0.9.61
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -360,4 +360,4 @@ spec:
   provider:
     name: LibreDB
     url: https://libredb.org
-  version: 0.9.60
+  version: 0.9.61

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/libredb/libredb-studio-operator
-  newTag: 0.9.60
+  newTag: 0.9.61

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.21
-appVersion: "0.9.60"
+version: 0.1.22
+appVersion: "0.9.61"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.60
+      image: ghcr.io/libredb/libredb-studio:0.9.61
       platforms:
         - linux/amd64
         - linux/arm64
@@ -43,9 +43,8 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "OpenShift compatibility - global.compatibility.openshift.adaptSecurityContext (auto/force/disabled, default auto) drops the fixed runAsUser/runAsGroup/fsGroup so pods pass the restricted-v2 SCC; the Bitnami postgresql subchart honours the same value"
-    - "PostgreSQL subchart - default image redirected to docker.io/bitnamilegacy/postgresql after the Bitnami catalog freeze removed the pinned tag from docker.io/bitnami; global.security.allowInsecureImages is set accordingly"
-    - "seedConnections.enabled without inline config or an existing ConfigMap now fails the render instead of shipping a Deployment that mounts a ConfigMap that does not exist"
+    - "Application updated to 0.9.61 - AUTH_COOKIE_SECURE controls the Secure flag on the auth cookies, so a deployment the browser reaches over plain HTTP can hold a session; set it via extraEnv"
+    - "No chart template changes - the rendered manifests are identical to 0.1.21"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.21 \
+  --version 0.1.22 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.60",
+  "version": "0.9.61",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packaging/flatpak/org.libredb.Studio.metainfo.xml
+++ b/packaging/flatpak/org.libredb.Studio.metainfo.xml
@@ -100,6 +100,12 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.9.61" date="2026-07-29">
+      <description>
+        <p>Auth cookies can now drop the Secure flag on a deployment the browser reaches over plain HTTP, so a login holds on a trusted local network.</p>
+      </description>
+      <url type="details">https://github.com/libredb/libredb-studio/releases/tag/0.9.61</url>
+    </release>
     <release version="0.9.60" date="2026-07-28">
       <description>
         <p>First release with the desktop application: the AppImage this Flatpak repacks.</p>


### PR DESCRIPTION
Release bump for **0.9.61** (chart **0.1.22** / appVersion 0.9.61).

## Contents since 0.9.60

- **#236 — `AUTH_COOKIE_SECURE`**: controls the `Secure` flag on the auth cookies
  (`auth-token` and `oidc-state`). A deployment the browser reaches over plain
  HTTP — umbrelOS on the LAN, getumbrel/umbrel-apps#5847 — can now hold a session
  instead of bouncing back to `/login`. Default unchanged; the flag folds into the
  same resolver as the loopback exception from #232, so both cookies of the OIDC
  flow always agree.
- Chores that landed after the 0.9.60 tag and therefore ship here: the OLM bundle
  regeneration for 0.9.60, the release-bump rule in CLAUDE.md, and the 0.9.60
  Flathub metainfo entry.

## Bump mechanics

| Change | Why |
|---|---|
| `package.json` 0.9.60 → 0.9.61 | the version the release publishes |
| `bun run chart:bump` → chart 0.1.22, appVersion 0.9.61, image tag, README examples | required `chart:check` gate (#138); a `charts/**` change without a version bump would amend the already-released chart index (#167) |
| `make -C operator bundle` → CSV + `config/manager` | the CSV takes its version and controller image tag from `package.json`; without this the operator freshness gate fails, and the bundle must exist on the tagged ref |
| `packaging/flatpak/.../metainfo.xml` 0.9.61 entry | Flathub requires a `releases` entry for the submitted version; the External Data Checker does not maintain this list. Validated with `appstreamcli` (successful, 1 pedantic) |
| `artifacthub.io/changes` rewritten | it still described 0.1.20's OpenShift work, which 0.1.21 then published as its own changelog. Now states what 0.1.22 actually carries |

## Verification

Six local gates green (`format`, `lint`, `typecheck`, `knip`, `test`, `build`),
plus `helm lint charts/libredb-studio --strict`, `bun run chart:check`
(`chart 0.1.22 / appVersion 0.9.61 in sync with package.json 0.9.61`), and
`operator-sdk bundle validate ./bundle --select-optional suite=operatorframework`
("All validation tests have completed successfully"; the two v1.25 deprecation
warnings are pre-existing).

Tag `0.9.61` goes on `main` only after this merges, so the tagged ref carries the
refreshed bundle.
