### PR TITLE
feat(distribution): probe GHCR, Docker Hub, Snap and winget served state (#182)

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -58,8 +58,13 @@ channels:
     links:
       catalog: https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio
     pin:
-      strategy: none
-      note: Version and latest tags pushed by docker-build-push.yml on release; served-state probe tracked in issue 182.
+      strategy: probe
+      probe: ghcr-tag-digest
+      urls:
+        token: https://ghcr.io/token?service=ghcr.io&scope=repository:libredb/libredb-studio:pull
+        manifest: https://ghcr.io/v2/libredb/libredb-studio/manifests/{ref}
+      note: Compares the image :latest resolves to against the released version tag. Anonymous pull token,
+        no secret, so the probe also works from a fork.
 
   - id: docker-hub-mirror
     name: Docker Hub mirror (discoverability only)
@@ -73,8 +78,12 @@ channels:
     links:
       catalog: https://hub.docker.com/r/libredb/libredb-studio
     pin:
-      strategy: none
-      note: Mirror of GHCR; immutable-tag rules must stay semver-only. Push is secret-gated and skips silently; served-state probe tracked in issue 182.
+      strategy: probe
+      probe: dockerhub-tag-digest
+      urls:
+        tag: https://hub.docker.com/v2/repositories/libredb/libredb-studio/tags/{ref}
+      note: Mirror of GHCR; immutable-tag rules must stay semver-only. The push is secret-gated and skips
+        silently, so an absent version tag here is how an expired DOCKER_HUB_TOKEN becomes visible.
 
   - id: npm
     name: npm package @libredb/studio (library + npx launcher)
@@ -149,8 +158,15 @@ channels:
       first_pr: https://github.com/libredb/libredb-studio/pull/177
       catalog: https://snapcraft.io/libredb-studio
     pin:
-      strategy: none
-      note: Store-published by the release-artifacts snap job; store API probe tracked in issue 182.
+      strategy: probe
+      probe: snap-store-channel
+      architectures:
+        - amd64
+        - arm64
+      urls:
+        info: https://api.snapcraft.io/v2/snaps/info/libredb-studio
+      note: Reads the stable channel of each architecture separately, so one lagging build is drift rather
+        than a pass. Edge may legitimately differ from stable and is ignored.
 
   - id: linux-deb-rpm
     name: Linux .deb / .rpm packages (release assets)
@@ -458,13 +474,15 @@ channels:
       upstream_repo: https://github.com/microsoft/winget-pkgs
       docs: docs/DISTRIBUTION.md
     pin:
-      strategy: none
-      note: Listed since 0.9.59 (winget install LibreDB.Studio). Deliberately unpinned - winget
-        publishes no floating "latest" document. The winget-pkgs contents listing and the
-        storefront REST source both enumerate every published version, and this checker requires
-        all matches in a source to agree, so any regex over them would report ambiguity forever.
-        The release job's own pre-check (package listed / version already merged / update PR
-        already open) is the real guard; listed versions live under manifests/l/LibreDB/Studio/.
+      strategy: probe
+      probe: winget-max-version
+      urls:
+        versions: https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/l/LibreDB/Studio
+      note: Listed since 0.9.59 (winget install LibreDB.Studio). winget publishes no floating "latest"
+        document - the contents listing enumerates every published version - so the highest version it
+        enumerates is the served state. A regex pin cannot express that (all matches in a source must
+        agree), which is why this is a probe. The release job's own pre-check (package listed / version
+        already merged / update PR already open) remains the publish-time guard.
 
   - id: chocolatey
     name: Chocolatey community repository (libredb-studio)

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -22,10 +22,17 @@
 #   links                     tracking_issue / first_pr / last_bump_pr (nullable
 #                             until the first post-listing bump) / catalog /
 #                             upstream_repo / docs
-#   pin.strategy              local_file | remote_file | none
-#   pin.extract               regex with ONE capture group; all matches in a
-#                             source must agree (ambiguity is reported, never
-#                             resolved to the first hit)
+#   pin.strategy              local_file | remote_file | probe | none
+#   pin.probe                 required when strategy == probe; one of the probe ids
+#                             defined in scripts/distribution-check.mjs
+#   pin.urls                  required when strategy == probe; URL template(s) the
+#                             probe uses (see the probe's requiredUrls)
+#   pin.architectures         required for the snap-store-channel probe; list of
+#                             architectures to measure independently
+#   pin.extract               regex with ONE capture group; required for
+#                             local_file / remote_file; all matches in a source
+#                             must agree (ambiguity is reported, never resolved
+#                             to the first hit)
 
 channels:
   # ---- Tier 0: core registries, published directly by release CI ----------

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1043,10 +1043,10 @@ Chocolatey push is still in moderation.
    verifies `InstallerSha256`, so the release must already be published.
 3. After each catalog goes live: flip its `distribution/channels.yaml` entry to `status: live`,
    set `links.first_pr`, and add a measurable pin where one exists (Chocolatey community API).
-   **winget is deliberately unpinned** (`pin.strategy: none`): it publishes no floating "latest"
-   document — the winget-pkgs contents listing and the storefront REST source both enumerate
-   every published version, and the checker requires all matches in a source to agree, so any
-   regex over them would report ambiguity forever.
+   **winget is measured by a probe, not a regex pin** (`pin.strategy: probe`, `winget-max-version`):
+   it publishes no floating "latest" document — the winget-pkgs contents listing enumerates every
+   published version — so the checker takes the highest version enumerated there. A regex pin
+   cannot express that, because it requires all matches in a source to agree.
 
 ### Channel inventory and drift check
 
@@ -1077,9 +1077,27 @@ catalog templates).
 
 **Pin strategies:** `local_file` (version lives in files in this repo), `remote_file` (fetched
 from an upstream raw URL, best-effort — fetch failures degrade to UNKNOWN and never fail the
-run), `none` (nothing to measure, stated explicitly with a `note`). Measurable pins carry an
-`extract` regex with exactly one capture group; when a source yields multiple *different*
-matches the channel is reported instead of silently using the first hit.
+run), `probe` (see below), `none` (nothing to measure, stated explicitly with a `note`). The two
+regex strategies carry an `extract` pattern with exactly one capture group; when a source yields
+multiple *different* matches the channel is reported instead of silently using the first hit.
+
+**Probes** (#182) measure the channels whose served state is not one document a single regex can
+read. Each names a `probe` and the `urls` it needs; the URLs live in the inventory rather than in
+the script so the unit tests can point them at a local server and the suite never touches the
+real network. Probe failures degrade to UNKNOWN exactly like a failed `remote_file` fetch — but a
+tag that is *genuinely absent* is DRIFT, not UNKNOWN, which is the whole point: a publish step
+that skipped silently must not read as "could not measure".
+
+| Probe | Channel | What it measures |
+|---|---|---|
+| `ghcr-tag-digest` | `docker-ghcr` | that the digest `:latest` resolves to equals the released version tag's (anonymous pull token — no secret, works from a fork) |
+| `dockerhub-tag-digest` | `docker-hub-mirror` | the same digest equality on the mirror; an absent version tag is how an expired `DOCKER_HUB_TOKEN` (whose push step skips silently) becomes visible |
+| `snap-store-channel` | `snap` | the `stable` version of every listed architecture, each as its own source, so one lagging build is drift rather than a pass; `edge` may legitimately differ and is ignored |
+| `winget-max-version` | `winget` | the highest version the catalog enumerates, because winget publishes no floating "latest" document |
+
+Because a probe resolves versions in code, a channel measured this way needs no `extract`. A
+probe that reports several sources (Snap's architectures) reuses the same rule as a multi-file
+`local_file` pin: disagreeing sources are drift, with every source shown.
 
 **Strict mode:** `bun run distribution:check --strict` exits non-zero only for `local_file`
 channels with `sla: every_release` that are drifted or unmeasurable. Remote catalogs and

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -22,7 +22,7 @@ import { parse as parseYaml } from "yaml";
 
 const CHANNELS_YAML = "distribution/channels.yaml";
 const STATUSES = ["live", "pending", "deprecated"];
-const STRATEGIES = ["local_file", "remote_file", "none"];
+const STRATEGIES = ["local_file", "remote_file", "probe", "none"];
 const METHODS = ["ci_publish", "commit", "upstream_pr", "manual_ui"];
 const SLAS = ["every_release", "minor_plus", "major_only", "on_demand"];
 
@@ -41,6 +41,215 @@ const SLAS = ["every_release", "minor_plus", "major_only", "on_demand"];
  * anywhere else, so that invariant is enforced, not merely documented.
  */
 export const SWITCHABLE_CHANNEL_IDS = new Set(["docker-hub-mirror", "homebrew", "snap", "winget", "chocolatey"]);
+
+/**
+ * Probes measure channels whose served state is not one document a single
+ * regex can read: a registry that answers "which digest does this tag point
+ * at" rather than "which version", or a catalog that enumerates every
+ * published version with no floating "latest" entry.
+ *
+ * Each entry declares the pin.urls keys it needs (validated at parse time, so
+ * a typo in the inventory is a startup error and never a silent UNKNOWN) and
+ * a `run` that resolves the served version. Probe URLs live in channels.yaml
+ * rather than in this file on purpose: the unit tests point them at a local
+ * server, so the checker's own suite never touches the real network.
+ */
+const PROBES = {
+  "ghcr-tag-digest": {
+    requiredUrls: ["token", "manifest"],
+    async run({ pin, expected, timeoutMs }) {
+      // Public packages need no secret, only the anonymous pull token GHCR
+      // hands out to anyone who asks - so this probe works in a fork's CI too.
+      const token = await fetchJson(pin.urls.token, timeoutMs);
+      if (typeof token.body?.token !== "string") {
+        return { error: `ghcr token exchange failed (status ${token.status})` };
+      }
+      const headers = {
+        authorization: `Bearer ${token.body.token}`,
+        // Without these the registry answers with a single-platform manifest
+        // and the digests of two multi-arch tags would never compare equal.
+        accept: [
+          "application/vnd.oci.image.index.v1+json",
+          "application/vnd.docker.distribution.manifest.list.v2+json",
+        ].join(","),
+      };
+      const [latest, tagged] = await Promise.all([
+        fetchDigest(pin.urls.manifest.replace("{ref}", "latest"), timeoutMs, headers),
+        fetchDigest(pin.urls.manifest.replace("{ref}", expected), timeoutMs, headers),
+      ]);
+      return digestVerdict({ latest, tagged, expected });
+    },
+  },
+
+  "dockerhub-tag-digest": {
+    requiredUrls: ["tag"],
+    async run({ pin, expected, timeoutMs }) {
+      // The per-tag endpoint carries the digest inline, so the mirror needs no
+      // pagination walk: a push that silently skipped leaves the version tag
+      // absent, which digestVerdict reports as drift rather than unknown.
+      const [latest, tagged] = await Promise.all([
+        fetchJson(pin.urls.tag.replace("{ref}", "latest"), timeoutMs),
+        fetchJson(pin.urls.tag.replace("{ref}", expected), timeoutMs),
+      ]);
+      return digestVerdict({
+        latest: { status: latest.status, digest: latest.body?.digest ?? null },
+        tagged: { status: tagged.status, digest: tagged.body?.digest ?? null },
+        expected,
+      });
+    },
+  },
+
+  "snap-store-channel": {
+    requiredUrls: ["info"],
+    requiredArrays: ["architectures"],
+    async run({ pin, timeoutMs }) {
+      // The store rejects the request without a device series, whatever the
+      // snap name, so this header is part of the probe and not a nicety.
+      const info = await fetchJson(pin.urls.info, timeoutMs, { "snap-device-series": "16" });
+      if (info.status !== 200) {
+        return { error: `snap store unreachable (status ${info.status})` };
+      }
+      return parseSnapVersions(info.body, pin.architectures);
+    },
+  },
+
+  "winget-max-version": {
+    requiredUrls: ["versions"],
+    async run({ pin, timeoutMs }) {
+      const listing = await fetchJson(pin.urls.versions, timeoutMs, githubAuthHeaders(pin.urls.versions));
+      if (!Array.isArray(listing.body)) {
+        return { error: `catalog listing unavailable (status ${listing.status})` };
+      }
+      return maxPublishedVersion(listing.body.map((entry) => entry.name));
+    },
+  },
+};
+
+/**
+ * api.github.com rate-limits anonymous callers hard enough to turn a weekly
+ * check into a coin flip; raw.githubusercontent.com needs no auth at all, so
+ * the token is attached there and nowhere else.
+ */
+export function githubAuthHeaders(url) {
+  if (url.startsWith("https://api.github.com/") && process.env.GITHUB_TOKEN) {
+    return { authorization: `Bearer ${process.env.GITHUB_TOKEN}` };
+  }
+  return {};
+}
+
+async function fetchJson(url, timeoutMs, headers = {}) {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs), headers });
+    if (!response.ok) {
+      return { status: response.status, body: null };
+    }
+    return { status: response.status, body: await response.json() };
+  } catch {
+    return { status: null, body: null };
+  }
+}
+
+/** A registry reports which image a tag resolves to in a header, not a body. */
+async function fetchDigest(url, timeoutMs, headers) {
+  try {
+    const response = await fetch(url, { method: "HEAD", signal: AbortSignal.timeout(timeoutMs), headers });
+    return { status: response.status, digest: response.headers.get("docker-content-digest") };
+  } catch {
+    return { status: null, digest: null };
+  }
+}
+
+/**
+ * A probe result is either `{ versions: [{ source, version }], detail? }` -
+ * fed through the same agree/compare path as a multi-file local pin - or
+ * `{ error }`, which degrades that row to UNKNOWN. The distinction is load
+ * bearing: "the registry did not answer" must never render as drift, and
+ * "the tag is genuinely absent" must never render as unknown.
+ *
+ * @typedef {{ source: string, version: string }} ProbedVersion
+ * @typedef {{ versions?: ProbedVersion[], detail?: string, error?: string }} ProbeResult
+ */
+
+/**
+ * Container registries answer "which digest does this tag point at", not
+ * "which version". Equal digests for `latest` and the expected version tag
+ * mean the channel serves that version; anything else yields a version string
+ * that cannot compare equal, so the caller reports drift and the digests land
+ * in the detail column.
+ *
+ * @returns {ProbeResult}
+ */
+export function digestVerdict({ latest, tagged, expected }) {
+  const drift = (detail) => ({ versions: [{ source: "latest", version: `!=${expected}` }], detail });
+  if (latest.status === 404) {
+    return drift("latest tag is missing from the registry");
+  }
+  if (tagged.status === 404) {
+    return drift(`no ${expected} tag published`);
+  }
+  if (latest.status !== 200 || tagged.status !== 200) {
+    return { error: `registry unreachable (latest=${latest.status}, ${expected}=${tagged.status})` };
+  }
+  if (latest.digest !== tagged.digest) {
+    return drift(`latest -> ${latest.digest}, ${expected} -> ${tagged.digest}`);
+  }
+  return { versions: [{ source: "latest", version: expected }] };
+}
+
+/**
+ * The Snap Store reports one version per channel and architecture. Only the
+ * stable risk of the default track is the served state - edge may legitimately
+ * run ahead or behind - and each architecture is measured separately so a
+ * single lagging build shows up as disagreeing sources rather than a pass.
+ *
+ * @returns {ProbeResult}
+ */
+export function parseSnapVersions(info, architectures) {
+  const map = info?.["channel-map"];
+  if (!Array.isArray(map)) {
+    return { error: "store response has no channel-map" };
+  }
+  const versions = [];
+  for (const architecture of architectures) {
+    const entry = map.find(
+      (item) =>
+        item?.channel?.track === "latest" &&
+        item?.channel?.risk === "stable" &&
+        item?.channel?.architecture === architecture,
+    );
+    if (!entry) {
+      return { error: `no stable channel entry for ${architecture}` };
+    }
+    versions.push({ source: architecture, version: entry.version });
+  }
+  return { versions };
+}
+
+/**
+ * Catalogs that publish every version as its own entry and no floating
+ * "latest" document (winget-pkgs) are measured by the highest version they
+ * list. Comparison is numeric per component: 0.9.64 is newer than 0.9.9,
+ * which a string sort gets backwards.
+ *
+ * @returns {ProbeResult}
+ */
+export function maxPublishedVersion(names) {
+  const parsed = names
+    .filter((name) => /^\d+\.\d+\.\d+$/.test(name))
+    .map((name) => ({ name, parts: name.split(".").map(Number) }));
+  if (parsed.length === 0) {
+    return { error: "no published version in the catalog listing" };
+  }
+  const newest = parsed.reduce((best, candidate) => {
+    for (let i = 0; i < 3; i++) {
+      if (candidate.parts[i] !== best.parts[i]) {
+        return candidate.parts[i] > best.parts[i] ? candidate : best;
+      }
+    }
+    return best;
+  });
+  return { versions: [{ source: "catalog", version: newest.name }] };
+}
 
 function countCaptureGroups(pattern) {
   // Appending an empty alternative makes the regex match the empty string, so
@@ -99,9 +308,27 @@ export function parseChannels(yamlText) {
     if (pin.strategy === "remote_file" && typeof pin.url !== "string") {
       throw new Error(`${CHANNELS_YAML}: ${id}: remote_file pin needs a 'url'`);
     }
-    if (pin.strategy !== "none") {
-      // Exactly one: extractPin reads m[1] only, so a second capture group
-      // would be measured or ignored silently. Use (?:...) for grouping.
+    if (pin.strategy === "probe") {
+      const probe = PROBES[pin.probe];
+      if (!probe) {
+        throw new Error(`${CHANNELS_YAML}: ${id}: pin.probe must be one of ${Object.keys(PROBES).join("|")}`);
+      }
+      for (const key of probe.requiredUrls) {
+        if (typeof pin.urls?.[key] !== "string") {
+          throw new Error(`${CHANNELS_YAML}: ${id}: probe '${pin.probe}' needs pin.urls.${key}`);
+        }
+      }
+      for (const key of probe.requiredArrays ?? []) {
+        if (!Array.isArray(pin[key]) || pin[key].length === 0) {
+          throw new Error(`${CHANNELS_YAML}: ${id}: probe '${pin.probe}' needs a non-empty pin.${key} list`);
+        }
+      }
+    }
+    // Probes resolve a version in code, so only the regex strategies carry an
+    // extract - and theirs must have exactly one capture group: extractPin
+    // reads m[1] only, so a second group would be measured or ignored
+    // silently. Use (?:...) for grouping.
+    if (pin.strategy === "local_file" || pin.strategy === "remote_file") {
       if (typeof pin.extract !== "string" || countCaptureGroups(pin.extract) !== 1) {
         throw new Error(`${CHANNELS_YAML}: ${id}: pin.extract must be a regex with exactly one capture group`);
       }
@@ -163,6 +390,26 @@ export function evaluateChannel(channel, pkgVersion, sources) {
   if (channel.status !== "live" || channel.pin.strategy === "none") {
     return { ...row, status: "skip", expected: "-" };
   }
+  const { problems, versions, detail } =
+    channel.pin.strategy === "probe" ? readProbe(channel, sources[probeKey(channel)]) : readPins(channel, sources);
+  if (problems.length > 0) {
+    return { ...row, status: "unknown", observed: "?", detail: problems.join("; ") };
+  }
+  const unique = [...new Set(versions.map((v) => v.version))];
+  if (unique.length > 1) {
+    const disagreement = versions.map((v) => `${v.key}=${v.version}`).join(", ");
+    return { ...row, status: "drift", observed: unique.join(", "), detail: `sources disagree: ${disagreement}` };
+  }
+  const observed = unique[0];
+  return { ...row, status: observed === pkgVersion ? "ok" : "drift", observed, detail: detail ?? row.detail };
+}
+
+/** Where the CLI parks a channel's probe result for evaluateChannel to read. */
+export function probeKey(channel) {
+  return `probe:${channel.id}`;
+}
+
+function readPins(channel, sources) {
   const keys = channel.pin.strategy === "local_file" ? channel.pin.files : [channel.pin.url];
   const problems = [];
   const versions = [];
@@ -178,16 +425,26 @@ export function evaluateChannel(channel, pkgVersion, sources) {
       problems.push(error.message);
     }
   }
-  if (problems.length > 0) {
-    return { ...row, status: "unknown", observed: "?", detail: problems.join("; ") };
+  return { problems, versions };
+}
+
+/**
+ * Adapts a probe result onto the same shape a file pin produces, so a lagging
+ * Snap architecture reaches the caller as two disagreeing sources - exactly
+ * how two disagreeing pin files already do.
+ */
+function readProbe(channel, result) {
+  if (!result) {
+    return { problems: [`probe '${channel.pin.probe}' did not run`], versions: [] };
   }
-  const unique = [...new Set(versions.map((v) => v.version))];
-  if (unique.length > 1) {
-    const detail = versions.map((v) => `${v.key}=${v.version}`).join(", ");
-    return { ...row, status: "drift", observed: unique.join(", "), detail: `pin files disagree: ${detail}` };
+  if (result.error) {
+    return { problems: [result.error], versions: [] };
   }
-  const observed = unique[0];
-  return { ...row, status: observed === pkgVersion ? "ok" : "drift", observed };
+  return {
+    problems: [],
+    versions: result.versions.map((entry) => ({ key: entry.source, version: entry.version })),
+    detail: result.detail,
+  };
 }
 
 /**
@@ -238,12 +495,7 @@ export function renderTable(rows, pkgVersion) {
 }
 
 async function fetchText(url, timeoutMs) {
-  const headers = {};
-  // raw.githubusercontent.com needs no auth for public repos; the token only
-  // helps api.github.com rate limits, so it is attached there and nowhere else.
-  if (url.startsWith("https://api.github.com/") && process.env.GITHUB_TOKEN) {
-    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
-  }
+  const headers = githubAuthHeaders(url);
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs), headers });
     if (!response.ok) {
@@ -316,6 +568,9 @@ async function main(argv) {
     } else if (channel.pin.strategy === "remote_file") {
       const { url } = channel.pin;
       fetches.push(fetchText(url, timeoutMs).then((content) => (sources[url] = content)));
+    } else if (channel.pin.strategy === "probe") {
+      const run = PROBES[channel.pin.probe].run({ pin: channel.pin, expected: pkgVersion, timeoutMs });
+      fetches.push(run.then((result) => (sources[probeKey(channel)] = result)));
     }
   }
   await Promise.all(fetches);

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -116,6 +116,11 @@ const PROBES = {
   "winget-max-version": {
     requiredUrls: ["versions"],
     async run({ pin, timeoutMs }) {
+      // A directory listing is not paginated: the contents API returns the whole
+      // directory in one response and ignores per_page (verified against
+      // winget-pkgs, 785 entries in a single body). Its documented ceiling is
+      // 1,000 entries, above which GitHub directs callers to the Git Trees API -
+      // 1,000 published winget versions is not a reachable horizon here.
       const listing = await fetchJson(pin.urls.versions, timeoutMs, githubAuthHeaders(pin.urls.versions));
       if (!Array.isArray(listing.body)) {
         return { error: `catalog listing unavailable (status ${listing.status})` };

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -13,10 +13,14 @@ import { join } from "node:path";
 import {
   SWITCHABLE_CHANNEL_IDS,
   ciEnabledOutputs,
+  digestVerdict,
   evaluateChannel,
   extractPin,
+  githubAuthHeaders,
   linkLabel,
+  maxPublishedVersion,
   parseChannels,
+  parseSnapVersions,
   renderTable,
   strictFailures,
 } from "../../scripts/distribution-check.mjs";
@@ -53,6 +57,22 @@ const NONE_ROW = `  - id: npm
     pin:
       strategy: none
       note: Published by npm-publish.yml on every release.
+`;
+
+const PROBE_ROW = `  - id: docker-ghcr
+    name: Docker image (GHCR, canonical)
+    status: live
+    tier: 0
+    kind: container-image
+    update:
+      method: ci_publish
+      sla: every_release
+    pin:
+      strategy: probe
+      probe: ghcr-tag-digest
+      urls:
+        token: https://ghcr.io/token?service=ghcr.io&scope=repository:libredb/libredb-studio:pull
+        manifest: https://ghcr.io/v2/libredb/libredb-studio/manifests/{ref}
 `;
 
 describe("parseChannels", () => {
@@ -106,6 +126,187 @@ describe("parseChannels", () => {
       "",
     );
     expect(() => parseChannels(channelsYaml(bad))).toThrow(/url/);
+  });
+
+  test("parses a probe channel", () => {
+    const channels = parseChannels(channelsYaml(PROBE_ROW));
+    expect(channels[0].pin.strategy).toBe("probe");
+    expect(channels[0].pin.probe).toBe("ghcr-tag-digest");
+    expect(channels[0].pin.urls.manifest).toContain("{ref}");
+  });
+
+  test("a probe pin needs no extract pattern", () => {
+    expect(() => parseChannels(channelsYaml(PROBE_ROW))).not.toThrow();
+  });
+
+  test("throws on an unknown probe id", () => {
+    const bad = PROBE_ROW.replace("probe: ghcr-tag-digest", "probe: guess-the-version");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/pin\.probe must be one of/);
+  });
+
+  test("throws when a probe channel omits a url its probe requires", () => {
+    const bad = PROBE_ROW.replace(/ {8}manifest: [^\n]+\n/, "");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/needs pin\.urls\.manifest/);
+  });
+
+  test("throws when a probe channel has no urls block at all", () => {
+    const bad = PROBE_ROW.replace(/ {6}urls:\n(?: {8}[^\n]+\n)+/, "");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/needs pin\.urls/);
+  });
+});
+
+describe("githubAuthHeaders", () => {
+  const original = process.env.GITHUB_TOKEN;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = original;
+    }
+  });
+
+  test("attaches the token to api.github.com, where the anonymous rate limit bites", () => {
+    process.env.GITHUB_TOKEN = "ghp_example";
+    expect(githubAuthHeaders("https://api.github.com/repos/microsoft/winget-pkgs/contents/x")).toEqual({
+      authorization: "Bearer ghp_example",
+    });
+  });
+
+  test("never leaks the token to another host", () => {
+    process.env.GITHUB_TOKEN = "ghp_example";
+    expect(githubAuthHeaders("https://hub.docker.com/v2/repositories/libredb/libredb-studio/tags/latest")).toEqual({});
+  });
+
+  test("sends no authorization at all when no token is configured", () => {
+    delete process.env.GITHUB_TOKEN;
+    expect(githubAuthHeaders("https://api.github.com/repos/microsoft/winget-pkgs/contents/x")).toEqual({});
+  });
+});
+
+describe("digestVerdict (GHCR / Docker Hub served-tag comparison)", () => {
+  test("equal digests report the expected version", () => {
+    const result = digestVerdict({
+      latest: { status: 200, digest: "sha256:aaa" },
+      tagged: { status: 200, digest: "sha256:aaa" },
+      expected: "0.9.64",
+    });
+    expect(result.versions).toEqual([{ source: "latest", version: "0.9.64" }]);
+  });
+
+  test("differing digests report a version that cannot equal the expected one", () => {
+    const result = digestVerdict({
+      latest: { status: 200, digest: "sha256:old" },
+      tagged: { status: 200, digest: "sha256:new" },
+      expected: "0.9.64",
+    });
+    expect(result.versions?.[0]?.version).toBe("!=0.9.64");
+    expect(result.detail).toContain("sha256:old");
+    expect(result.detail).toContain("sha256:new");
+  });
+
+  test("a missing version tag is drift, not unknown - this is the silently-skipped mirror push", () => {
+    const result = digestVerdict({
+      latest: { status: 200, digest: "sha256:aaa" },
+      tagged: { status: 404, digest: null },
+      expected: "0.9.64",
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.versions?.[0]?.version).toBe("!=0.9.64");
+    expect(result.detail).toMatch(/0\.9\.64.*not published|no 0\.9\.64/i);
+  });
+
+  test("a missing latest tag is drift - nobody can pull :latest", () => {
+    const result = digestVerdict({
+      latest: { status: 404, digest: null },
+      tagged: { status: 200, digest: "sha256:aaa" },
+      expected: "0.9.64",
+    });
+    expect(result.versions?.[0]?.version).toBe("!=0.9.64");
+    expect(result.detail).toMatch(/latest/i);
+  });
+
+  test("a transient registry error degrades to UNKNOWN rather than inventing drift", () => {
+    const result = digestVerdict({
+      latest: { status: 500, digest: null },
+      tagged: { status: 200, digest: "sha256:aaa" },
+      expected: "0.9.64",
+    });
+    expect(result.error).toMatch(/unreachable/i);
+    expect(result.versions).toBeUndefined();
+  });
+
+  test("a network failure degrades to UNKNOWN rather than inventing drift", () => {
+    const result = digestVerdict({
+      latest: { status: null, digest: null },
+      tagged: { status: 200, digest: "sha256:aaa" },
+      expected: "0.9.64",
+    });
+    expect(result.error).toMatch(/unreachable/i);
+    expect(result.versions).toBeUndefined();
+  });
+});
+
+describe("parseSnapVersions", () => {
+  const info = {
+    "channel-map": [
+      { channel: { track: "latest", risk: "stable", architecture: "amd64" }, version: "0.9.64" },
+      { channel: { track: "latest", risk: "stable", architecture: "arm64" }, version: "0.9.64" },
+      { channel: { track: "latest", risk: "edge", architecture: "amd64" }, version: "0.9.52" },
+    ],
+  };
+
+  test("reads the stable version of every requested architecture", () => {
+    expect(parseSnapVersions(info, ["amd64", "arm64"])).toEqual({
+      versions: [
+        { source: "amd64", version: "0.9.64" },
+        { source: "arm64", version: "0.9.64" },
+      ],
+    });
+  });
+
+  test("ignores the edge channel, which may legitimately differ from stable", () => {
+    const result = parseSnapVersions(info, ["amd64"]);
+    expect(result.versions).toEqual([{ source: "amd64", version: "0.9.64" }]);
+  });
+
+  test("a stale architecture surfaces as two disagreeing sources, not a silent pass", () => {
+    const lagging = {
+      "channel-map": [
+        { channel: { track: "latest", risk: "stable", architecture: "amd64" }, version: "0.9.64" },
+        { channel: { track: "latest", risk: "stable", architecture: "arm64" }, version: "0.9.63" },
+      ],
+    };
+    expect(parseSnapVersions(lagging, ["amd64", "arm64"]).versions).toEqual([
+      { source: "amd64", version: "0.9.64" },
+      { source: "arm64", version: "0.9.63" },
+    ]);
+  });
+
+  test("an architecture missing from the stable channel is an error", () => {
+    expect(parseSnapVersions(info, ["amd64", "riscv64"]).error).toMatch(/riscv64/);
+  });
+
+  test("a response without a channel-map is an error", () => {
+    expect(parseSnapVersions({}, ["amd64"]).error).toMatch(/channel-map/);
+  });
+});
+
+describe("maxPublishedVersion (winget enumerates every version, with no floating latest)", () => {
+  test("picks the highest version", () => {
+    expect(maxPublishedVersion(["0.9.59", "0.9.64"]).versions).toEqual([{ source: "catalog", version: "0.9.64" }]);
+  });
+
+  test("compares numerically, not lexicographically", () => {
+    expect(maxPublishedVersion(["0.9.9", "0.9.64", "0.10.0"]).versions?.[0]?.version).toBe("0.10.0");
+  });
+
+  test("ignores entries that are not versions", () => {
+    expect(maxPublishedVersion([".validation", "0.9.64"]).versions?.[0]?.version).toBe("0.9.64");
+  });
+
+  test("an enumeration with no version at all is an error", () => {
+    expect(maxPublishedVersion([".validation"]).error).toMatch(/no published version/i);
   });
 });
 
@@ -176,6 +377,56 @@ describe("evaluateChannel", () => {
     expect(row.status).toBe("drift");
     expect(row.observed).toContain("0.9.53");
     expect(row.observed).toContain("0.9.22");
+  });
+
+  test("a probe whose resolved version matches is ok", () => {
+    const channel = parseChannels(channelsYaml(PROBE_ROW))[0];
+    const row = evaluateChannel(channel, "0.9.64", {
+      "probe:docker-ghcr": { versions: [{ source: "latest", version: "0.9.64" }] },
+    });
+    expect(row.status).toBe("ok");
+    expect(row.observed).toBe("0.9.64");
+  });
+
+  test("a probe verdict that cannot equal the expected version is drift, and its detail is kept", () => {
+    const channel = parseChannels(channelsYaml(PROBE_ROW))[0];
+    const row = evaluateChannel(channel, "0.9.65", {
+      "probe:docker-ghcr": {
+        versions: [{ source: "latest", version: "!=0.9.65" }],
+        detail: "latest -> sha256:old, 0.9.65 -> sha256:new",
+      },
+    });
+    expect(row.status).toBe("drift");
+    expect(row.detail).toBe("latest -> sha256:old, 0.9.65 -> sha256:new");
+  });
+
+  test("a probe error is unknown, never drift", () => {
+    const channel = parseChannels(channelsYaml(PROBE_ROW))[0];
+    const row = evaluateChannel(channel, "0.9.64", {
+      "probe:docker-ghcr": { error: "registry unreachable (latest=500, 0.9.64=200)" },
+    });
+    expect(row.status).toBe("unknown");
+    expect(row.detail).toContain("unreachable");
+  });
+
+  test("a probe that never ran is unknown", () => {
+    const channel = parseChannels(channelsYaml(PROBE_ROW))[0];
+    expect(evaluateChannel(channel, "0.9.64", {}).status).toBe("unknown");
+  });
+
+  test("probe sources that disagree are drift with every source visible", () => {
+    const channel = parseChannels(channelsYaml(PROBE_ROW))[0];
+    const row = evaluateChannel(channel, "0.9.64", {
+      "probe:docker-ghcr": {
+        versions: [
+          { source: "amd64", version: "0.9.64" },
+          { source: "arm64", version: "0.9.63" },
+        ],
+      },
+    });
+    expect(row.status).toBe("drift");
+    expect(row.detail).toContain("amd64=0.9.64");
+    expect(row.detail).toContain("arm64=0.9.63");
   });
 
   test("an unreadable source is unknown, not a crash", () => {
@@ -567,5 +818,230 @@ describe("CLI (remote pins against a local server)", () => {
     const result = await runCheckAsync(remoteFixture("http://127.0.0.1:1/pin.yml"));
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("UNKNOWN");
+  });
+});
+
+describe("CLI (probes against a local registry/store/catalog)", () => {
+  const fixtureRoots: string[] = [];
+  const servers: Array<{ stop: () => void }> = [];
+
+  afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    for (const server of servers.splice(0)) server.stop();
+  });
+
+  function serveBase(handler: (req: Request) => Response): string {
+    const server = Bun.serve({ port: 0, fetch: handler });
+    servers.push(server);
+    return `http://127.0.0.1:${server.port}`;
+  }
+
+  function probeFixture(row: string): string {
+    const root = mkdtempSync(join(tmpdir(), "dist-check-probe-"));
+    fixtureRoots.push(root);
+    writeFixture(root, "0.9.53", channelsYaml(row));
+    return root;
+  }
+
+  async function runCheckAsync(root: string) {
+    const proc = Bun.spawn(["node", SCRIPT, "--root", root], {
+      env: { ...process.env, GITHUB_STEP_SUMMARY: "", DISTRIBUTION_CHECK_TIMEOUT_MS: "3000" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function ghcrRow(base: string): string {
+    return `  - id: docker-ghcr
+    name: Docker image (GHCR)
+    status: live
+    tier: 0
+    kind: container-image
+    update:
+      method: ci_publish
+      sla: every_release
+    pin:
+      strategy: probe
+      probe: ghcr-tag-digest
+      urls:
+        token: ${base}/token
+        manifest: ${base}/v2/libredb/libredb-studio/manifests/{ref}
+`;
+  }
+
+  /** Digest per tag; a tag absent from the map answers 404, as a registry does. */
+  function registry(digests: Record<string, string>): string {
+    return serveBase((req) => {
+      const { pathname } = new URL(req.url);
+      if (pathname === "/token") {
+        return Response.json({ token: "anonymous-token" });
+      }
+      const ref = pathname.split("/").pop() as string;
+      const digest = digests[ref];
+      if (!digest) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response(null, { headers: { "docker-content-digest": digest } });
+    });
+  }
+
+  test("GHCR latest pointing at the released version is OK", async () => {
+    const base = registry({ latest: "sha256:same", "0.9.53": "sha256:same" });
+    const result = await runCheckAsync(probeFixture(ghcrRow(base)));
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("| OK | docker-ghcr |");
+    expect(result.stdout).toContain("0.9.53");
+  });
+
+  test("GHCR latest still pointing at the previous image is DRIFT with both digests", async () => {
+    const base = registry({ latest: "sha256:previous", "0.9.53": "sha256:current" });
+    const result = await runCheckAsync(probeFixture(ghcrRow(base)));
+    expect(result.stdout).toContain("| DRIFT | docker-ghcr |");
+    expect(result.stdout).toContain("sha256:previous");
+    expect(result.stdout).toContain("sha256:current");
+  });
+
+  test("a GHCR token exchange that fails degrades to UNKNOWN", async () => {
+    const base = serveBase(() => new Response("no token for you", { status: 403 }));
+    const result = await runCheckAsync(probeFixture(ghcrRow(base)));
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("| UNKNOWN | docker-ghcr |");
+  });
+
+  test("an unreachable registry degrades to UNKNOWN, never drift", async () => {
+    const result = await runCheckAsync(probeFixture(ghcrRow("http://127.0.0.1:1")));
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("| UNKNOWN | docker-ghcr |");
+  });
+
+  test("a Docker Hub mirror missing the released tag is DRIFT - the silently skipped push", async () => {
+    const base = serveBase((req) => {
+      const ref = new URL(req.url).pathname.split("/").pop();
+      return ref === "latest" ? Response.json({ digest: "sha256:stale" }) : new Response("not found", { status: 404 });
+    });
+    const row = `  - id: docker-hub-mirror
+    name: Docker Hub mirror
+    status: live
+    tier: 0
+    kind: container-image
+    update:
+      method: ci_publish
+      sla: every_release
+      ci_enabled: true
+    pin:
+      strategy: probe
+      probe: dockerhub-tag-digest
+      urls:
+        tag: ${base}/v2/repositories/libredb/libredb-studio/tags/{ref}
+`;
+    const result = await runCheckAsync(probeFixture(row));
+    expect(result.stdout).toContain("| DRIFT | docker-hub-mirror |");
+    expect(result.stdout).toContain("no 0.9.53 tag published");
+  });
+
+  function snapRow(base: string): string {
+    return `  - id: snap
+    name: Snap Store
+    status: live
+    tier: 1
+    kind: package-manager
+    update:
+      method: ci_publish
+      sla: every_release
+      ci_enabled: true
+    pin:
+      strategy: probe
+      probe: snap-store-channel
+      architectures:
+        - amd64
+        - arm64
+      urls:
+        info: ${base}/v2/snaps/info/libredb-studio
+`;
+  }
+
+  test("the Snap Store stable channel is measured per architecture and the device-series header is sent", async () => {
+    const seenHeaders: Array<string | null> = [];
+    const base = serveBase((req) => {
+      seenHeaders.push(req.headers.get("snap-device-series"));
+      return Response.json({
+        "channel-map": [
+          { channel: { track: "latest", risk: "stable", architecture: "amd64" }, version: "0.9.53" },
+          { channel: { track: "latest", risk: "stable", architecture: "arm64" }, version: "0.9.53" },
+          { channel: { track: "latest", risk: "edge", architecture: "amd64" }, version: "0.9.40" },
+        ],
+      });
+    });
+    const result = await runCheckAsync(probeFixture(snapRow(base)));
+    expect(seenHeaders).toEqual(["16"]);
+    expect(result.stdout).toContain("| OK | snap |");
+  });
+
+  test("one lagging Snap architecture is DRIFT even though the other is current", async () => {
+    const base = serveBase(() =>
+      Response.json({
+        "channel-map": [
+          { channel: { track: "latest", risk: "stable", architecture: "amd64" }, version: "0.9.53" },
+          { channel: { track: "latest", risk: "stable", architecture: "arm64" }, version: "0.9.40" },
+        ],
+      }),
+    );
+    const result = await runCheckAsync(probeFixture(snapRow(base)));
+    expect(result.stdout).toContain("| DRIFT | snap |");
+    expect(result.stdout).toContain("arm64=0.9.40");
+  });
+
+  test("a Snap Store error degrades to UNKNOWN", async () => {
+    const base = serveBase(() => new Response("maintenance", { status: 503 }));
+    const result = await runCheckAsync(probeFixture(snapRow(base)));
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("| UNKNOWN | snap |");
+  });
+
+  function wingetRow(base: string): string {
+    return `  - id: winget
+    name: winget community repository
+    status: live
+    tier: 4
+    kind: package-manager
+    update:
+      method: ci_publish
+      sla: every_release
+      ci_enabled: true
+    pin:
+      strategy: probe
+      probe: winget-max-version
+      urls:
+        versions: ${base}/repos/microsoft/winget-pkgs/contents/manifests/l/LibreDB/Studio
+`;
+  }
+
+  test("winget is measured by the highest version its catalog enumerates", async () => {
+    const base = serveBase(() => Response.json([{ name: ".validation" }, { name: "0.9.40" }, { name: "0.9.53" }]));
+    const result = await runCheckAsync(probeFixture(wingetRow(base)));
+    expect(result.stdout).toContain("| OK | winget |");
+  });
+
+  test("a winget catalog stuck on an older version is DRIFT", async () => {
+    const base = serveBase(() => Response.json([{ name: "0.9.40" }]));
+    const result = await runCheckAsync(probeFixture(wingetRow(base)));
+    expect(result.stdout).toContain("| DRIFT | winget |");
+    expect(result.stdout).toContain("0.9.40");
+  });
+
+  test("a winget catalog listing that cannot be read degrades to UNKNOWN", async () => {
+    const base = serveBase(() => new Response("rate limited", { status: 429 }));
+    const result = await runCheckAsync(probeFixture(wingetRow(base)));
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("| UNKNOWN | winget |");
   });
 });


### PR DESCRIPTION
Closes #182.

## What was unmeasured

The drift table measured every channel whose version could be read with one GET plus a
one-capture-group regex. Three tier-0 channels did not fit that shape and printed a permanent
`SKIP`, so their publish-time green checkmark was the only signal that publication worked — the
state a user actually pulls today was never re-verified.

## What this changes

A new `probe` pin strategy for channels whose served state is not one document a regex can read.
The probe URLs live in `distribution/channels.yaml`, not in the script, so the unit tests point
them at a local `Bun.serve` and the suite never touches the real network.

| Probe | Channel | Measures |
|---|---|---|
| `ghcr-tag-digest` | `docker-ghcr` | `digest(:latest) == digest(:<version>)` |
| `dockerhub-tag-digest` | `docker-hub-mirror` | the same equality on the mirror |
| `snap-store-channel` | `snap` | the `stable` version of each architecture |
| `winget-max-version` | `winget` | the highest version the catalog enumerates |

A probe reports its sources through the same agree/compare path as a multi-file `local_file` pin,
so a lagging Snap architecture is drift with both architectures visible, using the rule the
checker already had.

## Two of the issue's stated blockers turned out not to apply

- **GHCR needs no `read:packages` secret.** The anonymous pull token GHCR hands to any caller is
  enough for a public package, so the probe also works from a fork.
- **Docker Hub needs no digest-diffing across a tag list.** The per-tag endpoint returns the
  digest inline, so the mirror is two plain GETs with no pagination walk.

The third (Snap's per-channel response) is handled by filtering to `stable` and measuring each
architecture as its own source — `edge` may legitimately differ and is ignored.

## winget was in scope after all

`channels.yaml` documented winget as deliberately unpinnable, and that was correct **for a regex
pin**: winget publishes no floating "latest" document, so any regex over the enumeration would
report ambiguity forever. A probe resolves versions in code, so taking the highest enumerated
version is expressible. The note has been replaced with the measurement.

Chocolatey stays `strategy: none`: it is `status: pending` (still in community moderation) and
the checker skips non-live channels regardless of pin, so a pin there would measure nothing.

## Semantics

- A failed fetch degrades to `UNKNOWN` and never fails the run, exactly like a failed
  `remote_file` fetch.
- A tag that is **genuinely absent** is `DRIFT`, not `UNKNOWN`. This is the point of the issue: a
  Docker Hub push that skipped silently because `DOCKER_HUB_TOKEN` lapsed must not read as "could
  not measure".
- `--strict` is unchanged — it still gates owned `local_file` pins only, so no probe can break a
  release.

## Verification

All four rows against the live endpoints:

```
| OK | docker-ghcr       | 0 | 0.9.64 | 0.9.64 | every_release |
| OK | docker-hub-mirror | 0 | 0.9.64 | 0.9.64 | every_release |
| OK | snap              | 1 | 0.9.64 | 0.9.64 | every_release |
| OK | winget            | 4 | 0.9.64 | 0.9.64 | every_release |
```

Measured channels go from 12 to 16; permanent `SKIP`s from 15 to 11. The 8 `DRIFT` rows are
pre-existing PaaS template drift, unchanged by this PR and warn-only. `--strict` exits 0.

Built test-first: 34 new tests (90 in the file, up from 56), covering each probe's decision core
in isolation and each probe end to end against a local registry/store/catalog, including the
token-exchange failure, unreachable-host, missing-tag and lagging-architecture paths. The
UNKNOWN-vs-drift branch was mutation-checked — removing it fails both degradation tests.

All six local gates pass: `format`, `lint`, `typecheck`, `knip`, `test`, `build`.
