### PR TITLE
chore(release): 0.9.63 - verified provenance for every download

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.23
-appVersion: "0.9.62"
+version: 0.1.24
+appVersion: "0.9.63"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.62
+      image: ghcr.io/libredb/libredb-studio:0.9.63
       platforms:
         - linux/amd64
         - linux/arm64
@@ -43,8 +43,8 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Application updated to 0.9.62 - the desktop build now also ships a GUI Debian package, and the bundled Node sidecar is named libredb-studio-node so it cannot collide with the distribution's nodejs package"
-    - "No chart template changes - the rendered manifests are identical to 0.1.22"
+    - "Application updated to 0.9.63 - every release download now carries a signed provenance attestation, the npx launcher verifies it before starting, and the SQL editor serves its own Monaco assets so the workspace opens with no internet access"
+    - "No chart template changes - the rendered manifests are identical to 0.1.23"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.23 \
+  --version 0.1.24 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -21,8 +21,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Database, Developer Tools
-    containerImage: ghcr.io/libredb/libredb-studio-operator:0.9.62
-    createdAt: "2026-07-30T00:26:06Z"
+    containerImage: ghcr.io/libredb/libredb-studio-operator:0.9.63
+    createdAt: "2026-07-31T06:58:27Z"
     description: Open-source web-based SQL IDE for PostgreSQL, MySQL, Oracle, SQL
       Server, SQLite, MongoDB and Redis, with AI-powered query assistance.
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: libredb-studio-operator.v0.9.62
+  name: libredb-studio-operator.v0.9.63
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -255,7 +255,7 @@ spec:
                 - --leader-elect
                 - --leader-election-id=libredb-studio-operator
                 - --health-probe-bind-address=:8081
-                image: ghcr.io/libredb/libredb-studio-operator:0.9.62
+                image: ghcr.io/libredb/libredb-studio-operator:0.9.63
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -360,4 +360,4 @@ spec:
   provider:
     name: LibreDB
     url: https://libredb.org
-  version: 0.9.62
+  version: 0.9.63

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/libredb/libredb-studio-operator
-  newTag: 0.9.62
+  newTag: 0.9.63

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.23
-appVersion: "0.9.62"
+version: 0.1.24
+appVersion: "0.9.63"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.62
+      image: ghcr.io/libredb/libredb-studio:0.9.63
       platforms:
         - linux/amd64
         - linux/arm64
@@ -43,8 +43,8 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Application updated to 0.9.62 - the desktop build now also ships a GUI Debian package, and the bundled Node sidecar is named libredb-studio-node so it cannot collide with the distribution's nodejs package"
-    - "No chart template changes - the rendered manifests are identical to 0.1.22"
+    - "Application updated to 0.9.63 - every release download now carries a signed provenance attestation, the npx launcher verifies it before starting, and the SQL editor serves its own Monaco assets so the workspace opens with no internet access"
+    - "No chart template changes - the rendered manifests are identical to 0.1.23"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.23 \
+  --version 0.1.24 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.62",
+  "version": "0.9.63",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packaging/flatpak/org.libredb.Studio.metainfo.xml
+++ b/packaging/flatpak/org.libredb.Studio.metainfo.xml
@@ -100,6 +100,12 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.9.63" date="2026-07-31">
+      <description>
+        <p>Every download for this release is now cryptographically attested, and the npx launcher verifies that attestation before it starts the app. The SQL editor also serves its own Monaco assets, so the workspace opens on a machine with no internet access.</p>
+      </description>
+      <url type="details">https://github.com/libredb/libredb-studio/releases/tag/0.9.63</url>
+    </release>
     <release version="0.9.62" date="2026-07-30">
       <description>
         <p>The desktop build now also ships a GUI Debian package alongside the AppImage, and the bundled Node runtime is installed as libredb-studio-node so it cannot claim a path the distribution's nodejs package owns.</p>


### PR DESCRIPTION
Release bump for **0.9.63** (chart **0.1.24**, appVersion 0.9.63). Merge this, and the tag push follows.

## What 0.9.63 ships (since 0.9.62)

Supply chain, end to end:
- `feat(release)`: every release asset and the GHCR image carry SLSA provenance attestations (#250)
- `feat(release)`: the npm tarball is published with Sigstore provenance (#248)
- `feat(npx)`: the launcher verifies the downloaded archive's provenance before starting (#253)

Editor and connections:
- `fix(editor)`: Monaco is served from our own origin, so the workspace works air-gapped (#251)
- `fix(editor)`: the Monaco Explain action stays in step with the active provider (#256)
- `fix(connections)`: SQLite is offered in the connection-form type picker (#249)

Release infrastructure and distribution:
- `fix(helm)`: an already-released chart version is never re-published (#255, closes #167)
- `feat(distribution)`: FlatPark is live; Flathub marked deprecated and Flatpak users routed to FlatPark (#252)
- `docs`: the first-run admin setup RFC landed, and the GUI Debian package is surfaced in the README

## What this PR changes

The three bump surfaces the release gates require, plus one AppStream entry:

- `package.json` 0.9.62 -> 0.9.63
- `charts/libredb-studio/` + `operator/helm-charts/libredb-studio/` (`bun run chart:bump`): chart 0.1.24, appVersion 0.9.63, `artifacthub.io/images` tag, README `--version` examples, operator copy refreshed
- `operator/bundle/` + `operator/config/manager/kustomization.yaml` (`make -C operator bundle`): CSV `libredb-studio-operator.v0.9.63`, controller image tag 0.9.63
- `packaging/flatpak/org.libredb.Studio.metainfo.xml`: 0.9.63 release entry

Two deliberate omissions:

- The chart's `artifacthub.io/changes` entries are hand-written per chart release (as in 0.1.23), not the generated `Track app release` line: this one tracks the app release and records that no template changed, so 0.1.24 renders identically to 0.1.23.
- `packaging/flatpark/org.libredb.Studio.metainfo.xml` is left at 0.9.62 on purpose. Its newest `<release>` must equal the version the manifest pins as extra-data, and that pin cannot move until the 0.9.63 GUI Debian package exists - `tests/unit/flatpark-descriptor.test.ts` enforces exactly that pairing. Both move together in the usual post-release follow-up commit.

## Local pre-release validation (all green on this branch)

- Six gates: `format`, `lint` (0 errors), `typecheck`, `knip`, `test` (21 groups, 2915 tests), `build`
- Coverage gate: `test:coverage` + `coverage:check` -> 25941/25941 lines (100.00%)
- Package surface: `build:lib` + `attw` (node16 CJS/ESM and bundler green; node10 ignored by policy)
- Chart: `helm lint --strict` clean, `chart:check` OK (chart 0.1.24 / appVersion 0.9.63 in sync)
- Operator: `make -C operator bundle` regenerated and `operator-sdk bundle validate --select-optional suite=operatorframework` reports all tests completed (the two v1.25 API-deprecation warnings are pre-existing)
- `distribution:check` exits 0; every DRIFT row is an `on_demand` PaaS channel already tracked in #175
