### PR TITLE
feat(release): publish the npm tarball with Sigstore provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,6 +78,13 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     needs: validate
+    permissions:
+      contents: read
+      # npm --provenance mints a Sigstore attestation from this job's GitHub
+      # OIDC identity (repo + workflow + commit), so the tarball's trust root
+      # sits outside the release it ships with. Job-level permissions replace
+      # the workflow-level block entirely — contents: read must be repeated.
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -110,15 +117,21 @@ jobs:
           echo "Package name: $(node -p "require('./package.json').name")"
           echo "Package version: $(node -p "require('./package.json').version")"
 
+      # --provenance is deliberately absent here: a dry run publishes nothing,
+      # so there is nothing to attest, and npm still tries to contact Sigstore
+      # for it (a failure mode that would break the manual dry-run fallback).
       - name: Publish (dry run)
         if: inputs.dry_run == true
         run: npm publish --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 
+      # --provenance requires id-token: write (above), a public package, and a
+      # resolvable package.json repository field. npm generates and uploads the
+      # Sigstore bundle itself; no extra secret and no cosign install needed.
       - name: Publish
         if: inputs.dry_run != true
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -352,6 +352,18 @@ rebuilt archive never invalidates a previously printed admin password.
   ([issue #114](https://github.com/libredb/libredb-studio/issues/114)).
 - Versions released before the standalone tarballs existed have no artifacts; the launcher
   detects this (HTTP 404) and suggests `npx @libredb/studio@latest`.
+- The npm package is published with **npm provenance** (`npm publish --provenance` in
+  `npm-publish.yml`, from 0.9.63). npmjs stores a Sigstore attestation naming the repo, workflow
+  and commit that built the tarball, so `npm audit signatures` verifies the package against a
+  trust root outside the release:
+
+  ```bash
+  npm i @libredb/studio && npm audit signatures   # "verified registry signatures / attestations"
+  ```
+
+  This covers the package you install from npm. The standalone archive the launcher then
+  downloads from the GitHub release is still checksum-only - see
+  [Artifact provenance roadmap](#artifact-provenance-roadmap).
 
 ## Homebrew
 
@@ -865,11 +877,26 @@ All channels have now had their first live run (the Snap publish completed its f
 
 Standalone tarballs and `.deb`/`.rpm` packages are checksum-verified against `SHA256SUMS` /
 per-package `.sha256` sidecars (see [Release artifact naming](#release-artifact-naming)) — both
-from the same GitHub release. The `.snap` release asset ships no sidecar (`--dangerous` installs
-skip the Snap Store's own verification), and the npm package tarball is verified separately
-through npm's own registry integrity metadata — a different trust domain than the GitHub release.
-Signed provenance (Sigstore/cosign signatures or SLSA attestations) across every channel is
-tracked as a follow-up issue.
+from the same GitHub release. That pairing detects corruption, not substitution: whoever can
+replace an asset can replace its checksum line too. The `.snap` release asset ships no sidecar
+(`--dangerous` installs skip the Snap Store's own verification).
+
+Signed provenance moves the trust root out of the release — the signer is the workflow's GitHub
+OIDC identity (repo + workflow + commit), recorded in a public transparency log. Rollout is
+incremental, tracked in [issue #123](https://github.com/libredb/libredb-studio/issues/123):
+
+| Step | Scope | State |
+|---|---|---|
+| npm provenance | npm tarball (`npm publish --provenance`, Sigstore bundle held by npmjs) | **done** (0.9.63) — verify with `npm audit signatures` |
+| SLSA build provenance | standalone tarballs, win32 zip, `.deb`/`.rpm`/`.AppImage`, GHCR image (`actions/attest-build-provenance`) | planned — will verify with `gh attestation verify` |
+| Launcher-side verification | `bin/studio.js` checks the downloaded archive's attestation when `gh` is present | planned |
+
+Until step 2 lands, the GitHub release assets carry checksums only. Steps 2 and 3 need no new
+secret: GitHub's attestation store, not the release, holds the bundles.
+
+**Failure mode to expect on release day:** `npm publish --provenance` hard-fails if the job lacks
+`id-token: write` or if Sigstore is unreachable. A failed publish cannot be retried on the same
+tag — follow the usual rule and cut the next patch version.
 
 ### CI secrets that gate publishing
 

--- a/tests/unit/release-provenance.test.ts
+++ b/tests/unit/release-provenance.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the signed-provenance invariants of the publish workflows
+ * (issue #123, step 1: npm provenance).
+ *
+ * Why a test for YAML: dropping `--provenance` does NOT break a release. The
+ * publish still succeeds, the tarball just ships unsigned - the guarantee
+ * disappears silently and nobody notices until someone tries to verify a
+ * months-old version. Dropping `id-token: write` fails the other way, loudly,
+ * but only on the release commit, where the retry costs a whole patch version
+ * (a published tag can never be re-published). Both directions are cheap to
+ * pin here and expensive to discover in a live release.
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { parse as parseYaml } from "yaml";
+
+interface Step {
+  name?: string;
+  run?: string;
+  if?: string;
+  uses?: string;
+}
+interface Job {
+  permissions?: Record<string, string>;
+  steps?: Step[];
+}
+
+const workflow = (name: string): { jobs: Record<string, Job> } =>
+  parseYaml(fs.readFileSync(path.join(__dirname, "../../.github/workflows", name), "utf8")) as {
+    jobs: Record<string, Job>;
+  };
+
+const npmPublish = workflow("npm-publish.yml");
+const publishJob = npmPublish.jobs.publish;
+const publishSteps = publishJob.steps ?? [];
+const realPublish = publishSteps.find((s) => s.run?.includes("npm publish") && !s.run.includes("--dry-run"));
+const dryRunPublish = publishSteps.find((s) => s.run?.includes("--dry-run"));
+
+describe("npm-publish.yml provenance", () => {
+  test("the publish job requests the OIDC token npm needs to sign", () => {
+    // libnpmpublish throws EUSAGE without ACTIONS_ID_TOKEN_REQUEST_URL, which
+    // GitHub only injects when the job asks for id-token: write.
+    expect(publishJob.permissions?.["id-token"]).toBe("write");
+  });
+
+  test("the publish job keeps contents: read (job permissions replace the workflow block)", () => {
+    expect(publishJob.permissions?.contents).toBe("read");
+  });
+
+  test("the real publish signs the tarball", () => {
+    expect(realPublish).toBeDefined();
+    expect(realPublish?.run).toContain("--provenance");
+  });
+
+  test("the real publish stays public (npm refuses provenance for private packages)", () => {
+    expect(realPublish?.run).toContain("--access public");
+  });
+
+  test("the dry run does not ask for provenance - there is no tarball to attest", () => {
+    expect(dryRunPublish).toBeDefined();
+    expect(dryRunPublish?.run).not.toContain("--provenance");
+  });
+});


### PR DESCRIPTION
Step 1 of #123 (signed release provenance). One PR per checkbox; this one is the npm slice.

## Why

Release assets and their checksums share a trust domain: `release-artifacts.yml` uploads both the
tarballs and `SHA256SUMS` to the same GitHub release. That detects corruption, not substitution -
whoever can replace an asset can replace its checksum line.

npm provenance is the cheapest fix with the widest audience: npmjs mints a Sigstore attestation
from the publish job's GitHub OIDC identity (repo + workflow + commit) and records it in a public
transparency log. No new secret, no `cosign` install, no change to the release chain.

## What changed

- `.github/workflows/npm-publish.yml` - `publish` job requests `id-token: write` (repeating
  `contents: read`, since job-level permissions replace the workflow-level block) and the real
  publish step passes `--provenance`.
- The dry-run step stays unsigned on purpose: it publishes nothing, so there is nothing to attest,
  and contacting Sigstore would only add a failure mode to the manual fallback path.
- `tests/unit/release-provenance.test.ts` - guard test over the workflow YAML.
- `docs/DISTRIBUTION.md` - the "Artifact provenance roadmap" section is now a three-step table
  (npm done; SLSA attestations for the release assets / GHCR image and launcher-side verification
  still open), plus a verification snippet in the npx section and the release-day failure mode.

## Why a test for a YAML file

The two ways this regresses fail in opposite directions, and both are expensive to discover live:

- Dropping `--provenance` **does not break anything**. The publish succeeds, the tarball just
  ships unsigned - invisible until someone tries to verify a months-old version.
- Dropping `id-token: write` fails loudly (`libnpmpublish` throws `EUSAGE` when
  `ACTIONS_ID_TOKEN_REQUEST_URL` is absent), but only on a release commit, where a failed publish
  cannot be retried on the same tag - the retry costs a whole patch version.

Red/green verified: with the workflow change stashed, 3 of the 5 tests fail.

## Verification

- Six local gates pass: `format`, `lint`, `typecheck`, `knip`, `test` (20 groups), `build`.
- No `src/` lines touched, so the 100% coverage gate is unaffected.
- Preconditions checked against the npm 11 client that CI will use
  (`libnpmpublish/lib/publish.js#ensureProvenanceGeneration`): GitHub Actions + `id-token: write`
  and `--access public` are the only client-side requirements, and `--access public` short-circuits
  the package-visibility probe. The attestation's source repo is built as
  `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY`, which matches this package's `repository.url`
  (`https://github.com/libredb/libredb-studio`) exactly, so the registry-side repository check
  cannot mismatch.

First signed publish will be the next release (0.9.63); verify with
`npm i @libredb/studio && npm audit signatures` and the "Built and signed on GitHub Actions" badge
on the package page.
