### PR TITLE
feat(distribution): channel coverage matrix for users, developers and buyers

### DIFF
--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -51,13 +51,16 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/bun-install
 
-      - name: Check CHANNELS.md matrix freshness
-        run: bun run distribution:matrix -- --check
-
       # Warn-only by design and it talks to GHCR, Docker Hub, Snap and winget.
-      # Keep it out of PR status; the freshness check above is offline and cheap.
+      # Runs first so the drift table still reaches the Job Summary even if the
+      # freshness check below fails main - that table is this workflow's actual
+      # reason to exist. Kept out of PR status; the freshness check is offline
+      # and cheap.
       - name: Check distribution channels
         if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run distribution:check
+
+      - name: Check CHANNELS.md matrix freshness
+        run: bun run distribution:matrix --check

--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -6,6 +6,10 @@ name: Distribution Check
 # routine and must never block anything; per-channel enforcement lives where
 # it is owned (e.g. the required chart:check gate for Helm).
 #
+# Also freshness-checks docs/CHANNELS.md (the audience matrix). Path-filtered
+# pull_request runs catch a forgotten `bun run distribution:matrix` before merge;
+# only that offline step runs on a PR, never the networked drift report.
+#
 # Deliberately NOT triggered on release: published - releases are published
 # by release-artifacts.yml under GITHUB_TOKEN, whose events never trigger
 # other workflows (see the explicit dispatch chain in that file). A weekly
@@ -15,9 +19,17 @@ on:
   schedule:
     - cron: "41 6 * * 1"
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "distribution/channels.yaml"
+      - "docs/CHANNELS.md"
+      - "scripts/distribution-check.mjs"
+      - ".github/workflows/distribution-check.yml"
 
 concurrency:
-  group: distribution-check
+  # Keyed by ref: without this, a pull_request run and the weekly cron run share
+  # one group and cancel each other, leaving a cancelled check on the PR.
+  group: distribution-check-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -39,7 +51,13 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/bun-install
 
+      - name: Check CHANNELS.md matrix freshness
+        run: bun run distribution:matrix -- --check
+
+      # Warn-only by design and it talks to GHCR, Docker Hub, Snap and winget.
+      # Keep it out of PR status; the freshness check above is offline and cheap.
       - name: Check distribution channels
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run distribution:check

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -150,7 +150,7 @@ Health check endpoint: `GET /api/db/health` · Container HTTP port: `3000`.
 
 - **Docker / Compose** — see Quick start above.
 - **Kubernetes (Helm)** — `oci://ghcr.io/libredb/charts/libredb-studio` · [Artifact Hub](https://artifacthub.io/packages/search?repo=libredb-studio)
-- **CapRover** — one-click app: add repo `https://libredb.org/caprover-one-click-apps`, then install **LibreDB Studio**.
+- **CapRover** — one-click app: add repo `https://raw.githubusercontent.com/libredb/caprover-one-click-apps/main/public/`, then install **LibreDB Studio**.
 - **PaaS** — one-click buttons for Koyeb & Render in the [GitHub README](https://github.com/libredb/libredb-studio#one-click-deploy).
 
 ---

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -150,7 +150,7 @@ Health check endpoint: `GET /api/db/health` · Container HTTP port: `3000`.
 
 - **Docker / Compose** — see Quick start above.
 - **Kubernetes (Helm)** — `oci://ghcr.io/libredb/charts/libredb-studio` · [Artifact Hub](https://artifacthub.io/packages/search?repo=libredb-studio)
-- **CapRover** — one-click app: add repo `https://raw.githubusercontent.com/libredb/caprover-one-click-apps/main/public/`, then install **LibreDB Studio**.
+- **CapRover** — built into the official One-Click Apps catalog: **Apps → One-Click Apps/Databases** → search **LibreDB Studio**. No third-party repo to add.
 - **PaaS** — one-click buttons for Koyeb & Render in the [GitHub README](https://github.com/libredb/libredb-studio#one-click-deploy).
 
 ---

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
   | **Desktop app (Debian/Ubuntu)** | `sudo apt install ./libredb-studio-desktop-<version>_amd64.deb` | Same desktop app, installed into the menu; needs no FUSE and takes WebKitGTK from the distribution. Not the server package — that one is `libredb-studio_<version>_<arch>.deb` |
   | **Desktop app (Flatpak)** | `flatpak --user remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo`<br>`flatpak --user install flatpark org.libredb.Studio` | Sandboxed desktop app from the [FlatPark](https://flatpark.org/) remote — no filesystem access at all; databases are reached over TCP. Developer-approved listing ([#241](https://github.com/libredb/libredb-studio/issues/241)) |
 
-  > Homebrew, deb/rpm, Snap, the Windows portable zip, winget/Chocolatey, the desktop AppImage and Debian package, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md).
+  > Homebrew, deb/rpm, Snap, the Windows portable zip, winget/Chocolatey, the desktop AppImage and Debian package, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md). Channel coverage scorecard (live / pending / categories) — [`docs/CHANNELS.md`](docs/CHANNELS.md).
 
   ### Quick Start (Docker)
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
   | **Desktop app (Debian/Ubuntu)** | `sudo apt install ./libredb-studio-desktop-<version>_amd64.deb` | Same desktop app, installed into the menu; needs no FUSE and takes WebKitGTK from the distribution. Not the server package — that one is `libredb-studio_<version>_<arch>.deb` |
   | **Desktop app (Flatpak)** | `flatpak --user remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo`<br>`flatpak --user install flatpark org.libredb.Studio` | Sandboxed desktop app from the [FlatPark](https://flatpark.org/) remote — no filesystem access at all; databases are reached over TCP. Developer-approved listing ([#241](https://github.com/libredb/libredb-studio/issues/241)) |
 
-  > Homebrew, deb/rpm, Snap, the Windows portable zip, winget/Chocolatey, the desktop AppImage and Debian package, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md). Channel coverage scorecard (live / pending / categories) — [`docs/CHANNELS.md`](docs/CHANNELS.md).
+  > Homebrew, deb/rpm, Snap, the Windows portable zip, winget/Chocolatey, the desktop AppImage and Debian package, and the npx launcher consume standalone artifacts attached to each GitHub release. Full per-channel guide — commands, configuration, systemd usage, and the Docker image tag model — in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md). Channel coverage scorecard (live / pending, by platform and category) — [`docs/CHANNELS.md`](docs/CHANNELS.md).
 
   ### Quick Start (Docker)
 

--- a/deploy/caprover/README.md
+++ b/deploy/caprover/README.md
@@ -10,32 +10,19 @@ This folder is the **source of truth** for deploying LibreDB Studio on
 | `libredb-studio.yml` | CapRover `captainVersion: 4` template (Docker-Compose + `caproverOneClickApp` block). |
 | `libredb-studio.png` | 256×256 app logo used by the CapRover one-click UI. |
 
-The same two files are published to two places:
+Both files are submitted as a PR to
+[`caprover/one-click-apps`](https://github.com/caprover/one-click-apps)
+(`public/v4/apps/libredb-studio.yml` + `public/v4/logos/libredb-studio.png`) —
+the official listing, merged and live.
 
-1. **Official repo** — submitted as a PR to
-   [`caprover/one-click-apps`](https://github.com/caprover/one-click-apps)
-   (`public/v4/apps/libredb-studio.yml` + `public/v4/logos/libredb-studio.png`).
-2. **LibreDB 3rd-party repo** — hosted by LibreDB so users can install
-   immediately, independent of the official repo's review queue.
-
-## Install (official repo, once merged)
+## Install (official one-click apps catalog)
 
 CapRover dashboard → **Apps → One-Click Apps/Databases** → search **LibreDB Studio**.
+No third-party repo to add.
 
-## Install (LibreDB 3rd-party repo, available now)
-
-CapRover dashboard → **Apps → One-Click Apps/Databases** → scroll to
-**3rd party repositories** → paste the URL below → **Connect New Repository** →
-search **LibreDB Studio**:
-
-```
-https://raw.githubusercontent.com/libredb/caprover-one-click-apps/main/public/
-```
-
-This raw URL is a stand-in while `https://libredb.org/caprover-one-click-apps` is
-not published (GitHub Pages is not enabled for that repo yet).
-
-Source for that repo: <https://github.com/libredb/caprover-one-click-apps>.
+The LibreDB 3rd-party repo that served this app while the official submission was
+in review is now retired. Source for that repo:
+<https://github.com/libredb/caprover-one-click-apps>.
 
 ## Install (manual template — works today, no repo needed)
 
@@ -67,8 +54,8 @@ Set these under the app's **App Configs** tab to extend the deployment:
 ## Maintaining this template
 
 When a new Studio version is released, bump the `defaultValue` of
-`$$cap_version` in `libredb-studio.yml` and re-publish to both repos. Validate
-locally with the CapRover repo's tooling:
+`$$cap_version` in `libredb-studio.yml` and submit an update PR to the official
+repo. Validate locally with the CapRover repo's tooling:
 
 ```bash
 npm ci && npm run validate_apps && npm run formatter

--- a/deploy/caprover/README.md
+++ b/deploy/caprover/README.md
@@ -29,8 +29,11 @@ CapRover dashboard → **Apps → One-Click Apps/Databases** → scroll to
 search **LibreDB Studio**:
 
 ```
-https://libredb.org/caprover-one-click-apps
+https://raw.githubusercontent.com/libredb/caprover-one-click-apps/main/public/
 ```
+
+This raw URL is a stand-in while `https://libredb.org/caprover-one-click-apps` is
+not published (GitHub Pages is not enabled for that repo yet).
 
 Source for that repo: <https://github.com/libredb/caprover-one-click-apps>.
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -2,13 +2,18 @@
 
 [`channels.yaml`](channels.yaml) is the human-maintained inventory of every place users can
 obtain LibreDB Studio - registries, package managers, PaaS catalogs, partner listings - with
-each channel's update policy, provenance links, and (where measurable) where its pinned
-version lives.
+each channel's business `category`, update policy, provenance links, and (where measurable)
+where its pinned version lives.
+
+Business / investment coverage (scorecard + full table): [`docs/CHANNELS.md`](../docs/CHANNELS.md)
+(`bun run distribution:matrix` to regenerate; `-- --check` for freshness).
 
 ```bash
 bun run distribution:check           # drift table for every live channel
 bun run distribution:check --strict  # gates owned every_release pins only
 bun run distribution:check --json    # machine-readable rows
+bun run distribution:matrix          # refresh docs/CHANNELS.md scorecard + table
+bun run distribution:matrix -- --check
 ```
 
 The weekly [`distribution-check.yml`](../.github/workflows/distribution-check.yml) workflow

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -6,14 +6,14 @@ each channel's business `category`, update policy, provenance links, and (where 
 where its pinned version lives.
 
 Business / investment coverage (scorecard + full table): [`docs/CHANNELS.md`](../docs/CHANNELS.md)
-(`bun run distribution:matrix` to regenerate; `-- --check` for freshness).
+(`bun run distribution:matrix` to regenerate; `--check` for freshness).
 
 ```bash
 bun run distribution:check           # drift table for every live channel
 bun run distribution:check --strict  # gates owned every_release pins only
 bun run distribution:check --json    # machine-readable rows
 bun run distribution:matrix          # refresh docs/CHANNELS.md scorecard + table
-bun run distribution:matrix -- --check
+bun run distribution:matrix --check
 ```
 
 The weekly [`distribution-check.yml`](../.github/workflows/distribution-check.yml) workflow

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -5,7 +5,7 @@ obtain LibreDB Studio - registries, package managers, PaaS catalogs, partner lis
 each channel's business `category`, update policy, provenance links, and (where measurable)
 where its pinned version lives.
 
-Business / investment coverage (scorecard + full table): [`docs/CHANNELS.md`](../docs/CHANNELS.md)
+Coverage matrix for users, developers and buyers (scorecard + full table): [`docs/CHANNELS.md`](../docs/CHANNELS.md)
 (`bun run distribution:matrix` to regenerate; `--check` for freshness).
 
 ```bash

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -9,6 +9,10 @@
 #
 # Field summary:
 #   id/name/status/tier/kind  identity; status: live | pending | deprecated
+#   category                  business bucket for docs/CHANNELS.md:
+#                             registries-releases | containers | kubernetes-operators |
+#                             package-managers | os-desktop | paas-one-click |
+#                             marketplaces-partners | closed
 #   update.method             ci_publish | commit | upstream_pr | manual_ui
 #   update.sla                every_release | minor_plus | major_only | on_demand
 #   update.ci_enabled         REQUIRED on, and allowed ONLY on, the switchable
@@ -40,6 +44,7 @@ channels:
   - id: github-release
     name: GitHub Releases (standalone tarballs, deb/rpm, snap assets)
     status: live
+    category: registries-releases
     tier: 0
     kind: release-assets
     update:
@@ -57,6 +62,7 @@ channels:
   - id: docker-ghcr
     name: Docker image (GHCR, canonical)
     status: live
+    category: containers
     tier: 0
     kind: container-image
     update:
@@ -76,6 +82,7 @@ channels:
   - id: docker-hub-mirror
     name: Docker Hub mirror (discoverability only)
     status: live
+    category: containers
     tier: 0
     kind: container-image
     update:
@@ -95,6 +102,7 @@ channels:
   - id: npm
     name: npm package @libredb/studio (library + npx launcher)
     status: live
+    category: registries-releases
     tier: 0
     kind: package-registry
     update:
@@ -115,6 +123,7 @@ channels:
   - id: helm
     name: Helm chart (libredb.org repo + GHCR OCI + ArtifactHub)
     status: live
+    category: kubernetes-operators
     tier: 1
     kind: helm-chart
     update:
@@ -135,6 +144,7 @@ channels:
   - id: homebrew
     name: Homebrew tap (libredb/tap/libredb-studio)
     status: live
+    category: package-managers
     tier: 1
     kind: package-manager
     update:
@@ -154,6 +164,7 @@ channels:
   - id: snap
     name: Snap Store (stable channel, amd64+arm64)
     status: live
+    category: package-managers
     tier: 1
     kind: package-manager
     update:
@@ -178,6 +189,7 @@ channels:
   - id: linux-deb-rpm
     name: Linux .deb / .rpm packages (release assets)
     status: live
+    category: os-desktop
     tier: 1
     kind: os-package
     update:
@@ -194,6 +206,7 @@ channels:
     # Quoted: an unquoted scalar containing ": " is a YAML mapping, not a string.
     name: "Desktop app (release assets: AppImage and GUI .deb, x64 + arm64)"
     status: live
+    category: os-desktop
     tier: 1
     kind: release-assets
     update:
@@ -217,6 +230,7 @@ channels:
   - id: caprover-local
     name: CapRover one-click template (in-repo source of truth)
     status: live
+    category: paas-one-click
     tier: 2
     kind: one-click-template
     update:
@@ -235,6 +249,7 @@ channels:
   - id: caprover-mirror
     name: CapRover 3rd-party repo (libredb.org/caprover-one-click-apps)
     status: live
+    category: paas-one-click
     tier: 2
     kind: one-click-template
     update:
@@ -252,6 +267,7 @@ channels:
   - id: railway-template
     name: Railway one-click template
     status: live
+    category: paas-one-click
     tier: 2
     kind: paas-template
     update:
@@ -274,6 +290,7 @@ channels:
   - id: koyeb-deploy-button
     name: Koyeb deploy button (repo README)
     status: live
+    category: paas-one-click
     tier: 2
     kind: deploy-button
     update:
@@ -288,6 +305,7 @@ channels:
   - id: fly-io
     name: Fly.io launch config (repo fly.toml)
     status: live
+    category: paas-one-click
     tier: 2
     kind: paas-template
     update:
@@ -307,6 +325,7 @@ channels:
   - id: render
     name: Render Blueprint (repo render.yaml)
     status: live
+    category: paas-one-click
     tier: 2
     kind: paas-template
     update:
@@ -324,6 +343,7 @@ channels:
   - id: caprover-official
     name: CapRover official one-click apps
     status: live
+    category: paas-one-click
     tier: 3
     kind: one-click-template
     update:
@@ -341,6 +361,7 @@ channels:
   - id: dokploy
     name: Dokploy template catalog
     status: live
+    category: paas-one-click
     tier: 3
     kind: paas-template
     update:
@@ -361,6 +382,7 @@ channels:
   - id: cosmos
     name: Cosmos servapp marketplace
     status: live
+    category: paas-one-click
     tier: 3
     kind: one-click-template
     update:
@@ -379,6 +401,7 @@ channels:
   - id: kubero
     name: Kubero template catalog
     status: live
+    category: paas-one-click
     tier: 3
     kind: paas-template
     update:
@@ -398,6 +421,7 @@ channels:
   - id: operatorhub-community
     name: OperatorHub / OpenShift community operator catalogs
     status: pending
+    category: kubernetes-operators
     tier: 3
     kind: operator-catalog
     update:
@@ -420,6 +444,7 @@ channels:
   - id: rancher-partner
     name: Rancher Partner Charts
     status: pending
+    category: kubernetes-operators
     tier: 4
     kind: partner-catalog
     update:
@@ -436,6 +461,7 @@ channels:
   - id: koyeb-catalog
     name: Koyeb One-Click Apps catalog (curated by Koyeb)
     status: pending
+    category: marketplaces-partners
     tier: 4
     kind: curated-catalog
     update:
@@ -450,6 +476,7 @@ channels:
   - id: digitalocean
     name: DigitalOcean Marketplace
     status: live
+    category: marketplaces-partners
     tier: 4
     kind: marketplace
     update:
@@ -466,6 +493,7 @@ channels:
   - id: winget
     name: winget community repository (LibreDB.Studio)
     status: live
+    category: package-managers
     tier: 4
     kind: package-manager
     update:
@@ -494,6 +522,7 @@ channels:
   - id: chocolatey
     name: Chocolatey community repository (libredb-studio)
     status: pending
+    category: package-managers
     tier: 4
     kind: package-manager
     update:
@@ -516,6 +545,7 @@ channels:
   - id: flathub
     name: Flathub community catalog (org.libredb.Studio)
     status: deprecated
+    category: closed
     tier: 4
     kind: package-manager
     update:
@@ -543,6 +573,7 @@ channels:
   - id: flatpark
     name: FlatPark signed Flatpak remote (org.libredb.Studio)
     status: live
+    category: package-managers
     tier: 4
     kind: package-manager
     update:

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -43,6 +43,7 @@ channels:
 
   - id: github-release
     name: GitHub Releases (standalone tarballs, deb/rpm, snap assets)
+    short_name: GitHub Releases
     status: live
     category: registries-releases
     platforms: [linux, macos, windows]
@@ -62,6 +63,7 @@ channels:
 
   - id: docker-ghcr
     name: Docker image (GHCR, canonical)
+    short_name: Docker image (GHCR)
     status: live
     category: containers
     platforms: [container]
@@ -83,6 +85,7 @@ channels:
 
   - id: docker-hub-mirror
     name: Docker Hub mirror (discoverability only)
+    short_name: Docker Hub mirror
     status: live
     category: containers
     platforms: [container]
@@ -104,6 +107,7 @@ channels:
 
   - id: npm
     name: npm package @libredb/studio (library + npx launcher)
+    short_name: npm @libredb/studio
     status: live
     category: registries-releases
     platforms: [linux, macos, windows]
@@ -126,6 +130,7 @@ channels:
 
   - id: helm
     name: Helm chart (libredb.org repo + GHCR OCI + ArtifactHub)
+    short_name: Helm chart
     status: live
     category: kubernetes-operators
     platforms: [kubernetes]
@@ -148,6 +153,7 @@ channels:
 
   - id: homebrew
     name: Homebrew tap (libredb/tap/libredb-studio)
+    short_name: Homebrew tap
     status: live
     category: package-managers
     platforms: [macos, linux]
@@ -169,6 +175,7 @@ channels:
 
   - id: snap
     name: Snap Store (stable channel, amd64+arm64)
+    short_name: Snap Store
     status: live
     category: package-managers
     platforms: [linux]
@@ -195,6 +202,7 @@ channels:
 
   - id: linux-deb-rpm
     name: Linux .deb / .rpm packages (release assets)
+    short_name: Linux .deb / .rpm
     status: live
     category: os-desktop
     platforms: [linux]
@@ -206,6 +214,7 @@ channels:
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/112
       first_pr: https://github.com/libredb/libredb-studio/pull/122
+      get: https://github.com/libredb/libredb-studio/releases/latest
     pin:
       strategy: none
       note: Built by nfpm from the tag in release-artifacts.yml; nothing to drift.
@@ -213,6 +222,7 @@ channels:
   - id: appimage
     # Quoted: an unquoted scalar containing ": " is a YAML mapping, not a string.
     name: "Desktop app (release assets: AppImage and GUI .deb, x64 + arm64)"
+    short_name: Desktop app (AppImage, .deb)
     status: live
     category: os-desktop
     platforms: [linux]
@@ -224,6 +234,7 @@ channels:
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/232
       first_pr: https://github.com/libredb/libredb-studio/pull/235
+      get: https://github.com/libredb/libredb-studio/releases/latest
       docs: desktop/README.md
     pin:
       strategy: none
@@ -238,6 +249,7 @@ channels:
 
   - id: caprover-local
     name: CapRover one-click template (in-repo source of truth)
+    short_name: CapRover template (in-repo)
     status: live
     category: paas-one-click
     platforms: [cloud]
@@ -249,6 +261,7 @@ channels:
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/56
       first_pr: https://github.com/libredb/libredb-studio/pull/57
+      get: https://github.com/libredb/libredb-studio/tree/main/deploy/caprover
       docs: deploy/caprover/README.md
     pin:
       strategy: local_file
@@ -258,6 +271,7 @@ channels:
 
   - id: caprover-mirror
     name: CapRover 3rd-party repo (libredb.org/caprover-one-click-apps)
+    short_name: CapRover 3rd-party repo
     status: live
     category: paas-one-click
     platforms: [cloud]
@@ -301,6 +315,7 @@ channels:
 
   - id: koyeb-deploy-button
     name: Koyeb deploy button (repo README)
+    short_name: Koyeb deploy button
     status: live
     category: paas-one-click
     platforms: [cloud]
@@ -310,6 +325,7 @@ channels:
       method: commit
       sla: on_demand
     links:
+      get: https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb
       docs: deploy/koyeb/README.md
     pin:
       strategy: none
@@ -317,6 +333,7 @@ channels:
 
   - id: fly-io
     name: Fly.io launch config (repo fly.toml)
+    short_name: Fly.io launch config
     status: live
     category: paas-one-click
     platforms: [cloud]
@@ -328,6 +345,7 @@ channels:
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/218
       first_pr: https://github.com/libredb/libredb-studio/pull/219
+      get: https://github.com/libredb/libredb-studio/blob/main/fly.toml
       docs: docs/FLY.md
     pin:
       strategy: local_file
@@ -338,6 +356,7 @@ channels:
 
   - id: render
     name: Render Blueprint (repo render.yaml)
+    short_name: Render Blueprint
     status: live
     category: paas-one-click
     platforms: [cloud]
@@ -357,6 +376,7 @@ channels:
 
   - id: caprover-official
     name: CapRover official one-click apps
+    short_name: CapRover official
     status: live
     category: paas-one-click
     platforms: [cloud]
@@ -439,6 +459,7 @@ channels:
 
   - id: operatorhub-community
     name: OperatorHub / OpenShift community operator catalogs
+    short_name: OperatorHub / OpenShift
     status: pending
     category: kubernetes-operators
     platforms: [kubernetes]
@@ -481,6 +502,7 @@ channels:
 
   - id: koyeb-catalog
     name: Koyeb One-Click Apps catalog (curated by Koyeb)
+    short_name: Koyeb One-Click Apps catalog
     status: pending
     category: marketplaces-partners
     platforms: [cloud]
@@ -515,6 +537,7 @@ channels:
 
   - id: winget
     name: winget community repository (LibreDB.Studio)
+    short_name: winget
     status: live
     category: package-managers
     platforms: [windows]
@@ -545,6 +568,7 @@ channels:
 
   - id: chocolatey
     name: Chocolatey community repository (libredb-studio)
+    short_name: Chocolatey
     status: pending
     category: package-managers
     platforms: [windows]
@@ -569,6 +593,7 @@ channels:
 
   - id: flathub
     name: Flathub community catalog (org.libredb.Studio)
+    short_name: Flathub
     status: deprecated
     category: closed
     platforms: [linux]
@@ -579,7 +604,6 @@ channels:
       sla: on_demand
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/232
-      upstream_repo: https://github.com/flathub/flathub
       first_pr: https://github.com/flathub/flathub/pull/9538
       docs: packaging/flatpak/README.md
     pin:
@@ -598,6 +622,7 @@ channels:
 
   - id: flatpark
     name: FlatPark signed Flatpak remote (org.libredb.Studio)
+    short_name: FlatPark (Flatpak)
     status: live
     category: package-managers
     platforms: [linux]

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -291,6 +291,7 @@ channels:
       sla: on_demand
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/56
+      get: https://github.com/libredb/caprover-one-click-apps
       catalog: https://libredb.org/caprover-one-click-apps
       upstream_repo: https://github.com/libredb/caprover-one-click-apps
     pin:

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -13,6 +13,11 @@
 #                             registries-releases | containers | kubernetes-operators |
 #                             package-managers | os-desktop | paas-one-click |
 #                             marketplaces-partners | closed
+#   platforms                 REQUIRED, non-empty list. Rendered and counted in
+#                             this canonical order in docs/CHANNELS.md:
+#                             linux | macos | windows | container | kubernetes | cloud
+#   short_name                optional; the display name docs/CHANNELS.md uses when
+#                             `name` is too long to scan. Falls back to `name`.
 #   update.method             ci_publish | commit | upstream_pr | manual_ui
 #   update.sla                every_release | minor_plus | major_only | on_demand
 #   update.ci_enabled         REQUIRED on, and allowed ONLY on, the switchable
@@ -25,7 +30,9 @@
 #                             required release assets have no flag on purpose.
 #   links                     tracking_issue / first_pr / last_bump_pr (nullable
 #                             until the first post-listing bump) / catalog /
-#                             upstream_repo / docs
+#                             upstream_repo / docs / get (user-facing "where do I
+#                             get it"; docs/CHANNELS.md resolves it as
+#                             get > catalog > upstream_repo)
 #   pin.strategy              local_file | remote_file | probe | none
 #   pin.probe                 required when strategy == probe; one of the probe ids
 #                             defined in scripts/distribution-check.mjs

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -256,32 +256,10 @@ channels:
 
   # ---- Tier 2: LibreDB-owned copies and listings, bumped by hand ----------
 
-  - id: caprover-local
-    name: CapRover one-click template (in-repo source of truth)
-    short_name: CapRover template (in-repo)
-    status: live
-    category: paas-one-click
-    platforms: [cloud]
-    tier: 2
-    kind: one-click-template
-    update:
-      method: commit
-      sla: on_demand
-    links:
-      tracking_issue: https://github.com/libredb/libredb-studio/issues/56
-      first_pr: https://github.com/libredb/libredb-studio/pull/57
-      get: https://github.com/libredb/libredb-studio/tree/main/deploy/caprover
-      docs: deploy/caprover/README.md
-    pin:
-      strategy: local_file
-      files:
-        - deploy/caprover/libredb-studio.yml
-      extract: "defaultValue: '(\\d+\\.\\d+\\.\\d+)'"
-
   - id: caprover-mirror
     name: CapRover 3rd-party repo (libredb.org/caprover-one-click-apps)
     short_name: CapRover 3rd-party repo
-    status: live
+    status: deprecated
     category: paas-one-click
     platforms: [cloud]
     tier: 2
@@ -291,13 +269,14 @@ channels:
       sla: on_demand
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/56
-      get: https://github.com/libredb/caprover-one-click-apps
       catalog: https://libredb.org/caprover-one-click-apps
       upstream_repo: https://github.com/libredb/caprover-one-click-apps
     pin:
-      strategy: remote_file
-      url: https://raw.githubusercontent.com/libredb/caprover-one-click-apps/main/public/v4/apps/libredb-studio.yml
-      extract: "defaultValue: '(\\d+\\.\\d+\\.\\d+)'"
+      strategy: none
+      note: This was a LibreDB-owned CapRover repo, published while the official catalog submission
+        (#56) was in review. The official listing (caprover-official) is now live, so this
+        fallback is retired. The libredb.org/caprover-one-click-apps path it was served from is not
+        currently published.
 
   - id: railway-template
     name: Railway one-click template

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -604,6 +604,7 @@ channels:
       sla: on_demand
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/232
+      upstream_repo: https://github.com/flathub/flathub
       first_pr: https://github.com/flathub/flathub/pull/9538
       docs: packaging/flatpak/README.md
     pin:

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -11,8 +11,8 @@
 #   id/name/status/tier/kind  identity; status: live | pending | deprecated
 #   category                  business bucket for docs/CHANNELS.md:
 #                             registries-releases | containers | kubernetes-operators |
-#                             package-managers | os-desktop | paas-one-click |
-#                             marketplaces-partners | closed
+#                             package-managers | os-desktop | paas-catalogs |
+#                             deploy-recipes | cloud-marketplaces | closed
 #   platforms                 REQUIRED, non-empty list. Rendered and counted in
 #                             this canonical order in docs/CHANNELS.md:
 #                             linux | macos | windows | container | kubernetes | cloud
@@ -260,7 +260,7 @@ channels:
     name: CapRover 3rd-party repo (libredb.org/caprover-one-click-apps)
     short_name: CapRover 3rd-party repo
     status: deprecated
-    category: paas-one-click
+    category: paas-catalogs
     platforms: [cloud]
     tier: 2
     kind: one-click-template
@@ -281,7 +281,7 @@ channels:
   - id: railway-template
     name: Railway one-click template
     status: live
-    category: paas-one-click
+    category: paas-catalogs
     platforms: [cloud]
     tier: 2
     kind: paas-template
@@ -306,7 +306,7 @@ channels:
     name: Koyeb deploy button (repo README)
     short_name: Koyeb deploy button
     status: live
-    category: paas-one-click
+    category: deploy-recipes
     platforms: [cloud]
     tier: 2
     kind: deploy-button
@@ -324,7 +324,7 @@ channels:
     name: Fly.io launch config (repo fly.toml)
     short_name: Fly.io launch config
     status: live
-    category: paas-one-click
+    category: deploy-recipes
     platforms: [cloud]
     tier: 2
     kind: paas-template
@@ -347,7 +347,7 @@ channels:
     name: Render Blueprint (repo render.yaml)
     short_name: Render Blueprint
     status: live
-    category: paas-one-click
+    category: deploy-recipes
     platforms: [cloud]
     tier: 2
     kind: paas-template
@@ -355,7 +355,7 @@ channels:
       method: commit
       sla: on_demand
     links:
-      catalog: https://render.com/deploy?repo=https://github.com/libredb/libredb-studio
+      get: https://github.com/libredb/libredb-studio/blob/main/render.yaml
       docs: docs/DISTRIBUTION.md
     pin:
       strategy: none
@@ -367,7 +367,7 @@ channels:
     name: CapRover official one-click apps
     short_name: CapRover official
     status: live
-    category: paas-one-click
+    category: paas-catalogs
     platforms: [cloud]
     tier: 3
     kind: one-click-template
@@ -386,7 +386,7 @@ channels:
   - id: dokploy
     name: Dokploy template catalog
     status: live
-    category: paas-one-click
+    category: paas-catalogs
     platforms: [cloud]
     tier: 3
     kind: paas-template
@@ -408,7 +408,7 @@ channels:
   - id: cosmos
     name: Cosmos servapp marketplace
     status: live
-    category: paas-one-click
+    category: paas-catalogs
     platforms: [cloud]
     tier: 3
     kind: one-click-template
@@ -428,7 +428,7 @@ channels:
   - id: kubero
     name: Kubero template catalog
     status: live
-    category: paas-one-click
+    category: paas-catalogs
     platforms: [cloud]
     tier: 3
     kind: paas-template
@@ -493,7 +493,7 @@ channels:
     name: Koyeb One-Click Apps catalog (curated by Koyeb)
     short_name: Koyeb One-Click Apps catalog
     status: pending
-    category: marketplaces-partners
+    category: cloud-marketplaces
     platforms: [cloud]
     tier: 4
     kind: curated-catalog
@@ -509,7 +509,7 @@ channels:
   - id: digitalocean
     name: DigitalOcean Marketplace
     status: live
-    category: marketplaces-partners
+    category: cloud-marketplaces
     platforms: [cloud]
     tier: 4
     kind: marketplace

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -13,6 +13,8 @@
 #                             registries-releases | containers | kubernetes-operators |
 #                             package-managers | os-desktop | paas-one-click |
 #                             marketplaces-partners | closed
+#   platforms                 non-empty list of platforms this channel serves:
+#                             linux | macos | windows | container | kubernetes | cloud
 #   update.method             ci_publish | commit | upstream_pr | manual_ui
 #   update.sla                every_release | minor_plus | major_only | on_demand
 #   update.ci_enabled         REQUIRED on, and allowed ONLY on, the switchable
@@ -45,6 +47,7 @@ channels:
     name: GitHub Releases (standalone tarballs, deb/rpm, snap assets)
     status: live
     category: registries-releases
+    platforms: [linux, macos, windows]
     tier: 0
     kind: release-assets
     update:
@@ -63,6 +66,7 @@ channels:
     name: Docker image (GHCR, canonical)
     status: live
     category: containers
+    platforms: [container]
     tier: 0
     kind: container-image
     update:
@@ -83,6 +87,7 @@ channels:
     name: Docker Hub mirror (discoverability only)
     status: live
     category: containers
+    platforms: [container]
     tier: 0
     kind: container-image
     update:
@@ -103,6 +108,7 @@ channels:
     name: npm package @libredb/studio (library + npx launcher)
     status: live
     category: registries-releases
+    platforms: [linux, macos, windows]
     tier: 0
     kind: package-registry
     update:
@@ -124,6 +130,7 @@ channels:
     name: Helm chart (libredb.org repo + GHCR OCI + ArtifactHub)
     status: live
     category: kubernetes-operators
+    platforms: [kubernetes]
     tier: 1
     kind: helm-chart
     update:
@@ -145,6 +152,7 @@ channels:
     name: Homebrew tap (libredb/tap/libredb-studio)
     status: live
     category: package-managers
+    platforms: [macos, linux]
     tier: 1
     kind: package-manager
     update:
@@ -165,6 +173,7 @@ channels:
     name: Snap Store (stable channel, amd64+arm64)
     status: live
     category: package-managers
+    platforms: [linux]
     tier: 1
     kind: package-manager
     update:
@@ -190,6 +199,7 @@ channels:
     name: Linux .deb / .rpm packages (release assets)
     status: live
     category: os-desktop
+    platforms: [linux]
     tier: 1
     kind: os-package
     update:
@@ -207,6 +217,7 @@ channels:
     name: "Desktop app (release assets: AppImage and GUI .deb, x64 + arm64)"
     status: live
     category: os-desktop
+    platforms: [linux]
     tier: 1
     kind: release-assets
     update:
@@ -231,6 +242,7 @@ channels:
     name: CapRover one-click template (in-repo source of truth)
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 2
     kind: one-click-template
     update:
@@ -250,6 +262,7 @@ channels:
     name: CapRover 3rd-party repo (libredb.org/caprover-one-click-apps)
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 2
     kind: one-click-template
     update:
@@ -268,6 +281,7 @@ channels:
     name: Railway one-click template
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 2
     kind: paas-template
     update:
@@ -291,6 +305,7 @@ channels:
     name: Koyeb deploy button (repo README)
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 2
     kind: deploy-button
     update:
@@ -306,6 +321,7 @@ channels:
     name: Fly.io launch config (repo fly.toml)
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 2
     kind: paas-template
     update:
@@ -326,6 +342,7 @@ channels:
     name: Render Blueprint (repo render.yaml)
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 2
     kind: paas-template
     update:
@@ -344,6 +361,7 @@ channels:
     name: CapRover official one-click apps
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 3
     kind: one-click-template
     update:
@@ -362,6 +380,7 @@ channels:
     name: Dokploy template catalog
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 3
     kind: paas-template
     update:
@@ -383,6 +402,7 @@ channels:
     name: Cosmos servapp marketplace
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 3
     kind: one-click-template
     update:
@@ -402,6 +422,7 @@ channels:
     name: Kubero template catalog
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 3
     kind: paas-template
     update:
@@ -422,6 +443,7 @@ channels:
     name: OperatorHub / OpenShift community operator catalogs
     status: pending
     category: kubernetes-operators
+    platforms: [kubernetes]
     tier: 3
     kind: operator-catalog
     update:
@@ -445,6 +467,7 @@ channels:
     name: Rancher Partner Charts
     status: pending
     category: kubernetes-operators
+    platforms: [kubernetes]
     tier: 4
     kind: partner-catalog
     update:
@@ -462,6 +485,7 @@ channels:
     name: Koyeb One-Click Apps catalog (curated by Koyeb)
     status: pending
     category: marketplaces-partners
+    platforms: [cloud]
     tier: 4
     kind: curated-catalog
     update:
@@ -477,6 +501,7 @@ channels:
     name: DigitalOcean Marketplace
     status: live
     category: marketplaces-partners
+    platforms: [cloud]
     tier: 4
     kind: marketplace
     update:
@@ -494,6 +519,7 @@ channels:
     name: winget community repository (LibreDB.Studio)
     status: live
     category: package-managers
+    platforms: [windows]
     tier: 4
     kind: package-manager
     update:
@@ -523,6 +549,7 @@ channels:
     name: Chocolatey community repository (libredb-studio)
     status: pending
     category: package-managers
+    platforms: [windows]
     tier: 4
     kind: package-manager
     update:
@@ -546,6 +573,7 @@ channels:
     name: Flathub community catalog (org.libredb.Studio)
     status: deprecated
     category: closed
+    platforms: [linux]
     tier: 4
     kind: package-manager
     update:
@@ -574,6 +602,7 @@ channels:
     name: FlatPark signed Flatpak remote (org.libredb.Studio)
     status: live
     category: package-managers
+    platforms: [linux]
     tier: 4
     kind: package-manager
     update:

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -8,11 +8,18 @@
 # check").
 #
 # Field summary:
-#   id/name/status/tier/kind  identity; status: live | pending | deprecated
+#   id/name/status/tier       identity; status: live | pending | deprecated
+#   kind                      the technical shape of the artefact (what it
+#                             literally is), independent of category (the audience-facing
+#                             bucket several kinds can share): one of release-assets |
+#                             container-image | package-registry | helm-chart |
+#                             package-manager | os-package | one-click-template |
+#                             paas-template | deploy-button | operator-catalog |
+#                             partner-catalog | curated-catalog | marketplace
 #   category                  business bucket for docs/CHANNELS.md:
 #                             registries-releases | containers | kubernetes-operators |
 #                             package-managers | os-desktop | paas-catalogs |
-#                             deploy-recipes | cloud-marketplaces | closed
+#                             deploy-recipes | cloud-marketplaces
 #   platforms                 REQUIRED, non-empty list. Rendered and counted in
 #                             this canonical order in docs/CHANNELS.md:
 #                             linux | macos | windows | container | kubernetes | cloud
@@ -584,7 +591,7 @@ channels:
     name: Flathub community catalog (org.libredb.Studio)
     short_name: Flathub
     status: deprecated
-    category: closed
+    category: package-managers
     platforms: [linux]
     tier: 4
     kind: package-manager

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -13,8 +13,6 @@
 #                             registries-releases | containers | kubernetes-operators |
 #                             package-managers | os-desktop | paas-one-click |
 #                             marketplaces-partners | closed
-#   platforms                 non-empty list of platforms this channel serves:
-#                             linux | macos | windows | container | kubernetes | cloud
 #   update.method             ci_publish | commit | upstream_pr | manual_ui
 #   update.sla                every_release | minor_plus | major_only | on_demand
 #   update.ci_enabled         REQUIRED on, and allowed ONLY on, the switchable

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -32,7 +32,9 @@
 #                             until the first post-listing bump) / catalog /
 #                             upstream_repo / docs / get (user-facing "where do I
 #                             get it"; docs/CHANNELS.md resolves it as
-#                             get > catalog > upstream_repo)
+#                             get > catalog > upstream_repo, except a deprecated
+#                             channel renders no link at all, whatever these
+#                             fields hold)
 #   pin.strategy              local_file | remote_file | probe | none
 #   pin.probe                 required when strategy == probe; one of the probe ids
 #                             defined in scripts/distribution-check.mjs

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -7,10 +7,11 @@ machine-readable inventory behind this page is
 [`distribution/channels.yaml`](../distribution/channels.yaml).
 
 **Users** — find your platform in the Platform column, then follow the Guide link
-for the exact command.
+for the install or deploy steps.
 
 **Developers** — the Updates column says whether release CI publishes the channel
-or a human opens a pull request. New channels are added in
+or a human updates it by hand, and how quickly it is expected to follow a release.
+New channels are added in
 [`distribution/channels.yaml`](../distribution/channels.yaml).
 
 **Buyers, investors, supporters** — the snapshot below is the coverage claim.
@@ -22,8 +23,9 @@ or a human opens a pull request. New channels are added in
 | `pending` | Submission or first listing in progress |
 | `deprecated` | Closed or declined — kept for honesty (for example Flathub) |
 
-A channel that serves several platforms is counted once per platform, so the
-platform numbers overlap and do not sum to the channel total.
+Platform counts cover live channels only, and a channel serving several
+platforms is counted once for each — so they overlap, and their sum is not a
+channel count.
 
 <!-- BEGIN:CHANNEL-SCORECARD -->
 

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -31,9 +31,9 @@ channel count.
 
 ## Coverage snapshot
 
-**27 channels · 22 live · 4 pending · 1 deprecated**
+**26 channels · 20 live · 4 pending · 2 deprecated**
 
-Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · Kubernetes 1 · Cloud 11**
+Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · Kubernetes 1 · Cloud 9**
 
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
@@ -42,7 +42,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | Kubernetes & operators | 1 | 2 | 0 |
 | Package managers | 4 | 1 | 0 |
 | OS / desktop packages | 2 | 0 | 0 |
-| PaaS & one-click | 10 | 0 | 0 |
+| PaaS & one-click | 8 | 0 | 1 |
 | Marketplaces & partners | 1 | 1 | 0 |
 | Closed / declined | 0 | 0 | 1 |
 
@@ -68,8 +68,6 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | [Chocolatey](https://community.chocolatey.org/packages/libredb-studio) | Package managers | Windows | pending | Automated (paused), every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Desktop app (AppImage, .deb)](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [desktop/README.md](../desktop/README.md) |
 | [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [CapRover template (in-repo)](https://github.com/libredb/libredb-studio/tree/main/deploy/caprover) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/caprover/README.md](../deploy/caprover/README.md) |
-| [CapRover 3rd-party repo](https://github.com/libredb/caprover-one-click-apps) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [CapRover official](https://github.com/caprover/one-click-apps) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
 | [Dokploy template catalog](https://templates.dokploy.com) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |
@@ -78,6 +76,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | [Kubero template catalog](https://www.kubero.dev/templates) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/kubero/README.md](../deploy/kubero/README.md) |
 | [Railway one-click template](https://railway.com/deploy/libredb-studio) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
 | [Render Blueprint](https://render.com/deploy?repo=https://github.com/libredb/libredb-studio) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| CapRover 3rd-party repo | PaaS & one-click | Cloud | deprecated | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/libredb-studio) | Marketplaces & partners | Cloud | live | Manual, on demand | [deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
 | [Koyeb One-Click Apps catalog](https://www.koyeb.com/deploy) | Marketplaces & partners | Cloud | pending | Manual, on demand | [deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
 | Flathub | Closed / declined | Linux | deprecated | — | [packaging/flatpak/README.md](../packaging/flatpak/README.md) |

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -25,6 +25,8 @@ To propose a new channel, add an entry to `distribution/channels.yaml` (with a
 
 **27 channels · 22 live · 4 pending · 1 deprecated**
 
+Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · Kubernetes 1 · Cloud 11**
+
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
 | Registries & releases | 2 | 0 | 0 |
@@ -35,8 +37,6 @@ To propose a new channel, add an entry to `distribution/channels.yaml` (with a
 | PaaS & one-click | 10 | 0 | 0 |
 | Marketplaces & partners | 1 | 1 | 0 |
 | Closed / declined | 0 | 0 | 1 |
-
-Coverage: Registries & releases; Containers; Kubernetes & operators; Package managers; OS / desktop packages; PaaS & one-click; Marketplaces & partners; Closed / declined.
 
 <!-- END:CHANNEL-SCORECARD -->
 

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -44,35 +44,35 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 
 <!-- BEGIN:CHANNEL-TABLE -->
 
-| Channel | Category | Status | Update | Catalog | Docs |
+| Channel | Category | Platform | Status | Updates | Guide |
 | --- | --- | --- | --- | --- | --- |
-| GitHub Releases (standalone tarballs, deb/rpm, snap assets) | Registries & releases | live | Every release | [link](https://github.com/libredb/libredb-studio/releases) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| npm package @libredb/studio (library + npx launcher) | Registries & releases | live | Every release | [link](https://www.npmjs.com/package/@libredb/studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| Docker image (GHCR, canonical) | Containers | live | Every release | [link](https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| Docker Hub mirror (discoverability only) | Containers | live | Every release | [link](https://hub.docker.com/r/libredb/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| Helm chart (libredb.org repo + GHCR OCI + ArtifactHub) | Kubernetes & operators | live | Every release | [link](https://artifacthub.io/packages/helm/libredb-studio/libredb-studio) | [HELM_CHART.md](HELM_CHART.md) |
-| OperatorHub / OpenShift community operator catalogs | Kubernetes & operators | pending | Every release | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| Rancher Partner Charts | Kubernetes & operators | pending | On demand | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| FlatPark signed Flatpak remote (org.libredb.Studio) | Package managers | live | Every release | [link](https://flatpark.org/) | [../packaging/flatpark/README.md](../packaging/flatpark/README.md) |
-| Homebrew tap (libredb/tap/libredb-studio) | Package managers | live | Every release | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| Snap Store (stable channel, amd64+arm64) | Package managers | live | Every release | [link](https://snapcraft.io/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| winget community repository (LibreDB.Studio) | Package managers | live | Every release | [link](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/LibreDB/Studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| Chocolatey community repository (libredb-studio) | Package managers | pending | Every release | [link](https://community.chocolatey.org/packages/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| Desktop app (release assets: AppImage and GUI .deb, x64 + arm64) | OS / desktop packages | live | Every release | — | [../desktop/README.md](../desktop/README.md) |
-| Linux .deb / .rpm packages (release assets) | OS / desktop packages | live | Every release | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| CapRover one-click template (in-repo source of truth) | PaaS & one-click | live | On demand | — | [../deploy/caprover/README.md](../deploy/caprover/README.md) |
-| CapRover 3rd-party repo (libredb.org/caprover-one-click-apps) | PaaS & one-click | live | On demand | [link](https://libredb.org/caprover-one-click-apps) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| CapRover official one-click apps | PaaS & one-click | live | On demand | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| Cosmos servapp marketplace | PaaS & one-click | live | On demand | — | [../deploy/cosmos/README.md](../deploy/cosmos/README.md) |
-| Dokploy template catalog | PaaS & one-click | live | On demand | [link](https://templates.dokploy.com) | [../deploy/dokploy/README.md](../deploy/dokploy/README.md) |
-| Fly.io launch config (repo fly.toml) | PaaS & one-click | live | On demand | — | [FLY.md](FLY.md) |
-| Koyeb deploy button (repo README) | PaaS & one-click | live | On demand | — | [../deploy/koyeb/README.md](../deploy/koyeb/README.md) |
-| Kubero template catalog | PaaS & one-click | live | On demand | [link](https://www.kubero.dev/templates) | [../deploy/kubero/README.md](../deploy/kubero/README.md) |
-| Railway one-click template | PaaS & one-click | live | On demand | [link](https://railway.com/deploy/libredb-studio) | [../deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
-| Render Blueprint (repo render.yaml) | PaaS & one-click | live | On demand | [link](https://render.com/deploy?repo=https://github.com/libredb/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| DigitalOcean Marketplace | Marketplaces & partners | live | On demand | [link](https://marketplace.digitalocean.com/apps/libredb-studio) | [../deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
-| Koyeb One-Click Apps catalog (curated by Koyeb) | Marketplaces & partners | pending | On demand | [link](https://www.koyeb.com/deploy) | [../deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
-| Flathub community catalog (org.libredb.Studio) | Closed / declined | deprecated | On demand | — | [../packaging/flatpak/README.md](../packaging/flatpak/README.md) |
+| [GitHub Releases](https://github.com/libredb/libredb-studio/releases) | Registries & releases | Linux, macOS, Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [npm @libredb/studio](https://www.npmjs.com/package/@libredb/studio) | Registries & releases | Linux, macOS, Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Docker image (GHCR)](https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio) | Containers | Container | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Docker Hub mirror](https://hub.docker.com/r/libredb/libredb-studio) | Containers | Container | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Helm chart](https://artifacthub.io/packages/helm/libredb-studio/libredb-studio) | Kubernetes & operators | Kubernetes | live | Automated, every release | [HELM_CHART.md](HELM_CHART.md) |
+| [OperatorHub / OpenShift](https://github.com/redhat-openshift-ecosystem/community-operators-prod) | Kubernetes & operators | Kubernetes | pending | Manual, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Rancher Partner Charts](https://github.com/rancher/partner-charts) | Kubernetes & operators | Kubernetes | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [FlatPark (Flatpak)](https://flatpark.org/) | Package managers | Linux | live | Manual, every release | [packaging/flatpark/README.md](../packaging/flatpark/README.md) |
+| [Homebrew tap](https://github.com/libredb/homebrew-tap) | Package managers | Linux, macOS | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Snap Store](https://snapcraft.io/libredb-studio) | Package managers | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [winget](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/LibreDB/Studio) | Package managers | Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Chocolatey](https://community.chocolatey.org/packages/libredb-studio) | Package managers | Windows | pending | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Desktop app (AppImage, .deb)](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [desktop/README.md](../desktop/README.md) |
+| [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [CapRover template (in-repo)](https://github.com/libredb/libredb-studio/tree/main/deploy/caprover) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/caprover/README.md](../deploy/caprover/README.md) |
+| [CapRover 3rd-party repo](https://libredb.org/caprover-one-click-apps) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [CapRover official](https://github.com/caprover/one-click-apps) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
+| [Dokploy template catalog](https://templates.dokploy.com) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |
+| [Fly.io launch config](https://github.com/libredb/libredb-studio/blob/main/fly.toml) | PaaS & one-click | Cloud | live | Manual, on demand | [FLY.md](FLY.md) |
+| [Koyeb deploy button](https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/koyeb/README.md](../deploy/koyeb/README.md) |
+| [Kubero template catalog](https://www.kubero.dev/templates) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/kubero/README.md](../deploy/kubero/README.md) |
+| [Railway one-click template](https://railway.com/deploy/libredb-studio) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
+| [Render Blueprint](https://render.com/deploy?repo=https://github.com/libredb/libredb-studio) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/libredb-studio) | Marketplaces & partners | Cloud | live | Manual, on demand | [deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
+| [Koyeb One-Click Apps catalog](https://www.koyeb.com/deploy) | Marketplaces & partners | Cloud | pending | Manual, on demand | [deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
+| Flathub | Closed / declined | Linux | deprecated | — | [packaging/flatpak/README.md](../packaging/flatpak/README.md) |
 
 <!-- END:CHANNEL-TABLE -->
 

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -1,23 +1,29 @@
 # Distribution channels
 
-This page is the **business / investment visibility matrix** for LibreDB Studio:
-how many places the product can be obtained from, which are live today, and how
-they group by audience-facing category.
-
-It is aimed at buyers evaluating coverage, investors and supporters assessing
-distribution footprint, and curious users who want a single overview. For
-install and operate instructions, use [DISTRIBUTION.md](DISTRIBUTION.md). The
-machine-readable inventory (and drift checker) lives in
+This page is the coverage matrix for LibreDB Studio: every place the product can
+be obtained from, which of them are live today, and which platforms they serve.
+For install and operate instructions, use [DISTRIBUTION.md](DISTRIBUTION.md). The
+machine-readable inventory behind this page is
 [`distribution/channels.yaml`](../distribution/channels.yaml).
+
+**Users** — find your platform in the Platform column, then follow the Guide link
+for the exact command.
+
+**Developers** — the Updates column says whether release CI publishes the channel
+or a human opens a pull request. New channels are added in
+[`distribution/channels.yaml`](../distribution/channels.yaml).
+
+**Buyers, investors, supporters** — the snapshot below is the coverage claim.
+`pending` and `deprecated` rows are listed on purpose, not hidden.
 
 | Status | Meaning |
 | --- | --- |
 | `live` | Listed and installable (or deployable) through that channel |
 | `pending` | Submission or first listing in progress |
-| `deprecated` | Closed / declined — kept for honesty (e.g. Flathub) |
+| `deprecated` | Closed or declined — kept for honesty (for example Flathub) |
 
-To propose a new channel, add an entry to `distribution/channels.yaml` (with a
-`category`) and regenerate this page with `bun run distribution:matrix`.
+A channel that serves several platforms is counted once per platform, so the
+platform numbers overlap and do not sum to the channel total.
 
 <!-- BEGIN:CHANNEL-SCORECARD -->
 
@@ -76,6 +82,8 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 
 <!-- END:CHANNEL-TABLE -->
 
-The scorecard and table above are generated from `distribution/channels.yaml`.
-Do not edit them by hand — run `bun run distribution:matrix` after inventory
-changes. Freshness is checked with `bun run distribution:matrix -- --check`.
+The scorecard and table above are generated from
+[`distribution/channels.yaml`](../distribution/channels.yaml). Do not edit them by
+hand. To propose a new channel, add an entry with a `category` and a `platforms`
+list, then run `bun run distribution:matrix`. Freshness is enforced on pull
+requests with `bun run distribution:matrix --check`.

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -40,12 +40,11 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | Registries & releases | 2 | 0 | 0 |
 | Containers | 2 | 0 | 0 |
 | Kubernetes & operators | 1 | 2 | 0 |
-| Package managers | 4 | 1 | 0 |
+| Package managers | 4 | 1 | 1 |
 | OS / desktop packages | 2 | 0 | 0 |
 | PaaS catalogs (listed) | 5 | 0 | 1 |
 | Deploy recipes | 3 | 0 | 0 |
 | Cloud marketplaces | 1 | 1 | 0 |
-| Closed / declined | 0 | 0 | 1 |
 
 <!-- END:CHANNEL-SCORECARD -->
 
@@ -67,6 +66,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | [Snap Store](https://snapcraft.io/libredb-studio) | Package managers | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [winget](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/LibreDB/Studio) | Package managers | Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Chocolatey](https://community.chocolatey.org/packages/libredb-studio) | Package managers | Windows | pending | Automated (paused), every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Flathub | Package managers | Linux | deprecated | — | [packaging/flatpak/README.md](../packaging/flatpak/README.md) |
 | [Desktop app (AppImage, .deb)](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [desktop/README.md](../desktop/README.md) |
 | [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [CapRover official](https://github.com/caprover/one-click-apps) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
@@ -80,7 +80,6 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | [Render Blueprint](https://github.com/libredb/libredb-studio/blob/main/render.yaml) | Deploy recipes | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/libredb-studio) | Cloud marketplaces | Cloud | live | Manual, on demand | [deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
 | [Koyeb One-Click Apps catalog](https://www.koyeb.com/deploy) | Cloud marketplaces | Cloud | pending | Manual, on demand | [deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
-| Flathub | Closed / declined | Linux | deprecated | — | [packaging/flatpak/README.md](../packaging/flatpak/README.md) |
 
 <!-- END:CHANNEL-TABLE -->
 

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -42,8 +42,9 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | Kubernetes & operators | 1 | 2 | 0 |
 | Package managers | 4 | 1 | 0 |
 | OS / desktop packages | 2 | 0 | 0 |
-| PaaS & one-click | 8 | 0 | 1 |
-| Marketplaces & partners | 1 | 1 | 0 |
+| PaaS catalogs (listed) | 5 | 0 | 1 |
+| Deploy recipes | 3 | 0 | 0 |
+| Cloud marketplaces | 1 | 1 | 0 |
 | Closed / declined | 0 | 0 | 1 |
 
 <!-- END:CHANNEL-SCORECARD -->
@@ -68,17 +69,17 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | [Chocolatey](https://community.chocolatey.org/packages/libredb-studio) | Package managers | Windows | pending | Automated (paused), every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Desktop app (AppImage, .deb)](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [desktop/README.md](../desktop/README.md) |
 | [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [CapRover official](https://github.com/caprover/one-click-apps) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
-| [Dokploy template catalog](https://templates.dokploy.com) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |
-| [Fly.io launch config](https://github.com/libredb/libredb-studio/blob/main/fly.toml) | PaaS & one-click | Cloud | live | Manual, on demand | [FLY.md](FLY.md) |
-| [Koyeb deploy button](https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/koyeb/README.md](../deploy/koyeb/README.md) |
-| [Kubero template catalog](https://www.kubero.dev/templates) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/kubero/README.md](../deploy/kubero/README.md) |
-| [Railway one-click template](https://railway.com/deploy/libredb-studio) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
-| [Render Blueprint](https://render.com/deploy?repo=https://github.com/libredb/libredb-studio) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| CapRover 3rd-party repo | PaaS & one-click | Cloud | deprecated | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/libredb-studio) | Marketplaces & partners | Cloud | live | Manual, on demand | [deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
-| [Koyeb One-Click Apps catalog](https://www.koyeb.com/deploy) | Marketplaces & partners | Cloud | pending | Manual, on demand | [deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
+| [CapRover official](https://github.com/caprover/one-click-apps) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
+| [Dokploy template catalog](https://templates.dokploy.com) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |
+| [Kubero template catalog](https://www.kubero.dev/templates) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/kubero/README.md](../deploy/kubero/README.md) |
+| [Railway one-click template](https://railway.com/deploy/libredb-studio) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
+| CapRover 3rd-party repo | PaaS catalogs (listed) | Cloud | deprecated | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Fly.io launch config](https://github.com/libredb/libredb-studio/blob/main/fly.toml) | Deploy recipes | Cloud | live | Manual, on demand | [FLY.md](FLY.md) |
+| [Koyeb deploy button](https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb) | Deploy recipes | Cloud | live | Manual, on demand | [deploy/koyeb/README.md](../deploy/koyeb/README.md) |
+| [Render Blueprint](https://github.com/libredb/libredb-studio/blob/main/render.yaml) | Deploy recipes | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/libredb-studio) | Cloud marketplaces | Cloud | live | Manual, on demand | [deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
+| [Koyeb One-Click Apps catalog](https://www.koyeb.com/deploy) | Cloud marketplaces | Cloud | pending | Manual, on demand | [deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
 | Flathub | Closed / declined | Linux | deprecated | — | [packaging/flatpak/README.md](../packaging/flatpak/README.md) |
 
 <!-- END:CHANNEL-TABLE -->
@@ -88,3 +89,6 @@ The scorecard and table above are generated from
 hand. To propose a new channel, add an entry with a `category` and a `platforms`
 list, then run `bun run distribution:matrix`. Freshness is enforced on pull
 requests with `bun run distribution:matrix --check`.
+
+Planned and deliberately not counted here until a listing exists: GCP, Azure, AWS
+and Alibaba cloud marketplaces, and Coolify, Portainer and Dokku deploy support.

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -1,0 +1,81 @@
+# Distribution channels
+
+This page is the **business / investment visibility matrix** for LibreDB Studio:
+how many places the product can be obtained from, which are live today, and how
+they group by audience-facing category.
+
+It is aimed at buyers evaluating coverage, investors and supporters assessing
+distribution footprint, and curious users who want a single overview. For
+install and operate instructions, use [DISTRIBUTION.md](DISTRIBUTION.md). The
+machine-readable inventory (and drift checker) lives in
+[`distribution/channels.yaml`](../distribution/channels.yaml).
+
+| Status | Meaning |
+| --- | --- |
+| `live` | Listed and installable (or deployable) through that channel |
+| `pending` | Submission or first listing in progress |
+| `deprecated` | Closed / declined — kept for honesty (e.g. Flathub) |
+
+To propose a new channel, add an entry to `distribution/channels.yaml` (with a
+`category`) and regenerate this page with `bun run distribution:matrix`.
+
+<!-- BEGIN:CHANNEL-SCORECARD -->
+
+### Coverage snapshot
+
+**27 channels · 22 live · 4 pending · 1 deprecated**
+
+| Category | Live | Pending | Deprecated |
+| --- | ---: | ---: | ---: |
+| Registries & releases | 2 | 0 | 0 |
+| Containers | 2 | 0 | 0 |
+| Kubernetes & operators | 1 | 2 | 0 |
+| Package managers | 4 | 1 | 0 |
+| OS / desktop packages | 2 | 0 | 0 |
+| PaaS & one-click | 10 | 0 | 0 |
+| Marketplaces & partners | 1 | 1 | 0 |
+| Closed / declined | 0 | 0 | 1 |
+
+Coverage: Registries & releases; Containers; Kubernetes & operators; Package managers; OS / desktop packages; PaaS & one-click; Marketplaces & partners; Closed / declined.
+
+<!-- END:CHANNEL-SCORECARD -->
+
+## All channels
+
+<!-- BEGIN:CHANNEL-TABLE -->
+
+| Channel | Category | Status | Update | Catalog | Docs |
+| --- | --- | --- | --- | --- | --- |
+| GitHub Releases (standalone tarballs, deb/rpm, snap assets) | Registries & releases | live | Every release | [link](https://github.com/libredb/libredb-studio/releases) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| npm package @libredb/studio (library + npx launcher) | Registries & releases | live | Every release | [link](https://www.npmjs.com/package/@libredb/studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Docker image (GHCR, canonical) | Containers | live | Every release | [link](https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Docker Hub mirror (discoverability only) | Containers | live | Every release | [link](https://hub.docker.com/r/libredb/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Helm chart (libredb.org repo + GHCR OCI + ArtifactHub) | Kubernetes & operators | live | Every release | [link](https://artifacthub.io/packages/helm/libredb-studio/libredb-studio) | [HELM_CHART.md](HELM_CHART.md) |
+| OperatorHub / OpenShift community operator catalogs | Kubernetes & operators | pending | Every release | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Rancher Partner Charts | Kubernetes & operators | pending | On demand | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| FlatPark signed Flatpak remote (org.libredb.Studio) | Package managers | live | Every release | [link](https://flatpark.org/) | [../packaging/flatpark/README.md](../packaging/flatpark/README.md) |
+| Homebrew tap (libredb/tap/libredb-studio) | Package managers | live | Every release | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Snap Store (stable channel, amd64+arm64) | Package managers | live | Every release | [link](https://snapcraft.io/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| winget community repository (LibreDB.Studio) | Package managers | live | Every release | [link](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/LibreDB/Studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Chocolatey community repository (libredb-studio) | Package managers | pending | Every release | [link](https://community.chocolatey.org/packages/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Desktop app (release assets: AppImage and GUI .deb, x64 + arm64) | OS / desktop packages | live | Every release | — | [../desktop/README.md](../desktop/README.md) |
+| Linux .deb / .rpm packages (release assets) | OS / desktop packages | live | Every release | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| CapRover one-click template (in-repo source of truth) | PaaS & one-click | live | On demand | — | [../deploy/caprover/README.md](../deploy/caprover/README.md) |
+| CapRover 3rd-party repo (libredb.org/caprover-one-click-apps) | PaaS & one-click | live | On demand | [link](https://libredb.org/caprover-one-click-apps) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| CapRover official one-click apps | PaaS & one-click | live | On demand | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Cosmos servapp marketplace | PaaS & one-click | live | On demand | — | [../deploy/cosmos/README.md](../deploy/cosmos/README.md) |
+| Dokploy template catalog | PaaS & one-click | live | On demand | [link](https://templates.dokploy.com) | [../deploy/dokploy/README.md](../deploy/dokploy/README.md) |
+| Fly.io launch config (repo fly.toml) | PaaS & one-click | live | On demand | — | [FLY.md](FLY.md) |
+| Koyeb deploy button (repo README) | PaaS & one-click | live | On demand | — | [../deploy/koyeb/README.md](../deploy/koyeb/README.md) |
+| Kubero template catalog | PaaS & one-click | live | On demand | [link](https://www.kubero.dev/templates) | [../deploy/kubero/README.md](../deploy/kubero/README.md) |
+| Railway one-click template | PaaS & one-click | live | On demand | [link](https://railway.com/deploy/libredb-studio) | [../deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
+| Render Blueprint (repo render.yaml) | PaaS & one-click | live | On demand | [link](https://render.com/deploy?repo=https://github.com/libredb/libredb-studio) | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| DigitalOcean Marketplace | Marketplaces & partners | live | On demand | [link](https://marketplace.digitalocean.com/apps/libredb-studio) | [../deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
+| Koyeb One-Click Apps catalog (curated by Koyeb) | Marketplaces & partners | pending | On demand | [link](https://www.koyeb.com/deploy) | [../deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
+| Flathub community catalog (org.libredb.Studio) | Closed / declined | deprecated | On demand | — | [../packaging/flatpak/README.md](../packaging/flatpak/README.md) |
+
+<!-- END:CHANNEL-TABLE -->
+
+The scorecard and table above are generated from `distribution/channels.yaml`.
+Do not edit them by hand — run `bun run distribution:matrix` after inventory
+changes. Freshness is checked with `bun run distribution:matrix -- --check`.

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -29,7 +29,7 @@ channel count.
 
 <!-- BEGIN:CHANNEL-SCORECARD -->
 
-### Coverage snapshot
+## Coverage snapshot
 
 **27 channels · 22 live · 4 pending · 1 deprecated**
 
@@ -65,11 +65,11 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | [Homebrew tap](https://github.com/libredb/homebrew-tap) | Package managers | Linux, macOS | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Snap Store](https://snapcraft.io/libredb-studio) | Package managers | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [winget](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/LibreDB/Studio) | Package managers | Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [Chocolatey](https://community.chocolatey.org/packages/libredb-studio) | Package managers | Windows | pending | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Chocolatey](https://community.chocolatey.org/packages/libredb-studio) | Package managers | Windows | pending | Automated (paused), every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Desktop app (AppImage, .deb)](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [desktop/README.md](../desktop/README.md) |
 | [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [CapRover template (in-repo)](https://github.com/libredb/libredb-studio/tree/main/deploy/caprover) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/caprover/README.md](../deploy/caprover/README.md) |
-| [CapRover 3rd-party repo](https://libredb.org/caprover-one-click-apps) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [CapRover 3rd-party repo](https://github.com/libredb/caprover-one-click-apps) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [CapRover official](https://github.com/caprover/one-click-apps) | PaaS & one-click | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
 | [Dokploy template catalog](https://templates.dokploy.com) | PaaS & one-click | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1071,7 +1071,7 @@ pin or editing a channel entry is always a human commit.
 |---|---|---|
 | 0 | Core registries, published directly by release CI | GitHub Releases, GHCR, Docker Hub, npm |
 | 1 | Packaged formats owned by this repo, CI-published | Helm, Homebrew tap, Snap, .deb/.rpm, desktop AppImage |
-| 2 | LibreDB-owned copies and listings, bumped by hand | CapRover source/mirror, Railway, Koyeb button, Fly.io config, Render Blueprint |
+| 2 | LibreDB-owned copies and listings, bumped by hand | CapRover mirror (deprecated), Railway, Koyeb button, Fly.io config, Render Blueprint |
 | 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero |
 | 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DO, winget, Chocolatey, Flathub |
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1078,12 +1078,25 @@ pin or editing a channel entry is always a human commit.
 **Categories** (`category` on every channel) are the business-facing buckets rendered in
 [`docs/CHANNELS.md`](CHANNELS.md): `registries-releases`, `containers`,
 `kubernetes-operators`, `package-managers`, `os-desktop`, `paas-catalogs`,
-`deploy-recipes`, `cloud-marketplaces`, `closed`. They are independent of tier (who
+`deploy-recipes`, `cloud-marketplaces`. They are independent of tier (who
 publishes). `paas-catalogs` and `deploy-recipes` look similar but answer different
 questions: `paas-catalogs` means the platform itself lists LibreDB Studio in its own
 catalog, so a user browsing that platform discovers it without visiting this repo;
 `deploy-recipes` means we publish a config file or instructions and the platform does
-not list us anywhere, so discovery only happens through our repo.
+not list us anywhere, so discovery only happens through our repo. There is no `closed`
+category: a declined or retired channel is `status: deprecated` with its `category`
+unchanged (Flathub is `category: package-managers`, `status: deprecated`) — `category`
+describes what the channel technically is, `status` describes its lifecycle, and an
+earlier revision that conflated the two (Flathub filed under a `closed` category) is
+what produced a false coverage claim in the scorecard.
+
+**Kind** (`kind` on every channel) is the technical shape of the artefact — a Helm
+chart, a container image, a curated marketplace listing — and is validated against a
+fixed enum in `scripts/distribution-check.mjs` (`CHANNEL_KINDS`). It is independent of
+`category`: `kubernetes-operators` (category) spans `helm-chart`, `operator-catalog`
+and `partner-catalog` (kind), and `paas-template` (kind) spans both `paas-catalogs` and
+`deploy-recipes` (category). Neither axis determines the other, so both are kept and
+validated separately rather than collapsed into one.
 
 **Platforms** (`platforms` on every channel, at least one) are the user-facing axis rendered
 in [`docs/CHANNELS.md`](CHANNELS.md): `linux`, `macos`, `windows`, `container`, `kubernetes`,

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1050,8 +1050,8 @@ Chocolatey push is still in moderation.
 
 ### Channel inventory and drift check
 
-For a **business / investment coverage view** (live counts by category, full channel
-table with catalog links), see [`docs/CHANNELS.md`](CHANNELS.md). Regenerate it with
+For the **coverage matrix** (live counts by category and platform, full channel
+table), see [`docs/CHANNELS.md`](CHANNELS.md). Regenerate it with
 `bun run distribution:matrix` after editing the inventory; `bun run distribution:matrix --check`
 fails when the generated regions are stale.
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1077,8 +1077,13 @@ pin or editing a channel entry is always a human commit.
 
 **Categories** (`category` on every channel) are the business-facing buckets rendered in
 [`docs/CHANNELS.md`](CHANNELS.md): `registries-releases`, `containers`,
-`kubernetes-operators`, `package-managers`, `os-desktop`, `paas-one-click`,
-`marketplaces-partners`, `closed`. They are independent of tier (who publishes).
+`kubernetes-operators`, `package-managers`, `os-desktop`, `paas-catalogs`,
+`deploy-recipes`, `cloud-marketplaces`, `closed`. They are independent of tier (who
+publishes). `paas-catalogs` and `deploy-recipes` look similar but answer different
+questions: `paas-catalogs` means the platform itself lists LibreDB Studio in its own
+catalog, so a user browsing that platform discovers it without visiting this repo;
+`deploy-recipes` means we publish a config file or instructions and the platform does
+not list us anywhere, so discovery only happens through our repo.
 
 **Platforms** (`platforms` on every channel, at least one) are the user-facing axis rendered
 in [`docs/CHANNELS.md`](CHANNELS.md): `linux`, `macos`, `windows`, `container`, `kubernetes`,

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1052,7 +1052,7 @@ Chocolatey push is still in moderation.
 
 For a **business / investment coverage view** (live counts by category, full channel
 table with catalog links), see [`docs/CHANNELS.md`](CHANNELS.md). Regenerate it with
-`bun run distribution:matrix` after editing the inventory; `bun run distribution:matrix -- --check`
+`bun run distribution:matrix` after editing the inventory; `bun run distribution:matrix --check`
 fails when the generated regions are stale.
 
 [`distribution/channels.yaml`](../distribution/channels.yaml) is the machine-readable inventory
@@ -1079,6 +1079,11 @@ pin or editing a channel entry is always a human commit.
 [`docs/CHANNELS.md`](CHANNELS.md): `registries-releases`, `containers`,
 `kubernetes-operators`, `package-managers`, `os-desktop`, `paas-one-click`,
 `marketplaces-partners`, `closed`. They are independent of tier (who publishes).
+
+**Platforms** (`platforms` on every channel, at least one) are the user-facing axis rendered
+in [`docs/CHANNELS.md`](CHANNELS.md): `linux`, `macos`, `windows`, `container`, `kubernetes`,
+`cloud`. They are independent of both tier (who publishes) and category (which business
+bucket). A channel may list several; the matrix always renders them in that canonical order.
 
 **SLAs** (`update.sla`) state how quickly a channel is expected to follow a release:
 `every_release` (bumped as part of releasing), `minor_plus` (bumped for minor releases and

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1050,8 +1050,13 @@ Chocolatey push is still in moderation.
 
 ### Channel inventory and drift check
 
+For a **business / investment coverage view** (live counts by category, full channel
+table with catalog links), see [`docs/CHANNELS.md`](CHANNELS.md). Regenerate it with
+`bun run distribution:matrix` after editing the inventory; `bun run distribution:matrix -- --check`
+fails when the generated regions are stale.
+
 [`distribution/channels.yaml`](../distribution/channels.yaml) is the machine-readable inventory
-of every distribution channel: identity, update policy, provenance links, and (where measurable)
+of every distribution channel: identity, business `category`, update policy, provenance links, and (where measurable)
 where its pinned version lives. `bun run distribution:check`
 ([`scripts/distribution-check.mjs`](../scripts/distribution-check.mjs)) compares every live
 channel's pin against `package.json` and prints a markdown drift table; the weekly
@@ -1069,6 +1074,11 @@ pin or editing a channel entry is always a human commit.
 | 2 | LibreDB-owned copies and listings, bumped by hand | CapRover source/mirror, Railway, Koyeb button, Fly.io config, Render Blueprint |
 | 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero |
 | 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DO, winget, Chocolatey, Flathub |
+
+**Categories** (`category` on every channel) are the business-facing buckets rendered in
+[`docs/CHANNELS.md`](CHANNELS.md): `registries-releases`, `containers`,
+`kubernetes-operators`, `package-managers`, `os-desktop`, `paas-one-click`,
+`marketplaces-partners`, `closed`. They are independent of tier (who publishes).
 
 **SLAs** (`update.sla`) state how quickly a channel is expected to follow a release:
 `every_release` (bumped as part of releasing), `minor_plus` (bumped for minor releases and

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "knip": "knip",
     "chart:check": "node scripts/sync-chart-version.mjs --check",
     "chart:bump": "node scripts/sync-chart-version.mjs --write",
-    "distribution:check": "node scripts/distribution-check.mjs"
+    "distribution:check": "node scripts/distribution-check.mjs",
+    "distribution:matrix": "node scripts/distribution-check.mjs --matrix"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -588,6 +588,15 @@ function sortedMatrixChannels(channels) {
   });
 }
 
+/** Live channels per platform, canonical order, zero-count platforms dropped. */
+function livePlatformCounts(channels) {
+  const live = channels.filter((c) => c.status === "live");
+  return PLATFORMS.map((platform) => ({
+    label: PLATFORM_LABELS[platform],
+    count: live.filter((c) => c.platforms.includes(platform)).length,
+  })).filter((entry) => entry.count > 0);
+}
+
 /** Business scorecard for docs/CHANNELS.md. */
 export function renderScorecard(channels) {
   const total = channels.length;
@@ -600,17 +609,23 @@ export function renderScorecard(channels) {
     "",
     `**${total} channels · ${live} live · ${pending} pending · ${deprecated} deprecated**`,
     "",
-    "| Category | Live | Pending | Deprecated |",
-    "| --- | ---: | ---: | ---: |",
   ];
 
-  const coverageLabels = [];
+  // A multi-platform channel is counted once per platform, so these overlap and
+  // do not sum to the total. Live only: pending and declined are not coverage.
+  const platforms = livePlatformCounts(channels)
+    .map((entry) => `${entry.label} ${entry.count}`)
+    .join(" · ");
+  if (platforms) {
+    lines.push(`Live channels by platform: **${platforms}**`, "");
+  }
+
+  lines.push("| Category | Live | Pending | Deprecated |", "| --- | ---: | ---: | ---: |");
   for (const category of CHANNEL_CATEGORIES) {
     const inCat = channels.filter((c) => c.category === category);
     if (inCat.length === 0) {
       continue;
     }
-    coverageLabels.push(CATEGORY_LABELS[category]);
     lines.push(
       `| ${CATEGORY_LABELS[category]} | ${inCat.filter((c) => c.status === "live").length} | ` +
         `${inCat.filter((c) => c.status === "pending").length} | ` +
@@ -618,7 +633,7 @@ export function renderScorecard(channels) {
     );
   }
 
-  lines.push("", `Coverage: ${coverageLabels.join("; ")}.`, "");
+  lines.push("");
   return `${lines.join("\n")}\n`;
 }
 

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -574,6 +574,41 @@ export function docsHref(docsPath) {
   return `../${docsPath}`;
 }
 
+/** Table display name: the short one when the inventory name is too long to scan. */
+function displayName(channel) {
+  return channel.short_name ?? channel.name ?? channel.id;
+}
+
+/**
+ * Where a user actually obtains this channel. Undefined when the inventory has
+ * nothing to point at - deliberately not a heuristic, because a fallback chain
+ * invented here would be a rule nobody reading channels.yaml can see.
+ */
+export function channelHref(channel) {
+  return channel.links?.get ?? channel.links?.catalog ?? channel.links?.upstream_repo;
+}
+
+/** Platform labels in canonical order, whatever order the yaml used. */
+export function platformCell(platforms) {
+  return PLATFORMS.filter((platform) => platforms.includes(platform))
+    .map((platform) => PLATFORM_LABELS[platform])
+    .join(", ");
+}
+
+/** Who bumps this channel and how fast. A dash for retired channels. */
+export function updateSummary(channel) {
+  if (channel.status === "deprecated") {
+    return "—";
+  }
+  const automation = channel.update.method === "ci_publish" ? "Automated" : "Manual";
+  return `${automation}, ${humanizeSla(channel.update.sla).toLowerCase()}`;
+}
+
+/** Guide column label: the href without its relative prefix. */
+export function guideLabel(href) {
+  return href.startsWith("../") ? href.slice("../".length) : href;
+}
+
 function sortedMatrixChannels(channels) {
   return [...channels].sort((a, b) => {
     const cat = CHANNEL_CATEGORIES.indexOf(a.category) - CHANNEL_CATEGORIES.indexOf(b.category);
@@ -639,15 +674,18 @@ export function renderScorecard(channels) {
 
 /** Full channel inventory table for docs/CHANNELS.md. */
 export function renderChannelMatrix(channels) {
-  const lines = ["| Channel | Category | Status | Update | Catalog | Docs |", "| --- | --- | --- | --- | --- | --- |"];
+  const lines = [
+    "| Channel | Category | Platform | Status | Updates | Guide |",
+    "| --- | --- | --- | --- | --- | --- |",
+  ];
   for (const channel of sortedMatrixChannels(channels)) {
-    const catalog = channel.links?.catalog ? `[${linkLabel(channel.links.catalog)}](${channel.links.catalog})` : "—";
-    const docsPath = channel.links?.docs;
-    const href = docsHref(docsPath);
-    const docs = `[${href}](${href})`;
+    const href = channelHref(channel);
+    const name = displayName(channel);
+    const guide = docsHref(channel.links?.docs);
     lines.push(
-      `| ${channel.name ?? channel.id} | ${CATEGORY_LABELS[channel.category]} | ${channel.status} | ` +
-        `${humanizeSla(channel.update.sla)} | ${catalog} | ${docs} |`,
+      `| ${href ? `[${name}](${href})` : name} | ${CATEGORY_LABELS[channel.category]} | ` +
+        `${platformCell(channel.platforms)} | ${channel.status} | ${updateSummary(channel)} | ` +
+        `[${guideLabel(guide)}](${guide}) |`,
     );
   }
   return `${lines.join("\n")}\n`;

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -49,6 +49,23 @@ export const CATEGORY_LABELS = {
   closed: "Closed / declined",
 };
 
+/**
+ * Platforms a channel serves. This order is canonical: the matrix renders and
+ * counts in it regardless of the order written in yaml, so output is stable.
+ * Not derivable from `kind` - `package-manager` alone spans Homebrew (macOS +
+ * Linux), Snap (Linux) and winget (Windows).
+ */
+export const PLATFORMS = ["linux", "macos", "windows", "container", "kubernetes", "cloud"];
+
+export const PLATFORM_LABELS = {
+  linux: "Linux",
+  macos: "macOS",
+  windows: "Windows",
+  container: "Container",
+  kubernetes: "Kubernetes",
+  cloud: "Cloud",
+};
+
 const SLA_LABELS = {
   every_release: "Every release",
   minor_plus: "Minor+",
@@ -319,6 +336,14 @@ export function parseChannels(yamlText) {
     }
     if (!CHANNEL_CATEGORIES.includes(channel.category)) {
       throw new Error(`${CHANNELS_YAML}: ${id}: category must be one of ${CHANNEL_CATEGORIES.join("|")}`);
+    }
+    if (!Array.isArray(channel.platforms) || channel.platforms.length === 0) {
+      throw new Error(`${CHANNELS_YAML}: ${id}: platforms must be a non-empty list`);
+    }
+    for (const platform of channel.platforms) {
+      if (!PLATFORMS.includes(platform)) {
+        throw new Error(`${CHANNELS_YAML}: ${id}: platforms entries must be one of ${PLATFORMS.join("|")}`);
+      }
     }
     if (!channel.update || !METHODS.includes(channel.update.method)) {
       throw new Error(`${CHANNELS_YAML}: ${id}: update.method must be one of ${METHODS.join("|")}`);

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -38,8 +38,9 @@ export const CHANNEL_CATEGORIES = [
   "kubernetes-operators",
   "package-managers",
   "os-desktop",
-  "paas-one-click",
-  "marketplaces-partners",
+  "paas-catalogs",
+  "deploy-recipes",
+  "cloud-marketplaces",
   "closed",
 ];
 
@@ -49,8 +50,9 @@ export const CATEGORY_LABELS = {
   "kubernetes-operators": "Kubernetes & operators",
   "package-managers": "Package managers",
   "os-desktop": "OS / desktop packages",
-  "paas-one-click": "PaaS & one-click",
-  "marketplaces-partners": "Marketplaces & partners",
+  "paas-catalogs": "PaaS catalogs (listed)",
+  "deploy-recipes": "Deploy recipes",
+  "cloud-marketplaces": "Cloud marketplaces",
   closed: "Closed / declined",
 };
 

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -41,7 +41,6 @@ export const CHANNEL_CATEGORIES = [
   "paas-catalogs",
   "deploy-recipes",
   "cloud-marketplaces",
-  "closed",
 ];
 
 export const CATEGORY_LABELS = {
@@ -53,8 +52,33 @@ export const CATEGORY_LABELS = {
   "paas-catalogs": "PaaS catalogs (listed)",
   "deploy-recipes": "Deploy recipes",
   "cloud-marketplaces": "Cloud marketplaces",
-  closed: "Closed / declined",
 };
+
+/**
+ * Technical shape of the artefact a channel actually is - independent of
+ * `category` (the audience-facing bucket several kinds can share). Neither
+ * axis determines the other: `kubernetes-operators` (category) spans
+ * `helm-chart`, `operator-catalog` and `partner-catalog` (kind), while
+ * `paas-template` (kind) spans both `paas-catalogs` and `deploy-recipes`
+ * (category). Exactly the 13 values in use across the inventory - a closed
+ * enum so a typo becomes a startup error instead of an unvalidated label
+ * that nothing ever reads.
+ */
+export const CHANNEL_KINDS = [
+  "release-assets",
+  "container-image",
+  "package-registry",
+  "helm-chart",
+  "package-manager",
+  "os-package",
+  "one-click-template",
+  "paas-template",
+  "deploy-button",
+  "operator-catalog",
+  "partner-catalog",
+  "curated-catalog",
+  "marketplace",
+];
 
 /**
  * Platforms a channel serves. This order is canonical: the matrix renders and
@@ -343,6 +367,9 @@ export function parseChannels(yamlText) {
     }
     if (!CHANNEL_CATEGORIES.includes(channel.category)) {
       throw new Error(`${CHANNELS_YAML}: ${id}: category must be one of ${CHANNEL_CATEGORIES.join("|")}`);
+    }
+    if (!CHANNEL_KINDS.includes(channel.kind)) {
+      throw new Error(`${CHANNELS_YAML}: ${id}: kind must be one of ${CHANNEL_KINDS.join("|")}`);
     }
     if (!Array.isArray(channel.platforms) || channel.platforms.length === 0) {
       throw new Error(`${CHANNELS_YAML}: ${id}: platforms must be a non-empty list`);

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -583,8 +583,18 @@ function displayName(channel) {
  * Where a user actually obtains this channel. Undefined when the inventory has
  * nothing to point at - deliberately not a heuristic, because a fallback chain
  * invented here would be a rule nobody reading channels.yaml can see.
+ *
+ * A deprecated channel is never a place to get the product - a link there
+ * would tell a user to go install something that is not being shipped - so it
+ * renders as plain text even when the inventory still records where its
+ * submission went (e.g. Flathub's upstream_repo). That is a property of the
+ * status, not of any one channel, so it is a status guard here rather than a
+ * data deletion in channels.yaml.
  */
 export function channelHref(channel) {
+  if (channel.status === "deprecated") {
+    return undefined;
+  }
   return channel.links?.get ?? channel.links?.catalog ?? channel.links?.upstream_repo;
 }
 

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -9,6 +9,11 @@
  * `--strict` exits 1 only for owned local_file pins whose update SLA is
  * every_release - remote catalogs are upstream-owned and never gate.
  *
+ * `--matrix` is this file's second job: it regenerates the marker regions of
+ * docs/CHANNELS.md (the audience coverage matrix) from the same channel
+ * inventory. `--check` alongside it verifies those regions are up to date
+ * without writing, for use as a freshness gate.
+ *
  * The checker only ever READS channels.yaml; version bumps in pin files and
  * inventory edits are human work (see docs/DISTRIBUTION.md). Mirrors the
  * style of scripts/sync-chart-version.mjs; the pure functions below are unit
@@ -610,7 +615,12 @@ export function updateSummary(channel) {
   if (channel.status === "deprecated") {
     return "—";
   }
-  const automation = channel.update.method === "ci_publish" ? "Automated" : "Manual";
+  const automation =
+    channel.update.method === "ci_publish"
+      ? channel.update.ci_enabled === false
+        ? "Automated (paused)"
+        : "Automated"
+      : "Manual";
   return `${automation}, ${humanizeSla(channel.update.sla).toLowerCase()}`;
 }
 
@@ -642,7 +652,7 @@ function livePlatformCounts(channels) {
   })).filter((entry) => entry.count > 0);
 }
 
-/** Business scorecard for docs/CHANNELS.md. */
+/** Coverage scorecard for docs/CHANNELS.md: users, developers and buyers in one snapshot. */
 export function renderScorecard(channels) {
   const total = channels.length;
   const live = channels.filter((c) => c.status === "live").length;
@@ -650,7 +660,7 @@ export function renderScorecard(channels) {
   const deprecated = channels.filter((c) => c.status === "deprecated").length;
 
   const lines = [
-    "### Coverage snapshot",
+    "## Coverage snapshot",
     "",
     `**${total} channels · ${live} live · ${pending} pending · ${deprecated} deprecated**`,
     "",
@@ -757,7 +767,7 @@ async function main(argv) {
   const timeoutMs = Number(process.env.DISTRIBUTION_CHECK_TIMEOUT_MS ?? 10_000);
 
   if (checkOnly && !matrix) {
-    console.error("ERROR: --check requires --matrix (use: bun run distribution:matrix -- --check)");
+    console.error("ERROR: --check requires --matrix (use: bun run distribution:matrix --check)");
     process.exit(2);
   }
 

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -26,6 +26,38 @@ const STRATEGIES = ["local_file", "remote_file", "probe", "none"];
 const METHODS = ["ci_publish", "commit", "upstream_pr", "manual_ui"];
 const SLAS = ["every_release", "minor_plus", "major_only", "on_demand"];
 
+/** Business-facing buckets for docs/CHANNELS.md (not the maintainer tier axis). */
+export const CHANNEL_CATEGORIES = [
+  "registries-releases",
+  "containers",
+  "kubernetes-operators",
+  "package-managers",
+  "os-desktop",
+  "paas-one-click",
+  "marketplaces-partners",
+  "closed",
+];
+
+export const CATEGORY_LABELS = {
+  "registries-releases": "Registries & releases",
+  containers: "Containers",
+  "kubernetes-operators": "Kubernetes & operators",
+  "package-managers": "Package managers",
+  "os-desktop": "OS / desktop packages",
+  "paas-one-click": "PaaS & one-click",
+  "marketplaces-partners": "Marketplaces & partners",
+  closed: "Closed / declined",
+};
+
+const SLA_LABELS = {
+  every_release: "Every release",
+  minor_plus: "Minor+",
+  major_only: "Major only",
+  on_demand: "On demand",
+};
+
+const STATUS_ORDER = { live: 0, pending: 1, deprecated: 2 };
+
 /**
  * Channels whose release-CI publish step may be switched off from this file via
  * `update.ci_enabled`, because they can be unavailable for reasons outside this
@@ -285,6 +317,9 @@ export function parseChannels(yamlText) {
     if (!STATUSES.includes(channel.status)) {
       throw new Error(`${CHANNELS_YAML}: ${id}: status must be one of ${STATUSES.join("|")}`);
     }
+    if (!CHANNEL_CATEGORIES.includes(channel.category)) {
+      throw new Error(`${CHANNELS_YAML}: ${id}: category must be one of ${CHANNEL_CATEGORIES.join("|")}`);
+    }
     if (!channel.update || !METHODS.includes(channel.update.method)) {
       throw new Error(`${CHANNELS_YAML}: ${id}: update.method must be one of ${METHODS.join("|")}`);
     }
@@ -499,6 +534,113 @@ export function renderTable(rows, pkgVersion) {
   return `${lines.join("\n")}\n`;
 }
 
+export function humanizeSla(sla) {
+  return SLA_LABELS[sla] ?? sla;
+}
+
+/** Resolve a channels.yaml docs path for links from docs/CHANNELS.md. */
+export function docsHref(docsPath) {
+  if (!docsPath) {
+    return "DISTRIBUTION.md";
+  }
+  if (docsPath.startsWith("docs/")) {
+    return docsPath.slice("docs/".length);
+  }
+  return `../${docsPath}`;
+}
+
+function sortedMatrixChannels(channels) {
+  return [...channels].sort((a, b) => {
+    const cat = CHANNEL_CATEGORIES.indexOf(a.category) - CHANNEL_CATEGORIES.indexOf(b.category);
+    if (cat !== 0) {
+      return cat;
+    }
+    const status = (STATUS_ORDER[a.status] ?? 99) - (STATUS_ORDER[b.status] ?? 99);
+    if (status !== 0) {
+      return status;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/** Business scorecard for docs/CHANNELS.md. */
+export function renderScorecard(channels) {
+  const total = channels.length;
+  const live = channels.filter((c) => c.status === "live").length;
+  const pending = channels.filter((c) => c.status === "pending").length;
+  const deprecated = channels.filter((c) => c.status === "deprecated").length;
+
+  const lines = [
+    "### Coverage snapshot",
+    "",
+    `**${total} channels · ${live} live · ${pending} pending · ${deprecated} deprecated**`,
+    "",
+    "| Category | Live | Pending | Deprecated |",
+    "| --- | ---: | ---: | ---: |",
+  ];
+
+  const coverageLabels = [];
+  for (const category of CHANNEL_CATEGORIES) {
+    const inCat = channels.filter((c) => c.category === category);
+    if (inCat.length === 0) {
+      continue;
+    }
+    coverageLabels.push(CATEGORY_LABELS[category]);
+    lines.push(
+      `| ${CATEGORY_LABELS[category]} | ${inCat.filter((c) => c.status === "live").length} | ` +
+        `${inCat.filter((c) => c.status === "pending").length} | ` +
+        `${inCat.filter((c) => c.status === "deprecated").length} |`,
+    );
+  }
+
+  lines.push("", `Coverage: ${coverageLabels.join("; ")}.`, "");
+  return `${lines.join("\n")}\n`;
+}
+
+/** Full channel inventory table for docs/CHANNELS.md. */
+export function renderChannelMatrix(channels) {
+  const lines = ["| Channel | Category | Status | Update | Catalog | Docs |", "| --- | --- | --- | --- | --- | --- |"];
+  for (const channel of sortedMatrixChannels(channels)) {
+    const catalog = channel.links?.catalog ? `[${linkLabel(channel.links.catalog)}](${channel.links.catalog})` : "—";
+    const docsPath = channel.links?.docs;
+    const href = docsHref(docsPath);
+    const docs = `[${href}](${href})`;
+    lines.push(
+      `| ${channel.name ?? channel.id} | ${CATEGORY_LABELS[channel.category]} | ${channel.status} | ` +
+        `${humanizeSla(channel.update.sla)} | ${catalog} | ${docs} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+const SCORECARD_BEGIN = "<!-- BEGIN:CHANNEL-SCORECARD -->";
+const SCORECARD_END = "<!-- END:CHANNEL-SCORECARD -->";
+const TABLE_BEGIN = "<!-- BEGIN:CHANNEL-TABLE -->";
+const TABLE_END = "<!-- END:CHANNEL-TABLE -->";
+
+function replaceMarkerRegion(doc, begin, end, body) {
+  const start = doc.indexOf(begin);
+  const stop = doc.indexOf(end);
+  if (start === -1 || stop === -1 || stop < start) {
+    throw new Error(`docs/CHANNELS.md is missing markers ${begin} / ${end}`);
+  }
+  const before = doc.slice(0, start + begin.length);
+  const after = doc.slice(stop);
+  const trimmed = body.replace(/^\n+/, "").replace(/\n+$/, "");
+  return `${before}\n\n${trimmed}\n\n${after}`;
+}
+
+/** Rewrite scorecard + table marker regions; leave narrative untouched. */
+export function applyMatrixMarkers(doc, scorecard, table) {
+  let next = replaceMarkerRegion(doc, SCORECARD_BEGIN, SCORECARD_END, scorecard);
+  next = replaceMarkerRegion(next, TABLE_BEGIN, TABLE_END, table);
+  return next;
+}
+
+export function buildChannelsDoc(doc, channels) {
+  return applyMatrixMarkers(doc, renderScorecard(channels), renderChannelMatrix(channels));
+}
+
 async function fetchText(url, timeoutMs) {
   const headers = githubAuthHeaders(url);
   try {
@@ -515,6 +657,8 @@ async function fetchText(url, timeoutMs) {
 async function main(argv) {
   const strict = argv.includes("--strict");
   const json = argv.includes("--json");
+  const matrix = argv.includes("--matrix");
+  const checkOnly = argv.includes("--check");
   const rootIdx = argv.indexOf("--root");
   const rootArg = rootIdx === -1 ? undefined : argv[rootIdx + 1];
   if (rootIdx !== -1 && (rootArg === undefined || rootArg.startsWith("--"))) {
@@ -523,6 +667,29 @@ async function main(argv) {
   }
   const root = rootIdx === -1 ? process.cwd() : path.resolve(rootArg);
   const timeoutMs = Number(process.env.DISTRIBUTION_CHECK_TIMEOUT_MS ?? 10_000);
+
+  if (checkOnly && !matrix) {
+    console.error("ERROR: --check requires --matrix (use: bun run distribution:matrix -- --check)");
+    process.exit(2);
+  }
+
+  if (matrix) {
+    const docPath = path.join(root, "docs/CHANNELS.md");
+    const channels = parseChannels(fs.readFileSync(path.join(root, CHANNELS_YAML), "utf8"));
+    const current = fs.readFileSync(docPath, "utf8");
+    const next = buildChannelsDoc(current, channels);
+    if (checkOnly) {
+      if (current !== next) {
+        console.error("ERROR: docs/CHANNELS.md is stale; run: bun run distribution:matrix");
+        process.exit(1);
+      }
+      console.log("docs/CHANNELS.md matrix regions are up to date");
+      return;
+    }
+    fs.writeFileSync(docPath, next);
+    console.log("Updated docs/CHANNELS.md matrix regions");
+    return;
+  }
 
   // The release workflow's automation gates. They answer from the inventory
   // alone - no package.json read, no network - so a gate check can never fail

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -12,15 +12,21 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   SWITCHABLE_CHANNEL_IDS,
+  applyMatrixMarkers,
+  buildChannelsDoc,
   ciEnabledOutputs,
   digestVerdict,
+  docsHref,
   evaluateChannel,
   extractPin,
   githubAuthHeaders,
+  humanizeSla,
   linkLabel,
   maxPublishedVersion,
   parseChannels,
   parseSnapVersions,
+  renderChannelMatrix,
+  renderScorecard,
   renderTable,
   strictFailures,
 } from "../../scripts/distribution-check.mjs";
@@ -32,6 +38,7 @@ function channelsYaml(rows: string): string {
 const HELM_ROW = `  - id: helm
     name: Helm chart
     status: live
+    category: kubernetes-operators
     tier: 1
     kind: chart
     update:
@@ -49,6 +56,7 @@ const HELM_ROW = `  - id: helm
 const NONE_ROW = `  - id: npm
     name: npm package
     status: live
+    category: registries-releases
     tier: 0
     kind: package-registry
     update:
@@ -62,6 +70,7 @@ const NONE_ROW = `  - id: npm
 const PROBE_ROW = `  - id: docker-ghcr
     name: Docker image (GHCR, canonical)
     status: live
+    category: containers
     tier: 0
     kind: container-image
     update:
@@ -100,6 +109,21 @@ describe("parseChannels", () => {
   test("throws on an unknown status", () => {
     const bad = HELM_ROW.replace("status: live", "status: shipped");
     expect(() => parseChannels(channelsYaml(bad))).toThrow(/status/);
+  });
+
+  test("throws when category is missing", () => {
+    const bad = HELM_ROW.replace("    category: kubernetes-operators\n", "");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/category/);
+  });
+
+  test("throws on an unknown category", () => {
+    const bad = HELM_ROW.replace("category: kubernetes-operators", "category: not-a-real-bucket");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/category/);
+  });
+
+  test("accepts a known category", () => {
+    const channels = parseChannels(channelsYaml(HELM_ROW));
+    expect(channels[0].category).toBe("kubernetes-operators");
   });
 
   test("throws when a local_file channel has no files", () => {
@@ -533,6 +557,7 @@ function switchableRow(id: string, enabled: boolean): string {
   return `  - id: ${id}
     name: ${id} channel
     status: live
+    category: package-managers
     tier: 1
     kind: package-manager
     update:
@@ -630,6 +655,7 @@ describe("CLI (subprocess against temp fixtures)", () => {
     return `  - id: railway
     name: Railway template
     status: live
+    category: paas-one-click
     tier: 2
     kind: paas-template
     update:
@@ -762,6 +788,7 @@ describe("CLI (remote pins against a local server)", () => {
     const row = `  - id: dokploy
     name: Dokploy template
     status: live
+    category: paas-one-click
     tier: 3
     kind: paas-template
     update:
@@ -864,6 +891,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     return `  - id: docker-ghcr
     name: Docker image (GHCR)
     status: live
+    category: containers
     tier: 0
     kind: container-image
     update:
@@ -931,6 +959,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     const row = `  - id: docker-hub-mirror
     name: Docker Hub mirror
     status: live
+    category: containers
     tier: 0
     kind: container-image
     update:
@@ -952,6 +981,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     return `  - id: snap
     name: Snap Store
     status: live
+    category: package-managers
     tier: 1
     kind: package-manager
     update:
@@ -1011,6 +1041,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     return `  - id: winget
     name: winget community repository
     status: live
+    category: package-managers
     tier: 4
     kind: package-manager
     update:
@@ -1043,5 +1074,206 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     const result = await runCheckAsync(probeFixture(wingetRow(base)));
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("| UNKNOWN | winget |");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Business visibility matrix (docs/CHANNELS.md)
+// ---------------------------------------------------------------------------
+
+const MATRIX_FIXTURE = `channels:
+  - id: npm
+    name: npm package
+    status: live
+    category: registries-releases
+    tier: 0
+    kind: package-registry
+    update:
+      method: ci_publish
+      sla: every_release
+    links:
+      catalog: https://www.npmjs.com/package/@libredb/studio
+      docs: docs/DISTRIBUTION.md
+    pin:
+      strategy: none
+      note: x
+  - id: chocolatey
+    name: Chocolatey
+    status: pending
+    category: package-managers
+    tier: 4
+    kind: package-manager
+    update:
+      method: ci_publish
+      sla: every_release
+      ci_enabled: false
+    pin:
+      strategy: none
+      note: x
+  - id: flathub
+    name: Flathub
+    status: deprecated
+    category: closed
+    tier: 4
+    kind: package-manager
+    update:
+      method: upstream_pr
+      sla: on_demand
+    links:
+      docs: packaging/flatpak/README.md
+    pin:
+      strategy: none
+      note: x
+`;
+
+describe("humanizeSla / docsHref", () => {
+  test("humanizeSla maps known SLAs", () => {
+    expect(humanizeSla("every_release")).toBe("Every release");
+    expect(humanizeSla("on_demand")).toBe("On demand");
+    expect(humanizeSla("custom")).toBe("custom");
+  });
+
+  test("docsHref rewrites paths relative to docs/CHANNELS.md", () => {
+    expect(docsHref(undefined)).toBe("DISTRIBUTION.md");
+    expect(docsHref("docs/HELM_CHART.md")).toBe("HELM_CHART.md");
+    expect(docsHref("desktop/README.md")).toBe("../desktop/README.md");
+  });
+});
+
+describe("renderScorecard / renderChannelMatrix", () => {
+  const channels = parseChannels(MATRIX_FIXTURE);
+
+  test("scorecard totals and category rows", () => {
+    const scorecard = renderScorecard(channels);
+    expect(scorecard).toContain("**3 channels · 1 live · 1 pending · 1 deprecated**");
+    expect(scorecard).toContain("| Registries & releases | 1 | 0 | 0 |");
+    expect(scorecard).toContain("| Package managers | 0 | 1 | 0 |");
+    expect(scorecard).toContain("| Closed / declined | 0 | 0 | 1 |");
+    expect(scorecard).toContain("Coverage: Registries & releases; Package managers; Closed / declined.");
+  });
+
+  test("matrix table columns, order, and links", () => {
+    const table = renderChannelMatrix(channels);
+    expect(table).toContain("| Channel | Category | Status | Update | Catalog | Docs |");
+    expect(table).toContain("| npm package | Registries & releases | live | Every release |");
+    expect(table).toContain("[link](https://www.npmjs.com/package/@libredb/studio)");
+    expect(table).toContain("[DISTRIBUTION.md](DISTRIBUTION.md)");
+    expect(table).toContain("| Chocolatey | Package managers | pending | Every release | — |");
+    expect(table).toContain("[../packaging/flatpak/README.md](../packaging/flatpak/README.md)");
+    const npmAt = table.indexOf("npm package");
+    const chocoAt = table.indexOf("Chocolatey");
+    const flatAt = table.indexOf("Flathub");
+    expect(npmAt).toBeLessThan(chocoAt);
+    expect(chocoAt).toBeLessThan(flatAt);
+    expect(table).not.toMatch(/[\u{1F300}-\u{1FAFF}]/u);
+  });
+});
+
+describe("applyMatrixMarkers / buildChannelsDoc", () => {
+  const skeleton = `# Title
+
+intro
+
+<!-- BEGIN:CHANNEL-SCORECARD -->
+
+old scorecard
+
+<!-- END:CHANNEL-SCORECARD -->
+
+mid
+
+<!-- BEGIN:CHANNEL-TABLE -->
+
+old table
+
+<!-- END:CHANNEL-TABLE -->
+
+footer
+`;
+
+  test("rewrites only marker regions", () => {
+    const next = applyMatrixMarkers(skeleton, "SCORE\n", "TABLE\n");
+    expect(next).toContain("# Title");
+    expect(next).toContain("intro");
+    expect(next).toContain("mid");
+    expect(next).toContain("footer");
+    expect(next).toContain("SCORE");
+    expect(next).toContain("TABLE");
+    expect(next).not.toContain("old scorecard");
+    expect(next).not.toContain("old table");
+  });
+
+  test("throws when markers are missing", () => {
+    expect(() => applyMatrixMarkers("# no markers\n", "a", "b")).toThrow(/missing markers/);
+  });
+
+  test("buildChannelsDoc is idempotent", () => {
+    const channels = parseChannels(MATRIX_FIXTURE);
+    const once = buildChannelsDoc(skeleton, channels);
+    const twice = buildChannelsDoc(once, channels);
+    expect(twice).toBe(once);
+  });
+});
+
+describe("CLI --matrix", () => {
+  const fixtureRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function matrixRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "dist-matrix-"));
+    fixtureRoots.push(root);
+    mkdirSync(join(root, "distribution"), { recursive: true });
+    mkdirSync(join(root, "docs"), { recursive: true });
+    writeFileSync(join(root, "distribution/channels.yaml"), MATRIX_FIXTURE);
+    writeFileSync(
+      join(root, "docs/CHANNELS.md"),
+      `# Channels\n\n<!-- BEGIN:CHANNEL-SCORECARD -->\n\n<!-- END:CHANNEL-SCORECARD -->\n\n<!-- BEGIN:CHANNEL-TABLE -->\n\n<!-- END:CHANNEL-TABLE -->\n`,
+    );
+    return root;
+  }
+
+  test("--matrix writes scorecard and table regions", () => {
+    const root = matrixRoot();
+    const result = Bun.spawnSync(["node", SCRIPT, "--matrix", "--root", root], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(0);
+    const doc = readFileSync(join(root, "docs/CHANNELS.md"), "utf8");
+    expect(doc).toContain("**3 channels · 1 live · 1 pending · 1 deprecated**");
+    expect(doc).toContain("| npm package | Registries & releases | live |");
+  });
+
+  test("--matrix --check exits 0 when fresh and 1 when stale", () => {
+    const root = matrixRoot();
+    const write = Bun.spawnSync(["node", SCRIPT, "--matrix", "--root", root], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(write.exitCode).toBe(0);
+    const ok = Bun.spawnSync(["node", SCRIPT, "--matrix", "--check", "--root", root], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(ok.exitCode).toBe(0);
+    writeFileSync(
+      join(root, "docs/CHANNELS.md"),
+      readFileSync(join(root, "docs/CHANNELS.md"), "utf8").replace("1 live", "0 live"),
+    );
+    const stale = Bun.spawnSync(["node", SCRIPT, "--matrix", "--check", "--root", root], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stale.exitCode).toBe(1);
+    expect(stale.stderr.toString()).toContain("stale");
+  });
+
+  test("--check without --matrix exits 2", () => {
+    const result = Bun.spawnSync(["node", SCRIPT, "--check"], { stdout: "pipe", stderr: "pipe" });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toContain("--matrix");
   });
 });

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -39,6 +39,7 @@ const HELM_ROW = `  - id: helm
     name: Helm chart
     status: live
     category: kubernetes-operators
+    platforms: [kubernetes]
     tier: 1
     kind: chart
     update:
@@ -57,6 +58,7 @@ const NONE_ROW = `  - id: npm
     name: npm package
     status: live
     category: registries-releases
+    platforms: [linux, macos, windows]
     tier: 0
     kind: package-registry
     update:
@@ -71,6 +73,7 @@ const PROBE_ROW = `  - id: docker-ghcr
     name: Docker image (GHCR, canonical)
     status: live
     category: containers
+    platforms: [container]
     tier: 0
     kind: container-image
     update:
@@ -124,6 +127,26 @@ describe("parseChannels", () => {
   test("accepts a known category", () => {
     const channels = parseChannels(channelsYaml(HELM_ROW));
     expect(channels[0].category).toBe("kubernetes-operators");
+  });
+
+  test("throws when platforms is missing", () => {
+    const bad = HELM_ROW.replace("    platforms: [kubernetes]\n", "");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/platforms must be a non-empty list/);
+  });
+
+  test("throws when platforms is empty", () => {
+    const bad = HELM_ROW.replace("platforms: [kubernetes]", "platforms: []");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/platforms must be a non-empty list/);
+  });
+
+  test("throws on an unknown platform id", () => {
+    const bad = HELM_ROW.replace("platforms: [kubernetes]", "platforms: [kubernetes, plan9]");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/platforms entries must be one of/);
+  });
+
+  test("accepts a multi-valued platforms list", () => {
+    const row = HELM_ROW.replace("platforms: [kubernetes]", "platforms: [macos, linux]");
+    expect(parseChannels(channelsYaml(row))[0].platforms).toEqual(["macos", "linux"]);
   });
 
   test("throws when a local_file channel has no files", () => {
@@ -558,6 +581,7 @@ function switchableRow(id: string, enabled: boolean): string {
     name: ${id} channel
     status: live
     category: package-managers
+    platforms: [linux]
     tier: 1
     kind: package-manager
     update:
@@ -656,6 +680,7 @@ describe("CLI (subprocess against temp fixtures)", () => {
     name: Railway template
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 2
     kind: paas-template
     update:
@@ -789,6 +814,7 @@ describe("CLI (remote pins against a local server)", () => {
     name: Dokploy template
     status: live
     category: paas-one-click
+    platforms: [cloud]
     tier: 3
     kind: paas-template
     update:
@@ -892,6 +918,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     name: Docker image (GHCR)
     status: live
     category: containers
+    platforms: [container]
     tier: 0
     kind: container-image
     update:
@@ -960,6 +987,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     name: Docker Hub mirror
     status: live
     category: containers
+    platforms: [container]
     tier: 0
     kind: container-image
     update:
@@ -982,6 +1010,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     name: Snap Store
     status: live
     category: package-managers
+    platforms: [linux]
     tier: 1
     kind: package-manager
     update:
@@ -1042,6 +1071,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     name: winget community repository
     status: live
     category: package-managers
+    platforms: [windows]
     tier: 4
     kind: package-manager
     update:
@@ -1086,6 +1116,7 @@ const MATRIX_FIXTURE = `channels:
     name: npm package
     status: live
     category: registries-releases
+    platforms: [linux, macos, windows]
     tier: 0
     kind: package-registry
     update:
@@ -1101,6 +1132,7 @@ const MATRIX_FIXTURE = `channels:
     name: Chocolatey
     status: pending
     category: package-managers
+    platforms: [windows]
     tier: 4
     kind: package-manager
     update:
@@ -1114,6 +1146,7 @@ const MATRIX_FIXTURE = `channels:
     name: Flathub
     status: deprecated
     category: closed
+    platforms: [linux]
     tier: 4
     kind: package-manager
     update:
@@ -1179,6 +1212,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     name: Mike Deprecated
     status: deprecated
     category: containers
+    platforms: [container]
     update:
       method: upstream_pr
       sla: on_demand
@@ -1189,6 +1223,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     name: Zulu Live
     status: live
     category: containers
+    platforms: [container]
     update:
       method: ci_publish
       sla: every_release
@@ -1199,6 +1234,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     name: Alpha Pending
     status: pending
     category: containers
+    platforms: [container]
     update:
       method: ci_publish
       sla: every_release
@@ -1209,6 +1245,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     name: Bravo Desktop
     status: live
     category: os-desktop
+    platforms: [linux]
     update:
       method: manual_ui
       sla: on_demand
@@ -1219,6 +1256,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     name: Alpha Desktop
     status: live
     category: os-desktop
+    platforms: [linux]
     update:
       method: manual_ui
       sla: on_demand

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -45,7 +45,7 @@ const HELM_ROW = `  - id: helm
     category: kubernetes-operators
     platforms: [kubernetes]
     tier: 1
-    kind: chart
+    kind: helm-chart
     update:
       method: ci_publish
       sla: every_release
@@ -131,6 +131,21 @@ describe("parseChannels", () => {
   test("accepts a known category", () => {
     const channels = parseChannels(channelsYaml(HELM_ROW));
     expect(channels[0].category).toBe("kubernetes-operators");
+  });
+
+  test("throws when kind is missing", () => {
+    const bad = HELM_ROW.replace(/ {4}kind: [^\n]+\n/, "");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/kind/);
+  });
+
+  test("throws on an unknown kind", () => {
+    const bad = HELM_ROW.replace(/kind: [^\n]+/, "kind: not-a-real-kind");
+    expect(() => parseChannels(channelsYaml(bad))).toThrow(/kind/);
+  });
+
+  test("accepts a known kind", () => {
+    const channels = parseChannels(channelsYaml(NONE_ROW));
+    expect(channels[0].kind).toBe("package-registry");
   });
 
   test("throws when platforms is missing", () => {
@@ -1149,7 +1164,7 @@ const MATRIX_FIXTURE = `channels:
   - id: flathub
     name: Flathub
     status: deprecated
-    category: closed
+    category: package-managers
     platforms: [linux]
     tier: 4
     kind: package-manager
@@ -1236,8 +1251,7 @@ describe("renderScorecard / renderChannelMatrix", () => {
     const scorecard = renderScorecard(channels);
     expect(scorecard).toContain("**3 channels · 1 live · 1 pending · 1 deprecated**");
     expect(scorecard).toContain("| Registries & releases | 1 | 0 | 0 |");
-    expect(scorecard).toContain("| Package managers | 0 | 1 | 0 |");
-    expect(scorecard).toContain("| Closed / declined | 0 | 0 | 1 |");
+    expect(scorecard).toContain("| Package managers | 0 | 1 | 1 |");
   });
 
   test("scorecard counts live channels per platform, once per platform", () => {
@@ -1266,7 +1280,7 @@ describe("renderScorecard / renderChannelMatrix", () => {
         "[DISTRIBUTION.md](DISTRIBUTION.md) |",
     );
     expect(table).toContain(
-      "| Flathub | Closed / declined | Linux | deprecated | — | " +
+      "| Flathub | Package managers | Linux | deprecated | — | " +
         "[packaging/flatpak/README.md](../packaging/flatpak/README.md) |",
     );
     const npmAt = table.indexOf("npm package");
@@ -1297,6 +1311,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     status: deprecated
     category: containers
     platforms: [container]
+    kind: container-image
     update:
       method: upstream_pr
       sla: on_demand
@@ -1308,6 +1323,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     status: live
     category: containers
     platforms: [container]
+    kind: container-image
     update:
       method: ci_publish
       sla: every_release
@@ -1319,6 +1335,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     status: pending
     category: containers
     platforms: [container]
+    kind: container-image
     update:
       method: ci_publish
       sla: every_release
@@ -1330,6 +1347,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     status: live
     category: os-desktop
     platforms: [linux]
+    kind: os-package
     update:
       method: manual_ui
       sla: on_demand
@@ -1341,6 +1359,7 @@ const MATRIX_TIEBREAK_FIXTURE = `channels:
     status: live
     category: os-desktop
     platforms: [linux]
+    kind: os-package
     update:
       method: manual_ui
       sla: on_demand

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -1169,6 +1169,88 @@ describe("renderScorecard / renderChannelMatrix", () => {
   });
 });
 
+// MATRIX_FIXTURE above puts every channel in its own category, so a table
+// render never falls past the category comparator: the status and id
+// tie-breaks inside sortedMatrixChannels never execute against it. This
+// fixture isolates both tie-breaks with a separate, deliberately scrambled
+// input order.
+const MATRIX_TIEBREAK_FIXTURE = `channels:
+  - id: ctr-mike
+    name: Mike Deprecated
+    status: deprecated
+    category: containers
+    update:
+      method: upstream_pr
+      sla: on_demand
+    pin:
+      strategy: none
+      note: x
+  - id: ctr-zulu
+    name: Zulu Live
+    status: live
+    category: containers
+    update:
+      method: ci_publish
+      sla: every_release
+    pin:
+      strategy: none
+      note: x
+  - id: ctr-alpha
+    name: Alpha Pending
+    status: pending
+    category: containers
+    update:
+      method: ci_publish
+      sla: every_release
+    pin:
+      strategy: none
+      note: x
+  - id: desk-bravo
+    name: Bravo Desktop
+    status: live
+    category: os-desktop
+    update:
+      method: manual_ui
+      sla: on_demand
+    pin:
+      strategy: none
+      note: x
+  - id: desk-alpha
+    name: Alpha Desktop
+    status: live
+    category: os-desktop
+    update:
+      method: manual_ui
+      sla: on_demand
+    pin:
+      strategy: none
+      note: x
+`;
+
+describe("sortedMatrixChannels tie-breaks (via renderChannelMatrix)", () => {
+  const channels = parseChannels(MATRIX_TIEBREAK_FIXTURE);
+  const table = renderChannelMatrix(channels);
+
+  test("same category, different status: live before pending before deprecated", () => {
+    const liveAt = table.indexOf("Zulu Live");
+    const pendingAt = table.indexOf("Alpha Pending");
+    const deprecatedAt = table.indexOf("Mike Deprecated");
+    expect(liveAt).toBeGreaterThan(-1);
+    expect(pendingAt).toBeGreaterThan(-1);
+    expect(deprecatedAt).toBeGreaterThan(-1);
+    expect(liveAt).toBeLessThan(pendingAt);
+    expect(pendingAt).toBeLessThan(deprecatedAt);
+  });
+
+  test("same category and status: falls back to id.localeCompare", () => {
+    const alphaAt = table.indexOf("Alpha Desktop");
+    const bravoAt = table.indexOf("Bravo Desktop");
+    expect(alphaAt).toBeGreaterThan(-1);
+    expect(bravoAt).toBeGreaterThan(-1);
+    expect(alphaAt).toBeLessThan(bravoAt);
+  });
+});
+
 describe("applyMatrixMarkers / buildChannelsDoc", () => {
   const skeleton = `# Title
 

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -1112,7 +1112,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Business visibility matrix (docs/CHANNELS.md)
+// Coverage matrix for users, developers and buyers (docs/CHANNELS.md)
 // ---------------------------------------------------------------------------
 
 const MATRIX_FIXTURE = `channels:
@@ -1210,6 +1210,18 @@ describe("matrix cell helpers", () => {
     expect(updateSummary({ status: "deprecated", update: { method: "upstream_pr", sla: "on_demand" } })).toBe("—");
   });
 
+  test("updateSummary marks a switched-off channel as paused", () => {
+    expect(
+      updateSummary({ status: "pending", update: { method: "ci_publish", sla: "every_release", ci_enabled: false } }),
+    ).toBe("Automated (paused), every release");
+    expect(
+      updateSummary({ status: "live", update: { method: "ci_publish", sla: "every_release", ci_enabled: true } }),
+    ).toBe("Automated, every release");
+    expect(updateSummary({ status: "live", update: { method: "ci_publish", sla: "every_release" } })).toBe(
+      "Automated, every release",
+    );
+  });
+
   test("guideLabel strips the relative prefix", () => {
     expect(guideLabel("DISTRIBUTION.md")).toBe("DISTRIBUTION.md");
     expect(guideLabel("HELM_CHART.md")).toBe("HELM_CHART.md");
@@ -1250,7 +1262,7 @@ describe("renderScorecard / renderChannelMatrix", () => {
         "Linux, macOS, Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |",
     );
     expect(table).toContain(
-      "| Chocolatey | Package managers | Windows | pending | Automated, every release | " +
+      "| Chocolatey | Package managers | Windows | pending | Automated (paused), every release | " +
         "[DISTRIBUTION.md](DISTRIBUTION.md) |",
     );
     expect(table).toContain(

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -1186,6 +1186,11 @@ describe("matrix cell helpers", () => {
     expect(channelHref({})).toBeUndefined();
   });
 
+  test("channelHref returns nothing for a deprecated channel that still has links", () => {
+    expect(channelHref({ status: "deprecated", links: { upstream_repo: "U" } })).toBeUndefined();
+    expect(channelHref({ status: "live", links: { upstream_repo: "U" } })).toBe("U");
+  });
+
   test("platformCell renders canonical order regardless of yaml order", () => {
     expect(platformCell(["macos", "linux"])).toBe("Linux, macOS");
     expect(platformCell(["cloud"])).toBe("Cloud");

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -1182,7 +1182,20 @@ describe("renderScorecard / renderChannelMatrix", () => {
     expect(scorecard).toContain("| Registries & releases | 1 | 0 | 0 |");
     expect(scorecard).toContain("| Package managers | 0 | 1 | 0 |");
     expect(scorecard).toContain("| Closed / declined | 0 | 0 | 1 |");
-    expect(scorecard).toContain("Coverage: Registries & releases; Package managers; Closed / declined.");
+  });
+
+  test("scorecard counts live channels per platform, once per platform", () => {
+    // Only `npm` is live in the fixture, and it lists three platforms.
+    expect(renderScorecard(channels)).toContain("Live channels by platform: **Linux 1 · macOS 1 · Windows 1**");
+  });
+
+  test("scorecard no longer emits the category coverage sentence", () => {
+    expect(renderScorecard(channels)).not.toContain("Coverage:");
+  });
+
+  test("scorecard omits the platform line when nothing is live", () => {
+    const noLive = parseChannels(MATRIX_FIXTURE.replace("status: live", "status: pending"));
+    expect(renderScorecard(noLive)).not.toContain("Live channels by platform");
   });
 
   test("matrix table columns, order, and links", () => {

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -683,7 +683,7 @@ describe("CLI (subprocess against temp fixtures)", () => {
     return `  - id: railway
     name: Railway template
     status: live
-    category: paas-one-click
+    category: paas-catalogs
     platforms: [cloud]
     tier: 2
     kind: paas-template
@@ -817,7 +817,7 @@ describe("CLI (remote pins against a local server)", () => {
     const row = `  - id: dokploy
     name: Dokploy template
     status: live
-    category: paas-one-click
+    category: paas-catalogs
     platforms: [cloud]
     tier: 3
     kind: paas-template

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -14,21 +14,25 @@ import {
   SWITCHABLE_CHANNEL_IDS,
   applyMatrixMarkers,
   buildChannelsDoc,
+  channelHref,
   ciEnabledOutputs,
   digestVerdict,
   docsHref,
   evaluateChannel,
   extractPin,
   githubAuthHeaders,
+  guideLabel,
   humanizeSla,
   linkLabel,
   maxPublishedVersion,
   parseChannels,
   parseSnapVersions,
+  platformCell,
   renderChannelMatrix,
   renderScorecard,
   renderTable,
   strictFailures,
+  updateSummary,
 } from "../../scripts/distribution-check.mjs";
 
 function channelsYaml(rows: string): string {
@@ -1173,6 +1177,41 @@ describe("humanizeSla / docsHref", () => {
   });
 });
 
+describe("matrix cell helpers", () => {
+  test("channelHref resolves get, then catalog, then upstream_repo", () => {
+    expect(channelHref({ links: { get: "G", catalog: "C", upstream_repo: "U" } })).toBe("G");
+    expect(channelHref({ links: { catalog: "C", upstream_repo: "U" } })).toBe("C");
+    expect(channelHref({ links: { upstream_repo: "U" } })).toBe("U");
+    expect(channelHref({ links: {} })).toBeUndefined();
+    expect(channelHref({})).toBeUndefined();
+  });
+
+  test("platformCell renders canonical order regardless of yaml order", () => {
+    expect(platformCell(["macos", "linux"])).toBe("Linux, macOS");
+    expect(platformCell(["cloud"])).toBe("Cloud");
+    expect(platformCell(["windows", "container", "linux"])).toBe("Linux, Windows, Container");
+  });
+
+  test("updateSummary separates automated from manual and retires deprecated", () => {
+    expect(updateSummary({ status: "live", update: { method: "ci_publish", sla: "every_release" } })).toBe(
+      "Automated, every release",
+    );
+    expect(updateSummary({ status: "live", update: { method: "upstream_pr", sla: "on_demand" } })).toBe(
+      "Manual, on demand",
+    );
+    expect(updateSummary({ status: "pending", update: { method: "manual_ui", sla: "minor_plus" } })).toBe(
+      "Manual, minor+",
+    );
+    expect(updateSummary({ status: "deprecated", update: { method: "upstream_pr", sla: "on_demand" } })).toBe("—");
+  });
+
+  test("guideLabel strips the relative prefix", () => {
+    expect(guideLabel("DISTRIBUTION.md")).toBe("DISTRIBUTION.md");
+    expect(guideLabel("HELM_CHART.md")).toBe("HELM_CHART.md");
+    expect(guideLabel("../deploy/railway/PUBLISH.md")).toBe("deploy/railway/PUBLISH.md");
+  });
+});
+
 describe("renderScorecard / renderChannelMatrix", () => {
   const channels = parseChannels(MATRIX_FIXTURE);
 
@@ -1198,20 +1237,35 @@ describe("renderScorecard / renderChannelMatrix", () => {
     expect(renderScorecard(noLive)).not.toContain("Live channels by platform");
   });
 
-  test("matrix table columns, order, and links", () => {
+  test("matrix table renders six columns, ordered by category then status", () => {
     const table = renderChannelMatrix(channels);
-    expect(table).toContain("| Channel | Category | Status | Update | Catalog | Docs |");
-    expect(table).toContain("| npm package | Registries & releases | live | Every release |");
-    expect(table).toContain("[link](https://www.npmjs.com/package/@libredb/studio)");
-    expect(table).toContain("[DISTRIBUTION.md](DISTRIBUTION.md)");
-    expect(table).toContain("| Chocolatey | Package managers | pending | Every release | — |");
-    expect(table).toContain("[../packaging/flatpak/README.md](../packaging/flatpak/README.md)");
+    expect(table).toContain("| Channel | Category | Platform | Status | Updates | Guide |");
+    expect(table).toContain(
+      "| [npm package](https://www.npmjs.com/package/@libredb/studio) | Registries & releases | " +
+        "Linux, macOS, Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |",
+    );
+    expect(table).toContain(
+      "| Chocolatey | Package managers | Windows | pending | Automated, every release | " +
+        "[DISTRIBUTION.md](DISTRIBUTION.md) |",
+    );
+    expect(table).toContain(
+      "| Flathub | Closed / declined | Linux | deprecated | — | " +
+        "[packaging/flatpak/README.md](../packaging/flatpak/README.md) |",
+    );
     const npmAt = table.indexOf("npm package");
     const chocoAt = table.indexOf("Chocolatey");
     const flatAt = table.indexOf("Flathub");
     expect(npmAt).toBeLessThan(chocoAt);
     expect(chocoAt).toBeLessThan(flatAt);
+    expect(table).not.toContain("[link](");
     expect(table).not.toMatch(/[\u{1F300}-\u{1FAFF}]/u);
+  });
+
+  test("short_name wins over name in the table", () => {
+    const withShort = parseChannels(
+      MATRIX_FIXTURE.replace("    name: npm package\n", "    name: npm package\n    short_name: npm\n"),
+    );
+    expect(renderChannelMatrix(withShort)).toContain("| [npm](https://www.npmjs.com/package/@libredb/studio) |");
   });
 });
 
@@ -1377,7 +1431,10 @@ describe("CLI --matrix", () => {
     expect(result.exitCode).toBe(0);
     const doc = readFileSync(join(root, "docs/CHANNELS.md"), "utf8");
     expect(doc).toContain("**3 channels · 1 live · 1 pending · 1 deprecated**");
-    expect(doc).toContain("| npm package | Registries & releases | live |");
+    expect(doc).toContain(
+      "| [npm package](https://www.npmjs.com/package/@libredb/studio) | Registries & releases | " +
+        "Linux, macOS, Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |",
+    );
   });
 
   test("--matrix --check exits 0 when fresh and 1 when stale", () => {


### PR DESCRIPTION
## Summary

Turns `docs/CHANNELS.md` from an investor-only page into a coverage matrix that serves three audiences at once — users, developers, and buyers/investors — and fixes a set of truthfulness defects found while auditing it.

The page is generated from `distribution/channels.yaml` by `scripts/distribution-check.mjs --matrix`, which rewrites only the bytes between two marker pairs. The surrounding narrative stays hand-written.

```
26 channels · 20 live · 4 pending · 2 deprecated
Live channels by platform: Linux 7 · macOS 3 · Windows 3 · Container 2 · Kubernetes 1 · Cloud 9
```

## What changed

**New inventory fields.** `platforms` (required, multi-valued, canonical order `linux, macos, windows, container, kubernetes, cloud`), plus optional `short_name` and `links.get`. `parseChannels` rejects a missing, empty, or unknown `platforms`.

**The table now answers three questions instead of one.** `| Channel | Category | Platform | Status | Updates | Guide |`. The channel name is the anchor, so the old column of fifteen identical `[link]` cells is gone. `Updates` merges automation and SLA, which is what a developer actually needs.

**Category split.** `paas-one-click` conflated two different things: platforms whose own catalog lists us, and platforms where we merely publish a config file. The scorecard read as eight PaaS channels when the real number of listings is five. Now `PaaS catalogs (listed)` / `Deploy recipes` / `Cloud marketplaces`.

## Truthfulness defects fixed

The page's only value is that a reader can verify it, so these mattered more than their size suggests.

1. **The coverage sentence claimed a category we were declined from.** It filtered on any status rather than live, so the published page listed `Closed / declined` as covered. Replaced with a live-only per-platform line.
2. **A dead link on a `live` row.** `https://libredb.org/caprover-one-click-apps` redirects to a 404. `DOCKERHUB.md` and `deploy/caprover/README.md` also told users to paste that exact URL into CapRover, so the documented install path was broken too.
3. **Render appeared to be a listing.** Its catalog link was `render.com/deploy?repo=...`, Render's generic deploy-button endpoint that works for any public repository. It rendered identically to Dokploy and Kubero, which genuinely are listed.
4. **Chocolatey advertised automation that is switched off.** `updateSummary` ignored `update.ci_enabled`, so a channel with `ci_enabled: false` still read `Automated, every release`. Now `Automated (paused)`.
5. **A prose claim contradicted the page's own arithmetic.** The narrative said platform counts "do not sum to the channel total" while they summed to exactly the channel total shown two lines below. Reworded to state what is actually true.
6. **CapRover occupied three rows while every comparable platform occupied one.** `caprover-local` is the in-repo source of truth, not a channel — issue #56 says so in its own words, and `deploy/cosmos/`, `deploy/dokploy/`, `deploy/kubero/` are equally sources and equally uncounted. Deleted. `caprover-mirror` was a fallback for the review queue; the official listing is now live, so it is deprecated rather than deleted, keeping the record visible.

Every listing claim in the table was verified against the channel's own `pin.url`: CapRover official, Dokploy, Cosmos, Kubero and Railway all resolve.

## Deprecated channels never render a link

A status rule in `channelHref`, not a per-channel exception. Flathub still records `upstream_repo` from its declined submission, and the fallback chain would otherwise have linked our rejected listing to the generic Flathub monorepo. `channels.yaml` is a provenance file, so the rule lives in code and the data stays.

## CI

`.github/workflows/distribution-check.yml` gains a path-filtered `pull_request` trigger running only the offline freshness check; the networked drift report stays off pull requests, as the workflow's warn-only design intends. The concurrency group is now keyed by ref — without that, a PR run and the weekly cron shared one group and cancelled each other.

## Verification

All six local gates pass: `format`, `lint` (0 errors), `typecheck`, `knip`, `test` (21/21 groups), `build`. `bun run distribution:matrix --check` exits 0, and regeneration is idempotent.

## Follow-ups, deliberately not in this PR

- **A release check was lost.** `caprover-local` held the only `local_file` pin on `deploy/caprover/libredb-studio.yml`, so nothing now verifies that the in-repo CapRover template was version-bumped at release. Moving that pin onto `caprover-official` would be wrong: its pin must keep measuring what upstream actually serves.
- **`libredb.org/caprover-one-click-apps` is unpublished.** The instructions now point at CapRover's built-in catalog, which is the better answer anyway.
- **Eleven of 26 Guide links point at an un-anchored `DISTRIBUTION.md`.** `docsHref` already passes anchors through, so `docs: docs/DISTRIBUTION.md#homebrew` would work today.
- **`platforms` validation gates release automation.** It lives in the shared `parseChannels`, which the release workflow's `continue-on-error` channels job also calls, so a channel merged without it would silently skip publishing every optional channel that release. `category` already established this pattern. The fix is making the distribution-check job a required check.
