### PR TITLE
fix(ci): retry and cache bun install so a flaky download stops breaking releases

### DIFF
--- a/.github/actions/bun-install/action.yml
+++ b/.github/actions/bun-install/action.yml
@@ -1,0 +1,38 @@
+name: Install dependencies
+description: A warm Bun dependency cache plus a retrying bun install - the one place every workflow gets both.
+
+# Why a composite action: this repository installs dependencies in 17 places
+# across 7 workflows. `bun install` has no retry, and one failed package
+# download fails the step ("error: Fail extracting tarball for <package>") - on
+# 2026-07-29 that broke three runs in one day, one of them the npm publish of
+# release 0.9.61, which left the release published while npm sat on the previous
+# version. Retry and cache policy belongs in one reviewable place rather than
+# duplicated 17 times, where it would drift immediately.
+#
+# The cache is the other half of the fix: a warm ~/.bun/install/cache means the
+# packages are not fetched at all, removing the exposure instead of retrying
+# through it. A cache miss is not a failure - it just downloads.
+#
+# Deliberately does NOT set up Bun: the caller's existing `Setup Bun` step keeps
+# owning the pinned version, and this action makes no assumption about being
+# adjacent to it. Requires bun on PATH and the repository checked out.
+
+runs:
+  using: composite
+  steps:
+    - name: Restore the Bun dependency cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        # bun's global package cache - same path on Linux, macOS and Windows.
+        path: ~/.bun/install/cache
+        # Keyed on the lockfile so a dependency change starts a fresh entry;
+        # restore-keys still warms it from the previous lockfile, which is what
+        # keeps a lockfile bump cheap instead of a full cold download.
+        key: bun-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          bun-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Install dependencies (with retry)
+      shell: bash
+      # Absolute path: some jobs set a working-directory of their own.
+      run: bash "$GITHUB_WORKSPACE/scripts/ci-install.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Chart version sync guard (issue #138)
         # Runs inside the required "Lint, Typecheck and Build" check on
@@ -104,7 +104,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
@@ -155,7 +155,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
@@ -203,7 +203,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Build standalone payload
         run: bash scripts/build-standalone-payload.sh dist-payload
@@ -273,7 +273,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium

--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -37,7 +37,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Check distribution channels
         env:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -58,7 +58,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Run ESLint
         run: bun run lint
@@ -260,7 +260,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium

--- a/.github/workflows/flatpak-smoke.yml
+++ b/.github/workflows/flatpak-smoke.yml
@@ -73,7 +73,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Setup Rust toolchain
         run: |

--- a/.github/workflows/integration-check.yml
+++ b/.github/workflows/integration-check.yml
@@ -24,7 +24,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Build library dist
         run: bun run build:lib

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,7 +39,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
@@ -94,7 +94,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Build library (tsup)
         run: bun run build:lib

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -135,7 +135,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Read update.ci_enabled from distribution/channels.yaml
         id: flags
@@ -206,7 +206,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Build payload and run smoke test
         run: bash scripts/build-standalone-payload.sh dist --smoke
@@ -274,7 +274,7 @@ jobs:
           go test ./...
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Build the standalone payload zip
         run: bash scripts/build-standalone-payload.sh dist
@@ -576,7 +576,7 @@ jobs:
 
       - name: Install dependencies (channel E2E)
         if: matrix.arch == 'amd64'
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Install Playwright browsers (channel E2E)
         if: matrix.arch == 'amd64'
@@ -771,7 +771,7 @@ jobs:
 
       - name: Install dependencies (channel E2E)
         if: steps.snapstore.outputs.enabled == 'true' && matrix.arch == 'amd64'
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install
 
       - name: Install Playwright browsers (channel E2E)
         if: steps.snapstore.outputs.enabled == 'true' && matrix.arch == 'amd64'

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -202,6 +202,36 @@ check (`bun run format`), linters (`bun run lint`, i.e. oxlint then ESLint), typ
 hook (`.claude/settings.json`) runs `lint && typecheck && test && build` and now transitively enforces oxlint
 and the type-aware layer via `bun run lint`.
 
+### Dependency installation in CI
+
+Every workflow job installs dependencies through the local composite action
+[`.github/actions/bun-install`](../.github/actions/bun-install/action.yml), never with a bare
+`bun install`:
+
+```yaml
+      - name: Install dependencies
+        uses: ./.github/actions/bun-install
+```
+
+It restores bun's global package cache (`~/.bun/install/cache`, keyed on `bun.lock` with a
+`restore-keys` prefix so a lockfile bump warms from the previous entry) and then runs
+[`scripts/ci-install.sh`](../scripts/ci-install.sh), which retries `bun install --frozen-lockfile`
+with a linear backoff and logs a `::warning::` per failed attempt.
+
+**Why:** `bun install` has no retry of its own, so one failed package download fails the step with
+`error: Fail extracting tarball for <package>`. On 2026-07-29 that broke three runs in a single day
+— two CI runs and the **npm publish of release 0.9.61**, which left the release published on GitHub
+while npm still served the previous version. Nothing was reproducible or code-related; a re-run of
+the same commit passed. The cache is the other half of the fix: warm, the packages are not fetched
+at all, which removes the exposure rather than retrying through it.
+
+The action deliberately does **not** set up Bun — each job's existing `Setup Bun` step keeps owning
+the pinned version, so the action makes no assumption about being adjacent to it. It requires bun on
+`PATH` and the repository checked out. The retry policy lives in one place because there are 17
+install sites across 7 workflows; duplicated, it would drift immediately.
+`tests/unit/ci-install.test.ts` covers the policy against a stub `bun` (first-try success, retry then
+success, exhaustion, custom attempt count, no dead sleep after the final attempt).
+
 ## Rollout order and per-phase gate
 
 1. Biome formatter + `.editorconfig` (one-shot reformat PR).

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# `bun install --frozen-lockfile` with a retry, for every CI job.
+#
+# bun has no retry of its own, so a single failed package download fails the
+# whole step: "error: Fail extracting tarball for <package>". On 2026-07-29 that
+# took out three runs in one day - two CI runs and, worse, the npm publish of
+# release 0.9.61, which left the release published while npm sat on the previous
+# version. Nothing about it was reproducible or code-related; the same commit
+# passed on a re-run.
+#
+# Every attempt is logged, so a registry that is degrading rather than broken
+# shows up as warnings instead of hiding behind a green step. Tuning knobs exist
+# for the unit tests (tests/unit/ci-install.test.ts), not for callers.
+set -uo pipefail
+
+attempts=${CI_INSTALL_ATTEMPTS:-3}
+backoff=${CI_INSTALL_BACKOFF_SECONDS:-10}
+
+attempt=1
+while [ "$attempt" -le "$attempts" ]; do
+  if bun install --frozen-lockfile; then
+    exit 0
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    delay=$((backoff * attempt))
+    echo "::warning::bun install failed (attempt ${attempt}/${attempts}); retrying in ${delay}s"
+    sleep "$delay"
+  fi
+  attempt=$((attempt + 1))
+done
+
+echo "::error::bun install failed after ${attempts} attempts - see the attempt logs above"
+exit 1

--- a/tests/unit/ci-install.test.ts
+++ b/tests/unit/ci-install.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for scripts/ci-install.sh - the retrying `bun install` every CI
+ * job goes through.
+ *
+ * `bun install` has no retry of its own, and "error: Fail extracting tarball
+ * for <package>" killed three runs on 2026-07-29, one of them the 0.9.61 npm
+ * publish. The script is exercised against a stub `bun` on PATH that fails a
+ * chosen number of times, so the retry policy is verified without a network.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(import.meta.dir, "../../scripts/ci-install.sh");
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+/**
+ * A fake `bun` that records every invocation and fails the first
+ * `failuresBeforeSuccess` of them. `never` makes it fail every time.
+ */
+function stubBun(failuresBeforeSuccess: number | "never") {
+  const root = mkdtempSync(join(tmpdir(), "ci-install-"));
+  roots.push(root);
+  const bin = join(root, "bin");
+  mkdirSync(bin, { recursive: true });
+  const log = join(root, "calls.log");
+  const fail = failuresBeforeSuccess === "never" ? "always" : String(failuresBeforeSuccess);
+  writeFileSync(
+    join(bin, "bun"),
+    `#!/usr/bin/env bash
+echo "$@" >> ${JSON.stringify(log)}
+calls=$(wc -l < ${JSON.stringify(log)})
+if [ "${fail}" = "always" ]; then exit 1; fi
+if [ "$calls" -le "${fail}" ]; then echo "error: Fail extracting tarball for next" >&2; exit 1; fi
+exit 0
+`,
+  );
+  chmodSync(join(bin, "bun"), 0o755);
+  return { bin, log };
+}
+
+function run(bin: string, env: Record<string, string> = {}) {
+  return Bun.spawnSync(["bash", SCRIPT], {
+    // PATH is replaced, not prepended: the stub must be the only bun in reach.
+    env: { PATH: `${bin}:/usr/bin:/bin`, CI_INSTALL_BACKOFF_SECONDS: "0", ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function callCount(log: string): number {
+  try {
+    return readFileSync(log, "utf8").trimEnd().split("\n").filter(Boolean).length;
+  } catch {
+    return 0;
+  }
+}
+
+describe("scripts/ci-install.sh", () => {
+  test("installs once when the first attempt succeeds", () => {
+    const { bin, log } = stubBun(0);
+    const result = run(bin);
+    expect(result.exitCode).toBe(0);
+    expect(callCount(log)).toBe(1);
+    expect(readFileSync(log, "utf8")).toContain("install --frozen-lockfile");
+  });
+
+  test("retries and succeeds after a transient failure", () => {
+    const { bin, log } = stubBun(1);
+    const result = run(bin);
+    expect(result.exitCode).toBe(0);
+    expect(callCount(log)).toBe(2);
+    // The retry is visible in the job log; a silent retry would hide a
+    // registry that is degrading rather than broken.
+    expect(result.stdout.toString()).toContain("::warning::");
+  });
+
+  test("gives up after the configured attempts and fails the step", () => {
+    const { bin, log } = stubBun("never");
+    const result = run(bin, { CI_INSTALL_ATTEMPTS: "3" });
+    expect(result.exitCode).toBe(1);
+    expect(callCount(log)).toBe(3);
+    expect(result.stdout.toString()).toContain("::error::");
+  });
+
+  test("honours a custom attempt count", () => {
+    const { bin, log } = stubBun("never");
+    expect(run(bin, { CI_INSTALL_ATTEMPTS: "5" }).exitCode).toBe(1);
+    expect(callCount(log)).toBe(5);
+  });
+
+  test("does not sleep after the final attempt", () => {
+    // A backoff after the last failure is pure dead time in a red job.
+    const { bin } = stubBun("never");
+    const started = Bun.nanoseconds();
+    run(bin, { CI_INSTALL_ATTEMPTS: "2", CI_INSTALL_BACKOFF_SECONDS: "1" });
+    const elapsedMs = (Bun.nanoseconds() - started) / 1_000_000;
+    // One backoff of 1s between the two attempts, none after the second.
+    expect(elapsedMs).toBeLessThan(1900);
+  });
+});


### PR DESCRIPTION
`bun install` has no retry of its own, so a single failed package download fails the whole step:

```
error: Fail extracting tarball for "next"
error: Fail extracting tarball from next
##[error]Process completed with exit code 1
```

On **2026-07-29 that broke three runs in one day**:

| Run | Where | Consequence |
|---|---|---|
| `30412412050` attempt 1 | `Lint, Typecheck and Build` on a branch whose only change was a Rust test | required check red for an unrelated reason |
| `30412412050` attempt 2 | same job, re-run | red again — two consecutive attempts |
| `30415638577` | **`NPM Publish` for release 0.9.61** | the release published on GitHub with 20 assets while npm still served **0.9.60** |

The npm one is what makes this worth fixing rather than re-running: the release was already out and
immutable, so recovery meant diagnosing which side of `publish-release` had failed and
re-dispatching a single workflow on the tag ref. Nothing about any of the three was reproducible or
code-related — re-running the same commit passed.

## What changes

All **17 install sites across 7 workflows** become the same one-line step:

```yaml
      - name: Install dependencies
        uses: ./.github/actions/bun-install
```

[`.github/actions/bun-install`](.github/actions/bun-install/action.yml) does two things:

1. **Restores bun's package cache** (`~/.bun/install/cache`, same path on Linux/macOS/Windows),
   keyed on `hashFiles('bun.lock')` with a `restore-keys` prefix so a lockfile bump warms from the
   previous entry instead of downloading cold. A miss is not a failure — it just downloads.
2. **Runs [`scripts/ci-install.sh`](scripts/ci-install.sh)**, which retries
   `bun install --frozen-lockfile` with a linear backoff (10s, 20s) and logs a `::warning::` per
   failed attempt.

The cache is the other half of the fix, not a speed tweak: warm, the packages are not fetched at
all, so the exposure is removed rather than retried through.

## Two deliberate choices

**The action does not set up Bun.** Each job's existing `Setup Bun` step keeps owning the pinned
version, so the action makes no assumption about being adjacent to it. That is what let every call
site become the same one-line change regardless of what sits between the two steps — two of them
have an `if:` in between, and some jobs run other steps there. It requires bun on `PATH` and the
repo checked out, both already true everywhere.

**A composite action rather than an inline loop.** 17 sites × a retry loop would drift the moment
anyone tuned one of them. One place also means the policy is unit-testable.

**Retries are logged, not silent.** A registry that is degrading rather than broken shows up as
warnings in the job log instead of hiding behind a green step.

## Tests

`tests/unit/ci-install.test.ts` runs the script against a stub `bun` on `PATH` (`PATH` is replaced,
not prepended, so the stub is the only `bun` in reach) that fails a chosen number of times:

- succeeds on the first attempt → exit 0, `bun` invoked once
- retries and succeeds after a transient failure → exit 0, invoked twice, `::warning::` emitted
- exhausts the attempts → exit 1, invoked exactly `CI_INSTALL_ATTEMPTS` times, `::error::` emitted
- honours a custom attempt count
- does not sleep after the final attempt (a backoff there is pure dead time in a red job)

## Verification

Six local gates green (`format`, `lint`, `typecheck`, `knip`, `test`, `build`); all 8 workflow files
and the action YAML parse. Coverage stays at `25912/25912 (100.00%)` — the merged lcov went from 162
to 163 files (the new test group) with no phantom records, and bash is outside that universe, so the
policy is covered by the tests above rather than by the coverage gate.

**This PR's own CI is the live proof:** every check on it installs dependencies through the new
action, on Linux, macOS and Windows runners — including the `fix/**` Docker build and the channel
E2E jobs. The cache works end to end within a single run: the first job missed (nothing was cached
yet) and populated it, and a later job in the same run restored it —

```
Lint, Typecheck and Build:  Cache not found for input keys: bun-Linux-X64-1aa611b5…, bun-Linux-X64-
E2E Tests:                  Received 33843768 of 33843768 (100.0%), 26.2 MBs/sec
                            Cache hit for: bun-Linux-X64-1aa611b5…
```

One honest note on a cold run: `ci.yml` has five jobs installing concurrently, so only the first to
finish can reserve the key and the others log `Failed to save: Unable to reserve cache with key …,
another job may be creating this cache`. That is documented `actions/cache` behaviour, it is a plain
log line rather than an annotation (it does not surface in the PR checks or the job summary), and
every job stays green — one job populates the entry and the rest restore from it, as the hit above
shows. Not worth splitting restore/save across a designated saver job for.
