### PR TITLE
fix(explain): share one explainable-statement check across all six strategies

### DIFF
--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -404,6 +404,21 @@ control that only emits invalid input. That is the defect class
   strategy declines, so the button is dead while only the background pre-warm works. When the engine
   has no analyze equivalent, return the estimate for both modes — `sqlite-queryplan.ts` and
   `couchbase-json.ts` both do exactly that.
+- **Decide what is explainable with `classifySelectPrefix()`**
+  ([`explain/select-prefix.ts`](../src/lib/explain/select-prefix.ts)), never with a fresh regex. It
+  accepts a leading CTE and leading SQL comments as well as a bare `SELECT`, which every dialect here
+  was live-verified to explain, and it returns `"select"` or `"with"` so a strategy can treat the two
+  differently. Each of the six strategies used to carry its own `/^\s*SELECT\b/i`, and every one of
+  them refused a CTE — while the shared `analyzeQuery` already classified `WITH … SELECT` as a SELECT
+  and injected a `LIMIT` into one.
+- **Ask whether your engine's EXPLAIN executes what it explains before widening anything.** This is
+  the one place the six strategies genuinely differ. PostgreSQL's emits
+  `EXPLAIN (ANALYZE, …)`, which runs the statement — so a data-modifying CTE is a write wearing a
+  `WITH`, and explaining one performs it (verified: the row really landed). `postgres-json.ts`
+  therefore pairs the shared classification with `hasDataModifyingStatement()`, and it applies that
+  screen **only** to the `"with"` case, because a statement leading with `SELECT` cannot carry such a
+  CTE and screening it too would strip the button off anything that merely mentions `insert`. The
+  other five engines describe without running and need no screen.
 - A capability can be absent because the **grammar** lacks it rather than because nobody implemented
   it, and the flag reads the same either way — so check, and then say so. Druid answers
   `CREATE TABLE t (id BIGINT)` with a syntax error, because `CREATE` is not one of its statements at

--- a/src/lib/explain/clickhouse-json.ts
+++ b/src/lib/explain/clickhouse-json.ts
@@ -1,6 +1,5 @@
+import { classifySelectPrefix } from "./select-prefix";
 import type { ExplainStrategy, ExplainTreeNode } from "./types";
-
-const SELECT_ONLY = /^\s*SELECT\b/i;
 
 /**
  * `FORMAT <Name>` where nothing but a `SETTINGS` clause or a semicolon follows it.
@@ -168,7 +167,8 @@ export const clickhouseJsonStrategy: ExplainStrategy = {
   // (use-query-execution.ts:165) and refuses the run when the strategy returns null -
   // so both modes return the estimate, as the SQLite and Couchbase strategies do.
   buildSql(sql) {
-    if (!SELECT_ONLY.test(sql.trim())) return null;
+    // ClickHouse's `EXPLAIN` describes without running, so a CTE is safe to explain.
+    if (classifySelectPrefix(sql) === null) return null;
     // A trailing FORMAT would reformat the PLAN, not the statement's rows: live, a
     // wrapped `... FORMAT TSV` comes back as TSV text and the tree can never be
     // built. The clause describes the statement's own result, which an EXPLAIN never

--- a/src/lib/explain/couchbase-json.ts
+++ b/src/lib/explain/couchbase-json.ts
@@ -1,6 +1,5 @@
+import { classifySelectPrefix } from "./select-prefix";
 import type { ExplainStrategy, ExplainTreeNode } from "./types";
-
-const SELECT_ONLY = /^\s*SELECT\b/i;
 
 /** How many wrapper layers ({ plan }, row arrays) toPlanRoot peels before giving up. */
 const MAX_UNWRAP_DEPTH = 4;
@@ -119,7 +118,8 @@ export const couchbaseJsonStrategy: ExplainStrategy = {
   // mode "analyze" (use-query-execution.ts:165) and refuses the run when the
   // strategy returns null.
   buildSql(sql) {
-    if (!SELECT_ONLY.test(sql.trim())) return null;
+    // Couchbase's `EXPLAIN` describes without running, so a `WITH` binding is safe to explain.
+    if (classifySelectPrefix(sql) === null) return null;
     return `EXPLAIN ${sql}`;
   },
   extractPlan(result) {

--- a/src/lib/explain/druid-native.ts
+++ b/src/lib/explain/druid-native.ts
@@ -1,53 +1,8 @@
 // db/utils, not the Druid provider directory: an explain strategy that imported from
 // a provider would tie the registry to it (the rule clickhouse-json.ts records).
 import { quoteUnsafeIntegers } from "@/lib/db/utils/json-integers";
+import { classifySelectPrefix } from "./select-prefix";
 import type { ExplainStrategy, ExplainTreeNode } from "./types";
-
-/**
- * Does this statement lead to a SELECT, so that `EXPLAIN PLAN FOR` can wrap it?
- *
- * Broader than the bare `/^\s*SELECT\b/` the other strategies still use, because two
- * ordinary things a user types are genuinely explainable on Druid and were being
- * refused - which left the Explain button dead rather than merely narrow:
- *
- * - a CTE: `EXPLAIN PLAN FOR WITH t AS (...) SELECT * FROM t` is live-verified as
- *   accepted, and the shared `analyzeQuery` already classifies `WITH ... SELECT` as a
- *   SELECT (it injects a LIMIT into one), so refusing it here contradicted the rest of
- *   the pipeline;
- * - a leading comment: `-- note`, or a `/* ... *\/` licence header, before the SELECT.
- *   Live-verified as accepted too, both as a prefix and combined with a CTE.
- *
- * The SHAPE of this pattern matters as much as what it accepts, and it is deliberately
- * not the obvious `^\s*(--...|\/*...*\/|\s)*` spelling:
- *
- * Every one of the three alternatives had to be made unambiguous, because each is
- * inside a `*` quantifier and any way of matching the same text twice is a way for a
- * non-matching input to backtrack. All three were measured, with a tail that never
- * reaches SELECT:
- *
- * - there is no leading `\s*`, because whitespace is already one alternative below.
- *   Having both gives two ways to match the same run of spaces: quadratic, 958ms on
- *   20k leading spaces.
- * - the line comment must end at a newline OR at end-of-input. Without that tail,
- *   `[^\n]*` can give characters back and let a later iteration match `--` again, so a
- *   run of bare dashes partitions exponentially - 634ms on a FORTY-NINE character
- *   input, which is by far the cheapest of the three to trigger. Requiring the tail
- *   forces the branch to run to the newline or to the end, so there is nothing to give
- *   back. Found by CodeQL after the first two were fixed.
- * - the block-comment body is TEMPERED (`[^*]|\*(?!\/)`) rather than a lazy
- *   `[\s\S]*?\*\/`, which inside a `*` quantifier can extend past the first `*\/` and
- *   let one iteration swallow several comments: 852ms on a 4 KB run of `/**\/`.
- *
- * All three now answer in well under a millisecond.
- *
- * Both forms accept and reject exactly the same statements - the difference is only
- * how much backtracking a non-matching input costs. `buildSql` runs on whatever is in
- * the editor when a query is executed, so a buffer that opens with a large commented
- * block and then a non-SELECT is a reachable input, and this file follows the same
- * anti-backtracking care that made `query-limiter.ts` hand-write its semicolon strip
- * "without regex to avoid ReDoS".
- */
-const SELECT_ONLY = /^(?:\s|--[^\n]*(?:\n|$)|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:SELECT|WITH)\b/i;
 
 /**
  * Druid's EXPLAIN is a statement prefix, not a modifier with options, and it never
@@ -342,7 +297,9 @@ export const druidNativeStrategy: ExplainStrategy = {
   // (use-query-execution.ts:165) and refuses the run when the strategy returns null -
   // so both modes return the same plan, as the SQLite and Couchbase strategies do.
   buildSql(sql) {
-    if (!SELECT_ONLY.test(sql.trim())) return null;
+    // Druid's EXPLAIN never executes the statement, and its SQL cannot write at all
+    // on this endpoint, so classification alone is the whole policy here.
+    if (classifySelectPrefix(sql) === null) return null;
     return `${EXPLAIN_PREFIX}${sql}`;
   },
   // Parsing all three columns here rather than at render time is what gives the raw

--- a/src/lib/explain/mysql-json.ts
+++ b/src/lib/explain/mysql-json.ts
@@ -1,11 +1,11 @@
+import { classifySelectPrefix } from "./select-prefix";
 import type { ExplainPlanResult, ExplainStrategy } from "./types";
-
-const SELECT_ONLY = /^\s*SELECT\b/i;
 
 export const mysqlJsonStrategy: ExplainStrategy = {
   format: "mysql-json",
   buildSql(sql) {
-    if (!SELECT_ONLY.test(sql.trim())) return null;
+    // MySQL's `EXPLAIN FORMAT=JSON` describes without running, so a CTE is safe to explain.
+    if (classifySelectPrefix(sql) === null) return null;
     return `EXPLAIN FORMAT=JSON ${sql}`;
   },
   // Legacy extraction preserved on purpose (bug B4): MySQL output has an

--- a/src/lib/explain/postgres-json.ts
+++ b/src/lib/explain/postgres-json.ts
@@ -1,11 +1,40 @@
+import { classifySelectPrefix, hasDataModifyingStatement } from "./select-prefix";
 import type { ExplainPlanResult, ExplainStrategy } from "./types";
 
-const SELECT_ONLY = /^\s*SELECT\b/i;
+/**
+ * The one strategy that cannot simply take the shared classification, because it is
+ * the one whose EXPLAIN **executes** what it explains.
+ *
+ * `EXPLAIN (ANALYZE, ...)` runs the statement to report actual rows and timings, and a
+ * data-modifying CTE is a write wearing a `WITH`. Live-verified on PostgreSQL 18:
+ *
+ *     EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+ *       WITH t AS (INSERT INTO probe(id) VALUES (42) RETURNING id) SELECT * FROM t
+ *
+ *     -> 0 rows in the table before, 1 row (42) after. Explaining performed the insert.
+ *
+ * So a `WITH` is explainable here only when nothing in it writes. A statement leading
+ * with `SELECT` needs no such screen and deliberately does not get one: PostgreSQL
+ * refuses a data-modifying CTE anywhere but the top level ("WITH clause containing a
+ * data-modifying statement must be at the top level", verified), so one cannot hide
+ * behind a leading `SELECT` - and screening those too would strip the Explain button
+ * off queries that merely mention a keyword, such as `SELECT 'insert'`, which explains
+ * fine today.
+ *
+ * The narrower question of ANALYZE executing an ordinary SELECT twice - once for the
+ * user, once for the background pre-warm - is issue #194's remaining work, not this.
+ */
+function isExplainable(sql: string): boolean {
+  const prefix = classifySelectPrefix(sql);
+  if (prefix === null) return false;
+
+  return prefix === "select" || !hasDataModifyingStatement(sql);
+}
 
 export const postgresJsonStrategy: ExplainStrategy = {
   format: "postgres-json",
   buildSql(sql) {
-    if (!SELECT_ONLY.test(sql.trim())) return null;
+    if (!isExplainable(sql)) return null;
     return `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${sql}`;
   },
   extractPlan(result) {

--- a/src/lib/explain/select-prefix.ts
+++ b/src/lib/explain/select-prefix.ts
@@ -1,0 +1,107 @@
+/**
+ * What a statement has to look like before an EXPLAIN strategy will wrap it.
+ *
+ * Every strategy declines a statement it cannot explain by returning `null` from
+ * `buildSql`, which hides the Explain button. That check used to be a bare
+ * `/^\s*SELECT\b/i` copied into all six files, and it refused two statements every
+ * dialect here explains perfectly well: a CTE, and a SELECT behind a comment. Both
+ * were live-verified as accepted on PostgreSQL 18, MySQL 9, SQLite, Couchbase 8.0.2,
+ * ClickHouse 26.7 and Apache Druid 37, each through the exact EXPLAIN prefix its
+ * strategy emits.
+ *
+ * A CTE mattered for a second reason: the shared `analyzeQuery` in
+ * `db/utils/query-limiter.ts` already classifies `WITH ... SELECT` as a SELECT and
+ * injects a LIMIT into one, so six strategies refusing it disagreed with the rest of
+ * the pipeline.
+ *
+ * The classification is shared but the POLICY is not - see `hasDataModifyingStatement`
+ * for the one dialect that has to be stricter.
+ */
+
+/**
+ * Which keyword a statement leads with, ignoring whitespace and comments, or `null`
+ * when it leads with neither.
+ *
+ * The two are distinguished rather than collapsed into a boolean because a `WITH` can
+ * carry a statement that WRITES, and whether that matters depends on whether the
+ * dialect's EXPLAIN executes what it explains.
+ */
+export type SelectPrefix = "select" | "with";
+
+/**
+ * Leading whitespace and SQL comments, then `SELECT` or `WITH`.
+ *
+ * The SHAPE of this pattern matters as much as what it accepts. Each of the three
+ * alternatives sits inside a `*` quantifier, so any way of matching the same text
+ * twice is a way for a NON-matching input to backtrack, and all three had to be made
+ * unambiguous independently. Measured on this file's predecessors, with a tail that
+ * never reaches a keyword:
+ *
+ * - No leading `\s*`. Whitespace is already an alternative below; having both gives
+ *   two ways to match one run of spaces. Quadratic - 958ms on 20k leading spaces.
+ * - The line comment is anchored to a newline OR end-of-input. Without that tail
+ *   `[^\n]*` can give characters back and let a later iteration match `--` again, so a
+ *   run of bare dashes partitions exponentially - 634ms on a FORTY-NINE character
+ *   input, by far the cheapest of the three to trigger. Found by CodeQL (`js/redos`)
+ *   after the other two were already fixed.
+ * - The block-comment body is TEMPERED (`[^*]|\*(?!\/)`) rather than a lazy
+ *   `[\s\S]*?\*\/`, which inside a `*` quantifier can run past the first `*\/` and let
+ *   one iteration swallow several comments - 852ms on a 4 KB run of `/**\/`.
+ *
+ * All three now answer in well under a millisecond, and `select-prefix.test.ts` keeps
+ * them that way with a bounded-time guard. This is the same care that made
+ * `query-limiter.ts` hand-write its semicolon strip "without regex to avoid ReDoS".
+ */
+const LEADING_KEYWORD = /^(?:\s|--[^\n]*(?:\n|$)|\/\*(?:[^*]|\*(?!\/))*\*\/)*(SELECT|WITH)\b/i;
+
+/**
+ * Statements that write. Used only to keep a dialect whose EXPLAIN EXECUTES from
+ * executing one - see `hasDataModifyingStatement`.
+ *
+ * Flat, with no nested quantifier, so it carries none of the backtracking risk the
+ * pattern above had to be shaped around.
+ */
+const DATA_MODIFYING = /\b(?:INSERT|UPDATE|DELETE|MERGE)\b/i;
+
+/**
+ * The keyword this statement leads with, or `null` if it leads with neither.
+ *
+ * `null` is the "not explainable" answer every strategy turns into a `null` from
+ * `buildSql`. A comment on its own is `null`: a comment is not a statement.
+ */
+export function classifySelectPrefix(sql: string): SelectPrefix | null {
+  const match = LEADING_KEYWORD.exec(sql);
+  if (match === null) return null;
+
+  return match[1]?.toUpperCase() === "WITH" ? "with" : "select";
+}
+
+/**
+ * Does this statement contain a writing keyword anywhere?
+ *
+ * For the one dialect whose EXPLAIN *executes* what it explains. PostgreSQL's
+ * strategy emits `EXPLAIN (ANALYZE, ...)`, and a data-modifying CTE is a write
+ * wearing a `WITH`, so explaining one performs it. Live-verified on 18:
+ *
+ *     EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+ *       WITH t AS (INSERT INTO probe(id) VALUES (42) RETURNING id) SELECT * FROM t
+ *
+ *     -> the row is really inserted. 0 rows before, 1 row after "only explaining".
+ *
+ * So a `WITH` is only explainable there when nothing in it writes. This errs toward
+ * refusing: `WITH t AS (SELECT 'insert') SELECT ...` is declined even though it is
+ * harmless, which costs an Explain button, while the other direction would perform a
+ * write the user only asked to see. It cannot miss a real one, because a
+ * data-modifying CTE is exactly an `INSERT`/`UPDATE`/`DELETE`/`MERGE` and PostgreSQL
+ * refuses one anywhere but the top level ("WITH clause containing a data-modifying
+ * statement must be at the top level", verified), so there is nowhere for such a
+ * statement to hide behind a leading `SELECT`.
+ *
+ * That last point is why the guard is scoped to the `with` case in the caller rather
+ * than applied to every statement: a statement leading with `SELECT` cannot carry one,
+ * so screening those too would only strip the Explain button off queries that merely
+ * mention a keyword - `SELECT 'insert'` explains fine today and must keep doing so.
+ */
+export function hasDataModifyingStatement(sql: string): boolean {
+  return DATA_MODIFYING.test(sql);
+}

--- a/src/lib/explain/select-prefix.ts
+++ b/src/lib/explain/select-prefix.ts
@@ -58,6 +58,17 @@ const LEADING_KEYWORD = /^(?:\s|--[^\n]*(?:\n|$)|\/\*(?:[^*]|\*(?!\/))*\*\/)*(SE
  * Statements that write. Used only to keep a dialect whose EXPLAIN EXECUTES from
  * executing one - see `hasDataModifyingStatement`.
  *
+ * These four and no others, because the list only has to cover what can ride inside a
+ * `WITH`. Both halves of that were verified on PostgreSQL 18 rather than assumed:
+ *
+ * - `MERGE` belongs here. It is a real carrier, not a defensive guess:
+ *   `EXPLAIN (ANALYZE, FORMAT JSON) WITH t AS (MERGE INTO probe ... RETURNING id)
+ *   SELECT * FROM t` really inserted the row.
+ * - `TRUNCATE` does NOT belong here, and its absence is deliberate. It cannot be a
+ *   carrier at all - `WITH t AS (TRUNCATE probe) SELECT 1` is a *syntax* error - and a
+ *   statement that leads with it is already refused by `classifySelectPrefix`, which
+ *   only ever answers for `SELECT` or `WITH`. Same for `CREATE`, `DROP` and `ALTER`.
+ *
  * Flat, with no nested quantifier, so it carries none of the backtracking risk the
  * pattern above had to be shaped around.
  */

--- a/src/lib/explain/sqlite-queryplan.ts
+++ b/src/lib/explain/sqlite-queryplan.ts
@@ -1,6 +1,5 @@
+import { classifySelectPrefix } from "./select-prefix";
 import type { ExplainStrategy, ExplainTreeNode } from "./types";
-
-const SELECT_ONLY = /^\s*SELECT\b/i;
 
 interface QueryPlanRow {
   id: number;
@@ -23,7 +22,8 @@ export const sqliteQueryplanStrategy: ExplainStrategy = {
   // EXPLAIN QUERY PLAN (not bare EXPLAIN, which dumps VDBE opcodes) and it
   // never executes the statement, so estimate and analyze are identical.
   buildSql(sql) {
-    if (!SELECT_ONLY.test(sql.trim())) return null;
+    // `EXPLAIN QUERY PLAN` describes without running, so a CTE is safe to explain.
+    if (classifySelectPrefix(sql) === null) return null;
     return `EXPLAIN QUERY PLAN ${sql}`;
   },
   extractPlan(result) {

--- a/tests/unit/lib/explain/clickhouse-json.test.ts
+++ b/tests/unit/lib/explain/clickhouse-json.test.ts
@@ -393,4 +393,22 @@ describe("clickhouseJsonStrategy", () => {
       clickhouseJsonStrategy.toRenderModel([{ Plan: [{ Plan: [{ Plan: { "Node Type": "Limit" } }] }] }]),
     ).toBeNull();
   });
+
+  // Both live-verified accepted through this exact prefix, and ClickHouse's EXPLAIN describes without running,
+  // so a CTE is safe to explain here - no write can hide inside one.
+  test("buildSql explains a CTE and a commented SELECT", () => {
+    const cte = "WITH t AS (SELECT 1 AS x) SELECT * FROM t";
+    expect(clickhouseJsonStrategy.buildSql(cte, "analyze")).toBe(`EXPLAIN json = 1, indexes = 1 ${cte}`);
+    expect(clickhouseJsonStrategy.buildSql("-- note\nSELECT 1", "estimate")).toBe(
+      "EXPLAIN json = 1, indexes = 1 -- note\nSELECT 1",
+    );
+    expect(clickhouseJsonStrategy.buildSql("/* note */ SELECT 1", "estimate")).toBe(
+      "EXPLAIN json = 1, indexes = 1 /* note */ SELECT 1",
+    );
+  });
+
+  test("buildSql still declines a comment with no statement behind it", () => {
+    expect(clickhouseJsonStrategy.buildSql("-- only a comment", "analyze")).toBeNull();
+    expect(clickhouseJsonStrategy.buildSql("/* only a comment */", "analyze")).toBeNull();
+  });
 });

--- a/tests/unit/lib/explain/couchbase-json.test.ts
+++ b/tests/unit/lib/explain/couchbase-json.test.ts
@@ -150,4 +150,22 @@ describe("couchbaseJsonStrategy", () => {
     // Unwrapping is depth-bounded so a pathological wrapper chain cannot loop.
     expect(couchbaseJsonStrategy.toRenderModel({ plan: { plan: { plan: { plan: PLAN } } } })).toBeNull();
   });
+
+  // SQL++ spells a CTE differently - `WITH alias AS (<expression>)` binds a value
+  // rather than a subquery - and both forms were live-verified accepted behind
+  // `EXPLAIN` on Couchbase 8.0.2. Couchbase's EXPLAIN describes without running, so
+  // there is no write that could hide in a binding.
+  test("buildSql explains a WITH binding and a commented SELECT", () => {
+    const withBinding = "WITH t AS ([{'x':1}]) SELECT * FROM t";
+    expect(couchbaseJsonStrategy.buildSql(withBinding, "analyze")).toBe(`EXPLAIN ${withBinding}`);
+    expect(couchbaseJsonStrategy.buildSql("-- note\nSELECT RAW 1", "estimate")).toBe("EXPLAIN -- note\nSELECT RAW 1");
+    expect(couchbaseJsonStrategy.buildSql("/* note */ SELECT RAW 1", "estimate")).toBe(
+      "EXPLAIN /* note */ SELECT RAW 1",
+    );
+  });
+
+  test("buildSql still declines a comment with no statement behind it", () => {
+    expect(couchbaseJsonStrategy.buildSql("-- only a comment", "analyze")).toBeNull();
+    expect(couchbaseJsonStrategy.buildSql("/* only a comment */", "analyze")).toBeNull();
+  });
 });

--- a/tests/unit/lib/explain/druid-native.test.ts
+++ b/tests/unit/lib/explain/druid-native.test.ts
@@ -354,49 +354,15 @@ describe("druidNativeStrategy", () => {
     expect(druidNativeStrategy.buildSql("/* unterminated SELECT 1", "estimate")).toBeNull();
   });
 
-  /**
-   * Regression guard on the SHAPE of SELECT_ONLY, not on what it accepts.
-   *
-   * The obvious spelling of this pattern - a leading `\s*` in front of an alternation
-   * that also contains `\s`, plus a lazy `[\s\S]*?` block-comment body inside a `*`
-   * quantifier - is ambiguous twice over, and a non-matching input pays for it by
-   * backtracking. Measured on the ambiguous form: 852ms for the 4 KB input below, and
-   * 958ms for 20k leading spaces. The tempered form used here answers both in well
-   * under a millisecond.
-   *
-   * `buildSql` runs on the editor's contents every time a query is executed, so a
-   * buffer that opens with a large commented-out block and then a non-SELECT is a
-   * reachable input. The bound is deliberately loose - three orders of magnitude above
-   * what the correct pattern needs - so it cannot flake on a slow runner while still
-   * failing outright if the ambiguity comes back.
-   */
-  test("buildSql does not backtrack on a long comment or whitespace run that never reaches a SELECT", () => {
-    const BOUND_MS = 200;
-    const adversarial = [
-      `${"/**/".repeat(1000)}UPDATE t SET a = 1`,
-      `${"/*a*/".repeat(1000)}DELETE FROM t`,
-      `${" ".repeat(20000)}UPDATE t SET a = 1`,
-      `${"-- a\n".repeat(1000)}UPDATE t SET a = 1`,
-      `${"/**/ -- a\n ".repeat(1000)}DELETE FROM t`,
-      // The cheapest of the lot, and the one the first two fixes missed: a run of BARE
-      // dashes with no newline. Without the `(?:\n|$)` tail on the line-comment branch
-      // this alone cost 634ms at FORTY-NINE characters, growing about fourfold per two
-      // extra dashes. CodeQL found it; `-- a\n` above cannot, because the newline makes
-      // that branch unambiguous.
-      `${"--".repeat(24)}X`,
-      `${"--".repeat(2000)}UPDATE t SET a = 1`,
-      `${"-".repeat(20000)}X`,
-    ];
+  // The prefix check now lives in `select-prefix.ts`, shared by all six strategies, and
+  // so does its backtracking guard - the ReDoS property belongs to the regex, not to
+  // this dialect. What stays here is that Druid ROUTES through it: a statement it
+  // cannot explain still declines, cheaply.
+  test("buildSql declines a long comment run that never reaches a SELECT, without backtracking", () => {
+    const started = performance.now();
 
-    for (const sql of adversarial) {
-      const started = performance.now();
-      const result = druidNativeStrategy.buildSql(sql, "analyze");
-      const elapsed = performance.now() - started;
-
-      // Correct answer AND a bounded one: a fast wrong answer is not a pass.
-      expect(result).toBeNull();
-      expect(elapsed).toBeLessThan(BOUND_MS);
-    }
+    expect(druidNativeStrategy.buildSql(`${"--".repeat(2000)}UPDATE t SET a = 1`, "analyze")).toBeNull();
+    expect(performance.now() - started).toBeLessThan(200);
   });
 
   // Druid rejects UPDATE and DELETE outright and routes INSERT/REPLACE to the MSQ

--- a/tests/unit/lib/explain/mysql-json.test.ts
+++ b/tests/unit/lib/explain/mysql-json.test.ts
@@ -22,4 +22,20 @@ describe("mysqlJsonStrategy", () => {
     const rows = [{ EXPLAIN: '{"query_block":{}}' }];
     expect(mysqlJsonStrategy.extractPlan({ rows })).toEqual(rows);
   });
+
+  // Both live-verified accepted through this exact prefix, and MySQL's EXPLAIN FORMAT=JSON describes without running,
+  // so a CTE is safe to explain here - no write can hide inside one.
+  test("buildSql explains a CTE and a commented SELECT", () => {
+    const cte = "WITH t AS (SELECT 1 AS x) SELECT * FROM t";
+    expect(mysqlJsonStrategy.buildSql(cte, "analyze")).toBe(`EXPLAIN FORMAT=JSON ${cte}`);
+    expect(mysqlJsonStrategy.buildSql("-- note\nSELECT 1", "estimate")).toBe("EXPLAIN FORMAT=JSON -- note\nSELECT 1");
+    expect(mysqlJsonStrategy.buildSql("/* note */ SELECT 1", "estimate")).toBe(
+      "EXPLAIN FORMAT=JSON /* note */ SELECT 1",
+    );
+  });
+
+  test("buildSql still declines a comment with no statement behind it", () => {
+    expect(mysqlJsonStrategy.buildSql("-- only a comment", "analyze")).toBeNull();
+    expect(mysqlJsonStrategy.buildSql("/* only a comment */", "analyze")).toBeNull();
+  });
 });

--- a/tests/unit/lib/explain/postgres-json.test.ts
+++ b/tests/unit/lib/explain/postgres-json.test.ts
@@ -31,6 +31,44 @@ describe("postgresJsonStrategy", () => {
     expect(postgresJsonStrategy.buildSql("EXPLAIN SELECT 1", "analyze")).toBeNull();
   });
 
+  test("buildSql explains a read-only CTE and a commented SELECT", () => {
+    const cte = "WITH t AS (SELECT 1 AS x) SELECT * FROM t";
+    expect(postgresJsonStrategy.buildSql(cte, "analyze")).toBe(`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${cte}`);
+    expect(postgresJsonStrategy.buildSql("-- note\nSELECT 1", "analyze")).toBe(
+      "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) -- note\nSELECT 1",
+    );
+  });
+
+  /**
+   * The reason this strategy screens more than the shared classification does.
+   *
+   * `EXPLAIN (ANALYZE, ...)` RUNS the statement, and a data-modifying CTE is a write
+   * wearing a `WITH`. Live-verified on PostgreSQL 18: explaining
+   * `WITH t AS (INSERT INTO probe(id) VALUES (42) RETURNING id) SELECT * FROM t`
+   * left the row really inserted - 0 rows before, 1 row after. Declining costs an
+   * Explain button; accepting performs a write the user only asked to see.
+   */
+  test.each<[string, string]>([
+    ["an INSERT CTE", "WITH t AS (INSERT INTO probe(id) VALUES (42) RETURNING id) SELECT * FROM t"],
+    ["an UPDATE CTE", "WITH t AS (UPDATE probe SET id = 1 RETURNING id) SELECT * FROM t"],
+    ["a DELETE CTE", "WITH t AS (DELETE FROM probe RETURNING id) SELECT * FROM t"],
+  ])("buildSql refuses %s, because ANALYZE would execute it", (_label, sql) => {
+    expect(postgresJsonStrategy.buildSql(sql, "analyze")).toBeNull();
+    expect(postgresJsonStrategy.buildSql(sql, "estimate")).toBeNull();
+  });
+
+  // The screen is scoped to the WITH form on purpose. A statement leading with SELECT
+  // cannot carry a data-modifying CTE (PostgreSQL allows one only at the top level), so
+  // screening those too would only strip the button off queries that mention a keyword.
+  test("buildSql still explains a SELECT that merely mentions a writing keyword", () => {
+    expect(postgresJsonStrategy.buildSql("SELECT 'insert' AS word", "analyze")).toBe(
+      "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT 'insert' AS word",
+    );
+    expect(postgresJsonStrategy.buildSql("SELECT updated_at FROM t", "analyze")).toBe(
+      "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT updated_at FROM t",
+    );
+  });
+
   test("extractPlan prefers the QUERY PLAN column", () => {
     const plan = [{ Plan: { "Node Type": "Seq Scan" } }];
     expect(postgresJsonStrategy.extractPlan({ rows: [{ "QUERY PLAN": plan }] })).toEqual(plan);

--- a/tests/unit/lib/explain/postgres-json.test.ts
+++ b/tests/unit/lib/explain/postgres-json.test.ts
@@ -57,6 +57,22 @@ describe("postgresJsonStrategy", () => {
     expect(postgresJsonStrategy.buildSql(sql, "estimate")).toBeNull();
   });
 
+  // The over-reach, pinned at the STRATEGY boundary rather than only on the helper.
+  // The screen is textual, so a keyword inside a string literal counts and this
+  // harmless read-only CTE loses its Explain button. That is the direction this has to
+  // err in - the other one performs a write the user only asked to see - and it is the
+  // documented behaviour, so it belongs in a test rather than in prose alone.
+  test("buildSql refuses a read-only CTE that merely mentions a writing keyword", () => {
+    expect(postgresJsonStrategy.buildSql("WITH t AS (SELECT 'insert' AS x) SELECT * FROM t", "analyze")).toBeNull();
+  });
+
+  // And the limit of that over-reach: the word boundary is what keeps it from swallowing
+  // every CTE that touches an `updated_at` column, which would be most of them.
+  test("buildSql still explains a CTE over a column whose name merely contains a keyword", () => {
+    const cte = "WITH t AS (SELECT updated_at FROM u) SELECT * FROM t";
+    expect(postgresJsonStrategy.buildSql(cte, "estimate")).toBe(`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${cte}`);
+  });
+
   // The screen is scoped to the WITH form on purpose. A statement leading with SELECT
   // cannot carry a data-modifying CTE (PostgreSQL allows one only at the top level), so
   // screening those too would only strip the button off queries that mention a keyword.

--- a/tests/unit/lib/explain/select-prefix.test.ts
+++ b/tests/unit/lib/explain/select-prefix.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { classifySelectPrefix, hasDataModifyingStatement } from "@/lib/explain/select-prefix";
+
+describe("classifySelectPrefix", () => {
+  test.each<[string, string]>([
+    ["a bare SELECT", "SELECT 1"],
+    ["leading spaces", "   SELECT 1"],
+    ["leading newlines and tabs", "\n\t SELECT 1"],
+    ["a line comment", "-- note\nSELECT 1"],
+    ["an empty line comment", "--\nSELECT 1"],
+    ["a block comment", "/* note */ SELECT 1"],
+    ["a multi-line block comment", "/* one\n   two */ SELECT 1"],
+    ["two adjacent block comments", "/*a*//*b*/SELECT 1"],
+    ["comments and whitespace interleaved", "-- a\n  /* b */\n\t-- c\nSELECT 1"],
+    ["lower case", "select 1"],
+    ["mixed case", "SeLeCt 1"],
+  ])("classifies %s as select", (_label, sql) => {
+    expect(classifySelectPrefix(sql)).toBe("select");
+  });
+
+  // Distinguished from `select` rather than collapsed into a boolean, because a WITH
+  // can carry a statement that writes and PostgreSQL's EXPLAIN executes what it
+  // explains. See postgres-json.ts.
+  test.each<[string, string]>([
+    ["a bare CTE", "WITH t AS (SELECT 1) SELECT * FROM t"],
+    ["a CTE behind a comment", "-- lead\nWITH t AS (SELECT 1) SELECT * FROM t"],
+    ["a CTE behind a block comment", "/* lead */ WITH t AS (SELECT 1) SELECT * FROM t"],
+    ["a recursive CTE", "WITH RECURSIVE t AS (SELECT 1) SELECT * FROM t"],
+    ["lower case", "with t as (select 1) select * from t"],
+  ])("classifies %s as with", (_label, sql) => {
+    expect(classifySelectPrefix(sql)).toBe("with");
+  });
+
+  // The near misses. Broadening the check must not turn it into "starts with anything":
+  // a comment is not a statement, and the word boundary is what keeps SELECTED out.
+  test.each<[string, string]>([
+    ["an UPDATE", "UPDATE t SET a = 1"],
+    ["a DELETE", "DELETE FROM t"],
+    ["an INSERT", "INSERT INTO t SELECT 1"],
+    ["a CREATE", "CREATE TABLE t (id INT)"],
+    ["an already-wrapped EXPLAIN", "EXPLAIN SELECT 1"],
+    ["a line comment alone", "-- only a comment"],
+    ["a block comment alone", "/* only a comment */"],
+    ["an empty string", ""],
+    ["only whitespace", "   "],
+    ["a word that merely starts with SELECT", "SELECTED 1"],
+    ["a word that merely starts with WITH", "WITHER"],
+    ["a word that merely starts with WITH, with a tail", "WITHOUT_A_KEYWORD 1"],
+    ["an unterminated block comment", "/* unterminated SELECT 1"],
+    ["a comment that never closes before the keyword", "-- SELECT 1"],
+  ])("returns null for %s", (_label, sql) => {
+    expect(classifySelectPrefix(sql)).toBeNull();
+  });
+
+  /**
+   * Regression guard on the SHAPE of the pattern, not on what it accepts.
+   *
+   * All three alternatives sit inside a `*` quantifier, so any way of matching the same
+   * text twice lets a NON-matching input backtrack. Each was measured on a predecessor
+   * of this pattern, and each is a different ambiguity:
+   *
+   *   a leading `\s*` beside a `\s` alternative      quadratic    958ms / 20k spaces
+   *   a lazy `[\s\S]*?\*\/` spanning two comments    quadratic    852ms / 4 KB
+   *   `--[^\n]*` with no `(?:\n|$)` tail             EXPONENTIAL  634ms / 49 chars
+   *
+   * The third is the one worth remembering: it needs three orders of magnitude less
+   * input than the others, it was introduced while fixing them, and it was found by
+   * CodeQL rather than by a guard like this one - because the guard exercised `-- a\n`
+   * repetitions, and the newline is exactly what makes that branch unambiguous. Hence
+   * the bare-dash cases below.
+   *
+   * The bound is loose on purpose - three orders of magnitude above what the correct
+   * pattern needs - so it cannot flake on a slow runner while still failing outright if
+   * any of the three ambiguities returns.
+   */
+  test("does not backtrack on long comment or whitespace runs that never reach a keyword", () => {
+    const BOUND_MS = 200;
+    const adversarial: [string, string][] = [
+      ["20k leading spaces", `${" ".repeat(20000)}UPDATE t SET a = 1`],
+      ["4 KB of empty block comments", `${"/**/".repeat(1000)}UPDATE t SET a = 1`],
+      ["block comments with bodies", `${"/*a*/".repeat(1000)}DELETE FROM t`],
+      ["line comments with newlines", `${"-- a\n".repeat(1000)}UPDATE t SET a = 1`],
+      ["mixed comments and whitespace", `${"/**/ -- a\n ".repeat(1000)}DELETE FROM t`],
+      ["24 bare dash pairs", `${"--".repeat(24)}X`],
+      ["2k bare dash pairs", `${"--".repeat(2000)}UPDATE t SET a = 1`],
+      ["20k bare dashes", `${"-".repeat(20000)}X`],
+    ];
+
+    for (const [label, sql] of adversarial) {
+      const started = performance.now();
+      const result = classifySelectPrefix(sql);
+      const elapsed = performance.now() - started;
+
+      // A correct answer AND a bounded one: a fast wrong answer is not a pass.
+      expect(result).toBeNull();
+      expect(elapsed, `${label} took ${elapsed.toFixed(1)}ms`).toBeLessThan(BOUND_MS);
+    }
+  });
+
+  test("stays fast on a large licence header that DOES reach a SELECT", () => {
+    const header = `/*\n${" * Licence line filler.\n".repeat(400)} */\n`;
+    const started = performance.now();
+
+    expect(classifySelectPrefix(`${header}SELECT 1`)).toBe("select");
+    expect(performance.now() - started).toBeLessThan(200);
+  });
+});
+
+describe("hasDataModifyingStatement", () => {
+  // Exists for PostgreSQL alone, whose EXPLAIN (ANALYZE) executes what it explains, so
+  // a data-modifying CTE would be PERFORMED by a button that claims to describe.
+  test.each<[string, string]>([
+    ["an INSERT CTE", "WITH t AS (INSERT INTO probe(id) VALUES (1) RETURNING id) SELECT * FROM t"],
+    ["an UPDATE CTE", "WITH t AS (UPDATE probe SET id = 1 RETURNING id) SELECT * FROM t"],
+    ["a DELETE CTE", "WITH t AS (DELETE FROM probe RETURNING id) SELECT * FROM t"],
+    ["a MERGE CTE", "WITH t AS (MERGE INTO probe USING x ON true WHEN MATCHED THEN DO NOTHING) SELECT 1"],
+    ["lower case", "with t as (insert into probe values (1) returning id) select * from t"],
+  ])("detects %s", (_label, sql) => {
+    expect(hasDataModifyingStatement(sql)).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["a read-only CTE", "WITH t AS (SELECT 1) SELECT * FROM t"],
+    ["a plain SELECT", "SELECT 1"],
+    ["a join", "SELECT * FROM a JOIN b ON a.id = b.id"],
+    // The word boundary keeps these out; without it every `updated_at` column would
+    // look like a write.
+    ["a column named updated_at", "SELECT updated_at FROM t"],
+    ["a column named inserted_by", "SELECT inserted_by FROM t"],
+    ["a table named deletions", "SELECT * FROM deletions"],
+  ])("does not flag %s", (_label, sql) => {
+    expect(hasDataModifyingStatement(sql)).toBe(false);
+  });
+
+  // Documented over-reach: the scan is textual, so a keyword inside a string literal
+  // counts. That costs an Explain button on an unusual CTE and never performs a write,
+  // which is the direction this has to err in.
+  test("errs toward refusing when a keyword appears inside a string literal", () => {
+    expect(hasDataModifyingStatement("WITH t AS (SELECT 'insert' AS x) SELECT * FROM t")).toBe(true);
+  });
+});

--- a/tests/unit/lib/explain/select-prefix.test.ts
+++ b/tests/unit/lib/explain/select-prefix.test.ts
@@ -109,14 +109,34 @@ describe("classifySelectPrefix", () => {
 describe("hasDataModifyingStatement", () => {
   // Exists for PostgreSQL alone, whose EXPLAIN (ANALYZE) executes what it explains, so
   // a data-modifying CTE would be PERFORMED by a button that claims to describe.
+  // All four are real carriers. MERGE especially is not a defensive guess: live on
+  // PostgreSQL 18, `EXPLAIN (ANALYZE, FORMAT JSON) WITH t AS (MERGE INTO probe ...
+  // RETURNING id) SELECT * FROM t` really inserted the row.
   test.each<[string, string]>([
     ["an INSERT CTE", "WITH t AS (INSERT INTO probe(id) VALUES (1) RETURNING id) SELECT * FROM t"],
     ["an UPDATE CTE", "WITH t AS (UPDATE probe SET id = 1 RETURNING id) SELECT * FROM t"],
     ["a DELETE CTE", "WITH t AS (DELETE FROM probe RETURNING id) SELECT * FROM t"],
-    ["a MERGE CTE", "WITH t AS (MERGE INTO probe USING x ON true WHEN MATCHED THEN DO NOTHING) SELECT 1"],
+    [
+      "a MERGE CTE",
+      "WITH t AS (MERGE INTO probe p USING (SELECT 99 AS mid) s ON p.id = s.mid " +
+        "WHEN NOT MATCHED THEN INSERT (id) VALUES (s.mid) RETURNING p.id) SELECT * FROM t",
+    ],
     ["lower case", "with t as (insert into probe values (1) returning id) select * from t"],
   ])("detects %s", (_label, sql) => {
     expect(hasDataModifyingStatement(sql)).toBe(true);
+  });
+
+  // TRUNCATE is deliberately absent: it cannot ride inside a WITH at all (live,
+  // `WITH t AS (TRUNCATE probe) SELECT 1` is a SYNTAX error), and a statement leading
+  // with it never reaches this function because `classifySelectPrefix` already answers
+  // null for anything but SELECT or WITH. Same for the other DDL verbs.
+  test.each<[string, string]>([
+    ["TRUNCATE", "TRUNCATE probe"],
+    ["DROP", "DROP TABLE probe"],
+    ["CREATE", "CREATE TABLE probe (id INT)"],
+  ])("leaves %s to the prefix classification, which refuses it outright", (_label, sql) => {
+    expect(hasDataModifyingStatement(sql)).toBe(false);
+    expect(classifySelectPrefix(sql)).toBeNull();
   });
 
   test.each<[string, string]>([

--- a/tests/unit/lib/explain/sqlite-queryplan.test.ts
+++ b/tests/unit/lib/explain/sqlite-queryplan.test.ts
@@ -58,4 +58,22 @@ describe("sqliteQueryplanStrategy", () => {
     expect(sqliteQueryplanStrategy.toRenderModel([])).toBeNull();
     expect(sqliteQueryplanStrategy.toRenderModel([{ nope: 1 }])).toBeNull();
   });
+
+  // Both live-verified accepted through this exact prefix, and EXPLAIN QUERY PLAN describes without running,
+  // so a CTE is safe to explain here - no write can hide inside one.
+  test("buildSql explains a CTE and a commented SELECT", () => {
+    const cte = "WITH t AS (SELECT 1 AS x) SELECT * FROM t";
+    expect(sqliteQueryplanStrategy.buildSql(cte, "analyze")).toBe(`EXPLAIN QUERY PLAN ${cte}`);
+    expect(sqliteQueryplanStrategy.buildSql("-- note\nSELECT 1", "estimate")).toBe(
+      "EXPLAIN QUERY PLAN -- note\nSELECT 1",
+    );
+    expect(sqliteQueryplanStrategy.buildSql("/* note */ SELECT 1", "estimate")).toBe(
+      "EXPLAIN QUERY PLAN /* note */ SELECT 1",
+    );
+  });
+
+  test("buildSql still declines a comment with no statement behind it", () => {
+    expect(sqliteQueryplanStrategy.buildSql("-- only a comment", "analyze")).toBeNull();
+    expect(sqliteQueryplanStrategy.buildSql("/* only a comment */", "analyze")).toBeNull();
+  });
 });


### PR DESCRIPTION
Follow-up to #271, which fixed this for Druid only.

All six explain strategies carried their own copy of `/^\s*SELECT\b/i`, and every one of them refused
two statements its engine explains perfectly well — **a CTE, and a SELECT behind a comment**. The
Explain button was simply absent for both. The check now lives in one place,
`src/lib/explain/select-prefix.ts`.

The CTE case was also an internal disagreement: the shared `analyzeQuery`
([`db/utils/query-limiter.ts`](../blob/main/src/lib/db/utils/query-limiter.ts)) already classifies
`WITH … SELECT` as a SELECT and injects a `LIMIT` into one, so six strategies declining it
contradicted the rest of the pipeline.

## Verified per dialect, not assumed

Each statement below was wrapped by the **real** strategy, executed against the **real** engine, and
rendered through `extractPlan` → `toRenderModel`:

| engine | forms checked | result |
|---|---|---|
| PostgreSQL 18 | CTE, line comment, block comment | all explain |
| MySQL 9 | CTE, line comment, block comment | all explain |
| SQLite | CTE, line comment, block comment | all explain |
| ClickHouse 26.7 | CTE, line comment, block comment | all explain |
| Couchbase 8.0.2 | `WITH` binding, line comment, block comment | all explain |
| Apache Druid 37 | CTE, line comment, block comment | all explain |

Couchbase needed its own spelling — SQL++ `WITH alias AS (<expression>)` binds a *value*, not a
subquery. That is the kind of thing a shared regex would have papered over.

## PostgreSQL could not take the shared answer, and that is why this was verified per engine

Its strategy emits `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)`, which **executes** the statement — and a
data-modifying CTE is a write wearing a `WITH`:

```
EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
  WITH t AS (INSERT INTO probe(id) VALUES (42) RETURNING id) SELECT * FROM t

rows before: 0
rows after:  1   (id = 42)
```

**Explaining performed the insert.** So accepting `WITH` there without a screen would have turned the
Explain button into a write — a regression introduced by a change whose whole purpose was consistency.

`postgres-json.ts` pairs the shared classification with `hasDataModifyingStatement()` and applies that
screen **only** to the `"with"` case. Two reasons it is scoped that way, both verified:

- PostgreSQL refuses a data-modifying CTE anywhere but the top level — *"WITH clause containing a
  data-modifying statement must be at the top level"* — so one cannot hide behind a leading `SELECT`.
- Screening `SELECT` too would strip the button off anything that merely mentions a keyword.
  `SELECT 'insert' AS word` and `SELECT updated_at FROM t` explain fine today and still do.

The screen errs toward refusing: a read-only CTE that merely mentions `insert` loses its Explain
button rather than risking a write. That is the only direction this can safely err in, and it is
documented as such.

`classifySelectPrefix()` returns `"select" | "with" | null` rather than a boolean precisely so that
asymmetry is expressible by a caller.

## The regex shape is carried over deliberately

#271 arrived at this pattern the hard way — all three alternatives sit inside a `*` quantifier, so each
had to be made unambiguous independently:

| ambiguity | cost | input needed |
|---|---|---|
| leading `\s*` beside a `\s` alternative | 958ms | 20 KB |
| lazy `[\s\S]*?\*\/` spanning two comments | 852ms | 4 KB |
| `--[^\n]*` with no `(?:\n\|$)` tail | **exponential**, 634ms | **49 chars** |

The third was found by CodeQL after the first two were fixed, and it is the one worth remembering: it
needs three orders of magnitude less input, and it slipped past a guard that exercised `-- a\n`
repetitions, because the newline is exactly what makes that branch unambiguous.

The bounded-time guard moves into `select-prefix.test.ts` with the regex — the property belongs to the
pattern, not to Druid — and now covers bare-dash runs explicitly. Druid keeps a lighter test proving it
still routes through the shared check.

## Verification

```
format · lint (0 errors) · typecheck · knip · test (0 failures) · build
check-coverage: OK — 28534/28534 lines (100.00%)
```

All **8** files under `src/lib/explain/` that carry executable lines are at 100% individually —
`clickhouse-json`, `couchbase-json`, `druid-native`, `index`, `mysql-json`, `postgres-json`,
`select-prefix`, `sqlite-queryplan`. The ninth, `types.ts`, is types only and so never appears in the
lcov at all.

(An earlier revision of this description said "nine files under `src/lib/explain/`". That was wrong:
the grep behind it matched `/explain/` and so also caught `src/app/api/ai/explain/route.ts`, which is
an API route rather than a strategy. Corrected here — thanks to the reviewer who asked for the
coverage report to be confirmed rather than taken on trust.)

`docs/ADDING_A_PROVIDER.md` gains both rules: use `classifySelectPrefix()` rather than a fresh regex,
and ask whether your engine's EXPLAIN executes before widening what it accepts.

## Review follow-ups (a8a224e)

- **PostgreSQL over-reach pinned at the strategy boundary.** `select-prefix.test.ts` covered
  `hasDataModifyingStatement` on a read-only CTE mentioning a keyword, but nothing pinned what
  `buildSql` does with it. It now does — together with the *limit* of that over-reach, which was the
  untested half: the word boundary is what stops the screen swallowing every CTE that touches an
  `updated_at` column, so that case still explains. Writing the pair caught a wrong assertion in my
  first draft, where I had expected `updated_at` to be refused.
- **`DATA_MODIFYING` membership is now recorded rather than assumed.** `MERGE` is a real carrier —
  live, `EXPLAIN (ANALYZE) WITH t AS (MERGE INTO probe … RETURNING id) SELECT * FROM t` inserted the
  row. `TRUNCATE` is deliberately absent: it cannot ride inside a `WITH` at all
  (`WITH t AS (TRUNCATE probe) SELECT 1` is a *syntax* error), and a statement leading with it is
  already refused by the prefix classification. Tested for `TRUNCATE`, `DROP` and `CREATE`.
- **The `analyzeQuery` note turned out to hide a live defect, not just drift risk.** A leading comment
  makes it classify a `SELECT` as `OTHER`, so `prepareQuery` injects no `LIMIT` and the query runs
  **unbounded** — the same root cause as this PR, with a worse outcome. Filed as **#275** with the
  reproduction. Deliberately not fixed here: `analyzeQuery` feeds the query path of all ten providers
  plus pagination, so it needs its own change and its own tests.
