### PR TITLE
docs: record the Sealos and Unraid listings, and consolidate CapRover to one row

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -368,6 +368,34 @@ channels:
       strategy: none
       note: Render builds from the repo Dockerfile (render.yaml dockerfilePath) on push, so there is no image tag to pin - the deployed version tracks whatever main builds. Like fly.toml, render.yaml is auto-detected at the repo root, so users deploy straight from the repo Blueprint.
 
+  - id: unraid-ca
+    name: Unraid Community Applications (libredb/unraid-templates)
+    short_name: Unraid Community Apps
+    status: live
+    category: paas-catalogs
+    platforms: [container]
+    tier: 2
+    kind: one-click-template
+    update:
+      method: commit
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/283
+      catalog: https://ca.unraid.net/apps/libredb-studio-0a5x41a1cy1kay
+      upstream_repo: https://github.com/libredb/unraid-templates
+      docs: docs/DISTRIBUTION.md
+    pin:
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/libredb/unraid-templates/main/templates/libredb-studio.xml
+      extract: 'libredb-studio:(\d+\.\d+\.\d+)'
+      note: The container template is LibreDB-owned (libredb/unraid-templates), so a version bump is a commit
+        in THAT repo - not a PR here and not an upstream PR - which is why this is tier 2 with a remote_file
+        pin rather than local_file. Community Applications only serves what its own periodic catalog build
+        picked up, so a bump reaches users one CA build after the commit. Submitted via ca.unraid.net/submit
+        on 2026-08-04 and auto-approved (a non-duplicate Docker app with no plugin needs no human review).
+        The `container` platform is deliberate and not a stand-in for cloud - the user installs a Docker
+        container on their own Unraid server.
+
   # ---- Tier 3: upstream community catalogs, bumped via PR -----------------
 
   - id: caprover-official
@@ -452,6 +480,34 @@ channels:
       strategy: remote_file
       url: https://raw.githubusercontent.com/kubero-dev/kubero/main/services/libredb-studio/app.yaml
       extract: 'ghcr\.io/libredb/libredb-studio\s+tag:\s*(\d+\.\d+\.\d+)'
+
+  - id: sealos
+    name: Sealos App Store template
+    status: live
+    category: paas-catalogs
+    platforms: [cloud]
+    tier: 3
+    kind: one-click-template
+    update:
+      method: upstream_pr
+      sla: on_demand
+    links:
+      tracking_issue: https://github.com/libredb/libredb-studio/issues/276
+      first_pr: https://github.com/labring-actions/templates/pull/739
+      catalog: https://sealos.io/products/app-store/libredb-studio
+      upstream_repo: https://github.com/labring-actions/templates
+      docs: docs/DISTRIBUTION.md
+    pin:
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/libredb-studio/index.yaml
+      extract: 'libredb-studio:(\d+\.\d+\.\d+)'
+      note: Sealos app-store templates live in labring-actions/templates (labring is the company behind
+        Sealos) and go in as a direct template PR - no upstream issue first. That repo's default branch is
+        `kb-0.9`, NOT main or master, so both the pin URL above and any bump PR must target it; a
+        raw.githubusercontent URL on `main` 404s, and `master` carries a copy that can lag. The template
+        pins the image twice (deploy plus the rendered docs block), which is why the shared
+        all-matches-must-agree rule matters here. Deploys SQLite on a 1 GiB PVC by default, with
+        KubeBlocks-managed PostgreSQL as an opt-in storage backend.
 
   - id: operatorhub-community
     name: OperatorHub / OpenShift community operator catalogs

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -263,28 +263,6 @@ channels:
 
   # ---- Tier 2: LibreDB-owned copies and listings, bumped by hand ----------
 
-  - id: caprover-mirror
-    name: CapRover 3rd-party repo (libredb.org/caprover-one-click-apps)
-    short_name: CapRover 3rd-party repo
-    status: deprecated
-    category: paas-catalogs
-    platforms: [cloud]
-    tier: 2
-    kind: one-click-template
-    update:
-      method: commit
-      sla: on_demand
-    links:
-      tracking_issue: https://github.com/libredb/libredb-studio/issues/56
-      catalog: https://libredb.org/caprover-one-click-apps
-      upstream_repo: https://github.com/libredb/caprover-one-click-apps
-    pin:
-      strategy: none
-      note: This was a LibreDB-owned CapRover repo, published while the official catalog submission
-        (#56) was in review. The official listing (caprover-official) is now live, so this
-        fallback is retired. The libredb.org/caprover-one-click-apps path it was served from is not
-        currently published.
-
   - id: railway-template
     name: Railway one-click template
     status: live
@@ -413,10 +391,18 @@ channels:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/56
       first_pr: https://github.com/caprover/one-click-apps/pull/1303
       upstream_repo: https://github.com/caprover/one-click-apps
+      docs: deploy/caprover/README.md
     pin:
       strategy: remote_file
       url: https://raw.githubusercontent.com/caprover/one-click-apps/master/public/v4/apps/libredb-studio.yml
       extract: "defaultValue: '(\\d+\\.\\d+\\.\\d+)'"
+      note: The single CapRover row. A LibreDB-owned 3rd-party repo
+        (libredb/caprover-one-click-apps) served the app while this submission was in review and was
+        retired once it merged; it had its own inventory entry until that duplicated CapRover in the
+        coverage matrix as one live and one dead route to the same platform, with the dead one's URL
+        no longer published. Its record lives in deploy/caprover/README.md, which is where a
+        maintainer bumping the template already looks. Users install from the official catalog only -
+        no third-party repo to add.
 
   - id: dokploy
     name: Dokploy template catalog

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -491,9 +491,10 @@ channels:
         Sealos) and go in as a direct template PR - no upstream issue first. That repo's default branch is
         `kb-0.9`, NOT main or master, so both the pin URL above and any bump PR must target it; a
         raw.githubusercontent URL on `main` 404s, and `master` carries a copy that can lag. The template
-        pins the image twice (deploy plus the rendered docs block), which is why the shared
-        all-matches-must-agree rule matters here. Deploys SQLite on a 1 GiB PVC by default, with
-        KubeBlocks-managed PostgreSQL as an opt-in storage backend.
+        pins the image in TWO places - the StatefulSet's `originImageName` annotation and the container
+        `image` - so the shared all-matches-must-agree rule is what catches a half-finished bump here.
+        Deploys SQLite on a 1 GiB PVC by default, with KubeBlocks-managed PostgreSQL as an opt-in
+        storage backend, and ships AUTH_BOOTSTRAP=off so the deployment starts in strict mode.
 
   - id: operatorhub-community
     name: OperatorHub / OpenShift community operator catalogs

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -31,7 +31,7 @@ channel count.
 
 ## Coverage snapshot
 
-**28 channels · 22 live · 4 pending · 2 deprecated**
+**27 channels · 22 live · 4 pending · 1 deprecated**
 
 Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 3 · Kubernetes 1 · Cloud 10**
 
@@ -42,7 +42,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 3 · K
 | Kubernetes & operators | 1 | 2 | 0 |
 | Package managers | 4 | 1 | 1 |
 | OS / desktop packages | 2 | 0 | 0 |
-| PaaS catalogs (listed) | 7 | 0 | 1 |
+| PaaS catalogs (listed) | 7 | 0 | 0 |
 | Deploy recipes | 3 | 0 | 0 |
 | Cloud marketplaces | 1 | 1 | 0 |
 
@@ -69,14 +69,13 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 3 · K
 | Flathub | Package managers | Linux | deprecated | — | [packaging/flatpak/README.md](../packaging/flatpak/README.md) |
 | [Desktop app (AppImage, .deb)](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [desktop/README.md](../desktop/README.md) |
 | [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [CapRover official](https://github.com/caprover/one-click-apps) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [CapRover official](https://github.com/caprover/one-click-apps) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/caprover/README.md](../deploy/caprover/README.md) |
 | [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
 | [Dokploy template catalog](https://templates.dokploy.com) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |
 | [Kubero template catalog](https://www.kubero.dev/templates) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/kubero/README.md](../deploy/kubero/README.md) |
 | [Railway one-click template](https://railway.com/deploy/libredb-studio) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
 | [Sealos App Store template](https://sealos.io/products/app-store/libredb-studio) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Unraid Community Apps](https://ca.unraid.net/apps/libredb-studio-0a5x41a1cy1kay) | PaaS catalogs (listed) | Container | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| CapRover 3rd-party repo | PaaS catalogs (listed) | Cloud | deprecated | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Fly.io launch config](https://github.com/libredb/libredb-studio/blob/main/fly.toml) | Deploy recipes | Cloud | live | Manual, on demand | [FLY.md](FLY.md) |
 | [Koyeb deploy button](https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb) | Deploy recipes | Cloud | live | Manual, on demand | [deploy/koyeb/README.md](../deploy/koyeb/README.md) |
 | [Render Blueprint](https://github.com/libredb/libredb-studio/blob/main/render.yaml) | Deploy recipes | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -31,9 +31,9 @@ channel count.
 
 ## Coverage snapshot
 
-**26 channels · 20 live · 4 pending · 2 deprecated**
+**28 channels · 22 live · 4 pending · 2 deprecated**
 
-Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · Kubernetes 1 · Cloud 9**
+Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 3 · Kubernetes 1 · Cloud 10**
 
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
@@ -42,7 +42,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | Kubernetes & operators | 1 | 2 | 0 |
 | Package managers | 4 | 1 | 1 |
 | OS / desktop packages | 2 | 0 | 0 |
-| PaaS catalogs (listed) | 5 | 0 | 1 |
+| PaaS catalogs (listed) | 7 | 0 | 1 |
 | Deploy recipes | 3 | 0 | 0 |
 | Cloud marketplaces | 1 | 1 | 0 |
 
@@ -74,6 +74,8 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 2 · K
 | [Dokploy template catalog](https://templates.dokploy.com) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |
 | [Kubero template catalog](https://www.kubero.dev/templates) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/kubero/README.md](../deploy/kubero/README.md) |
 | [Railway one-click template](https://railway.com/deploy/libredb-studio) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
+| [Sealos App Store template](https://sealos.io/products/app-store/libredb-studio) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [Unraid Community Apps](https://ca.unraid.net/apps/libredb-studio-0a5x41a1cy1kay) | PaaS catalogs (listed) | Container | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | CapRover 3rd-party repo | PaaS catalogs (listed) | Cloud | deprecated | — | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Fly.io launch config](https://github.com/libredb/libredb-studio/blob/main/fly.toml) | Deploy recipes | Cloud | live | Manual, on demand | [FLY.md](FLY.md) |
 | [Koyeb deploy button](https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb) | Deploy recipes | Cloud | live | Manual, on demand | [deploy/koyeb/README.md](../deploy/koyeb/README.md) |

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -34,7 +34,8 @@ have Docker images only.
 
 ## Zero-config first run
 
-Every channel works with no configuration. When `JWT_SECRET` / `ADMIN_PASSWORD` are not set
+Every channel works with no configuration, except the two catalog templates that collect
+credentials in their own install form (see the last bullet). When `JWT_SECRET` / `ADMIN_PASSWORD` are not set
 (and the auth provider is not OIDC), the server generates them on first start, persists them in
 `<data dir>/auth-bootstrap.json` (file mode 0600), and prints the admin password **once** to the
 server log:
@@ -53,12 +54,19 @@ server log:
 - Explicitly set environment variables always take precedence; only missing values are generated.
 - If the data dir is not persisted (ephemeral container, no volume), new credentials are
   generated on every recreate.
+- **The two catalog templates are the exception**, because their install form asks for the
+  credentials up front: the [Unraid](#unraid-community-applications) template requires
+  `ADMIN_PASSWORD` and `JWT_SECRET`, and the [Sealos](#sealos-app-store) template collects an admin
+  password and sets `AUTH_BOOTSTRAP=off`. Both therefore start with credentials you chose, print no
+  generated-password banner, and write no `auth-bootstrap.json`. Zero-config describes what the
+  server does when a channel leaves those variables unset.
 
 **Strict mode:** set `AUTH_BOOTSTRAP=off` to disable generation and require explicit
 `JWT_SECRET` and `ADMIN_PASSWORD` (recommended for production; missing values then surface as a
 clear error on the login page instead of silently generated credentials in collected logs). Every
-channel, the Helm chart included, defaults to zero-config; strict mode is always opt-in.
-Unrecognized `AUTH_BOOTSTRAP` values log a warning and keep bootstrap on.
+channel that starts the server itself, the Helm chart included, defaults to zero-config and takes
+strict mode as an opt-in; the [Sealos](#sealos-app-store) template is the one channel that ships
+with it already on. Unrecognized `AUTH_BOOTSTRAP` values log a warning and keep bootstrap on.
 
 ## Network exposure (bind address)
 
@@ -845,13 +853,16 @@ web UI: **Apps** tab, search for **LibreDB Studio**, then **Install**.
 
 - **The web UI host port defaults to 3006**, mapped to container port 3000. Any free host port
   works; the template steers away from 3000 because it commonly collides with other apps.
-- **App Data** is `/mnt/user/appdata/libredb-studio` mapped to `/app/data` - the server-side SQLite
-  storage (`STORAGE_SQLITE_PATH=/app/data/libredb-storage.db`) and the generated credentials file
-  live there, so both survive container updates and recreation.
+- **App Data** is `/mnt/user/appdata/libredb-studio` mapped to `/app/data`, holding the server-side
+  SQLite storage (`STORAGE_SQLITE_PATH=/app/data/libredb-storage.db`) - that database is what
+  survives container updates and recreation. **No `auth-bootstrap.json` is written here**, because
+  the template always supplies `ADMIN_PASSWORD` and `JWT_SECRET` and generation short-circuits when
+  both are set: back up the database, and keep the credentials you typed into the template.
 - **Credentials are entered in the Add Container form**, not read back from a log: the template
   marks `ADMIN_EMAIL`, `ADMIN_PASSWORD` (minimum 8 characters) and `JWT_SECRET` (minimum 32
-  characters) as required fields. That is a template choice for a NAS audience - the app's own
-  [zero-config first run](#zero-config-first-run) still applies to every other channel.
+  characters) as required fields. That is a template choice for a NAS audience, not an app
+  requirement - see the exception noted under
+  [Zero-config first run](#zero-config-first-run).
 - `AUTH_COOKIE_SECURE=false` ships as the default because a LAN install is served over plain HTTP.
   Set it to `true` once the app sits behind HTTPS (a reverse proxy); leaving it `false` on a
   public host sends the session cookie in cleartext.
@@ -873,6 +884,9 @@ provisions compute, networking, storage and ingress, so there is nothing to inst
 - **Storage** defaults to SQLite on a 1 GiB PVC. The template also offers **Use PostgreSQL
   storage**, which provisions a KubeBlocks-managed PostgreSQL instance and points
   `STORAGE_PROVIDER` / `STORAGE_POSTGRES_URL` at it - see [`docs/STORAGE.md`](STORAGE.md).
+- The template sets **`AUTH_BOOTSTRAP=off`** and generates `JWT_SECRET` itself, so the deployment
+  starts in [strict mode](#zero-config-first-run) with the password you entered - there is no
+  generated-credentials banner to read from the pod log.
 - Bumps go in as a template PR to `labring-actions/templates`. That repo's default branch is
   **`kb-0.9`**, not `main` or `master`, which is what both the drift-check pin URL and any bump PR
   must target.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1129,7 +1129,7 @@ pin or editing a channel entry is always a human commit.
 |---|---|---|
 | 0 | Core registries, published directly by release CI | GitHub Releases, GHCR, Docker Hub, npm |
 | 1 | Packaged formats owned by this repo, CI-published | Helm, Homebrew tap, Snap, .deb/.rpm, desktop AppImage |
-| 2 | LibreDB-owned copies and listings, bumped by hand | CapRover mirror (deprecated), Railway, Koyeb button, Fly.io config, Render Blueprint, Unraid CA template |
+| 2 | LibreDB-owned copies and listings, bumped by hand | Railway, Koyeb button, Fly.io config, Render Blueprint, Unraid CA template |
 | 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero, Sealos |
 | 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DO, winget, Chocolatey, Flathub |
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -14,6 +14,8 @@ how the release pipeline publishes each channel. For a one-line-per-channel over
 | Snap | Ubuntu and other snapd systems | [Snap](#snap) |
 | Windows (winget / Chocolatey / portable zip) | Windows workstations | [Windows](#windows-winget--chocolatey--portable-zip) |
 | Desktop app (AppImage, .deb, FlatPark) | Linux desktops - an application window, no browser tab | [Desktop app](#desktop-app-appimage-debian-package-flatpark) |
+| Unraid | An Unraid server - one click from the Apps tab | [Unraid](#unraid-community-applications) |
+| Sealos | One-click managed Kubernetes, nothing to install locally | [Sealos](#sealos-app-store) |
 
 All non-Docker channels ship or download the same **standalone server payload** (Next.js
 standalone output, started with `node server.js`) built by
@@ -819,6 +821,62 @@ flatpak --user uninstall -y org.libredb.Studio//stable
 flatpak --user remote-delete libredb-flatpark-local
 ```
 
+## App catalogs (Unraid, Sealos)
+
+Both channels install the same published container image through a catalog the platform itself
+publishes, so a user browsing that platform finds LibreDB Studio without ever visiting this repo.
+They are documented here rather than under `deploy/<provider>/` because neither descriptor lives in
+this repo: the Sealos template lives upstream in
+[`labring-actions/templates`](https://github.com/labring-actions/templates) and the Unraid template
+in [`libredb/unraid-templates`](https://github.com/libredb/unraid-templates). Catalog channels whose
+source descriptor *is* in this repo (CapRover, Railway, Dokploy, Kubero, Cosmos) keep their notes in
+`deploy/<provider>/README.md` instead. The full channel list is
+[`docs/CHANNELS.md`](CHANNELS.md).
+
+Both templates pin an explicit **version tag**, not `latest`, so a new release reaches these users
+only when the template is bumped - `on_demand` for both in
+[`distribution/channels.yaml`](../distribution/channels.yaml).
+
+### Unraid (Community Applications)
+
+Listed in [Community Applications](https://ca.unraid.net/apps/libredb-studio-0a5x41a1cy1kay) (CA)
+since 2026-08-04 ([issue #283](https://github.com/libredb/libredb-studio/issues/283)). In the Unraid
+web UI: **Apps** tab, search for **LibreDB Studio**, then **Install**.
+
+- **The web UI host port defaults to 3006**, mapped to container port 3000. Any free host port
+  works; the template steers away from 3000 because it commonly collides with other apps.
+- **App Data** is `/mnt/user/appdata/libredb-studio` mapped to `/app/data` - the server-side SQLite
+  storage (`STORAGE_SQLITE_PATH=/app/data/libredb-storage.db`) and the generated credentials file
+  live there, so both survive container updates and recreation.
+- **Credentials are entered in the Add Container form**, not read back from a log: the template
+  marks `ADMIN_EMAIL`, `ADMIN_PASSWORD` (minimum 8 characters) and `JWT_SECRET` (minimum 32
+  characters) as required fields. That is a template choice for a NAS audience - the app's own
+  [zero-config first run](#zero-config-first-run) still applies to every other channel.
+- `AUTH_COOKIE_SECURE=false` ships as the default because a LAN install is served over plain HTTP.
+  Set it to `true` once the app sits behind HTTPS (a reverse proxy); leaving it `false` on a
+  public host sends the session cookie in cleartext.
+- The container is unprivileged, on `bridge` networking, and needs no other service - databases are
+  reached over TCP from the Unraid host's network.
+
+Because the template repo is LibreDB-owned, a version bump is a commit in
+`libredb/unraid-templates` rather than a PR here or upstream; CA then serves it after its next
+catalog build, which is when Unraid offers the update.
+
+### Sealos (App Store)
+
+Listed in the [Sealos App Store](https://sealos.io/products/app-store/libredb-studio) since
+2026-08-04 ([issue #276](https://github.com/libredb/libredb-studio/issues/276),
+[labring-actions/templates#739](https://github.com/labring-actions/templates/pull/739)). Click
+**Deploy Now** and supply an administrator email and password (minimum 8 characters); the template
+provisions compute, networking, storage and ingress, so there is nothing to install locally.
+
+- **Storage** defaults to SQLite on a 1 GiB PVC. The template also offers **Use PostgreSQL
+  storage**, which provisions a KubeBlocks-managed PostgreSQL instance and points
+  `STORAGE_PROVIDER` / `STORAGE_POSTGRES_URL` at it - see [`docs/STORAGE.md`](STORAGE.md).
+- Bumps go in as a template PR to `labring-actions/templates`. That repo's default branch is
+  **`kb-0.9`**, not `main` or `master`, which is what both the drift-check pin URL and any bump PR
+  must target.
+
 ## Building a standalone payload locally
 
 The single source of truth for the release archives also works locally (Linux and macOS; on
@@ -1071,8 +1129,8 @@ pin or editing a channel entry is always a human commit.
 |---|---|---|
 | 0 | Core registries, published directly by release CI | GitHub Releases, GHCR, Docker Hub, npm |
 | 1 | Packaged formats owned by this repo, CI-published | Helm, Homebrew tap, Snap, .deb/.rpm, desktop AppImage |
-| 2 | LibreDB-owned copies and listings, bumped by hand | CapRover mirror (deprecated), Railway, Koyeb button, Fly.io config, Render Blueprint |
-| 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero |
+| 2 | LibreDB-owned copies and listings, bumped by hand | CapRover mirror (deprecated), Railway, Koyeb button, Fly.io config, Render Blueprint, Unraid CA template |
+| 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero, Sealos |
 | 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DO, winget, Chocolatey, Flathub |
 
 **Categories** (`category` on every channel) are the business-facing buckets rendered in
@@ -1193,10 +1251,13 @@ than under `deploy/<provider>/`: [`fly.toml`](../fly.toml) (Fly.io) and
 auto-detects the config at the working-directory root: `fly launch`/`fly deploy` read
 `./fly.toml` (see [docs/FLY.md](FLY.md)) and Render's Blueprint auto-detects `render.yaml`, so
 the documented "clone and deploy" flow only works from that location. Catalog-based channels
-(CapRover, Railway, Dokploy, Kubero, …) instead keep their source descriptor under
+(CapRover, Railway, Dokploy, Kubero, Cosmos) instead keep their source descriptor under
 `deploy/<provider>/`, because the consumable artifact lives in an external catalog and the
-in-repo file is only the source that gets pushed or PR'd upstream. Neither Fly.io nor Render has
-a marketplace or template gallery to publish into, which is why the repo file itself is the
+in-repo file is only the source that gets pushed or PR'd upstream. Two catalog channels keep **no**
+descriptor here at all — the Sealos template is authored in `labring-actions/templates` and the
+Unraid CA template in `libredb/unraid-templates` — so both are pinned with `remote_file` against
+those repos and documented under [App catalogs](#app-catalogs-unraid-sealos). Neither Fly.io nor
+Render has a marketplace or template gallery to publish into, which is why the repo file itself is the
 deliverable (`pin.strategy: local_file` for the version-pinned `fly.toml`; `none` for
 `render.yaml`, which builds from the repo Dockerfile and tracks whatever `main` builds).
 


### PR DESCRIPTION
## Description

Two listings went live and neither was in the visibility matrix, so the coverage claim in `docs/CHANNELS.md` was understating what users can actually install from:

- **Sealos App Store** - template merged upstream as [labring-actions/templates#739](https://github.com/labring-actions/templates/pull/739) on 2026-08-04 ([listing](https://sealos.io/products/app-store/libredb-studio)).
- **Unraid Community Applications** - submitted via the CA portal on 2026-08-04, auto-approved, and now served from the catalog ([listing](https://ca.unraid.net/apps/libredb-studio-0a5x41a1cy1kay)).

The Unraid tracking issue's last open checkbox ("Appears in CA catalog") is satisfied: the listing page resolves and serves `ghcr.io/libredb/libredb-studio:0.9.66`. That is why the channel goes in as `live` rather than `pending`.

While adding them, a second cleanup: **CapRover appeared twice**. The inventory carried both the live official one-click-apps listing and the LibreDB-owned 3rd-party repo that served the app while that submission was in review - two rows sharing tracking issue #56, one of them a dead route whose URL (`libredb.org/caprover-one-click-apps`) is no longer published. Consolidated to the one live row.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Related Issue

Closes #283
Refs #276 (already closed when the upstream template merged)
Refs #56 (CapRover - the surviving row keeps this tracking issue)

## Changes Made

- **`distribution/channels.yaml`** - two entries:
  - `sealos`: tier 3, `paas-catalogs` / `cloud`, `one-click-template`, `upstream_pr` + `on_demand`. Pinned `remote_file` against the upstream template.
  - `unraid-ca`: tier 2, `paas-catalogs` / `container`, `one-click-template`, `commit` + `on_demand`. Tier 2 rather than 3 because the template repo (`libredb/unraid-templates`) is LibreDB-owned, so a bump is a commit in that repo, not an upstream PR - and `remote_file` rather than `local_file` because that repo is not this one.
- **`distribution/channels.yaml`** - `caprover-mirror` removed (second commit). Its history moves into the surviving `caprover-official` note, which also gains a `docs: deploy/caprover/README.md` link so its Guide column matches its siblings. No record is lost: `deploy/caprover/README.md` already documented the retirement, and that is where a maintainer bumping the template looks.
- **`docs/CHANNELS.md`** - regenerated with `bun run distribution:matrix` (not hand-edited): 26 -> 27 channels, 20 -> 22 live, 2 -> 1 deprecated, Container 2 -> 3, Cloud 9 -> 10, PaaS catalogs 5 -> 7 live and 1 -> 0 deprecated.
- **`docs/DISTRIBUTION.md`** - two routing-table rows and a new "App catalogs (Unraid, Sealos)" section. It carries the install-relevant behaviour that lives nowhere else in this repo, since neither template is stored here: Unraid's 3006 host port (mapped to container 3000), the appdata mount, the credentials its template requires up front instead of using the zero-config first run, and its `AUTH_COOKIE_SECURE=false` LAN default; for Sealos, the SQLite-on-1GiB-PVC default versus opt-in KubeBlocks PostgreSQL. Tier examples in the inventory section updated too.

Two things worth a reviewer's eye:

- The template repo behind Sealos has default branch **`kb-0.9`**, not `main` or `master` - a `main` raw URL 404s. The pin URL and any future bump PR must target it, so that is recorded in the channel note and the docs.
- The "Root-level PaaS configs" paragraph asserted that catalog channels keep a source descriptor under `deploy/<provider>/`. These two break that rule (their descriptors live in other repositories entirely), so the paragraph is corrected rather than left to quietly mislead.
- **Deleting a `deprecated` row runs close to a documented policy** - `docs/CHANNELS.md` says pending and deprecated rows are listed on purpose, not hidden, and `docs/DISTRIBUTION.md` warns that an earlier revision which conflated lifecycle with category produced a false coverage claim. The policy is kept: Flathub stays and remains the worked example in both docs, and no live count moves. The judgement is that Flathub answers a question users ask ("is it on Flathub?"), while a retired private fallback repo for a platform whose official listing is live answers none - it only makes CapRover look like two channels. Say the word if you would rather keep the row.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests
- [x] All existing tests pass

No executable lines change, so no new tests: the inventory is data and `docs/CHANNELS.md` is generated. The one unit test that reads the real inventory (the switchable-`ci_enabled` invariant) is unaffected - neither new channel is switchable, and `parseChannels` rejects the flag outside the closed set.

Validation performed:

- `bun run distribution:check` - both new channels resolve against their live sources and read **OK at 0.9.66**. Pre-existing DRIFT on the older PaaS templates (railway, dokploy, cosmos, kubero, fly-io, caprover-official) is untouched by this PR.
- `bun run distribution:matrix --check` - generated regions are fresh.
- Confirmed the Unraid CA listing page returns HTTP 200 and read the template XML directly for the port, mount, and variable claims in the docs, rather than trusting the listing page summary.
- Verified the extract regex yields a single agreeing version per source (Unraid XML: 1 match; Sealos template: 2 matches, both `0.9.66`), so neither pin can trip the ambiguous-pin rule.
- Full local gate: `format`, `lint` (0 errors), `typecheck`, `knip`, `test` (21 groups, 0 failures), `build`.

### Test Environment
- **LibreDB Studio Version**: 0.9.66
- **Browser**: n/a (docs and inventory only)
- **OS**: Linux 6.8.0
- **Node.js/Bun Version**: Node 24.14.0 / Bun
- **Database Type**: n/a

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

`README.md` is deliberately untouched. It already carries the Sealos deploy button (#296) but has no Unraid entry; adding one to the One-Click Deploy section is a separate, self-contained follow-up.

Two classification calls are worth confirming and are one-line reverts if you disagree: Unraid sits at tier 2 (we own the template repo) and its platform is `container` rather than `cloud`, since the user runs a Docker container on their own Unraid server. Flipping either only needs a `distribution:matrix` regeneration.
