### PR TITLE
fix(desktop): stop the loopback health tests racing on arm64

### DIFF
--- a/desktop/src-tauri/src/net.rs
+++ b/desktop/src-tauri/src/net.rs
@@ -40,10 +40,13 @@ pub fn http_status(port: u16, path: &str, timeout: Duration) -> io::Result<u16> 
     let mut stream = TcpStream::connect_timeout(&addr, timeout)?;
     stream.set_read_timeout(Some(timeout))?;
     stream.set_write_timeout(Some(timeout))?;
-    write!(
-        stream,
-        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\nAccept: */*\r\n\r\n"
-    )?;
+    // Formatted first, then written once. `write!` on a TcpStream emits one
+    // write() syscall per format fragment, so the request leaves in pieces: a
+    // peer that answers and closes after reading only the first piece resets the
+    // connection, and the later pieces then fail with EPIPE before this function
+    // ever gets to read the status line.
+    let request = format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\nAccept: */*\r\n\r\n");
+    stream.write_all(request.as_bytes())?;
     stream.flush()?;
 
     let mut line = String::new();
@@ -96,10 +99,27 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Read;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::thread;
+
+    /// Read request lines until the blank line that ends the headers.
+    ///
+    /// A double that answers after a partial read closes with request bytes still
+    /// queued, and the kernel resets such a connection instead of finishing it.
+    /// The client then fails on a write or a read rather than parsing the status
+    /// line it was handed - which is how these tests used to fail on arm64 while
+    /// passing on x86_64, purely on scheduling luck.
+    fn drain_request(stream: &TcpStream) {
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        while let Ok(read) = reader.read_line(&mut line) {
+            if read == 0 || line == "\r\n" || line == "\n" {
+                return;
+            }
+            line.clear();
+        }
+    }
 
     /// Serve `count` requests with the given status line, then stop.
     fn serve(status: &'static str, count: usize) -> (u16, thread::JoinHandle<()>) {
@@ -108,8 +128,7 @@ mod tests {
         let handle = thread::spawn(move || {
             for _ in 0..count {
                 let Ok((mut stream, _)) = listener.accept() else { return };
-                let mut buf = [0u8; 512];
-                let _ = stream.read(&mut buf);
+                drain_request(&stream);
                 let _ = stream.write_all(format!("{status}\r\nContent-Length: 0\r\n\r\n").as_bytes());
             }
         });
@@ -152,6 +171,53 @@ mod tests {
     fn http_status_errors_when_nothing_listens() {
         let port = pick_free_port().expect("pick");
         assert!(http_status(port, HEALTH_PATH, Duration::from_millis(200)).is_err());
+    }
+
+    /// The server must receive a complete, well-formed request: the blank line
+    /// that ends the headers is what tells a real server to start answering.
+    /// Read to that terminator rather than counting bytes or reads - TCP is free
+    /// to split a write, and asserting otherwise is how a test starts flaking.
+    #[test]
+    fn http_status_sends_a_complete_request() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = String::new();
+            let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+            let mut line = String::new();
+            while reader.read_line(&mut line).expect("read") > 0 {
+                request.push_str(&line);
+                if line == "\r\n" {
+                    break;
+                }
+                line.clear();
+            }
+            let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+            request
+        });
+        assert_eq!(http_status(port, HEALTH_PATH, Duration::from_secs(2)).ok(), Some(200));
+        let request = handle.join().expect("join");
+        assert_eq!(
+            request,
+            format!("GET /api/db/health HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\nAccept: */*\r\n\r\n")
+        );
+    }
+
+    /// A peer that hangs up without answering must surface as an error, and the
+    /// assertion deliberately does not pin the `ErrorKind`: whether the loser of
+    /// that race sees `ConnectionReset`, `BrokenPipe` or `UnexpectedEof` depends
+    /// on scheduling, and pinning it is what made these tests flake.
+    #[test]
+    fn http_status_errors_when_the_peer_hangs_up_without_answering() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let handle = thread::spawn(move || {
+            let Ok((stream, _)) = listener.accept() else { return };
+            drop(stream);
+        });
+        assert!(http_status(port, HEALTH_PATH, Duration::from_secs(2)).is_err());
+        handle.join().expect("join");
     }
 
     #[test]


### PR DESCRIPTION
`Flatpak Smoke` has been failing on `main` ever since the desktop shell landed
(`dc3a02d`) — three consecutive runs, always in `Unit test the desktop shell`, always
on arm64, always in `net.rs`, and with two different symptoms:

| Run | Test | Expected | Got |
|---|---|---|---|
| `30411284471` | `http_status_rejects_a_non_http_greeting` | `InvalidData` | `BrokenPipe` |
| `30404853167` | `wait_for_health_returns_healthy_once_the_server_answers` | `Healthy` | `Timeout` |

The same code passed three times on the feature branch, so it looked like arm64
flakiness with no explanation. It has one, and it is in the test double.

## The cause

`serve()` answered after a **single** `read()` and then dropped the connection.
`write!` on a `TcpStream` emits one `write()` syscall per format fragment, so the
request leaves in pieces. The double read the first piece, replied, and closed with
the remaining pieces still queued — and a socket closed with unread data in its
receive queue is **reset**, not finished. The client's next fragment then fails with
EPIPE, so `http_status` returns `BrokenPipe` having never reached the status line it
was handed.

Reproduced locally by replicating that write pattern against a peer that closes
without reading:

```
EXPERIMENT first=Ok(()) second=Err(BrokenPipe)
```

The second symptom follows from the first: when the initial health poll fails that
way, `wait_for_health` loops and polls again — but `serve(count = 1)` has already
exited, so the retry hits nothing listening and the gate reports `Timeout`. One
defect, two faces. arm64 simply loses the race more often than x86_64.

## The fix

- `serve()` drains the request headers to the blank line before answering, the way a
  real server does. Nothing is ever left queued, so the close is a clean FIN.
- `http_status` formats the request first and writes it **once**. Fewer syscalls, and
  a real server never sees a dribbled request either.

## Tests

Two tests carry what the investigation established:

- `http_status_sends_a_complete_request` — the server receives a complete,
  well-formed request, asserted by reading **to the header terminator**, never by a
  byte count or a read count. TCP may split a write; asserting otherwise is how this
  whole thing started. I did in fact write that mistaken version first, and it
  passed against the old buggy code, which is how I caught it.
- `http_status_errors_when_the_peer_hangs_up_without_answering` — a peer that hangs
  up surfaces as an error, deliberately **without pinning the `ErrorKind`**. Whether
  the loser of that race sees `BrokenPipe`, `ConnectionReset` or `UnexpectedEof` is
  scheduling, not contract. Pinning it is the original sin here.

## Verification

`cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib` — 40 passed, 0
failed, no warnings (was 38). The x86_64 run always passed, so **the arm64 job in
this PR is the real verification**: `Build AppImage (arm64)` has to go green.

Locally the crate needs the staged sidecar to compile at all (`tauri-build` refuses
when the declared `externalBin`/`resources` are missing), which is why CI builds the
AppImage with `--keep-stage` before running `cargo test`.

Note on formatting: `cargo fmt --check` reports diffs here, as it does across this
crate on files this PR does not touch (`handoff.rs`, and 7 pre-existing diffs in
`net.rs` itself). The crate is written at the repo's ~120-column house style, not
rustfmt's default 100, and no CI job runs `cargo fmt`. The added lines match their
surroundings; reformatting the crate is a separate decision.

Not release-blocking, for the record: `cargo test` runs only in `flatpak-smoke.yml`,
never in `release-artifacts`, which is why 0.9.60 shipped its AppImages while this
was red.
