### PR TITLE
feat(db): add Couchbase provider (SQL++ over Query REST, no native dependency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ extraEnvFrom:
 | `defaults` | No | Default values merged into all connections |
 | `connections[].id` | Yes | Unique slug (`[a-z0-9-]+`, max 64 chars) |
 | `connections[].name` | Yes | Display name in UI |
-| `connections[].type` | Yes | `postgres`, `mysql`, `sqlite`, `mongodb`, `couchbase`, `redis`, `oracle`, `mssql` |
+| `connections[].type` | Yes | `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql`, `libredb`, `couchbase` |
 | `connections[].roles` | Yes | `["*"]` (everyone), `["admin"]`, `["user"]`, or `["admin", "user"]` |
 | `connections[].managed` | No | `true` = read-only (default), `false` = editable copy for user |
 | `connections[].password` | No | Use `${ENV_VAR}` syntax for secrets |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
 
 <p align="center">
   <img src="public/screenshots/connection-modal.png" alt="Multi-Database Connection Manager" width="100%" />
-  <br/><em>Connect to PostgreSQL, MySQL, Oracle, SQL Server, MongoDB, Redis, or SQLite with SSL/TLS and SSH Tunnel support.</em>
+  <br/><em>Connect to PostgreSQL, MySQL, Oracle, SQL Server, MongoDB, Couchbase, Redis, or SQLite with SSL/TLS and SSH Tunnel support.</em>
 </p>
 
 ---
@@ -183,6 +183,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
 | **SQL Server** | `mssql` (tedious) | Full SQL IDE, `TOP N` / `OFFSET FETCH` pagination, `sys.dm_*` DMVs, `UPDATE STATISTICS`, `DBCC CHECKDB`, transactions, Azure SQL auto-detect |
 | **SQLite** | `bun:sqlite` / `node:sqlite` (runtime-selected) | Full SQL IDE, file-based or in-memory databases (server-local file) |
 | **MongoDB** | `mongodb` | JSON query editor, collection operations (find, aggregate, insert, update, delete) |
+| **Couchbase** | none — HTTP (Query + management REST) | Full SQL++ IDE, EXPLAIN plans, bucket/scope/collection explorer, `INFER` column inference, read-your-writes consistency, `UPDATE STATISTICS` / `BUILD INDEX` / request kill |
 | **Redis** | `ioredis` | Command editor, key browser, INFO-based monitoring |
 
 > All SQL databases share: schema explorer, ER diagrams, schema diff & migration, display masking (preview), monitoring dashboard, and connection string import.
@@ -201,7 +202,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
 | **Editor** | Monaco Editor (VS Code Engine) | Web |
 | **AI** | Multi-Model (Gemini, OpenAI, Ollama, Custom) | Web, Mobile |
 | **Auth** | JWT (`jose`) + OIDC (`openid-client`), PKCE, Role Mapping | Web, Mobile |
-| **Database** | PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis | Web, Mobile |
+| **Database** | PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Couchbase, Redis | Web, Mobile |
 | **Charts** | Recharts (Bar, Line, Pie, Area, Scatter, Histogram, Stacked) | Web, Mobile |
 | **ERD** | React Flow, ELK.js (auto-layout) | Web |
 | **State/Grid** | TanStack Table & Virtual | Web, Mobile |
@@ -292,7 +293,7 @@ journalctl -u libredb-studio
 
   ### Prerequisites
   - [Bun](https://bun.sh/) (Recommended) or Node.js 24+
-  - A target database to query (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, or Redis)
+  - A target database to query (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Couchbase, or Redis)
 
   ### Quick Start (Local)
   1. **Clone & Install**
@@ -414,7 +415,7 @@ bun run test:coverage
 |-------|-----------|--------|-------|----------------|
 | **Unit** | `tests/unit/` | `bun:test` | ~1,609 | Pure functions: SQL parser, connection strings, data masking, query limiter, schema diff, error classes, DB icons, showcase queries |
 | **API** | `tests/api/` | `bun:test` | ~279 | Route handlers: auth, query, transaction, maintenance, AI endpoints, middleware |
-| **Integration** | `tests/integration/` | `bun:test` | ~346 | Database providers: PG, MySQL, SQLite, MongoDB, Redis, Oracle, MSSQL|
+| **Integration** | `tests/integration/` | `bun:test` | ~346 | Database providers: PG, MySQL, SQLite, MongoDB, Couchbase, Redis, Oracle, MSSQL|
 | **Hooks** | `tests/hooks/` | `bun:test` | ~251 | React hooks: auth, connections, tabs, query execution, transactions, inline editing, AI chat, monitoring |
 | **Components** | `tests/components/` | `bun:test` + happy-dom | ~570 | UI components: Studio, Sidebar, QueryEditor, ResultsGrid, Admin Dashboard, Charts, ERD |
 | **E2E** | `e2e/` | Playwright | ~32 | Full browser flows: login, connections, query execution, tabs, export, admin |
@@ -705,7 +706,7 @@ extraEnvFrom:
 | `defaults` | No | Default values merged into all connections |
 | `connections[].id` | Yes | Unique slug (`[a-z0-9-]+`, max 64 chars) |
 | `connections[].name` | Yes | Display name in UI |
-| `connections[].type` | Yes | `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql` |
+| `connections[].type` | Yes | `postgres`, `mysql`, `sqlite`, `mongodb`, `couchbase`, `redis`, `oracle`, `mssql` |
 | `connections[].roles` | Yes | `["*"]` (everyone), `["admin"]`, `["user"]`, or `["admin", "user"]` |
 | `connections[].managed` | No | `true` = read-only (default), `false` = editable copy for user |
 | `connections[].password` | No | Use `${ENV_VAR}` syntax for secrets |

--- a/database-compose.yml
+++ b/database-compose.yml
@@ -53,3 +53,79 @@ services:
       ORACLE_PASSWORD: Password123!
     ports:
       - "1521:1521"
+  couchbase:
+    # The image ships an uninitialized node: the cluster, the credentials below,
+    # the bucket and its primary index are all applied by the couchbase-init
+    # sidecar that follows.
+    image: couchbase:community-8.0.2
+    container_name: libredb-couchbase
+    restart: unless-stopped
+    environment:
+      COUCHBASE_USER: Administrator
+      COUCHBASE_PASSWORD: password123
+    ports:
+      # 8091 management REST, 8093 query service (SQL++). Those are the only two
+      # the provider needs: it speaks HTTP, never the binary KV protocol (11210).
+      - "8091:8091"
+      - "8093:8093"
+    ulimits:
+      # Couchbase warns at every start below this and degrades under load.
+      nofile:
+        soft: 200000
+        hard: 200000
+    healthcheck:
+      # Authenticated on purpose: /pools answers anonymously only until the
+      # cluster is initialized, and returns 401 for every later start, which
+      # would leave an initialized node permanently "unhealthy". With
+      # credentials it answers 200 in both states.
+      test:
+        - CMD-SHELL
+        - 'curl -sf -o /dev/null -u "$$COUCHBASE_USER:$$COUCHBASE_PASSWORD" http://localhost:8091/pools'
+      interval: 5s
+      timeout: 5s
+      retries: 40
+  couchbase-init:
+    # One-shot sidecar. A fresh node has no cluster, no bucket and no index, and
+    # SQL++ rejects a SELECT against an un-indexed keyspace with error 4000, so
+    # without this the service would come up unusable.
+    image: couchbase:community-8.0.2
+    container_name: libredb-couchbase-init
+    restart: "no"
+    depends_on:
+      couchbase:
+        condition: service_healthy
+    environment:
+      COUCHBASE_HOST: couchbase
+      COUCHBASE_USER: Administrator
+      COUCHBASE_PASSWORD: password123
+      COUCHBASE_BUCKET: travel
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      # $$ escapes compose interpolation: these expand in the container's shell.
+      - |
+        set -eu
+        couchbase-cli cluster-init -c "$$COUCHBASE_HOST" \
+          --cluster-username "$$COUCHBASE_USER" --cluster-password "$$COUCHBASE_PASSWORD" \
+          --cluster-name libredb --services data,index,query \
+          --cluster-ramsize 1024 --cluster-index-ramsize 512 --index-storage-setting default \
+          || echo "cluster already initialized - existing settings left untouched"
+        # Community Edition rejects Magma, which bucket-create defaults to, and a
+        # single node cannot honour a replica.
+        couchbase-cli bucket-create -c "$$COUCHBASE_HOST" \
+          -u "$$COUCHBASE_USER" -p "$$COUCHBASE_PASSWORD" \
+          --bucket "$$COUCHBASE_BUCKET" --bucket-type couchbase --storage-backend couchstore \
+          --bucket-ramsize 256 --bucket-replica 0 --wait \
+          || echo "bucket already exists - existing data left untouched"
+        # The query service accepts statements a few seconds after the node is
+        # initialized, so the index creation is retried rather than assumed.
+        for _ in $$(seq 1 30); do
+          if curl -sf -o /dev/null -u "$$COUCHBASE_USER:$$COUCHBASE_PASSWORD" \
+            "http://$$COUCHBASE_HOST:8093/query/service" \
+            --data-urlencode "statement=CREATE PRIMARY INDEX IF NOT EXISTS ON \`$$COUCHBASE_BUCKET\`"; then
+            echo "couchbase ready: bucket $$COUCHBASE_BUCKET has a primary index"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "couchbase-init: the query service never accepted CREATE PRIMARY INDEX" >&2
+        exit 1

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -24,12 +24,12 @@
 
 ## Overview
 
-LibreDB Studio provides a RESTful API for database management operations. The API supports PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis.
+LibreDB Studio provides a RESTful API for database management operations. The API supports PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, and Redis.
 
 ### Key Features
 
 - **JWT Authentication** - Secure token-based authentication stored in HTTP-only cookies
-- **Multi-Database Support** - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis
+- **Multi-Database Support** - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, Redis
 - **AI-Powered Queries** - Natural language to SQL with streaming responses
 - **Real-time Health Monitoring** - Database metrics and performance insights
 
@@ -344,6 +344,44 @@ For MongoDB connections, the `sql` field should contain a JSON query:
 - `aggregate` - Aggregation pipeline
 - `count` - Count documents matching a filter (runs `countDocuments` internally)
 - `distinct` - Distinct values for a field (the field is taken from the first key of `options.projection`)
+
+##### Couchbase Query Format
+
+Couchbase speaks **SQL++**, a SQL dialect, so the `sql` field carries an ordinary statement — there
+is no JSON envelope. Two things differ from the other SQL providers:
+
+- `connection.database` carries the **bucket** (one bucket per connection), and `connection.port` is
+  the **management** port (`8091`, or `18091` with TLS). The query port is discovered from
+  `GET /pools/default/nodeServices` at connect time and is never configured.
+- Keyspaces are backtick-quoted three-part paths. `SELECT *` nests the document under the keyspace
+  name and never yields the document key, so generated statements alias and project it explicitly.
+
+```json
+{
+  "connection": {
+    "type": "couchbase",
+    "host": "127.0.0.1",
+    "port": 8091,
+    "user": "Administrator",
+    "password": "password123",
+    "database": "travel"
+  },
+  "sql": "SELECT META(d).id AS __id, d.* FROM `travel`.`inventory`.`hotel` AS d LIMIT 50"
+}
+```
+
+**Notes:**
+- Every statement is sent with `scan_consistency: request_plus`, so a `SELECT` issued right after an
+  `INSERT` sees the new rows (the cluster default, `not_bounded`, does not).
+- A statement against a keyspace with no usable index returns `400 Bad Request` with code
+  `QUERY_ERROR`, and the message carries the runnable remedy
+  (``CREATE PRIMARY INDEX ON `travel`.`inventory`.`hotel` ``). A document whose key is known needs no
+  index at all: `SELECT d.* FROM ... AS d USE KEYS ["hotel::1"]`.
+- `POST /api/db/maintenance` accepts `analyze` (`UPDATE STATISTICS`, Enterprise Edition only),
+  `reindex` (`BUILD INDEX` over deferred indexes) and `kill` (a request id), each requiring a target.
+- Full reference: [`docs/providers/couchbase.md`](providers/couchbase.md).
+
+---
 
 ##### Redis Query Format
 
@@ -720,12 +758,12 @@ interface DatabaseConnection {
   port?: number;           // Port number
   user?: string;           // Username
   password?: string;       // Password
-  database?: string;       // Database name
+  database?: string;       // Database name (Couchbase: the bucket)
   connectionString?: string; // Full connection string (alternative)
   createdAt: Date;         // Creation timestamp
 }
 
-type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'redis' | 'oracle' | 'mssql';
+type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'couchbase' | 'redis' | 'oracle' | 'mssql';
 ```
 
 ### TableSchema

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -763,7 +763,7 @@ interface DatabaseConnection {
   createdAt: Date;         // Creation timestamp
 }
 
-type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'couchbase' | 'redis' | 'oracle' | 'mssql';
+type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'redis' | 'oracle' | 'mssql' | 'libredb' | 'couchbase';
 ```
 
 ### TableSchema

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document outlines the architectural patterns, tech stack, and system design
 
 ## System Overview
 
-LibreDB Studio is a hybrid, cloud-native database management tool that provides an IDE-like experience in the browser. It supports **8 database backends** via a Strategy Pattern abstraction: PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, Redis.
+LibreDB Studio is a hybrid, cloud-native database management tool that provides an IDE-like experience in the browser. It supports **9 database backends** via a Strategy Pattern abstraction: PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, Redis, LibreDB.
 
 It runs in two modes: as a **standalone Next.js app** and as an **embedded npm package** (`@libredb/studio`) consumed by libredb-platform. See [§4.6](#46-workspace-abstraction-npm-package-embedding).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document outlines the architectural patterns, tech stack, and system design
 
 ## System Overview
 
-LibreDB Studio is a hybrid, cloud-native database management tool that provides an IDE-like experience in the browser. It supports **7 database backends** via a Strategy Pattern abstraction: PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis.
+LibreDB Studio is a hybrid, cloud-native database management tool that provides an IDE-like experience in the browser. It supports **8 database backends** via a Strategy Pattern abstraction: PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, Redis.
 
 It runs in two modes: as a **standalone Next.js app** and as an **embedded npm package** (`@libredb/studio`) consumed by libredb-platform. See [§4.6](#46-workspace-abstraction-npm-package-embedding).
 
@@ -48,6 +48,7 @@ graph TD
         SQL --> Oracle[(Oracle)]
         SQL --> MSSQL[(SQL Server)]
         Document --> MongoDB[(MongoDB)]
+        Document --> Couchbase[(Couchbase)]
         KeyValue --> Redis[(Redis)]
     end
 
@@ -90,6 +91,7 @@ classDiagram
 
     BaseDatabaseProvider <|-- SQLBaseProvider
     BaseDatabaseProvider <|-- MongoDBProvider
+    BaseDatabaseProvider <|-- CouchbaseProvider
     BaseDatabaseProvider <|-- RedisProvider
 
     SQLBaseProvider <|-- PostgresProvider
@@ -105,6 +107,8 @@ Each provider implements:
 - **`prepareQuery()`** - handles query limiting per-provider (SQL LIMIT injection vs MongoDB native)
 
 Adding a new database type requires: **1 provider class** + **1 entry in `db-ui-config.ts`**.
+
+`CouchbaseProvider` extends `BaseDatabaseProvider` even though SQL++ is a SQL dialect: `SQLBaseProvider` owns pooled-driver mechanics (per-dialect escaping, placeholders, transactions, `cancelQuery`) that its stateless HTTP transport does not have, so the SQL-ness is declared through `queryLanguage: 'sql'` instead. It is also the only provider with no driver dependency — the cluster is reached over the documented Query and management REST APIs. See [`docs/providers/couchbase.md`](providers/couchbase.md).
 
 ## 4. Key Architectural Patterns
 
@@ -232,7 +236,7 @@ src/
     ├── db/                  # Database provider module
     │   ├── providers/
     │   │   ├── sql/         # postgres, mysql, sqlite (+ sqlite-driver runtime adapter), oracle, mssql
-    │   │   ├── document/    # mongodb
+    │   │   ├── document/    # mongodb, couchbase/ (transport seam + SQL++ over REST)
     │   │   ├── keyvalue/    # redis
     │   │   └── embedded/    # libredb (built-in embedded provider for the sample connection)
     │   ├── factory.ts       # Provider factory

--- a/docs/DATABASE_PROVIDERS.md
+++ b/docs/DATABASE_PROVIDERS.md
@@ -30,7 +30,13 @@ src/lib/db/
 │   │   ├── oracle.ts           # Oracle Strategy
 │   │   └── mssql.ts            # SQL Server Strategy
 │   ├── document/               # Document Database Providers
-│   │   └── mongodb.ts          # MongoDB Strategy
+│   │   ├── mongodb.ts          # MongoDB Strategy
+│   │   └── couchbase/          # Couchbase Strategy (SQL++ over REST, no driver)
+│   │       ├── index.ts        #   CouchbaseProvider
+│   │       ├── transport.ts    #   CouchbaseTransport seam + neutral result types
+│   │       ├── http-transport.ts #  Query REST + management REST (the one implementation)
+│   │       ├── keyspace.ts     #   display name <-> backtick-quoted keyspace path
+│   │       └── introspect.ts   #   system:* catalogs + INFER
 │   ├── keyvalue/               # Key-Value Providers
 │   │   └── redis.ts            # Redis Strategy
 │   └── embedded/               # Embedded (in-process) Providers
@@ -51,11 +57,14 @@ BaseDatabaseProvider (abstract)
 │   ├── OracleProvider                      │
 │   └── MSSQLProvider                       │
 ├── MongoDBProvider ────────────────────────┤ Document Database
+├── CouchbaseProvider ──────────────────────┤ Document Database (SQL++ over REST)
 ├── RedisProvider ──────────────────────────┤ Key-Value Store
 └── LibreDBProvider ────────────────────────┘ Embedded (key-value)
 ```
 
 `SQLBaseProvider` provides SQL-specific helpers (LIMIT injection, identifier escaping, placeholder generation). Non-SQL databases like MongoDB, Redis, and LibreDB extend `BaseDatabaseProvider` directly. LibreDB is embedded (opened in-process from a file, like SQLite) but, having no SQL, it is a key-value-style provider rather than a SQL one.
+
+Couchbase is the one provider that speaks a SQL dialect (SQL++) without extending `SQLBaseProvider`: that base owns pooled-driver mechanics — per-dialect escaping, placeholder generation, transactions, `cancelQuery` — that a stateless HTTP transport does not have. Its SQL-ness is expressed through `queryLanguage: 'sql'` in the capabilities instead. See [providers/couchbase.md](./providers/couchbase.md).
 
 The `SQLiteProvider` loads its embedded driver at runtime through `sqlite-driver.ts`: `bun:sqlite` under Bun, `node:sqlite` under plain Node (Node >= 24 built-in). Set `LIBREDB_SQLITE_DRIVER=bun|node` to force a driver. `better-sqlite3` is **not** used by the DB provider — it is only the SQLite driver for the storage layer (`src/lib/storage/`).
 
@@ -96,7 +105,7 @@ QueryEditor                      /api/db/query
 
 ## Supported Databases
 
-Eight providers are supported. For the per-provider reference (driver, pooling, query format,
+Nine providers are supported. For the per-provider reference (driver, pooling, query format,
 monitoring, limitations, …) see the prime docs in **[`docs/providers/`](./providers/README.md)**:
 
 | Provider | type-id | Family | Reference |
@@ -108,6 +117,7 @@ monitoring, limitations, …) see the prime docs in **[`docs/providers/`](./prov
 | SQLite | `sqlite` | SQL (embedded) | [providers/sqlite.md](./providers/sqlite.md) |
 | Redis | `redis` | Key-Value | [providers/redis.md](./providers/redis.md) |
 | MongoDB | `mongodb` | Document | [providers/mongodb.md](./providers/mongodb.md) |
+| Couchbase | `couchbase` | Document (SQL++) | [providers/couchbase.md](./providers/couchbase.md) |
 | LibreDB | `libredb` | Embedded (key-value) | [providers/libredb.md](./providers/libredb.md) |
 
 ## Core Interface
@@ -206,6 +216,11 @@ examples live in their prime docs:
   [`API_DOCS.md` MongoDB Query Format](./API_DOCS.md) section.
 - **Redis** (plain command or `{command, args}`): [providers/redis.md](./providers/redis.md).
 
+Couchbase is deliberately **not** in that list: SQL++ is a SQL dialect, so a Couchbase connection
+takes ordinary SQL in the `sql` field and inherits the SQL editor, the shared limiter, and NL2SQL.
+Its keyspaces are backtick-quoted three-part paths (`` `bucket`.`scope`.`collection` ``) — see
+[providers/couchbase.md](./providers/couchbase.md).
+
 ## Configuration
 
 ### Pool Configuration
@@ -275,7 +290,7 @@ DatabaseError (base)
 Provider-specific behaviour — pooling model, SSL/encryption, pagination, monitoring sources,
 maintenance operations, and known limitations — is documented per provider under
 [`docs/providers/`](./providers/README.md). Start there for anything specific to PostgreSQL, MySQL,
-Oracle, SQL Server, SQLite, Redis, MongoDB, or LibreDB.
+Oracle, SQL Server, SQLite, Redis, MongoDB, Couchbase, or LibreDB.
 
 ## Security Considerations
 
@@ -311,7 +326,7 @@ Before you start, decide:
    - `'sql'` → Monaco editor uses SQL mode with autocomplete
    - `'json'` → Monaco editor uses JSON mode with MQL-style autocomplete
 
-3. **Which npm driver?** (e.g., `pg`, `mysql2`, `mongodb`, `ioredis`, `oracledb`, `mssql`). SQLite is a special case — it uses the built-in `bun:sqlite`/`node:sqlite` via `sqlite-driver.ts` and needs no driver install.
+3. **Which npm driver?** (e.g., `pg`, `mysql2`, `mongodb`, `ioredis`, `oracledb`, `mssql`). Two providers need none: SQLite uses the built-in `bun:sqlite`/`node:sqlite` via `sqlite-driver.ts`, and Couchbase talks to the cluster over documented REST endpoints with `fetch`/`node:https` — a deliberate choice, since a native driver would be inherited by every distribution channel and by `@libredb/studio` ([couchbase.md](./providers/couchbase.md)).
 
 ## Step 1: Register the Database Type
 
@@ -321,10 +336,10 @@ Before you start, decide:
 
 ```typescript
 // Before:
-export type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'redis' | 'oracle' | 'mssql' | 'libredb';
+export type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'couchbase' | 'redis' | 'oracle' | 'mssql' | 'libredb';
 
 // After (example: adding CockroachDB):
-export type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'redis' | 'oracle' | 'mssql' | 'libredb' | 'cockroachdb';
+export type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'couchbase' | 'redis' | 'oracle' | 'mssql' | 'libredb' | 'cockroachdb';
 ```
 
 ### 1.2 — Add to `QueryTab.type` if needed
@@ -356,6 +371,7 @@ is kept in sync with its per-provider doc). Don't copy a skeleton from this guid
 | Pooled SQL (wire-protocol DB) | `SQLBaseProvider` | `postgres.ts` / `mysql.ts` | [postgres.md](./providers/postgres.md) · [mysql.md](./providers/mysql.md) |
 | Embedded / file SQL | `SQLBaseProvider` | `sqlite.ts` | [sqlite.md](./providers/sqlite.md) |
 | Document store | `BaseDatabaseProvider` | `mongodb.ts` | [mongodb.md](./providers/mongodb.md) |
+| Document store reached over HTTP/REST (no driver) | `BaseDatabaseProvider` | `document/couchbase/` | [couchbase.md](./providers/couchbase.md) |
 | Key-value store | `BaseDatabaseProvider` | `redis.ts` | [redis.md](./providers/redis.md) |
 | Embedded (in-process, no wire protocol) | `BaseDatabaseProvider` | `embedded/libredb.ts` | [libredb.md](./providers/libredb.md) |
 
@@ -456,7 +472,7 @@ Then add the type to the selectable list that drives the ConnectionModal picker:
 
 ```typescript
 const selectableTypes: DatabaseType[] = [
-  'postgres', 'mysql', 'oracle', 'mssql', 'mongodb', 'redis', 'libredb', 'cockroachdb'
+  'postgres', 'mysql', 'oracle', 'mssql', 'mongodb', 'couchbase', 'redis', 'libredb', 'cockroachdb'
 ];
 ```
 
@@ -473,7 +489,12 @@ bun add <driver-package>
 # bun add mongodb             (MongoDB)
 # bun add ioredis             (Redis)
 # SQLite needs no driver — bun:sqlite / node:sqlite are runtime built-ins (see sqlite-driver.ts)
+# Couchbase needs no driver — it speaks the Query and management REST APIs over fetch/node:https
 ```
+
+If your engine exposes a documented HTTP API, weigh it against the native driver before adding a
+dependency: a native module lands in the Docker image, every native distribution channel, and the
+`@libredb/studio` package that libredb-platform consumes.
 
 ## Step 6: Verify
 
@@ -573,11 +594,11 @@ For the authoritative, code-verified reference for each shipped provider (extend
 driver, pooling, capabilities, labels, `prepareQuery` behaviour, and limitations), see the prime
 docs — they are the single source of truth and are kept in sync with the code:
 
-**[docs/providers/](./providers/README.md)** → postgres · mysql · oracle · mssql · sqlite · redis · mongodb · libredb
+**[docs/providers/](./providers/README.md)** → postgres · mysql · oracle · mssql · sqlite · redis · mongodb · couchbase · libredb
 
 When implementing a new provider, the closest existing analogue is the best template: a pooled SQL
-provider (postgres/mysql), an embedded SQL provider (sqlite), or a non-SQL provider
-(mongodb/redis).
+provider (postgres/mysql), an embedded SQL provider (sqlite), a non-SQL provider (mongodb/redis), or
+a driverless provider reached over HTTP (couchbase).
 
 ## Quick Reference Checklist
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -27,7 +27,7 @@
 ### 4. Visual EXPLAIN (Query Analyzer)
 *   **Performance Visualization:** Visual execution plan to identify performance bottlenecks.
 *   **Detailed Metrics:** Graphical representation of database scan types, join operations, costs, and execution times.
-*   **Multi-DB Support:** Optimized for PostgreSQL and MySQL query plans.
+*   **Multi-DB Support:** PostgreSQL and MySQL JSON plans, SQLite `EXPLAIN QUERY PLAN`, and Couchbase SQL++ plan trees. Providers without a real analyze mode hide the toggle instead of degrading to an estimate.
 
 ### 5. AI Query Assistant (Multi-Provider LLM)
 *   **Natural Language to SQL:** Convert natural language requests into high-precision SQL code.
@@ -48,6 +48,7 @@
     *   **SQL Server:** Full support with connection pooling (`mssql`); monitoring via DMVs (`sys.dm_*`).
 *   **Document Databases:**
     *   **MongoDB:** Full support with official driver, JSON-based MQL queries, automatic schema inference, and aggregation pipelines.
+    *   **Couchbase:** Full support with **no driver dependency** — SQL++ over the documented Query and management REST APIs, so the SQL editor, limiter and NL2SQL all apply. Buckets/scopes/collections flattened into the schema explorer, `INFER`-based column inference, visual EXPLAIN plans, and read-your-writes query consistency by default.
 *   **Key-Value Stores:**
     *   **Redis:** Full support via the official `ioredis` driver — plain-command and JSON query styles, prefix-grouped key "schema" through a non-blocking `SCAN`, and `INFO`/`SLOWLOG`/`CLIENT LIST`-derived health and metrics.
 *   **Embedded Stores:**

--- a/docs/SEED_CONNECTIONS.md
+++ b/docs/SEED_CONNECTIONS.md
@@ -100,7 +100,7 @@ connections:
 | `connections` | Yes | — | Array of connection definitions (min 1) |
 | `connections[].id` | Yes | — | Unique slug: `[a-z0-9-]+`, max 64 chars |
 | `connections[].name` | Yes | — | Display name, max 128 chars |
-| `connections[].type` | Yes | — | Database type: `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql`, `libredb` |
+| `connections[].type` | Yes | — | Database type: `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql`, `libredb`, `couchbase` |
 | `connections[].host` | No | — | Hostname or IP |
 | `connections[].port` | No | — | Port number (1-65535) |
 | `connections[].database` | No | — | Database name |

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -13,13 +13,15 @@ in lockstep with the code (see the tri-sync rule in [`../../CLAUDE.md`](../../CL
 | SQLite | `sqlite` | SQL (embedded) | `bun:sqlite` (Bun) / `node:sqlite` (Node) | SQL | [sqlite.md](./sqlite.md) |
 | Redis | `redis` | Key-Value | `ioredis` | JSON | [redis.md](./redis.md) |
 | MongoDB | `mongodb` | Document | `mongodb` | JSON (MQL) | [mongodb.md](./mongodb.md) |
+| Couchbase | `couchbase` | Document | none (HTTP: Query + management REST) | SQL (SQL++) | [couchbase.md](./couchbase.md) |
 | LibreDB | `libredb` | Embedded (Key-Value) | `@libredb/libredb` | JSON (command grammar) | [libredb.md](./libredb.md) |
 
 ## Conventions
 
 - **Filename = canonical type-id** (`postgres.md`, `mssql.md`, …), mirroring the source file
-  (`src/lib/db/providers/<family>/<type-id>.ts`). The official product name (e.g. "SQL Server") is
-  used only in each doc's title and prose.
+  (`src/lib/db/providers/<family>/<type-id>.ts`, or a `<type-id>/` directory when a provider is
+  split across modules, as Couchbase is). The official product name (e.g. "SQL Server") is used only
+  in each doc's title and prose.
 - **Each doc mirrors the code.** Every `file:line` citation is verified, and the per-provider triad
   — code, this doc, and `tests/integration/db/<type-id>-provider.test.ts` — must stay in sync in the
   same PR (the *provider tri-sync invariant*).

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -371,12 +371,18 @@ uses. `~meta` becomes the leading `__id` column, marked primary.
 ([`src/lib/db/types.ts:93`](../../src/lib/db/types.ts)), with the strategy in
 [`src/lib/explain/couchbase-json.ts`](../../src/lib/explain/couchbase-json.ts):
 
-- `buildSql(sql, 'estimate')` returns `EXPLAIN ${sql}` for `SELECT` statements — it produces the plan
-  without executing anything.
-- `buildSql(sql, 'analyze')` returns `null`. SQL++ has no `EXPLAIN ANALYZE`; real timings come only
-  from the request-level `profile: "timings"` parameter, which `ExplainStrategy` cannot set by
-  design (it emits SQL only). Returning `null` hides the toggle — the honesty rule established in
-  #201 — rather than offering an "analyze" mode that silently degrades to an estimate.
+- `buildSql()` returns `EXPLAIN ${sql}` for `SELECT` statements, in **both** modes — it produces the
+  plan without executing anything. SQL++ has no `EXPLAIN ANALYZE`; real timings come only from the
+  request-level `profile: "timings"` parameter, which `ExplainStrategy` cannot set by design (it
+  emits SQL only), so the estimate is the best available answer for either mode. This mirrors
+  [`sqlite-queryplan.ts`](../../src/lib/explain/sqlite-queryplan.ts), which ignores the mode for the
+  same reason.
+
+  Returning `null` for analyze would not narrow the feature, it would disable it: the direct Explain
+  action always builds with mode `analyze`
+  ([`use-query-execution.ts:165`](../../src/hooks/use-query-execution.ts)) and refuses the run when
+  the strategy declines, so the button would be dead while only the background pre-warm worked.
+  A non-`SELECT` is still declined in both modes.
 - `toRenderModel()` walks `#operator` into the existing `{ kind: "tree" }` model.
 
 **Both child shapes are walked.** Couchbase plans use `~children` (an array, on `Sequence` and
@@ -507,8 +513,8 @@ What still needs an index is *discovering* keys you do not already know
 ### 5.4 EXPLAIN
 
 The EXPLAIN button is available (`supportsExplain: true`) and renders the plan tree described in
-[§3.11](#311-explain-reuses-the-shared-tree-model). There is no analyze mode; the toggle is hidden
-rather than degraded.
+[§3.11](#311-explain-reuses-the-shared-tree-model). Couchbase has no analyze mode, so both the
+direct action and the background pre-warm show the estimated plan.
 
 ---
 

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -1,0 +1,817 @@
+# Couchbase Provider
+
+> Couchbase Server support for LibreDB Studio, built on the documented REST surfaces — the Query
+> Service (`/query/service`) and the management API (`/pools/default...`) — with **no driver
+> dependency of any kind**. This document is the single reference point for the Couchbase provider:
+> design, architecture, usage, and tests. If you are reading the code, extending Couchbase support,
+> or authoring a new provider, start here.
+
+| | |
+|---|---|
+| **Status** | Implemented & shipped |
+| **Database type id** | `couchbase` |
+| **Family** | Document (`src/lib/db/providers/document/couchbase/`) |
+| **Driver** | None — HTTP only (`fetch` for plaintext, `node:https` for TLS; both runtime built-ins) |
+| **Query language** | `sql` (SQL++, formerly N1QL) |
+| **Default port** | `8091` management (`18091` with TLS). Query ports are **discovered**, never configured |
+| **Connection pooling** | None — each statement is one stateless HTTP request |
+| **Connection string** | Supported (`couchbase://`, `couchbases://`, Capella SRV endpoints) |
+| **EXPLAIN** | `couchbase-json` — estimate only, no `EXPLAIN ANALYZE` |
+| **Transactions** | Not exposed (no begin/commit/rollback API on this provider) |
+| **Query cancellation** | No `cancelQuery`; a running request is killed via maintenance `kill` |
+| **Source** | [`src/lib/db/providers/document/couchbase/`](../../src/lib/db/providers/document/couchbase/) |
+| **Tests** | [`tests/integration/db/couchbase-provider.test.ts`](../../tests/integration/db/couchbase-provider.test.ts) + [`tests/unit/db/couchbase/`](../../tests/unit/db/couchbase/) |
+| **Tracking issue** | [#262 — Add Couchbase provider (SQL++ over Query REST, no native dependency)](https://github.com/libredb/libredb-studio/issues/262) |
+
+---
+
+## 1. Overview
+
+Couchbase is a distributed document database whose query language, **SQL++**, is a real SQL dialect.
+That makes it an easier fit for this codebase than MongoDB was: the provider declares
+`queryLanguage: "sql"` and inherits Monaco SQL highlighting, the shared query limiter, the `"sql"`
+tab type, NL2SQL, and saved queries with no additional code.
+
+The two things that *are* Couchbase-shaped, and which every design decision below flows from:
+
+1. **The hierarchy has four levels** — cluster > bucket > scope > collection — while the schema
+   explorer renders a flat list. The bucket is pinned by the connection; scope and collection are
+   flattened exactly the way PostgreSQL flattens schema and table.
+2. **Indexes govern whether, and how fast, a keyspace can be read.** From Server 7.6 an un-indexed
+   collection is still readable through a *sequential scan*, but slowly; on 7.0-7.2 it fails
+   outright with error 4000. The provider handles both and tells the user what to do
+   ([§3.8](#38-un-indexed-keyspaces-sequential-scan-and-error-4000)).
+
+### Concept mapping
+
+| `DatabaseProvider` slot | Couchbase realisation | Mechanism |
+|-------------------------|-----------------------|-----------|
+| "Table" (`TableSchema`) | A **collection**, displayed as `collection` or `scope.collection` | `system:keyspaces` LEFT JOIN `system:scopes` |
+| "Row" | A **document** | SQL++ result row |
+| Columns | **Inferred** field types from a 100-document sample | `INFER <keyspace> WITH {"sample_size": 100}` |
+| Primary key | The document key, projected as `__id` | `META(d).id` |
+| `query(sql)` | A **SQL++** statement | `POST /query/service` |
+| Indexes | Global secondary indexes (GSI) | `system:indexes` |
+| Foreign keys | none (Couchbase has none) | always `[]` |
+| `getOverview()` / storage | Cluster and bucket runtime statistics | `/pools/default`, `/pools/default/buckets/<bucket>` |
+| `getSlowQueries()` / `getActiveSessions()` | Query-service request catalogs | `system:completed_requests`, `system:active_requests` |
+| Maintenance | `analyze` / `reindex` / `kill` | `UPDATE STATISTICS`, `BUILD INDEX`, `DELETE FROM system:active_requests` |
+
+---
+
+## 2. Architecture
+
+### 2.1 Where it sits
+
+The database layer uses the **Strategy Pattern**. Every provider implements the
+[`DatabaseProvider`](../../src/lib/db/types.ts) interface, and most shared mechanics live in the
+abstract [`BaseDatabaseProvider`](../../src/lib/db/base-provider.ts). Couchbase is the first
+provider that is a *directory* rather than a single file, because the transport is a seam
+([§3.2](#32-the-transport-seam-one-interface-one-implementation)):
+
+```
+src/lib/db/providers/document/
+├── mongodb.ts
+└── couchbase/
+    ├── index.ts             # CouchbaseProvider - the DatabaseProvider implementation
+    ├── transport.ts         # CouchbaseTransport interface + neutral result types (no I/O)
+    ├── http-transport.ts    # the one implementation: Query REST + management REST
+    ├── keyspace.ts          # display name <-> backtick-quoted keyspace path (pure)
+    └── introspect.ts        # system:* catalog reads + INFER
+```
+
+The explain strategy lives with the other strategies, not with the provider:
+[`src/lib/explain/couchbase-json.ts`](../../src/lib/explain/couchbase-json.ts).
+
+### 2.2 Class hierarchy
+
+```
+DatabaseProvider (interface, types.ts)
+        ^
+        | implements
+BaseDatabaseProvider (abstract, base-provider.ts)
+        ^
+        | extends
+CouchbaseProvider (couchbase/index.ts)
+```
+
+`CouchbaseProvider` extends `BaseDatabaseProvider` directly — the same pattern as `MongoDBProvider`
+and `RedisProvider`. It is **not** a `SQLBaseProvider`: that base owns pooled-driver mechanics
+(identifier escaping per dialect, placeholder generation, transactions, `cancelQuery`) that a
+stateless HTTP transport does not have. SQL++ being a SQL dialect is expressed through
+`queryLanguage: "sql"`, not through the class hierarchy.
+
+### 2.3 What the base class gives you for free
+
+`CouchbaseProvider` reuses these inherited members rather than reimplementing them:
+
+- **State machine** — `setConnected()`, `setError()`, `isConnected()`, `ensureConnected()`.
+- **Instrumentation** — `trackQuery()` (active-query counter) and `measureExecution()` (wall clock).
+- **Helpers** — `formatDuration()`, `getSafeConfig()` (password-stripped logging), `mapError()`.
+- **Default `getMonitoringData()`** — orchestrates `getOverview` + `getPerformanceMetrics` +
+  `getSlowQueries` + `getActiveSessions` (+ tables/indexes/storage) concurrently.
+
+### 2.4 Registration & lifecycle
+
+The factory wires Couchbase in via a dynamic import
+([`factory.ts:93`](../../src/lib/db/factory.ts)):
+
+```ts
+case 'couchbase': {
+  // The explicit /index specifier keeps this dynamic import statically analysable:
+  // a bare directory resolves only at runtime, which the bundler cannot trace into a chunk.
+  const { CouchbaseProvider } = await import('./providers/document/couchbase/index');
+  return new CouchbaseProvider(connection, options);
+}
+```
+
+`connect()` ([index.ts:335](../../src/lib/db/providers/document/couchbase/index.ts)) proves
+reachability *and* credentials with one `GET /pools/default` — the cheapest call that needs no RBAC
+role beyond cluster read — then keeps the transport. `disconnect()` clears the transport's cached
+endpoint discovery; there are no sockets to close. API routes use `getOrCreateProvider()`, which
+caches the connected provider per `connection.id` and evicts it after 30 minutes idle.
+
+---
+
+## 3. Design decisions
+
+These are the non-obvious choices. Read this section before changing the provider.
+
+### 3.1 HTTP transport only — no native dependency, mandatory or optional
+
+The official `couchbase` SDK is Apache-2.0 but weighs 64.6 MB unpacked across 3765 files, depends on
+`cmake-js` and `node-addon-api`, and runs a postinstall step that downloads a prebuilt binary or
+compiles from source. Studio ships as a Docker image, Snap, AppImage, Flatpak, deb/rpm **and** the
+`@libredb/studio` npm package that `libredb-platform` consumes — every one of those would inherit
+the native module.
+
+HTTP is also the more deployable choice, not the weaker one: air-gapped installs have no postinstall
+download to fail; the binary KV protocol on 11210 does not traverse corporate HTTP proxies while
+REST does; site firewall policy commonly opens 8091/18093 and not 11210; and container images need
+no glibc/musl matching. Couchbase's own Web Console and the Capella UI are browser applications, so
+they reach the cluster over exactly these endpoints.
+
+Two capabilities that look SDK-only are not:
+
+- **Direct document lookup by key** works over the Query Service via `USE KEYS`
+  ([§5.3](#53-use-keys-reads-a-document-with-no-index-at-all)).
+- **Distributed ACID transactions** work over REST (`BEGIN TRANSACTION` returns a `txid` carried as
+  a request parameter). This provider does not expose them yet — see
+  [§13](#13-known-limitations--future-work).
+
+What remains genuinely SDK-only is three things, all named honestly in
+[§13](#13-known-limitations--future-work): KV range scan, non-JSON documents, and subdocument
+operations.
+
+### 3.2 The transport seam: one interface, one implementation
+
+Provider logic never calls `fetch`. It goes through `CouchbaseTransport`
+([transport.ts:87](../../src/lib/db/providers/document/couchbase/transport.ts)), so adopting the SDK
+later would be one new file implementing the same contract rather than a rewrite:
+
+```ts
+interface CouchbaseTransport {
+  readonly kind: "http";
+  query(stmt: string, o?: QueryOpts): Promise<CouchbaseQueryResult>;
+  manage<T>(path: string): Promise<T>;
+  /** SDK extension point: KV range scan. Not available over HTTP. */
+  scanDocuments?(ks: Keyspace, limit: number, skip: number): Promise<CouchbaseRow[]>;
+  close(): Promise<void>;
+}
+```
+
+The result type is deliberately **neutral** rather than the REST envelope
+([transport.ts:45](../../src/lib/db/providers/document/couchbase/transport.ts)):
+
+```ts
+interface CouchbaseQueryResult {
+  rows: CouchbaseRow[];
+  fieldNames: string[] | null;   // null when the source cannot tell (SELECT *)
+  executionTimeMs: number;
+  mutationCount: number;
+  warnings: CouchbaseWarning[];
+}
+```
+
+An interface shaped like `{ results, signature, status, metrics, errors }` would force any future
+SDK adapter to fabricate fields only the REST API produces. Both sources produce the shape above
+without inventing anything. Errors follow the same rule: the transport throws a normalized
+`CouchbaseError { code, message, retriable }`
+([transport.ts:105](../../src/lib/db/providers/document/couchbase/transport.ts)) whose `code` is a
+single numeric space — SQL++ codes (3000, 4000, 13014, …) and HTTP codes (401, 403, 503) both land
+there, so provider-level mapping is one switch.
+
+`manage()` stays HTTP permanently: the SDK's management APIs cover bucket/index/user *settings*, not
+cluster and bucket *runtime statistics*, so `/pools/default` and `/pools/default/buckets/<bucket>`
+are required for overview, performance and storage metrics under any transport.
+
+> **Seam rule.** The REST envelope identifiers (`results`, `signature`, `requestID`, `status`) must
+> appear **only** in `http-transport.ts`. A stray `if (response.status === "errors")` in provider
+> logic quietly erodes the boundary and makes a future SDK adapter expensive.
+
+### 3.3 Ports are discovered, not configured
+
+`DatabaseConnection` carries one `port`, but Couchbase needs both a management endpoint and a query
+endpoint. Only the **management** port is stored (8091, or 18091 with TLS); the query endpoint comes
+from `GET /pools/default/nodeServices`, reading `nodesExt[].services.n1ql` (or `n1qlSSL` under TLS)
+and preferring `alternateAddresses.external` when present — which is what makes NAT, Docker port
+mapping and Capella work
+([http-transport.ts:445](../../src/lib/db/providers/document/couchbase/http-transport.ts)). With no
+`n1ql` entry anywhere the transport falls back to 8093 / 18093.
+
+Discovery is cached **as a promise**, so concurrent first queries share one round trip — but a
+*failed* discovery is not cached, or one unreachable moment would poison every later query on the
+connection ([http-transport.ts:431](../../src/lib/db/providers/document/couchbase/http-transport.ts)).
+
+Capella endpoints (`couchbases://cb.<id>.cloud.couchbase.com`) are SRV records, so a host given
+without an explicit port is resolved through `_couchbases._tcp.<host>` first; a DNS failure or an
+empty answer falls back to treating the host as a plain A record, which is what every self-hosted
+cluster needs anyway ([http-transport.ts:418](../../src/lib/db/providers/document/couchbase/http-transport.ts)).
+
+### 3.4 Keyspace flattening follows the PostgreSQL rule
+
+`keyspace.ts` is pure, with no I/O. The default scope is implicit and everything else is qualified,
+exactly as `postgres.ts` does for schema/table:
+
+```ts
+keyspaceDisplayName('_default', 'hotel')     // -> "hotel"
+keyspaceDisplayName('inventory', 'hotel')    // -> "inventory.hotel"
+keyspaceFromDisplayName('travel', 'inventory.hotel')
+// -> { bucket: 'travel', scope: 'inventory', collection: 'hotel' }
+keyspacePath({ bucket: 'travel', scope: 'inventory', collection: 'hotel' })
+// -> `travel`.`inventory`.`hotel`
+```
+
+**Quoting is a security boundary.** SQL++ has no bind parameter for identifiers, so keyspace paths
+are assembled by concatenation; `quoteIdentifier()`
+([keyspace.ts:31](../../src/lib/db/providers/document/couchbase/keyspace.ts)) doubles embedded
+backticks so a hostile identifier cannot terminate its own quoting and have the remainder parsed as
+SQL++. Backticks are also required for a second, mundane reason: **`bucket` and `scope` are reserved
+words** in SQL++, and an unquoted projection over `system:keyspaces` fails with error 3000 (verified
+on Server 8.0.2).
+
+### 3.5 HTTP 200 does not mean success
+
+The Query Service returns syntax and semantic errors **inside a 200 response** with
+`status: "errors"`. The transport therefore inspects the payload *before* the HTTP code
+([http-transport.ts:249](../../src/lib/db/providers/document/couchbase/http-transport.ts)); skipping
+that check reports a failed statement as "0 rows".
+
+### 3.6 `SELECT *` nests documents, so generated queries project the key explicitly
+
+`SELECT * FROM hotel` yields `[{ "hotel": { ... } }]` — the document is nested under the keyspace
+name, and the key is not part of the result at all. Generated queries therefore alias the keyspace
+and project the key ([`query-generators.ts`](../../src/lib/query-generators.ts)):
+
+```sql
+SELECT META(d).id AS __id, d.* FROM `travel`.`inventory`.`hotel` AS d LIMIT 50;
+```
+
+The alias `__id` matches `COUCHBASE_DOCUMENT_KEY_COLUMN` in the introspection module
+([introspect.ts:58](../../src/lib/db/providers/document/couchbase/introspect.ts)), so the schema tree
+and the result grid name the key identically. A hand-written `SELECT *` still works; its columns are
+then derived from the rows, because a wildcard signature tells the transport nothing
+([http-transport.ts:183](../../src/lib/db/providers/document/couchbase/http-transport.ts)).
+
+### 3.7 Read-your-writes: `scan_consistency` defaults to `request_plus`
+
+The query service defaults to `not_bounded`, reading the index in whatever state it happens to be
+in. That is unacceptable for an interactive editor. Verified against Couchbase Server 8.0.2:
+immediately after an `INSERT`, a `SELECT` returned **zero rows** while `COUNT(*)` already returned
+three, and the same `SELECT` returned three rows seconds later — a user inserts a row, selects, and
+sees nothing.
+
+The transport therefore sends `scan_consistency: "request_plus"` on **every** statement
+([http-transport.ts:55](../../src/lib/db/providers/document/couchbase/http-transport.ts)), so a user
+always sees their own writes. Callers that prefer latency over freshness opt out per statement:
+
+```ts
+await transport.query('SELECT ...', { scanConsistency: 'not_bounded' });
+```
+
+The trade-off is explicit: `request_plus` makes the query wait for the index to catch up with the
+mutations issued before it, which costs latency on a write-heavy cluster. Correctness in an editor
+is worth more than milliseconds; speed remains one option away.
+
+### 3.8 Un-indexed keyspaces: sequential scan, and error 4000
+
+What happens when a collection has no index depends on the server version, and the difference
+matters enough to state plainly.
+
+**Server 7.6 and later — it works, slowly.** The Query Service falls back to a *sequential scan*,
+which uses a KV range scan underneath to enumerate keys, so CRUD and JOIN all succeed with no
+primary or secondary index present. Verified on Community Edition 8.0.2: selecting from a
+collection with no index at all returns rows, and `EXPLAIN` shows the fallback explicitly:
+
+```json
+{ "#operator": "PrimaryScan3", "index": "#sequentialscan", "using": "sequentialscan" }
+```
+
+Clicking an un-indexed collection in the schema explorer therefore just works. The caveat is
+performance, not capability: a sequential scan is not optimised for throughput and degrades sharply
+on large collections, to the point of query timeouts. Creating an index remains the right thing to
+do for anything beyond a small or throwaway collection — it is a recommendation now, not a
+prerequisite.
+
+**Server 7.0 to 7.2 — it fails with error 4000.** Sequential scan does not exist there, so the same
+statement returns "No index available on keyspace". The provider re-raises it as a `QueryError`
+carrying the runnable remedy, quoted for the exact keyspace the statement read from
+([index.ts:473](../../src/lib/db/providers/document/couchbase/index.ts)):
+
+```text
+No index available on keyspace `travel`.`inventory`.`hotel` that matches your query.
+Create one first: CREATE PRIMARY INDEX ON `travel`.`inventory`.`hotel`
+```
+
+In both cases `getSchemaRelations()` reads `system:indexes`, so an un-indexed collection shows an
+empty index list in the explorer before anything is run. Documents whose key is known are reachable
+without any index on every supported version
+([§5.3](#53-use-keys-reads-a-document-with-no-index-at-all)).
+
+### 3.9 Monitoring degrades to empty, never throws
+
+`system:completed_requests`, `system:active_requests` and the index-service statistics require the
+**Query System Catalog** RBAC role, so a denial is the *normal* case for a restricted user. Every
+monitoring source funnels through one helper
+([index.ts:189](../../src/lib/db/providers/document/couchbase/index.ts)):
+
+```ts
+async function degradeTo<T>(operation: () => Promise<T>, fallback: T): Promise<T> {
+  try { return await operation(); } catch { return fallback; }
+}
+```
+
+A source the connected user cannot read yields the fallback instead of breaking an otherwise working
+connection. `getSchemaRelations()` is the deliberate exception: an empty index list *is* the
+un-indexed signal of §3.8, so degrading a failed catalog read to empty would fabricate that signal
+for the whole bucket ([introspect.ts:327](../../src/lib/db/providers/document/couchbase/introspect.ts)).
+
+### 3.10 INFER output is nested, and every flavour is unioned
+
+`INFER` returns one row that is itself an **array of flavours** — one entry per document shape it
+found. Each flavour carries a `properties` map whose values have `type`, `%docs` and `samples`, plus
+a `~meta` pseudo-property whose nested `id` describes the document key. Verified shape:
+
+```json
+{ "#docs": 3, "Flavor": "", "properties": {
+  "city": { "type": "string", "%docs": 100, "samples": ["Bursa", "Istanbul"] },
+  "~meta": { "properties": { "id": { "type": "string", "samples": ["hotel::1"] } } } } }
+```
+
+`columnsFromFlavours()`
+([introspect.ts:178](../../src/lib/db/providers/document/couchbase/introspect.ts)) unions **all**
+flavours — taking only the first would drop every field the other shapes carry. A field is nullable
+when `%docs < 100`, when `null` is among its observed types, or when it is missing from some
+flavour. Multiple observed types render as `mixed(a|b)`, the same convention the MongoDB provider
+uses. `~meta` becomes the leading `__id` column, marked primary.
+
+### 3.11 EXPLAIN reuses the shared tree model
+
+`ExplainFormat` gains `"couchbase-json"`
+([`src/lib/db/types.ts:93`](../../src/lib/db/types.ts)), with the strategy in
+[`src/lib/explain/couchbase-json.ts`](../../src/lib/explain/couchbase-json.ts):
+
+- `buildSql(sql, 'estimate')` returns `EXPLAIN ${sql}` for `SELECT` statements — it produces the plan
+  without executing anything.
+- `buildSql(sql, 'analyze')` returns `null`. SQL++ has no `EXPLAIN ANALYZE`; real timings come only
+  from the request-level `profile: "timings"` parameter, which `ExplainStrategy` cannot set by
+  design (it emits SQL only). Returning `null` hides the toggle — the honesty rule established in
+  #201 — rather than offering an "analyze" mode that silently degrades to an estimate.
+- `toRenderModel()` walks `#operator` into the existing `{ kind: "tree" }` model.
+
+**Both child shapes are walked.** Couchbase plans use `~children` (an array, on `Sequence` and
+friends) *and* `~child` (a single operator, observed on `Parallel`); a walker handling only
+`~children` silently truncates the tree. The strategy collects every tilde-prefixed key of either
+shape. Cost and cardinality are read flat on the operator or nested under `optimizer_estimates`, and
+`-1` is treated as "no estimate" rather than a metric. Couchbase 8.0.2 advertises
+`clusterCapabilities.n1ql` including `costBasedOptimizer` even on **Community Edition**, so cost and
+cardinality can appear on CE plans.
+
+---
+
+## 4. Connection
+
+### 4.1 Configuration fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `host` | Yes (or `connectionString`) | Cluster node hostname. `validate()` throws `DatabaseConfigError` when both are missing |
+| `port` | No | **Management** port only. Defaults to `8091` (`18091` when SSL is on). Query ports are discovered ([§3.3](#33-ports-are-discovered-not-configured)) |
+| `user` / `password` | No | Sent as HTTP Basic on every request |
+| `database` | **Yes** | Carries the **bucket** name. One bucket per connection; the ConnectionModal labels this field "Bucket" |
+| `connectionString` | No | `couchbase://` / `couchbases://`; see [§4.2](#42-connection-strings) |
+| `ssl` | No | See [§4.3](#43-tls) |
+
+`database` being the bucket is the one field that surprises people, so the form says so:
+`ConnectionModal` renders the label "Bucket" for `type === 'couchbase'`
+([`ConnectionModal.tsx:139`](../../src/components/ConnectionModal.tsx)), and `validate()` rejects a
+connection without one ([index.ts:325](../../src/lib/db/providers/document/couchbase/index.ts)):
+
+```text
+Couchbase requires a bucket (use the "database" field)
+```
+
+Multi-bucket browsing from a single connection is out of scope; create one connection per bucket.
+
+```ts
+const connection = {
+  id: 'cb-1',
+  name: 'Travel',
+  type: 'couchbase',
+  host: '127.0.0.1',
+  port: 8091,            // management port; 8093 is found from the cluster
+  user: 'Administrator',
+  password: 'password123',
+  database: 'travel',    // the BUCKET
+  createdAt: new Date(),
+};
+```
+
+### 4.2 Connection strings
+
+`supportsConnectionString` is `true`, and the UI parser
+([`connection-string-parser.ts:138`](../../src/lib/connection-string-parser.ts)) decomposes the URL
+into discrete fields before the provider sees it:
+
+| Input | host | port | database (bucket) |
+|-------|------|------|-------------------|
+| `couchbase://localhost:8091/travel` | `localhost` | `8091` | `travel` |
+| `couchbase://user:pw@node1,node2/travel` | `node1` (first host wins) | `8091` | `travel` |
+| `couchbases://cb.abc123.cloud.couchbase.com` | the host | `18091` | *(none — not invented)* |
+
+Only the **management** port is ever stored: `8091` for `couchbase://`, `18091` for `couchbases://`.
+A connection that carries *only* a connection string has its hostname lifted out for the transport
+and nothing else — the URL's port is deliberately not used, because a `couchbase://` URL from an
+application config carries the KV port, not the management port, and discovery handles the rest
+([index.ts:368](../../src/lib/db/providers/document/couchbase/index.ts)).
+`detectConnectionStringType()` maps both schemes to `couchbase`.
+
+A Capella endpoint carries neither a port nor a bucket path, so the bucket must be filled in by
+hand; nothing is invented for it.
+
+### 4.3 TLS
+
+`config.ssl` drives two things. When `mode` is anything but `disable`, requests switch from `fetch`
+to `node:https` and the scheme becomes `https`. Node's `fetch` cannot carry a custom CA or relax
+verification without an undici `Agent` passed as `dispatcher`, and undici is not a dependency of this
+project (and must not become one); `node:https` is a built-in that takes `ca`/`cert`/`key`/
+`rejectUnauthorized` directly, so self-signed self-hosted clusters work on the Node runtime that
+ships in the Docker image.
+
+`rejectUnauthorized` follows the same rule PostgreSQL and MySQL use: only `verify-ca` and
+`verify-full` verify the chain by default, because a self-hosted Couchbase node ships a self-signed
+certificate — an explicit `ssl.rejectUnauthorized` always wins
+([http-transport.ts:256](../../src/lib/db/providers/document/couchbase/http-transport.ts)).
+
+---
+
+## 5. Query interface
+
+### 5.1 Execution
+
+`query(sql, params?)` ([index.ts:408](../../src/lib/db/providers/document/couchbase/index.ts)) sends
+one SQL++ statement. Positional parameters map to `$1`-style placeholders:
+
+```ts
+await provider.query('SELECT h.name FROM `travel`.`inventory`.`hotel` AS h WHERE h.city = $1',
+                     ['Istanbul']);
+```
+
+The request carries `metrics: true`, the effective statement timeout, and
+`scan_consistency: request_plus` ([§3.7](#37-read-your-writes-scan_consistency-defaults-to-request_plus)).
+`prepareQuery()` injects `LIMIT`/`OFFSET` through the shared limiter
+(`supportsExternalQueryLimiting: true`), so paging behaves as it does for every SQL provider.
+
+### 5.2 Result shaping
+
+| Source field | `QueryResult` field | Notes |
+|--------------|---------------------|-------|
+| result rows | `rows` | JSON objects exactly as the cluster returned them |
+| signature | `fields` | `null` for a wildcard signature, in which case columns are the union of the keys the rows carry, first seen first |
+| — | `rowCount` | `rows.length`, or the mutation count when a statement returned no rows |
+| metrics `executionTime` | `executionTime` | The cluster's own time (excludes network latency); falls back to the measured wall clock when the cluster reported none |
+
+### 5.3 `USE KEYS` reads a document with no index at all
+
+This is the second thing that surprises people, and it is worth knowing before creating an index
+just to look at one document. `USE KEYS` bypasses index lookup and reads straight from KV:
+
+```sql
+SELECT META(d).id AS __id, d.* FROM `travel`.`inventory`.`hotel` AS d USE KEYS ["hotel::1"];
+```
+
+That statement succeeds on a keyspace that has **no index whatsoever** — error 4000 never fires.
+What still needs an index is *discovering* keys you do not already know
+([§13](#13-known-limitations--future-work)).
+
+### 5.4 EXPLAIN
+
+The EXPLAIN button is available (`supportsExplain: true`) and renders the plan tree described in
+[§3.11](#311-explain-reuses-the-shared-tree-model). There is no analyze mode; the toggle is hidden
+rather than degraded.
+
+---
+
+## 6. Schema introspection
+
+`getSchemaList()` is the primary path used by `/api/db/schema/list`, so columns are produced there
+([introspect.ts:306](../../src/lib/db/providers/document/couchbase/introspect.ts)):
+
+| Data | Source |
+|------|--------|
+| Collections | `system:keyspaces` LEFT JOIN `system:scopes`, filtered to the pinned bucket |
+| Columns | `INFER <keyspace> WITH {"sample_size": 100}` per collection, 4 at a time, 5 s server-side timeout each |
+| Indexes | `system:indexes` (via `getSchemaRelations()`) |
+| Foreign keys | always `[]` — Couchbase has none and none are invented |
+
+Three details are load-bearing:
+
+- **The join is a LEFT JOIN.** `system:scopes` does not list `_default` on Server 8.0.2, so an inner
+  join silently drops every collection in the default scope.
+- **The bucket-level catalog row is kept.** A row with `name = bucket` and no `bucket`/`scope`
+  fields *is* the pre-collections default collection; dropping it would hide every document written
+  before scopes existed.
+- **A failed INFER yields empty columns, never an error.** The two common causes — the user lacks
+  SELECT on the collection, and the collection is empty (error 7014, "No documents found, unable to
+  infer schema") — are both states the explorer should render, not fail on. Coverage is *not*
+  truncated to a fixed number of collections; the concurrency bound of 4 is what keeps the cost of
+  schema loading in hand ([introspect.ts:245](../../src/lib/db/providers/document/couchbase/introspect.ts)).
+
+`getSchema()` merges both halves. A primary index carries no `index_key`, so it is reported with the
+synthetic column `META().id`; `unique` is true only for primary indexes, because no secondary GSI
+enforces uniqueness.
+
+---
+
+## 7. Monitoring & health
+
+Every method below degrades to empty/zero on a permission error
+([§3.9](#39-monitoring-degrades-to-empty-never-throws)).
+
+| Method | Source | Notes |
+|--------|--------|-------|
+| `getOverview()` | `/pools/default`, `/pools/default/buckets/<bucket>`, `system:keyspaces`, `system:indexes` | version and uptime from the first node; `activeConnections` from the `curr_connections` series |
+| `getPerformanceMetrics()` | bucket stats | cache hit ratio is `100 - ep_cache_miss_rate` (clamped 0..100); `queriesPerSecond` is `cmd_get + cmd_set`; buffer-pool usage is `quotaPercentUsed` |
+| `getSlowQueries()` | `system:completed_requests` ordered by `elapsedTime` | one row per recorded request, so `calls` is always 1 — these are individual requests, not aggregates |
+| `getActiveSessions()` | `system:active_requests` | request id, statement, user, remote address, state, elapsed |
+| `getTableStats()` | `/pools/default/buckets/<bucket>` | **bucket level only** — per-collection item counts need a `COUNT(*)` per collection, too expensive for a monitoring poll |
+| `getIndexStats()` | `system:indexes` + `/pools/default/buckets/@index-<bucket>/stats` | index name, scope, collection, keys, type; size and scan counts fall back to 0 because modern servers no longer publish them there |
+| `getStorageStats()` | `/pools/default/buckets/<bucket>` | Data (`basicStats.diskUsed`) and RAM Quota (`quota.ram` with `quotaPercentUsed`) |
+| `getHealth()` | the four above, in parallel | connections, size, cache hit ratio, top 5 slow queries, top 10 sessions |
+
+`maxConnections` in the overview is the documented KV default (65536): Couchbase advertises no
+connection ceiling over REST, so the denominator is a constant while the numerator stays measured.
+
+---
+
+## 8. Maintenance
+
+`runMaintenance(type, target?)`
+([index.ts:762](../../src/lib/db/providers/document/couchbase/index.ts)). All three operations
+**require** a target.
+
+| Type | Couchbase action | Notes |
+|------|------------------|-------|
+| `analyze` | `UPDATE STATISTICS FOR <keyspace> INDEX ALL` | **Enterprise Edition only.** A Community cluster answers "'Update Statistics' is an enterprise level feature." — returned verbatim as a failed result, not swallowed or reworded |
+| `reindex` | `BUILD INDEX ON <keyspace>(...)` over the keyspace's deferred indexes | Reports "No deferred indexes on X" when there are none |
+| `kill` | `DELETE FROM system:active_requests WHERE requestId = $1` | Target is the request id shown in active sessions |
+
+`vacuum`, `optimize` and `check` have no Couchbase equivalent, so they are absent from
+`maintenanceOperations` and the UI never offers them; calling `runMaintenance` with one directly
+throws a `QueryError` naming the three supported operations.
+
+---
+
+## 9. Capabilities & labels
+
+### `getCapabilities()` ([index.ts:276](../../src/lib/db/providers/document/couchbase/index.ts))
+
+| Capability | Value |
+|------------|-------|
+| `queryLanguage` | `sql` |
+| `supportsExplain` | `true` |
+| `explainFormat` | `couchbase-json` |
+| `supportsExternalQueryLimiting` | `true` |
+| `supportsCreateTable` | `false` |
+| `supportsMaintenance` | `true` |
+| `maintenanceOperations` | `['analyze', 'reindex', 'kill']` |
+| `supportsConnectionString` | `true` |
+| `defaultPort` | `8091` |
+| `schemaRefreshPattern` | `\b(CREATE\|DROP\|ALTER)\s+(COLLECTION\|SCOPE\|INDEX)\b` |
+
+`supportsCreateTable: false` is deliberate: `CreateTableModal` builds `CREATE TABLE` from a column
+list, while Couchbase collections are schemaless and `CREATE COLLECTION` takes no columns. Leaving
+the flag on would render a control that can only emit invalid SQL++.
+
+### `getLabels()` ([index.ts:293](../../src/lib/db/providers/document/couchbase/index.ts))
+
+Document vocabulary: entity -> *Collection*, row -> *document*, select -> *Select Documents*,
+analyze -> *Update Statistics* (the card text names the Enterprise-only restriction), vacuum ->
+*Compact* (the card says Couchbase compacts automatically and there is nothing to run), search
+placeholder -> *Search collections or fields...*.
+
+---
+
+## 10. Error handling
+
+The transport normalizes every failure into `CouchbaseError { code, message, retriable }`; the
+provider maps that one numeric space onto the shared classes from
+[`src/lib/db/errors.ts`](../../src/lib/db/errors.ts)
+([index.ts:444](../../src/lib/db/providers/document/couchbase/index.ts)):
+
+| Code | Meaning | Error raised |
+|------|---------|--------------|
+| `4000` | No index available on keyspace | `QueryError` **+ the runnable `CREATE PRIMARY INDEX` remedy** ([§3.8](#38-un-indexed-keyspaces-sequential-scan-and-error-4000)) |
+| `1080` | Request timeout | `TimeoutError` |
+| `13014` | Missing or invalid credentials | `AuthenticationError` |
+| `401` / `403` | HTTP unauthorized / forbidden | `AuthenticationError` |
+| `503` | Query service unavailable (node warming up) | `ConnectionError` |
+| `0` with `retriable` | Network fault (DNS, refused, reset) | `ConnectionError` |
+| anything else (e.g. `3000` syntax) | Statement the cluster rejected | `QueryError` carrying the cluster's message |
+
+| Situation | Error |
+|-----------|-------|
+| Missing `host` **and** `connectionString` | `DatabaseConfigError` |
+| Missing `database` (bucket) | `DatabaseConfigError` |
+| Operation before `connect()` | `DatabaseConfigError` (via `ensureConnected()`) |
+| `connect()` fails on credentials | `AuthenticationError` |
+| `connect()` fails otherwise | `ConnectionError` (carries host/port) |
+
+`retriable` marks failures worth repeating (request timeout 1080, bulk KV fetch 12008, CAS mismatch
+12009, network faults) as opposed to ones that need a user fix.
+
+---
+
+## 11. Testing
+
+### 11.1 How the tests work
+
+There is **no `mock.module()` anywhere in the Couchbase suite**, which is why these files carry no
+process-wide contamination risk:
+
+- [`tests/integration/db/couchbase-provider.test.ts`](../../tests/integration/db/couchbase-provider.test.ts)
+  replaces `globalThis.fetch` per test and restores it in `afterEach`. Every payload in it was
+  captured from a live Couchbase Server 8.0.2 Community node, so the fake speaks exactly what the
+  cluster speaks.
+- [`tests/unit/db/couchbase/http-transport.test.ts`](../../tests/unit/db/couchbase/http-transport.test.ts)
+  drives the transport through its injected `requestJson` / `resolveSrv` dependencies, and exercises
+  the real `nodeRequestJson` against a local server rather than mocking it away.
+- [`tests/unit/db/couchbase/introspect.test.ts`](../../tests/unit/db/couchbase/introspect.test.ts)
+  and [`keyspace.test.ts`](../../tests/unit/db/couchbase/keyspace.test.ts) test pure functions and a
+  hand-written fake transport — the payoff of the seam in
+  [§3.2](#32-the-transport-seam-one-interface-one-implementation).
+- [`tests/unit/lib/explain/couchbase-json.test.ts`](../../tests/unit/lib/explain/couchbase-json.test.ts)
+  covers the plan walker, including the `~child` / `~children` pair.
+
+### 11.2 Coverage
+
+Validation, connect/disconnect, capabilities, labels, `prepareQuery`, query execution and result
+shaping, the full error map, endpoint discovery (including `alternateAddresses` and the fallback
+port), SRV resolution and its fallback, TLS material, `request_plus` **and** the `not_bounded`
+override, collection listing, INFER flavour union, index mapping, every monitoring method and its
+degraded path, all three maintenance operations, and the explain strategy.
+
+### 11.3 Run it
+
+```bash
+# Just this provider
+bun test tests/integration/db/couchbase-provider.test.ts
+bun test tests/unit/db/couchbase
+
+# Full isolated suite (CI-equivalent)
+bun run test
+```
+
+### 11.4 Optional: verifying against a live cluster
+
+The committed tests are mock-based by design. To smoke-test against a real server:
+
+```bash
+docker run --rm -d --name cb -p 8091-8096:8091-8096 couchbase:community
+
+# Community Edition REJECTS the Magma storage backend, which couchbase-cli defaults to,
+# and a single node cannot satisfy a replica - both flags are required.
+docker exec cb couchbase-cli cluster-init -c 127.0.0.1 \
+  --cluster-username Administrator --cluster-password password123 \
+  --services data,index,query --cluster-ramsize 512 --cluster-index-ramsize 256
+docker exec cb couchbase-cli bucket-create -c 127.0.0.1 \
+  -u Administrator -p password123 --bucket travel \
+  --bucket-type couchbase --bucket-ramsize 256 \
+  --storage-backend couchstore --bucket-replica 0
+```
+
+Then point a Studio connection at `127.0.0.1:8091` with bucket `travel`, and create a primary index
+so the collection can be browsed:
+
+```sql
+CREATE PRIMARY INDEX ON `travel`;
+```
+
+---
+
+## 12. Usage examples
+
+### 12.1 Programmatic (via the factory)
+
+```ts
+import { createDatabaseProvider } from '@/lib/db/factory';
+
+const provider = await createDatabaseProvider({
+  id: 'cb1', name: 'Travel', type: 'couchbase',
+  host: '127.0.0.1', port: 8091,
+  user: 'Administrator', password: 'password123',
+  database: 'travel',                    // the bucket
+  createdAt: new Date(),
+});
+
+await provider.connect();
+
+const rows = await provider.query(
+  'SELECT META(d).id AS __id, d.* FROM `travel`.`inventory`.`hotel` AS d LIMIT 50',
+);
+const byKey = await provider.query(
+  'SELECT d.* FROM `travel`.`inventory`.`hotel` AS d USE KEYS ["hotel::1"]',
+);
+const schema = await provider.getSchema();   // collections + inferred fields + indexes
+
+await provider.disconnect();
+```
+
+### 12.2 Over the API
+
+`POST /api/db/query` with the SQL++ statement in the `sql` field — the same contract every SQL
+provider uses. `POST /api/db/maintenance` (admin) accepts `analyze` / `reindex` / `kill`, each with a
+target. Transaction and cancel routes do not apply.
+
+---
+
+## 13. Known limitations & future work
+
+**What the HTTP transport does not provide.** These are real, they are the whole cost of having no
+native dependency, and they are listed first so nobody discovers them by accident:
+
+- **Direct KV range scan, on Server 7.0-7.2 only.** The SDK can stream a collection's documents
+  straight from the data service without touching an index. On 7.6 and later this gap has closed on
+  its own: the Query Service performs a sequential scan backed by a KV range scan, so an un-indexed
+  collection lists fine over plain SQL++ and no SDK is required
+  ([§3.8](#38-un-indexed-keyspaces-sequential-scan-and-error-4000)). The gap is therefore confined
+  to clusters older than 7.6, where an un-indexed collection raises error 4000 and the remedy is to
+  create the index. The seam still carries the `scanDocuments?()` extension point
+  ([§3.2](#32-the-transport-seam-one-interface-one-implementation)).
+- **Non-JSON documents.** The Query Service only sees JSON. Binary and raw-string documents stored
+  through the KV API are invisible to every SQL++ statement, so they appear in no result set and
+  contribute nothing to `INFER`.
+- **Subdocument operations.** The KV subdoc API (mutate/lookup a single path inside a document
+  without fetching it) has no REST equivalent. SQL++ projection covers reading a path; targeted
+  in-place path mutation does not exist here — an `UPDATE ... SET` rewrites through the query
+  service instead.
+
+A follow-up issue gets opened if a real user reports one of: browsing collections that have no
+index, viewing non-JSON documents, or a policy requiring the official SDK. At that point the work is
+one new file implementing `CouchbaseTransport`; provider logic, introspection, the explain strategy
+and all UI registration are untouched.
+
+Everything else:
+
+- **No transactions.** SQL++ transactions work over REST (`BEGIN TRANSACTION` returns a `txid`), but
+  the provider exposes no begin/commit/rollback API.
+- **No `cancelQuery`.** A running statement is terminated through maintenance `kill` with its
+  request id, which needs the Query System Catalog role.
+- **`UPDATE STATISTICS` is Enterprise-only.** On Community Edition the maintenance action returns
+  the cluster's refusal verbatim rather than pretending to succeed.
+- **No analyze-mode EXPLAIN.** SQL++ has none; see
+  [§3.11](#311-explain-reuses-the-shared-tree-model).
+- **Schema columns are a sample, not a declaration.** `INFER` reads 100 documents per collection, so
+  a field that appears only in unsampled documents will not show. Inference is flat: a nested object
+  is reported as its own type, not expanded into dotted sub-fields.
+- **Table stats are bucket level.** Per-collection item counts would need a `COUNT(*)` per
+  collection on every monitoring poll.
+- **Index size and scan counts are usually 0.** Modern servers no longer publish per-index series
+  under `@index-<bucket>`, and the provider does not guess.
+- **One bucket per connection.** Multi-bucket browsing from a single connection is out of scope;
+  `getSchemaList()` and every monitoring read are scoped to `config.database`.
+- **Analytics/Columnar, Full-Text Search, Eventing and Capella management APIs** (allowed-IP
+  administration, cluster provisioning) are not covered.
+- **Monitoring needs privileges.** Without the Query System Catalog role, slow queries and active
+  sessions are `[]` and index statistics fall back to zero — by design
+  ([§3.9](#39-monitoring-degrades-to-empty-never-throws)).
+
+---
+
+## 14. References
+
+- Tracking issue: [#262 — Add Couchbase provider](https://github.com/libredb/libredb-studio/issues/262)
+- Source: [`src/lib/db/providers/document/couchbase/`](../../src/lib/db/providers/document/couchbase/)
+- Explain strategy: [`src/lib/explain/couchbase-json.ts`](../../src/lib/explain/couchbase-json.ts)
+- Base class: [`src/lib/db/base-provider.ts`](../../src/lib/db/base-provider.ts)
+- Interface & DTOs: [`src/lib/db/types.ts`](../../src/lib/db/types.ts)
+- Errors: [`src/lib/db/errors.ts`](../../src/lib/db/errors.ts)
+- Tests: [`tests/integration/db/couchbase-provider.test.ts`](../../tests/integration/db/couchbase-provider.test.ts) · [`tests/unit/db/couchbase/`](../../tests/unit/db/couchbase/)
+- API contract: [`docs/API_DOCS.md`](../API_DOCS.md)
+- Query Service REST API: <https://docs.couchbase.com/server/current/n1ql/n1ql-rest-api/index.html>
+- Listing Node Services: <https://docs.couchbase.com/server/current/rest-api/rest-list-node-services.html>
+- System namespace catalogs: <https://docs.couchbase.com/server/current/n1ql/n1ql-intro/sysinfo.html>
+- USE clause (`USE KEYS`): <https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/hints.html>
+- INFER: <https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/infer.html>
+- EXPLAIN: <https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/explain.html>
+- Sibling provider docs: [PostgreSQL](./postgres.md) · [MySQL](./mysql.md) · [Oracle](./oracle.md) · [SQL Server](./mssql.md) · [SQLite](./sqlite.md) · [MongoDB](./mongodb.md) · [Redis](./redis.md) · [LibreDB](./libredb.md)

--- a/src/components/ConnectionModal.tsx
+++ b/src/components/ConnectionModal.tsx
@@ -134,6 +134,14 @@ export function ConnectionModal({
     dbTypes,
   } = useConnectionForm({ isOpen, onClose, onConnect, editConnection, onTestConnection });
 
+  // Couchbase pins one bucket per connection (issue #262, decision 4), so the shared
+  // `database` field holds a bucket name and the form must say so.
+  const isCouchbase = type === "couchbase";
+  const databaseFieldLabel = isCouchbase ? "Bucket" : "Database";
+  const connectionUriPlaceholder = isCouchbase
+    ? "couchbase://localhost:8091/travel-sample  or  couchbases://cb.<id>.cloud.couchbase.com/..."
+    : "mongodb://localhost:27017/mydb  or  mongodb+srv://...";
+
   const formContent = (
     <>
       {/* Progress bar — fixed top */}
@@ -327,7 +335,7 @@ export function ConnectionModal({
                       id="connectionString"
                       value={connectionString}
                       onChange={(e) => setConnectionString(e.target.value)}
-                      placeholder="mongodb://localhost:27017/mydb  or  mongodb+srv://..."
+                      placeholder={connectionUriPlaceholder}
                       className="h-10 bg-zinc-900/50 border-white/5 focus:border-blue-500/50 transition-all text-xs font-mono"
                     />
                   </div>
@@ -335,7 +343,7 @@ export function ConnectionModal({
                     <div className="flex items-center gap-2 mb-1">
                       <Database strokeWidth={1.5} className="w-3 h-3 text-zinc-500" />
                       <Label htmlFor="database" className="text-xs font-mediumr text-zinc-500">
-                        Database Name (optional override)
+                        {databaseFieldLabel} Name (optional override)
                       </Label>
                     </div>
                     <Input
@@ -427,7 +435,7 @@ export function ConnectionModal({
                     <div className="flex items-center gap-2 mb-1">
                       <Database strokeWidth={1.5} className="w-3 h-3 text-zinc-500" />
                       <Label htmlFor="database" className="text-xs font-mediumr text-zinc-500">
-                        Database Name
+                        {databaseFieldLabel} Name
                       </Label>
                     </div>
                     <Input

--- a/src/components/icons/db-icons.tsx
+++ b/src/components/icons/db-icons.tsx
@@ -151,6 +151,25 @@ export const MSSQLIcon: React.FC<IconProps> = ({ className, ...props }) => (
   </svg>
 );
 
+/** Couchbase bucket with its scope/collection dividers (simplified) */
+export const CouchbaseIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    <path d="M4 7l1.5-3h13L20 7" />
+    <path d="M4 7h16l-1.5 12a2 2 0 01-2 1.8H7.5a2 2 0 01-2-1.8L4 7z" />
+    <path d="M7.5 11h9" />
+    <path d="M7.5 15h9" />
+  </svg>
+);
+
 /** LibreDB database cylinder with L marker */
 export const LibreDBIcon: React.FC<IconProps> = ({ className, ...props }) => (
   <svg

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -301,7 +301,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       setTestResult({
         success: false,
         message:
-          "Could not parse connection string. Supported formats: postgres://, mysql://, mongodb://, redis://, oracle://, mssql://",
+          "Could not parse connection string. Supported formats: postgres://, mysql://, mongodb://, couchbase://, redis://, oracle://, mssql://",
       });
       return;
     }
@@ -314,8 +314,10 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     if (parsed.password) setPassword(parsed.password);
     if (parsed.database) setDatabase(parsed.database);
 
-    // For MongoDB, also set connection string mode
-    if (parsed.type === "mongodb" && parsed.connectionString) {
+    // A provider whose form offers the URI mode (MongoDB, Couchbase) switches to it,
+    // so the pasted string is what gets connected with rather than a lossy re-assembly
+    // of the fields parsed out of it.
+    if (getDBConfig(parsed.type).showConnectionStringToggle && parsed.connectionString) {
       setConnectionString(parsed.connectionString);
       setMongoConnectionMode("connectionString");
     }
@@ -341,6 +343,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     "oracle",
     "mssql",
     "mongodb",
+    "couchbase",
     "redis",
     "libredb",
   ];

--- a/src/lib/connection-string-parser.ts
+++ b/src/lib/connection-string-parser.ts
@@ -12,7 +12,8 @@ export interface ParsedConnection {
 
 /**
  * Parse a database connection string URL into its components.
- * Supports: postgres://, postgresql://, mysql://, mongodb://, mongodb+srv://, redis://
+ * Supports: postgres://, postgresql://, mysql://, mongodb://, mongodb+srv://, redis://,
+ * couchbase://, couchbases://
  */
 export function parseConnectionString(input: string): ParsedConnection | null {
   const trimmed = input.trim();
@@ -46,6 +47,14 @@ export function parseConnectionString(input: string): ParsedConnection | null {
   // MSSQL / SQL Server
   if (trimmed.startsWith("mssql://") || trimmed.startsWith("sqlserver://")) {
     return parseGenericURL(trimmed, "mssql", "1433");
+  }
+
+  // Couchbase — the TLS scheme is checked first, it is not a prefix of the plain one
+  if (trimmed.startsWith("couchbases://")) {
+    return parseCouchbaseString(trimmed, "18091");
+  }
+  if (trimmed.startsWith("couchbase://")) {
+    return parseCouchbaseString(trimmed, "8091");
   }
 
   // ADO.NET format: Server=host;Database=db;User Id=user;Password=pass;
@@ -107,6 +116,46 @@ function parseMongoDBString(uri: string): ParsedConnection {
   return result;
 }
 
+/**
+ * Percent-decode a component, keeping it verbatim when it is not a valid escape
+ * sequence. Couchbase bucket names may legally contain a literal "%".
+ */
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Parse a Couchbase connection string. Only the management port is stored — 8091 for
+ * couchbase://, 18091 for couchbases:// — because the query ports are discovered from the
+ * cluster at connect time. A Capella endpoint (couchbases://cb.<id>.cloud.couchbase.com)
+ * carries neither a port nor a bucket path, so both stay at their defaults and no bucket
+ * is invented. The full original string is always preserved.
+ */
+function parseCouchbaseString(uri: string, defaultPort: string): ParsedConnection | null {
+  try {
+    const url = new URL(uri);
+    // Multi-node connection strings list hosts comma-separated; take the first one.
+    const [firstHost] = url.hostname.split(",");
+    const bucket = url.pathname.slice(1); // remove leading /
+
+    return {
+      type: "couchbase",
+      host: firstHost || "localhost",
+      port: url.port || defaultPort,
+      user: url.username ? decodeURIComponent(url.username) : undefined,
+      password: url.password ? decodeURIComponent(url.password) : undefined,
+      database: bucket ? safeDecodeURIComponent(bucket) : undefined,
+      connectionString: uri,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function parseADONetString(input: string): ParsedConnection | null {
   try {
     const params: Record<string, string> = {};
@@ -163,6 +212,7 @@ export function detectConnectionStringType(input: string): DatabaseType | null {
   if (trimmed.startsWith("redis://") || trimmed.startsWith("rediss://")) return "redis";
   if (trimmed.startsWith("oracle://")) return "oracle";
   if (trimmed.startsWith("mssql://") || trimmed.startsWith("sqlserver://")) return "mssql";
+  if (trimmed.startsWith("couchbase://") || trimmed.startsWith("couchbases://")) return "couchbase";
   if (/^server\s*=/i.test(trimmed)) return "mssql";
   return null;
 }

--- a/src/lib/db-ui-config.ts
+++ b/src/lib/db-ui-config.ts
@@ -8,6 +8,7 @@ import {
   OracleIcon,
   MSSQLIcon,
   LibreDBIcon,
+  CouchbaseIcon,
 } from "@/components/icons/db-icons";
 import type { DatabaseType } from "@/lib/types";
 
@@ -88,6 +89,16 @@ const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     defaultPort: "1433",
     showConnectionStringToggle: false,
     connectionFields: ["host", "port", "user", "password", "database", "instanceName"],
+  },
+  couchbase: {
+    icon: CouchbaseIcon,
+    color: "text-orange-400",
+    label: "Couchbase",
+    // Management port. The query ports are discovered from the cluster at connect
+    // time (issue #262, decision 3), so only this one is ever stored.
+    defaultPort: "8091",
+    showConnectionStringToggle: true,
+    connectionFields: ["host", "port", "user", "password", "database", "connectionString"],
   },
   libredb: {
     icon: LibreDBIcon,

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -90,6 +90,14 @@ export async function createDatabaseProvider(
       return new MongoDBProvider(connection, options);
     }
 
+    case "couchbase": {
+      // The explicit /index specifier keeps this dynamic import statically
+      // analysable: a bare directory resolves only at runtime, which the bundler
+      // cannot trace into a chunk.
+      const { CouchbaseProvider } = await import("./providers/document/couchbase/index");
+      return new CouchbaseProvider(connection, options);
+    }
+
     // Key-Value Stores - dynamically imported
     case "redis": {
       const { RedisProvider } = await import("./providers/keyvalue/redis");
@@ -104,7 +112,7 @@ export async function createDatabaseProvider(
 
     default:
       throw new DatabaseConfigError(
-        `Unknown database type: ${connection.type}. Supported types: postgres, mysql, sqlite, oracle, mssql, mongodb, redis, libredb`,
+        `Unknown database type: ${connection.type}. Supported types: postgres, mysql, sqlite, oracle, mssql, mongodb, couchbase, redis, libredb`,
         connection.type,
       );
   }

--- a/src/lib/db/providers/document/couchbase/http-transport.ts
+++ b/src/lib/db/providers/document/couchbase/http-transport.ts
@@ -1,0 +1,484 @@
+/**
+ * Couchbase HTTP transport (issue #262, decisions 1, 3 and 5)
+ *
+ * The only implementation of the CouchbaseTransport seam. It speaks the two
+ * documented REST surfaces - the Query Service (`/query/service`) and the
+ * management API (`/pools/default...`) - so the provider needs no native
+ * dependency of any kind. This file is the ONLY place that may mention the wire
+ * envelope; a guard test fails the build if those identifiers leak out of it.
+ *
+ * Two transport paths, one seam:
+ *
+ * - Plaintext clusters go through global `fetch`.
+ * - TLS clusters go through `node:https`. Node's `fetch` cannot carry a custom
+ *   CA or relax verification without an undici `Agent` passed as `dispatcher`,
+ *   and undici is not a dependency of this project (and must not become one).
+ *   `node:https` is a built-in that takes `ca`/`cert`/`key`/`rejectUnauthorized`
+ *   directly, so self-signed self-hosted clusters work on the Node runtime that
+ *   ships in the Docker image.
+ */
+
+import { promises as dns, type SrvRecord } from "node:dns";
+import { request as httpRequest, type RequestOptions as HttpRequestOptions } from "node:http";
+import { request as httpsRequest, type RequestOptions as HttpsRequestOptions } from "node:https";
+import type { DatabaseConnection } from "@/lib/db/types";
+import type { SSLConfig } from "@/lib/types";
+import { quoteIdentifier } from "./keyspace";
+import {
+  CouchbaseError,
+  type CouchbaseQueryResult,
+  type CouchbaseRow,
+  type CouchbaseScanConsistency,
+  type CouchbaseTransport,
+  type CouchbaseWarning,
+  type QueryOpts,
+} from "./transport";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_HOST = "localhost";
+const DEFAULT_MANAGEMENT_PORT = 8091;
+const DEFAULT_MANAGEMENT_TLS_PORT = 18091;
+const DEFAULT_QUERY_PORT = 8093;
+const DEFAULT_QUERY_TLS_PORT = 18093;
+const QUERY_PATH = "/query/service";
+const NODE_SERVICES_PATH = "/pools/default/nodeServices";
+
+/** Capella endpoints are SRV records under this prefix. */
+const SRV_PREFIX = "_couchbases._tcp.";
+
+/** Server-side statement timeout when a caller does not set one. */
+const DEFAULT_QUERY_TIMEOUT_MS = 30000;
+
+/** Read-your-writes by default - see CouchbaseScanConsistency for why. */
+const DEFAULT_SCAN_CONSISTENCY: CouchbaseScanConsistency = "request_plus";
+
+const GENERIC_STATEMENT_FAILURE = "Couchbase rejected the statement";
+
+/**
+ * SQL++ codes worth retrying: request timeout, bulk KV fetch failure and the
+ * CAS mismatch a concurrent mutation produces. Everything else (syntax, missing
+ * index, missing privilege) needs a user fix, not another attempt.
+ */
+const RETRIABLE_CODES = new Set([1080, 12008, 12009]);
+
+const HTTP_MESSAGES: Record<number, string> = {
+  401: "Couchbase rejected the credentials (HTTP 401): check the username and password",
+  403: "Couchbase denied the request (HTTP 403): the user lacks permission for this operation",
+  503: "The Couchbase query service is unavailable (HTTP 503): the node may still be warming up",
+};
+
+/** Duration units the cluster emits, expressed in milliseconds. */
+const DURATION_UNITS_MS: Record<string, number> = {
+  ns: 1e-6,
+  us: 1e-3,
+  µs: 1e-3, // micro sign
+  μs: 1e-3, // greek small letter mu
+  ms: 1,
+  s: 1000,
+  m: 60000,
+  h: 3600000,
+};
+
+const DURATION_PATTERN = /(\d+(?:\.\d+)?)(ns|us|µs|μs|ms|s|m|h)/g;
+
+// ============================================================================
+// Transport-level types
+// ============================================================================
+
+/** TLS material handed to the node request path. */
+export interface CouchbaseTlsMaterial {
+  ca?: string;
+  cert?: string;
+  key?: string;
+  rejectUnauthorized: boolean;
+}
+
+export interface JsonRequestInit {
+  method: "GET" | "POST";
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export interface JsonResponse {
+  httpCode: number;
+  payload: unknown;
+}
+
+export type SecureJsonRequest = (
+  url: string,
+  init: JsonRequestInit,
+  tls: CouchbaseTlsMaterial,
+) => Promise<JsonResponse>;
+
+export type SrvResolver = (hostname: string) => Promise<SrvRecord[]>;
+
+/**
+ * Injection points. Both default to the real implementation; tests replace them
+ * rather than reaching for `mock.module()`, which is process-wide in bun.
+ */
+export interface CouchbaseHttpTransportDeps {
+  resolveSrv?: SrvResolver;
+  requestJson?: SecureJsonRequest;
+}
+
+interface NodeServicesEntry {
+  hostname?: string;
+  services?: Record<string, number | undefined>;
+  alternateAddresses?: { external?: { hostname?: string; ports?: Record<string, number | undefined> } };
+}
+
+interface NodeServicesPayload {
+  nodesExt?: NodeServicesEntry[];
+}
+
+// ============================================================================
+// Pure helpers
+// ============================================================================
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseJsonBody(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function readMessage(record: Record<string, unknown>, fallback: string): string {
+  if (typeof record.msg === "string") return record.msg;
+  if (typeof record.message === "string") return record.message;
+  return fallback;
+}
+
+/** Bracket a bare IPv6 literal so it can be used in a URL authority. */
+function formatHost(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+/**
+ * Parse a Go-style duration ("1.234ms", "1.5s", "2m30s") into milliseconds.
+ * Anything unparsable counts as zero rather than NaN.
+ */
+function parseDurationMs(value: unknown): number {
+  if (typeof value !== "string") return 0;
+  let total = 0;
+  for (const match of value.matchAll(DURATION_PATTERN)) {
+    total += Number.parseFloat(match[1]) * DURATION_UNITS_MS[match[2]];
+  }
+  return total;
+}
+
+/**
+ * Column names for a statement, or null when the source cannot tell.
+ * `SELECT *` advertises a single wildcard, so the caller derives columns from
+ * the rows instead of trusting it.
+ */
+function fieldNamesFromSignature(value: unknown): string[] | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const keys = Object.keys(record);
+  // A wildcard key means the signature does not describe the actual row shape:
+  // `SELECT *` signs as { "*": "*" }, and `SELECT META(u).id AS __id, u.*` signs
+  // as { id: "json", "*": "*" }. Returning those keys would name a literal "*"
+  // column and hide every field the wildcard expanded to, so the caller derives
+  // the field list from the rows instead.
+  if (keys.includes("*")) return null;
+  return keys;
+}
+
+function toWarnings(value: unknown): CouchbaseWarning[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => {
+    const record = asRecord(entry) ?? {};
+    return {
+      code: typeof record.code === "number" ? record.code : 0,
+      message: readMessage(record, ""),
+    };
+  });
+}
+
+function toQueryResult(payload: unknown): CouchbaseQueryResult {
+  const record = asRecord(payload) ?? {};
+  const metrics = asRecord(record.metrics) ?? {};
+  const duration = typeof metrics.executionTime === "string" ? metrics.executionTime : metrics.elapsedTime;
+
+  return {
+    rows: Array.isArray(record.results) ? (record.results as CouchbaseRow[]) : [],
+    fieldNames: fieldNamesFromSignature(record.signature),
+    executionTimeMs: parseDurationMs(duration),
+    mutationCount: typeof metrics.mutationCount === "number" ? metrics.mutationCount : 0,
+    warnings: toWarnings(record.warnings),
+  };
+}
+
+/**
+ * A failed statement can arrive inside a 200 response, so the payload is
+ * inspected BEFORE the HTTP code (decision 5). Skipping this reports a syntax
+ * error as "0 rows".
+ */
+function payloadError(payload: unknown): CouchbaseError | null {
+  const record = asRecord(payload);
+  if (!record) return null;
+
+  const errors = Array.isArray(record.errors) ? record.errors : [];
+  const first = asRecord(errors[0]);
+  if (first) {
+    const code = typeof first.code === "number" ? first.code : 0;
+    return new CouchbaseError(readMessage(first, GENERIC_STATEMENT_FAILURE), code, RETRIABLE_CODES.has(code));
+  }
+
+  if (record.status === "errors") return new CouchbaseError(GENERIC_STATEMENT_FAILURE, 0, false);
+  return null;
+}
+
+function httpError(httpCode: number): CouchbaseError {
+  return new CouchbaseError(
+    HTTP_MESSAGES[httpCode] ?? `Couchbase request failed with HTTP ${httpCode}`,
+    httpCode,
+    httpCode >= 500,
+  );
+}
+
+function networkError(error: unknown): CouchbaseError {
+  const message = error instanceof Error ? error.message : String(error);
+  return new CouchbaseError(`Couchbase request failed: ${message}`, 0, true);
+}
+
+function throwIfFailed(response: JsonResponse): void {
+  const failure = payloadError(response.payload);
+  if (failure) throw failure;
+  if (response.httpCode >= 200 && response.httpCode < 300) return;
+  throw httpError(response.httpCode);
+}
+
+function buildTlsMaterial(ssl: SSLConfig | undefined): CouchbaseTlsMaterial | null {
+  if (!ssl || ssl.mode === "disable") return null;
+
+  // Same rule the PostgreSQL and MySQL providers use: only the verifying modes
+  // check the chain, because a self-hosted Couchbase node ships a self-signed
+  // certificate by default. An explicit flag always wins.
+  const material: CouchbaseTlsMaterial = {
+    rejectUnauthorized: ssl.rejectUnauthorized ?? (ssl.mode === "verify-ca" || ssl.mode === "verify-full"),
+  };
+  if (ssl.caCert) material.ca = ssl.caCert;
+  if (ssl.clientCert) material.cert = ssl.clientCert;
+  if (ssl.clientKey) material.key = ssl.clientKey;
+  return material;
+}
+
+// ============================================================================
+// Request paths
+// ============================================================================
+
+async function fetchJson(url: string, init: JsonRequestInit): Promise<JsonResponse> {
+  let response: Response;
+  try {
+    response = await fetch(url, { method: init.method, headers: init.headers, body: init.body });
+  } catch (error) {
+    throw networkError(error);
+  }
+  return { httpCode: response.status, payload: parseJsonBody(await response.text()) };
+}
+
+/**
+ * TLS-capable request over the Node built-ins. Exported so the TLS path is
+ * exercised directly against a local server instead of being mocked away.
+ */
+export function nodeRequestJson(url: string, init: JsonRequestInit, tls: CouchbaseTlsMaterial): Promise<JsonResponse> {
+  const target = new URL(url);
+  const options: HttpsRequestOptions = {
+    protocol: target.protocol,
+    hostname: target.hostname,
+    port: target.port,
+    path: `${target.pathname}${target.search}`,
+    method: init.method,
+    headers: init.headers,
+    ca: tls.ca,
+    cert: tls.cert,
+    key: tls.key,
+    rejectUnauthorized: tls.rejectUnauthorized,
+  };
+
+  return new Promise<JsonResponse>((resolve, reject) => {
+    const onResponse = (response: import("node:http").IncomingMessage) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("end", () => {
+        resolve({
+          httpCode: response.statusCode ?? 0,
+          payload: parseJsonBody(Buffer.concat(chunks).toString("utf8")),
+        });
+      });
+    };
+
+    const clientRequest =
+      target.protocol === "https:"
+        ? httpsRequest(options, onResponse)
+        : httpRequest(options as HttpRequestOptions, onResponse);
+
+    clientRequest.on("error", (error: Error) => reject(networkError(error)));
+    if (init.body !== undefined) clientRequest.write(init.body);
+    clientRequest.end();
+  });
+}
+
+// ============================================================================
+// Transport
+// ============================================================================
+
+export class CouchbaseHttpTransport implements CouchbaseTransport {
+  public readonly kind = "http" as const;
+
+  private readonly host: string;
+  private readonly explicitPort: number | undefined;
+  private readonly managementPort: number;
+  private readonly scheme: "http" | "https";
+  private readonly tls: CouchbaseTlsMaterial | null;
+  private readonly authorization: string;
+  private readonly resolveSrv: SrvResolver;
+  private readonly requestJson: SecureJsonRequest;
+  /** `default:<bucket>`, or undefined when the connection pins no bucket. */
+  private readonly queryContext: string | undefined;
+
+  // The in-flight promise is cached, not just its value: concurrent queries on a
+  // fresh transport would otherwise each run their own discovery round-trip.
+  private hostLookup: Promise<string> | null = null;
+  private endpointLookup: Promise<string> | null = null;
+
+  constructor(config: DatabaseConnection, deps: CouchbaseHttpTransportDeps = {}) {
+    this.host = config.host ?? DEFAULT_HOST;
+    this.explicitPort = config.port;
+    this.tls = buildTlsMaterial(config.ssl);
+    this.scheme = this.tls ? "https" : "http";
+    this.managementPort = config.port ?? (this.tls ? DEFAULT_MANAGEMENT_TLS_PORT : DEFAULT_MANAGEMENT_PORT);
+    this.authorization = `Basic ${Buffer.from(`${config.user ?? ""}:${config.password ?? ""}`).toString("base64")}`;
+    this.resolveSrv = deps.resolveSrv ?? dns.resolveSrv.bind(dns);
+    this.requestJson = deps.requestJson ?? nodeRequestJson;
+    this.queryContext = config.database ? `default:${quoteIdentifier(config.database)}` : undefined;
+  }
+
+  public async query(stmt: string, o: QueryOpts = {}): Promise<CouchbaseQueryResult> {
+    const endpoint = await this.getQueryEndpoint();
+
+    const body: Record<string, unknown> = {
+      statement: stmt,
+      timeout: `${o.timeoutMs ?? DEFAULT_QUERY_TIMEOUT_MS}ms`,
+      metrics: true,
+      scan_consistency: o.scanConsistency ?? DEFAULT_SCAN_CONSISTENCY,
+    };
+    // The bucket is pinned by the connection, so the schema explorer shows a
+    // collection as `scope.collection`. SQL++ reads a bare two-part name as
+    // bucket.collection, which would send `inventory.hotel` looking for a BUCKET
+    // named inventory. Pinning the query context to the connection's bucket makes
+    // the displayed name directly runnable, and leaves fully qualified three-part
+    // paths resolving exactly as before.
+    if (this.queryContext) body.query_context = this.queryContext;
+    if (o.args && o.args.length > 0) body.args = o.args;
+    if (o.readonly !== undefined) body.readonly = o.readonly;
+    if (o.profile !== undefined) body.profile = o.profile;
+
+    const response = await this.send(endpoint, {
+      method: "POST",
+      headers: { ...this.baseHeaders(), "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    throwIfFailed(response);
+    return toQueryResult(response.payload);
+  }
+
+  public async manage<T>(path: string): Promise<T> {
+    const host = await this.getHost();
+    const response = await this.send(`${this.scheme}://${formatHost(host)}:${this.managementPort}${path}`, {
+      method: "GET",
+      headers: this.baseHeaders(),
+    });
+    throwIfFailed(response);
+    return response.payload as T;
+  }
+
+  public async close(): Promise<void> {
+    this.hostLookup = null;
+    this.endpointLookup = null;
+  }
+
+  // --------------------------------------------------------------------------
+  // Internals
+  // --------------------------------------------------------------------------
+
+  private baseHeaders(): Record<string, string> {
+    return { accept: "application/json", authorization: this.authorization };
+  }
+
+  private send(url: string, init: JsonRequestInit): Promise<JsonResponse> {
+    return this.tls ? this.requestJson(url, init, this.tls) : fetchJson(url, init);
+  }
+
+  /**
+   * Capella advertises its endpoint as an SRV record, so a host with no port is
+   * looked up before use. A DNS failure is never fatal: the host is then used
+   * as a plain A record, which is what every self-hosted cluster needs anyway.
+   */
+  private getHost(): Promise<string> {
+    this.hostLookup ??= this.resolveHost();
+    return this.hostLookup;
+  }
+
+  private async resolveHost(): Promise<string> {
+    if (this.explicitPort !== undefined) return this.host;
+
+    const records = await this.resolveSrv(`${SRV_PREFIX}${this.host}`).catch(() => [] as SrvRecord[]);
+    return records.length > 0 ? records[0].name : this.host;
+  }
+
+  /**
+   * `DatabaseConnection` carries one port, so the query endpoint is discovered
+   * rather than configured (decision 3). Cached for the transport's lifetime -
+   * but a FAILED discovery is not, or one unreachable moment would poison every
+   * later query on the same connection.
+   */
+  private getQueryEndpoint(): Promise<string> {
+    this.endpointLookup ??= this.discoverQueryEndpoint().catch((error: unknown) => {
+      this.endpointLookup = null;
+      throw error;
+    });
+    return this.endpointLookup;
+  }
+
+  private async discoverQueryEndpoint(): Promise<string> {
+    const host = await this.getHost();
+    const payload = await this.manage<NodeServicesPayload>(NODE_SERVICES_PATH);
+    return this.pickQueryEndpoint(payload, host);
+  }
+
+  private pickQueryEndpoint(payload: NodeServicesPayload, host: string): string {
+    const nodes = Array.isArray(payload.nodesExt) ? payload.nodesExt : [];
+    const serviceKey = this.tls ? "n1qlSSL" : "n1ql";
+
+    for (const node of nodes) {
+      // A NAT/Docker/Capella deployment advertises the reachable address here,
+      // so it wins over the node's internal hostname when it carries the port.
+      const external = node.alternateAddresses?.external;
+      const externalPort = external?.ports?.[serviceKey];
+      if (typeof externalPort === "number") {
+        return this.queryUrl(external?.hostname ?? node.hostname ?? host, externalPort);
+      }
+
+      const port = node.services?.[serviceKey];
+      if (typeof port === "number") return this.queryUrl(node.hostname ?? host, port);
+    }
+
+    return this.queryUrl(host, this.tls ? DEFAULT_QUERY_TLS_PORT : DEFAULT_QUERY_PORT);
+  }
+
+  private queryUrl(host: string, port: number): string {
+    return `${this.scheme}://${formatHost(host)}:${port}${QUERY_PATH}`;
+  }
+}

--- a/src/lib/db/providers/document/couchbase/index.ts
+++ b/src/lib/db/providers/document/couchbase/index.ts
@@ -75,6 +75,12 @@ const MONITORING_TIMEOUT_MS = 10000;
  */
 const KV_DEFAULT_MAX_CONNECTIONS = 65536;
 
+/**
+ * Column a SELECT RAW / SELECT VALUE scalar is wrapped in. Named like the
+ * document-key column so the two synthetic columns read as a pair.
+ */
+const COUCHBASE_RAW_VALUE_COLUMN = "__value";
+
 /** SQL++ codes this provider translates into a specific error class. */
 const NO_INDEX_CODE = 4000;
 const REQUEST_TIMEOUT_CODE = 1080;
@@ -233,6 +239,22 @@ function deriveFields(rows: CouchbaseRow[]): string[] {
     for (const key of Object.keys(row)) fields.add(key);
   }
   return [...fields];
+}
+
+/**
+ * SELECT RAW and SELECT VALUE project bare values, so a row can be a scalar, an
+ * array, or null rather than the object the grid's row contract assumes. Passed
+ * through unchanged, Object.keys turns a string into one column per character
+ * index and throws outright on null. Everything that is not a plain object is
+ * therefore wrapped in a single named column.
+ *
+ * This lives at the provider boundary rather than in the transport on purpose:
+ * INFER returns its flavour array as rows[0], and introspection reads that raw
+ * payload (see introspect.ts). Reshaping in the transport would break it.
+ */
+function normalizeRow(row: CouchbaseRow): CouchbaseRow {
+  if (typeof row === "object" && row !== null && !Array.isArray(row)) return row;
+  return { [COUCHBASE_RAW_VALUE_COLUMN]: row };
 }
 
 /**
@@ -427,11 +449,12 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
    */
   private toQueryResult(result: CouchbaseQueryResult, measuredMs: number): QueryResult {
     const reportedMs = Math.round(result.executionTimeMs);
+    const rows = result.rows.map(normalizeRow);
     return {
-      rows: result.rows,
-      fields: result.fieldNames ?? deriveFields(result.rows),
+      rows,
+      fields: result.fieldNames ?? deriveFields(rows),
       // A mutation returns no rows; its row count is what it changed.
-      rowCount: result.rows.length > 0 ? result.rows.length : result.mutationCount,
+      rowCount: rows.length > 0 ? rows.length : result.mutationCount,
       executionTime: reportedMs > 0 ? reportedMs : measuredMs,
     };
   }

--- a/src/lib/db/providers/document/couchbase/index.ts
+++ b/src/lib/db/providers/document/couchbase/index.ts
@@ -1,0 +1,852 @@
+/**
+ * Couchbase Database Provider (issue #262)
+ *
+ * SQL++ over the documented REST surfaces, with no native dependency: every
+ * statement and every management read goes through the CouchbaseTransport seam
+ * (decision 2), so this file never mentions the wire envelope and a future SDK
+ * adapter would not touch it.
+ *
+ * Three behaviours are worth knowing before reading the code:
+ *
+ * - Couchbase's four-level hierarchy is flattened for the schema explorer, so a
+ *   scope behaves exactly as a PostgreSQL schema does: `_default` is implicit,
+ *   everything else is `scope.collection` (decision 4, see keyspace.ts).
+ * - A keyspace with no usable index is REPORTED, not worked around: error 4000
+ *   is re-raised carrying the runnable `CREATE PRIMARY INDEX` remedy for that
+ *   exact keyspace (decision 6), because creating the index is the thing the
+ *   user has to do anyway.
+ * - Monitoring degrades to empty, never throws (decision 9). The system
+ *   monitoring keyspaces need the "Query System Catalog" RBAC role, so a denied
+ *   read is the NORMAL case for a restricted user and must not break an
+ *   otherwise working connection.
+ */
+
+import { BaseDatabaseProvider } from "@/lib/db/base-provider";
+import { AuthenticationError, ConnectionError, DatabaseConfigError, QueryError, TimeoutError } from "@/lib/db/errors";
+import {
+  type ActiveSession,
+  type ActiveSessionDetails,
+  type DatabaseConnection,
+  type DatabaseOverview,
+  type HealthInfo,
+  type IndexStats,
+  type MaintenanceResult,
+  type MaintenanceType,
+  type PerformanceMetrics,
+  type PreparedQuery,
+  type ProviderCapabilities,
+  type ProviderLabels,
+  type ProviderOptions,
+  type QueryPrepareOptions,
+  type QueryResult,
+  type SlowQuery,
+  type SlowQueryStats,
+  type StorageStats,
+  type TableRelations,
+  type TableSchema,
+  type TableStats,
+} from "@/lib/db/types";
+import { formatBytes } from "@/lib/db/utils/pool-manager";
+import { applyQueryLimit, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "@/lib/db/utils/query-limiter";
+import { CouchbaseHttpTransport } from "./http-transport";
+import {
+  CATALOG_TIMEOUT_MS,
+  getSchemaList as introspectSchemaList,
+  getSchemaRelations as introspectSchemaRelations,
+  listCollections,
+} from "./introspect";
+import { keyspaceFromDisplayName, keyspacePath, quoteIdentifier } from "./keyspace";
+import { CouchbaseError, type CouchbaseQueryResult, type CouchbaseRow, type CouchbaseTransport } from "./transport";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const POOLS_PATH = "/pools/default";
+
+/** Server-side timeout for a monitoring read: never stall the dashboard. */
+const MONITORING_TIMEOUT_MS = 10000;
+
+/**
+ * Couchbase advertises no connection ceiling over REST - neither
+ * `/pools/default` nor the bucket statistics carry the KV service's effective
+ * `maxconn`. The overview divides by this number, so the documented KV default
+ * is used as the denominator and the numerator stays a measured value.
+ */
+const KV_DEFAULT_MAX_CONNECTIONS = 65536;
+
+/** SQL++ codes this provider translates into a specific error class. */
+const NO_INDEX_CODE = 4000;
+const REQUEST_TIMEOUT_CODE = 1080;
+const MISSING_CREDENTIALS_CODE = 13014;
+
+/** HTTP codes the transport normalizes into the same numeric space. */
+const HTTP_UNAUTHORIZED = 401;
+const HTTP_FORBIDDEN = 403;
+const HTTP_UNAVAILABLE = 503;
+
+const KEYSPACE_COUNT_SQL = [
+  "SELECT COUNT(*) AS total FROM system:keyspaces AS k",
+  "WHERE k.`bucket` = $1 OR (k.`bucket` IS MISSING AND k.name = $1)",
+].join(" ");
+
+const INDEX_COUNT_SQL = [
+  "SELECT COUNT(*) AS total FROM system:indexes AS i",
+  "WHERE i.bucket_id = $1 OR (i.bucket_id IS MISSING AND i.keyspace_id = $1)",
+].join(" ");
+
+/**
+ * `bucket` and `scope` are reserved words in SQL++ and `using` is a keyword, so
+ * every one of them is backtick-quoted - unquoted they fail with error 3000
+ * (verified on Server 8.0.2).
+ */
+const INDEX_STATS_SQL = [
+  "SELECT i.name AS index_name, i.scope_id AS scope_name, i.keyspace_id AS collection_name,",
+  "i.index_key AS index_key, i.is_primary AS is_primary, i.`using` AS index_type",
+  "FROM system:indexes AS i",
+  "WHERE i.bucket_id = $1 OR (i.bucket_id IS MISSING AND i.keyspace_id = $1)",
+  "ORDER BY scope_name, collection_name, index_name",
+].join(" ");
+
+/** Requests slow enough that the cluster recorded them at all. */
+const SLOW_QUERY_SQL = [
+  "SELECT r.requestId AS request_id, r.statement AS statement,",
+  "STR_TO_DURATION(r.elapsedTime) AS elapsed_ns, r.resultCount AS result_count",
+  "FROM system:completed_requests AS r",
+  "ORDER BY elapsed_ns DESC",
+  "LIMIT $1",
+].join(" ");
+
+const ACTIVE_REQUEST_SQL = [
+  "SELECT r.requestId AS request_id, r.statement AS statement, r.users AS users,",
+  "r.remoteAddr AS remote_addr, r.state AS state, STR_TO_DURATION(r.elapsedTime) AS elapsed_ns",
+  "FROM system:active_requests AS r",
+  "ORDER BY elapsed_ns DESC",
+  "LIMIT $1",
+].join(" ");
+
+/**
+ * Deferred indexes of one keyspace. The second branch matches the pre-scopes
+ * bucket-level index, whose catalog row carries no `bucket_id` at all.
+ */
+const DEFERRED_INDEX_SQL = [
+  "SELECT i.name AS index_name FROM system:indexes AS i",
+  'WHERE i.state = "deferred"',
+  "AND ((i.bucket_id = $1 AND i.scope_id = $2 AND i.keyspace_id = $3)",
+  '  OR (i.bucket_id IS MISSING AND i.keyspace_id = $1 AND $3 = "_default"))',
+].join(" ");
+
+/**
+ * The keyspace path that follows the first FROM of a statement. Both segment
+ * shapes start with a distinct character and every repetition needs a literal
+ * separator, so the pattern is linear - no backtracking blow-up on long input.
+ */
+const FROM_CLAUSE = /\bfrom\s+((?:`[^`]*`|[\w$]+)(?:\s*[.:]\s*(?:`[^`]*`|[\w$]+))*)/i;
+const PATH_SEGMENT = /`([^`]*)`|([\w$]+)/g;
+
+/** A keyspace has at most bucket.scope.collection; anything before is a namespace. */
+const MAX_KEYSPACE_SEGMENTS = 3;
+
+const NANOSECONDS_PER_MS = 1e6;
+
+// ============================================================================
+// Management payload shapes (only the fields this provider reads)
+// ============================================================================
+
+interface PoolsPayload {
+  nodes?: { version?: string; uptime?: string }[];
+}
+
+interface BucketPayload {
+  quota?: { ram?: number };
+  basicStats?: {
+    itemCount?: number;
+    diskUsed?: number;
+    dataUsed?: number;
+    quotaPercentUsed?: number;
+  };
+}
+
+type SampleSet = Record<string, unknown>;
+
+interface BucketStatsPayload {
+  op?: { samples?: SampleSet };
+}
+
+interface CatalogCounts {
+  tableCount: number;
+  indexCount: number;
+}
+
+// ============================================================================
+// Pure helpers
+// ============================================================================
+
+/**
+ * The empty-on-denied rule of decision 9, in one place: a source the connected
+ * user cannot read yields the fallback instead of breaking the caller.
+ */
+async function degradeTo<T>(operation: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await operation();
+  } catch {
+    return fallback;
+  }
+}
+
+/** Latest value of a statistics series, or null when the cluster reported none. */
+function lastSample(samples: SampleSet, key: string): number | null {
+  const series = samples[key];
+  if (!Array.isArray(series) || series.length === 0) return null;
+  const value: unknown = series[series.length - 1];
+  return typeof value === "number" ? value : null;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}
+
+function nanosecondsToMs(value: unknown): number {
+  return Math.round(asNumber(value) / NANOSECONDS_PER_MS);
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Column names for a wildcard projection. `SELECT *` nests whole documents
+ * under the keyspace name and advertises only a wildcard signature, so the
+ * columns are the union of the keys the rows actually carry, first seen first.
+ */
+function deriveFields(rows: CouchbaseRow[]): string[] {
+  const fields = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) fields.add(key);
+  }
+  return [...fields];
+}
+
+/**
+ * Backtick-quoted keyspace path a statement reads from, or null when it has no
+ * recognizable FROM clause. A `namespace:bucket.scope.collection` path keeps
+ * only its trailing three segments.
+ */
+function keyspaceInStatement(statement: string): string | null {
+  const clause = FROM_CLAUSE.exec(statement);
+  if (!clause) return null;
+  const segments = [...clause[1].matchAll(PATH_SEGMENT)].map((segment) => segment[1] ?? segment[2]);
+  return segments.slice(-MAX_KEYSPACE_SEGMENTS).map(quoteIdentifier).join(".");
+}
+
+/** Strip the quoting Couchbase applies to a plain index key identifier. */
+function unquoteIndexKey(key: string): string {
+  return key.startsWith("`") && key.endsWith("`") ? key.slice(1, -1).replaceAll("``", "`") : key;
+}
+
+function indexColumns(row: CouchbaseRow): string[] {
+  if (!Array.isArray(row.index_key)) return [];
+  return row.index_key.filter((key): key is string => typeof key === "string").map(unquoteIndexKey);
+}
+
+// ============================================================================
+// Couchbase Provider
+// ============================================================================
+
+export class CouchbaseProvider extends BaseDatabaseProvider {
+  private transport: CouchbaseTransport | null = null;
+
+  constructor(config: DatabaseConnection, options: ProviderOptions = {}) {
+    super(config, options);
+    this.validate();
+  }
+
+  // ==========================================================================
+  // Provider metadata
+  // ==========================================================================
+
+  public override getCapabilities(): ProviderCapabilities {
+    return {
+      queryLanguage: "sql",
+      supportsExplain: true,
+      explainFormat: "couchbase-json",
+      supportsExternalQueryLimiting: true,
+      // Collections are schemaless and CREATE COLLECTION takes no columns, so a
+      // column-list modal could only ever emit invalid SQL++ (decision 7).
+      supportsCreateTable: false,
+      supportsMaintenance: true,
+      maintenanceOperations: ["analyze", "reindex", "kill"],
+      supportsConnectionString: true,
+      defaultPort: 8091,
+      schemaRefreshPattern: "\\b(CREATE|DROP|ALTER)\\s+(COLLECTION|SCOPE|INDEX)\\b",
+    };
+  }
+
+  public override getLabels(): ProviderLabels {
+    return {
+      entityName: "Collection",
+      entityNamePlural: "Collections",
+      rowName: "document",
+      rowNamePlural: "documents",
+      selectAction: "Select Documents",
+      generateAction: "Generate Query",
+      analyzeAction: "Update Statistics",
+      vacuumAction: "Compact",
+      searchPlaceholder: "Search collections or fields...",
+      analyzeGlobalLabel: "Update Statistics",
+      analyzeGlobalTitle: "Update Statistics",
+      analyzeGlobalDesc:
+        "Runs UPDATE STATISTICS on a collection so the cost-based optimizer plans against current distributions. Enterprise Edition only.",
+      vacuumGlobalLabel: "Compact",
+      vacuumGlobalTitle: "Compact Storage",
+      vacuumGlobalDesc: "Couchbase compacts its data files automatically; there is no manual equivalent to run here.",
+    };
+  }
+
+  public override prepareQuery(query: string, options: QueryPrepareOptions = {}): PreparedQuery {
+    const { limit = DEFAULT_QUERY_LIMIT, offset = 0, unlimited = false } = options;
+    const effectiveLimit = unlimited ? MAX_UNLIMITED_ROWS : limit;
+    const limited = applyQueryLimit(query, effectiveLimit, offset);
+    return { query: limited.sql, wasLimited: limited.wasLimited, limit: effectiveLimit, offset };
+  }
+
+  // ==========================================================================
+  // Validation and lifecycle
+  // ==========================================================================
+
+  public override validate(): void {
+    super.validate();
+    if (!this.config.host && !this.config.connectionString) {
+      throw new DatabaseConfigError("Couchbase requires a host or a connection string", this.type);
+    }
+    if (!this.config.database) {
+      throw new DatabaseConfigError('Couchbase requires a bucket (use the "database" field)', this.type);
+    }
+  }
+
+  public async connect(): Promise<void> {
+    this.validate();
+    const transport = new CouchbaseHttpTransport(this.transportConfig());
+
+    try {
+      // Cheapest proof that the cluster is reachable AND the credentials work:
+      // /pools/default needs no RBAC role beyond cluster read.
+      await transport.manage<PoolsPayload>(POOLS_PATH);
+    } catch (error) {
+      await transport.close();
+      const failure = this.describeConnectFailure(error);
+      this.setError(failure);
+      throw failure;
+    }
+
+    this.transport = transport;
+    this.setConnected(true);
+  }
+
+  public async disconnect(): Promise<void> {
+    if (this.transport) {
+      await this.transport.close();
+      this.transport = null;
+    }
+    this.setConnected(false);
+  }
+
+  /**
+   * The transport takes host and port, so a connection-string-only config has
+   * its hostname lifted out. The port is deliberately NOT taken from the URL: a
+   * `couchbase://` URL carries the KV port, not the management port this
+   * provider talks to, and port discovery handles the rest (decision 3).
+   */
+  private transportConfig(): DatabaseConnection {
+    if (this.config.host) return this.config;
+    const host = this.hostFromConnectionString();
+    return host ? { ...this.config, host } : this.config;
+  }
+
+  private hostFromConnectionString(): string | null {
+    try {
+      return new URL(this.config.connectionString ?? "").hostname || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private describeConnectFailure(error: unknown): Error {
+    const mapped = this.mapCouchbaseError(error);
+    if (mapped instanceof AuthenticationError) return mapped;
+    return new ConnectionError(
+      `Failed to connect to Couchbase: ${mapped.message}`,
+      this.type,
+      this.config.host,
+      this.config.port,
+    );
+  }
+
+  private requireTransport(): CouchbaseTransport {
+    this.ensureConnected();
+    // Assigned before setConnected(true) and cleared after setConnected(false),
+    // so a connected provider always has one.
+    return this.transport!;
+  }
+
+  private get bucket(): string {
+    return this.config.database ?? "";
+  }
+
+  // ==========================================================================
+  // Query execution
+  // ==========================================================================
+
+  public async query(sql: string, params?: unknown[]): Promise<QueryResult> {
+    const transport = this.requireTransport();
+
+    return this.trackQuery(async () => {
+      const { result, executionTime } = await this.measureExecution(async () => {
+        try {
+          return await transport.query(sql, { args: params, timeoutMs: this.queryTimeout });
+        } catch (error) {
+          throw this.mapCouchbaseError(error, sql);
+        }
+      });
+      return this.toQueryResult(result, executionTime);
+    });
+  }
+
+  /**
+   * The cluster's own execution time is preferred over the round trip because
+   * it excludes network latency; a source that reports none falls back to the
+   * measured wall clock rather than claiming zero.
+   */
+  private toQueryResult(result: CouchbaseQueryResult, measuredMs: number): QueryResult {
+    const reportedMs = Math.round(result.executionTimeMs);
+    return {
+      rows: result.rows,
+      fields: result.fieldNames ?? deriveFields(result.rows),
+      // A mutation returns no rows; its row count is what it changed.
+      rowCount: result.rows.length > 0 ? result.rows.length : result.mutationCount,
+      executionTime: reportedMs > 0 ? reportedMs : measuredMs,
+    };
+  }
+
+  /**
+   * Normalized transport failure -> the provider error vocabulary. Everything
+   * arrives in one numeric space (SQL++ codes and HTTP codes alike), so this is
+   * a single switch rather than message sniffing.
+   */
+  private mapCouchbaseError(error: unknown, statement?: string): Error {
+    if (!(error instanceof CouchbaseError)) return this.mapError(error, statement);
+
+    switch (error.code) {
+      case NO_INDEX_CODE:
+        return new QueryError(`${error.message} ${this.primaryIndexRemedy(statement)}`, this.type, statement);
+      case REQUEST_TIMEOUT_CODE:
+        return new TimeoutError(error.message, this.type, this.queryTimeout, statement);
+      case MISSING_CREDENTIALS_CODE:
+      case HTTP_UNAUTHORIZED:
+      case HTTP_FORBIDDEN:
+        return new AuthenticationError(error.message, this.type);
+      case HTTP_UNAVAILABLE:
+        return new ConnectionError(error.message, this.type, this.config.host, this.config.port);
+    }
+
+    // Reached only for codes no case matched; a bare `default:` label is not
+    // attributable in bun lcov. A retriable failure with no cluster code at all
+    // is a network fault, everything else is a statement the cluster rejected.
+    if (error.retriable && error.code === 0) {
+      return new ConnectionError(error.message, this.type, this.config.host, this.config.port);
+    }
+    return new QueryError(error.message, this.type, statement);
+  }
+
+  /**
+   * Decision 6: a keyspace with no usable index is reported with the statement
+   * that fixes it, quoted for the exact keyspace the query read from.
+   */
+  private primaryIndexRemedy(statement: string | undefined): string {
+    const keyspace = (statement ? keyspaceInStatement(statement) : null) ?? quoteIdentifier(this.bucket);
+    return `Create one first: CREATE PRIMARY INDEX ON ${keyspace}`;
+  }
+
+  /** Run an operation whose failures should surface as provider errors. */
+  private async guarded<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      throw this.mapCouchbaseError(error);
+    }
+  }
+
+  // ==========================================================================
+  // Schema
+  // ==========================================================================
+
+  public async getSchemaList(): Promise<TableSchema[]> {
+    const transport = this.requireTransport();
+    return this.guarded(() => introspectSchemaList(transport, this.bucket));
+  }
+
+  public async getSchemaRelations(): Promise<TableRelations[]> {
+    const transport = this.requireTransport();
+    return this.guarded(() => introspectSchemaRelations(transport, this.bucket));
+  }
+
+  public async getSchema(): Promise<TableSchema[]> {
+    const [tables, relations] = await Promise.all([this.getSchemaList(), this.getSchemaRelations()]);
+    const indexes = new Map(relations.map((relation) => [relation.name, relation.indexes]));
+
+    return tables.map((table) => ({
+      name: table.name,
+      columns: table.columns,
+      indexes: indexes.get(table.name) ?? [],
+      // Couchbase has no foreign keys and none are invented.
+      foreignKeys: [],
+    }));
+  }
+
+  public override async getTables(): Promise<string[]> {
+    const transport = this.requireTransport();
+    const collections = await this.guarded(() => listCollections(transport, this.bucket));
+    return collections.map((collection) => collection.displayName);
+  }
+
+  // ==========================================================================
+  // Monitoring (decision 9: every source degrades to empty, never throws)
+  // ==========================================================================
+
+  public async getOverview(): Promise<DatabaseOverview> {
+    const transport = this.requireTransport();
+
+    const [pools, bucketInfo, samples, counts] = await Promise.all([
+      degradeTo<PoolsPayload>(() => transport.manage(POOLS_PATH), {}),
+      degradeTo<BucketPayload>(() => transport.manage(this.bucketPath()), {}),
+      this.bucketSamples(transport),
+      degradeTo(() => this.catalogCounts(transport), { tableCount: 0, indexCount: 0 }),
+    ]);
+
+    const node = pools.nodes?.[0] ?? {};
+    const uptimeMs = (Number.parseInt(node.uptime ?? "", 10) || 0) * 1000;
+    const diskUsed = bucketInfo.basicStats?.diskUsed ?? 0;
+
+    return {
+      version: node.version ?? "unknown",
+      uptime: this.formatDuration(uptimeMs),
+      startTime: new Date(Date.now() - uptimeMs),
+      activeConnections: lastSample(samples, "curr_connections") ?? 0,
+      maxConnections: KV_DEFAULT_MAX_CONNECTIONS,
+      databaseSize: formatBytes(diskUsed),
+      databaseSizeBytes: diskUsed,
+      tableCount: counts.tableCount,
+      indexCount: counts.indexCount,
+    };
+  }
+
+  public async getPerformanceMetrics(): Promise<PerformanceMetrics> {
+    const transport = this.requireTransport();
+
+    const [bucketInfo, samples] = await Promise.all([
+      degradeTo<BucketPayload>(() => transport.manage(this.bucketPath()), {}),
+      this.bucketSamples(transport),
+    ]);
+
+    // The KV engine reports a miss rate, so the hit ratio is its complement.
+    // An unreadable source reports zero rather than a flattering 100.
+    const missRate = lastSample(samples, "ep_cache_miss_rate");
+    const operations = (lastSample(samples, "cmd_get") ?? 0) + (lastSample(samples, "cmd_set") ?? 0);
+
+    return {
+      cacheHitRatio: missRate === null ? 0 : round2(Math.max(0, Math.min(100, 100 - missRate))),
+      queriesPerSecond: round2(operations),
+      bufferPoolUsage: round2(bucketInfo.basicStats?.quotaPercentUsed ?? 0),
+    };
+  }
+
+  public async getSlowQueries(options: { limit?: number } = {}): Promise<SlowQueryStats[]> {
+    const rows = await this.monitoringRows(SLOW_QUERY_SQL, options.limit ?? 10);
+
+    return rows.map((row) => {
+      const elapsedMs = nanosecondsToMs(row.elapsed_ns);
+      return {
+        queryId: asString(row.request_id),
+        query: asString(row.statement),
+        // system:completed_requests records individual requests, not aggregates.
+        calls: 1,
+        totalTime: elapsedMs,
+        avgTime: elapsedMs,
+        rows: asNumber(row.result_count),
+      };
+    });
+  }
+
+  public async getActiveSessions(options: { limit?: number } = {}): Promise<ActiveSessionDetails[]> {
+    const rows = await this.monitoringRows(ACTIVE_REQUEST_SQL, options.limit ?? 50);
+
+    return rows.map((row) => {
+      const durationMs = nanosecondsToMs(row.elapsed_ns);
+      return {
+        pid: asString(row.request_id),
+        user: asString(row.users, "unknown"),
+        database: this.bucket,
+        clientAddr: asString(row.remote_addr),
+        state: asString(row.state, "unknown"),
+        query: asString(row.statement),
+        duration: this.formatDuration(durationMs),
+        durationMs,
+      };
+    });
+  }
+
+  /**
+   * Bucket-level only: per-collection item counts need a COUNT(*) per
+   * collection, which is not cheap enough to run on a monitoring poll.
+   */
+  public async getTableStats(): Promise<TableStats[]> {
+    const transport = this.requireTransport();
+    const bucketInfo = await degradeTo<BucketPayload>(() => transport.manage(this.bucketPath()), {});
+    const stats = bucketInfo.basicStats;
+    if (!stats) return [];
+
+    const dataUsed = stats.dataUsed ?? 0;
+    const diskUsed = stats.diskUsed ?? 0;
+
+    return [
+      {
+        schemaName: this.bucket,
+        tableName: this.bucket,
+        rowCount: stats.itemCount ?? 0,
+        tableSize: formatBytes(dataUsed),
+        tableSizeBytes: dataUsed,
+        totalSize: formatBytes(diskUsed),
+        totalSizeBytes: diskUsed,
+      },
+    ];
+  }
+
+  public async getIndexStats(): Promise<IndexStats[]> {
+    const transport = this.requireTransport();
+
+    const [rows, samples] = await Promise.all([
+      degradeTo(
+        async () =>
+          (await transport.query(INDEX_STATS_SQL, { args: [this.bucket], timeoutMs: CATALOG_TIMEOUT_MS })).rows,
+        [] as CouchbaseRow[],
+      ),
+      // Per-index runtime statistics live under the index service's own bucket.
+      // Modern servers no longer publish them there, which is exactly why every
+      // value below falls back to zero instead of failing the listing.
+      degradeTo<BucketStatsPayload>(
+        () => transport.manage(`/pools/default/buckets/@index-${encodeURIComponent(this.bucket)}/stats`),
+        {},
+      ),
+    ]);
+
+    const indexSamples = samples.op?.samples ?? {};
+
+    return rows.map((row) => {
+      const name = asString(row.index_name, "unknown");
+      const isPrimary = row.is_primary === true;
+      const sizeBytes = lastSample(indexSamples, `index/${name}/data_size`) ?? 0;
+
+      return {
+        schemaName: asString(row.scope_name, "_default"),
+        tableName: asString(row.collection_name, "unknown"),
+        indexName: name,
+        indexType: asString(row.index_type, "gsi"),
+        columns: indexColumns(row),
+        // No secondary index enforces uniqueness; only the document key is unique.
+        isUnique: isPrimary,
+        isPrimary,
+        indexSize: formatBytes(sizeBytes),
+        indexSizeBytes: sizeBytes,
+        scans: lastSample(indexSamples, `index/${name}/num_requests`) ?? 0,
+      };
+    });
+  }
+
+  public async getStorageStats(): Promise<StorageStats[]> {
+    const transport = this.requireTransport();
+    const bucketInfo = await degradeTo<BucketPayload>(() => transport.manage(this.bucketPath()), {});
+    const stats = bucketInfo.basicStats;
+    if (!stats) return [];
+
+    const diskUsed = stats.diskUsed ?? 0;
+    const quota = bucketInfo.quota?.ram ?? 0;
+
+    return [
+      { name: "Data", location: this.bucket, size: formatBytes(diskUsed), sizeBytes: diskUsed },
+      {
+        name: "RAM Quota",
+        size: formatBytes(quota),
+        sizeBytes: quota,
+        usagePercent: round2(stats.quotaPercentUsed ?? 0),
+      },
+    ];
+  }
+
+  public async getHealth(): Promise<HealthInfo> {
+    const [overview, performance, slowQueries, sessions] = await Promise.all([
+      this.getOverview(),
+      this.getPerformanceMetrics(),
+      this.getSlowQueries({ limit: 5 }),
+      this.getActiveSessions({ limit: 10 }),
+    ]);
+
+    const slow: SlowQuery[] = slowQueries.map((entry) => ({
+      query: entry.query,
+      calls: entry.calls,
+      avgTime: `${Math.round(entry.avgTime)}ms`,
+    }));
+
+    const active: ActiveSession[] = sessions.map((session) => ({
+      pid: session.pid,
+      user: session.user,
+      database: session.database,
+      state: session.state,
+      query: session.query,
+      duration: session.duration,
+    }));
+
+    return {
+      activeConnections: overview.activeConnections,
+      databaseSize: overview.databaseSize,
+      cacheHitRatio: performance.cacheHitRatio.toFixed(1),
+      slowQueries: slow,
+      activeSessions: active,
+    };
+  }
+
+  private bucketPath(): string {
+    return `/pools/default/buckets/${encodeURIComponent(this.bucket)}`;
+  }
+
+  private async bucketSamples(transport: CouchbaseTransport): Promise<SampleSet> {
+    const stats = await degradeTo<BucketStatsPayload>(() => transport.manage(`${this.bucketPath()}/stats`), {});
+    return stats.op?.samples ?? {};
+  }
+
+  private async catalogCounts(transport: CouchbaseTransport): Promise<CatalogCounts> {
+    const [keyspaces, indexes] = await Promise.all([
+      transport.query(KEYSPACE_COUNT_SQL, { args: [this.bucket], timeoutMs: CATALOG_TIMEOUT_MS }),
+      transport.query(INDEX_COUNT_SQL, { args: [this.bucket], timeoutMs: CATALOG_TIMEOUT_MS }),
+    ]);
+
+    return {
+      tableCount: asNumber(keyspaces.rows[0]?.total),
+      indexCount: asNumber(indexes.rows[0]?.total),
+    };
+  }
+
+  /**
+   * One monitoring keyspace read. These need the "Query System Catalog" role,
+   * so a denial is ordinary and yields no rows rather than an error.
+   */
+  private monitoringRows(statement: string, limit: number): Promise<CouchbaseRow[]> {
+    const transport = this.requireTransport();
+    return degradeTo(
+      async () => (await transport.query(statement, { args: [limit], timeoutMs: MONITORING_TIMEOUT_MS })).rows,
+      [] as CouchbaseRow[],
+    );
+  }
+
+  // ==========================================================================
+  // Maintenance
+  // ==========================================================================
+
+  public async runMaintenance(type: MaintenanceType, target?: string): Promise<MaintenanceResult> {
+    const transport = this.requireTransport();
+    const { result, executionTime } = await this.measureExecution(() =>
+      this.guarded(() => this.dispatchMaintenance(transport, type, target)),
+    );
+    return { ...result, executionTime };
+  }
+
+  private dispatchMaintenance(
+    transport: CouchbaseTransport,
+    type: MaintenanceType,
+    target?: string,
+  ): Promise<Omit<MaintenanceResult, "executionTime">> {
+    switch (type) {
+      case "analyze":
+        return this.updateStatistics(transport, this.requireTarget(type, target));
+      case "reindex":
+        return this.buildDeferredIndexes(transport, this.requireTarget(type, target));
+      case "kill":
+        return this.cancelRequest(transport, this.requireTarget(type, target));
+    }
+
+    // Reached only for the operations Couchbase has no equivalent for; they are
+    // absent from maintenanceOperations, so the UI never offers them.
+    throw new QueryError(
+      `Unsupported maintenance operation for Couchbase: ${type}. Supported: analyze, reindex, kill`,
+      this.type,
+    );
+  }
+
+  private requireTarget(type: MaintenanceType, target?: string): string {
+    if (!target) {
+      throw new QueryError(`The "${type}" operation requires a target`, this.type);
+    }
+    return target;
+  }
+
+  private async updateStatistics(
+    transport: CouchbaseTransport,
+    target: string,
+  ): Promise<Omit<MaintenanceResult, "executionTime">> {
+    const keyspace = keyspacePath(keyspaceFromDisplayName(this.bucket, target));
+
+    try {
+      await transport.query(`UPDATE STATISTICS FOR ${keyspace} INDEX ALL`, { timeoutMs: this.queryTimeout });
+      return { success: true, message: `Updated statistics for ${target}` };
+    } catch (error) {
+      // UPDATE STATISTICS is Enterprise-only; a Community Edition cluster
+      // answers "'Update Statistics' is an enterprise level feature." That
+      // sentence is the whole explanation the user needs, so it is passed
+      // through verbatim rather than swallowed or reworded.
+      return { success: false, message: messageOf(error) };
+    }
+  }
+
+  private async buildDeferredIndexes(
+    transport: CouchbaseTransport,
+    target: string,
+  ): Promise<Omit<MaintenanceResult, "executionTime">> {
+    const keyspace = keyspaceFromDisplayName(this.bucket, target);
+    const deferred = await transport.query(DEFERRED_INDEX_SQL, {
+      args: [keyspace.bucket, keyspace.scope, keyspace.collection],
+      timeoutMs: CATALOG_TIMEOUT_MS,
+    });
+
+    const names = deferred.rows
+      .map((row) => row.index_name)
+      .filter((name): name is string => typeof name === "string")
+      .map(quoteIdentifier);
+
+    if (names.length === 0) {
+      return { success: true, message: `No deferred indexes on ${target}` };
+    }
+
+    await transport.query(`BUILD INDEX ON ${keyspacePath(keyspace)}(${names.join(", ")})`, {
+      timeoutMs: this.queryTimeout,
+    });
+    return { success: true, message: `Building ${names.length} deferred index(es) on ${target}` };
+  }
+
+  private async cancelRequest(
+    transport: CouchbaseTransport,
+    target: string,
+  ): Promise<Omit<MaintenanceResult, "executionTime">> {
+    await transport.query("DELETE FROM system:active_requests WHERE requestId = $1", {
+      args: [target],
+      timeoutMs: MONITORING_TIMEOUT_MS,
+    });
+    return { success: true, message: `Cancelled request ${target}` };
+  }
+}

--- a/src/lib/db/providers/document/couchbase/introspect.ts
+++ b/src/lib/db/providers/document/couchbase/introspect.ts
@@ -1,0 +1,341 @@
+/**
+ * Couchbase schema introspection (issue #262, decision 10)
+ *
+ * Three catalog reads, all through the transport seam so this file stays free
+ * of any wire vocabulary:
+ *
+ * - `system:keyspaces` (joined with `system:scopes`) lists the collections of
+ *   the pinned bucket.
+ * - `INFER` samples documents per collection to produce columns. Couchbase is
+ *   schemaless, so the column list is statistical: it describes the sample, not
+ *   a declared shape.
+ * - `system:indexes` supplies the index list. Foreign keys are always empty -
+ *   Couchbase has none and none are invented.
+ *
+ * Two rules the live cluster forced, both load-bearing:
+ *
+ * 1. `bucket` and `scope` are reserved words in SQL++. Unquoted, a projection
+ *    over `system:keyspaces` fails with error 3000 (verified on Server 8.0.2),
+ *    so every occurrence is backtick-quoted.
+ * 2. INFER fails on a collection the user cannot read AND on an empty one
+ *    (error 7014, "No documents found, unable to infer schema"). Both are
+ *    ordinary states, so a failed INFER yields empty columns and never fails
+ *    the tree. The concurrency bound - not truncation of the collection list -
+ *    is what keeps the cost of schema loading in hand.
+ */
+
+import type { ColumnSchema, IndexSchema, TableRelations, TableSchema } from "@/lib/types";
+import { COUCHBASE_DEFAULT_SCOPE, keyspaceDisplayName, keyspacePath } from "./keyspace";
+import type { CouchbaseRow, CouchbaseTransport, Keyspace } from "./transport";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Collection every bucket has, and the one a bucket-level catalog row means. */
+const DEFAULT_COLLECTION = "_default";
+
+/** Documents INFER samples per collection. Mirrors the MongoDB provider. */
+const INFER_SAMPLE_SIZE = 100;
+
+/** Property name INFER uses for document metadata rather than a real field. */
+const META_PROPERTY = "~meta";
+
+/** Type reported for a property whose INFER entry names none. */
+const UNKNOWN_TYPE = "unknown";
+
+/** Name for an index row that carries none, mirroring the MongoDB provider. */
+const UNKNOWN_INDEX_NAME = "unknown";
+
+/** How SQL++ addresses the document key a primary index is built on. */
+const DOCUMENT_KEY_EXPRESSION = "META().id";
+
+/**
+ * Column carrying the document key. It matches the alias the generated
+ * `SELECT META(h).id AS __id, h.*` projection uses (decision 5), so the schema
+ * tree and the result grid name the key the same way.
+ */
+export const COUCHBASE_DOCUMENT_KEY_COLUMN = "__id";
+
+/** Concurrent INFER statements. Bounds schema-load cost without truncating. */
+export const INFER_CONCURRENCY = 4;
+
+/** Per-INFER server-side timeout: one unreadable collection cannot stall the tree. */
+export const INFER_TIMEOUT_MS = 5000;
+
+/** Server-side timeout for the `system:*` catalog reads. */
+export const CATALOG_TIMEOUT_MS = 15000;
+
+/**
+ * Collections of the pinned bucket.
+ *
+ * The LEFT JOIN is deliberate. `system:scopes` does not list `_default` on
+ * Server 8.0.2, so an inner join silently drops every collection in the default
+ * scope. The second predicate is equally deliberate: the bucket-level row
+ * (name = bucket, no `bucket`/`scope` fields) IS the pre-collections default
+ * collection, and dropping it would hide every document written before scopes
+ * existed.
+ */
+const COLLECTION_LIST_SQL = [
+  "SELECT k.`bucket` AS bucket_name, k.`scope` AS scope_name, k.name AS collection_name",
+  "FROM system:keyspaces AS k",
+  "LEFT JOIN system:scopes AS s ON k.`bucket` = s.`bucket` AND k.`scope` = s.name",
+  "WHERE k.`bucket` = $1 OR (k.`bucket` IS MISSING AND k.name = $1)",
+  "ORDER BY scope_name, collection_name",
+].join(" ");
+
+/** Indexes of the pinned bucket, aliased onto the same row shape as above. */
+const INDEX_LIST_SQL = [
+  "SELECT i.name AS index_name, i.bucket_id AS bucket_name, i.scope_id AS scope_name,",
+  "i.keyspace_id AS collection_name, i.index_key AS index_key, i.is_primary AS is_primary",
+  "FROM system:indexes AS i",
+  "WHERE i.bucket_id = $1 OR (i.bucket_id IS MISSING AND i.keyspace_id = $1)",
+  "ORDER BY scope_name, collection_name, index_name",
+].join(" ");
+
+/** A single backtick-quoted identifier, with embedded backticks doubled. */
+const QUOTED_IDENTIFIER = /^`((?:[^`]|``)*)`$/;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** A collection and the name the flat schema explorer shows for it. */
+export interface CouchbaseCollection {
+  keyspace: Keyspace;
+  displayName: string;
+}
+
+/** What the sampled documents say about one field. */
+interface FieldStats {
+  types: Set<string>;
+  nullable: boolean;
+  flavourCount: number;
+}
+
+// ============================================================================
+// Pure helpers
+// ============================================================================
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Catalog row -> keyspace, shared by both catalogs because their projections
+ * are aliased onto the same field names. Returns null for a row that cannot be
+ * placed, so one malformed row cannot take the whole listing down.
+ */
+function resolveKeyspace(bucket: string, row: CouchbaseRow): Keyspace | null {
+  if (typeof row.bucket_name !== "string") {
+    return { bucket, scope: COUCHBASE_DEFAULT_SCOPE, collection: DEFAULT_COLLECTION };
+  }
+  if (typeof row.collection_name !== "string") return null;
+  return {
+    bucket,
+    scope: typeof row.scope_name === "string" ? row.scope_name : COUCHBASE_DEFAULT_SCOPE,
+    collection: row.collection_name,
+  };
+}
+
+/** Type names an INFER property carries: one string, or a JSON-schema array. */
+function propertyTypes(property: Record<string, unknown>): string[] {
+  if (typeof property.type === "string") return [property.type];
+  if (Array.isArray(property.type)) {
+    const names = property.type.filter((entry): entry is string => typeof entry === "string");
+    if (names.length > 0) return names;
+  }
+  return [UNKNOWN_TYPE];
+}
+
+/** Render a union of observed types the way the MongoDB provider does. */
+function formatType(types: Set<string>): string {
+  const names = [...types].sort();
+  return names.length === 1 ? names[0] : `mixed(${names.join("|")})`;
+}
+
+/** True when the field is missing from part of the flavour it belongs to. */
+function isPartial(property: Record<string, unknown>): boolean {
+  return typeof property["%docs"] === "number" && property["%docs"] < 100;
+}
+
+/** Document key type from the `~meta` pseudo-property. */
+function documentKeyType(meta: Record<string, unknown>): string {
+  const id = asRecord(asRecord(meta.properties)?.id);
+  return id ? formatType(new Set(propertyTypes(id))) : "string";
+}
+
+/**
+ * Flatten INFER flavours into columns.
+ *
+ * Every flavour is unioned: a collection holding two document shapes reports
+ * two flavours, and taking only the first would drop every field the other one
+ * carries. A field missing from some flavour is nullable for the same reason a
+ * field with %docs below 100 is - part of the collection does not have it.
+ */
+function columnsFromFlavours(flavours: unknown[]): ColumnSchema[] {
+  const fields = new Map<string, FieldStats>();
+  let keyType: string | null = null;
+  let flavourCount = 0;
+
+  for (const entry of flavours) {
+    const properties = asRecord(asRecord(entry)?.properties);
+    if (!properties) continue;
+    flavourCount += 1;
+
+    for (const [name, rawProperty] of Object.entries(properties)) {
+      const property = asRecord(rawProperty);
+      if (!property) continue;
+
+      if (name === META_PROPERTY) {
+        keyType = documentKeyType(property);
+        continue;
+      }
+
+      const stats = fields.get(name) ?? { types: new Set<string>(), nullable: false, flavourCount: 0 };
+      for (const type of propertyTypes(property)) stats.types.add(type);
+      stats.nullable = stats.nullable || isPartial(property) || stats.types.has("null");
+      stats.flavourCount += 1;
+      fields.set(name, stats);
+    }
+  }
+
+  const columns: ColumnSchema[] = [...fields.entries()]
+    .map(([name, stats]) => ({
+      name,
+      type: formatType(stats.types),
+      nullable: stats.nullable || stats.flavourCount < flavourCount,
+      isPrimary: false,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  if (keyType !== null) {
+    columns.unshift({ name: COUCHBASE_DOCUMENT_KEY_COLUMN, type: keyType, nullable: false, isPrimary: true });
+  }
+  return columns;
+}
+
+/** Strip the quoting Couchbase applies to a plain index key identifier. */
+function unquoteIndexKey(key: string): string {
+  const match = QUOTED_IDENTIFIER.exec(key);
+  return match ? match[1].replaceAll("``", "`") : key;
+}
+
+function toIndexSchema(row: CouchbaseRow): IndexSchema {
+  const isPrimary = row.is_primary === true;
+  const keys = Array.isArray(row.index_key)
+    ? row.index_key.filter((key): key is string => typeof key === "string").map(unquoteIndexKey)
+    : [];
+
+  return {
+    name: typeof row.index_name === "string" ? row.index_name : UNKNOWN_INDEX_NAME,
+    // A primary index carries no index_key: it keys the document key itself.
+    columns: isPrimary && keys.length === 0 ? [DOCUMENT_KEY_EXPRESSION] : keys,
+    // No secondary GSI enforces uniqueness; only the document key is unique.
+    unique: isPrimary,
+  };
+}
+
+/**
+ * Run `worker` over `items`, at most `limit` at a time, preserving order.
+ * Results are written by index, so no item is dropped and none is reordered.
+ */
+async function mapWithConcurrency<T, R>(items: T[], limit: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const mapped = new Array<R>(items.length);
+  let cursor = 0;
+
+  const runner = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      mapped[index] = await worker(items[index]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, runner));
+  return mapped;
+}
+
+// ============================================================================
+// Introspection
+// ============================================================================
+
+/** The INFER statement for one collection. The path is quoted, never inlined raw. */
+function inferStatement(keyspace: Keyspace): string {
+  return `INFER ${keyspacePath(keyspace)} WITH {"sample_size": ${INFER_SAMPLE_SIZE}}`;
+}
+
+/** Collections of the pinned bucket, with their flat display names. */
+export async function listCollections(transport: CouchbaseTransport, bucket: string): Promise<CouchbaseCollection[]> {
+  const result = await transport.query(COLLECTION_LIST_SQL, { args: [bucket], timeoutMs: CATALOG_TIMEOUT_MS });
+
+  const collections: CouchbaseCollection[] = [];
+  for (const row of result.rows) {
+    const keyspace = resolveKeyspace(bucket, row);
+    if (!keyspace) continue;
+    collections.push({ keyspace, displayName: keyspaceDisplayName(keyspace.scope, keyspace.collection) });
+  }
+  return collections;
+}
+
+/**
+ * Statistical columns for one collection.
+ *
+ * A rejected INFER yields no columns rather than an error: the two common
+ * causes - the user lacks SELECT on the collection, and the collection is empty
+ * (error 7014) - are both states the explorer should render, not fail on.
+ */
+export async function inferColumns(transport: CouchbaseTransport, keyspace: Keyspace): Promise<ColumnSchema[]> {
+  let flavours: unknown;
+  try {
+    const result = await transport.query(inferStatement(keyspace), { timeoutMs: INFER_TIMEOUT_MS });
+    flavours = result.rows[0];
+  } catch {
+    return [];
+  }
+  return Array.isArray(flavours) ? columnsFromFlavours(flavours) : [];
+}
+
+/**
+ * Fast structural schema: every collection of the bucket, with inferred
+ * columns. Indexes are left to getSchemaRelations() so their cost never blocks
+ * the tree, exactly as in the SQL providers.
+ */
+export async function getSchemaList(transport: CouchbaseTransport, bucket: string): Promise<TableSchema[]> {
+  const collections = await listCollections(transport, bucket);
+  const columns = await mapWithConcurrency(collections, INFER_CONCURRENCY, (collection) =>
+    inferColumns(transport, collection.keyspace),
+  );
+
+  return collections.map((collection, index) => ({
+    name: collection.displayName,
+    columns: columns[index],
+    indexes: [],
+    foreignKeys: [],
+  }));
+}
+
+/**
+ * Index lists keyed by display name.
+ *
+ * Failure propagates on purpose. An empty index list is the signal that a
+ * collection has no usable index (decision 6), so degrading a failed catalog
+ * read to empty would fabricate that signal for the whole bucket.
+ */
+export async function getSchemaRelations(transport: CouchbaseTransport, bucket: string): Promise<TableRelations[]> {
+  const result = await transport.query(INDEX_LIST_SQL, { args: [bucket], timeoutMs: CATALOG_TIMEOUT_MS });
+
+  const byCollection = new Map<string, IndexSchema[]>();
+  for (const row of result.rows) {
+    const keyspace = resolveKeyspace(bucket, row);
+    if (!keyspace) continue;
+    const displayName = keyspaceDisplayName(keyspace.scope, keyspace.collection);
+    const indexes = byCollection.get(displayName) ?? [];
+    indexes.push(toIndexSchema(row));
+    byCollection.set(displayName, indexes);
+  }
+
+  return [...byCollection.entries()].map(([name, indexes]) => ({ name, foreignKeys: [], indexes }));
+}

--- a/src/lib/db/providers/document/couchbase/introspect.ts
+++ b/src/lib/db/providers/document/couchbase/introspect.ts
@@ -152,7 +152,7 @@ function propertyTypes(property: Record<string, unknown>): string[] {
 
 /** Render a union of observed types the way the MongoDB provider does. */
 function formatType(types: Set<string>): string {
-  const names = [...types].sort();
+  const names = [...types].sort((a, b) => a.localeCompare(b));
   return names.length === 1 ? names[0] : `mixed(${names.join("|")})`;
 }
 

--- a/src/lib/db/providers/document/couchbase/keyspace.ts
+++ b/src/lib/db/providers/document/couchbase/keyspace.ts
@@ -1,0 +1,61 @@
+/**
+ * Couchbase keyspace mapping (issue #262, decision 4)
+ *
+ * Pure functions, no I/O. Two jobs:
+ *
+ * 1. Flatten bucket > scope > collection for the flat schema explorer, using
+ *    exactly the rule PostgreSQL uses for schema > table: the default scope is
+ *    implicit, everything else is qualified.
+ * 2. Build the executable, backtick-quoted keyspace path.
+ *
+ * Quoting is a security boundary. SQL++ has no bind parameter for identifiers,
+ * so keyspace paths are assembled by concatenation; an identifier carrying a
+ * backtick must not be able to terminate its own quoting and have the remainder
+ * parsed as SQL++. Couchbase escapes an embedded backtick by doubling it.
+ */
+
+import type { Keyspace } from "./transport";
+
+/** Scope every bucket has and which the explorer renders implicitly. */
+export const COUCHBASE_DEFAULT_SCOPE = "_default";
+
+/** Separator between scope and collection in a display name. */
+const DISPLAY_SEPARATOR = ".";
+
+/**
+ * Quote an identifier for use in a SQL++ statement.
+ *
+ * Reserved words (`bucket`, `scope`, ...) only parse when quoted, and doubling
+ * embedded backticks keeps hostile identifiers inside their quotes.
+ */
+export function quoteIdentifier(identifier: string): string {
+  return `\`${identifier.replaceAll("`", "``")}\``;
+}
+
+/** Flatten a scope/collection pair into the name the explorer shows. */
+export function keyspaceDisplayName(scope: string, collection: string): string {
+  return scope === COUCHBASE_DEFAULT_SCOPE ? collection : `${scope}${DISPLAY_SEPARATOR}${collection}`;
+}
+
+/**
+ * Inverse of {@link keyspaceDisplayName}.
+ *
+ * Scope names cannot contain a dot, so the first separator is the boundary and
+ * anything after it belongs to the collection.
+ */
+export function keyspaceFromDisplayName(bucket: string, displayName: string): Keyspace {
+  const separatorIndex = displayName.indexOf(DISPLAY_SEPARATOR);
+  if (separatorIndex === -1) {
+    return { bucket, scope: COUCHBASE_DEFAULT_SCOPE, collection: displayName };
+  }
+  return {
+    bucket,
+    scope: displayName.slice(0, separatorIndex),
+    collection: displayName.slice(separatorIndex + DISPLAY_SEPARATOR.length),
+  };
+}
+
+/** Build the executable keyspace path, every segment quoted. */
+export function keyspacePath(keyspace: Keyspace): string {
+  return [keyspace.bucket, keyspace.scope, keyspace.collection].map(quoteIdentifier).join(DISPLAY_SEPARATOR);
+}

--- a/src/lib/db/providers/document/couchbase/transport.ts
+++ b/src/lib/db/providers/document/couchbase/transport.ts
@@ -1,0 +1,115 @@
+/**
+ * Couchbase transport seam (issue #262, decision 2)
+ *
+ * Provider logic never talks to the cluster directly. It goes through this
+ * interface, so adopting the official SDK later is an additive change (one new
+ * file implementing the same contract) rather than a rewrite of the provider.
+ *
+ * The types below are deliberately NEUTRAL: they describe what a caller needs,
+ * not how any single source encodes it. An HTTP implementation and a future SDK
+ * implementation can both produce this shape without inventing fields. Keeping
+ * the wire envelope out of this file is what makes the seam real - a guard test
+ * asserts the envelope identifiers appear only in http-transport.ts.
+ *
+ * This file is purely structural: no I/O, no wire-format vocabulary.
+ */
+
+/** A single result row. Couchbase documents are JSON objects. */
+export type CouchbaseRow = Record<string, unknown>;
+
+/**
+ * A fully qualified collection inside a bucket.
+ * Couchbase nests cluster > bucket > scope > collection; the bucket is pinned
+ * by the connection, so a keyspace only needs the lower three levels.
+ */
+export interface Keyspace {
+  bucket: string;
+  scope: string;
+  collection: string;
+}
+
+/** A non-fatal notice the cluster attached to a completed statement. */
+export interface CouchbaseWarning {
+  code: number;
+  message: string;
+}
+
+/**
+ * Normalized outcome of one SQL++ statement.
+ *
+ * `fieldNames` is null when the source cannot tell which columns a statement
+ * produced - a `SELECT *` projection nests whole documents under the keyspace
+ * name and advertises only a wildcard, so the caller derives columns from the
+ * rows instead.
+ */
+export interface CouchbaseQueryResult {
+  rows: CouchbaseRow[];
+  fieldNames: string[] | null;
+  executionTimeMs: number;
+  mutationCount: number;
+  warnings: CouchbaseWarning[];
+}
+
+/**
+ * Index freshness for a statement.
+ *
+ * The query service defaults to `not_bounded`, which reads the index in
+ * whatever state it happens to be in. That is unacceptable for an interactive
+ * editor: verified against Couchbase Server 8.0.2, a SELECT issued immediately
+ * after an INSERT returned zero rows while COUNT(*) already returned three, and
+ * the same SELECT returned three rows seconds later. The transport therefore
+ * sends `request_plus` by default so a user always sees their own writes;
+ * callers that prefer latency over freshness opt into `not_bounded`.
+ */
+export type CouchbaseScanConsistency = "not_bounded" | "request_plus";
+
+/** Per-statement options. */
+export interface QueryOpts {
+  /** Positional parameters for `$1`-style placeholders. */
+  args?: unknown[];
+  /** Server-side statement timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Reject any statement that would mutate data. */
+  readonly?: boolean;
+  /** Plan/timing detail the cluster should attach to the response. */
+  profile?: "off" | "phases" | "timings";
+  /** Override the read-your-writes default. */
+  scanConsistency?: CouchbaseScanConsistency;
+}
+
+/**
+ * The seam itself.
+ *
+ * `manage()` stays HTTP permanently: cluster and bucket runtime statistics
+ * (`/pools/default`, `/pools/default/buckets/<bucket>`) have no SDK equivalent,
+ * so overview, performance and storage metrics need it under any transport.
+ */
+export interface CouchbaseTransport {
+  readonly kind: "http";
+  query(stmt: string, o?: QueryOpts): Promise<CouchbaseQueryResult>;
+  manage<T>(path: string): Promise<T>;
+  /** SDK extension point: KV range scan. Not available over HTTP. */
+  scanDocuments?(ks: Keyspace, limit: number, skip: number): Promise<CouchbaseRow[]>;
+  close(): Promise<void>;
+}
+
+/**
+ * Normalized transport failure.
+ *
+ * `code` is a single numeric space: SQL++ error codes (3000 syntax, 4000 no
+ * index, 13014 missing credentials, ...) and HTTP codes (401, 403, 503) both
+ * land here, so provider-level mapping has one thing to switch on. `retriable`
+ * marks failures that are worth repeating (timeouts, CAS conflicts, a query
+ * node that is not ready yet) as opposed to ones that need a user fix.
+ */
+export class CouchbaseError extends Error {
+  constructor(
+    message: string,
+    public readonly code: number,
+    public readonly retriable: boolean = false,
+  ) {
+    super(message);
+    this.name = "CouchbaseError";
+    Object.setPrototypeOf(this, CouchbaseError.prototype);
+  }
+}

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -90,7 +90,7 @@ export interface MaintenanceResult {
  * Each id selects one strategy module in `src/lib/explain`. Extended per
  * provider as explain support lands.
  */
-export type ExplainFormat = "postgres-json" | "mysql-json" | "sqlite-queryplan";
+export type ExplainFormat = "postgres-json" | "mysql-json" | "sqlite-queryplan" | "couchbase-json";
 
 export interface ProviderCapabilities {
   queryLanguage: "sql" | "json";

--- a/src/lib/explain/couchbase-json.ts
+++ b/src/lib/explain/couchbase-json.ts
@@ -1,0 +1,131 @@
+import type { ExplainStrategy, ExplainTreeNode } from "./types";
+
+const SELECT_ONLY = /^\s*SELECT\b/i;
+
+/** How many wrapper layers ({ plan }, row arrays) toPlanRoot peels before giving up. */
+const MAX_UNWRAP_DEPTH = 4;
+
+/** Keys whose values compose the qualified keyspace path, in path order. */
+const KEYSPACE_PATH_KEYS = ["bucket", "scope", "keyspace"] as const;
+
+/**
+ * A node of a Couchbase EXPLAIN plan. "#operator" is the discriminator; child
+ * operators hang off tilde-prefixed keys — "~children" (array) on Sequence and
+ * friends, "~child" (single operator) on Parallel — so both forms are walked.
+ */
+interface CouchbaseOperator {
+  "#operator": string;
+  [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOperator(value: unknown): value is CouchbaseOperator {
+  return isRecord(value) && typeof value["#operator"] === "string";
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/** Couchbase writes -1 where the optimizer produced no estimate; that is not a metric. */
+function isEstimate(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+/** Accepts the plan itself, the EXPLAIN row ({ plan }) and the row array, in any nesting up to MAX_UNWRAP_DEPTH. */
+function toPlanRoot(raw: unknown): CouchbaseOperator | null {
+  let current = raw;
+  for (let depth = 0; depth < MAX_UNWRAP_DEPTH; depth++) {
+    if (isOperator(current)) return current;
+    if (Array.isArray(current)) {
+      current = current[0];
+    } else if (isRecord(current) && "plan" in current) {
+      current = current.plan;
+    } else {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Enterprise's cost-based optimizer reports estimates either flat on the operator
+ * or grouped under "optimizer_estimates", depending on server version.
+ */
+function readEstimate(op: CouchbaseOperator, key: "cost" | "cardinality"): number | undefined {
+  const flat = op[key];
+  if (isEstimate(flat)) return flat;
+  const grouped = op.optimizer_estimates;
+  if (!isRecord(grouped)) return undefined;
+  const nested = grouped[key];
+  return isEstimate(nested) ? nested : undefined;
+}
+
+function buildMetrics(op: CouchbaseOperator): ExplainTreeNode["metrics"] {
+  const estCost = readEstimate(op, "cost");
+  const estRows = readEstimate(op, "cardinality");
+  if (estCost === undefined && estRows === undefined) return undefined;
+  const metrics: NonNullable<ExplainTreeNode["metrics"]> = {};
+  if (estCost !== undefined) metrics.estCost = estCost;
+  if (estRows !== undefined) metrics.estRows = estRows;
+  return metrics;
+}
+
+function buildDetail(op: CouchbaseOperator): string | undefined {
+  const parts: string[] = [];
+  const keyspacePath = KEYSPACE_PATH_KEYS.map((key) => op[key])
+    .filter(isNonEmptyString)
+    .join(".");
+  if (keyspacePath.length > 0) parts.push(keyspacePath);
+  if (isNonEmptyString(op.index)) parts.push(`index: ${op.index}`);
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+function collectChildren(op: CouchbaseOperator): CouchbaseOperator[] {
+  const children: CouchbaseOperator[] = [];
+  for (const [key, value] of Object.entries(op)) {
+    if (!key.startsWith("~")) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isOperator(item)) children.push(item);
+      }
+    } else if (isOperator(value)) {
+      children.push(value);
+    }
+  }
+  return children;
+}
+
+function toTreeNode(op: CouchbaseOperator): ExplainTreeNode {
+  const node: ExplainTreeNode = { label: op["#operator"], children: collectChildren(op).map(toTreeNode) };
+  const detail = buildDetail(op);
+  if (detail !== undefined) node.detail = detail;
+  const metrics = buildMetrics(op);
+  if (metrics !== undefined) node.metrics = metrics;
+  return node;
+}
+
+export const couchbaseJsonStrategy: ExplainStrategy = {
+  format: "couchbase-json",
+  // EXPLAIN produces the plan without executing the statement. There is no
+  // EXPLAIN ANALYZE in SQL++ — real timings come only from the request-level
+  // profile parameter, which ExplainStrategy cannot set (it emits SQL only), so
+  // analyze reports "unavailable" rather than silently returning an estimate.
+  buildSql(sql, mode) {
+    if (mode === "analyze") return null;
+    if (!SELECT_ONLY.test(sql.trim())) return null;
+    return `EXPLAIN ${sql}`;
+  },
+  extractPlan(result) {
+    const plan = result.rows?.[0]?.plan;
+    return plan === undefined ? result.rows : plan;
+  },
+  toRenderModel(raw) {
+    const root = toPlanRoot(raw);
+    if (!root) return null;
+    return { kind: "tree", root: toTreeNode(root), raw };
+  },
+};

--- a/src/lib/explain/couchbase-json.ts
+++ b/src/lib/explain/couchbase-json.ts
@@ -110,12 +110,15 @@ function toTreeNode(op: CouchbaseOperator): ExplainTreeNode {
 
 export const couchbaseJsonStrategy: ExplainStrategy = {
   format: "couchbase-json",
-  // EXPLAIN produces the plan without executing the statement. There is no
-  // EXPLAIN ANALYZE in SQL++ — real timings come only from the request-level
-  // profile parameter, which ExplainStrategy cannot set (it emits SQL only), so
-  // analyze reports "unavailable" rather than silently returning an estimate.
-  buildSql(sql, mode) {
-    if (mode === "analyze") return null;
+  // EXPLAIN produces the plan without executing the statement. SQL++ has no
+  // EXPLAIN ANALYZE - real timings come only from the request-level profile
+  // parameter, which ExplainStrategy cannot set because it emits SQL only - so
+  // both modes return the estimate, exactly as the SQLite strategy does for
+  // EXPLAIN QUERY PLAN. Declining analyze instead would disable the feature
+  // entirely rather than narrow it: the direct Explain action always builds with
+  // mode "analyze" (use-query-execution.ts:165) and refuses the run when the
+  // strategy returns null.
+  buildSql(sql) {
     if (!SELECT_ONLY.test(sql.trim())) return null;
     return `EXPLAIN ${sql}`;
   },

--- a/src/lib/explain/index.ts
+++ b/src/lib/explain/index.ts
@@ -3,6 +3,7 @@ import type { ExplainPlanInput, ExplainStrategy, StoredExplainPlan } from "./typ
 import { postgresJsonStrategy } from "./postgres-json";
 import { mysqlJsonStrategy } from "./mysql-json";
 import { sqliteQueryplanStrategy } from "./sqlite-queryplan";
+import { couchbaseJsonStrategy } from "./couchbase-json";
 
 export type { ExplainMode, ExplainStrategy } from "./types";
 export type { ExplainPlanInput, ExplainTreeNode, StoredExplainPlan } from "./types";
@@ -13,6 +14,7 @@ const registry: Record<ExplainFormat, ExplainStrategy> = {
   "postgres-json": postgresJsonStrategy,
   "mysql-json": mysqlJsonStrategy,
   "sqlite-queryplan": sqliteQueryplanStrategy,
+  "couchbase-json": couchbaseJsonStrategy,
 };
 
 export function getExplainStrategy(format: ExplainFormat | undefined): ExplainStrategy | null {

--- a/src/lib/query-generators.ts
+++ b/src/lib/query-generators.ts
@@ -1,6 +1,38 @@
 import type { ProviderCapabilities } from "@/lib/db/types";
 import type { ColumnSchema } from "@/lib/types";
 
+/** Couchbase management port, the capability signal for the SQL++ dialect. */
+const COUCHBASE_PORT = 8091;
+
+/**
+ * Alias every generated Couchbase statement binds its keyspace to. SQL++ needs a
+ * name to hang `META()` and field references off, and the generator has only the
+ * collection name to work from, so the alias is fixed rather than derived: `d`
+ * for document. It never collides with a field, because fields are only ever
+ * referenced through it.
+ */
+const COUCHBASE_ALIAS = "d";
+
+/**
+ * Column carrying the document key. Kept in step with
+ * `COUCHBASE_DOCUMENT_KEY_COLUMN` in the provider's introspection: the schema tree
+ * and the generated projection must name the key identically, or the grid shows a
+ * column the query never produces.
+ */
+const COUCHBASE_DOCUMENT_KEY_COLUMN = "__id";
+
+/** Backtick-quote a SQL++ identifier, doubling any backtick it contains. */
+function couchbaseQuote(name: string): string {
+  return `\`${name.replaceAll("`", "``")}\``;
+}
+
+/**
+ * The document key projection. `SELECT *` nests whole documents under the
+ * keyspace name and never yields the key at all (issue #262, decision 5), so
+ * every generated statement projects it explicitly through the alias.
+ */
+const COUCHBASE_KEY_PROJECTION = `META(${COUCHBASE_ALIAS}).id AS ${COUCHBASE_DOCUMENT_KEY_COLUMN}`;
+
 /**
  * Quote a SQL identifier (table/column) for the target dialect, but ONLY when
  * needed. Plain identifiers that round-trip unquoted are left as-is so generated
@@ -12,6 +44,7 @@ import type { ColumnSchema } from "@/lib/types";
  *  - Oracle (1521): unquoted folds to UPPERCASE  → quote unless plain UPPER
  *  - SQL Server (1433): case-insensitive          → bracket-quote only specials
  *  - MySQL (3306): case-preserving                → backtick-quote only specials
+ *  - Couchbase (8091): SQL++                      → always backtick-quote
  *  - PostgreSQL (5432) / SQLite / default: unquoted folds to lowercase (pg)
  *                                                  → quote unless plain lower
  */
@@ -19,6 +52,12 @@ export function quoteIdentifier(name: string, capabilities: ProviderCapabilities
   // Document stores (MongoDB) don't use SQL identifier quoting.
   if (capabilities.queryLanguage === "json") return name;
 
+  if (capabilities.defaultPort === COUCHBASE_PORT) {
+    // Couchbase (SQL++): quote unconditionally. Reserved words (`bucket`, `scope`,
+    // ...) are a syntax error unquoted, and a schemaless document may name a field
+    // anything at all, so there is no safe unquoted subset worth detecting.
+    return couchbaseQuote(name);
+  }
   if (capabilities.defaultPort === 1521) {
     // Oracle
     return /^[A-Z_][A-Z0-9_$#]*$/.test(name) ? name : `"${name.replaceAll('"', '""')}"`;
@@ -107,6 +146,10 @@ export function generateTableQuery(tableName: string, capabilities: ProviderCapa
     return JSON.stringify({ collection: tableName, operation: "find", filter: {}, options: { limit: 50 } }, null, 2);
   }
   const table = quoteQualifiedName(tableName, capabilities);
+  // Couchbase (SQL++)
+  if (capabilities.defaultPort === COUCHBASE_PORT) {
+    return `SELECT ${COUCHBASE_KEY_PROJECTION}, ${COUCHBASE_ALIAS}.* FROM ${table} AS ${COUCHBASE_ALIAS} LIMIT 50;`;
+  }
   // Oracle
   if (capabilities.defaultPort === 1521) {
     return `SELECT * FROM ${table} FETCH FIRST 50 ROWS ONLY;`;
@@ -182,6 +225,17 @@ export function generateSelectQuery(
     );
   }
   const table = quoteQualifiedName(tableName, capabilities);
+  // Couchbase (SQL++): every field is reached through the keyspace alias, and the
+  // document key comes from META() rather than from the document body.
+  if (capabilities.defaultPort === COUCHBASE_PORT) {
+    const fields = columns.filter((c) => c.name !== COUCHBASE_DOCUMENT_KEY_COLUMN);
+    const projected =
+      fields.length > 0
+        ? fields.map((c) => `  ${COUCHBASE_ALIAS}.${quoteIdentifier(c.name, capabilities)}`)
+        : [`  ${COUCHBASE_ALIAS}.*`];
+    const projection = [`  ${COUCHBASE_KEY_PROJECTION}`, ...projected].join(",\n");
+    return `SELECT\n${projection}\nFROM ${table} AS ${COUCHBASE_ALIAS}\nWHERE 1=1\nLIMIT 100;`;
+  }
   const cols = columns.map((c) => `  ${quoteIdentifier(c.name, capabilities)}`).join(",\n") || "  *";
   // Oracle
   if (capabilities.defaultPort === 1521) {

--- a/src/lib/seed/types.ts
+++ b/src/lib/seed/types.ts
@@ -19,7 +19,17 @@ const ConnectionEnvironmentSchema = z.enum(["production", "staging", "developmen
 // Allowed roles in current iteration (matches JWT role: 'admin' | 'user' + wildcard)
 const AllowedRoleSchema = z.enum(["*", "admin", "user"]);
 
-const SeedDatabaseType = z.enum(["postgres", "mysql", "sqlite", "mongodb", "redis", "oracle", "mssql", "libredb"]);
+const SeedDatabaseType = z.enum([
+  "postgres",
+  "mysql",
+  "sqlite",
+  "mongodb",
+  "redis",
+  "oracle",
+  "mssql",
+  "libredb",
+  "couchbase",
+]);
 
 export const SeedDefaultsSchema = z.object({
   managed: z.boolean().optional(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,13 @@
-export type DatabaseType = "postgres" | "mysql" | "sqlite" | "mongodb" | "redis" | "oracle" | "mssql" | "libredb";
+export type DatabaseType =
+  | "postgres"
+  | "mysql"
+  | "sqlite"
+  | "mongodb"
+  | "redis"
+  | "oracle"
+  | "mssql"
+  | "libredb"
+  | "couchbase";
 
 export type ConnectionEnvironment = "production" | "staging" | "development" | "local" | "other";
 

--- a/tests/components/ConnectionModal.test.tsx
+++ b/tests/components/ConnectionModal.test.tsx
@@ -227,7 +227,8 @@ mock.module("@/lib/db-ui-config", () => ({
     color: "text-blue-400",
     label: type,
     defaultPort: type === "mysql" ? "3306" : type === "mongodb" ? "27017" : "5432",
-    showConnectionStringToggle: type === "mongodb",
+    // Mirrors the real config: the URI-addressed providers offer the toggle.
+    showConnectionStringToggle: type === "mongodb" || type === "couchbase",
     connectionFields: ["host", "port", "user", "password", "database"],
   }),
   getDBIcon: () => () => null,
@@ -644,5 +645,35 @@ describe("ConnectionModal", () => {
     expect(passphraseInput).not.toBeNull();
     fireEvent.change(passphraseInput as HTMLInputElement, { target: { value: "secret-pass" } });
     expect(mockSetSSHPassphrase).toHaveBeenCalledWith("secret-pass");
+  });
+
+  // ── 34. Couchbase labels the database field as the bucket it actually is ──
+
+  test("Couchbase type labels the database field Bucket Name", () => {
+    mockFormOverrides = { type: "couchbase" };
+    const props = createDefaultProps();
+    const { queryByText } = render(React.createElement(ConnectionModal, props));
+
+    expect(queryByText("Bucket Name")).not.toBeNull();
+    expect(queryByText("Database Name")).toBeNull();
+  });
+
+  test("Couchbase connection-string mode labels the override Bucket and shows a couchbase:// example", () => {
+    mockFormOverrides = { type: "couchbase", mongoConnectionMode: "connectionString" };
+    const props = createDefaultProps();
+    const { queryByText, container } = render(React.createElement(ConnectionModal, props));
+
+    expect(queryByText("Bucket Name (optional override)")).not.toBeNull();
+    const uriInput = container.querySelector("#connectionString") as HTMLInputElement | null;
+    expect(uriInput).not.toBeNull();
+    expect(uriInput!.placeholder).toContain("couchbase://");
+  });
+
+  test("non-Couchbase types keep the Database Name label", () => {
+    const props = createDefaultProps();
+    const { queryByText } = render(React.createElement(ConnectionModal, props));
+
+    expect(queryByText("Database Name")).not.toBeNull();
+    expect(queryByText("Bucket Name")).toBeNull();
   });
 });

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -9,13 +9,21 @@ import { mockToastSuccess, mockToastError } from "../helpers/mock-sonner";
 import "../helpers/mock-navigation";
 
 // ── Mock @/lib/db-ui-config ─────────────────────────────────────────────────
+const DEFAULT_PORTS: Record<string, string> = {
+  mysql: "3306",
+  mongodb: "27017",
+  redis: "6379",
+  couchbase: "8091",
+};
+
 mock.module("@/lib/db-ui-config", () => ({
   getDBConfig: (type: string) => ({
     label: type.charAt(0).toUpperCase() + type.slice(1),
     icon: "Database",
     color: "#000",
-    defaultPort: type === "mysql" ? "3306" : type === "mongodb" ? "27017" : type === "redis" ? "6379" : "5432",
-    showConnectionStringToggle: type === "mongodb",
+    defaultPort: DEFAULT_PORTS[type] ?? "5432",
+    // Mirrors the real config: the URI-addressed providers offer the toggle.
+    showConnectionStringToggle: type === "mongodb" || type === "couchbase",
     connectionFields: ["host", "port", "user", "password", "database"],
   }),
 }));
@@ -338,6 +346,7 @@ describe("useConnectionForm", () => {
     mongodb: true,
     redis: true,
     libredb: true,
+    couchbase: true,
   };
 
   test("dbTypes offers every database type a connection can carry", () => {
@@ -742,6 +751,28 @@ describe("useConnectionForm", () => {
 
     expect(result.current.type).toBe("mongodb");
     expect(result.current.connectionString).toBe("mongodb://admin:pass@mongo.example.com:27017/mydb");
+    expect(result.current.mongoConnectionMode).toBe("connectionString");
+  });
+
+  // ── handlePasteConnectionString for Couchbase ──────────────────────────
+
+  test("handlePasteConnectionString sets Couchbase bucket and connectionString mode", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("couchbase://admin:pass@cb.example.com:8091/travel");
+    });
+
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.type).toBe("couchbase");
+    expect(result.current.host).toBe("cb.example.com");
+    expect(result.current.port).toBe("8091");
+    // The bucket rides in the `database` field.
+    expect(result.current.database).toBe("travel");
+    expect(result.current.connectionString).toBe("couchbase://admin:pass@cb.example.com:8091/travel");
     expect(result.current.mongoConnectionMode).toBe("connectionString");
   });
 

--- a/tests/integration/db/couchbase-provider.test.ts
+++ b/tests/integration/db/couchbase-provider.test.ts
@@ -1,0 +1,871 @@
+/**
+ * Couchbase Provider Integration Tests (issue #262)
+ *
+ * globalThis.fetch is replaced per test and restored in afterEach. mock.module()
+ * is deliberately not used: it is process-wide in bun and would poison sibling
+ * test files. Every payload below was captured from a live Couchbase Server
+ * 8.0.2 Community node, so the fake speaks exactly what the cluster speaks.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import type { DatabaseConnection, DatabaseType } from "@/lib/types";
+import { CouchbaseProvider } from "@/lib/db/providers/document/couchbase";
+import { AuthenticationError, ConnectionError, DatabaseConfigError, QueryError, TimeoutError } from "@/lib/db/errors";
+
+// ============================================================================
+// Connection
+// ============================================================================
+
+// The DatabaseType union gains "couchbase" in the registration commit; the
+// double assertion keeps this file compiling on either side of that change.
+const COUCHBASE: DatabaseType = "couchbase" as unknown as DatabaseType;
+
+const BUCKET = "travel";
+
+function makeConnection(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
+  return {
+    id: "cb-1",
+    name: "Couchbase",
+    type: COUCHBASE,
+    host: "127.0.0.1",
+    port: 8091,
+    user: "Administrator",
+    password: "password123",
+    database: BUCKET,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Management payloads (captured from Couchbase Server 8.0.2 Community)
+// ============================================================================
+
+const NODE_SERVICES = {
+  nodesExt: [{ hostname: "127.0.0.1", services: { mgmt: 8091, n1ql: 8093 } }],
+};
+
+const POOLS = {
+  name: "default",
+  nodes: [{ version: "8.0.2-5503-community", uptime: "2722", status: "healthy" }],
+};
+
+const BUCKET_INFO = {
+  name: BUCKET,
+  storageBackend: "couchstore",
+  quota: { ram: 268435456, rawRAM: 268435456 },
+  basicStats: {
+    quotaPercentUsed: 14.6,
+    opsPerSec: 0,
+    itemCount: 7,
+    diskUsed: 17581056,
+    dataUsed: 1814878,
+    memUsed: 39189488,
+  },
+};
+
+const BUCKET_STATS = {
+  op: {
+    samples: {
+      curr_connections: [55, 55, 55],
+      cmd_get: [1, 2, 3],
+      cmd_set: [0, 0, 1],
+      ep_cache_miss_rate: [0, 0, 2.5],
+    },
+  },
+};
+
+const INDEX_STATS_SAMPLES = {
+  op: {
+    samples: {
+      "index/idx_hotel_city/data_size": [1, 2, 4096],
+      "index/idx_hotel_city/num_requests": [0, 0, 7],
+    },
+  },
+};
+
+// ============================================================================
+// Query payloads
+// ============================================================================
+
+const COLLECTION_ROWS = [
+  { bucket_name: BUCKET, scope_name: "_default", collection_name: "airline" },
+  { bucket_name: BUCKET, scope_name: "inventory", collection_name: "hotel" },
+];
+
+const INDEX_ROWS = [
+  {
+    index_name: "#primary",
+    bucket_name: BUCKET,
+    scope_name: "_default",
+    collection_name: "airline",
+    index_key: [],
+    is_primary: true,
+    state: "online",
+    index_type: "gsi",
+  },
+  {
+    index_name: "idx_hotel_city",
+    bucket_name: BUCKET,
+    scope_name: "inventory",
+    collection_name: "hotel",
+    index_key: ["`city`"],
+    state: "online",
+    index_type: "gsi",
+  },
+];
+
+const INFER_FLAVOURS = [
+  {
+    "#docs": 3,
+    Flavor: "",
+    properties: {
+      city: { type: "string", "%docs": 100, samples: ["Bursa", "Istanbul"] },
+      "~meta": { properties: { id: { type: "string", samples: ["hotel::1"] } } },
+    },
+  },
+];
+
+const COMPLETED_REQUEST_ROWS = [
+  {
+    request_id: "2c95157c",
+    statement: "CREATE INDEX idx_hotel_city ON `travel`.`inventory`.`hotel`(city)",
+    elapsed_ns: 4410636437,
+    result_count: 1,
+  },
+];
+
+const ACTIVE_REQUEST_ROWS = [
+  {
+    request_id: "8a45dcda",
+    statement: "SELECT * FROM `travel`.`inventory`.`hotel`",
+    users: "builtin:Administrator",
+    remote_addr: "172.17.0.1:41136",
+    state: "running",
+    elapsed_ns: 914475,
+  },
+];
+
+// ============================================================================
+// fetch harness
+// ============================================================================
+
+interface ManageStub {
+  match: string;
+  payload: unknown;
+  httpCode: number;
+}
+
+const originalFetch = globalThis.fetch;
+
+let manageStubs: ManageStub[] = [];
+let manageUrls: string[] = [];
+let queryBodies: Record<string, unknown>[] = [];
+let queryHandler: (statement: string) => unknown;
+let queryHttpCode = 200;
+let deferredIndexRows: Record<string, unknown>[] = [];
+let networkFailure: Error | null = null;
+
+function jsonResponse(payload: unknown, httpCode: number): Response {
+  return new Response(JSON.stringify(payload), {
+    status: httpCode,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function queryPayload(rows: unknown[], overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    requestID: "req-1",
+    signature: { "*": "*" },
+    results: rows,
+    status: "success",
+    metrics: { elapsedTime: "2.5ms", executionTime: "1.234ms", resultCount: rows.length, mutationCount: 0 },
+    ...overrides,
+  };
+}
+
+function errorPayload(code: number, msg: string): Record<string, unknown> {
+  return {
+    requestID: "req-1",
+    errors: [{ code, msg }],
+    status: "fatal",
+    metrics: { elapsedTime: "0.4ms", executionTime: "0.3ms", resultCount: 0, errorCount: 1 },
+  };
+}
+
+/** Route a statement onto the catalog fixtures above. */
+function defaultQueryPayload(statement: string): unknown {
+  if (statement.startsWith("INFER")) return queryPayload([INFER_FLAVOURS]);
+  if (statement.includes("system:keyspaces")) {
+    return statement.includes("COUNT(*)") ? queryPayload([{ total: 4 }]) : queryPayload(COLLECTION_ROWS);
+  }
+  if (statement.includes("system:indexes")) {
+    if (statement.includes("COUNT(*)")) return queryPayload([{ total: 3 }]);
+    if (statement.includes("deferred")) return queryPayload(deferredIndexRows);
+    return queryPayload(INDEX_ROWS);
+  }
+  if (statement.includes("system:completed_requests")) return queryPayload(COMPLETED_REQUEST_ROWS);
+  if (statement.includes("system:active_requests")) {
+    return statement.startsWith("DELETE") ? queryPayload([]) : queryPayload(ACTIVE_REQUEST_ROWS);
+  }
+  return queryPayload([]);
+}
+
+function stubManage(match: string, payload: unknown, httpCode = 200): void {
+  manageStubs.unshift({ match, payload, httpCode });
+}
+
+function installFetch(): void {
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    if (networkFailure) throw networkFailure;
+    const url = String(input);
+
+    if (url.includes("/query/service")) {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      queryBodies.push(body);
+      return jsonResponse(queryHandler(String(body.statement)), queryHttpCode);
+    }
+
+    manageUrls.push(url);
+    const stub = manageStubs.find((entry) => url.includes(entry.match));
+    return jsonResponse(stub?.payload ?? {}, stub?.httpCode ?? 404);
+  }) as typeof fetch;
+}
+
+function bodyOf(match: string): Record<string, unknown> {
+  const body = queryBodies.find((entry) => String(entry.statement).includes(match));
+  if (!body) throw new Error(`no statement matching "${match}" was sent`);
+  return body;
+}
+
+async function connectProvider(overrides: Partial<DatabaseConnection> = {}): Promise<CouchbaseProvider> {
+  const provider = new CouchbaseProvider(makeConnection(overrides));
+  await provider.connect();
+  return provider;
+}
+
+beforeEach(() => {
+  manageUrls = [];
+  queryBodies = [];
+  deferredIndexRows = [];
+  networkFailure = null;
+  queryHttpCode = 200;
+  queryHandler = defaultQueryPayload;
+  manageStubs = [
+    { match: "/pools/default/nodeServices", payload: NODE_SERVICES, httpCode: 200 },
+    { match: `/pools/default/buckets/@index-${BUCKET}/stats`, payload: INDEX_STATS_SAMPLES, httpCode: 200 },
+    { match: `/pools/default/buckets/${BUCKET}/stats`, payload: BUCKET_STATS, httpCode: 200 },
+    { match: `/pools/default/buckets/${BUCKET}`, payload: BUCKET_INFO, httpCode: 200 },
+    { match: "/pools/default", payload: POOLS, httpCode: 200 },
+  ];
+  installFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+describe("CouchbaseProvider metadata", () => {
+  test("declares the capabilities issue #262 specifies", () => {
+    const capabilities = new CouchbaseProvider(makeConnection()).getCapabilities();
+
+    expect(capabilities).toEqual({
+      queryLanguage: "sql",
+      supportsExplain: true,
+      explainFormat: "couchbase-json",
+      supportsExternalQueryLimiting: true,
+      supportsCreateTable: false,
+      supportsMaintenance: true,
+      maintenanceOperations: ["analyze", "reindex", "kill"],
+      supportsConnectionString: true,
+      defaultPort: 8091,
+      schemaRefreshPattern: "\\b(CREATE|DROP|ALTER)\\s+(COLLECTION|SCOPE|INDEX)\\b",
+    });
+  });
+
+  test("labels collections and documents", () => {
+    const labels = new CouchbaseProvider(makeConnection()).getLabels();
+
+    expect(labels.entityName).toBe("Collection");
+    expect(labels.entityNamePlural).toBe("Collections");
+    expect(labels.rowName).toBe("document");
+    expect(labels.rowNamePlural).toBe("documents");
+    expect(labels.analyzeGlobalDesc).toContain("Enterprise");
+  });
+});
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+describe("CouchbaseProvider validation", () => {
+  test("requires a host or a connection string", () => {
+    expect(() => new CouchbaseProvider(makeConnection({ host: undefined }))).toThrow(DatabaseConfigError);
+  });
+
+  test("requires a bucket in the database field", () => {
+    expect(() => new CouchbaseProvider(makeConnection({ database: undefined }))).toThrow(/bucket/i);
+  });
+
+  test("accepts a connection string instead of a host and targets its hostname", async () => {
+    const provider = await connectProvider({
+      host: undefined,
+      connectionString: "couchbases://cb.example.cloud.couchbase.com",
+    });
+
+    expect(manageUrls[0]).toContain("cb.example.cloud.couchbase.com:8091/pools/default");
+    await provider.disconnect();
+  });
+
+  test("keeps the configured host when the connection string is unparsable", async () => {
+    const provider = await connectProvider({ host: undefined, connectionString: "not a url" });
+
+    expect(manageUrls[0]).toContain("localhost:8091/pools/default");
+    await provider.disconnect();
+  });
+});
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+describe("CouchbaseProvider lifecycle", () => {
+  test("connect verifies the cluster and marks the provider connected", async () => {
+    const provider = await connectProvider();
+
+    expect(provider.isConnected()).toBe(true);
+    expect(manageUrls[0]).toContain("/pools/default");
+  });
+
+  test("connect maps rejected credentials to an AuthenticationError", async () => {
+    stubManage("/pools/default", {}, 401);
+    const provider = new CouchbaseProvider(makeConnection());
+
+    await expect(provider.connect()).rejects.toBeInstanceOf(AuthenticationError);
+    expect(provider.isConnected()).toBe(false);
+  });
+
+  test("connect maps an unreachable cluster to a ConnectionError", async () => {
+    networkFailure = new Error("connect ECONNREFUSED 127.0.0.1:8091");
+    const provider = new CouchbaseProvider(makeConnection());
+
+    await expect(provider.connect()).rejects.toBeInstanceOf(ConnectionError);
+    expect(provider.isConnected()).toBe(false);
+  });
+
+  test("disconnect releases the transport and is safe to call twice", async () => {
+    const provider = await connectProvider();
+
+    await provider.disconnect();
+    await provider.disconnect();
+
+    expect(provider.isConnected()).toBe(false);
+  });
+
+  test("query before connect is refused", async () => {
+    const provider = new CouchbaseProvider(makeConnection());
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(DatabaseConfigError);
+  });
+});
+
+// ============================================================================
+// Query execution
+// ============================================================================
+
+describe("CouchbaseProvider query", () => {
+  test("returns rows, fields, row count and the cluster execution time", async () => {
+    const provider = await connectProvider();
+    queryHandler = () =>
+      queryPayload([{ id: "hotel::1", city: "Bursa" }], { signature: { id: "string", city: "string" } });
+
+    const result = await provider.query("SELECT id, city FROM `travel`.`inventory`.`hotel`");
+
+    expect(result.rows).toEqual([{ id: "hotel::1", city: "Bursa" }]);
+    expect(result.fields).toEqual(["id", "city"]);
+    expect(result.rowCount).toBe(1);
+    expect(result.executionTime).toBe(1);
+  });
+
+  test("derives fields from the rows when the projection is a wildcard", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => queryPayload([{ hotel: { city: "Bursa" } }, { hotel: {}, __id: "hotel::2" }]);
+
+    const result = await provider.query("SELECT * FROM `travel`.`inventory`.`hotel`");
+
+    expect(result.fields).toEqual(["hotel", "__id"]);
+  });
+
+  test("reports the mutation count as the row count when a statement returns no rows", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => queryPayload([], { metrics: { elapsedTime: "5ms", executionTime: "4ms", mutationCount: 3 } });
+
+    const result = await provider.query("INSERT INTO `travel`.`_default`.`airline` VALUES ('a', {})");
+
+    expect(result.rowCount).toBe(3);
+    expect(result.rows).toEqual([]);
+  });
+
+  test("falls back to the measured time when the cluster reports no metrics", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => queryPayload([], { metrics: {} });
+
+    const result = await provider.query("SELECT 1");
+
+    expect(result.executionTime).toBeGreaterThanOrEqual(0);
+  });
+
+  test("asks for request_plus so a user always sees their own writes", async () => {
+    const provider = await connectProvider();
+
+    await provider.query("SELECT 1");
+
+    expect(bodyOf("SELECT 1").scan_consistency).toBe("request_plus");
+  });
+
+  test("forwards positional parameters to the cluster", async () => {
+    const provider = await connectProvider();
+
+    await provider.query("SELECT * FROM `travel`.`_default`.`airline` WHERE country = $1", ["France"]);
+
+    expect(bodyOf("country = $1").args).toEqual(["France"]);
+  });
+});
+
+// ============================================================================
+// Error mapping
+// ============================================================================
+
+describe("CouchbaseProvider error mapping", () => {
+  test("error 4000 carries the CREATE PRIMARY INDEX remedy for the quoted keyspace", async () => {
+    const provider = await connectProvider();
+    queryHandler = () =>
+      errorPayload(
+        4000,
+        "No index available on keyspace `default`:`travel`.`inventory`.`hotel` that matches your query.",
+      );
+
+    const failure = provider.query("SELECT * FROM `travel`.`inventory`.`hotel` LIMIT 10");
+
+    await expect(failure).rejects.toBeInstanceOf(QueryError);
+    await expect(failure).rejects.toThrow("CREATE PRIMARY INDEX ON `travel`.`inventory`.`hotel`");
+  });
+
+  test("error 4000 on an unquoted keyspace still produces a runnable remedy", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(4000, "No index available on keyspace travel");
+
+    await expect(provider.query("select * from travel")).rejects.toThrow("CREATE PRIMARY INDEX ON `travel`");
+  });
+
+  test("error 4000 without a FROM clause falls back to the pinned bucket", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(4000, "No index available on keyspace");
+
+    await expect(provider.query("EXECUTE 'p1'")).rejects.toThrow("CREATE PRIMARY INDEX ON `travel`");
+  });
+
+  test("a missing privilege becomes an AuthenticationError", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(13014, "User does not have credentials to run SELECT queries");
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  test("a request timeout becomes a TimeoutError", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(1080, "Timeout 30s exceeded");
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  test("an unavailable query service becomes a ConnectionError", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(503, "service unavailable");
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(ConnectionError);
+  });
+
+  test("an HTTP-level rejection with no payload still maps by its code", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => ({});
+    queryHttpCode = 403;
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  test("a network fault becomes a ConnectionError", async () => {
+    const provider = await connectProvider();
+    networkFailure = new Error("socket hang up");
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(ConnectionError);
+  });
+
+  test("a rejected statement becomes a QueryError", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(3000, "syntax error - line 1, column 8, near 'SELEC'");
+
+    await expect(provider.query("SELEC 1")).rejects.toBeInstanceOf(QueryError);
+  });
+
+  test("a statement rejected with no code at all still becomes a QueryError", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => ({ requestID: "req-1", status: "errors" });
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(QueryError);
+  });
+});
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+describe("CouchbaseProvider schema", () => {
+  test("getSchemaList flattens scopes and infers columns", async () => {
+    const provider = await connectProvider();
+
+    const tables = await provider.getSchemaList();
+
+    expect(tables.map((table) => table.name)).toEqual(["airline", "inventory.hotel"]);
+    expect(tables[0].columns.map((column) => column.name)).toEqual(["__id", "city"]);
+    expect(tables[0].indexes).toEqual([]);
+  });
+
+  test("getSchemaRelations lists indexes and never invents foreign keys", async () => {
+    const provider = await connectProvider();
+
+    const relations = await provider.getSchemaRelations();
+
+    expect(relations.map((relation) => relation.name)).toEqual(["airline", "inventory.hotel"]);
+    expect(relations[0].indexes[0]).toEqual({ name: "#primary", columns: ["META().id"], unique: true });
+    expect(relations[0].foreignKeys).toEqual([]);
+  });
+
+  test("getSchema merges indexes into the inferred columns", async () => {
+    const provider = await connectProvider();
+
+    const schema = await provider.getSchema();
+
+    expect(schema.map((table) => table.name)).toEqual(["airline", "inventory.hotel"]);
+    expect(schema[1].indexes.map((index) => index.name)).toEqual(["idx_hotel_city"]);
+    expect(schema[1].columns.length).toBeGreaterThan(0);
+  });
+
+  test("getTables lists collections without paying for INFER", async () => {
+    const provider = await connectProvider();
+
+    const tables = await provider.getTables();
+
+    expect(tables).toEqual(["airline", "inventory.hotel"]);
+    expect(queryBodies.some((body) => String(body.statement).startsWith("INFER"))).toBe(false);
+  });
+
+  test("a denied catalog read surfaces as an AuthenticationError", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(13014, "User does not have credentials to run queries");
+
+    await expect(provider.getSchemaRelations()).rejects.toBeInstanceOf(AuthenticationError);
+  });
+});
+
+// ============================================================================
+// Monitoring
+// ============================================================================
+
+describe("CouchbaseProvider monitoring", () => {
+  test("getOverview combines cluster, bucket and catalog counts", async () => {
+    const provider = await connectProvider();
+
+    const overview = await provider.getOverview();
+
+    expect(overview.version).toBe("8.0.2-5503-community");
+    expect(overview.uptime).toBe("45.37m");
+    expect(overview.activeConnections).toBe(55);
+    expect(overview.maxConnections).toBe(65536);
+    expect(overview.databaseSizeBytes).toBe(17581056);
+    expect(overview.databaseSize).toBe("16.77 MB");
+    expect(overview.tableCount).toBe(4);
+    expect(overview.indexCount).toBe(3);
+    expect(overview.startTime).toBeInstanceOf(Date);
+  });
+
+  test("getOverview degrades to zeros when every source is denied", async () => {
+    const provider = await connectProvider();
+    stubManage("/pools/default", {}, 403);
+    queryHandler = () => errorPayload(13014, "User does not have credentials");
+
+    const overview = await provider.getOverview();
+
+    expect(overview.version).toBe("unknown");
+    expect(overview.activeConnections).toBe(0);
+    expect(overview.databaseSizeBytes).toBe(0);
+    expect(overview.tableCount).toBe(0);
+    expect(overview.indexCount).toBe(0);
+  });
+
+  test("getPerformanceMetrics derives the hit ratio from the miss rate", async () => {
+    const provider = await connectProvider();
+
+    const performance = await provider.getPerformanceMetrics();
+
+    expect(performance.cacheHitRatio).toBe(97.5);
+    expect(performance.queriesPerSecond).toBe(4);
+    expect(performance.bufferPoolUsage).toBe(14.6);
+  });
+
+  test("getPerformanceMetrics reports zero rather than a perfect score when denied", async () => {
+    const provider = await connectProvider();
+    stubManage(`/pools/default/buckets/${BUCKET}`, {}, 403);
+
+    const performance = await provider.getPerformanceMetrics();
+
+    expect(performance.cacheHitRatio).toBe(0);
+    expect(performance.queriesPerSecond).toBe(0);
+    expect(performance.bufferPoolUsage).toBe(0);
+  });
+
+  test("getSlowQueries reads system:completed_requests", async () => {
+    const provider = await connectProvider();
+
+    const slow = await provider.getSlowQueries({ limit: 5 });
+
+    expect(slow).toHaveLength(1);
+    expect(slow[0].queryId).toBe("2c95157c");
+    expect(slow[0].totalTime).toBe(4411);
+    expect(slow[0].avgTime).toBe(4411);
+    expect(slow[0].rows).toBe(1);
+    expect(bodyOf("system:completed_requests").args).toEqual([5]);
+  });
+
+  test("getSlowQueries returns empty when the Query System Catalog role is missing", async () => {
+    const provider = await connectProvider();
+    queryHandler = () =>
+      errorPayload(13014, "User does not have credentials to run queries on system:completed_requests");
+
+    expect(await provider.getSlowQueries()).toEqual([]);
+  });
+
+  test("getActiveSessions reads system:active_requests", async () => {
+    const provider = await connectProvider();
+
+    const sessions = await provider.getActiveSessions({ limit: 7 });
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].pid).toBe("8a45dcda");
+    expect(sessions[0].user).toBe("builtin:Administrator");
+    expect(sessions[0].database).toBe(BUCKET);
+    expect(sessions[0].state).toBe("running");
+    expect(sessions[0].clientAddr).toBe("172.17.0.1:41136");
+    expect(sessions[0].durationMs).toBe(1);
+    expect(bodyOf("system:active_requests").args).toEqual([7]);
+  });
+
+  test("getActiveSessions returns empty when the system keyspace is denied", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(13014, "User does not have credentials");
+
+    expect(await provider.getActiveSessions()).toEqual([]);
+  });
+
+  test("getTableStats reports the bucket, the only cheap granularity", async () => {
+    const provider = await connectProvider();
+
+    const stats = await provider.getTableStats();
+
+    expect(stats).toHaveLength(1);
+    expect(stats[0].tableName).toBe(BUCKET);
+    expect(stats[0].rowCount).toBe(7);
+    expect(stats[0].tableSizeBytes).toBe(1814878);
+    expect(stats[0].totalSizeBytes).toBe(17581056);
+  });
+
+  test("getTableStats returns empty when the bucket endpoint is denied", async () => {
+    const provider = await connectProvider();
+    stubManage(`/pools/default/buckets/${BUCKET}`, {}, 403);
+
+    expect(await provider.getTableStats()).toEqual([]);
+  });
+
+  test("getIndexStats joins system:indexes with the index service samples", async () => {
+    const provider = await connectProvider();
+
+    const stats = await provider.getIndexStats();
+
+    expect(stats).toHaveLength(2);
+    expect(stats[0]).toEqual({
+      schemaName: "_default",
+      tableName: "airline",
+      indexName: "#primary",
+      indexType: "gsi",
+      columns: [],
+      isUnique: true,
+      isPrimary: true,
+      indexSize: "0 B",
+      indexSizeBytes: 0,
+      scans: 0,
+    });
+    expect(stats[1].columns).toEqual(["city"]);
+    expect(stats[1].isPrimary).toBe(false);
+    expect(stats[1].indexSizeBytes).toBe(4096);
+    expect(stats[1].scans).toBe(7);
+  });
+
+  test("getIndexStats returns empty when system:indexes is denied", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(13014, "User does not have credentials");
+
+    expect(await provider.getIndexStats()).toEqual([]);
+  });
+
+  test("getStorageStats reports disk usage and the RAM quota", async () => {
+    const provider = await connectProvider();
+
+    const storage = await provider.getStorageStats();
+
+    expect(storage).toHaveLength(2);
+    expect(storage[0]).toEqual({
+      name: "Data",
+      location: BUCKET,
+      size: "16.77 MB",
+      sizeBytes: 17581056,
+    });
+    expect(storage[1].sizeBytes).toBe(268435456);
+    expect(storage[1].usagePercent).toBe(14.6);
+  });
+
+  test("getStorageStats returns empty when the bucket endpoint is denied", async () => {
+    const provider = await connectProvider();
+    stubManage(`/pools/default/buckets/${BUCKET}`, {}, 403);
+
+    expect(await provider.getStorageStats()).toEqual([]);
+  });
+
+  test("getHealth composes the degrading sources", async () => {
+    const provider = await connectProvider();
+
+    const health = await provider.getHealth();
+
+    expect(health.activeConnections).toBe(55);
+    expect(health.databaseSize).toBe("16.77 MB");
+    expect(health.cacheHitRatio).toBe("97.5");
+    expect(health.slowQueries[0].avgTime).toBe("4411ms");
+    expect(health.activeSessions[0].pid).toBe("8a45dcda");
+  });
+
+  test("getMonitoringData survives a user who can read nothing", async () => {
+    const provider = await connectProvider();
+    stubManage("/pools/default", {}, 403);
+    queryHandler = () => errorPayload(13014, "User does not have credentials");
+
+    const data = await provider.getMonitoringData();
+
+    expect(data.slowQueries).toEqual([]);
+    expect(data.activeSessions).toEqual([]);
+    expect(data.tables).toEqual([]);
+    expect(data.indexes).toEqual([]);
+    expect(data.storage).toEqual([]);
+    expect(data.performance.cacheHitRatio).toBe(0);
+  });
+});
+
+// ============================================================================
+// Maintenance
+// ============================================================================
+
+describe("CouchbaseProvider maintenance", () => {
+  test("analyze runs UPDATE STATISTICS for the keyspace", async () => {
+    const provider = await connectProvider();
+
+    const result = await provider.runMaintenance("analyze", "inventory.hotel");
+
+    expect(result.success).toBe(true);
+    expect(bodyOf("UPDATE STATISTICS").statement).toBe("UPDATE STATISTICS FOR `travel`.`inventory`.`hotel` INDEX ALL");
+  });
+
+  test("analyze surfaces the Community Edition rejection verbatim", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(3230, "'Update Statistics' is an enterprise level feature.");
+
+    const result = await provider.runMaintenance("analyze", "inventory.hotel");
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("'Update Statistics' is an enterprise level feature.");
+  });
+
+  test("analyze without a target is refused", async () => {
+    const provider = await connectProvider();
+
+    await expect(provider.runMaintenance("analyze")).rejects.toBeInstanceOf(QueryError);
+  });
+
+  test("reindex builds the deferred indexes of the keyspace", async () => {
+    const provider = await connectProvider();
+    deferredIndexRows = [{ index_name: "idx_city" }, { index_name: "idx_name" }, { index_name: 42 }];
+
+    const result = await provider.runMaintenance("reindex", "inventory.hotel");
+
+    expect(result.success).toBe(true);
+    expect(bodyOf("BUILD INDEX").statement).toBe("BUILD INDEX ON `travel`.`inventory`.`hotel`(`idx_city`, `idx_name`)");
+    expect(result.message).toContain("2");
+  });
+
+  test("reindex reports when nothing is deferred", async () => {
+    const provider = await connectProvider();
+
+    const result = await provider.runMaintenance("reindex", "inventory.hotel");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("No deferred");
+    expect(queryBodies.some((body) => String(body.statement).startsWith("BUILD INDEX"))).toBe(false);
+  });
+
+  test("kill deletes the row from system:active_requests", async () => {
+    const provider = await connectProvider();
+
+    const result = await provider.runMaintenance("kill", "8a45dcda");
+
+    expect(result.success).toBe(true);
+    expect(bodyOf("DELETE FROM system:active_requests").args).toEqual(["8a45dcda"]);
+  });
+
+  test("an operation Couchbase has no equivalent for is refused", async () => {
+    const provider = await connectProvider();
+
+    await expect(provider.runMaintenance("vacuum", "inventory.hotel")).rejects.toThrow(/vacuum/);
+  });
+
+  test("a rejected maintenance statement is mapped like any other failure", async () => {
+    const provider = await connectProvider();
+    queryHandler = () => errorPayload(13014, "User does not have credentials");
+
+    await expect(provider.runMaintenance("kill", "8a45dcda")).rejects.toBeInstanceOf(AuthenticationError);
+  });
+});
+
+// ============================================================================
+// Query preparation
+// ============================================================================
+
+describe("CouchbaseProvider query preparation", () => {
+  test("applies the external row limit to a SELECT", () => {
+    const provider = new CouchbaseProvider(makeConnection());
+
+    const prepared = provider.prepareQuery("SELECT * FROM `travel`.`inventory`.`hotel`", { limit: 25 });
+
+    expect(prepared.query).toContain("LIMIT 25");
+    expect(prepared.wasLimited).toBe(true);
+    expect(prepared.limit).toBe(25);
+  });
+
+  test("leaves a mutation untouched", () => {
+    const provider = new CouchbaseProvider(makeConnection());
+
+    const prepared = provider.prepareQuery("DELETE FROM `travel`.`_default`.`airline`");
+
+    expect(prepared.query).toBe("DELETE FROM `travel`.`_default`.`airline`");
+    expect(prepared.wasLimited).toBe(false);
+  });
+});

--- a/tests/integration/db/couchbase-provider.test.ts
+++ b/tests/integration/db/couchbase-provider.test.ts
@@ -399,6 +399,31 @@ describe("CouchbaseProvider query", () => {
     expect(result.fields).toEqual(["hotel", "__id"]);
   });
 
+  test("wraps SELECT RAW scalars so the grid gets one honest column", async () => {
+    // SELECT RAW / SELECT VALUE return bare scalars, not objects. Handing those
+    // through unchanged makes deriveFields call Object.keys on a string, which
+    // yields one column per character index.
+    const provider = await connectProvider();
+    queryHandler = () => queryPayload(["Grand Plaza", "Seaside Inn"] as unknown as Record<string, unknown>[]);
+
+    const result = await provider.query("SELECT RAW h.name FROM `travel`.`inventory`.`hotel` AS h");
+
+    expect(result.rows).toEqual([{ __value: "Grand Plaza" }, { __value: "Seaside Inn" }]);
+    expect(result.fields).toEqual(["__value"]);
+  });
+
+  test("wraps null and array rows rather than crashing on them", async () => {
+    // A RAW projection of a missing field yields null, and Object.keys(null)
+    // throws - the whole request used to fail with a 500.
+    const provider = await connectProvider();
+    queryHandler = () => queryPayload([null, [1, 2]] as unknown as Record<string, unknown>[]);
+
+    const result = await provider.query("SELECT RAW h.missing FROM `travel`.`inventory`.`hotel` AS h");
+
+    expect(result.rows).toEqual([{ __value: null }, { __value: [1, 2] }]);
+    expect(result.fields).toEqual(["__value"]);
+  });
+
   test("reports the mutation count as the row count when a statement returns no rows", async () => {
     const provider = await connectProvider();
     queryHandler = () => queryPayload([], { metrics: { elapsedTime: "5ms", executionTime: "4ms", mutationCount: 3 } });

--- a/tests/unit/db/couchbase/http-transport.test.ts
+++ b/tests/unit/db/couchbase/http-transport.test.ts
@@ -1,0 +1,859 @@
+/**
+ * Couchbase HTTP transport (issue #262, decisions 1, 3 and 5)
+ *
+ * globalThis.fetch is replaced per test and restored in afterEach. mock.module()
+ * is deliberately not used: it is process-wide in bun and would poison sibling
+ * test files, so the DNS resolver and the TLS request function are injected
+ * through the transport's dependency seam instead.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { DatabaseConnection, DatabaseType } from "@/lib/db/types";
+import type { SSLConfig } from "@/lib/types";
+import { CouchbaseError } from "@/lib/db/providers/document/couchbase/transport";
+import {
+  CouchbaseHttpTransport,
+  nodeRequestJson,
+  type CouchbaseHttpTransportDeps,
+  type CouchbaseTlsMaterial,
+  type JsonRequestInit,
+} from "@/lib/db/providers/document/couchbase/http-transport";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// The DatabaseType union gains "couchbase" in the registration commit; the
+// double assertion keeps this file compiling on either side of that change.
+const COUCHBASE: DatabaseType = "couchbase" as unknown as DatabaseType;
+
+interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+const originalFetch = globalThis.fetch;
+let calls: FetchCall[] = [];
+let handler: (url: string, init?: RequestInit) => Response | Promise<Response>;
+
+function jsonResponse(body: unknown, httpCode = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status: httpCode,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const NODE_SERVICES = {
+  nodesExt: [{ hostname: "node1.local", services: { mgmt: 8091, n1ql: 8093, n1qlSSL: 18093 } }],
+};
+
+/** Route the management discovery call, send everything else to the query handler. */
+function routeQuery(payload: unknown, httpCode = 200, nodeServices: unknown = NODE_SERVICES) {
+  return (url: string): Response => {
+    if (url.includes("/pools/default/nodeServices")) return jsonResponse(nodeServices);
+    return jsonResponse(payload, httpCode);
+  };
+}
+
+function makeConnection(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
+  return {
+    id: "cb-1",
+    name: "Couchbase",
+    type: COUCHBASE,
+    host: "127.0.0.1",
+    port: 8091,
+    user: "Administrator",
+    password: "password123",
+    database: "travel",
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeTransport(overrides: Partial<DatabaseConnection> = {}, deps: CouchbaseHttpTransportDeps = {}) {
+  return new CouchbaseHttpTransport(makeConnection(overrides), deps);
+}
+
+function successPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    requestID: "0e0e0e",
+    signature: { id: "string", city: "string" },
+    results: [{ id: "hotel::1", city: "Bursa" }],
+    status: "success",
+    metrics: { elapsedTime: "2.5ms", executionTime: "1.234ms", resultCount: 1, mutationCount: 0 },
+    ...overrides,
+  };
+}
+
+function queryCalls(): FetchCall[] {
+  return calls.filter((call) => call.url.includes("/query/service"));
+}
+
+function lastQueryBody(): Record<string, unknown> {
+  const body = queryCalls().at(-1)?.init?.body;
+  return JSON.parse(String(body ?? "{}")) as Record<string, unknown>;
+}
+
+function headerOf(call: FetchCall | undefined, name: string): string | undefined {
+  return (call?.init?.headers as Record<string, string> | undefined)?.[name];
+}
+
+async function startServer(listener: (req: IncomingMessage, res: ServerResponse) => void) {
+  const server = createServer(listener);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+const NO_TLS: CouchbaseTlsMaterial = { rejectUnauthorized: false };
+const GET_INIT: JsonRequestInit = { method: "GET", headers: { accept: "application/json" } };
+
+beforeEach(() => {
+  calls = [];
+  handler = routeQuery(successPayload());
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return handler(url, init);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ============================================================================
+// Query execution
+// ============================================================================
+
+describe("CouchbaseHttpTransport.query", () => {
+  test("throws when a 200 response reports a failed statement (decision 5)", async () => {
+    handler = routeQuery({
+      requestID: "1",
+      signature: null,
+      results: [],
+      status: "errors",
+      errors: [{ code: 3000, msg: "syntax error - line 1, column 8, near 'SELCT'" }],
+    });
+
+    const transport = makeTransport();
+    const error = (await transport.query("SELCT 1").catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error).toBeInstanceOf(CouchbaseError);
+    expect(error.code).toBe(3000);
+    expect(error.message).toContain("syntax error");
+    expect(error.retriable).toBe(false);
+  });
+
+  test("throws a generic failure when the failed statement carries no error detail", async () => {
+    handler = routeQuery({ requestID: "1", results: [], status: "errors", errors: [] });
+
+    const error = (await makeTransport()
+      .query("SELECT 1")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error).toBeInstanceOf(CouchbaseError);
+    expect(error.code).toBe(0);
+    expect(error.retriable).toBe(false);
+  });
+
+  test("marks a transient statement failure as retriable", async () => {
+    handler = routeQuery({
+      results: [],
+      status: "errors",
+      errors: [{ code: 1080, msg: "Timeout 30s exceeded" }],
+    });
+
+    const error = (await makeTransport()
+      .query("SELECT 1")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error.code).toBe(1080);
+    expect(error.retriable).toBe(true);
+  });
+
+  test("reads an error message from the message field and defaults a missing code", async () => {
+    handler = routeQuery({ results: [], status: "errors", errors: [{ message: "alternate wording" }] });
+
+    const error = (await makeTransport()
+      .query("SELECT 1")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error.code).toBe(0);
+    expect(error.message).toBe("alternate wording");
+  });
+
+  test("falls back to a default message when the failure carries neither msg nor message", async () => {
+    handler = routeQuery({ results: [], status: "errors", errors: [{ code: 5000 }] });
+
+    const error = (await makeTransport()
+      .query("SELECT 1")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error.code).toBe(5000);
+    expect(error.message.length).toBeGreaterThan(0);
+  });
+
+  test("maps rows, field names, execution time, mutations and warnings", async () => {
+    handler = routeQuery(
+      successPayload({
+        results: [
+          { id: "hotel::1", city: "Bursa" },
+          { id: "hotel::2", city: "Istanbul" },
+        ],
+        metrics: { executionTime: "12.5ms", mutationCount: 2 },
+        warnings: [{ code: 3239, msg: "advisor is unavailable" }],
+      }),
+    );
+
+    const result = await makeTransport().query("SELECT id, city FROM hotel");
+
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]).toEqual({ id: "hotel::1", city: "Bursa" });
+    expect(result.fieldNames).toEqual(["id", "city"]);
+    expect(result.executionTimeMs).toBe(12.5);
+    expect(result.mutationCount).toBe(2);
+    expect(result.warnings).toEqual([{ code: 3239, message: "advisor is unavailable" }]);
+  });
+
+  test("normalizes warnings that are not objects or carry no code", async () => {
+    handler = routeQuery(successPayload({ warnings: [null, { message: "no code here" }] }));
+
+    const result = await makeTransport().query("SELECT 1");
+
+    expect(result.warnings).toEqual([
+      { code: 0, message: "" },
+      { code: 0, message: "no code here" },
+    ]);
+  });
+
+  test("returns an empty warning list when the cluster sends none", async () => {
+    const result = await makeTransport().query("SELECT 1");
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("returns null field names for the SELECT * wildcard", async () => {
+    handler = routeQuery(successPayload({ signature: { "*": "*" }, results: [{ hotel: { city: "Bursa" } }] }));
+
+    const result = await makeTransport().query("SELECT * FROM hotel");
+
+    expect(result.fieldNames).toBeNull();
+    expect(result.rows).toEqual([{ hotel: { city: "Bursa" } }]);
+  });
+
+  test("returns null field names when a wildcard is mixed with named projections", async () => {
+    // Verified live: `SELECT META(u).id AS __id, u.* FROM ks AS u` signs as
+    // { id: "json", "*": "*" }. Taking the signature keys verbatim would name the
+    // columns __id and "*", so the grid would render an empty "*" column and hide
+    // every field the wildcard actually expanded to. Any wildcard key means the
+    // signature cannot describe the rows; the caller derives fields from them instead.
+    handler = routeQuery(
+      successPayload({
+        signature: { id: "json", "*": "*" },
+        results: [{ __id: "u::1", n: 1, note: "no index here" }],
+      }),
+    );
+
+    const result = await makeTransport().query("SELECT META(u).id AS __id, u.* FROM ks AS u");
+
+    expect(result.fieldNames).toBeNull();
+    expect(result.rows).toEqual([{ __id: "u::1", n: 1, note: "no index here" }]);
+  });
+
+  test("returns null field names when the signature is not an object", async () => {
+    handler = routeQuery(successPayload({ signature: "json" }));
+    expect((await makeTransport().query("INFER hotel")).fieldNames).toBeNull();
+  });
+
+  test("returns null field names when the response carries no signature", async () => {
+    handler = routeQuery({ requestID: "1", results: [], status: "success", metrics: {} });
+    expect((await makeTransport().query("SELECT 1")).fieldNames).toBeNull();
+  });
+
+  test("returns no rows when the response carries no row array", async () => {
+    handler = routeQuery({ requestID: "1", status: "success", metrics: {} });
+
+    const result = await makeTransport().query("UPDATE hotel SET x = 1");
+
+    expect(result.rows).toEqual([]);
+    expect(result.mutationCount).toBe(0);
+    expect(result.executionTimeMs).toBe(0);
+  });
+
+  test("returns zeroed metrics when the response carries no metrics object", async () => {
+    handler = routeQuery({ requestID: "1", results: [], status: "success" });
+
+    const result = await makeTransport().query("SELECT 1");
+
+    expect(result.executionTimeMs).toBe(0);
+    expect(result.mutationCount).toBe(0);
+  });
+
+  test("parses every duration format the cluster emits", async () => {
+    const cases: Array<[string, number]> = [
+      ["1.234ms", 1.234],
+      ["1.5s", 1500],
+      ["2m30s", 150000],
+      ["1h2m3.5s", 3723500],
+      ["750µs", 0.75],
+      ["750us", 0.75],
+      ["900ns", 0.0009],
+      ["not-a-duration", 0],
+    ];
+
+    // The statement doubles as the duration the mocked cluster reports back, so
+    // every case can run against one transport.
+    handler = (url: string, init?: RequestInit) => {
+      if (url.includes("/pools/default/nodeServices")) return jsonResponse(NODE_SERVICES);
+      const { statement } = JSON.parse(String(init?.body ?? "{}")) as { statement: string };
+      return jsonResponse(successPayload({ metrics: { executionTime: statement } }));
+    };
+
+    const transport = makeTransport();
+    const results = await Promise.all(cases.map(([duration]) => transport.query(duration)));
+
+    results.forEach((result, index) => {
+      expect(result.executionTimeMs).toBeCloseTo(cases[index][1], 6);
+    });
+  });
+
+  test("falls back to the elapsed duration when no execution duration is reported", async () => {
+    handler = routeQuery(successPayload({ metrics: { elapsedTime: "3.5ms" } }));
+    expect((await makeTransport().query("SELECT 1")).executionTimeMs).toBe(3.5);
+  });
+
+  test("sends request_plus scan consistency by default so a user sees their own writes", async () => {
+    await makeTransport().query("SELECT city FROM hotel");
+
+    const body = lastQueryBody();
+    expect(body.statement).toBe("SELECT city FROM hotel");
+    expect(body.scan_consistency).toBe("request_plus");
+    expect(body.timeout).toBe("30000ms");
+    expect(body.metrics).toBe(true);
+    expect(body.args).toBeUndefined();
+
+    const call = queryCalls().at(-1);
+    expect(call?.init?.method).toBe("POST");
+    expect(headerOf(call, "content-type")).toBe("application/json");
+    expect(headerOf(call, "authorization")).toBe(
+      `Basic ${Buffer.from("Administrator:password123").toString("base64")}`,
+    );
+  });
+
+  test("pins the query context to the connection's bucket so scope.collection resolves", async () => {
+    // The schema explorer shows a collection as `scope.collection` (the bucket is
+    // pinned by the connection), and the generated statement uses that same name.
+    // SQL++ reads a bare two-part name as bucket.collection, so without a query
+    // context `inventory.hotel` is looked up as a BUCKET called inventory and the
+    // statement dies with "Ambiguous reference to field 'inventory'". Verified live:
+    // sending query_context resolves both the two-part name and a fully qualified
+    // three-part path, so what the sidebar displays is what the user can run.
+    await makeTransport().query("SELECT d.* FROM `inventory`.`hotel` AS d");
+
+    expect(lastQueryBody().query_context).toBe("default:`travel`");
+  });
+
+  test("omits the query context when the connection pins no bucket", async () => {
+    await makeTransport({ database: undefined }).query("SELECT 1");
+    expect(lastQueryBody().query_context).toBeUndefined();
+  });
+
+  test("honours scan consistency, args, timeout, readonly and profile overrides", async () => {
+    await makeTransport().query("SELECT city FROM hotel WHERE country = $1", {
+      args: ["Turkey"],
+      timeoutMs: 5000,
+      readonly: true,
+      profile: "timings",
+      scanConsistency: "not_bounded",
+    });
+
+    const body = lastQueryBody();
+    expect(body.scan_consistency).toBe("not_bounded");
+    expect(body.args).toEqual(["Turkey"]);
+    expect(body.timeout).toBe("5000ms");
+    expect(body.readonly).toBe(true);
+    expect(body.profile).toBe("timings");
+  });
+
+  test("omits an empty argument list", async () => {
+    await makeTransport().query("SELECT 1", { args: [] });
+    expect(lastQueryBody().args).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Query port discovery (decision 3)
+// ============================================================================
+
+describe("CouchbaseHttpTransport query endpoint discovery", () => {
+  test("resolves the query port from nodeServices and caches it", async () => {
+    const transport = makeTransport();
+    await transport.query("SELECT 1");
+    await transport.query("SELECT 2");
+
+    expect(calls.filter((call) => call.url.includes("/pools/default/nodeServices"))).toHaveLength(1);
+    expect(queryCalls()).toHaveLength(2);
+    expect(queryCalls()[0].url).toBe("http://node1.local:8093/query/service");
+    expect(calls[0].url).toBe("http://127.0.0.1:8091/pools/default/nodeServices");
+  });
+
+  test("prefers an advertised alternate address", async () => {
+    handler = routeQuery(successPayload(), 200, {
+      nodesExt: [
+        {
+          hostname: "node1.local",
+          services: { n1ql: 8093 },
+          alternateAddresses: { external: { hostname: "cb.example.com", ports: { n1ql: 30093 } } },
+        },
+      ],
+    });
+
+    await makeTransport().query("SELECT 1");
+
+    expect(queryCalls()[0].url).toBe("http://cb.example.com:30093/query/service");
+  });
+
+  test("falls back to the node's own hostname when the alternate address has no query port", async () => {
+    handler = routeQuery(successPayload(), 200, {
+      nodesExt: [
+        {
+          hostname: "node1.local",
+          services: { n1ql: 8093 },
+          alternateAddresses: { external: { hostname: "cb.example.com", ports: { mgmt: 30001 } } },
+        },
+      ],
+    });
+
+    await makeTransport().query("SELECT 1");
+
+    expect(queryCalls()[0].url).toBe("http://node1.local:8093/query/service");
+  });
+
+  test("falls back to the request host when a node advertises no hostname", async () => {
+    handler = routeQuery(successPayload(), 200, { nodesExt: [{ services: { n1ql: 8093 } }] });
+
+    await makeTransport().query("SELECT 1");
+
+    expect(queryCalls()[0].url).toBe("http://127.0.0.1:8093/query/service");
+  });
+
+  test("falls back to the default query port when no node runs the query service", async () => {
+    handler = routeQuery(successPayload(), 200, { nodesExt: [{ hostname: "node1.local", services: { mgmt: 8091 } }] });
+
+    await makeTransport().query("SELECT 1");
+
+    expect(queryCalls()[0].url).toBe("http://127.0.0.1:8093/query/service");
+  });
+
+  test("falls back to the default query port when the cluster reports no nodes at all", async () => {
+    handler = routeQuery(successPayload(), 200, {});
+
+    await makeTransport().query("SELECT 1");
+
+    expect(queryCalls()[0].url).toBe("http://127.0.0.1:8093/query/service");
+  });
+
+  test("brackets an IPv6 host", async () => {
+    handler = routeQuery(successPayload(), 200, { nodesExt: [{ hostname: "fd00::1", services: { n1ql: 8093 } }] });
+
+    await makeTransport({ host: "::1" }).query("SELECT 1");
+
+    expect(calls[0].url).toBe("http://[::1]:8091/pools/default/nodeServices");
+    expect(queryCalls()[0].url).toBe("http://[fd00::1]:8093/query/service");
+  });
+
+  test("discovers once for concurrent queries", async () => {
+    const transport = makeTransport();
+    await Promise.all([transport.query("SELECT 1"), transport.query("SELECT 2"), transport.query("SELECT 3")]);
+
+    expect(calls.filter((call) => call.url.includes("/pools/default/nodeServices"))).toHaveLength(1);
+    expect(queryCalls()).toHaveLength(3);
+  });
+
+  test("does not cache a failed discovery", async () => {
+    handler = () => jsonResponse({}, 503);
+
+    await expect(makeTransport().query("SELECT 1")).rejects.toBeInstanceOf(CouchbaseError);
+
+    const transport = makeTransport();
+    await expect(transport.query("SELECT 1")).rejects.toBeInstanceOf(CouchbaseError);
+
+    handler = routeQuery(successPayload());
+    const result = await transport.query("SELECT 1");
+
+    expect(result.rows).toHaveLength(1);
+  });
+
+  test("re-discovers the endpoint after close()", async () => {
+    const transport = makeTransport();
+    await transport.query("SELECT 1");
+    await transport.close();
+    await transport.query("SELECT 2");
+
+    expect(calls.filter((call) => call.url.includes("/pools/default/nodeServices"))).toHaveLength(2);
+  });
+});
+
+// ============================================================================
+// Capella SRV resolution (decision 3)
+// ============================================================================
+
+describe("CouchbaseHttpTransport SRV resolution", () => {
+  test("resolves the SRV record when the connection carries no explicit port", async () => {
+    const seen: string[] = [];
+    const deps: CouchbaseHttpTransportDeps = {
+      resolveSrv: async (name: string) => {
+        seen.push(name);
+        return [{ name: "node-1.cb.example.com", port: 11207, priority: 0, weight: 0 }];
+      },
+    };
+
+    await makeTransport({ host: "cb.example.com", port: undefined }, deps).query("SELECT 1");
+
+    expect(seen).toEqual(["_couchbases._tcp.cb.example.com"]);
+    expect(calls[0].url).toBe("http://node-1.cb.example.com:8091/pools/default/nodeServices");
+  });
+
+  test("treats the host as a direct A record when the SRV lookup returns nothing", async () => {
+    const deps: CouchbaseHttpTransportDeps = { resolveSrv: async () => [] };
+
+    await makeTransport({ host: "cb.example.com", port: undefined }, deps).query("SELECT 1");
+
+    expect(calls[0].url).toBe("http://cb.example.com:8091/pools/default/nodeServices");
+  });
+
+  test("never lets a DNS failure be fatal", async () => {
+    const deps: CouchbaseHttpTransportDeps = {
+      resolveSrv: async () => {
+        throw new Error("ENOTFOUND");
+      },
+    };
+
+    const result = await makeTransport({ host: "cb.example.com", port: undefined }, deps).query("SELECT 1");
+
+    expect(result.rows).toHaveLength(1);
+    expect(calls[0].url).toBe("http://cb.example.com:8091/pools/default/nodeServices");
+  });
+
+  test("skips the SRV lookup when the connection carries an explicit port", async () => {
+    let called = false;
+    const deps: CouchbaseHttpTransportDeps = {
+      resolveSrv: async () => {
+        called = true;
+        return [];
+      },
+    };
+
+    await makeTransport({ port: 9000 }, deps).query("SELECT 1");
+
+    expect(called).toBe(false);
+    expect(calls[0].url).toBe("http://127.0.0.1:9000/pools/default/nodeServices");
+  });
+
+  test("resolves the SRV record again after close()", async () => {
+    let lookups = 0;
+    const deps: CouchbaseHttpTransportDeps = {
+      resolveSrv: async () => {
+        lookups += 1;
+        return [];
+      },
+    };
+
+    const transport = makeTransport({ host: "cb.example.com", port: undefined }, deps);
+    await transport.query("SELECT 1");
+    await transport.close();
+    await transport.query("SELECT 2");
+
+    expect(lookups).toBe(2);
+  });
+});
+
+// ============================================================================
+// Error mapping
+// ============================================================================
+
+describe("CouchbaseHttpTransport error mapping", () => {
+  const httpCases: Array<[number, boolean, string]> = [
+    [401, false, "credentials"],
+    [403, false, "permission"],
+    [503, true, "unavailable"],
+  ];
+
+  for (const [httpCode, retriable, fragment] of httpCases) {
+    test(`maps HTTP ${httpCode}`, async () => {
+      handler = routeQuery({}, httpCode);
+
+      const error = (await makeTransport()
+        .query("SELECT 1")
+        .catch((e: unknown) => e)) as CouchbaseError;
+
+      expect(error).toBeInstanceOf(CouchbaseError);
+      expect(error.code).toBe(httpCode);
+      expect(error.retriable).toBe(retriable);
+      expect(error.message.toLowerCase()).toContain(fragment);
+    });
+  }
+
+  test("treats any other server error as retriable", async () => {
+    handler = routeQuery({}, 500);
+
+    const error = (await makeTransport()
+      .query("SELECT 1")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error.code).toBe(500);
+    expect(error.retriable).toBe(true);
+  });
+
+  test("treats a non-JSON client error as a non-retriable failure", async () => {
+    handler = (url: string) => {
+      if (url.includes("/pools/default/nodeServices")) return jsonResponse(NODE_SERVICES);
+      return new Response("<html>not found</html>", { status: 404, headers: { "content-type": "text/html" } });
+    };
+
+    const error = (await makeTransport()
+      .query("SELECT 1")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error.code).toBe(404);
+    expect(error.retriable).toBe(false);
+  });
+
+  test("wraps a transport-level network failure as retriable", async () => {
+    handler = () => {
+      throw new TypeError("fetch failed");
+    };
+
+    const error = (await makeTransport()
+      .query("SELECT 1")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error).toBeInstanceOf(CouchbaseError);
+    expect(error.code).toBe(0);
+    expect(error.retriable).toBe(true);
+    expect(error.message).toContain("fetch failed");
+  });
+
+  test("wraps a non-Error network rejection", async () => {
+    handler = () => Promise.reject("socket closed");
+
+    const error = (await makeTransport()
+      .query("SELECT 1")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error.message).toContain("socket closed");
+  });
+});
+
+// ============================================================================
+// Management REST
+// ============================================================================
+
+describe("CouchbaseHttpTransport.manage", () => {
+  test("returns the parsed management payload", async () => {
+    handler = (url: string) => {
+      if (url.includes("/pools/default/buckets/travel")) return jsonResponse({ basicStats: { diskUsed: 1024 } });
+      return jsonResponse(NODE_SERVICES);
+    };
+
+    const stats = await makeTransport().manage<{ basicStats: { diskUsed: number } }>("/pools/default/buckets/travel");
+
+    expect(stats.basicStats.diskUsed).toBe(1024);
+    expect(calls[0].url).toBe("http://127.0.0.1:8091/pools/default/buckets/travel");
+    expect(calls[0].init?.method).toBe("GET");
+    expect(headerOf(calls[0], "authorization")).toBe(
+      `Basic ${Buffer.from("Administrator:password123").toString("base64")}`,
+    );
+  });
+
+  test("maps a management failure the same way as a query failure", async () => {
+    handler = () => jsonResponse({}, 403);
+
+    const error = (await makeTransport()
+      .manage("/pools/default")
+      .catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error).toBeInstanceOf(CouchbaseError);
+    expect(error.code).toBe(403);
+  });
+
+  test("uses an empty credential pair when the connection carries none", async () => {
+    handler = () => jsonResponse({});
+
+    await makeTransport({ user: undefined, password: undefined }).manage("/pools/default");
+
+    expect(headerOf(calls[0], "authorization")).toBe(`Basic ${Buffer.from(":").toString("base64")}`);
+  });
+
+  test("defaults the host when the connection carries none", async () => {
+    handler = () => jsonResponse({});
+
+    await makeTransport({ host: undefined }).manage("/pools/default");
+
+    expect(calls[0].url).toBe("http://localhost:8091/pools/default");
+  });
+});
+
+// ============================================================================
+// TLS (SSLConfig on DatabaseConnection)
+// ============================================================================
+
+describe("CouchbaseHttpTransport TLS", () => {
+  interface RecordedRequest {
+    url: string;
+    init: JsonRequestInit;
+    tls: CouchbaseTlsMaterial;
+  }
+
+  function tlsDeps(recorded: RecordedRequest[]): CouchbaseHttpTransportDeps {
+    return {
+      // Injected so a portless connection never triggers a real DNS lookup.
+      resolveSrv: async () => [],
+      requestJson: async (url, init, tls) => {
+        recorded.push({ url, init, tls });
+        if (url.includes("/pools/default/nodeServices")) return { httpCode: 200, payload: NODE_SERVICES };
+        return { httpCode: 200, payload: successPayload() };
+      },
+    };
+  }
+
+  test("routes a TLS connection through the node request path with the secure ports", async () => {
+    const recorded: RecordedRequest[] = [];
+    const ssl: SSLConfig = {
+      mode: "verify-full",
+      caCert: "ca-pem",
+      clientCert: "cert-pem",
+      clientKey: "key-pem",
+    };
+
+    const result = await makeTransport({ ssl, port: undefined }, tlsDeps(recorded)).query("SELECT 1");
+
+    expect(result.rows).toHaveLength(1);
+    expect(calls).toHaveLength(0);
+    expect(recorded[0].url).toBe("https://127.0.0.1:18091/pools/default/nodeServices");
+    expect(recorded[1].url).toBe("https://node1.local:18093/query/service");
+    expect(recorded[1].init.method).toBe("POST");
+    expect(recorded[0].tls).toEqual({
+      ca: "ca-pem",
+      cert: "cert-pem",
+      key: "key-pem",
+      rejectUnauthorized: true,
+    });
+  });
+
+  test("accepts a self-signed cluster in require mode", async () => {
+    const recorded: RecordedRequest[] = [];
+
+    await makeTransport({ ssl: { mode: "require" } }, tlsDeps(recorded)).query("SELECT 1");
+
+    expect(recorded[0].tls).toEqual({ rejectUnauthorized: false });
+  });
+
+  test("honours an explicit rejectUnauthorized override", async () => {
+    const recorded: RecordedRequest[] = [];
+
+    await makeTransport({ ssl: { mode: "require", rejectUnauthorized: true } }, tlsDeps(recorded)).query("SELECT 1");
+
+    expect(recorded[0].tls.rejectUnauthorized).toBe(true);
+
+    const relaxed: RecordedRequest[] = [];
+    await makeTransport({ ssl: { mode: "verify-ca", rejectUnauthorized: false } }, tlsDeps(relaxed)).query("SELECT 1");
+
+    expect(relaxed[0].tls.rejectUnauthorized).toBe(false);
+  });
+
+  test("keeps a disabled SSL config on the plain fetch path", async () => {
+    await makeTransport({ ssl: { mode: "disable" } }).query("SELECT 1");
+
+    expect(calls[0].url).toBe("http://127.0.0.1:8091/pools/default/nodeServices");
+  });
+});
+
+// ============================================================================
+// node:http / node:https request helper
+// ============================================================================
+
+describe("nodeRequestJson", () => {
+  test("performs a GET and parses the JSON body", async () => {
+    const seen: Array<{ method?: string; url?: string; accept?: string }> = [];
+    const server = await startServer((req, res) => {
+      seen.push({ method: req.method, url: req.url, accept: req.headers.accept });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    try {
+      const response = await nodeRequestJson(`${server.url}/pools/default?x=1`, GET_INIT, NO_TLS);
+
+      expect(response.httpCode).toBe(200);
+      expect(response.payload).toEqual({ ok: true });
+      expect(seen[0]).toEqual({ method: "GET", url: "/pools/default?x=1", accept: "application/json" });
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("writes the request body on POST", async () => {
+    let received = "";
+    const server = await startServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        received = Buffer.concat(chunks).toString("utf8");
+        res.writeHead(201, { "content-type": "application/json" });
+        res.end(JSON.stringify({ created: true }));
+      });
+    });
+
+    try {
+      const response = await nodeRequestJson(
+        `${server.url}/query/service`,
+        { method: "POST", headers: { "content-type": "application/json" }, body: '{"statement":"SELECT 1"}' },
+        NO_TLS,
+      );
+
+      expect(response.httpCode).toBe(201);
+      expect(response.payload).toEqual({ created: true });
+      expect(received).toBe('{"statement":"SELECT 1"}');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("returns a null payload when the body is not JSON", async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(500, { "content-type": "text/plain" });
+      res.end("boom");
+    });
+
+    try {
+      const response = await nodeRequestJson(server.url, GET_INIT, NO_TLS);
+
+      expect(response.httpCode).toBe(500);
+      expect(response.payload).toBeNull();
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("rejects with a retriable error when the connection fails", async () => {
+    const server = await startServer((_req, res) => res.end("{}"));
+    const deadUrl = server.url;
+    await server.close();
+
+    const error = (await nodeRequestJson(deadUrl, GET_INIT, NO_TLS).catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error).toBeInstanceOf(CouchbaseError);
+    expect(error.code).toBe(0);
+    expect(error.retriable).toBe(true);
+  });
+});

--- a/tests/unit/db/couchbase/introspect.test.ts
+++ b/tests/unit/db/couchbase/introspect.test.ts
@@ -1,0 +1,590 @@
+/**
+ * Couchbase schema introspection (issue #262, decision 10)
+ *
+ * Everything is driven through a hand-built CouchbaseTransport, which is the
+ * point of the seam: no fetch mocking, no mock.module() (process-wide in bun),
+ * and no cluster. The payload shapes below were captured from a live Couchbase
+ * Server 8.0.2 node, so the fake speaks exactly what the cluster speaks.
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  CATALOG_TIMEOUT_MS,
+  COUCHBASE_DOCUMENT_KEY_COLUMN,
+  INFER_CONCURRENCY,
+  INFER_TIMEOUT_MS,
+  getSchemaList,
+  getSchemaRelations,
+  inferColumns,
+  listCollections,
+} from "@/lib/db/providers/document/couchbase/introspect";
+import {
+  CouchbaseError,
+  type CouchbaseQueryResult,
+  type CouchbaseRow,
+  type CouchbaseTransport,
+  type Keyspace,
+  type QueryOpts,
+} from "@/lib/db/providers/document/couchbase/transport";
+
+// ============================================================================
+// Fake transport
+// ============================================================================
+
+interface RecordedCall {
+  statement: string;
+  opts: QueryOpts | undefined;
+}
+
+interface FakeTransportOptions {
+  /** Rows the system:keyspaces catalog query returns. */
+  collections?: CouchbaseRow[];
+  /** Rows the system:indexes catalog query returns. */
+  indexes?: CouchbaseRow[];
+  /** INFER responder; throwing simulates a rejected statement. */
+  infer?: (statement: string) => Promise<CouchbaseRow[]> | CouchbaseRow[];
+  /** Failure raised by the catalog queries instead of returning rows. */
+  catalogError?: Error;
+}
+
+function queryResult(rows: CouchbaseRow[]): CouchbaseQueryResult {
+  return { rows, fieldNames: null, executionTimeMs: 1, mutationCount: 0, warnings: [] };
+}
+
+function createTransport(options: FakeTransportOptions = {}) {
+  const calls: RecordedCall[] = [];
+
+  const transport: CouchbaseTransport = {
+    kind: "http",
+    query: async (statement: string, opts?: QueryOpts) => {
+      calls.push({ statement, opts });
+      if (statement.startsWith("INFER")) {
+        const respond = options.infer ?? (() => []);
+        return queryResult(await respond(statement));
+      }
+      if (options.catalogError) throw options.catalogError;
+      if (statement.includes("system:indexes")) return queryResult(options.indexes ?? []);
+      return queryResult(options.collections ?? []);
+    },
+    manage: <T>() => Promise.resolve({} as T),
+    close: () => Promise.resolve(),
+  };
+
+  return { transport, calls };
+}
+
+// ============================================================================
+// Payload builders (shapes verified against Couchbase Server 8.0.2)
+// ============================================================================
+
+function property(type: unknown, percentDocs: unknown = 100): Record<string, unknown> {
+  return { type, "%docs": percentDocs, "#docs": 3, nestingDepth: 0, samples: [] };
+}
+
+/**
+ * INFER reports the document key as a "~meta" pseudo-property whose nested id
+ * carries the key type.
+ */
+const META_PROPERTY: Record<string, unknown> = {
+  type: "object",
+  "%docs": 100,
+  properties: { id: { type: "string", "%docs": 100, samples: ["hotel::1"] } },
+};
+
+function flavour(properties: Record<string, unknown>, name = ""): Record<string, unknown> {
+  return { "#docs": 3, Flavor: name, type: "object", properties };
+}
+
+/** INFER nests its payload: the single row it returns IS the flavour array. */
+function inferRows(...flavours: Record<string, unknown>[]): CouchbaseRow[] {
+  return [flavours as unknown as CouchbaseRow];
+}
+
+function collectionRow(scope: string | undefined, collection: string): CouchbaseRow {
+  const row: CouchbaseRow = { bucket_name: "travel", collection_name: collection };
+  if (scope !== undefined) row.scope_name = scope;
+  return row;
+}
+
+const HOTEL: Keyspace = { bucket: "travel", scope: "inventory", collection: "hotel" };
+
+function createGate() {
+  let open!: () => void;
+  const opened = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { opened, open };
+}
+
+/** Let every pending microtask and timer callback run. */
+function flushPending(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function columnNames(columns: { name: string }[]): string[] {
+  return columns.map((column) => column.name);
+}
+
+// ============================================================================
+// Collection listing
+// ============================================================================
+
+describe("listCollections", () => {
+  test("restricts the catalog query to the pinned bucket and quotes the reserved words", async () => {
+    const { transport, calls } = createTransport();
+
+    await listCollections(transport, "travel");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].statement).toContain("system:keyspaces");
+    expect(calls[0].statement).toContain("system:scopes");
+    // Verified on Server 8.0.2: unquoted bucket/scope fail with error 3000.
+    expect(calls[0].statement).toContain("k.`bucket`");
+    expect(calls[0].statement).toContain("k.`scope`");
+    // The bucket travels as a positional argument, never concatenated in.
+    expect(calls[0].statement).not.toContain("travel");
+    expect(calls[0].opts?.args).toEqual(["travel"]);
+    expect(calls[0].opts?.timeoutMs).toBe(CATALOG_TIMEOUT_MS);
+  });
+
+  test("renders a _default scope collection bare and any other scope qualified", async () => {
+    const { transport } = createTransport({
+      collections: [collectionRow("_default", "airline"), collectionRow("inventory", "hotel")],
+    });
+
+    const collections = await listCollections(transport, "travel");
+
+    expect(collections).toEqual([
+      { keyspace: { bucket: "travel", scope: "_default", collection: "airline" }, displayName: "airline" },
+      { keyspace: HOTEL, displayName: "inventory.hotel" },
+    ]);
+  });
+
+  test("maps the bucket-level catalog row onto the default collection", async () => {
+    // Verified on Server 8.0.2: the pre-collections default collection is
+    // represented by a row carrying the bucket name and no bucket/scope field.
+    // Dropping it would hide every document written before scopes existed.
+    const { transport } = createTransport({ collections: [{ collection_name: "travel" }] });
+
+    const collections = await listCollections(transport, "travel");
+
+    expect(collections).toEqual([
+      { keyspace: { bucket: "travel", scope: "_default", collection: "_default" }, displayName: "_default" },
+    ]);
+  });
+
+  test("defaults a collection row with no scope to the default scope", async () => {
+    const { transport } = createTransport({ collections: [collectionRow(undefined, "airline")] });
+
+    const collections = await listCollections(transport, "travel");
+
+    expect(collections[0].keyspace.scope).toBe("_default");
+    expect(collections[0].displayName).toBe("airline");
+  });
+
+  test("skips a catalog row whose collection name is not a string", async () => {
+    const { transport } = createTransport({
+      collections: [
+        { bucket_name: "travel", scope_name: "inventory", collection_name: 42 },
+        collectionRow("inventory", "hotel"),
+      ],
+    });
+
+    const collections = await listCollections(transport, "travel");
+
+    expect(collections).toEqual([{ keyspace: HOTEL, displayName: "inventory.hotel" }]);
+  });
+});
+
+// ============================================================================
+// Column inference
+// ============================================================================
+
+describe("inferColumns", () => {
+  test("samples 100 documents from the quoted keyspace path under a per-query timeout", async () => {
+    const { transport, calls } = createTransport({ infer: () => inferRows(flavour({ "~meta": META_PROPERTY })) });
+
+    await inferColumns(transport, HOTEL);
+
+    expect(calls[0].statement).toBe('INFER `travel`.`inventory`.`hotel` WITH {"sample_size": 100}');
+    expect(calls[0].opts?.timeoutMs).toBe(INFER_TIMEOUT_MS);
+  });
+
+  test("flattens a flavour into columns, document key first then alphabetical", async () => {
+    const { transport } = createTransport({
+      infer: () =>
+        inferRows(
+          flavour({
+            rooms: property("number"),
+            city: property("string"),
+            "~meta": META_PROPERTY,
+          }),
+        ),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columns).toEqual([
+      { name: COUCHBASE_DOCUMENT_KEY_COLUMN, type: "string", nullable: false, isPrimary: true },
+      { name: "city", type: "string", nullable: false, isPrimary: false },
+      { name: "rooms", type: "number", nullable: false, isPrimary: false },
+    ]);
+  });
+
+  test("unions divergent flavours instead of keeping only the first", async () => {
+    // Verified on Server 8.0.2: two document shapes in one collection produce
+    // two flavours, each reporting %docs relative to its own document count.
+    const { transport } = createTransport({
+      infer: () =>
+        inferRows(
+          flavour({ n: property("string"), other: property("boolean"), "~meta": META_PROPERTY }, '`n` = "x"'),
+          flavour({ n: property("number"), note: property("string"), "~meta": META_PROPERTY }),
+        ),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columnNames(columns)).toEqual([COUCHBASE_DOCUMENT_KEY_COLUMN, "n", "note", "other"]);
+    expect(columns[1]).toEqual({ name: "n", type: "mixed(number|string)", nullable: false, isPrimary: false });
+    // Present in one flavour only, so absent from part of the collection.
+    expect(columns[2].nullable).toBe(true);
+    expect(columns[3].nullable).toBe(true);
+  });
+
+  test("marks a field only some sampled documents carry as nullable", async () => {
+    const { transport } = createTransport({
+      infer: () => inferRows(flavour({ city: property("string", 60), "~meta": META_PROPERTY })),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columns[1]).toEqual({ name: "city", type: "string", nullable: true, isPrimary: false });
+  });
+
+  test("treats a property with no %docs as present in every sampled document", async () => {
+    const { transport } = createTransport({
+      infer: () => inferRows(flavour({ city: property("string", undefined) })),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columns).toEqual([{ name: "city", type: "string", nullable: false, isPrimary: false }]);
+  });
+
+  test("unions a JSON-schema type array and treats a null member as nullable", async () => {
+    const { transport } = createTransport({
+      infer: () => inferRows(flavour({ city: property(["string", "null"]) })),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columns[0]).toEqual({ name: "city", type: "mixed(null|string)", nullable: true, isPrimary: false });
+  });
+
+  test("falls back to an unknown type for a missing type and for a nameless type array", async () => {
+    const { transport } = createTransport({
+      infer: () => inferRows(flavour({ city: { "%docs": 100 }, zone: property([7]) })),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columns).toEqual([
+      { name: "city", type: "unknown", nullable: false, isPrimary: false },
+      { name: "zone", type: "unknown", nullable: false, isPrimary: false },
+    ]);
+  });
+
+  test("ignores a flavour that is not an object and one that carries no properties", async () => {
+    const { transport } = createTransport({
+      infer: () =>
+        inferRows("not-a-flavour" as unknown as Record<string, unknown>, flavour({ city: property("string") })),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    // The unusable flavour must not count towards the flavour total either, or
+    // every real field would be reported as nullable.
+    expect(columns).toEqual([{ name: "city", type: "string", nullable: false, isPrimary: false }]);
+  });
+
+  test("ignores a flavour whose properties map is missing", async () => {
+    const { transport } = createTransport({
+      infer: () => inferRows({ "#docs": 1, Flavor: "" }, flavour({ city: property("string") })),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columns).toEqual([{ name: "city", type: "string", nullable: false, isPrimary: false }]);
+  });
+
+  test("ignores a property entry that is not an object", async () => {
+    const { transport } = createTransport({
+      infer: () => inferRows(flavour({ city: property("string"), broken: "not-a-property" })),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columnNames(columns)).toEqual(["city"]);
+  });
+
+  test("emits no document key column when the sample carries no ~meta", async () => {
+    const { transport } = createTransport({ infer: () => inferRows(flavour({ city: property("string") })) });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columnNames(columns)).toEqual(["city"]);
+  });
+
+  test("defaults the document key type to string when ~meta carries no id", async () => {
+    const { transport } = createTransport({
+      infer: () => inferRows(flavour({ "~meta": { type: "object", "%docs": 100 } })),
+    });
+
+    const columns = await inferColumns(transport, HOTEL);
+
+    expect(columns).toEqual([
+      { name: COUCHBASE_DOCUMENT_KEY_COLUMN, type: "string", nullable: false, isPrimary: true },
+    ]);
+  });
+
+  test("returns no columns when the payload is not a flavour array", async () => {
+    const { transport } = createTransport({ infer: () => [] });
+
+    expect(await inferColumns(transport, HOTEL)).toEqual([]);
+  });
+
+  test("returns no columns when the collection is empty (error 7014)", async () => {
+    // Verified on Server 8.0.2: INFER against an empty collection fails with
+    // "No documents found, unable to infer schema", which is an ordinary state
+    // for a freshly created collection, not a broken connection.
+    const { transport } = createTransport({
+      infer: () => {
+        throw new CouchbaseError("No documents found, unable to infer schema.", 7014);
+      },
+    });
+
+    expect(await inferColumns(transport, HOTEL)).toEqual([]);
+  });
+
+  test("returns no columns when the user may not read the collection", async () => {
+    const { transport } = createTransport({
+      infer: () => {
+        throw new CouchbaseError("User does not have credentials to run SELECT queries", 13014);
+      },
+    });
+
+    expect(await inferColumns(transport, HOTEL)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// getSchemaList
+// ============================================================================
+
+describe("getSchemaList", () => {
+  test("returns one entry per collection with inferred columns, no indexes and no foreign keys", async () => {
+    const { transport } = createTransport({
+      collections: [collectionRow("inventory", "hotel")],
+      infer: () => inferRows(flavour({ city: property("string"), "~meta": META_PROPERTY })),
+    });
+
+    const schemas = await getSchemaList(transport, "travel");
+
+    expect(schemas).toEqual([
+      {
+        name: "inventory.hotel",
+        columns: [
+          { name: COUCHBASE_DOCUMENT_KEY_COLUMN, type: "string", nullable: false, isPrimary: true },
+          { name: "city", type: "string", nullable: false, isPrimary: false },
+        ],
+        indexes: [],
+        foreignKeys: [],
+      },
+    ]);
+  });
+
+  test("keeps a collection whose INFER fails, with empty columns", async () => {
+    const { transport } = createTransport({
+      collections: [collectionRow("inventory", "hotel"), collectionRow("inventory", "secret")],
+      infer: (statement) => {
+        if (statement.includes("secret")) throw new CouchbaseError("no privilege", 13014);
+        return inferRows(flavour({ city: property("string") }));
+      },
+    });
+
+    const schemas = await getSchemaList(transport, "travel");
+
+    expect(schemas.map((schema) => schema.name)).toEqual(["inventory.hotel", "inventory.secret"]);
+    expect(columnNames(schemas[0].columns)).toEqual(["city"]);
+    expect(schemas[1].columns).toEqual([]);
+  });
+
+  test("runs INFER at a bounded concurrency and still lists every collection", async () => {
+    const collections = Array.from({ length: 10 }, (_, index) => collectionRow("inventory", `c${index}`));
+    const gate = createGate();
+    let inFlight = 0;
+    let peakInFlight = 0;
+
+    const { transport } = createTransport({
+      collections,
+      infer: async () => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await gate.opened;
+        inFlight -= 1;
+        return inferRows(flavour({ city: property("string") }));
+      },
+    });
+
+    const pending = getSchemaList(transport, "travel");
+    await flushPending();
+
+    // The bound holds while work is outstanding, not just on average.
+    expect(inFlight).toBe(INFER_CONCURRENCY);
+
+    gate.open();
+    const schemas = await pending;
+
+    expect(peakInFlight).toBe(INFER_CONCURRENCY);
+    // The concurrency limit bounds cost; it must never truncate the tree.
+    expect(schemas.map((schema) => schema.name)).toEqual(
+      Array.from({ length: 10 }, (_, index) => `inventory.c${index}`),
+    );
+  });
+
+  test("runs no INFER at all for a bucket with no collections", async () => {
+    const { transport, calls } = createTransport({ collections: [] });
+
+    expect(await getSchemaList(transport, "travel")).toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// getSchemaRelations
+// ============================================================================
+
+describe("getSchemaRelations", () => {
+  test("queries system:indexes for the pinned bucket only", async () => {
+    const { transport, calls } = createTransport({ indexes: [] });
+
+    await getSchemaRelations(transport, "travel");
+
+    expect(calls[0].statement).toContain("system:indexes");
+    expect(calls[0].statement).not.toContain("travel");
+    expect(calls[0].opts?.args).toEqual(["travel"]);
+    expect(calls[0].opts?.timeoutMs).toBe(CATALOG_TIMEOUT_MS);
+  });
+
+  test("groups indexes by display name, unquotes index keys and invents no foreign keys", async () => {
+    const { transport } = createTransport({
+      indexes: [
+        {
+          index_name: "idx_hotel_city",
+          bucket_name: "travel",
+          scope_name: "inventory",
+          collection_name: "hotel",
+          index_key: ["`city`", "`geo``x`"],
+        },
+        {
+          index_name: "idx_hotel_stars",
+          bucket_name: "travel",
+          scope_name: "inventory",
+          collection_name: "hotel",
+          index_key: ["`stars`"],
+        },
+        {
+          index_name: "#primary",
+          bucket_name: "travel",
+          scope_name: "_default",
+          collection_name: "airline",
+          index_key: [],
+          is_primary: true,
+        },
+      ],
+    });
+
+    const relations = await getSchemaRelations(transport, "travel");
+
+    expect(relations).toEqual([
+      {
+        name: "inventory.hotel",
+        foreignKeys: [],
+        indexes: [
+          { name: "idx_hotel_city", columns: ["city", "geo`x"], unique: false },
+          { name: "idx_hotel_stars", columns: ["stars"], unique: false },
+        ],
+      },
+      {
+        name: "airline",
+        foreignKeys: [],
+        // A primary index carries no index_key: it keys the document key, which
+        // the KV layer guarantees unique.
+        indexes: [{ name: "#primary", columns: ["META().id"], unique: true }],
+      },
+    ]);
+  });
+
+  test("keeps an index key that is not a plain quoted identifier verbatim", async () => {
+    const { transport } = createTransport({
+      indexes: [
+        {
+          index_name: "idx_expr",
+          bucket_name: "travel",
+          scope_name: "inventory",
+          collection_name: "hotel",
+          index_key: ["(`geo`.`lat`)", 7],
+        },
+      ],
+    });
+
+    const relations = await getSchemaRelations(transport, "travel");
+
+    expect(relations[0].indexes[0].columns).toEqual(["(`geo`.`lat`)"]);
+  });
+
+  test("maps a bucket-level index row onto the default collection", async () => {
+    const { transport } = createTransport({
+      indexes: [{ index_name: "#primary", collection_name: "travel", index_key: [], is_primary: true }],
+    });
+
+    const relations = await getSchemaRelations(transport, "travel");
+
+    expect(relations[0].name).toBe("_default");
+  });
+
+  test("names an index with no name and tolerates a non-array index key", async () => {
+    const { transport } = createTransport({
+      indexes: [{ bucket_name: "travel", scope_name: "inventory", collection_name: "hotel", index_key: null }],
+    });
+
+    const relations = await getSchemaRelations(transport, "travel");
+
+    expect(relations[0].indexes).toEqual([{ name: "unknown", columns: [], unique: false }]);
+  });
+
+  test("skips an index row whose collection name is not a string", async () => {
+    const { transport } = createTransport({
+      indexes: [{ index_name: "#primary", bucket_name: "travel", scope_name: "inventory", collection_name: null }],
+    });
+
+    expect(await getSchemaRelations(transport, "travel")).toEqual([]);
+  });
+
+  test("returns nothing for a bucket with no indexes", async () => {
+    const { transport } = createTransport({ indexes: [] });
+
+    expect(await getSchemaRelations(transport, "travel")).toEqual([]);
+  });
+
+  test("propagates a catalog failure rather than reporting an empty index list", async () => {
+    // An empty index list is the un-indexed-collection signal (decision 6), so
+    // swallowing a failure here would fabricate that signal for every
+    // collection in the bucket.
+    const { transport } = createTransport({ catalogError: new CouchbaseError("no privilege", 13014) });
+
+    const error = (await getSchemaRelations(transport, "travel").catch((e: unknown) => e)) as CouchbaseError;
+
+    expect(error).toBeInstanceOf(CouchbaseError);
+    expect(error.code).toBe(13014);
+  });
+});

--- a/tests/unit/db/couchbase/keyspace.test.ts
+++ b/tests/unit/db/couchbase/keyspace.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Couchbase keyspace mapping (issue #262, decision 4)
+ *
+ * The schema explorer is flat, so bucket > scope > collection is flattened the
+ * same way PostgreSQL flattens schema > table: the _default scope renders as a
+ * bare collection name, every other scope renders as "scope.collection".
+ *
+ * Quoting is a security boundary: SQL++ has no bind parameter for identifiers,
+ * so a keyspace path is built by string concatenation and an identifier that
+ * carries a backtick must not be able to escape its own quoting.
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  COUCHBASE_DEFAULT_SCOPE,
+  keyspaceDisplayName,
+  keyspaceFromDisplayName,
+  keyspacePath,
+  quoteIdentifier,
+} from "@/lib/db/providers/document/couchbase/keyspace";
+
+/**
+ * Number of backticks that are NOT part of an escaped (doubled) pair.
+ * A correctly quoted path has exactly two per segment and nothing else.
+ */
+function structuralBacktickCount(value: string): number {
+  return value
+    .replace(/``/g, "")
+    .split("")
+    .filter((char) => char === "`").length;
+}
+
+describe("keyspaceDisplayName", () => {
+  test("renders a _default scope collection as the bare collection name", () => {
+    expect(keyspaceDisplayName(COUCHBASE_DEFAULT_SCOPE, "hotel")).toBe("hotel");
+  });
+
+  test("renders any other scope as scope.collection", () => {
+    expect(keyspaceDisplayName("inventory", "hotel")).toBe("inventory.hotel");
+  });
+});
+
+describe("keyspaceFromDisplayName", () => {
+  test("maps a bare collection name onto the _default scope", () => {
+    expect(keyspaceFromDisplayName("travel", "hotel")).toEqual({
+      bucket: "travel",
+      scope: COUCHBASE_DEFAULT_SCOPE,
+      collection: "hotel",
+    });
+  });
+
+  test("splits a qualified display name into scope and collection", () => {
+    expect(keyspaceFromDisplayName("travel", "inventory.hotel")).toEqual({
+      bucket: "travel",
+      scope: "inventory",
+      collection: "hotel",
+    });
+  });
+
+  test("splits on the first separator only, so extra dots stay with the collection", () => {
+    expect(keyspaceFromDisplayName("travel", "inventory.hotel.eu")).toEqual({
+      bucket: "travel",
+      scope: "inventory",
+      collection: "hotel.eu",
+    });
+  });
+
+  test("round-trips a display name in both directions", () => {
+    const keyspace = keyspaceFromDisplayName("travel", "inventory.hotel");
+    expect(keyspaceDisplayName(keyspace.scope, keyspace.collection)).toBe("inventory.hotel");
+
+    const defaultKeyspace = keyspaceFromDisplayName("travel", "hotel");
+    expect(keyspaceDisplayName(defaultKeyspace.scope, defaultKeyspace.collection)).toBe("hotel");
+  });
+});
+
+describe("quoteIdentifier", () => {
+  test("wraps a plain identifier in backticks", () => {
+    expect(quoteIdentifier("hotel")).toBe("`hotel`");
+  });
+
+  test("quotes reserved words such as bucket and scope", () => {
+    // Verified against Couchbase Server 8.0.2: unquoted `bucket` / `scope` in a
+    // system:keyspaces projection fails with error 3000 (syntax error).
+    expect(quoteIdentifier("bucket")).toBe("`bucket`");
+    expect(quoteIdentifier("scope")).toBe("`scope`");
+  });
+
+  test("doubles an embedded backtick so it cannot close the quoting", () => {
+    expect(quoteIdentifier("ev`il")).toBe("`ev``il`");
+  });
+
+  test("doubles a trailing backtick", () => {
+    expect(quoteIdentifier("x`")).toBe("`x```");
+  });
+
+  test("leaves single quotes and backslashes untouched", () => {
+    expect(quoteIdentifier("o'brien\\x")).toBe("`o'brien\\x`");
+  });
+});
+
+describe("keyspacePath", () => {
+  test("quotes every segment of the executable path", () => {
+    expect(keyspacePath({ bucket: "travel-sample", scope: "inventory", collection: "hotel" })).toBe(
+      "`travel-sample`.`inventory`.`hotel`",
+    );
+  });
+
+  test("quotes the _default scope explicitly rather than omitting it", () => {
+    expect(keyspacePath({ bucket: "travel", scope: COUCHBASE_DEFAULT_SCOPE, collection: "hotel" })).toBe(
+      "`travel`.`_default`.`hotel`",
+    );
+  });
+
+  test("keeps a hostile collection name inside its quotes", () => {
+    const path = keyspacePath({ bucket: "travel", scope: "_default", collection: "x` OR 1=1 --" });
+
+    expect(path).toBe("`travel`.`_default`.`x`` OR 1=1 --`");
+    // Two structural backticks per segment and no stray one that could end the
+    // identifier early and turn the payload into executable SQL++.
+    expect(structuralBacktickCount(path)).toBe(6);
+  });
+
+  test("keeps a hostile bucket and scope inside their quotes", () => {
+    const path = keyspacePath({
+      bucket: "b`ucket",
+      scope: "s`cope",
+      collection: "c`ollection",
+    });
+
+    expect(path).toBe("`b``ucket`.`s``cope`.`c``ollection`");
+    expect(structuralBacktickCount(path)).toBe(6);
+  });
+
+  test("builds the path a display name maps to", () => {
+    expect(keyspacePath(keyspaceFromDisplayName("travel", "inventory.hotel"))).toBe("`travel`.`inventory`.`hotel`");
+  });
+});

--- a/tests/unit/db/couchbase/seam-guard.test.ts
+++ b/tests/unit/db/couchbase/seam-guard.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Couchbase transport seam guard (issue #262, decision 2)
+ *
+ * The Couchbase provider is worth building without the official SDK only while
+ * swapping the transport stays cheap, and it stays cheap only while the REST
+ * envelope lives in exactly one file. This test is the mechanism that keeps
+ * that true: it parses every source of the provider and fails the build the
+ * moment a wire field is read outside http-transport.ts.
+ *
+ * The detector is a parser, not a grep. A substring search for the envelope
+ * names is simultaneously too loose and too strict - it fires on prose, on
+ * `statusText`, on a local variable named `results` and on the `r.requestId`
+ * column of `system:completed_requests`, while missing `payload["results"]` -
+ * and a guard that cries wolf is a guard the next contributor deletes. The
+ * detector is therefore tested against a compliant sample and a violating one,
+ * so it is proven to fire and proven not to over-fire.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+const ROOT = join(import.meta.dir, "..", "..", "..", "..");
+const PROVIDER_DIR = join(ROOT, "src", "lib", "db", "providers", "document", "couchbase");
+
+/** The fields the Query Service wraps every response in. */
+const ENVELOPE_FIELDS = new Set(["results", "signature", "requestID", "status"]);
+
+/** The single file allowed to know the wire format. */
+const TRANSPORT_FILE = "http-transport.ts";
+
+/**
+ * Why the rule exists, printed on failure. Whoever trips this needs to see the
+ * boundary they are crossing, otherwise the cheapest fix looks like deleting
+ * the test.
+ */
+const SEAM_RULE = [
+  `The Couchbase REST envelope leaked out of ${TRANSPORT_FILE}.`,
+  "",
+  "The Query Service wraps every response in { requestID, signature, results, status, metrics }.",
+  "Issue #262 decision 2 keeps that envelope inside the transport: provider logic reads the neutral",
+  "CouchbaseQueryResult (rows, fieldNames, executionTimeMs, mutationCount, warnings) through the",
+  "CouchbaseTransport seam. That is what makes adopting the official Couchbase SDK later one new file",
+  "implementing the same interface, instead of a rewrite of the provider, the introspection and the",
+  "explain strategy.",
+  "",
+  `Fix an access below by mapping the field inside ${TRANSPORT_FILE} and widening CouchbaseQueryResult`,
+  "when the value is genuinely needed. A management payload (/pools/default...) that happens to carry",
+  "one of these names belongs there too - manage() stays HTTP permanently, so HTTP-shaped knowledge",
+  "lives in the transport. Do not weaken or delete this test: it is the only thing keeping the seam real.",
+  "",
+  "Envelope reads outside the transport:",
+].join("\n");
+
+interface EnvelopeAccess {
+  file: string;
+  line: number;
+  field: string;
+  snippet: string;
+}
+
+/**
+ * The payload field this node reads, or null when it reads none.
+ *
+ * Only three syntactic forms actually take a field off a payload, and all three
+ * are envelope access regardless of how the value is spelled afterwards:
+ *
+ *   payload.results / payload?.results   PropertyAccessExpression
+ *   payload["results"]                   ElementAccessExpression, literal key
+ *   const { results } = payload          BindingElement of an object pattern
+ *
+ * A declaration or a constructed literal (`interface E { results: Row[] }`,
+ * `return { status: "ok" }`) is deliberately not a violation: a shape is inert
+ * until something reads it, and the read is what the three forms above catch.
+ */
+function accessedField(node: ts.Node): string | null {
+  if (ts.isPropertyAccessExpression(node)) return node.name.text;
+  if (ts.isElementAccessExpression(node)) {
+    const key = node.argumentExpression;
+    return ts.isStringLiteralLike(key) ? key.text : null;
+  }
+  // Array patterns bind by position, so only an object pattern names a field.
+  if (ts.isBindingElement(node) && ts.isObjectBindingPattern(node.parent)) {
+    const key = node.propertyName ?? node.name;
+    return ts.isIdentifier(key) || ts.isStringLiteralLike(key) ? key.text : null;
+  }
+  return null;
+}
+
+function findEnvelopeAccesses(file: string, source: string): EnvelopeAccess[] {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const lines = source.split("\n");
+  const found: EnvelopeAccess[] = [];
+
+  const visit = (node: ts.Node): void => {
+    const field = accessedField(node);
+    if (field !== null && ENVELOPE_FIELDS.has(field)) {
+      const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line;
+      found.push({ file, line: line + 1, field, snippet: lines[line].trim() });
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+}
+
+/** Empty when the seam holds; the rule plus every offending line when it does not. */
+function violationReport(accesses: EnvelopeAccess[]): string {
+  if (accesses.length === 0) return "";
+  const offences = accesses.map(
+    (access) => `  ${access.file}:${access.line} reads "${access.field}" -> ${access.snippet}`,
+  );
+  return [SEAM_RULE, ...offences].join("\n");
+}
+
+function providerSources(): string[] {
+  return readdirSync(PROVIDER_DIR, { recursive: true })
+    .map(String)
+    .filter((name) => name.endsWith(".ts"))
+    .sort();
+}
+
+function readProviderSource(file: string): string {
+  return readFileSync(join(PROVIDER_DIR, file), "utf8");
+}
+
+describe("Couchbase transport seam", () => {
+  const sources = providerSources();
+
+  test("the guard scans the whole provider directory", () => {
+    expect(sources).toContain(TRANSPORT_FILE);
+    expect(sources.length).toBeGreaterThan(1);
+  });
+
+  // A detector that finds nothing anywhere is indistinguishable from a broken
+  // one, so the file that is SUPPOSED to speak REST must light it up.
+  test("the transport itself reads the envelope, proving the detector looks at real code", () => {
+    const fields = findEnvelopeAccesses(TRANSPORT_FILE, readProviderSource(TRANSPORT_FILE)).map((a) => a.field);
+
+    expect(fields).toContain("results");
+    expect(fields).toContain("signature");
+    expect(fields).toContain("status");
+  });
+
+  test(`the REST envelope is read only in ${TRANSPORT_FILE}`, () => {
+    const violations = sources
+      .filter((file) => file !== TRANSPORT_FILE)
+      .flatMap((file) => findEnvelopeAccesses(file, readProviderSource(file)));
+
+    expect(violationReport(violations)).toBe("");
+  });
+});
+
+describe("the seam guard detector", () => {
+  /**
+   * Everything a compliant provider file legitimately does with these words:
+   * name them in prose, read them off a row that the cluster produced, keep a
+   * local variable called `results`, and build an object with a `status` key.
+   * None of it is envelope access, and none of it may fire.
+   */
+  const COMPLIANT_SAMPLE = `
+/**
+ * Prose may name the envelope: results, signature, requestID and status all
+ * stay behind the seam. Even payload.status written in a comment is prose.
+ */
+import type { CouchbaseTransport } from "./transport";
+
+const LIST_REQUESTS = "SELECT r.requestId, r.status FROM system:completed_requests AS r";
+
+export async function listRequests(transport: CouchbaseTransport, field: string) {
+  const outcome = await transport.query(LIST_REQUESTS);
+  const { rows, fieldNames } = outcome;
+  const results = rows.filter((row) => row.state !== "cancelled");
+  const [first] = results;
+  const dynamic = first[field];
+  return { rows, fieldNames, dynamic, status: "ok", statusText: outcome.warnings.length };
+}
+`;
+
+  const VIOLATING_SAMPLE = `
+export function readEnvelope(payload: Record<string, unknown>) {
+  const { requestID } = payload;
+  return { id: requestID, rows: payload.results, columns: payload["signature"] };
+}
+`;
+
+  test("passes a file that stays behind the seam", () => {
+    expect(findEnvelopeAccesses("index.ts", COMPLIANT_SAMPLE)).toEqual([]);
+  });
+
+  test("fails a file that reads the envelope, once per access", () => {
+    const violations = findEnvelopeAccesses("index.ts", VIOLATING_SAMPLE);
+
+    expect(violations.map((violation) => violation.field)).toEqual(["requestID", "results", "signature"]);
+    expect(violations[0].line).toBe(3);
+    expect(violations[1].line).toBe(4);
+    expect(violations[1].snippet).toBe(
+      'return { id: requestID, rows: payload.results, columns: payload["signature"] };',
+    );
+  });
+
+  test.each<[string, string, string]>([
+    ["a member access", "const rows = payload.results;", "results"],
+    ["an optional-chained access", "const columns = payload?.signature;", "signature"],
+    ["a bracket access with a literal key", 'const id = payload["requestID"];', "requestID"],
+    ["a destructured field", "const { status } = payload;", "status"],
+    ["a renamed destructured field", "const { results: rows } = payload;", "results"],
+    [
+      "the status check decision 5 warns about",
+      'if (payload.status === "errors") throw new Error("failed");',
+      "status",
+    ],
+  ])("flags %s", (_label, source, field) => {
+    const [violation, ...rest] = findEnvelopeAccesses("index.ts", source);
+
+    expect(rest).toEqual([]);
+    expect(violation.field).toBe(field);
+    expect(violation.line).toBe(1);
+  });
+
+  test.each([
+    ["a near-miss property name", "const label = response.statusText;"],
+    ["a local variable that shares a name", "const results = rows.slice(0, 10);"],
+    ["an array destructuring binding", "const [results, signature] = tuple;"],
+    ["a computed key that is not a literal", "const value = payload[field];"],
+    ["a constructed object, which declares rather than reads", 'return { status: "ok", results: rows };'],
+  ])("does not flag %s", (_label, source) => {
+    expect(findEnvelopeAccesses("index.ts", source)).toEqual([]);
+  });
+
+  test("reports nothing when the seam holds", () => {
+    expect(violationReport([])).toBe("");
+  });
+
+  test("the failure report explains the rule and points at the issue", () => {
+    const report = violationReport(findEnvelopeAccesses("index.ts", "const rows = payload.results;"));
+
+    expect(report).toContain("#262");
+    expect(report).toContain(TRANSPORT_FILE);
+    expect(report).toContain("CouchbaseQueryResult");
+    expect(report).toContain('index.ts:1 reads "results" -> const rows = payload.results;');
+  });
+});

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -274,6 +274,11 @@ describe("createDatabaseProvider", () => {
     await expect(createDatabaseProvider(conn)).rejects.toThrow(/Unknown database type: unknown/);
   });
 
+  test("the unknown-type error lists every supported type", async () => {
+    const conn = makeConnection("unknown");
+    await expect(createDatabaseProvider(conn)).rejects.toThrow(/couchbase/);
+  });
+
   test('creates provider for type "postgres"', async () => {
     const conn = makeConnection("postgres");
     const provider = await createDatabaseProvider(conn);
@@ -321,6 +326,14 @@ describe("createDatabaseProvider", () => {
     const provider = await createDatabaseProvider(conn);
     expect(provider).toBeDefined();
     expect(provider.type).toBe("mssql");
+  });
+
+  test('creates provider for type "couchbase"', async () => {
+    // The bucket is the `database` field; the provider refuses a connection without one.
+    const conn = makeConnection("couchbase", { port: 8091, database: "travel" });
+    const provider = await createDatabaseProvider(conn);
+    expect(provider).toBeDefined();
+    expect(provider.type).toBe("couchbase");
   });
 
   test('creates provider for type "libredb"', async () => {

--- a/tests/unit/lib/connection-string-parser.test.ts
+++ b/tests/unit/lib/connection-string-parser.test.ts
@@ -204,6 +204,107 @@ describe("parseConnectionString", () => {
     });
   });
 
+  // ── Couchbase ───────────────────────────────────────────────────────────
+
+  describe("couchbase:// and couchbases:// URLs", () => {
+    test("parses full couchbase URL", () => {
+      const uri = "couchbase://Administrator:password123@127.0.0.1:8091/travel";
+      const result = parseConnectionString(uri);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe("couchbase");
+      expect(result!.host).toBe("127.0.0.1");
+      expect(result!.port).toBe("8091");
+      expect(result!.user).toBe("Administrator");
+      expect(result!.password).toBe("password123");
+      expect(result!.database).toBe("travel");
+      expect(result!.connectionString).toBe(uri);
+    });
+
+    test("uses default management port 8091 when port is omitted", () => {
+      const result = parseConnectionString("couchbase://Administrator:pass@cb-host/travel");
+      expect(result!.type).toBe("couchbase");
+      expect(result!.host).toBe("cb-host");
+      expect(result!.port).toBe("8091");
+    });
+
+    test("uses default TLS management port 18091 for couchbases URLs", () => {
+      const result = parseConnectionString("couchbases://Administrator:pass@secure-host/travel");
+      expect(result!.type).toBe("couchbase");
+      expect(result!.host).toBe("secure-host");
+      expect(result!.port).toBe("18091");
+      expect(result!.database).toBe("travel");
+    });
+
+    test("respects an explicit port on a couchbases URL", () => {
+      const result = parseConnectionString("couchbases://user:pass@host:18092/travel");
+      expect(result!.port).toBe("18092");
+    });
+
+    test("parses a Capella endpoint with no port and no bucket path", () => {
+      const uri = "couchbases://cb.abc123.cloud.couchbase.com";
+      const result = parseConnectionString(uri);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe("couchbase");
+      expect(result!.host).toBe("cb.abc123.cloud.couchbase.com");
+      expect(result!.port).toBe("18091");
+      expect(result!.database).toBeUndefined();
+      expect(result!.connectionString).toBe(uri);
+    });
+
+    test("parses a Capella endpoint with credentials and a trailing slash", () => {
+      const result = parseConnectionString("couchbases://app%40corp:s3cret@cb.abc123.cloud.couchbase.com/");
+      expect(result!.host).toBe("cb.abc123.cloud.couchbase.com");
+      expect(result!.user).toBe("app@corp");
+      expect(result!.password).toBe("s3cret");
+      expect(result!.database).toBeUndefined();
+    });
+
+    test("preserves the full original string including query parameters", () => {
+      const uri = "couchbase://user:pass@cb-host:8091/travel?ssl=no_verify";
+      const result = parseConnectionString(uri);
+      expect(result!.connectionString).toBe(uri);
+      expect(result!.database).toBe("travel");
+    });
+
+    test("takes the first host from a multi-node connection string", () => {
+      const result = parseConnectionString("couchbase://user:pass@node1,node2,node3:8091/travel");
+      expect(result!.host).toBe("node1");
+      expect(result!.port).toBe("8091");
+      expect(result!.database).toBe("travel");
+    });
+
+    test("handles couchbase URL without credentials", () => {
+      const result = parseConnectionString("couchbase://cb-host:8091/travel");
+      expect(result!.user).toBeUndefined();
+      expect(result!.password).toBeUndefined();
+      expect(result!.database).toBe("travel");
+    });
+
+    test("decodes URL-encoded credentials and bucket name", () => {
+      const result = parseConnectionString("couchbase://user%40corp:p%40ss%23word@cb-host/my%20bucket");
+      expect(result!.user).toBe("user@corp");
+      expect(result!.password).toBe("p@ss#word");
+      expect(result!.database).toBe("my bucket");
+    });
+
+    test("keeps a bucket name containing a literal percent sign", () => {
+      // "%" is legal in Couchbase bucket names and is not always a valid escape sequence.
+      const result = parseConnectionString("couchbase://cb-host/100%");
+      expect(result!.database).toBe("100%");
+    });
+
+    test("falls back to localhost when the URL carries no host", () => {
+      const result = parseConnectionString("couchbase:///travel");
+      expect(result!.host).toBe("localhost");
+      expect(result!.database).toBe("travel");
+    });
+
+    test("returns null for a malformed couchbase URL", () => {
+      expect(parseConnectionString("couchbase://:::bad")).toBeNull();
+      expect(parseConnectionString("couchbases://:::bad")).toBeNull();
+    });
+  });
+
   // ── ADO.NET format ──────────────────────────────────────────────────────
 
   describe("ADO.NET format", () => {
@@ -313,6 +414,14 @@ describe("detectConnectionStringType", () => {
 
   test("detects sqlserver://", () => {
     expect(detectConnectionStringType("sqlserver://host")).toBe("mssql");
+  });
+
+  test("detects couchbase://", () => {
+    expect(detectConnectionStringType("couchbase://host")).toBe("couchbase");
+  });
+
+  test("detects couchbases://", () => {
+    expect(detectConnectionStringType("couchbases://cb.abc123.cloud.couchbase.com")).toBe("couchbase");
   });
 
   test("detects ADO.NET Server= format", () => {

--- a/tests/unit/lib/db-icons.test.tsx
+++ b/tests/unit/lib/db-icons.test.tsx
@@ -10,6 +10,7 @@ import {
   OracleIcon,
   MSSQLIcon,
   LibreDBIcon,
+  CouchbaseIcon,
 } from "@/components/icons/db-icons";
 
 describe("db-icons", () => {
@@ -22,6 +23,7 @@ describe("db-icons", () => {
     { name: "OracleIcon", Component: OracleIcon },
     { name: "MSSQLIcon", Component: MSSQLIcon },
     { name: "LibreDBIcon", Component: LibreDBIcon },
+    { name: "CouchbaseIcon", Component: CouchbaseIcon },
   ];
 
   for (const { name, Component } of icons) {

--- a/tests/unit/lib/db-ui-config.test.ts
+++ b/tests/unit/lib/db-ui-config.test.ts
@@ -2,7 +2,17 @@ import { describe, test, expect } from "bun:test";
 import { getDBConfig, getDBIcon, getDBColor, isFileBased } from "@/lib/db-ui-config";
 import type { DatabaseType } from "@/lib/types";
 
-const ALL_TYPES: DatabaseType[] = ["postgres", "mysql", "sqlite", "mongodb", "redis", "oracle", "mssql", "libredb"];
+const ALL_TYPES: DatabaseType[] = [
+  "postgres",
+  "mysql",
+  "sqlite",
+  "mongodb",
+  "redis",
+  "oracle",
+  "mssql",
+  "libredb",
+  "couchbase",
+];
 
 describe("db-ui-config", () => {
   describe("getDBConfig", () => {
@@ -28,10 +38,31 @@ describe("db-ui-config", () => {
       expect(getDBConfig("sqlite").defaultPort).toBe("");
     });
 
-    test("only mongodb exposes the connection string toggle", () => {
+    test("exposes the connection string toggle only for the URI-addressed providers", () => {
+      // MongoDB (mongodb+srv) and Couchbase (couchbase://, couchbases://) are the
+      // providers a user routinely has a full URI for; everything else is field-based.
+      const withToggle = new Set<DatabaseType>(["mongodb", "couchbase"]);
       for (const type of ALL_TYPES) {
-        expect(getDBConfig(type).showConnectionStringToggle).toBe(type === "mongodb");
+        expect(getDBConfig(type).showConnectionStringToggle).toBe(withToggle.has(type));
       }
+    });
+
+    test("couchbase exposes its label, management port and connection fields", () => {
+      expect(getDBConfig("couchbase").label).toBe("Couchbase");
+      expect(getDBConfig("couchbase").defaultPort).toBe("8091");
+      expect(getDBConfig("couchbase").connectionFields).toEqual([
+        "host",
+        "port",
+        "user",
+        "password",
+        "database",
+        "connectionString",
+      ]);
+    });
+
+    test("every provider carries a distinct colour class", () => {
+      const colors = ALL_TYPES.map((type) => getDBConfig(type).color);
+      expect(new Set(colors).size).toBe(colors.length);
     });
   });
 
@@ -68,6 +99,7 @@ describe("db-ui-config", () => {
       expect(isFileBased("redis")).toBe(false);
       expect(isFileBased("oracle")).toBe(false);
       expect(isFileBased("mssql")).toBe(false);
+      expect(isFileBased("couchbase")).toBe(false);
     });
   });
 });

--- a/tests/unit/lib/explain/couchbase-json.test.ts
+++ b/tests/unit/lib/explain/couchbase-json.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from "bun:test";
+import { getExplainStrategy } from "@/lib/explain";
+import { couchbaseJsonStrategy } from "@/lib/explain/couchbase-json";
+import type { ExplainTreeNode } from "@/lib/explain/types";
+
+// Shape verified against a live Couchbase Server 8.0.2 node: the plan tree nests
+// under both "~children" (array) and "~child" (single operator).
+const PLAN = {
+  "#operator": "Sequence",
+  "~children": [
+    {
+      "#operator": "IndexScan3",
+      index: "idx_hotel_city",
+      keyspace: "hotel",
+      scope: "inventory",
+      bucket: "travel",
+      using: "gsi",
+    },
+    { "#operator": "Fetch", keyspace: "hotel", scope: "inventory", bucket: "travel" },
+    {
+      "#operator": "Parallel",
+      "~child": {
+        "#operator": "Sequence",
+        "~children": [{ "#operator": "InitialProject", result_terms: [{ expr: "self", star: true }] }],
+      },
+    },
+  ],
+};
+
+function treeRoot(raw: unknown): ExplainTreeNode {
+  const model = couchbaseJsonStrategy.toRenderModel(raw);
+  expect(model?.kind).toBe("tree");
+  return (model as { root: ExplainTreeNode }).root;
+}
+
+describe("couchbaseJsonStrategy", () => {
+  test("format id", () => {
+    expect(couchbaseJsonStrategy.format).toBe("couchbase-json");
+  });
+
+  test("is registered in the explain registry", () => {
+    expect(getExplainStrategy("couchbase-json")).toBe(couchbaseJsonStrategy);
+  });
+
+  test("buildSql prefixes EXPLAIN in estimate mode", () => {
+    expect(couchbaseJsonStrategy.buildSql("SELECT * FROM hotel", "estimate")).toBe("EXPLAIN SELECT * FROM hotel");
+    expect(couchbaseJsonStrategy.buildSql("  SELECT 1", "estimate")).toBe("EXPLAIN   SELECT 1");
+  });
+
+  // SQL++ has no EXPLAIN ANALYZE: real timings come only from the request-level
+  // profile parameter, which ExplainStrategy cannot set (it emits SQL only).
+  test("buildSql returns null in analyze mode instead of downgrading to an estimate", () => {
+    expect(couchbaseJsonStrategy.buildSql("SELECT * FROM hotel", "analyze")).toBeNull();
+  });
+
+  test("buildSql returns null for non-SELECT statements", () => {
+    expect(couchbaseJsonStrategy.buildSql("UPDATE hotel SET city = 'Bursa'", "estimate")).toBeNull();
+    expect(couchbaseJsonStrategy.buildSql("EXPLAIN SELECT 1", "estimate")).toBeNull();
+    expect(couchbaseJsonStrategy.buildSql("INFER `travel`", "estimate")).toBeNull();
+  });
+
+  test("extractPlan stores the plan carried by the EXPLAIN result row", () => {
+    expect(couchbaseJsonStrategy.extractPlan({ rows: [{ plan: PLAN, text: "SELECT * FROM hotel" }] })).toEqual(PLAN);
+  });
+
+  test("extractPlan falls back to the raw rows when no plan field is present", () => {
+    const rows = [{ nope: 1 }];
+    expect(couchbaseJsonStrategy.extractPlan({ rows })).toEqual(rows);
+    expect(couchbaseJsonStrategy.extractPlan({ rows: [] })).toEqual([]);
+    expect(couchbaseJsonStrategy.extractPlan({})).toBeUndefined();
+  });
+
+  test("toRenderModel walks the operator tree, keeping the raw plan alongside it", () => {
+    const model = couchbaseJsonStrategy.toRenderModel(PLAN);
+    expect(model).toEqual({ kind: "tree", root: expect.anything(), raw: PLAN });
+    const root = (model as { root: ExplainTreeNode }).root;
+    expect(root.label).toBe("Sequence");
+    expect(root.children.map((child) => child.label)).toEqual(["IndexScan3", "Fetch", "Parallel"]);
+  });
+
+  test("toRenderModel follows the single-operator ~child key, not just ~children", () => {
+    const parallel = treeRoot(PLAN).children[2];
+    expect(parallel.children.map((child) => child.label)).toEqual(["Sequence"]);
+    expect(parallel.children[0].children.map((child) => child.label)).toEqual(["InitialProject"]);
+  });
+
+  test("toRenderModel puts keyspace path and index name in detail", () => {
+    const children = treeRoot(PLAN).children;
+    expect(children[0].detail).toBe("travel.inventory.hotel index: idx_hotel_city");
+    expect(children[1].detail).toBe("travel.inventory.hotel");
+    expect(children[2].detail).toBeUndefined();
+    expect(treeRoot({ "#operator": "IndexScan3", index: "idx_city" }).detail).toBe("index: idx_city");
+  });
+
+  test("toRenderModel ignores tilde keys that do not carry operators", () => {
+    const root = treeRoot({
+      "#operator": "Sequence",
+      "~versions": ["8.0.2"],
+      "~children": [{ notAnOperator: true }, { "#operator": "Fetch" }],
+    });
+    expect(root.children.map((child) => child.label)).toEqual(["Fetch"]);
+  });
+
+  test("toRenderModel maps cost-based optimizer estimates onto estCost and estRows", () => {
+    expect(treeRoot({ "#operator": "PrimaryScan3", cost: 12.5, cardinality: 3 }).metrics).toEqual({
+      estCost: 12.5,
+      estRows: 3,
+    });
+    expect(
+      treeRoot({
+        "#operator": "IndexScan3",
+        optimizer_estimates: { cardinality: 187, cost: 20.32, fr_cost: 10.6, size: 25 },
+      }).metrics,
+    ).toEqual({ estCost: 20.32, estRows: 187 });
+    expect(treeRoot({ "#operator": "Fetch", cost: 4 }).metrics).toEqual({ estCost: 4 });
+  });
+
+  test("toRenderModel omits metrics when estimates are absent, sentinel or non-numeric", () => {
+    expect(treeRoot({ "#operator": "Fetch" }).metrics).toBeUndefined();
+    // -1 is what Couchbase writes when the optimizer produced no estimate.
+    expect(treeRoot({ "#operator": "Fetch", cost: -1, cardinality: -1 }).metrics).toBeUndefined();
+    expect(treeRoot({ "#operator": "Fetch", cost: "cheap", cardinality: Number.NaN }).metrics).toBeUndefined();
+    expect(
+      treeRoot({ "#operator": "Fetch", optimizer_estimates: { cost: -1, cardinality: null } }).metrics,
+    ).toBeUndefined();
+    expect(treeRoot({ "#operator": "Fetch", optimizer_estimates: "none" }).metrics).toBeUndefined();
+  });
+
+  test("toRenderModel unwraps the EXPLAIN row shapes extractPlan may have stored", () => {
+    expect(treeRoot({ plan: PLAN }).label).toBe("Sequence");
+    expect(treeRoot([{ plan: PLAN }]).label).toBe("Sequence");
+  });
+
+  test("toRenderModel rejects shapes that are not Couchbase plans", () => {
+    expect(couchbaseJsonStrategy.toRenderModel(null)).toBeNull();
+    expect(couchbaseJsonStrategy.toRenderModel(undefined)).toBeNull();
+    expect(couchbaseJsonStrategy.toRenderModel("EXPLAIN")).toBeNull();
+    expect(couchbaseJsonStrategy.toRenderModel({})).toBeNull();
+    expect(couchbaseJsonStrategy.toRenderModel([])).toBeNull();
+    expect(couchbaseJsonStrategy.toRenderModel([{ id: 3, parent: 0, detail: "SCAN employee" }])).toBeNull();
+    expect(couchbaseJsonStrategy.toRenderModel({ "#operator": 7 })).toBeNull();
+    // Unwrapping is depth-bounded so a pathological wrapper chain cannot loop.
+    expect(couchbaseJsonStrategy.toRenderModel({ plan: { plan: { plan: { plan: PLAN } } } })).toBeNull();
+  });
+});

--- a/tests/unit/lib/explain/couchbase-json.test.ts
+++ b/tests/unit/lib/explain/couchbase-json.test.ts
@@ -47,10 +47,18 @@ describe("couchbaseJsonStrategy", () => {
     expect(couchbaseJsonStrategy.buildSql("  SELECT 1", "estimate")).toBe("EXPLAIN   SELECT 1");
   });
 
-  // SQL++ has no EXPLAIN ANALYZE: real timings come only from the request-level
-  // profile parameter, which ExplainStrategy cannot set (it emits SQL only).
-  test("buildSql returns null in analyze mode instead of downgrading to an estimate", () => {
-    expect(couchbaseJsonStrategy.buildSql("SELECT * FROM hotel", "analyze")).toBeNull();
+  // SQL++ has no EXPLAIN ANALYZE, and ExplainStrategy emits SQL only so it cannot
+  // reach the request-level profile parameter that would carry real timings. The
+  // estimate is therefore returned for both modes, exactly as the SQLite strategy
+  // does for EXPLAIN QUERY PLAN. Returning null for analyze instead would kill the
+  // direct Explain action outright: use-query-execution.ts:165 builds that action
+  // with mode "analyze" and refuses the run when the strategy declines it.
+  test("buildSql returns the estimate plan in analyze mode, matching the SQLite strategy", () => {
+    expect(couchbaseJsonStrategy.buildSql("SELECT * FROM hotel", "analyze")).toBe("EXPLAIN SELECT * FROM hotel");
+  });
+
+  test("buildSql declines a non-SELECT in analyze mode too", () => {
+    expect(couchbaseJsonStrategy.buildSql("UPDATE hotel SET city = 'Bursa'", "analyze")).toBeNull();
   });
 
   test("buildSql returns null for non-SELECT statements", () => {

--- a/tests/unit/lib/query-generators.test.ts
+++ b/tests/unit/lib/query-generators.test.ts
@@ -189,6 +189,66 @@ describe("generateSelectQuery", () => {
 });
 
 // ============================================================================
+// Couchbase (SQL++) — issue #262, decision 5
+// ============================================================================
+
+describe("Couchbase (SQL++) generation", () => {
+  const couchbaseCaps = makeCaps({ defaultPort: 8091 });
+
+  // A collection's fields as the INFER-based introspection reports them: the
+  // document key first, under the same "__id" alias the generated projection uses.
+  const hotelColumns: ColumnSchema[] = [
+    { name: "__id", type: "string", nullable: false, isPrimary: true },
+    { name: "city", type: "string", nullable: true, isPrimary: false },
+  ];
+
+  test("generateTableQuery aliases the keyspace and projects the document key", () => {
+    expect(generateTableQuery("hotel", couchbaseCaps)).toBe(
+      "SELECT META(d).id AS __id, d.* FROM `hotel` AS d LIMIT 50;",
+    );
+  });
+
+  test("generateTableQuery quotes every segment of a scope-qualified collection", () => {
+    expect(generateTableQuery("inventory.hotel", couchbaseCaps)).toBe(
+      "SELECT META(d).id AS __id, d.* FROM `inventory`.`hotel` AS d LIMIT 50;",
+    );
+  });
+
+  test("generateSelectQuery projects fields through the alias and the key through META", () => {
+    expect(generateSelectQuery("inventory.hotel", hotelColumns, couchbaseCaps)).toBe(
+      "SELECT\n  META(d).id AS __id,\n  d.`city`\nFROM `inventory`.`hotel` AS d\nWHERE 1=1\nLIMIT 100;",
+    );
+  });
+
+  test("generateSelectQuery falls back to the wildcard when no columns are known", () => {
+    expect(generateSelectQuery("hotel", [], couchbaseCaps)).toBe(
+      "SELECT\n  META(d).id AS __id,\n  d.*\nFROM `hotel` AS d\nWHERE 1=1\nLIMIT 100;",
+    );
+  });
+
+  test("generateSelectQuery adds the key projection even when the columns carry no key", () => {
+    const cityOnly: ColumnSchema[] = [{ name: "city", type: "string", nullable: true, isPrimary: false }];
+    const out = generateSelectQuery("hotel", cityOnly, couchbaseCaps);
+    expect(out).toContain("META(d).id AS __id");
+    expect(out).not.toContain("d.`__id`");
+  });
+
+  test("quoteIdentifier always backtick-quotes, so SQL++ reserved words parse", () => {
+    // `bucket` and `scope` are reserved words: unquoted they are a syntax error.
+    expect(quoteIdentifier("bucket", couchbaseCaps)).toBe("`bucket`");
+    expect(quoteIdentifier("city", couchbaseCaps)).toBe("`city`");
+  });
+
+  test("quoteIdentifier doubles an embedded backtick so it cannot terminate its quoting", () => {
+    expect(quoteIdentifier("we`ird", couchbaseCaps)).toBe("`we``ird`");
+  });
+
+  test("quoteQualifiedName quotes each segment independently", () => {
+    expect(quoteQualifiedName("inventory.hotel", couchbaseCaps)).toBe("`inventory`.`hotel`");
+  });
+});
+
+// ============================================================================
 // quoteIdentifier (dialect-aware, quote-only-when-needed)
 // ============================================================================
 

--- a/tests/unit/seed/types.test.ts
+++ b/tests/unit/seed/types.test.ts
@@ -61,8 +61,8 @@ describe("SeedConnectionSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("accepts all 7 valid database types", () => {
-    for (const type of ["postgres", "mysql", "sqlite", "mongodb", "redis", "oracle", "mssql"]) {
+  it("accepts every valid database type", () => {
+    for (const type of ["postgres", "mysql", "sqlite", "mongodb", "redis", "oracle", "mssql", "libredb", "couchbase"]) {
       const result = SeedConnectionSchema.safeParse({ ...validConn, type });
       expect(result.success).toBe(true);
     }


### PR DESCRIPTION
Closes #262.

Adds Couchbase as the ninth database provider, speaking SQL++ over the documented Query Service and
management REST APIs. **The provider adds no runtime dependency of any kind** — `package.json` is
untouched, so the Docker image, Snap, AppImage, Flatpak, deb/rpm and the `@libredb/studio` npm
package that `libredb-platform` consumes all stay exactly the same size.

## Why no SDK

The official `couchbase` SDK is 64.6 MB unpacked across 3765 files, depends on `cmake-js` and
`node-addon-api`, and runs a postinstall step that downloads a prebuilt binary or compiles from
source. The capability it would buy turned out to be very small: `USE KEYS` reads a document by key
with no index, ACID transactions work over REST, and — verified live on 8.0.2 — the Query Service
performs a sequential scan for un-indexed collections, so even KV range scan is not a gap on Server
7.6+. Only non-JSON documents and subdocument operations remain SDK-only.

HTTP is also the more deployable choice in enterprise environments: nothing to download during an
air-gapped install, REST traverses corporate HTTP proxies while the binary KV protocol on 11210
does not, site firewall policy commonly opens 8091/18093 and not 11210, and container images need
no native module or glibc/musl matching.

The transport is still a seam (`CouchbaseTransport`) with one implementation, so adopting the SDK
later is a new file rather than a rewrite. A guard test keeps the REST envelope from leaking out of
`http-transport.ts`, which is what makes that promise hold.

## What it does

- **SQL++ as a first-class SQL dialect.** `queryLanguage: "sql"` inherits Monaco highlighting, the
  shared query limiter, the `sql` tab type, NL2SQL and saved queries with no extra code.
- **Keyspace mapping follows the PostgreSQL rule.** The bucket is pinned by the connection; a
  collection in `_default` shows as `airline`, anything else as `inventory.hotel` — the same rule as
  `postgres.ts:818`.
- **Ports are discovered, not configured.** Only the management port is stored; query ports come
  from `/pools/default/nodeServices`, including `alternateAddresses` for NAT and Docker. Capella SRV
  endpoints resolve via `dns.promises.resolveSrv` with an A-record fallback.
- **Schema from `system:*` plus `INFER`,** at a bounded concurrency, where a collection the user
  cannot read yields empty columns instead of failing the whole tree.
- **EXPLAIN** via a new `couchbase-json` strategy reusing the existing tree render model. `analyze`
  returns null rather than silently degrading to an estimate, matching #201.
- **Monitoring degrades to empty, never throws** — the monitoring catalogs need the Query System
  Catalog RBAC role, so a denial is the normal case for a restricted user.
- **Maintenance** maps to `UPDATE STATISTICS`, `BUILD INDEX` and killing a request; the
  Enterprise-only refusal of `UPDATE STATISTICS` is surfaced verbatim rather than hidden.

## Non-obvious behaviours handled

Each of these silently produces wrong output if missed, and each has a test:

- A **200 response can carry `status: "errors"`**. The payload is checked before the HTTP code, or a
  syntax error reads as "0 rows".
- **`SELECT *` nests documents** under the keyspace name and omits the key, so generated statements
  alias and project `META(d).id`.
- **A wildcard in the signature does not describe the rows.** `{ id, "*" }` would name a literal `*`
  column and hide every expanded field, so any wildcard falls back to deriving fields from rows.
- **The query context is pinned to the bucket.** SQL++ reads a bare `inventory.hotel` as
  *bucket*`.collection`, so without `query_context` the generated statement dies with "Ambiguous
  reference to field 'inventory'".
- **`bucket`, `scope` and `using` are reserved words** in the system catalogs and must be
  backtick-quoted.
- **`scan_consistency` defaults to `request_plus`** so a user always sees their own writes. The
  default `not_bounded` returned zero rows immediately after an INSERT in testing.

## Verification

Six local gates green: `format`, `lint` (0 errors), `typecheck`, `knip`, `test`, `build`. Coverage
is at the required 100%.

Verified end to end against a real Couchbase Server 8.0.2 Community node driving the running
application, not mocks: full INSERT / UPDATE / SELECT / DELETE through both the query API and the
browser UI, read-your-writes, the un-indexed collection, both error paths, schema introspection with
INFER-derived column types, the Explain tree including the `Parallel` operator's nested `~child`,
every monitoring surface, and all three maintenance operations.

That pass found three defects, each fixed with a test first: the wildcard signature, the missing
query context, and a documentation claim that un-indexed collections cannot be listed.

## Not in this PR

The SDK and what it gates (non-JSON documents, subdocument operations); Analytics, Full-Text Search
and Eventing; Capella management APIs; multi-bucket browsing from one connection. Chart and operator
bundle versions are untouched — those gates trigger on a `package.json` version change, which
belongs to a separate release step.
