### PR TITLE
fix(editor): keep the Monaco Explain action in step with the active provider

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -19,6 +19,11 @@ import { useAiChat } from "@/hooks/use-ai-chat";
 // Runs at module load so it is in place before the first <Editor> mounts.
 configureMonacoLoader();
 
+// Context key gating the "Explain Plan" context-menu action. Monaco evaluates an action's
+// precondition when the menu opens, so the key — not the mounting render — decides whether
+// the affordance is offered (see the explain-capability gate below).
+const CAN_EXPLAIN_CONTEXT_KEY = "libredbCanExplain";
+
 export interface QueryEditorRef {
   getSelectedText: () => string;
   getEffectiveQuery: () => string;
@@ -115,6 +120,21 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
     const monaco = useMonaco();
     const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
     const [hasSelection, setHasSelection] = useState(false);
+
+    // Explain capability gate, shared by the toolbar button and the context-menu action.
+    const canExplain = Boolean(onExplain) && Boolean(capabilities?.supportsExplain);
+    // The context-menu action is registered once, in onMount, so it must not close over the
+    // mounting render: `onExplain` is undefined until /api/db/provider-meta resolves, and it
+    // changes again on every connection switch. Both the handler and the visibility key are
+    // therefore read at invocation time (#200).
+    const explainHandlerRef = useRef<(() => void) | undefined>(canExplain ? onExplain : undefined);
+    const canExplainKeyRef = useRef<Monaco.editor.IContextKey<boolean> | null>(null);
+
+    useEffect(() => {
+      explainHandlerRef.current = canExplain ? onExplain : undefined;
+      // Null until the editor mounts; onMount seeds the key from the ref instead.
+      canExplainKeyRef.current?.set(canExplain);
+    }, [canExplain, onExplain]);
 
     // Line numbers toggle — default must be SSR-stable; localStorage is applied after mount.
     const [showLineNumbers, setShowLineNumbers] = useState(true);
@@ -584,7 +604,7 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
           <div className="flex-1" />
 
           <div className="flex items-center gap-2 opacity-50 hover:opacity-100 transition-opacity">
-            {onExplain && capabilities?.supportsExplain && (
+            {canExplain && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -751,15 +771,18 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
                 run: () => handleExecute(),
               });
 
-              if (onExplain) {
-                editor.addAction({
-                  id: "explain-query",
-                  label: "Explain Plan",
-                  contextMenuGroupId: "navigation",
-                  contextMenuOrder: 2,
-                  run: () => onExplain(),
-                });
-              }
+              canExplainKeyRef.current = editor.createContextKey<boolean>(
+                CAN_EXPLAIN_CONTEXT_KEY,
+                Boolean(explainHandlerRef.current),
+              );
+              editor.addAction({
+                id: "explain-query",
+                label: "Explain Plan",
+                precondition: CAN_EXPLAIN_CONTEXT_KEY,
+                contextMenuGroupId: "navigation",
+                contextMenuOrder: 2,
+                run: () => explainHandlerRef.current?.(),
+              });
 
               editor.addAction({
                 id: "format-sql",

--- a/tests/components/QueryEditor.test.tsx
+++ b/tests/components/QueryEditor.test.tsx
@@ -9,7 +9,8 @@ import React from "react";
 let capturedBlurCb: (() => void) | null = null;
 let capturedSelectionCb: (() => void) | null = null;
 let capturedCommands: Array<{ keybinding: number; handler: () => void }> = [];
-let capturedActions: Array<{ id: string; run: () => void }> = [];
+let capturedActions: Array<{ id: string; precondition?: string; run: () => void }> = [];
+let capturedContextKeys: Record<string, boolean> = {};
 let mockSelectionReturn: { isEmpty: () => boolean } | null = null;
 let mockSelectedText = "";
 let mockUseMonacoReturn: unknown = null;
@@ -95,8 +96,23 @@ mock.module("@monaco-editor/react", () => ({
         addCommand: (_keybinding: number, handler: () => void) => {
           capturedCommands.push({ keybinding: _keybinding, handler });
         },
-        addAction: (action: { id: string; run: () => void }) => {
+        addAction: (action: { id: string; precondition?: string; run: () => void }) => {
           capturedActions.push(action);
+        },
+        // Real Monaco resolves an action's `precondition` against context keys at
+        // invocation time, which is how an action registered once at mount can still
+        // follow the current render's capabilities.
+        createContextKey: (key: string, defaultValue: boolean) => {
+          capturedContextKeys[key] = defaultValue;
+          return {
+            set: (value: boolean) => {
+              capturedContextKeys[key] = value;
+            },
+            get: () => capturedContextKeys[key],
+            reset: () => {
+              delete capturedContextKeys[key];
+            },
+          };
         },
         focus: mock(() => {}),
         updateOptions: (...args: unknown[]) => mockUpdateOptions(...args),
@@ -276,6 +292,7 @@ describe("QueryEditor", () => {
     capturedSelectionCb = null;
     capturedCommands = [];
     capturedActions = [];
+    capturedContextKeys = {};
     mockSelectionReturn = null;
     mockSelectedText = "";
     mockUseMonacoReturn = null;
@@ -1164,6 +1181,88 @@ describe("QueryEditor", () => {
     );
     const actionIds = capturedActions.map((a) => a.id);
     expect(actionIds).toContain("explain-query");
+  });
+
+  // Monaco fires onMount exactly once, so anything the explain action needs must be
+  // read at invocation time rather than captured from the mounting render (#200).
+
+  test("explain action is registered even when capability metadata has not arrived yet", () => {
+    render(React.createElement(QueryEditor, createDefaultProps({ onExplain: undefined, capabilities: undefined })));
+
+    expect(capturedActions.map((a) => a.id)).toContain("explain-query");
+    expect(capturedContextKeys["libredbCanExplain"]).toBe(false);
+  });
+
+  test("explain action becomes usable when capability metadata arrives after mount", () => {
+    const onExplain = mock(() => {});
+    const props = createDefaultProps({ onExplain: undefined, capabilities: undefined });
+    const { rerender } = render(React.createElement(QueryEditor, props));
+
+    rerender(React.createElement(QueryEditor, { ...props, onExplain, capabilities: defaultCapabilities }));
+
+    expect(capturedContextKeys["libredbCanExplain"]).toBe(true);
+    const explainAction = capturedActions.find((a) => a.id === "explain-query");
+    act(() => {
+      explainAction!.run();
+    });
+    expect(onExplain).toHaveBeenCalledTimes(1);
+  });
+
+  test("explain action invokes the current handler after a connection switch", () => {
+    const firstOnExplain = mock(() => {});
+    const secondOnExplain = mock(() => {});
+    const props = createDefaultProps({ onExplain: firstOnExplain, capabilities: defaultCapabilities });
+    const { rerender } = render(React.createElement(QueryEditor, props));
+
+    rerender(React.createElement(QueryEditor, { ...props, onExplain: secondOnExplain }));
+
+    const explainAction = capturedActions.find((a) => a.id === "explain-query");
+    act(() => {
+      explainAction!.run();
+    });
+    expect(secondOnExplain).toHaveBeenCalledTimes(1);
+    expect(firstOnExplain).not.toHaveBeenCalled();
+  });
+
+  test("explain action is hidden and inert after switching to a provider without explain", () => {
+    const onExplain = mock(() => {});
+    const props = createDefaultProps({ onExplain, capabilities: defaultCapabilities });
+    const { rerender } = render(React.createElement(QueryEditor, props));
+    expect(capturedContextKeys["libredbCanExplain"]).toBe(true);
+
+    // e.g. PostgreSQL -> Redis: the parent drops the handler along with the capability.
+    rerender(
+      React.createElement(QueryEditor, {
+        ...props,
+        onExplain: undefined,
+        capabilities: { ...defaultCapabilities, supportsExplain: false },
+      }),
+    );
+
+    expect(capturedContextKeys["libredbCanExplain"]).toBe(false);
+    const explainAction = capturedActions.find((a) => a.id === "explain-query");
+    expect(explainAction!.precondition).toBe("libredbCanExplain");
+    act(() => {
+      explainAction!.run();
+    });
+    expect(onExplain).not.toHaveBeenCalled();
+  });
+
+  test("explain action stays inert when the provider declares no explain support at mount", () => {
+    const onExplain = mock(() => {});
+    render(
+      React.createElement(
+        QueryEditor,
+        createDefaultProps({ onExplain, capabilities: { ...defaultCapabilities, supportsExplain: false } }),
+      ),
+    );
+
+    expect(capturedContextKeys["libredbCanExplain"]).toBe(false);
+    const explainAction = capturedActions.find((a) => a.id === "explain-query");
+    act(() => {
+      explainAction!.run();
+    });
+    expect(onExplain).not.toHaveBeenCalled();
   });
 
   test("run-query context action dispatches execute event", () => {


### PR DESCRIPTION
Fixes #200.

## The bug

The Monaco context-menu "Explain Plan" action was created inside `onMount` behind `if (onExplain)`. Monaco fires `onMount` exactly once and `QueryEditor` is never keyed on the connection, so the action froze the mounting render:

1. **Missing on a metadata race.** `onExplain` is only passed once `/api/db/provider-meta` resolves. An editor that mounts first never gets the action, even for PostgreSQL — and it cannot recover, because there is no second mount. Serving Monaco from our own origin (#247 / PR #251) removed the CDN round trip that used to hide this, so `onMount` now wins the race more often.
2. **Stale across a connection switch.** Registered while PostgreSQL was active, the item stayed on the menu after switching to, say, Redis, and ran the mount-era closure: the previous dialect's `EXPLAIN` against the previous connection payload, writing its result into the current tab. The `supportsExplain` guard in `use-query-execution.ts` could not stop it, because the frozen closure also carries the stale `metadata` that guard consults.

The toolbar button, mobile-header item and bottom-panel tab were all already render-time gated (#194 parts 1-2, PRs #198/#199); this affordance was the one that stayed mount-time gated.

## The fix

Register the action unconditionally and resolve both halves at invocation time:

- a ref carries the current effective handler, so `run` always calls the live one (and no-ops when the capability gate is closed);
- a `libredbCanExplain` context key drives the action's `precondition`. `StandaloneCodeEditor.addAction` maps `precondition` onto the context-menu item's `when` clause and onto the action's own supported-ness, so an unmet key removes the item rather than greying it out — the capability-honesty invariant from #199 is preserved, now evaluated as the menu opens instead of at mount.

The key is seeded from the ref at `onMount` (real Monaco mounts long after the parent's effects have run) and updated by an effect on every change. The gate predicate is now shared with the toolbar button, so the two affordances cannot disagree.

## Tests

TDD, all five written failing first:

- action is registered even when capability metadata has not arrived yet (key starts `false`)
- it becomes usable once metadata arrives after mount
- it invokes the current handler after a connection switch, not the mount-era one
- it is hidden (`precondition` set, key `false`) and inert after switching to a provider without explain
- it stays inert when the provider declares no explain support at mount

Reproducing these needed two facts the mock did not model, so the Monaco mock gained `createContextKey` and now records each action's `precondition`. The mock already fired `onMount` once, which is why the stale-closure test is a faithful reproduction rather than an artifact.

## Verification

`format` - `lint` (0 errors; the two `QueryEditor.tsx` warnings are pre-existing and on untouched lines) - `typecheck` - `knip` - `test` (21 groups, all green) - `test:coverage` + `coverage:check` (100%, 25941/25941) - `build` - `build:lib` - `attw`.

Not covered by automation: that the real Monaco menu visibly drops the item. That rests on the `precondition` -> `when` mapping in `standaloneCodeEditor.js`, asserted here at the context-key level.
