### PR TITLE
feat(db): add ClickHouse provider (SQL over the HTTP interface, no native dependency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
 
 <p align="center">
   <img src="public/screenshots/connection-modal.png" alt="Multi-Database Connection Manager" width="100%" />
-  <br/><em>Connect to PostgreSQL, MySQL, Oracle, SQL Server, MongoDB, Couchbase, Redis, or SQLite with SSL/TLS and SSH Tunnel support.</em>
+  <br/><em>Connect to PostgreSQL, MySQL, Oracle, SQL Server, MongoDB, Couchbase, ClickHouse, Redis, or SQLite with SSL/TLS and SSH Tunnel support.</em>
 </p>
 
 ---
@@ -184,6 +184,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
 | **SQLite** | `bun:sqlite` / `node:sqlite` (runtime-selected) | Full SQL IDE, file-based or in-memory databases (server-local file) |
 | **MongoDB** | `mongodb` | JSON query editor, collection operations (find, aggregate, insert, update, delete) |
 | **Couchbase** | none — HTTP (Query + management REST) | Full SQL++ IDE, EXPLAIN plans, bucket/scope/collection explorer, `INFER` column inference, read-your-writes consistency, `UPDATE STATISTICS` / `BUILD INDEX` / request kill |
+| **ClickHouse** | none — HTTP (SQL interface, port 8123) | Full SQL IDE, JSON EXPLAIN plan trees, system-table schema introspection, `OPTIMIZE TABLE` / table statistics / query kill maintenance |
 | **Redis** | `ioredis` | Command editor, key browser, INFO-based monitoring |
 
 > All SQL databases share: schema explorer, ER diagrams, schema diff & migration, display masking (preview), monitoring dashboard, and connection string import.
@@ -202,7 +203,7 @@ The test instance comes with a pre-configured PostgreSQL database via [Seed Conn
 | **Editor** | Monaco Editor (VS Code Engine) | Web |
 | **AI** | Multi-Model (Gemini, OpenAI, Ollama, Custom) | Web, Mobile |
 | **Auth** | JWT (`jose`) + OIDC (`openid-client`), PKCE, Role Mapping | Web, Mobile |
-| **Database** | PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Couchbase, Redis | Web, Mobile |
+| **Database** | PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Couchbase, ClickHouse, Redis | Web, Mobile |
 | **Charts** | Recharts (Bar, Line, Pie, Area, Scatter, Histogram, Stacked) | Web, Mobile |
 | **ERD** | React Flow, ELK.js (auto-layout) | Web |
 | **State/Grid** | TanStack Table & Virtual | Web, Mobile |
@@ -293,7 +294,7 @@ journalctl -u libredb-studio
 
   ### Prerequisites
   - [Bun](https://bun.sh/) (Recommended) or Node.js 24+
-  - A target database to query (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Couchbase, or Redis)
+  - A target database to query (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Couchbase, ClickHouse, or Redis)
 
   ### Quick Start (Local)
   1. **Clone & Install**
@@ -415,7 +416,7 @@ bun run test:coverage
 |-------|-----------|--------|-------|----------------|
 | **Unit** | `tests/unit/` | `bun:test` | ~1,609 | Pure functions: SQL parser, connection strings, data masking, query limiter, schema diff, error classes, DB icons, showcase queries |
 | **API** | `tests/api/` | `bun:test` | ~279 | Route handlers: auth, query, transaction, maintenance, AI endpoints, middleware |
-| **Integration** | `tests/integration/` | `bun:test` | ~346 | Database providers: PG, MySQL, SQLite, MongoDB, Couchbase, Redis, Oracle, MSSQL|
+| **Integration** | `tests/integration/` | `bun:test` | ~346 | Database providers: PG, MySQL, SQLite, MongoDB, Couchbase, Redis, Oracle, MSSQL, ClickHouse|
 | **Hooks** | `tests/hooks/` | `bun:test` | ~251 | React hooks: auth, connections, tabs, query execution, transactions, inline editing, AI chat, monitoring |
 | **Components** | `tests/components/` | `bun:test` + happy-dom | ~570 | UI components: Studio, Sidebar, QueryEditor, ResultsGrid, Admin Dashboard, Charts, ERD |
 | **E2E** | `e2e/` | Playwright | ~32 | Full browser flows: login, connections, query execution, tabs, export, admin |
@@ -706,7 +707,7 @@ extraEnvFrom:
 | `defaults` | No | Default values merged into all connections |
 | `connections[].id` | Yes | Unique slug (`[a-z0-9-]+`, max 64 chars) |
 | `connections[].name` | Yes | Display name in UI |
-| `connections[].type` | Yes | `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql`, `libredb`, `couchbase` |
+| `connections[].type` | Yes | `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql`, `libredb`, `couchbase`, `clickhouse` |
 | `connections[].roles` | Yes | `["*"]` (everyone), `["admin"]`, `["user"]`, or `["admin", "user"]` |
 | `connections[].managed` | No | `true` = read-only (default), `false` = editable copy for user |
 | `connections[].password` | No | Use `${ENV_VAR}` syntax for secrets |

--- a/database-compose.yml
+++ b/database-compose.yml
@@ -129,3 +129,37 @@ services:
         done
         echo "couchbase-init: the query service never accepted CREATE PRIMARY INDEX" >&2
         exit 1
+  clickhouse:
+    # Pinned to the exact build the design spec (docs/superpowers/specs/2026-08-03-clickhouse-provider-design.md)
+    # was live-verified against, so status codes, header names and the mid-stream-failure
+    # trailer documented there stay reproducible for the next person.
+    image: clickhouse/clickhouse-server:26.7.1.1315
+    container_name: libredb-clickhouse
+    restart: unless-stopped
+    environment:
+      CLICKHOUSE_USER: libredb
+      CLICKHOUSE_PASSWORD: password123
+      CLICKHOUSE_DB: demo
+      # Lets the live pass GRANT/REVOKE a second, restricted user (needed to reproduce the
+      # ACCESS_DENIED-arrives-as-500 finding, spec section 2.5) without hand-editing users.xml.
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    ports:
+      # 8123 is HTTP, the only protocol the provider speaks. 9000 (native TCP) is deliberately
+      # NOT exposed: there is no native-protocol transport in this codebase to connect with it.
+      - "8123:8123"
+    ulimits:
+      # ClickHouse warns at every start below this and degrades under load, same class of
+      # issue as the couchbase nofile setting above.
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      # /ping needs no auth and returns "Ok." once the server can accept queries. The image has
+      # no curl (unlike couchbase's), so this uses wget, which it does ship.
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8123/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 40
+    # No seed sidecar: CLICKHOUSE_DB above creates `demo` on first boot, and unlike Couchbase
+    # there is no index prerequisite - a SELECT against a freshly created table works
+    # immediately. Do not add one.

--- a/database-compose.yml
+++ b/database-compose.yml
@@ -130,9 +130,9 @@ services:
         echo "couchbase-init: the query service never accepted CREATE PRIMARY INDEX" >&2
         exit 1
   clickhouse:
-    # Pinned to the exact build the design spec (docs/superpowers/specs/2026-08-03-clickhouse-provider-design.md)
-    # was live-verified against, so status codes, header names and the mid-stream-failure
-    # trailer documented there stay reproducible for the next person.
+    # Pinned to the exact build the provider was live-verified against, so the status
+    # codes, header names and mid-stream-failure trailer recorded in
+    # docs/providers/clickhouse.md stay reproducible for the next person.
     image: clickhouse/clickhouse-server:26.7.1.1315
     container_name: libredb-clickhouse
     restart: unless-stopped

--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -545,11 +545,43 @@ reviewable PR.
 The integration points, all of which need an entry. This is the list the Strategy Pattern does
 *not* spare you — provider logic stays self-contained, registration does not:
 
-- [ ] `src/lib/types.ts` — Add to `DatabaseType` union (if not already there)
-- [ ] `src/lib/db/providers/<category>/<name>.ts` — **New file:** provider class
-- [ ] `src/lib/db/factory.ts` — Add `case` with dynamic import
-- [ ] `src/lib/db-ui-config.ts` — Add UI config entry
-- [ ] `src/hooks/use-connection-form.ts` — Add to `selectableTypes` array
-- [ ] `package.json` — Install driver (`bun add <driver>`; SQLite needs none — uses `bun:sqlite`/`node:sqlite`)
+**Always:**
 
-**No other files should need changes.** If you find yourself editing routes, components, or utilities — you're likely bypassing the abstraction. Use `getCapabilities()` and `getLabels()` instead.
+- [ ] `src/lib/types.ts` — add to the `DatabaseType` union
+- [ ] `src/lib/db/providers/<family>/<type-id>.ts` (or a directory) — **new:** the provider class
+- [ ] `src/lib/db/factory.ts` — add a `case` with a **dynamic** import
+- [ ] `src/lib/db-ui-config.ts` — icon, colour, label, default port, connection fields
+- [ ] `src/hooks/use-connection-form.ts` — **append** to `selectableTypes` (do not retype the array)
+- [ ] `src/components/icons/db-icons.tsx` — the engine's mark (`strokeWidth={1.5}`, no HTML size attrs)
+- [ ] `src/lib/seed/types.ts` — the seed-config `type` enum, or seeded connections fail validation
+- [ ] `package.json` — the driver, **if** it needs one. A driver-free provider leaves it untouched
+- [ ] `database-compose.yml` — a service, so the next person can repeat the live pass
+
+**Conditionally, and each one is easy to miss because the code still compiles without it:**
+
+- [ ] `src/lib/db/types.ts` — add to the **`ExplainFormat`** union whenever `supportsExplain` is true.
+      The `Record<ExplainFormat, …>` registry is exhaustive, so this and the next item must land
+      together or neither compiles
+- [ ] `src/lib/explain/index.ts` — register the strategy
+- [ ] `src/lib/connection-string-parser.ts` — the scheme(s), if `supportsConnectionString`
+- [ ] `src/lib/query-generators.ts` — only if the dialect needs its own branch; the default is
+      PostgreSQL-shaped, so check before assuming it fits
+
+**And the tests for every exhaustive map**, which are the real checklist — several are exhaustive
+*by construction* (`Record<DatabaseType, …>` in `db-ui-config`, `PICKER_COVERAGE` in the
+connection-form test), so the compiler and those tests refuse to pass until each is updated:
+`tests/unit/db/factory.test.ts`, `tests/unit/lib/db-ui-config.test.ts`,
+`tests/unit/lib/db-icons.test.tsx`, `tests/unit/lib/connection-string-parser.test.ts`,
+`tests/unit/lib/query-generators.test.ts`, `tests/unit/seed/types.test.ts`,
+`tests/hooks/use-connection-form.test.ts`.
+
+> **`git grep -l <the-previous-provider-type-id> -- src/ tests/` is the authoritative checklist.**
+> This list is maintained by hand and has been wrong before: it long claimed "no other files should
+> need changes", while Couchbase (#263) and ClickHouse (#264) each touched 27 files under `src/` and
+> `tests/`. Trust the grep over this list.
+
+What the Strategy Pattern *does* spare you is **provider logic**: no route, no shared component and no
+existing provider needs to know your engine exists. If you find yourself adding a `=== '<type-id>'`
+check in a route, a component or a utility, that is the abstraction being bypassed — express it as a
+capability or a label instead. Registration is the part it does not spare you, and the grep above is
+how you find all of it.

--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -19,11 +19,12 @@ Three decisions. The first is the consequential one, which is why it is first.
 
 1. **Does it need a driver at all?** Score the engine against the rubric below. A database with a
    first-class HTTP API can be supported with no dependency at all, and that is worth real effort to
-   establish before you start. Two shipped providers need no driver: SQLite uses the built-in
-   `bun:sqlite`/`node:sqlite` via `sqlite-driver.ts`, and Couchbase talks to the cluster over
-   documented REST endpoints with `fetch`/`node:https` ([couchbase.md](./providers/couchbase.md)).
-   If it does need one, it will be something like `pg`, `mysql2`, `mongodb`, `ioredis`, `oracledb`
-   or `mssql`.
+   establish before you start. Three shipped providers need no driver: SQLite uses the built-in
+   `bun:sqlite`/`node:sqlite` via `sqlite-driver.ts`, Couchbase talks to the cluster over
+   documented REST endpoints with `fetch`/`node:https` ([couchbase.md](./providers/couchbase.md)),
+   and ClickHouse speaks SQL over its HTTP interface the same way
+   ([clickhouse.md](./providers/clickhouse.md)). If it does need one, it will be something like `pg`,
+   `mysql2`, `mongodb`, `ioredis`, `oracledb` or `mssql`.
 
 2. **Which base class?**
    - **SQL databases → extend `SQLBaseProvider`.** It is
@@ -184,6 +185,7 @@ is kept in sync with its per-provider doc). Don't copy a skeleton from this guid
 |-------------------|--------|------------------|-----------|
 | Pooled SQL (wire-protocol DB) | `SQLBaseProvider` | `postgres.ts` / `mysql.ts` | [postgres.md](./providers/postgres.md) · [mysql.md](./providers/mysql.md) |
 | Embedded / file SQL | `SQLBaseProvider` | `sqlite.ts` | [sqlite.md](./providers/sqlite.md) |
+| SQL database reached over HTTP (no driver) | `SQLBaseProvider` | `sql/clickhouse/` | [clickhouse.md](./providers/clickhouse.md) |
 | Document store | `BaseDatabaseProvider` | `mongodb.ts` | [mongodb.md](./providers/mongodb.md) |
 | Document store reached over HTTP/REST (no driver) | `BaseDatabaseProvider` | `document/couchbase/` | [couchbase.md](./providers/couchbase.md) |
 | Key-value store | `BaseDatabaseProvider` | `redis.ts` | [redis.md](./providers/redis.md) |
@@ -514,7 +516,7 @@ For the authoritative, code-verified reference for each shipped provider (extend
 driver, pooling, capabilities, labels, `prepareQuery` behaviour, and limitations), see the prime
 docs — they are the single source of truth and are kept in sync with the code:
 
-**[docs/providers/](./providers/README.md)** → postgres · mysql · oracle · mssql · sqlite · redis · mongodb · couchbase · libredb
+**[docs/providers/](./providers/README.md)** → postgres · mysql · oracle · mssql · sqlite · redis · mongodb · couchbase · clickhouse · libredb
 
 When implementing a new provider, the closest existing analogue is the best template: a pooled SQL
 provider (postgres/mysql), an embedded SQL provider (sqlite), a non-SQL provider (mongodb/redis), or
@@ -526,7 +528,6 @@ Assessed against the rubric in [Prerequisites](#prerequisites). Anything not lis
 
 | Candidate | Verdict |
 |---|---|
-| **ClickHouse** ([#264](https://github.com/libredb/libredb-studio/issues/264)) | Scores on all seven, and easier than Couchbase was: a real declared schema so no inference step, a two-level model needing no flattening, and column types carried in the response |
 | **Apache Druid** ([#265](https://github.com/libredb/libredb-studio/issues/265)) | Strong, and it returns errors with real HTTP status codes. `EXPLAIN PLAN FOR` returns a native-query translation rather than an operator tree, so it does not fit the existing tree render model |
 | **Trino / Starburst** | Highest strategic value — one provider fronts S3, Iceberg, Delta and Hive. Unscheduled on purpose: a catalog is another *system*, so what a connection pins is a product question. Also a `nextUri` polling protocol and a fragmented auth matrix |
 | **OpenSearch / Elasticsearch** | HTTP is the only protocol. Needs a dialect decision first: the SQL endpoint is a subset, the native DSL is JSON. OpenSearch is Apache 2.0 and the cleaner primary target |

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -24,12 +24,12 @@
 
 ## Overview
 
-LibreDB Studio provides a RESTful API for database management operations. The API supports PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, and Redis.
+LibreDB Studio provides a RESTful API for database management operations. The API supports PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, ClickHouse, and Redis.
 
 ### Key Features
 
 - **JWT Authentication** - Secure token-based authentication stored in HTTP-only cookies
-- **Multi-Database Support** - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, Redis
+- **Multi-Database Support** - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, ClickHouse, Redis
 - **AI-Powered Queries** - Natural language to SQL with streaming responses
 - **Real-time Health Monitoring** - Database metrics and performance insights
 
@@ -380,6 +380,40 @@ is no JSON envelope. Two things differ from the other SQL providers:
 - `POST /api/db/maintenance` accepts `analyze` (`UPDATE STATISTICS`, Enterprise Edition only),
   `reindex` (`BUILD INDEX` over deferred indexes) and `kill` (a request id), each requiring a target.
 - Full reference: [`docs/providers/couchbase.md`](providers/couchbase.md).
+
+---
+
+##### ClickHouse Query Format
+
+ClickHouse speaks ordinary SQL over its HTTP interface, so the `sql` field carries a plain
+statement — no JSON envelope, the same as PostgreSQL or MySQL. Two things differ from the other SQL
+providers:
+
+- A statement ending in an explicit `FORMAT ...` or `SETTINGS ...` clause is sent unchanged: the
+  server rejects a `LIMIT` appended after either, so the auto-limiter skips injection and
+  `wasLimited` is `false` for those statements.
+- `written_rows` is the only mutation count the server reports, so `rowCount` on an
+  `ALTER TABLE ... UPDATE` or a lightweight `DELETE FROM` is `0` even though the statement applied —
+  this mirrors the server's own reporting, it is not a bug.
+
+```json
+{
+  "connection": {
+    "type": "clickhouse",
+    "host": "localhost",
+    "port": 8123,
+    "user": "default",
+    "password": "",
+    "database": "default"
+  },
+  "sql": "SELECT * FROM events LIMIT 50"
+}
+```
+
+**Notes:**
+- `POST /api/db/maintenance` accepts `optimize` (`OPTIMIZE TABLE ... FINAL`), `analyze` (statistics
+  from `system.parts`) and `kill` (`KILL QUERY WHERE query_id = ... SYNC`).
+- Full reference: [`docs/providers/clickhouse.md`](providers/clickhouse.md).
 
 ---
 
@@ -763,7 +797,7 @@ interface DatabaseConnection {
   createdAt: Date;         // Creation timestamp
 }
 
-type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'redis' | 'oracle' | 'mssql' | 'libredb' | 'couchbase';
+type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'redis' | 'oracle' | 'mssql' | 'libredb' | 'couchbase' | 'clickhouse';
 ```
 
 ### TableSchema

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document outlines the architectural patterns, tech stack, and system design
 
 ## System Overview
 
-LibreDB Studio is a hybrid, cloud-native database management tool that provides an IDE-like experience in the browser. It supports **9 database backends** via a Strategy Pattern abstraction: PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, Redis, LibreDB.
+LibreDB Studio is a hybrid, cloud-native database management tool that provides an IDE-like experience in the browser. It supports **10 database backends** via a Strategy Pattern abstraction: PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Couchbase, ClickHouse, Redis, LibreDB.
 
 It runs in two modes: as a **standalone Next.js app** and as an **embedded npm package** (`@libredb/studio`) consumed by libredb-platform. See [§4.6](#46-workspace-abstraction-npm-package-embedding).
 
@@ -47,6 +47,7 @@ graph TD
         SQL --> SQLite[(SQLite)]
         SQL --> Oracle[(Oracle)]
         SQL --> MSSQL[(SQL Server)]
+        SQL --> ClickHouse[(ClickHouse)]
         Document --> MongoDB[(MongoDB)]
         Document --> Couchbase[(Couchbase)]
         KeyValue --> Redis[(Redis)]
@@ -99,6 +100,7 @@ classDiagram
     SQLBaseProvider <|-- SQLiteProvider
     SQLBaseProvider <|-- OracleProvider
     SQLBaseProvider <|-- MSSQLProvider
+    SQLBaseProvider <|-- ClickHouseProvider
 ```
 
 Each provider implements:
@@ -235,7 +237,7 @@ src/
 └── lib/
     ├── db/                  # Database provider module
     │   ├── providers/
-    │   │   ├── sql/         # postgres, mysql, sqlite (+ sqlite-driver runtime adapter), oracle, mssql
+    │   │   ├── sql/         # postgres, mysql, sqlite (+ sqlite-driver runtime adapter), oracle, mssql, clickhouse/ (transport seam + SQL over HTTP)
     │   │   ├── document/    # mongodb, couchbase/ (transport seam + SQL++ over REST)
     │   │   ├── keyvalue/    # redis
     │   │   └── embedded/    # libredb (built-in embedded provider for the sample connection)

--- a/docs/DATABASE_PROVIDERS.md
+++ b/docs/DATABASE_PROVIDERS.md
@@ -28,7 +28,12 @@ src/lib/db/
 │   │   ├── sqlite.ts           # SQLite Strategy
 │   │   ├── sqlite-driver.ts    # SQLite runtime driver adapter (bun:sqlite | node:sqlite)
 │   │   ├── oracle.ts           # Oracle Strategy
-│   │   └── mssql.ts            # SQL Server Strategy
+│   │   ├── mssql.ts            # SQL Server Strategy
+│   │   └── clickhouse/         # ClickHouse Strategy (SQL over HTTP, no driver)
+│   │       ├── index.ts        #   ClickHouseProvider
+│   │       ├── transport.ts    #   ClickHouseTransport seam + neutral result types
+│   │       ├── http-transport.ts # The one HTTP implementation (fetch)
+│   │       └── introspect.ts   #   system.* catalogs (databases/tables/columns/data_skipping_indices)
 │   ├── document/               # Document Database Providers
 │   │   ├── mongodb.ts          # MongoDB Strategy
 │   │   └── couchbase/          # Couchbase Strategy (SQL++ over REST, no driver)
@@ -55,7 +60,8 @@ BaseDatabaseProvider (abstract)
 │   ├── MySQLProvider                       │ SQL Databases
 │   ├── SQLiteProvider                      │ (shared SQL utilities)
 │   ├── OracleProvider                      │
-│   └── MSSQLProvider                       │
+│   ├── MSSQLProvider                       │
+│   └── ClickHouseProvider                  │
 ├── MongoDBProvider ────────────────────────┤ Document Database
 ├── CouchbaseProvider ──────────────────────┤ Document Database (SQL++ over REST)
 ├── RedisProvider ──────────────────────────┤ Key-Value Store
@@ -105,7 +111,7 @@ QueryEditor                      /api/db/query
 
 ## Supported Databases
 
-Nine providers are supported. For the per-provider reference (driver, pooling, query format,
+Ten providers are supported. For the per-provider reference (driver, pooling, query format,
 monitoring, limitations, …) see the prime docs in **[`docs/providers/`](./providers/README.md)**:
 
 | Provider | type-id | Family | Reference |
@@ -118,6 +124,7 @@ monitoring, limitations, …) see the prime docs in **[`docs/providers/`](./prov
 | Redis | `redis` | Key-Value | [providers/redis.md](./providers/redis.md) |
 | MongoDB | `mongodb` | Document | [providers/mongodb.md](./providers/mongodb.md) |
 | Couchbase | `couchbase` | Document (SQL++) | [providers/couchbase.md](./providers/couchbase.md) |
+| ClickHouse | `clickhouse` | SQL | [providers/clickhouse.md](./providers/clickhouse.md) |
 | LibreDB | `libredb` | Embedded (key-value) | [providers/libredb.md](./providers/libredb.md) |
 
 ## Core Interface
@@ -290,7 +297,7 @@ DatabaseError (base)
 Provider-specific behaviour — pooling model, SSL/encryption, pagination, monitoring sources,
 maintenance operations, and known limitations — is documented per provider under
 [`docs/providers/`](./providers/README.md). Start there for anything specific to PostgreSQL, MySQL,
-Oracle, SQL Server, SQLite, Redis, MongoDB, Couchbase, or LibreDB.
+Oracle, SQL Server, SQLite, Redis, MongoDB, Couchbase, ClickHouse, or LibreDB.
 
 ## Security Considerations
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -27,7 +27,7 @@
 ### 4. Visual EXPLAIN (Query Analyzer)
 *   **Performance Visualization:** Visual execution plan to identify performance bottlenecks.
 *   **Detailed Metrics:** Graphical representation of database scan types, join operations, costs, and execution times.
-*   **Multi-DB Support:** PostgreSQL and MySQL JSON plans, SQLite `EXPLAIN QUERY PLAN`, and Couchbase SQL++ plan trees. Providers without a real analyze mode hide the toggle instead of degrading to an estimate.
+*   **Multi-DB Support:** PostgreSQL and MySQL JSON plans, SQLite `EXPLAIN QUERY PLAN`, Couchbase SQL++ plan trees, and ClickHouse JSON plan trees. Providers without a real analyze mode hide the toggle instead of degrading to an estimate.
 
 ### 5. AI Query Assistant (Multi-Provider LLM)
 *   **Natural Language to SQL:** Convert natural language requests into high-precision SQL code.
@@ -46,6 +46,7 @@
     *   **SQLite:** File-based database support via the runtime's built-in driver — `bun:sqlite` under Bun, `node:sqlite` under Node (the storage layer uses `better-sqlite3`).
     *   **Oracle:** Full support with connection pooling (`oracledb`); introspection/monitoring via the `ALL_*`/`DBA_*` data-dictionary views.
     *   **SQL Server:** Full support with connection pooling (`mssql`); monitoring via DMVs (`sys.dm_*`).
+    *   **ClickHouse:** Full support with **no driver dependency** — SQL over the documented HTTP interface, so the SQL editor, limiter and NL2SQL all apply. Column types read verbatim from `system.columns`, JSON EXPLAIN plan trees, and `OPTIMIZE TABLE` / table-statistics / query-kill maintenance.
 *   **Document Databases:**
     *   **MongoDB:** Full support with official driver, JSON-based MQL queries, automatic schema inference, and aggregation pipelines.
     *   **Couchbase:** Full support with **no driver dependency** — SQL++ over the documented Query and management REST APIs, so the SQL editor, limiter and NL2SQL all apply. Buckets/scopes/collections flattened into the schema explorer, `INFER`-based column inference, visual EXPLAIN plans, and read-your-writes query consistency by default.

--- a/docs/SEED_CONNECTIONS.md
+++ b/docs/SEED_CONNECTIONS.md
@@ -100,7 +100,7 @@ connections:
 | `connections` | Yes | — | Array of connection definitions (min 1) |
 | `connections[].id` | Yes | — | Unique slug: `[a-z0-9-]+`, max 64 chars |
 | `connections[].name` | Yes | — | Display name, max 128 chars |
-| `connections[].type` | Yes | — | Database type: `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql`, `libredb`, `couchbase` |
+| `connections[].type` | Yes | — | Database type: `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql`, `libredb`, `couchbase`, `clickhouse` |
 | `connections[].host` | No | — | Hostname or IP |
 | `connections[].port` | No | — | Port number (1-65535) |
 | `connections[].database` | No | — | Database name |

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -14,6 +14,7 @@ in lockstep with the code (see the tri-sync rule in [`../../CLAUDE.md`](../../CL
 | Redis | `redis` | Key-Value | `ioredis` | JSON | [redis.md](./redis.md) |
 | MongoDB | `mongodb` | Document | `mongodb` | JSON (MQL) | [mongodb.md](./mongodb.md) |
 | Couchbase | `couchbase` | Document | none (HTTP: Query + management REST) | SQL (SQL++) | [couchbase.md](./couchbase.md) |
+| ClickHouse | `clickhouse` | SQL | none (HTTP interface) | SQL | [clickhouse.md](./clickhouse.md) |
 | LibreDB | `libredb` | Embedded (Key-Value) | `@libredb/libredb` | JSON (command grammar) | [libredb.md](./libredb.md) |
 
 ## Conventions

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -1,0 +1,913 @@
+# ClickHouse Provider
+
+> ClickHouse support for LibreDB Studio, built on the documented HTTP interface (port `8123`) with
+> **no driver dependency of any kind**: every statement is the body of a `POST /` and the answer
+> comes back through the runtime's own `fetch`. This document is the single reference point for the
+> ClickHouse provider: design, architecture, usage, and tests. If you are reading the code, extending
+> ClickHouse support, or authoring a new provider, start here.
+
+| | |
+|---|---|
+| **Status** | Implemented & shipped |
+| **Database type id** | `clickhouse` |
+| **Family** | SQL (`src/lib/db/providers/sql/clickhouse/`) |
+| **Driver** | None — HTTP only (`fetch`, a runtime built-in) |
+| **Query language** | `sql` |
+| **Default port** | `8123` (HTTP). `8443` when TLS is on. The native protocol port `9000` is never used — this provider does not speak it |
+| **Connection pooling** | None — each statement is one stateless HTTP request |
+| **Connection string** | Supported (`clickhouse://`, plain `http://` / `https://`) |
+| **EXPLAIN** | `clickhouse-json` — estimate only; ClickHouse's `EXPLAIN` never executes the statement, so there is no separate analyze mode |
+| **Transactions** | Not exposed (ClickHouse has no multi-statement transactions to expose) |
+| **Query cancellation** | No `cancelQuery`; a running statement is killed via maintenance `kill` |
+| **Source** | [`src/lib/db/providers/sql/clickhouse/`](../../src/lib/db/providers/sql/clickhouse/) |
+| **Tests** | [`tests/integration/db/clickhouse-provider.test.ts`](../../tests/integration/db/clickhouse-provider.test.ts) + [`tests/unit/db/clickhouse/`](../../tests/unit/db/clickhouse/) + [`tests/unit/lib/explain/clickhouse-json.test.ts`](../../tests/unit/lib/explain/clickhouse-json.test.ts) |
+| **Tracking issue** | [#264 — Add ClickHouse provider](https://github.com/libredb/libredb-studio/issues/264) |
+
+---
+
+## 1. Overview
+
+ClickHouse is a column-oriented analytical database whose primary interface is a first-class HTTP
+API — the same one its own `clickhouse-client` and every third-party tool use. That makes it an
+easier fit for this codebase than Couchbase was: the SQL dialect is close enough to standard that
+the provider extends `SQLBaseProvider` directly and inherits identifier quoting and `LIMIT`
+injection for free, tables have a real declared schema (no sampling or inference step), and the
+query-response envelope already carries column types.
+
+The two things that *are* ClickHouse-shaped, and which nearly every design decision below flows
+from:
+
+1. **The HTTP interface is honest about failure, except once.** A syntax error, an unknown table, or
+   bad credentials all come back as real HTTP status codes with a numeric exception code in a
+   header — until the first block of a streaming response has already gone out, at which point a
+   failure arrives as a `200` with a truncated body and the real error fenced in a trailer
+   ([§3.7](#37-a-mid-stream-failure-still-arrives-as-200)).
+2. **A permission denial looks exactly like a server crash by status code alone.** `ACCESS_DENIED`
+   answers HTTP `500`, not `403` or `401`. Every error path in this provider is classified by the
+   numeric exception code, never by status or by sniffing the message text
+   ([§3.3](#33-a-permission-denial-arrives-as-http-500-not-403)).
+
+### Concept mapping
+
+| `DatabaseProvider` slot | ClickHouse realisation | Mechanism |
+|-------------------------|-------------------------|-----------|
+| "Table" (`TableSchema`) | A table, displayed as `name` or `database.name` | `system.tables`, filtered to non-system databases |
+| "Row" | One result row | JSON `data` array element |
+| Columns | The declared column list, types verbatim | `system.columns` / the query response `meta` |
+| Primary key | The MergeTree sparse primary index | `system.tables.primary_key`, `is_in_primary_key` |
+| `query(sql)` | One SQL statement | `POST /?default_format=JSON` |
+| Indexes | The primary key, the sorting key (when it differs), and data-skipping indexes | `system.tables` + `system.data_skipping_indices` |
+| Foreign keys | none (ClickHouse has none) | always `[]` |
+| `getOverview()` / storage | Server identity, connection counts, part sizes | `version()`, `uptime()`, `system.metrics`, `system.parts`, `system.disks` |
+| `getSlowQueries()` / `getActiveSessions()` | Finished and in-flight statements | `system.query_log`, `system.processes` |
+| Maintenance | `optimize` / `analyze` / `kill` | `OPTIMIZE TABLE ... FINAL`, a `system.parts` summary, `KILL QUERY ... SYNC` |
+
+---
+
+## 2. Architecture
+
+### 2.1 Where it sits
+
+The database layer uses the **Strategy Pattern**. SQL providers add an intermediate abstract layer,
+`SQLBaseProvider`, between the generic base and each concrete provider — the same layer PostgreSQL
+and MySQL extend. ClickHouse is a *directory* rather than a single file, because the HTTP transport
+is a seam ([§3.2](#32-the-transport-seam-one-interface-one-implementation)):
+
+```
+src/lib/db/providers/sql/
+├── postgres.ts
+├── sql-base.ts
+└── clickhouse/
+    ├── index.ts             # ClickHouseProvider - the SQLBaseProvider subclass
+    ├── transport.ts         # ClickHouseTransport interface + neutral result types (no I/O)
+    ├── http-transport.ts    # the one implementation: the HTTP interface on port 8123
+    └── introspect.ts        # system.* catalog reads
+```
+
+The explain strategy lives with the other strategies, not with the provider:
+[`src/lib/explain/clickhouse-json.ts`](../../src/lib/explain/clickhouse-json.ts).
+
+### 2.2 Class hierarchy
+
+```
+DatabaseProvider (interface, types.ts)
+        ^
+        | implements
+BaseDatabaseProvider (abstract, base-provider.ts)
+        ^
+        | extends
+SQLBaseProvider (abstract, sql-base.ts)
+        ^
+        | extends
+ClickHouseProvider (clickhouse/index.ts)
+```
+
+`ClickHouseProvider` extends `SQLBaseProvider` — not `BaseDatabaseProvider` directly, the way
+Couchbase does — because the dialect really is standard on the points the shared helpers care
+about: double-quoted identifiers and `LIMIT n OFFSET m` are both correct here, live-verified
+(`SELECT "id" FROM "probe"` and the bare unquoted form both parse). This is exactly the case
+[`docs/ADDING_A_PROVIDER.md`](../ADDING_A_PROVIDER.md) names ClickHouse for. Only `prepareQuery()`
+is overridden, for the trailing-clause trap in [§3.8](#38-the-preparequery-override).
+
+### 2.3 What `SQLBaseProvider` gives for free
+
+`ClickHouseProvider` reuses these inherited members rather than reimplementing them:
+
+| Member | Purpose |
+|--------|---------|
+| `escapeIdentifier()` | Double-quoted, since `this.type` (`clickhouse`) falls through to the default branch — the same quoting PostgreSQL uses. Both quoted and unquoted forms parse (live-verified) |
+| `buildLimitClause()` | `LIMIT n` / `LIMIT n OFFSET m` |
+| `getPlaceholder()` | Falls through to `?`, but is moot here: ClickHouse binds only named `{name:Type}` parameters over HTTP, and `query()` throws rather than send an unbound `?` ([§5.1](#51-execution)) |
+| `shouldEnableSSL()` | Inherited but **never called**, and deliberately so. It infers TLS from substrings in the host (`cloud`, `aws`, …), which would silently switch a self-hosted node whose hostname merely contains one of them. TLS here comes from the connection's own `ssl` config or from an `https://` scheme, never from a guess ([§4.3](#43-tls)) |
+| `prepareQuery()` (base) | The shared query limiter; `ClickHouseProvider` calls it first and only overrides the trailing-clause case |
+
+### 2.4 Registration & lifecycle
+
+The factory wires ClickHouse in via a dynamic import
+([`factory.ts:87`](../../src/lib/db/factory.ts)):
+
+```ts
+case 'clickhouse': {
+  // The explicit /index specifier keeps this dynamic import statically analysable:
+  // a bare directory resolves only at runtime, which the bundler cannot trace into a chunk.
+  const { ClickHouseProvider } = await import('./providers/sql/clickhouse/index');
+  return new ClickHouseProvider(connection, options);
+}
+```
+
+`connect()` proves the server, the credentials, and the database together with one `SELECT 1` —
+the cheapest statement that exercises all three at once. This matters here specifically because a
+non-existent `database` URL parameter is **not** checked when the connection is made; it fails
+`404` / code `81` on the first statement that uses it (live-verified), so without the probe a bad
+database would surface much later and somewhere else in the UI. `disconnect()` has nothing to
+release — there is no pool and no session — so it only clears the cached transport reference. API
+routes use `getOrCreateProvider()`, which caches the connected provider per `connection.id` and
+evicts it after 30 minutes idle.
+
+---
+
+## 3. Design decisions
+
+These are the non-obvious choices. Read this section before changing the provider.
+
+### 3.1 HTTP transport only — no native dependency
+
+ClickHouse's own native protocol runs on port `9000` and needs a binary client; this provider never
+speaks it. Every capability the provider needs — querying, catalog introspection, monitoring, and
+maintenance — is reachable over the documented HTTP interface on `8123`, the same interface
+`clickhouse-client --host ... --send_logs_level` and every third-party BI tool that supports
+ClickHouse use. There is no install step to fail, no native module in the Docker image or any
+distribution channel, and no N-API compatibility question for the Bun runtime — the same case
+Couchbase makes in [`docs/ADDING_A_PROVIDER.md`](../ADDING_A_PROVIDER.md).
+
+### 3.2 The transport seam: one interface, one implementation
+
+Provider logic never calls `fetch`. It goes through `ClickHouseTransport`
+([transport.ts:114](../../src/lib/db/providers/sql/clickhouse/transport.ts)), so adopting the
+native protocol later would be one new file implementing the same contract rather than a rewrite:
+
+```ts
+interface ClickHouseTransport {
+  readonly kind: "http";
+  query(sql: string, opts?: ClickHouseQueryOptions): Promise<ClickHouseQueryResult>;
+  close(): Promise<void>;
+}
+```
+
+There is no second entry point next to `query()`, unlike Couchbase's `manage()`: every ClickHouse
+metric, session and storage statistic the provider needs is a `system.*` table reachable by SQL, so
+a permanent second HTTP surface would buy nothing.
+
+The result type is deliberately **neutral** rather than the HTTP response envelope
+([transport.ts:37](../../src/lib/db/providers/sql/clickhouse/transport.ts)):
+
+```ts
+interface ClickHouseQueryResult {
+  rows: Record<string, unknown>[];
+  fieldNames: string[] | null;                 // null when the source cannot describe the rows
+  columnTypes: Record<string, string> | null;  // declared type per column, verbatim
+  executionTimeMs: number;
+  mutationCount: number;                       // what the server says it wrote/changed
+  rawText: string | null;                      // set only when the format was not JSON
+}
+```
+
+`columnTypes` sits in the neutral type rather than behind the HTTP implementation because *any*
+ClickHouse client — HTTP or native — knows the type of the columns it received; it is not a REST
+artefact. `rawText` is neutral for the same reason: output formats are a server feature, not a REST
+feature. Errors follow the same rule: the transport throws one normalized
+`ClickHouseTransportError { code, name, message }`
+([transport.ts:178](../../src/lib/db/providers/sql/clickhouse/transport.ts)), where `code` is
+ClickHouse's own numeric exception code, so the provider switches on a number instead of sniffing
+message strings.
+
+> **Seam rule.** The HTTP envelope identifiers (`X-ClickHouse-Summary`,
+> `X-ClickHouse-Exception-Code`, `X-ClickHouse-Exception-Tag`, `X-ClickHouse-Format`,
+> `default_format`, `output_format_json_quote_64bit_integers`, `elapsed_ns`,
+> `rows_before_limit_at_least`) must appear **only** in `http-transport.ts`.
+> [`seam-guard.test.ts`](../../tests/unit/db/clickhouse/seam-guard.test.ts) parses every source file
+> in the directory with the TypeScript compiler API — not a grep — and fails the build the moment
+> any of that vocabulary is *read* anywhere else, whether as a string, a header lookup, or a
+> destructured field. Two identifiers (`written_rows`, `statistics`) are also real column names on
+> `system.processes` / `system.query_log` / `system.columns`, so the guard only flags them as a
+> *payload read* (`summary.written_rows`), never as SQL text (`SELECT written_rows FROM
+> system.query_log`) — both are legitimate and both are exercised by the introspection and
+> monitoring code.
+
+### 3.3 A permission denial arrives as HTTP 500, not 403
+
+Verified with a purpose-made restricted user granted `SELECT` on one table only:
+
+| Surface as a restricted user | Status | Code |
+|---|---|---|
+| `system.query_log`, `system.processes`, `system.metrics`, `system.data_skipping_indices` | **`500`** | `497` `ACCESS_DENIED` |
+| `OPTIMIZE TABLE`, `KILL QUERY` | **`500`** | `497` |
+| `system.tables`, `system.columns` | `200` | — implicitly filtered to what the user may see |
+| `uptime()`, `version()` | `200` | — needs no grant |
+
+The `497` message reads *"Not enough privileges. To execute this query, it's necessary to have
+grant SELECT"* — it contains neither "access denied" nor "permission denied", so message sniffing
+would miss it entirely. **Detecting** a failure is status-based (`!response.ok`, inside the
+transport); **classifying** it is code-based, from `X-ClickHouse-Exception-Code`
+([index.ts:637](../../src/lib/db/providers/sql/clickhouse/index.ts)). A permission problem looks
+like a server fault by status alone, so any logic keyed on `403` would miss every real denial.
+
+The upside is real: **the schema tree and the overview panel survive a restricted user** — only the
+monitoring panels and maintenance operations that need their own grant degrade
+([§7](#7-monitoring--health)).
+
+### 3.4 `default_format=JSON` as a URL parameter, never appended to the SQL
+
+`POST /?default_format=JSON` with the raw statement as the body returns the JSON envelope. User SQL
+is never rewritten to add a format — the editor sends exactly what the user typed.
+
+**An explicit `FORMAT` in the user's own SQL wins over `default_format`, live-verified.**
+`SELECT 1 FORMAT TSV` genuinely comes back as TSV even with `default_format=JSON` on the URL. The
+response header `X-ClickHouse-Format` reports the format the server actually used, and the transport
+branches on it before parsing the body
+([`toQueryResult`](../../src/lib/db/providers/sql/clickhouse/http-transport.ts)): when it is not
+`JSON`, the raw text comes back as `rawText` rather than being parsed or thrown away — the user asked
+for that format deliberately. The provider then surfaces it as one synthetic column,
+`__text` ([`RAW_TEXT_COLUMN`, index.ts:102](../../src/lib/db/providers/sql/clickhouse/index.ts)),
+the same convention Couchbase uses for a scalar projection.
+
+### 3.5 64-bit integers are quoted on purpose, to stop `JSON.parse` from rounding them
+
+By default `SELECT toUInt64(18446744073709551615)` returns the **unquoted** JSON number
+`18446744073709551615`, which `JSON.parse` silently rounds to `18446744073709552000` — a real,
+reproducible precision loss, not a theoretical one.
+
+**Decision: the transport always sends `output_format_json_quote_64bit_integers=1`**
+([`buildUrl`](../../src/lib/db/providers/sql/clickhouse/http-transport.ts)). Verified: a
+`UInt64` then arrives as the string `"18446744073709551615"`, while an `Int32` or a `Float64` stays
+an unquoted number. This matches the `pg` driver's existing `int8`-as-string behaviour, so the grid
+already renders it correctly with no further change. Every reader in the provider and the
+introspection module accepts both encodings, because `system.asynchronous_metrics` is `Float64` and
+genuinely arrives unquoted in the same response cycle as a quoted `UInt64` counter elsewhere.
+
+### 3.6 Writes return an empty 200 body; the row count lives in a header
+
+A successful `INSERT`, `ALTER TABLE ... UPDATE`, or lightweight `DELETE FROM` answers `200` with
+**no body at all**. Row counts appear only in `X-ClickHouse-Summary`, whose values are all
+**strings**:
+
+```
+X-ClickHouse-Summary: {"read_rows":"2","written_rows":"2","result_rows":"2","elapsed_ns":"56463623", ...}
+```
+
+`written_rows` becomes `mutationCount` on the neutral result. The transport recognises the empty
+body as success *before* it asks what format the response used
+([`toQueryResult`](../../src/lib/db/providers/sql/clickhouse/http-transport.ts)) — a DDL
+response carries no `X-ClickHouse-Format` header at all, so checking format first would
+misclassify it.
+
+**Honesty caveat, live-verified:** for `ALTER TABLE ... UPDATE` and a lightweight `DELETE FROM`,
+`written_rows` is `0` even though the mutation genuinely applied — the row really did change,
+verified independently. Both statement types are queued as background mutations rather than applied
+synchronously, and ClickHouse counts no rows written for either. The provider reports this number
+verbatim and never derives or fabricates a plausible-looking count in its place
+([transport.ts:69](../../src/lib/db/providers/sql/clickhouse/transport.ts)).
+
+### 3.7 A mid-stream failure still arrives as 200
+
+Found during implementation and independently reproduced: once the first block of a streaming
+response has been written, the status line is already committed as `200`, so a statement that fails
+part-way through does not get to report a real status or exception-code header. What arrives
+instead is:
+
+- status **`200`**, with **no** `X-ClickHouse-Exception-Code` header
+- a body **truncated mid-array** (not valid JSON on its own)
+- the real exception fenced in a trailer at the end of the body:
+
+```
+        { "number": 180999 }
+__exception__
+rdlnavwamgbwoyjw
+Code: 395. DB::Exception: boom: ... (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) (version 26.7.1.1315 (official build))
+286 rdlnavwamgbwoyjw
+__exception__
+```
+
+Reproduced with `POST /?default_format=JSON&max_block_size=1000` and
+`SELECT number, throwIf(number = 200000, 'boom') FROM numbers(1000000)`. Without special handling
+the only symptom is a JSON parse complaint, which tells the person who wrote the statement nothing
+about what actually happened.
+
+**The transport checks for this trailer before it looks at the format and before it parses the body,
+and treats it as authoritative on its own**
+([`midstreamError`](../../src/lib/db/providers/sql/clickhouse/http-transport.ts)) — a statement can
+fail after emitting a body that still happens to parse, and reporting that as a short successful
+result would silently lose rows.
+
+**The check has to precede the format branch, not just the parse.** The fence and its tag are
+format-independent, so a statement carrying its own `FORMAT` that dies part-way through would
+otherwise be handed back through the `rawText` path as a success, with the trailer buried in the
+text: live-reproduced as 805000 lost rows reported as `rowCount 1`.
+
+**There is a second variant, and it needs different handling.** Whether the failure streams or not
+depends on how much output had been flushed, and JSON output is *buffered* so the server can count
+`rows`. When the exception wins that race the response is instead:
+
+- status **`500`**, **with** `X-ClickHouse-Exception-Code: 395`
+- the half-built `meta`/`data` JSON, and the exception appended to it
+- **no `__exception__` fence at all** — there is nothing to cut on
+
+So the ordinary error path handles this one, and it trims the partial result off the front of the
+message: without that, the failure is reported with several hundred characters of JSON in front of
+the only line that says what went wrong. The trim deliberately does **not** anchor to a line start,
+because whether a newline precedes the exception depends on how much of a row had been written —
+anchoring silently failed for exactly the longest bodies.
+
+**The fence is keyed on the per-request `X-ClickHouse-Exception-Tag` header**, sent on every
+response including successful ones, rather than on the literal string `__exception__` alone:
+`SELECT '__exception__'` is a legal statement whose result would otherwise be misread as a failure.
+The tag is server-generated per request, so result data can never forge it, which is exactly why the
+header exists and why the transport trusts it.
+
+### 3.8 The `prepareQuery()` override
+
+`SQLBaseProvider.prepareQuery()` appends `LIMIT n` at the very end of a statement. ClickHouse allows
+`FORMAT x` and `SETTINGS ...` as **trailing** clauses, and `LIMIT` after either is a hard syntax
+error, live-verified:
+
+- `SELECT * FROM probe FORMAT TSV LIMIT 1` → `400` / code `62`, *"Expected one of: SETTINGS, ... end
+  of query"*
+- `SELECT * FROM probe SETTINGS max_threads=1 LIMIT 1` → `400` / code `62`
+
+`SELECT * FROM probe LIMIT 1 FORMAT TSV` — limit before either clause — is the order that actually
+works.
+
+`ClickHouseProvider.prepareQuery()`
+([index.ts:515](../../src/lib/db/providers/sql/clickhouse/index.ts)) detects a trailing `FORMAT` or
+`SETTINGS` clause with two patterns anchored at the **end** of the statement (after stripping one
+trailing semicolon, which the server accepts) and, when either matches, returns the query
+**unchanged** with `wasLimited: false` rather than delegating to the inherited limiter. Anchoring at
+the end is what keeps the check off a statement that merely mentions the word: `SELECT * FROM t
+WHERE note = 'format'` and `SELECT name FROM system.settings` are ordinary statements that still get
+limited normally, because neither ends in the clause pattern. A user who wrote a trailing `FORMAT`
+or `SETTINGS` clause is expressing intent the editor must not silently rewrite, and the bias has to
+favour not rewriting: rewriting wrongly turns a working statement into a syntax error, while leaving
+it alone at worst returns more rows than the page size.
+
+One false positive is accepted on purpose rather than fixed: a statement ending in a string literal
+that itself contains an assignment (`... WHERE note = 'SETTINGS foo = 1'`) is read as carrying a
+trailing clause, because ruling it out needs a string-literal-aware tokenizer. The cost of that false
+positive is only a missing row limit — the statement still runs and still returns correct rows —
+whereas the other direction would produce a hard syntax error, which is why the bias sits where it
+does.
+
+### 3.9 Column types are the declared strings, verbatim
+
+Types come back exactly as declared, with no normalization attempted:
+
+`Int32` · `Nullable(String)` · `Array(UInt8)` · `Map(String,String)` · `Enum8('x'=1,'y'=2)` ·
+`LowCardinality(String)` · `Decimal(10,3)` · `DateTime64(3)` · `UUID`
+
+**Decision: `ColumnSchema.type` carries the declared type string unchanged**
+([introspect.ts:290](../../src/lib/db/providers/sql/clickhouse/introspect.ts)). It is precise, it
+is what a ClickHouse user already reads in `SHOW CREATE TABLE`, and collapsing it onto a generic
+family would throw away the wrapper — which is exactly the part that says nullable, low-cardinality,
+parameterised, or enumerated.
+
+**Nullability is derived by testing for the `Nullable(...)` wrapper, not by a bare substring
+search**, because the wrapper is not always outermost and not always the column's own:
+`LowCardinality(Nullable(String))` is nullable (the wrapper comes *after* `LowCardinality`), while
+`Array(Nullable(String))`, `Map(String, Nullable(String))`, and
+`SimpleAggregateFunction(any, Nullable(UInt64))` all qualify an *inner* type and are not nullable
+columns themselves
+([introspect.ts:186](../../src/lib/db/providers/sql/clickhouse/introspect.ts)).
+
+**There is a spacing inconsistency between the two surfaces that carry types**, and it matters
+because they must never be compared as strings: the query-response `meta` array renders
+`Map(String, UInt8)` with a space after the comma, while `system.columns.type` renders the same
+type as `Map(String,String)` with no space.
+
+### 3.10 `supportsCreateTable` is false — live-disproved the issue's own guess
+
+The tracking issue expected `ENGINE` / `ORDER BY` to be the blocker for `CREATE TABLE`. They are
+not: `CREATE TABLE t (id Int32, name String)` succeeds outright on ClickHouse 26.x, because it
+defaults `default_table_engine = MergeTree` with an implied `ORDER BY tuple()`.
+
+The real blocker is what `CreateTableModal` actually emits:
+
+| Modal output | ClickHouse result (live-verified) |
+|---|---|
+| `id SERIAL PRIMARY KEY` (the modal's **default** column) | `Code: 50 ... Unknown data type family: SERIAL` |
+| `email VARCHAR(255) UNIQUE` | `Code: 62 ... Syntax error ... (UNIQUE)` |
+| `id Int32 PRIMARY KEY, name VARCHAR(255) NOT NULL` | works — `VARCHAR(255)` aliases to `String` |
+
+The modal's *default* state produces invalid SQL before a user changes anything, and it offers no
+ClickHouse type list. Per the capability-honesty rule in
+[`docs/ADDING_A_PROVIDER.md`](../ADDING_A_PROVIDER.md#capability-honesty) — a flag that is `true`
+but produces a control that can only emit invalid input is a defect, not a feature — the flag stays
+`false`. DDL typed directly into the query editor works normally; that is how a ClickHouse user
+creates a table today.
+
+### 3.11 Statelessness: no `session_id` is pinned
+
+`SET max_block_size = 4096` inside a ClickHouse `session_id` genuinely persists across requests —
+verified `4096` inside the session versus the default `65409` outside it. The provider deliberately
+does **not** pin one:
+
+- One HTTP request per statement keeps the provider stateless and safely concurrent — nothing to
+  coordinate, nothing to leak across users of a shared connection.
+- A pinned session serializes requests server-side: ClickHouse rejects concurrent use of one
+  `session_id`, which would break parallel schema introspection (`getSchema()` reads three catalogs
+  at once with `Promise.all`).
+- `SET` and temp tables are the only things lost to this, and neither is reachable from the editor's
+  one-statement-per-execution model regardless.
+
+Per-request settings are still sent as URL parameters (`ClickHouseQueryOptions.settings`), which is
+everything the provider actually needs — a statement deadline via `max_execution_time`, for
+instance.
+
+### 3.12 EXPLAIN reuses the shared tree model
+
+`ExplainFormat` gains `"clickhouse-json"`, with the strategy in
+[`src/lib/explain/clickhouse-json.ts`](../../src/lib/explain/clickhouse-json.ts):
+
+- `buildSql()` returns `EXPLAIN json = 1, indexes = 1 ${sql}` for `SELECT` statements, in **both**
+  modes. ClickHouse's `EXPLAIN` never executes the statement — there is no `EXPLAIN ANALYZE` to ask
+  for — so the estimate is the only plan available either way. Returning `null` for analyze mode
+  would not narrow the feature, it would disable it: the direct Explain action always builds with
+  mode `analyze` and refuses to run when the strategy declines, so the button would go dead while
+  only the background pre-warm worked. This mirrors `sqlite-queryplan.ts` and `couchbase-json.ts`,
+  which make the same call for the same reason.
+- `actions = 1` is deliberately **not** requested: it multiplies plan size roughly tenfold (21 KB for
+  a two-table join, live-measured) with expression internals the tree render model has no way to
+  show.
+- The result is one row, one `String` column named `explain`, whose *value* is the plan as a JSON
+  **string** needing a second `JSON.parse` — `extractPlan()` does that parse so the stored value
+  feeds the raw-JSON and AI tabs as a structure rather than one escaped blob. The parsed shape is an
+  array of one `{ Plan: {...} }` object; `toPlanRoot()` unwraps up to five layers (cell text, the
+  outer array, the `Plan` member, the node itself, plus one guard layer) so it accepts the plan at
+  whichever depth the server or the storage layer hands it back.
+- Children always live under **`Plans`**, always an array — there is no `~child` / `~children`
+  duality to walk, unlike Couchbase.
+- `indexes = 1` adds an `Indexes` array on `ReadFromMergeTree` nodes (`Type`, `Keys`, `Condition`,
+  `Search Algorithm`, `Initial Parts`/`Selected Parts`, `Initial Granules`/`Selected Granules`).
+  `toRenderModel()` renders each entry as its own child row rather than folding it into one detail
+  string, because a MergeTree read can report up to four of them (Min-Max, Partition, PrimaryKey,
+  and each data-skipping index) and each deserves its own line, with the selected-over-initial ratio
+  shown when both counts are present.
+
+---
+
+## 4. Connection
+
+### 4.1 Configuration fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `host` | Yes (or `connectionString`) | `validate()` throws `DatabaseConfigError` when both are missing |
+| `port` | No | Defaults to `8123`, or `8443` when `ssl.mode` is anything but `disable` |
+| `user` / `password` | No | Sent as HTTP Basic **only when `user` is set**. Live-verified: an empty Basic username fails hard (*"Got an empty user name from Authorization HTTP header"*, code `516`), while sending no header at all resolves to the `default` user — the correct behaviour for a stock local install |
+| `database` | No | Sent as the `database` URL parameter on every request. A connection that names none resolves against `default`, which always exists — a database is deliberately not required the way Couchbase requires a bucket |
+| `connectionString` | No | `clickhouse://`, `http://`, `https://`; see [§4.2](#42-connection-strings) |
+| `ssl` | No | Any mode but `disable` switches the transport to `https` and the default port to `8443` |
+
+```ts
+const connection = {
+  id: 'ch-1',
+  name: 'ClickHouse',
+  type: 'clickhouse',
+  host: '127.0.0.1',
+  port: 8123,
+  user: 'libredb',
+  password: 'password123',
+  database: 'demo',
+  createdAt: new Date(),
+};
+```
+
+### 4.2 Connection strings
+
+`supportsConnectionString` is `true`. Two related but distinct paths exist:
+
+- **A pasted URL** goes through the shared parser
+  ([`connection-string-parser.ts:66`](../../src/lib/connection-string-parser.ts)), which decomposes
+  it into discrete fields (host/port/user/password/database) before the provider ever sees it, and
+  stores no `connectionString` on the connection.
+- **A hand-typed connection string** (the ConnectionModal's URI tab clears host, port, user and
+  password when it submits) is resolved by the provider itself,
+  `resolveConnection()` ([index.ts:402](../../src/lib/db/providers/sql/clickhouse/index.ts)), which
+  is not optional politeness: for a connection typed there, the URL is the *only* place any of those
+  fields exist. Percent-encoded credentials are decoded (`p%40ss%2Fword` → `p@ss/word`), an
+  unparsable string leaves every configured field untouched rather than emptying a working
+  connection, and `https://` sets `ssl.mode = "require"` and switches the default port to `8443`.
+
+| Input | host | port | database |
+|-------|------|------|----------|
+| `clickhouse://localhost:8123/demo` | `localhost` | `8123` | `demo` |
+| `http://reader:s3cret@ch.internal:9123/analytics` | `ch.internal` | `9123` | `analytics` |
+| `https://abc.clickhouse.cloud/default` | `abc.clickhouse.cloud` | `8443` (TLS default, none in URL) | `default` |
+
+A bare `http://` or `https://` URL is treated as canonically ClickHouse — no other provider claims
+those schemes — because the HTTP interface *is* the connection target here, unlike a wire-protocol
+database where an HTTP URL would mean nothing.
+
+### 4.3 TLS
+
+`config.ssl` with any `mode` but `disable` switches the transport from `http` to `https` and the
+default port from `8123` to `8443`
+([the transport constructor](../../src/lib/db/providers/sql/clickhouse/http-transport.ts)). There is no
+separate CA/client-certificate plumbing the way Couchbase's `node:https` path has: the transport
+uses the runtime's own `fetch`, whose TLS trust follows the platform's default certificate store.
+
+Two consequences worth stating plainly:
+
+- **`ssl.caCert`, `ssl.clientCert` and `ssl.rejectUnauthorized` are not honoured.** Global `fetch`
+  cannot carry a custom CA or relax verification without an undici `Agent` as its `dispatcher`, and
+  undici is not a dependency. A self-hosted node behind a **self-signed** certificate therefore fails
+  verification; ClickHouse Cloud and any node with a publicly-trusted certificate work. Honouring
+  them needs the `node:https` path Couchbase already has, which is a follow-up rather than a
+  limitation of the scheme.
+- **A pasted `https://` URL keeps its TLS intent.** `parseConnectionString` returns
+  `sslMode: "require"` for that scheme and the connection form applies it, because the parsed
+  host/port fields alone cannot express TLS — without it the connection would go out as plaintext
+  HTTP to the TLS port and fail with a bare `fetch failed`.
+
+---
+
+## 5. Query interface
+
+### 5.1 Execution
+
+`query(sql, params?)` ([index.ts:593](../../src/lib/db/providers/sql/clickhouse/index.ts)) sends one
+statement with a server-side deadline (`max_execution_time`, derived from `queryTimeout`, default 60
+seconds) so a runaway statement cannot hang the editor indefinitely:
+
+```ts
+await provider.query('SELECT id, email FROM users');
+```
+
+**Positional parameters are refused, not silently ignored.** ClickHouse's HTTP interface binds only
+named `{name:Type}` parameters, so there is nowhere on the wire to put a positional value; a caller
+that passed one would otherwise have the statement run with its placeholders unbound. `query(sql,
+params)` throws a `QueryError` the moment `params` is non-empty. An empty array is accepted, because
+that is how the rest of the application calls every provider uniformly.
+
+`prepareQuery()` injects `LIMIT`/`OFFSET` through the shared limiter
+(`supportsExternalQueryLimiting: true`) unless the statement carries a trailing `FORMAT` or
+`SETTINGS` clause ([§3.8](#38-the-preparequery-override)).
+
+### 5.2 Result shaping
+
+| Source | `QueryResult` field | Notes |
+|--------|----------------------|-------|
+| `data` array | `rows` | Objects exactly as the server returned them |
+| `meta` array | `fields` | Declared column order; `[]` when the source could not describe the rows (a non-JSON format, or a write) |
+| — | `rowCount` | `rows.length` when there are rows; otherwise `mutationCount` from `X-ClickHouse-Summary`, verbatim, zero included ([§3.6](#36-writes-return-an-empty-200-body-the-row-count-lives-in-a-header)) |
+| `X-ClickHouse-Summary.elapsed_ns` | `executionTime` | The server's own duration, preferred because it excludes network latency; falls back to the envelope's `statistics.elapsed` (seconds), then to the measured wall clock when neither source reported anything |
+| a non-JSON `X-ClickHouse-Format` | `rows` / `fields` | One synthetic row `{ __text: "<raw body>" }` under the single column `__text` ([§3.4](#34-default_formatjson-as-a-url-parameter-never-appended-to-the-sql)) |
+
+### 5.3 EXPLAIN
+
+The EXPLAIN button is available (`supportsExplain: true`) and renders the plan tree described in
+[§3.12](#312-explain-reuses-the-shared-tree-model). ClickHouse has no analyze mode, so both the
+direct action and the background pre-warm show the same estimated plan.
+
+---
+
+## 6. Schema introspection
+
+Three separate reads of the `system.*` catalogs, run in parallel with `Promise.all`, all through the
+transport seam:
+
+| Data | Source |
+|------|--------|
+| Tables | `system.tables` — name, `total_rows`, `total_bytes`, `sorting_key`, `primary_key`, filtered to non-system databases |
+| Columns | `system.columns` — name, type, `is_in_primary_key`, `default_kind`/`default_expression`, ordered by declaration `position` |
+| Indexes | `system.data_skipping_indices` — the nearest thing ClickHouse has to a secondary index object, plus the synthesized `PRIMARY KEY` / `ORDER BY` entries |
+| Foreign keys | always `[]` — ClickHouse has no foreign-key concept anywhere: no engine, no table setting, no DDL declares one |
+
+Non-system databases are `system`, `information_schema`, and `INFORMATION_SCHEMA` (the last exists
+as its own separate row in `system.databases`, live-verified, so excluding only one leaves a
+duplicate ANSI catalog in the tree). `default` is deliberately **kept** — it is an ordinary writable
+database and the one a connection that names none lands in, so hiding it would empty the commonest
+setup.
+
+Load-bearing details:
+
+- **`total_rows` / `total_bytes` are `Nullable(UInt64)` and really are null** for a view and for
+  every non-MergeTree engine (live-verified). Null is reported as `undefined` — unknown — never
+  coerced to zero; a table shown as "0 rows" when the server never said so is a number the explorer
+  would have invented.
+- **A key expression is a comma-separated list that can itself contain commas** —
+  `a, b, cityHash64(c, c)` — so splitting is parenthesis-depth-aware, never a naive `.split(',')`.
+  A one-element key renders as `(a)` while a multi-element one renders as `a, b`; the parser strips
+  exactly one wrapping pair when the whole expression is parenthesized.
+- **The primary key and the sorting key are reported as separate index entries only when they
+  differ.** ClickHouse's primary index is a real sparse index over the sort order — reporting no
+  index at all on a MergeTree table would be misleading — but `ORDER BY` may extend `PRIMARY KEY`
+  with trailing columns that genuinely shape the on-disk order and the query plan, so those are
+  surfaced as a second `ORDER BY` entry when they add anything the primary key entry does not
+  already say (comparing the split element lists, because the server renders the same one-element
+  key as `(a)` in one column and `a` in the other).
+- **No index ClickHouse reports is unique** — not the data-skipping indexes, which only prune
+  granules, and not the primary key either: live-verified, three identical values were accepted into
+  a table declared `PRIMARY KEY (a)`.
+- **Each catalog degrades independently.** `system.tables` and `system.columns` are pre-filtered to
+  what the connected user may read and answer `200`; `system.data_skipping_indices` needs its own
+  grant and answers `500` / code `497` without it (live-verified). A denied index catalog still
+  yields a full table-and-column tree; only the data-skipping-index list is empty. Any *other*
+  failure propagates rather than degrading — an empty tree standing in for a real error would hide
+  it forever.
+
+`getSchemaList()` defers the index catalog entirely so a third catalog read never blocks the table
+list, exactly as the SQL providers' two-phase loading does; `getSchemaRelations()` reads it and
+returns an entry — empty list included — for every table, so the client can merge indexes in
+without losing a table that legitimately has none.
+
+---
+
+## 7. Monitoring & health
+
+Every method below degrades to empty/zero on `ACCESS_DENIED` (497) or `UNKNOWN_TABLE` (60) — and
+**only** those two codes; any other failure propagates, because those are the two live-verified
+codes for "this surface does not exist for this user or this deployment" (a missing grant, or
+`query_log` switched off on a given server), while anything else is the user's own mistake that must
+keep surfacing.
+
+| Method | Source | Notes |
+|--------|--------|-------|
+| `getOverview()` | `version()`, `uptime()`, `system.metrics`, `system.server_settings`, `system.parts`, `system.tables`, `system.data_skipping_indices` | Five separate reads on purpose: a restricted user gets `200` from `version()`/`uptime()` and `system.tables`, but `500`/497 from `system.metrics` and the two count queries — combining them into one statement would throw away the panels a restricted user CAN see |
+| `getPerformanceMetrics()` | `system.events` (`MarkCacheHits`/`MarkCacheMisses`/`Query`), `system.asynchronous_metrics` (`MemoryResident`/`OSMemoryTotal`) | cache-hit ratio from the mark cache (ClickHouse's nearest buffer-cache equivalent); `queriesPerSecond` divides the lifetime `Query` counter by uptime, since neither is ever sampled twice in a single-shot read; buffer-pool usage is resident memory against total machine memory |
+| `getSlowQueries()` | `system.query_log` where `type = 'QueryFinish'`, grouped by `normalized_query_hash` | Grouped the way `pg_stat_statements` groups — one row per statement *shape*, with its call count and min/max/avg duration, not one row per execution. Flushed **asynchronously**, so a statement that just ran may be absent for a few seconds |
+| `getActiveSessions()` | `system.processes` | Excludes its own read (`query NOT LIKE '%system.processes%'`), the same trick `postgres.ts` applies to `pg_stat_activity`; every row is reported with a constant `state: "active"`, because ClickHouse has no idle-in-transaction equivalent to distinguish |
+| `getTableStats()` / `getIndexStats()` | `system.parts` (active parts only) / `system.data_skipping_indices` | Accept an optional `{ schema }` filter; without one, every non-system database is covered. Index scan counts are always `0` — ClickHouse publishes no per-index usage counter anywhere, and a guessed number would be worse than an obvious zero |
+| `getStorageStats()` | `system.disks` | Name, path, total/free bytes, and a usage percentage per configured disk |
+| `getHealth()` | the four above, composed | connections, size, cache-hit ratio, top-5 slow queries, top-10 sessions |
+
+---
+
+## 8. Maintenance
+
+`runMaintenance(type, target?)`
+([index.ts:920](../../src/lib/db/providers/sql/clickhouse/index.ts)). `optimize` and `kill` **require**
+a target; `analyze` does not.
+
+| Type | ClickHouse action | Notes |
+|------|--------------------|-------|
+| `optimize` | `OPTIMIZE TABLE <db>.<table> FINAL` | Merges the table down to one part per partition and applies pending mutations — the operation a ClickHouse user reaches for where another engine would vacuum. A target is mandatory, because `OPTIMIZE` names a table |
+| `analyze` | Reports a `system.parts` summary (part count, row count, on-disk size) for the target, **or for the whole pinned database when no target is given** | ClickHouse has no `ANALYZE` and needs none: a MergeTree's statistics *are* its parts, and they are current by construction, so the honest equivalent is to report them rather than pretend something was recomputed. The targetless form exists because `MaintenanceModal`'s global Analyze button (labelled by `analyzeGlobalLabel`) sends no target — a live run showed it failing with "requires a target", i.e. a control the UI always offers that could never work. A scope with no active parts (a view, or a non-MergeTree engine) is reported as such rather than as an error |
+| `kill` | `KILL QUERY WHERE query_id = '<target>' SYNC` | `SYNC` so the result is reported after the query has actually stopped, not after the kill was merely queued |
+
+`vacuum`, `reindex` and `check` have no ClickHouse equivalent, so they are absent from
+`maintenanceOperations` and the UI never offers them; calling `runMaintenance` with one directly
+throws a `QueryError` naming the three supported operations. A target is qualified through
+`escapeIdentifier()` (`"database"."table"`, defaulting the database to the pinned one when the
+target names none), so a hostile or oddly-named table cannot break out of the generated statement.
+
+---
+
+## 9. Capabilities & labels
+
+### `getCapabilities()` ([index.ts:461](../../src/lib/db/providers/sql/clickhouse/index.ts))
+
+| Capability | Value |
+|------------|-------|
+| `queryLanguage` | `sql` |
+| `supportsExplain` | `true` |
+| `explainFormat` | `clickhouse-json` |
+| `supportsExternalQueryLimiting` | `true` |
+| `supportsCreateTable` | `false` |
+| `supportsMaintenance` | `true` |
+| `maintenanceOperations` | `['optimize', 'analyze', 'kill']` |
+| `supportsConnectionString` | `true` |
+| `defaultPort` | `8123` |
+| `schemaRefreshPattern` | `\b(CREATE\|DROP\|ALTER\|RENAME\|TRUNCATE\|ATTACH\|DETACH)\b` |
+
+`supportsCreateTable: false` is deliberate, not an oversight — see
+[§3.10](#310-supportscreatetable-is-false--live-disproved-the-issues-own-guess).
+
+### `getLabels()` ([index.ts:489](../../src/lib/db/providers/sql/clickhouse/index.ts))
+
+Tables and rows are the right words here, so only the maintenance vocabulary changes — ClickHouse
+has no VACUUM and no ANALYZE, and offering either by that name would describe an operation that does
+not exist: `analyzeAction`/`analyzeGlobalLabel`/`analyzeGlobalTitle` → *"Table Statistics"*,
+`vacuumAction` → *"Optimize Table"*, `vacuumGlobalLabel` → *"Optimize"*, `vacuumGlobalTitle` →
+*"Merge Parts"*. The card descriptions name the substituted operation explicitly (`OPTIMIZE TABLE
+... FINAL`) rather than reusing generic wording that would describe a command ClickHouse does not
+have.
+
+---
+
+## 10. Error handling
+
+The transport normalizes every failure into `ClickHouseTransportError { code, name, message }`; the
+provider maps that one numeric space onto the shared classes from
+[`src/lib/db/errors.ts`](../../src/lib/db/errors.ts)
+([index.ts:637](../../src/lib/db/providers/sql/clickhouse/index.ts)):
+
+| Code | Meaning | Error raised |
+|------|---------|--------------|
+| `516` `AUTHENTICATION_FAILED`, `497` `ACCESS_DENIED` | Bad credentials, or a missing grant | `AuthenticationError` |
+| `159` `TIMEOUT_EXCEEDED`, `209` `SOCKET_TIMEOUT` | The statement deadline was hit | `TimeoutError` |
+| `394` `QUERY_WAS_CANCELLED` | The statement was killed (by this provider's own `kill`, or by another client) | `QueryCancelledError` |
+| `210` `NETWORK_ERROR` | The server itself reported a network fault reaching a remote replica | `ConnectionError` |
+| `0` (no server code) | Nothing below the SQL layer answered — a refused socket, an abort, a rewritten response | Falls through to the shared message-based mapping (`mapError()`), which recognises a refused connection and a generic timeout by message text |
+| anything else (e.g. `62` syntax, `60` unknown table, `81` unknown database, `48` not implemented) | A statement the server understood and rejected | `QueryError` carrying the server's own message |
+
+| Situation | Error |
+|-----------|-------|
+| Missing `host` **and** `connectionString` | `DatabaseConfigError` |
+| Operation before `connect()` | `DatabaseConfigError` (via `ensureConnected()`) |
+| `connect()` fails on credentials | `AuthenticationError` |
+| `connect()` fails otherwise (including a non-existent database) | `ConnectionError` (carries host/port) |
+
+A bare `UPDATE ... SET` — as opposed to `ALTER TABLE ... UPDATE` — is code `48` `NOT_IMPLEMENTED`
+(HTTP `501`, live-verified), and the server's own message names the exact precondition (*"Lightweight
+updates are supported only for tables with materialized \_block\_number column"*), which is more
+useful than any wording this provider could add, so it is surfaced verbatim as a `QueryError`.
+
+---
+
+## 11. Testing
+
+### 11.1 How the tests work
+
+There is **no `mock.module()` anywhere in the ClickHouse suite**, so none of these files carry
+process-wide contamination risk:
+
+- [`tests/integration/db/clickhouse-provider.test.ts`](../../tests/integration/db/clickhouse-provider.test.ts)
+  replaces `globalThis.fetch` per test and restores it in `afterEach`. Every payload in it —
+  catalog rows, monitoring rows, exception bodies — was captured from a live ClickHouse
+  26.7.1.1315 server (database `demo`), so the fake speaks exactly what the cluster speaks.
+- [`tests/unit/db/clickhouse/http-transport.test.ts`](../../tests/unit/db/clickhouse/http-transport.test.ts)
+  drives `ClickHouseHttpTransport` directly against a faked `fetch`: request shape, endpoint
+  construction (host/port/TLS/IPv6 bracketing), the JSON result path, the write path (empty body,
+  summary header, DDL with no format header), non-JSON formats, failures (status, version-suffix
+  stripping, exception-name/code extraction), the mid-stream trailer, and transport-level failures
+  (unparsable JSON, a refused connection, an abort).
+- [`tests/unit/db/clickhouse/introspect.test.ts`](../../tests/unit/db/clickhouse/introspect.test.ts)
+  tests the introspection module against a hand-written fake `ClickHouseTransport` — the payoff of
+  the seam in [§3.2](#32-the-transport-seam-one-interface-one-implementation): the system-database
+  filter, null-vs-zero row counts, comma-in-parentheses key splitting, primary/sorting-key
+  synthesis, data-skipping-index reporting, cross-database table-name disambiguation, and every
+  degradation path.
+- [`tests/unit/db/clickhouse/seam-guard.test.ts`](../../tests/unit/db/clickhouse/seam-guard.test.ts)
+  is a parser, not a grep, and proves itself in both directions: it must fire on the transport file
+  (which is *supposed* to speak the wire vocabulary) and stay silent on a compliant sample, before
+  it asserts the real provider directory is clean.
+- [`tests/unit/lib/explain/clickhouse-json.test.ts`](../../tests/unit/lib/explain/clickhouse-json.test.ts)
+  covers the plan walker: wrapper-depth unwrapping, the `Plans` array walk, `Indexes` rendering
+  (including the selected/initial ratio and a degraded entry missing type/keys/counts), and
+  rejecting shapes that are not ClickHouse plans at all.
+
+### 11.2 Coverage
+
+The suite covers: validation (host-or-connection-string), the connection model (pinned database as
+a URL parameter, hand-typed connection-string resolution including percent-decoding and the
+TLS-port switch), connect/disconnect (including the `SELECT 1` probe surfacing a bad database or bad
+credentials immediately), query execution and result shaping (declared column order, the server's
+own duration, write row counts including the `ALTER ... UPDATE` zero, the non-JSON-format synthetic
+column, positional-parameter refusal), the full error-code map, the `prepareQuery()` trailing-clause
+override (both directions — statements that must be limited and statements that must not), every
+schema method, every monitoring method and its degraded path, and all three maintenance operations
+including identifier quoting and literal escaping.
+
+### 11.3 Run it
+
+```bash
+# Just this provider
+bun test tests/integration/db/clickhouse-provider.test.ts
+bun test tests/unit/db/clickhouse
+bun test tests/unit/lib/explain/clickhouse-json.test.ts
+
+# Full isolated suite (CI-equivalent)
+bun run test
+```
+
+### 11.4 Optional: verifying against a live server
+
+The committed tests are mock-based by design. `database-compose.yml` carries a `clickhouse`
+service pinned to the exact build (`clickhouse/clickhouse-server:26.7.1.1315`) this document and the
+design spec were verified against, so status codes, header names, and the mid-stream-failure
+trailer stay reproducible:
+
+```bash
+docker compose -f database-compose.yml up clickhouse
+# then point a Studio connection at localhost:8123, user libredb / password123, database demo
+```
+
+Port `9000` (the native protocol) is deliberately not exposed — there is no native-protocol
+transport in this codebase to connect with it.
+
+---
+
+## 12. Usage examples
+
+### 12.1 Programmatic (via the factory)
+
+```ts
+import { createDatabaseProvider } from '@/lib/db/factory';
+
+const provider = await createDatabaseProvider({
+  id: 'ch1', name: 'ClickHouse', type: 'clickhouse',
+  host: '127.0.0.1', port: 8123,
+  user: 'libredb', password: 'password123',
+  database: 'demo',
+  createdAt: new Date(),
+});
+
+await provider.connect();
+
+const result = await provider.query('SELECT id, email FROM users LIMIT 50');
+const schema = await provider.getSchema();           // tables + columns + indexes, one round trip
+const list = await provider.getSchemaList();          // fast: tables + columns, no index catalog
+const relations = await provider.getSchemaRelations(); // indexes to merge in
+
+await provider.disconnect();
+```
+
+### 12.2 Over the API
+
+`POST /api/db/query` with the SQL statement in the `sql` field — the same contract every SQL
+provider uses. `POST /api/db/maintenance` (admin) accepts `optimize` / `analyze` / `kill`, each with
+a target. Transaction and cancel routes do not apply — see [§13](#13-known-limitations--future-work).
+
+---
+
+## 13. Known limitations & future work
+
+- **No transactions.** ClickHouse has no multi-statement transaction model to expose over this
+  interface, so there is no begin/commit/rollback API here.
+- **No `cancelQuery`.** A running statement is terminated through maintenance `kill` with its
+  `query_id`, which needs its own grant like any other `system.processes` operation.
+- **No analyze-mode EXPLAIN.** ClickHouse's `EXPLAIN` never executes the statement; see
+  [§3.12](#312-explain-reuses-the-shared-tree-model).
+- **`ALTER TABLE ... UPDATE` and lightweight `DELETE FROM` report zero rows changed even on
+  success.** This is the server's own number, not a provider limitation to fix — see
+  [§3.6](#36-writes-return-an-empty-200-body-the-row-count-lives-in-a-header).
+- **Two shared SQL-generating features are not dialect-aware, and neither is fixed here.** Both live
+  outside this provider's files, both are pre-existing rather than introduced by it, and both are
+  tracked in [#269](https://github.com/libredb/libredb-studio/issues/269):
+  - The results grid's **inline row editing** generates a bare `UPDATE ... SET ... WHERE`, which
+    ClickHouse rejects outright (`NOT_IMPLEMENTED`, code `48`, HTTP `501`) rather than running as an
+    `ALTER TABLE ... UPDATE`. It also emits several statements separated by `;`, which the server
+    rejects on its own (see the multi-statement note at the end of this section). Use
+    `ALTER TABLE ... UPDATE` in the editor instead.
+  - The **schema-diff migration generator** has no ClickHouse branch, so a nullability or type change
+    emits PostgreSQL's `ALTER TABLE ... ALTER COLUMN ... SET NOT NULL` where ClickHouse wants
+    `ALTER TABLE ... MODIFY COLUMN <col> Nullable(T)`. Identifier quoting is already correct (both
+    dialects use `"`); only the statement shape is wrong. Oracle falls through the same branch and is
+    approximate for the same reason, so this is a gap in that generator rather than in this provider.
+- **No native protocol.** Port `9000` and everything that needs it — the native wire format, some
+  server-side settings only exposed there — is out of scope; see
+  [§3.1](#31-http-transport-only--no-native-dependency).
+- **No dictionaries or materialized-view management.** Both are visible through `system.tables` like
+  any other object (a materialized view's target table shows up as an ordinary table), but there is
+  no dedicated UI or API surface for creating, refreshing, or reloading either.
+- **Index scan counts are always zero.** ClickHouse publishes no per-index usage counter anywhere
+  the HTTP interface can reach, and a guessed number would be worse than an obvious zero — see
+  [§7](#7-monitoring--health).
+- **Row counts and table sizes are the server's own bookkeeping** (`system.tables.total_rows` /
+  `total_bytes`), not `COUNT(*)` — fast, and null (reported as unknown) for views and non-MergeTree
+  engines rather than a computed figure.
+- **`query_log`-backed monitoring needs its own grant and may be switched off entirely** on a given
+  deployment; both are ordinary, expected configurations and degrade to an empty panel rather than
+  an error — see [§7](#7-monitoring--health).
+- **Multi-statement SQL is rejected by the server itself** (`Multi-statements are not allowed`,
+  code `62`), so the provider does no client-side statement splitting; a single trailing semicolon is
+  accepted.
+
+---
+
+## 14. References
+
+- Source: [`src/lib/db/providers/sql/clickhouse/`](../../src/lib/db/providers/sql/clickhouse/)
+- Explain strategy: [`src/lib/explain/clickhouse-json.ts`](../../src/lib/explain/clickhouse-json.ts)
+- SQL base: [`src/lib/db/providers/sql/sql-base.ts`](../../src/lib/db/providers/sql/sql-base.ts)
+- Base class: [`src/lib/db/base-provider.ts`](../../src/lib/db/base-provider.ts)
+- Interface & DTOs: [`src/lib/db/types.ts`](../../src/lib/db/types.ts)
+- Errors: [`src/lib/db/errors.ts`](../../src/lib/db/errors.ts)
+- Tests: [`tests/integration/db/clickhouse-provider.test.ts`](../../tests/integration/db/clickhouse-provider.test.ts) · [`tests/unit/db/clickhouse/`](../../tests/unit/db/clickhouse/) · [`tests/unit/lib/explain/clickhouse-json.test.ts`](../../tests/unit/lib/explain/clickhouse-json.test.ts)
+- API contract: [`docs/API_DOCS.md`](../API_DOCS.md)
+- Tracking issue: [#264 — Add ClickHouse provider](https://github.com/libredb/libredb-studio/issues/264)
+- HTTP interface: <https://clickhouse.com/docs/en/interfaces/http>
+- System tables: <https://clickhouse.com/docs/en/operations/system-tables/tables>,
+  <https://clickhouse.com/docs/en/operations/system-tables/columns>,
+  <https://clickhouse.com/docs/en/operations/system-tables/data_skipping_indices>
+- EXPLAIN: <https://clickhouse.com/docs/en/sql-reference/statements/explain>
+- Sibling provider docs: [PostgreSQL](./postgres.md) · [MySQL](./mysql.md) · [Oracle](./oracle.md) · [SQL Server](./mssql.md) · [SQLite](./sqlite.md) · [MongoDB](./mongodb.md) · [Couchbase](./couchbase.md) · [Redis](./redis.md) · [LibreDB](./libredb.md)

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -659,6 +659,15 @@ keep surfacing.
 | `getStorageStats()` | `system.disks` | Name, path, total/free bytes, and a usage percentage per configured disk |
 | `getHealth()` | the four above, composed | connections, size, cache-hit ratio, top-5 slow queries, top-10 sessions |
 
+Two honest zeroes in the overview, so neither reads as a measurement:
+
+- **`maxConnections` is `0` where `system.server_settings` is unavailable.** It is an ordinary system
+  table on self-managed builds (verified present on OSS 26.7.1), but it is recent enough that an older
+  server may not have it, and it is grant-gated like every other `system.*` read. Either way the read
+  degrades rather than failing the panel.
+- **Index scan counts are always `0`**, because ClickHouse publishes no per-index usage counter that
+  the HTTP interface can reach.
+
 ---
 
 ## 8. Maintenance

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -27,8 +27,11 @@
 
 ## 1. Overview
 
-ClickHouse is a column-oriented analytical database whose primary interface is a first-class HTTP
-API — the same one its own `clickhouse-client` and every third-party tool use. That makes it an
+ClickHouse is a column-oriented analytical database with a **first-class HTTP interface** — a
+documented, fully-featured peer of the native protocol rather than a bolt-on, and the surface the
+Play UI and most third-party integrations speak. (Its own `clickhouse-client` uses the *native*
+protocol on `9000`, which this provider deliberately does not implement — see
+[§3.1](#31-http-transport-only--no-native-dependency).) That makes it an
 easier fit for this codebase than Couchbase was: the SQL dialect is close enough to standard that
 the provider extends `SQLBaseProvider` directly and inherits identifier quoting and `LIMIT`
 injection for free, tables have a real declared schema (no sampling or inference step), and the
@@ -554,8 +557,19 @@ Two consequences worth stating plainly:
 ### 5.1 Execution
 
 `query(sql, params?)` ([index.ts:593](../../src/lib/db/providers/sql/clickhouse/index.ts)) sends one
-statement with a server-side deadline (`max_execution_time`, derived from `queryTimeout`, default 60
-seconds) so a runaway statement cannot hang the editor indefinitely:
+statement under **two** deadlines, both derived from `queryTimeout` (default 60 seconds), because
+neither covers the other:
+
+- **`max_execution_time`**, server-side, so a runaway statement cannot hang the editor. It only
+  starts counting once ClickHouse has *accepted* the statement.
+- **`timeoutMs` on the transport seam**, client-side, armed as an `AbortSignal` on the request. This
+  is what bounds everything the server-side limit cannot: a stalled DNS lookup, TCP connect or TLS
+  handshake, and a response body that stops arriving part-way. The same signal covers the body read,
+  since a response whose headers arrive promptly can still stall mid-stream. Without it the advertised
+  query timeout would quietly not apply to transport failures at all.
+
+Monitoring reads carry the same pair at a shorter 10-second bound — a hanging panel is worse than an
+empty one.
 
 ```ts
 await provider.query('SELECT id, email FROM users');
@@ -853,8 +867,11 @@ await provider.disconnect();
 ### 12.2 Over the API
 
 `POST /api/db/query` with the SQL statement in the `sql` field — the same contract every SQL
-provider uses. `POST /api/db/maintenance` (admin) accepts `optimize` / `analyze` / `kill`, each with
-a target. Transaction and cancel routes do not apply — see [§13](#13-known-limitations--future-work).
+provider uses. `POST /api/db/maintenance` (admin) accepts `optimize` / `analyze` / `kill`;
+`optimize` and `kill` require a `target`, while `analyze` treats a missing one as "the whole pinned
+database" ([§8](#8-maintenance)) — so a client should omit it rather than invent one for
+database-wide statistics. Transaction and cancel routes do not apply — see
+[§13](#13-known-limitations--future-work).
 
 ---
 
@@ -900,6 +917,14 @@ a target. Transaction and cancel routes do not apply — see [§13](#13-known-li
 - **Multi-statement SQL is rejected by the server itself** (`Multi-statements are not allowed`,
   code `62`), so the provider does no client-side statement splitting; a single trailing semicolon is
   accepted.
+- **A dot inside a database or table name cannot be told apart from the qualifier separator.**
+  ClickHouse accepts `` CREATE DATABASE `a.b` `` (verified), but a table outside the pinned database
+  is displayed and generated as `database.table`, so `a.b` + `c` renders as `a.b.c` and every consumer
+  that splits on the dot reads it as three parts. Introspection is internally safe — the grouping key
+  joins on `NUL`, not a dot — so only the *display name* is ambiguous. This is the same limitation
+  `postgres.ts` carries for schema-qualified names; removing it means giving `TableSchema` structured
+  segments instead of one string, which is a cross-provider change rather than a ClickHouse one.
+  Dotted database names are vanishingly rare in practice.
 
 ---
 

--- a/src/components/icons/db-icons.tsx
+++ b/src/components/icons/db-icons.tsx
@@ -170,6 +170,31 @@ export const CouchbaseIcon: React.FC<IconProps> = ({ className, ...props }) => (
   </svg>
 );
 
+/**
+ * ClickHouse bar-chart mark: a horizontal rule over five columns, the last one
+ * half height. That short column is the distinguishing feature of the brand mark,
+ * so it is not simplified away.
+ */
+export const ClickHouseIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    <path d="M4 4h16" />
+    <path d="M4 8v12" />
+    <path d="M8 8v12" />
+    <path d="M12 8v12" />
+    <path d="M16 8v12" />
+    <path d="M20 8v6" />
+  </svg>
+);
+
 /** LibreDB database cylinder with L marker */
 export const LibreDBIcon: React.FC<IconProps> = ({ className, ...props }) => (
   <svg

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -301,7 +301,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       setTestResult({
         success: false,
         message:
-          "Could not parse connection string. Supported formats: postgres://, mysql://, mongodb://, couchbase://, redis://, oracle://, mssql://",
+          "Could not parse connection string. Supported formats: postgres://, mysql://, mongodb://, couchbase://, clickhouse://, http(s)://, redis://, oracle://, mssql://",
       });
       return;
     }
@@ -313,6 +313,10 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     if (parsed.user) setUser(parsed.user);
     if (parsed.password) setPassword(parsed.password);
     if (parsed.database) setDatabase(parsed.database);
+    // A scheme that IS the transport (https:// for ClickHouse) carries TLS that no
+    // field can express. Without this the form keeps its "disable" default and the
+    // connection goes out as plaintext HTTP to a TLS port.
+    if (parsed.sslMode) setSSLMode(parsed.sslMode);
 
     // A provider whose form offers the URI mode (MongoDB, Couchbase) switches to it,
     // so the pasted string is what gets connected with rather than a lossy re-assembly
@@ -346,6 +350,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     "couchbase",
     "redis",
     "libredb",
+    "clickhouse",
   ];
   const dbTypes = selectableTypes.map((t) => {
     const cfg = getDBConfig(t);

--- a/src/lib/connection-string-parser.ts
+++ b/src/lib/connection-string-parser.ts
@@ -1,4 +1,4 @@
-import { DatabaseType } from "@/lib/types";
+import { DatabaseType, type SSLMode } from "@/lib/types";
 
 export interface ParsedConnection {
   type: DatabaseType;
@@ -8,12 +8,23 @@ export interface ParsedConnection {
   password?: string;
   database?: string;
   connectionString?: string;
+  /**
+   * TLS the scheme asked for, when the fields alone could not express it.
+   *
+   * Only set by schemes that ARE the transport, currently `https://` for
+   * ClickHouse: dropping it would leave the form on its "disable" default and the
+   * provider would post plaintext HTTP to a TLS port, which fails with a bare
+   * "fetch failed" and nothing pointing at the scheme. Schemes that carry TLS in
+   * their own connection string (`couchbases://`, `mongodb+srv://`) keep using
+   * `connectionString` instead, because the provider re-reads the scheme there.
+   */
+  sslMode?: SSLMode;
 }
 
 /**
  * Parse a database connection string URL into its components.
  * Supports: postgres://, postgresql://, mysql://, mongodb://, mongodb+srv://, redis://,
- * couchbase://, couchbases://
+ * couchbase://, couchbases://, clickhouse://, http://, https://
  */
 export function parseConnectionString(input: string): ParsedConnection | null {
   const trimmed = input.trim();
@@ -55,6 +66,23 @@ export function parseConnectionString(input: string): ParsedConnection | null {
   }
   if (trimmed.startsWith("couchbase://")) {
     return parseCouchbaseString(trimmed, "8091");
+  }
+
+  // ClickHouse — the HTTP endpoint IS the connection target, so a bare http(s) URL is
+  // as canonical as the clickhouse:// scheme and no other provider claims those
+  // schemes. 8123 rather than 9000 because the provider speaks HTTP, never the native
+  // protocol the CLI's clickhouse:// URIs point at; https:// defaults to the server's
+  // https_port instead. The result is field-based (no connectionString), so the pasted
+  // URL never has to be re-parsed at connect time.
+  if (trimmed.startsWith("clickhouse://") || trimmed.startsWith("http://")) {
+    return parseGenericURL(trimmed, "clickhouse", "8123");
+  }
+  if (trimmed.startsWith("https://")) {
+    // sslMode is what stops a pasted Cloud endpoint becoming a plaintext POST to
+    // the TLS port; the fields on their own cannot say "use TLS". A malformed URL
+    // must still parse to null, so this cannot spread the result unconditionally.
+    const parsed = parseGenericURL(trimmed, "clickhouse", "8443");
+    return parsed && { ...parsed, sslMode: "require" };
   }
 
   // ADO.NET format: Server=host;Database=db;User Id=user;Password=pass;
@@ -213,6 +241,8 @@ export function detectConnectionStringType(input: string): DatabaseType | null {
   if (trimmed.startsWith("oracle://")) return "oracle";
   if (trimmed.startsWith("mssql://") || trimmed.startsWith("sqlserver://")) return "mssql";
   if (trimmed.startsWith("couchbase://") || trimmed.startsWith("couchbases://")) return "couchbase";
+  if (trimmed.startsWith("clickhouse://") || trimmed.startsWith("http://") || trimmed.startsWith("https://"))
+    return "clickhouse";
   if (/^server\s*=/i.test(trimmed)) return "mssql";
   return null;
 }

--- a/src/lib/connection-string-parser.ts
+++ b/src/lib/connection-string-parser.ts
@@ -74,15 +74,19 @@ export function parseConnectionString(input: string): ParsedConnection | null {
   // protocol the CLI's clickhouse:// URIs point at; https:// defaults to the server's
   // https_port instead. The result is field-based (no connectionString), so the pasted
   // URL never has to be re-parsed at connect time.
-  if (trimmed.startsWith("clickhouse://") || trimmed.startsWith("http://")) {
+  // The three schemes differ in what they say about TLS, and each has to be able to
+  // OVERWRITE a mode the form already carries - pasting is not a merge:
+  //   clickhouse:// names no transport  -> say nothing, defer to the form
+  //   http://       explicitly plaintext -> disable, or a stale "require" survives
+  //   https://      explicitly TLS       -> require, or a Cloud endpoint gets plain HTTP
+  if (trimmed.startsWith("clickhouse://")) {
     return parseGenericURL(trimmed, "clickhouse", "8123");
   }
+  if (trimmed.startsWith("http://")) {
+    return withSSLMode(parseGenericURL(trimmed, "clickhouse", "8123"), "disable");
+  }
   if (trimmed.startsWith("https://")) {
-    // sslMode is what stops a pasted Cloud endpoint becoming a plaintext POST to
-    // the TLS port; the fields on their own cannot say "use TLS". A malformed URL
-    // must still parse to null, so this cannot spread the result unconditionally.
-    const parsed = parseGenericURL(trimmed, "clickhouse", "8443");
-    return parsed && { ...parsed, sslMode: "require" };
+    return withSSLMode(parseGenericURL(trimmed, "clickhouse", "8443"), "require");
   }
 
   // ADO.NET format: Server=host;Database=db;User Id=user;Password=pass;
@@ -91,6 +95,13 @@ export function parseConnectionString(input: string): ParsedConnection | null {
   }
 
   return null;
+}
+
+/**
+ * Attach a scheme's TLS intent, preserving the null a malformed URL parses to.
+ */
+function withSSLMode(parsed: ParsedConnection | null, sslMode: SSLMode): ParsedConnection | null {
+  return parsed && { ...parsed, sslMode };
 }
 
 function parseMongoDBString(uri: string): ParsedConnection {

--- a/src/lib/db-ui-config.ts
+++ b/src/lib/db-ui-config.ts
@@ -9,6 +9,7 @@ import {
   MSSQLIcon,
   LibreDBIcon,
   CouchbaseIcon,
+  ClickHouseIcon,
 } from "@/components/icons/db-icons";
 import type { DatabaseType } from "@/lib/types";
 
@@ -97,6 +98,16 @@ const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     // Management port. The query ports are discovered from the cluster at connect
     // time (issue #262, decision 3), so only this one is ever stored.
     defaultPort: "8091",
+    showConnectionStringToggle: true,
+    connectionFields: ["host", "port", "user", "password", "database", "connectionString"],
+  },
+  clickhouse: {
+    icon: ClickHouseIcon,
+    color: "text-yellow-400",
+    label: "ClickHouse",
+    // The HTTP interface port. The provider speaks HTTP only, so the native
+    // protocol port 9000 is never a valid value here (issue #264).
+    defaultPort: "8123",
     showConnectionStringToggle: true,
     connectionFields: ["host", "port", "user", "password", "database", "connectionString"],
   },

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -84,6 +84,14 @@ export async function createDatabaseProvider(
       return new MSSQLProvider(connection, options);
     }
 
+    case "clickhouse": {
+      // The explicit /index specifier keeps this dynamic import statically
+      // analysable: a bare directory resolves only at runtime, which the bundler
+      // cannot trace into a chunk.
+      const { ClickHouseProvider } = await import("./providers/sql/clickhouse/index");
+      return new ClickHouseProvider(connection, options);
+    }
+
     // Document Databases - dynamically imported
     case "mongodb": {
       const { MongoDBProvider } = await import("./providers/document/mongodb");
@@ -112,7 +120,7 @@ export async function createDatabaseProvider(
 
     default:
       throw new DatabaseConfigError(
-        `Unknown database type: ${connection.type}. Supported types: postgres, mysql, sqlite, oracle, mssql, mongodb, couchbase, redis, libredb`,
+        `Unknown database type: ${connection.type}. Supported types: postgres, mysql, sqlite, oracle, mssql, clickhouse, mongodb, couchbase, redis, libredb`,
         connection.type,
       );
   }

--- a/src/lib/db/providers/sql/clickhouse/http-transport.ts
+++ b/src/lib/db/providers/sql/clickhouse/http-transport.ts
@@ -1,0 +1,425 @@
+/**
+ * ClickHouse HTTP transport (issue #264, design spec 1.1, 1.2, 2.1 and 2.2)
+ *
+ * The only implementation of the ClickHouseTransport seam, and the only file in
+ * the provider allowed to know how ClickHouse's HTTP interface encodes a result:
+ * its `default_format` parameter, its `X-ClickHouse-*` headers and the JSON
+ * envelope it wraps rows in. `seam-guard.test.ts` fails the build the moment any
+ * of that vocabulary appears elsewhere in the directory, which is what keeps
+ * "a native-protocol client is one new file" true rather than aspirational.
+ *
+ * Zero runtime dependency: the statement is the body of a POST and the answer
+ * comes back through the runtime's own `fetch`.
+ *
+ * Three live-verified shapes drive nearly every decision below, and all three are
+ * the opposite of what a JSON API teaches:
+ *
+ * - Failures are real status codes, so `!response.ok` is the whole test and the
+ *   body is never inspected to find out whether the statement failed (spec 1.1).
+ * - An error body is plain TEXT even when the content type says
+ *   `application/json`, so it must never reach `JSON.parse`.
+ * - A successful write answers 200 with NO body, and its row count lives only in
+ *   a header, so an empty body is success rather than an error (spec 2.2).
+ */
+
+import type { DatabaseConnection } from "@/lib/db/types";
+import {
+  type ClickHouseQueryOptions,
+  type ClickHouseQueryResult,
+  type ClickHouseRow,
+  type ClickHouseTransport,
+  ClickHouseTransportError,
+} from "./transport";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_HOST = "localhost";
+const DEFAULT_PORT = 8123;
+const DEFAULT_TLS_PORT = 8443;
+
+/**
+ * The envelope this file parses. Requested per statement instead of appended to
+ * the user's SQL, so what the editor sends is what the server parses (spec 1.2).
+ */
+const RESPONSE_FORMAT = "JSON";
+
+/** Header names are matched case-insensitively by `Headers.get`, hence lower case. */
+const SUMMARY_HEADER = "x-clickhouse-summary";
+const FORMAT_HEADER = "x-clickhouse-format";
+const EXCEPTION_CODE_HEADER = "x-clickhouse-exception-code";
+/**
+ * Sent on every response, successful ones included, so the client can tell a
+ * genuine mid-stream exception trailer from result data that merely looks like
+ * one. See `midstreamError`.
+ */
+const EXCEPTION_TAG_HEADER = "x-clickhouse-exception-tag";
+
+const UNPARSABLE_JSON = "ClickHouse announced a JSON result the client could not parse";
+
+/**
+ * Trailing build metadata on an exception message: `... (SYNTAX_ERROR) (version
+ * 26.7.1.1315 (official build))`. Optional, live-verified: an authentication
+ * failure carries no version at all. It is noise to the person who mistyped a
+ * table name, so it is stripped before the message is shown.
+ */
+const VERSION_SUFFIX = /\s*\(version [^()]*(?:\([^()]*\))?\)\s*$/;
+
+/** `Code: 62.` at the head of every exception body. */
+const CODE_PREFIX = /^Code:\s*(\d+)\./;
+
+/**
+ * The same marker anywhere in the body, used to drop a partial result that precedes
+ * it.
+ *
+ * JSON output is buffered so the server can count `rows`, which means a statement
+ * that fails part-way through can still be answered with a real error STATUS and the
+ * half-built body in front of the exception. Live-verified on 26.7.1: that response is
+ * `500` carrying `X-ClickHouse-Exception-Code: 395`, a `meta`/`data` prefix and -
+ * unlike the streamed case - NO `__exception__` fence to cut on.
+ *
+ * Deliberately not anchored to a line start. Whether a newline precedes the exception
+ * depends on how much of a row had already been written, so an anchored pattern
+ * silently failed for exactly the longer bodies that most need trimming.
+ */
+const CODE_ANYWHERE = /Code:\s*\d+\./;
+
+/** The exception name ClickHouse puts last: `... (UNKNOWN_TABLE)`. */
+const EXCEPTION_NAME = /\(([A-Z][A-Z0-9_]*)\)\s*$/;
+
+/** A header that is nothing but digits. */
+const INTEGER_HEADER = /^\s*(\d+)\s*$/;
+
+// ============================================================================
+// Wire shapes
+// ============================================================================
+
+interface EnvelopeColumn {
+  name: string;
+  type: string;
+}
+
+/**
+ * The JSON envelope, documented here in full because this file is the record of
+ * what the wire looks like. Members are `unknown` where the code guards them: the
+ * shape is what the server promised, not what a proxy is guaranteed to deliver.
+ */
+interface ClickHouseJsonEnvelope {
+  meta?: unknown;
+  data?: unknown;
+  statistics?: { elapsed?: unknown };
+  /**
+   * Added by the server whenever the statement carries a LIMIT. Deliberately not
+   * surfaced (spec 2.6): nothing in the UI consumes it, and widening the neutral
+   * result for it would force a native implementation to fabricate the field.
+   */
+  rows_before_limit_at_least?: number;
+}
+
+/** What the summary header told us, with nulls where it told us nothing usable. */
+interface ResponseSummary {
+  mutationCount: number;
+  elapsedMs: number | null;
+}
+
+const NO_SUMMARY: ResponseSummary = { mutationCount: 0, elapsedMs: null };
+
+/** One HTTP response, already drained so the body can be read twice. */
+interface HttpOutcome {
+  ok: boolean;
+  status: number;
+  headers: Headers;
+  text: string;
+}
+
+// ============================================================================
+// Pure helpers
+// ============================================================================
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/** Bracket a bare IPv6 literal, which is otherwise not a legal URL authority. */
+function formatHost(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+/** A counter the server reports as a string, or 0 when it reported nothing usable. */
+function toCount(value: unknown): number {
+  const count = Number(value);
+  return Number.isFinite(count) ? count : 0;
+}
+
+/**
+ * Spec 2.2: the counters a write produces exist only in this header, and every
+ * value in it is a STRING. A reverse proxy is free to drop or mangle it, so a
+ * missing or unparsable header degrades to "the server did not say" rather than
+ * failing the statement that already succeeded.
+ */
+function parseSummary(raw: string | null): ResponseSummary {
+  const summary = asRecord(parseJson(raw ?? ""));
+  if (!summary) return NO_SUMMARY;
+
+  const elapsedNs = Number(summary.elapsed_ns);
+  return {
+    mutationCount: toCount(summary.written_rows),
+    elapsedMs: Number.isFinite(elapsedNs) ? elapsedNs / 1e6 : null,
+  };
+}
+
+/**
+ * The header is authoritative because it is present on every response, including
+ * the empty-bodied ones. The envelope's own number is the fallback for a stripped
+ * header - it is in seconds where the header is in nanoseconds - and zero is the
+ * last resort, since a fabricated duration is worse than an obvious absence.
+ */
+function executionTimeMs(summary: ResponseSummary, envelope: ClickHouseJsonEnvelope | null): number {
+  if (summary.elapsedMs !== null) return summary.elapsedMs;
+
+  const elapsed = envelope?.statistics?.elapsed;
+  return typeof elapsed === "number" ? elapsed * 1000 : 0;
+}
+
+/**
+ * Declared column order and types, or nulls when the envelope described neither.
+ * Types are copied verbatim, wrappers included (spec 1.7): `Nullable(String)` is
+ * what tells the user the column is nullable, and collapsing it would lose that.
+ */
+function describeColumns(envelope: ClickHouseJsonEnvelope): Pick<ClickHouseQueryResult, "fieldNames" | "columnTypes"> {
+  if (!Array.isArray(envelope.meta)) return { fieldNames: null, columnTypes: null };
+
+  const columns = envelope.meta as EnvelopeColumn[];
+  return {
+    fieldNames: columns.map((column) => column.name),
+    columnTypes: Object.fromEntries(columns.map((column) => [column.name, column.type])),
+  };
+}
+
+function parseEnvelope(text: string): ClickHouseJsonEnvelope {
+  const envelope = asRecord(parseJson(text));
+  // The server announced JSON, so a body that is not a JSON object means
+  // something between here and it rewrote the response. Normalizing that keeps
+  // the seam's promise that every throw is a ClickHouseTransportError - a raw
+  // SyntaxError would slip past every `instanceof` branch in the provider.
+  if (!envelope) throw new ClickHouseTransportError(UNPARSABLE_JSON, 0);
+
+  return envelope as ClickHouseJsonEnvelope;
+}
+
+/** A result that describes no columns: a write, or a format the user chose. */
+function untabulated(summary: ResponseSummary, rawText: string | null): ClickHouseQueryResult {
+  return {
+    rows: [],
+    fieldNames: null,
+    columnTypes: null,
+    executionTimeMs: executionTimeMs(summary, null),
+    mutationCount: summary.mutationCount,
+    rawText,
+  };
+}
+
+function toQueryResult(outcome: HttpOutcome): ClickHouseQueryResult {
+  const summary = parseSummary(outcome.headers.get(SUMMARY_HEADER));
+
+  // Spec 2.2: a write answers with no body, and a DDL statement answers with no
+  // format header either, so the empty body has to be recognised as success
+  // before anything asks what format it was in.
+  if (outcome.text === "") return untabulated(summary, null);
+
+  // Spec 2.8, and it must come BEFORE the format branch: the fence and its tag are
+  // format-independent, so a statement carrying its own FORMAT that dies part-way
+  // through streaming would otherwise be handed back as a successful short result
+  // with the trailer buried in the text - live-reproduced as 805000 lost rows
+  // reported as success. Authoritative on its own, too, because a body that still
+  // parses can nonetheless be a failed statement's truncated output.
+  const aborted = midstreamError(outcome);
+  if (aborted) throw aborted;
+
+  // Spec 1.2: an explicit FORMAT in the user's SQL beats the requested one, and this
+  // header reports what the server actually used. Handing the text back beats parsing
+  // it - the user asked for that format deliberately - and it beats guessing, which is
+  // why nothing about the rows is described alongside it.
+  if (outcome.headers.get(FORMAT_HEADER) !== RESPONSE_FORMAT) return untabulated(summary, outcome.text);
+
+  const envelope = parseEnvelope(outcome.text);
+  return {
+    rows: Array.isArray(envelope.data) ? (envelope.data as ClickHouseRow[]) : [],
+    ...describeColumns(envelope),
+    executionTimeMs: executionTimeMs(summary, envelope),
+    mutationCount: summary.mutationCount,
+    rawText: null,
+  };
+}
+
+/**
+ * The numeric code, preferring the header because it is a discrete integer the
+ * server sets, where the `Code: NN.` prefix has to be scraped out of prose. The
+ * fallback matters: a proxy that strips unknown headers would otherwise turn
+ * every failure into an unclassifiable one, and the provider branches on the code.
+ */
+function exceptionCode(header: string | null, message: string): number {
+  return toCount(INTEGER_HEADER.exec(header ?? "")?.[1] ?? CODE_PREFIX.exec(message)?.[1]);
+}
+
+/**
+ * Spec 1.1: the status code already said this failed, so the body is read only to
+ * describe the failure, never to detect it. The body is plain text under an
+ * `application/json` content type (live-verified), which is why it goes nowhere
+ * near JSON.parse.
+ */
+function statementError(outcome: HttpOutcome): ClickHouseTransportError {
+  const body = outcome.text.trim();
+  // Keep only the exception itself when a partial result precedes it, so the reader
+  // sees the failure and not the buffered rows that never arrived.
+  const start = CODE_ANYWHERE.exec(body)?.index ?? 0;
+  const message = body.slice(start).trim().replace(VERSION_SUFFIX, "");
+
+  return new ClickHouseTransportError(
+    message || `ClickHouse request failed with HTTP ${outcome.status}`,
+    exceptionCode(outcome.headers.get(EXCEPTION_CODE_HEADER), message),
+    EXCEPTION_NAME.exec(message)?.[1],
+  );
+}
+
+/**
+ * The exception a statement that had already started streaming reports at the end
+ * of its own body.
+ *
+ * Spec 2.8, live-verified on 26.7.1: once the first block has been written the
+ * status line is already committed as 200, so a failure part-way through arrives
+ * as `200` with NO exception-code header, a body truncated mid-array, and the real
+ * exception fenced in a trailer:
+ *
+ *     ...
+ *     __exception__
+ *     <tag>
+ *     Code: 395. DB::Exception: boom: ... (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) (version ...)
+ *     286 <tag>
+ *     __exception__
+ *
+ * Without this the only symptom is a JSON parse complaint, which tells the person
+ * who wrote the statement nothing about what actually went wrong.
+ *
+ * The fence is keyed on the per-request tag rather than on `__exception__` alone,
+ * because `SELECT '__exception__'` is a legal statement whose result would
+ * otherwise be read as a failure. The tag is server-generated per request, so
+ * result data cannot forge it - which is precisely why the header exists.
+ */
+function midstreamError(outcome: HttpOutcome): ClickHouseTransportError | null {
+  const tag = outcome.headers.get(EXCEPTION_TAG_HEADER);
+  if (!tag) return null;
+
+  const fence = `__exception__\n${tag}\n`;
+  const start = outcome.text.indexOf(fence);
+  if (start === -1) return null;
+
+  const message = outcome.text
+    .slice(start + fence.length)
+    // Drop the closing `<byte count> <tag>\n__exception__` fence when it arrived;
+    // a connection cut mid-trailer means it did not.
+    .replace(new RegExp(`\\n\\d+ ${tag}\\n__exception__\\s*$`), "")
+    .trim()
+    .replace(VERSION_SUFFIX, "");
+
+  return new ClickHouseTransportError(
+    message || `ClickHouse aborted the response with HTTP ${outcome.status}`,
+    exceptionCode(null, message),
+    EXCEPTION_NAME.exec(message)?.[1],
+  );
+}
+
+/** A failure that never reached the server, or never came back from it. */
+function transportError(cause: unknown): ClickHouseTransportError {
+  const reason = cause instanceof Error ? cause.message : String(cause);
+  return new ClickHouseTransportError(`ClickHouse request failed: ${reason}`, 0);
+}
+
+// ============================================================================
+// Transport
+// ============================================================================
+
+export class ClickHouseHttpTransport implements ClickHouseTransport {
+  public readonly kind = "http" as const;
+
+  private readonly origin: string;
+  private readonly database: string | undefined;
+  private readonly authorization: string | undefined;
+
+  constructor(config: DatabaseConnection) {
+    const secure = config.ssl !== undefined && config.ssl.mode !== "disable";
+    const port = config.port ?? (secure ? DEFAULT_TLS_PORT : DEFAULT_PORT);
+    this.origin = `${secure ? "https" : "http"}://${formatHost(config.host ?? DEFAULT_HOST)}:${port}`;
+    this.database = config.database;
+    // Live-verified: an EMPTY Basic username fails hard - "Got an empty user name
+    // from Authorization HTTP header", code 516 - while sending no header at all
+    // resolves to the `default` user, which is what a stock local install
+    // expects. So a connection with no user must send no header.
+    this.authorization = config.user
+      ? `Basic ${Buffer.from(`${config.user}:${config.password ?? ""}`).toString("base64")}`
+      : undefined;
+  }
+
+  public async query(sql: string, opts: ClickHouseQueryOptions = {}): Promise<ClickHouseQueryResult> {
+    const outcome = await this.send(this.endpoint(opts), sql);
+    if (!outcome.ok) throw statementError(outcome);
+
+    return toQueryResult(outcome);
+  }
+
+  /**
+   * Nothing to release: one HTTP request per statement and no session pinned
+   * (spec 1.4), so this exists only because every implementation of the seam has
+   * to be closeable.
+   */
+  public close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  private endpoint(opts: ClickHouseQueryOptions): string {
+    const params = new URLSearchParams();
+    // Caller settings go first so they cannot reach the parameters below: this
+    // file's parser assumes the envelope it asked for, and `settings` is
+    // deliberately open-ended, so a caller could otherwise change the response
+    // format out from under it.
+    for (const [name, value] of Object.entries(opts.settings ?? {})) params.set(name, String(value));
+
+    params.set("default_format", RESPONSE_FORMAT);
+    // Spec 2.1: without this a UInt64 arrives as an unquoted JSON number and
+    // JSON.parse silently rounds 18446744073709551615 to ...552000. Quoted, it
+    // arrives as a string, which is what the `pg` driver already does for int8.
+    params.set("output_format_json_quote_64bit_integers", "1");
+
+    const database = opts.database ?? this.database;
+    if (database) params.set("database", database);
+
+    return `${this.origin}/?${params.toString()}`;
+  }
+
+  private async send(url: string, sql: string): Promise<HttpOutcome> {
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: this.authorization ? { authorization: this.authorization } : {},
+        body: sql,
+      });
+
+      return { ok: response.ok, status: response.status, headers: response.headers, text: await response.text() };
+    } catch (error) {
+      // A refused socket, an abort and a truncated body all arrive here, and all
+      // have to leave as the seam's own error type.
+      throw transportError(error);
+    }
+  }
+}

--- a/src/lib/db/providers/sql/clickhouse/http-transport.ts
+++ b/src/lib/db/providers/sql/clickhouse/http-transport.ts
@@ -372,7 +372,7 @@ export class ClickHouseHttpTransport implements ClickHouseTransport {
   }
 
   public async query(sql: string, opts: ClickHouseQueryOptions = {}): Promise<ClickHouseQueryResult> {
-    const outcome = await this.send(this.endpoint(opts), sql);
+    const outcome = await this.send(this.endpoint(opts), sql, opts.timeoutMs);
     if (!outcome.ok) throw statementError(outcome);
 
     return toQueryResult(outcome);
@@ -407,12 +407,19 @@ export class ClickHouseHttpTransport implements ClickHouseTransport {
     return `${this.origin}/?${params.toString()}`;
   }
 
-  private async send(url: string, sql: string): Promise<HttpOutcome> {
+  private async send(url: string, sql: string, timeoutMs?: number): Promise<HttpOutcome> {
+    // One signal for the request AND the body read: a response whose headers
+    // arrive promptly can still stall mid-body, and awaiting text() below is
+    // otherwise unbounded. Passing the signal to fetch covers both, which a
+    // timer around fetch alone would not.
+    const signal = timeoutMs === undefined ? undefined : AbortSignal.timeout(timeoutMs);
+
     try {
       const response = await fetch(url, {
         method: "POST",
         headers: this.authorization ? { authorization: this.authorization } : {},
         body: sql,
+        ...(signal ? { signal } : {}),
       });
 
       return { ok: response.ok, status: response.status, headers: response.headers, text: await response.text() };

--- a/src/lib/db/providers/sql/clickhouse/index.ts
+++ b/src/lib/db/providers/sql/clickhouse/index.ts
@@ -101,10 +101,17 @@ const UNKNOWN_VERSION = "unknown";
  */
 const RAW_TEXT_COLUMN = "__text";
 
+const MILLISECONDS_PER_SECOND = 1000;
+
 /** Server-side deadline for a monitoring read, in `max_execution_time`'s unit. */
 const MONITORING_TIMEOUT_SECONDS = 10;
 
-const MILLISECONDS_PER_SECOND = 1000;
+/**
+ * The same deadline as a client-side one. A monitoring panel that hangs on a
+ * stalled socket is worse than an empty one, and `max_execution_time` cannot bound
+ * a connection that never gets as far as executing anything.
+ */
+const MONITORING_TIMEOUT_MS = MONITORING_TIMEOUT_SECONDS * MILLISECONDS_PER_SECOND;
 
 const DEFAULT_SLOW_QUERY_LIMIT = 10;
 const DEFAULT_SESSION_LIMIT = 50;
@@ -120,6 +127,9 @@ const UNKNOWN_USER = "unknown";
 
 /** The scheme that makes the transport speak TLS and default to the https port. */
 const TLS_SCHEME = "https:";
+
+/** The scheme that explicitly asks for plaintext, as opposed to not saying. */
+const PLAINTEXT_SCHEME = "http:";
 
 /**
  * Codes this file branches on that the shared table does not carry, because
@@ -412,8 +422,24 @@ function resolveConnection(config: DatabaseConnection): DatabaseConnection {
     user: decodeURIComponent(url.username) || config.user,
     password: decodeURIComponent(url.password) || config.password,
     database: decodeURIComponent(url.pathname.slice(1)) || config.database,
-    ssl: url.protocol === TLS_SCHEME ? { mode: "require" } : config.ssl,
+    ssl: sslForScheme(url, config.ssl),
   };
+}
+
+/**
+ * TLS as the URL's scheme states it, falling back to the connection's own setting
+ * only when the scheme does not say.
+ *
+ * The scheme is the more specific statement: it names the transport, while `ssl` is
+ * a separate field that can be left over from an earlier edit. So an explicit
+ * `http://` has to be able to turn TLS OFF - deferring would send HTTPS to a
+ * plaintext endpoint and fail with a bare "fetch failed" - while `clickhouse://`
+ * names no transport and is the one scheme that must defer.
+ */
+function sslForScheme(url: URL, configured: DatabaseConnection["ssl"]): DatabaseConnection["ssl"] {
+  if (url.protocol === TLS_SCHEME) return { mode: "require" };
+  if (url.protocol === PLAINTEXT_SCHEME) return undefined;
+  return configured;
 }
 
 /**
@@ -543,7 +569,7 @@ export class ClickHouseProvider extends SQLBaseProvider {
       // live-verified, a non-existent one fails 404 / code 81 on the FIRST
       // statement - so the cheapest possible statement proves the server, the
       // credentials and the database together, here, where the user is looking.
-      await transport.query(CONNECT_PROBE_SQL);
+      await transport.query(CONNECT_PROBE_SQL, { timeoutMs: this.queryTimeout });
     } catch (error) {
       await transport.close();
       const failure = this.describeConnectFailure(error);
@@ -606,7 +632,13 @@ export class ClickHouseProvider extends SQLBaseProvider {
     return this.trackQuery(async () => {
       const { result, executionTime } = await this.measureExecution(async () => {
         try {
-          return await transport.query(sql, { settings: { max_execution_time: this.deadlineSeconds() } });
+          // Both halves of the same promise: max_execution_time bounds the server
+          // once it has accepted the statement, timeoutMs bounds everything before
+          // and after that - connect, handshake, and the body still arriving.
+          return await transport.query(sql, {
+            settings: { max_execution_time: this.deadlineSeconds() },
+            timeoutMs: this.queryTimeout,
+          });
         } catch (error) {
           throw this.mapClickHouseError(error, sql);
         }
@@ -706,7 +738,10 @@ export class ClickHouseProvider extends SQLBaseProvider {
     const transport = this.requireTransport();
 
     try {
-      const result = await transport.query(sql, { settings: { max_execution_time: MONITORING_TIMEOUT_SECONDS } });
+      const result = await transport.query(sql, {
+        settings: { max_execution_time: MONITORING_TIMEOUT_SECONDS },
+        timeoutMs: MONITORING_TIMEOUT_MS,
+      });
       return result.rows;
     } catch (error) {
       if (error instanceof ClickHouseTransportError && error.isMonitoringUnavailable()) return [];
@@ -995,6 +1030,7 @@ export class ClickHouseProvider extends SQLBaseProvider {
       : `database = ${literal(database)}`;
     const result = await transport.query(`${PART_SUMMARY_SELECT_SQL} ${where}`, {
       settings: { max_execution_time: MONITORING_TIMEOUT_SECONDS },
+      timeoutMs: MONITORING_TIMEOUT_MS,
     });
     const row = result.rows[0];
     const parts = asNumber(row?.partCount);

--- a/src/lib/db/providers/sql/clickhouse/index.ts
+++ b/src/lib/db/providers/sql/clickhouse/index.ts
@@ -1,0 +1,1025 @@
+/**
+ * ClickHouse Database Provider (issue #264)
+ *
+ * SQL over ClickHouse's HTTP interface with no native dependency: every
+ * statement, catalog read and metric goes through the ClickHouseTransport seam,
+ * so this file never names a header, a request parameter or an envelope field,
+ * and `seam-guard.test.ts` fails the build if it starts to.
+ *
+ * It extends `SQLBaseProvider` rather than `BaseDatabaseProvider` because the
+ * dialect really is standard on the points the shared helpers care about -
+ * double-quoted identifiers and `LIMIT n OFFSET m` are both correct here
+ * (live-verified) - which is exactly the case `docs/ADDING_A_PROVIDER.md` names
+ * ClickHouse for. Only `prepareQuery()` is overridden, for the trailing-clause
+ * trap below.
+ *
+ * Four live-verified behaviours shape almost everything here, and each one
+ * silently produces wrong output if forgotten:
+ *
+ * - `FORMAT` and `SETTINGS` are TRAILING clauses, so the inherited limiter -
+ *   which appends `LIMIT n` at the very end - turns a working statement into a
+ *   syntax error. `prepareQuery()` refuses to rewrite such a statement.
+ * - A permission denial arrives as HTTP 500, not 403, so failures are DETECTED
+ *   by status (inside the transport) and CLASSIFIED by exception code (here).
+ *   The 497 message says "Not enough privileges", which contains neither
+ *   "access denied" nor "permission denied", so message sniffing would miss it.
+ * - Monitoring surfaces are permission-gated and `query_log` is switched off on
+ *   some deployments, so every monitoring read degrades to an empty or zeroed
+ *   panel on those two codes - and only those two, because an empty panel that
+ *   hides a real error hides it forever.
+ * - A write reports its row count in a header, and for `ALTER TABLE ... UPDATE`
+ *   and a lightweight `DELETE` that count is zero even though the mutation
+ *   applied. The number the server gave is the number reported.
+ */
+
+import { SQLBaseProvider } from "../sql-base";
+import {
+  AuthenticationError,
+  ConnectionError,
+  DatabaseConfigError,
+  QueryCancelledError,
+  QueryError,
+  TimeoutError,
+} from "@/lib/db/errors";
+import {
+  type ActiveSession,
+  type ActiveSessionDetails,
+  type DatabaseConnection,
+  type DatabaseOverview,
+  type HealthInfo,
+  type IndexStats,
+  type MaintenanceResult,
+  type MaintenanceType,
+  type PerformanceMetrics,
+  type PreparedQuery,
+  type ProviderCapabilities,
+  type ProviderLabels,
+  type ProviderOptions,
+  type QueryPrepareOptions,
+  type QueryResult,
+  type SlowQuery,
+  type SlowQueryStats,
+  type StorageStats,
+  type TableRelations,
+  type TableSchema,
+  type TableStats,
+} from "@/lib/db/types";
+import { formatBytes } from "@/lib/db/utils/pool-manager";
+import { ClickHouseHttpTransport } from "./http-transport";
+import {
+  CLICKHOUSE_SYSTEM_DATABASES,
+  getSchema as introspectSchema,
+  getSchemaList as introspectSchemaList,
+  getSchemaRelations as introspectSchemaRelations,
+} from "./introspect";
+import {
+  type ClickHouseQueryResult,
+  type ClickHouseRow,
+  type ClickHouseTransport,
+  ClickHouseTransportError,
+} from "./transport";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** The database a connection that names none lands in, and an ordinary one. */
+const DEFAULT_DATABASE = "default";
+
+const CONNECT_PROBE_SQL = "SELECT 1";
+
+const UNKNOWN_VERSION = "unknown";
+
+/**
+ * Column a result in a format the user chose is handed back in.
+ *
+ * An explicit `FORMAT` in the user's own SQL beats the format the transport asks
+ * for (live-verified), so the body is genuinely TSV, CSV or Pretty text. The
+ * grid's row contract needs an object, and the double underscore marks the
+ * column as synthesized rather than projected - the same convention the
+ * Couchbase provider uses for a scalar projection.
+ */
+const RAW_TEXT_COLUMN = "__text";
+
+/** Server-side deadline for a monitoring read, in `max_execution_time`'s unit. */
+const MONITORING_TIMEOUT_SECONDS = 10;
+
+const MILLISECONDS_PER_SECOND = 1000;
+
+const DEFAULT_SLOW_QUERY_LIMIT = 10;
+const DEFAULT_SESSION_LIMIT = 50;
+
+/**
+ * Every row of `system.processes` is a statement the server is executing right
+ * now: ClickHouse has no idle-in-transaction equivalent to distinguish, so the
+ * state is a constant rather than a column.
+ */
+const RUNNING_STATE = "active";
+
+const UNKNOWN_USER = "unknown";
+
+/** The scheme that makes the transport speak TLS and default to the https port. */
+const TLS_SCHEME = "https:";
+
+/**
+ * Codes this file branches on that the shared table does not carry, because
+ * nothing but the error mapping below needs them.
+ *
+ * Read back from the live server's own numbering rather than transcribed from
+ * documentation (`SELECT number, errorCodeToName(toUInt32(number)) FROM
+ * numbers(1500)` on 26.7.1.1315).
+ */
+const CLICKHOUSE_FAILURE_CODES = Object.freeze({
+  TIMEOUT_EXCEEDED: 159,
+  SOCKET_TIMEOUT: 209,
+  NETWORK_ERROR: 210,
+  QUERY_WAS_CANCELLED: 394,
+  /**
+   * No server exception at all: the request never reached ClickHouse, never came
+   * back, or came back rewritten. There is no code to classify by, so the shared
+   * message-based mapping takes over.
+   */
+  NO_SERVER_CODE: 0,
+} as const);
+
+const TIMEOUT_CODES: readonly number[] = [
+  CLICKHOUSE_FAILURE_CODES.TIMEOUT_EXCEEDED,
+  CLICKHOUSE_FAILURE_CODES.SOCKET_TIMEOUT,
+];
+
+// ============================================================================
+// Trailing-clause detection (the prepareQuery override)
+// ----------------------------------------------------------------------------
+// Both patterns are anchored at the END of the statement, which is what keeps
+// them off a statement that merely mentions the words. Live-verified traps:
+// `SELECT * FROM t WHERE note = 'format'` and `SELECT name FROM system.settings`
+// are ordinary statements that must still be limited, while
+// `... FORMAT TSV LIMIT 1` and `... SETTINGS max_threads=1 LIMIT 1` are both
+// 400 / code 62. Anchoring is what spares the ordinary forms: a string literal
+// ends in a quote, so `= 'FORMAT TSV'` cannot reach the anchor, and the settings
+// TABLE is not followed by an assignment.
+//
+// One accepted false positive remains, and it is deliberate rather than missed:
+// a statement ending in a string literal that itself contains an assignment,
+// `... WHERE note = 'SETTINGS foo = 1'`, is read as carrying a trailing clause.
+// Ruling it out needs a string-literal-aware tokenizer, and the cost of being
+// wrong here is only that no row limit is injected - the statement still runs and
+// still returns correct rows. Mis-detecting in the other direction would produce
+// a hard syntax error, so the bias is on purpose.
+// ============================================================================
+
+/** `FORMAT <Name>` as the last thing in the statement. */
+const TRAILING_FORMAT = /\bFORMAT\s+[A-Za-z][A-Za-z0-9_]*\s*$/i;
+
+/** `SETTINGS name = value` (one or many) as the last thing in the statement. */
+const TRAILING_SETTINGS = /\bSETTINGS\s+[A-Za-z_][A-Za-z0-9_]*\s*=[\s\S]*$/i;
+
+// ============================================================================
+// Monitoring SQL
+// ----------------------------------------------------------------------------
+// Hoisted to module scope and joined from single lines rather than written as
+// multi-line template literals in the method bodies: bun's coverage instruments
+// the interior lines of a template literal inside a function body as 0-hit in
+// any process that imports this file without executing that method, which the
+// merged lcov then reports as uncovered SQL. The same reason `postgres.ts`
+// hoists its own.
+//
+// The overview is five separate reads on purpose. Live-verified with a
+// restricted user: `system.tables` is pre-filtered to what the user may see and
+// answers 200, `uptime()` and `version()` need no grant at all, while
+// `system.metrics`, `system.parts` and `system.data_skipping_indices` each
+// answer 500 / code 497 without their own grant. Combining them into one
+// statement would throw away the panels a restricted user CAN see.
+// ============================================================================
+
+const OVERVIEW_IDENTITY_SQL = "SELECT version() AS version, toUInt64(uptime()) AS uptimeSeconds";
+
+const OVERVIEW_CONNECTIONS_SQL = [
+  "SELECT",
+  "(SELECT sum(value) FROM system.metrics",
+  " WHERE metric IN ('TCPConnection', 'HTTPConnection', 'MySQLConnection', 'PostgreSQLConnection')) AS connections,",
+  "(SELECT toUInt64(value) FROM system.server_settings WHERE name = 'max_connections') AS maxConnections",
+].join(" ");
+
+const OVERVIEW_SIZE_SQL = [
+  "SELECT sum(bytes_on_disk) AS databaseSizeBytes",
+  "FROM system.parts",
+  "WHERE active AND database = currentDatabase()",
+].join(" ");
+
+const OVERVIEW_TABLE_COUNT_SQL = "SELECT count() AS tableCount FROM system.tables WHERE database = currentDatabase()";
+
+const OVERVIEW_INDEX_COUNT_SQL = [
+  "SELECT count() AS indexCount",
+  "FROM system.data_skipping_indices",
+  "WHERE database = currentDatabase()",
+].join(" ");
+
+/**
+ * The mark cache is ClickHouse's nearest equivalent of a buffer cache, and
+ * `system.events` counts its hits and misses since start-up. `Query` is a
+ * lifetime counter too, so dividing it by the uptime read alongside it gives an
+ * average rather than an instantaneous rate - which is the honest reading of a
+ * counter that is never sampled twice.
+ */
+const PERFORMANCE_EVENTS_SQL = [
+  "SELECT",
+  "sumIf(value, event = 'MarkCacheHits') AS cacheHits,",
+  "sumIf(value, event = 'MarkCacheMisses') AS cacheMisses,",
+  "sumIf(value, event = 'Query') AS queryCount,",
+  "toUInt64(uptime()) AS uptimeSeconds",
+  "FROM system.events",
+].join(" ");
+
+/** Float64 here, so these two arrive as JSON numbers where a UInt64 arrives quoted. */
+const PERFORMANCE_MEMORY_SQL = [
+  "SELECT",
+  "sumIf(value, metric = 'MemoryResident') AS memoryBytes,",
+  "sumIf(value, metric = 'OSMemoryTotal') AS memoryTotalBytes",
+  "FROM system.asynchronous_metrics",
+].join(" ");
+
+/**
+ * Grouped by `normalized_query_hash` so one entry is one statement SHAPE with
+ * its call count and its min/max, the way `pg_stat_statements` reports it -
+ * ungrouped, the panel would be a list of individual executions of the same
+ * statement. `query_log` is flushed asynchronously, so a statement that just ran
+ * may be absent for a few seconds.
+ */
+const SLOW_QUERY_SQL = [
+  "SELECT toString(normalized_query_hash) AS queryId, any(query) AS query, count() AS calls,",
+  "sum(query_duration_ms) AS totalMs, avg(query_duration_ms) AS avgMs,",
+  "min(query_duration_ms) AS minMs, max(query_duration_ms) AS maxMs, sum(result_rows) AS resultRows",
+  "FROM system.query_log",
+  "WHERE type = 'QueryFinish' AND current_database = currentDatabase()",
+  "GROUP BY normalized_query_hash",
+  "ORDER BY totalMs DESC",
+].join(" ");
+
+/**
+ * The read excludes itself: this statement is in `system.processes` while it
+ * runs, and reporting it as a session would make the panel describe the act of
+ * looking. Same trick `postgres.ts` applies to `pg_stat_activity`.
+ */
+const ACTIVE_SESSION_SQL = [
+  "SELECT query_id AS queryId, user AS user, current_database AS database,",
+  "toString(address) AS clientAddr, elapsed AS elapsedSeconds, query AS query",
+  "FROM system.processes",
+  "WHERE query NOT LIKE '%system.processes%'",
+  "ORDER BY elapsed DESC",
+].join(" ");
+
+/**
+ * Only ACTIVE parts count: an inactive part is a merge input the server has not
+ * finished dropping yet, so including it would double-count both rows and bytes.
+ */
+const TABLE_STATS_SELECT_SQL = [
+  "SELECT database, table, sum(rows) AS rowCount, sum(data_compressed_bytes) AS dataBytes,",
+  "sum(marks_bytes + primary_key_bytes_in_memory) AS indexBytes, sum(bytes_on_disk) AS totalBytes",
+  "FROM system.parts",
+  "WHERE active AND",
+].join(" ");
+
+const TABLE_STATS_GROUP_SQL = "GROUP BY database, table ORDER BY totalBytes DESC";
+
+const INDEX_STATS_SELECT_SQL = [
+  "SELECT database, table, name AS indexName, type AS indexType, expr,",
+  "data_compressed_bytes AS indexSizeBytes",
+  "FROM system.data_skipping_indices",
+  "WHERE",
+].join(" ");
+
+const INDEX_STATS_ORDER_SQL = "ORDER BY database, table, indexName";
+
+const STORAGE_SQL = [
+  "SELECT name, path, total_space AS totalBytes, free_space AS freeBytes",
+  "FROM system.disks",
+  "ORDER BY name",
+].join(" ");
+
+/** Part statistics of one table, which is what `analyze` reports (see below). */
+const PART_SUMMARY_SELECT_SQL = [
+  "SELECT count() AS partCount, sum(rows) AS rowCount, sum(bytes_on_disk) AS totalBytes",
+  "FROM system.parts",
+  "WHERE active AND",
+].join(" ");
+
+/** Names are compile-time constants, so inlining them as literals is safe. */
+const NON_SYSTEM_DATABASE = `database NOT IN (${CLICKHOUSE_SYSTEM_DATABASES.map((name) => `'${name}'`).join(", ")})`;
+
+// ============================================================================
+// Pure helpers
+// ============================================================================
+
+/**
+ * A counter the server reported, or 0 when it reported nothing usable.
+ *
+ * Both encodings are real and both appear in the same panel: the transport asks
+ * for 64-bit quoting so nothing rounds through `JSON.parse`, which turns every
+ * `UInt64` into a decimal STRING, while `system.asynchronous_metrics` is
+ * `Float64` and stays an unquoted number. A null - what a scalar subquery over
+ * no rows produces - is neither.
+ */
+function asNumber(value: unknown): number {
+  if (typeof value === "number") return value;
+  const parsed = Number(value);
+  return typeof value === "string" && value !== "" && Number.isFinite(parsed) ? parsed : 0;
+}
+
+function asText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value !== "" ? value : fallback;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * A percentage, or 0 when there is nothing to divide by. Zero rather than a
+ * flattering 100: a denied or absent source must not look like a healthy one.
+ */
+function percentOf(part: number, whole: number): number {
+  return whole > 0 ? round2((part / whole) * 100) : 0;
+}
+
+/** A row cap that is always a positive integer, so it can be inlined into SQL. */
+function rowLimit(limit: number | undefined, fallback: number): number {
+  const requested = Math.trunc(limit ?? fallback);
+  return requested > 0 ? requested : fallback;
+}
+
+/**
+ * A value as a ClickHouse string literal. The backslash escape has to be applied
+ * as well as the doubled quote: ClickHouse honours both inside a literal
+ * (live-verified), so escaping only the quote would leave `\'` as a way out.
+ */
+function literal(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "''")}'`;
+}
+
+/**
+ * `database.table` when the target names one, otherwise the pinned database.
+ * The same rule `postgres.ts` applies to `public`, and the same limitation: a
+ * dot inside a name cannot be told apart from the separator.
+ */
+function splitTarget(target: string, pinnedDatabase: string): [database: string, table: string] {
+  const separator = target.indexOf(".");
+  if (separator === -1) return [pinnedDatabase, target];
+  return [target.slice(0, separator), target.slice(separator + 1)];
+}
+
+/**
+ * Whether the statement ends in a clause that `LIMIT` may not follow.
+ *
+ * The trailing semicolon is stripped for the test only: a single one is accepted
+ * by the server, and it would otherwise hide the clause from both patterns.
+ */
+function hasTrailingClause(sql: string): boolean {
+  const trimmed = sql.trimEnd();
+  const statement = trimmed.endsWith(";") ? trimmed.slice(0, -1).trimEnd() : trimmed;
+  return TRAILING_FORMAT.test(statement) || TRAILING_SETTINGS.test(statement);
+}
+
+function parseUrl(connectionString: string | undefined): URL | null {
+  if (connectionString === undefined || connectionString === "") return null;
+  try {
+    return new URL(connectionString);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A hand-typed connection string lifted into the fields the transport takes.
+ *
+ * This is not optional politeness: the URI tab clears host, port, user and
+ * password when it submits, so for a connection typed there the URL is the only
+ * place any of them exist. A pasted URL takes the other path - the shared parser
+ * fills the fields and stores no connection string - so this runs only for the
+ * hand-typed case. Each component still falls back to its field, which is what
+ * keeps an unparsable string from emptying a working connection.
+ */
+function resolveConnection(config: DatabaseConnection): DatabaseConnection {
+  const url = parseUrl(config.connectionString);
+  if (url === null) return config;
+
+  return {
+    ...config,
+    host: url.hostname || config.host,
+    // Left undefined when the URL names no port, so the transport picks the
+    // default for the scheme instead of the plain-HTTP port for an https URL.
+    port: url.port === "" ? config.port : Number(url.port),
+    user: decodeURIComponent(url.username) || config.user,
+    password: decodeURIComponent(url.password) || config.password,
+    database: decodeURIComponent(url.pathname.slice(1)) || config.database,
+    ssl: url.protocol === TLS_SCHEME ? { mode: "require" } : config.ssl,
+  };
+}
+
+/**
+ * The neutral transport result as the grid's row contract.
+ *
+ * The server's own duration is preferred over the round trip because it excludes
+ * network latency, and the measured wall clock is the fallback rather than a
+ * claimed zero.
+ */
+function toQueryResult(result: ClickHouseQueryResult, measuredMs: number): QueryResult {
+  const textual = result.rawText !== null;
+  const rows = textual ? [{ [RAW_TEXT_COLUMN]: result.rawText }] : result.rows;
+  const reportedMs = Math.round(result.executionTimeMs);
+
+  return {
+    rows,
+    fields: textual ? [RAW_TEXT_COLUMN] : (result.fieldNames ?? []),
+    // A write returns no rows, so its row count is what the server says it
+    // changed - verbatim, including the zero a queued mutation reports.
+    rowCount: rows.length > 0 ? rows.length : result.mutationCount,
+    executionTime: reportedMs > 0 ? reportedMs : measuredMs,
+  };
+}
+
+// ============================================================================
+// ClickHouse Provider
+// ============================================================================
+
+export class ClickHouseProvider extends SQLBaseProvider {
+  private transport: ClickHouseTransport | null = null;
+
+  /** The configuration with a hand-typed connection string already resolved. */
+  private readonly connection: DatabaseConnection;
+
+  constructor(config: DatabaseConnection, options: ProviderOptions = {}) {
+    super(config, options);
+    this.validate();
+    this.connection = resolveConnection(config);
+  }
+
+  // ==========================================================================
+  // Provider metadata
+  // ==========================================================================
+
+  public override getCapabilities(): ProviderCapabilities {
+    return {
+      queryLanguage: "sql",
+      supportsExplain: true,
+      explainFormat: "clickhouse-json",
+      supportsExternalQueryLimiting: true,
+      // Live-verified, and deliberate rather than an oversight: `CREATE TABLE t
+      // (id Int32, name String)` succeeds on 26.x, but what CreateTableModal
+      // EMITS does not. Its default column is `id SERIAL PRIMARY KEY` (code 50,
+      // unknown data type family SERIAL) and its UNIQUE checkbox emits `UNIQUE`
+      // (code 62, syntax error), so the modal's default state produces invalid
+      // SQL and it offers no ClickHouse type list. A control that can only
+      // produce invalid input is not a supported capability. DDL typed into the
+      // editor works normally, which is how a ClickHouse user creates a table.
+      supportsCreateTable: false,
+      supportsMaintenance: true,
+      maintenanceOperations: ["optimize", "analyze", "kill"],
+      supportsConnectionString: true,
+      defaultPort: 8123,
+      schemaRefreshPattern: "\\b(CREATE|DROP|ALTER|RENAME|TRUNCATE|ATTACH|DETACH)\\b",
+    };
+  }
+
+  /**
+   * Tables and rows are the right words here, so only the maintenance labels
+   * change: ClickHouse has no VACUUM and no ANALYZE, and offering either by name
+   * would describe an operation that does not exist.
+   */
+  public override getLabels(): ProviderLabels {
+    return {
+      ...super.getLabels(),
+      analyzeAction: "Table Statistics",
+      vacuumAction: "Optimize Table",
+      analyzeGlobalLabel: "Table Statistics",
+      analyzeGlobalTitle: "Table Statistics",
+      analyzeGlobalDesc:
+        "ClickHouse has no ANALYZE: a MergeTree's statistics are its parts and are always current, so this reports them rather than computing anything.",
+      vacuumGlobalLabel: "Optimize",
+      vacuumGlobalTitle: "Merge Parts",
+      vacuumGlobalDesc:
+        "Runs OPTIMIZE TABLE ... FINAL, which merges a table's parts and applies pending mutations. ClickHouse reclaims space by merging, so there is no VACUUM equivalent.",
+    };
+  }
+
+  /**
+   * The inherited limiter appends `LIMIT n` at the very END of the statement,
+   * and ClickHouse allows `FORMAT x` and `SETTINGS ...` as TRAILING clauses, so
+   * on either of those the inherited behaviour produces a hard syntax error
+   * (live-verified: 400 / code 62 for both). Such a statement is returned
+   * untouched: a user who wrote either clause is expressing intent the editor
+   * must not silently rewrite, and the bias has to be "do not rewrite" because
+   * rewriting wrongly fails the query outright while leaving it alone only
+   * returns more rows.
+   */
+  public override prepareQuery(query: string, options: QueryPrepareOptions = {}): PreparedQuery {
+    const prepared = super.prepareQuery(query, options);
+    if (!hasTrailingClause(query)) return prepared;
+
+    return { ...prepared, query, wasLimited: false };
+  }
+
+  // ==========================================================================
+  // Validation and lifecycle
+  // ==========================================================================
+
+  /**
+   * A database is deliberately NOT required: `default` always exists, and a
+   * connection that names none resolves against it, which is what a stock local
+   * install expects.
+   */
+  public override validate(): void {
+    super.validate();
+    if (!this.config.host && !this.config.connectionString) {
+      throw new DatabaseConfigError("ClickHouse requires a host or a connection string", this.type);
+    }
+  }
+
+  public async connect(): Promise<void> {
+    const transport = new ClickHouseHttpTransport(this.connection);
+
+    try {
+      // The `database` parameter is not checked when the connection is made -
+      // live-verified, a non-existent one fails 404 / code 81 on the FIRST
+      // statement - so the cheapest possible statement proves the server, the
+      // credentials and the database together, here, where the user is looking.
+      await transport.query(CONNECT_PROBE_SQL);
+    } catch (error) {
+      await transport.close();
+      const failure = this.describeConnectFailure(error);
+      this.setError(failure);
+      throw failure;
+    }
+
+    this.transport = transport;
+    this.setConnected(true);
+  }
+
+  public async disconnect(): Promise<void> {
+    if (this.transport) {
+      await this.transport.close();
+      this.transport = null;
+    }
+    this.setConnected(false);
+  }
+
+  private describeConnectFailure(error: unknown): Error {
+    const mapped = this.mapClickHouseError(error);
+    if (mapped instanceof AuthenticationError) return mapped;
+
+    return new ConnectionError(
+      `Failed to connect to ClickHouse: ${mapped.message}`,
+      this.type,
+      this.connection.host,
+      this.connection.port,
+    );
+  }
+
+  private requireTransport(): ClickHouseTransport {
+    this.ensureConnected();
+    // Assigned before setConnected(true) and cleared after setConnected(false),
+    // so a connected provider always has one.
+    return this.transport!;
+  }
+
+  private get pinnedDatabase(): string {
+    return this.connection.database ?? DEFAULT_DATABASE;
+  }
+
+  // ==========================================================================
+  // Query execution
+  // ==========================================================================
+
+  public async query(sql: string, params?: unknown[]): Promise<QueryResult> {
+    const transport = this.requireTransport();
+    if (params !== undefined && params.length > 0) {
+      // The HTTP interface binds named `{name:Type}` parameters only, so there
+      // is nowhere to put a positional value. Failing loudly beats running the
+      // statement with its placeholders unbound.
+      throw new QueryError(
+        "ClickHouse binds named parameters only, so positional parameters cannot be sent",
+        this.type,
+        sql,
+      );
+    }
+
+    return this.trackQuery(async () => {
+      const { result, executionTime } = await this.measureExecution(async () => {
+        try {
+          return await transport.query(sql, { settings: { max_execution_time: this.deadlineSeconds() } });
+        } catch (error) {
+          throw this.mapClickHouseError(error, sql);
+        }
+      });
+
+      return toQueryResult(result, executionTime);
+    });
+  }
+
+  /**
+   * The statement deadline the server enforces, in seconds. A URL setting is
+   * overridden by a `SETTINGS` clause in the statement itself, so a user who
+   * asks for longer still gets it.
+   */
+  private deadlineSeconds(): number {
+    return Math.ceil(this.queryTimeout / MILLISECONDS_PER_SECOND);
+  }
+
+  /**
+   * Normalized transport failure -> the provider error vocabulary, keyed on the
+   * numeric exception code.
+   *
+   * The code rather than the message, and the code rather than the HTTP status:
+   * a denial arrives as 500 (so status reads as a server fault) and its message
+   * says "Not enough privileges" (so sniffing for "access denied" misses it).
+   * The code is the only discrete thing the server reports.
+   */
+  private mapClickHouseError(error: unknown, sql?: string): Error {
+    if (!(error instanceof ClickHouseTransportError)) return this.mapError(error, sql);
+
+    if (error.is("AUTHENTICATION_FAILED") || error.is("ACCESS_DENIED")) {
+      return new AuthenticationError(error.message, this.type);
+    }
+    if (TIMEOUT_CODES.includes(error.code)) {
+      return new TimeoutError(error.message, this.type, this.queryTimeout, sql);
+    }
+    if (error.code === CLICKHOUSE_FAILURE_CODES.QUERY_WAS_CANCELLED) {
+      return new QueryCancelledError(error.message, this.type, sql);
+    }
+    if (error.code === CLICKHOUSE_FAILURE_CODES.NETWORK_ERROR) {
+      return new ConnectionError(error.message, this.type, this.connection.host, this.connection.port);
+    }
+    if (error.code === CLICKHOUSE_FAILURE_CODES.NO_SERVER_CODE) {
+      // Nothing below the SQL layer answered, so there is no code to key on and
+      // the shared message-based mapping - which recognises a refused socket and
+      // a timeout - is the best classification available.
+      return this.mapError(error, sql);
+    }
+
+    // Reached only for a code no branch matched: the server named an exception
+    // for a statement it rejected.
+    return new QueryError(error.message, this.type, sql);
+  }
+
+  /** Run an operation whose failures should surface as provider errors. */
+  private async guarded<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      throw this.mapClickHouseError(error);
+    }
+  }
+
+  // ==========================================================================
+  // Schema
+  // ==========================================================================
+
+  public async getSchema(): Promise<TableSchema[]> {
+    const transport = this.requireTransport();
+    return this.guarded(() => introspectSchema(transport, this.pinnedDatabase));
+  }
+
+  public async getSchemaList(): Promise<TableSchema[]> {
+    const transport = this.requireTransport();
+    return this.guarded(() => introspectSchemaList(transport, this.pinnedDatabase));
+  }
+
+  public async getSchemaRelations(): Promise<TableRelations[]> {
+    const transport = this.requireTransport();
+    return this.guarded(() => introspectSchemaRelations(transport, this.pinnedDatabase));
+  }
+
+  // ==========================================================================
+  // Monitoring (every source degrades to empty or zeroed, never throws)
+  // ==========================================================================
+
+  /**
+   * One monitoring read.
+   *
+   * `ACCESS_DENIED` and `UNKNOWN_TABLE` are the two codes that mean "this
+   * surface does not exist for this user or this deployment", and both are
+   * ordinary: the system tables need their own grants, and `query_log` is
+   * switched off on plenty of servers. Every OTHER failure propagates, because
+   * an empty panel in place of a real error hides it forever.
+   */
+  private async monitoringRows(sql: string): Promise<ClickHouseRow[]> {
+    const transport = this.requireTransport();
+
+    try {
+      const result = await transport.query(sql, { settings: { max_execution_time: MONITORING_TIMEOUT_SECONDS } });
+      return result.rows;
+    } catch (error) {
+      if (error instanceof ClickHouseTransportError && error.isMonitoringUnavailable()) return [];
+      throw this.mapClickHouseError(error, sql);
+    }
+  }
+
+  private async monitoringRow(sql: string): Promise<ClickHouseRow | null> {
+    const rows = await this.monitoringRows(sql);
+    return rows[0] ?? null;
+  }
+
+  public async getOverview(): Promise<DatabaseOverview> {
+    const [identity, connections, size, tables, indexes] = await Promise.all([
+      this.monitoringRow(OVERVIEW_IDENTITY_SQL),
+      this.monitoringRow(OVERVIEW_CONNECTIONS_SQL),
+      this.monitoringRow(OVERVIEW_SIZE_SQL),
+      this.monitoringRow(OVERVIEW_TABLE_COUNT_SQL),
+      this.monitoringRow(OVERVIEW_INDEX_COUNT_SQL),
+    ]);
+
+    const uptimeMs = asNumber(identity?.uptimeSeconds) * MILLISECONDS_PER_SECOND;
+    const sizeBytes = asNumber(size?.databaseSizeBytes);
+
+    return {
+      version: asText(identity?.version, UNKNOWN_VERSION),
+      uptime: this.formatDuration(uptimeMs),
+      // Left undefined when the identity read failed: a start time derived from
+      // a zero uptime would claim the server booted this instant.
+      startTime: identity === null ? undefined : new Date(Date.now() - uptimeMs),
+      activeConnections: asNumber(connections?.connections),
+      maxConnections: asNumber(connections?.maxConnections),
+      databaseSize: formatBytes(sizeBytes),
+      databaseSizeBytes: sizeBytes,
+      tableCount: asNumber(tables?.tableCount),
+      indexCount: asNumber(indexes?.indexCount),
+    };
+  }
+
+  public async getPerformanceMetrics(): Promise<PerformanceMetrics> {
+    const [events, memory] = await Promise.all([
+      this.monitoringRow(PERFORMANCE_EVENTS_SQL),
+      this.monitoringRow(PERFORMANCE_MEMORY_SQL),
+    ]);
+
+    const cacheHits = asNumber(events?.cacheHits);
+    const lookups = cacheHits + asNumber(events?.cacheMisses);
+    const uptimeSeconds = asNumber(events?.uptimeSeconds);
+
+    return {
+      cacheHitRatio: percentOf(cacheHits, lookups),
+      queriesPerSecond: uptimeSeconds > 0 ? round2(asNumber(events?.queryCount) / uptimeSeconds) : 0,
+      // The server's resident memory against the machine's, which is the closest
+      // ClickHouse gets to a buffer pool: its caches are many and separately
+      // configured, and the mark cache alone is near-empty on a healthy server.
+      bufferPoolUsage: percentOf(asNumber(memory?.memoryBytes), asNumber(memory?.memoryTotalBytes)),
+    };
+  }
+
+  public async getSlowQueries(options: { limit?: number } = {}): Promise<SlowQueryStats[]> {
+    const limit = rowLimit(options.limit, DEFAULT_SLOW_QUERY_LIMIT);
+    const rows = await this.monitoringRows(`${SLOW_QUERY_SQL} LIMIT ${limit}`);
+
+    return rows.map((row) => ({
+      queryId: asText(row.queryId),
+      query: asText(row.query),
+      calls: asNumber(row.calls),
+      totalTime: asNumber(row.totalMs),
+      avgTime: round2(asNumber(row.avgMs)),
+      minTime: asNumber(row.minMs),
+      maxTime: asNumber(row.maxMs),
+      rows: asNumber(row.resultRows),
+    }));
+  }
+
+  public async getActiveSessions(options: { limit?: number } = {}): Promise<ActiveSessionDetails[]> {
+    const limit = rowLimit(options.limit, DEFAULT_SESSION_LIMIT);
+    const rows = await this.monitoringRows(`${ACTIVE_SESSION_SQL} LIMIT ${limit}`);
+
+    return rows.map((row) => {
+      const durationMs = Math.round(asNumber(row.elapsedSeconds) * MILLISECONDS_PER_SECOND);
+      return {
+        pid: asText(row.queryId),
+        user: asText(row.user, UNKNOWN_USER),
+        database: asText(row.database),
+        clientAddr: asText(row.clientAddr),
+        state: RUNNING_STATE,
+        query: asText(row.query),
+        duration: this.formatDuration(durationMs),
+        durationMs,
+      };
+    });
+  }
+
+  public async getTableStats(options: { schema?: string } = {}): Promise<TableStats[]> {
+    const filter = this.databaseFilter(options.schema);
+    const rows = await this.monitoringRows(`${TABLE_STATS_SELECT_SQL} ${filter} ${TABLE_STATS_GROUP_SQL}`);
+
+    return rows.map((row) => {
+      const tableSizeBytes = asNumber(row.dataBytes);
+      const indexSizeBytes = asNumber(row.indexBytes);
+      const totalSizeBytes = asNumber(row.totalBytes);
+
+      return {
+        schemaName: asText(row.database),
+        tableName: asText(row.table),
+        rowCount: asNumber(row.rowCount),
+        tableSize: formatBytes(tableSizeBytes),
+        tableSizeBytes,
+        indexSize: formatBytes(indexSizeBytes),
+        indexSizeBytes,
+        totalSize: formatBytes(totalSizeBytes),
+        totalSizeBytes,
+      };
+    });
+  }
+
+  /**
+   * The data-skipping indexes, which are the only index OBJECTS ClickHouse has.
+   *
+   * The sparse primary index is deliberately absent here even though the schema
+   * tree reports it: it is part of the table rather than a separate object, so it
+   * has no name, no size and no statistics of its own to fill this row with.
+   * `scans` is zero for the same reason - ClickHouse publishes no per-index usage
+   * counter anywhere, and a guessed number is worse than an obvious zero.
+   */
+  public async getIndexStats(options: { schema?: string } = {}): Promise<IndexStats[]> {
+    const filter = this.databaseFilter(options.schema);
+    const rows = await this.monitoringRows(`${INDEX_STATS_SELECT_SQL} ${filter} ${INDEX_STATS_ORDER_SQL}`);
+
+    return rows.map((row) => {
+      const indexSizeBytes = asNumber(row.indexSizeBytes);
+
+      return {
+        schemaName: asText(row.database),
+        tableName: asText(row.table),
+        indexName: asText(row.indexName),
+        indexType: asText(row.indexType),
+        // One entry, verbatim: a data-skipping index is declared over an
+        // EXPRESSION rather than a column list, and splitting `cityHash64(a, b)`
+        // on its commas would invent two columns that do not exist.
+        columns: [asText(row.expr)],
+        // Neither a data-skipping index nor the primary key enforces uniqueness
+        // (live-verified: three identical values were accepted into a table
+        // declared PRIMARY KEY (a)), so no index ClickHouse reports is unique.
+        isUnique: false,
+        isPrimary: false,
+        indexSize: formatBytes(indexSizeBytes),
+        indexSizeBytes,
+        scans: 0,
+      };
+    });
+  }
+
+  public async getStorageStats(): Promise<StorageStats[]> {
+    const rows = await this.monitoringRows(STORAGE_SQL);
+
+    return rows.map((row) => {
+      const sizeBytes = asNumber(row.totalBytes);
+      return {
+        name: asText(row.name),
+        location: asText(row.path),
+        size: formatBytes(sizeBytes),
+        sizeBytes,
+        usagePercent: percentOf(sizeBytes - asNumber(row.freeBytes), sizeBytes),
+      };
+    });
+  }
+
+  public async getHealth(): Promise<HealthInfo> {
+    const [overview, performance, slowQueries, sessions] = await Promise.all([
+      this.getOverview(),
+      this.getPerformanceMetrics(),
+      this.getSlowQueries({ limit: 5 }),
+      this.getActiveSessions({ limit: 10 }),
+    ]);
+
+    const slow: SlowQuery[] = slowQueries.map((entry) => ({
+      query: entry.query,
+      calls: entry.calls,
+      avgTime: `${Math.round(entry.avgTime)}ms`,
+    }));
+
+    const active: ActiveSession[] = sessions.map((session) => ({
+      pid: session.pid,
+      user: session.user,
+      database: session.database,
+      state: session.state,
+      query: session.query,
+      duration: session.duration,
+    }));
+
+    return {
+      activeConnections: overview.activeConnections,
+      databaseSize: overview.databaseSize,
+      cacheHitRatio: performance.cacheHitRatio.toFixed(1),
+      slowQueries: slow,
+      activeSessions: active,
+    };
+  }
+
+  /** One database when the caller named one, every user database otherwise. */
+  private databaseFilter(schema: string | undefined): string {
+    return schema === undefined ? NON_SYSTEM_DATABASE : `database = ${literal(schema)}`;
+  }
+
+  // ==========================================================================
+  // Maintenance
+  // ==========================================================================
+
+  public async runMaintenance(type: MaintenanceType, target?: string): Promise<MaintenanceResult> {
+    const transport = this.requireTransport();
+    const { result, executionTime } = await this.measureExecution(() =>
+      this.guarded(() => this.dispatchMaintenance(transport, type, target)),
+    );
+
+    return { ...result, executionTime };
+  }
+
+  private dispatchMaintenance(
+    transport: ClickHouseTransport,
+    type: MaintenanceType,
+    target?: string,
+  ): Promise<Omit<MaintenanceResult, "executionTime">> {
+    switch (type) {
+      case "optimize":
+        return this.optimizeTable(transport, this.requireTarget(type, target));
+      // No target is legitimate here, unlike optimize: MaintenanceModal's global
+      // Analyze button sends none, and a database's parts are as well defined as a
+      // table's. Demanding one made a control the UI always offers always fail.
+      case "analyze":
+        return this.describeParts(transport, target);
+      case "kill":
+        return this.cancelQueryById(transport, this.requireTarget(type, target));
+    }
+
+    // Reached only for the operations ClickHouse has no equivalent for; they are
+    // absent from maintenanceOperations, so the UI never offers them.
+    throw new QueryError(
+      `Unsupported maintenance operation for ClickHouse: ${type}. Supported: optimize, analyze, kill`,
+      this.type,
+    );
+  }
+
+  private requireTarget(type: MaintenanceType, target?: string): string {
+    if (!target) {
+      throw new QueryError(`The "${type}" operation requires a target`, this.type);
+    }
+    return target;
+  }
+
+  private qualify(target: string): string {
+    const [database, table] = splitTarget(target, this.pinnedDatabase);
+    return `${this.escapeIdentifier(database)}.${this.escapeIdentifier(table)}`;
+  }
+
+  /**
+   * FINAL merges the table down to one part per partition and applies pending
+   * mutations, which is the operation a ClickHouse user reaches for where
+   * another engine would vacuum.
+   */
+  private async optimizeTable(
+    transport: ClickHouseTransport,
+    target: string,
+  ): Promise<Omit<MaintenanceResult, "executionTime">> {
+    await transport.query(`OPTIMIZE TABLE ${this.qualify(target)} FINAL`);
+    return { success: true, message: `Optimized ${target}` };
+  }
+
+  /**
+   * ClickHouse has no ANALYZE, and it needs none: a MergeTree's statistics ARE
+   * its parts, and they are current by construction. So the honest equivalent of
+   * the operation is to report them rather than to pretend something was
+   * recomputed.
+   */
+  private async describeParts(
+    transport: ClickHouseTransport,
+    target?: string,
+  ): Promise<Omit<MaintenanceResult, "executionTime">> {
+    // Without a target the scope is the whole pinned database, which is what the
+    // global Analyze button asks for.
+    const [database, table] = target ? splitTarget(target, this.pinnedDatabase) : [this.pinnedDatabase, undefined];
+    const scope = target ?? database;
+    const where = table
+      ? `database = ${literal(database)} AND table = ${literal(table)}`
+      : `database = ${literal(database)}`;
+    const result = await transport.query(`${PART_SUMMARY_SELECT_SQL} ${where}`, {
+      settings: { max_execution_time: MONITORING_TIMEOUT_SECONDS },
+    });
+    const row = result.rows[0];
+    const parts = asNumber(row?.partCount);
+
+    if (parts === 0) {
+      return {
+        success: true,
+        message: `${scope}: no active parts (a view or a non-MergeTree engine keeps none)`,
+      };
+    }
+
+    const rowCount = asNumber(row?.rowCount);
+    const onDisk = formatBytes(asNumber(row?.totalBytes));
+    return { success: true, message: `${scope}: ${parts} active parts, ${rowCount} rows, ${onDisk} on disk` };
+  }
+
+  /**
+   * SYNC so the result is reported after the query has actually stopped rather
+   * than after the kill was queued.
+   */
+  private async cancelQueryById(
+    transport: ClickHouseTransport,
+    target: string,
+  ): Promise<Omit<MaintenanceResult, "executionTime">> {
+    await transport.query(`KILL QUERY WHERE query_id = ${literal(target)} SYNC`);
+    return { success: true, message: `Cancelled query ${target}` };
+  }
+}

--- a/src/lib/db/providers/sql/clickhouse/introspect.ts
+++ b/src/lib/db/providers/sql/clickhouse/introspect.ts
@@ -212,16 +212,53 @@ function readDefault(kind: string, expression: string): string | undefined {
  * expression comes back as `(lower(b))`. The depth walk is what refuses
  * `(a), (b)`, where the first parenthesis closes long before the end.
  */
+/** The quote characters ClickHouse opens a span with: identifiers, then literals. */
+const QUOTES = new Set(["`", '"', "'"]);
+
+/**
+ * The index just past the quoted span opening at `open`.
+ *
+ * Needed because a quoted span may legally contain the very characters the scans
+ * below treat as syntax: `` `region,code` `` is one identifier, and `` `a(b` ``
+ * contains a parenthesis that must not move the depth counter. Both a backslash and
+ * a doubled quote escape the quote rather than closing it. An unterminated span
+ * consumes the rest of the string, which is the reading that cannot mis-split.
+ */
+function endOfQuoted(text: string, open: number): number {
+  const quote = text[open];
+  for (let index = open + 1; index < text.length; index += 1) {
+    if (text[index] === "\\") {
+      index += 1;
+      continue;
+    }
+    if (text[index] === quote) {
+      if (text[index + 1] === quote) {
+        index += 1;
+        continue;
+      }
+      return index + 1;
+    }
+  }
+  return text.length;
+}
+
 function unwrapOuterParens(expression: string): string {
   if (!expression.startsWith("(") || !expression.endsWith(")")) return expression;
 
   let depth = 0;
-  for (let index = 0; index < expression.length; index += 1) {
-    if (expression[index] === "(") depth += 1;
-    else if (expression[index] === ")") {
+  let index = 0;
+  while (index < expression.length) {
+    const char = expression[index];
+    if (QUOTES.has(char)) {
+      index = endOfQuoted(expression, index);
+      continue;
+    }
+    if (char === "(") depth += 1;
+    else if (char === ")") {
       depth -= 1;
       if (depth === 0 && index < expression.length - 1) return expression;
     }
+    index += 1;
   }
   return expression.slice(1, -1).trim();
 }
@@ -242,14 +279,20 @@ function splitKeyExpression(expression: string): string[] {
   const elements: string[] = [];
   let depth = 0;
   let start = 0;
-  for (let index = 0; index < listed.length; index += 1) {
+  let index = 0;
+  while (index < listed.length) {
     const char = listed[index];
+    if (QUOTES.has(char)) {
+      index = endOfQuoted(listed, index);
+      continue;
+    }
     if (char === "(") depth += 1;
     else if (char === ")") depth -= 1;
     else if (char === "," && depth === 0) {
       elements.push(listed.slice(start, index).trim());
       start = index + 1;
     }
+    index += 1;
   }
   elements.push(listed.slice(start).trim());
   return elements.filter((element) => element !== "");

--- a/src/lib/db/providers/sql/clickhouse/introspect.ts
+++ b/src/lib/db/providers/sql/clickhouse/introspect.ts
@@ -1,0 +1,493 @@
+/**
+ * ClickHouse schema introspection (issue #264, design spec section 3.6)
+ *
+ * Three reads of the `system.*` catalogs, all through the transport seam so this
+ * file stays free of any wire vocabulary:
+ *
+ * - `system.tables` -> the table list, its row counts and sizes, and the two
+ *   keys a MergeTree sorts by.
+ * - `system.columns` -> columns in declaration order, with the declared type
+ *   string, primary-key membership and the column default.
+ * - `system.data_skipping_indices` -> the nearest thing ClickHouse has to a
+ *   secondary index.
+ *
+ * Foreign keys are absent everywhere by construction: ClickHouse has none - no
+ * engine, no table setting and no DDL declares one - so an empty list here is a
+ * fact about the engine, not a load that failed or was deferred.
+ *
+ * Five things the live server (26.7.1.1315) forced, each load-bearing:
+ *
+ * 1. `total_rows`/`total_bytes` are `Nullable(UInt64)` and really are null for a
+ *    view and for every non-MergeTree engine. Null is UNKNOWN, never zero.
+ * 2. A `UInt64` arrives as a decimal STRING because the transport always sends
+ *    64-bit quoting (spec 2.1), while a `UInt8` such as `is_in_primary_key`
+ *    stays an unquoted number. Both encodings are accepted.
+ * 3. A key expression is a comma-separated list that can itself contain commas -
+ *    `a, b, cityHash64(c, c)` - and a one-element key keeps the parentheses a
+ *    multi-element one drops: `(a)` versus `a, b`. Splitting has to be
+ *    parenthesis-aware or a column ends up named `(a)` or `cityHash64(c`.
+ * 4. `Nullable` is not always the outermost wrapper, and is not always the
+ *    column's own: `LowCardinality(Nullable(String))` is nullable while
+ *    `Array(Nullable(String))` is not.
+ * 5. `system.tables` and `system.columns` are pre-filtered to what the user may
+ *    read, but `system.data_skipping_indices` needs its own grant and answers
+ *    500 / code 497 without it. Each catalog therefore degrades on its own.
+ */
+
+import type { ColumnSchema, IndexSchema, TableRelations, TableSchema } from "@/lib/types";
+import { formatBytes } from "../../../utils/pool-manager";
+import { type ClickHouseRow, type ClickHouseTransport, ClickHouseTransportError } from "./transport";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Databases holding the server's own bookkeeping rather than a user's data.
+ *
+ * `information_schema` exists twice, once in each case, and both are real
+ * separate entries in `system.databases` (live-verified) - excluding one leaves
+ * a duplicate of every ANSI catalog view in the tree. `default` is deliberately
+ * NOT here: it is an ordinary writable database, and it is where a connection
+ * that names none lands, so hiding it would empty the commonest setup.
+ *
+ * Exported because the monitoring reads (spec 3.7) filter `system.parts` by the
+ * same rule, and one definition is the point.
+ */
+export const CLICKHOUSE_SYSTEM_DATABASES: readonly string[] = Object.freeze([
+  "system",
+  "information_schema",
+  "INFORMATION_SCHEMA",
+]);
+
+/**
+ * Name for the synthesized primary-key index.
+ *
+ * ClickHouse does not name its primary index - it is part of the table, not a
+ * separate object - so this is the wording `SHOW CREATE TABLE` uses, which is
+ * what a ClickHouse user already reads.
+ */
+export const CLICKHOUSE_PRIMARY_INDEX_NAME = "PRIMARY KEY";
+
+/** Name for the sorting key, reported only when it extends the primary key. */
+export const CLICKHOUSE_SORTING_INDEX_NAME = "ORDER BY";
+
+/**
+ * Server-side deadline for a catalog read, in seconds (`max_execution_time`'s
+ * unit). A cluster with thousands of tables or one stuck replica must not leave
+ * the schema tree spinning with no way out.
+ */
+export const CLICKHOUSE_CATALOG_TIMEOUT_SECONDS = 15;
+
+/** Names are compile-time constants, so inlining them as literals is safe. */
+const NON_SYSTEM_DATABASE = `database NOT IN (${CLICKHOUSE_SYSTEM_DATABASES.map((name) => `'${name}'`).join(", ")})`;
+
+const TABLE_LIST_SQL = [
+  "SELECT database, name, total_rows, total_bytes, sorting_key, primary_key",
+  "FROM system.tables",
+  `WHERE ${NON_SYSTEM_DATABASE}`,
+  "ORDER BY database, name",
+].join(" ");
+
+/** `position` orders the projection rather than appearing in it: it IS the declared column order. */
+const COLUMN_LIST_SQL = [
+  "SELECT database, table, name, type, is_in_primary_key, default_kind, default_expression",
+  "FROM system.columns",
+  `WHERE ${NON_SYSTEM_DATABASE}`,
+  "ORDER BY database, table, position",
+].join(" ");
+
+/**
+ * The database filter is not an optimisation here. Live-verified: the system
+ * databases contribute around forty rows of their own, which swamp a user's
+ * handful of indexes when the predicate is left off.
+ */
+const INDEX_LIST_SQL = [
+  "SELECT database, table, name, expr",
+  "FROM system.data_skipping_indices",
+  `WHERE ${NON_SYSTEM_DATABASE}`,
+  "ORDER BY database, table, name",
+].join(" ");
+
+/** The one wrapper ClickHouse puts outside `Nullable` instead of inside it. */
+const LOW_CARDINALITY_PREFIX = "LowCardinality(";
+
+const NULLABLE_PREFIX = "Nullable(";
+
+/** The only `default_kind` that is an insert-time default rather than a computed column. */
+const DEFAULT_KIND = "DEFAULT";
+
+/**
+ * Separator joining a database to a table in the grouping key. NUL rather than a
+ * dot because a dot is ambiguous - a quoted database or table name may contain
+ * one, so `"a.b" + "c"` and `"a" + "b.c"` would land in the same bucket.
+ */
+const KEY_SEPARATOR = "\u0000";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** One `system.tables` row, decoded. */
+interface TableInfo {
+  database: string;
+  name: string;
+  /** Undefined when the server reported null - unknown, not zero. */
+  rowCount: number | undefined;
+  sizeBytes: number | undefined;
+  primaryKey: string[];
+  sortingKey: string[];
+}
+
+/** A catalog row placed against the table that owns it. */
+interface OwnedEntry<T> {
+  key: string;
+  value: T;
+}
+
+// ============================================================================
+// Value readers
+// ============================================================================
+
+/** An identifier, or null for a row that cannot be placed and must be skipped. */
+function readIdentifier(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+function readText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * A `Nullable(UInt64)` count.
+ *
+ * Both encodings are real: the transport sends 64-bit quoting so nothing rounds
+ * through `JSON.parse` (spec 2.1), which turns a `UInt64` into a decimal string,
+ * while a source without that setting would send a number. Anything else -
+ * null, an empty string, prose - is UNKNOWN and must stay undefined: a table
+ * shown as "0 rows" when the server never said so is a number the explorer
+ * invented, and a view reports null for exactly this field.
+ */
+function readCount(value: unknown): number | undefined {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") return undefined;
+  const parsed = Number(value);
+  return value.length > 0 && Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Whether the COLUMN accepts null, which is not the same as the type mentioning
+ * `Nullable`. Live-verified: `Array(Nullable(String))`,
+ * `Map(String, Nullable(String))` and `SimpleAggregateFunction(any,
+ * Nullable(UInt64))` all qualify an inner type, so a substring search calls
+ * three non-nullable columns nullable; `LowCardinality(Nullable(String))` is the
+ * one combination spelled the other way round, so a bare prefix test misses it.
+ */
+function isNullableType(type: string): boolean {
+  const inner = type.startsWith(LOW_CARDINALITY_PREFIX) ? type.slice(LOW_CARDINALITY_PREFIX.length) : type;
+  return inner.startsWith(NULLABLE_PREFIX);
+}
+
+/**
+ * The column default as the explorer should show it.
+ *
+ * Live-verified kinds are `DEFAULT`, `MATERIALIZED` and `ALIAS`. Only the first
+ * is a default an INSERT may override; the other two are computed columns, and
+ * printing their expression bare would read as a value the user could supply.
+ */
+function readDefault(kind: string, expression: string): string | undefined {
+  if (kind === "" || expression === "") return undefined;
+  return kind === DEFAULT_KIND ? expression : `${kind} ${expression}`;
+}
+
+// ============================================================================
+// Key expressions
+// ============================================================================
+
+/**
+ * Drop one pair of parentheses when it wraps the whole expression.
+ *
+ * Live-verified rendering: a one-element key comes back as `(a)` while a
+ * multi-element one comes back as `a, b`, and a data-skipping index over an
+ * expression comes back as `(lower(b))`. The depth walk is what refuses
+ * `(a), (b)`, where the first parenthesis closes long before the end.
+ */
+function unwrapOuterParens(expression: string): string {
+  if (!expression.startsWith("(") || !expression.endsWith(")")) return expression;
+
+  let depth = 0;
+  for (let index = 0; index < expression.length; index += 1) {
+    if (expression[index] === "(") depth += 1;
+    else if (expression[index] === ")") {
+      depth -= 1;
+      if (depth === 0 && index < expression.length - 1) return expression;
+    }
+  }
+  return expression.slice(1, -1).trim();
+}
+
+/**
+ * Split a key or index expression into the elements it lists.
+ *
+ * Splitting on every comma is the trap: live-verified keys include
+ * `a, b, cityHash64(c, c)` and `a, concat(b, 'x, y')`, both of which carry
+ * commas that belong to a nested call, so only a top-level comma separates two
+ * elements. Every comma that matters is outside every parenthesis, which is why
+ * depth alone is enough and no lexer is needed.
+ */
+function splitKeyExpression(expression: string): string[] {
+  const listed = unwrapOuterParens(expression.trim());
+  if (listed === "") return [];
+
+  const elements: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let index = 0; index < listed.length; index += 1) {
+    const char = listed[index];
+    if (char === "(") depth += 1;
+    else if (char === ")") depth -= 1;
+    else if (char === "," && depth === 0) {
+      elements.push(listed.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  elements.push(listed.slice(start).trim());
+  return elements.filter((element) => element !== "");
+}
+
+// ============================================================================
+// Row decoding
+// ============================================================================
+
+function tableKey(database: string, table: string): string {
+  return `${database}${KEY_SEPARATOR}${table}`;
+}
+
+function readTableInfo(row: ClickHouseRow): TableInfo | null {
+  const database = readIdentifier(row.database);
+  const name = readIdentifier(row.name);
+  if (database === null || name === null) return null;
+
+  return {
+    database,
+    name,
+    rowCount: readCount(row.total_rows),
+    sizeBytes: readCount(row.total_bytes),
+    primaryKey: splitKeyExpression(readText(row.primary_key)),
+    sortingKey: splitKeyExpression(readText(row.sorting_key)),
+  };
+}
+
+function readColumn(row: ClickHouseRow): OwnedEntry<ColumnSchema> | null {
+  const database = readIdentifier(row.database);
+  const table = readIdentifier(row.table);
+  const name = readIdentifier(row.name);
+  if (database === null || table === null || name === null) return null;
+
+  // Spec 1.7: the declared type goes through verbatim. Collapsing it onto a
+  // generic family would throw away the wrapper, and the wrapper is the part
+  // that says nullable, low-cardinality, parameterised or enumerated.
+  const type = readText(row.type);
+
+  return {
+    key: tableKey(database, table),
+    value: {
+      name,
+      type,
+      nullable: isNullableType(type),
+      // `is_in_primary_key` is the authority: the sorting key may extend past
+      // the primary key, and those trailing columns are not primary.
+      isPrimary: row.is_in_primary_key === 1,
+      defaultValue: readDefault(readText(row.default_kind), readText(row.default_expression)),
+    },
+  };
+}
+
+function readIndex(row: ClickHouseRow): OwnedEntry<IndexSchema> | null {
+  const database = readIdentifier(row.database);
+  const table = readIdentifier(row.table);
+  const name = readIdentifier(row.name);
+  if (database === null || table === null || name === null) return null;
+
+  return {
+    key: tableKey(database, table),
+    // A data-skipping index prunes granules and enforces nothing, so no index
+    // ClickHouse reports is unique. Nor is the primary key: live-verified, three
+    // identical values were accepted into a table declared PRIMARY KEY (a).
+    value: { name, columns: splitKeyExpression(readText(row.expr)), unique: false },
+  };
+}
+
+/**
+ * Bucket rows by the table that owns them. A row the decoder cannot place is
+ * dropped rather than fatal, so one malformed row costs one entry instead of
+ * the whole tree.
+ */
+function groupByTable<T>(
+  rows: ClickHouseRow[],
+  decode: (row: ClickHouseRow) => OwnedEntry<T> | null,
+): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const row of rows) {
+    const entry = decode(row);
+    if (entry === null) continue;
+    const owned = grouped.get(entry.key) ?? [];
+    owned.push(entry.value);
+    grouped.set(entry.key, owned);
+  }
+  return grouped;
+}
+
+// ============================================================================
+// Catalog reads
+// ============================================================================
+
+/**
+ * One catalog read, degrading to no rows when the catalog is not available.
+ *
+ * `ACCESS_DENIED` and `UNKNOWN_TABLE` are the two codes that mean "this surface
+ * does not exist for this user or this deployment", and both are ordinary rather
+ * than broken - live-verified, a user granted SELECT on a single table reads
+ * `system.tables` and `system.columns` happily but gets 497 from
+ * `system.data_skipping_indices`, which needs its own grant. Losing the whole
+ * schema tree over that would punish a perfectly usable connection. Every other
+ * failure propagates: an empty tree in place of a real error hides it forever.
+ */
+async function readCatalog(transport: ClickHouseTransport, sql: string): Promise<ClickHouseRow[]> {
+  try {
+    const settings = { max_execution_time: CLICKHOUSE_CATALOG_TIMEOUT_SECONDS };
+    const result = await transport.query(sql, { settings });
+    return result.rows;
+  } catch (error) {
+    if (error instanceof ClickHouseTransportError && error.isMonitoringUnavailable()) return [];
+    throw error;
+  }
+}
+
+async function readTables(transport: ClickHouseTransport): Promise<TableInfo[]> {
+  const rows = await readCatalog(transport, TABLE_LIST_SQL);
+  return rows.map(readTableInfo).filter((table): table is TableInfo => table !== null);
+}
+
+async function readColumns(transport: ClickHouseTransport): Promise<Map<string, ColumnSchema[]>> {
+  return groupByTable(await readCatalog(transport, COLUMN_LIST_SQL), readColumn);
+}
+
+async function readIndexes(transport: ClickHouseTransport): Promise<Map<string, IndexSchema[]>> {
+  return groupByTable(await readCatalog(transport, INDEX_LIST_SQL), readIndex);
+}
+
+// ============================================================================
+// Assembly
+// ============================================================================
+
+/**
+ * The name the flat schema explorer shows, and the name the generated SQL uses.
+ *
+ * A bare name resolves against the database the connection pinned, so
+ * qualifying a table inside it would be noise; a table outside it must be
+ * qualified or the generated statement reads the wrong database. Same rule
+ * `postgres.ts` applies to `public`.
+ */
+function displayName(table: TableInfo, pinnedDatabase: string): string {
+  return table.database === pinnedDatabase ? table.name : `${table.database}.${table.name}`;
+}
+
+function sameColumns(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((column, index) => column === right[index]);
+}
+
+/**
+ * The primary key, plus the sorting key when it says something the primary key
+ * does not.
+ *
+ * ClickHouse's primary key is a real sparse index over the sort order, so a
+ * MergeTree table reporting no index at all would be misleading. `ORDER BY` may
+ * extend `PRIMARY KEY`, and the trailing columns genuinely shape the on-disk
+ * order and the query plan, so they are reported as their own entry - comparing
+ * the split element lists rather than the raw strings, because the server
+ * renders the same one-element key as `(a)` in one column and `a` in the other.
+ */
+function keyIndexes(table: TableInfo): IndexSchema[] {
+  const indexes: IndexSchema[] = [];
+  if (table.primaryKey.length > 0) {
+    indexes.push({ name: CLICKHOUSE_PRIMARY_INDEX_NAME, columns: table.primaryKey, unique: false });
+  }
+  if (table.sortingKey.length > 0 && !sameColumns(table.primaryKey, table.sortingKey)) {
+    indexes.push({ name: CLICKHOUSE_SORTING_INDEX_NAME, columns: table.sortingKey, unique: false });
+  }
+  return indexes;
+}
+
+function tableIndexes(table: TableInfo, indexes: Map<string, IndexSchema[]>): IndexSchema[] {
+  return [...keyIndexes(table), ...(indexes.get(tableKey(table.database, table.name)) ?? [])];
+}
+
+function toTableSchema(
+  table: TableInfo,
+  pinnedDatabase: string,
+  columns: ColumnSchema[],
+  indexes: IndexSchema[],
+): TableSchema {
+  return {
+    name: displayName(table, pinnedDatabase),
+    columns,
+    indexes,
+    foreignKeys: [],
+    rowCount: table.rowCount,
+    size: table.sizeBytes === undefined ? undefined : formatBytes(table.sizeBytes),
+  };
+}
+
+// ============================================================================
+// Introspection
+// ============================================================================
+
+/** Every table of every non-system database, with its columns and indexes. */
+export async function getSchema(transport: ClickHouseTransport, pinnedDatabase: string): Promise<TableSchema[]> {
+  const [tables, columns, indexes] = await Promise.all([
+    readTables(transport),
+    readColumns(transport),
+    readIndexes(transport),
+  ]);
+
+  return tables.map((table) => {
+    const owned = columns.get(tableKey(table.database, table.name)) ?? [];
+    return toTableSchema(table, pinnedDatabase, owned, tableIndexes(table, indexes));
+  });
+}
+
+/**
+ * Fast structural schema: tables and columns only. Indexes are left to
+ * `getSchemaRelations()` so a third catalog read never blocks the table list,
+ * exactly as in the SQL providers.
+ */
+export async function getSchemaList(transport: ClickHouseTransport, pinnedDatabase: string): Promise<TableSchema[]> {
+  const [tables, columns] = await Promise.all([readTables(transport), readColumns(transport)]);
+
+  return tables.map((table) => {
+    const owned = columns.get(tableKey(table.database, table.name)) ?? [];
+    return toTableSchema(table, pinnedDatabase, owned, []);
+  });
+}
+
+/**
+ * Index lists keyed by the same display name `getSchemaList()` produced, so the
+ * client can merge them in.
+ *
+ * An entry is returned for every table, not only for the ones carrying an index:
+ * an empty list is the honest statement that the table has none, and omitting
+ * the table would instead leave whatever the client already had on screen.
+ */
+export async function getSchemaRelations(
+  transport: ClickHouseTransport,
+  pinnedDatabase: string,
+): Promise<TableRelations[]> {
+  const [tables, indexes] = await Promise.all([readTables(transport), readIndexes(transport)]);
+
+  return tables.map((table) => ({
+    name: displayName(table, pinnedDatabase),
+    foreignKeys: [],
+    indexes: tableIndexes(table, indexes),
+  }));
+}

--- a/src/lib/db/providers/sql/clickhouse/transport.ts
+++ b/src/lib/db/providers/sql/clickhouse/transport.ts
@@ -101,6 +101,19 @@ export interface ClickHouseQueryOptions {
    * the server takes `true`/`false` for boolean settings (live-verified).
    */
   settings?: Record<string, string | number | boolean>;
+
+  /**
+   * Wall-clock deadline for the whole exchange, client side.
+   *
+   * Distinct from a server-side execution limit, and not a duplicate of one: an
+   * execution limit only starts counting once the server has accepted the
+   * statement, so it cannot bound a stalled connect, handshake, or a response body
+   * that stops arriving part-way. The provider advertises a query timeout, and this
+   * is what makes that promise cover the transport rather than only the query.
+   *
+   * Neutral rather than HTTP-specific: any implementation can honour a deadline.
+   */
+  timeoutMs?: number;
 }
 
 /**

--- a/src/lib/db/providers/sql/clickhouse/transport.ts
+++ b/src/lib/db/providers/sql/clickhouse/transport.ts
@@ -1,0 +1,200 @@
+/**
+ * ClickHouse transport seam (issue #264, design spec section 3.3)
+ *
+ * Provider logic never talks to the server directly. It goes through this
+ * interface, so adopting a native-protocol client later is an additive change
+ * (one new file implementing the same contract) rather than a rewrite of the
+ * provider, the introspection and the explain strategy. This is the sibling of
+ * the Couchbase seam in `providers/document/couchbase/transport.ts`.
+ *
+ * The types below are deliberately NEUTRAL: they describe what a caller needs,
+ * not how one source encodes it. Anything the HTTP interface invented - its
+ * response envelope, its parameter names, its summary fields - stays inside
+ * `http-transport.ts`, and `seam-guard.test.ts` fails the build when that
+ * vocabulary appears anywhere else in the provider directory. That is what keeps
+ * the "one new file" estimate for a second implementation true.
+ *
+ * Apart from the error type this file is purely structural: no I/O.
+ */
+
+/**
+ * One result row.
+ *
+ * Unlike Couchbase SQL++ - where `SELECT RAW` yields bare scalars and the
+ * equivalent declaration is a known unsoundness - ClickHouse has no projection
+ * that produces a non-object row, so this type is honest rather than a cast.
+ */
+export type ClickHouseRow = Record<string, unknown>;
+
+/**
+ * Normalized outcome of one statement.
+ *
+ * `columnTypes` sits in the neutral type rather than behind the HTTP
+ * implementation because *any* ClickHouse client knows the types of the columns
+ * it received; it is not an artefact of one protocol. `rawText` is neutral for
+ * the same reason - output formats are a server feature, not a REST feature.
+ */
+export interface ClickHouseQueryResult {
+  rows: ClickHouseRow[];
+
+  /**
+   * Column order as the server declared it, or null when the source could not
+   * describe the rows (see `rawText`). Declared order matters: it is the only
+   * way to render columns the way the statement projected them, since object
+   * keys of an all-null first row cannot be trusted to be complete.
+   */
+  fieldNames: string[] | null;
+
+  /**
+   * Declared type per column, verbatim as ClickHouse spells it - `Int32`,
+   * `Nullable(String)`, `Map(String, UInt8)`, `Enum8('x' = 1)`,
+   * `LowCardinality(String)`. Live-verified in spec 1.7: collapsing these onto a
+   * generic family loses the wrapper, and the wrapper is exactly what tells a
+   * user whether a column is nullable or low-cardinality. Null when the source
+   * could not describe the rows.
+   */
+  columnTypes: Record<string, string> | null;
+
+  executionTimeMs: number;
+
+  /**
+   * How many rows the server says the statement changed.
+   *
+   * Report this verbatim and never derive it. Live-verified (spec 2.2): an
+   * `ALTER TABLE ... UPDATE` and a lightweight `DELETE FROM` both report zero
+   * even though the mutation really applied, because they are queued as
+   * background mutations. Fabricating a plausible count here would turn an
+   * honest "the server did not say" into a wrong number on screen.
+   */
+  mutationCount: number;
+
+  /**
+   * The result verbatim as text, set only when the statement produced something
+   * other than JSON.
+   *
+   * Live-verified (spec 1.2): an explicit `FORMAT` clause in the user's own SQL
+   * wins over the format the transport asks for, so `SELECT 1 FORMAT TSV`
+   * genuinely comes back as TSV. Surfacing the text beats throwing - the user
+   * asked for that format deliberately - and it beats guessing, which is why
+   * `fieldNames` and `columnTypes` are null whenever this is set.
+   */
+  rawText: string | null;
+}
+
+/** Per-statement options. */
+export interface ClickHouseQueryOptions {
+  /**
+   * Run this one statement against a different database than the connection's.
+   * Needed because the connection pins a default database and introspection or
+   * a data preview may target another one without rewriting the user's SQL.
+   */
+  database?: string;
+
+  /**
+   * ClickHouse settings to apply to this statement only.
+   *
+   * Deliberately open-ended rather than a fixed list of knobs: settings are a
+   * first-class server feature reachable from any client, and this is where a
+   * caller expresses a deadline (`max_execution_time`), a read-only guard
+   * (`readonly`) or a thread cap without the seam growing a field per concern.
+   * Values are stringified by the implementation; booleans are accepted because
+   * the server takes `true`/`false` for boolean settings (live-verified).
+   */
+  settings?: Record<string, string | number | boolean>;
+}
+
+/**
+ * The seam itself.
+ *
+ * There is no management method next to `query()`, unlike Couchbase: every
+ * ClickHouse metric, session and storage statistic the provider needs is a
+ * `system.*` table reachable by SQL, so a second entry point would be a
+ * permanent HTTP dependency for nothing.
+ */
+export interface ClickHouseTransport {
+  /** Widen when a native-protocol implementation appears. */
+  readonly kind: "http";
+  query(sql: string, opts?: ClickHouseQueryOptions): Promise<ClickHouseQueryResult>;
+  close(): Promise<void>;
+}
+
+/**
+ * The exception codes the provider branches on.
+ *
+ * Read back from the live server's own numbering rather than transcribed from
+ * documentation (`SELECT number, errorCodeToName(toUInt32(number)) FROM
+ * numbers(1500)` on 26.7.1.1315), and exported frozen so the provider, the
+ * transport and the tests share one definition instead of repeating literals
+ * that drift apart.
+ */
+export const CLICKHOUSE_ERROR_CODES = Object.freeze({
+  /** A statement ClickHouse does not implement, such as a bare `UPDATE ... SET`. */
+  NOT_IMPLEMENTED: 48,
+  UNKNOWN_TABLE: 60,
+  SYNTAX_ERROR: 62,
+  UNKNOWN_DATABASE: 81,
+  /** A user without the grant for the table it asked for. */
+  ACCESS_DENIED: 497,
+  AUTHENTICATION_FAILED: 516,
+} as const);
+
+export type ClickHouseErrorName = keyof typeof CLICKHOUSE_ERROR_CODES;
+
+/**
+ * Stand-in name for a failure that never reached the server, or reached it and
+ * came back without an exception name to read - a refused socket, an aborted
+ * request. There is nothing to scrape in those cases, and inventing a specific
+ * name would let a caller believe the server had spoken.
+ */
+export const CLICKHOUSE_UNKNOWN_ERROR_NAME = "CLICKHOUSE_ERROR";
+
+/**
+ * Codes that mean "this surface is not available here", as opposed to "this
+ * request was wrong".
+ *
+ * Spec 1.6 and 3.7: a user without monitoring grants and a deployment with
+ * `query_log` switched off are both ordinary, expected configurations, so every
+ * monitoring read degrades to an empty panel on these two codes and only these
+ * two. Anything else is the user's own mistake and must keep propagating -
+ * hiding a syntax error behind an empty panel is the failure mode this list
+ * exists to prevent.
+ */
+const MONITORING_UNAVAILABLE_CODES: readonly number[] = [
+  CLICKHOUSE_ERROR_CODES.ACCESS_DENIED,
+  CLICKHOUSE_ERROR_CODES.UNKNOWN_TABLE,
+];
+
+/**
+ * Normalized transport failure.
+ *
+ * `code` is ClickHouse's numeric exception code and is the only thing callers
+ * should branch on: the server reports it as a discrete value, whereas the
+ * symbolic name has to be recovered from the message prose and can be missing
+ * or, on a wrapped exception, describe an inner failure. `name` carries that
+ * symbol anyway - overriding the conventional class name - because it is the
+ * vocabulary a ClickHouse user already reads in `clickhouse-client` output,
+ * while the class itself stays recoverable through `instanceof`.
+ */
+export class ClickHouseTransportError extends Error {
+  constructor(
+    message: string,
+    public readonly code: number,
+    name: string = CLICKHOUSE_UNKNOWN_ERROR_NAME,
+  ) {
+    super(message);
+    this.name = name;
+    // Subclassing a builtin loses the prototype under a downlevel emit, which
+    // would make every instanceof check in the provider quietly fall through.
+    Object.setPrototypeOf(this, ClickHouseTransportError.prototype);
+  }
+
+  /** True when this failure is the named one. Keyed by name so no call site spells a number. */
+  is(errorName: ClickHouseErrorName): boolean {
+    return this.code === CLICKHOUSE_ERROR_CODES[errorName];
+  }
+
+  /** True when a monitoring read should degrade to empty instead of surfacing this. */
+  isMonitoringUnavailable(): boolean {
+    return MONITORING_UNAVAILABLE_CODES.includes(this.code);
+  }
+}

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -90,7 +90,7 @@ export interface MaintenanceResult {
  * Each id selects one strategy module in `src/lib/explain`. Extended per
  * provider as explain support lands.
  */
-export type ExplainFormat = "postgres-json" | "mysql-json" | "sqlite-queryplan" | "couchbase-json";
+export type ExplainFormat = "postgres-json" | "mysql-json" | "sqlite-queryplan" | "couchbase-json" | "clickhouse-json";
 
 export interface ProviderCapabilities {
   queryLanguage: "sql" | "json";

--- a/src/lib/explain/clickhouse-json.ts
+++ b/src/lib/explain/clickhouse-json.ts
@@ -1,0 +1,180 @@
+import type { ExplainStrategy, ExplainTreeNode } from "./types";
+
+const SELECT_ONLY = /^\s*SELECT\b/i;
+
+/**
+ * `FORMAT <Name>` as the last thing in the statement.
+ *
+ * Anchored at the end so it cannot match a `formatDateTime(...)` call or the words
+ * inside a string literal, which end in a quote. The provider carries the same
+ * pattern for its own reason (it must not append a LIMIT past this clause); the
+ * duplication is deliberate, since an explain strategy importing from one provider
+ * would tie the registry to it.
+ */
+const TRAILING_FORMAT = /\s*\bFORMAT\s+[A-Za-z][A-Za-z0-9_]*\s*$/i;
+
+/** The one column of the one row EXPLAIN returns; its value is the plan as JSON text. */
+const EXPLAIN_COLUMN = "explain";
+
+/**
+ * How many wrapper layers toPlanRoot peels before giving up. The deepest legitimate
+ * chain is four hops - cell text, the outer array, the { Plan } member, then the node
+ * itself - so the extra layer only keeps a pathological chain from looping.
+ */
+const MAX_UNWRAP_DEPTH = 5;
+
+/**
+ * A node of a ClickHouse EXPLAIN plan. "Node Type" is the discriminator and children
+ * always live under "Plans" as an array, so there is no single-child form to walk.
+ */
+interface ClickHousePlanNode {
+  "Node Type": string;
+  [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPlanNode(value: unknown): value is ClickHousePlanNode {
+  return isRecord(value) && typeof value["Node Type"] === "string";
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function parseJsonText(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Accepts the node itself, the { Plan } member, the outer array and - because the
+ * result cell is a String holding JSON - the still-unparsed plan text, in any nesting
+ * up to MAX_UNWRAP_DEPTH.
+ */
+function toPlanRoot(raw: unknown): ClickHousePlanNode | null {
+  let current = raw;
+  for (let depth = 0; depth < MAX_UNWRAP_DEPTH; depth++) {
+    if (isPlanNode(current)) return current;
+    if (typeof current === "string") {
+      current = parseJsonText(current);
+    } else if (Array.isArray(current)) {
+      current = current[0];
+    } else if (isRecord(current) && "Plan" in current) {
+      current = current.Plan;
+    } else {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * "Description" carries what distinguishes two nodes of the same type - the read
+ * table, "preliminary LIMIT", the WHERE it folded in - and VisualExplain renders only
+ * the label, so it belongs there rather than in detail.
+ */
+function buildLabel(node: ClickHousePlanNode): string {
+  const description = node.Description;
+  return isNonEmptyString(description) ? `${node["Node Type"]}: ${description}` : node["Node Type"];
+}
+
+function toStringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter(isNonEmptyString) : [];
+}
+
+function buildRatio(unit: string, selected: unknown, initial: unknown): string | undefined {
+  return isCount(selected) && isCount(initial) ? `${unit} ${selected}/${initial}` : undefined;
+}
+
+/** Selected-over-initial is the whole point of indexes = 1: it is what the index pruned. */
+function buildIndexSelection(entry: Record<string, unknown>): string | undefined {
+  const ratios = [
+    buildRatio("parts", entry["Selected Parts"], entry["Initial Parts"]),
+    buildRatio("granules", entry["Selected Granules"], entry["Initial Granules"]),
+  ].filter(isNonEmptyString);
+  return ratios.length > 0 ? ratios.join(", ") : undefined;
+}
+
+function buildIndexLabel(entry: Record<string, unknown>): string {
+  // "Name" is present on data-skipping entries only; "Type" alone identifies the rest.
+  const head = ["Index", entry.Type, entry.Name].filter(isNonEmptyString).join(" ");
+  const keys = toStringList(entry.Keys);
+  const named = keys.length > 0 ? `${head} (${keys.join(", ")})` : head;
+  const selection = buildIndexSelection(entry);
+  return selection === undefined ? named : `${named}: ${selection}`;
+}
+
+function buildIndexDetail(entry: Record<string, unknown>): string | undefined {
+  const parts: string[] = [];
+  if (isNonEmptyString(entry.Condition)) parts.push(`condition: ${entry.Condition}`);
+  if (isNonEmptyString(entry["Search Algorithm"])) parts.push(`search: ${entry["Search Algorithm"]}`);
+  // On a data-skipping entry "Description" is the index definition, e.g. "set GRANULARITY 4".
+  if (isNonEmptyString(entry.Description)) parts.push(`definition: ${entry.Description}`);
+  return parts.length > 0 ? parts.join(" | ") : undefined;
+}
+
+/**
+ * Index usage becomes child rows rather than one detail string: a MergeTree read
+ * reports up to four entries (Min-Max, Partition, PrimaryKey and each skip index) and
+ * each deserves its own line.
+ */
+function collectIndexNodes(node: ClickHousePlanNode): ExplainTreeNode[] {
+  const indexes = node.Indexes;
+  if (!Array.isArray(indexes)) return [];
+  return indexes.filter(isRecord).map((entry) => {
+    const indexNode: ExplainTreeNode = { label: buildIndexLabel(entry), children: [] };
+    const detail = buildIndexDetail(entry);
+    if (detail !== undefined) indexNode.detail = detail;
+    return indexNode;
+  });
+}
+
+function toTreeNode(node: ClickHousePlanNode): ExplainTreeNode {
+  const plans = node.Plans;
+  const children = Array.isArray(plans) ? plans.filter(isPlanNode).map(toTreeNode) : [];
+  return { label: buildLabel(node), children: [...children, ...collectIndexNodes(node)] };
+}
+
+export const clickhouseJsonStrategy: ExplainStrategy = {
+  format: "clickhouse-json",
+  // json = 1 for the tree, indexes = 1 for what the primary key and skip indexes
+  // pruned. actions = 1 is left out on purpose: it grew a two-table join plan roughly
+  // tenfold with expression internals the tree model cannot show.
+  //
+  // ClickHouse EXPLAIN never executes the statement, so there is nothing different to
+  // build for analyze. Declining that mode would disable the feature instead of
+  // narrowing it - the direct Explain action always builds with mode "analyze"
+  // (use-query-execution.ts:165) and refuses the run when the strategy returns null -
+  // so both modes return the estimate, as the SQLite and Couchbase strategies do.
+  buildSql(sql) {
+    if (!SELECT_ONLY.test(sql.trim())) return null;
+    // A trailing FORMAT would reformat the PLAN, not the statement's rows: live, a
+    // wrapped `... FORMAT TSV` comes back as TSV text and the tree can never be
+    // built. The clause describes the statement's own result, which an EXPLAIN never
+    // produces, so dropping it is what makes the intent survive.
+    return `EXPLAIN json = 1, indexes = 1 ${sql.replace(TRAILING_FORMAT, "")}`;
+  },
+  // The envelope parse leaves the cell as a String whose value is JSON, so the plan
+  // needs a second parse. It happens here rather than at render time so the stored
+  // value feeds the raw JSON and AI tabs as a structure instead of one escaped blob.
+  extractPlan(result) {
+    const cell = result.rows?.[0]?.[EXPLAIN_COLUMN];
+    if (typeof cell !== "string") return result.rows;
+    return parseJsonText(cell) ?? cell;
+  },
+  toRenderModel(raw) {
+    const root = toPlanRoot(raw);
+    if (!root) return null;
+    return { kind: "tree", root: toTreeNode(root), raw };
+  },
+};

--- a/src/lib/explain/clickhouse-json.ts
+++ b/src/lib/explain/clickhouse-json.ts
@@ -3,15 +3,26 @@ import type { ExplainStrategy, ExplainTreeNode } from "./types";
 const SELECT_ONLY = /^\s*SELECT\b/i;
 
 /**
- * `FORMAT <Name>` as the last thing in the statement.
+ * `FORMAT <Name>` where nothing but a `SETTINGS` clause or a semicolon follows it.
  *
- * Anchored at the end so it cannot match a `formatDateTime(...)` call or the words
- * inside a string literal, which end in a quote. The provider carries the same
- * pattern for its own reason (it must not append a LIMIT past this clause); the
- * duplication is deliberate, since an explain strategy importing from one provider
- * would tie the registry to it.
+ * The tail is a lookahead rather than part of the match, so only the FORMAT clause
+ * is removed. `SETTINGS` is deliberately kept: it applies to the inner statement and
+ * carries real meaning (`max_execution_time` and friends), whereas FORMAT would
+ * reformat the EXPLAIN output itself and leave no JSON cell to parse.
+ *
+ * The tail is also why this is not simply anchored to the end: `... FORMAT TSV;` and
+ * `... FORMAT TSV SETTINGS max_threads=1` are both statements `prepareQuery` already
+ * treats as carrying a trailing FORMAT, so an end-anchored pattern silently disagreed
+ * with it and left the plan unparseable.
+ *
+ * It still cannot match `formatDateTime(...)` (no whitespace after the word) or the
+ * words inside a string literal (a quote is not an accepted tail). The provider
+ * carries a related pattern for its own reason - it must not append a LIMIT past this
+ * clause - and the duplication is deliberate: an explain strategy importing from one
+ * provider would tie the registry to it.
  */
-const TRAILING_FORMAT = /\s*\bFORMAT\s+[A-Za-z][A-Za-z0-9_]*\s*$/i;
+const TRAILING_FORMAT =
+  /\s*\bFORMAT\s+[A-Za-z][A-Za-z0-9_]*(?=\s*(?:SETTINGS\s+[A-Za-z_][A-Za-z0-9_]*\s*=[\s\S]*?)?;?\s*$)/i;
 
 /** The one column of the one row EXPLAIN returns; its value is the plan as JSON text. */
 const EXPLAIN_COLUMN = "explain";
@@ -162,7 +173,9 @@ export const clickhouseJsonStrategy: ExplainStrategy = {
     // wrapped `... FORMAT TSV` comes back as TSV text and the tree can never be
     // built. The clause describes the statement's own result, which an EXPLAIN never
     // produces, so dropping it is what makes the intent survive.
-    return `EXPLAIN json = 1, indexes = 1 ${sql.replace(TRAILING_FORMAT, "")}`;
+    // trimEnd because the tail above is a lookahead: whitespace that sat between the
+    // format name and the end of the statement is not part of the match.
+    return `EXPLAIN json = 1, indexes = 1 ${sql.replace(TRAILING_FORMAT, "").trimEnd()}`;
   },
   // The envelope parse leaves the cell as a String whose value is JSON, so the plan
   // needs a second parse. It happens here rather than at render time so the stored

--- a/src/lib/explain/index.ts
+++ b/src/lib/explain/index.ts
@@ -4,6 +4,7 @@ import { postgresJsonStrategy } from "./postgres-json";
 import { mysqlJsonStrategy } from "./mysql-json";
 import { sqliteQueryplanStrategy } from "./sqlite-queryplan";
 import { couchbaseJsonStrategy } from "./couchbase-json";
+import { clickhouseJsonStrategy } from "./clickhouse-json";
 
 export type { ExplainMode, ExplainStrategy } from "./types";
 export type { ExplainPlanInput, ExplainTreeNode, StoredExplainPlan } from "./types";
@@ -15,6 +16,7 @@ const registry: Record<ExplainFormat, ExplainStrategy> = {
   "mysql-json": mysqlJsonStrategy,
   "sqlite-queryplan": sqliteQueryplanStrategy,
   "couchbase-json": couchbaseJsonStrategy,
+  "clickhouse-json": clickhouseJsonStrategy,
 };
 
 export function getExplainStrategy(format: ExplainFormat | undefined): ExplainStrategy | null {

--- a/src/lib/query-generators.ts
+++ b/src/lib/query-generators.ts
@@ -45,8 +45,13 @@ const COUCHBASE_KEY_PROJECTION = `META(${COUCHBASE_ALIAS}).id AS ${COUCHBASE_DOC
  *  - SQL Server (1433): case-insensitive          → bracket-quote only specials
  *  - MySQL (3306): case-preserving                → backtick-quote only specials
  *  - Couchbase (8091): SQL++                      → always backtick-quote
- *  - PostgreSQL (5432) / SQLite / default: unquoted folds to lowercase (pg)
- *                                                  → quote unless plain lower
+ *  - PostgreSQL (5432) / SQLite / ClickHouse (8123) / default: unquoted folds to
+ *    lowercase (pg)                                → quote unless plain lower
+ *
+ * ClickHouse deliberately has no branch of its own: it never folds case and its
+ * quote character is the double quote, so the default branch is already exactly
+ * right — both `SELECT "id" FROM "probe"` and the bare form parse (issue #264).
+ * Adding a branch would only duplicate it.
  */
 export function quoteIdentifier(name: string, capabilities: ProviderCapabilities): string {
   // Document stores (MongoDB) don't use SQL identifier quoting.
@@ -158,6 +163,10 @@ export function generateTableQuery(tableName: string, capabilities: ProviderCapa
   if (capabilities.defaultPort === 1433) {
     return `SELECT TOP 50 * FROM ${table};`;
   }
+  // PostgreSQL / MySQL / SQLite / ClickHouse. The trailing LIMIT matters for
+  // ClickHouse specifically: it also accepts `FORMAT x` and `SETTINGS ...` as
+  // trailing clauses, and a LIMIT placed after either is a syntax error, so the
+  // limit must stay last (issue #264).
   return `SELECT * FROM ${table} LIMIT 50;`;
 }
 

--- a/src/lib/seed/types.ts
+++ b/src/lib/seed/types.ts
@@ -29,6 +29,7 @@ const SeedDatabaseType = z.enum([
   "mssql",
   "libredb",
   "couchbase",
+  "clickhouse",
 ]);
 
 export const SeedDefaultsSchema = z.object({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,8 @@ export type DatabaseType =
   | "oracle"
   | "mssql"
   | "libredb"
-  | "couchbase";
+  | "couchbase"
+  | "clickhouse";
 
 export type ConnectionEnvironment = "production" | "staging" | "development" | "local" | "other";
 

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -290,6 +290,41 @@ describe("useConnectionForm", () => {
     expect(result.current.sslMode).toBe("disable");
   });
 
+  // Pasting is an overwrite, not a merge. After editing a TLS connection the form
+  // still holds "require", and an explicit http:// URL that left it alone would be
+  // saved as HTTPS against a plaintext endpoint.
+  test("handlePasteConnectionString clears a stale TLS mode when the pasted URL is plaintext", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setSSLMode("require");
+    });
+    act(() => {
+      result.current.setPasteInput("http://ch-host:8123/demo");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.sslMode).toBe("disable");
+  });
+
+  test("handlePasteConnectionString keeps the form's TLS mode for the scheme-neutral clickhouse:// form", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setSSLMode("require");
+    });
+    act(() => {
+      result.current.setPasteInput("clickhouse://ch-host:8123/demo");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.sslMode).toBe("require");
+  });
+
   // ── handlePasteConnectionString shows error for invalid string ─────────────
 
   test("handlePasteConnectionString shows error for invalid string", () => {

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -259,6 +259,37 @@ describe("useConnectionForm", () => {
     expect(result.current.testResult!.message).toContain("parsed successfully");
   });
 
+  test("handlePasteConnectionString keeps the TLS intent of a pasted https ClickHouse URL", () => {
+    // A ClickHouse Cloud endpoint is the common case. Losing the scheme here sends a
+    // plaintext POST to the TLS port, which fails with a bare "fetch failed".
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("https://user:pass@abc.clickhouse.cloud/default");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.type).toBe("clickhouse");
+    expect(result.current.port).toBe("8443");
+    expect(result.current.sslMode).toBe("require");
+  });
+
+  test("handlePasteConnectionString leaves TLS off for a plaintext ClickHouse URL", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("http://ch-host:8123/demo");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.type).toBe("clickhouse");
+    expect(result.current.sslMode).toBe("disable");
+  });
+
   // ── handlePasteConnectionString shows error for invalid string ─────────────
 
   test("handlePasteConnectionString shows error for invalid string", () => {
@@ -347,6 +378,7 @@ describe("useConnectionForm", () => {
     redis: true,
     libredb: true,
     couchbase: true,
+    clickhouse: true,
   };
 
   test("dbTypes offers every database type a connection can carry", () => {

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -1,0 +1,1331 @@
+/**
+ * ClickHouse Provider Integration Tests (issue #264)
+ *
+ * globalThis.fetch is replaced per test and restored in afterEach, so the real
+ * transport, the real introspection and the real provider all run - only the
+ * server is fake. mock.module() is deliberately not used: it is process-wide in
+ * bun and would poison sibling test files.
+ *
+ * Every payload below was captured from a live ClickHouse 26.7.1.1315 server
+ * (database `demo`), so the fake speaks exactly what the server speaks. That
+ * matters more here than in a typical mock, because four behaviours the provider
+ * depends on are the opposite of what a JSON API teaches:
+ *
+ * - Failures are real HTTP status codes, but a permission denial arrives as 500
+ *   and must be classified by `X-ClickHouse-Exception-Code`, never by status.
+ * - A `UInt64` arrives as a decimal STRING (the transport asks for 64-bit
+ *   quoting) while a `Float64` stays a number, so both encodings appear below.
+ * - A write answers 200 with NO body and reports its row count in a header - and
+ *   for `ALTER TABLE ... UPDATE` that count is 0 even though the mutation
+ *   applied.
+ * - `FORMAT`/`SETTINGS` are TRAILING clauses, so appending `LIMIT n` after one
+ *   is a hard syntax error.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import type { DatabaseConnection, DatabaseType } from "@/lib/types";
+import { ClickHouseProvider } from "@/lib/db/providers/sql/clickhouse";
+import {
+  AuthenticationError,
+  ConnectionError,
+  DatabaseConfigError,
+  QueryCancelledError,
+  QueryError,
+  TimeoutError,
+} from "@/lib/db/errors";
+
+// ============================================================================
+// Connection
+// ============================================================================
+
+const CLICKHOUSE: DatabaseType = "clickhouse";
+
+const DATABASE = "demo";
+
+function makeConnection(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
+  return {
+    id: "ch-1",
+    name: "ClickHouse",
+    type: CLICKHOUSE,
+    host: "127.0.0.1",
+    port: 8123,
+    user: "libredb",
+    password: "password123",
+    database: DATABASE,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Exception codes, read back from the live server's own numbering
+// (SELECT number, errorCodeToName(toUInt32(number)) FROM numbers(1500))
+// ============================================================================
+
+const NOT_IMPLEMENTED = 48;
+const UNKNOWN_TABLE = 60;
+const SYNTAX_ERROR = 62;
+const UNKNOWN_DATABASE = 81;
+const TIMEOUT_EXCEEDED = 159;
+const NETWORK_ERROR = 210;
+const QUERY_WAS_CANCELLED = 394;
+const ACCESS_DENIED = 497;
+const AUTHENTICATION_FAILED = 516;
+
+// ============================================================================
+// Catalog payloads (captured from ClickHouse 26.7.1.1315, trimmed)
+// ----------------------------------------------------------------------------
+// `default.audit` is the one row not captured live: it is the table outside the
+// pinned database, and its sorting key extends its primary key, which is what
+// makes the qualified display name and the synthesized ORDER BY entry testable.
+// ============================================================================
+
+const TABLE_ROWS = [
+  {
+    database: "default",
+    name: "audit",
+    total_rows: "12",
+    total_bytes: "4096",
+    sorting_key: "tenant, ts",
+    primary_key: "tenant",
+  },
+  // A view reports NULL for both counters - unknown, never zero.
+  { database: DATABASE, name: "daily_events", total_rows: null, total_bytes: null, sorting_key: "", primary_key: "" },
+  {
+    database: DATABASE,
+    name: "orders",
+    total_rows: "5",
+    total_bytes: "2613",
+    sorting_key: "user_id, order_id",
+    primary_key: "user_id, order_id",
+  },
+  { database: DATABASE, name: "users", total_rows: "3", total_bytes: "2506", sorting_key: "id", primary_key: "id" },
+];
+
+const COLUMN_ROWS = [
+  {
+    database: "default",
+    table: "audit",
+    name: "tenant",
+    type: "String",
+    is_in_primary_key: 1,
+    default_kind: "",
+    default_expression: "",
+  },
+  {
+    database: DATABASE,
+    table: "daily_events",
+    name: "day",
+    type: "Date",
+    is_in_primary_key: 0,
+    default_kind: "",
+    default_expression: "",
+  },
+  {
+    database: DATABASE,
+    table: "orders",
+    name: "order_id",
+    type: "UInt64",
+    is_in_primary_key: 1,
+    default_kind: "",
+    default_expression: "",
+  },
+  {
+    database: DATABASE,
+    table: "orders",
+    name: "status",
+    type: "LowCardinality(String)",
+    is_in_primary_key: 0,
+    default_kind: "",
+    default_expression: "",
+  },
+  {
+    database: DATABASE,
+    table: "users",
+    name: "id",
+    type: "UInt32",
+    is_in_primary_key: 1,
+    default_kind: "",
+    default_expression: "",
+  },
+  {
+    database: DATABASE,
+    table: "users",
+    name: "full_name",
+    type: "Nullable(String)",
+    is_in_primary_key: 0,
+    default_kind: "",
+    default_expression: "",
+  },
+];
+
+const SKIPPING_INDEX_ROWS = [{ database: DATABASE, table: "orders", name: "idx_status", expr: "status" }];
+
+// ============================================================================
+// Monitoring payloads (captured live)
+// ============================================================================
+
+const IDENTITY_ROW = { version: "26.7.1.1315", uptimeSeconds: "1898" };
+const CONNECTION_ROW = { connections: "1", maxConnections: "4096" };
+const DATABASE_SIZE_ROW = { databaseSizeBytes: "3959" };
+const TABLE_COUNT_ROW = { tableCount: "3" };
+const INDEX_COUNT_ROW = { indexCount: "1" };
+
+const EVENT_ROW = { cacheHits: "4", cacheMisses: "7", queryCount: "145", uptimeSeconds: "1898" };
+// system.asynchronous_metrics is Float64, so these arrive unquoted - the readers
+// have to accept both encodings.
+const MEMORY_ROW = { memoryBytes: 1026949120, memoryTotalBytes: 67118129152 };
+
+const SLOW_QUERY_ROWS = [
+  {
+    queryId: "7283842689206104996",
+    query: "SELECT count() FROM orders WHERE status = 'paid'",
+    calls: "3",
+    totalMs: "1179",
+    avgMs: 393,
+    minMs: "281",
+    maxMs: "505",
+    resultRows: "3",
+  },
+];
+
+const SESSION_ROWS = [
+  {
+    queryId: "1b39563e-105b-42dd-9a49-7fb7e0618f94",
+    user: "libredb",
+    database: DATABASE,
+    clientAddr: "::ffff:172.17.0.1",
+    elapsedSeconds: 12.5,
+    query: "SELECT * FROM orders",
+  },
+  {
+    queryId: "8a45dcda-0000-0000-0000-000000000000",
+    user: "libredb",
+    database: DATABASE,
+    clientAddr: "::ffff:172.17.0.1",
+    elapsedSeconds: 0.000923,
+    query: "SELECT 1",
+  },
+];
+
+const TABLE_STAT_ROWS = [
+  { database: DATABASE, table: "orders", rowCount: "5", dataBytes: "621", indexBytes: "228", totalBytes: "2613" },
+  { database: DATABASE, table: "users", rowCount: "3", dataBytes: "597", indexBytes: "132", totalBytes: "1346" },
+];
+
+const INDEX_STAT_ROWS = [
+  {
+    database: DATABASE,
+    table: "orders",
+    indexName: "idx_status",
+    indexType: "set",
+    expr: "status",
+    indexSizeBytes: "219",
+  },
+  // A skipping index is declared over an EXPRESSION, and the expression may
+  // carry commas of its own - which is why it is reported as one entry.
+  {
+    database: DATABASE,
+    table: "orders",
+    indexName: "idx_bucket",
+    indexType: "minmax",
+    expr: "cityHash64(user_id, status)",
+    indexSizeBytes: "96",
+  },
+];
+
+const DISK_ROWS = [
+  {
+    name: "default",
+    path: "/var/lib/clickhouse/",
+    totalBytes: "294147883008",
+    freeBytes: "198620180480",
+  },
+];
+
+const PART_SUMMARY_ROW = { partCount: "2", rowCount: "5", totalBytes: "2613" };
+
+// ============================================================================
+// fetch harness
+// ============================================================================
+
+/** One canned HTTP answer. Defaults describe a successful JSON result. */
+interface Reply {
+  status?: number;
+  body?: string;
+  /** What the server says it USED; null omits the header, as a DDL answer does. */
+  format?: string | null;
+  summary?: Record<string, string> | null;
+  exceptionCode?: number;
+}
+
+const originalFetch = globalThis.fetch;
+
+let sentSql: string[] = [];
+let sentUrls: string[] = [];
+let sentAuth: (string | null)[] = [];
+let networkFailure: Error | null = null;
+let replyFor: (sql: string) => Reply;
+
+/** The JSON envelope, verbatim in shape: meta, data, rows, statistics. */
+function envelope(rows: Record<string, unknown>[], meta?: { name: string; type: string }[]): string {
+  const columns = meta ?? Object.keys(rows[0] ?? {}).map((name) => ({ name, type: "String" }));
+  return JSON.stringify({ meta: columns, data: rows, rows: rows.length, statistics: { elapsed: 0.0012 } });
+}
+
+function jsonReply(rows: Record<string, unknown>[], meta?: { name: string; type: string }[]): Reply {
+  return { body: envelope(rows, meta) };
+}
+
+/**
+ * A write: 200, empty body, counters in the summary header only. `writtenRows`
+ * is what the server reported, which for a mutation is honestly zero.
+ */
+function writeReply(writtenRows: string): Reply {
+  return { body: "", format: null, summary: { written_rows: writtenRows, elapsed_ns: "1200000" } };
+}
+
+/** An exception: the body is plain TEXT even under an application/json content type. */
+function exceptionReply(code: number, name: string, message: string, status = 400): Reply {
+  return {
+    status,
+    exceptionCode: code,
+    body: `Code: ${code}. DB::Exception: ${message}. (${name}) (version 26.7.1.1315 (official build))`,
+  };
+}
+
+const DENIED = () =>
+  exceptionReply(
+    ACCESS_DENIED,
+    "ACCESS_DENIED",
+    "libredb: Not enough privileges. To execute this query, it's necessary to have grant SELECT",
+    500,
+  );
+
+function toResponse(reply: Reply): Response {
+  const headers = new Headers({ "content-type": "application/json" });
+  const format = reply.format === undefined ? "JSON" : reply.format;
+  if (format !== null) headers.set("x-clickhouse-format", format);
+  const summary = reply.summary === undefined ? { written_rows: "0", elapsed_ns: "1200000" } : reply.summary;
+  if (summary !== null) headers.set("x-clickhouse-summary", JSON.stringify(summary));
+  if (reply.exceptionCode !== undefined) headers.set("x-clickhouse-exception-code", String(reply.exceptionCode));
+
+  return new Response(reply.body ?? "", { status: reply.status ?? 200, headers });
+}
+
+/**
+ * Route a statement onto the fixtures above. Keyed on the column aliases the
+ * provider itself chose, so a routing miss is a renamed alias rather than a
+ * fragile substring.
+ */
+function defaultReply(sql: string): Reply {
+  if (sql === "SELECT 1") return jsonReply([{ "1": 1 }]);
+
+  if (sql.includes("version()")) return jsonReply([IDENTITY_ROW]);
+  if (sql.includes("system.metrics")) return jsonReply([CONNECTION_ROW]);
+  if (sql.includes("system.events")) return jsonReply([EVENT_ROW]);
+  if (sql.includes("system.asynchronous_metrics")) return jsonReply([MEMORY_ROW]);
+  if (sql.includes("system.query_log")) return jsonReply(SLOW_QUERY_ROWS);
+  if (sql.includes("system.processes")) return jsonReply(SESSION_ROWS);
+  if (sql.includes("system.disks")) return jsonReply(DISK_ROWS);
+
+  if (sql.includes("system.tables")) {
+    return sql.includes("tableCount") ? jsonReply([TABLE_COUNT_ROW]) : jsonReply(TABLE_ROWS);
+  }
+  if (sql.includes("system.columns")) return jsonReply(COLUMN_ROWS);
+  if (sql.includes("system.data_skipping_indices")) {
+    if (sql.includes("indexCount")) return jsonReply([INDEX_COUNT_ROW]);
+    return sql.includes("indexName") ? jsonReply(INDEX_STAT_ROWS) : jsonReply(SKIPPING_INDEX_ROWS);
+  }
+  if (sql.includes("system.parts")) {
+    if (sql.includes("partCount")) return jsonReply([PART_SUMMARY_ROW]);
+    return sql.includes("databaseSizeBytes") ? jsonReply([DATABASE_SIZE_ROW]) : jsonReply(TABLE_STAT_ROWS);
+  }
+
+  // OPTIMIZE and KILL QUERY both answer 200 with no body (live-verified).
+  return writeReply("0");
+}
+
+function installFetch(): void {
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    if (networkFailure) throw networkFailure;
+    const sql = String(init?.body);
+    sentUrls.push(String(input));
+    sentSql.push(sql);
+    sentAuth.push(new Headers(init?.headers).get("authorization"));
+    return toResponse(replyFor(sql));
+  }) as typeof fetch;
+}
+
+/** The credentials the transport put on the wire, decoded back into `user:password`. */
+function credentialsOf(match: string): string {
+  const index = sentSql.findIndex((statement) => statement.includes(match));
+  return Buffer.from((sentAuth[index] ?? "").replace("Basic ", ""), "base64").toString();
+}
+
+/** The statement the provider sent that mentions `match`, or a failure naming it. */
+function sqlWith(match: string): string {
+  const sql = sentSql.find((statement) => statement.includes(match));
+  if (sql === undefined) throw new Error(`no statement matching "${match}" was sent`);
+  return sql;
+}
+
+function urlWith(match: string): string {
+  const index = sentSql.findIndex((statement) => statement.includes(match));
+  if (index === -1) throw new Error(`no statement matching "${match}" was sent`);
+  return sentUrls[index];
+}
+
+async function connectProvider(overrides: Partial<DatabaseConnection> = {}): Promise<ClickHouseProvider> {
+  const provider = new ClickHouseProvider(makeConnection(overrides));
+  await provider.connect();
+  return provider;
+}
+
+/** Every read fails the way a user without monitoring grants sees it. */
+function denyEverything(): void {
+  replyFor = () => DENIED();
+}
+
+beforeEach(() => {
+  sentSql = [];
+  sentUrls = [];
+  sentAuth = [];
+  networkFailure = null;
+  replyFor = defaultReply;
+  installFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+describe("ClickHouseProvider metadata", () => {
+  test("declares the capabilities the design spec settled on", () => {
+    const capabilities = new ClickHouseProvider(makeConnection()).getCapabilities();
+
+    expect(capabilities).toEqual({
+      queryLanguage: "sql",
+      supportsExplain: true,
+      explainFormat: "clickhouse-json",
+      supportsExternalQueryLimiting: true,
+      supportsCreateTable: false,
+      supportsMaintenance: true,
+      maintenanceOperations: ["optimize", "analyze", "kill"],
+      supportsConnectionString: true,
+      defaultPort: 8123,
+      schemaRefreshPattern: "\\b(CREATE|DROP|ALTER|RENAME|TRUNCATE|ATTACH|DETACH)\\b",
+    });
+  });
+
+  test("keeps supportsCreateTable false because the modal's default output is invalid here", () => {
+    // Live-verified, and the reason the flag is not an oversight: the modal's
+    // default column emits `id SERIAL PRIMARY KEY` (code 50, unknown data type
+    // family) and its UNIQUE checkbox emits `UNIQUE` (code 62, syntax error).
+    expect(new ClickHouseProvider(makeConnection()).getCapabilities().supportsCreateTable).toBe(false);
+  });
+
+  test("labels the maintenance actions ClickHouse actually has", () => {
+    const labels = new ClickHouseProvider(makeConnection()).getLabels();
+
+    expect(labels.entityName).toBe("Table");
+    expect(labels.rowName).toBe("row");
+    expect(labels.analyzeAction).toBe("Table Statistics");
+    expect(labels.vacuumAction).toBe("Optimize Table");
+    expect(labels.vacuumGlobalDesc).toContain("OPTIMIZE");
+    expect(labels.analyzeGlobalDesc).toContain("no ANALYZE");
+  });
+});
+
+// ============================================================================
+// Validation and the connection model
+// ============================================================================
+
+describe("ClickHouseProvider validation", () => {
+  test("requires a host or a connection string", () => {
+    expect(() => new ClickHouseProvider(makeConnection({ host: undefined }))).toThrow(DatabaseConfigError);
+  });
+
+  test("does not require a database, because the server always has `default`", async () => {
+    const provider = await connectProvider({ database: undefined });
+
+    expect(urlWith("SELECT 1")).not.toContain("database=");
+    await provider.disconnect();
+  });
+
+  test("sends the pinned database as a request parameter", async () => {
+    const provider = await connectProvider();
+
+    expect(urlWith("SELECT 1")).toContain(`database=${DATABASE}`);
+    await provider.disconnect();
+  });
+
+  test("lifts a hand-typed connection string into host, credentials and database", async () => {
+    // The URI tab clears host/port/user/password, so the URL is the only source
+    // for all four; the provider has to honour it or the connection has no target.
+    const provider = await connectProvider({
+      host: undefined,
+      port: undefined,
+      user: undefined,
+      password: undefined,
+      database: undefined,
+      connectionString: "http://reader:s3cret@ch.internal:9123/analytics",
+    });
+
+    const url = urlWith("SELECT 1");
+    expect(url).toContain("http://ch.internal:9123/");
+    expect(url).toContain("database=analytics");
+    expect(credentialsOf("SELECT 1")).toBe("reader:s3cret");
+    await provider.disconnect();
+  });
+
+  test("decodes percent-encoded credentials out of a clickhouse:// string", async () => {
+    // A password with a reserved character has to be encoded to survive the URL,
+    // so sending it verbatim would authenticate as the wrong secret.
+    const provider = await connectProvider({
+      host: undefined,
+      user: undefined,
+      password: undefined,
+      connectionString: "clickhouse://reader:p%40ss%2Fword@ch.internal:8123/demo",
+    });
+
+    expect(credentialsOf("SELECT 1")).toBe("reader:p@ss/word");
+    await provider.disconnect();
+  });
+
+  test("an https connection string switches scheme and takes the TLS default port", async () => {
+    const provider = await connectProvider({
+      host: undefined,
+      port: undefined,
+      connectionString: "https://abc.clickhouse.cloud/default",
+    });
+
+    expect(urlWith("SELECT 1")).toContain("https://abc.clickhouse.cloud:8443/");
+    await provider.disconnect();
+  });
+
+  test("keeps the configured fields when the connection string is unparsable", async () => {
+    const provider = await connectProvider({ connectionString: "not a url" });
+
+    expect(urlWith("SELECT 1")).toContain("http://127.0.0.1:8123/");
+    await provider.disconnect();
+  });
+});
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+describe("ClickHouseProvider lifecycle", () => {
+  test("connect proves the server, the credentials and the database with SELECT 1", async () => {
+    const provider = await connectProvider();
+
+    expect(provider.isConnected()).toBe(true);
+    expect(sentSql[0]).toBe("SELECT 1");
+  });
+
+  test("connect reports a non-existent database immediately rather than at first query", async () => {
+    // Live-verified: a bad `database` parameter is not rejected when the
+    // connection is made - it fails 404 / code 81 on the first statement - so
+    // without the probe the user would see it much later and somewhere else.
+    replyFor = () => exceptionReply(UNKNOWN_DATABASE, "UNKNOWN_DATABASE", "Database nope does not exist", 404);
+    const provider = new ClickHouseProvider(makeConnection({ database: "nope" }));
+
+    await expect(provider.connect()).rejects.toBeInstanceOf(ConnectionError);
+    expect(provider.isConnected()).toBe(false);
+  });
+
+  test("connect maps rejected credentials to an AuthenticationError", async () => {
+    replyFor = () => exceptionReply(AUTHENTICATION_FAILED, "AUTHENTICATION_FAILED", "Authentication failed", 403);
+    const provider = new ClickHouseProvider(makeConnection());
+
+    await expect(provider.connect()).rejects.toBeInstanceOf(AuthenticationError);
+    expect(provider.isConnected()).toBe(false);
+  });
+
+  test("connect maps an unreachable server to a ConnectionError", async () => {
+    networkFailure = new Error("connect ECONNREFUSED 127.0.0.1:8123");
+    const provider = new ClickHouseProvider(makeConnection());
+
+    await expect(provider.connect()).rejects.toBeInstanceOf(ConnectionError);
+  });
+
+  test("disconnect releases the transport and is safe to call twice", async () => {
+    const provider = await connectProvider();
+
+    await provider.disconnect();
+    await provider.disconnect();
+
+    expect(provider.isConnected()).toBe(false);
+  });
+
+  test("query before connect is refused", async () => {
+    const provider = new ClickHouseProvider(makeConnection());
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(DatabaseConfigError);
+  });
+});
+
+// ============================================================================
+// Query execution
+// ============================================================================
+
+describe("ClickHouseProvider query", () => {
+  test("returns rows, the declared column order and the server's own duration", async () => {
+    const provider = await connectProvider();
+    replyFor = () =>
+      jsonReply(
+        [{ id: 1, email: "a@b.c" }],
+        [
+          { name: "id", type: "UInt32" },
+          { name: "email", type: "String" },
+        ],
+      );
+
+    const result = await provider.query("SELECT id, email FROM users");
+
+    expect(result.rows).toEqual([{ id: 1, email: "a@b.c" }]);
+    expect(result.fields).toEqual(["id", "email"]);
+    expect(result.rowCount).toBe(1);
+    expect(result.executionTime).toBe(1);
+  });
+
+  test("gives the server a deadline so a runaway statement cannot hang the editor", async () => {
+    const provider = await connectProvider();
+
+    await provider.query("SELECT count() FROM orders");
+
+    expect(urlWith("count()")).toContain("max_execution_time=60");
+  });
+
+  test("reports an INSERT row count from what the server said it wrote", async () => {
+    const provider = await connectProvider();
+    replyFor = () => writeReply("2");
+
+    const result = await provider.query("INSERT INTO users VALUES (1, 'a@b.c'), (2, 'd@e.f')");
+
+    expect(result.rowCount).toBe(2);
+    expect(result.rows).toEqual([]);
+    expect(result.fields).toEqual([]);
+  });
+
+  test("reports zero for an ALTER TABLE UPDATE, because that is what the server reports", async () => {
+    // Live-verified honesty caveat: the mutation really applies, but it is queued
+    // as a background mutation and the server counts no written rows for it.
+    // Fabricating a plausible count here would put a wrong number on screen.
+    const provider = await connectProvider();
+    replyFor = () => writeReply("0");
+
+    const result = await provider.query("ALTER TABLE users UPDATE email = 'x@y.z' WHERE id = 1");
+
+    expect(result.rowCount).toBe(0);
+  });
+
+  test("surfaces a format the user chose as one synthetic text column", async () => {
+    // Live-verified: an explicit FORMAT in the user's SQL beats the JSON the
+    // transport asked for, so the body is TSV. The user asked for that
+    // deliberately, so it is shown rather than thrown away or parsed.
+    const provider = await connectProvider();
+    replyFor = () => ({ body: "1\ta@b.c\n2\td@e.f\n", format: "TSV" });
+
+    const result = await provider.query("SELECT id, email FROM users FORMAT TSV");
+
+    expect(result.fields).toEqual(["__text"]);
+    expect(result.rows).toEqual([{ __text: "1\ta@b.c\n2\td@e.f\n" }]);
+    expect(result.rowCount).toBe(1);
+  });
+
+  test("falls back to the measured duration when the server reported none", async () => {
+    const provider = await connectProvider();
+    replyFor = () => ({ body: JSON.stringify({ meta: [], data: [] }), summary: null });
+
+    const result = await provider.query("SELECT 1");
+
+    expect(result.executionTime).toBeGreaterThanOrEqual(0);
+  });
+
+  test("refuses positional parameters instead of silently ignoring them", async () => {
+    // The HTTP interface binds only named `{name:Type}` parameters, so a caller
+    // that passed positional ones would otherwise get a statement run with the
+    // placeholders unbound.
+    const provider = await connectProvider();
+
+    await expect(provider.query("SELECT * FROM users WHERE id = ?", [1])).rejects.toBeInstanceOf(QueryError);
+  });
+
+  test("accepts an empty parameter array, which is how the app calls every provider", async () => {
+    const provider = await connectProvider();
+
+    await expect(provider.query("SELECT 1", [])).resolves.toBeDefined();
+  });
+});
+
+// ============================================================================
+// Error mapping
+// ============================================================================
+
+describe("ClickHouseProvider error mapping", () => {
+  test("a missing grant becomes an AuthenticationError even though its prose says neither denied nor permission", async () => {
+    // The 497 message reads "Not enough privileges. To execute this query, it's
+    // necessary to have grant ...", so message sniffing would miss it entirely.
+    // Classification is by code for exactly this reason.
+    const provider = await connectProvider();
+    replyFor = () => DENIED();
+
+    await expect(provider.query("SELECT * FROM system.query_log")).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  test("bad credentials become an AuthenticationError", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(AUTHENTICATION_FAILED, "AUTHENTICATION_FAILED", "Authentication failed", 403);
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  test("a syntax error becomes a QueryError carrying the statement", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(SYNTAX_ERROR, "SYNTAX_ERROR", "Syntax error: failed at position 1", 400);
+
+    const failure = provider.query("SELEC 1");
+
+    await expect(failure).rejects.toBeInstanceOf(QueryError);
+    await expect(failure).rejects.toThrow("Syntax error");
+  });
+
+  test("an unknown table becomes a QueryError", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(UNKNOWN_TABLE, "UNKNOWN_TABLE", "Unknown table expression identifier", 404);
+
+    await expect(provider.query("SELECT * FROM nope")).rejects.toBeInstanceOf(QueryError);
+  });
+
+  test("a bare UPDATE surfaces the server's own explanation of why it is unsupported", async () => {
+    // Live-verified on 26.7.1: `UPDATE ... SET` is code 48, and its message names
+    // the exact precondition, which is far more useful than any wording here.
+    const provider = await connectProvider();
+    replyFor = () =>
+      exceptionReply(
+        NOT_IMPLEMENTED,
+        "NOT_IMPLEMENTED",
+        "Lightweight updates are not supported. Lightweight updates are supported only for tables with materialized _block_number column",
+        501,
+      );
+
+    const failure = provider.query("UPDATE users SET email = 'x@y.z' WHERE id = 1");
+
+    await expect(failure).rejects.toBeInstanceOf(QueryError);
+    await expect(failure).rejects.toThrow("Lightweight updates are not supported");
+  });
+
+  test("an exceeded deadline becomes a TimeoutError", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(TIMEOUT_EXCEEDED, "TIMEOUT_EXCEEDED", "Timeout exceeded: elapsed 60s", 500);
+
+    await expect(provider.query("SELECT sleep(3)")).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  test("a killed query becomes a QueryCancelledError", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(QUERY_WAS_CANCELLED, "QUERY_WAS_CANCELLED", "Query was cancelled", 500);
+
+    await expect(provider.query("SELECT count() FROM orders")).rejects.toBeInstanceOf(QueryCancelledError);
+  });
+
+  test("a server-side network fault becomes a ConnectionError", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(NETWORK_ERROR, "NETWORK_ERROR", "All connection tries failed", 500);
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(ConnectionError);
+  });
+
+  test("a failure that never reached the server is classified from the socket error", async () => {
+    const provider = await connectProvider();
+    networkFailure = new Error("connect ECONNREFUSED 127.0.0.1:8123");
+
+    await expect(provider.query("SELECT 1")).rejects.toBeInstanceOf(ConnectionError);
+  });
+
+  test("a client-side abort with no server code still surfaces as a database error", async () => {
+    const provider = await connectProvider();
+    networkFailure = new Error("The operation was aborted");
+
+    await expect(provider.query("SELECT 1")).rejects.toThrow(/aborted/);
+  });
+});
+
+// ============================================================================
+// Query preparation (the trailing-clause override)
+// ============================================================================
+
+describe("ClickHouseProvider query preparation", () => {
+  const provider = () => new ClickHouseProvider(makeConnection());
+
+  test("applies the external row limit to a plain SELECT", () => {
+    const prepared = provider().prepareQuery("SELECT * FROM users", { limit: 25 });
+
+    expect(prepared.query).toBe("SELECT * FROM users LIMIT 25");
+    expect(prepared.wasLimited).toBe(true);
+    expect(prepared.limit).toBe(25);
+  });
+
+  test.each([
+    ["a trailing FORMAT clause", "SELECT * FROM users FORMAT TSV"],
+    ["a trailing FORMAT clause and a semicolon", "SELECT * FROM users FORMAT JSONEachRow;"],
+    ["a trailing SETTINGS clause", "SELECT * FROM users SETTINGS max_threads = 1"],
+    ["several settings", "SELECT * FROM users SETTINGS max_threads=1, max_block_size=100"],
+    ["FORMAT followed by SETTINGS", "SELECT * FROM users FORMAT TSV SETTINGS max_threads=1"],
+    ["an existing LIMIT before FORMAT", "SELECT * FROM users LIMIT 1 FORMAT TSV"],
+  ])("leaves %s untouched, because LIMIT after either is a hard syntax error", (_label, sql) => {
+    // Live-verified: `SELECT * FROM probe FORMAT TSV LIMIT 1` and
+    // `... SETTINGS max_threads=1 LIMIT 1` both answer 400 / code 62. The
+    // inherited limiter appends LIMIT at the very END, so it must not run here.
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(sql);
+    expect(prepared.wasLimited).toBe(false);
+    expect(prepared.limit).toBe(25);
+  });
+
+  test.each([
+    ["the word format inside a string literal", "SELECT * FROM users WHERE note = 'format'"],
+    ["a whole clause quoted inside a literal", "SELECT * FROM users WHERE note = 'FORMAT TSV'"],
+    ["the settings table itself", "SELECT name, value FROM system.settings"],
+    ["a filtered read of the settings table", "SELECT name FROM system.settings WHERE name = 'max_threads'"],
+    ["a column named settings", "SELECT settings FROM system.columns WHERE database = 'demo'"],
+    ["a comparison against a settings column", "SELECT * FROM audit WHERE settings = 1"],
+  ])("still limits %s", (_label, sql) => {
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(`${sql} LIMIT 25`);
+    expect(prepared.wasLimited).toBe(true);
+  });
+
+  test("accepts one false positive: an assignment inside a trailing string literal", () => {
+    // Documented trade-off, not an oversight. Ruling this out needs a
+    // string-literal-aware tokenizer; the cost of being wrong in THIS direction is
+    // only a missing row limit, while the opposite error produces a hard syntax
+    // error. If a tokenizer ever lands, this expectation should flip deliberately.
+    const sql = "SELECT * FROM audit WHERE note = 'SETTINGS foo = 1'";
+
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(sql);
+    expect(prepared.wasLimited).toBe(false);
+  });
+
+  test("leaves a write untouched", () => {
+    const prepared = provider().prepareQuery("INSERT INTO users VALUES (1, 'a@b.c')");
+
+    expect(prepared.query).toBe("INSERT INTO users VALUES (1, 'a@b.c')");
+    expect(prepared.wasLimited).toBe(false);
+  });
+
+  test("lifts the ceiling for an unlimited export", () => {
+    const prepared = provider().prepareQuery("SELECT * FROM users", { unlimited: true });
+
+    expect(prepared.query).toBe("SELECT * FROM users LIMIT 100000");
+    expect(prepared.limit).toBe(100000);
+  });
+});
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+describe("ClickHouseProvider schema", () => {
+  test("getSchema reports every non-system database, qualifying only the ones outside the pin", async () => {
+    const provider = await connectProvider();
+
+    const schema = await provider.getSchema();
+
+    expect(schema.map((table) => table.name)).toEqual(["default.audit", "daily_events", "orders", "users"]);
+    expect(schema[3].columns).toEqual([
+      { name: "id", type: "UInt32", nullable: false, isPrimary: true, defaultValue: undefined },
+      { name: "full_name", type: "Nullable(String)", nullable: true, isPrimary: false, defaultValue: undefined },
+    ]);
+  });
+
+  test("getSchema reports the sparse primary index and the data-skipping indexes, none of them unique", async () => {
+    // ClickHouse's primary key is a real sparse index but enforces nothing
+    // (live-verified: three identical values were accepted into a table declared
+    // PRIMARY KEY (a)), and a data-skipping index only prunes granules.
+    const provider = await connectProvider();
+
+    const schema = await provider.getSchema();
+
+    expect(schema[2].indexes).toEqual([
+      { name: "PRIMARY KEY", columns: ["user_id", "order_id"], unique: false },
+      { name: "idx_status", columns: ["status"], unique: false },
+    ]);
+  });
+
+  test("getSchema reports ORDER BY separately only when the sorting key extends the primary key", async () => {
+    const provider = await connectProvider();
+
+    const schema = await provider.getSchema();
+
+    expect(schema[0].indexes).toEqual([
+      { name: "PRIMARY KEY", columns: ["tenant"], unique: false },
+      { name: "ORDER BY", columns: ["tenant", "ts"], unique: false },
+    ]);
+  });
+
+  test("getSchema leaves a view's row count and size unknown rather than zero", async () => {
+    const provider = await connectProvider();
+
+    const schema = await provider.getSchema();
+
+    expect(schema[1].rowCount).toBeUndefined();
+    expect(schema[1].size).toBeUndefined();
+    expect(schema[2].rowCount).toBe(5);
+    expect(schema[2].size).toBe("2.55 KB");
+  });
+
+  test("getSchema never invents a foreign key, because ClickHouse has none", async () => {
+    const provider = await connectProvider();
+
+    const schema = await provider.getSchema();
+
+    expect(schema.every((table) => table.foreignKeys?.length === 0)).toBe(true);
+  });
+
+  test("getSchemaList skips the index catalog so the table list is never blocked by it", async () => {
+    const provider = await connectProvider();
+
+    const tables = await provider.getSchemaList();
+
+    expect(tables.map((table) => table.name)).toEqual(["default.audit", "daily_events", "orders", "users"]);
+    expect(tables.every((table) => table.indexes.length === 0)).toBe(true);
+    expect(sentSql.some((sql) => sql.includes("system.data_skipping_indices"))).toBe(false);
+  });
+
+  test("getSchemaRelations returns an entry for every table, empty lists included", async () => {
+    const provider = await connectProvider();
+
+    const relations = await provider.getSchemaRelations();
+
+    expect(relations.map((relation) => relation.name)).toEqual(["default.audit", "daily_events", "orders", "users"]);
+    expect(relations[1].indexes).toEqual([]);
+    expect(relations[1].foreignKeys).toEqual([]);
+  });
+
+  test("getTables lists the display names", async () => {
+    const provider = await connectProvider();
+
+    expect(await provider.getTables()).toEqual(["default.audit", "daily_events", "orders", "users"]);
+  });
+
+  test("a denied index catalog still yields a schema tree", async () => {
+    // Live-verified: system.tables and system.columns are pre-filtered to what
+    // the user may read, but system.data_skipping_indices needs its own grant.
+    // Losing the whole tree over that would punish a usable connection.
+    const provider = await connectProvider();
+    replyFor = (sql) => (sql.includes("system.data_skipping_indices") ? DENIED() : defaultReply(sql));
+
+    const schema = await provider.getSchema();
+
+    expect(schema[2].indexes).toEqual([{ name: "PRIMARY KEY", columns: ["user_id", "order_id"], unique: false }]);
+  });
+
+  test("a real catalog failure propagates instead of showing an empty tree", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(SYNTAX_ERROR, "SYNTAX_ERROR", "Syntax error", 400);
+
+    await expect(provider.getSchema()).rejects.toBeInstanceOf(QueryError);
+  });
+});
+
+// ============================================================================
+// Monitoring
+// ============================================================================
+
+describe("ClickHouseProvider monitoring", () => {
+  test("getOverview combines the ungated identity read with the gated catalogs", async () => {
+    const provider = await connectProvider();
+
+    const overview = await provider.getOverview();
+
+    expect(overview.version).toBe("26.7.1.1315");
+    expect(overview.uptime).toBe("31.63m");
+    expect(overview.startTime).toBeInstanceOf(Date);
+    expect(overview.activeConnections).toBe(1);
+    expect(overview.maxConnections).toBe(4096);
+    expect(overview.databaseSizeBytes).toBe(3959);
+    expect(overview.databaseSize).toBe("3.87 KB");
+    expect(overview.tableCount).toBe(3);
+    expect(overview.indexCount).toBe(1);
+  });
+
+  test("getOverview zeroes out rather than throwing when every source is denied", async () => {
+    const provider = await connectProvider();
+    denyEverything();
+
+    const overview = await provider.getOverview();
+
+    expect(overview.version).toBe("unknown");
+    expect(overview.startTime).toBeUndefined();
+    expect(overview.activeConnections).toBe(0);
+    expect(overview.maxConnections).toBe(0);
+    expect(overview.databaseSizeBytes).toBe(0);
+    expect(overview.tableCount).toBe(0);
+    expect(overview.indexCount).toBe(0);
+  });
+
+  test("getPerformanceMetrics derives the ratios the server does not publish directly", async () => {
+    const provider = await connectProvider();
+
+    const performance = await provider.getPerformanceMetrics();
+
+    expect(performance.cacheHitRatio).toBe(36.36);
+    expect(performance.queriesPerSecond).toBe(0.08);
+    expect(performance.bufferPoolUsage).toBe(1.53);
+  });
+
+  test("getPerformanceMetrics reports zero rather than a flattering score when denied", async () => {
+    const provider = await connectProvider();
+    denyEverything();
+
+    const performance = await provider.getPerformanceMetrics();
+
+    expect(performance.cacheHitRatio).toBe(0);
+    expect(performance.queriesPerSecond).toBe(0);
+    expect(performance.bufferPoolUsage).toBe(0);
+  });
+
+  test("getSlowQueries aggregates system.query_log by normalized statement", async () => {
+    const provider = await connectProvider();
+
+    const slow = await provider.getSlowQueries({ limit: 5 });
+
+    expect(slow).toEqual([
+      {
+        queryId: "7283842689206104996",
+        query: "SELECT count() FROM orders WHERE status = 'paid'",
+        calls: 3,
+        totalTime: 1179,
+        avgTime: 393,
+        minTime: 281,
+        maxTime: 505,
+        rows: 3,
+      },
+    ]);
+    expect(sqlWith("system.query_log")).toContain("LIMIT 5");
+  });
+
+  test("getSlowQueries returns empty when query_log is switched off or ungranted", async () => {
+    // Both are ordinary deployments: query_log is permission-gated AND absent on
+    // some servers, so an empty panel is the honest answer, not a failure.
+    const provider = await connectProvider();
+    denyEverything();
+
+    expect(await provider.getSlowQueries()).toEqual([]);
+  });
+
+  test("getSlowQueries returns empty when the table does not exist at all", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(UNKNOWN_TABLE, "UNKNOWN_TABLE", "Table system.query_log does not exist", 404);
+
+    expect(await provider.getSlowQueries()).toEqual([]);
+  });
+
+  test("a limit that is not a positive whole number falls back to the default", async () => {
+    // The row cap is inlined into the statement rather than bound, so it has to
+    // be a positive integer before it gets there.
+    const provider = await connectProvider();
+
+    await provider.getSlowQueries({ limit: 0 });
+
+    expect(sqlWith("system.query_log")).toContain("LIMIT 10");
+  });
+
+  test("getActiveSessions reads system.processes and hides its own read", async () => {
+    const provider = await connectProvider();
+
+    const sessions = await provider.getActiveSessions({ limit: 7 });
+
+    expect(sessions[0].pid).toBe("1b39563e-105b-42dd-9a49-7fb7e0618f94");
+    expect(sessions[0].user).toBe("libredb");
+    expect(sessions[0].database).toBe(DATABASE);
+    expect(sessions[0].clientAddr).toBe("::ffff:172.17.0.1");
+    expect(sessions[0].state).toBe("active");
+    expect(sessions[0].durationMs).toBe(12500);
+    expect(sessions[0].duration).toBe("12.50s");
+    expect(sessions[1].durationMs).toBe(1);
+    expect(sqlWith("system.processes")).toContain("NOT LIKE");
+    expect(sqlWith("system.processes")).toContain("LIMIT 7");
+  });
+
+  test("getActiveSessions returns empty when the process list is denied", async () => {
+    const provider = await connectProvider();
+    denyEverything();
+
+    expect(await provider.getActiveSessions()).toEqual([]);
+  });
+
+  test("getTableStats groups the active parts by table", async () => {
+    const provider = await connectProvider();
+
+    const stats = await provider.getTableStats();
+
+    expect(stats[0]).toEqual({
+      schemaName: DATABASE,
+      tableName: "orders",
+      rowCount: 5,
+      tableSize: "621 B",
+      tableSizeBytes: 621,
+      indexSize: "228 B",
+      indexSizeBytes: 228,
+      totalSize: "2.55 KB",
+      totalSizeBytes: 2613,
+    });
+    expect(stats).toHaveLength(2);
+  });
+
+  test("getTableStats narrows to one database when asked", async () => {
+    const provider = await connectProvider();
+
+    await provider.getTableStats({ schema: "demo" });
+
+    expect(sqlWith("system.parts")).toContain("database = 'demo'");
+  });
+
+  test("getTableStats excludes the server's own databases when not narrowed", async () => {
+    const provider = await connectProvider();
+
+    await provider.getTableStats();
+
+    expect(sqlWith("system.parts")).toContain("database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')");
+  });
+
+  test("getTableStats returns empty when system.parts is denied", async () => {
+    const provider = await connectProvider();
+    denyEverything();
+
+    expect(await provider.getTableStats()).toEqual([]);
+  });
+
+  test("getIndexStats lists the data-skipping indexes with no scan counters", async () => {
+    // ClickHouse publishes no per-index usage statistics anywhere, so a scan
+    // count is reported as zero rather than guessed, and no index is unique.
+    const provider = await connectProvider();
+
+    const stats = await provider.getIndexStats();
+
+    expect(stats[0]).toEqual({
+      schemaName: DATABASE,
+      tableName: "orders",
+      indexName: "idx_status",
+      indexType: "set",
+      columns: ["status"],
+      isUnique: false,
+      isPrimary: false,
+      indexSize: "219 B",
+      indexSizeBytes: 219,
+      scans: 0,
+    });
+    // The expression stays one entry: splitting on its commas would invent two
+    // columns named `cityHash64(user_id` and `status)`, neither of which exists.
+    expect(stats[1].columns).toEqual(["cityHash64(user_id, status)"]);
+  });
+
+  test("getIndexStats narrows to one database when asked", async () => {
+    const provider = await connectProvider();
+
+    await provider.getIndexStats({ schema: "demo" });
+
+    expect(sqlWith("indexName")).toContain("database = 'demo'");
+  });
+
+  test("getIndexStats returns empty when the index catalog is denied", async () => {
+    const provider = await connectProvider();
+    denyEverything();
+
+    expect(await provider.getIndexStats()).toEqual([]);
+  });
+
+  test("getStorageStats reports the disks the server stores parts on", async () => {
+    const provider = await connectProvider();
+
+    const storage = await provider.getStorageStats();
+
+    expect(storage).toEqual([
+      {
+        name: "default",
+        location: "/var/lib/clickhouse/",
+        size: "273.95 GB",
+        sizeBytes: 294147883008,
+        usagePercent: 32.48,
+      },
+    ]);
+  });
+
+  test("getStorageStats returns empty when system.disks is denied", async () => {
+    const provider = await connectProvider();
+    denyEverything();
+
+    expect(await provider.getStorageStats()).toEqual([]);
+  });
+
+  test("getHealth composes the degrading sources", async () => {
+    const provider = await connectProvider();
+
+    const health = await provider.getHealth();
+
+    expect(health.activeConnections).toBe(1);
+    expect(health.databaseSize).toBe("3.87 KB");
+    expect(health.cacheHitRatio).toBe("36.4");
+    expect(health.slowQueries[0].calls).toBe(3);
+    expect(health.slowQueries[0].avgTime).toBe("393ms");
+    expect(health.activeSessions[0].pid).toBe("1b39563e-105b-42dd-9a49-7fb7e0618f94");
+  });
+
+  test("getMonitoringData survives a user who may read nothing", async () => {
+    const provider = await connectProvider();
+    denyEverything();
+
+    const data = await provider.getMonitoringData();
+
+    expect(data.slowQueries).toEqual([]);
+    expect(data.activeSessions).toEqual([]);
+    expect(data.tables).toEqual([]);
+    expect(data.indexes).toEqual([]);
+    expect(data.storage).toEqual([]);
+    expect(data.performance.cacheHitRatio).toBe(0);
+    expect(data.overview.version).toBe("unknown");
+  });
+
+  test("a monitoring failure that is not a denial propagates, so no panel hides a bug", async () => {
+    const provider = await connectProvider();
+    replyFor = () => exceptionReply(SYNTAX_ERROR, "SYNTAX_ERROR", "Syntax error", 400);
+
+    await expect(provider.getSlowQueries()).rejects.toBeInstanceOf(QueryError);
+  });
+});
+
+// ============================================================================
+// Maintenance
+// ============================================================================
+
+describe("ClickHouseProvider maintenance", () => {
+  test("optimize merges the parts of one table", async () => {
+    const provider = await connectProvider();
+
+    const result = await provider.runMaintenance("optimize", "users");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("users");
+    expect(sqlWith("OPTIMIZE")).toBe('OPTIMIZE TABLE "demo"."users" FINAL');
+  });
+
+  test("optimize keeps a qualified target in its own database", async () => {
+    const provider = await connectProvider();
+
+    await provider.runMaintenance("optimize", "default.audit");
+
+    expect(sqlWith("OPTIMIZE")).toBe('OPTIMIZE TABLE "default"."audit" FINAL');
+  });
+
+  test("optimize quotes an identifier that carries a quote", async () => {
+    const provider = await connectProvider();
+
+    await provider.runMaintenance("optimize", 'we"ird');
+
+    expect(sqlWith("OPTIMIZE")).toBe('OPTIMIZE TABLE "demo"."we""ird" FINAL');
+  });
+
+  test("analyze reports the part statistics ClickHouse keeps instead of computing new ones", async () => {
+    // There is no ANALYZE: a MergeTree's statistics are its parts, and they are
+    // always current. Reporting them is the honest equivalent of the operation.
+    const provider = await connectProvider();
+
+    const result = await provider.runMaintenance("analyze", "orders");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("orders: 2 active parts, 5 rows, 2.55 KB on disk");
+    expect(sqlWith("partCount")).toContain("database = 'demo' AND table = 'orders'");
+  });
+
+  test("analyze reports honestly when the table has no parts at all", async () => {
+    const provider = await connectProvider();
+    replyFor = (sql) =>
+      sql.includes("partCount") ? jsonReply([{ partCount: "0", rowCount: "0", totalBytes: "0" }]) : defaultReply(sql);
+
+    const result = await provider.runMaintenance("analyze", "daily_events");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("daily_events: no active parts (a view or a non-MergeTree engine keeps none)");
+  });
+
+  test("analyze without a target reports the whole pinned database", async () => {
+    // MaintenanceModal's global Analyze button sends no target (it is what
+    // `analyzeGlobalLabel` labels), and a live run showed it failing with
+    // "requires a target" - a control the UI offers that could never work.
+    // Reporting the database's parts is well defined and is what the label says.
+    const provider = await connectProvider();
+
+    const result = await provider.runMaintenance("analyze");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("demo: 2 active parts, 5 rows, 2.55 KB on disk");
+    expect(sqlWith("partCount")).toContain("database = 'demo'");
+    expect(sqlWith("partCount")).not.toContain("table =");
+  });
+
+  test("analyze without a target reports honestly when the database has no parts", async () => {
+    const provider = await connectProvider();
+    replyFor = (sql) =>
+      sql.includes("partCount") ? jsonReply([{ partCount: "0", rowCount: "0", totalBytes: "0" }]) : defaultReply(sql);
+
+    const result = await provider.runMaintenance("analyze");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("no active parts");
+  });
+
+  test("optimize still requires a target, because OPTIMIZE needs a table", async () => {
+    const provider = await connectProvider();
+
+    await expect(provider.runMaintenance("optimize")).rejects.toThrow(/requires a target/);
+  });
+
+  test("kill cancels one running query by id", async () => {
+    const provider = await connectProvider();
+
+    const result = await provider.runMaintenance("kill", "1b39563e-105b-42dd-9a49-7fb7e0618f94");
+
+    expect(result.success).toBe(true);
+    expect(sqlWith("KILL QUERY")).toBe("KILL QUERY WHERE query_id = '1b39563e-105b-42dd-9a49-7fb7e0618f94' SYNC");
+  });
+
+  test("kill escapes a target that tries to close the literal", async () => {
+    const provider = await connectProvider();
+
+    await provider.runMaintenance("kill", "a' OR 1 = 1 --");
+
+    expect(sqlWith("KILL QUERY")).toBe("KILL QUERY WHERE query_id = 'a'' OR 1 = 1 --' SYNC");
+  });
+
+  test("an operation without a target is refused", async () => {
+    const provider = await connectProvider();
+
+    await expect(provider.runMaintenance("optimize")).rejects.toBeInstanceOf(QueryError);
+  });
+
+  test("an operation ClickHouse has no equivalent for is refused", async () => {
+    const provider = await connectProvider();
+
+    await expect(provider.runMaintenance("vacuum", "users")).rejects.toThrow(/vacuum/);
+  });
+
+  test("a denied maintenance statement is mapped like any other failure", async () => {
+    // Live-verified: OPTIMIZE and KILL QUERY both answer 500 / code 497 without
+    // the grant, so the status alone would read as a server fault.
+    const provider = await connectProvider();
+    denyEverything();
+
+    await expect(provider.runMaintenance("optimize", "users")).rejects.toBeInstanceOf(AuthenticationError);
+  });
+});

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -507,6 +507,35 @@ describe("ClickHouseProvider validation", () => {
     await provider.disconnect();
   });
 
+  // The scheme is the more specific statement of intent: it names the transport,
+  // while the ssl setting is a separate field that may be left over from an earlier
+  // edit. An explicit http:// URL that deferred to it would send HTTPS to a
+  // plaintext endpoint and fail with a bare "fetch failed".
+  test("an explicit http connection string overrides a leftover TLS setting", async () => {
+    const provider = await connectProvider({
+      host: undefined,
+      port: undefined,
+      ssl: { mode: "require" },
+      connectionString: "http://ch.internal:8123/demo",
+    });
+
+    expect(urlWith("SELECT 1")).toContain("http://ch.internal:8123/");
+    await provider.disconnect();
+  });
+
+  // clickhouse:// names no transport, so it is the one scheme that must defer.
+  test("a clickhouse:// connection string defers to the configured TLS setting", async () => {
+    const provider = await connectProvider({
+      host: undefined,
+      port: undefined,
+      ssl: { mode: "require" },
+      connectionString: "clickhouse://ch.internal/demo",
+    });
+
+    expect(urlWith("SELECT 1")).toContain("https://ch.internal:8443/");
+    await provider.disconnect();
+  });
+
   test("keeps the configured fields when the connection string is unparsable", async () => {
     const provider = await connectProvider({ connectionString: "not a url" });
 

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -1308,6 +1308,26 @@ describe("ClickHouseProvider maintenance", () => {
     expect(sqlWith("KILL QUERY")).toBe("KILL QUERY WHERE query_id = 'a'' OR 1 = 1 --' SYNC");
   });
 
+  // A backslash is the other escape character in a ClickHouse literal, and doubling
+  // the quote alone would leave `\'` reading as an escaped quote rather than a
+  // terminator. Live-verified on 26.7.1: with the doubled backslash,
+  // `name = 'back\\slash'` matches a table genuinely named `back\slash`.
+  test("escapes a backslash in a target, not only the quote", async () => {
+    const provider = await connectProvider();
+
+    await provider.runMaintenance("analyze", "back\\slash");
+
+    expect(sqlWith("partCount")).toContain("table = 'back\\\\slash'");
+  });
+
+  test("escapes a target combining a backslash and a quote", async () => {
+    const provider = await connectProvider();
+
+    await provider.runMaintenance("kill", "a\\' OR 1 = 1");
+
+    expect(sqlWith("KILL QUERY")).toBe("KILL QUERY WHERE query_id = 'a\\\\'' OR 1 = 1' SYNC");
+  });
+
   test("an operation without a target is refused", async () => {
     const provider = await connectProvider();
 

--- a/tests/unit/db/clickhouse/http-transport.test.ts
+++ b/tests/unit/db/clickhouse/http-transport.test.ts
@@ -188,6 +188,50 @@ describe("ClickHouseHttpTransport request", () => {
     expect(lastParam("log_comment")).toBe("probe");
   });
 
+  // max_execution_time only bounds execution AFTER ClickHouse has accepted the
+  // statement. A stalled DNS/TCP/TLS handshake, or a response body that never
+  // finishes arriving, is not covered by it, so the deadline the provider
+  // advertises has to be armed on the client too.
+  test("arms a client-side deadline when one is given", async () => {
+    await makeTransport().query("SELECT 1", { timeoutMs: 5000 });
+
+    const signal = lastCall().init?.signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+  });
+
+  test("sends no signal when no deadline is given", async () => {
+    await makeTransport().query("SELECT 1");
+
+    expect(lastCall().init?.signal).toBeUndefined();
+  });
+
+  test("reports a client-side timeout as a timeout, so the shared mapping classifies it", async () => {
+    // src/lib/db/errors.ts keys on "timeout"/"timed out" in the message, and a
+    // transport-level stall has no ClickHouse exception code to key on instead.
+    handler = () => {
+      throw new DOMException("The operation timed out.", "TimeoutError");
+    };
+
+    const error = await captureError(() => makeTransport().query("SELECT 1", { timeoutMs: 5 }));
+
+    expect(error.code).toBe(0);
+    expect(error.message.toLowerCase()).toContain("timed out");
+  });
+
+  test("aborts the in-flight request once the deadline passes", async () => {
+    // Proves the signal is live rather than merely attached: the handler waits on
+    // it instead of answering.
+    handler = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+      }) as unknown as Response;
+
+    const error = await captureError(() => makeTransport().query("SELECT 1", { timeoutMs: 10 }));
+
+    expect(error.message.toLowerCase()).toContain("timed out");
+  });
+
   // The parser below assumes the envelope it asked for. A caller that could set
   // the format through settings would silently turn every result into raw text.
   test("does not let a setting hijack the response format", async () => {

--- a/tests/unit/db/clickhouse/http-transport.test.ts
+++ b/tests/unit/db/clickhouse/http-transport.test.ts
@@ -1,0 +1,927 @@
+/**
+ * ClickHouse HTTP transport (issue #264, design spec 1.1, 1.2, 2.1 and 2.2)
+ *
+ * globalThis.fetch is replaced per test and restored in afterEach. mock.module()
+ * is deliberately not used: it is process-wide in bun, so mocking a module here
+ * would poison every sibling test file sharing the process.
+ *
+ * Every response replayed below was captured verbatim from ClickHouse 26.7.1.1315
+ * over its HTTP interface, including the shapes that look like bugs and are not:
+ * an error body that is plain text under an `application/json` content type, a
+ * successful write with no body at all, and a DDL response that carries no format
+ * header. Those are the cases a hand-written envelope parser gets wrong, so they
+ * are pinned here rather than assumed.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ClickHouseHttpTransport } from "@/lib/db/providers/sql/clickhouse/http-transport";
+import { CLICKHOUSE_UNKNOWN_ERROR_NAME, ClickHouseTransportError } from "@/lib/db/providers/sql/clickhouse/transport";
+import type { DatabaseConnection, DatabaseType } from "@/lib/db/types";
+
+// ============================================================================
+// Harness
+// ============================================================================
+
+// The DatabaseType union gains "clickhouse" in the registration commit; the
+// double assertion keeps this file compiling on either side of that change.
+const CLICKHOUSE: DatabaseType = "clickhouse" as unknown as DatabaseType;
+
+interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+const originalFetch = globalThis.fetch;
+let calls: FetchCall[] = [];
+let handler: (url: string, init?: RequestInit) => Response;
+
+/** A captured summary header: every value is a string, never a number (spec 2.2). */
+function summaryHeader(overrides: Record<string, string> = {}): string {
+  return JSON.stringify({ read_rows: "2", written_rows: "2", elapsed_ns: "58781261", ...overrides });
+}
+
+/** Headers a JSON-format 200 really carries. */
+function jsonHeaders(overrides: Record<string, string> = {}): Record<string, string> {
+  return {
+    "content-type": "application/json; charset=UTF-8",
+    "x-clickhouse-format": "JSON",
+    "x-clickhouse-summary": summaryHeader(),
+    ...overrides,
+  };
+}
+
+function respond(body: string, init: { status?: number; headers?: Record<string, string> } = {}): Response {
+  return new Response(body, { status: init.status ?? 200, headers: init.headers });
+}
+
+/**
+ * `SELECT id, big FROM tx_probe LIMIT 1` as the server returned it: UInt64 quoted
+ * because of `output_format_json_quote_64bit_integers` (spec 2.1), `statistics`
+ * in seconds, and the `rows_before_limit_at_least` a LIMIT adds (spec 2.6).
+ */
+const SELECT_BODY = JSON.stringify({
+  meta: [
+    { name: "id", type: "Int32" },
+    { name: "big", type: "UInt64" },
+  ],
+  data: [{ id: 1, big: "18446744073709551615" }],
+  rows: 1,
+  rows_before_limit_at_least: 2,
+  statistics: { elapsed: 0.001164102, rows_read: 2, bytes_read: 12 },
+});
+
+function makeConnection(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
+  return {
+    id: "ch-1",
+    name: "ClickHouse",
+    type: CLICKHOUSE,
+    host: "127.0.0.1",
+    port: 18123,
+    user: "libredb",
+    password: "password123",
+    database: "demo",
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeTransport(overrides: Partial<DatabaseConnection> = {}): ClickHouseHttpTransport {
+  return new ClickHouseHttpTransport(makeConnection(overrides));
+}
+
+function lastCall(): FetchCall {
+  const call = calls.at(-1);
+  if (!call) throw new Error("no request was made");
+  return call;
+}
+
+function lastUrl(): URL {
+  return new URL(lastCall().url);
+}
+
+function lastParam(name: string): string | null {
+  return lastUrl().searchParams.get(name);
+}
+
+function lastHeader(name: string): string | undefined {
+  return (lastCall().init?.headers as Record<string, string> | undefined)?.[name];
+}
+
+/** The thrown ClickHouseTransportError, or a failed expectation if none was thrown. */
+async function captureError(run: () => Promise<unknown>): Promise<ClickHouseTransportError> {
+  try {
+    await run();
+  } catch (caught) {
+    expect(caught).toBeInstanceOf(ClickHouseTransportError);
+    return caught as ClickHouseTransportError;
+  }
+  throw new Error("the transport resolved where it should have thrown");
+}
+
+beforeEach(() => {
+  calls = [];
+  handler = () => respond(SELECT_BODY, { headers: jsonHeaders() });
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return handler(url, init);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ============================================================================
+// The request
+// ============================================================================
+
+describe("ClickHouseHttpTransport request", () => {
+  // Spec 1.2: the statement is the body of a POST to "/" and is never rewritten
+  // to carry a FORMAT clause, so what the user typed is what the server parses.
+  test("posts the statement verbatim as the body of a request to /", async () => {
+    await makeTransport().query("SELECT id, big FROM tx_probe LIMIT 1");
+
+    expect(lastCall().init?.method).toBe("POST");
+    expect(lastCall().init?.body).toBe("SELECT id, big FROM tx_probe LIMIT 1");
+    expect(lastUrl().pathname).toBe("/");
+  });
+
+  test("asks for the JSON envelope through default_format", async () => {
+    await makeTransport().query("SELECT 1");
+
+    expect(lastParam("default_format")).toBe("JSON");
+  });
+
+  // Spec 2.1: without this, `SELECT toUInt64(18446744073709551615)` arrives as an
+  // unquoted JSON number and JSON.parse silently rounds it to ...552000.
+  test("always quotes 64-bit integers so JSON.parse cannot round them", async () => {
+    await makeTransport().query("SELECT toUInt64(18446744073709551615)");
+
+    expect(lastParam("output_format_json_quote_64bit_integers")).toBe("1");
+  });
+
+  test("sends the connection's database as a URL parameter", async () => {
+    await makeTransport().query("SELECT 1");
+
+    expect(lastParam("database")).toBe("demo");
+  });
+
+  test("lets one statement target another database without rewriting its SQL", async () => {
+    await makeTransport().query("SELECT 1", { database: "system" });
+
+    expect(lastParam("database")).toBe("system");
+  });
+
+  test("omits the database parameter when the connection pins none", async () => {
+    await makeTransport({ database: undefined }).query("SELECT 1");
+
+    expect(lastParam("database")).toBeNull();
+  });
+
+  test("passes per-statement settings through as URL parameters", async () => {
+    await makeTransport().query("SELECT 1", {
+      settings: { max_execution_time: 5, allow_experimental_analyzer: true, log_comment: "probe" },
+    });
+
+    expect(lastParam("max_execution_time")).toBe("5");
+    expect(lastParam("allow_experimental_analyzer")).toBe("true");
+    expect(lastParam("log_comment")).toBe("probe");
+  });
+
+  // The parser below assumes the envelope it asked for. A caller that could set
+  // the format through settings would silently turn every result into raw text.
+  test("does not let a setting hijack the response format", async () => {
+    await makeTransport().query("SELECT 1", {
+      settings: { default_format: "TSV", output_format_json_quote_64bit_integers: 0, database: "other" },
+    });
+
+    expect(lastParam("default_format")).toBe("JSON");
+    expect(lastParam("output_format_json_quote_64bit_integers")).toBe("1");
+    expect(lastParam("database")).toBe("demo");
+  });
+
+  test("authenticates with HTTP Basic", async () => {
+    await makeTransport().query("SELECT 1");
+
+    expect(lastHeader("authorization")).toBe(`Basic ${Buffer.from("libredb:password123").toString("base64")}`);
+  });
+
+  test("sends an empty password rather than dropping the header", async () => {
+    await makeTransport({ password: undefined }).query("SELECT 1");
+
+    expect(lastHeader("authorization")).toBe(`Basic ${Buffer.from("libredb:").toString("base64")}`);
+  });
+
+  // Live-verified: an empty Basic username is a hard failure - "Code: 516 ... Got
+  // an empty user name from Authorization HTTP header" - whereas sending no
+  // header at all resolves to the `default` user, which is what a stock local
+  // install expects. So a connection without a user must send no header.
+  test("sends no authorization header when the connection names no user", async () => {
+    await makeTransport({ user: undefined }).query("SELECT 1");
+
+    expect(lastHeader("authorization")).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// The endpoint
+// ============================================================================
+
+describe("ClickHouseHttpTransport endpoint", () => {
+  test("defaults to the documented HTTP port on localhost", async () => {
+    await new ClickHouseHttpTransport({
+      id: "ch-2",
+      name: "ClickHouse",
+      type: CLICKHOUSE,
+      createdAt: new Date(),
+    }).query("SELECT 1");
+
+    expect(lastUrl().origin).toBe("http://localhost:8123");
+  });
+
+  test("uses the TLS port and scheme when the connection asks for SSL", async () => {
+    await makeTransport({ port: undefined, ssl: { mode: "require" } }).query("SELECT 1");
+
+    expect(lastUrl().origin).toBe("https://127.0.0.1:8443");
+  });
+
+  test("keeps plain HTTP when SSL is explicitly disabled", async () => {
+    await makeTransport({ port: undefined, ssl: { mode: "disable" } }).query("SELECT 1");
+
+    expect(lastUrl().origin).toBe("http://127.0.0.1:8123");
+  });
+
+  test("an explicit port wins over the scheme's default", async () => {
+    await makeTransport({ port: 9000, ssl: { mode: "verify-full" } }).query("SELECT 1");
+
+    expect(lastUrl().origin).toBe("https://127.0.0.1:9000");
+  });
+
+  // A bare IPv6 literal is not a legal URL authority, so it has to be bracketed
+  // or the request never leaves the process.
+  test("brackets a bare IPv6 host", async () => {
+    await makeTransport({ host: "::1" }).query("SELECT 1");
+
+    expect(lastUrl().origin).toBe("http://[::1]:18123");
+  });
+
+  test("leaves an already-bracketed IPv6 host alone", async () => {
+    await makeTransport({ host: "[::1]" }).query("SELECT 1");
+
+    expect(lastUrl().origin).toBe("http://[::1]:18123");
+  });
+});
+
+// ============================================================================
+// A tabular result
+// ============================================================================
+
+describe("ClickHouseHttpTransport JSON results", () => {
+  test("describes the rows from meta, in the order the statement projected them", async () => {
+    const result = await makeTransport().query("SELECT id, big FROM tx_probe LIMIT 1");
+
+    expect(result.rows).toEqual([{ id: 1, big: "18446744073709551615" }]);
+    expect(result.fieldNames).toEqual(["id", "big"]);
+    expect(result.columnTypes).toEqual({ id: "Int32", big: "UInt64" });
+    expect(result.rawText).toBeNull();
+  });
+
+  // Spec 1.7: the declared type is carried through untouched, wrappers included,
+  // because the wrapper is what tells the user it is nullable or low-cardinality.
+  test("carries declared types verbatim, wrappers and all", async () => {
+    handler = () =>
+      respond(
+        JSON.stringify({
+          meta: [
+            { name: "a", type: "Nullable(String)" },
+            { name: "b", type: "Map(String, UInt8)" },
+            { name: "c", type: "Enum8('x' = 1, 'y' = 2)" },
+            { name: "d", type: "LowCardinality(String)" },
+          ],
+          data: [],
+        }),
+        { headers: jsonHeaders() },
+      );
+
+    const result = await makeTransport().query("SELECT a, b, c, d FROM wrapped");
+
+    expect(result.columnTypes).toEqual({
+      a: "Nullable(String)",
+      b: "Map(String, UInt8)",
+      c: "Enum8('x' = 1, 'y' = 2)",
+      d: "LowCardinality(String)",
+    });
+  });
+
+  test("reports the mutation count and elapsed time the summary header carries", async () => {
+    const result = await makeTransport().query("SELECT 1");
+
+    expect(result.mutationCount).toBe(2);
+    expect(result.executionTimeMs).toBeCloseTo(58.781261, 6);
+  });
+
+  // The header is the authority because it is present on every response; the
+  // in-body statistics only exist on a JSON result. But a reverse proxy can drop
+  // an unknown header, and losing the timing entirely is worse than reading the
+  // body's own number.
+  test("falls back to the envelope's own elapsed seconds when the header is missing", async () => {
+    handler = () => respond(SELECT_BODY, { headers: jsonHeaders({ "x-clickhouse-summary": "" }) });
+
+    const result = await makeTransport().query("SELECT 1");
+
+    expect(result.executionTimeMs).toBeCloseTo(1.164102, 6);
+    expect(result.mutationCount).toBe(0);
+  });
+
+  test("reports no elapsed time rather than a guess when neither source has one", async () => {
+    handler = () => respond(JSON.stringify({ meta: [], data: [] }), { headers: { "x-clickhouse-format": "JSON" } });
+
+    const result = await makeTransport().query("SELECT 1");
+
+    expect(result.executionTimeMs).toBe(0);
+  });
+
+  // Spec 2.6: nothing in the UI consumes it, so it is deliberately not surfaced.
+  // Asserted so a future widening of the seam is a decision, not an accident.
+  test("does not surface the row-count estimate a LIMIT adds", async () => {
+    const result = await makeTransport().query("SELECT * FROM tx_probe LIMIT 1");
+
+    expect(Object.keys(result).sort()).toEqual([
+      "columnTypes",
+      "executionTimeMs",
+      "fieldNames",
+      "mutationCount",
+      "rawText",
+      "rows",
+    ]);
+  });
+
+  test("describes nothing when the envelope carries no meta", async () => {
+    handler = () => respond(JSON.stringify({ data: [{ x: 1 }] }), { headers: jsonHeaders() });
+
+    const result = await makeTransport().query("SELECT 1");
+
+    expect(result.rows).toEqual([{ x: 1 }]);
+    expect(result.fieldNames).toBeNull();
+    expect(result.columnTypes).toBeNull();
+  });
+
+  test("yields no rows when the envelope carries no data array", async () => {
+    handler = () => respond(JSON.stringify({ meta: [{ name: "x", type: "UInt8" }] }), { headers: jsonHeaders() });
+
+    const result = await makeTransport().query("SELECT 1");
+
+    expect(result.rows).toEqual([]);
+    expect(result.fieldNames).toEqual(["x"]);
+  });
+});
+
+// ============================================================================
+// A write
+// ============================================================================
+
+describe("ClickHouseHttpTransport writes", () => {
+  // Spec 2.2: an INSERT is a 200 with NO body. Treating an empty body as a
+  // failure - the reflex a JSON API teaches - would report every write as broken.
+  test("treats an empty body as the success a write really is", async () => {
+    handler = () =>
+      respond("", {
+        headers: { "content-type": "text/plain; charset=UTF-8", "x-clickhouse-summary": summaryHeader() },
+      });
+
+    const result = await makeTransport().query("INSERT INTO tx_probe VALUES (1,'a'),(2,'b')");
+
+    expect(result.mutationCount).toBe(2);
+    expect(result.executionTimeMs).toBeCloseTo(58.781261, 6);
+    expect(result.rows).toEqual([]);
+    expect(result.fieldNames).toBeNull();
+    expect(result.columnTypes).toBeNull();
+    expect(result.rawText).toBeNull();
+  });
+
+  // Live-verified: a DDL statement answers 200 with an empty body and no format
+  // header at all, so the empty-body check has to come before any format check.
+  test("accepts a DDL response that carries neither body nor format header", async () => {
+    handler = () => respond("", { headers: { "x-clickhouse-summary": summaryHeader({ written_rows: "0" }) } });
+
+    const result = await makeTransport().query("CREATE TABLE tx_probe (id Int32) ENGINE = MergeTree ORDER BY id");
+
+    expect(result.mutationCount).toBe(0);
+    expect(result.rawText).toBeNull();
+  });
+
+  // Spec 2.2, the honesty caveat: an ALTER ... UPDATE really did change the row
+  // and still reports written_rows 0. Reporting the server's zero is the point -
+  // a fabricated "1 row affected" would be a lie on screen.
+  test("reports the server's zero for a mutation it queued in the background", async () => {
+    handler = () => respond("", { headers: { "x-clickhouse-summary": summaryHeader({ written_rows: "0" }) } });
+
+    const result = await makeTransport().query("ALTER TABLE tx_probe UPDATE name = 'z' WHERE id = 1");
+
+    expect(result.mutationCount).toBe(0);
+  });
+});
+
+// ============================================================================
+// A format the user chose
+// ============================================================================
+
+describe("ClickHouseHttpTransport non-JSON formats", () => {
+  // Spec 1.2: an explicit FORMAT in the user's SQL beats default_format, so the
+  // response really is TSV. Parsing it would throw on something the user asked
+  // for deliberately.
+  test("returns the body as text when the server reports a format other than JSON", async () => {
+    handler = () =>
+      respond("1\n", {
+        headers: {
+          "content-type": "text/tab-separated-values; charset=UTF-8",
+          "x-clickhouse-format": "TSV",
+          "x-clickhouse-summary": summaryHeader(),
+        },
+      });
+
+    const result = await makeTransport().query("SELECT 1 FORMAT TSV");
+
+    expect(result.rawText).toBe("1\n");
+    expect(result.rows).toEqual([]);
+    expect(result.fieldNames).toBeNull();
+    expect(result.columnTypes).toBeNull();
+    expect(result.mutationCount).toBe(2);
+    expect(result.executionTimeMs).toBeCloseTo(58.781261, 6);
+  });
+
+  test.each(["TSV", "CSV", "JSONEachRow", "Pretty"])("does not parse a %s response", async (format) => {
+    handler = () => respond("payload", { headers: { "x-clickhouse-format": format } });
+
+    expect((await makeTransport().query(`SELECT 1 FORMAT ${format}`)).rawText).toBe("payload");
+  });
+
+  // Defensive: a body with no format header is not JSON on the server's own
+  // account, so handing it back as text beats parsing it and throwing.
+  test("returns text when a non-empty body arrives with no format header", async () => {
+    handler = () => respond("unlabelled", { headers: { "x-clickhouse-summary": summaryHeader() } });
+
+    expect((await makeTransport().query("SELECT 1")).rawText).toBe("unlabelled");
+  });
+});
+
+// ============================================================================
+// The summary header
+// ============================================================================
+
+describe("ClickHouseHttpTransport summary header", () => {
+  test.each<[string, string]>([
+    ["malformed JSON", "{not json"],
+    ["a JSON array", "[]"],
+    ["a JSON scalar", '"58781261"'],
+    ["JSON null", "null"],
+  ])("degrades to zeroes when the header is %s", async (_label, summary) => {
+    handler = () => respond("", { headers: { "x-clickhouse-summary": summary } });
+
+    const result = await makeTransport().query("INSERT INTO tx_probe VALUES (1,'a')");
+
+    expect(result.mutationCount).toBe(0);
+    expect(result.executionTimeMs).toBe(0);
+  });
+
+  test("degrades to zeroes when the header is absent entirely", async () => {
+    handler = () => respond("");
+
+    const result = await makeTransport().query("INSERT INTO tx_probe VALUES (1,'a')");
+
+    expect(result.mutationCount).toBe(0);
+    expect(result.executionTimeMs).toBe(0);
+  });
+
+  test.each<[string, string]>([
+    ["non-numeric", '{"written_rows":"lots","elapsed_ns":"ages"}'],
+    ["absent", '{"read_rows":"2"}'],
+  ])("degrades to zeroes when the counters are %s", async (_label, summary) => {
+    handler = () => respond("", { headers: { "x-clickhouse-summary": summary } });
+
+    const result = await makeTransport().query("INSERT INTO tx_probe VALUES (1,'a')");
+
+    expect(result.mutationCount).toBe(0);
+    expect(result.executionTimeMs).toBe(0);
+  });
+});
+
+// ============================================================================
+// Failures
+// ============================================================================
+
+describe("ClickHouseHttpTransport failures", () => {
+  /** The body a real exception carries, version suffix included. */
+  function exceptionBody(code: number, text: string, name: string): string {
+    return `Code: ${code}. DB::Exception: ${text}. (${name}) (version 26.7.1.1315 (official build))`;
+  }
+
+  function failWith(status: number, body: string, headers: Record<string, string> = {}): void {
+    handler = () =>
+      respond(body, {
+        status,
+        // Live-verified: the content type claims JSON while the body is plain
+        // text, which is exactly the trap this pins.
+        headers: { "content-type": "application/json; charset=UTF-8", ...headers },
+      });
+  }
+
+  // Spec 1.1: ClickHouse uses real status codes, so !response.ok is the whole
+  // test. Inspecting the payload for an error - the Couchbase rule - is wrong
+  // here, and would misread a row whose text happens to mention an exception.
+  test("a 200 is a success even when a value looks like an exception", async () => {
+    handler = () =>
+      respond(
+        JSON.stringify({
+          meta: [{ name: "query", type: "String" }],
+          data: [{ query: "Code: 62. DB::Exception: Syntax error (SYNTAX_ERROR)" }],
+        }),
+        { headers: jsonHeaders() },
+      );
+
+    const result = await makeTransport().query("SELECT query FROM system.query_log");
+
+    expect(result.rows).toEqual([{ query: "Code: 62. DB::Exception: Syntax error (SYNTAX_ERROR)" }]);
+  });
+
+  test("any non-2xx status is a failure", async () => {
+    failWith(400, exceptionBody(62, "Syntax error: failed at position 8", "SYNTAX_ERROR"), {
+      "x-clickhouse-exception-code": "62",
+    });
+
+    const error = await captureError(() => makeTransport().query("SELECT FROM"));
+
+    expect(error.code).toBe(62);
+    expect(error.is("SYNTAX_ERROR")).toBe(true);
+  });
+
+  // The trailing "(version ...)" is build metadata, not information for the
+  // person who mistyped a table name.
+  test("strips the version suffix from the message the user sees", async () => {
+    failWith(404, exceptionBody(60, "Table demo.nope does not exist", "UNKNOWN_TABLE"), {
+      "x-clickhouse-exception-code": "60",
+    });
+
+    const error = await captureError(() => makeTransport().query("SELECT * FROM nope"));
+
+    expect(error.message).toBe("Code: 60. DB::Exception: Table demo.nope does not exist. (UNKNOWN_TABLE)");
+    expect(error.name).toBe("UNKNOWN_TABLE");
+  });
+
+  // Live-verified: an authentication failure carries no version suffix at all.
+  test("leaves a message that has no version suffix untouched", async () => {
+    failWith(
+      403,
+      "Code: 516. DB::Exception: libredb: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)",
+      { "x-clickhouse-exception-code": "516" },
+    );
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error.is("AUTHENTICATION_FAILED")).toBe(true);
+    expect(error.message).toContain("password is incorrect");
+    expect(error.message).toContain("(AUTHENTICATION_FAILED)");
+  });
+
+  // Live-verified: sending no credentials at all produces a multi-line body with
+  // the exception name after a blank line, so the name has to be found at the end
+  // of the whole string rather than on the first line.
+  test("finds the exception name at the end of a multi-line body", async () => {
+    failWith(
+      403,
+      [
+        "Code: 194. DB::Exception: default: Authentication failed: password is incorrect, or there is no user with such name",
+        "",
+        "If you use ClickHouse Cloud, the password can be reset at https://clickhouse.cloud/",
+        "",
+        ". (REQUIRED_PASSWORD)",
+      ].join("\n"),
+    );
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error.name).toBe("REQUIRED_PASSWORD");
+    expect(error.code).toBe(194);
+  });
+
+  // The header is a discrete integer; the "Code: NN." prefix has to be scraped
+  // out of prose. Prefer the header, but do not lose the code when it is absent -
+  // a proxy that strips unknown headers would otherwise turn every failure into
+  // an unclassifiable one.
+  test("takes the code from the exception header when it is present", async () => {
+    failWith(404, exceptionBody(81, "Database nosuchdb does not exist", "UNKNOWN_DATABASE"), {
+      "x-clickhouse-exception-code": "81",
+    });
+
+    expect((await captureError(() => makeTransport().query("SELECT 1"))).is("UNKNOWN_DATABASE")).toBe(true);
+  });
+
+  test("falls back to the Code: prefix when the header is absent", async () => {
+    failWith(501, exceptionBody(48, "Mutations are not supported", "NOT_IMPLEMENTED"));
+
+    expect((await captureError(() => makeTransport().query("UPDATE t SET a = 1"))).is("NOT_IMPLEMENTED")).toBe(true);
+  });
+
+  test("falls back to the Code: prefix when the header is not a number", async () => {
+    failWith(400, exceptionBody(62, "Syntax error", "SYNTAX_ERROR"), { "x-clickhouse-exception-code": "unknown" });
+
+    expect((await captureError(() => makeTransport().query("SELECT FROM"))).code).toBe(62);
+  });
+
+  test("reports no code rather than a wrong one when nothing carries it", async () => {
+    failWith(502, "<html>Bad Gateway</html>");
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error.code).toBe(0);
+    expect(error.name).toBe(CLICKHOUSE_UNKNOWN_ERROR_NAME);
+    expect(error.message).toBe("<html>Bad Gateway</html>");
+  });
+
+  // A gateway can fail with nothing in the body. The status is then the only
+  // thing there is to say, and saying it beats an empty message.
+  test("describes the status when the body is empty", async () => {
+    failWith(503, "");
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error.message).toBe("ClickHouse request failed with HTTP 503");
+    expect(error.code).toBe(0);
+  });
+
+  // The one thing that must never happen: the error body is plain text under an
+  // application/json content type, so JSON.parse would throw a SyntaxError over
+  // the real message.
+  test("never parses an error body, whatever the content type claims", async () => {
+    failWith(404, exceptionBody(60, "Unknown table expression identifier 'probe'", "UNKNOWN_TABLE"), {
+      "x-clickhouse-exception-code": "60",
+    });
+
+    const error = await captureError(() => makeTransport().query("SELECT * FROM probe"));
+
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error.message).toContain("Unknown table expression identifier 'probe'");
+  });
+});
+
+// ============================================================================
+// Mid-stream failures (issue #264, spec 2.8)
+// ============================================================================
+
+/**
+ * A statement that throws after the response has already started streaming.
+ * Live-verified on 26.7.1: the status is 200, no exception-code header is sent,
+ * the JSON body is truncated mid-array, and the real exception arrives as a
+ * trailer fenced by `__exception__` and the per-request tag from
+ * `X-ClickHouse-Exception-Tag`.
+ *
+ * Repro: POST `SELECT number, throwIf(number = 200000, 'boom') FROM
+ * numbers(1000000)` to `/?default_format=JSON&max_block_size=1000`.
+ */
+const MIDSTREAM_TAG = "rdlnavwamgbwoyjw";
+const MIDSTREAM_MESSAGE =
+  "Code: 395. DB::Exception: boom: while executing 'FUNCTION throwIf(equals(__table1.number, " +
+  "200000_UInt32) :: 0, 'boom'_String :: 2) -> throwIf(equals(__table1.number, 200000_UInt32), " +
+  "'boom'_String) UInt8 : 3'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) (version 26.7.1.1315 (official build))";
+
+function midstreamBody(tag: string = MIDSTREAM_TAG, message: string = MIDSTREAM_MESSAGE): string {
+  return [
+    '{\n\t"meta":\n\t[\n\t\t{ "name": "number", "type": "UInt64" }\n\t],\n\n\t"data":\n\t[',
+    '\t\t{ "number": 180999 }',
+    "__exception__",
+    tag,
+    message,
+    `286 ${tag}`,
+    "__exception__",
+  ].join("\n");
+}
+
+/** Headers such a response really carries: JSON format, a tag, and NO exception code. */
+function midstreamHeaders(tag: string = MIDSTREAM_TAG): Record<string, string> {
+  return jsonHeaders({ "x-clickhouse-exception-tag": tag });
+}
+
+describe("ClickHouseHttpTransport mid-stream exceptions", () => {
+  test("reports the trailer's exception rather than a parse failure", async () => {
+    handler = () => respond(midstreamBody(), { headers: midstreamHeaders() });
+
+    const error = await captureError(() => makeTransport().query("SELECT throwIf(1, 'boom')"));
+
+    expect(error.code).toBe(395);
+    expect(error.name).toBe("FUNCTION_THROW_IF_VALUE_IS_NON_ZERO");
+    expect(error.message).toContain("boom");
+    // The build metadata is noise to the person who wrote the statement.
+    expect(error.message).not.toContain("official build");
+    // A parse complaint here would bury the only useful part of the failure.
+    expect(error.message).not.toContain("could not parse");
+  });
+
+  test("keeps a literal __exception__ in the data a success, because the tag does not match", async () => {
+    // `SELECT '__exception__' AS x` is a legal statement. Only the per-request
+    // tag distinguishes a real trailer from user data that happens to say this.
+    handler = () =>
+      respond(JSON.stringify({ meta: [{ name: "x", type: "String" }], data: [{ x: "__exception__" }] }), {
+        headers: midstreamHeaders(),
+      });
+
+    const result = await makeTransport().query("SELECT '__exception__' AS x");
+
+    expect(result.rows).toEqual([{ x: "__exception__" }]);
+  });
+
+  test("reports the trailer even when the statement chose a non-JSON format", async () => {
+    // Live-reproduced: `... FROM numbers(1000000) FORMAT TSV` that throws part-way
+    // answers 200 with X-ClickHouse-Format: TSV, the tag, no exception-code header,
+    // 195000 of 1000000 rows, and the fence. The fence is format-independent, so
+    // checking it only for JSON reports 805000 lost rows as a success.
+    const body = [
+      "1\t0",
+      "2\t0",
+      "__exception__",
+      MIDSTREAM_TAG,
+      MIDSTREAM_MESSAGE,
+      `286 ${MIDSTREAM_TAG}`,
+      "__exception__",
+    ].join("\n");
+    handler = () =>
+      respond(body, {
+        headers: { "x-clickhouse-format": "TSV", "x-clickhouse-exception-tag": MIDSTREAM_TAG },
+      });
+
+    const error = await captureError(() => makeTransport().query("SELECT 1 FORMAT TSV"));
+
+    expect(error.code).toBe(395);
+    expect(error.name).toBe("FUNCTION_THROW_IF_VALUE_IS_NON_ZERO");
+  });
+
+  test("still returns raw text for a non-JSON format that did NOT fail", async () => {
+    // The tag is on every response, so the trailer check must key on the fence and
+    // not merely on the tag being present, or every FORMAT query becomes an error.
+    handler = () =>
+      respond("1\t0\n2\t0\n", {
+        headers: { "x-clickhouse-format": "TSV", "x-clickhouse-exception-tag": MIDSTREAM_TAG },
+      });
+
+    const result = await makeTransport().query("SELECT 1 FORMAT TSV");
+
+    expect(result.rawText).toBe("1\t0\n2\t0\n");
+    expect(result.fieldNames).toBeNull();
+  });
+
+  test("strips a partial result body that precedes the exception", async () => {
+    // The buffered-output variant: JSON output is accumulated so the server can count
+    // `rows`, which means a failure part-way through can still be sent with a real
+    // error STATUS and the partially built body ahead of the exception. Live-observed
+    // through the app as an error message with ~400 characters of meta/data JSON in
+    // front of the only useful line.
+    const partial = '{\n\t"meta":\n\t[\n\t\t{ "name": "number", "type": "UInt64" }\n\t],\n\n\t"data":\n\t[\n';
+    handler = () =>
+      respond(`${partial}${MIDSTREAM_MESSAGE}`, {
+        status: 500,
+        headers: { "content-type": "application/json; charset=UTF-8", "x-clickhouse-exception-code": "395" },
+      });
+
+    const error = await captureError(() => makeTransport().query("SELECT throwIf(1, 'boom')"));
+
+    expect(error.code).toBe(395);
+    expect(error.name).toBe("FUNCTION_THROW_IF_VALUE_IS_NON_ZERO");
+    expect(error.message.startsWith("Code: 395.")).toBe(true);
+    expect(error.message).not.toContain('"meta"');
+  });
+
+  test("strips a partial body even when no newline precedes the exception", async () => {
+    // The live shape when rows had already been written: the exception is appended
+    // straight onto the truncated row, so a line-anchored match misses it - and those
+    // are the longest, noisiest bodies of all.
+    handler = () =>
+      respond(`{"meta":[],"data":[{"number": "2"${MIDSTREAM_MESSAGE}`, {
+        status: 500,
+        headers: { "x-clickhouse-exception-code": "395" },
+      });
+
+    const error = await captureError(() => makeTransport().query("SELECT throwIf(1, 'boom')"));
+
+    expect(error.message.startsWith("Code: 395.")).toBe(true);
+    expect(error.message).not.toContain('"meta"');
+  });
+
+  test("leaves an ordinary error message that already starts with its code alone", async () => {
+    handler = () =>
+      respond("Code: 60. DB::Exception: Unknown table expression identifier 'nope'. (UNKNOWN_TABLE)", {
+        status: 404,
+        headers: { "x-clickhouse-exception-code": "60" },
+      });
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error.message).toBe("Code: 60. DB::Exception: Unknown table expression identifier 'nope'. (UNKNOWN_TABLE)");
+  });
+
+  test("falls back to the parse failure when the response carries no tag", async () => {
+    handler = () => respond(midstreamBody(), { headers: jsonHeaders() });
+
+    expect((await captureError(() => makeTransport().query("SELECT 1"))).code).toBe(0);
+  });
+
+  test("still reports the exception when the truncated body happens to stay parseable", async () => {
+    // The trailer is authoritative on its own: a plan that fails after emitting a
+    // complete-looking envelope must not be reported as a successful empty result.
+    handler = () =>
+      respond(`${JSON.stringify({ meta: [], data: [] })}\n__exception__\n${MIDSTREAM_TAG}\n${MIDSTREAM_MESSAGE}`, {
+        headers: midstreamHeaders(),
+      });
+
+    expect((await captureError(() => makeTransport().query("SELECT 1"))).code).toBe(395);
+  });
+
+  test("degrades to a normalized error when the trailer carries no recognizable code", async () => {
+    handler = () =>
+      respond(midstreamBody(MIDSTREAM_TAG, "truncated beyond recognition"), {
+        headers: midstreamHeaders(),
+      });
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error.code).toBe(0);
+    expect(error.name).toBe(CLICKHOUSE_UNKNOWN_ERROR_NAME);
+  });
+});
+
+// ============================================================================
+// Failures that are not the server's
+// ============================================================================
+
+describe("ClickHouseHttpTransport transport failures", () => {
+  test("normalizes a body that claims to be JSON and is not", async () => {
+    handler = () => respond("{not json", { headers: jsonHeaders() });
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error.code).toBe(0);
+    expect(error.name).toBe(CLICKHOUSE_UNKNOWN_ERROR_NAME);
+    expect(error.message).toContain("JSON");
+  });
+
+  test("normalizes a JSON body that is not an envelope object", async () => {
+    handler = () => respond("[1, 2]", { headers: jsonHeaders() });
+
+    expect((await captureError(() => makeTransport().query("SELECT 1"))).code).toBe(0);
+  });
+
+  // Every throw out of the seam has to be a ClickHouseTransportError or the
+  // provider's `instanceof` branches fall through to a generic message.
+  test("normalizes a refused connection", async () => {
+    handler = () => {
+      throw new Error("fetch failed");
+    };
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error.code).toBe(0);
+    expect(error.name).toBe(CLICKHOUSE_UNKNOWN_ERROR_NAME);
+    expect(error.message).toBe("ClickHouse request failed: fetch failed");
+  });
+
+  test("normalizes an aborted request", async () => {
+    handler = () => {
+      const abort = new Error("The operation was aborted.");
+      abort.name = "AbortError";
+      throw abort;
+    };
+
+    const error = await captureError(() => makeTransport().query("SELECT 1"));
+
+    expect(error).toBeInstanceOf(ClickHouseTransportError);
+    expect(error.message).toBe("ClickHouse request failed: The operation was aborted.");
+  });
+
+  test("normalizes a rejection that is not an Error at all", async () => {
+    handler = () => {
+      throw "socket hang up";
+    };
+
+    expect((await captureError(() => makeTransport().query("SELECT 1"))).message).toBe(
+      "ClickHouse request failed: socket hang up",
+    );
+  });
+});
+
+// ============================================================================
+// The seam
+// ============================================================================
+
+describe("ClickHouseHttpTransport seam", () => {
+  test("announces itself as the HTTP implementation", () => {
+    expect(makeTransport().kind).toBe("http");
+  });
+
+  // Spec 1.4: one request per statement, no session pinned, so there is nothing
+  // to release. close() exists because every implementation of the seam has it.
+  test("closes without holding anything open", async () => {
+    const transport = makeTransport();
+
+    await transport.close();
+
+    await expect(transport.query("SELECT 1")).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/db/clickhouse/introspect.test.ts
+++ b/tests/unit/db/clickhouse/introspect.test.ts
@@ -1,0 +1,820 @@
+/**
+ * ClickHouse schema introspection (issue #264, design spec section 3.6)
+ *
+ * Driven entirely through a hand-built ClickHouseTransport - the point of the
+ * seam: no fetch mocking, no `mock.module()` (process-wide in bun) and no
+ * server. Every row shape below was captured from a live ClickHouse
+ * 26.7.1.1315 instance, so the fake speaks exactly what the server speaks,
+ * including the two encodings that break naive parsing: a `UInt64` arrives as a
+ * decimal STRING (spec 2.1 quoting) while a `UInt8` stays a NUMBER, and a
+ * `Nullable(UInt64)` arrives as `null` for anything that is not a MergeTree.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  CLICKHOUSE_CATALOG_TIMEOUT_SECONDS,
+  CLICKHOUSE_PRIMARY_INDEX_NAME,
+  CLICKHOUSE_SORTING_INDEX_NAME,
+  CLICKHOUSE_SYSTEM_DATABASES,
+  getSchema,
+  getSchemaList,
+  getSchemaRelations,
+} from "@/lib/db/providers/sql/clickhouse/introspect";
+import {
+  CLICKHOUSE_ERROR_CODES,
+  type ClickHouseQueryOptions,
+  type ClickHouseQueryResult,
+  type ClickHouseRow,
+  type ClickHouseTransport,
+  ClickHouseTransportError,
+} from "@/lib/db/providers/sql/clickhouse/transport";
+
+// ============================================================================
+// Fake transport
+// ============================================================================
+
+/** Which system table a recorded statement reads. */
+type Surface = "tables" | "columns" | "indices";
+
+interface RecordedCall {
+  sql: string;
+  opts: ClickHouseQueryOptions | undefined;
+}
+
+interface FakeOptions {
+  tables?: ClickHouseRow[];
+  columns?: ClickHouseRow[];
+  indices?: ClickHouseRow[];
+  /** Raised instead of returning rows, per surface. */
+  failures?: Partial<Record<Surface, Error>>;
+}
+
+function surfaceOf(sql: string): Surface {
+  if (sql.includes("system.data_skipping_indices")) return "indices";
+  if (sql.includes("system.columns")) return "columns";
+  return "tables";
+}
+
+function createTransport(options: FakeOptions = {}) {
+  const calls: RecordedCall[] = [];
+
+  const transport: ClickHouseTransport = {
+    kind: "http",
+    query: async (sql: string, opts?: ClickHouseQueryOptions): Promise<ClickHouseQueryResult> => {
+      calls.push({ sql, opts });
+      const surface = surfaceOf(sql);
+      const failure = options.failures?.[surface];
+      if (failure) throw failure;
+      return {
+        rows: options[surface] ?? [],
+        fieldNames: null,
+        columnTypes: null,
+        executionTimeMs: 1,
+        mutationCount: 0,
+        rawText: null,
+      };
+    },
+    close: () => Promise.resolve(),
+  };
+
+  return { transport, calls };
+}
+
+function sqlFor(calls: RecordedCall[], surface: Surface): string {
+  const call = calls.find((entry) => surfaceOf(entry.sql) === surface);
+  if (!call) throw new Error(`no ${surface} statement was sent`);
+  return call.sql;
+}
+
+function accessDenied(): ClickHouseTransportError {
+  return new ClickHouseTransportError(
+    "libredb: Not enough privileges. To execute this query, it's necessary to have the grant SELECT " +
+      "for at least one column on system.data_skipping_indices. (ACCESS_DENIED)",
+    CLICKHOUSE_ERROR_CODES.ACCESS_DENIED,
+    "ACCESS_DENIED",
+  );
+}
+
+// ============================================================================
+// Row builders (shapes captured from ClickHouse 26.7.1.1315)
+// ============================================================================
+
+/**
+ * A `system.tables` row. `total_rows`/`total_bytes` default to the quoted-string
+ * form a MergeTree reports; pass null for the view / non-MergeTree case.
+ */
+function tableRow(overrides: Partial<ClickHouseRow> = {}): ClickHouseRow {
+  return {
+    database: "demo",
+    name: "users",
+    total_rows: "3",
+    total_bytes: "1346",
+    sorting_key: "id",
+    primary_key: "id",
+    ...overrides,
+  };
+}
+
+function columnRow(overrides: Partial<ClickHouseRow> = {}): ClickHouseRow {
+  return {
+    database: "demo",
+    table: "users",
+    name: "id",
+    type: "UInt32",
+    is_in_primary_key: 0,
+    default_kind: "",
+    default_expression: "",
+    ...overrides,
+  };
+}
+
+function indexRow(overrides: Partial<ClickHouseRow> = {}): ClickHouseRow {
+  return {
+    database: "demo",
+    table: "orders",
+    name: "idx_status",
+    expr: "status",
+    ...overrides,
+  };
+}
+
+/** The pinned database of the live probe connection. */
+const PINNED = "demo";
+
+// ============================================================================
+// The system-database filter
+// ============================================================================
+
+describe("the system-database filter", () => {
+  test.each<[Surface]>([
+    ["tables"],
+    ["columns"],
+    ["indices"],
+  ])("excludes every system database from the %s read", async (surface) => {
+    const { transport, calls } = createTransport();
+
+    await getSchema(transport, PINNED);
+    const sql = sqlFor(calls, surface);
+
+    expect(sql).toContain("NOT IN (");
+    for (const name of CLICKHOUSE_SYSTEM_DATABASES) expect(sql).toContain(`'${name}'`);
+  });
+
+  test("names exactly the three system databases the live server reports", () => {
+    expect([...CLICKHOUSE_SYSTEM_DATABASES]).toEqual(["system", "information_schema", "INFORMATION_SCHEMA"]);
+  });
+
+  // `default` is a real, user-writable database - it is where a connection with
+  // no explicit database lands - so excluding it with the system catalogs would
+  // hide the tables of the commonest single-database setup.
+  test("keeps the default database", async () => {
+    const { transport, calls } = createTransport({ tables: [tableRow({ database: "default", name: "events" })] });
+
+    const schema = await getSchema(transport, PINNED);
+
+    expect(sqlFor(calls, "tables")).not.toContain("'default'");
+    expect(schema.map((table) => table.name)).toEqual(["default.events"]);
+  });
+
+  // Live-verified: system.data_skipping_indices carries ~40 rows for the system
+  // databases alone, which swamp a user's own handful without this predicate.
+  test("filters the data-skipping-index read by database, not just the table list", async () => {
+    const { transport, calls } = createTransport();
+
+    await getSchemaRelations(transport, PINNED);
+
+    expect(sqlFor(calls, "indices")).toContain("system.data_skipping_indices");
+    expect(sqlFor(calls, "indices")).toContain("NOT IN (");
+  });
+
+  // A stuck replica or a cluster with thousands of tables must not leave the
+  // schema tree spinning forever.
+  test("bounds every catalog read with a server-side deadline", async () => {
+    const { transport, calls } = createTransport();
+
+    await getSchema(transport, PINNED);
+
+    expect(calls).toHaveLength(3);
+    for (const call of calls) {
+      expect(call.opts?.settings).toEqual({ max_execution_time: CLICKHOUSE_CATALOG_TIMEOUT_SECONDS });
+    }
+  });
+});
+
+// ============================================================================
+// Row counts and sizes
+// ============================================================================
+
+describe("row counts and sizes", () => {
+  // The correctness requirement of this file. total_rows/total_bytes are
+  // Nullable(UInt64) and live-verified null for a View and for every
+  // non-MergeTree engine. Coercing that to 0 would print "0 rows" for a view
+  // that returns thousands - a number the server never said.
+  test("reports an unknown row count and size as unknown, never as zero", async () => {
+    const { transport } = createTransport({
+      tables: [
+        tableRow({ name: "daily_events", total_rows: null, total_bytes: null, sorting_key: "", primary_key: "" }),
+      ],
+    });
+
+    const [view] = await getSchema(transport, PINNED);
+
+    expect(view.rowCount).toBeUndefined();
+    expect(view.size).toBeUndefined();
+  });
+
+  test("keeps a genuine zero distinct from unknown", async () => {
+    const { transport } = createTransport({ tables: [tableRow({ total_rows: "0", total_bytes: "0" })] });
+
+    const [empty] = await getSchema(transport, PINNED);
+
+    expect(empty.rowCount).toBe(0);
+    expect(empty.size).toBe("0 B");
+  });
+
+  // Spec 2.1: with 64-bit quoting on - which the transport always sends, so
+  // JSON.parse cannot round a UInt64 - a count arrives as a decimal string.
+  test("parses the quoted-string form a UInt64 arrives in", async () => {
+    const { transport } = createTransport({ tables: [tableRow({ total_rows: "5", total_bytes: "2613" })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.rowCount).toBe(5);
+    expect(table.size).toBe("2.55 KB");
+  });
+
+  // The same read has to keep working if a transport ever stops quoting, so the
+  // unquoted number is accepted too.
+  test("accepts an unquoted count", async () => {
+    const { transport } = createTransport({ tables: [tableRow({ total_rows: 3, total_bytes: 1346 })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.rowCount).toBe(3);
+    expect(table.size).toBe("1.31 KB");
+  });
+
+  test.each<[string, unknown]>([
+    ["an empty string", ""],
+    ["a non-numeric string", "not-a-number"],
+    ["a value of another type", { nested: true }],
+  ])("treats %s as unknown rather than zero", async (_label, value) => {
+    const { transport } = createTransport({ tables: [tableRow({ total_rows: value, total_bytes: value })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.rowCount).toBeUndefined();
+    expect(table.size).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Columns
+// ============================================================================
+
+describe("columns", () => {
+  // Spec 1.7: the declared type is precise and is what a ClickHouse user expects
+  // to read. Mapping it onto a generic family would throw away the wrapper -
+  // and the wrapper is what says nullable, low-cardinality or parameterised.
+  test.each([
+    "Int32",
+    "Nullable(String)",
+    "Array(UInt8)",
+    "Map(String,String)",
+    "Enum8('x' = 1, 'y' = 2)",
+    "LowCardinality(String)",
+    "Decimal(10, 3)",
+    "DateTime64(3)",
+    "UUID",
+  ])("carries the declared type %s verbatim", async (type) => {
+    const { transport } = createTransport({ tables: [tableRow()], columns: [columnRow({ type })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns[0].type).toBe(type);
+  });
+
+  test.each<[string, boolean]>([
+    ["Nullable(String)", true],
+    ["Nullable(Int32)", true],
+    ["String", false],
+    ["UInt32", false],
+    // Live-verified: the one wrapper ClickHouse puts OUTSIDE Nullable. The
+    // column really does accept NULL, so a bare startsWith would get it wrong.
+    ["LowCardinality(Nullable(String))", true],
+    // Live-verified counter-cases: here Nullable qualifies the ELEMENT type, not
+    // the column, so a substring search would get all three wrong.
+    ["Array(Nullable(String))", false],
+    ["Map(String, Nullable(String))", false],
+    ["SimpleAggregateFunction(any, Nullable(UInt64))", false],
+  ])("derives nullability from the Nullable wrapper of %s", async (type, nullable) => {
+    const { transport } = createTransport({ tables: [tableRow()], columns: [columnRow({ type })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns[0].nullable).toBe(nullable);
+  });
+
+  // is_in_primary_key is a UInt8, so it stays an unquoted number even with
+  // 64-bit quoting on. It is the authority on membership: the sorting key can
+  // extend past the primary key, and those extra columns are not primary.
+  test("marks a column primary from is_in_primary_key", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "id, email", primary_key: "id" })],
+      columns: [
+        columnRow({ name: "id", is_in_primary_key: 1 }),
+        columnRow({ name: "email", type: "String", is_in_primary_key: 0 }),
+      ],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns.map((column) => [column.name, column.isPrimary])).toEqual([
+      ["id", true],
+      ["email", false],
+    ]);
+  });
+
+  test("preserves the order the catalog returned, and asks for declaration order", async () => {
+    const { transport, calls } = createTransport({
+      tables: [tableRow()],
+      columns: [
+        columnRow({ name: "id" }),
+        columnRow({ name: "email", type: "String" }),
+        columnRow({ name: "country", type: "LowCardinality(String)" }),
+      ],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns.map((column) => column.name)).toEqual(["id", "email", "country"]);
+    expect(sqlFor(calls, "columns")).toContain("ORDER BY database, table, position");
+  });
+
+  test("groups columns onto the table they belong to and leaves an unmatched table empty", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ name: "users" }), tableRow({ name: "orders" }), tableRow({ name: "lonely" })],
+      columns: [
+        columnRow({ table: "users", name: "id" }),
+        columnRow({ table: "orders", name: "order_id" }),
+        columnRow({ table: "orders", name: "amount", type: "Decimal(12, 2)" }),
+      ],
+    });
+
+    const schema = await getSchema(transport, PINNED);
+
+    expect(schema.map((table) => table.columns.map((column) => column.name))).toEqual([
+      ["id"],
+      ["order_id", "amount"],
+      [],
+    ]);
+  });
+
+  // Two databases may each hold a table of the same name, and a same-named
+  // column in both must not be merged onto one of them.
+  test("keeps same-named tables in different databases apart", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ database: "demo", name: "users" }), tableRow({ database: "staging", name: "users" })],
+      columns: [
+        columnRow({ database: "demo", table: "users", name: "id" }),
+        columnRow({ database: "staging", table: "users", name: "legacy_id" }),
+      ],
+    });
+
+    const schema = await getSchema(transport, PINNED);
+
+    expect(schema.map((table) => [table.name, table.columns.map((column) => column.name)])).toEqual([
+      ["users", ["id"]],
+      ["staging.users", ["legacy_id"]],
+    ]);
+  });
+
+  // Live-verified: `CREATE DATABASE `a.b`` is accepted and system.databases
+  // reports the name verbatim, so joining database to table with a dot really
+  // does collide - "a.b" + "c" and "a" + "b.c" produce the same string, and the
+  // two tables would swap columns.
+  test("keeps a dotted database name from colliding with a dotted table name", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ database: "a.b", name: "c" }), tableRow({ database: "a", name: "b.c" })],
+      columns: [
+        columnRow({ database: "a.b", table: "c", name: "from_dotted_database" }),
+        columnRow({ database: "a", table: "b.c", name: "from_dotted_table" }),
+      ],
+    });
+
+    const schema = await getSchema(transport, PINNED);
+
+    expect(schema.map((table) => table.columns.map((column) => column.name))).toEqual([
+      ["from_dotted_database"],
+      ["from_dotted_table"],
+    ]);
+  });
+
+  test.each<[string, string, string | undefined]>([
+    ["", "", undefined],
+    ["DEFAULT", "'x'", "'x'"],
+    // A MATERIALIZED or ALIAS column is computed, not defaulted. Showing the
+    // bare expression would read as a value an INSERT could override.
+    ["MATERIALIZED", "a * 2", "MATERIALIZED a * 2"],
+    ["ALIAS", "a + 1", "ALIAS a + 1"],
+  ])("renders a %s column default", async (kind, expression, expected) => {
+    const { transport } = createTransport({
+      tables: [tableRow()],
+      columns: [columnRow({ default_kind: kind, default_expression: expression })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns[0].defaultValue).toBe(expected);
+  });
+
+  test("ignores a default kind that carries no expression", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow()],
+      columns: [columnRow({ default_kind: "DEFAULT", default_expression: "" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns[0].defaultValue).toBeUndefined();
+  });
+
+  test("skips a column row that names neither a table nor itself", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow()],
+      columns: [columnRow({ name: 7 }), columnRow({ table: null, name: "orphan" }), columnRow({ name: "id" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns.map((column) => column.name)).toEqual(["id"]);
+  });
+
+  test("falls back to an empty declared type when the catalog omits it", async () => {
+    const { transport } = createTransport({ tables: [tableRow()], columns: [columnRow({ type: null })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns[0]).toEqual({ name: "id", type: "", nullable: false, isPrimary: false });
+  });
+});
+
+// ============================================================================
+// Indexes
+// ============================================================================
+
+describe("indexes", () => {
+  // ClickHouse's primary key is a sparse index over the sort order, not a
+  // constraint. Live-verified: three identical values were accepted into a
+  // table declared PRIMARY KEY (a), so `unique` is false as a matter of fact.
+  test("reports the primary key as a non-unique index", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "user_id, order_id", primary_key: "user_id, order_id" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes).toEqual([
+      { name: CLICKHOUSE_PRIMARY_INDEX_NAME, columns: ["user_id", "order_id"], unique: false },
+    ]);
+  });
+
+  // ORDER BY may extend PRIMARY KEY. The extra columns are genuinely part of the
+  // on-disk sort order and drive query planning, so they are reported - but as a
+  // separate entry, because they are not primary-key columns.
+  test("adds the sorting key as its own index when it extends the primary key", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "a, b, cityHash64(c)", primary_key: "(a)" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes).toEqual([
+      { name: CLICKHOUSE_PRIMARY_INDEX_NAME, columns: ["a"], unique: false },
+      { name: CLICKHOUSE_SORTING_INDEX_NAME, columns: ["a", "b", "cityHash64(c)"], unique: false },
+    ]);
+  });
+
+  test("does not repeat the key when the sorting key and the primary key agree", async () => {
+    const { transport } = createTransport({ tables: [tableRow({ sorting_key: "id", primary_key: "id" })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes.map((index) => index.name)).toEqual([CLICKHOUSE_PRIMARY_INDEX_NAME]);
+  });
+
+  // Live-verified rendering: a table declared PRIMARY KEY tuple() ORDER BY x
+  // reports an empty primary_key with a populated sorting_key.
+  test("reports a sorting key that has no primary key at all", async () => {
+    const { transport } = createTransport({ tables: [tableRow({ sorting_key: "id", primary_key: "" })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes).toEqual([{ name: CLICKHOUSE_SORTING_INDEX_NAME, columns: ["id"], unique: false }]);
+  });
+
+  // Live-verified: ORDER BY tuple() and a View both report both keys as "".
+  test("synthesizes nothing for a table with no key", async () => {
+    const { transport } = createTransport({ tables: [tableRow({ sorting_key: "", primary_key: "" })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes).toEqual([]);
+  });
+
+  // Live-verified rendering trap: a one-element key keeps its parentheses
+  // ("(a)") while a multi-element one drops them ("a, b"). Taking the string
+  // verbatim would name a column "(a)".
+  test.each<[string, string[]]>([
+    ["(a)", ["a"]],
+    ["a, b", ["a", "b"]],
+    ["  id  ", ["id"]],
+    // Live-verified: a function call inside the key carries its own commas, so
+    // splitting on every comma yields "cityHash64(c" and "c)".
+    ["a, b, cityHash64(c, c)", ["a", "b", "cityHash64(c, c)"]],
+    // Live-verified: a string literal inside the key carries commas too.
+    ["a, concat(b, 'x, y')", ["a", "concat(b, 'x, y')"]],
+    // Parentheses that do not wrap the whole expression are not a wrapper.
+    ["(a), (b)", ["(a)", "(b)"]],
+  ])("splits the key expression %p at top level only", async (primaryKey, columns) => {
+    const { transport } = createTransport({ tables: [tableRow({ sorting_key: "", primary_key: primaryKey })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes[0].columns).toEqual(columns);
+  });
+
+  test("reports a data-skipping index against the table that owns it", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ name: "orders", sorting_key: "", primary_key: "" }), tableRow({ name: "users" })],
+      indices: [indexRow({ table: "orders", name: "idx_status", expr: "status" })],
+    });
+
+    const schema = await getSchema(transport, PINNED);
+
+    expect(schema[0].indexes).toEqual([{ name: "idx_status", columns: ["status"], unique: false }]);
+    expect(schema[1].indexes.map((index) => index.name)).toEqual([CLICKHOUSE_PRIMARY_INDEX_NAME]);
+  });
+
+  // Live-verified: an expression index renders parenthesised, and a multi-argument
+  // function inside it makes a naive comma split produce two broken column names.
+  test.each<[string, string[]]>([
+    ["(lower(b))", ["lower(b)"]],
+    ["(cityHash64(a, b))", ["cityHash64(a, b)"]],
+    ["a, b", ["a", "b"]],
+  ])("splits the data-skipping index expression %p", async (expr, columns) => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "", primary_key: "" })],
+      indices: [indexRow({ table: "users", expr })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes[0].columns).toEqual(columns);
+  });
+
+  // A data-skipping index prunes granules; it enforces nothing. Nothing in a
+  // ClickHouse schema is unique, so reporting one would be a fabricated
+  // constraint the user could rely on.
+  test("never reports a data-skipping index as unique", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "", primary_key: "" })],
+      indices: [indexRow({ table: "users", name: "idx_email", expr: "email" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes.every((index) => index.unique === false)).toBe(true);
+  });
+
+  test("skips an index row that names neither a table nor itself", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "", primary_key: "" })],
+      indices: [indexRow({ table: "users", name: null }), indexRow({ table: 9, name: "idx_orphan" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes).toEqual([]);
+  });
+
+  test("treats an index row with no expression as covering no column", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "", primary_key: "" })],
+      indices: [indexRow({ table: "users", name: "idx_empty", expr: null })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes).toEqual([{ name: "idx_empty", columns: [], unique: false }]);
+  });
+});
+
+// ============================================================================
+// Foreign keys
+// ============================================================================
+
+describe("foreign keys", () => {
+  // ClickHouse has no foreign keys: no engine, no table setting and no DDL
+  // declares one. Empty here is a fact about the engine, not a load that failed
+  // or was deferred, and the doc says so in the same words.
+  test("are empty because ClickHouse has none", async () => {
+    const { transport } = createTransport({ tables: [tableRow()], columns: [columnRow()] });
+
+    const [fromSchema] = await getSchema(transport, PINNED);
+    const [fromList] = await getSchemaList(transport, PINNED);
+    const [fromRelations] = await getSchemaRelations(transport, PINNED);
+
+    expect(fromSchema.foreignKeys).toEqual([]);
+    expect(fromList.foreignKeys).toEqual([]);
+    expect(fromRelations.foreignKeys).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Table naming (spec 3.4)
+// ============================================================================
+
+describe("table naming", () => {
+  const tables = [
+    tableRow({ database: "demo", name: "users" }),
+    tableRow({ database: "analytics", name: "events" }),
+    tableRow({ database: "default", name: "probe" }),
+  ];
+
+  // A bare name resolves against the connection's pinned database, so
+  // qualifying a table inside it would only add noise; a table outside it must
+  // be qualified or the generated SQL would hit the wrong database.
+  test("qualifies only the tables outside the pinned database", async () => {
+    const { transport } = createTransport({ tables });
+
+    const schema = await getSchema(transport, PINNED);
+
+    expect(schema.map((table) => table.name)).toEqual(["users", "analytics.events", "default.probe"]);
+  });
+
+  test("applies the same rule when the pinned database is default", async () => {
+    const { transport } = createTransport({ tables });
+
+    const schema = await getSchema(transport, "default");
+
+    expect(schema.map((table) => table.name)).toEqual(["demo.users", "analytics.events", "probe"]);
+  });
+
+  test.each<[string]>([["getSchemaList"], ["getSchemaRelations"]])("%s names tables the same way", async (entry) => {
+    const { transport } = createTransport({ tables });
+
+    const rows =
+      entry === "getSchemaList" ? await getSchemaList(transport, PINNED) : await getSchemaRelations(transport, PINNED);
+
+    expect(rows.map((row) => row.name)).toEqual(["users", "analytics.events", "default.probe"]);
+  });
+
+  test("skips a table row that does not name itself", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ name: null }), tableRow({ database: 4, name: "nowhere" }), tableRow({ name: "users" })],
+    });
+
+    const schema = await getSchema(transport, PINNED);
+
+    expect(schema.map((table) => table.name)).toEqual(["users"]);
+  });
+});
+
+// ============================================================================
+// The split reads
+// ============================================================================
+
+describe("getSchemaList", () => {
+  // Its contract is the fast structural read: indexes are getSchemaRelations()'s
+  // job, so the tree renders without waiting on them.
+  test("returns tables and columns but defers every index", async () => {
+    const { transport, calls } = createTransport({
+      tables: [tableRow()],
+      columns: [columnRow({ name: "id", is_in_primary_key: 1 })],
+      indices: [indexRow({ table: "users" })],
+    });
+
+    const [table] = await getSchemaList(transport, PINNED);
+
+    expect(table.columns.map((column) => column.name)).toEqual(["id"]);
+    expect(table.indexes).toEqual([]);
+    expect(table.rowCount).toBe(3);
+    expect(calls.map((call) => surfaceOf(call.sql)).sort()).toEqual(["columns", "tables"]);
+  });
+});
+
+describe("getSchemaRelations", () => {
+  test("returns an entry for every table, including one with no index", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ name: "orders", sorting_key: "", primary_key: "" }), tableRow({ name: "users" })],
+      indices: [indexRow({ table: "users", name: "idx_email", expr: "email" })],
+    });
+
+    const relations = await getSchemaRelations(transport, PINNED);
+
+    expect(relations).toEqual([
+      { name: "orders", foreignKeys: [], indexes: [] },
+      {
+        name: "users",
+        foreignKeys: [],
+        indexes: [
+          { name: CLICKHOUSE_PRIMARY_INDEX_NAME, columns: ["id"], unique: false },
+          { name: "idx_email", columns: ["email"], unique: false },
+        ],
+      },
+    ]);
+  });
+
+  test("does not read the column catalog it has no use for", async () => {
+    const { transport, calls } = createTransport({ tables: [tableRow()] });
+
+    await getSchemaRelations(transport, PINNED);
+
+    expect(calls.map((call) => surfaceOf(call.sql)).sort()).toEqual(["indices", "tables"]);
+  });
+});
+
+// ============================================================================
+// Degradation
+// ============================================================================
+
+describe("degradation", () => {
+  // The live case that makes this mandatory: a user granted SELECT on one table
+  // reads system.tables and system.columns fine (both are pre-filtered to what
+  // is granted) but gets 500 / code 497 from system.data_skipping_indices, which
+  // needs its own grant. Failing the read would cost that user the whole tree.
+  test("keeps the tree when the data-skipping-index catalog is denied", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow()],
+      columns: [columnRow({ name: "id", is_in_primary_key: 1 })],
+      failures: { indices: accessDenied() },
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.columns.map((column) => column.name)).toEqual(["id"]);
+    expect(table.indexes).toEqual([{ name: CLICKHOUSE_PRIMARY_INDEX_NAME, columns: ["id"], unique: false }]);
+  });
+
+  test("keeps the table list when the column catalog is denied", async () => {
+    const { transport } = createTransport({ tables: [tableRow()], failures: { columns: accessDenied() } });
+
+    const schema = await getSchema(transport, PINNED);
+
+    expect(schema.map((table) => table.name)).toEqual(["users"]);
+    expect(schema[0].columns).toEqual([]);
+  });
+
+  test("degrades to an empty tree when the table catalog itself is denied", async () => {
+    const { transport } = createTransport({ tables: [tableRow()], failures: { tables: accessDenied() } });
+
+    await expect(getSchema(transport, PINNED)).resolves.toEqual([]);
+    await expect(getSchemaList(transport, PINNED)).resolves.toEqual([]);
+    await expect(getSchemaRelations(transport, PINNED)).resolves.toEqual([]);
+  });
+
+  // A deployment that does not expose a catalog at all is the same situation as
+  // one the user may not read: nothing to show, not a broken connection.
+  test("degrades when a catalog does not exist on this deployment", async () => {
+    const missing = new ClickHouseTransportError(
+      "Unknown table expression identifier 'system.data_skipping_indices' (UNKNOWN_TABLE)",
+      CLICKHOUSE_ERROR_CODES.UNKNOWN_TABLE,
+      "UNKNOWN_TABLE",
+    );
+    const { transport } = createTransport({ tables: [tableRow()], failures: { indices: missing } });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes).toEqual([{ name: CLICKHOUSE_PRIMARY_INDEX_NAME, columns: ["id"], unique: false }]);
+  });
+
+  // Only "this surface is unavailable" degrades. Anything else is a real
+  // failure, and an empty tree in its place would hide it forever.
+  test.each<[string, ClickHouseTransportError]>([
+    [
+      "a syntax error",
+      new ClickHouseTransportError("Syntax error (SYNTAX_ERROR)", CLICKHOUSE_ERROR_CODES.SYNTAX_ERROR, "SYNTAX_ERROR"),
+    ],
+    [
+      "a rejected credential",
+      new ClickHouseTransportError(
+        "Authentication failed (AUTHENTICATION_FAILED)",
+        CLICKHOUSE_ERROR_CODES.AUTHENTICATION_FAILED,
+        "AUTHENTICATION_FAILED",
+      ),
+    ],
+  ])("propagates %s", async (_label, failure) => {
+    const { transport } = createTransport({ tables: [tableRow()], failures: { tables: failure } });
+
+    await expect(getSchema(transport, PINNED)).rejects.toThrow(failure.message);
+  });
+
+  test("propagates a failure that never reached the server", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow()],
+      failures: { indices: new TypeError("fetch failed") },
+    });
+
+    await expect(getSchema(transport, PINNED)).rejects.toThrow("fetch failed");
+  });
+});

--- a/tests/unit/db/clickhouse/introspect.test.ts
+++ b/tests/unit/db/clickhouse/introspect.test.ts
@@ -494,6 +494,82 @@ describe("indexes", () => {
     ]);
   });
 
+  // A backtick-quoted identifier may legally contain a comma or a parenthesis, and
+  // splitting on those blindly reports one column as two - or, worse, an unbalanced
+  // paren inside quotes corrupts the depth counter and swallows every later
+  // top-level comma.
+  test("keeps a quoted identifier containing a comma as one key column", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "`region,code`, id", primary_key: "`region,code`, id" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes).toEqual([
+      { name: CLICKHOUSE_PRIMARY_INDEX_NAME, columns: ["`region,code`", "id"], unique: false },
+    ]);
+  });
+
+  test("does not let an unbalanced parenthesis inside quotes swallow later commas", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "`a(b`, c", primary_key: "`a(b`, c" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes[0].columns).toEqual(["`a(b`", "c"]);
+  });
+
+  test("treats a doubled quote as an escape rather than the end of the span", async () => {
+    const key = "`a``b,c`, d";
+    const { transport } = createTransport({ tables: [tableRow({ sorting_key: key, primary_key: key })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes[0].columns).toEqual(["`a``b,c`", "d"]);
+  });
+
+  test("treats a backslash as escaping the next character inside a literal", async () => {
+    const key = "concat(a, 'x\\', y'), b";
+    const { transport } = createTransport({ tables: [tableRow({ sorting_key: key, primary_key: key })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes[0].columns).toEqual(["concat(a, 'x\\', y')", "b"]);
+  });
+
+  // An unterminated span is malformed input that cannot be split sensibly; consuming
+  // the rest is the reading that at least never reports a fragment as a column.
+  test("treats an unterminated quote as running to the end", async () => {
+    const key = "`a, b";
+    const { transport } = createTransport({ tables: [tableRow({ sorting_key: key, primary_key: key })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes[0].columns).toEqual(["`a, b"]);
+  });
+
+  // The outer-paren unwrap runs the same scan, so a quoted paren must not fool it
+  // into thinking the wrapper closes early.
+  test("unwraps an outer paren list whose quoted identifier contains a parenthesis", async () => {
+    const key = "(`a(b`, c)";
+    const { transport } = createTransport({ tables: [tableRow({ sorting_key: key, primary_key: key })] });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes[0].columns).toEqual(["`a(b`", "c"]);
+  });
+
+  test("keeps a comma inside a string literal out of the split", async () => {
+    const { transport } = createTransport({
+      tables: [tableRow({ sorting_key: "concat(a, 'x, y'), b", primary_key: "concat(a, 'x, y'), b" })],
+    });
+
+    const [table] = await getSchema(transport, PINNED);
+
+    expect(table.indexes[0].columns).toEqual(["concat(a, 'x, y')", "b"]);
+  });
+
   test("does not repeat the key when the sorting key and the primary key agree", async () => {
     const { transport } = createTransport({ tables: [tableRow({ sorting_key: "id", primary_key: "id" })] });
 

--- a/tests/unit/db/clickhouse/seam-guard.test.ts
+++ b/tests/unit/db/clickhouse/seam-guard.test.ts
@@ -1,0 +1,326 @@
+/**
+ * ClickHouse transport seam guard (issue #264, design spec 3.3)
+ *
+ * The ClickHouse provider is worth building without a client library only while
+ * swapping the transport stays cheap, and it stays cheap only while the HTTP
+ * envelope lives in exactly one file. This test is the mechanism that keeps that
+ * true: it parses every source in the provider directory and fails the build the
+ * moment the wire vocabulary is used outside http-transport.ts. It reads the
+ * directory from disk rather than from a list, so it keeps holding as the provider
+ * grows.
+ *
+ * The guard is a parser, not a grep, and it sorts the vocabulary into two classes
+ * because the two need opposite treatment - established against the live server
+ * (26.7.1.1315) rather than guessed:
+ *
+ *   SELECT DISTINCT name FROM system.columns
+ *   WHERE name IN ('written_rows', 'elapsed_ns', 'statistics',
+ *                  'rows_before_limit_at_least', 'default_format')
+ *
+ * returned `written_rows` (a column of system.processes and system.query_log) and
+ * `statistics` (a column of system.columns) - both surfaces the monitoring and
+ * introspection code legitimately queries by name. Those two are therefore
+ * detected only as a READ off a payload, never as text, so `SELECT written_rows
+ * FROM system.query_log` does not fire. Everything else in the vocabulary exists
+ * nowhere in the server's own schema, so it is matched as text and a mention
+ * anywhere outside the transport is a leak. A guard that cries wolf is a guard the
+ * next contributor deletes, so both directions are proven below: the detector must
+ * light up on the file that is SUPPOSED to speak HTTP, and stay silent on a
+ * compliant one.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+const ROOT = join(import.meta.dir, "..", "..", "..", "..");
+const PROVIDER_DIR = join(ROOT, "src", "lib", "db", "providers", "sql", "clickhouse");
+
+/** The single file allowed to know the wire format. */
+const TRANSPORT_FILE = "http-transport.ts";
+
+/**
+ * Identifiers that exist nowhere in ClickHouse's own schema and nowhere in
+ * English: two request parameters, three response headers, and the one envelope
+ * field the seam deliberately drops (spec 2.6). Naming any of them outside the
+ * transport - in a string, a header lookup or a variable - is a leak, so these are
+ * matched as text, case-insensitively, because `Headers.get` is case-insensitive
+ * and the transport spells them in lower case.
+ */
+const WIRE_TOKENS = [
+  "X-ClickHouse-Summary",
+  "X-ClickHouse-Exception-Code",
+  // How a mid-stream failure is told apart from result data that says
+  // `__exception__` (spec 2.8). Wire vocabulary like any other header.
+  "X-ClickHouse-Exception-Tag",
+  "X-ClickHouse-Format",
+  "default_format",
+  "output_format_json_quote_64bit_integers",
+  "elapsed_ns",
+  "rows_before_limit_at_least",
+];
+
+/**
+ * Envelope and summary fields that are ALSO live column names, so text matching
+ * would fire on legitimate SQL. Reading one off a payload is still a leak: the
+ * neutral result calls them `mutationCount` and `executionTimeMs`.
+ */
+const ENVELOPE_FIELDS = new Set(["written_rows", "statistics"]);
+
+/** Everything the transport must speak, and nothing else may. */
+const WIRE_VOCABULARY = [...WIRE_TOKENS, ...ENVELOPE_FIELDS];
+
+/**
+ * Why the rule exists, printed on failure. Whoever trips this needs to see the
+ * boundary they are crossing, otherwise the cheapest fix looks like deleting the
+ * test.
+ */
+const SEAM_RULE = [
+  `The ClickHouse HTTP envelope leaked out of ${TRANSPORT_FILE}.`,
+  "",
+  "ClickHouse's HTTP interface asks for a format through default_format, reports what it actually",
+  "used in X-ClickHouse-Format, hides the row counts of a write in X-ClickHouse-Summary and wraps",
+  "rows in { meta, data, statistics }. Issue #264 keeps all of that inside the transport: provider",
+  "logic reads the neutral ClickHouseQueryResult (rows, fieldNames, columnTypes, executionTimeMs,",
+  "mutationCount, rawText) through the ClickHouseTransport seam. That is what makes adopting a",
+  "native-protocol client later one new file implementing the same interface, instead of a rewrite of",
+  "the provider, the introspection and the explain strategy.",
+  "",
+  `Fix an access below by mapping the field inside ${TRANSPORT_FILE} and widening ClickHouseQueryResult`,
+  "when the value is genuinely needed. If you tripped this on SQL rather than on the wire - system.processes",
+  "and system.query_log really do have a written_rows column, and system.columns a statistics column - read",
+  "it under an alias (`written_rows AS writtenRows`) so one layer keeps one vocabulary. Do not weaken or",
+  "delete this test: it is the only thing keeping the seam real.",
+  "",
+  "Wire vocabulary outside the transport:",
+].join("\n");
+
+interface WireLeak {
+  file: string;
+  line: number;
+  token: string;
+  snippet: string;
+}
+
+/**
+ * The wire tokens this node spells out.
+ *
+ * Only text carries them: a header lookup (`headers.get("x-clickhouse-format")`),
+ * a parameter (`params.set("default_format", ...)`), a template that builds either,
+ * or an identifier that names one. Comments are trivia rather than nodes, so prose
+ * naming the envelope is deliberately free - the point is that no code depends on
+ * it.
+ */
+function spelledTokens(node: ts.Node): string[] {
+  const carriesText = ts.isStringLiteral(node) || ts.isTemplateLiteralToken(node) || ts.isIdentifier(node);
+  if (!carriesText) return [];
+
+  const text = node.text.toLowerCase();
+  return WIRE_TOKENS.filter((token) => text.includes(token.toLowerCase()));
+}
+
+/**
+ * The payload field this node reads, or null when it reads none.
+ *
+ * Only three syntactic forms take a field off a payload, and all three are a leak
+ * regardless of how the value is spelled afterwards:
+ *
+ *   summary.written_rows / summary?.written_rows   PropertyAccessExpression
+ *   summary["written_rows"]                        ElementAccessExpression, literal key
+ *   const { written_rows } = summary               BindingElement of an object pattern
+ *
+ * A declaration or a constructed literal (`interface E { statistics?: ... }`,
+ * `return { written_rows: 0 }`) is deliberately not a leak: a shape is inert until
+ * something reads it, and the read is what the three forms above catch.
+ */
+function accessedField(node: ts.Node): string | null {
+  if (ts.isPropertyAccessExpression(node)) return node.name.text;
+  if (ts.isElementAccessExpression(node)) {
+    const key = node.argumentExpression;
+    return ts.isStringLiteralLike(key) ? key.text : null;
+  }
+  // Array patterns bind by position, so only an object pattern names a field.
+  if (ts.isBindingElement(node) && ts.isObjectBindingPattern(node.parent)) {
+    const key = node.propertyName ?? node.name;
+    return ts.isIdentifier(key) || ts.isStringLiteralLike(key) ? key.text : null;
+  }
+  return null;
+}
+
+function findWireLeaks(file: string, source: string): WireLeak[] {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const lines = source.split("\n");
+  // One leak per line and token: an element access reports the same token as the
+  // string literal it contains, and reporting it twice reads like two problems.
+  const found = new Map<string, WireLeak>();
+
+  const report = (node: ts.Node, token: string): void => {
+    const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line;
+    found.set(`${line}:${token}`, { file, line: line + 1, token, snippet: lines[line].trim() });
+  };
+
+  const visit = (node: ts.Node): void => {
+    for (const token of spelledTokens(node)) report(node, token);
+
+    const field = accessedField(node);
+    if (field !== null && ENVELOPE_FIELDS.has(field)) report(node, field);
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return [...found.values()].sort((a, b) => a.line - b.line);
+}
+
+/** Empty when the seam holds; the rule plus every offending line when it does not. */
+function violationReport(leaks: WireLeak[]): string {
+  if (leaks.length === 0) return "";
+
+  const offences = leaks.map((leak) => `  ${leak.file}:${leak.line} uses "${leak.token}" -> ${leak.snippet}`);
+  return [SEAM_RULE, ...offences].join("\n");
+}
+
+function providerSources(): string[] {
+  return readdirSync(PROVIDER_DIR, { recursive: true })
+    .map(String)
+    .filter((name) => name.endsWith(".ts"))
+    .sort();
+}
+
+function readProviderSource(file: string): string {
+  return readFileSync(join(PROVIDER_DIR, file), "utf8");
+}
+
+describe("ClickHouse transport seam", () => {
+  const sources = providerSources();
+
+  test("the guard scans the whole provider directory", () => {
+    expect(sources).toContain(TRANSPORT_FILE);
+    expect(sources.length).toBeGreaterThan(1);
+  });
+
+  // A detector that finds nothing anywhere is indistinguishable from a broken one,
+  // so the file that is SUPPOSED to speak HTTP must light it up - every token,
+  // including the one the seam deliberately drops, because the transport is also
+  // the record of what the wire contains.
+  test.each(WIRE_VOCABULARY)("the transport itself uses %s, proving the detector reads real code", (token) => {
+    const tokens = findWireLeaks(TRANSPORT_FILE, readProviderSource(TRANSPORT_FILE)).map((leak) => leak.token);
+
+    expect(tokens).toContain(token);
+  });
+
+  test(`the HTTP envelope is used only in ${TRANSPORT_FILE}`, () => {
+    const leaks = sources
+      .filter((file) => file !== TRANSPORT_FILE)
+      .flatMap((file) => findWireLeaks(file, readProviderSource(file)));
+
+    expect(violationReport(leaks)).toBe("");
+  });
+});
+
+describe("the seam guard detector", () => {
+  /**
+   * Everything a compliant provider file legitimately does: name the envelope in
+   * prose, read the neutral result, query the system tables whose columns happen
+   * to share a name with a summary field, and keep a local called `statistics`.
+   * None of it is a leak, and none of it may fire.
+   */
+  const COMPLIANT_SAMPLE = `
+/**
+ * Prose may name the envelope: X-ClickHouse-Summary, default_format and
+ * rows_before_limit_at_least all stay behind the seam. Even summary.written_rows
+ * written in a comment is prose.
+ */
+import type { ClickHouseTransport } from "./transport";
+
+const SLOW_QUERIES = "SELECT query, written_rows, query_duration_ms FROM system.query_log";
+const RUNNING = "SELECT query_id, elapsed, written_rows FROM system.processes";
+const COLUMN_STATS = "SELECT name, type, statistics FROM system.columns WHERE database = {db:String}";
+
+export async function slowQueries(transport: ClickHouseTransport, field: string) {
+  const result = await transport.query(SLOW_QUERIES);
+  const { rows, fieldNames, columnTypes } = result;
+  const statistics = rows.map((row) => row[field]);
+  const elapsedNs = result.executionTimeMs * 1e6;
+  return { rows, fieldNames, columnTypes, statistics, elapsedNs, written: result.mutationCount, RUNNING, COLUMN_STATS };
+}
+`;
+
+  const VIOLATING_SAMPLE = `
+export function readEnvelope(payload: Record<string, unknown>, headers: Headers) {
+  const { statistics } = payload;
+  const format = headers.get("X-ClickHouse-Format");
+  return { format, statistics, written: payload["written_rows"], limit: payload.rows_before_limit_at_least };
+}
+`;
+
+  test("passes a file that stays behind the seam", () => {
+    expect(findWireLeaks("introspect.ts", COMPLIANT_SAMPLE)).toEqual([]);
+  });
+
+  test("fails a file that speaks the wire, once per line and token", () => {
+    const leaks = findWireLeaks("index.ts", VIOLATING_SAMPLE);
+
+    expect(leaks.map((leak) => leak.token)).toEqual([
+      "statistics",
+      "X-ClickHouse-Format",
+      "written_rows",
+      "rows_before_limit_at_least",
+    ]);
+    expect(leaks[1].line).toBe(4);
+    expect(leaks[3].snippet).toBe(
+      'return { format, statistics, written: payload["written_rows"], limit: payload.rows_before_limit_at_least };',
+    );
+  });
+
+  test.each<[string, string, string]>([
+    ["a header read", 'const s = headers.get("x-clickhouse-summary");', "X-ClickHouse-Summary"],
+    ["an exception header read", 'headers.get("X-ClickHouse-Exception-Code");', "X-ClickHouse-Exception-Code"],
+    ["a request parameter", 'params.set("default_format", "JSON");', "default_format"],
+    [
+      "the 64-bit setting",
+      'url += "&output_format_json_quote_64bit_integers=1";',
+      "output_format_json_quote_64bit_integers",
+    ],
+    ["a token built into a template", "const u = `${base}?default_format=JSON`;", "default_format"],
+    ["a variable named after a summary field", "const elapsed_ns = 1;", "elapsed_ns"],
+    ["a member access on the summary", "const n = summary.written_rows;", "written_rows"],
+    ["an optional-chained access", "const e = envelope?.statistics;", "statistics"],
+    ["a bracket access with a literal key", 'const n = summary["written_rows"];', "written_rows"],
+    ["a destructured field", "const { statistics } = envelope;", "statistics"],
+    ["a renamed destructured field", "const { written_rows: n } = summary;", "written_rows"],
+  ])("flags %s", (_label, source, token) => {
+    const [leak, ...rest] = findWireLeaks("index.ts", source);
+
+    expect(rest).toEqual([]);
+    expect(leak.token).toBe(token);
+    expect(leak.line).toBe(1);
+  });
+
+  test.each([
+    ["a system column of the same name in SQL", 'const q = "SELECT written_rows FROM system.query_log";'],
+    ["the statistics column of system.columns", 'const q = "SELECT statistics FROM system.columns";'],
+    ["a near-miss column name", 'const q = "SELECT elapsed FROM system.processes";'],
+    ["a camelCase name that is not the wire spelling", "const elapsedNs = summary.elapsed * 1e9;"],
+    ["a local variable that shares a name", "const statistics = rows.slice(0, 10);"],
+    ["an array destructuring binding", "const [statistics, rest] = tuple;"],
+    ["a computed key that is not a literal", "const value = payload[field];"],
+    ["a constructed object, which declares rather than reads", "return { statistics: null, rows };"],
+    ["an interface member, which is inert until something reads it", "interface E { statistics?: number }"],
+  ])("does not flag %s", (_label, source) => {
+    expect(findWireLeaks("index.ts", source)).toEqual([]);
+  });
+
+  test("reports nothing when the seam holds", () => {
+    expect(violationReport([])).toBe("");
+  });
+
+  test("the failure report explains the rule and points at the issue", () => {
+    const report = violationReport(findWireLeaks("index.ts", "const n = summary.written_rows;"));
+
+    expect(report).toContain("#264");
+    expect(report).toContain(TRANSPORT_FILE);
+    expect(report).toContain("ClickHouseQueryResult");
+    expect(report).toContain('index.ts:1 uses "written_rows" -> const n = summary.written_rows;');
+  });
+});

--- a/tests/unit/db/clickhouse/transport.test.ts
+++ b/tests/unit/db/clickhouse/transport.test.ts
@@ -1,0 +1,245 @@
+/**
+ * ClickHouse transport seam (issue #264, design spec section 3.3)
+ *
+ * Almost all of transport.ts is type declarations, which erase at build time.
+ * What survives is the vocabulary every other file in the provider switches on:
+ * the frozen exception-code table and the normalized error. Those are pinned
+ * here, ahead of the transport and the provider, because a wrong code silently
+ * turns a degradation path into a thrown error (or the reverse).
+ *
+ * The numbering is not transcribed from documentation. It was read back from the
+ * live server (ClickHouse 26.7.1.1315) with
+ *   SELECT number, errorCodeToName(toUInt32(number)) FROM numbers(1500)
+ * which is why ACCESS_DENIED is 497 and not one of the neighbouring codes.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  CLICKHOUSE_ERROR_CODES,
+  CLICKHOUSE_UNKNOWN_ERROR_NAME,
+  type ClickHouseErrorName,
+  type ClickHouseQueryOptions,
+  type ClickHouseQueryResult,
+  type ClickHouseRow,
+  ClickHouseTransportError,
+  type ClickHouseTransport,
+} from "@/lib/db/providers/sql/clickhouse/transport";
+
+/** Every name in the frozen table, so a new code cannot escape the matrix below. */
+const ERROR_NAMES = Object.keys(CLICKHOUSE_ERROR_CODES) as ClickHouseErrorName[];
+
+function errorWithCode(code: number, name = "IRRELEVANT"): ClickHouseTransportError {
+  return new ClickHouseTransportError(`Code: ${code}. DB::Exception: probe`, code, name);
+}
+
+// ============================================================================
+// The shared code table
+// ============================================================================
+
+describe("CLICKHOUSE_ERROR_CODES", () => {
+  test("carries exactly the codes read back from the live server", () => {
+    expect(CLICKHOUSE_ERROR_CODES).toEqual({
+      NOT_IMPLEMENTED: 48,
+      UNKNOWN_TABLE: 60,
+      SYNTAX_ERROR: 62,
+      UNKNOWN_DATABASE: 81,
+      ACCESS_DENIED: 497,
+      AUTHENTICATION_FAILED: 516,
+    });
+  });
+
+  test("maps every name to a distinct code", () => {
+    const codes = Object.values(CLICKHOUSE_ERROR_CODES);
+
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  // A consumer that can retune a code at runtime makes the table advisory, and
+  // the whole point of exporting it is that there is one definition.
+  test("is frozen, so no consumer can retune a code", () => {
+    const mutable = CLICKHOUSE_ERROR_CODES as unknown as Record<string, number>;
+
+    expect(Object.isFrozen(CLICKHOUSE_ERROR_CODES)).toBe(true);
+    expect(() => {
+      mutable.UNKNOWN_TABLE = 1;
+    }).toThrow(TypeError);
+    expect(CLICKHOUSE_ERROR_CODES.UNKNOWN_TABLE).toBe(60);
+  });
+});
+
+// ============================================================================
+// The normalized error
+// ============================================================================
+
+describe("ClickHouseTransportError", () => {
+  test("is a real Error carrying the code and the message the server reported", () => {
+    const error = new ClickHouseTransportError("Unknown table expression identifier 'nope'", 60, "UNKNOWN_TABLE");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ClickHouseTransportError);
+    expect(error.code).toBe(60);
+    expect(error.message).toBe("Unknown table expression identifier 'nope'");
+  });
+
+  // `name` deliberately holds ClickHouse's own symbol instead of the class name.
+  // It is the vocabulary a ClickHouse user already knows from clickhouse-client,
+  // and the class is recoverable through instanceof, which nothing else is.
+  test("uses the ClickHouse exception name as the error name", () => {
+    expect(new ClickHouseTransportError("boom", 62, "SYNTAX_ERROR").name).toBe("SYNTAX_ERROR");
+  });
+
+  test("falls back to a generic name when there was no exception name to read", () => {
+    const error = new ClickHouseTransportError("socket hang up", 0);
+
+    expect(error.name).toBe(CLICKHOUSE_UNKNOWN_ERROR_NAME);
+    expect(error.code).toBe(0);
+  });
+
+  // Subclassing a builtin loses the prototype under some downlevel emits, which
+  // would make every `catch` in the provider fall through to the generic path.
+  test("survives being thrown and caught", () => {
+    try {
+      throw new ClickHouseTransportError("nope", 81, "UNKNOWN_DATABASE");
+    } catch (caught) {
+      expect(caught).toBeInstanceOf(ClickHouseTransportError);
+      expect((caught as ClickHouseTransportError).code).toBe(81);
+    }
+  });
+
+  // Verified live: a query that fails mid-result reports code 395
+  // (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO), far outside the named table. The
+  // named codes are the ones the provider branches on, not the only legal ones.
+  test("accepts a code that is not in the named table", () => {
+    const error = errorWithCode(395, "FUNCTION_THROW_IF_VALUE_IS_NON_ZERO");
+
+    expect(error.code).toBe(395);
+    expect(ERROR_NAMES.some((name) => error.is(name))).toBe(false);
+    expect(error.isMonitoringUnavailable()).toBe(false);
+  });
+});
+
+describe("ClickHouseTransportError.is", () => {
+  test.each(ERROR_NAMES)("recognises %s and rejects every other name", (name) => {
+    const error = errorWithCode(CLICKHOUSE_ERROR_CODES[name]);
+
+    expect(error.is(name)).toBe(true);
+    expect(ERROR_NAMES.filter((other) => other !== name).some((other) => error.is(other))).toBe(false);
+  });
+
+  // The numeric code is a discrete field the server reports; the symbolic name
+  // has to be scraped out of the message prose and can therefore be missing or
+  // wrong. Matching on the code is what keeps the provider's branches reliable.
+  test("matches on the code even when the name says something else", () => {
+    const error = new ClickHouseTransportError("Code: 60. DB::Exception: mislabelled", 60, "SOMETHING_ELSE");
+
+    expect(error.is("UNKNOWN_TABLE")).toBe(true);
+    expect(error.name).toBe("SOMETHING_ELSE");
+  });
+});
+
+describe("ClickHouseTransportError.isMonitoringUnavailable", () => {
+  // Spec 1.6 / 3.7: a restricted user is the normal case, and query_log is
+  // absent on plenty of deployments. Both must degrade to an empty panel.
+  test.each<[ClickHouseErrorName]>([
+    ["ACCESS_DENIED"],
+    ["UNKNOWN_TABLE"],
+  ])("treats %s as an unavailable monitoring surface", (name) => {
+    expect(errorWithCode(CLICKHOUSE_ERROR_CODES[name]).isMonitoringUnavailable()).toBe(true);
+  });
+
+  // These are the user's own mistakes. Swallowing them would hide a real failure
+  // behind an empty panel, which is the opposite of the honesty rule.
+  test.each<[ClickHouseErrorName]>([
+    ["SYNTAX_ERROR"],
+    ["UNKNOWN_DATABASE"],
+    ["AUTHENTICATION_FAILED"],
+    ["NOT_IMPLEMENTED"],
+  ])("does not swallow %s", (name) => {
+    expect(errorWithCode(CLICKHOUSE_ERROR_CODES[name]).isMonitoringUnavailable()).toBe(false);
+  });
+});
+
+// ============================================================================
+// The seam contract
+// ============================================================================
+
+describe("the ClickHouseTransport contract", () => {
+  /** A transport built out of nothing but the neutral types, proving they suffice. */
+  class RecordingTransport implements ClickHouseTransport {
+    readonly kind = "http" as const;
+    readonly calls: { sql: string; opts?: ClickHouseQueryOptions }[] = [];
+    closed = false;
+
+    constructor(private readonly result: ClickHouseQueryResult) {}
+
+    async query(sql: string, opts?: ClickHouseQueryOptions): Promise<ClickHouseQueryResult> {
+      this.calls.push({ sql, opts });
+      return this.result;
+    }
+
+    async close(): Promise<void> {
+      this.closed = true;
+    }
+  }
+
+  const rows: ClickHouseRow[] = [{ id: 1, big: "18446744073709551615" }];
+
+  const jsonResult: ClickHouseQueryResult = {
+    rows,
+    fieldNames: ["id", "big"],
+    // Declared types are carried verbatim (spec 1.7), wrappers included.
+    columnTypes: { id: "Int32", big: "UInt64" },
+    executionTimeMs: 3,
+    mutationCount: 0,
+    rawText: null,
+  };
+
+  test("a result describes its rows, their order and their declared types", async () => {
+    const transport = new RecordingTransport(jsonResult);
+
+    const result = await transport.query("SELECT id, big FROM probe", { database: "demo" });
+
+    expect(transport.kind).toBe("http");
+    expect(result.rows).toEqual(rows);
+    expect(result.fieldNames).toEqual(["id", "big"]);
+    expect(result.columnTypes).toEqual({ id: "Int32", big: "UInt64" });
+    expect(result.rawText).toBeNull();
+  });
+
+  test("options retarget the database and add per-statement settings", async () => {
+    const transport = new RecordingTransport(jsonResult);
+
+    await transport.query("SELECT 1", { database: "other", settings: { max_execution_time: 5, readonly: true } });
+
+    expect(transport.calls).toEqual([
+      { sql: "SELECT 1", opts: { database: "other", settings: { max_execution_time: 5, readonly: true } } },
+    ]);
+  });
+
+  // Spec 1.2: an explicit FORMAT in the user's SQL wins, so a result is not
+  // always tabular. The seam represents that without a wire-shaped field.
+  test("a non-tabular result is carried as text with nothing described", async () => {
+    const transport = new RecordingTransport({
+      rows: [],
+      fieldNames: null,
+      columnTypes: null,
+      executionTimeMs: 1,
+      mutationCount: 0,
+      rawText: "1\n",
+    });
+
+    const result = await transport.query("SELECT 1 FORMAT TSV");
+
+    expect(result.rawText).toBe("1\n");
+    expect(result.rows).toEqual([]);
+    expect(result.fieldNames).toBeNull();
+    expect(result.columnTypes).toBeNull();
+  });
+
+  test("close is part of the contract even when a transport holds nothing open", async () => {
+    const transport = new RecordingTransport(jsonResult);
+
+    await transport.close();
+
+    expect(transport.closed).toBe(true);
+  });
+});

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -277,6 +277,7 @@ describe("createDatabaseProvider", () => {
   test("the unknown-type error lists every supported type", async () => {
     const conn = makeConnection("unknown");
     await expect(createDatabaseProvider(conn)).rejects.toThrow(/couchbase/);
+    await expect(createDatabaseProvider(conn)).rejects.toThrow(/clickhouse/);
   });
 
   test('creates provider for type "postgres"', async () => {
@@ -334,6 +335,13 @@ describe("createDatabaseProvider", () => {
     const provider = await createDatabaseProvider(conn);
     expect(provider).toBeDefined();
     expect(provider.type).toBe("couchbase");
+  });
+
+  test('creates provider for type "clickhouse"', async () => {
+    const conn = makeConnection("clickhouse", { port: 8123, database: "demo" });
+    const provider = await createDatabaseProvider(conn);
+    expect(provider).toBeDefined();
+    expect(provider.type).toBe("clickhouse");
   });
 
   test('creates provider for type "libredb"', async () => {

--- a/tests/unit/lib/connection-string-parser.test.ts
+++ b/tests/unit/lib/connection-string-parser.test.ts
@@ -360,8 +360,16 @@ describe("parseConnectionString", () => {
       expect(parseConnectionString("https://ch.example.clickhouse.cloud/default")!.sslMode).toBe("require");
     });
 
-    test("leaves the TLS intent unset for the plaintext schemes", () => {
-      expect(parseConnectionString("http://ch-host:8123/demo")!.sslMode).toBeUndefined();
+    // http:// is an explicit choice, not an absent one: pasting it must be able to
+    // turn TLS OFF, or a form still holding "require" from a previous edit would
+    // send HTTPS to a plaintext endpoint.
+    test("carries the plaintext intent of an http:// endpoint", () => {
+      expect(parseConnectionString("http://ch-host:8123/demo")!.sslMode).toBe("disable");
+    });
+
+    // clickhouse:// names no transport, so it is the one scheme that must defer to
+    // whatever TLS setting the form already carries.
+    test("leaves the TLS intent unset for the scheme-neutral clickhouse:// form", () => {
       expect(parseConnectionString("clickhouse://ch-host:8123/demo")!.sslMode).toBeUndefined();
     });
 

--- a/tests/unit/lib/connection-string-parser.test.ts
+++ b/tests/unit/lib/connection-string-parser.test.ts
@@ -305,6 +305,85 @@ describe("parseConnectionString", () => {
     });
   });
 
+  // ── ClickHouse ──────────────────────────────────────────────────────────
+
+  describe("clickhouse://, http:// and https:// URLs", () => {
+    test("parses a full clickhouse:// URL", () => {
+      const result = parseConnectionString("clickhouse://libredb:password123@127.0.0.1:8123/demo");
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe("clickhouse");
+      expect(result!.host).toBe("127.0.0.1");
+      expect(result!.port).toBe("8123");
+      expect(result!.user).toBe("libredb");
+      expect(result!.password).toBe("password123");
+      expect(result!.database).toBe("demo");
+    });
+
+    test("uses the HTTP port 8123 when clickhouse:// omits it, not the native 9000", () => {
+      const result = parseConnectionString("clickhouse://libredb:pass@ch-host/demo");
+      expect(result!.type).toBe("clickhouse");
+      expect(result!.host).toBe("ch-host");
+      expect(result!.port).toBe("8123");
+    });
+
+    test("parses a plain http:// endpoint as ClickHouse", () => {
+      const result = parseConnectionString("http://libredb:password123@localhost:18123/demo");
+      expect(result!.type).toBe("clickhouse");
+      expect(result!.port).toBe("18123");
+      expect(result!.database).toBe("demo");
+    });
+
+    test("uses 8123 for an http:// endpoint with no port", () => {
+      const result = parseConnectionString("http://ch-host/demo");
+      expect(result!.type).toBe("clickhouse");
+      expect(result!.port).toBe("8123");
+      expect(result!.user).toBeUndefined();
+      expect(result!.password).toBeUndefined();
+    });
+
+    test("uses 8443 for an https:// endpoint with no port", () => {
+      const result = parseConnectionString("https://ch.example.clickhouse.cloud/default");
+      expect(result!.type).toBe("clickhouse");
+      expect(result!.host).toBe("ch.example.clickhouse.cloud");
+      expect(result!.port).toBe("8443");
+      expect(result!.database).toBe("default");
+    });
+
+    test("respects an explicit port on an https:// endpoint", () => {
+      const result = parseConnectionString("https://user:pass@ch.example.clickhouse.cloud:9440/default");
+      expect(result!.port).toBe("9440");
+    });
+
+    // Without this the fields alone cannot express TLS, so a pasted ClickHouse Cloud
+    // URL would connect as plaintext HTTP to an https port and fail opaquely.
+    test("carries the TLS intent of an https:// endpoint", () => {
+      expect(parseConnectionString("https://ch.example.clickhouse.cloud/default")!.sslMode).toBe("require");
+    });
+
+    test("leaves the TLS intent unset for the plaintext schemes", () => {
+      expect(parseConnectionString("http://ch-host:8123/demo")!.sslMode).toBeUndefined();
+      expect(parseConnectionString("clickhouse://ch-host:8123/demo")!.sslMode).toBeUndefined();
+    });
+
+    test("leaves the database undefined when the URL carries no path", () => {
+      const result = parseConnectionString("clickhouse://ch-host:8123");
+      expect(result!.type).toBe("clickhouse");
+      expect(result!.database).toBeUndefined();
+    });
+
+    test("decodes URL-encoded credentials", () => {
+      const result = parseConnectionString("https://user%40corp:p%40ss%23word@ch-host/demo");
+      expect(result!.user).toBe("user@corp");
+      expect(result!.password).toBe("p@ss#word");
+    });
+
+    test("returns null for a malformed ClickHouse URL", () => {
+      expect(parseConnectionString("clickhouse://:::bad")).toBeNull();
+      expect(parseConnectionString("http://:::bad")).toBeNull();
+      expect(parseConnectionString("https://:::bad")).toBeNull();
+    });
+  });
+
   // ── ADO.NET format ──────────────────────────────────────────────────────
 
   describe("ADO.NET format", () => {
@@ -422,6 +501,17 @@ describe("detectConnectionStringType", () => {
 
   test("detects couchbases://", () => {
     expect(detectConnectionStringType("couchbases://cb.abc123.cloud.couchbase.com")).toBe("couchbase");
+  });
+
+  test("detects clickhouse://", () => {
+    expect(detectConnectionStringType("clickhouse://host")).toBe("clickhouse");
+  });
+
+  test("detects a bare http:// and https:// endpoint as clickhouse", () => {
+    // ClickHouse is the only provider addressed over plain HTTP, so the generic
+    // schemes are unambiguous.
+    expect(detectConnectionStringType("http://host:8123/demo")).toBe("clickhouse");
+    expect(detectConnectionStringType("https://ch.example.clickhouse.cloud")).toBe("clickhouse");
   });
 
   test("detects ADO.NET Server= format", () => {

--- a/tests/unit/lib/db-icons.test.tsx
+++ b/tests/unit/lib/db-icons.test.tsx
@@ -11,6 +11,7 @@ import {
   MSSQLIcon,
   LibreDBIcon,
   CouchbaseIcon,
+  ClickHouseIcon,
 } from "@/components/icons/db-icons";
 
 describe("db-icons", () => {
@@ -24,6 +25,7 @@ describe("db-icons", () => {
     { name: "MSSQLIcon", Component: MSSQLIcon },
     { name: "LibreDBIcon", Component: LibreDBIcon },
     { name: "CouchbaseIcon", Component: CouchbaseIcon },
+    { name: "ClickHouseIcon", Component: ClickHouseIcon },
   ];
 
   for (const { name, Component } of icons) {
@@ -38,6 +40,16 @@ describe("db-icons", () => {
         React.createElement(Component, { "data-testid": `icon-${name}` } as React.SVGAttributes<SVGSVGElement>),
       );
       expect(html).toContain(`data-testid="icon-${name}"`);
+    });
+
+    test(`${name} follows the embedded-mode icon contract`, () => {
+      // .claude/rules/platform-integration.md: DB marks scale from the className alone
+      // at stroke weight 1.5. An HTML width/height attribute would win over platform's
+      // size classes, so the icon would render at 24px inside libredb-platform only.
+      const html = renderToStaticMarkup(React.createElement(Component, { className: "w-3.5 h-3.5" }));
+      expect(html).toContain('stroke-width="1.5"');
+      expect(html).not.toMatch(/\swidth="/);
+      expect(html).not.toMatch(/\sheight="/);
     });
   }
 });

--- a/tests/unit/lib/db-ui-config.test.ts
+++ b/tests/unit/lib/db-ui-config.test.ts
@@ -12,6 +12,7 @@ const ALL_TYPES: DatabaseType[] = [
   "mssql",
   "libredb",
   "couchbase",
+  "clickhouse",
 ];
 
 describe("db-ui-config", () => {
@@ -39,9 +40,10 @@ describe("db-ui-config", () => {
     });
 
     test("exposes the connection string toggle only for the URI-addressed providers", () => {
-      // MongoDB (mongodb+srv) and Couchbase (couchbase://, couchbases://) are the
-      // providers a user routinely has a full URI for; everything else is field-based.
-      const withToggle = new Set<DatabaseType>(["mongodb", "couchbase"]);
+      // MongoDB (mongodb+srv), Couchbase (couchbase://, couchbases://) and ClickHouse
+      // (its HTTP endpoint is itself a URL) are the providers a user routinely has a
+      // full URI for; everything else is field-based.
+      const withToggle = new Set<DatabaseType>(["mongodb", "couchbase", "clickhouse"]);
       for (const type of ALL_TYPES) {
         expect(getDBConfig(type).showConnectionStringToggle).toBe(withToggle.has(type));
       }
@@ -51,6 +53,19 @@ describe("db-ui-config", () => {
       expect(getDBConfig("couchbase").label).toBe("Couchbase");
       expect(getDBConfig("couchbase").defaultPort).toBe("8091");
       expect(getDBConfig("couchbase").connectionFields).toEqual([
+        "host",
+        "port",
+        "user",
+        "password",
+        "database",
+        "connectionString",
+      ]);
+    });
+
+    test("clickhouse exposes its label, HTTP port and connection fields", () => {
+      expect(getDBConfig("clickhouse").label).toBe("ClickHouse");
+      expect(getDBConfig("clickhouse").defaultPort).toBe("8123");
+      expect(getDBConfig("clickhouse").connectionFields).toEqual([
         "host",
         "port",
         "user",
@@ -100,6 +115,7 @@ describe("db-ui-config", () => {
       expect(isFileBased("oracle")).toBe(false);
       expect(isFileBased("mssql")).toBe(false);
       expect(isFileBased("couchbase")).toBe(false);
+      expect(isFileBased("clickhouse")).toBe(false);
     });
   });
 });

--- a/tests/unit/lib/explain/clickhouse-json.test.ts
+++ b/tests/unit/lib/explain/clickhouse-json.test.ts
@@ -1,0 +1,371 @@
+import { describe, test, expect } from "bun:test";
+import { getExplainStrategy } from "@/lib/explain";
+import { clickhouseJsonStrategy } from "@/lib/explain/clickhouse-json";
+import type { ExplainTreeNode } from "@/lib/explain/types";
+
+// Captured verbatim from ClickHouse 26.7.1.1315 for
+// `EXPLAIN json = 1, indexes = 1 SELECT id, email FROM users WHERE id > 1 ORDER BY email LIMIT 10`.
+// The outer array with a single { Plan } member, the "Plans" child arrays and the
+// "Indexes" array on ReadFromMergeTree are all exactly as the server emits them.
+const LIVE_PLAN = [
+  {
+    Plan: {
+      "Node Type": "Expression",
+      "Node Id": "Expression_7",
+      Description: "Project names",
+      Plans: [
+        {
+          "Node Type": "Limit",
+          "Node Id": "Limit_6",
+          Description: "preliminary LIMIT",
+          Plans: [
+            {
+              "Node Type": "Sorting",
+              "Node Id": "Sorting_5",
+              Description: "Sorting for ORDER BY",
+              Plans: [
+                {
+                  "Node Type": "Expression",
+                  "Node Id": "Expression_9",
+                  Description: "(Before ORDER BY + Projection)",
+                  Plans: [
+                    {
+                      "Node Type": "Expression",
+                      "Node Id": "Expression_10",
+                      Description: "(WHERE + Change column names to column identifiers)",
+                      Plans: [
+                        {
+                          "Node Type": "ReadFromMergeTree",
+                          "Node Id": "ReadFromMergeTree_0",
+                          Description: "demo.users",
+                          Indexes: [
+                            {
+                              Type: "PrimaryKey",
+                              Keys: ["id"],
+                              Condition: "(id in [2, +Inf))",
+                              "Search Algorithm": "binary search",
+                              "Initial Parts": 1,
+                              "Selected Parts": 1,
+                              "Initial Granules": 1,
+                              "Selected Granules": 1,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+// Also live: `EXPLAIN json = 1, indexes = 1 SELECT count() FROM orders WHERE status = 'paid' GROUP BY user_id`.
+// One ReadFromMergeTree carries four Indexes entries, and the data-skipping one adds
+// "Name"/"Description" plus the only non-trivial pruning numbers in the payload.
+const LIVE_INDEXES = [
+  {
+    Type: "Min-Max",
+    Condition: "true",
+    "Initial Parts": 3,
+    "Selected Parts": 3,
+    "Initial Granules": 3,
+    "Selected Granules": 3,
+  },
+  {
+    Type: "Partition",
+    Condition: "true",
+    "Initial Parts": 3,
+    "Selected Parts": 3,
+    "Initial Granules": 3,
+    "Selected Granules": 3,
+  },
+  {
+    Type: "PrimaryKey",
+    Condition: "true",
+    "Initial Parts": 3,
+    "Selected Parts": 3,
+    "Initial Granules": 3,
+    "Selected Granules": 3,
+  },
+  {
+    Type: "Skip",
+    Name: "idx_status",
+    Description: "set GRANULARITY 4",
+    Condition: "(status in ['paid', 'paid'])",
+    "Initial Parts": 3,
+    "Selected Parts": 0,
+    "Initial Granules": 3,
+    "Selected Granules": 0,
+  },
+];
+
+// Live shape for an INNER JOIN: "Plans" holds two children, and a node may omit "Description".
+const LIVE_JOIN_PLAN = [
+  {
+    Plan: {
+      "Node Type": "Expression",
+      "Node Id": "Expression_20",
+      Plans: [
+        {
+          "Node Type": "Join",
+          "Node Id": "Join_18",
+          Description: "JOIN FillRightFirst",
+          Plans: [
+            { "Node Type": "Expression", "Node Id": "Expression_16", Description: "Left Pre Join Actions" },
+            { "Node Type": "Expression", "Node Id": "Expression_17", Description: "Right Pre Join Actions" },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+/** The wire shape: one row, one String column named "explain" whose value is the plan as JSON text. */
+function explainResult(plan: unknown): { rows: Array<Record<string, unknown>> } {
+  return { rows: [{ explain: JSON.stringify(plan) }] };
+}
+
+function treeRoot(raw: unknown): ExplainTreeNode {
+  const model = clickhouseJsonStrategy.toRenderModel(raw);
+  expect(model?.kind).toBe("tree");
+  return (model as { root: ExplainTreeNode }).root;
+}
+
+/** Follows first children down from the root, collecting every label on the way. */
+function spineLabels(root: ExplainTreeNode): string[] {
+  const labels: string[] = [];
+  for (let node: ExplainTreeNode | undefined = root; node !== undefined; node = node.children[0]) {
+    labels.push(node.label);
+  }
+  return labels;
+}
+
+function readFromMergeTree(raw: unknown): ExplainTreeNode {
+  const node = spineNode(treeRoot(raw), 5);
+  expect(node.label).toBe("ReadFromMergeTree: demo.users");
+  return node;
+}
+
+function spineNode(root: ExplainTreeNode, depth: number): ExplainTreeNode {
+  let node = root;
+  for (let step = 0; step < depth; step++) {
+    node = node.children[0];
+    expect(node).toBeDefined();
+  }
+  return node;
+}
+
+/** Builds a plan whose single ReadFromMergeTree node carries the given Indexes payload. */
+function planWithIndexes(indexes: unknown): unknown {
+  return [{ Plan: { "Node Type": "ReadFromMergeTree", Description: "demo.orders", Indexes: indexes } }];
+}
+
+describe("clickhouseJsonStrategy", () => {
+  test("format id", () => {
+    expect(clickhouseJsonStrategy.format).toBe("clickhouse-json");
+  });
+
+  test("is registered in the explain registry", () => {
+    expect(getExplainStrategy("clickhouse-json")).toBe(clickhouseJsonStrategy);
+  });
+
+  // actions = 1 is deliberately absent: it inflated a two-table join plan roughly
+  // tenfold on the live server and adds only expression internals the tree model
+  // cannot render.
+  test("buildSql asks for the JSON plan with index details and nothing else", () => {
+    expect(clickhouseJsonStrategy.buildSql("SELECT id FROM users", "estimate")).toBe(
+      "EXPLAIN json = 1, indexes = 1 SELECT id FROM users",
+    );
+    expect(clickhouseJsonStrategy.buildSql("  SELECT 1", "estimate")).toBe("EXPLAIN json = 1, indexes = 1   SELECT 1");
+  });
+
+  // ClickHouse EXPLAIN never executes the statement, so there is no analyze
+  // equivalent to build. Returning null instead would kill the Explain button
+  // outright: the direct action always builds with mode "analyze"
+  // (use-query-execution.ts:165) and refuses the run when the strategy declines.
+  // sqlite-queryplan.ts and couchbase-json.ts return the estimate for both modes
+  // for the same reason.
+  test("buildSql returns the estimate plan in analyze mode, matching the SQLite and Couchbase strategies", () => {
+    expect(clickhouseJsonStrategy.buildSql("SELECT id FROM users", "analyze")).toBe(
+      "EXPLAIN json = 1, indexes = 1 SELECT id FROM users",
+    );
+  });
+
+  // Live-verified: `EXPLAIN json = 1, indexes = 1 SELECT id FROM users FORMAT TSV`
+  // answers with X-ClickHouse-Format: TSV and the plan as escaped TSV text, so the
+  // tree can never be built. The FORMAT belongs to the statement's own result, not to
+  // the plan, so it is dropped rather than honoured.
+  test("buildSql drops a trailing FORMAT clause, which would otherwise reformat the plan itself", () => {
+    expect(clickhouseJsonStrategy.buildSql("SELECT id FROM users FORMAT TSV", "estimate")).toBe(
+      "EXPLAIN json = 1, indexes = 1 SELECT id FROM users",
+    );
+    expect(clickhouseJsonStrategy.buildSql("SELECT id FROM users format JSONEachRow  ", "analyze")).toBe(
+      "EXPLAIN json = 1, indexes = 1 SELECT id FROM users",
+    );
+  });
+
+  test("buildSql keeps a statement whose FORMAT is not a trailing clause intact", () => {
+    expect(clickhouseJsonStrategy.buildSql("SELECT formatDateTime(d, '%Y') FROM t", "estimate")).toBe(
+      "EXPLAIN json = 1, indexes = 1 SELECT formatDateTime(d, '%Y') FROM t",
+    );
+    expect(clickhouseJsonStrategy.buildSql("SELECT id FROM t WHERE note = 'FORMAT TSV'", "estimate")).toBe(
+      "EXPLAIN json = 1, indexes = 1 SELECT id FROM t WHERE note = 'FORMAT TSV'",
+    );
+  });
+
+  test("buildSql returns null for non-SELECT statements in both modes", () => {
+    expect(clickhouseJsonStrategy.buildSql("INSERT INTO users FORMAT Values (1)", "estimate")).toBeNull();
+    expect(
+      clickhouseJsonStrategy.buildSql("ALTER TABLE users UPDATE country = 'TR' WHERE id = 1", "estimate"),
+    ).toBeNull();
+    expect(clickhouseJsonStrategy.buildSql("EXPLAIN json = 1 SELECT 1", "estimate")).toBeNull();
+    expect(clickhouseJsonStrategy.buildSql("OPTIMIZE TABLE users FINAL", "analyze")).toBeNull();
+  });
+
+  // The single cell is a String whose value is JSON, so the envelope parse leaves a
+  // string behind and a second parse is mandatory. Storing the parsed array keeps the
+  // raw JSON tab and the AI tab readable instead of showing one escaped blob.
+  test("extractPlan parses the JSON string carried by the single explain cell", () => {
+    expect(clickhouseJsonStrategy.extractPlan(explainResult(LIVE_PLAN))).toEqual(LIVE_PLAN);
+  });
+
+  test("extractPlan keeps the cell text when the inner JSON cannot be parsed", () => {
+    expect(clickhouseJsonStrategy.extractPlan({ rows: [{ explain: "[{ oops" }] })).toBe("[{ oops");
+    expect(clickhouseJsonStrategy.extractPlan({ rows: [{ explain: "" }] })).toBe("");
+  });
+
+  test("extractPlan falls back to the raw rows when there is no explain cell", () => {
+    const rows = [{ nope: 1 }];
+    expect(clickhouseJsonStrategy.extractPlan({ rows })).toEqual(rows);
+    expect(clickhouseJsonStrategy.extractPlan({ rows: [] })).toEqual([]);
+    expect(clickhouseJsonStrategy.extractPlan({})).toBeUndefined();
+  });
+
+  test("toRenderModel walks the nested Plans arrays down to the table read", () => {
+    const model = clickhouseJsonStrategy.toRenderModel(LIVE_PLAN);
+    expect(model).toEqual({ kind: "tree", root: expect.anything(), raw: LIVE_PLAN });
+    expect(spineLabels((model as { root: ExplainTreeNode }).root)).toEqual([
+      "Expression: Project names",
+      "Limit: preliminary LIMIT",
+      "Sorting: Sorting for ORDER BY",
+      "Expression: (Before ORDER BY + Projection)",
+      "Expression: (WHERE + Change column names to column identifiers)",
+      "ReadFromMergeTree: demo.users",
+      "Index PrimaryKey (id): parts 1/1, granules 1/1",
+    ]);
+  });
+
+  test("toRenderModel renders end to end from what extractPlan stored", () => {
+    const root = treeRoot(clickhouseJsonStrategy.extractPlan(explainResult(LIVE_PLAN)));
+    expect(root.label).toBe("Expression: Project names");
+  });
+
+  // A plan stored before extractPlan parsed it - or read back from an older tab -
+  // is still the unparsed cell text, so the render boundary parses too.
+  test("toRenderModel accepts the unparsed cell text as well as the parsed array", () => {
+    expect(treeRoot(JSON.stringify(LIVE_PLAN)).label).toBe("Expression: Project names");
+  });
+
+  test("toRenderModel surfaces every Indexes entry as a child of the read node", () => {
+    const children = treeRoot(planWithIndexes(LIVE_INDEXES)).children;
+    expect(children.map((child) => child.label)).toEqual([
+      "Index Min-Max: parts 3/3, granules 3/3",
+      "Index Partition: parts 3/3, granules 3/3",
+      "Index PrimaryKey: parts 3/3, granules 3/3",
+      "Index Skip idx_status: parts 0/3, granules 0/3",
+    ]);
+    expect(children[3].detail).toBe("condition: (status in ['paid', 'paid']) | definition: set GRANULARITY 4");
+    expect(children[3].children).toEqual([]);
+  });
+
+  test("toRenderModel puts the index condition and search algorithm in detail", () => {
+    expect(readFromMergeTree(LIVE_PLAN).children[0].detail).toBe(
+      "condition: (id in [2, +Inf)) | search: binary search",
+    );
+  });
+
+  test("toRenderModel keeps plan children ahead of index children", () => {
+    const root = treeRoot([
+      {
+        Plan: {
+          "Node Type": "ReadFromMergeTree",
+          Plans: [{ "Node Type": "ReadFromSystemNumbers" }],
+          Indexes: [{ Type: "PrimaryKey" }],
+        },
+      },
+    ]);
+    expect(root.children.map((child) => child.label)).toEqual(["ReadFromSystemNumbers", "Index PrimaryKey"]);
+  });
+
+  test("toRenderModel degrades an index entry that omits type, keys or counts", () => {
+    const children = treeRoot(
+      planWithIndexes([
+        {},
+        { Type: "Skip", Keys: ["status", 7, ""], "Selected Parts": 1 },
+        { Type: "MinMax", "Selected Granules": 0, "Initial Granules": 4, "Initial Parts": "3" },
+      ]),
+    ).children;
+    expect(children.map((child) => child.label)).toEqual([
+      "Index",
+      "Index Skip (status)",
+      "Index MinMax: granules 0/4",
+    ]);
+    expect(children.map((child) => child.detail)).toEqual([undefined, undefined, undefined]);
+  });
+
+  test("toRenderModel treats a node without Plans as a leaf", () => {
+    const root = treeRoot([{ Plan: { "Node Type": "ReadFromStorage", Description: "SystemOne" } }]);
+    expect(root).toEqual({ label: "ReadFromStorage: SystemOne", children: [] });
+  });
+
+  test("toRenderModel ignores Plans and Indexes values that are not the expected shape", () => {
+    expect(treeRoot([{ Plan: { "Node Type": "Union", Plans: "none", Indexes: "none" } }]).children).toEqual([]);
+    expect(
+      treeRoot([{ Plan: { "Node Type": "Union", Plans: [{ nope: 1 }, { "Node Type": "Limit" }], Indexes: [7] } }])
+        .children,
+    ).toEqual([{ label: "Limit", children: [] }]);
+  });
+
+  test("toRenderModel omits the description suffix when the node has none", () => {
+    const root = treeRoot(LIVE_JOIN_PLAN);
+    expect(root.label).toBe("Expression");
+    expect(root.children[0].label).toBe("Join: JOIN FillRightFirst");
+    expect(root.children[0].children.map((child) => child.label)).toEqual([
+      "Expression: Left Pre Join Actions",
+      "Expression: Right Pre Join Actions",
+    ]);
+    expect(treeRoot([{ Plan: { "Node Type": "Limit", Description: "" } }]).label).toBe("Limit");
+  });
+
+  test("toRenderModel accepts the plan node at every wrapper depth the server or storage may present", () => {
+    const node = { "Node Type": "Limit" };
+    expect(treeRoot(node).label).toBe("Limit");
+    expect(treeRoot({ Plan: node }).label).toBe("Limit");
+    expect(treeRoot([{ Plan: node }]).label).toBe("Limit");
+  });
+
+  test("toRenderModel rejects shapes that are not ClickHouse plans", () => {
+    expect(clickhouseJsonStrategy.toRenderModel(null)).toBeNull();
+    expect(clickhouseJsonStrategy.toRenderModel(undefined)).toBeNull();
+    expect(clickhouseJsonStrategy.toRenderModel(7)).toBeNull();
+    expect(clickhouseJsonStrategy.toRenderModel([])).toBeNull();
+    expect(clickhouseJsonStrategy.toRenderModel({})).toBeNull();
+    expect(clickhouseJsonStrategy.toRenderModel([{ Plan: {} }])).toBeNull();
+    expect(clickhouseJsonStrategy.toRenderModel({ "Node Type": 7 })).toBeNull();
+    expect(clickhouseJsonStrategy.toRenderModel([{ id: 3, parent: 0, detail: "SCAN users" }])).toBeNull();
+  });
+
+  test("toRenderModel rejects cell text that is not JSON", () => {
+    expect(clickhouseJsonStrategy.toRenderModel("[{ oops")).toBeNull();
+    expect(clickhouseJsonStrategy.toRenderModel("")).toBeNull();
+    // Unwrapping is depth-bounded so a pathological wrapper chain cannot loop.
+    expect(
+      clickhouseJsonStrategy.toRenderModel([{ Plan: [{ Plan: [{ Plan: { "Node Type": "Limit" } }] }] }]),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/lib/explain/clickhouse-json.test.ts
+++ b/tests/unit/lib/explain/clickhouse-json.test.ts
@@ -209,6 +209,31 @@ describe("clickhouseJsonStrategy", () => {
     );
   });
 
+  // prepareQuery already treats both of these as carrying a trailing FORMAT (its own
+  // tests cover "a trailing FORMAT clause and a semicolon" and "FORMAT followed by
+  // SETTINGS"), so the explain builder has to recognise the same shapes or the plan
+  // comes back as TSV and no tree can be built.
+  test("buildSql drops a trailing FORMAT that is followed by a semicolon", () => {
+    expect(clickhouseJsonStrategy.buildSql("SELECT id FROM users FORMAT TSV;", "estimate")).toBe(
+      "EXPLAIN json = 1, indexes = 1 SELECT id FROM users;",
+    );
+  });
+
+  // The SETTINGS clause is kept: it applies to the inner statement and is
+  // semantically meaningful (max_execution_time and friends). Only FORMAT changes
+  // the shape of the EXPLAIN output itself.
+  test("buildSql drops a trailing FORMAT but keeps a SETTINGS clause after it", () => {
+    expect(
+      clickhouseJsonStrategy.buildSql("SELECT id FROM users FORMAT TSV SETTINGS max_threads = 1", "estimate"),
+    ).toBe("EXPLAIN json = 1, indexes = 1 SELECT id FROM users SETTINGS max_threads = 1");
+  });
+
+  test("buildSql drops a trailing FORMAT before SETTINGS and a semicolon together", () => {
+    expect(
+      clickhouseJsonStrategy.buildSql("SELECT id FROM users FORMAT JSONEachRow SETTINGS max_threads=2;", "analyze"),
+    ).toBe("EXPLAIN json = 1, indexes = 1 SELECT id FROM users SETTINGS max_threads=2;");
+  });
+
   test("buildSql keeps a statement whose FORMAT is not a trailing clause intact", () => {
     expect(clickhouseJsonStrategy.buildSql("SELECT formatDateTime(d, '%Y') FROM t", "estimate")).toBe(
       "EXPLAIN json = 1, indexes = 1 SELECT formatDateTime(d, '%Y') FROM t",

--- a/tests/unit/lib/query-generators.test.ts
+++ b/tests/unit/lib/query-generators.test.ts
@@ -249,6 +249,55 @@ describe("Couchbase (SQL++) generation", () => {
 });
 
 // ============================================================================
+// ClickHouse (issue #264) — no dialect branch of its own, and that is the claim
+// under test: every string below was run against ClickHouse 26.7.1 and accepted.
+// ============================================================================
+
+describe("ClickHouse (8123) generation", () => {
+  const clickhouseCaps = makeCaps({ defaultPort: 8123 });
+
+  test("generateTableQuery uses the plain LIMIT form", () => {
+    expect(generateTableQuery("events", clickhouseCaps)).toBe("SELECT * FROM events LIMIT 50;");
+  });
+
+  test("generateTableQuery qualifies and quotes a database-scoped table per segment", () => {
+    // Cross-database tables are addressed as `database.table`, so the dot must stay
+    // a separator; ClickHouse is case-sensitive, so a mixed-case name needs quoting.
+    expect(generateTableQuery("demo.Events", clickhouseCaps)).toBe('SELECT * FROM demo."Events" LIMIT 50;');
+  });
+
+  test("generateSelectQuery emits a double-quoted column list and LIMIT 100", () => {
+    const cols: ColumnSchema[] = [
+      { name: "id", type: "Int32", nullable: false, isPrimary: true },
+      { name: "Name", type: "Nullable(String)", nullable: true, isPrimary: false },
+    ];
+    expect(generateSelectQuery("demo.regtest", cols, clickhouseCaps)).toBe(
+      'SELECT\n  id,\n  "Name"\nFROM demo.regtest\nWHERE 1=1\nLIMIT 100;',
+    );
+  });
+
+  test("the trailing LIMIT is the last clause, so a user-appended FORMAT stays legal", () => {
+    // `... FORMAT TSV LIMIT 1` is a syntax error; `... LIMIT 1 FORMAT TSV` is not.
+    const out = generateTableQuery("events", clickhouseCaps);
+    expect(out.trimEnd().endsWith("LIMIT 50;")).toBe(true);
+  });
+
+  test("quoteIdentifier keeps plain lowercase bare and double-quotes anything else", () => {
+    // ClickHouse never folds case, so quoting is only about parseability, and its
+    // quote character is the double quote the default branch already emits.
+    expect(quoteIdentifier("events", clickhouseCaps)).toBe("events");
+    expect(quoteIdentifier("Events", clickhouseCaps)).toBe('"Events"');
+    expect(quoteIdentifier("weird name", clickhouseCaps)).toBe('"weird name"');
+    expect(quoteIdentifier('we"ird', clickhouseCaps)).toBe('"we""ird"');
+  });
+
+  test("quoteQualifiedName keeps the database separator intact", () => {
+    expect(quoteQualifiedName("demo.regtest", clickhouseCaps)).toBe("demo.regtest");
+    expect(quoteQualifiedName("demo.Events", clickhouseCaps)).toBe('demo."Events"');
+  });
+});
+
+// ============================================================================
 // quoteIdentifier (dialect-aware, quote-only-when-needed)
 // ============================================================================
 

--- a/tests/unit/seed/types.test.ts
+++ b/tests/unit/seed/types.test.ts
@@ -61,8 +61,25 @@ describe("SeedConnectionSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects a database type outside the DatabaseType union", () => {
+    const result = SeedConnectionSchema.safeParse({ ...validConn, type: "clickhous" });
+    expect(result.success).toBe(false);
+  });
+
   it("accepts every valid database type", () => {
-    for (const type of ["postgres", "mysql", "sqlite", "mongodb", "redis", "oracle", "mssql", "libredb", "couchbase"]) {
+    const allTypes = [
+      "postgres",
+      "mysql",
+      "sqlite",
+      "mongodb",
+      "redis",
+      "oracle",
+      "mssql",
+      "libredb",
+      "couchbase",
+      "clickhouse",
+    ];
+    for (const type of allTypes) {
       const result = SeedConnectionSchema.safeParse({ ...validConn, type });
       expect(result.success).toBe(true);
     }


### PR DESCRIPTION
Closes #264.

ClickHouse as a database provider, speaking SQL over the documented HTTP interface on port 8123,
with **zero runtime dependency** — `package.json` and `bun.lock` are untouched, so no distribution
channel grows.

## What is different from the Couchbase precedent

| | Couchbase (#263) | ClickHouse |
|---|---|---|
| Base class | `BaseDatabaseProvider` | **`SQLBaseProvider`** — identifier quoting and the shared limiter are inherited, not reimplemented |
| Error detection | Payload first (a 200 can carry `status: "errors"`) | **Status first** — real HTTP status codes |
| Schema | `INFER` sampling | Real declared schema from `system.columns` |
| Column types | Derived, wildcard fallback needed | Carried verbatim in the response |

`ADDING_A_PROVIDER.md` names ClickHouse as the case for `SQLBaseProvider`, and it held up: only
`prepareQuery()` needed an override.

## Verified against a live server, not only mocks

Everything below was confirmed against `clickhouse/clickhouse-server:26.7.1.1315`, and each item is
covered by a test. These are the things that silently produce wrong output if missed.

- **`ACCESS_DENIED` arrives as HTTP `500`, not `403`.** Failures are *detected* by status but
  *classified* by the numeric exception code. The 497 message reads "Not enough privileges" and
  contains neither "access denied" nor "permission denied", so message sniffing would miss every real
  denial. Good news from the same probe: a restricted user still gets a working schema tree and
  overview panel — only monitoring and maintenance degrade.
- **Error bodies are plain text even under an `application/json` content type**, so an error body is
  never handed to `JSON.parse`.
- **64-bit integers arrive unquoted and `JSON.parse` silently rounds them** —
  `18446744073709551615` becomes `...552000`. The transport always sends
  `output_format_json_quote_64bit_integers=1`, which matches `pg`'s existing `int8`-as-string
  behaviour, so the grid already renders it correctly.
- **A statement that fails after output has started answers `200`** with a truncated body and the real
  exception in an `__exception__` trailer, keyed on the per-request `X-ClickHouse-Exception-Tag`
  (`SELECT '__exception__'` is legal, so the marker alone is not safe to key on). The check runs
  *before* the format branch and before parsing, because the fence is format-independent — checking
  it only for JSON reported **805000 lost rows as a successful short result**. There is a second,
  buffered variant (`500`, no fence, partial body ahead of the exception), so the error path also
  trims that prefix off the message.
- **`FORMAT` and `SETTINGS` are trailing clauses** and the inherited limiter appends `LIMIT` at the
  very end, which is a hard syntax error after either. `prepareQuery()` refuses to rewrite such a
  statement. One contrived false positive is accepted and pinned by a test, because erring this way
  only omits a row limit while erring the other way produces invalid SQL.
- **Writes answer `200` with an empty body**; counts come from `X-ClickHouse-Summary`, whose values
  are strings. For `ALTER TABLE ... UPDATE` and lightweight `DELETE` the server reports **zero even
  on success** — the provider reports the server's number rather than fabricating one, and the doc
  says so plainly.
- **Multi-statement is rejected by the server itself**, so there is no client-side splitting.
- **`supportsCreateTable` is `false`, live-disproving the issue's own guess.** `ENGINE`/`ORDER BY`
  turned out to have working defaults, but `CreateTableModal`'s *default* output emits `SERIAL`
  (`UNKNOWN_TYPE`) and `UNIQUE` (`SYNTAX_ERROR`).
- **A pasted `https://` URL now carries its TLS intent** (`sslMode: "require"`), so a ClickHouse Cloud
  endpoint cannot become a plaintext POST to the TLS port.

## Schema, monitoring, EXPLAIN

`system.tables` / `system.columns` / `system.data_skipping_indices`, each filtered by database and
each degrading to empty on its **own** denial — only `data_skipping_indices` needs a separate grant.
Nullable `total_rows`/`total_bytes` are reported as **unknown, not zero**, so a view does not claim to
be empty. Column types are the declared strings verbatim (`Enum8('free' = 1, ...)`,
`LowCardinality(Nullable(String))` correctly nullable, `Array(Nullable(String))` correctly not).

Monitoring reads `system.query_log`, `system.processes`, `system.metrics` and `system.parts`. The
overview is deliberately five separate reads so a restricted user keeps the panels it can still see
instead of losing all of them to one denial.

EXPLAIN reuses the existing `{ kind: "tree" }` model. `EXPLAIN json = 1` returns a JSON **string**
inside a one-cell result, so it needs a second parse; children walk `Plans`; index rows carry the
pruning ratios that are the whole point of `indexes = 1`. Both modes return the same estimate, since
ClickHouse's `EXPLAIN` never executes — returning `null` for `analyze` would leave the button dead.

## Live end-to-end pass

Driven through the running app against a real server, not the DB directly:

- 26/26 CRUD checks — `18446744073709551615` survives round-trip, read-your-writes works,
  `ALTER TABLE ... UPDATE` really applies
- error paths surface as errors and never as zero rows (`SYNTAX_ERROR`, `UNKNOWN_TABLE`, bare
  `UPDATE` → `NOT_IMPLEMENTED`)
- both mid-stream failure variants report the real exception with a clean message
- EXPLAIN driven the way the hook drives it, in **both** modes, rendering
  `ReadFromMergeTree → Index PrimaryKey (id): parts 3/3, granules 3/3`
- all four maintenance operations, every monitoring panel, and the seeded connection in the sidebar

`database-compose.yml` gains a pinned `clickhouse` service so the next person can repeat this.

## One behaviour change found by the live pass

`MaintenanceModal`'s global Analyze button sends no target, and `analyze` threw
`"analyze" requires a target` — a control the UI always offers that could never work. `analyze` now
reports the whole pinned database when given no target; `optimize` still requires one, because
`OPTIMIZE` names a table.

## Deliberately out of scope

Two shared features that generate SQL are **not dialect-aware**, both pre-existing and neither living
in this provider's files. They are documented as limitations and tracked in **#269**:

- inline row editing emits a bare `UPDATE ... SET` (and several statements joined by `;`)
- the schema-diff migration generator has no ClickHouse branch, so it emits PostgreSQL syntax —
  Oracle falls through the same branch for the same reason

Also out of scope, per the issue: the native protocol on 9000, Cloud management APIs, dictionaries,
materialized-view management, cluster administration.

## Verification

All six local gates pass, plus the coverage gate:

| Gate | Result |
|---|---|
| `format` | pass |
| `lint` | 0 errors, 0 warnings in any new file |
| `typecheck` | pass |
| `knip` | pass |
| `test` | 0 fail |
| `build` | pass |
| `coverage:check` | **100.00% — 27694/27694 lines** |

Tri-sync per `CLAUDE.md`: provider code, `docs/providers/clickhouse.md` and
`tests/integration/db/clickhouse-provider.test.ts` land together. `ADDING_A_PROVIDER.md` moves
ClickHouse out of the candidate table into the shipped, driver-free examples.
