### PR TITLE
ci(docker): build arm64 only for main, releases and manual dispatches

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -91,7 +91,31 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Version: ${VERSION}"
 
+      - name: Resolve build platforms
+        id: platforms
+        # arm64 has no native runner in this job, so buildx emulates it through
+        # QEMU: native module compilation in the deps stage plus a full
+        # `next build` run under emulation, which is most of this job's runtime.
+        # A feature-branch push only produces the mutable "dev" tag, consumed by
+        # the amd64 Channel E2E job below and nothing else, so paying for arm64
+        # on every commit of a PR buys nothing. main, releases and manual
+        # dispatches (the release chain) always build the full manifest.
+        # Single source of truth: the QEMU step and the build step below both
+        # read this output, so they cannot drift into "two arches, no emulator".
+        env:
+          # Via env, not inline interpolation: a branch name reaches this step
+          # and git allows characters a shell would reinterpret.
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ] && [ "$REF" != "refs/heads/main" ]; then
+            echo "list=linux/amd64" >> "$GITHUB_OUTPUT"
+          else
+            echo "list=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up QEMU for multi-platform builds
+        if: contains(steps.platforms.outputs.list, 'arm64')
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
@@ -184,7 +208,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.platforms.outputs.list }}
           build-args: |
             JWT_SECRET_BUILD=build-time-placeholder-secret-32ch
             ADMIN_PASSWORD_BUILD=build
@@ -197,6 +221,7 @@ jobs:
           echo "**Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.extract-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Docker Hub mirror:** ${{ steps.dockerhub.outputs.enabled }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Platforms:** ${{ steps.platforms.outputs.list }}" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** ${{ steps.image.outputs.name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Tags:" >> $GITHUB_STEP_SUMMARY

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -77,10 +77,10 @@ A ready-to-use, fully-commented compose file is in the repo: [`docker-compose.ex
 |-----|-------------|-----|
 | `latest` | `main` | Latest stable build |
 | `X.Y.Z` | `main` / release | Pin an exact version, e.g. `docker pull libredb/libredb-studio:0.9.16` (recommended for production) |
-| `dev` | `feat/**`, `fix/**` branches | Bleeding-edge / preview |
+| `dev` | `feat/**`, `fix/**` branches | Bleeding-edge / preview (`linux/amd64` only) |
 | `sha-<commit>` | every build | Exact immutable commit |
 
-- **Architectures:** `linux/amd64`, `linux/arm64` (multi-arch manifest).
+- **Architectures:** `linux/amd64` and `linux/arm64` as a multi-arch manifest for `latest`, `X.Y.Z`, `main` and their `sha-` tags. Preview builds from `feat/**` / `fix/**` branches (`dev` and their `sha-` tags) are `linux/amd64` only: CI has no native arm64 runner for this job, so arm64 is emulated, and paying for that on every branch commit is not worth it for an image no arm64 consumer pins.
 - **Primary registry:** `ghcr.io/libredb/libredb-studio` (GitHub Container Registry — no pull rate limits, preferred for Kubernetes/CI). This Docker Hub repository is a convenience mirror for discoverability; both registries serve the identical multi-arch image.
 
 ---

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -171,6 +171,13 @@ Published by [`.github/workflows/docker-build-push.yml`](../.github/workflows/do
 Use `<version>` or `sha-<commit>` for reproducible deployments; `main` / `dev` are for testing
 unreleased code.
 
+**Architectures:** every tag published from `main`, a release or a manual dispatch is a
+`linux/amd64` + `linux/arm64` manifest. Branch previews (`dev` and the `sha-` tag of a
+`feat/**` / `fix/**` push) are `linux/amd64` only — the build job has no native arm64 runner, so
+arm64 goes through QEMU and dominates the job's runtime; spending that on every commit of an open
+PR buys nothing, since the only consumer of `dev` is the amd64 Channel E2E gate. Pull `main` (or a
+released version) when you need arm64 from an unreleased line.
+
 ## Helm (Kubernetes)
 
 ```bash


### PR DESCRIPTION
Feature-branch pushes stop paying for the emulated arm64 leg of the Docker build.

## Why

The build job runs on `ubuntu-latest` and asks buildx for `linux/amd64,linux/arm64`,
so arm64 is produced under QEMU emulation. What gets emulated is the expensive part
of the Dockerfile: the `deps` stage compiles native modules (`python3 make g++`),
and the `builder` stage runs a full `next build`. Measured on the last green run
(`30405619999`, warm cache): **the build step is 7m57s of a 9m job**. Cold — a
`bun.lock` or Dockerfile change, or an eviction from the GHA cache, which is capped
at 10 GB per repo while `mode=max` writes every intermediate layer of two
architectures — it goes well past 20 minutes.

A `feat/**` / `fix/**` push publishes only the mutable `dev` tag plus its `sha-`
tag. The one consumer of `dev` is the amd64 `Channel E2E (docker)` job in this same
workflow. So during PR iteration the emulated leg costs minutes per commit and
nothing reads it.

Caching is not the missing piece here — `cache-from`/`cache-to: type=gha,mode=max`
has been in place all along. The emulation is the cost.

## What changes

| Trigger | Platforms |
|---|---|
| push to `feat/**` / `fix/**` | `linux/amd64` |
| push to `main` | `linux/amd64,linux/arm64` |
| `release: published` | `linux/amd64,linux/arm64` |
| `workflow_dispatch` (the release chain) | `linux/amd64,linux/arm64` |

Every tag anyone can pin — `latest`, `X.Y.Z`, `main` — keeps its full multi-arch
manifest. Only branch previews narrow.

## Notes on the implementation

- The platform list is resolved **once** into a step output that both the QEMU
  setup and the build step read. Two independent `if:` conditions could drift into
  the one broken state that matters: asking for two architectures with no emulator
  installed.
- The resolver reads `github.event_name` and `github.ref` through `env:` rather
  than inline interpolation. A branch name reaches this step, and git permits
  characters a shell would reinterpret.
- The build summary now prints the platforms actually built, so a reader of a
  branch build is not left guessing.
- `DOCKERHUB.md` and `docs/DISTRIBUTION.md` state that branch previews are amd64
  only, so nobody pins `dev` expecting arm64.

## Verification

Six local gates green (`format`, `lint`, `typecheck`, `knip`, `test`, `build`);
workflow YAML parses.

The real proof is this PR's own `Build and Push Docker Image` run. The branch is
deliberately named `fix/**` so the workflow triggers and exercises the new path: it
should build `linux/amd64` only, skip the QEMU step, and finish well under the
previous 9 minutes. Compare its duration against run `30405619999` (9m, both
arches, warm cache).
