### PR TITLE
feat(release): attest every release asset and the GHCR image with SLSA provenance

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -44,6 +44,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # SLSA build provenance for the image (issue #123). Separate from the
+      # inline provenance buildx attaches to the manifest: that one is
+      # unsigned, this one is signed with the job's GitHub OIDC identity and
+      # verifiable with `gh attestation verify oci://...`.
+      id-token: write
+      attestations: write
     outputs:
       version: ${{ steps.extract-version.outputs.version }}
       image: ${{ steps.meta.outputs.tags }}
@@ -209,6 +215,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
@@ -222,6 +229,25 @@ jobs:
             JWT_SECRET_BUILD=build-time-placeholder-secret-32ch
             ADMIN_PASSWORD_BUILD=build
             USER_PASSWORD_BUILD=build
+
+      # Release-context builds only, matching the version-tag condition above:
+      # branch pushes move the mutable main/dev tags, and signing an image no
+      # user installs only adds noise to the transparency log.
+      #
+      # Subject is the digest, never a tag - latest/main move, and the manifest
+      # list digest is the image's only stable identity. The Docker Hub mirror
+      # publishes the same digest, so `gh attestation verify` resolves it there
+      # too; GHCR is the name recorded because it is the canonical registry.
+      #
+      # push-to-registry stays off on purpose: writing an OCI referrer back to
+      # GHCR is a second failure mode on the release path, and the attestation
+      # is already retrievable from GitHub without it.
+      - name: Attest the pushed image
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
 
       - name: Generate build summary
         run: |

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -243,7 +243,7 @@ jobs:
       # GHCR is a second failure mode on the release path, and the attestation
       # is already retrievable from GitHub without it.
       - name: Attest the pushed image
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.ref_name == 'feat/slsa-attestations-123'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -243,7 +243,7 @@ jobs:
       # GHCR is a second failure mode on the release path, and the attestation
       # is already retrievable from GitHub without it.
       - name: Attest the pushed image
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.ref_name == 'feat/slsa-attestations-123'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -370,6 +370,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # SLSA build provenance (issue #123): id-token mints the OIDC identity
+      # the attestation is signed with, attestations writes it to GitHub's
+      # attestation store - deliberately NOT the release, so the signature and
+      # the asset it covers no longer share a trust domain.
+      id-token: write
+      attestations: write
     steps:
       # Checkout provides the Homebrew formula template and its render script;
       # it must run before download-artifact so it cannot clobber dist/.
@@ -390,6 +396,17 @@ jobs:
           cd dist
           sha256sum libredb-studio-standalone-*.tar.gz libredb-studio-standalone-*.zip > SHA256SUMS
           cat SHA256SUMS
+
+      # Sign before shipping: the action hashes the files itself, so the attested
+      # digest is the artifact's own - not whatever SHA256SUMS claims. Only the
+      # artifacts are subjects; attesting the checksum file would prove nothing
+      # about what it describes.
+      - name: Attest the standalone archives
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/libredb-studio-standalone-*.tar.gz
+            dist/libredb-studio-standalone-*.zip
 
       - name: Upload artifacts to GitHub release
         env:
@@ -469,6 +486,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # SLSA build provenance (issue #123) - one attestation per matrix arch.
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -597,6 +617,15 @@ jobs:
           RPM_ARCH: ${{ matrix.rpm_arch }}
         run: bash scripts/channel-embedded-sample-e2e.sh rpm "pkgs/libredb-studio-${VERSION}.${RPM_ARCH}.rpm"
 
+      # The packages only - pkgs/ also holds the .sha256 sidecars, and a
+      # checksum file is not a subject worth a signature.
+      - name: Attest the .deb and .rpm
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            pkgs/*.deb
+            pkgs/*.rpm
+
       - name: Upload packages to GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -621,6 +650,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
+      # SLSA build provenance (issue #123). Flathub and FlatPark both repack
+      # these artifacts, so a verifiable origin matters more here than anywhere
+      # else in the release: their users never see this repo.
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -677,6 +711,13 @@ jobs:
             --payload "dist/libredb-studio-standalone-${VERSION}-linux-${ARCH}.tar.gz" \
             --smoke
 
+      - name: Attest the AppImage and GUI .deb
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist-desktop/*.AppImage
+            dist-desktop/*.deb
+
       - name: Upload the desktop artifacts to the GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -698,6 +739,12 @@ jobs:
     needs: [guard, build, draft, channels]
     permissions:
       contents: write
+      # SLSA build provenance (issue #123). The .snap is the one release asset
+      # that ships no checksum sidecar at all - a `--dangerous` local install
+      # skips the Snap Store's own signature check, so until now nothing about
+      # the GitHub-release copy was verifiable.
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -800,6 +847,14 @@ jobs:
         with:
           snap: ${{ steps.snapcraft.outputs.snap }}
           release: stable
+
+      # Same gate as the upload below: with no store credentials nothing is
+      # built or attached, so there is nothing to attest.
+      - name: Attest the snap
+        if: steps.snapstore.outputs.enabled == 'true'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: ${{ steps.snapcraft.outputs.snap }}
 
       - name: Upload snap to GitHub release
         if: steps.snapstore.outputs.enabled == 'true'

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -362,8 +362,10 @@ rebuilt archive never invalidates a previously printed admin password.
   ```
 
   This covers the package you install from npm. The standalone archive the launcher then
-  downloads from the GitHub release is still checksum-only - see
-  [Artifact provenance roadmap](#artifact-provenance-roadmap).
+  downloads from the GitHub release carries its own SLSA attestation, which the launcher does
+  not yet check for you - verify it by hand if you care:
+  `gh attestation verify ~/.libredb-studio/<version>/<archive> --repo libredb/libredb-studio`.
+  See [Artifact provenance roadmap](#artifact-provenance-roadmap).
 
 ## Homebrew
 
@@ -872,6 +874,12 @@ All channels have now had their first live run (the Snap publish completed its f
 4. Download the `.deb` on Debian/Ubuntu: `dpkg -i`, `systemctl start libredb-studio`, health 200
    on `127.0.0.1:3000`; verify the arm64 package on an arm64 machine (the CI smoke covers amd64
    only; the bundled node arch is statically asserted for both).
+5. Spot-check provenance on one downloaded asset and the image - a green release job proves the
+   attestation step ran, not that the published asset is the one it covers:
+   `gh attestation verify <asset> --repo libredb/libredb-studio` and
+   `gh attestation verify oci://ghcr.io/libredb/libredb-studio:<version> --repo libredb/libredb-studio`,
+   plus `npm audit signatures` after installing the package (see
+   [Verifying a release artifact](#verifying-a-release-artifact)).
 
 ### Artifact provenance roadmap
 
@@ -888,15 +896,49 @@ incremental, tracked in [issue #123](https://github.com/libredb/libredb-studio/i
 | Step | Scope | State |
 |---|---|---|
 | npm provenance | npm tarball (`npm publish --provenance`, Sigstore bundle held by npmjs) | **done** (0.9.63) — verify with `npm audit signatures` |
-| SLSA build provenance | standalone tarballs, win32 zip, `.deb`/`.rpm`/`.AppImage`, GHCR image (`actions/attest-build-provenance`) | planned — will verify with `gh attestation verify` |
+| SLSA build provenance | standalone tarballs, win32 zip, `.deb`/`.rpm`, desktop AppImage + GUI `.deb`, `.snap`, GHCR image (`actions/attest-build-provenance`) | **done** (0.9.63) — verify with `gh attestation verify` |
 | Launcher-side verification | `bin/studio.js` checks the downloaded archive's attestation when `gh` is present | planned |
 
-Until step 2 lands, the GitHub release assets carry checksums only. Steps 2 and 3 need no new
-secret: GitHub's attestation store, not the release, holds the bundles.
+Neither step needed a new secret: the attestations live in GitHub's attestation store, not in the
+release, so nothing an attacker can reach by replacing a release asset also lets them forge a
+signature.
 
-**Failure mode to expect on release day:** `npm publish --provenance` hard-fails if the job lacks
-`id-token: write` or if Sigstore is unreachable. A failed publish cannot be retried on the same
-tag — follow the usual rule and cut the next patch version.
+#### Verifying a release artifact
+
+```bash
+# Any release asset (tarball, zip, .deb, .rpm, .AppImage, .snap)
+gh attestation verify libredb-studio-standalone-0.9.63-linux-x64.tar.gz \
+  --repo libredb/libredb-studio
+
+# The container image, by digest or by tag
+gh attestation verify oci://ghcr.io/libredb/libredb-studio:0.9.63 \
+  --repo libredb/libredb-studio
+```
+
+A pass prints the workflow and commit that produced the artifact. `gh attestation verify` reaches
+GitHub for the bundle, so it needs network access; `--bundle` verifies a previously downloaded
+one offline.
+
+Notes on what is and is not covered:
+
+- The `.snap` attestation only exists when the release actually built one (the job is gated on
+  `SNAPCRAFT_STORE_CREDENTIALS`); Snap Store installs are verified by the store instead.
+- `SHA256SUMS` and the `.sha256` sidecars are deliberately **not** attested — a signature over a
+  checksum file proves nothing about the artifact it describes. The artifacts are the subjects.
+- Images built from branch pushes (the mutable `main` / `dev` tags) are not attested; only
+  release-context builds are.
+- The image attestation is not pushed to GHCR as an OCI referrer, so `cosign`-style registry-only
+  verification will not find it — fetch it from GitHub with `gh attestation verify oci://…`.
+- Buildx's own inline provenance on the manifest is unrelated and unsigned; it is left at the
+  action's defaults on purpose (changing it rewrites the manifest structure, which the Docker Hub
+  mirror's immutable-tag rules are sensitive to).
+
+**Failure modes to expect on release day:** `npm publish --provenance` hard-fails if the job lacks
+`id-token: write` or if Sigstore is unreachable, and `actions/attest-build-provenance` fails the
+same way — with a job-level `attestations: write` missing, or if the GitHub attestation API is
+down. A failed npm publish cannot be retried on the same tag (follow the usual rule and cut the
+next patch version); a failed attestation happens before `gh release upload` in the same job, so
+re-running that job is safe — the release is still a draft at that point.
 
 ### CI secrets that gate publishing
 

--- a/tests/unit/release-provenance.test.ts
+++ b/tests/unit/release-provenance.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for the signed-provenance invariants of the publish workflows
- * (issue #123, step 1: npm provenance).
+ * (issue #123: npm provenance + SLSA build provenance).
  *
  * Why a test for YAML: dropping `--provenance` does NOT break a release. The
  * publish still succeeds, the tarball just ships unsigned - the guarantee
@@ -9,6 +9,10 @@
  * but only on the release commit, where the retry costs a whole patch version
  * (a published tag can never be re-published). Both directions are cheap to
  * pin here and expensive to discover in a live release.
+ *
+ * The same asymmetry drives the attestation assertions below: an artifact that
+ * is uploaded before it is attested, or a job that lost `attestations: write`,
+ * produces a release whose assets look fine and cannot be verified.
  */
 import { describe, expect, test } from "bun:test";
 import * as fs from "fs";
@@ -19,7 +23,9 @@ interface Step {
   name?: string;
   run?: string;
   if?: string;
+  id?: string;
   uses?: string;
+  with?: Record<string, string | boolean>;
 }
 interface Job {
   permissions?: Record<string, string>;
@@ -30,6 +36,10 @@ const workflow = (name: string): { jobs: Record<string, Job> } =>
   parseYaml(fs.readFileSync(path.join(__dirname, "../../.github/workflows", name), "utf8")) as {
     jobs: Record<string, Job>;
   };
+
+const ATTEST_ACTION = "actions/attest-build-provenance@";
+const isAttestStep = (s: Step): boolean => s.uses?.startsWith(ATTEST_ACTION) === true;
+const subjectPathOf = (s: Step | undefined): string => String(s?.with?.["subject-path"] ?? "");
 
 const npmPublish = workflow("npm-publish.yml");
 const publishJob = npmPublish.jobs.publish;
@@ -60,5 +70,106 @@ describe("npm-publish.yml provenance", () => {
   test("the dry run does not ask for provenance - there is no tarball to attest", () => {
     expect(dryRunPublish).toBeDefined();
     expect(dryRunPublish?.run).not.toContain("--provenance");
+  });
+});
+
+const releaseArtifacts = workflow("release-artifacts.yml");
+
+/**
+ * Every job that ships a release asset must attest it. `globs` are the subject
+ * patterns the attestation has to cover - a job that grows a new artifact kind
+ * (as desktop-appimage did with the GUI .deb) has to extend both the glob and
+ * this list, which is the point.
+ */
+const ATTESTED_JOBS: { job: string; globs: string[] }[] = [
+  { job: "publish", globs: ["libredb-studio-standalone-*.tar.gz", "libredb-studio-standalone-*.zip"] },
+  { job: "linux-packages", globs: ["pkgs/*.deb", "pkgs/*.rpm"] },
+  { job: "desktop-appimage", globs: ["dist-desktop/*.AppImage", "dist-desktop/*.deb"] },
+  { job: "snap", globs: ["${{ steps.snapcraft.outputs.snap }}"] },
+];
+
+describe.each(ATTESTED_JOBS)("release-artifacts.yml attestation: $job", ({ job, globs }) => {
+  const steps = releaseArtifacts.jobs[job]?.steps ?? [];
+  const permissions = releaseArtifacts.jobs[job]?.permissions;
+  const attestSteps = steps.filter(isAttestStep);
+  const subjects = attestSteps.map(subjectPathOf).join("\n");
+
+  test("keeps contents: write and adds the two permissions the attestation API needs", () => {
+    expect(permissions?.contents).toBe("write");
+    expect(permissions?.["id-token"]).toBe("write");
+    expect(permissions?.attestations).toBe("write");
+  });
+
+  test("attests its artifacts", () => {
+    expect(attestSteps.length).toBeGreaterThan(0);
+    for (const glob of globs) {
+      expect(subjects).toContain(glob);
+    }
+  });
+
+  test("does not waste a subject slot on a checksum sidecar", () => {
+    // Attesting a .sha256 text file proves nothing about the artifact it
+    // describes - the artifact itself is the subject.
+    expect(subjects).not.toContain(".sha256");
+  });
+
+  test("signs before it ships", () => {
+    // Ordering is the difference between a failed run that published nothing
+    // and a draft release carrying assets no attestation covers.
+    const firstAttest = steps.findIndex(isAttestStep);
+    const firstUpload = steps.findIndex((s) => s.run?.includes("gh release upload") === true);
+    expect(firstUpload).toBeGreaterThan(-1);
+    expect(firstAttest).toBeLessThan(firstUpload);
+  });
+});
+
+const docker = workflow("docker-build-push.yml");
+const dockerJob = docker.jobs["build-and-push"];
+const dockerSteps = dockerJob?.steps ?? [];
+const buildPush = dockerSteps.find((s) => s.uses?.startsWith("docker/build-push-action@"));
+const dockerAttest = dockerSteps.find(isAttestStep);
+
+describe("docker-build-push.yml attestation", () => {
+  test("the job can mint attestations without losing its registry write", () => {
+    expect(dockerJob?.permissions?.["id-token"]).toBe("write");
+    expect(dockerJob?.permissions?.attestations).toBe("write");
+    expect(dockerJob?.permissions?.packages).toBe("write");
+    expect(dockerJob?.permissions?.contents).toBe("read");
+  });
+
+  test("the attestation binds the digest buildx actually pushed", () => {
+    // An image is attested by digest, never by tag: latest/main/dev move, and
+    // the multi-arch manifest list digest is the only stable identity.
+    expect(buildPush?.id).toBeTruthy();
+    expect(dockerAttest?.with?.["subject-digest"]).toContain(`steps.${buildPush?.id}.outputs.digest`);
+  });
+
+  test("the subject is the untagged canonical GHCR name", () => {
+    // Reuses the job's existing lowercase-image step: OCI names must be
+    // lowercase, and the tag list is the wrong subject (it moves, and it may
+    // carry the Docker Hub mirror too - GHCR is the canonical registry).
+    const name = String(dockerAttest?.with?.["subject-name"] ?? "");
+    expect(name).toContain("env.REGISTRY");
+    expect(name).toContain("steps.image.outputs.name");
+    expect(name).not.toContain("steps.meta.outputs.tags");
+  });
+
+  test("only release-context builds are attested", () => {
+    // Branch pushes publish the mutable main/dev tags; signing those would fill
+    // the transparency log with images no user installs.
+    expect(dockerAttest?.if).toContain("github.event_name");
+  });
+});
+
+describe("attestation action pinning", () => {
+  const attestUses = [releaseArtifacts, docker].flatMap((wf) =>
+    Object.values(wf.jobs).flatMap((j) => (j.steps ?? []).filter(isAttestStep).map((s) => s.uses ?? "")),
+  );
+
+  test("every attest step is pinned to a full commit SHA", () => {
+    expect(attestUses.length).toBeGreaterThan(0);
+    for (const uses of attestUses) {
+      expect(uses).toMatch(/^actions\/attest-build-provenance@[0-9a-f]{40}$/);
+    }
   });
 });


### PR DESCRIPTION
Step 2 of #123, following the npm slice in #248. Every artifact a release ships now carries a
signed SLSA build-provenance attestation, minted from the job's GitHub OIDC identity and stored in
GitHub's attestation store - **not** in the release, so replacing an asset no longer lets you
replace what vouches for it.

## Coverage

| Job | Subjects |
|---|---|
| `publish` | standalone tarballs + win32 zip (attested where the downloaded artifacts are the exact bytes that reach the release) |
| `linux-packages` | `.deb` + `.rpm`, per matrix arch |
| `desktop-appimage` | desktop AppImage + GUI `.deb`, per matrix arch - both feed catalogs (Flathub, FlatPark) whose users never see this repo |
| `snap` | the `.snap` - the only release asset with no checksum sidecar at all |
| `docker-build-push` | the GHCR image, by manifest digest |

Every attestation runs immediately **before** its `gh release upload`. A signing failure then
leaves the draft release without that asset rather than with an unattested one, and re-running the
job is safe while the release is still a draft.

## Deliberate omissions

- **`SHA256SUMS` and the `.sha256` sidecars are not subjects.** A signature over a checksum file
  proves nothing about the artifact it describes - the artifacts are the subjects, and the action
  hashes them itself, so the attested digest is the file's own rather than whatever the checksum
  file claims.
- **Branch-push images are not attested.** Only release-context builds, matching the existing
  condition that gates the version tag; `main`/`dev` are mutable tags nobody installs from.
- **`push-to-registry` stays off.** Writing an OCI referrer back to GHCR is a second failure mode
  on the release path, and `gh attestation verify oci://...` resolves the bundle from GitHub
  without it. Trade-off: `cosign`-style registry-only verification won't find it (documented).
- **Buildx's inline provenance is untouched.** It is unsigned and unrelated; changing its mode
  rewrites the manifest structure, and Docker Hub's immutable-tag rules on the mirror repo are
  already sensitive to that.

The image is attested **by digest, never by tag** - `latest` and `main` move, and the manifest
list digest is the image's only stable identity.

## Verification

```bash
gh attestation verify libredb-studio-standalone-0.9.63-linux-x64.tar.gz --repo libredb/libredb-studio
gh attestation verify oci://ghcr.io/libredb/libredb-studio:0.9.63 --repo libredb/libredb-studio
```

- Six local gates pass: `format`, `lint`, `typecheck`, `knip`, `test` (20 groups), `build`.
- TDD: the 13 new assertions were written first and all 13 failed before the workflow edits.
- `actions/attest-build-provenance` pinned to `0f67c3f` (v4.1.1), matching the repo's SHA-pinning
  convention; inputs checked against that exact ref's `action.yml`.
- `${{ env.REGISTRY }}` inside a step `with:` is already load-bearing in this workflow
  (`docker/login-action`, lines 133 and 297), so the expression context is proven, not assumed.
- No `src/` lines touched - the 100% coverage gate is unaffected.

## Tests

Extends the step-1 guard file. The four attesting jobs must keep `contents: write` while gaining
`id-token` + `attestations`, cover their artifact globs, never list a `.sha256`, and sign before
they ship; the docker attestation must be wired to the build step's `digest` output and gated to
release context; every attest step must be pinned to a full commit SHA.

The ordering assertion is the one worth having: nothing in CI notices an asset that was uploaded
before it was attested, and the result is a release whose assets look fine and cannot be verified.

## Remaining

Step 3 (launcher-side verification in `bin/studio.js`) stays open on #123. Until it lands, the npx
launcher still verifies the downloaded archive by checksum only - users can check the attestation
by hand with the command above.
