### PR TITLE
fix(editor): refuse Explain runs with no built EXPLAIN SQL (#201)

### DIFF
--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -164,7 +164,14 @@ Every SELECT query automatically runs EXPLAIN in the background (parallel execut
 |----------|---------------|
 | PostgreSQL | `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` |
 | MySQL | `EXPLAIN FORMAT=JSON` |
-| SQLite | Not supported (no JSON format) |
+| SQLite | `EXPLAIN QUERY PLAN` (tree, no cost/timing metrics) |
+
+### Non-SELECT Statements
+
+EXPLAIN is built for SELECT statements only. Clicking **Explain** with anything else
+(`UPDATE`, `INSERT`, DDL, …) executes nothing and reports "Only SELECT statements can
+be explained" — an explain run never falls back to running the original statement,
+because it deliberately bypasses the dangerous-query confirmation dialog.
 
 ### How It Works
 

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -149,10 +149,14 @@ export function useQueryExecution({
       const directExplainSql =
         isExplain && explainSupported ? (explainStrategy?.buildSql(queryToExecute, "analyze") ?? null) : null;
       if (isExplain && !directExplainSql) {
+        // Absent metadata means "not loaded yet", not "unsupported" — blaming
+        // the database type there would be misleading.
+        const metadataPending = !metadata;
         toast({
-          title: "Not Supported",
-          description:
-            explainSupported && explainStrategy
+          title: metadataPending ? "Not Ready" : "Not Supported",
+          description: metadataPending
+            ? "Connection metadata is still loading. Try again in a moment."
+            : explainStrategy && explainSupported
               ? "Only SELECT statements can be explained."
               : "EXPLAIN is not available for this database type.",
           variant: "destructive",

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -34,6 +34,21 @@ interface UseQueryExecutionParams {
   queryEditorRef: RefObject<QueryEditorRef | null>;
 }
 
+/**
+ * Why an explain run cannot proceed, phrased for the user. Absent metadata means
+ * "not loaded yet", not "unsupported" — blaming the database type there would be
+ * misleading.
+ */
+function explainRefusal(metadata: ProviderMetadata | null, hasStrategy: boolean) {
+  if (!metadata) {
+    return { title: "Not Ready", description: "Connection metadata is still loading. Try again in a moment." };
+  }
+  if (hasStrategy && metadata.capabilities.supportsExplain) {
+    return { title: "Not Supported", description: "Only SELECT statements can be explained." };
+  }
+  return { title: "Not Supported", description: "EXPLAIN is not available for this database type." };
+}
+
 export function useQueryExecution({
   activeConnection,
   metadata,
@@ -149,18 +164,7 @@ export function useQueryExecution({
       const directExplainSql =
         isExplain && explainSupported ? (explainStrategy?.buildSql(queryToExecute, "analyze") ?? null) : null;
       if (isExplain && !directExplainSql) {
-        // Absent metadata means "not loaded yet", not "unsupported" — blaming
-        // the database type there would be misleading.
-        const metadataPending = !metadata;
-        toast({
-          title: metadataPending ? "Not Ready" : "Not Supported",
-          description: metadataPending
-            ? "Connection metadata is still loading. Try again in a moment."
-            : explainStrategy && explainSupported
-              ? "Only SELECT statements can be explained."
-              : "EXPLAIN is not available for this database type.",
-          variant: "destructive",
-        });
+        toast({ ...explainRefusal(metadata, Boolean(explainStrategy)), variant: "destructive" });
         setTabs((prev) =>
           prev.map((t) => (t.id === targetTabId ? { ...t, isExecuting: false, isLoadingMore: false } : t)),
         );

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -138,11 +138,23 @@ export function useQueryExecution({
       );
       setBottomPanelMode(isExplain ? "explain" : "results");
 
-      // Check EXPLAIN support via capabilities
-      if (isExplain && metadata && !metadata.capabilities.supportsExplain) {
+      const explainStrategy = getExplainStrategy(metadata?.capabilities.explainFormat);
+
+      // An explain run skips the dangerous-query gate above, so it may only ever
+      // send SQL the dialect actually built for it — whether the provider denies
+      // EXPLAIN outright, ships no strategy, or the statement is not a SELECT.
+      // Falling back to the original statement would execute e.g. an UPDATE
+      // unguarded (#201).
+      const explainSupported = !metadata || metadata.capabilities.supportsExplain;
+      const directExplainSql =
+        isExplain && explainSupported ? (explainStrategy?.buildSql(queryToExecute, "analyze") ?? null) : null;
+      if (isExplain && !directExplainSql) {
         toast({
           title: "Not Supported",
-          description: "EXPLAIN is not available for this database type.",
+          description:
+            explainSupported && explainStrategy
+              ? "Only SELECT statements can be explained."
+              : "EXPLAIN is not available for this database type.",
           variant: "destructive",
         });
         setTabs((prev) =>
@@ -150,8 +162,6 @@ export function useQueryExecution({
         );
         return;
       }
-
-      const explainStrategy = getExplainStrategy(metadata?.capabilities.explainFormat);
 
       const startTime = Date.now();
       // Set up abort controller for query cancellation
@@ -176,13 +186,7 @@ export function useQueryExecution({
         }
 
         // If isExplain mode, run the dialect's EXPLAIN query instead
-        let queryToRun = queryToExecute;
-        if (isExplain && explainStrategy) {
-          const explainSql = explainStrategy.buildSql(queryToExecute, "analyze");
-          if (explainSql) {
-            queryToRun = explainSql;
-          }
-        }
+        const queryToRun = directExplainSql || queryToExecute;
 
         // Detect multi-statement queries (not for EXPLAIN or load-more or transaction)
         const useMultiQuery =

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -716,8 +716,14 @@ describe("useQueryExecution", () => {
 
   // ── executeQuery shows toast when EXPLAIN not supported ────────────────
 
-  test("executeQuery shows toast when EXPLAIN not supported", async () => {
-    mockGlobalFetch({});
+  test("executeQuery executes nothing when EXPLAIN not supported", async () => {
+    // A reachable route must be mocked: with no route the query would fail and
+    // toast anyway, which cannot distinguish the capability bail-out from a
+    // network error. `explainFormat` deliberately stays set, so a strategy
+    // exists and could build EXPLAIN SQL — the capability denial must still win.
+    const fetchMock = mockGlobalFetch({
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
     const noExplainMetadata: ProviderMetadata = {
       ...mockMetadata,
       capabilities: { ...mockMetadata.capabilities, supportsExplain: false },
@@ -730,7 +736,13 @@ describe("useQueryExecution", () => {
       await result.current.executeQuery("SELECT * FROM users", undefined, true); // isExplain = true
     });
 
-    expect(mockToastError).toHaveBeenCalled();
+    const queryCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
+    );
+    expect(queryCall).toBeUndefined();
+    expect(mockToastError).toHaveBeenCalledWith("Not Supported", {
+      description: "EXPLAIN is not available for this database type.",
+    });
   });
 
   // ── executeQuery in playground mode begins + rollbacks transaction ─────
@@ -1081,7 +1093,9 @@ describe("useQueryExecution", () => {
       (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
     );
     expect(queryCall).toBeUndefined();
-    expect(mockToastError).toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledWith("Not Supported", {
+      description: "Only SELECT statements can be explained.",
+    });
   });
 
   // ── executeQuery load more appends rows ────────────────────────────────
@@ -1158,12 +1172,15 @@ describe("useQueryExecution", () => {
 
     // Metadata is the sole source of dialect knowledge (no falling back to
     // connection.type), so no EXPLAIN SQL exists to run — and the original
-    // statement must not run in its place (#201).
+    // statement must not run in its place (#201). Absent metadata means "not
+    // loaded yet", which must not be reported as an unsupported database.
     const queryCall = fetchMock.mock.calls.find(
       (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
     );
     expect(queryCall).toBeUndefined();
-    expect(mockToastError).toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledWith("Not Ready", {
+      description: "Connection metadata is still loading. Try again in a moment.",
+    });
   });
 
   // ── no EXPLAIN without explainFormat, even if supportsExplain is true ──
@@ -1191,7 +1208,9 @@ describe("useQueryExecution", () => {
       (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
     );
     expect(queryCall).toBeUndefined();
-    expect(mockToastError).toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledWith("Not Supported", {
+      description: "EXPLAIN is not available for this database type.",
+    });
   });
 
   // ── handleLoadMore uses result.rows.length when currentOffset undefined ─

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -1061,9 +1061,9 @@ describe("useQueryExecution", () => {
     expect(body.sql).toContain("EXPLAIN FORMAT=JSON");
   });
 
-  // ── executeQuery EXPLAIN skips non-SELECT ──────────────────────────────
+  // ── executeQuery EXPLAIN refuses non-SELECT ────────────────────────────
 
-  test("executeQuery EXPLAIN on non-SELECT sends original query", async () => {
+  test("executeQuery EXPLAIN on non-SELECT executes nothing", async () => {
     const fetchMock = mockGlobalFetch({
       "/api/db/query": { ok: true, json: { rows: [], fields: [], rowCount: 0, executionTime: 5 } },
     });
@@ -1075,13 +1075,13 @@ describe("useQueryExecution", () => {
       await result.current.executeQuery("INSERT INTO users (name) VALUES ('test')", undefined, true);
     });
 
+    // The dangerous-query gate is skipped for explain runs, so falling back to
+    // the original statement would run it unguarded (#201).
     const queryCall = fetchMock.mock.calls.find(
       (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
     );
-    expect(queryCall).toBeDefined();
-    const body = JSON.parse(queryCall![1]!.body as string);
-    // Non-SELECT queries should not be wrapped in EXPLAIN
-    expect(body.sql).not.toContain("EXPLAIN");
+    expect(queryCall).toBeUndefined();
+    expect(mockToastError).toHaveBeenCalled();
   });
 
   // ── executeQuery load more appends rows ────────────────────────────────
@@ -1139,9 +1139,9 @@ describe("useQueryExecution", () => {
     expect(setTabsMock).toHaveBeenCalled();
   });
 
-  // ── metadata=null + isExplain=true → skips EXPLAIN support check ──────
+  // ── metadata=null + isExplain=true → nothing is built, nothing runs ────
 
-  test("executeQuery with metadata=null and isExplain=true skips support check", async () => {
+  test("executeQuery with metadata=null and isExplain=true executes nothing", async () => {
     const fetchMock = mockGlobalFetch({
       "/api/db/query": {
         ok: true,
@@ -1156,16 +1156,14 @@ describe("useQueryExecution", () => {
       await result.current.executeQuery("SELECT * FROM users", undefined, true);
     });
 
-    // Should proceed to execute (no toast about unsupported)
-    expect(mockToastError).not.toHaveBeenCalled();
+    // Metadata is the sole source of dialect knowledge (no falling back to
+    // connection.type), so no EXPLAIN SQL exists to run — and the original
+    // statement must not run in its place (#201).
     const queryCall = fetchMock.mock.calls.find(
       (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
     );
-    expect(queryCall).toBeDefined();
-    // Metadata is the sole source of dialect knowledge now — without it, no
-    // EXPLAIN SQL is built (no more falling back to connection.type).
-    const body = JSON.parse(queryCall![1]!.body as string);
-    expect(body.sql).not.toContain("EXPLAIN");
+    expect(queryCall).toBeUndefined();
+    expect(mockToastError).toHaveBeenCalled();
   });
 
   // ── no EXPLAIN without explainFormat, even if supportsExplain is true ──
@@ -1186,12 +1184,14 @@ describe("useQueryExecution", () => {
       await result.current.executeQuery("SELECT 1", undefined, true);
     });
 
+    // Divergent state reachable via custom metadata in embedded mode: the
+    // Explain affordance keys on supportsExplain, so the run must bail out
+    // instead of sending the unexplained statement (#201).
     const queryCall = fetchMock.mock.calls.find(
       (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
     );
-    expect(queryCall).toBeDefined();
-    const body = JSON.parse(queryCall![1]!.body as string);
-    expect(body.sql).toBe("SELECT 1");
+    expect(queryCall).toBeUndefined();
+    expect(mockToastError).toHaveBeenCalled();
   });
 
   // ── handleLoadMore uses result.rows.length when currentOffset undefined ─


### PR DESCRIPTION
Fixes #201.

## Problem

`src/hooks/use-query-execution.ts` skips the dangerous-query confirmation dialog for explain runs (`!isExplain` in the safety gate), but the direct-explain path fell back to the *original* statement whenever the dialect strategy could not build EXPLAIN SQL:

```ts
let queryToRun = queryToExecute;
if (isExplain && explainStrategy) {
  const explainSql = explainStrategy.buildSql(queryToExecute, "analyze");
  if (explainSql) {
    queryToRun = explainSql;   // else: keeps the original statement
  }
}
```

Clicking **Explain** with, say, `UPDATE employee SET ...` in the editor executed the UPDATE with no safety dialog and then rendered an empty plan. Verified live before fixing — the request body sent to `/api/db/query` was the raw `INSERT INTO users (name) VALUES ('test')`.

All three strategies return `null` for non-SELECT input (`postgres-json.ts`, `mysql-json.ts`, `sqlite-queryplan.ts`), and the Explain affordance is gated on `capabilities.supportsExplain` only (`Studio.tsx`, `QueryEditor.tsx`) — never on the statement — so the button is offered for any statement.

## Fix

An explain run may now only ever send SQL a strategy actually built for it; otherwise it bails out with a toast and resets the tab's executing state. This closes **both** routes into the old fallback:

1. **Non-SELECT statement** — `buildSql` returns `null`. Toast: "Only SELECT statements can be explained."
2. **No strategy at all** — `explainFormat` undefined while `supportsExplain` is `true`, a divergent state reachable via custom metadata in embedded mode (the Explain button is still rendered there, since it keys on `supportsExplain`). Toast: "EXPLAIN is not available for this database type."

Route 2 is outside the issue's stated scope; it is the same vulnerability two lines away, so it is closed here deliberately rather than left as a half-fix. The pre-existing `supportsExplain` capability check folds into the same gate, removing a duplicated bail-out block.

## Tests

TDD, failing-test-first. Three existing tests changed from asserting the fallback to asserting the invariant — each was watched failing for the right reason (the raw statement reaching `/api/db/query`) before the implementation landed:

- `executeQuery EXPLAIN on non-SELECT executes nothing` (was: "sends original query")
- `executeQuery with metadata=null and isExplain=true executes nothing` (was: "skips support check")
- `no EXPLAIN built when metadata lacks explainFormat even if supportsExplain is true` — now also asserts nothing runs

Their original intent (metadata is the sole source of dialect knowledge, no fallback to `connection.type`) is preserved; the assertions just no longer treat "the original statement ran instead" as acceptable.

## Docs

`docs/editor/query-optimization.md` gains the refusal behaviour, and its SQLite row — which still claimed EXPLAIN was unsupported — is corrected to `EXPLAIN QUERY PLAN`, shipped in 0.9.63 via #202.

## Verification

All six local gates pass, plus the package build:

- `bun run format` — clean (576 files)
- `bun run lint` — 0 errors (74 pre-existing warnings)
- `bun run typecheck` — clean
- `bun run knip` — clean
- `bun run test` — all 21 groups passed
- `bun run build` — clean
- `bun run test:coverage && bun run coverage:check` — 25965/25965 lines (100.00%)
- `bun run build:lib` — clean (hook is platform-facing)
