### PR TITLE
fix(connections): offer SQLite in the connection form type picker

### DIFF
--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -214,9 +214,17 @@ users:
 
 Exposing the type in the picker grants no new server-side reach: the connection travels in the
 request body and `resolveConnection()` accepts `type: "sqlite"` regardless of what the form offers,
-so the picker was never a security control. Restricting *which* paths are resolvable is tracked
-separately as [issue #125](https://github.com/libredb/libredb-studio/issues/125) — see
-[Known limitations](#13-known-limitations--future-work).
+so the picker was never a security control. What it does change is **discoverability**. On a shared
+self-hosted instance, every authenticated user now sees a field for typing an arbitrary server-side
+path, where reaching the same capability previously took a hand-crafted API call. The reachable set
+of files is identical either way — see
+[No path sandboxing](#13-known-limitations--future-work) — but operators of multi-user deployments
+should treat "any logged-in user can open any SQLite file the Studio process can read" as an
+explicit assumption to check against their threat model, not a corner case. Where that assumption
+does not hold, the mitigations available today are OS-level: run Studio as a user with a narrow
+read scope, or isolate it in a container whose mounts contain only the databases it should serve.
+An optional in-app base-dir allowlist is tracked in
+[issue #125](https://github.com/libredb/libredb-studio/issues/125).
 
 ### 4.1 Embedded sample database (standalone mode)
 
@@ -435,9 +443,15 @@ not apply to SQLite ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
 - **Single schema (`main`)** — `ATTACH`ed databases are not surfaced.
 - **No path sandboxing (by design).** `getDatabasePath()` validates only that the path contains
   no NUL byte; the resolved absolute path — `..` segments included — is used as-is. This grants an
-  untrusted client no access: the path comes from an authenticated user's connection config, and
-  reading arbitrary server-side files by path is the feature. *Future:* an optional base-dir
-  allowlist restricting resolvable paths (proposed in
+  *unauthenticated* client no access: the path comes from an authenticated user's connection config,
+  and reading arbitrary server-side files by path is the feature. The distinction that matters for
+  multi-user installs is the next one down: **authenticated does not imply trusted with the host
+  filesystem.** Since the type became selectable in the connection modal (#127), that path field is
+  directly discoverable by every logged-in user — the reachable set of files did not grow, but the
+  effort needed to reach it dropped from an API call to typing in a form. On a single-operator
+  install this is the intended feature; on a shared instance it is a deployment decision, and until
+  #125 lands the controls are OS-level (process user, container mounts). *Future:* an optional
+  base-dir allowlist restricting resolvable paths (proposed in
   [issue #125](https://github.com/libredb/libredb-studio/issues/125)) was deliberately left out of
   this honesty fix — new security-configuration surface needs its own issue.
 

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -198,6 +198,26 @@ or `connectionString` (else "Database file path is required … or `:memory:`").
 path by `getDatabasePath()` — the flag reflects that there is no network DSN, not that the field is
 ignored.
 
+**From the UI.** SQLite is offered in the connection modal's type picker
+([`src/hooks/use-connection-form.ts`](../../src/hooks/use-connection-form.ts)). Because its
+`connectionFields` entry is just `["database"]`, `isFileBased()`
+([`src/lib/db-ui-config.ts`](../../src/lib/db-ui-config.ts)) collapses the form to a single
+**"Database File Path"** input — no host, port, user, or password. Two things to be clear about with
+users:
+
+- **The path is resolved on the server, not in the browser.** It is passed through to
+  `getDatabasePath()` in the Studio process, so `/data/app.db` means that path on the machine
+  running Studio. A remote user of a hosted deployment cannot reach a file on their own laptop —
+  see [Deployment constraint](#deployment-constraint-the-strategic-bit).
+- **`:memory:` is accepted here too**, which makes the modal a zero-setup way to get a scratch
+  database for trying out the editor.
+
+Exposing the type in the picker grants no new server-side reach: the connection travels in the
+request body and `resolveConnection()` accepts `type: "sqlite"` regardless of what the form offers,
+so the picker was never a security control. Restricting *which* paths are resolvable is tracked
+separately as [issue #125](https://github.com/libredb/libredb-studio/issues/125) — see
+[Known limitations](#13-known-limitations--future-work).
+
 ### 4.1 Embedded sample database (standalone mode)
 
 On standalone startup (never when embedded in libredb-platform),

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -331,7 +331,19 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     setTestResult({ success: true, message: "Connection string parsed successfully. Review the fields and connect." });
   }, [pasteInput, name]);
 
-  const selectableTypes: DatabaseType[] = ["postgres", "mysql", "oracle", "mssql", "mongodb", "redis", "libredb"];
+  // Ordered for display (the modal renders these as a 2-column grid), and covering the whole
+  // DatabaseType union — the same form edits existing connections, so an omitted type leaves the
+  // picker with nothing selected. tests/hooks/use-connection-form.test.ts enforces the coverage.
+  const selectableTypes: DatabaseType[] = [
+    "postgres",
+    "mysql",
+    "sqlite",
+    "oracle",
+    "mssql",
+    "mongodb",
+    "redis",
+    "libredb",
+  ];
   const dbTypes = selectableTypes.map((t) => {
     const cfg = getDBConfig(t);
     return { value: t, label: cfg.label, icon: cfg.icon, color: cfg.color };

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -21,7 +21,7 @@ mock.module("@/lib/db-ui-config", () => ({
 }));
 
 import { useConnectionForm } from "@/hooks/use-connection-form";
-import type { DatabaseConnection } from "@/lib/types";
+import type { DatabaseConnection, DatabaseType } from "@/lib/types";
 
 // =============================================================================
 // useConnectionForm Tests
@@ -320,6 +320,51 @@ describe("useConnectionForm", () => {
     expect(first).toHaveProperty("label");
     expect(first).toHaveProperty("icon");
     expect(first).toHaveProperty("color");
+  });
+
+  // ── Every connectable type is offered by the picker (#127) ─────────────────
+
+  // The picker must cover the whole DatabaseType union, because this form is also the EDIT
+  // form: a type missing here renders the edit dialog with no tile selected. Keyed by
+  // DatabaseType, so adding a provider to the union fails `typecheck` on the missing key
+  // instead of silently dropping it from the UI. Set an entry to false only to hide a type
+  // on purpose — and say why.
+  const PICKER_COVERAGE: Record<DatabaseType, boolean> = {
+    postgres: true,
+    mysql: true,
+    sqlite: true,
+    oracle: true,
+    mssql: true,
+    mongodb: true,
+    redis: true,
+    libredb: true,
+  };
+
+  test("dbTypes offers every database type a connection can carry", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    const offered = result.current.dbTypes.map((t: { value: string }) => t.value).sort();
+    const expected = Object.entries(PICKER_COVERAGE)
+      .filter(([, selectable]) => selectable)
+      .map(([type]) => type)
+      .sort();
+
+    expect(offered).toEqual(expected);
+  });
+
+  test("dbTypes includes sqlite so the seeded sample connection can be edited", () => {
+    const sampleConn: DatabaseConnection = {
+      id: "seed:sqlite-embedded-sample",
+      name: "Sample (Employees)",
+      type: "sqlite",
+      database: "/var/lib/libredb/sample-employees.db",
+      createdAt: new Date(),
+    };
+
+    const { result } = renderHook(() => useConnectionForm({ ...defaultProps, editConnection: sampleConn }));
+
+    expect(result.current.type).toBe("sqlite");
+    expect(result.current.dbTypes.some((t: { value: string }) => t.value === "sqlite")).toBe(true);
   });
 
   // ── handleTestConnection handles network error ─────────────────────────────


### PR DESCRIPTION
Closes #127.

## The problem

`selectableTypes` in [`src/hooks/use-connection-form.ts`](https://github.com/libredb/libredb-studio/blob/main/src/hooks/use-connection-form.ts#L334) listed seven of the eight `DatabaseType` members — sqlite was missing — so users could not create a SQLite connection from the modal even though the provider has been complete for a long time (factory case, provider class, `db-ui-config` entry, reference doc, integration tests).

Since 0.9.56 this stopped being merely a missing feature. The embedded employees sample (#191) seeds a `type: "sqlite"` connection and advertises it as editable, and `Studio.tsx` opens this same form in edit mode for any sidebar connection. The picker is a button grid fed by `selectableTypes`, so editing the sample rendered a dialog with **no tile selected and every tile dimmed to `opacity-30`** — the form reported no database type at all for a connection that ships by default.

## The fix

Add `"sqlite"` to the list, positioned with the other SQL engines. No new form code was required:

- `db-ui-config.ts` already carries the sqlite entry with `connectionFields: ["database"]`
- `isFileBased()` derives from that entry rather than hard-coding type ids
- `ConnectionModal.tsx` already renders the "Database File Path" input for file-based types — the exact path the selectable `libredb` type exercises today

The multi-line reformat of the array is Biome's doing: with the eighth element the single-line form is 124 characters, past the configured `lineWidth` of 120.

## Closing the class of bug, not just the instance

The interesting part of #127 is that a hand-maintained allowlist diverged silently from `DB_UI_CONFIG` for weeks. The regression test is therefore keyed on the `DatabaseType` union rather than on sqlite alone:

```ts
const PICKER_COVERAGE: Record<DatabaseType, boolean> = { postgres: true, /* ... */ libredb: true };
```

Adding a provider to the union now fails `bun run typecheck` on the missing key, forcing an explicit decision, and the test asserts every type marked `true` is actually offered. Hiding a type in future means writing `false` in one place with a reason next to it.

Display order stays explicit in the hook rather than being derived from `DB_UI_CONFIG` keys, so the picker grid users already know does not get reshuffled — and eight entries now fill the two-column grid evenly instead of leaving an orphan row.

## Security note

Exposing the type grants no new server-side reach. Connections travel in the request body and `resolveConnection()` accepts `type: "sqlite"` regardless of what the form offers, so the picker was never a security control — omitting it only blocked legitimate users.

What *does* change is **discoverability**, and the second commit documents that rather than stopping at the reassurance. On a shared self-hosted instance every authenticated user now sees a field for typing an arbitrary server-side path, where the same capability previously took a hand-crafted API call. The reachable set of files is identical, but the effort to reach it drops to typing in a form — so `docs/providers/sqlite.md` now states the assumption operators need to check ("any logged-in user can open any SQLite file the Studio process can read"), names the controls available today (process user, container mounts), and sharpens the "No path sandboxing" limitation to separate *unauthenticated gets nothing* from *authenticated does not imply trusted with the host filesystem*. Single-operator install: intended feature. Shared instance: a deployment decision until #125 lands.

The doc also leads with the point users most need: the path resolves on the **server**, not in the browser.

The rationale in the original report is also stronger now that every native channel (npx, deb/rpm, Homebrew, snap, AppImage, Flatpak, Windows) ships and runs on the user's own machine — exactly the deployment shape the doc positions SQLite-as-target for.

## Testing

TDD: both tests were watched failing first — the union-coverage test reported `sqlite` as the single missing element, and the edit-mode test showed the form correctly holding `type: "sqlite"` while the picker lacked it, which is the reported bug verbatim.

All local gates pass on this branch:

| Gate | Result |
|------|--------|
| `bun run format` | 564 files, no fixes |
| `bun run lint` | 0 errors (73 pre-existing warnings, none in the diff) |
| `bun run typecheck` | clean |
| `bun run knip` | clean |
| `bun run test` | all 20 groups passed |
| `bun run build` | clean |
| `bun run build:lib` | clean |
| `bun run coverage:check` | 25920/25920 lines (100.00%) |

That table was produced by the first commit. The follow-up commit touches only `docs/providers/sqlite.md` — no source, test, or config file — so `format` was re-run (clean) and the inputs to every other gate are byte-identical to the run above.
