### PR TITLE
fix(helm): never re-publish an already-released chart version (#167)

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -6,6 +6,14 @@ on:
     paths:
       - "charts/**"
   workflow_dispatch:
+    inputs:
+      force_republish:
+        description: >-
+          Republish this chart version even though it is already released. ONLY for
+          repairing a failed index/OCI push whose chart content is unchanged since the
+          release - it overwrites the published index digest and OCI tag (#167).
+        type: boolean
+        default: false
 
 # Serialize helm-release runs: overlapping runs would race on the shared
 # gh-pages index/release state, so queue them instead. Defense-in-depth -
@@ -24,6 +32,10 @@ permissions:
 
 jobs:
   preflight:
+    # Two gates decide whether this run may publish at all: the image gate
+    # below (may the chart be released yet?) and the publish gate in the last
+    # step (is this chart version already published, #167?).
+    #
     # Image gate: the chart deploys ghcr.io/libredb/libredb-studio:<appVersion>
     # by default, so nothing here may run (or publish) before that image
     # exists. A version-bump merge fires this workflow ~25-35 minutes before
@@ -34,19 +46,21 @@ jobs:
     # pointless). Chart-only releases pass instantly: their appVersion image
     # is already published. No polling by design: a wait would burn 45 min on
     # an image that a failed Docker run will never produce.
-    name: Image gate
+    name: Preflight gates
     runs-on: ubuntu-latest
     # A registry query is near-instant; never let a network hang hold a
     # runner.
     timeout-minutes: 5
-    # The gate only reads Chart.yaml and queries the registry anonymously -
-    # this relies on the GHCR package being PUBLIC (if visibility ever
-    # changes, this step fails loudly and needs a registry login). Do not
-    # inherit the workflow-level write scopes.
+    # The image gate only reads Chart.yaml and queries the registry
+    # anonymously - this relies on the GHCR package being PUBLIC (if
+    # visibility ever changes, this step fails loudly and needs a registry
+    # login). The already-published check reads releases, which contents:read
+    # covers. Do not inherit the workflow-level write scopes.
     permissions:
       contents: read
     outputs:
       proceed: ${{ steps.gate.outputs.proceed }}
+      chart_published: ${{ steps.published.outputs.chart_published }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -95,6 +109,76 @@ jobs:
             echo ""
             echo "\`${image}\` is not on GHCR yet. This push-triggered run is a no-op;"
             echo "the release chain re-dispatches helm-release after the image is published."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Publish gate (#167): the release-asset step is guarded against an
+      # already-released version, but the gh-pages index push and the OCI push
+      # re-package whatever charts/** currently holds, unconditionally. So a
+      # charts/** merge that changed chart content WITHOUT bumping the chart
+      # version rewrote the released version's index digest and its OCI copy
+      # while the (immutable) release asset kept the original bytes - a live
+      # index-vs-asset mismatch, and silent digest drift on OCI. Decide the
+      # state once here and gate both publish jobs on it, so such a merge is a
+      # full no-op after lint-test.
+      #
+      # Only "published AND carrying the chart asset" counts as done: no
+      # release yet or a leftover draft must still publish, and a published
+      # release WITHOUT its asset must still reach the release job, whose loud
+      # #154 error is the right output there. Publishing chart CHANGES always
+      # means bumping the chart version - never re-running this workflow.
+      # A failed query is treated as "not published": the release job re-checks
+      # authoritatively, so that case is no worse than the pre-guard behaviour.
+      #
+      # The one legitimate reason to publish over a released version is repairing
+      # a run whose asset upload succeeded but whose index or OCI push failed
+      # (it happened to chart 0.1.5, hand-patched at the time). Bumping the chart
+      # version cannot fix that - the released version would stay missing from
+      # the index - so the force_republish dispatch input exists for exactly this
+      # case and is loud about it. The release chain's dispatch passes no inputs,
+      # so it can never take this path.
+      - name: Check whether this chart version is already published
+        id: published
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          FORCE_REPUBLISH: ${{ github.event.inputs.force_republish }}
+        run: |
+          set -euo pipefail
+          # grep/awk for the same reason as the appVersion read above: yq is not
+          # preinstalled and this job stays lean. '^version:' cannot match the
+          # indented dependency versions or appVersion.
+          version=$(grep '^version:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
+          if [ -z "$version" ]; then
+            echo "::error::could not read version from charts/libredb-studio/Chart.yaml"
+            exit 1
+          fi
+          tag="libredb-studio-${version}"
+          asset="${tag}.tgz"
+          if [ "${FORCE_REPUBLISH:-}" = "true" ]; then
+            echo "chart_published=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::force_republish requested - publishing over '${tag}' if it already exists. Valid ONLY when charts/** is unchanged since that release; otherwise the published index/OCI digest drifts from the release asset (#167)."
+            exit 0
+          fi
+          if ! is_draft=$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null); then
+            echo "chart_published=false" >> "$GITHUB_OUTPUT"
+            echo "No release '${tag}' yet - publishing may proceed."
+            exit 0
+          fi
+          if [ "$is_draft" = "true" ] || ! gh release view "$tag" --json assets --jq '.assets[].name' | grep -Fqx "$asset"; then
+            echo "chart_published=false" >> "$GITHUB_OUTPUT"
+            echo "Release '${tag}' exists but is not published with '${asset}' - publishing may proceed."
+            exit 0
+          fi
+          echo "chart_published=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::${tag} is already published with ${asset} - skipping the index and OCI publishes (#167). Bump the chart version to publish chart changes."
+          {
+            echo "## Chart publish skipped"
+            echo ""
+            echo "\`${tag}\` is already released with \`${asset}\`, so this run touches neither the"
+            echo "gh-pages index nor the OCI registry: re-packaging would change the published"
+            echo "digest of an immutable release (#167). Bump \`version:\` in"
+            echo "\`charts/libredb-studio/Chart.yaml\` to publish chart changes."
           } >> "$GITHUB_STEP_SUMMARY"
 
   lint-test:
@@ -149,7 +233,12 @@ jobs:
             --charts charts/libredb-studio
 
   release-github-pages:
-    needs: lint-test
+    needs: [preflight, lint-test]
+    # Publish gate (#167): skip entirely when this chart version is already
+    # released with its asset - see the preflight step for the rationale. The
+    # expression carries no status-check function, so the implicit success()
+    # keeps the existing "skipped when lint-test is skipped or fails" chaining.
+    if: needs.preflight.outputs.chart_published != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -291,7 +380,11 @@ jobs:
           exit 1
 
   release-oci:
-    needs: lint-test
+    needs: [preflight, lint-test]
+    # Publish gate (#167): `helm push` overwrites an existing OCI tag silently,
+    # so this job is the other half of the guard. Immutable releases cover only
+    # the release asset; the OCI copy and the index are mutable surfaces.
+    if: needs.preflight.outputs.chart_published != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,11 @@ Web-based SQL IDE for cloud-native teams: PostgreSQL, MySQL, SQLite, Oracle, SQL
 > version (#138), and a second gate fails when `operator/bundle` / `operator/config` still carry the
 > previous version (the OLM CSV takes its version and controller image tag from `package.json`).
 > Tag only after both are committed: the tag ref is what the operator image and bundle are built
-> from, so a bundle refreshed later lives on `main` only.
+> from, so a bundle refreshed later lives on `main` only. A PR that changes any packaged file under
+> `charts/libredb-studio/` must ALSO bump `Chart.yaml version` whenever the current chart version is
+> already released — the same required check enforces it (#167), and `chart:bump` will not do it for
+> you while `appVersion` is already in sync, so bump `version:` and the README `--version` examples
+> by hand.
 
 ## GitHub
 

--- a/docs/HELM_CHART.md
+++ b/docs/HELM_CHART.md
@@ -220,13 +220,16 @@ Push to main (charts/** changed)   OR   dispatched by docker-build-push
 ┌─────────────────────────────────────────┐
 │  helm-release.yml                       │
 │                                         │
-│  Job 0: preflight (image gate)          │
+│  Job 0: preflight gates                 │
 │    ghcr image <appVersion> published?   │
 │    ├── yes → proceed                    │
 │    ├── no + push event → green no-op    │
 │    │   (the release chain re-dispatches │
 │    │    after the image is published)   │
 │    └── no + dispatch → fail fast        │
+│                                         │
+│    chart <version> already released     │
+│    with its .tgz? → skip jobs 2 and 3   │
 │                                         │
 │  Job 1: lint-test                       │
 │    ├── ct lint (chart-testing)          │
@@ -255,6 +258,29 @@ image is on GHCR - the gate fails fast by design. A failed image build
 dispatches nothing, so the chart correctly stays unpublished. The gate
 queries GHCR anonymously and relies on the image package being public.
 
+The second preflight gate protects the published surfaces from re-publication
+(#167). Immutable releases freeze the release asset, but the gh-pages index and
+the OCI tag are mutable: both publish jobs re-package whatever `charts/**`
+currently holds, so a `charts/**` merge that changed chart content without
+bumping the chart version used to rewrite the released version's index digest
+and its OCI copy while the asset kept the original bytes. When the release for
+`libredb-studio-<version>` already exists, is published, and carries its
+`.tgz`, jobs 2 and 3 are skipped and the run is a full no-op after `lint-test`.
+A missing release, a leftover draft, or a published release without its asset
+all still publish - the last one so the release job's loud immutability error
+(#154) is what the run reports. Publishing chart changes therefore always means
+bumping `version:`; `bun run chart:check` now refuses the un-bumped state at PR
+time, so this gate is the backstop rather than the first line of defence.
+
+The gate has one escape hatch, the `force_republish` dispatch input, for the
+single case a version bump cannot fix: a run whose asset upload succeeded but
+whose index or OCI push failed, leaving a released version missing from the
+index (this happened to chart 0.1.5 and was hand-patched at the time). Dispatch
+`helm-release.yml` with `force_republish=true` **on the released version's ref**
+and only while `charts/**` is byte-identical to what that version shipped -
+otherwise it does exactly the damage the gate exists to prevent. The release
+chain's automated dispatch passes no inputs, so it can never take this path.
+
 ### Version Management
 
 - `Chart.yaml version` (e.g., `0.1.4`): the chart's own SemVer. Chart-only fixes bump it
@@ -270,6 +296,14 @@ queries GHCR anonymously and relies on the image package being public.
   `--version` example in step. The `artifacthub.io/changes` line is written by
   `chart:bump` but deliberately not checked, so hand-written changelog entries for
   chart-only releases never trip the guard.
+- Guard (#167): a PR that changes any packaged file under `charts/libredb-studio/`
+  while leaving the chart `version` at an **already-released** value fails the same
+  check - re-publishing that version would mutate its gh-pages/OCI digest. Fix it by
+  bumping `version:` (and the README `--version` examples) by hand: `chart:bump` only
+  moves the chart version when `appVersion` is out of sync, so a chart-only content
+  change needs the manual bump. Paths matched by the chart's `.helmignore` (`ci/`) are
+  excluded because they never reach the packaged `.tgz`, and a version that has not
+  been released yet stays freely editable.
 - Base comparisons read main's `Chart.yaml` at the merge-base of `HEAD` and `origin/main`,
   so a release merged to `main` after your branch point cannot false-positive the
   already-released check on a stale branch (issue #151); in shallow checkouts with no

--- a/scripts/sync-chart-version.mjs
+++ b/scripts/sync-chart-version.mjs
@@ -97,6 +97,19 @@ export function refreshOperatorCopy(root) {
   return true;
 }
 
+/**
+ * Filters a chart-dir diff down to the paths whose content ends up inside the
+ * packaged .tgz - the only ones that can move the published digest.
+ *
+ * Mirrors charts/libredb-studio/.helmignore: `ci/` holds chart-testing values,
+ * so editing them cannot change what consumers download and must not demand a
+ * version bump. The editor/OS junk patterns in .helmignore are never tracked
+ * files, so they are deliberately not mirrored here.
+ */
+export function packagedChartChanges(paths) {
+  return paths.filter((p) => p !== "" && !p.startsWith(`${SOURCE_CHART_DIR}/ci/`));
+}
+
 export function parseChart(chartYaml) {
   const version = chartYaml.match(/^version:\s*(\S+)\s*$/m)?.[1];
   const appVersion = chartYaml.match(/^appVersion:\s*"?([^"\s]+)"?\s*$/m)?.[1];
@@ -188,15 +201,31 @@ export function checkChangesAnnotation(chartYaml) {
 }
 
 /**
- * The released-version check only matters when the appVersion changed against the base
- * AND the chart version moved off the base's (otherwise the chart-releaser violation
- * covers it). Shared by checkSync() and main() so the gating cannot drift (#151).
+ * Whether the origin tag list must be queried. Two independent reasons:
+ * - #151: the appVersion changed AND the chart version moved off the base's - is the
+ *   version about to be published already taken? (Otherwise the chart-releaser
+ *   violation below covers it.)
+ * - #167: the packaged chart changed while the chart version stayed put - is that
+ *   version already published, so re-publishing would mutate its digest?
  *
- * @param {{ baseChart: { version: string, appVersion: string } | null, version: string, appVersion: string }} input
+ * Shared by checkSync() and main() so the gating cannot drift (#151).
+ *
+ * @param {{
+ *   baseChart: { version: string, appVersion: string } | null,
+ *   version: string,
+ *   appVersion: string,
+ *   chartChanges?: string[],
+ * }} input
  * @returns {boolean}
  */
-export function tagQueryNeeded({ baseChart, version, appVersion }) {
-  return Boolean(baseChart && baseChart.appVersion !== appVersion && baseChart.version !== version);
+export function tagQueryNeeded({ baseChart, version, appVersion, chartChanges = [] }) {
+  if (!baseChart) {
+    return false;
+  }
+  if (baseChart.appVersion !== appVersion && baseChart.version !== version) {
+    return true;
+  }
+  return chartChanges.length > 0 && baseChart.version === version;
 }
 
 /**
@@ -205,16 +234,27 @@ export function tagQueryNeeded({ baseChart, version, appVersion }) {
  * true/false, or null when origin tags could not be queried (check skipped, CLI prints
  * a warning).
  *
+ * chartChanges lists the packaged chart files that differ from the base (see
+ * packagedChartChanges), or is empty when the base is unavailable.
+ *
  * @param {{
  *   pkgVersion: string,
  *   chartYaml: string,
  *   readme: string,
  *   baseChart?: { version: string, appVersion: string } | null,
  *   chartTagExists?: boolean | null,
+ *   chartChanges?: string[],
  * }} input
  * @returns {string[]}
  */
-export function checkSync({ pkgVersion, chartYaml, readme, baseChart = null, chartTagExists = null }) {
+export function checkSync({
+  pkgVersion,
+  chartYaml,
+  readme,
+  baseChart = null,
+  chartTagExists = null,
+  chartChanges = [],
+}) {
   const violations = [];
   const { version, appVersion } = parseChart(chartYaml);
   if (appVersion !== pkgVersion) {
@@ -239,6 +279,18 @@ export function checkSync({ pkgVersion, chartYaml, readme, baseChart = null, cha
     violations.push(
       `${CHART_YAML}: chart version '${version}' is already released (tag libredb-studio-${version} exists) - ` +
         `bump to an unreleased version`,
+    );
+  }
+  // #167: helm-release re-packages whatever charts/** holds, so a content change
+  // under a released version rewrites that version's gh-pages index digest and
+  // its OCI copy while the (immutable) release asset keeps the original bytes.
+  if (chartChanges.length > 0 && baseChart && baseChart.version === version && chartTagExists === true) {
+    const shown = chartChanges.slice(0, 3).join(", ");
+    const more = chartChanges.length > 3 ? ` (+${chartChanges.length - 3} more)` : "";
+    violations.push(
+      `${CHART_YAML}: ${SOURCE_CHART_DIR} changed (${shown}${more}) but chart version '${version}' is an ` +
+        `already-released version (tag libredb-studio-${version} exists) - re-publishing it would mutate the ` +
+        `released index/OCI digest (#167). Bump 'version:' and the README --version example instead.`,
     );
   }
   return violations;
@@ -281,14 +333,15 @@ function git(root, args) {
  * check on a stale branch (#151). Shallow CI checkouts (ci.yml: depth-1 merge ref plus a
  * depth-1 fetch of main) have no computable merge-base; there the origin/main tip is used
  * as before - effectively exact on PR merge refs, which are built against the current main tip.
- * Returns { chart, reason }: chart is null when unavailable, with reason "missing-ref"
+ * Returns { chart, reason, ref }: chart is null when unavailable, with reason "missing-ref"
  * (origin/main not resolvable, e.g. a git-less fixture dir) or "unparseable" (the base
  * Chart.yaml exists but has no version/appVersion) kept distinct for strict-mode reporting.
+ * ref is the resolved base revision, reused for the chart-content diff (#167).
  */
 function readBaseChart(root) {
   let content;
+  let baseRef;
   try {
-    let baseRef;
     try {
       baseRef = git(root, ["merge-base", "HEAD", "origin/main"]);
     } catch {
@@ -296,13 +349,23 @@ function readBaseChart(root) {
     }
     content = git(root, ["show", `${baseRef}:${CHART_YAML}`]);
   } catch {
-    return { chart: null, reason: "missing-ref" };
+    return { chart: null, reason: "missing-ref", ref: null };
   }
   try {
-    return { chart: parseChart(content), reason: null };
+    return { chart: parseChart(content), reason: null, ref: baseRef };
   } catch {
-    return { chart: null, reason: "unparseable" };
+    return { chart: null, reason: "unparseable", ref: baseRef };
   }
+}
+
+/**
+ * Packaged chart files that differ between baseRef and the working tree (#167). Only
+ * called with a baseRef that readBaseChart already read Chart.yaml from, so the git
+ * call cannot fail for a reachability reason - an error here must stay loud.
+ */
+function changedChartFiles(root, baseRef) {
+  const diff = git(root, ["diff", "--name-only", baseRef, "--", SOURCE_CHART_DIR]);
+  return packagedChartChanges(diff.split("\n").map((line) => line.trim()));
 }
 
 /** true/false from origin, or null (skip + warn) when the remote is unreachable. */
@@ -340,7 +403,7 @@ function main(argv) {
 
   if (mode === "check") {
     const { version, appVersion } = parseChart(chartYaml);
-    const { chart: baseChart, reason: baseReason } = readBaseChart(root);
+    const { chart: baseChart, reason: baseReason, ref: baseRef } = readBaseChart(root);
     const baseUnavailable =
       baseReason === "unparseable"
         ? `${CHART_YAML} at the merge-base of HEAD and origin/main is unparseable`
@@ -351,11 +414,14 @@ function main(argv) {
       console.error(`ERROR: ${baseUnavailable} and CHART_SYNC_STRICT is set - refusing to skip base-comparison checks`);
       process.exit(1);
     }
+    // Only meaningful against a usable base; without one every base-comparison check
+    // is skipped (or strict-failed) above anyway.
+    const chartChanges = baseChart ? changedChartFiles(root, baseRef) : [];
     let chartTagExists = null;
-    if (tagQueryNeeded({ baseChart, version, appVersion })) {
+    if (tagQueryNeeded({ baseChart, version, appVersion, chartChanges })) {
       chartTagExists = chartTagExistsOnOrigin(root, version);
       if (chartTagExists === null && strict) {
-        for (const violation of checkSync({ pkgVersion, chartYaml, readme, baseChart, chartTagExists })) {
+        for (const violation of checkSync({ pkgVersion, chartYaml, readme, baseChart, chartTagExists, chartChanges })) {
           console.error(`ERROR: ${violation}`);
         }
         console.error(
@@ -364,7 +430,7 @@ function main(argv) {
         process.exit(1);
       }
     }
-    const violations = checkSync({ pkgVersion, chartYaml, readme, baseChart, chartTagExists });
+    const violations = checkSync({ pkgVersion, chartYaml, readme, baseChart, chartTagExists, chartChanges });
     violations.push(...operatorCopyViolations(root));
     if (violations.length > 0) {
       for (const violation of violations) console.error(`ERROR: ${violation}`);

--- a/tests/unit/sync-chart-version.test.ts
+++ b/tests/unit/sync-chart-version.test.ts
@@ -17,6 +17,7 @@ import {
   checkSync,
   listChartFiles,
   operatorCopyViolations,
+  packagedChartChanges,
   parseChart,
   parseImageTag,
   parseReadmeVersion,
@@ -248,6 +249,59 @@ describe("checkSync", () => {
     expect(violations.some((v) => v.includes("already released"))).toBe(true);
   });
 
+  test("changing the packaged chart under an already-released version is a violation (#167)", () => {
+    const violations = checkSync({
+      pkgVersion: "0.9.44",
+      chartYaml: chartYaml(),
+      readme: readme(),
+      baseChart: { version: "0.1.3", appVersion: "0.9.44" },
+      chartChanges: ["charts/libredb-studio/templates/deployment.yaml"],
+      chartTagExists: true,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("templates/deployment.yaml");
+    expect(violations[0]).toContain("already-released");
+    expect(violations[0]).toContain("#167");
+  });
+
+  test("the #167 violation names at most three changed files and counts the rest", () => {
+    const violations = checkSync({
+      pkgVersion: "0.9.44",
+      chartYaml: chartYaml(),
+      readme: readme(),
+      baseChart: { version: "0.1.3", appVersion: "0.9.44" },
+      chartChanges: ["a.yaml", "b.yaml", "c.yaml", "d.yaml", "e.yaml"],
+      chartTagExists: true,
+    });
+    expect(violations[0]).toContain("a.yaml, b.yaml, c.yaml");
+    expect(violations[0]).toContain("(+2 more)");
+    expect(violations[0]).not.toContain("d.yaml");
+  });
+
+  test("changing the packaged chart under an unreleased version is fine (#167)", () => {
+    const violations = checkSync({
+      pkgVersion: "0.9.44",
+      chartYaml: chartYaml(),
+      readme: readme(),
+      baseChart: { version: "0.1.3", appVersion: "0.9.44" },
+      chartChanges: ["charts/libredb-studio/values.yaml"],
+      chartTagExists: false,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  test("a released version with no packaged-chart change is fine (#167)", () => {
+    const violations = checkSync({
+      pkgVersion: "0.9.44",
+      chartYaml: chartYaml(),
+      readme: readme(),
+      baseChart: { version: "0.1.3", appVersion: "0.9.44" },
+      chartChanges: [],
+      chartTagExists: true,
+    });
+    expect(violations).toEqual([]);
+  });
+
   test("unknown tag state (offline) skips the released-version check", () => {
     const violations = checkSync({
       pkgVersion: "0.9.45",
@@ -278,6 +332,38 @@ describe("tagQueryNeeded", () => {
   test("true when appVersion changed and the chart version moved off the base's", () => {
     const baseChart = { version: "0.1.3", appVersion: "0.9.44" };
     expect(tagQueryNeeded({ baseChart, version: "0.1.4", appVersion: "0.9.45" })).toBe(true);
+  });
+
+  test("true when the packaged chart changed under an unchanged chart version (#167)", () => {
+    const baseChart = { version: "0.1.3", appVersion: "0.9.44" };
+    const input = { baseChart, version: "0.1.3", appVersion: "0.9.44" };
+    expect(tagQueryNeeded({ ...input, chartChanges: ["charts/libredb-studio/values.yaml"] })).toBe(true);
+    expect(tagQueryNeeded(input)).toBe(false);
+  });
+
+  test("false when the packaged chart changed and the version was bumped (#167)", () => {
+    // The bumped version is unreleased by construction: it is the chart-only
+    // release path, already covered by the appVersion/chart-releaser rules.
+    const baseChart = { version: "0.1.3", appVersion: "0.9.44" };
+    const chartChanges = ["charts/libredb-studio/values.yaml"];
+    expect(tagQueryNeeded({ baseChart, version: "0.1.4", appVersion: "0.9.44", chartChanges })).toBe(false);
+  });
+});
+
+describe("packagedChartChanges", () => {
+  test("keeps files that end up in the packaged tgz", () => {
+    const paths = [
+      "charts/libredb-studio/Chart.yaml",
+      "charts/libredb-studio/templates/deployment.yaml",
+      "charts/libredb-studio/values.schema.json",
+    ];
+    expect(packagedChartChanges(paths)).toEqual(paths);
+  });
+
+  test("drops .helmignore'd ci values and empty lines", () => {
+    expect(
+      packagedChartChanges(["charts/libredb-studio/ci/default-values.yaml", "", "charts/libredb-studio/values.yaml"]),
+    ).toEqual(["charts/libredb-studio/values.yaml"]);
   });
 });
 
@@ -421,7 +507,7 @@ describe("CLI (--check via subprocess)", () => {
   });
 });
 
-describe("CLI (--check against git fixtures, #151)", () => {
+describe("CLI (--check against git fixtures, #151/#167)", () => {
   const fixtureRoots: string[] = [];
 
   afterEach(() => {
@@ -520,6 +606,64 @@ describe("CLI (--check against git fixtures, #151)", () => {
     expect(runGit(root, "show", "origin/main:charts/libredb-studio/Chart.yaml")).toContain("appVersion");
 
     const result = runCheck(root, { CHART_SYNC_STRICT: "1" });
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  /**
+   * Upstream with a released chart 0.1.3 (tag libredb-studio-0.1.3) plus a template file,
+   * cloned so `origin` is a real remote whose tags `git ls-remote` can see. Returns the
+   * clone root; callers then mutate its working tree.
+   */
+  function makeReleasedChartClone(): string {
+    const upstream = makeDir("chart-sync-upstream-");
+    runGit(upstream, "init", "-q", "-b", "main");
+    writeTree(upstream, "0.9.44", chartYaml(), readme());
+    mkdirSync(join(upstream, "charts/libredb-studio/templates"), { recursive: true });
+    writeFileSync(join(upstream, "charts/libredb-studio/templates/deployment.yaml"), "kind: Deployment\n");
+    runGit(upstream, "add", "-A");
+    runGit(upstream, "commit", "-q", "-m", "chart 0.1.3");
+    runGit(upstream, "tag", "libredb-studio-0.1.3", runGit(upstream, "rev-parse", "HEAD"));
+
+    const root = makeDir("chart-sync-");
+    runGit(root, "clone", "-q", upstream, ".");
+    return root;
+  }
+
+  test("changing a chart template without a version bump fails once the version is released (#167)", () => {
+    const root = makeReleasedChartClone();
+    writeFileSync(
+      join(root, "charts/libredb-studio/templates/deployment.yaml"),
+      "kind: Deployment\n# zero-config default\n",
+    );
+
+    const result = runCheck(root);
+    expect(result.exitCode).toBe(1);
+    const stderr = result.stderr.toString();
+    expect(stderr).toContain("charts/libredb-studio/templates/deployment.yaml");
+    expect(stderr).toContain("already-released");
+    expect(stderr).toContain("#167");
+  });
+
+  test("the same template change passes once the chart version is bumped (#167)", () => {
+    const root = makeReleasedChartClone();
+    writeFileSync(
+      join(root, "charts/libredb-studio/templates/deployment.yaml"),
+      "kind: Deployment\n# zero-config default\n",
+    );
+    writeFileSync(join(root, "charts/libredb-studio/Chart.yaml"), chartYaml({ version: "0.1.4" }));
+    writeFileSync(join(root, "charts/libredb-studio/README.md"), readme("0.1.4"));
+
+    const result = runCheck(root);
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("a change outside the chart directory never demands a chart bump (#167)", () => {
+    const root = makeReleasedChartClone();
+    writeFileSync(join(root, "unrelated.md"), "docs only\n");
+
+    const result = runCheck(root);
     expect(result.stderr.toString()).toBe("");
     expect(result.exitCode).toBe(0);
   });


### PR DESCRIPTION
Closes #167.

## The gap

`helm-release.yml` guarded only the release-asset step against an already-published chart version. The gh-pages index push (`Update Helm repo index on gh-pages`) and the whole `release-oci` job re-package whatever `charts/**` currently holds, unconditionally - and the asset step's `exit 0` ends that step, not the job. So a `charts/**` merge that changed chart content without bumping the chart version rewrote the released version's index digest and its OCI copy while the immutable release asset kept the original bytes: a live index-vs-asset mismatch plus silent OCI drift (`helm-index-check.yml` detects the index half within a day; nothing watches OCI).

The index step's `cmp -s` check cannot prevent this. Verified locally with a synthetic chart: with the version held constant and content changed, `helm repo index --merge` keeps the **freshly packaged** entry for the duplicate version (the merge only fills in versions the new index lacks), so the digest moves to the new tgz - and the regenerated file always differs by its `generated:` timestamp anyway, so the "nothing to push" branch is effectively unreachable.

At PR time nothing stopped the state either: `chart:check` only demanded a chart bump when `appVersion` changed (`scripts/sync-chart-version.mjs`), so a template-only change under a released version passed. Commit `32f4cd8` (2026-07-12, Chart.yaml quoting with chart 0.1.13 held) hit exactly this path and escaped damage only because release `libredb-studio-0.1.13` was still a draft at that moment (created 13:36:04Z, published 13:48:53Z) and the asset was uploaded from the new tree.

## The fix

**1. Publish gate in `helm-release.yml`.** A second preflight step resolves once whether `libredb-studio-<version>` is already released **and** carries its `.tgz`; `release-github-pages` and `release-oci` are both gated on that output, so a no-bump `charts/**` merge is a full no-op after `lint-test`. Deliberately narrow: no release yet, a leftover draft, or a published release **without** its asset all still publish - the last one so the release job's loud immutability error (#154) is what the run reports. A failed query degrades to "not published", i.e. today's behaviour, and the release job re-checks authoritatively.

`force_republish` (a `workflow_dispatch` boolean, default false) is the one escape hatch, for the case a version bump cannot fix: a run whose asset upload succeeded but whose index or OCI push failed, leaving a released version missing from the index (chart 0.1.5 was hand-patched for this). It logs a warning about its precondition. The release chain's dispatch passes no inputs, so it can never take that path.

**2. PR-time preventer in `chart:check`.** Changing any packaged file under `charts/libredb-studio/` while the chart version stays at an already-released value is now a violation, naming the offending files. Paths matched by the chart's `.helmignore` (`ci/`) are excluded because they never reach the packaged `.tgz`, and an unreleased chart version stays freely editable, so iterating on a bumped-but-unpublished chart is unaffected. Note `chart:bump` does **not** fix this one - it only moves the chart version when `appVersion` is out of sync - so the message says to bump `version:` and the README `--version` examples by hand.

## Verification

- Unit + CLI tests written first (red, then green): `checkSync`/`tagQueryNeeded`/`packagedChartChanges` cases plus three hermetic-git CLI fixtures (released chart + template change fails; same change with a version bump passes; a change outside the chart dir is ignored). 64 tests in that file.
- Dogfooded on this repo: appending a line to `charts/libredb-studio/values.yaml` makes `bun run chart:check` fail with the new message (chart 0.1.23 is released), and it passes on this branch, which touches no chart file.
- The publish gate's shell body was extracted verbatim from the workflow and run against a stub `gh` in all five states: no release, draft, published-without-asset, published-with-asset, and `force_republish=true` -> `false,false,false,true,false`.
- Six local gates green: `format`, `lint` (0 errors), `typecheck`, `knip`, `test` (21 groups), `build`. The coverage gate is unaffected: `scripts/merge-lcov.mjs` keeps only `src/**` records and this PR touches no `src/` file.
- `helm-release.yml` parses, and the release-pipeline ASCII diagram in `docs/HELM_CHART.md` keeps its box alignment.

## Notes

- This PR touches no `charts/**` file, so merging it does not trigger `helm-release` at all.
- Sibling issue #170 (chart/docs follow-ups from the same review round) is intentionally left out; its chart-content items will need a chart version bump once this guard is on `main`, which is the intended behaviour.
