### PR TITLE
fix: where a SQL statement begins, ends, and what operates it (#287, #280, #281, #291, #294)

### DIFF
--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -30,7 +30,7 @@ All SELECT queries are automatically paginated to prevent browser freezes when d
 ### How It Works
 
 1. User executes a SELECT query
-2. System automatically adds `LIMIT 500` if no LIMIT exists (an `OFFSET` clause is only appended when the offset is greater than 0)
+2. System automatically adds `LIMIT 500` if no LIMIT exists (an `OFFSET` clause is only appended when the offset is greater than 0). The clause is inserted at the end of the statement itself, before any trailing comment or `;` — see [Where the bound is placed](#where-the-bound-is-placed)
 3. If user already specified a LIMIT, it's preserved (no override)
 4. Results display with pagination metadata
 
@@ -83,6 +83,7 @@ const result = applyQueryLimit('SELECT * FROM users', 500, 0);
 |------------|-------------------|
 | SELECT | Yes |
 | SELECT behind a leading comment | Yes |
+| SELECT ending in a comment | Yes (the bound is placed before the comment), except a `#` comment — see below |
 | SELECT with LIMIT | No (preserved) |
 | SELECT with UNION | Yes (LIMIT appended after the last statement) |
 | Read-only CTE (`WITH … SELECT`) | Yes |
@@ -117,6 +118,67 @@ return every row:
 
 Both are reads, so the cost is an unbounded result set rather than a partial write, and both are
 pinned by tests in `tests/unit/sql/operative-keyword.test.ts` so the gap stays a decision.
+
+### Where the bound is placed
+
+The clause is inserted **between the statement and its trailing trivia** — whitespace, comments and
+the terminating `;` — and the trivia is re-attached verbatim. A statement carrying no trailing trivia
+is emitted exactly as it was before this rule existed.
+
+| Statement | Emitted SQL |
+|-----------|-------------|
+| `SELECT * FROM t` | `SELECT * FROM t LIMIT 500` |
+| `SELECT * FROM t;` | `SELECT * FROM t LIMIT 500;` |
+| `SELECT * FROM t -- note` | `SELECT * FROM t LIMIT 500 -- note` |
+| `SELECT * FROM t; -- note` | `SELECT * FROM t LIMIT 500; -- note` |
+| `SELECT * FROM t /* note */` | `SELECT * FROM t LIMIT 500 /* note */` |
+
+Appending after the trivia instead put the bound **inside** a trailing line comment: the engine ran
+the statement unbounded while the badge reported it as capped, and the re-appended `;` ended up
+inside the comment as well.
+
+The same reading of the end answers "is this statement already bounded". The `LIMIT n`,
+`FETCH FIRST n ROWS ONLY` and `OFFSET n` probes are anchored at the end of the **statement**
+(`src/lib/sql/statement-end.ts`), so:
+
+- a bound written inside a trailing comment (`SELECT … -- LIMIT 10`) is not mistaken for a real one,
+  and the statement is bounded;
+- a real bound followed by a comment (`SELECT … LIMIT 10 -- deliberate`) is still detected, honoured
+  and never doubled — a second bound is a syntax error, not extra rows.
+
+Reading where a statement ends and **cutting** it there are separate answers, because they are not
+equally risky: a probe that stops early merely finds no bound, while a clause inserted early lands in
+the middle of the statement and the server rejects it outright. Two shapes are therefore read but not
+cut, and a statement carrying either is **returned untouched with `wasLimited: false`** — the second
+branch of "never `true` alongside a bound the engine cannot see":
+
+| Shape | Why the cut is refused |
+|-------|------------------------|
+| An unterminated comment or literal, or a quote behind an odd backslash run (`… WHERE name = 'O\'Brien'`) | MySQL escapes with backslashes and PostgreSQL does not, so the two close the literal in different places; inserting on a guess puts the bound after the statement's own `;` |
+| A `#` run at the end of the statement (`SELECT * FROM #tmp`, `… WHERE ID# = 1`, `SELECT flags # 5`) | `#` is MySQL's second comment marker and ordinary code elsewhere — a T-SQL temp table, an Oracle identifier, a PostgreSQL XOR — and nothing in the text tells them apart (`#note` and `#tmp` are the same characters) |
+
+Both are a **deliberate loss of a bound**: appending after everything, as the limiter used to, was
+valid SQL for the dialect in which those characters are code, and is exactly what put the clause
+inside a trailing comment for the dialect in which they are not. Not bounding costs an over-large
+read the user can re-run, which is the trade every reader in `src/lib/sql/` makes.
+
+A `#` comment with code after it on a later line is unaffected. Where the cut is refused, the
+statement's *text* is still read to its very end (trailing whitespace and `;` aside), so a bound
+written after a `#` is still found and never doubled — which is also why MSSQL's `TOP` splice, writing
+into the head, keeps bounding `SELECT * FROM #tmp` while leaving a temp-table page that already
+carries a `FETCH NEXT` alone. That last part is not airtight: trailing trivia written *after* such a
+bound hides it from the end-anchored probe, so the `TOP` is spliced anyway — unchanged from before
+this section existed, and noted here rather than claimed closed. The
+one shape that stays wrong is a bound commented out with `#` (`… # LIMIT 10`): it is still read as
+real, so that statement is left alone instead of being bounded. The `--` form, which is unambiguous,
+is fixed.
+
+Providers that append a clause of their own follow the same rule: Oracle's `FETCH FIRST` and
+`OFFSET … FETCH NEXT`, and MSSQL's `OFFSET … FETCH NEXT` pagination branch. MSSQL's `SELECT TOP n`
+splices into the head, which no trailing comment can reach, and is unchanged. ClickHouse's refusal to
+rewrite a statement ending in `FORMAT`/`SETTINGS`, and Druid's refusal to rewrite one ending in an
+`OFFSET`, both read the same end — otherwise a trailing comment would hide the clause from them and
+the bound placed before that comment would turn a working statement into a server-side syntax error.
 
 ---
 

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -85,7 +85,8 @@ const result = applyQueryLimit('SELECT * FROM users', 500, 0);
 | SELECT behind a leading comment | Yes |
 | SELECT with LIMIT | No (preserved) |
 | SELECT with UNION | Yes (LIMIT appended after the last statement) |
-| SELECT with CTE | Yes |
+| Read-only CTE (`WITH … SELECT`) | Yes |
+| Data-modifying CTE (`WITH … INSERT`/`UPDATE`/`DELETE`/`MERGE`) | No — the bound would apply to the rows the statement writes, committing only part of it |
 | INSERT/UPDATE/DELETE | No |
 | DDL (CREATE, ALTER) | No |
 
@@ -95,6 +96,27 @@ are skipped and the limit is still applied. Before this, an annotated `SELECT` w
 unknown statement type and returned **every** row while the badge reported it as not limited.
 An already-bounded annotated statement (`LIMIT n`, `FETCH FIRST n ROWS ONLY`, `SELECT TOP n`) is
 still recognised as bounded and is not limited twice.
+
+A statement leading with `WITH` is typed by the keyword its CTE list **operates** — the first one
+after the list, read by walking the list's grammar in `src/lib/sql/operative-keyword.ts`. Asking
+instead whether the text contained `SELECT` let the `INSERT INTO … SELECT` idiom answer for its own
+statement: a data-modifying CTE was typed `SELECT`, received a `LIMIT`, and in PostgreSQL that bound
+applies to the rows the statement **writes** — it committed at most 500 of them while the badge
+reported a truncated result set. Where the CTE list's shape cannot be determined, the statement is
+not treated as a `SELECT` and is not bounded: an over-large read can be re-run, a partly committed
+write cannot be undone.
+
+That covers malformed input (an unclosed body, a missing `AS`, an unterminated comment or literal)
+and, deliberately, two **well-formed** forms the reader does not walk — so they lose their bound and
+return every row:
+
+| Form | Why it is not read | Effect |
+|------|--------------------|--------|
+| ClickHouse's `WITH <expr> AS <alias>` (`WITH now() AS ts SELECT …`) | puts an expression where the standard form puts a CTE name; reading it needs an expression parser | idiomatic on ClickHouse, and a regression there — tracked for follow-up |
+| PostgreSQL's `SEARCH` / `CYCLE` clause after a recursive CTE list | sits between the list and the operative keyword; the reader stops at the first word after the list | rare |
+
+Both are reads, so the cost is an unbounded result set rather than a partial write, and both are
+pinned by tests in `tests/unit/sql/operative-keyword.test.ts` so the gap stays a decision.
 
 ---
 

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -99,25 +99,40 @@ An already-bounded annotated statement (`LIMIT n`, `FETCH FIRST n ROWS ONLY`, `S
 still recognised as bounded and is not limited twice.
 
 A statement leading with `WITH` is typed by the keyword its CTE list **operates** — the first one
-after the list, read by walking the list's grammar in `src/lib/sql/operative-keyword.ts`. Asking
+after the list, read by walking the list's grammar in `src/lib/sql/operative-keyword.ts`. A list
+element is read in either of the two shapes the supported dialects use: the standard
+`name [(cols)] AS [[NOT] MATERIALIZED] (body)`, and ClickHouse's `<expr> AS <alias>`
+(`WITH now() AS ts SELECT …`, `WITH 1 AS one SELECT …`) — an element the walker cannot cross ends the
+reading, and the statement then loses its bound, which is what happened to ClickHouse's own CTE idiom
+between the two fixes. The shapes are told apart by whether the element's head reads as a name and by
+what follows its `AS`: a body or one of PostgreSQL's inlining hints can only be the standard shape,
+anything else is an alias. Asking
 instead whether the text contained `SELECT` let the `INSERT INTO … SELECT` idiom answer for its own
 statement: a data-modifying CTE was typed `SELECT`, received a `LIMIT`, and in PostgreSQL that bound
 applies to the rows the statement **writes** — it committed at most 500 of them while the badge
-reported a truncated result set. Where the CTE list's shape cannot be determined, the statement is
-not treated as a `SELECT` and is not bounded: an over-large read can be re-run, a partly committed
-write cannot be undone.
+reported a truncated result set. Where the reader cannot cross the CTE list, the statement is not
+treated as a `SELECT` and is not bounded: an over-large read can be re-run, a partly committed write
+cannot be undone.
 
-That covers malformed input (an unclosed body, a missing `AS`, an unterminated comment or literal)
-and, deliberately, two **well-formed** forms the reader does not walk — so they lose their bound and
-return every row:
+That covers most malformed input (an unclosed body, a missing `AS`, an unterminated comment or
+literal) and, deliberately, two **well-formed** forms the reader does not walk — so they lose their
+bound and return every row:
 
 | Form | Why it is not read | Effect |
 |------|--------------------|--------|
-| ClickHouse's `WITH <expr> AS <alias>` (`WITH now() AS ts SELECT …`) | puts an expression where the standard form puts a CTE name; reading it needs an expression parser | idiomatic on ClickHouse, and a regression there — tracked for follow-up |
 | PostgreSQL's `SEARCH` / `CYCLE` clause after a recursive CTE list | sits between the list and the operative keyword; the reader stops at the first word after the list | rare |
+| An expression element aliased with an inlining hint (`WITH col AS materialized SELECT …`) | the hint commits the element to the standard shape, which then expects a body | rare, and the alternative reading would let `WITH t AS NOT LAZY (…)` report `LAZY` as the operative keyword |
 
 Both are reads, so the cost is an unbounded result set rather than a partial write, and both are
 pinned by tests in `tests/unit/sql/operative-keyword.test.ts` so the gap stays a decision.
+
+The reverse also has a narrow case, pinned in the same file: reading an expression element means
+knowing where it ends only by its `AS`, so any element the standard shape **declines** — a head that is
+not a name, or an `AS` with no body after it — is re-read as an expression that ends at the first
+`AS <name>` at depth 0, however far away. `WITH 2 INSERT INTO users AS u SELECT 1` and
+`WITH x AS DELETE, foo AS (SELECT 1) SELECT 1` therefore answer `SELECT` and receive a bound. No
+supported dialect accepts such text, so what the server receives is a rejected statement either way
+rather than a partly limited write.
 
 ### Where the bound is placed
 

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -180,6 +180,31 @@ rewrite a statement ending in `FORMAT`/`SETTINGS`, and Druid's refusal to rewrit
 `OFFSET`, both read the same end — otherwise a trailing comment would hide the clause from them and
 the bound placed before that comment would turn a working statement into a server-side syntax error.
 
+### Multi-statement runs
+
+In standalone studio, a script holding several statements is split
+(`src/lib/sql/statement-splitter.ts`) and sent to `POST /api/db/multi-query`, which bounds the **last**
+statement only, and only when it is a `SELECT`. Embedded in a host application the query goes to the
+host's own executor and none of this route applies.
+
+Whether that last statement *is* a `SELECT` is the shared reading described above (`isSelectQuery`),
+not a pattern belonging to the route. It used to be `/^\s*SELECT\b/i`, which tolerates whitespace but
+not a comment — and the splitter keeps each statement's leading comments — so a final `SELECT` behind a
+`-- note` was not recognised and reached the engine unbounded, the one place the comment-tolerant
+classifier had not been adopted (#281). The CTE typing applies here too: a final read-only CTE is
+bounded, a final data-modifying one is not.
+
+Last-only is that route's own policy, and it leaves a hole this section does not close: a non-final
+`SELECT` runs exactly as written, and its **entire** result set travels back in `statements[i].rows`.
+That is also what the grid displays whenever the final statement returns no rows of its own
+(`SELECT * FROM huge; INSERT INTO t VALUES (1)`), since the response picks the last result that *has*
+rows. Noted here rather than claimed closed.
+
+Two indicators do not follow the bound onto this route, because it returns no pagination metadata at
+all: the **AUTO-LIMITED badge does not appear** for a multi-statement run, and **Load More is not
+offered** even when rows were capped. The bound itself is real and applied — re-run the final statement
+on its own to page through it.
+
 ---
 
 ## Load More Functionality

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -6,6 +6,7 @@ LibreDB Studio includes enterprise-grade query optimization features to prevent 
 
 - [Query Pagination System](#query-pagination-system)
 - [Silent Auto-Limiting](#silent-auto-limiting)
+- [Destructive-Statement Confirmation](#destructive-statement-confirmation)
 - [Load More Functionality](#load-more-functionality)
 - [Result-Level Signals](#result-level-signals)
 - [Query EXPLAIN Integration](#query-explain-integration)
@@ -219,6 +220,59 @@ Two indicators do not follow the bound onto this route, because it returns no pa
 all: the **AUTO-LIMITED badge does not appear** for a multi-statement run, and **Load More is not
 offered** even when rows were capped. The bound itself is real and applied — re-run the final statement
 on its own to page through it.
+
+---
+
+## Destructive-Statement Confirmation
+
+Before a destructive statement runs, studio opens a confirmation dialog carrying an AI risk
+analysis (`src/components/QuerySafetyDialog.tsx`). Which statements reach it is decided by the
+same reading the auto-limiter uses, so the two cannot disagree about where a statement begins.
+
+| Statement | Confirmation |
+|-----------|--------------|
+| `DELETE` / `DROP` / `TRUNCATE` / `ALTER` / `GRANT` / `REVOKE` / `UPDATE` | Yes |
+| Any of those behind a comment (`-- note`, `/* note */`, MySQL's `# note`, several stacked) | Yes |
+| A `WITH` whose CTE list precedes one (`WITH x AS (…) DELETE FROM …`) | Yes |
+| A `WITH` whose CTE list *contains* an `UPDATE … SET` (PostgreSQL's data-modifying CTE) | Yes |
+| `SELECT`, including one naming a destructive keyword in a string or a comment | No |
+
+The statement's own keyword is read with `src/lib/sql/operative-keyword.ts` and tested against a
+keyword set. It used to be re-derived here as six anchored patterns (`/^\s*DROP\b/i`, …), which
+tolerate whitespace but not a comment — so `-- cleanup` above a `DROP TABLE` skipped the dialog
+and the statement executed unconfirmed, on both the standalone and the embedded execution path.
+Writing a note above a destructive statement is ordinary, and it is exactly where a confirmation
+matters most.
+
+One probe stays deliberately unanchored: a statement whose code contains `UPDATE` followed by
+`SET` asks for confirmation whatever its own keyword is. PostgreSQL's data-modifying CTE is
+*operated* by its `SELECT` — which is the honest answer, and the one the limiter needs so it does
+not bound the rows a write commits — so anchoring this probe too would take the last check away
+from a statement that really does write. It reads the statement's **code** rather than its text
+(`src/lib/sql/words.ts`), so unlike the pattern before it, a read that merely quotes
+`'UPDATE t SET x = 1'` or mentions it in a comment no longer prompts.
+
+Three gaps are known and pinned by tests rather than claimed closed:
+
+- **Only `UPDATE … SET` is looked for inside a read.** A write hidden in a CTE *body* under any
+  other keyword (`WITH gone AS (DELETE FROM t RETURNING *) SELECT * FROM gone`) does not prompt.
+  Widening the probe to `DELETE`/`INSERT`/`MERGE` would also make every read whose code names one
+  of them prompt, so the asymmetry is inherited from the vocabulary above rather than chosen here.
+- **A statement whose shape cannot be read at all** — an unclosed CTE list, or an undeterminable
+  literal such as `'\'`, which closes the string in PostgreSQL and not in MySQL — hides what
+  follows it. The text is a syntax error under at least one dialect, so the server rejects it
+  either way.
+- **A multi-statement script is read as one statement.** `SELECT 1; DROP TABLE users` does not
+  prompt (its first keyword is the `SELECT`), while `SELECT 1; UPDATE t SET x = 1` does, because
+  the unanchored probe finds it. Executing the destructive statement on its own always prompts.
+
+Four runs bypass the gate on purpose, all on the standalone path
+(`src/hooks/use-query-execution.ts`): an EXPLAIN run (see below), a Load-More page of a result the
+user already has, a playground run (rolled back rather than committed), and anything carrying
+`skipSafety` — which is the dialog's own "Execute Anyway" button and the inline row editor, whose
+`UPDATE` comes from a grid edit the user has already confirmed. The embedded adapter
+(`src/workspace/hooks/use-query-adapter.ts`) has only the force-execute bypass, so every other
+query a host application runs through it reaches the gate.
 
 ---
 

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -389,6 +389,17 @@ positive is only a missing row limit — the statement still runs and still retu
 whereas the other direction would produce a hard syntax error, which is why the bias sits where it
 does.
 
+**Expression-form CTEs are limited too.** A CTE is ordinarily written `WITH <expr> AS <alias>` here —
+`WITH 1 AS one SELECT one, count(*) FROM events GROUP BY one`, `WITH now() AS t SELECT * FROM events
+WHERE ts < t` — which is not the `name AS (body)` shape the other dialects use. The shared statement
+typer (`src/lib/sql/operative-keyword.ts`) walks a CTE-list element in both shapes, so these type
+`SELECT` and receive the inherited bound. While it walked only the standard shape they typed `OTHER`
+and reached the server unbounded ([#291](https://github.com/libredb/libredb-studio/issues/291)) — on
+the one engine here whose ordinary result set is larger than a browser can hold. Nothing is made
+unsafe by reading the form: ClickHouse has no data-modifying CTE, so a missing bound was the whole
+cost. Detection and typing still agree on the same statement — `WITH 1 AS one SELECT one FORMAT TSV`
+comes back untouched, because the trailing-clause refusal above reads it as well.
+
 ### 3.9 Column types are the declared strings, verbatim
 
 Types come back exactly as declared, with no normalization attempted:

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -361,9 +361,10 @@ error, live-verified:
 works.
 
 `ClickHouseProvider.prepareQuery()`
-([index.ts:515](../../src/lib/db/providers/sql/clickhouse/index.ts)) detects a trailing `FORMAT` or
-`SETTINGS` clause with two patterns anchored at the **end** of the statement (after stripping one
-trailing semicolon, which the server accepts) and, when either matches, returns the query
+([index.ts:562](../../src/lib/db/providers/sql/clickhouse/index.ts)) detects a trailing `FORMAT` or
+`SETTINGS` clause with two patterns anchored at the **end** of the statement — as
+`src/lib/sql/statement-end.ts` delimits it, so the terminating semicolon and any trailing comment are
+outside what the patterns read — and, when either matches, returns the query
 **unchanged** with `wasLimited: false` rather than delegating to the inherited limiter. Anchoring at
 the end is what keeps the check off a statement that merely mentions the word: `SELECT * FROM t
 WHERE note = 'format'` and `SELECT name FROM system.settings` are ordinary statements that still get
@@ -371,6 +372,15 @@ limited normally, because neither ends in the clause pattern. A user who wrote a
 or `SETTINGS` clause is expressing intent the editor must not silently rewrite, and the bias has to
 favour not rewriting: rewriting wrongly turns a working statement into a syntax error, while leaving
 it alone at worst returns more rows than the page size.
+
+A hand-rolled semicolon strip used to stand in for that reading, so `... FORMAT TSV -- note` read as
+carrying no trailing clause at all. That was harmless only while the inherited limiter appended its
+bound after the comment, where the server never saw it; now that the bound is placed **before** the
+comment, the same miss would emit `... FORMAT TSV LIMIT n -- note` — the very `400` / code `62` above.
+Detection and placement therefore read one shared definition of where a statement ends. Where that
+reader refuses to let the statement be cut at all — an unterminated literal, or a trailing `#` run —
+the inherited limiter declines on its own, so such a statement is passed through untouched whatever
+this override answers.
 
 One false positive is accepted on purpose rather than fixed: a statement ending in a string literal
 that itself contains an assignment (`... WHERE note = 'SETTINGS foo = 1'`) is read as carrying a

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -492,7 +492,9 @@ await provider.query('SELECT h.name FROM `travel`.`inventory`.`hotel` AS h WHERE
 The request carries `metrics: true`, the effective statement timeout, and
 `scan_consistency: request_plus` ([§3.7](#37-read-your-writes-scan_consistency-defaults-to-request_plus)).
 `prepareQuery()` injects `LIMIT`/`OFFSET` through the shared limiter
-(`supportsExternalQueryLimiting: true`), so paging behaves as it does for every SQL provider.
+(`supportsExternalQueryLimiting: true`), so paging behaves as it does for every SQL provider —
+including where the clause is placed: at the end of the statement, before a trailing comment or `;`
+([`query-optimization.md`](../editor/query-optimization.md#where-the-bound-is-placed)).
 
 ### 5.2 Result shaping
 

--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -515,9 +515,10 @@ panel is worse than an empty one.
 ### 3.9 The `prepareQuery()` override: `OFFSET` with no `LIMIT`
 
 The inherited limiter is otherwise correct for Druid: `LIMIT 500` appends cleanly, an existing `LIMIT`
-is left alone, and the shared `applyQueryLimit` already strips and re-appends a trailing semicolon —
-which matters, because Druid accepts `SELECT 1 AS c1;` but rejects `SELECT 1 AS c1; LIMIT 2`, and the
-shared limiter never produces the latter.
+is left alone, and the shared `applyQueryLimit` inserts the bound at the end of the **statement**,
+before the terminating semicolon and any trailing comment, which it then re-attaches — which matters,
+because Druid accepts `SELECT 1 AS c1;` but rejects `SELECT 1 AS c1; LIMIT 2`, and the shared limiter
+never produces the latter.
 
 The one failure is a statement ending in **`OFFSET n` with no `LIMIT`**. The limiter appends `LIMIT`
 after it, and Druid rejects the result outright (live-verified):
@@ -528,11 +529,18 @@ SELECT id FROM libredb_demo OFFSET 2 LIMIT 3
 ```
 
 `DruidProvider.prepareQuery()`
-([index.ts:218](../../src/lib/db/providers/sql/druid/index.ts)) asks `analyzeQuery()` — the shared
-analyzer, not a regex of its own, because it already handles the trailing semicolon and already
+([index.ts:271](../../src/lib/db/providers/sql/druid/index.ts)) asks `analyzeQuery()` — the shared
+analyzer, not a regex of its own, because it already reads the end of the statement (so the
+terminating semicolon and any trailing comment are outside what its probes see) and already
 distinguishes an `OFFSET` that follows a `LIMIT` (the ordinary paginated form, which the limiter
 leaves alone anyway) from one that stands alone. When the statement has an `OFFSET` and no `LIMIT`, it
 returns the query **untouched** with `wasLimited: false`.
+
+Routing that decision through the shared analyzer is also what fixed `SELECT … OFFSET 2 -- paged`
+here with no edit to this provider: the probe was anchored at the end of the raw text, so a trailing
+comment hid the `OFFSET`, the limiter appended a bound and Druid answered `400`. The analyzer now
+reads the end of the **statement** ([`statement-end.ts`](../../src/lib/sql/statement-end.ts)), and
+this override inherits that (#280).
 
 The bias is the same one ClickHouse's trailing-clause case takes, for the same reason: **rewriting
 wrongly turns a working statement into a syntax error, while leaving it alone at worst returns more
@@ -859,7 +867,8 @@ Quoting is what makes the word an identifier — `SELECT 1 AS "one"` is accepted
 statement and get an unexplained syntax error near a perfectly ordinary word, quote it.
 
 **`LIMIT 5 LIMIT 2` is a syntax error**, and so is `SELECT 1 AS c1; LIMIT 2`. The shared limiter never
-produces either: it preserves an existing `LIMIT`, and it strips and re-appends a trailing semicolon.
+produces either: it preserves an existing `LIMIT`, and it inserts its own before the terminating
+semicolon rather than after it.
 
 ### 5.5 Druid SQL cannot write, and the server says so clearly
 

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -96,6 +96,28 @@ limit-less `SELECT`: with no offset it injects `TOP n` right after `SELECT [DIST
 offset it appends `OFFSET m ROWS FETCH NEXT n ROWS ONLY` — and because T-SQL requires an `ORDER BY`
 for `OFFSET … FETCH`, it injects `ORDER BY (SELECT NULL)` when the query has none.
 
+The two branches differ in where a **trailing** comment can reach them. `TOP` is spliced into the
+head, so `SELECT * FROM t -- note` has always come back as `SELECT TOP n * FROM t -- note` and is
+unchanged. The `OFFSET … FETCH` branch appends at the tail, so a trailing `-- note` used to swallow
+its clause while this method reported `wasLimited: true`; it now appends at the end of the statement
+as `src/lib/sql/statement-end.ts` delimits it, before any trailing comment and before the `;`, both
+of which are re-attached verbatim. Whitespace written before the terminator is now preserved rather
+than dropped, which is the only emitted-SQL difference on the `TOP` branch.
+
+That reader also answers whether the end may be **cut**, and the two branches differ there too. A
+statement ending in a `#` run — `SELECT * FROM #tmp`, everyday T-SQL, which the shared scanner reads
+as a MySQL comment because nothing in the text distinguishes the two — may not be cut, so the
+appending branch declines. The `TOP` splice writes into the head and rejoins the tail verbatim, so it
+still bounds such a statement, and `SELECT * FROM #tmp` comes back as `SELECT TOP 500 * FROM #tmp`.
+What makes that tolerable is that a refused cut still reports the statement's whole text as its end:
+the shared already-bounded probe therefore sees a `FETCH NEXT` written after the `#`, so a temp-table
+page the user already bounded is left alone rather than collecting a `TOP` — which SQL Server rejects
+outright alongside `OFFSET … FETCH`. It is not airtight. Put trailing trivia after that bound
+(`… FETCH NEXT 10 ROWS ONLY -- daily`) and the end-anchored probe stops seeing it, so the `TOP` is
+spliced anyway. That shape behaves exactly as it did before — the probe was end-anchored on the raw
+text then too — and closing it needs the `#` end re-read under a hash-is-code scan, which is a change
+of its own.
+
 The `SELECT` it splices after is located with `src/lib/sql/leading-keyword.ts`, so a T-SQL comment
 before the statement (`-- note` or `/* note */`) is skipped rather than defeating the injection. That
 shared helper also skips `#`, which is a comment in MySQL only; T-SQL rejects a statement opening with
@@ -111,6 +133,10 @@ returning the statement untouched. It never reports a limit while handing back t
   probe missed it, because that probe wants literal whitespace between `SELECT` and `TOP`, which both a
   comment (`SELECT/* c */TOP 10 …`) and a `DISTINCT` defeat. Splicing would emit `SELECT TOP n TOP 10`
   and a syntax error.
+
+The `OFFSET … FETCH` branch declines in one further case of its own: **an end that may not be cut** —
+a trailing `#` run, or a quote behind an odd backslash run, which T-SQL and MySQL close in different
+places. It has nowhere to append; the `TOP` branch, which does not append, is unaffected.
 
 ### 3.3 Five-query schema introspection, cross-schema
 

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -208,6 +208,15 @@ MySQL's `#` line comment is skipped when the statement type is read, alongside `
 for: a `# note`-led `SELECT` used to classify as an unknown statement type and reach the server with
 no `LIMIT` at all (#275).
 
+A **trailing** `#` comment is the one place MySQL is treated more conservatively than the other
+dialects. `SELECT … # note` is not bounded at all: the bound has to go before the comment, and the
+same characters are a temp table, an identifier or an operator in T-SQL, Oracle and PostgreSQL, which
+the shared reader cannot rule out (see
+[Where the bound is placed](../editor/query-optimization.md#where-the-bound-is-placed)). Before this
+the clause was appended *inside* that comment while the UI reported the query as capped, so the
+statement ran unbounded either way — it is now honest about it. A trailing `-- note` is bounded
+normally.
+
 ### 5.3 Query cancellation
 
 A query issued with a `queryId` records its connection `threadId`. `cancelQuery(queryId)`

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -103,6 +103,22 @@ overrides the base and appends `FETCH FIRST n ROWS ONLY` (or `OFFSET m ROWS FETC
 when an offset is set) to bare `SELECT`s that don't already have a limit. Default page size
 `DEFAULT_QUERY_LIMIT = 500`; unlimited caps at `MAX_UNLIMITED_ROWS = 100000`.
 
+Both branches append at the **end of the statement**, which `src/lib/sql/statement-end.ts` delimits —
+before any trailing comment and before the terminating `;`, both of which are then re-attached
+verbatim. Appending after them instead put the clause inside a trailing `-- note` while this method
+still reported `wasLimited: true`, so the statement reached Oracle unbounded and the UI called the
+result capped. A statement with no trailing comment is emitted exactly as it was before. The same
+reading answers whether the statement already carries a `FETCH FIRST`, so
+`SELECT … FETCH FIRST 10 ROWS ONLY -- deliberate` is still honoured and never gets a second clause.
+A statement whose end may not be **cut** is returned untouched with `wasLimited: false` rather than
+bounded on a guess. Two shapes reach that on Oracle: a literal Oracle and MySQL would close in
+different places (a quote behind an odd backslash run), and `#` inside an identifier (`ID#`, common
+in legacy schemas), which the shared scanner has to read as MySQL's comment marker because nothing in
+the text distinguishes the two. Both are a **deliberate loss of a bound**: appending after the whole
+text, as this method used to, happened to be valid Oracle for these two shapes, and is what puts the
+clause inside a trailing comment everywhere else. They now return every row rather than being bounded
+on a reading that is right for Oracle and wrong for the dialect the scanner cannot rule out.
+
 ### 3.3 Owner-scoped, five-query schema introspection
 
 `getSchema()` ([oracle.ts:323](../../src/lib/db/providers/sql/oracle.ts)) runs **five bulk queries**

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -259,7 +259,7 @@ timeout → `TimeoutError`, etc.).
 ### 5.2 Automatic `LIMIT` injection
 
 `prepareQuery()` (inherited from `SQLBaseProvider`) protects the UI from runaway result sets. It
-runs the query through `analyzeQuery()` ([query-limiter.ts:59](../../src/lib/db/utils/query-limiter.ts))
+runs the query through `analyzeQuery()` ([query-limiter.ts:88](../../src/lib/db/utils/query-limiter.ts))
 and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`**, appends one via
 `applyQueryLimit()`:
 
@@ -274,6 +274,14 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   already-limited check, so an annotated bounded query is not bounded twice. Before this, an
   annotated `SELECT` classified as an unknown statement type and returned **every** row while the
   UI badge reported it as not limited (#275).
+- A statement leading with `WITH` is typed by the keyword its CTE list **operates**
+  ([`operative-keyword.ts`](../../src/lib/sql/operative-keyword.ts)), so a data-modifying CTE
+  (`WITH t AS (UPDATE … RETURNING …) INSERT INTO … SELECT …`) is **not** bounded. This matters most on
+  PostgreSQL, where data-modifying CTEs are an everyday idiom and the appended `LIMIT` applied to the
+  rows the statement *writes*: it committed at most 500 of them while reporting a truncated result
+  set (#287). Undeterminable CTE shapes are likewise not bounded — an over-large read can be re-run,
+  a partly committed write cannot. Asserted at the shared seam in `tests/unit/db/sql-base.test.ts`,
+  since the behaviour is `SQLBaseProvider`'s for every SQL provider.
 
 `prepareQuery()` is a *preparation* step (the UI calls it before `query()`); `query()` itself runs
 exactly the SQL it is handed.

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -282,6 +282,17 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   set (#287). Undeterminable CTE shapes are likewise not bounded — an over-large read can be re-run,
   a partly committed write cannot. Asserted at the shared seam in `tests/unit/db/sql-base.test.ts`,
   since the behaviour is `SQLBaseProvider`'s for every SQL provider.
+- The clause is inserted at the end of the **statement** as
+  [`statement-end.ts`](../../src/lib/sql/statement-end.ts) delimits it — before any trailing comment
+  and before the terminating `;`, both re-attached verbatim — and the already-limited probes read the
+  same end. Appending after the trivia put the bound inside a trailing `-- note`, so the query ran
+  unbounded while the badge said it was capped; reading the bound off the same text made
+  `-- LIMIT 10` look like a real one, so nothing was injected (#280). A statement with no trailing
+  trivia is emitted exactly as before. A statement whose end may not be **cut** is returned untouched
+  with `wasLimited: false`, since a guess would place the bound after the `;` or in the middle of the
+  statement: a quote behind an odd backslash run (MySQL and PostgreSQL close it in different places)
+  and a trailing `#` run, which is a comment in MySQL and PostgreSQL's XOR operator here
+  (`SELECT flags # 5`).
 
 `prepareQuery()` is a *preparation* step (the UI calls it before `query()`); `query()` itself runs
 exactly the SQL it is handed.

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -297,6 +297,14 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
 `prepareQuery()` is a *preparation* step (the UI calls it before `query()`); `query()` itself runs
 exactly the SQL it is handed.
 
+Which routes call it is a caller policy, not the provider's: `POST /api/db/query` and the transaction
+route's `query` action prepare every statement they are given, while `POST /api/db/multi-query` prepares
+the **last** statement of a script and only when it is a `SELECT` — so a non-final `SELECT` returns its
+full result set, which that route's own
+[section](../editor/query-optimization.md#multi-statement-runs) records rather than claims closed. It
+decided "is this a `SELECT`" with its own `/^\s*SELECT\b/i` until #281 and so skipped preparation for a
+comment-led final `SELECT`; it now reads `isSelectQuery()` from the same classifier as everything above.
+
 ### 5.3 Query cancellation
 
 A query issued with a `queryId` records its backend PID in a `Map`. `cancelQuery(queryId)`

--- a/src/app/api/db/multi-query/route.ts
+++ b/src/app/api/db/multi-query/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getOrCreateProvider } from "@/lib/db";
 import { splitStatements } from "@/lib/sql/statement-splitter";
+import { isSelectQuery } from "@/lib/db/utils/query-limiter";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { getSession } from "@/lib/auth";
@@ -48,8 +49,16 @@ export async function POST(req: NextRequest) {
       const startTime = performance.now();
 
       try {
-        // For the last statement that is a SELECT, apply limit
-        const isLastSelect = i === statements.length - 1 && /^\s*SELECT\b/i.test(stmt.sql);
+        // For the last statement that is a SELECT, apply limit. "Last statement
+        // only" is this route's own policy; whether the statement IS a SELECT is
+        // not — that reading is shared, and this route used to re-derive it with
+        // `/^\s*SELECT\b/i`. `splitStatements` keeps each statement's leading
+        // comments, so an annotated final SELECT failed that pattern and reached
+        // the engine unprepared, which is the unbounded read the shared classifier
+        // was made comment-tolerant to close (#281, #275). The shared reading also
+        // types a `WITH` by the keyword its CTE list operates (#287), so a
+        // read-only CTE is bounded here and a data-modifying one is not.
+        const isLastSelect = i === statements.length - 1 && isSelectQuery(stmt.sql);
         const prepared = isLastSelect
           ? provider.prepareQuery(stmt.sql, options)
           : { query: stmt.sql, wasLimited: false, limit: 0, offset: 0 };

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -3,6 +3,8 @@
 import React, { useState, useEffect } from "react";
 import { ShieldAlert, ShieldCheck, AlertTriangle, Loader2, Play, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
+import { findCodeWord } from "@/lib/sql/words";
 
 interface SafetyAnalysis {
   riskLevel: "safe" | "low" | "medium" | "high" | "critical";
@@ -298,25 +300,47 @@ export function QuerySafetyDialog({
 }
 
 /**
+ * Statements whose own keyword is enough to want a confirmation: they delete rows,
+ * remove objects or change who may reach them.
+ *
+ * The same vocabulary the six anchored patterns here used to spell out, now tested
+ * against one reading of the statement instead of re-derived per keyword.
+ */
+const DANGEROUS_KEYWORDS = new Set(["DELETE", "DROP", "TRUNCATE", "ALTER", "GRANT", "REVOKE", "UPDATE"]);
+
+/**
  * Detect if a query is potentially dangerous and should trigger safety analysis.
+ *
+ * This gates the confirmation dialog on BOTH execution paths - `use-query-execution`
+ * standalone and the embedded `use-query-adapter` - so it is the last check before a
+ * destructive statement runs.
+ *
+ * It used to re-derive the leading-keyword test with its own anchored patterns
+ * (`/^\s*DROP\b/i`, …), which tolerate whitespace but not a comment, so
+ * `-- cleanup\nDROP TABLE users` executed with no confirmation at all (#294) - the
+ * same blindness this project has now removed from the query limiter (#275) and the
+ * multi-statement route (#281). Reading the shared primitive instead means the
+ * dialog and the limiter agree about where a statement starts, and a `WITH` whose CTE
+ * list only precedes a write (`WITH x AS (…) DELETE FROM …`) is now recognised too.
+ *
+ * KNOWN GAP, and it is the uncomfortable direction for a safety check: text the
+ * reading cannot resolve HIDES what follows it, so this answers false there rather
+ * than asking. `SELECT '\';` + a following write is the case — the two dialect
+ * readings of `'\'` end the string in different places, so `spans.ts` declines to
+ * guess and everything after is inside a literal as far as this predicate can tell.
+ * A test pins it. Reachable only from text carrying a backslash immediately before a
+ * closing quote, and whether an unresolvable statement should ASK instead is a policy
+ * question with its own UX cost, tracked separately rather than decided here.
  */
 export function isDangerousQuery(query: string): boolean {
-  const normalized = query.trim().toUpperCase();
+  const keyword = readOperativeKeyword(query)?.keyword;
+  if (keyword !== undefined && DANGEROUS_KEYWORDS.has(keyword)) return true;
 
-  // Dangerous patterns
-  const patterns = [
-    /^\s*DELETE\b/i,
-    /^\s*DROP\b/i,
-    /^\s*TRUNCATE\b/i,
-    /^\s*ALTER\b/i,
-    /\bUPDATE\b[\s\S]*?\bSET\b/i,
-    /^\s*GRANT\b/i,
-    /^\s*REVOKE\b/i,
-  ];
-
-  // Check for UPDATE/DELETE without WHERE (most dangerous)
-  if (/^\s*DELETE\b/i.test(normalized) && !/\bWHERE\b/.test(normalized)) return true;
-  if (/\bUPDATE\b[\s\S]*?\bSET\b/i.test(normalized) && !/\bWHERE\b/.test(normalized)) return true;
-
-  return patterns.some((p) => p.test(query));
+  // A write the statement's own keyword does not report: PostgreSQL's data-modifying
+  // CTE is OPERATED by its SELECT (`WITH x AS (UPDATE … SET …) SELECT * FROM x`), so
+  // this probe stays unanchored deliberately. It reads the statement's CODE rather
+  // than its text, so a read that merely quotes or comments the two words - which
+  // the pattern before it treated as a write - no longer asks for a confirmation.
+  const update = findCodeWord(query, "UPDATE");
+  return update !== null && findCodeWord(query, "SET", update.end) !== null;
 }

--- a/src/lib/db/providers/sql/clickhouse/index.ts
+++ b/src/lib/db/providers/sql/clickhouse/index.ts
@@ -66,6 +66,7 @@ import {
 } from "@/lib/db/types";
 import { formatCacheHitRatio } from "@/lib/monitoring-cache-ratio";
 import { formatBytes } from "@/lib/db/utils/pool-manager";
+import { readStatementEnd } from "@/lib/sql/statement-end";
 import { ClickHouseHttpTransport } from "./http-transport";
 import {
   CLICKHOUSE_SYSTEM_DATABASES,
@@ -382,12 +383,17 @@ function splitTarget(target: string, pinnedDatabase: string): [database: string,
 /**
  * Whether the statement ends in a clause that `LIMIT` may not follow.
  *
- * The trailing semicolon is stripped for the test only: a single one is accepted
- * by the server, and it would otherwise hide the clause from both patterns.
+ * Both patterns are anchored at the end of the STATEMENT, which the shared reader
+ * delimits: the terminating semicolon and any trailing comment are outside it. A
+ * hand-rolled semicolon strip used to stand in for that, so `... FORMAT TSV
+ * -- note` read as carrying no trailing clause. That was harmless only while the
+ * inherited bound landed inside the same comment; now that the limiter places it
+ * before the comment, missing the clause would emit `... FORMAT TSV LIMIT n
+ * -- note` and turn a working statement into the 400 / code 62 this override
+ * exists to prevent (#280).
  */
 function hasTrailingClause(sql: string): boolean {
-  const trimmed = sql.trimEnd();
-  const statement = trimmed.endsWith(";") ? trimmed.slice(0, -1).trimEnd() : trimmed;
+  const statement = sql.slice(0, readStatementEnd(sql).end);
   return TRAILING_FORMAT.test(statement) || TRAILING_SETTINGS.test(statement);
 }
 

--- a/src/lib/db/providers/sql/druid/index.ts
+++ b/src/lib/db/providers/sql/druid/index.ts
@@ -260,8 +260,11 @@ export class DruidProvider extends SQLBaseProvider {
    * reason as ClickHouse's trailing-clause case: rewriting wrongly fails the
    * query outright, while leaving it alone only returns more rows than asked for.
    *
-   * `analyzeQuery` rather than a regex of this file's own: it already strips a
-   * trailing semicolon, and it already distinguishes the OFFSET that follows a
+   * `analyzeQuery` rather than a regex of this file's own: it already reads the
+   * end of the statement - so the terminating semicolon and any trailing comment
+   * are outside what its probes see, which is what makes
+   * `SELECT ... OFFSET 2 -- paged` refuse here with no edit to this file (#280) -
+   * and it already distinguishes the OFFSET that follows a
    * LIMIT (which is the ordinary paginated form, and which the limiter leaves
    * alone anyway) from the OFFSET that stands alone.
    */

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -31,6 +31,7 @@ import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } fr
 import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
+import { readStatementEnd } from "@/lib/sql/statement-end";
 
 // Row shape used to group foreign keys per table in getSchema().
 type ForeignKeyInfo = { columnName: string; referencedTable: string; referencedColumn: string };
@@ -561,11 +562,41 @@ export class MSSQLProvider extends SQLBaseProvider {
     const queryInfo = analyzeQuery(query);
 
     if (queryInfo.type === "SELECT" && !queryInfo.hasLimit) {
-      let modifiedSql = query.trim();
-      const hasSemicolon = modifiedSql.endsWith(";");
-      if (hasSemicolon) modifiedSql = modifiedSql.slice(0, -1).trim();
+      // The `TOP` branch writes into the HEAD and was never reachable by a
+      // trailing comment, but the pagination branch below appends at the tail
+      // exactly as PostgreSQL's and Oracle's do, so it shared #280: the clause
+      // landed inside the comment while this method reported a limit. Both
+      // branches now build on the statement's own text and re-attach whatever
+      // trailed it, which leaves the `TOP` output unchanged except that
+      // whitespace before a terminating `;` is preserved instead of dropped.
+      //
+      // Splitting and rejoining is lossless and the splice does not depend on
+      // where the statement ends, so the `TOP` branch stays correct even where
+      // the tail may not be CUT - which matters here more than anywhere else,
+      // because a T-SQL temp table (`SELECT * FROM #tmp`) is exactly such a
+      // statement and is entirely ordinary. Only the appending branch has to
+      // decline.
+      //
+      // What makes that tolerable is that a refused cut still reports the whole
+      // statement as its end, so the already-bounded probe above sees a
+      // `FETCH NEXT` written after the `#` and this block is not entered for an
+      // already-paged temp table. It is not airtight: put trailing trivia after
+      // that bound (`... FETCH NEXT 10 ROWS ONLY -- daily`) and the end-anchored
+      // probe stops seeing it, so a `TOP` is spliced alongside an `OFFSET …
+      // FETCH` that SQL Server rejects. That shape behaves exactly as it did
+      // before this change - the probe was end-anchored on the raw text then too
+      // - and closing it needs the `#` end re-read under a hash-is-code scan,
+      // which is a change of its own with its own tests.
+      const source = query.trim();
+      const { end, rewritable } = readStatementEnd(source);
+      let modifiedSql = source.slice(0, end);
+      const trailing = source.slice(end);
 
       if (offset > 0) {
+        if (!rewritable) {
+          return { query, wasLimited: false, limit: effectiveLimit, offset };
+        }
+
         // OFFSET FETCH requires ORDER BY
         const hasOrderBy = /\bORDER\s+BY\b/i.test(modifiedSql);
         if (!hasOrderBy) {
@@ -587,10 +618,8 @@ export class MSSQLProvider extends SQLBaseProvider {
         modifiedSql = injected;
       }
 
-      if (hasSemicolon) modifiedSql += ";";
-
       return {
-        query: modifiedSql,
+        query: `${modifiedSql}${trailing}`,
         wasLimited: true,
         limit: effectiveLimit,
         offset,

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -30,6 +30,7 @@ import {
 import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
 import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
+import { readStatementEnd } from "@/lib/sql/statement-end";
 
 // ============================================================================
 // SQL Statements
@@ -396,20 +397,31 @@ export class OracleProvider extends SQLBaseProvider {
     const queryInfo = analyzeQuery(query);
 
     if (queryInfo.type === "SELECT" && !queryInfo.hasLimit) {
-      let modifiedSql = query.trim();
-      const hasSemicolon = modifiedSql.endsWith(";");
-      if (hasSemicolon) modifiedSql = modifiedSql.slice(0, -1).trim();
-
-      if (offset > 0) {
-        modifiedSql = `${modifiedSql} OFFSET ${offset} ROWS FETCH NEXT ${effectiveLimit} ROWS ONLY`;
-      } else {
-        modifiedSql = `${modifiedSql} FETCH FIRST ${effectiveLimit} ROWS ONLY`;
+      // Both branches append at the tail, so both used to have their clause
+      // swallowed by a trailing line comment while this method still reported
+      // `wasLimited: true` - the statement reached Oracle unbounded and the UI
+      // said it was capped (#280). The clause goes between the statement and its
+      // trailing trivia instead, which also keeps the `;` out of the comment.
+      // A statement whose end may not be cut has nowhere honest to take the
+      // clause, so it is returned untouched rather than bounded on a guess. On
+      // Oracle the live shape is `#` in an identifier (`ID#`), which is legal
+      // there and a comment marker in MySQL.
+      const source = query.trim();
+      const { end, rewritable } = readStatementEnd(source);
+      if (!rewritable) {
+        return { query, wasLimited: false, limit: effectiveLimit, offset };
       }
 
-      if (hasSemicolon) modifiedSql += ";";
+      const statement = source.slice(0, end);
+      const trailing = source.slice(end);
+
+      const clause =
+        offset > 0
+          ? `OFFSET ${offset} ROWS FETCH NEXT ${effectiveLimit} ROWS ONLY`
+          : `FETCH FIRST ${effectiveLimit} ROWS ONLY`;
 
       return {
-        query: modifiedSql,
+        query: `${statement} ${clause}${trailing}`,
         wasLimited: true,
         limit: effectiveLimit,
         offset,

--- a/src/lib/db/utils/query-limiter.ts
+++ b/src/lib/db/utils/query-limiter.ts
@@ -15,10 +15,19 @@
  * that types the statement is the one AFTER it. Testing whether the text contained
  * `SELECT` let `INSERT INTO ... SELECT` type its own statement as a read, and the
  * appended LIMIT then bounded the rows that statement WROTE (#287).
+ *
+ * Where the statement ENDS comes from `lib/sql/statement-end`, and both the
+ * "already bounded" probes and the injection use that one reading. They used to
+ * disagree with each other by accident - each worked on the raw text - and a
+ * trailing line comment then broke the limiter in both directions: the injected
+ * bound landed inside the comment while the caller was told the statement was
+ * limited, and a commented-out bound was read as a real one so nothing was
+ * injected at all (#280).
  */
 
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
+import { readStatementEnd } from "@/lib/sql/statement-end";
 
 // ============================================================================
 // Constants
@@ -66,14 +75,6 @@ export interface LimitedQueryResult {
 /**
  * SQL sorgusunu analiz eder ve türünü, LIMIT/OFFSET durumunu belirler.
  */
-/** Strip trailing semicolons and whitespace without regex to avoid ReDoS */
-function stripTrailingSemicolon(s: string): string {
-  let end = s.length;
-  while (end > 0 && (s[end - 1] === " " || s[end - 1] === "\t" || s[end - 1] === "\n" || s[end - 1] === "\r")) end--;
-  while (end > 0 && s[end - 1] === ";") end--;
-  while (end > 0 && (s[end - 1] === " " || s[end - 1] === "\t" || s[end - 1] === "\n" || s[end - 1] === "\r")) end--;
-  return s.slice(0, end);
-}
 
 /** The type this module reports for a statement operated by `keyword`. */
 function classifyKeyword(keyword: string | undefined): ParsedQueryInfo["type"] {
@@ -86,18 +87,28 @@ function classifyKeyword(keyword: string | undefined): ParsedQueryInfo["type"] {
 }
 
 export function analyzeQuery(sql: string): ParsedQueryInfo {
-  // Strip trailing whitespace and semicolons upfront to avoid ReDoS-prone patterns
-  const trimmed = stripTrailingSemicolon(sql.trim());
+  // The statement's own text, with its trailing trivia and terminator removed.
+  // Every end-anchored probe below reads THIS rather than the raw input: the
+  // anchor is what keeps them off a statement that merely mentions a bound, and
+  // a trailing comment used to sit between the anchor and the bound, so a real
+  // `LIMIT 10 -- note` read as unbounded while `-- LIMIT 10` read as bounded.
+  //
+  // Only the END is read here. Whether that end may be CUT is a separate answer
+  // and belongs to `applyQueryLimit` and to the providers that append their own
+  // clause. Where the cut is refused this end is the terminator strip, which is
+  // what these probes read before the reader existed, so none of them answers
+  // differently than it used to.
+  const statement = sql.slice(0, readStatementEnd(sql).end);
 
   // Query type detection - from the first keyword that is not whitespace or a comment
-  const leading = readLeadingKeyword(trimmed);
+  const leading = readLeadingKeyword(statement);
   const keyword = leading?.keyword;
   // The statement from its own first keyword onward. Anything that searches the
   // statement's TEXT rather than just its leading keyword has to start here, or a
   // word written in the leading comment answers for the statement itself.
-  const fromKeyword = leading === null ? trimmed : trimmed.slice(leading.start);
+  const fromKeyword = leading === null ? statement : statement.slice(leading.start);
   // Whitespace-collapsed, upper-cased body for the probes that scan text. Built
-  // from `fromKeyword`, NOT from `trimmed`: a leading comment reading
+  // from `fromKeyword`, NOT from `statement`: a leading comment reading
   // "switch to ROWNUM <= 10" once marked the statement already bounded, which
   // left the query unbounded - the very symptom #275 removed (PR #289 review).
   const normalized = fromKeyword.replace(/\s+/g, " ").toUpperCase();
@@ -113,12 +124,12 @@ export function analyzeQuery(sql: string): ParsedQueryInfo {
   // module - `sql-base.ts`, `oracle.ts` and `mssql.ts` - test `=== "SELECT"` and
   // nothing else, so the honest answer costs nothing.
   // `MERGE`, which the union cannot name, falls through to OTHER.
-  const typingKeyword = keyword === "WITH" ? readOperativeKeyword(trimmed)?.keyword : keyword;
+  const typingKeyword = keyword === "WITH" ? readOperativeKeyword(statement)?.keyword : keyword;
   const type = classifyKeyword(typingKeyword);
 
   // LIMIT/OFFSET detection - en dıştaki sorgunun LIMIT'ini bul
   // Regex: Sorgunun sonundaki LIMIT [sayı] [OFFSET sayı] pattern'i
-  const limitMatch = trimmed.match(/\bLIMIT\s+(\d+)(?:\s*,\s*(\d+)|\s+OFFSET\s+(\d+))?\s*$/i);
+  const limitMatch = statement.match(/\bLIMIT\s+(\d+)(?:\s*,\s*(\d+)|\s+OFFSET\s+(\d+))?\s*$/i);
 
   let hasLimit = false;
   let existingLimit: number | undefined;
@@ -139,7 +150,7 @@ export function analyzeQuery(sql: string): ParsedQueryInfo {
 
   // Oracle/MSSQL: FETCH FIRST N ROWS ONLY / FETCH NEXT N ROWS ONLY
   if (!hasLimit) {
-    const fetchMatch = trimmed.match(/\bFETCH\s+(?:FIRST|NEXT)\s+(\d+)\s+ROWS?\s+ONLY\s*$/i);
+    const fetchMatch = statement.match(/\bFETCH\s+(?:FIRST|NEXT)\s+(\d+)\s+ROWS?\s+ONLY\s*$/i);
     if (fetchMatch) {
       hasLimit = true;
       existingLimit = parseInt(fetchMatch[1]);
@@ -163,7 +174,7 @@ export function analyzeQuery(sql: string): ParsedQueryInfo {
   }
 
   // OFFSET without LIMIT (rare but possible in PostgreSQL)
-  const offsetOnlyMatch = !hasLimit && trimmed.match(/\bOFFSET\s+(\d+)\s*$/i);
+  const offsetOnlyMatch = !hasLimit && statement.match(/\bOFFSET\s+(\d+)\s*$/i);
   const hasOffset = hasLimit ? existingOffset !== undefined : !!offsetOnlyMatch;
 
   if (offsetOnlyMatch && !hasLimit) {
@@ -232,30 +243,44 @@ export function applyQueryLimit(
     };
   }
 
-  // Check for trailing semicolon before stripping (string-based to avoid ReDoS)
-  const trimmedInput = sql.trim();
-  let modifiedSql = stripTrailingSemicolon(trimmedInput);
-  const hasSemicolon = modifiedSql.length < trimmedInput.length && trimmedInput.includes(";");
+  // The clause goes between the statement and its trailing trivia, and the
+  // trivia is re-attached verbatim. Appending after the trivia instead is what
+  // let a trailing line comment swallow the bound - together with the `;`, which
+  // then sat inside the comment too. Splitting here rather than normalising the
+  // tail also leaves the emitted SQL byte-identical for every statement that
+  // carries no trailing trivia, which is nearly all of them.
+  //
+  // A statement whose end may not be cut is returned untouched: there is nowhere
+  // honest to put the clause, and `wasLimited: false` says so. The two shapes are
+  // a literal MySQL and PostgreSQL would close in different places
+  // (`… WHERE name = 'O\'Brien';`, where inserting on a guess puts the bound after
+  // the `;`) and a trailing `#` run, which is a comment in MySQL and a temp table,
+  // an identifier or an operator elsewhere.
+  const source = sql.trim();
+  const { end, rewritable } = readStatementEnd(source);
 
-  // Mevcut LIMIT/OFFSET'i kaldır (eğer forceLimit true ise)
+  if (!rewritable) {
+    return { sql, wasLimited: false, originalLimit: info.existingLimit, appliedLimit: 0, appliedOffset: 0 };
+  }
+
+  let statement = source.slice(0, end);
+  const trailing = source.slice(end);
+
+  // Mevcut LIMIT/OFFSET'i kaldır (eğer forceLimit true ise). These are anchored
+  // at the end of the STATEMENT, so a trailing comment neither hides the bound
+  // from them nor gets torn apart by them.
   if (info.hasLimit && forceLimit) {
     // MySQL style: LIMIT offset, count
-    modifiedSql = modifiedSql.replace(/\bLIMIT\s+\d+\s*,\s*\d+\s*$/i, "").trim();
+    statement = statement.replace(/\bLIMIT\s+\d+\s*,\s*\d+\s*$/i, "").trim();
     // Standard style: LIMIT count OFFSET offset
-    modifiedSql = modifiedSql.replace(/\bLIMIT\s+\d+(?:\s+OFFSET\s+\d+)?\s*$/i, "").trim();
+    statement = statement.replace(/\bLIMIT\s+\d+(?:\s+OFFSET\s+\d+)?\s*$/i, "").trim();
   }
 
   // LIMIT OFFSET clause'u ekle
   const limitClause = offset > 0 ? `LIMIT ${limit} OFFSET ${offset}` : `LIMIT ${limit}`;
 
-  modifiedSql = `${modifiedSql} ${limitClause}`;
-
-  if (hasSemicolon) {
-    modifiedSql += ";";
-  }
-
   return {
-    sql: modifiedSql,
+    sql: `${statement} ${limitClause}${trailing}`,
     wasLimited: true,
     originalLimit: info.existingLimit,
     appliedLimit: limit,

--- a/src/lib/db/utils/query-limiter.ts
+++ b/src/lib/db/utils/query-limiter.ts
@@ -9,9 +9,16 @@
  * so no LIMIT was injected and the entire result set came back while the UI badge
  * reported the query as unlimited (#275). Every dialect here accepts a comment
  * before a statement, so every dialect had the defect.
+ *
+ * For a statement leading with `WITH` the type comes from
+ * `lib/sql/operative-keyword` instead: the CTE list is a preamble, so the keyword
+ * that types the statement is the one AFTER it. Testing whether the text contained
+ * `SELECT` let `INSERT INTO ... SELECT` type its own statement as a read, and the
+ * appended LIMIT then bounded the rows that statement WROTE (#287).
  */
 
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
+import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
 
 // ============================================================================
 // Constants
@@ -68,6 +75,16 @@ function stripTrailingSemicolon(s: string): string {
   return s.slice(0, end);
 }
 
+/** The type this module reports for a statement operated by `keyword`. */
+function classifyKeyword(keyword: string | undefined): ParsedQueryInfo["type"] {
+  if (keyword === "SELECT") return "SELECT";
+  if (keyword === "INSERT") return "INSERT";
+  if (keyword === "UPDATE") return "UPDATE";
+  if (keyword === "DELETE") return "DELETE";
+  if (keyword !== undefined && DDL_KEYWORDS.has(keyword)) return "DDL";
+  return "OTHER";
+}
+
 export function analyzeQuery(sql: string): ParsedQueryInfo {
   // Strip trailing whitespace and semicolons upfront to avoid ReDoS-prone patterns
   const trimmed = stripTrailingSemicolon(sql.trim());
@@ -85,18 +102,19 @@ export function analyzeQuery(sql: string): ParsedQueryInfo {
   // left the query unbounded - the very symptom #275 removed (PR #289 review).
   const normalized = fromKeyword.replace(/\s+/g, " ").toUpperCase();
 
-  let type: ParsedQueryInfo["type"] = "OTHER";
-  if (keyword === "SELECT") type = "SELECT";
-  else if (keyword === "INSERT") type = "INSERT";
-  else if (keyword === "UPDATE") type = "UPDATE";
-  else if (keyword === "DELETE") type = "DELETE";
-  else if (keyword !== undefined && DDL_KEYWORDS.has(keyword)) type = "DDL";
-  // CTE (WITH clause) that leads to SELECT - searched from the keyword, so a
-  // `SELECT` mentioned in the leading comment cannot make a writing CTE look like
-  // one and earn it a LIMIT it would choke on
-  else if (keyword === "WITH" && /\bSELECT\b/i.test(fromKeyword)) {
-    type = "SELECT";
-  }
+  // A `WITH` statement is typed by the keyword its CTE list OPERATES, not by the
+  // keyword it opens with and not by a `SELECT` found in its text. Asking whether
+  // the text contained `SELECT` let the `INSERT INTO ... SELECT` idiom answer for
+  // the whole statement, so a data-modifying CTE was typed SELECT and a LIMIT was
+  // appended to it - and in PostgreSQL that LIMIT applies to the rows the
+  // statement WRITES, committing at most `limit` of them while the UI reported a
+  // truncated result set (#287). The operative keyword is reported as its own type
+  // rather than as a blanket OTHER: all three consumers of `type` outside this
+  // module - `sql-base.ts`, `oracle.ts` and `mssql.ts` - test `=== "SELECT"` and
+  // nothing else, so the honest answer costs nothing.
+  // `MERGE`, which the union cannot name, falls through to OTHER.
+  const typingKeyword = keyword === "WITH" ? readOperativeKeyword(trimmed)?.keyword : keyword;
+  const type = classifyKeyword(typingKeyword);
 
   // LIMIT/OFFSET detection - en dıştaki sorgunun LIMIT'ini bul
   // Regex: Sorgunun sonundaki LIMIT [sayı] [OFFSET sayı] pattern'i
@@ -155,8 +173,10 @@ export function analyzeQuery(sql: string): ParsedQueryInfo {
   // UNION detection
   const isUnion = /\bUNION\b/i.test(normalized);
 
-  // CTE detection (WITH clause) - from the same reading as the type above, so the
-  // two cannot disagree about what the statement leads with
+  // CTE detection (WITH clause) - this answers what the statement LEADS with,
+  // which is a different question from what it operates: `WITH t AS (...) INSERT
+  // ...` has a CTE and is typed INSERT. So this deliberately stays on the leading
+  // keyword and is true for every `WITH`, whatever its type turned out to be.
   const hasCTE = keyword === "WITH";
 
   // Subquery detection (nested SELECT - birden fazla SELECT var mı)

--- a/src/lib/sql/operative-keyword.ts
+++ b/src/lib/sql/operative-keyword.ts
@@ -6,6 +6,12 @@
  * exception: its CTE list is a preamble, and the statement the server executes is
  * whatever follows the list. `WITH t AS (…) INSERT INTO … SELECT …` is an INSERT.
  *
+ * A list element comes in two shapes across the dialects here - the standard
+ * `name [(cols)] AS (body)` and ClickHouse's `<expr> AS <alias>` - and both are
+ * read, because an element this walker cannot cross ends the reading and costs the
+ * statement its bound. Recognising only the standard one is how ClickHouse's own
+ * CTE idiom stopped being limited (#291).
+ *
  * The query limiter used to type a `WITH` by asking whether the word `SELECT`
  * appeared anywhere in its text. The `INSERT … SELECT` idiom supplies that word
  * itself, so an ordinary data-modifying CTE was typed `SELECT` and a bound was
@@ -103,6 +109,41 @@ function skipParenthesised(sql: string, open: number): number {
   return -1;
 }
 
+/**
+ * The index past a `[…]` run, or `-1` when it never closes.
+ *
+ * Brackets are read HERE and not in `readSqlSpan`: in a name position `[…]` can
+ * only be a quoted identifier, while elsewhere `a[1]` is array subscripting in
+ * PostgreSQL and ClickHouse, which a literal reader must not swallow. Two readers
+ * below want the run skipped whole - a name may be written `[my cte]`, and a
+ * ClickHouse expression may be the array literal `[1, 2, 3]`, whose commas would
+ * otherwise look like the end of a CTE-list element.
+ *
+ * The run is scanned for its `]` without consulting `readSqlSpan`, so a `]` written
+ * inside a string closes it early (`WITH map['a]'] AS v SELECT 1` reads as
+ * undeterminable and loses its bound). That is the safe direction and it is what a
+ * bracketed NAME already did before this reader existed; closing it needs a
+ * bracket run that skips spans, which is a change of its own.
+ */
+function skipBracketed(sql: string, open: number): number {
+  let i = open + 1;
+
+  while (i < sql.length) {
+    if (sql[i] === "]") {
+      // MSSQL escapes a closing bracket by doubling it, the same rule the quoted
+      // forms use.
+      if (sql[i + 1] === "]") {
+        i += 2;
+        continue;
+      }
+      return i + 1;
+    }
+    i++;
+  }
+
+  return -1;
+}
+
 /** The index past a CTE's name - a bare word or a quoted identifier - or `-1`. */
 function skipCteName(sql: string, index: number): number {
   const span = readSqlSpan(sql, index);
@@ -113,38 +154,166 @@ function skipCteName(sql: string, index: number): number {
     return -1;
   }
 
-  // MSSQL brackets, accepted HERE and not in `readSqlSpan`: in a name position
-  // `[…]` can only be a quoted identifier, while elsewhere `a[1]` is array
-  // subscripting in PostgreSQL and ClickHouse, which a literal reader must not
-  // swallow. Without this a bracketed CTE name would read as undeterminable and
-  // the statement would silently lose its bound.
-  if (sql[index] === "[") {
-    let i = index + 1;
-    while (i < sql.length) {
-      if (sql[i] === "]") {
-        // MSSQL escapes a closing bracket by doubling it, the same rule the
-        // quoted forms use.
-        if (sql[i + 1] === "]") {
-          i += 2;
-          continue;
-        }
-        return i + 1;
-      }
-      i++;
-    }
-    return -1;
-  }
+  if (sql[index] === "[") return skipBracketed(sql, index);
 
   return readWord(sql, index)?.end ?? -1;
 }
 
 /**
+ * How far one element of a CTE list reaches when read as the standard shape,
+ * `name [(cols)] AS [[NOT] MATERIALIZED] (body)`.
+ *
+ * `other-shape` is what lets ClickHouse's `<expr> AS <alias>` element be read
+ * instead, and it is reported at exactly the two places the shapes diverge: the
+ * head is not a name (`1`, `[1, 2]`, `(SELECT …)`, `'x'`), or what follows the
+ * element's `AS` is not a body. Everything else is `malformed` - the input opened
+ * the standard shape and then broke, so re-reading it as an expression would be
+ * guessing at the same input twice. The distinction is load-bearing:
+ * `WITH t AS NOT LAZY (SELECT 1) SELECT 2` has to stay undeterminable rather than
+ * read `NOT` as an alias and `LAZY` as the keyword that operates the statement.
+ */
+type StandardElement = { kind: "element"; end: number } | { kind: "other-shape" } | { kind: "malformed" };
+
+function readStandardElement(sql: string, index: number): StandardElement {
+  const afterName = skipCteName(sql, index);
+  if (afterName < 0) return { kind: "other-shape" };
+
+  let i = skipTrivia(sql, afterName);
+  if (i < 0) return { kind: "malformed" };
+
+  // An optional column list: `WITH t (a, b) AS (…)`. It closes back to depth 0
+  // exactly as the body does, which is why the two are told apart by position in
+  // the grammar rather than by "the last paren that closed". A function call's
+  // argument list (`now()`) is consumed here too and reaches the same index, so the
+  // two need no telling apart: what follows the `AS` decides the shape.
+  if (sql[i] === "(") {
+    const afterColumns = skipParenthesised(sql, i);
+    if (afterColumns < 0) return { kind: "malformed" };
+    i = skipTrivia(sql, afterColumns);
+    if (i < 0) return { kind: "malformed" };
+  }
+
+  const as = readWord(sql, i);
+  if (as?.text !== "AS") return { kind: "other-shape" };
+  i = skipTrivia(sql, as.end);
+  if (i < 0) return { kind: "malformed" };
+
+  // PostgreSQL's inlining hints sit between `AS` and the body. Neither word exists
+  // in the expression shape, so reading one COMMITS this element to the standard
+  // one: from here a missing body is malformed input, not an alias.
+  let hint = readWord(sql, i);
+  const committed = hint?.text === "NOT" || hint?.text === "MATERIALIZED";
+  if (hint?.text === "NOT") {
+    i = skipTrivia(sql, hint.end);
+    if (i < 0) return { kind: "malformed" };
+    hint = readWord(sql, i);
+    if (hint?.text !== "MATERIALIZED") return { kind: "malformed" };
+  }
+  if (hint?.text === "MATERIALIZED") {
+    i = skipTrivia(sql, hint.end);
+    if (i < 0) return { kind: "malformed" };
+  }
+
+  if (sql[i] !== "(") return { kind: committed ? "malformed" : "other-shape" };
+
+  const afterBody = skipParenthesised(sql, i);
+  if (afterBody < 0) return { kind: "malformed" };
+
+  return { kind: "element", end: afterBody };
+}
+
+/**
+ * The index past a ClickHouse `<expr> AS <alias>` element, or `-1`.
+ *
+ * The expression is not parsed, only scanned for the `AS` that ends it: at paren
+ * depth 0, outside every literal, comment and bracketed run. That is where the
+ * element's own `AS` is and where an expression's internal one (`CAST(x AS Int32)`)
+ * is not - which is all this module needs, since it never has to understand the
+ * expression, only find where it stops.
+ */
+function skipExpressionElement(sql: string, index: number): number {
+  let depth = 0;
+  let i = index;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i);
+    if (span !== null) {
+      if (!span.terminated) return -1;
+      i = span.end;
+      continue;
+    }
+
+    const ch = sql[i];
+    if (ch === "(") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === ")") {
+      depth--;
+      // More closing parens than opening ones: whatever this is, it is not one
+      // expression, and a reader that carried on would read the statement after it
+      // as part of the CTE list.
+      if (depth < 0) return -1;
+      i++;
+      continue;
+    }
+    if (ch === "[") {
+      const afterBracket = skipBracketed(sql, i);
+      if (afterBracket < 0) return -1;
+      i = afterBracket;
+      continue;
+    }
+    // A comma at depth 0 ends the element, and this one got there without an `AS`,
+    // so there is no element here to read.
+    if (ch === "," && depth === 0) return -1;
+
+    const word = readWord(sql, i);
+    if (word === null) {
+      i++;
+      continue;
+    }
+    if (depth === 0 && word.text === "AS") {
+      const aliasAt = skipTrivia(sql, word.end);
+      if (aliasAt < 0) return -1;
+      // The alias is a plain name. Anything else - a body, a literal - means this
+      // is not the shape either, and `-1` reaches the caller as "cannot tell".
+      return skipCteName(sql, aliasAt);
+    }
+    i = word.end;
+  }
+
+  return -1;
+}
+
+/**
+ * The index past one element of a CTE list, or `-1` when it cannot be read.
+ *
+ * Two shapes, tried in this order:
+ *
+ * - the standard `name [(cols)] AS [[NOT] MATERIALIZED] (body)`, which every
+ *   dialect here has and the only one that can carry a WRITE;
+ * - ClickHouse's `<expr> AS <alias>`, which puts an expression where the standard
+ *   shape puts a name (#291). It is reached only where the standard read reports
+ *   the element is not that shape at all, so adding it cannot retype a statement
+ *   the standard shape already reads - which is what keeps #287's writing CTEs
+ *   answering their own write keyword.
+ */
+function skipCteElement(sql: string, index: number): number {
+  const standard = readStandardElement(sql, index);
+  if (standard.kind === "element") return standard.end;
+  if (standard.kind === "malformed") return -1;
+
+  return skipExpressionElement(sql, index);
+}
+
+/**
  * The keyword after a `WITH` statement's CTE list.
  *
- * Walks the list's real grammar - `[RECURSIVE] name [(cols)] AS [[NOT]
- * MATERIALIZED] (body) [, …]` - rather than searching the text, because every
- * text search over a CTE can be answered by the CTE's own body. Anything that
- * does not match answers `null`: see the bias note on the exported function.
+ * Walks the list's real grammar - `[RECURSIVE] <element> [, …]` - rather than
+ * searching the text, because every text search over a CTE can be answered by the
+ * CTE's own body. Anything that does not match answers `null`: see the bias note
+ * on the exported function.
  */
 function readKeywordAfterCteList(sql: string, afterWith: number): LeadingKeyword | null {
   let i = skipTrivia(sql, afterWith);
@@ -157,43 +326,9 @@ function readKeywordAfterCteList(sql: string, afterWith: number): LeadingKeyword
   }
 
   for (;;) {
-    const afterName = skipCteName(sql, i);
-    if (afterName < 0) return null;
-    i = skipTrivia(sql, afterName);
-    if (i < 0) return null;
-
-    // An optional column list: `WITH t (a, b) AS (…)`. It closes back to depth 0
-    // exactly as the body does, which is why the two are told apart by position in
-    // the grammar rather than by "the last paren that closed".
-    if (sql[i] === "(") {
-      const afterColumns = skipParenthesised(sql, i);
-      if (afterColumns < 0) return null;
-      i = skipTrivia(sql, afterColumns);
-      if (i < 0) return null;
-    }
-
-    const as = readWord(sql, i);
-    if (as?.text !== "AS") return null;
-    i = skipTrivia(sql, as.end);
-    if (i < 0) return null;
-
-    // PostgreSQL's inlining hints sit between `AS` and the body.
-    let hint = readWord(sql, i);
-    if (hint?.text === "NOT") {
-      i = skipTrivia(sql, hint.end);
-      if (i < 0) return null;
-      hint = readWord(sql, i);
-      if (hint?.text !== "MATERIALIZED") return null;
-    }
-    if (hint?.text === "MATERIALIZED") {
-      i = skipTrivia(sql, hint.end);
-      if (i < 0) return null;
-    }
-
-    if (sql[i] !== "(") return null;
-    const afterBody = skipParenthesised(sql, i);
-    if (afterBody < 0) return null;
-    i = skipTrivia(sql, afterBody);
+    const afterElement = skipCteElement(sql, i);
+    if (afterElement < 0) return null;
+    i = skipTrivia(sql, afterElement);
     if (i < 0) return null;
 
     if (sql[i] !== ",") break;
@@ -211,31 +346,40 @@ function readKeywordAfterCteList(sql: string, afterWith: number): LeadingKeyword
  * The keyword that operates this statement, or `null` when there is none to read.
  *
  * `null` covers both "no statement here" (empty, whitespace, comments only) and
- * "the statement's shape cannot be determined" - an unclosed CTE body, a malformed
- * CTE list, an unterminated comment or literal, or a `WITH` with nothing after its
- * list. Both answer `null` on purpose: callers use this to decide whether to
- * REWRITE a statement, and the two ways of being wrong are not equally bad.
- * Declining to bound a statement costs an over-large read the user can re-run;
- * bounding one that writes commits part of it. So undeterminable input is never
- * reported as a read.
+ * "the statement's shape cannot be determined" - an unclosed CTE body, a CTE list
+ * in which no element can be read, an unterminated comment or literal, or a `WITH`
+ * with nothing after its list. Both answer `null` on purpose: callers use this to
+ * decide whether to REWRITE a statement, and the two ways of being wrong are not
+ * equally bad. Declining to bound a statement costs an over-large read the user can
+ * re-run; bounding one that writes commits part of it. So input this reader cannot
+ * cross is not reported as a read.
  *
  * Two known shapes are WELL FORMED and still answer not-`SELECT`, so they lose a
- * bound they used to get. Both are reads, so the cost is an over-large result set
- * and neither can bound a write; each is pinned by a test so the gap is a decision
- * rather than a surprise:
+ * bound. Both are reads, so the cost is an over-large result set and neither can
+ * bound a write; each is pinned by a test so the gap is a decision rather than a
+ * surprise:
  *
  * - A recursive CTE's optional `SEARCH` / `CYCLE` clause sits between the list and
  *   the operative statement, and this reader stops at the first word after the
  *   list, so it reports `SEARCH` there.
- * - ClickHouse's `WITH <expr> AS <alias>` form puts an expression where the
- *   standard form puts a name; reading it needs an expression parser. That form is
- *   idiomatic there and this is a real regression for it, recorded for follow-up
- *   rather than papered over - ClickHouse has no data-modifying CTE, so nothing on
- *   that provider is made unsafe by it.
+ * - An expression element whose head reads as a NAME and whose alias is one of
+ *   PostgreSQL's inlining hints (`WITH col AS materialized SELECT …`): the hint
+ *   commits the element to the standard shape, which then wants a body. Accepting
+ *   the hint as an alias instead is what would let `WITH t AS NOT LAZY (…)` report
+ *   `LAZY` as the operative keyword, so the trade goes this way on purpose.
  *
- * Two more go the OTHER way, and are recorded here precisely because they are the
- * direction this function otherwise promises to avoid - both are pinned by tests:
+ * Three more go the OTHER way, and are recorded here precisely because they are the
+ * direction this function otherwise promises to avoid - each is pinned by a test:
  *
+ * - Any element the standard read DECLINES - a head that is not a name, or an `AS`
+ *   with no body after it - is re-read as an expression, and that read ends at the
+ *   first `AS <name>` at paren depth 0 however far away it is. So
+ *   `WITH 2 INSERT INTO users AS u SELECT 1` and
+ *   `WITH x AS DELETE, foo AS (SELECT 1) SELECT 1` both answer `SELECT`. Reading an
+ *   expression means knowing where it ends only by its `AS`, so this is the price of
+ *   reading the shape at all. No dialect here accepts such text - a CTE element is a
+ *   name or an expression, and neither is a statement - so the cost is a bound
+ *   appended to text the server rejects either way, not a partially committed write.
  * - Oracle's alternative quoting (`q'{…}'`) is not a literal to `readSqlSpan`, so
  *   its body is walked as code, and a `)` or a keyword written inside one moves the
  *   reading. Unreachable in Oracle itself, which has no `WITH … DELETE`, and no

--- a/src/lib/sql/operative-keyword.ts
+++ b/src/lib/sql/operative-keyword.ts
@@ -32,30 +32,8 @@
  */
 
 import { readLeadingKeyword, type LeadingKeyword } from "./leading-keyword";
-import { IDENTIFIER_PART, IDENTIFIER_START, readSqlSpan } from "./spans";
-
-/** A word (identifier or keyword) and where it ends, or `null` if none starts here. */
-interface Word {
-  text: string;
-  end: number;
-}
-
-/**
- * A word runs over the shared identifier alphabet, plus `$` after the first
- * character: it is legal inside a MySQL identifier and after the first character
- * in PostgreSQL. It stays out of the START position so a dollar-quoted string is
- * still read as the literal it is.
- */
-function readWord(sql: string, index: number): Word | null {
-  if (index >= sql.length || !IDENTIFIER_START.test(sql[index])) return null;
-
-  let end = index + 1;
-  while (end < sql.length && (IDENTIFIER_PART.test(sql[end]) || sql[end] === "$")) end++;
-
-  // Upper-cased for the keyword comparisons below. Every keyword this module
-  // tests for is ASCII, so the locale-independent mapping is all it needs.
-  return { text: sql.slice(index, end).toUpperCase(), end };
-}
+import { readSqlSpan } from "./spans";
+import { readSqlWord } from "./words";
 
 /**
  * The next index at which the statement's own code resumes, or `-1` when it never
@@ -156,7 +134,7 @@ function skipCteName(sql: string, index: number): number {
 
   if (sql[index] === "[") return skipBracketed(sql, index);
 
-  return readWord(sql, index)?.end ?? -1;
+  return readSqlWord(sql, index)?.end ?? -1;
 }
 
 /**
@@ -193,7 +171,7 @@ function readStandardElement(sql: string, index: number): StandardElement {
     if (i < 0) return { kind: "malformed" };
   }
 
-  const as = readWord(sql, i);
+  const as = readSqlWord(sql, i);
   if (as?.text !== "AS") return { kind: "other-shape" };
   i = skipTrivia(sql, as.end);
   if (i < 0) return { kind: "malformed" };
@@ -201,12 +179,12 @@ function readStandardElement(sql: string, index: number): StandardElement {
   // PostgreSQL's inlining hints sit between `AS` and the body. Neither word exists
   // in the expression shape, so reading one COMMITS this element to the standard
   // one: from here a missing body is malformed input, not an alias.
-  let hint = readWord(sql, i);
+  let hint = readSqlWord(sql, i);
   const committed = hint?.text === "NOT" || hint?.text === "MATERIALIZED";
   if (hint?.text === "NOT") {
     i = skipTrivia(sql, hint.end);
     if (i < 0) return { kind: "malformed" };
-    hint = readWord(sql, i);
+    hint = readSqlWord(sql, i);
     if (hint?.text !== "MATERIALIZED") return { kind: "malformed" };
   }
   if (hint?.text === "MATERIALIZED") {
@@ -268,7 +246,7 @@ function skipExpressionElement(sql: string, index: number): number {
     // so there is no element here to read.
     if (ch === "," && depth === 0) return -1;
 
-    const word = readWord(sql, i);
+    const word = readSqlWord(sql, i);
     if (word === null) {
       i++;
       continue;
@@ -319,7 +297,7 @@ function readKeywordAfterCteList(sql: string, afterWith: number): LeadingKeyword
   let i = skipTrivia(sql, afterWith);
   if (i < 0) return null;
 
-  const recursive = readWord(sql, i);
+  const recursive = readSqlWord(sql, i);
   if (recursive?.text === "RECURSIVE") {
     i = skipTrivia(sql, recursive.end);
     if (i < 0) return null;
@@ -336,7 +314,7 @@ function readKeywordAfterCteList(sql: string, afterWith: number): LeadingKeyword
     if (i < 0) return null;
   }
 
-  const operative = readWord(sql, i);
+  const operative = readSqlWord(sql, i);
   if (operative === null) return null;
 
   return { keyword: operative.text, start: i, end: operative.end };

--- a/src/lib/sql/operative-keyword.ts
+++ b/src/lib/sql/operative-keyword.ts
@@ -1,0 +1,253 @@
+/**
+ * Which keyword actually OPERATES a SQL statement.
+ *
+ * For every statement but one that leads with `WITH`, that is the leading keyword
+ * and this module answers exactly what `leading-keyword.ts` does. A `WITH` is the
+ * exception: its CTE list is a preamble, and the statement the server executes is
+ * whatever follows the list. `WITH t AS (…) INSERT INTO … SELECT …` is an INSERT.
+ *
+ * The query limiter used to type a `WITH` by asking whether the word `SELECT`
+ * appeared anywhere in its text. The `INSERT … SELECT` idiom supplies that word
+ * itself, so an ordinary data-modifying CTE was typed `SELECT` and a bound was
+ * appended to it. In PostgreSQL that bound applies to the rows the statement
+ * WRITES: it committed at most the default limit of them while the UI reported a
+ * truncated result set (#287). Every other failure in this family costs an
+ * over-large read; this one costs a partially committed write, which re-running
+ * the query cannot undo.
+ *
+ * The explain guard's `hasDataModifyingStatement` (`lib/explain/select-prefix.ts`)
+ * answers a similar-looking question and is deliberately NOT reused here. It is a
+ * whole-text `/\b(?:INSERT|UPDATE|DELETE|MERGE)\b/i` that over-refuses on purpose,
+ * because its cost of being wrong is a disabled EXPLAIN button. Inverted into the
+ * limiter the same over-detection costs a BOUND: a read-only CTE whose text merely
+ * quotes a write keyword (`FROM "delete_queue"`, `WHERE action = 'delete'`) would
+ * return every row, re-opening the unbounded read #275 closed. Explain needs a
+ * SAFE answer, the limiter needs a PRECISE one, so this reads the grammar.
+ */
+
+import { readLeadingKeyword, type LeadingKeyword } from "./leading-keyword";
+import { IDENTIFIER_PART, IDENTIFIER_START, readSqlSpan } from "./spans";
+
+/** A word (identifier or keyword) and where it ends, or `null` if none starts here. */
+interface Word {
+  text: string;
+  end: number;
+}
+
+/**
+ * A word runs over the shared identifier alphabet, plus `$` after the first
+ * character: it is legal inside a MySQL identifier and after the first character
+ * in PostgreSQL. It stays out of the START position so a dollar-quoted string is
+ * still read as the literal it is.
+ */
+function readWord(sql: string, index: number): Word | null {
+  if (index >= sql.length || !IDENTIFIER_START.test(sql[index])) return null;
+
+  let end = index + 1;
+  while (end < sql.length && (IDENTIFIER_PART.test(sql[end]) || sql[end] === "$")) end++;
+
+  // Upper-cased for the keyword comparisons below. Every keyword this module
+  // tests for is ASCII, so the locale-independent mapping is all it needs.
+  return { text: sql.slice(index, end).toUpperCase(), end };
+}
+
+/**
+ * The next index at which the statement's own code resumes, or `-1` when it never
+ * does - the input ended, or ended inside a comment, so there is nothing further
+ * to read and no honest way to guess what it would have been.
+ */
+function skipTrivia(sql: string, from: number): number {
+  let i = from;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i);
+    if (span === null) return i;
+    if (span.kind !== "whitespace" && span.kind !== "line-comment" && span.kind !== "block-comment") return i;
+    if (!span.terminated) return -1;
+    i = span.end;
+  }
+
+  return -1;
+}
+
+/**
+ * The index past the `)` that closes the paren at `open`, or `-1` when it is never
+ * closed.
+ *
+ * Literals and comments are skipped whole, so a paren inside a string, a quoted
+ * identifier, a dollar-quoted body or a comment cannot close a CTE definition.
+ * That is the case a naive scan gets wrong in the direction that matters: stopping
+ * at the first `)` inside a definition would put the reader in the middle of the
+ * CTE body and let a `SELECT` there answer for the whole statement.
+ */
+function skipParenthesised(sql: string, open: number): number {
+  let depth = 0;
+  let i = open;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i);
+    if (span !== null) {
+      if (!span.terminated) return -1;
+      i = span.end;
+      continue;
+    }
+
+    if (sql[i] === "(") depth++;
+    else if (sql[i] === ")") {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+    i++;
+  }
+
+  return -1;
+}
+
+/** The index past a CTE's name - a bare word or a quoted identifier - or `-1`. */
+function skipCteName(sql: string, index: number): number {
+  const span = readSqlSpan(sql, index);
+  if (span !== null) {
+    // A quoted identifier is a name; a string or dollar-quoted body is not, and
+    // trivia has already been skipped by the caller.
+    if (span.kind === "quoted-identifier" && span.terminated) return span.end;
+    return -1;
+  }
+
+  // MSSQL brackets, accepted HERE and not in `readSqlSpan`: in a name position
+  // `[…]` can only be a quoted identifier, while elsewhere `a[1]` is array
+  // subscripting in PostgreSQL and ClickHouse, which a literal reader must not
+  // swallow. Without this a bracketed CTE name would read as undeterminable and
+  // the statement would silently lose its bound.
+  if (sql[index] === "[") {
+    let i = index + 1;
+    while (i < sql.length) {
+      if (sql[i] === "]") {
+        // MSSQL escapes a closing bracket by doubling it, the same rule the
+        // quoted forms use.
+        if (sql[i + 1] === "]") {
+          i += 2;
+          continue;
+        }
+        return i + 1;
+      }
+      i++;
+    }
+    return -1;
+  }
+
+  return readWord(sql, index)?.end ?? -1;
+}
+
+/**
+ * The keyword after a `WITH` statement's CTE list.
+ *
+ * Walks the list's real grammar - `[RECURSIVE] name [(cols)] AS [[NOT]
+ * MATERIALIZED] (body) [, …]` - rather than searching the text, because every
+ * text search over a CTE can be answered by the CTE's own body. Anything that
+ * does not match answers `null`: see the bias note on the exported function.
+ */
+function readKeywordAfterCteList(sql: string, afterWith: number): LeadingKeyword | null {
+  let i = skipTrivia(sql, afterWith);
+  if (i < 0) return null;
+
+  const recursive = readWord(sql, i);
+  if (recursive?.text === "RECURSIVE") {
+    i = skipTrivia(sql, recursive.end);
+    if (i < 0) return null;
+  }
+
+  for (;;) {
+    const afterName = skipCteName(sql, i);
+    if (afterName < 0) return null;
+    i = skipTrivia(sql, afterName);
+    if (i < 0) return null;
+
+    // An optional column list: `WITH t (a, b) AS (…)`. It closes back to depth 0
+    // exactly as the body does, which is why the two are told apart by position in
+    // the grammar rather than by "the last paren that closed".
+    if (sql[i] === "(") {
+      const afterColumns = skipParenthesised(sql, i);
+      if (afterColumns < 0) return null;
+      i = skipTrivia(sql, afterColumns);
+      if (i < 0) return null;
+    }
+
+    const as = readWord(sql, i);
+    if (as?.text !== "AS") return null;
+    i = skipTrivia(sql, as.end);
+    if (i < 0) return null;
+
+    // PostgreSQL's inlining hints sit between `AS` and the body.
+    let hint = readWord(sql, i);
+    if (hint?.text === "NOT") {
+      i = skipTrivia(sql, hint.end);
+      if (i < 0) return null;
+      hint = readWord(sql, i);
+      if (hint?.text !== "MATERIALIZED") return null;
+    }
+    if (hint?.text === "MATERIALIZED") {
+      i = skipTrivia(sql, hint.end);
+      if (i < 0) return null;
+    }
+
+    if (sql[i] !== "(") return null;
+    const afterBody = skipParenthesised(sql, i);
+    if (afterBody < 0) return null;
+    i = skipTrivia(sql, afterBody);
+    if (i < 0) return null;
+
+    if (sql[i] !== ",") break;
+    i = skipTrivia(sql, i + 1);
+    if (i < 0) return null;
+  }
+
+  const operative = readWord(sql, i);
+  if (operative === null) return null;
+
+  return { keyword: operative.text, start: i, end: operative.end };
+}
+
+/**
+ * The keyword that operates this statement, or `null` when there is none to read.
+ *
+ * `null` covers both "no statement here" (empty, whitespace, comments only) and
+ * "the statement's shape cannot be determined" - an unclosed CTE body, a malformed
+ * CTE list, an unterminated comment or literal, or a `WITH` with nothing after its
+ * list. Both answer `null` on purpose: callers use this to decide whether to
+ * REWRITE a statement, and the two ways of being wrong are not equally bad.
+ * Declining to bound a statement costs an over-large read the user can re-run;
+ * bounding one that writes commits part of it. So undeterminable input is never
+ * reported as a read.
+ *
+ * Two known shapes are WELL FORMED and still answer not-`SELECT`, so they lose a
+ * bound they used to get. Both are reads, so the cost is an over-large result set
+ * and neither can bound a write; each is pinned by a test so the gap is a decision
+ * rather than a surprise:
+ *
+ * - A recursive CTE's optional `SEARCH` / `CYCLE` clause sits between the list and
+ *   the operative statement, and this reader stops at the first word after the
+ *   list, so it reports `SEARCH` there.
+ * - ClickHouse's `WITH <expr> AS <alias>` form puts an expression where the
+ *   standard form puts a name; reading it needs an expression parser. That form is
+ *   idiomatic there and this is a real regression for it, recorded for follow-up
+ *   rather than papered over - ClickHouse has no data-modifying CTE, so nothing on
+ *   that provider is made unsafe by it.
+ *
+ * Two more go the OTHER way, and are recorded here precisely because they are the
+ * direction this function otherwise promises to avoid - both are pinned by tests:
+ *
+ * - Oracle's alternative quoting (`q'{…}'`) is not a literal to `readSqlSpan`, so
+ *   its body is walked as code, and a `)` or a keyword written inside one moves the
+ *   reading. Unreachable in Oracle itself, which has no `WITH … DELETE`, and no
+ *   other dialect here has the form.
+ * - A MySQL line comment whose first character makes a PostgreSQL operator (`#-`,
+ *   `#>`) is code by the deliberate trade `spans.ts` documents, so a paren inside
+ *   such a comment can end a CTE body early. Contrived, and paid for on purpose:
+ *   closing it would cost every PostgreSQL jsonb-operator CTE its bound.
+ */
+export function readOperativeKeyword(sql: string): LeadingKeyword | null {
+  const leading = readLeadingKeyword(sql);
+  if (leading === null || leading.keyword !== "WITH") return leading;
+
+  return readKeywordAfterCteList(sql, leading.end);
+}

--- a/src/lib/sql/spans.ts
+++ b/src/lib/sql/spans.ts
@@ -1,0 +1,243 @@
+/**
+ * Where the non-code runs of a SQL statement are: trivia and literals.
+ *
+ * Every reader in this folder that has to answer a question about a statement's
+ * STRUCTURE - where its CTE list ends, where its text ends, where it splits -
+ * first has to know which characters are code. A paren written inside a comment,
+ * a semicolon inside a string and a keyword inside a quoted identifier all look
+ * like code to a reader that only sees characters, and each one has already cost
+ * this project a bug (#275, #280, #287).
+ *
+ * This is deliberately a character scanner rather than a regex. The regex shape
+ * for the same job backtracks catastrophically over parenthesised bodies and
+ * comment runs: `leading-keyword.ts` records three measured failures in its
+ * predecessors (quadratic 958ms, quadratic 852ms, and exponential 634ms on a
+ * FORTY-NINE character input, the last found by CodeQL), and
+ * `db/utils/query-limiter.ts` hand-writes its semicolon strip for the same
+ * reason. A scanner that advances one span at a time cannot backtrack at all.
+ *
+ * Two older readers in this folder overlap with it and are deliberately left
+ * alone, because rewriting either changes behaviour this module is not chartered
+ * to change:
+ *
+ * - `statement-splitter.ts` inlines the same scan, wound together with the line
+ *   counting it needs, and treats `#` as ordinary code - so a MySQL hash comment
+ *   containing a `;` still splits there. Reusing this module would move statement
+ *   boundaries: a separate bug with its own tests.
+ * - `alias-extractor.ts:134-135` blanks literals with a regex that honours
+ *   BACKSLASH escapes, which this module reports as undeterminable instead (see
+ *   `readQuoted`). Its job is autocomplete, where a wrong alias costs a
+ *   suggestion; here a wrong literal boundary costs a bound on a write.
+ *
+ * This module is what every NEW reader builds on, so the count does not grow.
+ */
+
+/**
+ * What kind of non-code run a span is.
+ *
+ * Callers care about the distinction in two ways: trivia (`whitespace`,
+ * `line-comment`, `block-comment`) can be skipped between tokens, while a
+ * literal is a token - a quoted identifier can BE a name, so a reader that
+ * skipped it as trivia would misread `WITH "my cte" AS (…)`.
+ */
+export type SqlSpanKind =
+  | "whitespace"
+  | "line-comment"
+  | "block-comment"
+  | "string"
+  | "quoted-identifier"
+  | "dollar-string";
+
+export interface SqlSpan {
+  kind: SqlSpanKind;
+  /** Index one past the span's last character, so `sql.slice(index, end)` is the span. */
+  end: number;
+  /**
+   * Whether the span reached its closing delimiter.
+   *
+   * `false` means the input ended inside the span, and a caller that needs to
+   * know what follows it cannot: there is no "what follows". Callers deciding
+   * whether to REWRITE a statement must treat that as undeterminable rather than
+   * guessing - see `operative-keyword.ts`, where the guess would be a bound
+   * appended to a write.
+   *
+   * A line comment closed by the end of the input is `true`: end-of-input closes
+   * it in every dialect, and nothing follows it to be wrong about.
+   */
+  terminated: boolean;
+}
+
+/** Whitespace as SQL counts it - the same set `String.prototype.trim` removes. */
+function isWhitespace(ch: string): boolean {
+  return ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "\f" || ch === "\v";
+}
+
+/** The characters that turn a `#` into a PostgreSQL operator rather than a comment. */
+function isHashOperatorTail(ch: string | undefined): boolean {
+  return ch === ">" || ch === "-" || ch === "#";
+}
+
+/**
+ * The identifier alphabet, shared with `operative-keyword.ts` so the two readers
+ * in one walk cannot disagree about what a name is.
+ *
+ * Deliberately not `\w`: an ASCII-only alphabet fails on ordinary localized names
+ * (`WITH müşteri AS (SELECT 1) SELECT * FROM müşteri` is a plain read-only CTE),
+ * and every name a reader cannot read costs its statement a bound. `$` is legal
+ * inside identifiers in MySQL and after the first character in PostgreSQL, but it
+ * is left OUT of these classes because it also closes a dollar-quote tag; the
+ * caller that wants it adds it.
+ */
+export const IDENTIFIER_START = /[\p{L}\p{Nl}_]/u;
+export const IDENTIFIER_PART = /[\p{L}\p{N}\p{Mn}\p{Pc}]/u;
+
+/** Whether the delimiter at `at` is preceded by an odd number of backslashes. */
+function hasOddBackslashRunBefore(sql: string, from: number, at: number): boolean {
+  let backslashes = 0;
+  let i = at - 1;
+  while (i > from && sql[i] === "\\") {
+    backslashes++;
+    i--;
+  }
+  return backslashes % 2 === 1;
+}
+
+/**
+ * A quoted run (`'…'`, `"…"`, `` `…` ``) where the delimiter is escaped by
+ * doubling it.
+ *
+ * `backslashEscapes` marks the delimiters for which a preceding backslash MIGHT
+ * also escape. Whether it does is a dialect setting rather than a property of the
+ * text - MySQL escapes with backslashes by default, PostgreSQL does not unless the
+ * literal is written `E'…'` - and the two readings put the end of the string in
+ * different places, which then moves the end of every construct around it. So a
+ * delimiter behind an odd backslash run is reported as UNDETERMINABLE instead of
+ * guessed: `WITH t AS (SELECT '\') SELECT ') DELETE FROM users` reads as a SELECT
+ * under one dialect and a DELETE under the other, and guessing the first would
+ * append a bound to a DELETE. Callers already decline to rewrite what they cannot
+ * read, so the cost of the safe answer is at most an unbounded read.
+ */
+function readQuoted(sql: string, index: number, quote: string, kind: SqlSpanKind, backslashEscapes: boolean): SqlSpan {
+  let i = index + 1;
+
+  while (i < sql.length) {
+    if (sql[i] === quote) {
+      // The backslash question is asked BEFORE the doubling rule, because the two
+      // meet: `\''` is how a MySQL string ending in an apostrophe is written, and
+      // testing the doubling first consumes both quotes and never reaches the
+      // ambiguity. Asking first also makes the invariant provable - the two
+      // readings can diverge ONLY at a delimiter behind an odd backslash run,
+      // since everywhere else both consume identically and both honour doubling -
+      // so `terminated: true` here is a dialect-independent answer.
+      if (backslashEscapes && hasOddBackslashRunBefore(sql, index, i)) {
+        return { kind, end: sql.length, terminated: false };
+      }
+      // A doubled delimiter is an escape, not the end. Reading it as the end is
+      // how "find the next quote" scanners lose track of the rest of the
+      // statement - and a run of quotes is ALL escapes, so it never closes.
+      if (sql[i + 1] === quote) {
+        i += 2;
+        continue;
+      }
+      return { kind, end: i + 1, terminated: true };
+    }
+    i++;
+  }
+
+  return { kind, end: sql.length, terminated: false };
+}
+
+/**
+ * The length of a PostgreSQL dollar-quote tag at `index` (`$$`, `$fn$`), or 0
+ * when this `$` opens no tag.
+ *
+ * The tag body follows identifier rules - the same ones names follow, non-ASCII
+ * included - which is what keeps a positional parameter (`$1`) and a bare `$` out
+ * of it.
+ */
+function measureDollarTag(sql: string, index: number): number {
+  let i = index + 1;
+
+  if (sql[i] !== "$") {
+    if (i >= sql.length || !IDENTIFIER_START.test(sql[i])) return 0;
+    i++;
+    while (i < sql.length && IDENTIFIER_PART.test(sql[i])) i++;
+    if (sql[i] !== "$") return 0;
+  }
+
+  return i + 1 - index;
+}
+
+/**
+ * The trivia or literal run starting at `index`, or `null` when code starts there
+ * (including when `index` is past the end of the input).
+ *
+ * Callers walk a statement by asking at every position: is this a span? If yes,
+ * jump to `end`; if no, this character is the statement's own code.
+ */
+export function readSqlSpan(sql: string, index: number): SqlSpan | null {
+  const ch = sql[index];
+  if (ch === undefined) return null;
+
+  if (isWhitespace(ch)) {
+    let end = index + 1;
+    while (end < sql.length && isWhitespace(sql[end])) end++;
+    return { kind: "whitespace", end, terminated: true };
+  }
+
+  // `#` is MySQL's and MariaDB's second line-comment marker. Unlike
+  // `leading-keyword.ts`, which only ever looks at a statement's LEADING trivia,
+  // this reader is asked about every position - and mid-statement `#` is a live
+  // PostgreSQL operator: `#>` and `#>>` walk a jsonb path, `#-` deletes one, `##`
+  // is geometric. Reading `SELECT meta #> '{a}'` as a comment swallows the rest of
+  // the line and costs an everyday jsonb query its bound, so a `#` that opens one
+  // of those operators is code.
+  //
+  // The trade is stated exactly, because this is the one place the module takes a
+  // dialect's SIDE instead of reporting that the dialects disagree. A MySQL comment
+  // whose first character is one of those (`#- note`) reads as code here, so the
+  // rest of that line is read as SQL where MySQL reads it as comment - and if that
+  // text contains a paren, the two readings end a construct in different places.
+  // `WITH t AS (\n #- note )\n SELECT 1) DELETE FROM users` is a DELETE in MySQL and
+  // reads as a SELECT here, which is the direction `operative-keyword.ts` otherwise
+  // promises to avoid. Reporting it undeterminable would close that, at the price of
+  // every PostgreSQL jsonb-operator CTE losing its bound: a certain cost against a
+  // contrived one. So the reading stands, the gap is recorded rather than hidden
+  // (`operative-keyword.ts`, and a test pins it), and `# note` - how comments are
+  // actually written - is unaffected either way.
+  if ((ch === "-" && sql[index + 1] === "-") || (ch === "#" && !isHashOperatorTail(sql[index + 1]))) {
+    const newline = sql.indexOf("\n", index);
+    // The newline belongs to the comment: it is what closes it.
+    return { kind: "line-comment", end: newline === -1 ? sql.length : newline + 1, terminated: true };
+  }
+
+  if (ch === "/" && sql[index + 1] === "*") {
+    const close = sql.indexOf("*/", index + 2);
+    if (close === -1) return { kind: "block-comment", end: sql.length, terminated: false };
+    return { kind: "block-comment", end: close + 2, terminated: true };
+  }
+
+  if (ch === "'") return readQuoted(sql, index, "'", "string", true);
+  // `"` is a quoted identifier in every dialect this project supports except
+  // MySQL with its default settings, where it is a string - and therefore takes
+  // backslash escapes. Either way it is an opaque literal and the doubling rule is
+  // the same, so one reading serves both.
+  if (ch === '"') return readQuoted(sql, index, '"', "quoted-identifier", true);
+  // Backticks are MySQL's identifier quotes. Without them a backtick-quoted CTE
+  // name would read as undeterminable input and cost that statement its bound. No
+  // dialect gives a backslash meaning inside them, so one before the closing
+  // delimiter is simply part of the name.
+  if (ch === "`") return readQuoted(sql, index, "`", "quoted-identifier", false);
+
+  if (ch === "$") {
+    const tagLength = measureDollarTag(sql, index);
+    if (tagLength === 0) return null;
+
+    const tag = sql.slice(index, index + tagLength);
+    const close = sql.indexOf(tag, index + tagLength);
+    if (close === -1) return { kind: "dollar-string", end: sql.length, terminated: false };
+    return { kind: "dollar-string", end: close + tagLength, terminated: true };
+  }
+
+  return null;
+}

--- a/src/lib/sql/statement-end.ts
+++ b/src/lib/sql/statement-end.ts
@@ -1,0 +1,146 @@
+/**
+ * Where a SQL statement's own text ends.
+ *
+ * Everything a statement carries after its last code character - whitespace, line
+ * comments, block comments and the terminating semicolon - is trivia. The query
+ * limiter used to have no notion of it at all, and that broke it in both
+ * directions at once (#280):
+ *
+ * - Appending ` LIMIT n` after a trailing line comment put the bound INSIDE the
+ *   comment. The engine ran the statement unbounded while the caller was handed
+ *   `wasLimited: true`, so the UI reported a capped result set over a full table
+ *   scan - the one shape worse than not limiting, because it stops the warning.
+ * - Reading an existing bound off the same text made a commented-out one look
+ *   real (`SELECT … -- LIMIT 10`), so nothing was injected and the statement ran
+ *   unbounded again.
+ *
+ * One reading serves both: the placement inserts at this index and re-attaches
+ * what follows, and the "already bounded" probes read only what precedes it. Two
+ * notions of the end is what produced the pair of defects above, and it is also
+ * what would make an intermediate state dangerous - a bound placed before a
+ * comment while the probes still read past it collects a SECOND bound, which is
+ * a syntax error rather than merely too many rows.
+ *
+ * The one place the two do differ is whether the end may be CUT, which is a
+ * separate answer on the result rather than a separate reading - see
+ * `rewritable`.
+ *
+ * A character scanner over `spans.ts`, not a regex, for the reason that module
+ * documents: the pattern shape for "everything up to the trailing comment"
+ * backtracks catastrophically, and `leading-keyword.ts` records three measured
+ * failures of exactly that kind.
+ */
+
+import { readSqlSpan } from "./spans";
+
+export interface StatementEnd {
+  /**
+   * The index past the statement's last code character: `sql.slice(0, end)` is
+   * the statement's own text and `sql.slice(end)` is its trailing trivia and
+   * terminator, so the two halves always rejoin to the input exactly.
+   */
+  end: number;
+  /**
+   * Whether text may be INSERTED at `end`.
+   *
+   * `false` means the index is not one the statement may be split at - either
+   * because the scan could not settle where the statement ends, or because it
+   * settled somewhere only one dialect agrees with. The `end` above is then the
+   * terminator strip: trailing whitespace and semicolons removed and nothing
+   * else, which is what this module's callers read before it existed (their old
+   * helper stopped after the first run of `;`, so `LIMIT 10 ; ;` reads one
+   * character further here - in the direction that finds the bound rather than
+   * doubling it). So a refused cut costs a caller nothing it used to have: its
+   * probes see the text they always saw, and only the rewrite is declined.
+   *
+   * The two answers are separate because the risks are: a probe reading the
+   * wrong text at worst reports a bound that is not there (and the caller then
+   * leaves the statement alone), while a clause inserted at the wrong index
+   * lands in the middle of the statement and the server rejects it outright.
+   */
+  rewritable: boolean;
+}
+
+/** The index past the last character that is neither whitespace nor `;`. */
+function endBeforeTerminator(sql: string): number {
+  let end = sql.length;
+  while (end > 0 && (isTrailingSpace(sql[end - 1]) || sql[end - 1] === ";")) end--;
+  return end;
+}
+
+/** Whitespace as the terminator strip counts it, matching `String.prototype.trim`. */
+function isTrailingSpace(ch: string): boolean {
+  return ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "\f" || ch === "\v";
+}
+
+/**
+ * Where this statement ends, and whether a clause may be inserted there.
+ *
+ * A semicolon does not advance the end - it terminates the statement rather than
+ * belonging to it - but a semicolon with code after it does, since what follows
+ * is another statement rather than trivia. Splitting statements is
+ * `statement-splitter.ts`'s job; this reader only has to find the LAST end.
+ *
+ * Two shapes answer `rewritable: false`, and both then report the terminator
+ * strip as their end:
+ *
+ * 1. **A span that never closes** - an unterminated block comment or literal, or
+ *    a quote behind an odd backslash run, which `spans.ts` reports as
+ *    undeterminable because MySQL escapes with backslashes and PostgreSQL does
+ *    not, so the two readings end the statement in different places. (A `$` in a
+ *    bare identifier reaches this too: `a$b$c` opens a dollar-quote tag that
+ *    never closes.) Inserting on a guess emits `… 'O\'Brien'; LIMIT 500`, a bound
+ *    after the statement's own `;`, which is a syntax error rather than too many
+ *    rows.
+ * 2. **A `#` line comment in the trailing run.** `spans.ts` reads `#` as MySQL's
+ *    second comment marker, but it is ordinary code in three other dialects this
+ *    project supports - `#tmp` is a T-SQL temp table, `ID#` a legal Oracle
+ *    identifier, `flags # 5` a PostgreSQL XOR - and nothing in the text tells the
+ *    two apart (`#note` and `#tmp` are the same characters). Cutting there emits
+ *    `SELECT * FROM LIMIT 500 #tmp`. The `#` run is reported as part of the
+ *    statement rather than trimmed off it, because the reading that costs least
+ *    when wrong is the LONGER one: a bound written after a `#` is then still
+ *    found (`… FROM #tmp ORDER BY id FETCH NEXT 10 ROWS ONLY` is a bounded T-SQL
+ *    page, and a caller that could not see that bound would add a second), while
+ *    the opposite mistake only reports a bound the caller responds to by leaving
+ *    the statement alone - which is what it does here anyway.
+ *
+ * A `#` comment with code after it on a later line is unaffected: the end then
+ * advances past it, and inserting at the end of the statement is correct under
+ * both readings.
+ */
+export function readStatementEnd(sql: string): StatementEnd {
+  let end = 0;
+  let i = 0;
+  // Whether the run since the last code character contains a `#` line comment.
+  let hashInTrailingRun = false;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i);
+
+    if (span !== null) {
+      if (!span.terminated) return { end: endBeforeTerminator(sql), rewritable: false };
+      // A literal is the statement's own text; trivia is not. Both are skipped
+      // whole, which is what keeps a `;` or a `--` written inside one from
+      // looking like the end of the statement.
+      if (span.kind === "string" || span.kind === "quoted-identifier" || span.kind === "dollar-string") {
+        end = span.end;
+        hashInTrailingRun = false;
+      } else if (span.kind === "line-comment" && sql[i] === "#") {
+        hashInTrailingRun = true;
+      }
+      i = span.end;
+      continue;
+    }
+
+    if (sql[i] !== ";") {
+      end = i + 1;
+      hashInTrailingRun = false;
+    }
+    i++;
+  }
+
+  if (hashInTrailingRun) return { end: endBeforeTerminator(sql), rewritable: false };
+
+  return { end, rewritable: true };
+}

--- a/src/lib/sql/words.ts
+++ b/src/lib/sql/words.ts
@@ -1,0 +1,95 @@
+/**
+ * Where a SQL statement's own code WORDS are.
+ *
+ * `spans.ts` answers where a statement's non-code runs are - trivia and literals -
+ * and this is the complement every reader above it needs: a word is only the
+ * statement's if it is not inside one of those runs. Splitting them this way is what
+ * lets `readSqlWord` be shared by the readers that walk a statement token by token
+ * (`operative-keyword.ts`) and by the ones that only need to know whether a word is
+ * present at all.
+ *
+ * `findCodeWord` exists because the alternative - `/\bWORD\b/i` over the whole text
+ * - answers for a word the statement merely MENTIONS. That is the same defect this
+ * folder has now fixed four times over (#275, #280, #287, #294): a keyword inside a
+ * comment, a string or a quoted identifier is not the statement doing it. It is also
+ * measurably cheaper on the shapes that matter: the pattern it replaced in the
+ * dangerous-query predicate, `/\bUPDATE\b[\s\S]*?\bSET\b/i`, restarts its lazy tail
+ * at every `UPDATE` in the input and took 1025ms on 140 KB of them (guarded in
+ * `tests/components/QuerySafetyDialog.test.tsx`), while a scan that advances one span
+ * or one word at a time cannot backtrack at all.
+ */
+
+import { IDENTIFIER_PART, IDENTIFIER_START, readSqlSpan } from "./spans";
+
+/** A word (identifier or keyword) and where it ends. */
+export interface SqlWord {
+  /**
+   * The word, upper-cased so callers can compare without re-normalising. The
+   * input's own spelling stays reachable by slicing up to `end`.
+   */
+  text: string;
+  /** Index one past its last character. */
+  end: number;
+}
+
+/**
+ * The word at `index`, or `null` when one does not start there.
+ *
+ * A word runs over the shared identifier alphabet, plus `$` after the first
+ * character: it is legal inside a MySQL identifier and after the first character in
+ * PostgreSQL. It stays out of the START position so a dollar-quoted string is still
+ * read as the literal it is.
+ */
+export function readSqlWord(sql: string, index: number): SqlWord | null {
+  if (index >= sql.length || !IDENTIFIER_START.test(sql[index])) return null;
+
+  let end = index + 1;
+  while (end < sql.length && (IDENTIFIER_PART.test(sql[end]) || sql[end] === "$")) end++;
+
+  // Upper-cased for the keyword comparisons callers make. Every keyword read
+  // through this module is ASCII, so the locale-independent mapping is all it needs.
+  return { text: sql.slice(index, end).toUpperCase(), end };
+}
+
+/** Where a word the statement's code contains begins and ends. */
+export interface CodeWord {
+  start: number;
+  end: number;
+}
+
+/**
+ * Where `word` appears in this statement's CODE at or after `from`, or `null`.
+ *
+ * Whole words only - `UPDATED` and `xUPDATE` are not `UPDATE` - and `word` may be
+ * written in any case.
+ *
+ * An undeterminable literal or comment (`spans.ts` reports one as reaching the end
+ * of the input) therefore hides whatever follows it, which for a caller asking "does
+ * this statement write?" is the unhelpful direction. It is left where `spans.ts`
+ * decided it: the two dialect readings of `'\'` put the end of the string in
+ * different places, the text is a syntax error under one of them, and guessing here
+ * would answer for words inside a literal under the other. Pinned by a test in
+ * `tests/unit/sql/words.test.ts`.
+ */
+export function findCodeWord(sql: string, word: string, from = 0): CodeWord | null {
+  const target = word.toUpperCase();
+  let i = from;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i);
+    if (span !== null) {
+      i = span.end;
+      continue;
+    }
+
+    const found = readSqlWord(sql, i);
+    if (found === null) {
+      i++;
+      continue;
+    }
+    if (found.text === target) return { start: i, end: found.end };
+    i = found.end;
+  }
+
+  return null;
+}

--- a/tests/api/db/multi-query.test.ts
+++ b/tests/api/db/multi-query.test.ts
@@ -306,6 +306,104 @@ describe("POST /api/db/multi-query", () => {
     expect(mockProvider.prepareQuery).not.toHaveBeenCalled();
   });
 
+  // ─── Which final statement gets bounded (#281) ─────────────────────────────
+  // The route used to answer "is this a SELECT" with its own `/^\s*SELECT\b/i`,
+  // which tolerates whitespace but not a comment, so an annotated final SELECT
+  // reached the engine unprepared. It now reads the shared classifier.
+  //
+  // The ` LIMIT 50` these assert on is the mock provider's marker, not the real
+  // limiter's output: what is under test here is WHICH statement the route hands
+  // to `prepareQuery` and that it executes the prepared text. The bound a real
+  // provider produces for these same statements is pinned at the shared seam, in
+  // `tests/unit/db/query-limiter.test.ts` and `tests/unit/db/sql-base.test.ts`.
+  describe("final-statement classification", () => {
+    test("comment-led final SELECT is prepared and the bounded SQL reaches the engine", async () => {
+      const finalStatement = "-- final read\nSELECT * FROM users";
+
+      const req = createMockRequest("/api/db/multi-query", {
+        method: "POST",
+        body: {
+          connection: validConnection,
+          sql: `INSERT INTO users (name) VALUES ('a');\n${finalStatement}`,
+          options: { limit: 50 },
+        },
+      });
+
+      await POST(req as never);
+
+      expect(mockProvider.prepareQuery).toHaveBeenCalledWith(finalStatement, { limit: 50 });
+      // The response echoes the original text, so the engine-visible bound is the
+      // only honest assertion that the statement was actually limited.
+      expect(mockProvider.query).toHaveBeenCalledWith(`${finalStatement} LIMIT 50`);
+    });
+
+    test("final statement that is not a SELECT is executed unprepared", async () => {
+      const req = createMockRequest("/api/db/multi-query", {
+        method: "POST",
+        body: {
+          connection: validConnection,
+          sql: "SELECT * FROM users;\n-- annotated write\nUPDATE users SET name = 'b'",
+        },
+      });
+
+      await POST(req as never);
+
+      expect(mockProvider.prepareQuery).not.toHaveBeenCalled();
+      expect(mockProvider.query).toHaveBeenCalledWith("-- annotated write\nUPDATE users SET name = 'b'");
+    });
+
+    test("non-final SELECT is executed unprepared", async () => {
+      const req = createMockRequest("/api/db/multi-query", {
+        method: "POST",
+        body: {
+          connection: validConnection,
+          sql: "-- first read\nSELECT * FROM a;\nINSERT INTO b VALUES (1)",
+        },
+      });
+
+      await POST(req as never);
+
+      expect(mockProvider.prepareQuery).not.toHaveBeenCalled();
+      expect(mockProvider.query).toHaveBeenCalledWith("-- first read\nSELECT * FROM a");
+    });
+
+    test("comment-led final read-only CTE is prepared", async () => {
+      const finalStatement = "-- read\nWITH c AS (SELECT 1 AS a) SELECT * FROM c";
+
+      const req = createMockRequest("/api/db/multi-query", {
+        method: "POST",
+        body: {
+          connection: validConnection,
+          sql: `INSERT INTO t VALUES (1);\n${finalStatement}`,
+        },
+      });
+
+      await POST(req as never);
+
+      expect(mockProvider.query).toHaveBeenCalledWith(`${finalStatement} LIMIT 50`);
+    });
+
+    test("comment-led final data-modifying CTE is executed unprepared", async () => {
+      // The shared classifier types a `WITH` by the keyword its CTE list operates
+      // (#287), so the `SELECT` this statement supplies itself must not win it a
+      // bound - that bound would cap the rows it WRITES.
+      const finalStatement = "-- write\nWITH c AS (DELETE FROM logs RETURNING id) INSERT INTO audit SELECT id FROM c";
+
+      const req = createMockRequest("/api/db/multi-query", {
+        method: "POST",
+        body: {
+          connection: validConnection,
+          sql: `SELECT 1;\n${finalStatement}`,
+        },
+      });
+
+      await POST(req as never);
+
+      expect(mockProvider.prepareQuery).not.toHaveBeenCalled();
+      expect(mockProvider.query).toHaveBeenCalledWith(finalStatement);
+    });
+  });
+
   test("QueryError from getOrCreateProvider returns 400", async () => {
     mockGetOrCreateProvider.mockImplementation(async () => {
       throw new QueryError("Bad query", "postgres");

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -613,4 +613,123 @@ describe("isDangerousQuery", () => {
     expect(isDangerousQuery("SELECT * FROM users")).toBe(false);
     expect(isDangerousQuery("WITH cte AS (SELECT 1) SELECT * FROM cte")).toBe(false);
   });
+
+  // ── A comment cannot hide the statement (#294) ───────────────────────────
+
+  /**
+   * The predicate used to re-derive the leading-keyword test with its own anchored
+   * patterns (`/^\s*DROP\b/i`, …), which tolerate whitespace but not a comment. So
+   * writing a note above a destructive statement - the most ordinary habit there is
+   * - skipped the confirmation dialog entirely on both execution paths.
+   */
+  test.each<[string, string]>([
+    ["a line comment", "-- cleanup\nDROP TABLE users"],
+    ["a block comment", "/* nightly */ TRUNCATE TABLE audit"],
+    ["stacked comments", "-- one\n/* two */\n-- three\nDELETE FROM sessions"],
+    ["a MySQL hash comment", "# note\nDELETE FROM sessions"],
+    ["an indented comment", "   -- note\n   ALTER TABLE users ADD COLUMN x int"],
+    ["a comment above GRANT", "-- audit\nGRANT SELECT ON users TO analyst"],
+    ["a comment above REVOKE", "/* audit */ REVOKE SELECT ON users FROM analyst"],
+    ["a comment above UPDATE", "-- fix\nUPDATE users SET admin = true"],
+  ])("prompts for a destructive statement behind %s", (_label, query) => {
+    expect(isDangerousQuery(query)).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["a plain read", "SELECT * FROM users"],
+    ["a read behind a comment", "-- daily report\nSELECT * FROM users"],
+    ["a read whose comment names DROP", "SELECT * FROM t -- DROP TABLE users"],
+    ["a read whose comment names UPDATE ... SET", "SELECT * FROM t /* UPDATE t SET x = 1 */"],
+    ["a read quoting UPDATE ... SET in a string", "SELECT note FROM logs WHERE note = 'UPDATE t SET x = 1'"],
+    ["a read of a column named UPDATE", 'SELECT "UPDATE" FROM audit'],
+  ])("never prompts for %s", (_label, query) => {
+    expect(isDangerousQuery(query)).toBe(false);
+  });
+
+  // ── Writes a read-shaped statement carries ───────────────────────────────
+
+  /**
+   * The `UPDATE … SET` probe is deliberately NOT anchored to the statement's own
+   * keyword, unlike the vocabulary test above.
+   *
+   * PostgreSQL's data-modifying CTE is OPERATED by its `SELECT` - which is the
+   * honest answer, and the one the query limiter needs to avoid bounding the rows a
+   * write commits (#287) - so anchoring this probe too would take the last human
+   * check away from a statement that really does write. The probe reads the
+   * statement's CODE (`findCodeWord`), so the cost of keeping it unanchored is no
+   * longer a prompt on every read that merely mentions both words: the two string
+   * and comment cases above used to prompt and now do not.
+   */
+  test("prompts for a write hidden inside a read-shaped statement", () => {
+    expect(isDangerousQuery("WITH moved AS (UPDATE t SET a = 1 RETURNING *) SELECT * FROM moved")).toBe(true);
+  });
+
+  test("prompts for a destructive statement a CTE list only precedes", () => {
+    expect(isDangerousQuery("WITH x AS (SELECT id FROM t) DELETE FROM t USING x WHERE t.id = x.id")).toBe(true);
+  });
+
+  // ── Nothing to read ─────────────────────────────────────────────────────
+
+  test.each<[string, string]>([
+    ["empty text", ""],
+    ["whitespace only", "   \n"],
+    ["a comment only", "-- just a note"],
+    ["a parenthesised read", "(SELECT 1)"],
+  ])("does not prompt for %s, which is not a statement", (_label, query) => {
+    expect(isDangerousQuery(query)).toBe(false);
+  });
+
+  /**
+   * A `WITH` whose list never closes cannot be read, so the destructive keyword
+   * inside it is not reported. No dialect accepts the text either, so what the
+   * server receives is a syntax error rather than a dropped table - pinned so the
+   * gap stays a decision.
+   */
+  test("does not prompt when the statement's shape cannot be read at all", () => {
+    expect(isDangerousQuery("WITH t AS (DELETE FROM x")).toBe(false);
+  });
+
+  /**
+   * The gaps this predicate does NOT close, pinned so each stays a decision and so
+   * `docs/editor/query-optimization.md` cannot drift from them.
+   *
+   * The write-inside-a-read probe looks for `UPDATE … SET` only, because widening it
+   * to the other write keywords would make every read whose code names one of them
+   * prompt. And the whole editor text is read as one statement, so a destructive
+   * statement later in a script is only caught by that same unanchored probe.
+   */
+  test.each<[string, string, boolean]>([
+    ["a DELETE hidden in a CTE body", "WITH gone AS (DELETE FROM t RETURNING *) SELECT * FROM gone", false],
+    ["a DROP after a leading SELECT", "SELECT 1; DROP TABLE users", false],
+    ["an UPDATE after a leading SELECT", "SELECT 1;\nUPDATE t SET x = 1", true],
+    ["a write behind an undeterminable literal", "SELECT '\\';\nUPDATE t SET x = 1", false],
+  ])("answers %s with %p", (_label, query, expected) => {
+    expect(isDangerousQuery(query)).toBe(expected);
+  });
+
+  // ── Shape of the scan ───────────────────────────────────────────────────
+
+  /**
+   * A timing guard: this predicate runs on the editor's execute path, and the
+   * pattern it replaced was measurably quadratic.
+   *
+   * `/\bUPDATE\b[\s\S]*?\bSET\b/i` restarts its lazy tail at every `UPDATE` in the
+   * text, so a script holding many of them and no `SET` cost one full scan each -
+   * measured on the real export before this change: 10.5ms at 14 KB, **1025ms at
+   * 140 KB**, 6406ms at 350 KB. A pasted migration script reaches those sizes.
+   *
+   * The statement below leads with `SELECT` on purpose: a leading `UPDATE` is
+   * answered by the vocabulary test without the probe ever running, so it would
+   * guard nothing.
+   */
+  test("answers in bounded time on a statement holding many UPDATE words and no SET", () => {
+    const query = `SELECT ${"UPDATE ".repeat(20000)}(`;
+
+    const started = performance.now();
+    const dangerous = isDangerousQuery(query);
+    const elapsed = performance.now() - started;
+
+    expect(dangerous).toBe(false);
+    expect(elapsed, `took ${elapsed.toFixed(1)}ms`).toBeLessThan(200);
+  });
 });

--- a/tests/hooks/use-query-adapter.test.ts
+++ b/tests/hooks/use-query-adapter.test.ts
@@ -331,6 +331,28 @@ describe("useQueryAdapter", () => {
     expect(params.onQueryExecute).not.toHaveBeenCalled();
   });
 
+  /**
+   * The same gate with a note above the statement (#294).
+   *
+   * This file uses the REAL `isDangerousQuery`, and this is the packaged product's
+   * execution path - a host application embedding studio runs every query through
+   * this adapter - so the annotated statement has to reach the dialog here, not
+   * only in the predicate's own unit tests.
+   */
+  test("executeQuery sets safetyCheckQuery for a destructive statement behind a comment", async () => {
+    const params = makeHookParams();
+
+    const { result } = renderHook(() => useQueryAdapter(params));
+
+    const annotated = "-- cleanup\nDROP TABLE users";
+    await act(async () => {
+      await result.current.executeQuery(annotated);
+    });
+
+    expect(result.current.safetyCheckQuery).toBe(annotated);
+    expect(params.onQueryExecute).not.toHaveBeenCalled();
+  });
+
   // ── executeQuery leaves other tabs untouched ────────────────────────────────
 
   test("executeQuery updates only the target tab when multiple tabs exist", async () => {

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -8,9 +8,17 @@ import { mockGlobalFetch, restoreGlobalFetch } from "../helpers/mock-fetch";
 import { storage } from "@/lib/storage";
 
 // ── Mock QuerySafetyDialog ──────────────────────────────────────────────────
-mock.module("@/components/QuerySafetyDialog", () => ({
-  isDangerousQuery: (q: string) =>
+// The stub is deliberately more permissive than the real predicate - it answers for
+// DROP/DELETE/TRUNCATE only - which is what lets the UPDATE and DDL tests further
+// down execute without a confirmation. It is a spy so the gate test can assert WHICH
+// text the hook asks about; what the real predicate ANSWERS for that text is pinned
+// in tests/components/QuerySafetyDialog.test.tsx.
+const isDangerousQueryMock = mock(
+  (q: string) =>
     q.toUpperCase().includes("DROP") || q.toUpperCase().includes("DELETE") || q.toUpperCase().includes("TRUNCATE"),
+);
+mock.module("@/components/QuerySafetyDialog", () => ({
+  isDangerousQuery: isDangerousQueryMock,
 }));
 
 import { useQueryExecution } from "@/hooks/use-query-execution";
@@ -250,6 +258,30 @@ describe("useQueryExecution", () => {
     });
 
     expect(result.current.safetyCheckQuery).toBe("DROP TABLE users");
+  });
+
+  /**
+   * The standalone path's half of #294: the hook must ask the gate about the query
+   * text AS WRITTEN, comments included, and open the dialog on a positive answer.
+   *
+   * The predicate itself is stubbed in this file (see the top), so this asserts the
+   * call site's contract - no trimming, no normalising, no re-derived SELECT test
+   * before the gate - while the predicate's comment tolerance is pinned in
+   * tests/components/QuerySafetyDialog.test.tsx against the real export.
+   */
+  test("executeQuery asks the safety gate about the query text as written", async () => {
+    mockGlobalFetch({});
+    const params = createDefaultParams();
+
+    const { result } = renderHook(() => useQueryExecution(params));
+
+    const annotated = "-- cleanup\nDROP TABLE users";
+    await act(async () => {
+      await result.current.executeQuery(annotated);
+    });
+
+    expect(isDangerousQueryMock).toHaveBeenCalledWith(annotated);
+    expect(result.current.safetyCheckQuery).toBe(annotated);
   });
 
   test("executeQuery sets safetyCheckQuery for DELETE queries", async () => {

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -936,6 +936,39 @@ describe("ClickHouseProvider query preparation", () => {
     expect(prepared.wasLimited).toBe(true);
   });
 
+  // ── Expression-form CTEs (#291) ───────────────────────────────────────────
+  //
+  // `WITH <expr> AS <alias>` is how a CTE is ordinarily written here, and it is
+  // not the `name AS (body)` shape the statement typer walks. While that walk
+  // recognised only the standard shape, these statements typed OTHER and reached
+  // the server with no bound at all - on the engine whose whole point is scanning
+  // more rows than a browser can hold. ClickHouse has no data-modifying CTE, so
+  // the missing bound was the entire cost, and the entire fix.
+  test.each([
+    ["a scalar alias", "WITH 1 AS one SELECT one, count(*) FROM events GROUP BY one"],
+    ["a function alias", "WITH now() AS t SELECT * FROM events WHERE ts < t"],
+    ["an array alias", "WITH [1, 2, 3] AS arr SELECT arrayJoin(arr)"],
+    ["a subquery alias", "WITH (SELECT max(id) FROM events) AS m SELECT m"],
+    ["a mixed CTE list", "WITH 1 AS one, t AS (SELECT 2 AS two) SELECT one, two FROM t"],
+    ["a standard read-only CTE", "WITH t AS (SELECT 1 AS one) SELECT one FROM t"],
+  ])("bounds a CTE written with %s", (_label, sql) => {
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(`${sql} LIMIT 25`);
+    expect(prepared.wasLimited).toBe(true);
+  });
+
+  test("keeps a trailing FORMAT clause safe on an expression CTE", () => {
+    // The two readings have to agree on the same statement: typed as a SELECT by
+    // the CTE reader, refused by the trailing-clause override.
+    const sql = "WITH 1 AS one SELECT one FORMAT TSV";
+
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(sql);
+    expect(prepared.wasLimited).toBe(false);
+  });
+
   test("leaves a write untouched", () => {
     const prepared = provider().prepareQuery("INSERT INTO users VALUES (1, 'a@b.c')");
 

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -905,6 +905,37 @@ describe("ClickHouseProvider query preparation", () => {
     expect(prepared.wasLimited).toBe(false);
   });
 
+  // ── Trailing comments (#280) ──────────────────────────────────────────────
+  //
+  // The trailing-clause patterns are anchored at the end of the statement, and
+  // until the limiter learned where a statement ends, a line comment after the
+  // clause hid it from them. That was harmless only for as long as the inherited
+  // bound landed inside the same comment: once it is placed before the comment,
+  // `... FORMAT TSV LIMIT 25 -- note` is the 400 / code 62 this override exists
+  // to prevent. Detection and placement have to read the same end.
+  test.each([
+    ["FORMAT before a line comment", "SELECT * FROM users FORMAT TSV -- exported nightly"],
+    ["FORMAT before a semicolon and a comment", "SELECT * FROM users FORMAT JSONEachRow; -- exported nightly"],
+    ["SETTINGS before a line comment", "SELECT * FROM users SETTINGS max_threads = 1 -- tuned"],
+    ["FORMAT before a block comment", "SELECT * FROM users FORMAT TSV /* exported nightly */"],
+    // Two reasons agree here: the pattern still matches (a refused cut reports
+    // the whole text as the end) AND the shared limiter declines on its own,
+    // because a literal it cannot close is one it will not rewrite.
+    ["a statement whose end may not be cut", "SELECT * FROM users WHERE path = 'C:\\' FORMAT TSV"],
+  ])("still refuses to rewrite %s", (_label, sql) => {
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(sql);
+    expect(prepared.wasLimited).toBe(false);
+  });
+
+  test("bounds an ordinary statement that ends in a comment, before the comment", () => {
+    const prepared = provider().prepareQuery("SELECT * FROM users -- daily check", { limit: 25 });
+
+    expect(prepared.query).toBe("SELECT * FROM users LIMIT 25 -- daily check");
+    expect(prepared.wasLimited).toBe(true);
+  });
+
   test("leaves a write untouched", () => {
     const prepared = provider().prepareQuery("INSERT INTO users VALUES (1, 'a@b.c')");
 

--- a/tests/integration/db/couchbase-provider.test.ts
+++ b/tests/integration/db/couchbase-provider.test.ts
@@ -944,6 +944,19 @@ describe("CouchbaseProvider query preparation", () => {
     expect(prepared.wasLimited).toBe(true);
   });
 
+  // Same inheritance for the trailing edge (#280): the bound has to land before a
+  // closing comment, and a backtick-quoted path must not be mistaken for one.
+  test("puts the bound before a trailing comment", () => {
+    const provider = new CouchbaseProvider(makeConnection());
+
+    const prepared = provider.prepareQuery("SELECT * FROM `travel`.`inventory`.`hotel` -- daily check", {
+      limit: 25,
+    });
+
+    expect(prepared.query).toBe("SELECT * FROM `travel`.`inventory`.`hotel` LIMIT 25 -- daily check");
+    expect(prepared.wasLimited).toBe(true);
+  });
+
   test("leaves a mutation untouched", () => {
     const provider = new CouchbaseProvider(makeConnection());
 

--- a/tests/integration/db/druid-provider.test.ts
+++ b/tests/integration/db/druid-provider.test.ts
@@ -1094,6 +1094,27 @@ describe("DruidProvider query preparation", () => {
     expect(prepared.limit).toBe(25);
   });
 
+  // #280. This override reads `analyzeQuery`'s `hasOffset`, which was anchored at
+  // the end of the raw text: a trailing comment hid the OFFSET, the shared limiter
+  // appended a bound, and Druid answered 400. It inherits the fix rather than
+  // implementing one - the point of routing the decision through the shared probe.
+  test.each([
+    ["OFFSET before a line comment", "SELECT id FROM libredb_demo ORDER BY __time OFFSET 2 -- paged"],
+    ["OFFSET before a semicolon and a comment", "SELECT id FROM libredb_demo OFFSET 2; -- paged"],
+  ])("leaves a statement ending in %s untouched", (_label, sql) => {
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(sql);
+    expect(prepared.wasLimited).toBe(false);
+  });
+
+  test("bounds a statement ending in a comment, before the comment", () => {
+    const prepared = provider().prepareQuery('SELECT * FROM "libredb_demo" -- daily check', { limit: 25 });
+
+    expect(prepared.query).toBe('SELECT * FROM "libredb_demo" LIMIT 25 -- daily check');
+    expect(prepared.wasLimited).toBe(true);
+  });
+
   test("still limits a statement that merely mentions an offset column", () => {
     const sql = "SELECT offset_minutes FROM libredb_demo WHERE region = 'emea'";
 

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -641,6 +641,84 @@ describe("MSSQLProvider", () => {
         expect(result.query.match(/\bTOP\b/gi)).toHaveLength(1);
       });
 
+      // ── Trailing comments (#280) ──────────────────────────────────────────
+      //
+      // The `TOP` head splice was never affected - it writes into the head, which
+      // no trailing comment can reach - but the pagination branch appends at the
+      // tail exactly as PostgreSQL's and Oracle's do, so it shared the defect.
+      // Both are asserted here: the one that changes, and the one that must not.
+
+      describe("trailing comments", () => {
+        test("the offset branch appends before the comment", () => {
+          const result = provider.prepareQuery("SELECT id FROM users -- daily check", { limit: 50, offset: 10 });
+
+          expect(result.query).toBe(
+            "SELECT id FROM users ORDER BY (SELECT NULL) OFFSET 10 ROWS FETCH NEXT 50 ROWS ONLY -- daily check",
+          );
+          expect(result.wasLimited).toBe(true);
+        });
+
+        test("the offset branch keeps the terminating semicolon outside the comment", () => {
+          const result = provider.prepareQuery("SELECT id FROM users ORDER BY id; -- daily check", {
+            limit: 50,
+            offset: 10,
+          });
+
+          expect(result.query).toBe(
+            "SELECT id FROM users ORDER BY id OFFSET 10 ROWS FETCH NEXT 50 ROWS ONLY; -- daily check",
+          );
+        });
+
+        // The head splice is lossless whatever follows the statement, so it keeps
+        // working where the tail may not be cut. A temp table is the case that
+        // makes this matter: `#tmp` is everyday T-SQL and reads as a MySQL
+        // comment to the shared scanner, so a tail append would have emitted
+        // `SELECT * FROM ... OFFSET ... #tmp`.
+        test.each<[string, string, string]>([
+          ["a temp table", "SELECT * FROM #tmp", "SELECT TOP 50 * FROM #tmp"],
+          [
+            "a literal whose end is undeterminable",
+            "SELECT id FROM users WHERE path = 'C:\\';",
+            "SELECT TOP 50 id FROM users WHERE path = 'C:\\';",
+          ],
+        ])("still splices TOP into %s", (_label, sql, expected) => {
+          const result = provider.prepareQuery(sql, { limit: 50 });
+
+          expect(result.query).toBe(expected);
+          expect(result.wasLimited).toBe(true);
+        });
+
+        // `TOP` and `OFFSET … FETCH` cannot both appear in one query expression
+        // (Msg 10741), so the splice must not fire on a page the user already
+        // bounded. It does not, because a refused cut still reports the whole
+        // statement, and the already-bounded probe reads that.
+        test("does not splice TOP into a temp-table page that already carries a bound", () => {
+          const sql = "SELECT * FROM #tmp ORDER BY id OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY";
+
+          const result = provider.prepareQuery(sql, { limit: 50 });
+
+          expect(result.query).toBe(sql);
+          expect(result.wasLimited).toBe(false);
+        });
+
+        test.each<[string, string]>([
+          ["a temp table", "SELECT * FROM #tmp ORDER BY id"],
+          ["a literal whose end is undeterminable", "SELECT id FROM users WHERE path = 'C:\\';"],
+        ])("the offset branch declines on %s, which it cannot append to", (_label, sql) => {
+          const result = provider.prepareQuery(sql, { limit: 50, offset: 10 });
+
+          expect(result.query).toBe(sql);
+          expect(result.wasLimited).toBe(false);
+        });
+
+        test("the TOP head splice is unchanged by a trailing comment", () => {
+          const result = provider.prepareQuery("SELECT * FROM users -- daily check", { limit: 50 });
+
+          expect(result.query).toBe("SELECT TOP 50 * FROM users -- daily check");
+          expect(result.wasLimited).toBe(true);
+        });
+      });
+
       test("appends OFFSET FETCH to a commented SELECT, which needs no head rewrite", () => {
         const result = provider.prepareQuery("-- annotated\nSELECT * FROM users", { limit: 50, offset: 10 });
 

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -620,6 +620,60 @@ describe("OracleProvider", () => {
       expect(result.limit).toBe(100000);
       expect(result.query).toContain("FETCH FIRST 100000 ROWS ONLY");
     });
+
+    // ── Trailing comments (#280) ────────────────────────────────────────────
+    //
+    // Both branches below append their clause at the tail, so a trailing line
+    // comment used to absorb it whole - the statement reached Oracle unbounded
+    // while this method reported `wasLimited: true`. Oracle accepts `--` and
+    // ignores `#`, so only the dash form is asserted here.
+
+    describe("trailing comments", () => {
+      test("FETCH FIRST lands before a trailing comment", () => {
+        const result = provider.prepareQuery("SELECT * FROM USERS -- daily check");
+
+        expect(result.query).toBe("SELECT * FROM USERS FETCH FIRST 500 ROWS ONLY -- daily check");
+        expect(result.wasLimited).toBe(true);
+      });
+
+      test("OFFSET/FETCH NEXT lands before a trailing comment", () => {
+        const result = provider.prepareQuery("SELECT * FROM USERS -- daily check", { offset: 20, limit: 10 });
+
+        expect(result.query).toBe("SELECT * FROM USERS OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY -- daily check");
+        expect(result.wasLimited).toBe(true);
+      });
+
+      test("the terminating semicolon stays outside the comment", () => {
+        const result = provider.prepareQuery("SELECT * FROM USERS; -- daily check");
+
+        expect(result.query).toBe("SELECT * FROM USERS FETCH FIRST 500 ROWS ONLY; -- daily check");
+      });
+
+      test.each<[string, string]>([
+        // A quote behind an odd backslash run: Oracle and MySQL close that
+        // literal in different places, so there is no honest place for the
+        // clause. Appending on a guess would put it after the terminator.
+        ["a literal whose end is undeterminable", "SELECT * FROM USERS WHERE PATH = 'C:\\';"],
+        // `#` is legal in an Oracle identifier and is MySQL's comment marker, and
+        // nothing in the text tells them apart. Appending would have emitted
+        // `... WHERE ID FETCH FIRST 500 ROWS ONLY# = 1`.
+        ["an identifier carrying a hash", "SELECT * FROM EMP WHERE ID# = 1"],
+      ])("returns %s untouched rather than bounding it on a guess", (_label, sql) => {
+        const result = provider.prepareQuery(sql);
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+
+      test("a real FETCH FIRST before a comment is still honoured", () => {
+        const sql = "SELECT * FROM USERS FETCH FIRST 10 ROWS ONLY -- deliberate";
+
+        const result = provider.prepareQuery(sql);
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+    });
   });
 
   // =========================================================================

--- a/tests/unit/db/query-limiter.test.ts
+++ b/tests/unit/db/query-limiter.test.ts
@@ -400,6 +400,25 @@ describe("a CTE is typed by the keyword its list operates", () => {
       expect(analyzeQuery(sql).type).toBe("SELECT");
     });
 
+    // #291. A CTE element may also be `<expr> AS <alias>`, which is how ClickHouse
+    // ordinarily writes one. The walker introduced above read only the standard
+    // `name AS (body)` shape, so these typed OTHER and streamed unbounded off an
+    // analytics engine - a protection switched off by the change that closed #287.
+    test.each<[string, string]>([
+      ["a scalar alias", "WITH 1 AS one SELECT one, count(*) FROM events GROUP BY one"],
+      ["a function alias", "WITH now() AS t SELECT * FROM events WHERE ts < t"],
+      ["an array alias", "WITH [1, 2, 3] AS arr SELECT arrayJoin(arr)"],
+      ["a mixed CTE list", "WITH 1 AS one, t AS (SELECT 2) SELECT one, * FROM t"],
+    ])("types an expression CTE with %s as SELECT", (_label, sql) => {
+      expect(analyzeQuery(sql).type).toBe("SELECT");
+    });
+
+    // And the direction that may not move with it: an expression element in front
+    // of a write is still a write.
+    test("types a write after an expression CTE as the write", () => {
+      expect(analyzeQuery("WITH 1 AS x INSERT INTO t VALUES (x)").type).toBe("INSERT");
+    });
+
     // Not being able to tell must never resolve to SELECT: an unbounded read is
     // recoverable, a partially committed write is not.
     test.each<[string, string]>([
@@ -446,6 +465,24 @@ describe("a CTE is typed by the keyword its list operates", () => {
 
       expect(result.sql).toBe(`${sql} LIMIT 500`);
       expect(result.wasLimited).toBe(true);
+    });
+
+    test("bounds an expression CTE (#291)", () => {
+      const sql = "WITH 1 AS one SELECT one, count(*) FROM events GROUP BY one";
+
+      const result = applyQueryLimit(sql, 500);
+
+      expect(result.sql).toBe(`${sql} LIMIT 500`);
+      expect(result.wasLimited).toBe(true);
+    });
+
+    test("leaves a write after an expression CTE byte-identical", () => {
+      const sql = "WITH 1 AS x INSERT INTO t VALUES (x)";
+
+      const result = applyQueryLimit(sql, 500);
+
+      expect(result.sql).toBe(sql);
+      expect(result.wasLimited).toBe(false);
     });
 
     test("reports a writing CTE as not a SELECT through isSelectQuery", () => {

--- a/tests/unit/db/query-limiter.test.ts
+++ b/tests/unit/db/query-limiter.test.ts
@@ -239,21 +239,21 @@ describe("classification behind a leading comment", () => {
     });
 
     // Same principle, on the one branch that reads more than the leading keyword:
-    // `WITH` is a SELECT only when the statement also CONTAINS a SELECT, and that
-    // search has to start past the trivia too. A LEADING comment could not reach this
-    // branch before the classifier saw behind one, which is what makes this the
-    // task's own regression to guard. An INTERIOR comment has always been able to
-    // answer for the statement here (`WITH t AS (UPDATE …) /* SELECT */ INSERT …`
-    // still classifies as SELECT) - same pre-existing family as the trailing-comment
-    // swallow, out of this task's scope. Below: a CTE that writes, annotated with a
-    // comment that happens to say SELECT.
+    // a `WITH` is typed by the keyword its CTE list operates (#287), and finding
+    // that keyword has to start past the trivia too. A LEADING comment could not
+    // reach this branch before the classifier saw behind one, which is what makes
+    // this the task's own regression to guard. Below: a CTE that writes, annotated
+    // with a comment that happens to say SELECT.
     const writingCTE =
       "-- remember to SELECT afterwards\nWITH t AS (UPDATE x SET a = 1 RETURNING id) INSERT INTO y VALUES (1)";
 
     test("does not let a SELECT inside the comment body turn a writing CTE into a SELECT", () => {
       const info = analyzeQuery(writingCTE);
 
-      expect(info.type).toBe("OTHER");
+      // INSERT rather than OTHER since #287: the statement is typed by the keyword
+      // after its CTE list, which is the honest answer and the one the four
+      // consumers of `type` (all of which test `=== "SELECT"`) already handle.
+      expect(info.type).toBe("INSERT");
       expect(info.hasCTE).toBe(true);
     });
 
@@ -331,6 +331,126 @@ describe("classification behind a leading comment", () => {
     test("reports a commented bound through hasQueryLimit", () => {
       expect(hasQueryLimit("-- annotated\nSELECT TOP 10 * FROM users")).toBe(true);
       expect(hasQueryLimit("-- annotated\nSELECT * FROM users")).toBe(false);
+    });
+  });
+});
+
+// ─── Data-modifying CTEs (#287) ─────────────────────────────────────────────
+//
+// A `WITH` statement used to be typed by testing whether the word SELECT appeared
+// anywhere in its text. `INSERT INTO … SELECT` supplies that word itself, so an
+// ordinary data-modifying CTE was typed SELECT and the limiter appended a bound to
+// it. In PostgreSQL that bound applies to the rows the statement WRITES: the
+// statement commits at most the default limit and the UI reports a truncated
+// result set. A write that commits 500 of 10,000 rows is not recoverable the way a
+// truncated read is, which is what makes this the worst failure in this family.
+//
+// The type now comes from the keyword the CTE list actually operates
+// (`lib/sql/operative-keyword`), and that keyword is reported as its own type
+// rather than as a blanket OTHER - every consumer of `type` tests `=== "SELECT"`,
+// so the honest answer costs nothing.
+
+describe("a CTE is typed by the keyword its list operates", () => {
+  describe("type detection", () => {
+    test.each<[string, ParsedQueryInfo["type"], string]>([
+      [
+        "INSERT ... SELECT after an UPDATE ... RETURNING CTE",
+        "INSERT",
+        "WITH t AS (UPDATE logs SET seen = true RETURNING id) INSERT INTO audit SELECT id FROM t",
+      ],
+      [
+        "INSERT ... SELECT after a DELETE ... RETURNING CTE",
+        "INSERT",
+        "WITH gone AS (DELETE FROM sessions RETURNING id) INSERT INTO audit SELECT id FROM gone",
+      ],
+      [
+        "UPDATE ... FROM a read-only CTE",
+        "UPDATE",
+        "WITH stale AS (SELECT id FROM sessions) UPDATE users SET flag = 1 FROM stale",
+      ],
+      [
+        "DELETE ... USING a read-only CTE",
+        "DELETE",
+        "WITH doomed AS (SELECT id FROM sessions) DELETE FROM users USING doomed WHERE users.id = doomed.id",
+      ],
+      // MERGE has no member in the type union, so it lands on OTHER - which is
+      // still not SELECT, and not being bounded is the whole point.
+      [
+        "MERGE after a read-only CTE",
+        "OTHER",
+        "WITH src AS (SELECT 1 AS id) MERGE INTO target USING src ON target.id = src.id WHEN MATCHED THEN DELETE",
+      ],
+      [
+        "a parenthesised subquery SELECT inside the writing CTE's definition",
+        "INSERT",
+        "WITH t AS (UPDATE logs SET n = (SELECT count(*) FROM x) RETURNING id) INSERT INTO audit SELECT id FROM t",
+      ],
+    ])("types %s as %s", (_label, expected, sql) => {
+      expect(analyzeQuery(sql).type).toBe(expected);
+    });
+
+    test.each<[string, string]>([
+      ["one CTE", "WITH t AS (SELECT 1) SELECT * FROM t"],
+      ["several CTEs", "WITH a AS (SELECT 1), b AS (SELECT 2) SELECT * FROM a, b"],
+      ["a nested CTE", "WITH o AS (WITH i AS (SELECT 1) SELECT * FROM i) SELECT * FROM o"],
+      ["WITH RECURSIVE", "WITH RECURSIVE t AS (SELECT 1 UNION ALL SELECT 2) SELECT * FROM t"],
+      ["a column list before AS", "WITH t (a) AS (SELECT 1) SELECT * FROM t"],
+      ["MATERIALIZED", "WITH t AS MATERIALIZED (SELECT 1) SELECT * FROM t"],
+    ])("still types a read-only CTE with %s as SELECT", (_label, sql) => {
+      expect(analyzeQuery(sql).type).toBe("SELECT");
+    });
+
+    // Not being able to tell must never resolve to SELECT: an unbounded read is
+    // recoverable, a partially committed write is not.
+    test.each<[string, string]>([
+      ["an unclosed CTE body", "WITH t AS (SELECT 1"],
+      ["nothing after the CTE list", "WITH t AS (SELECT 1)"],
+      ["a malformed CTE list", "WITH t AS SELECT 1"],
+    ])("does not type %s as SELECT", (_label, sql) => {
+      expect(analyzeQuery(sql).type).not.toBe("SELECT");
+    });
+
+    // hasCTE answers "does this statement lead with WITH", which is independent of
+    // what the CTE list operates - the two readings must not start disagreeing.
+    test.each<[string, string]>([
+      ["a read-only CTE", "WITH t AS (SELECT 1) SELECT * FROM t"],
+      ["a writing CTE", "WITH t AS (SELECT 1) INSERT INTO u SELECT * FROM t"],
+      ["a MERGE CTE", "WITH s AS (SELECT 1) MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE"],
+      ["an unclosed CTE body", "WITH t AS (SELECT 1"],
+      ["a commented writing CTE", "-- note\nWITH t AS (SELECT 1) DELETE FROM u WHERE id IN (SELECT id FROM t)"],
+    ])("flags %s as a CTE", (_label, sql) => {
+      expect(analyzeQuery(sql).hasCTE).toBe(true);
+    });
+  });
+
+  describe("limiting", () => {
+    test.each<[string, string]>([
+      ["INSERT", "WITH t AS (UPDATE logs SET seen = true RETURNING id) INSERT INTO audit SELECT id FROM t"],
+      ["UPDATE", "WITH stale AS (SELECT id FROM sessions) UPDATE users SET flag = 1 FROM stale"],
+      ["DELETE", "WITH doomed AS (SELECT id FROM s) DELETE FROM users USING doomed WHERE users.id = doomed.id"],
+      [
+        "MERGE",
+        "WITH src AS (SELECT 1 AS id) MERGE INTO target USING src ON target.id = src.id WHEN MATCHED THEN DELETE",
+      ],
+    ])("leaves a CTE that operates an %s byte-identical", (_label, sql) => {
+      const result = applyQueryLimit(sql, 500);
+
+      expect(result.sql).toBe(sql);
+      expect(result.wasLimited).toBe(false);
+    });
+
+    test("still bounds a read-only CTE", () => {
+      const sql = "WITH RECURSIVE t AS (SELECT 1 UNION ALL SELECT 2) SELECT * FROM t";
+
+      const result = applyQueryLimit(sql, 500);
+
+      expect(result.sql).toBe(`${sql} LIMIT 500`);
+      expect(result.wasLimited).toBe(true);
+    });
+
+    test("reports a writing CTE as not a SELECT through isSelectQuery", () => {
+      expect(isSelectQuery("WITH t AS (SELECT 1) INSERT INTO u SELECT * FROM t")).toBe(false);
+      expect(isSelectQuery("WITH t AS (SELECT 1) SELECT * FROM t")).toBe(true);
     });
   });
 });

--- a/tests/unit/db/query-limiter.test.ts
+++ b/tests/unit/db/query-limiter.test.ts
@@ -697,3 +697,188 @@ describe("analyzeQuery: leading comments cannot answer for the statement body", 
     expect(analyzeQuery("SELECT (SELECT 1) AS x").hasSubquery).toBe(true);
   });
 });
+
+// ─── trailing trivia (#280) ─────────────────────────────────────────────────
+//
+// The limiter used to treat the END of a statement as plain text, which broke it
+// in both directions at once. Appending `LIMIT n` after a trailing line comment
+// puts the bound INSIDE the comment while the caller is told the statement was
+// limited, and reading an existing bound off the same text makes a commented-out
+// one look real, so nothing is injected. Either way the query runs unbounded, and
+// the first also lights the "limited" badge over a full table scan.
+//
+// The fix is one reading of where the statement ends, shared by the placement and
+// by the probes (`lib/sql/statement-end`).
+
+describe("trailing trivia: placement", () => {
+  test.each<[string, string, string]>([
+    // label, input, expected output
+    ["a line comment", "SELECT * FROM t -- note", "SELECT * FROM t LIMIT 500 -- note"],
+    ["a semicolon then a comment", "SELECT * FROM t; -- note", "SELECT * FROM t LIMIT 500; -- note"],
+    ["a comment then a semicolon", "SELECT * FROM t -- note\n;", "SELECT * FROM t LIMIT 500 -- note\n;"],
+    ["a comment carrying a semicolon", "SELECT * FROM t -- a; b", "SELECT * FROM t LIMIT 500 -- a; b"],
+    // A block comment closes, so the bound was already engine-visible after it.
+    // It moves anyway: one reading of the end serves both the placement and the
+    // probes, and a probe that had to look PAST a trailing block comment is how
+    // `LIMIT 10 /* note */` used to collect a second bound (below).
+    ["a block comment", "SELECT * FROM t /* note */", "SELECT * FROM t LIMIT 500 /* note */"],
+    ["mixed trivia", "SELECT * FROM t /* a */ ; -- b", "SELECT * FROM t LIMIT 500 /* a */ ; -- b"],
+  ])("puts the bound before %s", (_label, sql, expected) => {
+    const result = applyQueryLimit(sql, 500);
+
+    expect(result.sql).toBe(expected);
+    expect(result.wasLimited).toBe(true);
+  });
+
+  test("an offset bound also lands before the comment", () => {
+    const result = applyQueryLimit("SELECT * FROM t -- note", 500, 20);
+
+    expect(result.sql).toBe("SELECT * FROM t LIMIT 500 OFFSET 20 -- note");
+    expect(result.wasLimited).toBe(true);
+  });
+
+  // The flag is the part a user acts on: a badge reading "limited to 500" over a
+  // statement the engine ran unbounded is worse than no badge at all.
+  test("never reports a bound the engine cannot see", () => {
+    for (const sql of ["SELECT * FROM t -- note", "SELECT * FROM t /* note */", "SELECT * FROM t; -- note"]) {
+      const result = applyQueryLimit(sql, 500);
+
+      // Everything the engine reads: the comment and what follows it removed.
+      const executed = result.sql.split(/--|#/)[0];
+      expect(result.wasLimited && executed.includes("LIMIT 500"), sql).toBe(true);
+    }
+  });
+
+  test("a statement with no trailing trivia is emitted exactly as before", () => {
+    expect(applyQueryLimit("SELECT * FROM t", 500).sql).toBe("SELECT * FROM t LIMIT 500");
+    expect(applyQueryLimit("SELECT * FROM t;", 500).sql).toBe("SELECT * FROM t LIMIT 500;");
+  });
+});
+
+describe("trailing trivia: detection", () => {
+  // A bound written inside a comment is a bound the user turned OFF. Reading it
+  // as real leaves the statement unbounded, which is what #280 reported.
+  test.each<[string, string]>([
+    ["a commented-out LIMIT", "SELECT * FROM t -- LIMIT 10"],
+    ["a commented-out FETCH FIRST", "SELECT * FROM t -- FETCH FIRST 10 ROWS ONLY"],
+    ["a commented-out OFFSET", "SELECT * FROM t -- OFFSET 5"],
+    ["a commented-out ROWNUM bound", "SELECT * FROM t -- ROWNUM <= 10"],
+    ["a commented-out LIMIT in a block comment", "SELECT * FROM t /* LIMIT 10 */"],
+  ])("does not mistake %s for a real one", (_label, sql) => {
+    const info = analyzeQuery(sql);
+    expect(info.hasLimit).toBe(false);
+
+    const result = applyQueryLimit(sql, 500);
+    expect(result.sql).toContain("LIMIT 500");
+    expect(result.wasLimited).toBe(true);
+  });
+
+  test.each<[string, string, number]>([
+    ["a LIMIT before a line comment", "SELECT * FROM t LIMIT 10 -- deliberate", 10],
+    ["a LIMIT before a block comment", "SELECT * FROM t LIMIT 10 /* deliberate */", 10],
+    ["a LIMIT before a semicolon and a comment", "SELECT * FROM t LIMIT 10; -- deliberate", 10],
+    ["a FETCH FIRST before a comment", "SELECT * FROM t FETCH FIRST 25 ROWS ONLY -- deliberate", 25],
+  ])("still honours %s", (_label, sql, expected) => {
+    const info = analyzeQuery(sql);
+    expect(info.hasLimit).toBe(true);
+    expect(info.existingLimit).toBe(expected);
+
+    // Not doubled: a second bound after the first is a syntax error, not extra rows.
+    const result = applyQueryLimit(sql, 500);
+    expect(result.sql).toBe(sql);
+    expect(result.wasLimited).toBe(false);
+  });
+
+  test("an OFFSET without a LIMIT is seen behind a comment", () => {
+    const info = analyzeQuery("SELECT * FROM t OFFSET 5 -- note");
+
+    expect(info.hasOffset).toBe(true);
+    expect(info.existingOffset).toBe(5);
+  });
+
+  test("hasQueryLimit reads the statement, not its trailing comment", () => {
+    expect(hasQueryLimit("SELECT * FROM t -- LIMIT 10")).toBe(false);
+    expect(hasQueryLimit("SELECT * FROM t LIMIT 10 -- note")).toBe(true);
+  });
+
+  // forceLimit strips the old bound before writing the new one, and that strip is
+  // end-anchored too: run against the raw text it either misses the bound (two
+  // LIMITs) or tears the comment apart.
+  test("forceLimit replaces a real bound and leaves the comment intact", () => {
+    const result = applyQueryLimit("SELECT * FROM t LIMIT 10 -- deliberate", 500, 0, { forceLimit: true });
+
+    expect(result.sql).toBe("SELECT * FROM t LIMIT 500 -- deliberate");
+    expect(result.wasLimited).toBe(true);
+    expect(result.originalLimit).toBe(10);
+  });
+
+  test("forceLimit replaces a MySQL-style bound behind a comment", () => {
+    const result = applyQueryLimit("SELECT * FROM t LIMIT 5, 10 -- deliberate", 500, 0, { forceLimit: true });
+
+    expect(result.sql).toBe("SELECT * FROM t LIMIT 500 -- deliberate");
+    expect(result.wasLimited).toBe(true);
+  });
+});
+
+// A statement whose end may not be cut has nowhere honest to take a bound, and
+// `wasLimited: false` is the honest answer - the second branch of the spec's own
+// item 1. Two shapes reach it, and both are ordinary SQL somewhere:
+//
+//   - a literal MySQL and PostgreSQL close in different places (`'O\'Brien'`),
+//     where inserting on a guess emits the bound after the statement's own `;`;
+//   - a trailing `#` run, which is a comment in MySQL and a temp table, an
+//     identifier or an XOR operator in the dialects that are not MySQL. Cutting
+//     there emitted `SELECT * FROM LIMIT 500 #tmp`.
+//
+// The cost is that these statements are not bounded: an over-large read the user
+// can re-run, against a statement the server would have rejected outright.
+describe("a statement whose end may not be cut is not rewritten", () => {
+  test.each<[string, string]>([
+    ["a quote behind an odd backslash run", "SELECT * FROM users WHERE name = 'O\\'Brien'"],
+    ["the same with a terminator", "SELECT * FROM users WHERE name = 'O\\'Brien';"],
+    ["the same with a trailing comment", "SELECT * FROM users WHERE name = 'O\\'Brien' -- note"],
+    ["an unterminated block comment", "SELECT * FROM users /* note"],
+    ["a T-SQL temp table", "SELECT * FROM #tmp"],
+    ["an Oracle identifier carrying a hash", "SELECT * FROM EMP WHERE ID# = 1"],
+    ["a PostgreSQL XOR operator", "SELECT flags # 5 AS x FROM t"],
+    ["a MySQL trailing hash comment", "SELECT * FROM t # note"],
+  ])("returns %s untouched", (_label, sql) => {
+    const result = applyQueryLimit(sql, 500);
+
+    expect(result.sql).toBe(sql);
+    expect(result.wasLimited).toBe(false);
+    expect(result.appliedLimit).toBe(0);
+  });
+
+  // Reading is not cutting. Where the cut is refused the probes read the WHOLE
+  // statement, which is what they read before this reader existed - so a bound
+  // written after a `#` is still found, and this is the one shape where a bound
+  // written INSIDE a line comment is still taken for a real one. That is the
+  // pre-existing reading for `#` and it is left as it is deliberately: the
+  // alternative hides `SELECT * FROM #t FETCH NEXT 10 ROWS ONLY`'s real bound
+  // from every caller, and the outcome here is the same either way - the
+  // statement is returned untouched.
+  test("a bound written after a hash is still found", () => {
+    expect(analyzeQuery("SELECT * FROM #t FETCH NEXT 10 ROWS ONLY").hasLimit).toBe(true);
+    expect(analyzeQuery("SELECT * FROM t # LIMIT 10").hasLimit).toBe(true);
+  });
+
+  // KNOWN LIMITATION, pinned: for `#` alone, a commented-out bound is still read
+  // as a real one, so the statement is left alone as "already bounded" instead of
+  // being bounded. The `--` form, which is unambiguous, is fixed above.
+  test("a bound commented out with a hash is read as real, and the statement is left alone", () => {
+    const sql = "SELECT * FROM t # LIMIT 10";
+
+    const result = applyQueryLimit(sql, 500);
+
+    expect(result.sql).toBe(sql);
+    expect(result.wasLimited).toBe(false);
+  });
+
+  test("a hash comment with code after it does not stop the statement", () => {
+    const result = applyQueryLimit("SELECT * FROM t # note\nWHERE a = 1", 500);
+
+    expect(result.sql).toBe("SELECT * FROM t # note\nWHERE a = 1 LIMIT 500");
+    expect(result.wasLimited).toBe(true);
+  });
+});

--- a/tests/unit/db/sql-base.test.ts
+++ b/tests/unit/db/sql-base.test.ts
@@ -588,5 +588,46 @@ describe("SQLBaseProvider", () => {
         expect(result.wasLimited).toBe(true);
       });
     });
+
+    // #280. The bound used to be appended after everything, so a trailing line
+    // comment swallowed it: the engine ran the statement unbounded while the
+    // caller was handed `wasLimited: true` and the UI reported a capped result.
+    describe("a statement ending in a comment", () => {
+      test("gets its bound before the comment, not inside it", () => {
+        const p = new TestSQLProvider(makeConfig("postgres"));
+
+        const result = p.prepareQuery("SELECT * FROM users -- daily check", { limit: 50 });
+
+        expect(result.query).toBe("SELECT * FROM users LIMIT 50 -- daily check");
+        expect(result.wasLimited).toBe(true);
+      });
+
+      test("keeps its terminating semicolon outside the comment", () => {
+        const p = new TestSQLProvider(makeConfig("postgres"));
+
+        const result = p.prepareQuery("SELECT * FROM users; -- daily check", { limit: 50 });
+
+        expect(result.query).toBe("SELECT * FROM users LIMIT 50; -- daily check");
+      });
+
+      test("is bounded even when the comment contains a bound", () => {
+        const p = new TestSQLProvider(makeConfig("postgres"));
+
+        const result = p.prepareQuery("SELECT * FROM users -- LIMIT 10", { limit: 50 });
+
+        expect(result.query).toBe("SELECT * FROM users LIMIT 50 -- LIMIT 10");
+        expect(result.wasLimited).toBe(true);
+      });
+
+      test("keeps a real bound written before the comment", () => {
+        const p = new TestSQLProvider(makeConfig("postgres"));
+        const sql = "SELECT * FROM users LIMIT 10 -- deliberate";
+
+        const result = p.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+    });
   });
 });

--- a/tests/unit/db/sql-base.test.ts
+++ b/tests/unit/db/sql-base.test.ts
@@ -554,5 +554,39 @@ describe("SQLBaseProvider", () => {
       expect(result.query).toBe("-- annotated\nSELECT * FROM users LIMIT 50");
       expect(result.wasLimited).toBe(true);
     });
+
+    // #287. This is the seam through which the misclassification reached the
+    // engine: a data-modifying CTE was typed SELECT, so a bound was appended to a
+    // statement that WRITES. In PostgreSQL the bound applies to the written rows,
+    // so the statement committed at most `limit` of them and reported a truncated
+    // result set - the one failure in this family that re-running cannot undo.
+    describe("a CTE that operates a write reaches the engine untouched", () => {
+      test.each<[string, string]>([
+        ["INSERT", "WITH t AS (UPDATE logs SET seen = true RETURNING id) INSERT INTO audit SELECT id FROM t"],
+        ["UPDATE", "WITH stale AS (SELECT id FROM sessions) UPDATE users SET flag = 1 FROM stale"],
+        ["DELETE", "WITH doomed AS (SELECT id FROM s) DELETE FROM users USING doomed WHERE users.id = doomed.id"],
+        [
+          "MERGE",
+          "WITH src AS (SELECT 1 AS id) MERGE INTO target USING src ON target.id = src.id WHEN MATCHED THEN DELETE",
+        ],
+      ])("passes a CTE operating an %s through byte-identical", (_label, sql) => {
+        const p = new TestSQLProvider(makeConfig("postgres"));
+
+        const result = p.prepareQuery(sql, { limit: 500 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+
+      test("still bounds a read-only CTE", () => {
+        const p = new TestSQLProvider(makeConfig("postgres"));
+        const sql = "WITH t AS (SELECT 1) SELECT * FROM t";
+
+        const result = p.prepareQuery(sql, { limit: 500 });
+
+        expect(result.query).toBe(`${sql} LIMIT 500`);
+        expect(result.wasLimited).toBe(true);
+      });
+    });
   });
 });

--- a/tests/unit/sql/operative-keyword.test.ts
+++ b/tests/unit/sql/operative-keyword.test.ts
@@ -73,6 +73,11 @@ describe("readOperativeKeyword", () => {
       ["a non-ASCII name among several CTEs", "WITH t AS (SELECT 1), ürün AS (SELECT 2) SELECT * FROM t, ürün"],
       ["a dollar in a CTE name (MySQL)", "WITH t$x AS (SELECT 1) SELECT * FROM t$x"],
       ["a subquery inside the definition", "WITH t AS (SELECT * FROM (SELECT 1) inner_q) SELECT * FROM t"],
+      // A CTE named with a word that is also a statement keyword. Reading the
+      // list's grammar answers this; the alternative considered for #291 - "the
+      // first statement keyword at paren depth 0" - would have read the NAME as
+      // the operative keyword and cost this read its bound.
+      ["a CTE named with a statement keyword", "WITH insert AS (SELECT 1) SELECT * FROM insert"],
       ["comments around the CTE list", "WITH /* a */ t AS /* b */ (SELECT 1) -- c\nSELECT * FROM t"],
       ["a newline before the operative keyword", "WITH t AS (\n  SELECT 1\n)\nSELECT * FROM t"],
       ["parens written inside a string literal", "WITH t AS (SELECT ') ) )' AS s) SELECT * FROM t"],
@@ -143,6 +148,56 @@ describe("readOperativeKeyword", () => {
     });
   });
 
+  // ── ClickHouse's expression form ─────────────────────────────────────────
+  //
+  // `WITH <expr> AS <alias>` puts an expression where the standard form puts a
+  // name, and on ClickHouse it is how a CTE is ordinarily written. The walker
+  // #287 introduced recognised only the standard shape and answered null for
+  // these, so the statement typed OTHER and lost its bound on the one engine
+  // where an unbounded read hurts most (#291).
+  //
+  // The two shapes are told apart by what follows the element's `AS`: a body or
+  // one of PostgreSQL's inlining hints can only be the standard form, anything
+  // else is an alias. The expression itself is never parsed - the reader only has
+  // to find where the element stops.
+
+  describe("a CTE whose element is an expression", () => {
+    test.each<[string, string]>([
+      ["a scalar", "WITH 1 AS x SELECT x FROM t"],
+      ["a negative scalar", "WITH -1 AS x SELECT x FROM t"],
+      ["a string", "WITH 'nope' AS s SELECT s FROM t"],
+      ["an array", "WITH [1, 2, 3] AS arr SELECT arrayJoin(arr)"],
+      ["a function call", "WITH now() AS ts SELECT ts FROM t"],
+      ["a function call with several arguments", "WITH concat(a, b) AS c SELECT c FROM t"],
+      ["an arithmetic expression", "WITH x + 1 AS y SELECT y FROM t"],
+      ["a parenthesised subquery", "WITH (SELECT max(id) FROM t) AS m SELECT m"],
+      // `CAST`'s own `AS` sits inside its parens, so only a depth-aware reader
+      // finds the element's own `AS` rather than that one.
+      ["a CAST whose own AS is nested", "WITH CAST(1 AS Int32) AS n SELECT n"],
+      ["several expression elements", "WITH 1 AS one, 2 AS two SELECT one + two"],
+      ["an expression element after a standard one", "WITH t AS (SELECT 1), 2 AS two SELECT * FROM t"],
+      ["a standard element after an expression one", "WITH 2 AS two, t AS (SELECT 1) SELECT * FROM t"],
+      ["an aggregate over the alias", "WITH 1 AS one SELECT one, count(*) FROM events GROUP BY one"],
+      ["a quoted alias", 'WITH now() AS "ts" SELECT * FROM events'],
+      ["a comment before the operative keyword", "WITH 1 AS x /* note */ SELECT x"],
+      ["a comment inside the expression", "WITH now() /* clock */ AS ts SELECT ts"],
+    ])("reports SELECT for %s", (_label, sql) => {
+      expect(operativeOf(sql)).toBe("SELECT");
+    });
+
+    // The direction that must not move: reading a new element shape may not let a
+    // statement that WRITES be typed as a read. #287's whole cost was a bound
+    // appended to a write, so each of these is asserted here as well as through
+    // the standard-form fixtures above.
+    test.each<[string, string, string]>([
+      ["an INSERT after an expression element", "WITH 1 AS x INSERT INTO t VALUES (x)", "INSERT"],
+      ["a DELETE after an expression element", "WITH now() AS ts DELETE FROM logs WHERE at < ts", "DELETE"],
+      ["an UPDATE after a mixed CTE list", "WITH 1 AS x, s AS (SELECT id FROM t) UPDATE u SET a = x FROM s", "UPDATE"],
+    ])("reports the write keyword for %s", (_label, sql, expected) => {
+      expect(operativeOf(sql)).toBe(expected);
+    });
+  });
+
   // ── Undeterminable input biases to "not a read" ──────────────────────────
   //
   // Every caller of this primitive uses "is it SELECT" to decide whether to
@@ -168,6 +223,24 @@ describe("readOperativeKeyword", () => {
       ["an unterminated bracket CTE name", "WITH [never closed AS (SELECT 1) SELECT 2"],
       ["a string literal where the CTE name belongs", "WITH 'nope' AS (SELECT 1) SELECT 2"],
       ["a comma with no further CTE", "WITH a AS (SELECT 1), SELECT 2"],
+      // PostgreSQL's inlining hints exist only in the standard shape, so reading
+      // one COMMITS the element to it: what follows must be a body, and a failure
+      // there is malformed input rather than an expression element whose alias
+      // happens to be the word `MATERIALIZED`.
+      ["MATERIALIZED with no body", "WITH t AS MATERIALIZED SELECT 1"],
+      ["NOT MATERIALIZED with no body", "WITH t AS NOT MATERIALIZED SELECT 1"],
+      // The expression shape's own failures, each answering "cannot tell" rather
+      // than guessing (#291).
+      ["an expression element with no AS at all", "WITH 1 SELECT 2"],
+      ["an expression element whose alias is missing", "WITH 1 AS"],
+      ["an expression element whose alias is a literal", "WITH 1 AS 2 SELECT 3"],
+      ["nothing after an expression element", "WITH now() AS ts"],
+      ["an unclosed paren inside an expression", "WITH now( AS ts SELECT ts"],
+      ["an unbalanced closing paren inside an expression", "WITH 1) AS x SELECT 2"],
+      ["an unterminated string where an expression belongs", "WITH 'unclosed AS x SELECT 1"],
+      ["an unterminated bracket where an expression belongs", "WITH [1, 2 AS arr SELECT 1"],
+      ["an expression element that reaches a comma with no AS", "WITH 1, 2 AS two SELECT 1"],
+      ["a comma with no further element after an expression one", "WITH 1 AS x, SELECT 2"],
       // Where a string literal ends is dialect-dependent when a backslash sits
       // before its closing quote, and the two readings disagree about the rest of
       // the statement. Under the MySQL reading this text is a DELETE, so guessing
@@ -198,26 +271,27 @@ describe("readOperativeKeyword", () => {
       expect(operativeOf(sql)).toBe("SEARCH");
     });
 
-    // KNOWN LIMITATION, pinned for the same reason: ClickHouse's `WITH <expr> AS
-    // <alias>` puts an EXPRESSION where the standard form puts a name, and reading
-    // one needs an expression parser rather than a grammar walk. These are reads,
-    // and they lose their bound - a cost, not a hazard, and ClickHouse has no
-    // data-modifying CTE for the safe direction to protect anything from.
+    // KNOWN LIMITATION, pinned for the same reason: an expression element whose
+    // head reads as a NAME and whose alias is one of PostgreSQL's inlining hints
+    // (`WITH col AS materialized …`) is committed to the standard shape by that
+    // word, so it is expected to carry a body and answers "cannot tell" without
+    // one. A read loses its bound; nothing is made unsafe, and the alternative -
+    // accepting the hint as an alias - would let `WITH t AS NOT LAZY (…)` read
+    // `LAZY` as the keyword that operates the statement.
     test.each<[string, string]>([
-      ["a scalar", "WITH 1 AS x SELECT x FROM t"],
-      ["an array", "WITH [1, 2, 3] AS arr SELECT arr FROM t"],
-      ["a function call", "WITH now() AS ts SELECT ts FROM t"],
-    ])("does not read ClickHouse's %s CTE form", (_label, sql) => {
+      ["MATERIALIZED", "WITH col AS materialized SELECT materialized FROM t"],
+      ["NOT", "WITH col AS not SELECT not FROM t"],
+    ])("does not read %s used as an expression alias", (_label, sql) => {
       expect(readOperativeKeyword(sql)).toBeNull();
     });
   });
 
   // ── Recorded gaps in the UNSAFE direction ────────────────────────────────
   //
-  // Everything above errs toward "cannot tell", which costs a bound. These two
-  // inputs go the other way - they answer SELECT for text that writes - so they
-  // are pinned here rather than left to be discovered. Neither is reachable in
-  // ordinary use, and each is paid for on purpose; the reasoning lives in
+  // Everything above errs toward "cannot tell", which costs a bound. The inputs
+  // below go the other way - they answer SELECT for text that writes - so they are
+  // pinned here rather than left to be discovered. None is reachable in ordinary
+  // use, and each is paid for on purpose; the reasoning lives in
   // `operative-keyword.ts` and `spans.ts`. A test that starts failing here means
   // someone closed a gap, which is welcome - update the expectation and say so.
 
@@ -249,6 +323,24 @@ describe("readOperativeKeyword", () => {
 
       expect(operativeOf(sql)).toBe("DELETE");
     });
+
+    // Reading an expression means knowing where it ends only by its `AS`, so any
+    // element the standard read DECLINES - a head that is not a name, or an `AS`
+    // with no body after it - is re-read as an expression that ends at the first
+    // `AS <name>` at depth 0, however far away. Each of these mentions a write and
+    // answers SELECT, which is why it is pinned here - but none is accepted by any
+    // dialect supported here (a CTE element is a name or an expression, and neither
+    // is a statement), so the cost is a bound appended to text the server rejects
+    // anyway, not a partial write (#291).
+    test.each<[string, string]>([
+      ["a literal head", "WITH 2 INSERT INTO users AS u SELECT 1"],
+      ["a string head", "WITH 'a' INSERT INTO users AS u SELECT 1"],
+      ["an empty parenthesised head", "WITH () INSERT INTO users AS u SELECT 1"],
+      ["a name head whose AS never comes", "WITH 1 AS one, INSERT INTO t AS u SELECT one"],
+      ["a statement keyword read as an alias", "WITH x AS DELETE, foo AS (SELECT 1) SELECT 1"],
+    ])("reads %s as an expression element and answers for what follows", (_label, sql) => {
+      expect(operativeOf(sql)).toBe("SELECT");
+    });
   });
 
   // ── Bounded time ────────────────────────────────────────────────────────
@@ -276,6 +368,16 @@ describe("readOperativeKeyword", () => {
         "SELECT",
       ],
       ["20k whitespace inside the CTE list", `WITH t AS ${" ".repeat(20000)}(SELECT 1) SELECT 2`, "SELECT"],
+      // The expression shape is scanned from the element's start after the standard
+      // read declines it, so every element is walked at most twice - a constant,
+      // not a second dimension (#291).
+      [
+        "5k expression elements",
+        `WITH ${Array.from({ length: 5000 }, (_v, i) => `${i} AS a${i}`).join(", ")} SELECT 1`,
+        "SELECT",
+      ],
+      ["20k open parens inside an expression", `WITH now(${"(".repeat(20000)} AS ts SELECT ts`, null],
+      ["20k close parens after an expression", `WITH 1 ${")".repeat(20000)} AS x SELECT 2`, null],
     ];
 
     for (const [label, sql, expected] of adversarial) {

--- a/tests/unit/sql/operative-keyword.test.ts
+++ b/tests/unit/sql/operative-keyword.test.ts
@@ -1,0 +1,290 @@
+import { describe, test, expect } from "bun:test";
+import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function operativeOf(sql: string): string | null {
+  return readOperativeKeyword(sql)?.keyword ?? null;
+}
+
+// ─── readOperativeKeyword ───────────────────────────────────────────────────
+//
+// Which keyword actually OPERATES a statement. For everything but `WITH` that is
+// the leading keyword; for a `WITH` it is the first keyword after the CTE list,
+// because the CTE list is a preamble and the statement that follows it is the one
+// the server executes. Typing a `WITH` by "does the text contain SELECT" made
+// `WITH t AS (UPDATE …) INSERT INTO … SELECT …` look like a read, and the query
+// limiter then appended a bound to the rows that statement WRITES (#287).
+
+describe("readOperativeKeyword", () => {
+  // ── Statements that are not CTEs ─────────────────────────────────────────
+
+  describe("a statement that does not lead with WITH", () => {
+    test.each<[string, string, string]>([
+      ["SELECT", "SELECT * FROM t", "SELECT"],
+      ["INSERT", "INSERT INTO t VALUES (1)", "INSERT"],
+      ["UPDATE", "UPDATE t SET a = 1", "UPDATE"],
+      ["a comment-led SELECT", "-- note\nSELECT 1", "SELECT"],
+      ["a word that merely starts with WITH", "WITHDRAW 1", "WITHDRAW"],
+    ])("reports the leading keyword of %s", (_label, sql, expected) => {
+      expect(operativeOf(sql)).toBe(expected);
+    });
+
+    test("reports where the keyword is, so callers can slice the statement's own spelling", () => {
+      const operative = readOperativeKeyword("/* note */ select 1");
+
+      expect(operative).not.toBeNull();
+      expect("/* note */ select 1".slice(operative?.start, operative?.end)).toBe("select");
+    });
+
+    test("reports null when there is no statement at all", () => {
+      expect(readOperativeKeyword("")).toBeNull();
+      expect(readOperativeKeyword("   \n ")).toBeNull();
+      expect(readOperativeKeyword("-- just a note\n")).toBeNull();
+    });
+  });
+
+  // ── Read-only CTEs ──────────────────────────────────────────────────────
+
+  describe("a CTE whose operative statement reads", () => {
+    test.each<[string, string]>([
+      ["one CTE", "WITH t AS (SELECT 1) SELECT * FROM t"],
+      ["lower case", "with t as (select 1) select * from t"],
+      ["WITH RECURSIVE", "WITH RECURSIVE t AS (SELECT 1 UNION ALL SELECT 2) SELECT * FROM t"],
+      ["several comma-separated CTEs", "WITH a AS (SELECT 1), b AS (SELECT 2) SELECT * FROM a, b"],
+      ["a column list before AS", "WITH t (a, b) AS (SELECT 1, 2) SELECT * FROM t"],
+      ["MATERIALIZED (PostgreSQL)", "WITH t AS MATERIALIZED (SELECT 1) SELECT * FROM t"],
+      ["NOT MATERIALIZED (PostgreSQL)", "WITH t AS NOT MATERIALIZED (SELECT 1) SELECT * FROM t"],
+      [
+        "a nested CTE inside the definition",
+        "WITH outer_q AS (WITH inner_q AS (SELECT 1) SELECT * FROM inner_q) SELECT * FROM outer_q",
+      ],
+      ["a double-quoted CTE name", 'WITH "my cte" AS (SELECT 1) SELECT * FROM "my cte"'],
+      ["a backtick-quoted CTE name (MySQL)", "WITH `my cte` AS (SELECT 1) SELECT * FROM `my cte`"],
+      ["a bracket-quoted CTE name (MSSQL)", "WITH [my cte] AS (SELECT 1) SELECT * FROM [my cte]"],
+      ["a bracket-quoted name with MSSQL's ]] escape", "WITH [my]]cte] AS (SELECT 1) SELECT 1"],
+      // A jsonb path operator inside a CTE body is an everyday PostgreSQL read.
+      ["a jsonb path operator in the definition", "WITH t AS (SELECT meta #> '{a}' AS v FROM docs) SELECT * FROM t"],
+      // A reader whose identifier alphabet is ASCII cannot walk past a localized
+      // CTE name, and every statement it cannot walk loses its bound. This
+      // project's own comments are Turkish, so these are not exotic inputs.
+      ["a non-ASCII CTE name", "WITH müşteri AS (SELECT 1) SELECT * FROM müşteri"],
+      ["a non-ASCII recursive CTE name", "WITH RECURSIVE ağaç AS (SELECT 1) SELECT * FROM ağaç"],
+      ["a non-ASCII name among several CTEs", "WITH t AS (SELECT 1), ürün AS (SELECT 2) SELECT * FROM t, ürün"],
+      ["a dollar in a CTE name (MySQL)", "WITH t$x AS (SELECT 1) SELECT * FROM t$x"],
+      ["a subquery inside the definition", "WITH t AS (SELECT * FROM (SELECT 1) inner_q) SELECT * FROM t"],
+      ["comments around the CTE list", "WITH /* a */ t AS /* b */ (SELECT 1) -- c\nSELECT * FROM t"],
+      ["a newline before the operative keyword", "WITH t AS (\n  SELECT 1\n)\nSELECT * FROM t"],
+      ["parens written inside a string literal", "WITH t AS (SELECT ') ) )' AS s) SELECT * FROM t"],
+      ["parens written inside a comment", "WITH t AS (SELECT 1 -- ) ) )\n) SELECT * FROM t"],
+      ["parens written inside a block comment", "WITH t AS (SELECT 1 /* ) ) */) SELECT * FROM t"],
+      ["parens written inside a dollar-quoted body", "WITH t AS (SELECT $$ ) ) $$ AS s) SELECT * FROM t"],
+      ["parens written inside a quoted identifier", 'WITH t AS (SELECT 1 AS ")wat") SELECT * FROM t'],
+    ])("reports SELECT for %s", (_label, sql) => {
+      expect(operativeOf(sql)).toBe("SELECT");
+    });
+  });
+
+  // ── Writing CTEs ────────────────────────────────────────────────────────
+  //
+  // The defect itself: each of these supplies the word SELECT somewhere in its
+  // body, and each one WRITES.
+
+  describe("a CTE whose operative statement writes", () => {
+    test.each<[string, string, string]>([
+      [
+        "INSERT ... SELECT after an UPDATE ... RETURNING CTE",
+        "WITH t AS (UPDATE logs SET seen = true RETURNING id) INSERT INTO audit SELECT id FROM t",
+        "INSERT",
+      ],
+      [
+        "INSERT ... SELECT after a DELETE ... RETURNING CTE",
+        "WITH gone AS (DELETE FROM sessions WHERE stale RETURNING id) INSERT INTO audit SELECT id FROM gone",
+        "INSERT",
+      ],
+      [
+        "UPDATE ... FROM a read-only CTE",
+        "WITH stale AS (SELECT id FROM sessions WHERE expired) UPDATE users SET flag = 1 FROM stale",
+        "UPDATE",
+      ],
+      [
+        "DELETE ... USING a read-only CTE",
+        "WITH doomed AS (SELECT id FROM sessions) DELETE FROM users USING doomed WHERE users.id = doomed.id",
+        "DELETE",
+      ],
+      [
+        "MERGE after a read-only CTE",
+        "WITH src AS (SELECT 1 AS id) MERGE INTO target USING src ON target.id = src.id WHEN MATCHED THEN DELETE",
+        "MERGE",
+      ],
+      [
+        "a parenthesised subquery SELECT inside the definition of a writing CTE",
+        "WITH t AS (UPDATE logs SET n = (SELECT count(*) FROM x) RETURNING id) INSERT INTO audit SELECT id FROM t",
+        "INSERT",
+      ],
+      [
+        "several CTEs before the write",
+        "WITH a AS (SELECT 1), b AS (SELECT 2) INSERT INTO t SELECT * FROM a, b",
+        "INSERT",
+      ],
+      [
+        "a column list before AS on a writing CTE",
+        "WITH t (id) AS (SELECT 1) DELETE FROM users WHERE id IN (SELECT id FROM t)",
+        "DELETE",
+      ],
+      [
+        "a comment between the CTE list and the write",
+        "WITH t AS (SELECT 1) /* here comes the write */ INSERT INTO u SELECT * FROM t",
+        "INSERT",
+      ],
+      ["lower case", "with t as (select 1) insert into u select * from t", "INSERT"],
+    ])("reports the write keyword for %s", (_label, sql, expected) => {
+      expect(operativeOf(sql)).toBe(expected);
+    });
+  });
+
+  // ── Undeterminable input biases to "not a read" ──────────────────────────
+  //
+  // Every caller of this primitive uses "is it SELECT" to decide whether to
+  // REWRITE the statement. Answering null (so: not SELECT) costs an unbounded
+  // read; answering SELECT on a guess would cost a partially-committed write.
+  // The ranking is not symmetric, so malformed input answers null.
+
+  describe("input whose operative keyword cannot be determined", () => {
+    test.each<[string, string]>([
+      ["WITH on its own", "WITH"],
+      ["WITH RECURSIVE on its own", "WITH RECURSIVE"],
+      ["a CTE list that never closes its body", "WITH t AS (SELECT 1"],
+      ["a CTE body with unbalanced parens", "WITH t AS ((SELECT 1) SELECT * FROM t"],
+      ["nothing after the CTE list", "WITH t AS (SELECT 1)"],
+      ["only a comment after the CTE list", "WITH t AS (SELECT 1) -- and then?"],
+      ["a semicolon after the CTE list", "WITH t AS (SELECT 1);"],
+      ["a missing AS", "WITH t (SELECT 1) SELECT 2"],
+      ["a body that is not parenthesised", "WITH t AS SELECT 1"],
+      ["NOT followed by something other than MATERIALIZED", "WITH t AS NOT LAZY (SELECT 1) SELECT 2"],
+      ["an unterminated block comment inside the CTE list", "WITH t AS /* never closed (SELECT 1) SELECT 2"],
+      ["an unterminated string inside the CTE body", "WITH t AS (SELECT 'never closed) SELECT 2"],
+      ["an unterminated quoted CTE name", 'WITH "never closed AS (SELECT 1) SELECT 2'],
+      ["an unterminated bracket CTE name", "WITH [never closed AS (SELECT 1) SELECT 2"],
+      ["a string literal where the CTE name belongs", "WITH 'nope' AS (SELECT 1) SELECT 2"],
+      ["a comma with no further CTE", "WITH a AS (SELECT 1), SELECT 2"],
+      // Where a string literal ends is dialect-dependent when a backslash sits
+      // before its closing quote, and the two readings disagree about the rest of
+      // the statement. Under the MySQL reading this text is a DELETE, so guessing
+      // the standard reading (which finds a `SELECT` inside what is really string
+      // content) would bound a write - the failure #287 is about.
+      ["a backslash-escaped quote inside a CTE body", "WITH t AS (SELECT '\\') SELECT ') DELETE FROM users"],
+      // The same ambiguity where the escaped quote is FOLLOWED by another one -
+      // how a MySQL string ending in an apostrophe is actually written. Under the
+      // MySQL reading this statement is a DELETE; the standard reading finds a
+      // `SELECT` that is really string content.
+      [
+        "a backslash-escaped quote followed by another quote",
+        "WITH t AS (SELECT 'a\\'') DELETE FROM users WHERE note = ') SELECT 1'",
+      ],
+    ])("reports null for %s", (_label, sql) => {
+      expect(readOperativeKeyword(sql)).toBeNull();
+    });
+
+    // KNOWN LIMITATION, asserted so it is a decision and not a surprise: the
+    // PostgreSQL recursive-CTE clauses SEARCH and CYCLE sit BETWEEN the CTE list
+    // and the operative statement, and this reader stops at the first word after
+    // the list. It answers SEARCH, which is not SELECT, so such a statement is
+    // simply not bounded - the honest direction. Widening the grammar to skip
+    // these clauses is a separate change with its own tests.
+    test("stops at a SEARCH clause rather than guessing past it", () => {
+      const sql = "WITH RECURSIVE t AS (SELECT 1) SEARCH DEPTH FIRST BY id SET ord SELECT * FROM t";
+
+      expect(operativeOf(sql)).toBe("SEARCH");
+    });
+
+    // KNOWN LIMITATION, pinned for the same reason: ClickHouse's `WITH <expr> AS
+    // <alias>` puts an EXPRESSION where the standard form puts a name, and reading
+    // one needs an expression parser rather than a grammar walk. These are reads,
+    // and they lose their bound - a cost, not a hazard, and ClickHouse has no
+    // data-modifying CTE for the safe direction to protect anything from.
+    test.each<[string, string]>([
+      ["a scalar", "WITH 1 AS x SELECT x FROM t"],
+      ["an array", "WITH [1, 2, 3] AS arr SELECT arr FROM t"],
+      ["a function call", "WITH now() AS ts SELECT ts FROM t"],
+    ])("does not read ClickHouse's %s CTE form", (_label, sql) => {
+      expect(readOperativeKeyword(sql)).toBeNull();
+    });
+  });
+
+  // ── Recorded gaps in the UNSAFE direction ────────────────────────────────
+  //
+  // Everything above errs toward "cannot tell", which costs a bound. These two
+  // inputs go the other way - they answer SELECT for text that writes - so they
+  // are pinned here rather than left to be discovered. Neither is reachable in
+  // ordinary use, and each is paid for on purpose; the reasoning lives in
+  // `operative-keyword.ts` and `spans.ts`. A test that starts failing here means
+  // someone closed a gap, which is welcome - update the expectation and say so.
+
+  describe("known gaps that answer SELECT for a statement that writes", () => {
+    // Oracle's alternative quoting is not a literal to `readSqlSpan`, so the `)`
+    // inside this one closes the CTE body early. Unreachable in Oracle itself,
+    // which has no `WITH … DELETE`, and no other dialect here has the form.
+    test("walks an Oracle q-quoted literal as code", () => {
+      expect(operativeOf("WITH t AS (SELECT q'{it's ) SELECT x}' FROM dual) DELETE FROM users")).toBe("SELECT");
+    });
+
+    // `#-` is a PostgreSQL jsonb operator and a MySQL comment opener at once.
+    // Reading it as code is what keeps `SELECT meta #> '{a}'` bounded; the price
+    // is that a MySQL comment opening with those characters is read as SQL, so a
+    // paren inside it ends the CTE body early. MySQL 8 accepts both `WITH … DELETE`
+    // and `LIMIT` on a `DELETE`, so this really is the bad direction - it is
+    // contrived rather than impossible, and closing it would cost every
+    // jsonb-operator CTE its bound.
+    test("walks a MySQL hash comment opening with an operator character as code", () => {
+      const sql = "WITH t AS (\n  #- drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
+
+      expect(operativeOf(sql)).toBe("SELECT");
+    });
+
+    // The same statement with an ordinary `# ` comment - how they are actually
+    // written - reads correctly, which is what makes the gap narrow.
+    test("reads the same statement correctly when the comment opens plainly", () => {
+      const sql = "WITH t AS (\n  # drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
+
+      expect(operativeOf(sql)).toBe("DELETE");
+    });
+  });
+
+  // ── Bounded time ────────────────────────────────────────────────────────
+  //
+  // The CTE-list scan is a character scanner rather than a regex over
+  // parenthesised bodies for the reason `leading-keyword.ts` documents in
+  // measured detail: a nested quantifier over that shape backtracks
+  // catastrophically (its predecessors cost 958ms, 852ms and - exponentially -
+  // 634ms on a 49-character input). This guard fails outright if the scan is
+  // ever replaced by one that can backtrack, and it asserts the ANSWER too,
+  // because a fast wrong answer is not a pass.
+
+  test("answers in bounded time on adversarial input", () => {
+    const BOUND_MS = 200;
+    const adversarial: [string, string, string | null][] = [
+      ["20k unbalanced open parens", `WITH t AS ${"(".repeat(20000)}`, null],
+      ["20k unbalanced close parens", `WITH t AS ${")".repeat(20000)}`, null],
+      ["20k deeply nested parens", `WITH t AS ${"(".repeat(20000)}SELECT 1${")".repeat(20000)} SELECT 2`, "SELECT"],
+      ["20k unterminated quotes", `WITH t AS (SELECT ${"'".repeat(20001)}`, null],
+      ["20k dashes", `WITH t AS (SELECT 1) ${"-".repeat(20000)}`, null],
+      ["2k empty block comments", `WITH t AS (SELECT 1) ${"/**/".repeat(2000)}INSERT INTO u VALUES (1)`, "INSERT"],
+      [
+        "5k CTEs",
+        `WITH ${Array.from({ length: 5000 }, (_v, i) => `t${i} AS (SELECT ${i})`).join(", ")} SELECT 1`,
+        "SELECT",
+      ],
+      ["20k whitespace inside the CTE list", `WITH t AS ${" ".repeat(20000)}(SELECT 1) SELECT 2`, "SELECT"],
+    ];
+
+    for (const [label, sql, expected] of adversarial) {
+      const started = performance.now();
+      const keyword = operativeOf(sql);
+      const elapsed = performance.now() - started;
+
+      expect(keyword, label).toBe(expected);
+      expect(elapsed, `${label} took ${elapsed.toFixed(1)}ms`).toBeLessThan(BOUND_MS);
+    }
+  });
+});

--- a/tests/unit/sql/spans.test.ts
+++ b/tests/unit/sql/spans.test.ts
@@ -1,0 +1,286 @@
+import { describe, test, expect } from "bun:test";
+import { readSqlSpan } from "@/lib/sql/spans";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** The span at index 0, as `kind|text` (or `null`), which is what most cases assert. */
+function spanOf(sql: string, index = 0): string | null {
+  const span = readSqlSpan(sql, index);
+  return span === null ? null : `${span.kind}|${sql.slice(index, span.end)}`;
+}
+
+// ─── readSqlSpan ────────────────────────────────────────────────────────────
+//
+// The primitive every SQL-text reader in `lib/sql` needs before it can trust a
+// character: whether the text at this index is trivia or a literal, and where
+// that runs to. Without it, a paren, a semicolon or a keyword written inside a
+// comment or a string answers for the statement itself.
+
+describe("readSqlSpan", () => {
+  // ── Ordinary code is not a span ──────────────────────────────────────────
+
+  describe("reports null where code begins", () => {
+    test.each<[string, string]>([
+      ["a letter", "SELECT 1"],
+      ["a digit", "1 + 1"],
+      ["an open paren", "(1)"],
+      ["a semicolon", ";"],
+      ["a lone dash (subtraction)", "a - b"],
+      ["a lone slash (division)", "a / b"],
+      ["a star", "*"],
+      ["a lone dollar", "$ "],
+      ["a positional parameter", "$1"],
+      ["a dollar tag that never closes", "$tag SELECT"],
+      ["a dollar tag starting with a digit", "$1$ x"],
+    ])("returns null for %s", (_label, sql) => {
+      expect(readSqlSpan(sql, 0)).toBeNull();
+    });
+
+    test("returns null past the end of the input", () => {
+      expect(readSqlSpan("ab", 2)).toBeNull();
+      expect(readSqlSpan("", 0)).toBeNull();
+    });
+  });
+
+  // ── Whitespace ──────────────────────────────────────────────────────────
+
+  describe("whitespace", () => {
+    test("reads a whole run of whitespace in one span", () => {
+      expect(spanOf(" \t\n\r\f\vSELECT")).toBe("whitespace| \t\n\r\f\v");
+    });
+
+    test("reads whitespace at an arbitrary index", () => {
+      expect(spanOf("SELECT   1", 6)).toBe("whitespace|   ");
+    });
+
+    test("whitespace running to the end of input is terminated", () => {
+      expect(readSqlSpan("SELECT 1  ", 8)).toEqual({ kind: "whitespace", end: 10, terminated: true });
+    });
+  });
+
+  // ── Comments ────────────────────────────────────────────────────────────
+
+  describe("line comments", () => {
+    test("a dash comment ends with its newline, which belongs to the span", () => {
+      expect(spanOf("-- note\nSELECT 1")).toBe("line-comment|-- note\n");
+    });
+
+    test("a hash comment (MySQL) is read the same way", () => {
+      expect(spanOf("# note\nSELECT 1")).toBe("line-comment|# note\n");
+    });
+
+    // Unlike `leading-keyword.ts`, this reader is asked about every position in a
+    // statement, not just the leading trivia - and mid-statement `#` is a live
+    // PostgreSQL operator. Reading `meta #> '{a}'` as a comment swallows the rest
+    // of the line and costs an ordinary jsonb query its bound.
+    test.each<[string, string]>([
+      ["#> (jsonb path)", "meta #> '{a}'"],
+      ["#>> (jsonb path as text)", "meta #>> '{a}'"],
+      ["#- (jsonb delete path)", "meta #- '{a}'"],
+      ["## (geometric closest point)", "meta ## other"],
+    ])("does not read the PostgreSQL %s operator as a comment", (_label, sql) => {
+      expect(readSqlSpan(sql, 5)).toBeNull();
+    });
+
+    // The trade that buys the operators back, stated as a test: a MySQL comment
+    // whose first character is one of those operator characters reads as code, so
+    // the rest of that line is read as SQL where MySQL reads it as comment. That is
+    // a real gap rather than a safe "cannot tell" - a paren inside such a comment
+    // moves a construct's end, which `operative-keyword.test.ts` pins with the
+    // statement it costs. `# note`, how comments are actually written, is untouched.
+    test("a hash comment opening with an operator character reads as code", () => {
+      expect(readSqlSpan("SELECT 1 #> note", 9)).toBeNull();
+    });
+
+    // A line comment closed by the end of the input is closed, not truncated:
+    // nothing follows it that a reader could be misled about.
+    test("a line comment with no newline runs to the end and is terminated", () => {
+      expect(readSqlSpan("SELECT 1 -- note", 9)).toEqual({ kind: "line-comment", end: 16, terminated: true });
+    });
+
+    test("an empty line comment is still a span", () => {
+      expect(spanOf("--\nSELECT")).toBe("line-comment|--\n");
+    });
+  });
+
+  describe("block comments", () => {
+    test("reads to the first closing delimiter", () => {
+      expect(spanOf("/* a */ /* b */ SELECT")).toBe("block-comment|/* a */");
+    });
+
+    test("spans newlines", () => {
+      expect(spanOf("/* one\n   two */SELECT")).toBe("block-comment|/* one\n   two */");
+    });
+
+    // An unterminated block comment is the one case where a reader must NOT
+    // assume it knows where the statement's text is: everything after it is
+    // comment, so callers bias to "cannot tell" rather than guessing.
+    test("an unterminated block comment reports terminated: false", () => {
+      expect(readSqlSpan("/* never closed", 0)).toEqual({ kind: "block-comment", end: 15, terminated: false });
+    });
+  });
+
+  // ── Literals ────────────────────────────────────────────────────────────
+
+  describe("single-quoted strings", () => {
+    test("reads a plain string", () => {
+      expect(spanOf("'abc' x")).toBe("string|'abc'");
+    });
+
+    test("a doubled quote is an escape, not the end", () => {
+      expect(spanOf("'it''s' x")).toBe("string|'it''s'");
+    });
+
+    test("a paren inside a string belongs to the string", () => {
+      expect(spanOf("') SELECT' x")).toBe("string|') SELECT'");
+    });
+
+    test("an unterminated string reports terminated: false", () => {
+      expect(readSqlSpan("'abc", 0)).toEqual({ kind: "string", end: 4, terminated: false });
+    });
+
+    // A run of quotes is all escapes, so it never closes - the trap a
+    // "find the next quote" reader falls into.
+    test("an odd run of quotes is unterminated", () => {
+      expect(readSqlSpan("'''", 0)).toEqual({ kind: "string", end: 3, terminated: false });
+    });
+
+    // Whether a backslash escapes the following quote is a DIALECT setting, not a
+    // property of the text: MySQL escapes by default, PostgreSQL does not unless
+    // the literal is an `E'…'`. The two readings disagree about where the string
+    // ends and therefore about the rest of the statement, so a delimiter behind an
+    // odd backslash run is reported as undeterminable rather than guessed. The
+    // guess is not free: it can put a bound on a statement that writes.
+    test("a quote behind an odd backslash run does not close the string", () => {
+      expect(readSqlSpan("'a\\' , x", 0)).toEqual({ kind: "string", end: 8, terminated: false });
+    });
+
+    test("a quote behind an even backslash run does close it", () => {
+      expect(spanOf("'a\\\\' x")).toBe("string|'a\\\\'");
+    });
+
+    // The two escape rules can MEET: `\''` is the ordinary way to end a MySQL
+    // string with an apostrophe. Testing the doubling rule first consumes both
+    // quotes and never reaches the backslash question, so the ambiguity has to be
+    // answered BEFORE the doubling branch or the safe answer is unreachable
+    // exactly where the two dialects disagree most often.
+    test("a doubled quote behind an odd backslash run is undeterminable, not an escape", () => {
+      // Taking the doubling branch here ends the literal at the LAST quote instead
+      // of reporting the ambiguity, which puts everything between the two readings
+      // inside a string under one of them and outside it under the other.
+      expect(readSqlSpan("'a\\'' x'", 0)?.terminated).toBe(false);
+    });
+
+    test("a backslash immediately after the opening delimiter is still counted", () => {
+      expect(readSqlSpan("'\\' , x", 0)?.terminated).toBe(false);
+    });
+  });
+
+  describe("quoted identifiers", () => {
+    test.each<[string, string, string]>([
+      ["double quotes (SQL standard)", '"my table" x', 'quoted-identifier|"my table"'],
+      ["a doubled double quote is an escape", '"say ""hi""" x', 'quoted-identifier|"say ""hi"""'],
+      ["backticks (MySQL)", "`my table` x", "quoted-identifier|`my table`"],
+      ["a doubled backtick is an escape", "`a``b` x", "quoted-identifier|`a``b`"],
+    ])("reads %s", (_label, sql, expected) => {
+      expect(spanOf(sql)).toBe(expected);
+    });
+
+    test.each<[string, string]>([
+      ["a double-quoted identifier", '"unclosed'],
+      ["a backtick-quoted identifier", "`unclosed"],
+    ])("an unterminated %s reports terminated: false", (_label, sql) => {
+      expect(readSqlSpan(sql, 0)?.terminated).toBe(false);
+    });
+
+    // `"` is a STRING in MySQL unless ANSI_QUOTES is set, so it inherits the
+    // backslash ambiguity above. Backticks do not: no dialect gives a backslash
+    // any meaning inside them, so one behind the closing delimiter is just a
+    // character in the name.
+    test("a double quote behind an odd backslash run is undeterminable", () => {
+      expect(readSqlSpan('"a\\" x', 0)?.terminated).toBe(false);
+    });
+
+    test("a backtick behind a backslash still closes the identifier", () => {
+      expect(spanOf("`a\\` x")).toBe("quoted-identifier|`a\\`");
+    });
+  });
+
+  describe("dollar-quoted strings (PostgreSQL)", () => {
+    test("reads an untagged $$ body", () => {
+      expect(spanOf("$$ a ) b $$ x")).toBe("dollar-string|$$ a ) b $$");
+    });
+
+    test("reads a tagged body", () => {
+      expect(spanOf("$fn$ BEGIN END $fn$ x")).toBe("dollar-string|$fn$ BEGIN END $fn$");
+    });
+
+    test("a tag may carry digits and underscores after its first character", () => {
+      expect(spanOf("$_t1$ body $_t1$ x")).toBe("dollar-string|$_t1$ body $_t1$");
+    });
+
+    // Tags follow identifier rules, and identifiers are not ASCII. A reader that
+    // rejects the tag scans the body as code.
+    test("a tag may be non-ASCII", () => {
+      expect(spanOf("$gövde$ içerik $gövde$ x")).toBe("dollar-string|$gövde$ içerik $gövde$");
+    });
+
+    test("a differently tagged delimiter inside the body does not close it", () => {
+      expect(spanOf("$a$ $b$ inner $b$ $a$ x")).toBe("dollar-string|$a$ $b$ inner $b$ $a$");
+    });
+
+    test("an unterminated dollar string reports terminated: false", () => {
+      expect(readSqlSpan("$$ body", 0)).toEqual({ kind: "dollar-string", end: 7, terminated: false });
+    });
+  });
+
+  // ── Bounded time ────────────────────────────────────────────────────────
+  //
+  // This module exists partly because the regex alternative is a ReDoS trap:
+  // `leading-keyword.ts` records three measured backtracking failures (quadratic
+  // 958ms, quadratic 852ms, exponential 634ms on a 49-character input) in the
+  // equivalent pattern. A character scanner cannot backtrack, and this guard is
+  // what keeps anyone from replacing it with one that can.
+
+  test("answers in bounded time on adversarial input", () => {
+    const BOUND_MS = 200;
+    const adversarial: [string, string, boolean][] = [
+      // label, input, whether a span is expected at index 0
+      ["20k quotes (all escapes, never closes)", "'".repeat(20001), true],
+      // The backslash walk-back runs at every candidate delimiter, so a long run
+      // followed by many candidates is where a quadratic version of it would show.
+      ["a 20k backslash run before a quote", `'${"\\".repeat(20000)}' x`, true],
+      ["a 20k backslash run before 10k doubled quotes", `'${"\\".repeat(20000)}${"''".repeat(10000)}`, true],
+      ["20k backticks", "`".repeat(20001), true],
+      ["a 20k unterminated block comment", `/*${"a".repeat(20000)}`, true],
+      ["a 20k line comment", `--${"a".repeat(20000)}`, true],
+      ["20k whitespace", " ".repeat(20000), true],
+      ["a 20k unterminated dollar string", `$$${"a".repeat(20000)}`, true],
+      // A run of dollars is a run of EMPTY dollar-quoted strings (`$$$$` is a
+      // valid empty literal in PostgreSQL), so the first two of them are a span.
+      ["20k bare dollars", "$".repeat(20000), true],
+      // A 20k tag that never closes is not one: the tag scan has to walk the whole
+      // run before it can say so, which is the bounded-time case here.
+      ["a 20k unclosed dollar tag", `$${"a".repeat(20000)}`, false],
+      // The body search is an `indexOf` for the whole tag. A long tag against a
+      // body full of near-misses is where a naive character-by-character substring
+      // search would degrade to O(n·m), so the guard covers it rather than assuming
+      // the engine's sublinear search.
+      [
+        "a 200-char tag against a 20k near-matching body",
+        `$${"a".repeat(200)}$${`$${"a".repeat(199)}$`.repeat(100)}`,
+        true,
+      ],
+    ];
+
+    for (const [label, sql, expectSpan] of adversarial) {
+      const started = performance.now();
+      const span = readSqlSpan(sql, 0);
+      const elapsed = performance.now() - started;
+
+      // A correct answer AND a bounded one: a fast wrong answer is not a pass.
+      expect(span === null, label).toBe(!expectSpan);
+      expect(elapsed, `${label} took ${elapsed.toFixed(1)}ms`).toBeLessThan(BOUND_MS);
+    }
+  });
+});

--- a/tests/unit/sql/statement-end.test.ts
+++ b/tests/unit/sql/statement-end.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect } from "bun:test";
+import { readStatementEnd } from "@/lib/sql/statement-end";
+
+/**
+ * `[statement, trailing]` - the split this reader exists to produce.
+ *
+ * Asserting on the two halves rather than on the index keeps the failure message
+ * readable and pins BOTH sides: a reader that loses characters would still return
+ * a plausible-looking number.
+ */
+function split(sql: string): [string, string] {
+  const { end } = readStatementEnd(sql);
+  return [sql.slice(0, end), sql.slice(end)];
+}
+
+describe("readStatementEnd", () => {
+  // ── The statement's own text ────────────────────────────────────────────
+
+  describe("nothing to strip", () => {
+    test.each<[string, string]>([
+      ["a bare statement", "SELECT 1"],
+      ["a statement ending in a string", "SELECT 'a'"],
+      ["a statement ending in a quoted identifier", 'SELECT "col"'],
+      ["a statement ending in a paren", "SELECT count(*) FROM t"],
+    ])("leaves %s whole", (_label, sql) => {
+      expect(split(sql)).toEqual([sql, ""]);
+    });
+  });
+
+  describe("trailing trivia", () => {
+    test.each<[string, string, string]>([
+      // label, statement, trailing
+      ["a semicolon", "SELECT 1", ";"],
+      ["repeated semicolons", "SELECT 1", ";;"],
+      ["whitespace", "SELECT 1", "  \n"],
+      ["a line comment", "SELECT 1", " -- note"],
+      ["a block comment", "SELECT 1", " /* note */"],
+      ["a semicolon then a comment", "SELECT 1", "; -- note"],
+      ["a comment then a semicolon", "SELECT 1", " -- note\n;"],
+      ["a comment carrying a semicolon", "SELECT 1", " -- ; note"],
+      ["several comments", "SELECT 1", " /* a */ -- b\n/* c */"],
+      ["a comment after a bound", "SELECT 1 LIMIT 10", " -- deliberate"],
+    ])("splits off %s", (_label, statement, trailing) => {
+      expect(split(`${statement}${trailing}`)).toEqual([statement, trailing]);
+    });
+
+    test("leading whitespace is not part of the answer - only the end moves", () => {
+      expect(split("  SELECT 1  ")).toEqual(["  SELECT 1", "  "]);
+    });
+
+    test("input that is only trivia has no statement", () => {
+      expect(split("-- note\n")).toEqual(["", "-- note\n"]);
+      expect(split("")).toEqual(["", ""]);
+    });
+  });
+
+  // ── Literals are code, and what they contain is not ─────────────────────
+  //
+  // The whole reason this is a scanner and not `lastIndexOf("--")`: a comment
+  // marker or a semicolon written inside a literal is data, and cutting the
+  // statement there would hand the engine half a query.
+
+  describe("a delimiter inside a literal does not end the statement", () => {
+    test.each<[string, string]>([
+      ["a semicolon in a string", "SELECT ';'"],
+      ["a dash pair in a string", "SELECT '-- not a comment'"],
+      ["a hash in a string", "SELECT '# not a comment'"],
+      ["a block-comment opener in a string", "SELECT '/* not a comment'"],
+      ["a comment marker in a quoted identifier", 'SELECT "a -- b"'],
+      ["a comment marker in a backtick identifier", "SELECT `a -- b`"],
+      ["a comment marker in a dollar-quoted body", "SELECT $$ ; -- $$"],
+      ["a doubled quote inside a string", "SELECT 'it''s -- fine'"],
+    ])("keeps %s inside the statement", (_label, sql) => {
+      expect(split(sql)).toEqual([sql, ""]);
+    });
+
+    test("code after a comment is still part of the statement", () => {
+      expect(split("SELECT /* c */ 1")).toEqual(["SELECT /* c */ 1", ""]);
+      expect(split("SELECT 1 -- c\nFROM t")).toEqual(["SELECT 1 -- c\nFROM t", ""]);
+    });
+
+    test("a semicolon that separates statements is not trailing trivia", () => {
+      expect(split("SELECT 1; SELECT 2;")).toEqual(["SELECT 1; SELECT 2", ";"]);
+    });
+  });
+
+  // ── Ends that may not be cut ────────────────────────────────────────────
+  //
+  // Reading a statement's text and cutting it in two are not equally risky, so
+  // `rewritable` answers the second question separately: a probe reading the
+  // wrong text at worst reports a bound that is not there, and the caller then
+  // leaves the statement alone, while a clause inserted at the wrong index lands
+  // in the middle of the statement and the server rejects it outright.
+
+  describe("rewritable", () => {
+    test.each<[string, string]>([
+      ["a bare statement", "SELECT 1"],
+      ["a trailing dash comment", "SELECT 1 -- note"],
+      ["a trailing block comment", "SELECT 1 /* note */"],
+      ["a terminator", "SELECT 1;"],
+      ["a hash comment with code after it", "SELECT * FROM t # note\nWHERE a = 1"],
+    ])("allows a cut after %s", (_label, sql) => {
+      expect(readStatementEnd(sql).rewritable).toBe(true);
+    });
+
+    // A refused cut always reports the terminator strip as its end - trailing
+    // whitespace and semicolons removed and nothing else, which is what this
+    // module's callers read before it existed. So a caller's probes lose
+    // nothing: only the rewrite is declined.
+    //
+    // A span that never closes is the first of the two shapes: the two dialect
+    // readings end the statement in different places, so the cut would be a guess.
+    test.each<[string, string, string]>([
+      ["an unterminated block comment", "SELECT 1 /* note", "SELECT 1 /* note"],
+      ["an unterminated string", "SELECT 'note", "SELECT 'note"],
+      ["an unterminated dollar-quoted body", "SELECT $$ note", "SELECT $$ note"],
+      ["a `$` inside a bare identifier", "SELECT a$b$c FROM t", "SELECT a$b$c FROM t"],
+      ["a quote behind an odd backslash run", "SELECT 'O\\'Brien' -- note", "SELECT 'O\\'Brien' -- note"],
+      ["the same before a terminator", "SELECT 'O\\'Brien';", "SELECT 'O\\'Brien'"],
+    ])("refuses a cut after %s", (_label, sql, statement) => {
+      expect(readStatementEnd(sql).rewritable).toBe(false);
+      expect(split(sql)[0]).toBe(statement);
+    });
+
+    // `#` is MySQL's comment marker and ordinary code in three other dialects
+    // this project supports, and nothing in the text tells them apart. Cutting
+    // there would emit `SELECT * FROM LIMIT 500 #tmp`; reporting the SHORTER
+    // reading would hide a bound written after the `#`, and a caller that cannot
+    // see one adds a second.
+    test.each<[string, string, string]>([
+      ["a T-SQL temp table", "SELECT * FROM #tmp", "SELECT * FROM #tmp"],
+      [
+        "an already-bounded temp-table page",
+        "SELECT * FROM #t FETCH NEXT 10 ROWS ONLY",
+        "SELECT * FROM #t FETCH NEXT 10 ROWS ONLY",
+      ],
+      ["an Oracle identifier carrying a hash", "SELECT * FROM EMP WHERE ID# = 1", "SELECT * FROM EMP WHERE ID# = 1"],
+      ["a PostgreSQL XOR operator", "SELECT flags # 5 AS x FROM t", "SELECT flags # 5 AS x FROM t"],
+      ["a MySQL trailing hash comment", "SELECT 1 # note", "SELECT 1 # note"],
+      ["a hash comment before a terminator", "SELECT 1 # note\n;", "SELECT 1 # note"],
+    ])("refuses a cut but reports the whole statement for %s", (_label, sql, statement) => {
+      expect(readStatementEnd(sql).rewritable).toBe(false);
+      expect(split(sql)[0]).toBe(statement);
+    });
+  });
+
+  // ── Bounded time ────────────────────────────────────────────────────────
+  //
+  // Same guard as `spans.ts` and `leading-keyword.ts` carry, for the same
+  // reason: the regex shape of this job ("everything up to the trailing
+  // comment") backtracks catastrophically, and three measured failures of that
+  // kind are recorded in `leading-keyword.ts`. A scan that advances one span at
+  // a time cannot backtrack, and this guard is what keeps it that way.
+
+  test("answers in bounded time on adversarial input", () => {
+    const BOUND_MS = 200;
+    const adversarial: [string, string, number][] = [
+      // label, input, expected end
+      ["20k semicolons", `SELECT 1${";".repeat(20000)}`, 8],
+      ["20k line comments", `SELECT 1${" -- note\n".repeat(20000)}`, 8],
+      ["20k empty block comments", `SELECT 1${"/**/".repeat(20000)}`, 8],
+      ["a 20k unterminated block comment", `SELECT 1 /*${"a".repeat(20000)}`, 20011],
+      ["20k quotes that never close", `SELECT ${"'".repeat(20001)}`, 20008],
+      // The run is EVEN, so the closing quote is a real one and the comment after
+      // it really is trailing - the walk-back has to prove that at every candidate.
+      ["a 20k backslash run before a quote", `SELECT '${"\\".repeat(20000)}' -- note`, 20009],
+      ["20k whitespace", `SELECT 1${" ".repeat(20000)}`, 8],
+      ["20k alternating trivia", `SELECT 1${"; -- a\n/**/ ".repeat(2000)}`, 8],
+    ];
+
+    for (const [label, sql, expected] of adversarial) {
+      const started = performance.now();
+      const { end } = readStatementEnd(sql);
+      const elapsed = performance.now() - started;
+
+      // A correct answer AND a bounded one: a fast wrong answer is not a pass.
+      expect(end, label).toBe(expected);
+      expect(elapsed, `${label} took ${elapsed.toFixed(1)}ms`).toBeLessThan(BOUND_MS);
+    }
+  });
+});

--- a/tests/unit/sql/words.test.ts
+++ b/tests/unit/sql/words.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from "bun:test";
+import { findCodeWord, readSqlWord } from "@/lib/sql/words";
+
+/** The word at an index as its text alone - the shape most assertions want. */
+function wordAt(sql: string, index = 0): string | null {
+  return readSqlWord(sql, index)?.text ?? null;
+}
+
+/**
+ * Where a code word starts, or -1.
+ *
+ * Asserting on the INDEX rather than on a boolean pins that the reader stopped in
+ * the right place: a scanner that answered from inside a literal would still say
+ * "found".
+ */
+function findAt(sql: string, word: string, from = 0): number {
+  return findCodeWord(sql, word, from)?.start ?? -1;
+}
+
+describe("readSqlWord", () => {
+  test.each<[string, string, string | null]>([
+    ["a keyword, upper-cased", "select 1", "SELECT"],
+    ["a name with digits and underscores", "t1_a", "T1_A"],
+    ["a name carrying a dollar", "a$b", "A$B"],
+    ["a localized name", "müşteri", "MÜŞTERI"],
+  ])("reads %s", (_label, sql, expected) => {
+    expect(wordAt(sql)).toBe(expected);
+  });
+
+  test.each<[string, string]>([
+    ["a digit", "1a"],
+    ["a paren", "(SELECT 1)"],
+    ["a quote", "'SELECT'"],
+    ["a dollar, so a dollar-quote tag stays the literal it is", "$tag$"],
+    ["the end of the input", ""],
+  ])("answers null where a word cannot open - %s", (_label, sql) => {
+    expect(wordAt(sql)).toBeNull();
+  });
+
+  test("reads from the given index and reports where the word ends", () => {
+    const word = readSqlWord("SELECT count", 7);
+
+    expect(word).toEqual({ text: "COUNT", end: 12 });
+  });
+});
+
+describe("findCodeWord", () => {
+  // ── Reading the statement's own code ────────────────────────────────────
+
+  test.each<[string, string, string, number]>([
+    // label, sql, word, expected start
+    ["a leading keyword", "UPDATE t SET x = 1", "UPDATE", 0],
+    ["a keyword further in", "UPDATE t SET x = 1", "SET", 9],
+    ["a word written in lower case", "update t", "UPDATE", 0],
+    ["a word searched for in lower case", "UPDATE t", "update", 0],
+    ["code that follows a comment", "-- note\nUPDATE t", "UPDATE", 8],
+    ["code that follows a literal", "SELECT 'x', UPDATE", "UPDATE", 12],
+  ])("finds %s", (_label, sql, word, expected) => {
+    expect(findAt(sql, word)).toBe(expected);
+  });
+
+  test("reports where the word ends, so a caller can search on past it", () => {
+    expect(findCodeWord("UPDATE t SET x = 1", "UPDATE")).toEqual({ start: 0, end: 6 });
+  });
+
+  test("searches from the given index, past an earlier occurrence", () => {
+    expect(findAt("SET a SET b", "SET", 1)).toBe(6);
+  });
+
+  // ── Whole words only ───────────────────────────────────────────────────
+
+  test.each<[string, string]>([
+    ["a longer word that starts with it", "UPDATED t SET x = 1"],
+    ["a longer word that ends with it", "xUPDATE t"],
+    ["a word joined to it by a dollar", "UPDATE$x t"],
+    ["a word that is absent", "SELECT * FROM t"],
+  ])("does not answer for %s", (_label, sql) => {
+    expect(findAt(sql, "UPDATE")).toBe(-1);
+  });
+
+  // ── Everything that is not code ────────────────────────────────────────
+
+  /**
+   * The reason this module exists rather than a `\bWORD\b` regex: every one of
+   * these inputs MENTIONS the word without the statement doing it. A regex reads
+   * all of them as the statement's own code, which is how a read that quotes
+   * `UPDATE … SET` in a string was treated as a write (#294).
+   */
+  test.each<[string, string]>([
+    ["a single-quoted string", "SELECT 'UPDATE t SET x' FROM notes"],
+    ["a string carrying a doubled quote", "SELECT 'it''s UPDATE' FROM notes"],
+    ["a double-quoted identifier", 'SELECT "UPDATE" FROM t'],
+    ["a backtick identifier", "SELECT `UPDATE` FROM t"],
+    ["a dollar-quoted body", "SELECT $$ UPDATE t $$"],
+    ["a tagged dollar-quoted body", "SELECT $fn$ UPDATE t $fn$"],
+    ["a line comment", "SELECT 1 -- UPDATE t SET x"],
+    ["a MySQL hash comment", "SELECT 1 # UPDATE t SET x"],
+    ["a block comment", "SELECT /* UPDATE */ 1"],
+    ["a block comment spanning lines", "SELECT 1\n/*\n UPDATE t\n*/"],
+  ])("skips %s", (_label, sql) => {
+    expect(findAt(sql, "UPDATE")).toBe(-1);
+  });
+
+  /**
+   * An undeterminable literal reaches the end of the input (`spans.ts` reports
+   * `end: sql.length` for one), so code written after it is not read at all.
+   *
+   * Recorded as a test because for THIS module's caller the direction is the
+   * unhelpful one: the safety dialog wants to prompt when it cannot tell, and a
+   * write hidden behind `'\'` - a complete string in PostgreSQL, an unterminated
+   * one in MySQL - is not detected. Every reader in this folder pays the same
+   * price for the same reason (the two dialect readings put the end of the string
+   * in different places), and the text is a syntax error under one of them, so it
+   * is left where `spans.ts` decided it rather than guessed at here.
+   */
+  test.each<[string, string]>([
+    ["an unterminated string", "SELECT 'x\nUPDATE t SET y = 1"],
+    ["a literal behind an odd backslash run", "SELECT '\\';\nUPDATE t SET y = 1"],
+    ["an unterminated block comment", "SELECT 1 /* note\nUPDATE t SET y = 1"],
+  ])("does not read code past %s", (_label, sql) => {
+    expect(findAt(sql, "UPDATE")).toBe(-1);
+  });
+
+  // ── Shape of the scan ──────────────────────────────────────────────────
+
+  /**
+   * A timing guard, because the pattern this reader replaced was measurably
+   * quadratic and lived on the editor's execute path.
+   *
+   * `/\bUPDATE\b[\s\S]*?\bSET\b/i` restarts its lazy tail at every `UPDATE` in the
+   * input, so text holding many of them and no `SET` costs one full scan each.
+   * Measured on the real predicate before this module existed:
+   *
+   *   14 KB of `UPDATE ` repeats     10.5ms
+   *   140 KB                          1025ms
+   *   350 KB                          6406ms
+   *
+   * A scanner that advances one span or one word at a time cannot do that: every
+   * input below is answered in a single pass. The bound is loose on purpose so it
+   * cannot flake on a slow runner while still failing outright if a backtracking
+   * pattern returns - the quadratic form is five times over it at 140 KB alone.
+   *
+   * Correctness is asserted with the timing: a fast wrong answer is not a pass.
+   */
+  test("answers in bounded time on input built to make a lazy pattern backtrack", () => {
+    const BOUND_MS = 200;
+    const adversarial: [string, string, number][] = [
+      ["20k UPDATE words, no SET", `${"UPDATE ".repeat(20000)}(`, 0],
+      ["50k UPDATE words, no SET", `${"UPDATE ".repeat(50000)}(`, 0],
+      ["20k words that only start with it", `${"UPDATED ".repeat(20000)}(`, -1],
+      ["20k leading spaces", `${" ".repeat(20000)}(`, -1],
+      ["4 KB of empty block comments", `${"/**/".repeat(1000)}(`, -1],
+      ["2k line comments", `${"-- a\n".repeat(2000)}(`, -1],
+      ["2k strings", `${"'a', ".repeat(2000)}(`, -1],
+      ["2k quote characters", `${"'".repeat(2000)}(`, -1],
+      ["a 20 KB string body", `SELECT '${"UPDATE ".repeat(3000)}'`, -1],
+    ];
+
+    for (const [label, sql, expected] of adversarial) {
+      const started = performance.now();
+      const found = findAt(sql, "UPDATE");
+      const elapsed = performance.now() - started;
+
+      expect(found, label).toBe(expected);
+      expect(elapsed, `${label} took ${elapsed.toFixed(1)}ms`).toBeLessThan(BOUND_MS);
+    }
+  });
+});


### PR DESCRIPTION
One defect class seen from five sides. #275 taught this code where a statement **begins**; it still had no
idea where a statement **ends**, or which keyword inside a `WITH` actually operates it. Every probe that
answered those questions read raw text, so a comment, a literal or a CTE list could answer for the
statement itself.

Fixes #287. Fixes #280. Fixes #281. Fixes #291. Fixes #294.

Produced by the maintainer loop (`loop/`) and reviewed commit by commit before publishing.

## What changed

| Commit | Issue | Change |
|---|---|---|
| `0d696db` | #287 | A `WITH` is typed by the keyword its CTE list operates, not by any `SELECT` in its text. New `src/lib/sql/spans.ts` + `operative-keyword.ts`. |
| `4235fe6` | #280 | The bound is inserted where the engine will see it, and an existing bound is no longer read out of trailing trivia — both directions of the same gap. |
| `c1ab745` | #281 | The multi-statement route reads the shared classifier instead of its own comment-blind `SELECT` test. |
| `46eee71` | #291 | A CTE-list element is read in both shapes the dialects use, restoring the bound for ClickHouse's `WITH <expr> AS <alias>`. |
| `f1a32f3` | #294 | The confirmation dialog reads the shared primitive, so a comment can no longer hide a destructive statement. New `src/lib/sql/words.ts`. |

#287 is the one to read first: `WITH t AS (UPDATE logs SET seen = true RETURNING id) INSERT INTO audit
SELECT id FROM t` was typed `SELECT`, so a bound was appended — and in PostgreSQL that bound applies to the
rows the statement **writes**. It committed at most 500 of them while the UI reported a truncated result
set. Every other member of this family costs an over-large read; that one costs a partial write.

#291 and #294 were filed during this milestone and fixed inside it. #291 is a regression T1 introduced
here — shipping "a protection silently switched off" while introducing one would have been the wrong trade.

## User-visible behaviour changes, all deliberate

**#287** — a data-modifying CTE stops being auto-limited, so a write that was silently partial now runs in
full. A `WITH` whose operative keyword the scanner cannot name is no longer typed `SELECT` and so is not
bounded; PostgreSQL's `SEARCH`/`CYCLE` clauses fall there. Named in `docs/editor/query-optimization.md` and
pinned by tests.

**#280** — the emitted SQL changes shape only for statements carrying trailing trivia: the bound now goes
*before* the trivia. A statement annotated with a trailing comment starts being genuinely bounded; one whose
bound sat inside a trailing comment stops being mistaken for already-bounded. Whitespace before a
terminating `;` is preserved rather than dropped.

**#280, a deliberate loss of a bound** — a statement whose end cannot safely be cut comes back untouched
with `wasLimited: false` instead of bounded: an unterminated literal or comment, a quote behind an odd
backslash run (MySQL `'O\'Brien'`), `a$b$c`, and any statement ending in a `#` run. Some of those were
bounded correctly before (Oracle `ID#`, PostgreSQL `flags # 5`), so it is a real trade — taken because that
same append is what buried the clause inside a MySQL `#` comment. MSSQL's `TOP` head splice still bounds
them.

**#281** — a multi-statement run whose final statement is a comment-led `SELECT` starts returning the
default 500 rows instead of everything.

**#291** — ClickHouse's `WITH <expr> AS <alias> SELECT …` is bounded again; net effect versus `main` is no
change for that form. Cost named and pinned: `WITH col AS materialized SELECT …` (a read) loses its bound,
because a hint word after an element's `AS` commits the element to the standard CTE shape.

**#294** — the confirmation dialog now fires for a destructive statement written under a comment
(`-- cleanup` above a `DROP`, and friends), on both the standalone and the embedded execution paths. Two
smaller shifts come with it: a `SET`-less `UPDATE` now asks (it did not before), and a read that merely
*quotes* `UPDATE … SET` inside a string no longer asks (it did). The `UPDATE … SET` probe stays unanchored
on purpose — PostgreSQL's data-modifying CTE is *operated* by its `SELECT`, so the operative keyword cannot
see that write. The pattern it replaced was also quadratic (1025 ms on 140 KB), so the dialog was a ReDoS
surface as well; a bounded-time test guards it now.

## Two acceptance sub-clauses declined, both needing a human call

Both are pinned by tests and disclosed in the docs rather than quietly dropped:

1. **#280's "a commented-out bound is not mistaken for a real one"** holds for `--` and `/* */` but not for
   `#`. Reading past `#` is the deliberate choice: the shorter reading would hide the real bound in
   `SELECT * FROM #t … FETCH NEXT 10 ROWS ONLY` from every caller, and a caller that cannot see a bound adds
   a second one — an invalid statement instead of an over-large read.
2. **#281's "with the limited flag reported"** — the bound is applied, but `/api/db/multi-query` carries no
   `pagination` field, and adding one is a response-shape change the plan forbade twice.

## T6's review is weaker than the others, and this is the disclosure

Every task here carried a fresh-context adversarial review except **#294**. That reviewer sub-task failed
twice the same way — once blocking a synchronous call for two hours until the iteration cap killed it, once
producing no output when launched asynchronously. The closing iteration then **refused to mark the milestone
complete**, because asserting a verdict that does not exist is the weak-gate failure the loop exists to
prevent. The exception was granted explicitly, scoped to that one task.

What #294 rests on instead: a maintainer review of the diff, which found and fixed a real defect (a
load-bearing comment claiming a fail-safe the code does not implement — now #297); a reconstruction of the
missing RED evidence, where reverting only `QuerySafetyDialog.tsx` fails 13 tests including one on the
embedded packaged path; and an independent probe of every fixture the plan named. That is weaker than a
review by something that has not read the reasoning behind the code.

## Verification

- `./loop/scripts/gate.sh` green on every commit and again on the final tree — 6541 tests, 0 failures
- merged coverage `28946/28946 lines (100.00%)`
- `./loop/scripts/functional-smoke.sh` green: login → create a PostgreSQL connection through the UI → run
  SQL → rows render
- `bun run build:lib` green; it matters here because #294 changes a packaged component
- every fix landed test-first, with the RED failures recorded

## Follow-ups filed, not fixed here

#292 (the scanner is dialect-blind, so two inputs still type a write as `SELECT`), #293 (a comment after
`OFFSET/FETCH` hides the bound and MSSQL splices `TOP`, producing an invalid statement), #295 (a `]` inside
a string literal ends a subscript scan early), #297 (the confirmation dialog stays silent on text it cannot
resolve), #298 (the PostgreSQL pool has no `error` listener, so an idle client error reaches
`uncaughtException`).

#298 is the widest in reach and has nothing to do with SQL text: no SQL provider attaches a pool error
listener, so a dropped idle connection can take down the server process.
