### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,11 +447,12 @@ bun run test:coverage
 
 ## One-Click Deploy
 
-Deploy your own instance of LibreDB Studio with a single click on DigitalOcean, Koyeb, Render, Railway, CapRover, or Dokploy:
+Deploy your own instance of LibreDB Studio with a single click on DigitalOcean, Koyeb, Render, Railway, Sealos, CapRover, or Dokploy:
 
  [![Deploy to Koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?name=libredb-studio&type=docker&image=ghcr.io%2Flibredb%2Flibredb-studio%3Alatest&instance_type=free&regions=fra&instances_min=0&autoscaling_sleep_idle_delay=3900&env%5BADMIN_EMAIL%5D=admin%40libredb.org&env%5BADMIN_PASSWORD%5D=LibreDB.2026&env%5BJWT_SECRET%5D=replace_with_openssl_rand_base64_32&env%5BLLM_API_KEY%5D=your_GEMINI_API_KEY&env%5BLLM_MODEL%5D=gemini-2.5-flash&env%5BLLM_PROVIDER%5D=gemini&env%5BNEXT_PUBLIC_AUTH_PROVIDER%5D=local&env%5BSTORAGE_PROVIDER%5D=local&env%5BUSER_EMAIL%5D=user%40libredb.org&env%5BUSER_PASSWORD%5D=LibreDB.2026&ports=3000%3Bhttp%3B%2F&hc_protocol%5B3000%5D=tcp&hc_grace_period%5B3000%5D=5&hc_interval%5B3000%5D=30&hc_restart_limit%5B3000%5D=3&hc_timeout%5B3000%5D=5&hc_path%5B3000%5D=%2F&hc_method%5B3000%5D=get)  
  [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/libredb/libredb-studio)  
  [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/libredb-studio?referralCode=libredb&utm_medium=integration&utm_source=template&utm_campaign=generic)  
+ [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/libredb-studio)  
  [![Deploy on DigitalOcean](https://img.shields.io/badge/Deploy%20on-DigitalOcean-0080FF?style=for-the-badge&logo=digitalocean&logoColor=white)](https://marketplace.digitalocean.com/apps/libredb-studio)  
  [![Deploy on CapRover](https://img.shields.io/badge/Deploy%20on-CapRover-2474ed?style=for-the-badge&logo=docker&logoColor=white)](https://github.com/caprover/one-click-apps/blob/master/public/v4/apps/libredb-studio.yml)  
  [![Deploy on Fly.io](https://img.shields.io/badge/Deploy%20on-Fly.io-24175B?style=for-the-badge&logo=flydotio&logoColor=white)](docs/FLY.md)  


### PR DESCRIPTION
## Description

Adds Sealos to the existing one-click deployment options. The new badge is placed immediately after Railway and links to the published LibreDB Studio template in the Sealos App Store.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Related Issue

N/A

## Changes Made

- Add Sealos to the one-click deployment provider list.
- Add the official Deploy on Sealos badge immediately after Railway.
- Link the badge to the published LibreDB Studio App Store page.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [ ] All existing tests pass

Validation performed:

- Confirmed the App Store page and badge asset both return HTTP 200.
- Rendered the README through GitHub's Markdown API and confirmed the badge link, image source, alt text, and line break.
- Smoke-tested LibreDB Studio 0.9.66 on Sealos with authenticated admin login, core navigation, query execution, and persistence across restart.
- Validated both SQLite and PostgreSQL storage modes.

### Test Environment

- **LibreDB Studio Version**: 0.9.66
- **Browser**: Chromium
- **OS**: Sealos Cloud (Kubernetes)
- **Node.js/Bun Version**: N/A (documentation-only change)
- **Database Type**: SQLite and PostgreSQL

## Screenshots (if applicable)

N/A (README badge only)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- App Store page: https://sealos.io/products/app-store/libredb-studio
- Template publication: https://github.com/labring-actions/templates/pull/740
- The Sealos template is maintained in `labring-actions/templates`, and I can follow up on deployment-link or template issues.
- All deployment-test resources were cleaned up after validation.
