### PR TITLE
feat(distribution): switch a channel's release automation from channels.yaml

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -136,7 +136,16 @@ jobs:
         env:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
         run: |
-          if [ -n "$DOCKER_HUB_TOKEN" ]; then
+          # Two gates: the secret says CI *can* push, update.ci_enabled in
+          # distribution/channels.yaml says it *should*. Read here rather than
+          # in a separate job because this one already has the dependencies
+          # installed - and an unreadable inventory leaves the mirror off
+          # instead of failing the canonical GHCR publish alongside it.
+          ci_enabled=$(node scripts/distribution-check.mjs --ci-enabled docker-hub-mirror 2>/dev/null || echo unresolved)
+          if [ "$ci_enabled" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::docker-hub-mirror update.ci_enabled is '$ci_enabled' in distribution/channels.yaml - skipping the Docker Hub mirror"
+          elif [ -n "$DOCKER_HUB_TOKEN" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -104,6 +104,44 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version: ${VERSION}"
 
+  channels:
+    # Reads update.ci_enabled out of distribution/channels.yaml so the optional
+    # channels below can be switched off in one reviewable place, without
+    # deleting a secret or editing this workflow. A channel that is known to be
+    # unable to publish (a package in community moderation, a listing still
+    # under review) must not paint a good release run red.
+    #
+    # continue-on-error is the fail-safe: if this job cannot run, its outputs
+    # come out empty, every gate below reads "not true" and the optional
+    # channels skip - the release itself is never blocked by the switchboard.
+    # The weekly distribution:check drift table is what notices a channel that
+    # stopped publishing.
+    name: Resolve channel automation
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      docker_hub_mirror: ${{ steps.flags.outputs.docker_hub_mirror }}
+      homebrew: ${{ steps.flags.outputs.homebrew }}
+      snap: ${{ steps.flags.outputs.snap }}
+      winget: ${{ steps.flags.outputs.winget }}
+      chocolatey: ${{ steps.flags.outputs.chocolatey }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Read update.ci_enabled from distribution/channels.yaml
+        id: flags
+        # tee: the resolved switchboard is visible in the log, not just consumed.
+        run: node scripts/distribution-check.mjs --ci-outputs | tee -a "$GITHUB_OUTPUT"
+
   draft:
     # Immutable releases (issue #154): assets can only be attached while the
     # release is a draft. Reuse a hand-written draft when one exists for the
@@ -327,7 +365,7 @@ jobs:
 
   publish:
     name: Attach artifacts to release
-    needs: [guard, build, windows-package, draft]
+    needs: [guard, build, windows-package, draft, channels]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -369,8 +407,15 @@ jobs:
         id: tap
         env:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          # Both gates must pass: the secret says CI *can* publish, the
+          # inventory flag says it *should*. Secrets cannot be read in a
+          # job-level if, which is why this stays a step gate.
+          CI_ENABLED: ${{ needs.channels.outputs.homebrew }}
         run: |
-          if [ -n "$TAP_GITHUB_TOKEN" ]; then
+          if [ "$CI_ENABLED" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::homebrew update.ci_enabled is '${CI_ENABLED:-<unresolved>}' in distribution/channels.yaml - skipping the Homebrew tap update"
+          elif [ -n "$TAP_GITHUB_TOKEN" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -641,7 +686,7 @@ jobs:
     # SNAPCRAFT_STORE_CREDENTIALS with the same pattern as Docker Hub in
     # docker-build-push.yml: without the secret every step is skipped and
     # the job succeeds cleanly (secrets are unavailable in job-level if).
-    needs: [guard, build, draft]
+    needs: [guard, build, draft, channels]
     permissions:
       contents: write
     strategy:
@@ -660,8 +705,12 @@ jobs:
         id: snapstore
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          CI_ENABLED: ${{ needs.channels.outputs.snap }}
         run: |
-          if [ -n "$SNAPCRAFT_STORE_CREDENTIALS" ]; then
+          if [ "$CI_ENABLED" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::snap update.ci_enabled is '${CI_ENABLED:-<unresolved>}' in distribution/channels.yaml - skipping the Snap build and publish"
+          elif [ -n "$SNAPCRAFT_STORE_CREDENTIALS" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -864,17 +913,23 @@ jobs:
     # the release is published: chocolateyinstall.ps1 downloads the zip from
     # the release URL, which only becomes public at publish time (draft
     # assets are not downloadable). Gated on CHOCO_API_KEY with the same
-    # pattern as the snap job; the first push enters human moderation - see
-    # docs/DISTRIBUTION.md ("Windows").
-    needs: [guard, publish-release]
+    # pattern as the snap job, and on update.ci_enabled - push.chocolatey.org
+    # answers 403 for every version while the first submission sits in human
+    # moderation, which failed the 0.9.60 and 0.9.61 runs after both releases
+    # had published fine. See docs/DISTRIBUTION.md ("Windows").
+    needs: [guard, publish-release, channels]
     runs-on: ubuntu-latest
     steps:
       - name: Check Chocolatey availability
         id: choco
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          CI_ENABLED: ${{ needs.channels.outputs.chocolatey }}
         run: |
-          if [ -n "$CHOCO_API_KEY" ]; then
+          if [ "$CI_ENABLED" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::chocolatey update.ci_enabled is '${CI_ENABLED:-<unresolved>}' in distribution/channels.yaml - skipping the Chocolatey publish. Flip it to true once the package clears moderation."
+          elif [ -n "$CHOCO_API_KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -933,7 +988,7 @@ jobs:
     # submission is manual, see docs/DISTRIBUTION.md) or when this version
     # is already in the community repo (wingetcreate has no duplicate-PR
     # detection of its own).
-    needs: [guard, publish-release]
+    needs: [guard, publish-release, channels]
     runs-on: windows-latest
     steps:
       - name: Check winget submission availability
@@ -943,7 +998,13 @@ jobs:
           WINGETCREATE_GITHUB_TOKEN: ${{ secrets.WINGETCREATE_GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.guard.outputs.version }}
+          CI_ENABLED: ${{ needs.channels.outputs.winget }}
         run: |
+          if [ "$CI_ENABLED" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::winget update.ci_enabled is '${CI_ENABLED:-<unresolved>}' in distribution/channels.yaml - skipping the winget submission. Flip it to true once the first listing merges."
+            exit 0
+          fi
           if [ -z "$WINGETCREATE_GITHUB_TOKEN" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "::notice::WINGETCREATE_GITHUB_TOKEN is not configured - skipping the winget submission"

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -11,6 +11,14 @@
 #   id/name/status/tier/kind  identity; status: live | pending | deprecated
 #   update.method             ci_publish | commit | upstream_pr | manual_ui
 #   update.sla                every_release | minor_plus | major_only | on_demand
+#   update.ci_enabled         REQUIRED on, and allowed ONLY on, the switchable
+#                             channels (docker-hub-mirror, homebrew, snap,
+#                             winget, chocolatey): may release CI publish this
+#                             channel? The release workflow reads it, so turning
+#                             a channel off here is the whole switch - no secret
+#                             to delete, no workflow edit. The core release path
+#                             (github-release, docker-ghcr, npm, helm) and the
+#                             required release assets have no flag on purpose.
 #   links                     tracking_issue / first_pr / last_bump_pr (nullable
 #                             until the first post-listing bump) / catalog /
 #                             upstream_repo / docs
@@ -61,6 +69,7 @@ channels:
     update:
       method: ci_publish
       sla: every_release
+      ci_enabled: true
     links:
       catalog: https://hub.docker.com/r/libredb/libredb-studio
     pin:
@@ -115,6 +124,7 @@ channels:
     update:
       method: ci_publish
       sla: every_release
+      ci_enabled: true
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/111
       first_pr: https://github.com/libredb/libredb-studio/pull/122
@@ -133,6 +143,7 @@ channels:
     update:
       method: ci_publish
       sla: every_release
+      ci_enabled: true
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/113
       first_pr: https://github.com/libredb/libredb-studio/pull/177
@@ -433,6 +444,9 @@ channels:
     update:
       method: ci_publish
       sla: every_release
+      # No listing to update yet: the first submission (winget-pkgs#402985) is
+      # still under review, and wingetcreate update cannot create one.
+      ci_enabled: false
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/114
       upstream_repo: https://github.com/microsoft/winget-pkgs
@@ -451,6 +465,10 @@ channels:
     update:
       method: ci_publish
       sla: every_release
+      # push.chocolatey.org answers 403 for EVERY version while an account's
+      # first submission is unapproved, which failed the 0.9.60 and 0.9.61
+      # release runs after the releases themselves had published fine.
+      ci_enabled: false
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/114
       catalog: https://community.chocolatey.org/packages/libredb-studio
@@ -458,8 +476,8 @@ channels:
     pin:
       strategy: none
       note: win32 zip ships in every release since 0.9.59. CI packs and pushes via the choco
-        container (CHOCO_API_KEY gate); the first push (0.9.59) is in human moderation. Flip to
-        live and add a community-API pin once approved.
+        container (CHOCO_API_KEY gate) once ci_enabled is flipped; the first push (0.9.59) is in
+        human moderation. When approved, set ci_enabled true, flip to live, add a community-API pin.
 
   - id: flathub
     name: Flathub community catalog (org.libredb.Studio)

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -546,11 +546,22 @@ Full variable reference: [`.env.example`](../.env.example). OIDC setup details:
 
 The win32-x64 standalone zip is built and attached to every
 [GitHub release](https://github.com/libredb/libredb-studio/releases) since 0.9.59. The
-winget/Chocolatey CI automation is in place and secret-gated; the first winget listing
+winget/Chocolatey CI automation is in place and gated; the first winget listing
 ([microsoft/winget-pkgs#402985](https://github.com/microsoft/winget-pkgs/pull/402985)) and the
 first Chocolatey push are in community review (see the
 [first-listing checklist](#windows-first-listing-checklist) — track
 [issue #114](https://github.com/libredb/libredb-studio/issues/114)).
+
+> **Both Windows package channels are switched off in the inventory until their reviews clear**
+> (`update.ci_enabled: false` in [`distribution/channels.yaml`](../distribution/channels.yaml) —
+> see [Turning a channel's automation off](#turning-a-channels-automation-off)). Chocolatey is the
+> reason the switch exists: `push.chocolatey.org` answers `403 Forbidden` for *every* version
+> while an account's first submission is unapproved, which failed the 0.9.60 and 0.9.61 release
+> runs even though both releases published correctly. **To re-enable:** set `ci_enabled: true` and
+> flip `status` to `live` in the same edit. The next release publishes the channel; do not
+> re-dispatch `release-artifacts` for an already-published version to backfill the feed, because
+> its asset steps would fight the immutable release — push a back version by hand with the same
+> choco container the job uses if the feed needs it.
 
 ```powershell
 # winget (after the first listing merges in microsoft/winget-pkgs)
@@ -775,11 +786,15 @@ setups still publish the rest:
 | `SNAPCRAFT_STORE_CREDENTIALS` | The entire snap build/publish job (exported via `snapcraft export-login`) | Snap job skipped |
 | `DOCKER_HUB_TOKEN` (+ `DOCKER_HUB_USERNAME` variable) | The Docker Hub mirror push | GHCR-only publish |
 | `CHOCO_API_KEY` | The chocolatey job: `choco pack` + `choco push` to `https://push.chocolatey.org/` (API key of the `libredb` community account) | Chocolatey publish skipped; the win32 zip still attaches to the release |
+| — | Every row above whose channel is switchable also needs `update.ci_enabled: true` in [`distribution/channels.yaml`](../distribution/channels.yaml): the secret says CI *can* publish, the flag says it *should*. See [Turning a channel's automation off](#turning-a-channels-automation-off) | Channel skipped with a notice; the release publishes normally |
 | `WINGETCREATE_GITHUB_TOKEN` | The winget job: `wingetcreate update --submit` PRs to `microsoft/winget-pkgs`. Classic PAT with `public_repo` scope — wingetcreate does not support fine-grained PATs | winget submission skipped |
 
 The chocolatey and winget jobs run strictly **after** `publish-release`: both channels download
-the zip from the release URL, which is public only once the release is published. A failure
-there never blocks the release itself (same trust model as the npm/Docker dispatch chain).
+the zip from the release URL, which is public only once the release is published. A failure there
+never *unpublishes* or blocks the release (same trust model as the npm/Docker dispatch chain) —
+but it does make the workflow run report `failure` overall, which reads as a failed release when
+it was not. That is why a channel known to be unable to publish is switched off in the inventory
+rather than left to fail: the run's colour has to mean something.
 
 By contrast, the `windows-package` job (which builds the win32 zip) **is a hard release gate**,
 exactly like the POSIX build matrix: the zip is on the publish-release required-assets list, so
@@ -861,6 +876,46 @@ channels with `sla: every_release` that are drifted or unmeasurable. Remote cata
 historical PaaS drift. For the Helm chart the enforcement remains the required `chart:check` CI
 gate (#138) — the matrix row is visibility, not a second gate. `--json` emits the rows for
 scripting.
+
+#### Turning a channel's automation off
+
+Some channels can be temporarily unable to publish for reasons outside this repository — a package
+waiting in community moderation, a listing still under review. Left to fail they make a *published*
+release report `failure`, which is worse than not publishing: the run's colour stops meaning
+anything. `update.ci_enabled` in `channels.yaml` is the switch:
+
+```yaml
+  - id: chocolatey
+    update:
+      method: ci_publish
+      sla: every_release
+      ci_enabled: false   # 403 for every version while the first push is in moderation
+```
+
+The release workflow reads it (`distribution-check.mjs --ci-outputs` in the `channels` job, whose
+outputs each channel's availability step consults), so **the edit is the whole switch** — no
+secret to delete, no workflow change, and the decision is reviewable in a diff next to the
+channel's `status` and note. A channel is published only when its flag says `true` *and* its
+secret is present.
+
+Three deliberate constraints:
+
+- **Only optional channels may carry the flag:** `docker-hub-mirror`, `homebrew`, `snap`,
+  `winget`, `chocolatey`. The core release path (`github-release`, `docker-ghcr`, `npm`, `helm`)
+  and the assets `publish-release` requires (`.deb`/`.rpm`, AppImage, the win32 zip) have no
+  switch, because one mistyped `false` there would silently ship a release with no npm package or
+  no image. `parseChannels` **rejects** the flag anywhere else, so this is enforced, not just
+  documented.
+- **It is required, never defaulted,** on those five: CI behaviour for a channel has to be a
+  stated decision in this file, not an omission.
+- **Failure leaves channels off, never the release blocked.** The `channels` job is
+  `continue-on-error`; if it cannot run, its outputs are empty, every gate reads "not true", and
+  the optional channels skip while the release publishes normally. A forgotten re-enable surfaces
+  in the weekly drift table rather than in a broken release.
+
+Do not confuse it with `status`: `status` describes the channel's listing (`appimage` is `pending`
+because its Flathub listing is, while its asset is built and required on every release), whereas
+`ci_enabled` describes only whether release CI may publish it.
 
 **Adding a channel** = one new entry in `channels.yaml` (copy a neighbour of the same tier; the
 schema is validated on every run). Set `links.first_pr` to the PR that landed the listing, and

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -26,6 +26,22 @@ const STRATEGIES = ["local_file", "remote_file", "none"];
 const METHODS = ["ci_publish", "commit", "upstream_pr", "manual_ui"];
 const SLAS = ["every_release", "minor_plus", "major_only", "on_demand"];
 
+/**
+ * Channels whose release-CI publish step may be switched off from this file via
+ * `update.ci_enabled`, because they can be unavailable for reasons outside this
+ * repository (a package awaiting community moderation, a listing still under
+ * review) and a channel that cannot publish must not paint a good release run
+ * red.
+ *
+ * The set is deliberately closed and deliberately small. The core release path
+ * - github-release, docker-ghcr, npm, helm - and the assets publish-release
+ * requires (deb/rpm, AppImage, the win32 zip) are absent on purpose: a switch
+ * there would be a way to ship a release with no npm package or no image, and
+ * one mistyped `false` would do it silently. parseChannels rejects the flag
+ * anywhere else, so that invariant is enforced, not merely documented.
+ */
+export const SWITCHABLE_CHANNEL_IDS = new Set(["docker-hub-mirror", "homebrew", "snap", "winget", "chocolatey"]);
+
 function countCaptureGroups(pattern) {
   // Appending an empty alternative makes the regex match the empty string, so
   // exec() always returns: array length - 1 == number of capture groups.
@@ -61,6 +77,18 @@ export function parseChannels(yamlText) {
     if (!SLAS.includes(channel.update.sla)) {
       throw new Error(`${CHANNELS_YAML}: ${id}: update.sla must be one of ${SLAS.join("|")}`);
     }
+    const ciEnabled = channel.update.ci_enabled;
+    if (SWITCHABLE_CHANNEL_IDS.has(id)) {
+      // Required, not defaulted: the release CI's behaviour for these channels
+      // has to be a stated decision in this file, never an omission.
+      if (typeof ciEnabled !== "boolean") {
+        throw new Error(`${CHANNELS_YAML}: ${id}: update.ci_enabled must be true or false`);
+      }
+    } else if (ciEnabled !== undefined) {
+      throw new Error(
+        `${CHANNELS_YAML}: ${id}: update.ci_enabled is only allowed on ${[...SWITCHABLE_CHANNEL_IDS].join(", ")}`,
+      );
+    }
     const pin = channel.pin;
     if (!pin || !STRATEGIES.includes(pin.strategy)) {
       throw new Error(`${CHANNELS_YAML}: ${id}: pin.strategy must be one of ${STRATEGIES.join("|")}`);
@@ -80,6 +108,17 @@ export function parseChannels(yamlText) {
     }
   }
   return doc.channels;
+}
+
+/**
+ * `<name>=<bool>` lines for $GITHUB_OUTPUT, one per switchable channel present.
+ * Dashes become underscores because a GitHub expression cannot dot-access an
+ * output name that contains one.
+ */
+export function ciEnabledOutputs(channels) {
+  return channels
+    .filter((channel) => SWITCHABLE_CHANNEL_IDS.has(channel.id))
+    .map((channel) => `${channel.id.replaceAll("-", "_")}=${channel.update.ci_enabled}`);
 }
 
 /**
@@ -227,6 +266,35 @@ async function main(argv) {
   }
   const root = rootIdx === -1 ? process.cwd() : path.resolve(rootArg);
   const timeoutMs = Number(process.env.DISTRIBUTION_CHECK_TIMEOUT_MS ?? 10_000);
+
+  // The release workflow's automation gates. They answer from the inventory
+  // alone - no package.json read, no network - so a gate check can never fail
+  // for an unrelated reason and take a working channel down with it.
+  const ciOutputs = argv.includes("--ci-outputs");
+  const ciIdx = argv.indexOf("--ci-enabled");
+  const ciId = ciIdx === -1 ? undefined : argv[ciIdx + 1];
+  if (ciIdx !== -1 && (ciId === undefined || ciId.startsWith("--"))) {
+    console.error("ERROR: --ci-enabled requires a channel id");
+    process.exit(2);
+  }
+  if (ciOutputs || ciIdx !== -1) {
+    const inventory = parseChannels(fs.readFileSync(path.join(root, CHANNELS_YAML), "utf8"));
+    if (ciOutputs) {
+      for (const line of ciEnabledOutputs(inventory)) console.log(line);
+      return;
+    }
+    if (!SWITCHABLE_CHANNEL_IDS.has(ciId)) {
+      console.error(`ERROR: '${ciId}' is not a switchable channel (${[...SWITCHABLE_CHANNEL_IDS].join(", ")})`);
+      process.exit(2);
+    }
+    const channel = inventory.find((entry) => entry.id === ciId);
+    if (!channel) {
+      console.error(`ERROR: channel '${ciId}' is not in ${CHANNELS_YAML}`);
+      process.exit(2);
+    }
+    console.log(String(channel.update.ci_enabled));
+    return;
+  }
 
   const pkgVersion = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
   const channels = parseChannels(fs.readFileSync(path.join(root, CHANNELS_YAML), "utf8"));

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -11,6 +11,8 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  SWITCHABLE_CHANNEL_IDS,
+  ciEnabledOutputs,
   evaluateChannel,
   extractPin,
   linkLabel,
@@ -272,6 +274,77 @@ describe("renderTable", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// update.ci_enabled - the release CI's per-channel automation switch
+// ---------------------------------------------------------------------------
+
+function switchableRow(id: string, enabled: boolean): string {
+  return `  - id: ${id}
+    name: ${id} channel
+    status: live
+    tier: 1
+    kind: package-manager
+    update:
+      method: ci_publish
+      sla: every_release
+      ci_enabled: ${enabled}
+    pin:
+      strategy: none
+      note: Publishing is gated on ci_enabled.
+`;
+}
+
+describe("update.ci_enabled", () => {
+  test("the switchable set is exactly the optional channels", () => {
+    // The core release path (github-release, docker-ghcr, npm, helm) and the
+    // required release assets are deliberately absent: a flag there would be a
+    // way to publish a release with no npm package or no image.
+    expect([...SWITCHABLE_CHANNEL_IDS].sort()).toEqual([
+      "chocolatey",
+      "docker-hub-mirror",
+      "homebrew",
+      "snap",
+      "winget",
+    ]);
+  });
+
+  test("accepts a boolean flag on a switchable channel", () => {
+    const channels = parseChannels(channelsYaml(switchableRow("snap", true) + switchableRow("chocolatey", false)));
+    expect(channels[0].update.ci_enabled).toBe(true);
+    expect(channels[1].update.ci_enabled).toBe(false);
+  });
+
+  test("throws when a switchable channel omits the flag", () => {
+    const row = switchableRow("snap", true).replace("      ci_enabled: true\n", "");
+    expect(() => parseChannels(channelsYaml(row))).toThrow(/snap.*ci_enabled/);
+  });
+
+  test("throws when the flag is not a boolean", () => {
+    const row = switchableRow("snap", true).replace("ci_enabled: true", 'ci_enabled: "on"');
+    expect(() => parseChannels(channelsYaml(row))).toThrow(/ci_enabled/);
+  });
+
+  test("throws when the flag appears on a channel that must not be switchable", () => {
+    const row = NONE_ROW.replace("      sla: every_release\n", "      sla: every_release\n      ci_enabled: false\n");
+    expect(() => parseChannels(channelsYaml(row))).toThrow(/npm.*ci_enabled/);
+  });
+
+  test("ciEnabledOutputs emits one GITHUB_OUTPUT line per switchable channel", () => {
+    const channels = parseChannels(
+      channelsYaml(switchableRow("snap", true) + switchableRow("docker-hub-mirror", false) + NONE_ROW),
+    );
+    // Dashes become underscores: a GitHub expression cannot dot-access an
+    // output name containing a dash.
+    expect(ciEnabledOutputs(channels)).toEqual(["snap=true", "docker_hub_mirror=false"]);
+  });
+
+  test("the real inventory declares the flag for every switchable channel", () => {
+    const channels = parseChannels(readFileSync(join(import.meta.dir, "../../distribution/channels.yaml"), "utf8"));
+    const declared = channels.filter((c: { update: { ci_enabled?: boolean } }) => c.update.ci_enabled !== undefined);
+    expect(declared.map((c: { id: string }) => c.id).sort()).toEqual([...SWITCHABLE_CHANNEL_IDS].sort());
+  });
+});
+
 const SCRIPT = join(import.meta.dir, "../../scripts/distribution-check.mjs");
 
 function writeFixture(root: string, pkgVersion: string, channels: string): void {
@@ -381,6 +454,42 @@ describe("CLI (subprocess against temp fixtures)", () => {
     const result = Bun.spawnSync(["node", SCRIPT, "--root"], { stdout: "pipe", stderr: "pipe" });
     expect(result.exitCode).toBe(2);
     expect(result.stderr.toString()).toContain("--root requires");
+  });
+
+  // The release workflow reads these modes; they must answer from the inventory
+  // alone - no package.json, no network - so a gate check cannot fail for an
+  // unrelated reason and take a channel down with it.
+  test("--ci-outputs prints the flag of every switchable channel", () => {
+    const root = mkdtempSync(join(tmpdir(), "dist-check-"));
+    fixtureRoots.push(root);
+    mkdirSync(join(root, "distribution"), { recursive: true });
+    writeFileSync(
+      join(root, "distribution/channels.yaml"),
+      channelsYaml(switchableRow("snap", true) + switchableRow("chocolatey", false)),
+    );
+    const result = runCheck(root, ["--ci-outputs"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString().trim().split("\n")).toEqual(["snap=true", "chocolatey=false"]);
+  });
+
+  test("--ci-enabled <id> prints the flag alone", () => {
+    const root = makeFixture("0.9.61", channelsYaml(switchableRow("chocolatey", false)));
+    const result = runCheck(root, ["--ci-enabled", "chocolatey"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString().trim()).toBe("false");
+  });
+
+  test("--ci-enabled rejects a channel that is not switchable", () => {
+    const root = makeFixture("0.9.61", channelsYaml(NONE_ROW));
+    const result = runCheck(root, ["--ci-enabled", "npm"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toContain("npm");
+  });
+
+  test("--ci-enabled with no value exits 2 with usage", () => {
+    const result = Bun.spawnSync(["node", SCRIPT, "--ci-enabled"], { stdout: "pipe", stderr: "pipe" });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toContain("--ci-enabled requires");
   });
 });
 


### PR DESCRIPTION
A release run reported `failure` for **0.9.60 and 0.9.61 although both releases published
correctly**. The failing job was `Push Chocolatey package`: `push.chocolatey.org` answers
`403 Forbidden` for *every* version while an account's first submission sits in human moderation.
A channel that is known to be unable to publish must not paint a good release red — the run's
colour has to mean something.

## The switch

`update.ci_enabled` in [`distribution/channels.yaml`](distribution/channels.yaml):

```yaml
  - id: chocolatey
    status: pending
    update:
      method: ci_publish
      sla: every_release
      ci_enabled: false   # 403 for every version while the first push is in moderation
```

`release-artifacts.yml` resolves the flags once in a new `channels` job
(`distribution-check.mjs --ci-outputs`) and each optional channel's existing availability step
consults the output next to its secret check. So a channel publishes only when the **secret says
CI *can*** and the **inventory says it *should***. `docker-build-push.yml` reads its own flag
inline (`--ci-enabled docker-hub-mirror`) because that job already has dependencies installed.

Turning a channel off is one reviewable edit next to its `status` and note — no secret to delete,
no workflow change, no release re-cut.

| Channel | `ci_enabled` | Why |
|---|---|---|
| `docker-hub-mirror` | `true` | publishing |
| `homebrew` | `true` | publishing |
| `snap` | `true` | publishing |
| `winget` | `false` | first listing still under review (winget-pkgs#402985); `wingetcreate update` cannot create one |
| `chocolatey` | `false` | 403 for every version while the first push is in moderation |

## Three deliberate constraints

**Only optional channels may carry the flag.** The core release path (`github-release`,
`docker-ghcr`, `npm`, `helm`) and the assets `publish-release` requires (`.deb`/`.rpm`, AppImage,
win32 zip) have no switch: one mistyped `false` there would silently ship a release with no npm
package or no image. `parseChannels` **rejects** the flag anywhere else, so the invariant is
enforced by a test, not by a convention.

**Required on those five, never defaulted.** CI behaviour for a channel has to be a stated
decision in the file, not an omission — the parser fails when one of them omits it.

**Failure leaves channels off, never the release blocked.** The `channels` job is
`continue-on-error`: if it cannot run (it installs dependencies, and `bun install` is exactly what
flaked during the 0.9.61 release), its outputs come out empty, every gate reads "not true", the
optional channels skip, and the release publishes normally. A forgotten re-enable surfaces in the
weekly `distribution:check` drift table rather than in a broken release.

## `ci_enabled` is not `status`

Worth stating because the obvious shortcut — "derive it from `status: pending`" — is wrong and
would have broken this release. `appimage` is `pending` because its *Flathub listing* is pending,
while its asset is built and **required** on every release (0.9.61 shipped both arches). `status`
describes the channel's listing; `ci_enabled` describes only whether release CI may publish it.

## Tests

`tests/unit/distribution-check.test.ts` (+109 lines, TDD — the failing tests came first):

- the switchable set is exactly the five optional channels
- a boolean flag is accepted on a switchable channel
- a switchable channel that **omits** the flag throws
- a non-boolean flag throws
- the flag on a channel that must not be switchable throws
- `ciEnabledOutputs` emits one `name=bool` line per switchable channel, dashes → underscores (a
  GitHub expression cannot dot-access an output name containing a dash)
- the **real** inventory declares the flag for exactly the switchable set
- CLI: `--ci-outputs`, `--ci-enabled <id>`, a non-switchable id (exit 2), a missing value (exit 2)

## Verification

Six local gates green (`format`, `lint`, `typecheck`, `knip`, `test`, `build`), both workflow
files parse, `bun run distribution:check` renders the table with the new schema, and the new CLI
modes answer correctly against the real inventory:

```
$ node scripts/distribution-check.mjs --ci-outputs
docker_hub_mirror=true
homebrew=true
snap=true
winget=false
chocolatey=false
```

`coverage:check` stays at `25912/25912 (100.00%)` — unchanged because the merged lcov covers
`src/` only; `scripts/` is not in that universe, so the new script lines are covered by the tests
above but not measured by the coverage gate.

**Half the switch is verified live by this PR's own Docker run.** `docker-build-push.yml` runs on a
`feat/**` push, so its new gate really executed: the flag resolved to `true`, no skip notice fired,
and the build targeted both registries —

```
Target images:
ghcr.io/libredb/libredb-studio
docker.io/libredb/libredb-studio
```

The `release-artifacts.yml` gates (homebrew, snap, winget, chocolatey) only run on a tag push and
so cannot be exercised before merge. Their two paths are covered by the unit tests plus the shape
of the gate itself: a `false` flag skips with a notice naming the channel and the file, and an
unresolvable flag degrades to that same skip.
