### PR TITLE
fix: read a statement with its own dialect's grammar (#292, #293, #295, #297, #300, #298)

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ extraEnvFrom:
 | [Editor Docs](docs/editor/) | SQL editor internals — completion, performance, query optimization |
 | [Architecture](docs/ARCHITECTURE.md) | System architecture and design patterns |
 | [Adding a Provider](docs/ADDING_A_PROVIDER.md) | Step-by-step guide to adding a database, and how to tell whether it needs a driver at all |
+| [Backlog](docs/BACKLOG.md) | Known defects and deferred work that is not yet filed as an issue |
 
 ---
 

--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -672,6 +672,18 @@ The integration points, all of which need an entry. This is the list the Strateg
 - [ ] `src/lib/schema-diff/migration-generator.ts` — same shape, same hazard: the modified-column
       chain's trailing `else` is PostgreSQL DDL, so an unlisted id silently inherits it (#269). Give the
       dialect a branch, or list it in `NO_COLUMN_MODIFICATION` to emit an honest comment instead
+- [ ] `src/lib/sql/grammar.ts` — **two decisions, neither of which the compiler can force.** First,
+      whether your engine's query text is SQL at all (`NON_SQL_DIALECTS`): an id absent from that set is
+      declared to write SQL, and the confirmation gate then applies a SQL span reader to it — which for
+      a JSON or command-line grammar reports ordinary text as unreadable and prompts on every run (#297).
+      Second, the four grammar facts (`SQL_GRAMMARS`): `#`, `[…]`, whether block comments nest, and
+      whether `q'…'` is a literal. An id absent from that table reads under the compatibility default,
+      which is SQL Server's bracket reading and MySQL-ish everything else — fine where your engine
+      agrees, a lost row bound or a false prompt where it does not (that is what PostgreSQL's bracket
+      row cost before it was established). Establish each fact from your engine's own documentation or
+      its driver's tokenizer, never from a neighbouring dialect, and leave it at the default rather than
+      guess. `tests/unit/sql/grammar.test.ts` holds `Record<DatabaseType, …>` maps for both decisions,
+      so the compiler will at least stop you from *forgetting* that a decision exists
 
 **And the tests for every exhaustive map**, which are the real checklist — several are exhaustive
 *by construction* (`Record<DatabaseType, …>` in `db-ui-config`, `PICKER_COVERAGE` in the
@@ -681,7 +693,9 @@ connection-form test), so the compiler and those tests refuse to pass until each
 `tests/unit/lib/query-generators.test.ts`, `tests/unit/seed/types.test.ts`,
 `tests/hooks/use-connection-form.test.ts`,
 `tests/unit/schema-diff/migration-generator.test.ts` (`MODIFIED_COLUMN_COVERAGE` — classify the new id
-as having its own dialect branch or as unable to express a column modification).
+as having its own dialect branch or as unable to express a column modification),
+`tests/unit/sql/grammar.test.ts` (`GRAMMAR_COVERAGE` and `SQL_TEXT_COVERAGE` — record whether the id
+has an established grammar or reads at the default, and whether its query text is SQL).
 
 > **`git grep -l <the-previous-provider-type-id> -- src/ tests/` is the authoritative checklist.**
 > This list is maintained by hand and has been wrong before: it long claimed "no other files should

--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -432,7 +432,13 @@ control that only emits invalid input. That is the defect class
   therefore pairs the shared classification with `hasDataModifyingStatement()`, and it applies that
   screen **only** to the `"with"` case, because a statement leading with `SELECT` cannot carry such a
   CTE and screening it too would strip the button off anything that merely mentions `insert`. The
-  other five engines describe without running and need no screen.
+  other five engines describe without running and need no screen. `classifySelectPrefix()` takes an
+  optional grammar for the same reason: an explain run bypasses the confirmation dialog, so on the one
+  engine whose EXPLAIN executes, a comment read by the wrong dialect's rule is a write executed with no
+  prompt — `postgres-json.ts` therefore passes PostgreSQL's grammar (block comments nest there, and a
+  flat reading of `/* a /* b */ SELECT 1 */ DELETE …` reports `SELECT`; verified on 18, the rows were
+  deleted). If your engine's comment or quoting rules differ from the compatibility default, pass its
+  grammar too.
 - A capability can be absent because the **grammar** lacks it rather than because nobody implemented
   it, and the flag reads the same either way — so check, and then say so. Druid answers
   `CREATE TABLE t (id BIGINT)` with a syntax error, because `CREATE` is not one of its statements at

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -99,7 +99,9 @@ bracket row was established rather than left here: at the name reading, `ARRAY[[
 
 **Rows resting on documentation alone, worth re-checking against an artifact:** ClickHouse's `#` and
 bracket rows (HTTP-only provider, no driver package to read), MSSQL's block-comment nesting row
-(tedious ships no tokenizer), and the `nq'…'` spelling of Oracle's alternate quoting.
+(tedious ships no tokenizer), PostgreSQL's bracket and block-comment rows (`pg` is a wire-protocol
+driver and carries no SQL tokenizer, so both rest on the manual), and the `nq'…'` spelling of Oracle's
+alternate quoting.
 
 ### S7. A confirmation refinement that was considered and rejected
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,164 @@
+# Backlog — known defects and deferred work
+
+Work that is known, understood, and not yet scheduled. Every entry here was found while doing
+something else — a maintenance sweep, a review, a live probe — and was verified against the code at
+the time it was written down, but none of it has been filed as a GitHub issue.
+
+**How this file is used**
+
+- The GitHub issue tracker holds work that is filed, triaged, or in progress. This file holds
+  everything else: defects nobody has scheduled, deliberate deferrals, and open questions.
+- An entry states what is wrong, where, and what "done" looks like — enough for someone to pick it
+  up cold without re-deriving the finding.
+- **Delete an entry when the work lands.** A fixed item leaves this file; it does not get a
+  strikethrough or a DONE marker. Git history is the record of what was here.
+- Re-verify before acting. Line references and behaviour claims age, and some entries name a
+  reading of a database's grammar that ought to be checked against a first-party source again.
+- Promote an entry to a GitHub issue whenever it needs discussion, an outside reporter, or a
+  release note. This file is a holding area, not a competing tracker.
+
+---
+
+## SQL statement reading
+
+The readers under `src/lib/sql/` decide where a statement starts, where it ends, and what operates
+it. `src/lib/sql/grammar.ts` gave them a dialect (#292); these are what that channel does not yet
+cover.
+
+### S1. `statement-splitter.ts` is dialect-blind, and one shape yields a runnable bare `DROP`
+
+`src/lib/sql/statement-splitter.ts` runs its own span walk instead of `spans.ts`, so it disagrees
+with every other reader: a `;` inside a MySQL `#` comment, an Oracle `q'{a'b;c}'` body, a `[a;b]`
+name, or a backtick-quoted subscript key each split one statement into fragments.
+
+The sharp case: `/* a /* b */ ; DROP TABLE users; -- */ SELECT 1` splits into three fragments whose
+second is a bare, valid `DROP TABLE users` that the multi-statement route would run — while
+`isDangerousQuery` answers false, because the confirmation gate reads the whole editor text and
+never the fragments. Same family as #300, wider blast radius.
+
+Done when the splitter reads spans through the shared reader with the caller's dialect, and the
+confirmation gate and the splitter agree about what is going to run.
+
+### S2. Backslash escaping is not a grammar fact
+
+Whether `\` escapes inside a string literal differs by dialect (and, in MySQL, by session mode).
+Making it a row in `SqlGrammar` would narrow the false confirmation prompts introduced by #297 and
+would remove the MSSQL blunt decline in S4 entirely.
+
+Deliberately left out of maintainer-sweep-5: it retypes every literal in every dialect — a far wider
+behaviour change than any bar in that milestone asked for — and it would destroy the premise of two
+fixtures that milestone required (the "end cannot be cut because a literal is undeterminable" case
+and the "genuinely unresolvable text still has to ask" case). Those fixtures need replacing with
+shapes that stay unresolvable once `\` is understood.
+
+The single largest follow-up from that sweep.
+
+### S3. Comment and escape forms no reader models
+
+- **MySQL executable comments.** `/*!40000 DELETE FROM t */` is an ordinary comment to every reader
+  here, and MySQL executes it. Nothing asks before it runs.
+- **ClickHouse `//`.** Accepted as a line comment (live-verified), modelled nowhere, so
+  `// note\nDROP TABLE t` answers not-dangerous.
+- **MySQL connection charset.** On a `latin1` connection a leading U+00A0 executes.
+  `buildPoolConfig` passes a user's connection string straight to mysql2 as `uri`, so the charset is
+  outside the readers' view entirely.
+
+### S4. MSSQL: a parameterised page is still unrecognised
+
+`… OFFSET @skip ROWS` is not recognised as a page, so the statement collects a `TOP` and the server
+refuses it. This is a limitation of the shared probes' literal-count reading as much as of the
+provider. Verified by probe and documented in `docs/providers/mssql.md`.
+
+Related: the decline that keeps #293 safe keys on an unanchored `OFFSET`/`FETCH` mention wherever the
+cut was refused. The precise alternative — walk forward to where the unresolvable region starts — is
+only meaningful for a mention *before* the bad span, and costs a new shared-reader API.
+
+### S5. The limiter's whole-body probes still read inside comments
+
+`src/lib/db/utils/query-limiter.ts` runs its `ROWNUM` test, its `UNION` test and its subquery
+`SELECT` count over the whole statement text, so a statement that merely *mentions* a bound in an
+interior comment reads as already bounded. The statement's *type* stopped being fooled this way in
+maintainer-sweep-4/5; these flags did not.
+
+### S6. Grammar facts left undecided
+
+`grammar.ts` records a fact as established only when a first-party source was found for it, and
+writes `DEFAULT_SQL_GRAMMAR.<fact>` where it was not. Currently undecided:
+
+| Fact | Undecided for |
+|---|---|
+| `[…]` bracket reading | **mysql, postgres, oracle**, couchbase, druid, libredb |
+| `#` | couchbase, druid, libredb |
+| block-comment nesting | couchbase, druid, libredb |
+
+The cost is visible and pinned by fixtures, not hypothetical: on PostgreSQL a nested array
+constructor (`ARRAY[[1,2],[3,4]]`) and a jsonb key carrying a `]` (`j['a]b']`) lose their automatic
+row bound and, since #297, prompt for confirmation before running. Ordinary subscripts (`a[1]`,
+`ARRAY[1,2]`) are unaffected. Establishing PostgreSQL's bracket row from the manual is the smallest
+high-value item in this section.
+
+**Rows resting on documentation alone, worth re-checking against an artifact:** ClickHouse's `#` and
+bracket rows (HTTP-only provider, no driver package to read), MSSQL's block-comment nesting row
+(tedious ships no tokenizer), and the `nq'…'` spelling of Oracle's alternate quoting.
+
+### S7. A confirmation refinement that was considered and rejected
+
+Scanning an unreadable region for destructive vocabulary and asking only when a write could plausibly
+be in there. Sound on its face, but it substitutes a cleverer reading for the honesty rule #297
+pinned — the gate asks because it *cannot* read the text, not because it guessed what is in it. Only
+revisit this with an explicit product decision.
+
+---
+
+## Drivers and connections
+
+### D1. Fatal `error` events on the non-pooled clients were never audited
+
+#298 covered the pooled SQL drivers (`pg` in both the database and storage layers, `mssql`; mysql2
+and oracledb have no pool-level `error` event, and each `connect()` now records that). Whether the
+MongoDB, Redis, ClickHouse, Druid or Couchbase clients expose a fatal `error` event that can reach
+`uncaughtException` is an open question, not a claim.
+
+---
+
+## Value interpolation
+
+### V1. Four call sites escape by doubling quotes only
+
+`src/components/PivotTable.tsx`, `src/components/TestDataGenerator.tsx`, `src/components/Studio.tsx`
+and `src/components/DataImportModal.tsx` each build SQL by doubling quotes in a value, which a
+backslash-escaping dialect can still turn into SQL. The related inline-edit path
+(`src/hooks/use-inline-editing.ts`, a non-numeric primary-key value interpolated into `WHERE` with no
+escaping at all) is already covered by issue #290; these four are not.
+
+---
+
+## Tests
+
+### T1. Two disjuncts are pinned by almost nothing
+
+`isStatementText` (`src/lib/sql/statement-end.ts`) has a `dollar-string` disjunct pinned by exactly
+one assertion. That is the same
+hole that, for the `subscript` disjunct, let a statement-corrupting emission through the full gate,
+CI, 100% line coverage and five reviews — deleting the disjunct failed zero tests. Line coverage
+cannot see a missing disjunct in a one-line predicate; only a fixture where the two readings
+*disagree* can pin it.
+
+Done when deleting any single disjunct of `isStatementText` fails a test.
+
+### T2. `tests/unit/db/factory.test.ts` shares a `pg` mock with the storage provider
+
+The test mocks `pg` with a shared inert pool while the storage provider caches `Pool` in a
+module-level variable, so in a shared process the first initialize decides which mock every later one
+gets. Related to the `mock.module()` isolation rules in `docs/TOOLCHAIN.md`.
+
+---
+
+## Documentation
+
+### X1. Provider-doc line references are stale across the board
+
+`docs/providers/mssql.md` puts `getCapabilities()` at :57 and `getSchema()` at :369 where they are at
+391 and 749. The drift predates any recent milestone and the same line-anchoring style is used in
+every provider doc, so the fix is a convention change (anchor on symbol names, not line numbers) as
+much as a correction.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -87,15 +87,15 @@ writes `DEFAULT_SQL_GRAMMAR.<fact>` where it was not. Currently undecided:
 
 | Fact | Undecided for |
 |---|---|
-| `[…]` bracket reading | **mysql, postgres, oracle**, couchbase, druid, libredb |
+| `[…]` bracket reading | mysql, oracle, couchbase, druid, libredb |
 | `#` | couchbase, druid, libredb |
 | block-comment nesting | couchbase, druid, libredb |
 
-The cost is visible and pinned by fixtures, not hypothetical: on PostgreSQL a nested array
-constructor (`ARRAY[[1,2],[3,4]]`) and a jsonb key carrying a `]` (`j['a]b']`) lose their automatic
-row bound and, since #297, prompt for confirmation before running. Ordinary subscripts (`a[1]`,
-`ARRAY[1,2]`) are unaffected. Establishing PostgreSQL's bracket row from the manual is the smallest
-high-value item in this section.
+None of these currently costs everyday syntax anything — `[` carries no meaning in ordinary MySQL or
+Oracle SQL, and the three HTTP/embedded dialects were never probed for the other two facts. The cost
+of leaving one undecided is real when the dialect does use the syntax, which is why PostgreSQL's
+bracket row was established rather than left here: at the name reading, `ARRAY[[1,2],[3,4]]` and
+`j['a]b']` lost their bound and prompted for confirmation on an ordinary read.
 
 **Rows resting on documentation alone, worth re-checking against an artifact:** ClickHouse's `#` and
 bracket rows (HTTP-only provider, no driver package to read), MSSQL's block-comment nesting row
@@ -107,6 +107,19 @@ Scanning an unreadable region for destructive vocabulary and asking only when a 
 be in there. Sound on its face, but it substitutes a cleverer reading for the honesty rule #297
 pinned — the gate asks because it *cannot* read the text, not because it guessed what is in it. Only
 revisit this with an explicit product decision.
+
+---
+
+### S8. The confirmation gate's destructive vocabulary is SQL-only
+
+`isDangerousQuery` recognises SQL keywords, so it is close to inert for the two non-SQL types it is
+nevertheless asked about: a Redis `FLUSHALL` or `DEL key`, and a MongoDB `{"operation":"drop"}`, are
+destructive and match nothing. The span-based half of the gate no longer fires on their text at all
+(it is not SQL, so a SQL reader's verdict about it means nothing), which makes the keyword half the
+only thing left — and it does not speak their languages.
+
+Done when a destructive MongoDB operation and a destructive Redis command each ask before running,
+driven from the same single type-to-facts place rather than a type test in the component.
 
 ---
 

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -201,9 +201,19 @@ bun dev
 On the first API request, the PostgreSQL provider:
 
 1. **Creates a connection pool** — max 5 connections, 30s idle timeout
-2. **Creates the table** — `user_storage` table with the schema below via `CREATE TABLE IF NOT EXISTS`
+2. **Handles idle-client failures** — the pool gets an `error` listener immediately (see below)
+3. **Creates the table** — `user_storage` table with the schema below via `CREATE TABLE IF NOT EXISTS`
 
 The database itself must already exist. The **table** is auto-created, but the **database** is not.
+
+This pool is long-lived: once created it serves every storage request for the life of the process. A
+pooled client that fails while **idle** — the server dropped it, the network went away, the DBA
+restarted the database — has no query to reject, so `pg` destroys it and emits `error` on the pool.
+Node treats an `error` event with no listener as an uncaught exception, so the provider attaches one
+that logs through the storage logger (`provider=postgres`) and lets the pool open a fresh client on
+the next request. A dropped idle connection therefore costs one log line, never the server process.
+The PostgreSQL *database* provider carries the same guard for the same reason (see
+[providers/postgres.md](./providers/postgres.md#42-connection-pooling)).
 
 ### Required Privileges
 

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -154,13 +154,32 @@ id, so no reader can grow a dialect test of its own.
 | `#` | ordinary code — a jsonb/geometric operator, an identifier character, a temp-table name, a bind-variable prefix | PostgreSQL, Oracle, SQL Server, SQLite |
 | `q'…'` | a string literal (alternate quoting): the delimiter after the tag opens the body and its partner followed by `'` closes it, so the body carries apostrophes unescaped — `[ ] { } ( ) < >` pair up, any other character closes with itself, either letter case of the tag, and `nq'…'` is the same form for the national character set | Oracle only |
 | `q'…'` | not a form at all — a name followed by an ordinary string, which is what those characters are there | everything else, including the default |
+| `[…]` | a quoted **name**: everything between the brackets is the identifier (`SELECT [a--b] FROM t` selects a column called `a--b`) and the run does not nest. The doubled `]` this reading honours is SQL Server's escape — SQLite stops at the first `]` and has none, so `[a]]b]` reads as one name where SQLite reads `[a]` and then junk, which it rejects either way | SQL Server, SQLite |
+| `[…]` | an **array literal or subscript**: it nests (`[[1,2],[3,4]]`), nothing inside it is escaped, and a literal inside it is a literal (`m['a]b']`) | ClickHouse |
 
 Each row was established from an authoritative source: the engine's own documentation, or its
 driver's own tokenizer under `node_modules` (node-oracledb accepts `#` inside an identifier; the
-SQLite amalgamation classifies it as a bind-variable prefix). A rule that could **not** be
-established is not guessed from a neighbouring dialect — the dialect stays at the compatibility
-default below, and it is listed here rather than left implicit. Currently at the default: **Couchbase,
-Druid and the embedded LibreDB provider** (MongoDB and Redis never reach these readers).
+SQLite amalgamation classifies `#` as a bind-variable prefix and `[` as a "`[...]` style quoted id").
+A rule that could **not** be established is not guessed from a neighbouring dialect — the dialect stays
+at the compatibility default below, and it is listed here rather than left implicit. The default is per
+**fact**, not per dialect: a dialect whose `#` rule is known can still be undecided about its brackets.
+
+| Fact | Undecided, so left at the default | Established, and it happens to equal the default |
+|------|-----------------------------------|--------------------------------------------------|
+| `#` | Couchbase, Druid, the embedded LibreDB provider (MongoDB and Redis never reach these readers) | — |
+| `q'…'` | nobody | everything except Oracle: the form is Oracle's alone, so "not a literal" is the correct reading for the rest |
+| `[…]` | MySQL, PostgreSQL, Oracle, Couchbase, Druid, LibreDB | SQL Server and SQLite, whose rule the default already applied |
+
+The distinction is visible in `src/lib/sql/grammar.ts` too: an established fact is written out in that
+dialect's row, an undecided one is written `DEFAULT_SQL_GRAMMAR.<fact>`.
+
+The bracket row is the one where a default costs something: PostgreSQL subscripts arrays and jsonb with
+those characters, so a nested array or a subscript key containing a `]` loses its bound there, exactly as
+it did on ClickHouse before #295. It is left undecided because no first-party artifact for the subscript
+rule was established for those dialects and reading one engine's rule off another's is what this channel
+exists to stop. The direction is safe: a run the name reading cannot close is reported as
+undeterminable, and an undeterminable end is never cut, so the cost is an unbounded read and never a
+misplaced clause.
 
 **A call that names no dialect keeps today's reading**, and that is a decision with its own tests, not
 an accident: `#` opens a comment unless the next character makes a PostgreSQL operator (`#>`, `#>>`,
@@ -186,6 +205,9 @@ What changes for a caller that does name one:
 | `SELECT q'[it's a -- note )]' FROM dual` | Oracle | the `--` inside the literal read as a trailing comment, so the bound was inserted **inside** the literal and the statement was reported limited | the whole literal is the statement's text, bound appended after it |
 | `SELECT * FROM users # daily` | ClickHouse | not bounded | bound added before the comment |
 | `SELECT meta #> '{a}' FROM docs` | PostgreSQL | bounded (the default already read this correctly) | unchanged |
+| `WITH m['a]b'] AS v SELECT v` | ClickHouse | the `]` inside the key ended the bracketed run, the CTE element could not be crossed, not bounded | the subscript is one run, statement typed `SELECT`, bounded |
+| `SELECT [[1,2],[3,4]] AS a FROM t` | ClickHouse | the closing `]]` read as an escape, so the run never closed and the end was not cuttable, not bounded | the arrays nest, bound appended after them |
+| `SELECT [it's] FROM users` | SQL Server, SQLite | bounded (the name reading is these dialects' own) | unchanged, and now pinned as the dialect's answer rather than a shared default |
 
 ### Where the bound is placed
 
@@ -216,21 +238,22 @@ The same reading of the end answers "is this statement already bounded". The `LI
 
 Reading where a statement ends and **cutting** it there are separate answers, because they are not
 equally risky: a probe that stops early merely finds no bound, while a clause inserted early lands in
-the middle of the statement and the server rejects it outright. Two shapes are therefore read but not
-cut, and a statement carrying either is **returned untouched with `wasLimited: false`** — the second
+the middle of the statement and the server rejects it outright. Three shapes are therefore read but not
+cut, and a statement carrying one is **returned untouched with `wasLimited: false`** — the second
 branch of "never `true` alongside a bound the engine cannot see":
 
 | Shape | Why the cut is refused |
 |-------|------------------------|
 | An unterminated comment or literal, or a quote behind an odd backslash run (`… WHERE name = 'O\'Brien'`) | MySQL escapes with backslashes and PostgreSQL does not, so the two close the literal in different places; inserting on a guess puts the bound after the statement's own `;` |
 | A `#` run at the end of the statement (`SELECT * FROM #tmp`, `… WHERE ID# = 1`, `SELECT flags # 5`), **when no dialect was named** | `#` is a comment marker in MySQL and ClickHouse and ordinary code elsewhere — a T-SQL temp table, an Oracle identifier, a PostgreSQL XOR — and nothing in the *text* tells them apart (`#note` and `#tmp` are the same characters) |
+| A bracketed run that never closes — an unterminated name (`SELECT [abc`) or, under the subscript reading, an array short of a bracket (`SELECT [[1,2] AS a`) or one holding an unresolvable literal | a run cannot be more certain than what it contains; guessing where it ends puts the bound inside a name or a literal, which is the corrupted-statement shape rather than a missed bound |
 
-Both are a **deliberate loss of a bound**: appending after everything, as the limiter used to, was
+Each is a **deliberate loss of a bound**: appending after everything, as the limiter used to, was
 valid SQL for the dialect in which those characters are code, and is exactly what put the clause
 inside a trailing comment for the dialect in which they are not. Not bounding costs an over-large
 read the user can re-run, which is the trade every reader in `src/lib/sql/` makes.
 
-The second row applies to the **dialect-less** reading only. A caller that names its dialect has told
+The `#` row applies to the **dialect-less** reading only. A caller that names its dialect has told
 the two apart, so the refusal is lifted in whichever direction that dialect requires: MySQL and
 ClickHouse cut before the comment, PostgreSQL, Oracle, SQL Server and SQLite read the run as the
 statement's own text and cut after it. Every caller in this project names one, so the row describes

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -152,6 +152,8 @@ id, so no reader can grow a dialect test of its own.
 |-----------|--------------------|----------|
 | `#` | opens a line comment | MySQL, MariaDB, ClickHouse (which also has `#!`) |
 | `#` | ordinary code — a jsonb/geometric operator, an identifier character, a temp-table name, a bind-variable prefix | PostgreSQL, Oracle, SQL Server, SQLite |
+| `q'…'` | a string literal (alternate quoting): the delimiter after the tag opens the body and its partner followed by `'` closes it, so the body carries apostrophes unescaped — `[ ] { } ( ) < >` pair up, any other character closes with itself, either letter case of the tag, and `nq'…'` is the same form for the national character set | Oracle only |
+| `q'…'` | not a form at all — a name followed by an ordinary string, which is what those characters are there | everything else, including the default |
 
 Each row was established from an authoritative source: the engine's own documentation, or its
 driver's own tokenizer under `node_modules` (node-oracledb accepts `#` inside an identifier; the
@@ -162,9 +164,15 @@ Druid and the embedded LibreDB provider** (MongoDB and Redis never reach these r
 
 **A call that names no dialect keeps today's reading**, and that is a decision with its own tests, not
 an accident: `#` opens a comment unless the next character makes a PostgreSQL operator (`#>`, `#>>`,
-`#-`, `##`). It is neither of the honest readings — it is what this folder did for every engine before
-the channel existed, kept so that the fixtures written for #275, #280, #287, #291 and #294 keep
-asserting the behaviour they were written for.
+`#-`, `##`) — neither of the honest readings, but what this folder did for every engine before the
+channel existed, kept so that the fixtures written for #275, #280, #287, #291 and #294 keep asserting
+the behaviour they were written for. The default has no alternate-quoting form either, which is the
+same reading every non-Oracle dialect gets and the correct one for all of them.
+
+The alternate-quote tag has to **start** a word: Oracle's lexer reads a name greedily, so `freq'x'` is
+a name followed by an ordinary string there, and this reader answers the same. That makes the tag the
+one span in `src/lib/sql/spans.ts` whose reading depends on the character *before* it, so callers pass
+a whole statement (or a prefix of one), never a suffix.
 
 What changes for a caller that does name one:
 
@@ -174,6 +182,8 @@ What changes for a caller that does name one:
 | `SELECT * FROM t # LIMIT 10` | MySQL | the commented-out bound read as real, statement unbounded | bound added before the comment |
 | `SELECT * FROM #tmp` | SQL Server | end not cuttable, appending branch declines | `#tmp` is the statement's own text, the statement is bounded |
 | `SELECT * FROM EMP WHERE ID# = 1` | Oracle | not bounded | bounded |
+| `WITH t AS (SELECT q'{it's}' …) SELECT * FROM t` | Oracle | the apostrophe inside the literal opened a string, the CTE list could not be read, not bounded | the literal is a literal, statement typed `SELECT`, bounded |
+| `SELECT q'[it's a -- note )]' FROM dual` | Oracle | the `--` inside the literal read as a trailing comment, so the bound was inserted **inside** the literal and the statement was reported limited | the whole literal is the statement's text, bound appended after it |
 | `SELECT * FROM users # daily` | ClickHouse | not bounded | bound added before the comment |
 | `SELECT meta #> '{a}' FROM docs` | PostgreSQL | bounded (the default already read this correctly) | unchanged |
 

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -164,9 +164,14 @@ A rule that could **not** be established is not guessed from a neighbouring dial
 at the compatibility default below, and it is listed here rather than left implicit. The default is per
 **fact**, not per dialect: a dialect whose `#` rule is known can still be undecided about its brackets.
 
+The two non-SQL types, **MongoDB and Redis, are undecided about every fact** and are left out of the
+rows below to keep them readable: no SQL fact was established for either, their providers never reach
+these readers on the query path, and the confirmation gate — which reads whatever is in the editor —
+therefore reads their query text under the compatibility default (see the third accepted cost below).
+
 | Fact | Undecided, so left at the default | Established, and it happens to equal the default |
 |------|-----------------------------------|--------------------------------------------------|
-| `#` | Couchbase, Druid, the embedded LibreDB provider (MongoDB and Redis never reach these readers) | — |
+| `#` | Couchbase, Druid, the embedded LibreDB provider | — |
 | `q'…'` | nobody | everything except Oracle: the form is Oracle's alone, so "not a literal" is the correct reading for the rest |
 | `[…]` | MySQL, PostgreSQL, Oracle, Couchbase, Druid, LibreDB | SQL Server and SQLite, whose rule the default already applied |
 
@@ -179,7 +184,9 @@ it did on ClickHouse before #295. It is left undecided because no first-party ar
 rule was established for those dialects and reading one engine's rule off another's is what this channel
 exists to stop. The direction is safe: a run the name reading cannot close is reported as
 undeterminable, and an undeterminable end is never cut, so the cost is an unbounded read and never a
-misplaced clause.
+misplaced clause. The same undeterminable run is text the safety gate cannot read, so since #297 it
+also costs those statements a confirmation prompt — see
+[Text the reading cannot resolve asks, and says so](#text-the-reading-cannot-resolve-asks-and-says-so).
 
 **A call that names no dialect keeps today's reading**, and that is a decision with its own tests, not
 an accident: `#` opens a comment unless the next character makes a PostgreSQL operator (`#>`, `#>>`,
@@ -252,6 +259,12 @@ Each is a **deliberate loss of a bound**: appending after everything, as the lim
 valid SQL for the dialect in which those characters are code, and is exactly what put the clause
 inside a trailing comment for the dialect in which they are not. Not bounding costs an over-large
 read the user can re-run, which is the trade every reader in `src/lib/sql/` makes.
+
+Rows one and three cost one thing more since #297, because a run that never closes is also text the
+safety gate cannot read: such a statement asks for confirmation before it runs (see
+[Text the reading cannot resolve asks, and says so](#text-the-reading-cannot-resolve-asks-and-says-so)).
+The `#` row is the exception — a `#` line comment closed by the end of the input is terminated, so
+that shape loses its bound silently, as it always did.
 
 The `#` row applies to the **dialect-less** reading only. A caller that names its dialect has told
 the two apart, so the refusal is lifted in whichever direction that dialect requires: MySQL and
@@ -339,6 +352,7 @@ same reading the auto-limiter uses, so the two cannot disagree about where a sta
 | Any of those behind a comment (`-- note`, `/* note */`, MySQL's `# note`, several stacked) | Yes |
 | A `WITH` whose CTE list precedes one (`WITH x AS (…) DELETE FROM …`) | Yes |
 | A `WITH` whose CTE list *contains* an `UPDATE … SET` (PostgreSQL's data-modifying CTE) | Yes |
+| A statement carrying a run the reader cannot resolve (`SELECT '\';` and anything after it, an unterminated comment, literal, name or array) | Yes, and the dialog says why |
 | `SELECT`, including one naming a destructive keyword in a string or a comment | No |
 
 The reading is done under the **active connection's dialect** on both execution paths, because what
@@ -364,23 +378,69 @@ from a statement that really does write. It reads the statement's **code** rathe
 (`src/lib/sql/words.ts`), so unlike the pattern before it, a read that merely quotes
 `'UPDATE t SET x = 1'` or mentions it in a comment no longer prompts.
 
+### Text the reading cannot resolve asks, and says so
+
+Every other reader in `src/lib/sql/` errs toward **not acting** on text it cannot resolve, because
+its mistake would be a row bound appended to a write — a partial commit (#287). This gate's costs
+run the other way: a false prompt costs one click, silence costs an unconfirmed destructive
+statement. So a statement carrying a run that never closes prompts (#297), and the dialog leads with
+a distinct notice — *"Part of this statement could not be read"* — explaining that a quoted, commented
+or bracketed run never closes, that nothing after that point could be checked, and that this is why it
+is asking. The notice stays visible beside the AI risk verdict, including a verdict of *Safe*: that
+analysis was produced from text whose reading stopped early, so it may not describe what the
+statement does.
+
+`SELECT '\';` followed by a write is the shape the issue was filed about — `'\'` closes the string
+under PostgreSQL's `standard_conforming_strings` and continues it under MySQL's default, so
+`src/lib/sql/spans.ts` reports it as undeterminable rather than guessing, and everything after it
+was invisible to the reading. It now asks instead of executing.
+
+The accepted cost, pinned by tests rather than left to be discovered, in three classes:
+
+- **A closing quote behind an odd backslash run** is reported undeterminable whatever the dialect, and
+  this is the most frequent prompt the rule buys: it covers a literal ending in a backslash (a Windows
+  path) *and* `\'` as an escaped apostrophe — which is MySQL's own escape, so an everyday MySQL read
+  such as `… WHERE name = 'O\'Brien'` asks on every execute. Naming the dialect does not narrow this
+  one, because whether `\` escapes is deliberately not a fact the grammar record carries yet (fixtures
+  across this milestone rest on the undeterminable reading). What does *not* happen is a prompt
+  for a statement that merely contains a backslash — `SELECT 'a\nb' FROM t`, `… LIKE 'a\_b'` and
+  `'C:\\Users\\me'` all resolve and run without one.
+- **A bracketed run a dialect at the default bracket reading cannot close.** `[…]` is read as SQL
+  Server's quoted name for every dialect but ClickHouse (#295 established the subscript rule there
+  only), so a PostgreSQL nested array (`SELECT ARRAY[[1,2],[3,4]] AS a FROM t`), a nested subscript
+  (`t.data[idx[0]]`) and a subscript key carrying a `]` (`j['a]b']`) are unresolvable and ask, even
+  though they only read. Ordinary `a[1]` and `ARRAY[1,2]` resolve and do not. This is the second half
+  of a cost the limiter already paid as a lost bound — see
+  [docs/providers/postgres.md](../providers/postgres.md).
+- **Non-SQL query text.** Both execution paths ask about whatever is in the editor, so a MongoDB
+  document or a Redis command whose escaped quote this SQL span reader cannot resolve
+  (`{"filter":{"msg":"say \"hi\""}}`) prompts too, and the notice says the statement could not be
+  fully read — true, though the grammar it was read under is not the one the text is written in.
+
+Naming the dialect narrows the second class — ClickHouse's `[[1,2],[3,4]]` is a closed run under its
+own grammar (#295) and unresolvable only to a reader without it — and it lifts a form the default
+cannot read at all: Oracle's `q'{it's}'` (#292). It does nothing for the first class, per that
+bullet.
+
 Three gaps are known and pinned by tests rather than claimed closed:
 
 - **Only `UPDATE … SET` is looked for inside a read.** A write hidden in a CTE *body* under any
   other keyword (`WITH gone AS (DELETE FROM t RETURNING *) SELECT * FROM gone`) does not prompt.
   Widening the probe to `DELETE`/`INSERT`/`MERGE` would also make every read whose code names one
   of them prompt, so the asymmetry is inherited from the vocabulary above rather than chosen here.
-- **A statement whose shape cannot be read at all** — an unclosed CTE list, or an undeterminable
-  literal such as `'\'`, which closes the string in PostgreSQL and not in MySQL — hides what
-  follows it. The text is a syntax error under at least one dialect, so the server rejects it
-  either way. This is also the one place the reading NARROWED: the text-scanning probe it replaced
-  found an `UPDATE … SET` written after such a literal, so `SELECT '\';` followed by a write
-  prompted before and does not now. Whether unresolvable text should ask instead is tracked as
-  #297, and the dialect-aware reading #292 asks for would settle where the literal ends.
+- **A statement whose shape cannot be TYPED** — an unclosed CTE list such as
+  `WITH t AS (DELETE FROM x` — does not prompt. This is the boundary of the rule above rather than
+  an exception to it: every character was read, and what they spell is an incomplete statement
+  rather than a run hiding what is written inside it. No dialect accepts the text, so the server
+  rejects it; and the keyword inside the unclosed list is a CTE-body write, which the gap above
+  already does not prompt for even when the list closes. Pinned by
+  `tests/components/QuerySafetyDialog.test.tsx` ("does not prompt when the statement's shape cannot
+  be typed") so the boundary stays a decision — the shipped rule keys on unresolvable *runs*, and
+  widening it to every statement the reader cannot type would prompt for an empty editor.
 - **A multi-statement script is read as one statement.** `SELECT 1; DROP TABLE users` does not
   prompt (its first keyword is the `SELECT`), while `SELECT 1; UPDATE t SET x = 1` does, because
   the unanchored probe finds it. Executing the destructive statement on its own prompts, as long
-  as that statement's own shape can be read — the gap above is the exception.
+  as that statement's own shape can be typed — the gap above is the exception.
 
 Four runs bypass the gate on purpose, all on the standalone path
 (`src/hooks/use-query-execution.ts`): an EXPLAIN run (see below), a Load-More page of a result the

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -156,6 +156,8 @@ id, so no reader can grow a dialect test of its own.
 | `q'…'` | not a form at all — a name followed by an ordinary string, which is what those characters are there | everything else, including the default |
 | `[…]` | a quoted **name**: everything between the brackets is the identifier (`SELECT [a--b] FROM t` selects a column called `a--b`) and the run does not nest. The doubled `]` this reading honours is SQL Server's escape — SQLite stops at the first `]` and has none, so `[a]]b]` reads as one name where SQLite reads `[a]` and then junk, which it rejects either way | SQL Server, SQLite |
 | `[…]` | an **array literal or subscript**: it nests (`[[1,2],[3,4]]`), nothing inside it is escaped, and a literal inside it is a literal (`m['a]b']`) | ClickHouse |
+| `/* … /* … */ … */` | one **nesting** comment: a `/*` inside a comment opens another and the run continues until the depth returns to zero, so a region that already contains comments can be commented out. A run short of a closer is undeterminable rather than closed early | PostgreSQL, SQL Server, ClickHouse |
+| `/* … /* … */ … */` | a **flat** comment: the first `*/` ends it, and everything after that is the statement's own code | MySQL, MariaDB, SQLite, Oracle, and the default |
 
 Each row was established from an authoritative source: the engine's own documentation, or its
 driver's own tokenizer under `node_modules` (node-oracledb accepts `#` inside an identifier; the
@@ -174,6 +176,7 @@ therefore reads their query text under the compatibility default (see the third 
 | `#` | Couchbase, Druid, the embedded LibreDB provider | — |
 | `q'…'` | nobody | everything except Oracle: the form is Oracle's alone, so "not a literal" is the correct reading for the rest |
 | `[…]` | MySQL, PostgreSQL, Oracle, Couchbase, Druid, LibreDB | SQL Server and SQLite, whose rule the default already applied |
+| `/* … */` nesting | Couchbase, Druid, LibreDB | MySQL, SQLite and Oracle, whose flat rule the default already applied — each established from its own source rather than assumed to agree |
 
 The distinction is visible in `src/lib/sql/grammar.ts` too: an established fact is written out in that
 dialect's row, an undecided one is written `DEFAULT_SQL_GRAMMAR.<fact>`.
@@ -192,8 +195,17 @@ also costs those statements a confirmation prompt — see
 an accident: `#` opens a comment unless the next character makes a PostgreSQL operator (`#>`, `#>>`,
 `#-`, `##`) — neither of the honest readings, but what this folder did for every engine before the
 channel existed, kept so that the fixtures written for #275, #280, #287, #291 and #294 keep asserting
-the behaviour they were written for. The default has no alternate-quoting form either, which is the
+the behaviour they were written for. Block comments do not nest under the default for the same reason.
+The default has no alternate-quoting form either, which is the
 same reading every non-Oracle dialect gets and the correct one for all of them.
+
+One reading is deliberately **not** the dialect's, and it is the only such override in this folder:
+`#` in a statement's **leading** trivia is skipped as a comment on every dialect
+(`src/lib/sql/leading-keyword.ts`). No dialect here can *open* a statement with `#` — `#tmp`, `#>` and
+`ID#` are all mid-statement forms — so skipping the run only ever changes which syntax error the
+server reports, while reading it as code would take the bound back off a `# note`-led SELECT on
+PostgreSQL and SQL Server. Every other fact that reader consults, including where a block comment
+ends, is the dialect's own.
 
 The alternate-quote tag has to **start** a word: Oracle's lexer reads a name greedily, so `freq'x'` is
 a name followed by an ordinary string there, and this reader answers the same. That makes the tag the
@@ -215,6 +227,10 @@ What changes for a caller that does name one:
 | `WITH m['a]b'] AS v SELECT v` | ClickHouse | the `]` inside the key ended the bracketed run, the CTE element could not be crossed, not bounded | the subscript is one run, statement typed `SELECT`, bounded |
 | `SELECT [[1,2],[3,4]] AS a FROM t` | ClickHouse | the closing `]]` read as an escape, so the run never closed and the end was not cuttable, not bounded | the arrays nest, bound appended after them |
 | `SELECT [it's] FROM users` | SQL Server, SQLite | bounded (the name reading is these dialects' own) | unchanged, and now pinned as the dialect's answer rather than a shared default |
+| `WITH t AS (` + `/* a /* b */ ) SELECT 1 */` + `… ) INSERT INTO …` | PostgreSQL, ClickHouse | the comment closed at the inner `*/`, so the `)` after it ended the CTE body and the statement typed `SELECT` — a bound appended to an INSERT | the whole comment is a comment, the statement is typed `INSERT`, not bounded |
+| `/* a /* b */ x */ SELECT id FROM logs` | PostgreSQL, SQL Server, ClickHouse | the word after the inner `*/` typed the statement, so it was not bounded | typed `SELECT`, bounded, comment emitted intact |
+| `SELECT /* a /* b */ DISTINCT */ name FROM t` | SQL Server | `TOP` spliced after a `DISTINCT` that is inside the comment — i.e. inside the comment, so the statement ran unbounded while reporting a limit | `TOP` spliced before the comment |
+| `/* a /* b */ SELECT id FROM logs` | PostgreSQL, SQL Server, ClickHouse | the comment closed at its only `*/` and the statement read as an ordinary SELECT | the comment never closes, so the text is undeterminable: not bounded, and the safety gate asks |
 
 ### Where the bound is placed
 
@@ -252,6 +268,7 @@ branch of "never `true` alongside a bound the engine cannot see":
 | Shape | Why the cut is refused |
 |-------|------------------------|
 | An unterminated comment or literal, or a quote behind an odd backslash run (`… WHERE name = 'O\'Brien'`) | MySQL escapes with backslashes and PostgreSQL does not, so the two close the literal in different places; inserting on a guess puts the bound after the statement's own `;` |
+| On a dialect that **nests** block comments, a comment carrying one opener too many (`/* a /* b */ SELECT 1`) | the run never returns to depth zero, so it is an unterminated comment there — the same refusal as the row above, reached by a rule that is the dialect's own (#300) |
 | A `#` run at the end of the statement (`SELECT * FROM #tmp`, `… WHERE ID# = 1`, `SELECT flags # 5`), **when no dialect was named** | `#` is a comment marker in MySQL and ClickHouse and ordinary code elsewhere — a T-SQL temp table, an Oracle identifier, a PostgreSQL XOR — and nothing in the *text* tells them apart (`#note` and `#tmp` are the same characters) |
 | A bracketed run that never closes — an unterminated name (`SELECT [abc`) or, under the subscript reading, an array short of a bracket (`SELECT [[1,2] AS a`) or one holding an unresolvable literal | a run cannot be more certain than what it contains; guessing where it ends puts the bound inside a name or a literal, which is the corrupted-statement shape rather than a missed bound |
 
@@ -353,6 +370,8 @@ same reading the auto-limiter uses, so the two cannot disagree about where a sta
 | A `WITH` whose CTE list precedes one (`WITH x AS (…) DELETE FROM …`) | Yes |
 | A `WITH` whose CTE list *contains* an `UPDATE … SET` (PostgreSQL's data-modifying CTE) | Yes |
 | A statement carrying a run the reader cannot resolve (`SELECT '\';` and anything after it, an unterminated comment, literal, name or array) | Yes, and the dialog says why |
+| Any of those behind a **nested** comment (`/* a /* b */ c */ DROP TABLE users`), on a dialect that nests — PostgreSQL, SQL Server, ClickHouse | Yes: the comment is read whole, so the statement's own keyword is the one that answers |
+| The same text on a dialect that does **not** nest — MySQL, MariaDB, SQLite, Oracle | No, because there the comment closed at the first `*/` and what follows it is text the engine rejects outright |
 | `SELECT`, including one naming a destructive keyword in a string or a comment | No |
 
 The reading is done under the **active connection's dialect** on both execution paths, because what
@@ -416,6 +435,14 @@ The accepted cost, pinned by tests rather than left to be discovered, in three c
   document or a Redis command whose escaped quote this SQL span reader cannot resolve
   (`{"filter":{"msg":"say \"hi\""}}`) prompts too, and the notice says the statement could not be
   fully read — true, though the grammar it was read under is not the one the text is written in.
+
+A fourth class arrives with the nesting fact (#300), and it is the reverse of the ones above — a prompt
+the dialect *adds* rather than one it narrows: on PostgreSQL, SQL Server and ClickHouse a block comment
+carrying one opener too many (`/* a /* b */ SELECT 1`) never closes, so an ordinary read written that
+way asks before it runs. That is the fail-safe direction on those engines, where the same text is
+either an unterminated comment (so the server rejects it) or a comment hiding a statement nobody can
+see; the flat reading of it — comment closed, `SELECT 1` executed — is what a dialect-less caller and
+the flat dialects still get.
 
 Naming the dialect narrows the second class — ClickHouse's `[[1,2],[3,4]]` is a closed run under its
 own grammar (#295) and unresolvable only to a reader without it — and it lifts a form the default
@@ -571,6 +598,18 @@ EXPLAIN is built for SELECT statements only. Clicking **Explain** with anything 
 (`UPDATE`, `INSERT`, DDL, …) executes nothing and reports "Only SELECT statements can
 be explained" — an explain run never falls back to running the original statement,
 because it deliberately bypasses the dangerous-query confirmation dialog.
+
+Because it bypasses that dialog, the classification is the *only* screen on this path, and on
+PostgreSQL the wrapper is `EXPLAIN (ANALYZE, …)` — which **runs** what it explains. So the PostgreSQL
+and ClickHouse strategies read the statement under their own dialect's grammar rather than the shared
+default (#300): block comments nest in both, and a flat reading of
+`/* a /* b */ SELECT 1 */ DELETE FROM users` reports `SELECT` as the leading keyword while PostgreSQL
+reads the whole run as one comment and executes the `DELETE`. Verified on PostgreSQL 18: explaining
+that statement against a three-row table left zero rows. Under PostgreSQL's grammar the statement
+leads with `DELETE`, so nothing is built and the button reports that it cannot be explained. The other
+four strategies stay dialect-blind: their engines' comment rules are the flat one the default already
+applies (MySQL, SQLite) or were never established (Druid, Couchbase), and their EXPLAIN describes
+without running, so the worst a misread comment costs there is a refused button.
 
 ### How It Works
 

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -135,6 +135,48 @@ not a name, or an `AS` with no body after it — is re-read as an expression tha
 supported dialect accepts such text, so what the server receives is a rejected statement either way
 rather than a partly limited write.
 
+### Which dialect the readers are reading
+
+Every reader above answers from characters alone, and a few characters mean different things in
+different engines. Where they do, a reader with no dialect has to take one engine's side, and the
+wrong side moves where a construct ends — a `)` that closes a CTE body, a comment that hides a bound,
+the keyword that types the statement.
+
+The dialect was always available at the callers: every provider knows its own `type`, the
+multi-statement route resolves its provider before it asks, and both client-side execution paths hold
+the active connection. It is now passed down (`src/lib/sql/grammar.ts`), and **exactly one place**
+maps a database type to grammar facts — the readers receive the resolved record and never see a type
+id, so no reader can grow a dialect test of its own.
+
+| Character | Established reading | Dialects |
+|-----------|--------------------|----------|
+| `#` | opens a line comment | MySQL, MariaDB, ClickHouse (which also has `#!`) |
+| `#` | ordinary code — a jsonb/geometric operator, an identifier character, a temp-table name, a bind-variable prefix | PostgreSQL, Oracle, SQL Server, SQLite |
+
+Each row was established from an authoritative source: the engine's own documentation, or its
+driver's own tokenizer under `node_modules` (node-oracledb accepts `#` inside an identifier; the
+SQLite amalgamation classifies it as a bind-variable prefix). A rule that could **not** be
+established is not guessed from a neighbouring dialect — the dialect stays at the compatibility
+default below, and it is listed here rather than left implicit. Currently at the default: **Couchbase,
+Druid and the embedded LibreDB provider** (MongoDB and Redis never reach these readers).
+
+**A call that names no dialect keeps today's reading**, and that is a decision with its own tests, not
+an accident: `#` opens a comment unless the next character makes a PostgreSQL operator (`#>`, `#>>`,
+`#-`, `##`). It is neither of the honest readings — it is what this folder did for every engine before
+the channel existed, kept so that the fixtures written for #275, #280, #287, #291 and #294 keep
+asserting the behaviour they were written for.
+
+What changes for a caller that does name one:
+
+| Statement | Dialect | Before | Now |
+|-----------|---------|--------|-----|
+| `WITH t AS (` + `#- note )` + `SELECT 1) DELETE FROM users` | MySQL | typed `SELECT`, bound appended to a `DELETE` | typed `DELETE`, not bounded |
+| `SELECT * FROM t # LIMIT 10` | MySQL | the commented-out bound read as real, statement unbounded | bound added before the comment |
+| `SELECT * FROM #tmp` | SQL Server | end not cuttable, appending branch declines | `#tmp` is the statement's own text, the statement is bounded |
+| `SELECT * FROM EMP WHERE ID# = 1` | Oracle | not bounded | bounded |
+| `SELECT * FROM users # daily` | ClickHouse | not bounded | bound added before the comment |
+| `SELECT meta #> '{a}' FROM docs` | PostgreSQL | bounded (the default already read this correctly) | unchanged |
+
 ### Where the bound is placed
 
 The clause is inserted **between the statement and its trailing trivia** — whitespace, comments and
@@ -171,23 +213,29 @@ branch of "never `true` alongside a bound the engine cannot see":
 | Shape | Why the cut is refused |
 |-------|------------------------|
 | An unterminated comment or literal, or a quote behind an odd backslash run (`… WHERE name = 'O\'Brien'`) | MySQL escapes with backslashes and PostgreSQL does not, so the two close the literal in different places; inserting on a guess puts the bound after the statement's own `;` |
-| A `#` run at the end of the statement (`SELECT * FROM #tmp`, `… WHERE ID# = 1`, `SELECT flags # 5`) | `#` is MySQL's second comment marker and ordinary code elsewhere — a T-SQL temp table, an Oracle identifier, a PostgreSQL XOR — and nothing in the text tells them apart (`#note` and `#tmp` are the same characters) |
+| A `#` run at the end of the statement (`SELECT * FROM #tmp`, `… WHERE ID# = 1`, `SELECT flags # 5`), **when no dialect was named** | `#` is a comment marker in MySQL and ClickHouse and ordinary code elsewhere — a T-SQL temp table, an Oracle identifier, a PostgreSQL XOR — and nothing in the *text* tells them apart (`#note` and `#tmp` are the same characters) |
 
 Both are a **deliberate loss of a bound**: appending after everything, as the limiter used to, was
 valid SQL for the dialect in which those characters are code, and is exactly what put the clause
 inside a trailing comment for the dialect in which they are not. Not bounding costs an over-large
 read the user can re-run, which is the trade every reader in `src/lib/sql/` makes.
 
+The second row applies to the **dialect-less** reading only. A caller that names its dialect has told
+the two apart, so the refusal is lifted in whichever direction that dialect requires: MySQL and
+ClickHouse cut before the comment, PostgreSQL, Oracle, SQL Server and SQLite read the run as the
+statement's own text and cut after it. Every caller in this project names one, so the row describes
+the compatibility default rather than everyday behaviour.
+
 A `#` comment with code after it on a later line is unaffected. Where the cut is refused, the
 statement's *text* is still read to its very end (trailing whitespace and `;` aside), so a bound
 written after a `#` is still found and never doubled — which is also why MSSQL's `TOP` splice, writing
-into the head, keeps bounding `SELECT * FROM #tmp` while leaving a temp-table page that already
-carries a `FETCH NEXT` alone. That last part is not airtight: trailing trivia written *after* such a
-bound hides it from the end-anchored probe, so the `TOP` is spliced anyway — unchanged from before
-this section existed, and noted here rather than claimed closed. The
-one shape that stays wrong is a bound commented out with `#` (`… # LIMIT 10`): it is still read as
-real, so that statement is left alone instead of being bounded. The `--` form, which is unambiguous,
-is fixed.
+into the head, keeps bounding `SELECT * FROM #tmp` even without a dialect. Under the dialect-less
+reading that is not airtight — trailing trivia written *after* an existing bound hides it from the
+end-anchored probe, so a `TOP` is spliced alongside an `OFFSET … FETCH` that SQL Server rejects — and
+naming the dialect is what closes it: `#` is never a comment in T-SQL, so the probe sees the bound
+that is there. Likewise the one shape that stays wrong without a dialect, a bound commented out with
+`#` (`… # LIMIT 10`), is read correctly under MySQL's grammar: the commented-out clause is not a
+clause, and a real bound is added before it.
 
 Providers that append a clause of their own follow the same rule: Oracle's `FETCH FIRST` and
 `OFFSET … FETCH NEXT`, and MSSQL's `OFFSET … FETCH NEXT` pagination branch. MSSQL's `SELECT TOP n`
@@ -208,7 +256,14 @@ not a pattern belonging to the route. It used to be `/^\s*SELECT\b/i`, which tol
 not a comment — and the splitter keeps each statement's leading comments — so a final `SELECT` behind a
 `-- note` was not recognised and reached the engine unbounded, the one place the comment-tolerant
 classifier had not been adopted (#281). The CTE typing applies here too: a final read-only CTE is
-bounded, a final data-modifying one is not.
+bounded, a final data-modifying one is not. The route resolves its connection before it asks, so the
+reading is done under **that connection's dialect** and this route and the provider that runs the
+statement cannot disagree about what the statement is.
+
+The splitter itself is a separate, still dialect-blind scan: it inlines its own span walk and reads
+`#` as ordinary code, so a MySQL hash comment carrying a `;` still splits a statement there. Changing
+that moves statement boundaries, which is its own change with its own tests — recorded here rather
+than folded in.
 
 Last-only is that route's own policy, and it leaves a hole this section does not close: a non-final
 `SELECT` runs exactly as written, and its **entire** result set travels back in `statements[i].rows`.
@@ -236,6 +291,14 @@ same reading the auto-limiter uses, so the two cannot disagree about where a sta
 | A `WITH` whose CTE list precedes one (`WITH x AS (…) DELETE FROM …`) | Yes |
 | A `WITH` whose CTE list *contains* an `UPDATE … SET` (PostgreSQL's data-modifying CTE) | Yes |
 | `SELECT`, including one naming a destructive keyword in a string or a comment | No |
+
+The reading is done under the **active connection's dialect** on both execution paths, because what
+counts as a comment decides what the statement says. On MySQL, a `#` comment inside a CTE list used to
+hide the `)` that closes it, so the reader answered with the `SELECT` inside the comment's reach and
+the `DELETE` after the list ran with no confirmation at all; under MySQL's grammar the comment is a
+comment and the `DELETE` is seen. The other direction matters as much: `SELECT 1 # UPDATE t SET x = 1`
+is a commented-out note on MySQL — prompting there would be a false alarm — and is the statement's own
+code on PostgreSQL, where those characters are an operator.
 
 The statement's own keyword is read with `src/lib/sql/operative-keyword.ts` and tested against a
 keyword set. It used to be re-derived here as six anchored patterns (`/^\s*DROP\b/i`, …), which

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -155,7 +155,7 @@ id, so no reader can grow a dialect test of its own.
 | `q'…'` | a string literal (alternate quoting): the delimiter after the tag opens the body and its partner followed by `'` closes it, so the body carries apostrophes unescaped — `[ ] { } ( ) < >` pair up, any other character closes with itself, either letter case of the tag, and `nq'…'` is the same form for the national character set | Oracle only |
 | `q'…'` | not a form at all — a name followed by an ordinary string, which is what those characters are there | everything else, including the default |
 | `[…]` | a quoted **name**: everything between the brackets is the identifier (`SELECT [a--b] FROM t` selects a column called `a--b`) and the run does not nest. The doubled `]` this reading honours is SQL Server's escape — SQLite stops at the first `]` and has none, so `[a]]b]` reads as one name where SQLite reads `[a]` and then junk, which it rejects either way | SQL Server, SQLite |
-| `[…]` | an **array literal or subscript**: it nests (`[[1,2],[3,4]]`), nothing inside it is escaped, and a literal inside it is a literal (`m['a]b']`) | ClickHouse |
+| `[…]` | an **array literal or subscript**: it nests (`[[1,2],[3,4]]`), nothing inside it is escaped, and a literal inside it is a literal (`m['a]b']`) | ClickHouse, PostgreSQL |
 | `/* … /* … */ … */` | one **nesting** comment: a `/*` inside a comment opens another and the run continues until the depth returns to zero, so a region that already contains comments can be commented out. A run short of a closer is undeterminable rather than closed early | PostgreSQL, SQL Server, ClickHouse |
 | `/* … /* … */ … */` | a **flat** comment: the first `*/` ends it, and everything after that is the statement's own code | MySQL, MariaDB, SQLite, Oracle, and the default |
 
@@ -166,29 +166,33 @@ A rule that could **not** be established is not guessed from a neighbouring dial
 at the compatibility default below, and it is listed here rather than left implicit. The default is per
 **fact**, not per dialect: a dialect whose `#` rule is known can still be undecided about its brackets.
 
-The two non-SQL types, **MongoDB and Redis, are undecided about every fact** and are left out of the
-rows below to keep them readable: no SQL fact was established for either, their providers never reach
-these readers on the query path, and the confirmation gate — which reads whatever is in the editor —
-therefore reads their query text under the compatibility default (see the third accepted cost below).
+The two non-SQL types, **MongoDB and Redis, have no SQL grammar at all** and are left out of the rows
+below: their providers never reach these readers on the query path, and the confirmation gate — which
+reads whatever is in the editor — asks `readsSqlText()` before applying any span-based rule to their
+text, so a JSON document or a Redis command is not judged by a SQL reader that cannot parse it. The
+gate's keyword tests still run on that text.
 
 | Fact | Undecided, so left at the default | Established, and it happens to equal the default |
 |------|-----------------------------------|--------------------------------------------------|
 | `#` | Couchbase, Druid, the embedded LibreDB provider | — |
 | `q'…'` | nobody | everything except Oracle: the form is Oracle's alone, so "not a literal" is the correct reading for the rest |
-| `[…]` | MySQL, PostgreSQL, Oracle, Couchbase, Druid, LibreDB | SQL Server and SQLite, whose rule the default already applied |
+| `[…]` | MySQL, Oracle, Couchbase, Druid, LibreDB | SQL Server and SQLite, whose rule the default already applied |
 | `/* … */` nesting | Couchbase, Druid, LibreDB | MySQL, SQLite and Oracle, whose flat rule the default already applied — each established from its own source rather than assumed to agree |
 
 The distinction is visible in `src/lib/sql/grammar.ts` too: an established fact is written out in that
 dialect's row, an undecided one is written `DEFAULT_SQL_GRAMMAR.<fact>`.
 
-The bracket row is the one where a default costs something: PostgreSQL subscripts arrays and jsonb with
-those characters, so a nested array or a subscript key containing a `]` loses its bound there, exactly as
-it did on ClickHouse before #295. It is left undecided because no first-party artifact for the subscript
-rule was established for those dialects and reading one engine's rule off another's is what this channel
-exists to stop. The direction is safe: a run the name reading cannot close is reported as
-undeterminable, and an undeterminable end is never cut, so the cost is an unbounded read and never a
-misplaced clause. The same undeterminable run is text the safety gate cannot read, so since #297 it
-also costs those statements a confirmation prompt — see
+The bracket row is the one where a default costs something, and PostgreSQL is why it is worth
+establishing rather than accepting: left at the name reading, a nested array or a subscript key
+containing a `]` lost its bound there — and, since #297, also asked for confirmation, because the same
+undeterminable run is text the safety gate cannot read. A prompt on everyday syntax teaches operators
+to click the gate away, which costs more than the missed bound, so the rule was established from the
+manual (4.2.3 Subscripts, 4.2.12 Array Constructors). MySQL and Oracle stay undecided: `[` is not a
+name quote in either, but neither has a subscript rule to read it under instead, and reading one
+engine's rule off another's is what this channel exists to stop. The direction there is safe — a run
+the name reading cannot close is reported as undeterminable, an undeterminable end is never cut, so
+the cost is an unbounded read and never a misplaced clause — and those two dialects do not write
+bracket runs in everyday SQL. See
 [Text the reading cannot resolve asks, and says so](#text-the-reading-cannot-resolve-asks-and-says-so).
 
 **A call that names no dialect keeps today's reading**, and that is a decision with its own tests, not
@@ -414,7 +418,7 @@ under PostgreSQL's `standard_conforming_strings` and continues it under MySQL's 
 `src/lib/sql/spans.ts` reports it as undeterminable rather than guessing, and everything after it
 was invisible to the reading. It now asks instead of executing.
 
-The accepted cost, pinned by tests rather than left to be discovered, in three classes:
+The accepted cost, pinned by tests rather than left to be discovered, in two classes:
 
 - **A closing quote behind an odd backslash run** is reported undeterminable whatever the dialect, and
   this is the most frequent prompt the rule buys: it covers a literal ending in a backslash (a Windows
@@ -425,16 +429,20 @@ The accepted cost, pinned by tests rather than left to be discovered, in three c
   for a statement that merely contains a backslash — `SELECT 'a\nb' FROM t`, `… LIKE 'a\_b'` and
   `'C:\\Users\\me'` all resolve and run without one.
 - **A bracketed run a dialect at the default bracket reading cannot close.** `[…]` is read as SQL
-  Server's quoted name for every dialect but ClickHouse (#295 established the subscript rule there
-  only), so a PostgreSQL nested array (`SELECT ARRAY[[1,2],[3,4]] AS a FROM t`), a nested subscript
-  (`t.data[idx[0]]`) and a subscript key carrying a `]` (`j['a]b']`) are unresolvable and ask, even
-  though they only read. Ordinary `a[1]` and `ARRAY[1,2]` resolve and do not. This is the second half
-  of a cost the limiter already paid as a lost bound — see
-  [docs/providers/postgres.md](../providers/postgres.md).
-- **Non-SQL query text.** Both execution paths ask about whatever is in the editor, so a MongoDB
-  document or a Redis command whose escaped quote this SQL span reader cannot resolve
-  (`{"filter":{"msg":"say \"hi\""}}`) prompts too, and the notice says the statement could not be
-  fully read — true, though the grammar it was read under is not the one the text is written in.
+  Server's quoted name for the dialects with no established subscript rule (MySQL, Oracle, Couchbase,
+  Druid, LibreDB), so a nested run or a key carrying a `]` written there is unresolvable and asks.
+  ClickHouse and PostgreSQL read those as subscripts and do not — the PostgreSQL row was established
+  precisely because everyday syntax there (`ARRAY[[1,2],[3,4]]`, `j['a]b']`) was paying this prompt.
+  Ordinary `a[1]` and `ARRAY[1,2]` resolve under every reading.
+
+**Not a cost this rule pays: non-SQL query text.** Both execution paths ask about whatever is in the
+editor, so this predicate is handed MongoDB documents and Redis commands as well. A SQL span reader's
+verdict about text that is not SQL is not evidence of anything — the escaped quote in
+`{"filter":{"msg":"say \"hi\""}}` or in `SET k "a\"b"` closes perfectly in the grammar the text is
+actually written in — so the unresolvable-run rule is applied only where `readsSqlText()` says the
+dialect writes SQL. Saying *"could not be read"* about text that reads fine is the false alarm this
+notice exists to avoid, and a gate operators learn to click through protects nothing. The keyword
+tests still run on that text; only the span-based rule is narrowed.
 
 A fourth class arrives with the nesting fact (#300), and it is the reverse of the ones above — a prompt
 the dialect *adds* rather than one it narrows: on PostgreSQL, SQL Server and ClickHouse a block comment

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -265,14 +265,30 @@ written after a `#` is still found and never doubled — which is also why MSSQL
 into the head, keeps bounding `SELECT * FROM #tmp` even without a dialect. Under the dialect-less
 reading that is not airtight — trailing trivia written *after* an existing bound hides it from the
 end-anchored probe, so a `TOP` is spliced alongside an `OFFSET … FETCH` that SQL Server rejects — and
-naming the dialect is what closes it: `#` is never a comment in T-SQL, so the probe sees the bound
-that is there. Likewise the one shape that stays wrong without a dialect, a bound commented out with
-`#` (`… # LIMIT 10`), is read correctly under MySQL's grammar: the commented-out clause is not a
-clause, and a real bound is added before it.
+naming the dialect is what closes it *for a hash*: `#` is never a comment in T-SQL, so the probe sees
+the bound that is there. Every other route to a refused cut reached that provider the same way, and
+what closes those is the rule in the next paragraph. Likewise the one shape that stays wrong without a
+dialect, a bound commented out with `#` (`… # LIMIT 10`), is read correctly under MySQL's grammar: the
+commented-out clause is not a clause, and a real bound is added before it.
+
+A refused cut costs more than the bound, and this is the part that is easy to miss: it also makes every
+**already-bounded probe** unreliable. Those probes read the statement's own text, and where the cut is
+refused that text is the terminator strip — trailing whitespace and `;` removed and nothing else — so a
+real bound written *before* a trailing comment sits away from the end anchor and reads as absent. For a
+caller that responds to "not bounded" by leaving the statement alone, that is harmless. For a caller
+that responds by ADDING a clause, it is not: the clause lands beside a bound the probe could not see,
+and engines reject the pair outright rather than returning too many rows. So a provider that adds its
+own clause has to treat those probes as non-authoritative wherever the cut was refused. MSSQL is the
+one that adds a clause the refusal does not otherwise stop — `TOP n` goes into the head, which no
+trailing comment can reach — and it now declines whenever such a statement mentions an `OFFSET` or a
+`FETCH` at all, blunt on purpose, since a page cannot be ruled out from text nothing can read (#293).
 
 Providers that append a clause of their own follow the same rule: Oracle's `FETCH FIRST` and
 `OFFSET … FETCH NEXT`, and MSSQL's `OFFSET … FETCH NEXT` pagination branch. MSSQL's `SELECT TOP n`
-splices into the head, which no trailing comment can reach, and is unchanged. ClickHouse's refusal to
+splices into the head, which no trailing comment can reach, so it keeps bounding a statement whose end
+may not be cut — with the one exception above. MSSQL also recognises a page form of its own that the
+shared probes above do not, `OFFSET n ROWS` with no `FETCH` tail; it is read in that provider, because
+the form is T-SQL's alone and no other dialect's probes should move for it. ClickHouse's refusal to
 rewrite a statement ending in `FORMAT`/`SETTINGS`, and Druid's refusal to rewrite one ending in an
 `OFFSET`, both read the same end — otherwise a trailing comment would hide the clause from them and
 the bound placed before that comment would turn a working statement into a server-side syntax error.

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -383,6 +383,26 @@ comment, exactly as the `--` form is, and `SELECT * FROM users # FORMAT TSV` is 
 commented-out clause, not a trailing one (#292). See
 [Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
 
+The same channel carries the second reading this dialect needs: **`[…]` is an array literal or a
+subscript here, not a quoted name.** Arrays nest (`Array(Array(T))`) and nothing inside them is
+escaped, while SQL Server's `[name]` ends at the first unpaired `]` and writes a bracket inside a name
+by doubling it — two rules that cannot both hold, so the reading comes from the dialect (#295). Under
+the name reading ClickHouse lost bounds in two everyday shapes: a subscript whose key text contains a
+close bracket (`WITH m['a]b'] AS v SELECT v`) ended the run at that bracket, so the CTE element could
+not be crossed and the statement typed as unknown; and a nested array (`SELECT [[1,2],[3,4]] AS a`)
+ended with a doubled bracket read as an escape, so the run never closed and the statement's end was
+not cuttable. Both are now bounded, emitted byte-intact. A run that genuinely never closes
+(`SELECT [[1,2] AS a`) is still reported as undeterminable and the statement is passed through
+untouched — the same fail-safe direction as an unterminated literal.
+
+The same reading reaches the **destructive-statement confirmation**, because that predicate reads the
+statement under the connection's dialect too. It gains prompts here: a nested array before a
+destructive keyword (`WITH [[1,2],[3,4]] AS x DELETE FROM t`) used to leave the run unterminated and
+everything after it invisible, so nothing asked. One prompt is lost, and it is recorded rather than
+hidden: bracket text that does not *balance* (`WITH [[1,2] AS x DELETE FROM t`) is undeterminable under
+the array reading, and the predicate still answers "not dangerous" for text it cannot read — the input
+class tracked as #297. Both directions are pinned by tests.
+
 A hand-rolled semicolon strip used to stand in for that reading, so `... FORMAT TSV -- note` read as
 carrying no trailing clause at all. That was harmless only while the inherited limiter appended its
 bound after the comment, where the server never saw it; now that the bound is placed **before** the

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -398,10 +398,11 @@ untouched — the same fail-safe direction as an unterminated literal.
 The same reading reaches the **destructive-statement confirmation**, because that predicate reads the
 statement under the connection's dialect too. It gains prompts here: a nested array before a
 destructive keyword (`WITH [[1,2],[3,4]] AS x DELETE FROM t`) used to leave the run unterminated and
-everything after it invisible, so nothing asked. One prompt is lost, and it is recorded rather than
-hidden: bracket text that does not *balance* (`WITH [[1,2] AS x DELETE FROM t`) is undeterminable under
-the array reading, and the predicate still answers "not dangerous" for text it cannot read — the input
-class tracked as #297. Both directions are pinned by tests.
+everything after it invisible, so nothing asked. Nothing is lost either, since #297 closed the
+narrowing this paragraph used to record: bracket text that does not *balance*
+(`WITH [[1,2] AS x DELETE FROM t`) is undeterminable under the array reading, and unresolvable text
+now asks — the confirmation dialog says the statement could not be fully read instead of staying
+silent. The statement is a syntax error in ClickHouse either way. Both directions are pinned by tests.
 
 A hand-rolled semicolon strip used to stand in for that reading, so `... FORMAT TSV -- note` read as
 carrying no trailing clause at all. That was harmless only while the inherited limiter appended its

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -373,6 +373,16 @@ or `SETTINGS` clause is expressing intent the editor must not silently rewrite, 
 favour not rewriting: rewriting wrongly turns a working statement into a syntax error, while leaving
 it alone at worst returns more rows than the page size.
 
+Both the detection and the inherited limiter read the statement under **ClickHouse's** grammar, which
+this provider passes down from its own `type` ([`grammar.ts`](../../src/lib/sql/grammar.ts)).
+ClickHouse's syntax reference lists `#` and `#!` beside `--` as single-line comment forms, and the
+shared reader used to guess PostgreSQL's rule instead — a hash followed by `>`, `-` or `#` is an
+operator — so a comment written that way was read as SQL, and an ordinary one at the end of a
+statement made the bound unplaceable. `SELECT * FROM users # daily check` is now bounded before the
+comment, exactly as the `--` form is, and `SELECT * FROM users # FORMAT TSV` is read as what it is: a
+commented-out clause, not a trailing one (#292). See
+[Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
+
 A hand-rolled semicolon strip used to stand in for that reading, so `... FORMAT TSV -- note` read as
 carrying no trailing clause at all. That was harmless only while the inherited limiter appended its
 bound after the comment, where the server never saw it; now that the bound is placed **before** the

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -395,6 +395,18 @@ not cuttable. Both are now bounded, emitted byte-intact. A run that genuinely ne
 (`SELECT [[1,2] AS a`) is still reported as undeterminable and the statement is passed through
 untouched — the same fail-safe direction as an unterminated literal.
 
+A third fact of the same record: **block comments nest here.** ClickHouse's syntax reference states
+that C-style comments can be nested and gives a nested example, while the shared reader used to end
+every comment at its first `*/` — handing everything between that marker and the comment's real end to
+the readers as code, which cost the statement its bound. On this engine, whose whole point is scanning
+more rows than a browser can hold, a missing bound is the entire cost: there is no data-modifying CTE
+here, so no bound can land on a write. `/* a /* b */ x */ SELECT arrayJoin([1, 2]) AS n` and
+`WITH /* a /* b */ x */ 1 AS one SELECT one FROM events` are now bounded, and a trailing nested comment
+takes the bound before it rather than inside it. A comment carrying one opener too many
+(`/* a /* b */ SELECT n FROM events`) never closes here, so it is undeterminable and the statement is
+passed through untouched — the same fail-safe direction as an unclosed array, and it costs that
+statement a confirmation prompt as well (#300).
+
 The same reading reaches the **destructive-statement confirmation**, because that predicate reads the
 statement under the connection's dialect too. It gains prompts here: a nested array before a
 destructive keyword (`WITH [[1,2],[3,4]] AS x DELETE FROM t`) used to leave the run unterminated and

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -496,6 +496,13 @@ The request carries `metrics: true`, the effective statement timeout, and
 including where the clause is placed: at the end of the statement, before a trailing comment or `;`
 ([`query-optimization.md`](../editor/query-optimization.md#where-the-bound-is-placed)).
 
+The limiter is told which dialect it is reading (#292), and Couchbase is one of the dialects
+deliberately left at the **compatibility default**: no authoritative source was established for how
+SQL++ reads `#`, and guessing it from a neighbouring dialect is what that channel exists to stop. So
+the reading here is unchanged — `#` opens a line comment unless the next character makes a PostgreSQL
+operator — and a statement ending in a `#` run is returned unbounded rather than bounded on a guess
+([which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading)).
+
 ### 5.2 Result shaping
 
 | Source field | `QueryResult` field | Notes |

--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -800,6 +800,13 @@ await provider.query('SELECT COUNT(*) AS c FROM "libredb_demo" WHERE region = ?'
 (`supportsExternalQueryLimiting: true`) unless the statement ends in an `OFFSET` with no `LIMIT`
 ([§3.9](#39-the-preparequery-override-offset-with-no-limit)).
 
+The limiter is told which dialect it is reading (#292), and Druid is one of the dialects deliberately
+left at the **compatibility default**: no authoritative source was established for how Druid SQL reads
+`#`, and guessing it from a neighbouring dialect is what that channel exists to stop. The reading here
+is therefore unchanged — `#` opens a line comment unless the next character makes a PostgreSQL
+operator — and a statement ending in a `#` run is returned unbounded rather than bounded on a guess
+([which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading)).
+
 A write is **not special-cased**. Every write form Druid rejects, it rejects with a message that names
 both the reason and the alternative, which is more useful than anything this provider would substitute
 ([§5.5](#55-druid-sql-cannot-write-and-the-server-says-so-clearly)).

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -160,6 +160,19 @@ before the statement (`-- note` or `/* note */`) is skipped rather than defeatin
 shared helper also skips `#`, which is a comment in MySQL only; T-SQL rejects a statement opening with
 one either way, so skipping it changes which syntax error the server reports and nothing else.
 
+**Block comments NEST here** — "Slash Star (Block Comment) (Transact-SQL)" states that a `/*` anywhere
+inside a comment starts a nested one and requires its own `*/`, and that a missing closer is an error.
+The shared reader used to end every comment at its first `*/`, and on this provider that mattered more
+than a lost bound, because the `TOP` splice writes into the **head** at an index that reading chose:
+`SELECT /* a /* b */ DISTINCT */ name FROM t` was read as a comment ending after `/* a /* b */`,
+followed by a `DISTINCT` — which is inside the comment — so the `TOP` was spliced in after it, inside
+the comment too. SQL Server saw `SELECT name FROM t` and ran it unbounded while this method reported
+`wasLimited: true`. Under T-SQL's grammar the whole run is one comment, so the `TOP` goes before it,
+and a `DISTINCT` written *after* the comment still takes the `TOP` after itself (#300). The same fact
+bounds a read behind a leading nested comment (`/* a /* b */ x */ SELECT name FROM t`), declines on a
+write a nested comment hid inside a CTE list, and declines where the comment carries one opener too
+many and therefore never closes. Pinned in `tests/integration/db/mssql-provider.test.ts`.
+
 `prepareQuery` **declines** rather than splicing in two cases, reporting `wasLimited: false` and
 returning the statement untouched. It never reports a limit while handing back the statement unchanged.
 

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -127,6 +127,14 @@ See
 This closes the common half of #293; the remaining case — a statement whose end cannot be cut for a
 reason that is *not* the hash, such as a literal behind an odd backslash run — is tracked there.
 
+The same channel carries this dialect's bracket reading, and T-SQL's is the one the shared reader always
+applied: **`[…]` is a delimited identifier**, everything between the brackets is the name (apostrophe,
+comment marker and semicolon included), and a `]` inside one is written doubled — which is exactly what
+`escapeIdentifier()` emits. That is now the dialect's stated answer rather than a shared default:
+ClickHouse spells a nestable array with the same characters and gets the opposite reading (#295), and
+teaching one scan to step over string literals inside the brackets — the naive way to serve both —
+would have broken `SELECT [it's] FROM users`, which is legal here.
+
 The `SELECT` it splices after is located with `src/lib/sql/leading-keyword.ts`, so a T-SQL comment
 before the statement (`-- note` or `/* note */`) is skipped rather than defeating the injection. That
 shared helper also skips `#`, which is a comment in MySQL only; T-SQL rejects a statement opening with

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -104,19 +104,28 @@ as `src/lib/sql/statement-end.ts` delimits it, before any trailing comment and b
 of which are re-attached verbatim. Whitespace written before the terminator is now preserved rather
 than dropped, which is the only emitted-SQL difference on the `TOP` branch.
 
-That reader also answers whether the end may be **cut**, and the two branches differ there too. A
-statement ending in a `#` run — `SELECT * FROM #tmp`, everyday T-SQL, which the shared scanner reads
-as a MySQL comment because nothing in the text distinguishes the two — may not be cut, so the
-appending branch declines. The `TOP` splice writes into the head and rejoins the tail verbatim, so it
-still bounds such a statement, and `SELECT * FROM #tmp` comes back as `SELECT TOP 500 * FROM #tmp`.
-What makes that tolerable is that a refused cut still reports the statement's whole text as its end:
-the shared already-bounded probe therefore sees a `FETCH NEXT` written after the `#`, so a temp-table
-page the user already bounded is left alone rather than collecting a `TOP` — which SQL Server rejects
-outright alongside `OFFSET … FETCH`. It is not airtight. Put trailing trivia after that bound
-(`… FETCH NEXT 10 ROWS ONLY -- daily`) and the end-anchored probe stops seeing it, so the `TOP` is
-spliced anyway. That shape behaves exactly as it did before — the probe was end-anchored on the raw
-text then too — and closing it needs the `#` end re-read under a hash-is-code scan, which is a change
-of its own.
+That reader also answers whether the end may be **cut**, and until #292 it could not answer it for a
+statement ending in a `#` run — `SELECT * FROM #tmp` is everyday T-SQL, and the shared scanner had to
+read it as a MySQL comment because nothing in the *text* distinguishes the two. The appending branch
+therefore declined, and a temp-table page whose bound was followed by trailing trivia
+(`… FETCH NEXT 10 ROWS ONLY -- daily`) hid that bound from the end-anchored probe, so a `TOP` was
+spliced alongside an `OFFSET … FETCH` — which SQL Server rejects outright (Msg 10741).
+
+`prepareQuery()` now passes its own `type` to the shared readers, and under T-SQL's grammar `#` is
+never a comment: `#name` and `##name` are local and global temp tables. So the run is the statement's
+own text, the end is cuttable, and both halves close together:
+
+- `SELECT * FROM #tmp` still comes back as `SELECT TOP 500 * FROM #tmp` (the `TOP` splice writes into
+  the head and never depended on the cut);
+- `SELECT * FROM #tmp ORDER BY id` now takes a real page —
+  `… OFFSET 10 ROWS FETCH NEXT 50 ROWS ONLY` — instead of being returned untouched;
+- `SELECT * FROM #tmp … FETCH NEXT 10 ROWS ONLY -- daily` is recognised as already bounded and
+  collects no `TOP`.
+
+See
+[Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
+This closes the common half of #293; the remaining case — a statement whose end cannot be cut for a
+reason that is *not* the hash, such as a literal behind an odd backslash run — is tracked there.
 
 The `SELECT` it splices after is located with `src/lib/sql/leading-keyword.ts`, so a T-SQL comment
 before the statement (`-- note` or `/* note */`) is skipped rather than defeating the injection. That

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -265,6 +265,20 @@ This is the most complete pool/timeout mapping of any SQL provider. `getPoolStat
 ([mssql.ts:702](../../src/lib/db/providers/sql/mssql.ts)) exposes
 `{ total: size, idle: available, active, waiting: pending }`.
 
+#### Pool errors are handled, not fatal
+
+`mssql.ConnectionPool` is an `EventEmitter` and emits `error` in two situations: a background
+connection failure (a tedious connection error that is not `ESOCKET`) and a failed acquire. An
+`error` event with no listener is an uncaught exception, so `connect()` attaches a listener the
+moment the pool is constructed — otherwise either situation would take the whole server process
+down. The listener only reports (bracketed-prefix `console.error`, this file's convention): a failed
+acquire **also** rejects the caller's promise, so nothing may be swallowed here.
+
+PostgreSQL carries the same guard for its idle clients
+([postgres.md](./postgres.md#42-connection-pooling)). MySQL and Oracle do not, because mysql2 and
+oracledb expose no pool-level `error` event — that audit result is recorded at each of those
+providers' `connect()`.
+
 ### 4.3 Encryption / SSL
 
 `buildConfig()` resolves transport encryption from `connection.ssl`:

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -124,8 +124,28 @@ own text, the end is cuttable, and both halves close together:
 
 See
 [Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
-This closes the common half of #293; the remaining case — a statement whose end cannot be cut for a
-reason that is *not* the hash, such as a literal behind an odd backslash run — is tracked there.
+
+That closed the common half of the same hazard. The other half is not about the hash at all: **wherever
+the end may not be cut, no already-bounded probe is reading the statement's real tail.** Those probes
+are anchored at the end of the statement's own text, and a refused cut reports the terminator strip as
+that text — trailing whitespace and `;` removed and nothing else — so a real page written *before* a
+trailing comment sits away from the anchor and reads as absent. A `TOP` was then spliced beside it and
+SQL Server rejected the statement (Msg 10741): the query **failed** while this method reported a limit.
+Reading a page that is not there is harmless (the statement is left alone); missing one that is there
+is not, so where the cut is refused this provider asks the weaker question the situation allows — does
+the text mention an `OFFSET` or a `FETCH` at all? — and declines when it does. The check is unanchored
+and deliberately blunt: a column named `offset`, or a page belonging to a subquery, is enough to
+decline, so such a statement keeps its full result set and is reported honestly as unbounded (#293).
+
+One page form was invisible even where the end **is** cuttable: **`OFFSET n ROWS` with no `FETCH`
+tail** is a complete T-SQL page, and the shared probes recognise only a `FETCH … ROWS ONLY` tail or a
+bare `OFFSET n`. `SELECT … ORDER BY id OFFSET 10 ROWS` therefore collected a `TOP` — and with an offset
+requested, a second `OFFSET … FETCH` appended beside the first. It is now read here rather than in the
+shared limiter, since the form is this dialect's own and no other dialect's probes should move for it:
+`OFFSET n ROW` and `OFFSET n ROWS` at the end of the statement are a page, and the statement is
+returned untouched. The count must be a literal, exactly as the shared probes read — `OFFSET @skip
+ROWS` is not recognised, so a parameterised page still collects a `TOP`, which is a known limitation
+rather than a decision.
 
 The same channel carries this dialect's bracket reading, and T-SQL's is the one the shared reader always
 applied: **`[…]` is a delimited identifier**, everything between the brackets is the name (apostrophe,
@@ -150,10 +170,15 @@ returning the statement untouched. It never reports a limit while handing back t
   probe missed it, because that probe wants literal whitespace between `SELECT` and `TOP`, which both a
   comment (`SELECT/* c */TOP 10 …`) and a `DISTINCT` defeat. Splicing would emit `SELECT TOP n TOP 10`
   and a syntax error.
+- **A T-SQL page at the end of the statement** (`… ORDER BY id OFFSET 10 ROWS`) — a bound the shared
+  probes do not recognise, and a clause beside it is a rejected statement.
+- **An end that may not be cut, in a statement mentioning `OFFSET` or `FETCH`** — the already-bounded
+  probes cannot be trusted there, so a page cannot be ruled out.
 
-The `OFFSET … FETCH` branch declines in one further case of its own: **an end that may not be cut** —
-a trailing `#` run, or a quote behind an odd backslash run, which T-SQL and MySQL close in different
-places. It has nowhere to append; the `TOP` branch, which does not append, is unaffected.
+The `OFFSET … FETCH` branch declines in one further case of its own: **any end that may not be cut** —
+a trailing `#` run under the dialect-less reading, a quote behind an odd backslash run, an unterminated
+comment or bracket. It has nowhere to append; the `TOP` branch, which splices into the head, keeps
+bounding such a statement unless the rule above applies to it.
 
 ### 3.3 Five-query schema introspection, cross-schema
 
@@ -494,6 +519,11 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
   can lose precision; they would need to be fetched as strings to stay exact ([§5.3](#53-data-type--parameter-handling)).
 - **Parameters bound without explicit types** — relies on `mssql` type inference, which can mis-type
   `null`/large-integer/`NVARCHAR` values ([§5.3](#53-data-type--parameter-handling)).
+- **A parameterised page is not recognised as one.** The already-bounded probes read a literal count,
+  so `… OFFSET @skip ROWS [FETCH NEXT @take ROWS ONLY]` still looks unbounded and collects a `TOP`,
+  which SQL Server rejects beside it (Msg 10741) — the statement fails rather than returning too many
+  rows ([§3.2](#32-t-sql-pagination-top-and-offset--fetch)). *Future:* accept a variable or an
+  expression as the count.
 - **No Always On / high-availability options.** `MultiSubnetFailover` (fast failover to an
   availability-group listener) and `ApplicationIntent=ReadOnly` (read-only routing to a readable
   secondary) are not set — both are common requirements for enterprise HA SQL Server. *Future:*

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -208,14 +208,20 @@ MySQL's `#` line comment is skipped when the statement type is read, alongside `
 for: a `# note`-led `SELECT` used to classify as an unknown statement type and reach the server with
 no `LIMIT` at all (#275).
 
-A **trailing** `#` comment is the one place MySQL is treated more conservatively than the other
-dialects. `SELECT … # note` is not bounded at all: the bound has to go before the comment, and the
-same characters are a temp table, an identifier or an operator in T-SQL, Oracle and PostgreSQL, which
-the shared reader cannot rule out (see
-[Where the bound is placed](../editor/query-optimization.md#where-the-bound-is-placed)). Before this
-the clause was appended *inside* that comment while the UI reported the query as capped, so the
-statement ran unbounded either way — it is now honest about it. A trailing `-- note` is bounded
-normally.
+Every `#` is a comment marker here, and this provider now says so: `prepareQuery()` passes its own
+`type` to the shared readers, which resolve `#` under MySQL's grammar instead of the dialect-less
+compromise they used to apply to everyone (see
+[Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading)).
+Three readings change on this provider, and each was wrong in a way only MySQL sees:
+
+| Statement | Before | Now |
+|-----------|--------|-----|
+| `SELECT … # note` | not bounded at all — the bound has to go before the comment, and the reader could not rule out `#tmp`/`ID#`/XOR | bounded, with the clause before the comment |
+| `SELECT * FROM t # LIMIT 10` | the commented-out bound read as a real one, so the statement ran unbounded | the comment is a comment; a real bound is added before it |
+| `WITH t AS (` + `#- drop the ) SELECT here` + `…) DELETE FROM users` | the `#-` read as a PostgreSQL jsonb operator, so the `)` inside the comment closed the CTE body, the statement typed `SELECT` and a `LIMIT` was appended to a `DELETE` — which MySQL 8 accepts and commits | typed `DELETE`, not bounded |
+
+The third row is the one that cost more than rows: a bound on a `DELETE` commits part of it while the
+UI reports a truncated result set. A trailing `-- note` was always bounded normally and is unchanged.
 
 ### 5.3 Query cancellation
 

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -125,6 +125,32 @@ comments on `--` and `/* … */` only. `SELECT * FROM EMP WHERE ID# = 1` is ther
 as `… ID# = 1 FETCH FIRST 500 ROWS ONLY`. See
 [Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
 
+**Alternate quoting (`q'{it's}'`) is read as the literal it is** — the second half of the same fix, and
+Oracle is the only dialect that has the form. The delimiter after the tag opens the body and its
+partner followed by `'` closes it (`[ ] { } ( ) < >` pair up, any other character closes with itself,
+`q` or `Q`, and `nq'…'` / `NQ'…'` is the same form for `NCHAR`/`NVARCHAR2`), so the body carries
+apostrophes with nothing escaped. That is precisely what made reading it as code costly, and it cost
+two different things:
+
+- An apostrophe in the body opened a string, so everything after it was read one construct out of
+  step: a `)` inside the literal closed a CTE body early and the statement was typed by a keyword
+  written *inside* the literal. `WITH T AS (SELECT q'{it's}' AS S FROM DUAL) SELECT * FROM T` lost its
+  bound entirely.
+- A `--` in the body made the rest of the literal look like a trailing comment, and the
+  insert-before-trivia rule above then placed the clause **inside** the literal:
+  `SELECT q'[it's a -- note )]' AS S FROM DUAL` was emitted as
+  `SELECT q'[it's a FETCH FIRST 500 ROWS ONLY -- note )]' AS S FROM DUAL` with `wasLimited: true` —
+  a statement Oracle rejects, reported as capped.
+
+Both are gone for either spelling of the tag; the clause now lands after the literal. A body whose
+closing delimiter never arrives is undeterminable, so that statement is returned untouched rather than
+bounded on a guess. The tag must also **start** a word: in `SELECT FREQ'{it's}' …` the reader takes
+`FREQ` for a name and the apostrophe after it for an ordinary string, so that statement reaches the
+same refusal rather than a bound placed inside something that may not be a literal at all. That is
+deliberately stricter than node-oracledb's tokenizer, which opens a q-string at any `'` preceded by
+`q`/`Q` whatever comes before it; the strict side is the one whose mistake costs a bound rather than a
+misplaced clause.
+
 ### 3.3 Owner-scoped, five-query schema introspection
 
 `getSchema()` ([oracle.ts:323](../../src/lib/db/providers/sql/oracle.ts)) runs **five bulk queries**

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -115,7 +115,10 @@ bounded on a guess. One shape reaches that on Oracle: a literal Oracle and MySQL
 different places (a quote behind an odd backslash run). It is a **deliberate loss of a bound** —
 appending after the whole text, as this method used to, happened to be valid Oracle there, and is
 what puts the clause inside a trailing comment everywhere else — so that statement returns every row
-rather than being bounded on a guess.
+rather than being bounded on a guess. Since #297 the same unresolvable run also costs that statement a
+confirmation prompt, because the safety gate cannot read it either; the general rule and its accepted
+costs are in
+[query-optimization.md](../editor/query-optimization.md#text-the-reading-cannot-resolve-asks-and-says-so).
 
 `#` inside an identifier (`ID#`, common in legacy schemas) used to reach the same refusal and no
 longer does. `prepareQuery()` passes its own `type` to the shared readers (#292), and Oracle's grammar
@@ -148,8 +151,8 @@ bounded on a guess. The tag must also **start** a word: in `SELECT FREQ'{it's}' 
 `FREQ` for a name and the apostrophe after it for an ordinary string, so that statement reaches the
 same refusal rather than a bound placed inside something that may not be a literal at all. That is
 deliberately stricter than node-oracledb's tokenizer, which opens a q-string at any `'` preceded by
-`q`/`Q` whatever comes before it; the strict side is the one whose mistake costs a bound rather than a
-misplaced clause.
+`q`/`Q` whatever comes before it; the strict side is the one whose mistake costs a bound — and, since
+#297, a confirmation prompt on that statement — rather than a misplaced clause.
 
 ### 3.3 Owner-scoped, five-query schema introspection
 

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -111,13 +111,19 @@ result capped. A statement with no trailing comment is emitted exactly as it was
 reading answers whether the statement already carries a `FETCH FIRST`, so
 `SELECT … FETCH FIRST 10 ROWS ONLY -- deliberate` is still honoured and never gets a second clause.
 A statement whose end may not be **cut** is returned untouched with `wasLimited: false` rather than
-bounded on a guess. Two shapes reach that on Oracle: a literal Oracle and MySQL would close in
-different places (a quote behind an odd backslash run), and `#` inside an identifier (`ID#`, common
-in legacy schemas), which the shared scanner has to read as MySQL's comment marker because nothing in
-the text distinguishes the two. Both are a **deliberate loss of a bound**: appending after the whole
-text, as this method used to, happened to be valid Oracle for these two shapes, and is what puts the
-clause inside a trailing comment everywhere else. They now return every row rather than being bounded
-on a reading that is right for Oracle and wrong for the dialect the scanner cannot rule out.
+bounded on a guess. One shape reaches that on Oracle: a literal Oracle and MySQL would close in
+different places (a quote behind an odd backslash run). It is a **deliberate loss of a bound** —
+appending after the whole text, as this method used to, happened to be valid Oracle there, and is
+what puts the clause inside a trailing comment everywhere else — so that statement returns every row
+rather than being bounded on a guess.
+
+`#` inside an identifier (`ID#`, common in legacy schemas) used to reach the same refusal and no
+longer does. `prepareQuery()` passes its own `type` to the shared readers (#292), and Oracle's grammar
+says `#` opens no comment: node-oracledb's own SQL tokenizer
+(`node_modules/oracledb/lib/thin/statement.js`) accepts `#` as an identifier character and starts
+comments on `--` and `/* … */` only. `SELECT * FROM EMP WHERE ID# = 1` is therefore bounded, emitted
+as `… ID# = 1 FETCH FIRST 500 ROWS ONLY`. See
+[Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
 
 ### 3.3 Owner-scoped, five-query schema introspection
 

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -302,22 +302,18 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   bounded. Both are bounded now, and the emitted text is unchanged apart from the appended clause
   (#292). See
   [Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
-- **One grammar fact is deliberately left undecided for this dialect: how `[…]` is read.** PostgreSQL
-  subscripts arrays and jsonb with those characters, but the shared reader still reads a bracketed run
-  as SQL Server's quoted NAME here, because no first-party source for the subscript rule was
-  established for PostgreSQL and reading one engine's rule off another's is what the dialect channel
-  exists to stop (#295 established it for ClickHouse only). The cost is a **lost bound** and, since
-  #297, a **confirmation prompt** — never a misplaced clause. A nested array
-  (`SELECT ARRAY[[1,2],[3,4]] AS a FROM t`) ends with a `]]` the name reading takes for an escape, so
-  the run never closes; a subscript key containing a `]` (`SELECT j['a]b'] FROM t`) ends the run at
-  that bracket and the rest of the key then reads as an unterminated literal. Either way the end is
-  undeterminable, an undeterminable end is never cut, and the statement is returned untouched with
-  `wasLimited: false` — and because the same undeterminable run means the safety gate cannot read the
-  statement either, such a read-only statement now asks for confirmation before it runs
-  ([query-optimization.md](../editor/query-optimization.md#destructive-statement-confirmation)).
-  Ordinary subscripts (`a[1]`, `ARRAY[1,2]`) are unaffected: still bounded, and no prompt. All four
-  limiter shapes are pinned in `tests/integration/db/postgres-provider.test.ts`, the prompt they now
-  also cost in `tests/components/QuerySafetyDialog.test.tsx`.
+- **`[…]` is a SUBSCRIPT here, not a quoted name.** `expression[subscript]` extracts an element and
+  `expression[lower:upper]` a slice (manual 4.2.3), array constructors nest — the manual's own example
+  is `SELECT ARRAY[[1,2],[3,4]]` (4.2.12) — and identifiers are quoted with double quotes (4.1.1), so
+  `[` is never a name quote in this dialect. The run nests, nothing inside it is escaped, and a literal
+  inside it is read as a literal, so a nested array (`SELECT ARRAY[[1,2],[3,4]] AS a FROM t`), a
+  subscript key carrying a close bracket (`SELECT j['a]b'] FROM t`) and a nested subscript
+  (`SELECT t.data[idx[0]] FROM t`) are all read whole: bounded, emitted intact, no prompt (#295).
+  A run short of its closer (`SELECT ARRAY[[1,2] AS a FROM t`) is still undeterminable — not bounded,
+  and the safety gate asks — which is the fail-safe direction and the only bracket shape that costs
+  anything here. Pinned in `tests/integration/db/postgres-provider.test.ts`, including a statement that
+  ENDS with a nested array (nothing after the run would catch a bound placed by a reader that lost
+  track of where it closes), and on the gate side in `tests/components/QuerySafetyDialog.test.tsx`.
 - **Block comments NEST here, and that is the dialect's own rule** — PostgreSQL's manual (4.1.5
   Comments) says they nest "as specified in the SQL standard but unlike C", precisely so a region that
   already contains comments can be commented out. The shared reader used to end every comment at its
@@ -350,8 +346,8 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   trivia is emitted exactly as before. A statement whose end may not be **cut** is returned untouched
   with `wasLimited: false`, since a guess would place the bound after the `;` or in the middle of the
   statement. **On this dialect the shapes that reach it are a quote behind an odd backslash run** (MySQL
-  and PostgreSQL close such a literal in different places, so the reader declines to guess), **the
-  bracketed runs in the bullet above** (a nested array, a subscript key carrying a `]`) **and any other
+  and PostgreSQL close such a literal in different places, so the reader declines to guess), **a
+  bracketed run short of its closer** (see the bullet above) **and any other
   run that never closes** — an unterminated comment or literal. A trailing `#`
   run used to reach it too and no longer does — under PostgreSQL's grammar `#` is code, not a comment
   marker, so `SELECT flags # 5` is cut and bounded like any other statement (#292); the refusal survives

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -287,14 +287,18 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   subscripts arrays and jsonb with those characters, but the shared reader still reads a bracketed run
   as SQL Server's quoted NAME here, because no first-party source for the subscript rule was
   established for PostgreSQL and reading one engine's rule off another's is what the dialect channel
-  exists to stop (#295 established it for ClickHouse only). The cost is a **lost bound**, never a
-  misplaced clause. A nested array (`SELECT ARRAY[[1,2],[3,4]] AS a FROM t`) ends with a `]]` the name
-  reading takes for an escape, so the run never closes; a subscript key containing a `]`
-  (`SELECT j['a]b'] FROM t`) ends the run at that bracket and the rest of the key then reads as an
-  unterminated literal. Either way the end is undeterminable, an undeterminable end is never cut, and
-  the statement is returned untouched with `wasLimited: false`. Ordinary subscripts (`a[1]`,
-  `ARRAY[1,2]`) are unaffected and still bounded. All four shapes are pinned in
-  `tests/integration/db/postgres-provider.test.ts`.
+  exists to stop (#295 established it for ClickHouse only). The cost is a **lost bound** and, since
+  #297, a **confirmation prompt** — never a misplaced clause. A nested array
+  (`SELECT ARRAY[[1,2],[3,4]] AS a FROM t`) ends with a `]]` the name reading takes for an escape, so
+  the run never closes; a subscript key containing a `]` (`SELECT j['a]b'] FROM t`) ends the run at
+  that bracket and the rest of the key then reads as an unterminated literal. Either way the end is
+  undeterminable, an undeterminable end is never cut, and the statement is returned untouched with
+  `wasLimited: false` — and because the same undeterminable run means the safety gate cannot read the
+  statement either, such a read-only statement now asks for confirmation before it runs
+  ([query-optimization.md](../editor/query-optimization.md#destructive-statement-confirmation)).
+  Ordinary subscripts (`a[1]`, `ARRAY[1,2]`) are unaffected: still bounded, and no prompt. All four
+  limiter shapes are pinned in `tests/integration/db/postgres-provider.test.ts`, the prompt they now
+  also cost in `tests/components/QuerySafetyDialog.test.tsx`.
 - A statement leading with `WITH` is typed by the keyword its CTE list **operates**
   ([`operative-keyword.ts`](../../src/lib/sql/operative-keyword.ts)), so a data-modifying CTE
   (`WITH t AS (UPDATE … RETURNING …) INSERT INTO … SELECT …`) is **not** bounded. This matters most on
@@ -311,9 +315,15 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   `-- LIMIT 10` look like a real one, so nothing was injected (#280). A statement with no trailing
   trivia is emitted exactly as before. A statement whose end may not be **cut** is returned untouched
   with `wasLimited: false`, since a guess would place the bound after the `;` or in the middle of the
-  statement: a quote behind an odd backslash run (MySQL and PostgreSQL close it in different places)
-  and a trailing `#` run, which is a comment in MySQL and PostgreSQL's XOR operator here
-  (`SELECT flags # 5`).
+  statement. **On this dialect the shapes that reach it are a quote behind an odd backslash run** (MySQL
+  and PostgreSQL close such a literal in different places, so the reader declines to guess), **the
+  bracketed runs in the bullet above** (a nested array, a subscript key carrying a `]`) **and any other
+  run that never closes** — an unterminated comment or literal. A trailing `#`
+  run used to reach it too and no longer does — under PostgreSQL's grammar `#` is code, not a comment
+  marker, so `SELECT flags # 5` is cut and bounded like any other statement (#292); the refusal survives
+  only for a caller that names no dialect. The backslash shape also asks for confirmation since #297 —
+  an unresolvable run is text the safety gate cannot read either — see
+  [query-optimization.md](../editor/query-optimization.md#text-the-reading-cannot-resolve-asks-and-says-so).
 
 `prepareQuery()` is a *preparation* step (the UI calls it before `query()`); `query()` itself runs
 exactly the SQL it is handed.

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -299,6 +299,21 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   Ordinary subscripts (`a[1]`, `ARRAY[1,2]`) are unaffected: still bounded, and no prompt. All four
   limiter shapes are pinned in `tests/integration/db/postgres-provider.test.ts`, the prompt they now
   also cost in `tests/components/QuerySafetyDialog.test.tsx`.
+- **Block comments NEST here, and that is the dialect's own rule** — PostgreSQL's manual (4.1.5
+  Comments) says they nest "as specified in the SQL standard but unlike C", precisely so a region that
+  already contains comments can be commented out. The shared reader used to end every comment at its
+  first `*/`, which handed everything between that marker and the comment's real end to the readers as
+  code. On this provider that was the most expensive shape in the family, because a `)` written in that
+  region closes a CTE body that is still open: `WITH recent AS (/* a /* b */ ) SELECT 1 */ SELECT id
+  FROM logs) INSERT INTO archive (id) SELECT id FROM recent` typed as a `SELECT` and collected a bound,
+  and on PostgreSQL that bound applies to the rows the INSERT **writes** — a partial commit reported as
+  a truncated result set. Under PostgreSQL's grammar the comment is read whole, the statement is typed
+  `INSERT`, and nothing is appended (#300). The read side improves too: `/* a /* b */ x */ SELECT id
+  FROM logs` is now typed `SELECT` and bounded, comment emitted intact. A comment carrying one opener
+  too many (`/* a /* b */ SELECT 1`) never closes here, so it is undeterminable: not bounded, and the
+  safety gate asks — the fail-safe direction, since the same text is either an unterminated comment the
+  server rejects or a comment hiding a statement nobody can see. Pinned in
+  `tests/integration/db/postgres-provider.test.ts`.
 - A statement leading with `WITH` is typed by the keyword its CTE list **operates**
   ([`operative-keyword.ts`](../../src/lib/sql/operative-keyword.ts)), so a data-modifying CTE
   (`WITH t AS (UPDATE … RETURNING …) INSERT INTO … SELECT …`) is **not** bounded. This matters most on

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -274,6 +274,15 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   already-limited check, so an annotated bounded query is not bounded twice. Before this, an
   annotated `SELECT` classified as an unknown statement type and returned **every** row while the
   UI badge reported it as not limited (#275).
+- The statement's characters are read under **PostgreSQL's** grammar, which the provider passes down
+  from its own `type` ([`grammar.ts`](../../src/lib/sql/grammar.ts)). PostgreSQL has exactly two
+  comment forms, `--` and `/* … */`; `#` is an operator character (`#>` and `#>>` walk a jsonb path,
+  `#-` deletes one, `##` is geometric, `#` is integer XOR). The shared reader used to approximate
+  that with "a comment unless the next character makes an operator", which kept everyday jsonb queries
+  bounded but read `SELECT flags # 5 AS x FROM t` as a statement that ends at the `#` — so it was not
+  bounded. Both are bounded now, and the emitted text is unchanged apart from the appended clause
+  (#292). See
+  [Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
 - A statement leading with `WITH` is typed by the keyword its CTE list **operates**
   ([`operative-keyword.ts`](../../src/lib/sql/operative-keyword.ts)), so a data-modifying CTE
   (`WITH t AS (UPDATE … RETURNING …) INSERT INTO … SELECT …`) is **not** bounded. This matters most on

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -283,6 +283,18 @@ and, **only for `SELECT`/CTE-`SELECT` queries that don't already have a `LIMIT`*
   bounded. Both are bounded now, and the emitted text is unchanged apart from the appended clause
   (#292). See
   [Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
+- **One grammar fact is deliberately left undecided for this dialect: how `[…]` is read.** PostgreSQL
+  subscripts arrays and jsonb with those characters, but the shared reader still reads a bracketed run
+  as SQL Server's quoted NAME here, because no first-party source for the subscript rule was
+  established for PostgreSQL and reading one engine's rule off another's is what the dialect channel
+  exists to stop (#295 established it for ClickHouse only). The cost is a **lost bound**, never a
+  misplaced clause. A nested array (`SELECT ARRAY[[1,2],[3,4]] AS a FROM t`) ends with a `]]` the name
+  reading takes for an escape, so the run never closes; a subscript key containing a `]`
+  (`SELECT j['a]b'] FROM t`) ends the run at that bracket and the rest of the key then reads as an
+  unterminated literal. Either way the end is undeterminable, an undeterminable end is never cut, and
+  the statement is returned untouched with `wasLimited: false`. Ordinary subscripts (`a[1]`,
+  `ARRAY[1,2]`) are unaffected and still bounded. All four shapes are pinned in
+  `tests/integration/db/postgres-provider.test.ts`.
 - A statement leading with `WITH` is typed by the keyword its CTE list **operates**
   ([`operative-keyword.ts`](../../src/lib/sql/operative-keyword.ts)), so a data-modifying CTE
   (`WITH t AS (UPDATE … RETURNING …) INSERT INTO … SELECT …`) is **not** bounded. This matters most on

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -223,6 +223,25 @@ The statement timeout is **separate** from pool config: `ProviderOptions.queryTi
 live `{ total, idle, active, waiting }` counts. Every query acquires a client from the pool and
 releases it in a `finally` block.
 
+#### Idle-client failures are handled, not fatal
+
+`connect()` attaches an `error` listener to the pool as soon as it is constructed. This is not
+optional bookkeeping: a client that fails while **checked out** rejects its own query, but a client
+that fails while **idle** (the server dropped it, the network went away) has no query to reject, so
+`pg` removes and destroys it and emits `error` on the pool instead. An `error` event with no listener
+is an uncaught exception — i.e. a long-running server process would die from a dropped idle
+connection.
+
+The listener reports the failure with the file's usual bracketed-prefix `console.error` and does
+nothing else. `pg` has already discarded the client, so the handler exists to keep the event
+non-fatal and visible, not to reconnect; the pool opens a fresh client on the next acquire.
+
+The same guard is on the PostgreSQL **storage** pool (see [STORAGE.md](../STORAGE.md)), which is a
+second long-lived `pg.Pool` when `STORAGE_PROVIDER=postgres`. Across the other pooled drivers, only
+SQL Server needs the same treatment ([mssql.md](./mssql.md#42-connection-pooling)): mysql2 and
+oracledb expose no pool-level `error` event at all, which is recorded at each provider's
+`connect()`.
+
 ### 4.3 SSL
 
 `buildSSLConfig()` ([postgres.ts:342](../../src/lib/db/providers/sql/postgres.ts)) resolves SSL with

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -277,6 +277,16 @@ shared reader used to guess MySQL's rule here, which swallowed the rest of the l
 statement its bound, so `SELECT * FROM users WHERE id = #id` returned every row; it is now bounded,
 emitted intact (#292). See
 [Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
+
+The same tokenizer settles this dialect's second grammar fact: `[` is `CC_QUOTE2` there — "`[...]` style
+quoted ids", the Microsoft-style form SQLite accepts for compatibility — so **`[…]` is a quoted name
+here**, not ClickHouse's nestable array (#295). Everything between the brackets is the name, apostrophe
+and comment marker included, so `SELECT [it's] FROM users` and `SELECT [a--b] FROM users` are both
+bounded with the clause written after the whole name. One deliberate divergence: SQLite's tokenizer
+stops at the FIRST `]` and has no escape, while this reader honours SQL Server's doubled bracket, so
+`[a]]b]` reads as one name where SQLite reads `[a]` followed by junk. SQLite rejects that text either
+way, so the longer reading can only ever cost a bound on a statement the server refuses — it is pinned
+by a test rather than left to be discovered.
 `EXPLAIN QUERY PLAN` is supported (`supportsExplain: true`, `explainFormat: "sqlite-queryplan"`) — the UI renders the plan as a tree; SQLite reports no per-node cost or timing metrics, so none are shown.
 
 ---

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -268,6 +268,15 @@ Homebrew). Each channel is browser-verified by
 `query(sql, params?)` — positional params via the driver's `all()`/`run()`. There is no
 `prepareQuery()` override, so the inherited base injects a `LIMIT` into bare `SELECT`s
 (`DEFAULT_QUERY_LIMIT = 500`). No transactions, no cancellation ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
+
+The inherited path reads the statement under **SQLite's** grammar, which the base passes down from the
+provider's own `type` ([`grammar.ts`](../../src/lib/sql/grammar.ts)). SQLite has two comment forms,
+`--` and `/* … */`; `#` opens neither. Its own tokenizer (the amalgamation bundled with
+`better-sqlite3` classifies `#` as `CC_VARALPHA`) reads `#name` as a bind variable, i.e. code. The
+shared reader used to guess MySQL's rule here, which swallowed the rest of the line and cost the
+statement its bound, so `SELECT * FROM users WHERE id = #id` returned every row; it is now bounded,
+emitted intact (#292). See
+[Which dialect the readers are reading](../editor/query-optimization.md#which-dialect-the-readers-are-reading).
 `EXPLAIN QUERY PLAN` is supported (`supportsExplain: true`, `explainFormat: "sqlite-queryplan"`) — the UI renders the plan as a tree; SQLite reports no per-node cost or timing metrics, so none are shown.
 
 ---

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -285,8 +285,10 @@ and comment marker included, so `SELECT [it's] FROM users` and `SELECT [a--b] FR
 bounded with the clause written after the whole name. One deliberate divergence: SQLite's tokenizer
 stops at the FIRST `]` and has no escape, while this reader honours SQL Server's doubled bracket, so
 `[a]]b]` reads as one name where SQLite reads `[a]` followed by junk. SQLite rejects that text either
-way, so the longer reading can only ever cost a bound on a statement the server refuses — it is pinned
-by a test rather than left to be discovered.
+way, so the longer reading can only ever cost a bound — and, where the doubled bracket swallows the
+real closer so the run never terminates (`SELECT [a]] FROM t`), a confirmation prompt as well, since
+#297 asks about text the reader cannot resolve. Both are on statements the server refuses, and both are
+pinned by tests rather than left to be discovered.
 `EXPLAIN QUERY PLAN` is supported (`supportsExplain: true`, `explainFormat: "sqlite-queryplan"`) — the UI renders the plan as a tree; SQLite reports no per-node cost or timing metrics, so none are shown.
 
 ---

--- a/src/app/api/db/multi-query/route.ts
+++ b/src/app/api/db/multi-query/route.ts
@@ -58,7 +58,7 @@ export async function POST(req: NextRequest) {
         // was made comment-tolerant to close (#281, #275). The shared reading also
         // types a `WITH` by the keyword its CTE list operates (#287), so a
         // read-only CTE is bounded here and a data-modifying one is not.
-        const isLastSelect = i === statements.length - 1 && isSelectQuery(stmt.sql);
+        const isLastSelect = i === statements.length - 1 && isSelectQuery(stmt.sql, connection.type);
         const prepared = isLastSelect
           ? provider.prepareQuery(stmt.sql, options)
           : { query: stmt.sql, wasLimited: false, limit: 0, offset: 0 };

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { ShieldAlert, ShieldCheck, AlertTriangle, Loader2, Play, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { resolveSqlGrammar } from "@/lib/sql/grammar";
+import { readsSqlText, resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
 import { hasUnterminatedSpan } from "@/lib/sql/spans";
 import { findCodeWord } from "@/lib/sql/words";
@@ -113,10 +113,13 @@ export function QuerySafetyDialog({
    * Memoised because the analysis stream re-renders this component per chunk while
    * the query text does not change, and the scan is linear in that text.
    */
-  const unreadableRun = useMemo(
-    () => hasUnterminatedSpan(query, resolveSqlGrammar(databaseType as DatabaseType | undefined)),
-    [query, databaseType],
-  );
+  const unreadableRun = useMemo(() => {
+    const type = databaseType as DatabaseType | undefined;
+    // Asked first: a SQL span reader's verdict about text that is not SQL is not
+    // evidence of anything, and saying "could not be read" about a Mongo document
+    // that reads fine is the false alarm this notice exists to avoid.
+    return readsSqlText(type) && hasUnterminatedSpan(query, resolveSqlGrammar(type));
+  }, [query, databaseType]);
 
   useEffect(() => {
     if (isOpen && query) {
@@ -397,7 +400,13 @@ export function isDangerousQuery(query: string, databaseType?: DatabaseType): bo
   // on reading the statement: where a run never closes, every keyword test below
   // is reading text that stops early, so their `false` is "not found" rather than
   // "not there".
-  if (hasUnterminatedSpan(query, grammar)) return true;
+  //
+  // Only where the text IS SQL, though. Both execution paths ask about whatever is
+  // in the editor, so this predicate is handed MongoDB documents and Redis commands
+  // as well, and an escaped quote that a SQL span reader cannot resolve closes
+  // perfectly in the grammar those are written in. The keyword tests below still
+  // run: narrowing this rule is not switching the gate off.
+  if (readsSqlText(databaseType) && hasUnterminatedSpan(query, grammar)) return true;
 
   const keyword = readOperativeKeyword(query, grammar)?.keyword;
   if (keyword !== undefined && DANGEROUS_KEYWORDS.has(keyword)) return true;

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -3,8 +3,10 @@
 import React, { useState, useEffect } from "react";
 import { ShieldAlert, ShieldCheck, AlertTriangle, Loader2, Play, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
 import { findCodeWord } from "@/lib/sql/words";
+import type { DatabaseType } from "@/lib/types";
 
 interface SafetyAnalysis {
   riskLevel: "safe" | "low" | "medium" | "high" | "critical";
@@ -334,9 +336,18 @@ const DANGEROUS_KEYWORDS = new Set(["DELETE", "DROP", "TRUNCATE", "ALTER", "GRAN
  * immediately before a closing quote, and whether an unresolvable statement should ASK
  * instead is a policy question with its own UX cost - tracked as #297, with the
  * dialect-aware reading #292 asks for as the alternative, rather than decided here.
+ *
+ * `databaseType` is the connection the statement is about to run on, and both
+ * call sites hold one (#292). It decides the characters the engines read
+ * differently: a write written after a `#` is commented out in MySQL and the
+ * statement's own code in PostgreSQL, and a `#` comment inside a CTE list used to
+ * hide the `)` that closes it - so a `DELETE` after the list ran with no
+ * confirmation at all. Omitting it keeps the dialect-less reading.
  */
-export function isDangerousQuery(query: string): boolean {
-  const keyword = readOperativeKeyword(query)?.keyword;
+export function isDangerousQuery(query: string, databaseType?: DatabaseType): boolean {
+  const grammar = resolveSqlGrammar(databaseType);
+
+  const keyword = readOperativeKeyword(query, grammar)?.keyword;
   if (keyword !== undefined && DANGEROUS_KEYWORDS.has(keyword)) return true;
 
   // A write the statement's own keyword does not report: PostgreSQL's data-modifying
@@ -344,6 +355,6 @@ export function isDangerousQuery(query: string): boolean {
   // this probe stays unanchored deliberately. It reads the statement's CODE rather
   // than its text, so a read that merely quotes or comments the two words - which
   // the pattern before it treated as a write - no longer asks for a confirmation.
-  const update = findCodeWord(query, "UPDATE");
-  return update !== null && findCodeWord(query, "SET", update.end) !== null;
+  const update = findCodeWord(query, "UPDATE", 0, grammar);
+  return update !== null && findCodeWord(query, "SET", update.end, grammar) !== null;
 }

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { ShieldAlert, ShieldCheck, AlertTriangle, Loader2, Play, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
+import { hasUnterminatedSpan } from "@/lib/sql/spans";
 import { findCodeWord } from "@/lib/sql/words";
 import type { DatabaseType } from "@/lib/types";
 
@@ -97,6 +98,25 @@ export function QuerySafetyDialog({
   const [analysis, setAnalysis] = useState<SafetyAnalysis | null>(null);
   const [rawResponse, setRawResponse] = useState("");
   const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Whether the client-side reading that opened this dialog could not resolve part
+   * of the statement (#297).
+   *
+   * Recomputed here rather than passed in: the gate is a pure function of the text
+   * and the dialect, both of which this component already has, and a new required
+   * prop would be a breaking change for the published package. `databaseType`
+   * arrives as a plain string from the host application, and a value that is not one
+   * of the types this project knows resolves to the compatibility default - the
+   * same answer a dialect-less call gets everywhere else in `src/lib/sql`.
+   *
+   * Memoised because the analysis stream re-renders this component per chunk while
+   * the query text does not change, and the scan is linear in that text.
+   */
+  const unreadableRun = useMemo(
+    () => hasUnterminatedSpan(query, resolveSqlGrammar(databaseType as DatabaseType | undefined)),
+    [query, databaseType],
+  );
 
   useEffect(() => {
     if (isOpen && query) {
@@ -200,6 +220,25 @@ export function QuerySafetyDialog({
         </div>
 
         <div className="px-5 py-4 max-h-80 overflow-auto">
+          {/*
+            Said before the analysis and kept beside it: the reason this dialog
+            opened is the client-side reading, and a risk verdict produced from text
+            whose reading stopped early may not describe what the statement does.
+          */}
+          {unreadableRun && (
+            <div className="mb-3 flex items-start gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20">
+              <AlertTriangle strokeWidth={1.5} className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-400" />
+              <div>
+                <span className="text-xs font-medium text-amber-400">Part of this statement could not be read</span>
+                <p className="text-xs text-zinc-400 mt-0.5">
+                  A quoted, commented or bracketed run in it never closes (or its closing quote sits behind a backslash,
+                  which dialects read differently), so nothing written after that point could be checked. It may hide a
+                  write, which is why you are being asked.
+                </p>
+              </div>
+            </div>
+          )}
+
           {isAnalyzing && (
             <div className="flex items-center justify-center gap-2 py-8 text-zinc-500">
               <Loader2 strokeWidth={1.5} className="w-5 h-5 animate-spin" />
@@ -325,17 +364,24 @@ const DANGEROUS_KEYWORDS = new Set(["DELETE", "DROP", "TRUNCATE", "ALTER", "GRAN
  * dialog and the limiter agree about where a statement starts, and a `WITH` whose CTE
  * list only precedes a write (`WITH x AS (…) DELETE FROM …`) is now recognised too.
  *
- * KNOWN GAP, and it is the uncomfortable direction for a safety check: text the
- * reading cannot resolve HIDES what follows it, so this answers false there rather
- * than asking. `SELECT '\';` + a following write is the case — the two dialect
- * readings of `'\'` end the string in different places, so `spans.ts` declines to
- * guess and everything after is inside a literal as far as this predicate can tell.
- * A test pins it. It is also the ONE input class this reading NARROWED: the text scan
- * it replaced found an `UPDATE … SET` written after such a literal, so that script
- * prompted before and does not now. Reachable only from text carrying a backslash
- * immediately before a closing quote, and whether an unresolvable statement should ASK
- * instead is a policy question with its own UX cost - tracked as #297, with the
- * dialect-aware reading #292 asks for as the alternative, rather than decided here.
+ * Text the reading cannot resolve ASKS (#297). A run that never closes hides
+ * whatever is written inside it - `SELECT '\';` followed by a write is the case,
+ * because the two dialect readings of `'\'` end the string in different places and
+ * `spans.ts` declines to guess - so reading the code words finds nothing after it
+ * and every keyword test above answers false. Every other reader in `src/lib/sql/`
+ * errs toward not ACTING on such text, which is the safe direction for them (their
+ * mistake is a row bound appended to a write). Here the costs are reversed: a false
+ * prompt costs one click, silence costs an unconfirmed destructive statement. So
+ * this predicate treats an unresolvable run as a reason to ask, and the dialog says
+ * that is why it is asking rather than describing a risk it could not assess.
+ *
+ * The accepted cost, pinned by tests rather than left to be discovered: `spans.ts`
+ * reports an undeterminable literal for any closing quote behind an ODD backslash
+ * run, so a legitimate PostgreSQL literal ending in a backslash prompts every time.
+ * A statement whose runs all resolve does NOT prompt merely for carrying a
+ * backslash. Naming the dialect narrows this further where a dialect resolves the
+ * text (#292, #295): Oracle's `q'{it's}'` and ClickHouse's `[[1,2],[3,4]]` are
+ * closed runs under their own grammars and unresolvable under a reader without them.
  *
  * `databaseType` is the connection the statement is about to run on, and both
  * call sites hold one (#292). It decides the characters the engines read
@@ -346,6 +392,12 @@ const DANGEROUS_KEYWORDS = new Set(["DELETE", "DROP", "TRUNCATE", "ALTER", "GRAN
  */
 export function isDangerousQuery(query: string, databaseType?: DatabaseType): boolean {
   const grammar = resolveSqlGrammar(databaseType);
+
+  // Asked FIRST because it is the only question here whose answer does not depend
+  // on reading the statement: where a run never closes, every keyword test below
+  // is reading text that stops early, so their `false` is "not found" rather than
+  // "not there".
+  if (hasUnterminatedSpan(query, grammar)) return true;
 
   const keyword = readOperativeKeyword(query, grammar)?.keyword;
   if (keyword !== undefined && DANGEROUS_KEYWORDS.has(keyword)) return true;

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -128,7 +128,9 @@ export function useQueryExecution({
         !isExplain &&
         !executionOptions?.offset &&
         !playgroundMode &&
-        isDangerousQuery(queryToExecute)
+        // The connection's type is the dialect the statement is about to run
+        // under, and the gate reads the statement under it (#292).
+        isDangerousQuery(queryToExecute, activeConnection.type)
       ) {
         setSafetyCheckQuery(queryToExecute);
         return;

--- a/src/lib/db/providers/document/couchbase/index.ts
+++ b/src/lib/db/providers/document/couchbase/index.ts
@@ -346,7 +346,7 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
   public override prepareQuery(query: string, options: QueryPrepareOptions = {}): PreparedQuery {
     const { limit = DEFAULT_QUERY_LIMIT, offset = 0, unlimited = false } = options;
     const effectiveLimit = unlimited ? MAX_UNLIMITED_ROWS : limit;
-    const limited = applyQueryLimit(query, effectiveLimit, offset);
+    const limited = applyQueryLimit(query, effectiveLimit, offset, {}, this.type);
     return { query: limited.sql, wasLimited: limited.wasLimited, limit: effectiveLimit, offset };
   }
 

--- a/src/lib/db/providers/sql/clickhouse/index.ts
+++ b/src/lib/db/providers/sql/clickhouse/index.ts
@@ -66,6 +66,7 @@ import {
 } from "@/lib/db/types";
 import { formatCacheHitRatio } from "@/lib/monitoring-cache-ratio";
 import { formatBytes } from "@/lib/db/utils/pool-manager";
+import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
 import { ClickHouseHttpTransport } from "./http-transport";
 import {
@@ -392,8 +393,8 @@ function splitTarget(target: string, pinnedDatabase: string): [database: string,
  * -- note` and turn a working statement into the 400 / code 62 this override
  * exists to prevent (#280).
  */
-function hasTrailingClause(sql: string): boolean {
-  const statement = sql.slice(0, readStatementEnd(sql).end);
+function hasTrailingClause(sql: string, grammar: SqlGrammar): boolean {
+  const statement = sql.slice(0, readStatementEnd(sql, grammar).end);
   return TRAILING_FORMAT.test(statement) || TRAILING_SETTINGS.test(statement);
 }
 
@@ -561,7 +562,7 @@ export class ClickHouseProvider extends SQLBaseProvider {
    */
   public override prepareQuery(query: string, options: QueryPrepareOptions = {}): PreparedQuery {
     const prepared = super.prepareQuery(query, options);
-    if (!hasTrailingClause(query)) return prepared;
+    if (!hasTrailingClause(query, resolveSqlGrammar(this.type))) return prepared;
 
     return { ...prepared, query, wasLimited: false };
   }

--- a/src/lib/db/providers/sql/druid/index.ts
+++ b/src/lib/db/providers/sql/druid/index.ts
@@ -270,7 +270,7 @@ export class DruidProvider extends SQLBaseProvider {
    */
   public override prepareQuery(query: string, options: QueryPrepareOptions = {}): PreparedQuery {
     const prepared = super.prepareQuery(query, options);
-    const parsed = analyzeQuery(query);
+    const parsed = analyzeQuery(query, this.type);
     if (!parsed.hasOffset || parsed.hasLimit) return prepared;
 
     return { ...prepared, query, wasLimited: false };

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -515,6 +515,16 @@ export class MSSQLProvider extends SQLBaseProvider {
     try {
       const config = this.buildConfig();
       this.pool = new mssql.ConnectionPool(config);
+
+      // `mssql`'s ConnectionPool is an EventEmitter that emits `error` for a background
+      // connection failure (a non-ESOCKET tedious error) and for a failed acquire. An
+      // `error` event with no listener is an uncaught exception, so without this handler
+      // one of those takes the server process down (#298). A failed acquire ALSO rejects
+      // the caller's promise, so this handler must only log — swallowing nothing.
+      this.pool.on("error", (error: unknown) => {
+        console.error("[MSSQL] Pool error:", error);
+      });
+
       await this.pool.connect();
 
       // Test the connection

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -31,7 +31,7 @@ import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } fr
 import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
-import { resolveSqlGrammar } from "@/lib/sql/grammar";
+import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
 
 // Row shape used to group foreign keys per table in getSchema().
@@ -47,12 +47,23 @@ type ForeignKeyInfo = { columnName: string; referencedTable: string; referencedC
  * (#275). `DISTINCT` is found the same way, so `SELECT /* c *\/ DISTINCT a` places
  * `TOP` after the `DISTINCT` and not between the two - `SELECT TOP n DISTINCT ...`
  * is a syntax error in T-SQL.
+ *
+ * Every one of those three reads takes T-SQL's grammar, because this is a HEAD
+ * rewrite and the index comes from the reading: T-SQL nests block comments, so a
+ * flat reading of `SELECT /* a /* b *\/ DISTINCT *\/ name FROM t` found a
+ * `DISTINCT` that is inside the comment and spliced the `TOP` in after it - inside
+ * the comment too. SQL Server then ran the statement unbounded while this provider
+ * reported a limit, which is #280's shape rather than a missed bound (#300).
+ *
+ * The two SUFFIX slices are safe under this dialect's grammar specifically: only
+ * the alternate-quote tag reads the character before its index (see `readSqlSpan`),
+ * and T-SQL does not have that form.
  */
-function injectTop(sql: string, limit: number): string | null {
-  const select = readLeadingKeyword(sql);
+function injectTop(sql: string, limit: number, grammar: SqlGrammar): string | null {
+  const select = readLeadingKeyword(sql, grammar);
   if (select === null || select.keyword !== "SELECT") return null;
 
-  const next = readLeadingKeyword(sql.slice(select.end));
+  const next = readLeadingKeyword(sql.slice(select.end), grammar);
   const insertAt = next?.keyword === "DISTINCT" ? select.end + next.end : select.end;
 
   // A `TOP` already sitting where this one would go means the statement carries its
@@ -60,7 +71,7 @@ function injectTop(sql: string, limit: number): string | null {
   // whitespace between the two words, so a comment between them defeats it, as does
   // a `DISTINCT`. Splicing anyway yields `SELECT TOP 50 TOP 10` and a syntax error,
   // so decline and let the caller report that nothing was limited.
-  if (readLeadingKeyword(sql.slice(insertAt))?.keyword === "TOP") return null;
+  if (readLeadingKeyword(sql.slice(insertAt), grammar)?.keyword === "TOP") return null;
 
   return `${sql.slice(0, insertAt)} TOP ${limit}${sql.slice(insertAt)}`;
 }
@@ -623,7 +634,10 @@ export class MSSQLProvider extends SQLBaseProvider {
       // it, and the already-bounded probe sees a `FETCH NEXT` written after the
       // `#` even when trailing trivia follows it.
       const source = query.trim();
-      const { end, rewritable } = readStatementEnd(source, resolveSqlGrammar(this.type));
+      // Resolved once and handed to both readers below, so the head splice and the
+      // end reader cannot disagree about where a comment ends (#300).
+      const grammar = resolveSqlGrammar(this.type);
+      const { end, rewritable } = readStatementEnd(source, grammar);
       let modifiedSql = source.slice(0, end);
       const trailing = source.slice(end);
 
@@ -652,7 +666,7 @@ export class MSSQLProvider extends SQLBaseProvider {
         modifiedSql = `${modifiedSql} OFFSET ${offset} ROWS FETCH NEXT ${effectiveLimit} ROWS ONLY`;
       } else {
         // Inject TOP N after SELECT
-        const injected = injectTop(modifiedSql, effectiveLimit);
+        const injected = injectTop(modifiedSql, effectiveLimit, grammar);
 
         // Nothing to inject into: report the truth rather than a limit that is not
         // there. `analyzeQuery` also calls a CTE a SELECT, and `TOP` belongs to the

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -31,6 +31,7 @@ import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } fr
 import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
 
 // Row shape used to group foreign keys per table in getSchema().
@@ -559,7 +560,7 @@ export class MSSQLProvider extends SQLBaseProvider {
   public override prepareQuery(query: string, options: QueryPrepareOptions = {}): PreparedQuery {
     const { limit = DEFAULT_QUERY_LIMIT, offset = 0, unlimited = false } = options;
     const effectiveLimit = unlimited ? MAX_UNLIMITED_ROWS : limit;
-    const queryInfo = analyzeQuery(query);
+    const queryInfo = analyzeQuery(query, this.type);
 
     if (queryInfo.type === "SELECT" && !queryInfo.hasLimit) {
       // The `TOP` branch writes into the HEAD and was never reachable by a
@@ -572,23 +573,20 @@ export class MSSQLProvider extends SQLBaseProvider {
       //
       // Splitting and rejoining is lossless and the splice does not depend on
       // where the statement ends, so the `TOP` branch stays correct even where
-      // the tail may not be CUT - which matters here more than anywhere else,
-      // because a T-SQL temp table (`SELECT * FROM #tmp`) is exactly such a
-      // statement and is entirely ordinary. Only the appending branch has to
-      // decline.
+      // the tail may not be CUT. Only the appending branch has to decline there.
       //
-      // What makes that tolerable is that a refused cut still reports the whole
-      // statement as its end, so the already-bounded probe above sees a
-      // `FETCH NEXT` written after the `#` and this block is not entered for an
-      // already-paged temp table. It is not airtight: put trailing trivia after
-      // that bound (`... FETCH NEXT 10 ROWS ONLY -- daily`) and the end-anchored
-      // probe stops seeing it, so a `TOP` is spliced alongside an `OFFSET …
-      // FETCH` that SQL Server rejects. That shape behaves exactly as it did
-      // before this change - the probe was end-anchored on the raw text then too
-      // - and closing it needs the `#` end re-read under a hash-is-code scan,
-      // which is a change of its own with its own tests.
+      // The end is read under T-SQL's grammar (#292), where `#` opens no comment
+      // at all - `#name` and `##name` are temp tables. That is what makes a temp
+      // table an ordinary statement here rather than the special case it used to
+      // be: `SELECT * FROM #tmp` is cuttable, so BOTH branches are reachable for
+      // it, and the already-bounded probe sees a `FETCH NEXT` written after the
+      // `#` even when trailing trivia follows it - which is where a `TOP` used to
+      // be spliced alongside an `OFFSET … FETCH` that SQL Server rejects
+      // outright. What still declines is a statement whose end cannot be cut for
+      // a reason that is not the hash, such as a literal behind an odd backslash
+      // run; that class is #293's remaining half.
       const source = query.trim();
-      const { end, rewritable } = readStatementEnd(source);
+      const { end, rewritable } = readStatementEnd(source, resolveSqlGrammar(this.type));
       let modifiedSql = source.slice(0, end);
       const trailing = source.slice(end);
 

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -65,6 +65,47 @@ function injectTop(sql: string, limit: number): string | null {
   return `${sql.slice(0, insertAt)} TOP ${limit}${sql.slice(insertAt)}`;
 }
 
+/**
+ * A T-SQL page written as `OFFSET n ROW[S]`, at the end of the statement.
+ *
+ * That is a complete page here - "skip n rows and return the rest" - and it is
+ * the one bound form the shared probes in `query-limiter.ts` cannot see: they
+ * want a `FETCH … ROWS ONLY` tail or a bare `OFFSET n`, and `OFFSET 10 ROWS` is
+ * neither. Unseen, the statement looked unbounded and collected a clause beside
+ * its own page, which SQL Server rejects outright (Msg 10741) - so the statement
+ * FAILED rather than returning too many rows, and this method reported a limit
+ * for it. The form belongs to this dialect, so it is read here rather than in the
+ * shared limiter, where it would move every other dialect's probes (#293).
+ *
+ * Anchored at the end of the statement for the same reason the shared probes
+ * are: an `OFFSET` inside a subquery (`… FROM (SELECT … OFFSET 10 ROWS) x`) is a
+ * different query expression, which a `TOP` on the outer one may legally join,
+ * and one written in a trailing comment is not a page at all. A digit count only,
+ * as the shared probes read: `OFFSET @skip ROWS` is not recognised, which is the
+ * limitation `docs/providers/mssql.md` records.
+ */
+const TSQL_PAGE_TAIL = /\bOFFSET\s+\d+\s+ROWS?\s*$/i;
+
+/**
+ * Whether text mentions a clause a row-count clause may not sit beside.
+ *
+ * Consulted ONLY where the statement's end may not be cut. Every already-bounded
+ * probe - the shared ones and `TSQL_PAGE_TAIL` above - is anchored at the end of
+ * the statement's own text, and where the cut is refused that text still carries
+ * the trailing trivia: a real page written before a trailing comment then sits
+ * away from the anchor and reads as absent. An anchor that may be reading trivia
+ * is not an answer a decision that ADDS a clause may rest on, so this asks the
+ * weaker question the situation allows - is there anything here that could be a
+ * page? - and the branch declines when there is.
+ *
+ * Unanchored and deliberately blunt: it also fires on a column named `offset`
+ * and on a subquery's own page, so such a statement loses its bound. That is the
+ * trade the whole of `src/lib/sql/` makes for text it cannot resolve - an
+ * over-large read reported honestly as unbounded, never a statement the server
+ * refuses - and both halves are pinned in this provider's suite.
+ */
+const TSQL_ROW_BOUND_MENTION = /\b(?:OFFSET|FETCH)\b/i;
+
 // ============================================================================
 // SQL Statements
 // ============================================================================
@@ -580,15 +621,23 @@ export class MSSQLProvider extends SQLBaseProvider {
       // table an ordinary statement here rather than the special case it used to
       // be: `SELECT * FROM #tmp` is cuttable, so BOTH branches are reachable for
       // it, and the already-bounded probe sees a `FETCH NEXT` written after the
-      // `#` even when trailing trivia follows it - which is where a `TOP` used to
-      // be spliced alongside an `OFFSET … FETCH` that SQL Server rejects
-      // outright. What still declines is a statement whose end cannot be cut for
-      // a reason that is not the hash, such as a literal behind an odd backslash
-      // run; that class is #293's remaining half.
+      // `#` even when trailing trivia follows it.
       const source = query.trim();
       const { end, rewritable } = readStatementEnd(source, resolveSqlGrammar(this.type));
       let modifiedSql = source.slice(0, end);
       const trailing = source.slice(end);
+
+      // Two pages the shared probes cannot see, and a clause beside either is a
+      // statement SQL Server refuses (Msg 10741) rather than one that returns too
+      // many rows - so both decline here, before either branch commits to a
+      // `wasLimited: true` (#293). The first is this dialect's own `OFFSET n ROWS`
+      // form; the second is every statement whose end may not be cut, where no
+      // end anchor is reading the statement's real tail and the honest answer is
+      // that a page cannot be ruled out. Neither is the hash the paragraph above
+      // describes: that half is closed at the root by naming the dialect.
+      if (TSQL_PAGE_TAIL.test(modifiedSql) || (!rewritable && TSQL_ROW_BOUND_MENTION.test(modifiedSql))) {
+        return { query, wasLimited: false, limit: effectiveLimit, offset };
+      }
 
       if (offset > 0) {
         if (!rewritable) {

--- a/src/lib/db/providers/sql/mysql.ts
+++ b/src/lib/db/providers/sql/mysql.ts
@@ -303,6 +303,12 @@ export class MySQLProvider extends SQLBaseProvider {
     }
 
     try {
+      // No pool `error` listener here, unlike the PostgreSQL and SQL Server providers
+      // (#298): mysql2's pool has no pool-level `error` event to listen for. Audited in
+      // the installed package — `mysql2/lib/base/pool.js` emits only `acquire`,
+      // `connection`, `enqueue` and `release`, the promise wrapper forwards exactly those
+      // four (`lib/promise/pool.js`), and `typings/mysql/lib/Pool.d.ts` types no `error`
+      // overload. A connection that fails reports through the call that holds it.
       this.pool = mysql.createPool(this.buildPoolConfig());
 
       const conn = await this.pool.getConnection();

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -280,6 +280,11 @@ export class OracleProvider extends SQLBaseProvider {
     }
 
     try {
+      // No pool `error` listener here, unlike the PostgreSQL and SQL Server providers
+      // (#298): oracledb's pool has no pool-level `error` event to listen for. Audited in
+      // the installed package — `oracledb/lib/pool.js` extends EventEmitter but emits only
+      // the internal `_afterPoolClose` and `_allCheckedIn`, and nothing under `oracledb/lib`
+      // emits `error` at all. Connection failures surface through the awaiting call.
       this.pool = await oracledb.createPool({
         user: this.config.user,
         password: this.config.password,

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -30,6 +30,7 @@ import {
 import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
 import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
 
 // ============================================================================
@@ -394,7 +395,7 @@ export class OracleProvider extends SQLBaseProvider {
   public override prepareQuery(query: string, options: QueryPrepareOptions = {}): PreparedQuery {
     const { limit = DEFAULT_QUERY_LIMIT, offset = 0, unlimited = false } = options;
     const effectiveLimit = unlimited ? MAX_UNLIMITED_ROWS : limit;
-    const queryInfo = analyzeQuery(query);
+    const queryInfo = analyzeQuery(query, this.type);
 
     if (queryInfo.type === "SELECT" && !queryInfo.hasLimit) {
       // Both branches append at the tail, so both used to have their clause
@@ -404,10 +405,12 @@ export class OracleProvider extends SQLBaseProvider {
       // trailing trivia instead, which also keeps the `;` out of the comment.
       // A statement whose end may not be cut has nowhere honest to take the
       // clause, so it is returned untouched rather than bounded on a guess. On
-      // Oracle the live shape is `#` in an identifier (`ID#`), which is legal
-      // there and a comment marker in MySQL.
+      // Oracle that is a literal Oracle and MySQL would close in different
+      // places. `#` in an identifier (`ID#`) used to reach the same refusal and
+      // no longer does: the end is read under Oracle's own grammar (#292), where
+      // `#` is an identifier character and opens no comment.
       const source = query.trim();
-      const { end, rewritable } = readStatementEnd(source);
+      const { end, rewritable } = readStatementEnd(source, resolveSqlGrammar(this.type));
       if (!rewritable) {
         return { query, wasLimited: false, limit: effectiveLimit, offset };
       }

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -567,6 +567,7 @@ export class PostgresProvider extends SQLBaseProvider {
     try {
       const poolConfig = this.buildPoolConfig();
       this.pool = new Pool(poolConfig);
+      this.attachPoolErrorListener(this.pool);
 
       const client = await this.pool.connect();
       client.release();
@@ -589,6 +590,24 @@ export class PostgresProvider extends SQLBaseProvider {
       this.pool = null;
       this.setConnected(false);
     }
+  }
+
+  /**
+   * A client that fails while CHECKED OUT rejects its own query, which is why ordinary
+   * query failures behave correctly. A client that fails while IDLE — the server dropped
+   * it, the network went away — has no query to reject, so `pg` removes and destroys it
+   * and then emits `error` on the pool. An `error` event with no listener is an uncaught
+   * exception, so without this handler a dropped idle connection takes the whole server
+   * process down (#298).
+   *
+   * The client is already gone by the time this fires, so the handler exists to keep the
+   * event non-fatal and visible — not to reconnect. The pool opens a fresh client on the
+   * next acquire by itself.
+   */
+  private attachPoolErrorListener(pool: Pool): void {
+    pool.on("error", (error) => {
+      console.error("[Postgres] Idle pool client error:", error);
+    });
   }
 
   private buildPoolConfig(): PgPoolConfig {

--- a/src/lib/db/providers/sql/sql-base.ts
+++ b/src/lib/db/providers/sql/sql-base.ts
@@ -148,10 +148,13 @@ export abstract class SQLBaseProvider extends BaseDatabaseProvider {
   public override prepareQuery(query: string, options: QueryPrepareOptions = {}): PreparedQuery {
     const { limit = DEFAULT_QUERY_LIMIT, offset = 0, unlimited = false } = options;
     const effectiveLimit = unlimited ? MAX_UNLIMITED_ROWS : limit;
-    const queryInfo = analyzeQuery(query);
+    // `this.type` is the dialect channel (#292): the shared readers resolve `#`
+    // and the other characters the engines disagree about the way THIS engine
+    // does, rather than taking one engine's side for all of them.
+    const queryInfo = analyzeQuery(query, this.type);
 
     if (queryInfo.type === "SELECT") {
-      const limitResult = applyQueryLimit(query, effectiveLimit, offset);
+      const limitResult = applyQueryLimit(query, effectiveLimit, offset, {}, this.type);
       return {
         query: limitResult.sql,
         wasLimited: limitResult.wasLimited,

--- a/src/lib/db/providers/sql/sql-base.ts
+++ b/src/lib/db/providers/sql/sql-base.ts
@@ -11,6 +11,7 @@ import {
   type QueryPrepareOptions,
 } from "../../types";
 import { analyzeQuery, applyQueryLimit, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
 
 // ============================================================================
@@ -127,9 +128,18 @@ export abstract class SQLBaseProvider extends BaseDatabaseProvider {
    * write branch and returned no rows for a query that has data (#275). And
    * `startsWith` has no word boundary, so a statement led by an identifier that
    * merely begins with a keyword answered true; reading the whole word ends that.
+   *
+   * Both pass `this.type`, so the leading comment is read the way THIS engine reads
+   * it - which for a dialect that nests block comments is not where a flat reading
+   * ends one (#300). No provider's answer changes today: `isReadOnlyQuery`'s only
+   * caller is the SQLite provider's `all()`/`run()` routing and SQLite reads comments
+   * flat, while `isSchemaModifyingQuery` has no caller in `src/` at all. The grammar is
+   * threaded anyway, so that the day a nesting dialect routes on either predicate it
+   * reads the statement the way its own server will - and so that no reader in this
+   * class disagrees with the limiter one method below it.
    */
   protected isReadOnlyQuery(sql: string): boolean {
-    const keyword = readLeadingKeyword(sql)?.keyword;
+    const keyword = readLeadingKeyword(sql, resolveSqlGrammar(this.type))?.keyword;
     return keyword !== undefined && READ_ONLY_KEYWORDS.has(keyword);
   }
 
@@ -137,7 +147,7 @@ export abstract class SQLBaseProvider extends BaseDatabaseProvider {
    * Check if query modifies schema (CREATE, DROP, ALTER, TRUNCATE)
    */
   protected isSchemaModifyingQuery(sql: string): boolean {
-    const keyword = readLeadingKeyword(sql)?.keyword;
+    const keyword = readLeadingKeyword(sql, resolveSqlGrammar(this.type))?.keyword;
     return keyword !== undefined && SCHEMA_MODIFYING_KEYWORDS.has(keyword);
   }
 

--- a/src/lib/db/utils/query-limiter.ts
+++ b/src/lib/db/utils/query-limiter.ts
@@ -25,9 +25,11 @@
  * injected at all (#280).
  */
 
+import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
 import { readStatementEnd } from "@/lib/sql/statement-end";
+import type { DatabaseType } from "@/lib/types";
 
 // ============================================================================
 // Constants
@@ -86,7 +88,21 @@ function classifyKeyword(keyword: string | undefined): ParsedQueryInfo["type"] {
   return "OTHER";
 }
 
-export function analyzeQuery(sql: string): ParsedQueryInfo {
+/**
+ * The statement's shape, read under a dialect's grammar.
+ *
+ * `type` names the engine the statement is about to run on, so the readers below
+ * resolve the characters the dialects disagree about - today `#`, which is a
+ * comment marker in MySQL and ClickHouse and ordinary code everywhere else - the
+ * way that engine does. Omitting it means "no dialect named" and keeps the
+ * reading these functions had before the channel existed (#292); every caller in
+ * this project has one to pass.
+ */
+export function analyzeQuery(sql: string, type?: DatabaseType): ParsedQueryInfo {
+  return analyzeUnderGrammar(sql, resolveSqlGrammar(type));
+}
+
+function analyzeUnderGrammar(sql: string, grammar: SqlGrammar): ParsedQueryInfo {
   // The statement's own text, with its trailing trivia and terminator removed.
   // Every end-anchored probe below reads THIS rather than the raw input: the
   // anchor is what keeps them off a statement that merely mentions a bound, and
@@ -98,7 +114,7 @@ export function analyzeQuery(sql: string): ParsedQueryInfo {
   // clause. Where the cut is refused this end is the terminator strip, which is
   // what these probes read before the reader existed, so none of them answers
   // differently than it used to.
-  const statement = sql.slice(0, readStatementEnd(sql).end);
+  const statement = sql.slice(0, readStatementEnd(sql, grammar).end);
 
   // Query type detection - from the first keyword that is not whitespace or a comment
   const leading = readLeadingKeyword(statement);
@@ -124,7 +140,7 @@ export function analyzeQuery(sql: string): ParsedQueryInfo {
   // module - `sql-base.ts`, `oracle.ts` and `mssql.ts` - test `=== "SELECT"` and
   // nothing else, so the honest answer costs nothing.
   // `MERGE`, which the union cannot name, falls through to OTHER.
-  const typingKeyword = keyword === "WITH" ? readOperativeKeyword(statement)?.keyword : keyword;
+  const typingKeyword = keyword === "WITH" ? readOperativeKeyword(statement, grammar)?.keyword : keyword;
   const type = classifyKeyword(typingKeyword);
 
   // LIMIT/OFFSET detection - en dıştaki sorgunun LIMIT'ini bul
@@ -218,9 +234,13 @@ export function applyQueryLimit(
   limit: number,
   offset: number = 0,
   options: Partial<QueryLimitOptions> = {},
+  type?: DatabaseType,
 ): LimitedQueryResult {
   const { forceLimit = false } = options;
-  const info = analyzeQuery(sql);
+  // Resolved once and passed down, so the type it came from stops here: no reader
+  // below this line ever sees a database type id.
+  const grammar = resolveSqlGrammar(type);
+  const info = analyzeUnderGrammar(sql, grammar);
 
   // SELECT değilse, limit ekleme
   if (info.type !== "SELECT") {
@@ -251,13 +271,14 @@ export function applyQueryLimit(
   // carries no trailing trivia, which is nearly all of them.
   //
   // A statement whose end may not be cut is returned untouched: there is nowhere
-  // honest to put the clause, and `wasLimited: false` says so. The two shapes are
-  // a literal MySQL and PostgreSQL would close in different places
+  // honest to put the clause, and `wasLimited: false` says so. One shape always
+  // reaches that - a literal MySQL and PostgreSQL would close in different places
   // (`… WHERE name = 'O\'Brien';`, where inserting on a guess puts the bound after
-  // the `;`) and a trailing `#` run, which is a comment in MySQL and a temp table,
-  // an identifier or an operator elsewhere.
+  // the `;`). A trailing `#` run reaches it only when NO dialect was named, since
+  // it is a comment in MySQL and ClickHouse and a temp table, an identifier or an
+  // operator in the rest, and a named dialect has already told them apart.
   const source = sql.trim();
-  const { end, rewritable } = readStatementEnd(source);
+  const { end, rewritable } = readStatementEnd(source, grammar);
 
   if (!rewritable) {
     return { sql, wasLimited: false, originalLimit: info.existingLimit, appliedLimit: 0, appliedOffset: 0 };
@@ -298,8 +319,12 @@ export function hasQueryLimit(sql: string): boolean {
 
 /**
  * Sorgunun SELECT türünde olup olmadığını kontrol eder.
+ *
+ * `type` is the dialect, as on `analyzeQuery`. The multi-statement route passes
+ * its resolved connection's, so the route and the provider that runs the
+ * statement cannot disagree about what the statement is.
  */
-export function isSelectQuery(sql: string): boolean {
-  const info = analyzeQuery(sql);
+export function isSelectQuery(sql: string, type?: DatabaseType): boolean {
+  const info = analyzeQuery(sql, type);
   return info.type === "SELECT";
 }

--- a/src/lib/db/utils/query-limiter.ts
+++ b/src/lib/db/utils/query-limiter.ts
@@ -116,8 +116,12 @@ function analyzeUnderGrammar(sql: string, grammar: SqlGrammar): ParsedQueryInfo 
   // differently than it used to.
   const statement = sql.slice(0, readStatementEnd(sql, grammar).end);
 
-  // Query type detection - from the first keyword that is not whitespace or a comment
-  const leading = readLeadingKeyword(statement);
+  // Query type detection - from the first keyword that is not whitespace or a
+  // comment, and where a comment ENDS is the dialect's answer: on a dialect that
+  // nests block comments, a flat reading reports a word the operator commented out
+  // (#300). The grammar is already resolved here, so it costs one argument to keep
+  // this reader and `readStatementEnd` above reading the same comment.
+  const leading = readLeadingKeyword(statement, grammar);
   const keyword = leading?.keyword;
   // The statement from its own first keyword onward. Anything that searches the
   // statement's TEXT rather than just its leading keyword has to start here, or a

--- a/src/lib/explain/clickhouse-json.ts
+++ b/src/lib/explain/clickhouse-json.ts
@@ -1,5 +1,14 @@
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { classifySelectPrefix } from "./select-prefix";
 import type { ExplainStrategy, ExplainTreeNode } from "./types";
+
+/**
+ * This strategy's dialect, resolved once. Reached only through
+ * `explainFormat: "clickhouse-json"`, which only the ClickHouse provider declares, so
+ * the module's identity IS the dialect - the same shape as a provider passing
+ * `this.type`.
+ */
+const CLICKHOUSE_GRAMMAR = resolveSqlGrammar("clickhouse");
 
 /**
  * `FORMAT <Name>` where nothing but a `SETTINGS` clause or a semicolon follows it.
@@ -168,7 +177,11 @@ export const clickhouseJsonStrategy: ExplainStrategy = {
   // so both modes return the estimate, as the SQLite and Couchbase strategies do.
   buildSql(sql) {
     // ClickHouse's `EXPLAIN` describes without running, so a CTE is safe to explain.
-    if (classifySelectPrefix(sql) === null) return null;
+    // The statement is read under this dialect's grammar all the same (#300): block
+    // comments nest here, so a flat reading reports a keyword written inside one, and
+    // an Explain built for a statement whose real keyword is a write is a dishonest
+    // classification even where nothing executes.
+    if (classifySelectPrefix(sql, CLICKHOUSE_GRAMMAR) === null) return null;
     // A trailing FORMAT would reformat the PLAN, not the statement's rows: live, a
     // wrapped `... FORMAT TSV` comes back as TSV text and the tree can never be
     // built. The clause describes the statement's own result, which an EXPLAIN never

--- a/src/lib/explain/postgres-json.ts
+++ b/src/lib/explain/postgres-json.ts
@@ -1,5 +1,16 @@
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { classifySelectPrefix, hasDataModifyingStatement } from "./select-prefix";
 import type { ExplainPlanResult, ExplainStrategy } from "./types";
+
+/**
+ * This strategy's dialect, resolved once.
+ *
+ * The module IS the PostgreSQL strategy - it is reached only through
+ * `explainFormat: "postgres-json"`, which only `providers/sql/postgres.ts` declares -
+ * so naming the type here is the same shape as a provider passing `this.type`, not the
+ * type-switching this project bans. Nothing below the resolver sees a type id.
+ */
+const POSTGRES_GRAMMAR = resolveSqlGrammar("postgres");
 
 /**
  * The one strategy that cannot simply take the shared classification, because it is
@@ -23,9 +34,20 @@ import type { ExplainPlanResult, ExplainStrategy } from "./types";
  *
  * The narrower question of ANALYZE executing an ordinary SELECT twice - once for the
  * user, once for the background pre-warm - is issue #194's remaining work, not this.
+ *
+ * The classification is read under PostgreSQL's own grammar, and that is load-bearing
+ * rather than tidiness: block comments NEST here, so read flat,
+ * `/* a /* b *\/ SELECT 1 *\/ DELETE FROM users` leads with `SELECT` - the `DELETE`
+ * hides behind text a flat reader thinks is code - and this path has no other screen,
+ * because a `SELECT` prefix skips `hasDataModifyingStatement` by the paragraph above
+ * and an explain run skips the confirmation dialog entirely
+ * (`use-query-execution.ts`, `!isExplain`). Live-verified on PostgreSQL 18:
+ * `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` over that statement against a three-row
+ * table left zero rows. Under this dialect's grammar the comment is read whole, the
+ * statement leads with `DELETE`, and nothing is built (#300).
  */
 function isExplainable(sql: string): boolean {
-  const prefix = classifySelectPrefix(sql);
+  const prefix = classifySelectPrefix(sql, POSTGRES_GRAMMAR);
   if (prefix === null) return false;
 
   return prefix === "select" || !hasDataModifyingStatement(sql);

--- a/src/lib/explain/select-prefix.ts
+++ b/src/lib/explain/select-prefix.ts
@@ -22,6 +22,7 @@
  * tolerance (#275), and the ReDoS reasoning that shapes the pattern moved with it.
  */
 
+import type { SqlGrammar } from "@/lib/sql/grammar";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
 
 /**
@@ -49,8 +50,9 @@ export type SelectPrefix = "select" | "with";
  *   statement that leads with it is already refused by `classifySelectPrefix`, which
  *   only ever answers for `SELECT` or `WITH`. Same for `CREATE`, `DROP` and `ALTER`.
  *
- * Flat, with no nested quantifier, so it carries none of the backtracking risk that
- * the trivia pattern in `lib/sql/leading-keyword.ts` had to be shaped around.
+ * Flat, with no nested quantifier, so it carries none of the backtracking risk the
+ * trivia pattern `lib/sql/leading-keyword.ts` used to carry - the three measured
+ * failures that reader still records, and the reason it is a scanner now.
  */
 const DATA_MODIFYING = /\b(?:INSERT|UPDATE|DELETE|MERGE)\b/i;
 
@@ -61,9 +63,19 @@ const DATA_MODIFYING = /\b(?:INSERT|UPDATE|DELETE|MERGE)\b/i;
  * `buildSql`. A comment on its own is `null`: a comment is not a statement. So is any
  * other leading keyword - `readLeadingKeyword` reports what it finds, and only these
  * two are explainable.
+ *
+ * `grammar` is optional because for most strategies the reading cannot cost more than
+ * a refused Explain button, and omitting it keeps the dialect-less reading. One
+ * strategy must pass it: PostgreSQL's `EXPLAIN (ANALYZE, …)` EXECUTES what it
+ * explains, its execution path skips the confirmation gate (an explain run is not a
+ * dangerous-query check), and block comments NEST in PostgreSQL - so read flat, a
+ * `/* a /* b *\/ SELECT 1 *\/ DELETE FROM users` classified as a `SELECT` and the
+ * explain really deleted the rows (live-verified on PostgreSQL 18: 3 rows before, 0
+ * after). ClickHouse passes it too, for the honest classification rather than for
+ * safety - its EXPLAIN describes without running (#300).
  */
-export function classifySelectPrefix(sql: string): SelectPrefix | null {
-  const leading = readLeadingKeyword(sql)?.keyword;
+export function classifySelectPrefix(sql: string, grammar?: SqlGrammar): SelectPrefix | null {
+  const leading = readLeadingKeyword(sql, grammar)?.keyword;
 
   if (leading === "SELECT") return "select";
   if (leading === "WITH") return "with";

--- a/src/lib/sql/grammar.ts
+++ b/src/lib/sql/grammar.ts
@@ -1,0 +1,126 @@
+/**
+ * Which grammar the readers in this folder are reading.
+ *
+ * Every reader here answers a question about a statement's STRUCTURE from
+ * characters alone, and a handful of those characters mean different things in
+ * different engines. Where they do, a reader with no dialect has to take one
+ * engine's side, and taking the wrong one moves where a construct ends: a `)`
+ * that closes a CTE body, a comment that hides a bound, a keyword that types the
+ * statement. `operative-keyword.ts` records what that costs - a statement that
+ * WRITES typed as a read, and a row bound then appended to it, which on
+ * PostgreSQL and MySQL commits part of the write (#287).
+ *
+ * The dialect was always available at the callers - every provider knows its own
+ * `type`, the multi-statement route resolves its provider before it asks, and
+ * both client-side execution paths hold the active connection - so this module
+ * threads information that already exists rather than inferring it from the text
+ * (#292).
+ *
+ * Two rules keep this from becoming the type-switching this project bans
+ * ("no `=== 'mongodb'` type-checks outside provider classes - drive behaviour
+ * through capabilities"):
+ *
+ * 1. **Exactly one place maps a database type to grammar facts** - the table
+ *    below. Readers receive the resolved record and never see a type id, so no
+ *    reader can grow a dialect test of its own.
+ * 2. **A fact that could not be established from an authoritative source is not
+ *    guessed.** It stays at the compatibility default, and which dialects are
+ *    there is stated (in `docs/editor/query-optimization.md`) rather than
+ *    implied. Never read one dialect's rule off another's behaviour.
+ */
+
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * What a `#` opens.
+ *
+ * - `comment` - it opens a line comment, always. MySQL, MariaDB, ClickHouse.
+ * - `code` - it never opens one; it is an operator character, part of an
+ *   identifier, or a variable prefix. PostgreSQL, Oracle, SQL Server, SQLite.
+ * - `comment-unless-operator` - the compatibility default, and neither of the
+ *   honest readings: a comment unless the next character makes a PostgreSQL
+ *   jsonb/geometric operator. It is what this folder did before the dialect
+ *   reached it, and it is kept exactly so that a call naming no dialect answers
+ *   what it always answered.
+ */
+export type HashGrammar = "comment" | "code" | "comment-unless-operator";
+
+/** The grammar facts that differ between the engines this product supports. */
+export interface SqlGrammar {
+  readonly hash: HashGrammar;
+}
+
+/**
+ * What a call that names no dialect gets.
+ *
+ * Deliberately today's reading rather than a stricter "report undeterminable
+ * wherever the dialects disagree". The strict default is the more honest one in
+ * the abstract, but every fixture written for #275, #280, #287, #291 and #294
+ * calls these readers without a dialect, and rewriting the meaning of that whole
+ * suite in the same change that introduces the channel would leave nothing
+ * pinning the old behaviour. Pinned by its own tests instead, so it is a decision
+ * rather than an accident.
+ */
+export const DEFAULT_SQL_GRAMMAR: SqlGrammar = { hash: "comment-unless-operator" };
+
+const COMMENT_HASH: SqlGrammar = { hash: "comment" };
+const CODE_HASH: SqlGrammar = { hash: "code" };
+
+/**
+ * The established readings, one row per fact per dialect.
+ *
+ * A dialect absent from this table is at the compatibility default because its
+ * rule was not established, NOT because it agrees with the default. Currently
+ * absent: `couchbase`, `druid`, `libredb` (and the non-SQL `mongodb`, `redis`,
+ * whose providers never reach these readers).
+ *
+ * Sources, one per row, all offline or first-party documentation:
+ *
+ * - `mysql` - `#` to end of line is MySQL's and MariaDB's second comment form;
+ *   this repo already encodes it in `leading-keyword.ts`'s trivia pattern and
+ *   pins it in the MySQL provider suite (#275).
+ * - `clickhouse` - the ClickHouse SQL syntax reference
+ *   (clickhouse.com/docs/sql-reference/syntax, "Comments", checked 2026-08-05)
+ *   lists `#` and `#!` beside `--` as single-line comment forms. The only row
+ *   here with no offline artifact to check - ClickHouse is reached over HTTP and
+ *   has no driver package under `node_modules` - so it is named with its source
+ *   and date rather than left implicit.
+ * - `postgres` - PostgreSQL has exactly two comment forms, `--` and the block
+ *   form; `#` is an operator character (`#>`, `#>>`, `#-` walk or delete a jsonb
+ *   path, `#` is integer XOR).
+ * - `oracle` - node-oracledb's own SQL tokenizer (`lib/thin/statement.js`)
+ *   accepts `#` as an identifier character and opens comments on `--` and `/*`
+ *   only.
+ * - `sqlite` - the SQLite amalgamation bundled with `better-sqlite3` classifies
+ *   `#` as `CC_VARALPHA`, an alphabetic bind-variable prefix, and opens comments
+ *   on `--` and `/*` only.
+ * - `mssql` - `#name` and `##name` are local and global temp tables, which is
+ *   ordinary T-SQL; the comment forms are `--` and the block form.
+ */
+const SQL_GRAMMARS: Partial<Record<DatabaseType, SqlGrammar>> = {
+  mysql: COMMENT_HASH,
+  clickhouse: COMMENT_HASH,
+  postgres: CODE_HASH,
+  oracle: CODE_HASH,
+  mssql: CODE_HASH,
+  sqlite: CODE_HASH,
+};
+
+/** The grammar to read a statement of this dialect with. */
+export function resolveSqlGrammar(type?: DatabaseType): SqlGrammar {
+  if (type === undefined) return DEFAULT_SQL_GRAMMAR;
+  return SQL_GRAMMARS[type] ?? DEFAULT_SQL_GRAMMAR;
+}
+
+/**
+ * Whether a `#` run this grammar read as a comment might be code in the dialect
+ * actually meant.
+ *
+ * `statement-end.ts` asks, because it decides whether the statement may be CUT
+ * there, and cutting on the wrong reading emits `SELECT * FROM LIMIT 500 #tmp`.
+ * Only the compatibility default is ambiguous: the other two readings ARE the
+ * dialect's answer, so there is nothing left to be wrong about.
+ */
+export function hashRunIsAmbiguous(grammar: SqlGrammar): boolean {
+  return grammar.hash === "comment-unless-operator";
+}

--- a/src/lib/sql/grammar.ts
+++ b/src/lib/sql/grammar.ts
@@ -69,10 +69,29 @@ export type HashGrammar = "comment" | "code" | "comment-unless-operator";
  */
 export type BracketGrammar = "quoted-identifier" | "subscript";
 
+/**
+ * Where a block comment ENDS when a second `/*` is written inside it.
+ *
+ * - `flat` - the first `*\/` closes the run, whatever is inside it. MySQL,
+ *   MariaDB, SQLite, Oracle.
+ * - `nesting` - a `/*` inside a comment opens another one, so the run continues
+ *   until the depth returns to zero. PostgreSQL, SQL Server, ClickHouse. A run
+ *   short of a closer is then undeterminable rather than closed early, which costs
+ *   a bound and asks for a confirmation instead of hiding a write.
+ *
+ * The two readings put the comment's end in different places, and everything
+ * between the first `*\/` and the real end is either comment text or the
+ * statement's own code depending on which one applies - so a `)` written there
+ * either closes a CTE body or does not, and the keyword that types the statement
+ * changes with it (#300).
+ */
+export type BlockCommentGrammar = "flat" | "nesting";
+
 /** The grammar facts that differ between the engines this product supports. */
 export interface SqlGrammar {
   readonly hash: HashGrammar;
   readonly bracket: BracketGrammar;
+  readonly blockComment: BlockCommentGrammar;
   /**
    * Whether `q'…'` opens a string literal - Oracle's alternate quoting.
    *
@@ -100,6 +119,7 @@ export interface SqlGrammar {
 export const DEFAULT_SQL_GRAMMAR: SqlGrammar = {
   hash: "comment-unless-operator",
   bracket: "quoted-identifier",
+  blockComment: "flat",
   alternateQuoting: false,
 };
 
@@ -113,21 +133,39 @@ export const DEFAULT_SQL_GRAMMAR: SqlGrammar = {
 const MYSQL_GRAMMAR: SqlGrammar = {
   hash: "comment",
   bracket: DEFAULT_SQL_GRAMMAR.bracket,
+  blockComment: "flat",
   alternateQuoting: false,
 };
-const CLICKHOUSE_GRAMMAR: SqlGrammar = { hash: "comment", bracket: "subscript", alternateQuoting: false };
+const CLICKHOUSE_GRAMMAR: SqlGrammar = {
+  hash: "comment",
+  bracket: "subscript",
+  blockComment: "nesting",
+  alternateQuoting: false,
+};
 const POSTGRES_GRAMMAR: SqlGrammar = {
   hash: "code",
   bracket: DEFAULT_SQL_GRAMMAR.bracket,
+  blockComment: "nesting",
   alternateQuoting: false,
 };
 const ORACLE_GRAMMAR: SqlGrammar = {
   hash: "code",
   bracket: DEFAULT_SQL_GRAMMAR.bracket,
+  blockComment: "flat",
   alternateQuoting: true,
 };
-const MSSQL_GRAMMAR: SqlGrammar = { hash: "code", bracket: "quoted-identifier", alternateQuoting: false };
-const SQLITE_GRAMMAR: SqlGrammar = { hash: "code", bracket: "quoted-identifier", alternateQuoting: false };
+const MSSQL_GRAMMAR: SqlGrammar = {
+  hash: "code",
+  bracket: "quoted-identifier",
+  blockComment: "nesting",
+  alternateQuoting: false,
+};
+const SQLITE_GRAMMAR: SqlGrammar = {
+  hash: "code",
+  bracket: "quoted-identifier",
+  blockComment: "flat",
+  alternateQuoting: false,
+};
 
 /**
  * The established readings, one row per fact per dialect.
@@ -144,8 +182,9 @@ const SQLITE_GRAMMAR: SqlGrammar = { hash: "code", bracket: "quoted-identifier",
  * Sources, one per row, all offline or first-party documentation:
  *
  * - `mysql` - `#` to end of line is MySQL's and MariaDB's second comment form;
- *   this repo already encodes it in `leading-keyword.ts`'s trivia pattern and
- *   pins it in the MySQL provider suite (#275).
+ *   this repo already skipped such a run in a statement's LEADING trivia before the
+ *   record existed - `leading-keyword.ts` still does, on every dialect, and says
+ *   why - and pins it in the MySQL provider suite (#275).
  * - `clickhouse` - the ClickHouse SQL syntax reference
  *   (clickhouse.com/docs/sql-reference/syntax, "Comments", checked 2026-08-05)
  *   lists `#` and `#!` beside `--` as single-line comment forms. The only row
@@ -185,6 +224,31 @@ const SQLITE_GRAMMAR: SqlGrammar = { hash: "code", bracket: "quoted-identifier",
  *   (`WITH [1, 2, 3] AS arr SELECT arrayJoin(arr)`), and that it is NOT an
  *   identifier quote by `identifier.ts`, which quotes this dialect's names with the
  *   standard `"…"` form. The nesting half rests on the reference alone.
+ * - Block comments, one source per dialect and every row established, so no
+ *   dialect in this table is left undecided about this fact (#300):
+ *   - `postgres` NESTS - the PostgreSQL manual's lexical-structure chapter (4.1.5
+ *     Comments, postgresql.org/docs/current/sql-syntax-lexical.html; checked
+ *     2026-08-05) says block comments nest "as specified in the SQL standard but
+ *     unlike C", precisely so a region containing comments can be commented out.
+ *   - `mssql` NESTS - "Slash Star (Block Comment) (Transact-SQL)"
+ *     (learn.microsoft.com; checked 2026-08-05): nested comments are supported, a
+ *     `/*` anywhere inside a comment starts a nested one, and a missing closer is
+ *     an error. This is the row the report on #300 got wrong, which is why it was
+ *     re-established rather than copied.
+ *   - `clickhouse` NESTS - the ClickHouse SQL syntax reference
+ *     (clickhouse.com/docs/sql-reference/syntax; checked 2026-08-05) states C-style
+ *     comments can be nested and gives a nested example. Same caveat as its `#`
+ *     row: reached over HTTP, so there is no driver artifact to check it against.
+ *   - `mysql` is FLAT - the MySQL reference manual (11.7 Comments, dev.mysql.com;
+ *     checked 2026-08-05) states nested comments are not supported and are
+ *     deprecated. It adds that they "might be permitted" under some conditions and
+ *     that users should avoid them, which is a reason to read the first `*\/` as
+ *     the end rather than to guess at a second reading.
+ *   - `sqlite` is FLAT, from the bundled amalgamation's own tokenizer: `case
+ *     CC_SLASH` scans forward for the first `*\/` with no depth count at all.
+ *   - `oracle` is FLAT - node-oracledb's tokenizer (`_parseMultiLineComment`)
+ *     stops at the first `*\/`, and Oracle's PL/SQL Language Reference states that
+ *     one multiline comment cannot contain another.
  *
  * NOT established, and therefore left at the default: how `mysql`, `postgres` and
  * `oracle` read `[…]`. It is not an identifier quote in any of the three -

--- a/src/lib/sql/grammar.ts
+++ b/src/lib/sql/grammar.ts
@@ -55,7 +55,9 @@ export type HashGrammar = "comment" | "code" | "comment-unless-operator";
  *   followed by junk. SQLite rejects that text either way, so the longer reading
  *   can only cost a bound on a statement the server refuses - the fail-safe
  *   direction, pinned by a test in the SQLite provider suite rather than left to
- *   be discovered.
+ *   be discovered. Since #297 it can cost that statement a confirmation prompt as
+ *   well, where the doubled bracket swallows the real closer and the run therefore
+ *   never terminates (`SELECT [a]] FROM t`).
  * - `subscript` - an array literal or a subscript. It NESTS, nothing inside it is
  *   escaped, and a literal inside it is a literal. ClickHouse.
  *
@@ -132,10 +134,12 @@ const SQLITE_GRAMMAR: SqlGrammar = { hash: "code", bracket: "quoted-identifier",
  *
  * A dialect absent from this table is at the compatibility default because its
  * rule was not established, NOT because it agrees with the default. Currently
- * absent: `couchbase`, `druid`, `libredb` (and the non-SQL `mongodb`, `redis`,
- * whose providers never reach these readers). Present for one fact and undecided
- * about another: `mysql`, `postgres` and `oracle` carry no established BRACKET
- * reading (see the row below).
+ * absent: `couchbase`, `druid`, `libredb` and the non-SQL `mongodb`, `redis` -
+ * whose providers never reach these readers on the QUERY path, though the
+ * confirmation gate does read their editor text under the default, since both
+ * execution paths ask about whatever is in the editor (#297). Present for one fact
+ * and undecided about another: `mysql`, `postgres` and `oracle` carry no
+ * established BRACKET reading (see the row below).
  *
  * Sources, one per row, all offline or first-party documentation:
  *
@@ -192,6 +196,13 @@ const SQLITE_GRAMMAR: SqlGrammar = { hash: "code", bracket: "quoted-identifier",
  * can never misplace one: a run it cannot close is undeterminable, and an
  * undeterminable end is not cut. That is the fail-safe direction, so it is what
  * they keep.
+ *
+ * The same run costs one more thing since #297, and it is stated here because this
+ * table is where the default is chosen: an undeterminable run is text the
+ * confirmation gate cannot read, and that gate now ASKS rather than staying silent,
+ * so a PostgreSQL nested array in an everyday read prompts before it runs. Pinned in
+ * `tests/components/QuerySafetyDialog.test.tsx` and documented in
+ * `docs/providers/postgres.md`.
  */
 const SQL_GRAMMARS: Partial<Record<DatabaseType, SqlGrammar>> = {
   mysql: MYSQL_GRAMMAR,
@@ -202,9 +213,17 @@ const SQL_GRAMMARS: Partial<Record<DatabaseType, SqlGrammar>> = {
   sqlite: SQLITE_GRAMMAR,
 };
 
-/** The grammar to read a statement of this dialect with. */
+/**
+ * The grammar to read a statement of this dialect with.
+ *
+ * `Object.hasOwn` rather than a bare lookup: since #297 the packaged confirmation
+ * dialog resolves its own grammar from an optional prop a HOST application supplies
+ * as a plain string, and a prototype key (`"constructor"`, `"toString"`) would
+ * otherwise return something that is not a grammar at all instead of falling to the
+ * default.
+ */
 export function resolveSqlGrammar(type?: DatabaseType): SqlGrammar {
-  if (type === undefined) return DEFAULT_SQL_GRAMMAR;
+  if (type === undefined || !Object.hasOwn(SQL_GRAMMARS, type)) return DEFAULT_SQL_GRAMMAR;
   return SQL_GRAMMARS[type] ?? DEFAULT_SQL_GRAMMAR;
 }
 

--- a/src/lib/sql/grammar.ts
+++ b/src/lib/sql/grammar.ts
@@ -45,9 +45,32 @@ import type { DatabaseType } from "@/lib/types";
  */
 export type HashGrammar = "comment" | "code" | "comment-unless-operator";
 
+/**
+ * What a `[…]` run is.
+ *
+ * - `quoted-identifier` - everything between the brackets is a NAME and the run
+ *   does not nest. SQL Server, SQLite. The doubled `]` this reading honours is SQL
+ *   SERVER's escape; SQLite's own tokenizer stops at the first `]` and has no
+ *   escape at all, so this reads `[a]]b]` as one name where SQLite reads `[a]`
+ *   followed by junk. SQLite rejects that text either way, so the longer reading
+ *   can only cost a bound on a statement the server refuses - the fail-safe
+ *   direction, pinned by a test in the SQLite provider suite rather than left to
+ *   be discovered.
+ * - `subscript` - an array literal or a subscript. It NESTS, nothing inside it is
+ *   escaped, and a literal inside it is a literal. ClickHouse.
+ *
+ * The two are mutually exclusive rather than two spellings of one rule, which is
+ * why this is a dialect fact and not something the text could settle: `['a]b']` is
+ * a subscript whose key carries a close bracket under one reading and a name that
+ * ends at that bracket under the other, and `[a]]b]` is one name under the first
+ * and a closed run followed by junk under the second.
+ */
+export type BracketGrammar = "quoted-identifier" | "subscript";
+
 /** The grammar facts that differ between the engines this product supports. */
 export interface SqlGrammar {
   readonly hash: HashGrammar;
+  readonly bracket: BracketGrammar;
   /**
    * Whether `q'…'` opens a string literal - Oracle's alternate quoting.
    *
@@ -72,11 +95,37 @@ export interface SqlGrammar {
  * pinning the old behaviour. Pinned by its own tests instead, so it is a decision
  * rather than an accident.
  */
-export const DEFAULT_SQL_GRAMMAR: SqlGrammar = { hash: "comment-unless-operator", alternateQuoting: false };
+export const DEFAULT_SQL_GRAMMAR: SqlGrammar = {
+  hash: "comment-unless-operator",
+  bracket: "quoted-identifier",
+  alternateQuoting: false,
+};
 
-const COMMENT_HASH: SqlGrammar = { hash: "comment", alternateQuoting: false };
-const CODE_HASH: SqlGrammar = { hash: "code", alternateQuoting: false };
-const ORACLE_GRAMMAR: SqlGrammar = { hash: "code", alternateQuoting: true };
+/**
+ * One constant per dialect, and a fact spelled `DEFAULT_SQL_GRAMMAR.<fact>` is one
+ * this table could not establish for that dialect. The default is therefore per
+ * FACT, not per dialect: a dialect whose `#` rule is known can still be undecided
+ * about its brackets, and writing the default's own value there is what keeps that
+ * visible in the code rather than only in the doc.
+ */
+const MYSQL_GRAMMAR: SqlGrammar = {
+  hash: "comment",
+  bracket: DEFAULT_SQL_GRAMMAR.bracket,
+  alternateQuoting: false,
+};
+const CLICKHOUSE_GRAMMAR: SqlGrammar = { hash: "comment", bracket: "subscript", alternateQuoting: false };
+const POSTGRES_GRAMMAR: SqlGrammar = {
+  hash: "code",
+  bracket: DEFAULT_SQL_GRAMMAR.bracket,
+  alternateQuoting: false,
+};
+const ORACLE_GRAMMAR: SqlGrammar = {
+  hash: "code",
+  bracket: DEFAULT_SQL_GRAMMAR.bracket,
+  alternateQuoting: true,
+};
+const MSSQL_GRAMMAR: SqlGrammar = { hash: "code", bracket: "quoted-identifier", alternateQuoting: false };
+const SQLITE_GRAMMAR: SqlGrammar = { hash: "code", bracket: "quoted-identifier", alternateQuoting: false };
 
 /**
  * The established readings, one row per fact per dialect.
@@ -84,7 +133,9 @@ const ORACLE_GRAMMAR: SqlGrammar = { hash: "code", alternateQuoting: true };
  * A dialect absent from this table is at the compatibility default because its
  * rule was not established, NOT because it agrees with the default. Currently
  * absent: `couchbase`, `druid`, `libredb` (and the non-SQL `mongodb`, `redis`,
- * whose providers never reach these readers).
+ * whose providers never reach these readers). Present for one fact and undecided
+ * about another: `mysql`, `postgres` and `oracle` carry no established BRACKET
+ * reading (see the row below).
  *
  * Sources, one per row, all offline or first-party documentation:
  *
@@ -113,17 +164,42 @@ const ORACLE_GRAMMAR: SqlGrammar = { hash: "code", alternateQuoting: true };
  *   form, so Oracle is the only row that carries it.
  * - `sqlite` - the SQLite amalgamation bundled with `better-sqlite3` classifies
  *   `#` as `CC_VARALPHA`, an alphabetic bind-variable prefix, and opens comments
- *   on `--` and `/*` only.
+ *   on `--` and `/*` only. The same tokenizer is where its BRACKET row comes from:
+ *   `[` is `CC_QUOTE2`, "`[...]` style quoted ids", scanned to the first `]` -
+ *   Microsoft-style identifiers, accepted for compatibility.
  * - `mssql` - `#name` and `##name` are local and global temp tables, which is
- *   ordinary T-SQL; the comment forms are `--` and the block form.
+ *   ordinary T-SQL; the comment forms are `--` and the block form. `[name]` is a
+ *   delimited identifier and a `]` inside one is written doubled, which is exactly
+ *   what this repo's own quoter emits for the dialect (`src/lib/sql/identifier.ts`,
+ *   pinned by the MSSQL provider suite's `escapeIdentifier` test).
+ * - `clickhouse`, brackets - `[…]` is an array literal or a subscript there, and
+ *   arrays nest (`Array(Array(T))` is a type). Source: the ClickHouse SQL reference
+ *   (clickhouse.com/docs/sql-reference, the Array type and the `[]` operator,
+ *   checked 2026-08-05); as with the `#` row there is no offline artifact, so the
+ *   two halves are corroborated separately from inside this repo - that `[…]` is an
+ *   array literal by the provider suite's own live-verified fixture
+ *   (`WITH [1, 2, 3] AS arr SELECT arrayJoin(arr)`), and that it is NOT an
+ *   identifier quote by `identifier.ts`, which quotes this dialect's names with the
+ *   standard `"…"` form. The nesting half rests on the reference alone.
+ *
+ * NOT established, and therefore left at the default: how `mysql`, `postgres` and
+ * `oracle` read `[…]`. It is not an identifier quote in any of the three -
+ * PostgreSQL subscripts arrays and jsonb with it, MySQL gives it no meaning outside
+ * a JSON path written inside a string, and Oracle none outside an alternate-quote
+ * delimiter - but no first-party artifact for the SUBSCRIPT rule was established
+ * here, and PD-5 forbids reading one dialect's rule off another's. The name reading
+ * costs them a bound on a nested array or on a subscript key carrying a `]`, and it
+ * can never misplace one: a run it cannot close is undeterminable, and an
+ * undeterminable end is not cut. That is the fail-safe direction, so it is what
+ * they keep.
  */
 const SQL_GRAMMARS: Partial<Record<DatabaseType, SqlGrammar>> = {
-  mysql: COMMENT_HASH,
-  clickhouse: COMMENT_HASH,
-  postgres: CODE_HASH,
+  mysql: MYSQL_GRAMMAR,
+  clickhouse: CLICKHOUSE_GRAMMAR,
+  postgres: POSTGRES_GRAMMAR,
   oracle: ORACLE_GRAMMAR,
-  mssql: CODE_HASH,
-  sqlite: CODE_HASH,
+  mssql: MSSQL_GRAMMAR,
+  sqlite: SQLITE_GRAMMAR,
 };
 
 /** The grammar to read a statement of this dialect with. */

--- a/src/lib/sql/grammar.ts
+++ b/src/lib/sql/grammar.ts
@@ -59,7 +59,7 @@ export type HashGrammar = "comment" | "code" | "comment-unless-operator";
  *   well, where the doubled bracket swallows the real closer and the run therefore
  *   never terminates (`SELECT [a]] FROM t`).
  * - `subscript` - an array literal or a subscript. It NESTS, nothing inside it is
- *   escaped, and a literal inside it is a literal. ClickHouse.
+ *   escaped, and a literal inside it is a literal. ClickHouse, PostgreSQL.
  *
  * The two are mutually exclusive rather than two spellings of one rule, which is
  * why this is a dialect fact and not something the text could settle: `['a]b']` is
@@ -144,7 +144,7 @@ const CLICKHOUSE_GRAMMAR: SqlGrammar = {
 };
 const POSTGRES_GRAMMAR: SqlGrammar = {
   hash: "code",
-  bracket: DEFAULT_SQL_GRAMMAR.bracket,
+  bracket: "subscript",
   blockComment: "nesting",
   alternateQuoting: false,
 };
@@ -174,10 +174,10 @@ const SQLITE_GRAMMAR: SqlGrammar = {
  * rule was not established, NOT because it agrees with the default. Currently
  * absent: `couchbase`, `druid`, `libredb` and the non-SQL `mongodb`, `redis` -
  * whose providers never reach these readers on the QUERY path, though the
- * confirmation gate does read their editor text under the default, since both
- * execution paths ask about whatever is in the editor (#297). Present for one fact
- * and undecided about another: `mysql`, `postgres` and `oracle` carry no
- * established BRACKET reading (see the row below).
+ * confirmation gate reads their editor text as SQL only where `readsSqlText` says
+ * the text IS SQL, which for those two it does not (#297). Present for one fact and
+ * undecided about another: `mysql` and `oracle` carry no established BRACKET
+ * reading (see the row below).
  *
  * Sources, one per row, all offline or first-party documentation:
  *
@@ -250,23 +250,31 @@ const SQLITE_GRAMMAR: SqlGrammar = {
  *     stops at the first `*\/`, and Oracle's PL/SQL Language Reference states that
  *     one multiline comment cannot contain another.
  *
- * NOT established, and therefore left at the default: how `mysql`, `postgres` and
- * `oracle` read `[…]`. It is not an identifier quote in any of the three -
- * PostgreSQL subscripts arrays and jsonb with it, MySQL gives it no meaning outside
- * a JSON path written inside a string, and Oracle none outside an alternate-quote
- * delimiter - but no first-party artifact for the SUBSCRIPT rule was established
- * here, and PD-5 forbids reading one dialect's rule off another's. The name reading
- * costs them a bound on a nested array or on a subscript key carrying a `]`, and it
- * can never misplace one: a run it cannot close is undeterminable, and an
- * undeterminable end is not cut. That is the fail-safe direction, so it is what
- * they keep.
+ * - `postgres`, brackets - `expression[subscript]` extracts an element and
+ *   `expression[lower:upper]` a slice (PostgreSQL manual 4.2.3 Subscripts), and
+ *   array constructors nest: the manual's own example is
+ *   `SELECT ARRAY[[1,2],[3,4]]` (4.2.12 Array Constructors, which also notes the
+ *   inner `ARRAY` keyword may be omitted). Identifiers there are quoted with double
+ *   quotes (4.1.1), so `[` is never a name quote in this dialect.
  *
- * The same run costs one more thing since #297, and it is stated here because this
- * table is where the default is chosen: an undeterminable run is text the
- * confirmation gate cannot read, and that gate now ASKS rather than staying silent,
- * so a PostgreSQL nested array in an everyday read prompts before it runs. Pinned in
- * `tests/components/QuerySafetyDialog.test.tsx` and documented in
- * `docs/providers/postgres.md`.
+ * NOT established, and therefore left at the default: how `mysql` and `oracle` read
+ * `[…]`. It is not an identifier quote in either - MySQL gives it no meaning outside
+ * a JSON path written inside a string, and Oracle none outside an alternate-quote
+ * delimiter - but neither has a SUBSCRIPT rule to read it under instead, and PD-5
+ * forbids reading one dialect's rule off another's. The name reading costs them a
+ * bound on a nested bracket run, and it can never misplace one: a run it cannot
+ * close is undeterminable, and an undeterminable end is not cut. That is the
+ * fail-safe direction, so it is what they keep.
+ *
+ * PostgreSQL was briefly left there too, and the cost is why it is not: an
+ * undeterminable run is also text the confirmation gate cannot read, and since #297
+ * that gate ASKS rather than staying silent - so `ARRAY[[1,2],[3,4]]` and
+ * `j['a]b']`, everyday reads in this dialect, both lost their bound AND prompted
+ * before running. A confirmation an operator learns to click through protects
+ * nothing, so a false prompt on everyday syntax is not the cheap direction it looks
+ * like. The rule was established from the manual rather than the cost being
+ * accepted. Pinned in `tests/components/QuerySafetyDialog.test.tsx` and the
+ * PostgreSQL provider suite, and documented in `docs/providers/postgres.md`.
  */
 const SQL_GRAMMARS: Partial<Record<DatabaseType, SqlGrammar>> = {
   mysql: MYSQL_GRAMMAR,
@@ -289,6 +297,39 @@ const SQL_GRAMMARS: Partial<Record<DatabaseType, SqlGrammar>> = {
 export function resolveSqlGrammar(type?: DatabaseType): SqlGrammar {
   if (type === undefined || !Object.hasOwn(SQL_GRAMMARS, type)) return DEFAULT_SQL_GRAMMAR;
   return SQL_GRAMMARS[type] ?? DEFAULT_SQL_GRAMMAR;
+}
+
+/**
+ * The dialects whose query text is not SQL at all.
+ *
+ * MongoDB takes a JSON document and Redis a command line, and neither reaches the
+ * readers in this folder on the QUERY path - their providers extend
+ * `BaseDatabaseProvider` and never call `prepareQuery`. They reach the confirmation
+ * gate, though, because both execution paths ask about whatever is in the editor
+ * before running it (#297).
+ */
+const NON_SQL_DIALECTS: ReadonlySet<DatabaseType> = new Set<DatabaseType>(["mongodb", "redis"]);
+
+/**
+ * Whether this dialect's query text is SQL - the question BEFORE which SQL grammar
+ * to read it under.
+ *
+ * `resolveSqlGrammar` has an answer for every input, so without this a Mongo
+ * document or a Redis command is simply read as SQL under the compatibility
+ * grammar. For a reader that only ever declines to act, that costs nothing. For the
+ * confirmation gate it cost a false prompt on ordinary reads: the escaped quote in
+ * `{"filter":{"msg":"say \"hi\""}}` or in `SET k "a\"b"` is an unresolvable literal
+ * to a SQL span reader and a perfectly closed one in the grammar the text is
+ * actually written in - and the dialog then said the statement could not be read
+ * about text that reads fine. An operator who learns to click the confirmation away
+ * is the one thing that gate cannot survive.
+ *
+ * Unknown and absent both answer true, which keeps every existing caller and any
+ * host application passing an unrecognised string on today's reading rather than
+ * silently switching the SQL checks off.
+ */
+export function readsSqlText(type?: DatabaseType): boolean {
+  return type === undefined || !NON_SQL_DIALECTS.has(type);
 }
 
 /**

--- a/src/lib/sql/grammar.ts
+++ b/src/lib/sql/grammar.ts
@@ -48,6 +48,17 @@ export type HashGrammar = "comment" | "code" | "comment-unless-operator";
 /** The grammar facts that differ between the engines this product supports. */
 export interface SqlGrammar {
   readonly hash: HashGrammar;
+  /**
+   * Whether `q'…'` opens a string literal - Oracle's alternate quoting.
+   *
+   * Not a disagreement about a character like `hash` is, but a form ONE dialect
+   * has: `q'{it's}'` is how Oracle writes a literal carrying apostrophes without
+   * doubling them, and everywhere else those characters really are a name
+   * followed by an ordinary string. So the fact is whether the reader has the
+   * form at all, and reading it where the dialect does not have it would take a
+   * literal out of ordinary code.
+   */
+  readonly alternateQuoting: boolean;
 }
 
 /**
@@ -61,10 +72,11 @@ export interface SqlGrammar {
  * pinning the old behaviour. Pinned by its own tests instead, so it is a decision
  * rather than an accident.
  */
-export const DEFAULT_SQL_GRAMMAR: SqlGrammar = { hash: "comment-unless-operator" };
+export const DEFAULT_SQL_GRAMMAR: SqlGrammar = { hash: "comment-unless-operator", alternateQuoting: false };
 
-const COMMENT_HASH: SqlGrammar = { hash: "comment" };
-const CODE_HASH: SqlGrammar = { hash: "code" };
+const COMMENT_HASH: SqlGrammar = { hash: "comment", alternateQuoting: false };
+const CODE_HASH: SqlGrammar = { hash: "code", alternateQuoting: false };
+const ORACLE_GRAMMAR: SqlGrammar = { hash: "code", alternateQuoting: true };
 
 /**
  * The established readings, one row per fact per dialect.
@@ -90,7 +102,15 @@ const CODE_HASH: SqlGrammar = { hash: "code" };
  *   path, `#` is integer XOR).
  * - `oracle` - node-oracledb's own SQL tokenizer (`lib/thin/statement.js`)
  *   accepts `#` as an identifier character and opens comments on `--` and `/*`
- *   only.
+ *   only. The same tokenizer's `_parseQstring` is where the alternate-quoting
+ *   row comes from: a `'` preceded by `q`/`Q` opens a q-string, `[ ] { } ( ) < >`
+ *   are the paired delimiters, and any other character closes with itself. The
+ *   `nq'…'` spelling of the same form, for `NCHAR`/`NVARCHAR2`, and the same
+ *   delimiter-pairing rule are in Oracle's SQL Language Reference ("Literals" →
+ *   text literals, docs.oracle.com; checked 2026-08-05). The driver corroborates
+ *   the spelling behaviourally: its tokenizer opens a q-string at any `'` whose
+ *   previous character is `q`/`Q`, `nq'` included. No other dialect here has the
+ *   form, so Oracle is the only row that carries it.
  * - `sqlite` - the SQLite amalgamation bundled with `better-sqlite3` classifies
  *   `#` as `CC_VARALPHA`, an alphabetic bind-variable prefix, and opens comments
  *   on `--` and `/*` only.
@@ -101,7 +121,7 @@ const SQL_GRAMMARS: Partial<Record<DatabaseType, SqlGrammar>> = {
   mysql: COMMENT_HASH,
   clickhouse: COMMENT_HASH,
   postgres: CODE_HASH,
-  oracle: CODE_HASH,
+  oracle: ORACLE_GRAMMAR,
   mssql: CODE_HASH,
   sqlite: CODE_HASH,
 };

--- a/src/lib/sql/leading-keyword.ts
+++ b/src/lib/sql/leading-keyword.ts
@@ -20,6 +20,9 @@
  * the vocabulary to the caller.
  */
 
+import { DEFAULT_SQL_GRAMMAR, type SqlGrammar } from "./grammar";
+import { readSqlSpan, type SqlSpanKind } from "./spans";
+
 /** Where a statement's leading keyword is, and what it is. */
 export interface LeadingKeyword {
   /**
@@ -34,63 +37,146 @@ export interface LeadingKeyword {
 }
 
 /**
- * Leading whitespace and SQL comments, then the statement's first word.
+ * Whether a span is trivia the keyword can sit behind.
  *
- * The SHAPE of the trivia part matters as much as what it accepts. Each of the
- * three alternatives sits inside a `*` quantifier, so any way of matching the
- * same text twice is a way for a NON-matching input to backtrack, and all three
- * had to be made unambiguous independently. Measured on this pattern's
- * predecessors in `lib/explain/select-prefix.ts`, with a tail that never reaches
- * a keyword:
- *
- * - No leading `\s*`. Whitespace is already an alternative below; having both
- *   gives two ways to match one run of spaces. Quadratic - 958ms on 20k leading
- *   spaces.
- * - Both line-comment forms are anchored to a newline OR end-of-input. Without
- *   that tail `[^\n]*` can give characters back and let a later iteration match
- *   `--` again, so a run of bare dashes partitions exponentially - 634ms on a
- *   FORTY-NINE character input, by far the cheapest of the three to trigger.
- *   Found by CodeQL (`js/redos`) after the other two were already fixed. A run of
- *   single `#` characters partitions even more freely than a run of `--` pairs, so
- *   the anchor is load-bearing there too.
- * - The block-comment body is TEMPERED (`[^*]|\*(?!\/)`) rather than a lazy
- *   `[\s\S]*?\*\/`, which inside a `*` quantifier can run past the first `*\/`
- *   and let one iteration swallow several comments - 852ms on a 4 KB run of
- *   `/**\/`.
- *
- * All three answer in well under a millisecond, and `leading-keyword.test.ts`
- * keeps them that way with a bounded-time guard. This is the same care that made
- * `db/utils/query-limiter.ts` hand-write its semicolon strip "without regex to
- * avoid ReDoS".
- *
- * The word itself adds no ambiguity: no trivia alternative can begin with a
- * letter or underscore, so the first one ends the trivia run outright. Consuming
- * the whole word is what makes `SELECTED` fail a caller's `=== "SELECT"` test,
- * the job `\b` did when this pattern named its keywords inline.
- *
- * `#` is here because it is MySQL's and MariaDB's second line-comment marker, and
- * leaving it out left #275's reported bug live on that provider: `# note` before a
- * SELECT is an ordinary annotation there, and an unrecognised one meant no LIMIT.
- * It is NOT a comment in PostgreSQL, Oracle, SQL Server or SQLite - but no
- * statement in those dialects can OPEN with `#` either, so skipping it changes
- * which syntax error the server reports and never a result set.
+ * Whitespace and comments are; a literal, a quoted name and a bracketed run are
+ * the statement's own text, so the scan STOPS at one rather than stepping over it
+ * looking for a word. Skipping them instead would report `UPDATE` as the leading
+ * keyword of `'x' UPDATE t SET …`.
  */
-const LEADING_KEYWORD = /^(?:\s|(?:--|#)[^\n]*(?:\n|$)|\/\*(?:[^*]|\*(?!\/))*\*\/)*([A-Za-z_]\w*)/;
+function isLeadingTrivia(kind: SqlSpanKind): boolean {
+  return kind === "whitespace" || kind === "line-comment" || kind === "block-comment";
+}
+
+/**
+ * Whitespace as this reader counts it, which is JS `\s` and therefore WIDER than the
+ * ASCII set `spans.ts` reads as a whitespace span.
+ *
+ * The pattern this scan replaced used `\s`, and the compatibility rule is reason
+ * enough on its own: with `\s` tested per character, this scan answers what that
+ * pattern answered, for every input.
+ *
+ * One engine makes the narrower alphabet cost something real rather than merely
+ * differ, which is why the rule is stated here rather than quietly dropped: on a
+ * `latin1` connection MySQL reads byte 0xA0 as a space and RUNS the statement behind
+ * it - verified on MySQL 26.7 through this repo's own mysql2, where a leading U+00A0
+ * before `SELECT 2` returns a row under `charset=latin1` and is rejected under the
+ * `utf8mb4` this provider negotiates by default. A connection string selects that
+ * charset (`mysql.ts`'s `buildPoolConfig` hands the URI straight to mysql2), so the
+ * case is reachable rather than theoretical, and the cost would be a bound lost on an
+ * ordinary read and the confirmation prompt taken off a leading-U+00A0
+ * `DROP TABLE users` that the server still executes. U+2028, U+3000 and a BOM were
+ * rejected on every charset tried, and PostgreSQL 18 rejects all four - they are here
+ * for the compatibility rule alone.
+ *
+ * Applied one character at a time, so it carries no quantifier and cannot backtrack.
+ */
+const UNICODE_SPACE = /\s/;
+
+/** Whether `ch` can open a keyword, i.e. `/[A-Za-z_]/`. */
+function isKeywordStart(ch: string): boolean {
+  return (ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z") || ch === "_";
+}
+
+/** Whether `ch` continues one, i.e. `/\w/`. */
+function isKeywordPart(ch: string): boolean {
+  return isKeywordStart(ch) || (ch >= "0" && ch <= "9");
+}
+
+/**
+ * The trivia grammar this reader applies, which is the caller's with one
+ * deliberate override.
+ *
+ * `#` in LEADING position is read as a comment on every dialect, including the
+ * ones where `#` is code (`#tmp` is a T-SQL temp table, `ID#` an Oracle
+ * identifier, `#id` a SQLite bind variable, `#>` a PostgreSQL operator). No
+ * dialect here can OPEN a statement with one, so skipping the run costs nothing
+ * anywhere and keeps every dialect's `# note`-led statement classified - which is
+ * what #275 fixed and what the provider suites pin. Reading it as the dialect
+ * would take those bounds back off, so this override is the same decision the
+ * previous reading made, now stated instead of implied (#292 left this reader
+ * alone for exactly this reason).
+ *
+ * Every other fact is the caller's: where a block comment ENDS is the dialect's
+ * answer (#300), and so is whether a `q'…'` tag or a bracketed run is a literal,
+ * because the scan has to stop at one of those and stopping in the wrong place
+ * reports a word from inside a literal.
+ */
+function leadingTriviaGrammar(grammar: SqlGrammar): SqlGrammar {
+  return grammar.hash === "comment" ? grammar : { ...grammar, hash: "comment" };
+}
 
 /**
  * The keyword this statement leads with, or `null` when it leads with none -
  * empty, whitespace only, comments only, an unterminated comment, or anything
- * that does not open with a word (a parenthesised SELECT, a bare expression).
+ * that does not open with a word (a parenthesised SELECT, a bare expression, a
+ * literal).
  *
  * A comment is not a statement, so a comment on its own answers `null` rather
  * than reaching past itself for a keyword that is not there.
+ *
+ * `grammar` is the dialect's reading of the characters the engines disagree about;
+ * omitting it means no dialect was named and applies the compatibility default.
+ * It matters here because where a comment ENDS is one of those disagreements: a
+ * dialect that nests block comments keeps reading past the `*\/` a flat reading
+ * stops at, so the word a flat reading reports can be one the operator commented
+ * out - and this reader is what the confirmation gate and the query limiter type a
+ * statement by (#300).
+ *
+ * The trivia scan is `readSqlSpan`'s, so this reader and the ones that walk the
+ * rest of the statement cannot disagree about a comment. It used to be a regex
+ * whose own trivia grammar was hard-coded, and the SHAPE of that pattern was
+ * load-bearing: each of its three alternatives sat inside a `*` quantifier, so any
+ * way of matching the same text twice was a way for a NON-matching input to
+ * backtrack. All three were measured on its predecessors in
+ * `lib/explain/select-prefix.ts`, with a tail that never reaches a keyword:
+ *
+ * - No leading `\s*` beside a `\s` alternative - two ways to match one run of
+ *   spaces. Quadratic: 958ms on 20k leading spaces.
+ * - Both line-comment forms anchored to a newline OR end-of-input. Without that
+ *   tail `[^\n]*` could give characters back and let a later iteration match `--`
+ *   again, so a run of bare dashes partitioned exponentially: 634ms on a
+ *   FORTY-NINE character input, found by CodeQL (`js/redos`) after the other two
+ *   were fixed.
+ * - A TEMPERED block-comment body (`[^*]|\*(?!\/)`) rather than a lazy
+ *   `[\s\S]*?\*\/`, which inside a `*` quantifier could run past the first `*\/`
+ *   and swallow several comments: 852ms on a 4 KB run of `/**\/`.
+ *
+ * None of that risk transfers to a scanner: it advances one span or one character
+ * at a time and cannot backtrack at all. The reasoning is kept because it is why
+ * the replacement may not be a regex again, and `leading-keyword.test.ts` keeps
+ * its bounded-time guard on both readings - the flat one and the nesting one,
+ * whose depth count is the new thing that could have made this quadratic.
  */
-export function readLeadingKeyword(sql: string): LeadingKeyword | null {
-  const match = LEADING_KEYWORD.exec(sql);
-  if (match === null) return null;
+export function readLeadingKeyword(sql: string, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): LeadingKeyword | null {
+  const triviaGrammar = leadingTriviaGrammar(grammar);
+  let i = 0;
 
-  const keyword = match[1];
-  const end = match[0].length;
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i, triviaGrammar);
+    if (span === null) {
+      // Code, unless it is whitespace this module counts and the span reader does
+      // not - see `UNICODE_SPACE`.
+      if (!UNICODE_SPACE.test(sql[i])) break;
+      i++;
+      continue;
+    }
+    // A comment or literal that never closes: there is no "what follows it" to
+    // read a keyword out of, which is the answer the pattern before this gave too.
+    if (!isLeadingTrivia(span.kind) || !span.terminated) return null;
+    i = span.end;
+  }
 
-  return { keyword: keyword.toUpperCase(), start: end - keyword.length, end };
+  const first = sql[i];
+  if (first === undefined || !isKeywordStart(first)) return null;
+
+  let end = i + 1;
+  while (end < sql.length && isKeywordPart(sql[end])) end++;
+
+  // Consuming the whole word is what makes `SELECTED` fail a caller's
+  // `=== "SELECT"` test, the job `\b` did when this was a pattern. The alphabet
+  // stays ASCII - deliberately narrower than `spans.ts`'s identifier classes -
+  // because every keyword any caller here tests for is ASCII, and a statement
+  // opening with a localized identifier is not a keyword under either alphabet.
+  return { keyword: sql.slice(i, end).toUpperCase(), start: i, end };
 }

--- a/src/lib/sql/operative-keyword.ts
+++ b/src/lib/sql/operative-keyword.ts
@@ -324,10 +324,13 @@ function readKeywordAfterCteList(sql: string, afterWith: number, grammar: SqlGra
  *   reading the shape at all. No dialect here accepts such text - a CTE element is a
  *   name or an expression, and neither is a statement - so the cost is a bound
  *   appended to text the server rejects either way, not a partially committed write.
- * - Oracle's alternative quoting (`q'{…}'`) is not a literal to `readSqlSpan`, so
- *   its body is walked as code, and a `)` or a keyword written inside one moves the
- *   reading. Unreachable in Oracle itself, which has no `WITH … DELETE`, and no
- *   other dialect here has the form.
+ * - Oracle's alternate quoting (`q'{…}'`) is a literal only under a grammar that
+ *   has the form, which is Oracle's alone (#292). Under any other - including the
+ *   compatibility default - the body is walked as code, so a `)` or a keyword
+ *   written inside one moves the reading. That is the honest answer there: no other
+ *   dialect spells a literal that way, so those characters really are a name
+ *   followed by an ordinary string - which is also how Oracle itself reads a name
+ *   that merely ends in the tag's letters (`freq'x'`).
  * - A MySQL line comment whose first character makes a PostgreSQL operator (`#-`,
  *   `#>`) is code to a reader that was given NO dialect, so a paren inside such a
  *   comment can end a CTE body early. That is now only the dialect-less reading:

--- a/src/lib/sql/operative-keyword.ts
+++ b/src/lib/sql/operative-keyword.ts
@@ -342,7 +342,7 @@ function readKeywordAfterCteList(sql: string, afterWith: number, grammar: SqlGra
  *   operator is an operator (#292). Every caller in this project passes one.
  */
 export function readOperativeKeyword(sql: string, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): LeadingKeyword | null {
-  const leading = readLeadingKeyword(sql);
+  const leading = readLeadingKeyword(sql, grammar);
   if (leading === null || leading.keyword !== "WITH") return leading;
 
   return readKeywordAfterCteList(sql, leading.end, grammar);

--- a/src/lib/sql/operative-keyword.ts
+++ b/src/lib/sql/operative-keyword.ts
@@ -92,9 +92,13 @@ function skipParenthesised(sql: string, open: number, grammar: SqlGrammar): numb
 // name position and array subscripting elsewhere. `readSqlSpan` reads it now: the
 // statement-end reader needed the same run to be opaque, and leaving two scanners
 // for one delimiter is what this folder exists to stop. Both callers below reach it
-// through the span branch, with identical behaviour - including that a `]` inside a
-// string still closes the run early (`WITH map['a]'] AS v SELECT 1` loses its bound,
-// issue #295), since neither reader recurses into a literal.
+// through the span branch, so both get the reading the DIALECT gives those
+// characters (#295): a quoted name whose only escape is a doubled `]` in SQL Server
+// and SQLite, or a nestable array or subscript whose contents are code in ClickHouse
+// - where a `]` written inside a subscript key no longer ends the run and
+// `WITH m['a]'] AS v SELECT v` keeps its bound. Only the name reading can BE a name,
+// so a subscript reaches `skipCteName` as "not a name", which is what sends the
+// element to the expression shape it actually is.
 
 /** The index past a CTE's name - a bare word or a quoted identifier - or `-1`. */
 function skipCteName(sql: string, index: number, grammar: SqlGrammar): number {

--- a/src/lib/sql/operative-keyword.ts
+++ b/src/lib/sql/operative-keyword.ts
@@ -31,6 +31,7 @@
  * SAFE answer, the limiter needs a PRECISE one, so this reads the grammar.
  */
 
+import { DEFAULT_SQL_GRAMMAR, type SqlGrammar } from "./grammar";
 import { readLeadingKeyword, type LeadingKeyword } from "./leading-keyword";
 import { readSqlSpan } from "./spans";
 import { readSqlWord } from "./words";
@@ -40,11 +41,11 @@ import { readSqlWord } from "./words";
  * does - the input ended, or ended inside a comment, so there is nothing further
  * to read and no honest way to guess what it would have been.
  */
-function skipTrivia(sql: string, from: number): number {
+function skipTrivia(sql: string, from: number, grammar: SqlGrammar): number {
   let i = from;
 
   while (i < sql.length) {
-    const span = readSqlSpan(sql, i);
+    const span = readSqlSpan(sql, i, grammar);
     if (span === null) return i;
     if (span.kind !== "whitespace" && span.kind !== "line-comment" && span.kind !== "block-comment") return i;
     if (!span.terminated) return -1;
@@ -64,12 +65,12 @@ function skipTrivia(sql: string, from: number): number {
  * at the first `)` inside a definition would put the reader in the middle of the
  * CTE body and let a `SELECT` there answer for the whole statement.
  */
-function skipParenthesised(sql: string, open: number): number {
+function skipParenthesised(sql: string, open: number, grammar: SqlGrammar): number {
   let depth = 0;
   let i = open;
 
   while (i < sql.length) {
-    const span = readSqlSpan(sql, i);
+    const span = readSqlSpan(sql, i, grammar);
     if (span !== null) {
       if (!span.terminated) return -1;
       i = span.end;
@@ -96,8 +97,8 @@ function skipParenthesised(sql: string, open: number): number {
 // issue #295), since neither reader recurses into a literal.
 
 /** The index past a CTE's name - a bare word or a quoted identifier - or `-1`. */
-function skipCteName(sql: string, index: number): number {
-  const span = readSqlSpan(sql, index);
+function skipCteName(sql: string, index: number, grammar: SqlGrammar): number {
+  const span = readSqlSpan(sql, index, grammar);
   if (span !== null) {
     // A quoted identifier is a name; a string or dollar-quoted body is not, and
     // trivia has already been skipped by the caller.
@@ -123,11 +124,11 @@ function skipCteName(sql: string, index: number): number {
  */
 type StandardElement = { kind: "element"; end: number } | { kind: "other-shape" } | { kind: "malformed" };
 
-function readStandardElement(sql: string, index: number): StandardElement {
-  const afterName = skipCteName(sql, index);
+function readStandardElement(sql: string, index: number, grammar: SqlGrammar): StandardElement {
+  const afterName = skipCteName(sql, index, grammar);
   if (afterName < 0) return { kind: "other-shape" };
 
-  let i = skipTrivia(sql, afterName);
+  let i = skipTrivia(sql, afterName, grammar);
   if (i < 0) return { kind: "malformed" };
 
   // An optional column list: `WITH t (a, b) AS (…)`. It closes back to depth 0
@@ -136,15 +137,15 @@ function readStandardElement(sql: string, index: number): StandardElement {
   // argument list (`now()`) is consumed here too and reaches the same index, so the
   // two need no telling apart: what follows the `AS` decides the shape.
   if (sql[i] === "(") {
-    const afterColumns = skipParenthesised(sql, i);
+    const afterColumns = skipParenthesised(sql, i, grammar);
     if (afterColumns < 0) return { kind: "malformed" };
-    i = skipTrivia(sql, afterColumns);
+    i = skipTrivia(sql, afterColumns, grammar);
     if (i < 0) return { kind: "malformed" };
   }
 
   const as = readSqlWord(sql, i);
   if (as?.text !== "AS") return { kind: "other-shape" };
-  i = skipTrivia(sql, as.end);
+  i = skipTrivia(sql, as.end, grammar);
   if (i < 0) return { kind: "malformed" };
 
   // PostgreSQL's inlining hints sit between `AS` and the body. Neither word exists
@@ -153,19 +154,19 @@ function readStandardElement(sql: string, index: number): StandardElement {
   let hint = readSqlWord(sql, i);
   const committed = hint?.text === "NOT" || hint?.text === "MATERIALIZED";
   if (hint?.text === "NOT") {
-    i = skipTrivia(sql, hint.end);
+    i = skipTrivia(sql, hint.end, grammar);
     if (i < 0) return { kind: "malformed" };
     hint = readSqlWord(sql, i);
     if (hint?.text !== "MATERIALIZED") return { kind: "malformed" };
   }
   if (hint?.text === "MATERIALIZED") {
-    i = skipTrivia(sql, hint.end);
+    i = skipTrivia(sql, hint.end, grammar);
     if (i < 0) return { kind: "malformed" };
   }
 
   if (sql[i] !== "(") return { kind: committed ? "malformed" : "other-shape" };
 
-  const afterBody = skipParenthesised(sql, i);
+  const afterBody = skipParenthesised(sql, i, grammar);
   if (afterBody < 0) return { kind: "malformed" };
 
   return { kind: "element", end: afterBody };
@@ -180,12 +181,12 @@ function readStandardElement(sql: string, index: number): StandardElement {
  * is not - which is all this module needs, since it never has to understand the
  * expression, only find where it stops.
  */
-function skipExpressionElement(sql: string, index: number): number {
+function skipExpressionElement(sql: string, index: number, grammar: SqlGrammar): number {
   let depth = 0;
   let i = index;
 
   while (i < sql.length) {
-    const span = readSqlSpan(sql, i);
+    const span = readSqlSpan(sql, i, grammar);
     if (span !== null) {
       if (!span.terminated) return -1;
       i = span.end;
@@ -217,11 +218,11 @@ function skipExpressionElement(sql: string, index: number): number {
       continue;
     }
     if (depth === 0 && word.text === "AS") {
-      const aliasAt = skipTrivia(sql, word.end);
+      const aliasAt = skipTrivia(sql, word.end, grammar);
       if (aliasAt < 0) return -1;
       // The alias is a plain name. Anything else - a body, a literal - means this
       // is not the shape either, and `-1` reaches the caller as "cannot tell".
-      return skipCteName(sql, aliasAt);
+      return skipCteName(sql, aliasAt, grammar);
     }
     i = word.end;
   }
@@ -242,12 +243,12 @@ function skipExpressionElement(sql: string, index: number): number {
  *   the standard shape already reads - which is what keeps #287's writing CTEs
  *   answering their own write keyword.
  */
-function skipCteElement(sql: string, index: number): number {
-  const standard = readStandardElement(sql, index);
+function skipCteElement(sql: string, index: number, grammar: SqlGrammar): number {
+  const standard = readStandardElement(sql, index, grammar);
   if (standard.kind === "element") return standard.end;
   if (standard.kind === "malformed") return -1;
 
-  return skipExpressionElement(sql, index);
+  return skipExpressionElement(sql, index, grammar);
 }
 
 /**
@@ -258,24 +259,24 @@ function skipCteElement(sql: string, index: number): number {
  * CTE's own body. Anything that does not match answers `null`: see the bias note
  * on the exported function.
  */
-function readKeywordAfterCteList(sql: string, afterWith: number): LeadingKeyword | null {
-  let i = skipTrivia(sql, afterWith);
+function readKeywordAfterCteList(sql: string, afterWith: number, grammar: SqlGrammar): LeadingKeyword | null {
+  let i = skipTrivia(sql, afterWith, grammar);
   if (i < 0) return null;
 
   const recursive = readSqlWord(sql, i);
   if (recursive?.text === "RECURSIVE") {
-    i = skipTrivia(sql, recursive.end);
+    i = skipTrivia(sql, recursive.end, grammar);
     if (i < 0) return null;
   }
 
   for (;;) {
-    const afterElement = skipCteElement(sql, i);
+    const afterElement = skipCteElement(sql, i, grammar);
     if (afterElement < 0) return null;
-    i = skipTrivia(sql, afterElement);
+    i = skipTrivia(sql, afterElement, grammar);
     if (i < 0) return null;
 
     if (sql[i] !== ",") break;
-    i = skipTrivia(sql, i + 1);
+    i = skipTrivia(sql, i + 1, grammar);
     if (i < 0) return null;
   }
 
@@ -328,13 +329,14 @@ function readKeywordAfterCteList(sql: string, afterWith: number): LeadingKeyword
  *   reading. Unreachable in Oracle itself, which has no `WITH … DELETE`, and no
  *   other dialect here has the form.
  * - A MySQL line comment whose first character makes a PostgreSQL operator (`#-`,
- *   `#>`) is code by the deliberate trade `spans.ts` documents, so a paren inside
- *   such a comment can end a CTE body early. Contrived, and paid for on purpose:
- *   closing it would cost every PostgreSQL jsonb-operator CTE its bound.
+ *   `#>`) is code to a reader that was given NO dialect, so a paren inside such a
+ *   comment can end a CTE body early. That is now only the dialect-less reading:
+ *   pass MySQL's grammar and the comment is a comment, pass PostgreSQL's and the
+ *   operator is an operator (#292). Every caller in this project passes one.
  */
-export function readOperativeKeyword(sql: string): LeadingKeyword | null {
+export function readOperativeKeyword(sql: string, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): LeadingKeyword | null {
   const leading = readLeadingKeyword(sql);
   if (leading === null || leading.keyword !== "WITH") return leading;
 
-  return readKeywordAfterCteList(sql, leading.end);
+  return readKeywordAfterCteList(sql, leading.end, grammar);
 }

--- a/src/lib/sql/spans.ts
+++ b/src/lib/sql/spans.ts
@@ -151,8 +151,15 @@ function hasOddBackslashRunBefore(sql: string, from: number, at: number): boolea
  * delimiter behind an odd backslash run is reported as UNDETERMINABLE instead of
  * guessed: `WITH t AS (SELECT '\') SELECT ') DELETE FROM users` reads as a SELECT
  * under one dialect and a DELETE under the other, and guessing the first would
- * append a bound to a DELETE. Callers already decline to rewrite what they cannot
- * read, so the cost of the safe answer is at most an unbounded read.
+ * append a bound to a DELETE. The callers that REWRITE a statement decline to,
+ * so the cost there is at most an unbounded read.
+ *
+ * Since #297 it costs one thing more, and this rule is where the cost is largest:
+ * the confirmation gate asks about text it cannot resolve rather than staying
+ * silent, and `\'` is MySQL's own escape for an apostrophe, so an everyday read
+ * (`… WHERE name = 'O\'Brien'`) prompts on every execute. Naming the dialect does
+ * not narrow it, because whether `\` escapes is deliberately not one of the facts
+ * `grammar.ts` carries yet.
  */
 /**
  * A `[…]` quoted identifier, whose closing bracket is escaped by doubling.
@@ -473,4 +480,40 @@ export function readSqlSpan(sql: string, index: number, grammar: SqlGrammar = DE
   }
 
   return null;
+}
+
+/**
+ * Whether this text carries a run that never closes - i.e. whether part of it is
+ * text no reader over this module can resolve.
+ *
+ * Every OTHER reader here consumes `terminated: false` and then throws it away:
+ * `statement-end.ts` refuses the cut, `words.ts` reports the word it could not see
+ * as absent, `readSubscripted` above gives up on the bracket. Each is answering a
+ * question where declining to act is the safe direction, because their mistake
+ * would be a row bound appended to a write.
+ *
+ * The confirmation gate's costs run the other way - silence there is an
+ * unconfirmed destructive statement, while asking costs a click - so it needs the
+ * signal itself rather than a reader's response to it (#297). Hence a predicate
+ * over spans rather than a fourth reader that re-derives it: an unterminated run
+ * hides whatever is written INSIDE it, and the whole answer is whether one exists.
+ *
+ * A scanner for the same reason as the rest of this module: it advances one span
+ * or one character at a time and cannot backtrack, so it stays linear on the
+ * pasted-script sizes the execute path sees.
+ */
+export function hasUnterminatedSpan(sql: string, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): boolean {
+  let i = 0;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i, grammar);
+    if (span === null) {
+      i++;
+      continue;
+    }
+    if (!span.terminated) return true;
+    i = span.end;
+  }
+
+  return false;
 }

--- a/src/lib/sql/spans.ts
+++ b/src/lib/sql/spans.ts
@@ -21,13 +21,18 @@
  * to change:
  *
  * - `statement-splitter.ts` inlines the same scan, wound together with the line
- *   counting it needs, and knows neither of the dialect facts below: it treats `#`
- *   as ordinary code, so a MySQL hash comment containing a `;` still splits there,
- *   and it has no alternate-quoting branch, so an Oracle `q'{a'b;c}'` body splits
- *   at that `;` while every reader over this module sees one literal. Both
- *   divergences are safe in the same direction - the fragments lose a bound rather
- *   than gaining a misplaced one - and reusing this module would move statement
- *   boundaries: a separate bug with its own tests.
+ *   counting it needs, and knows none of the dialect facts below: it treats `#`
+ *   as ordinary code, so a MySQL hash comment containing a `;` still splits there;
+ *   it has no alternate-quoting branch, so an Oracle `q'{a'b;c}'` body splits
+ *   at that `;`; and it has no bracket branch of either kind, so a `;` inside a
+ *   bracket-quoted NAME (`SELECT [a;b] FROM t`, verified) splits one statement into
+ *   two while every reader over this module sees one name. The bracket fact's
+ *   SUBSCRIPT half escapes it only where the key is STRING-quoted, and by luck
+ *   rather than by design: the splitter reads `'…'` and `"…"` but not backticks, so
+ *   `SELECT arr[\`a;b\`] FROM t` splits there exactly as the bracketed name does.
+ *   All three divergences are safe in the same direction - the fragments lose a
+ *   bound rather than gaining a misplaced one - and reusing this module would move
+ *   statement boundaries: a separate bug with its own tests.
  * - `alias-extractor.ts:134-135` blanks literals with a regex that honours
  *   BACKSLASH escapes, which this module reports as undeterminable instead (see
  *   `readQuoted`). Its job is autocomplete, where a wrong alias costs a
@@ -47,9 +52,11 @@ import { DEFAULT_SQL_GRAMMAR, type SqlGrammar } from "./grammar";
  * What kind of non-code run a span is.
  *
  * Callers care about the distinction in two ways: trivia (`whitespace`,
- * `line-comment`, `block-comment`) can be skipped between tokens, while a
- * literal is a token - a quoted identifier can BE a name, so a reader that
- * skipped it as trivia would misread `WITH "my cte" AS (…)`.
+ * `line-comment`, `block-comment`) can be skipped between tokens, while the rest
+ * are the statement's own text - a quoted identifier can BE a name, so a reader
+ * that skipped it as trivia would misread `WITH "my cte" AS (…)`, and a
+ * `subscript` sits in the middle of an expression, so a reader that took it for
+ * trivia would place the statement's end before it.
  */
 export type SqlSpanKind =
   | "whitespace"
@@ -57,7 +64,8 @@ export type SqlSpanKind =
   | "block-comment"
   | "string"
   | "quoted-identifier"
-  | "dollar-string";
+  | "dollar-string"
+  | "subscript";
 
 export interface SqlSpan {
   kind: SqlSpanKind;
@@ -170,6 +178,59 @@ function readBracketed(sql: string, index: number): SqlSpan {
   }
 
   return { kind: "quoted-identifier", end: sql.length, terminated: false };
+}
+
+/**
+ * A `[…]` array literal or subscript, which NESTS and escapes nothing.
+ *
+ * The other reading of these characters (`readBracketed`) is a name, and the two
+ * disagree about the same text in both directions, which is why the grammar record
+ * picks between them rather than one scan trying to serve both: a `]` written
+ * inside a string ends a NAME (that is the whole point of `[a--b]`) and does not
+ * end a subscript, and a doubled `]` escapes inside a name and closes a nested
+ * array. Reaching into `readSqlSpan` for what a run CONTAINS is safe here for the
+ * same reason it would be wrong there - a subscript's contents are code, a name's
+ * are characters of the name.
+ *
+ * Depth is counted rather than matched, and both brackets are consumed before the
+ * span reader is asked, so the recursion is exactly one level deep and the scan
+ * still advances one span or one character at a time - it cannot backtrack.
+ */
+function readSubscripted(sql: string, index: number, grammar: SqlGrammar): SqlSpan {
+  let depth = 0;
+  let i = index;
+
+  while (i < sql.length) {
+    const ch = sql[i];
+    if (ch === "[") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === "]") {
+      depth--;
+      i++;
+      if (depth === 0) return { kind: "subscript", end: i, terminated: true };
+      continue;
+    }
+
+    const inner = readSqlSpan(sql, i, grammar);
+    if (inner !== null) {
+      // A run cannot be more certain than what it contains: an unterminated literal
+      // inside means the closing bracket cannot be found, only guessed at, and a
+      // guess here puts the statement's end inside a literal. Every span kind in
+      // this module currently ends an unterminated run at the input's end, so
+      // falling through the loop would reach the same record - this says the reason
+      // locally rather than resting on that coincidence, and it is what keeps the
+      // answer right if a future span kind ever ends BEFORE the input does.
+      if (!inner.terminated) return { kind: "subscript", end: sql.length, terminated: false };
+      i = inner.end;
+      continue;
+    }
+    i++;
+  }
+
+  return { kind: "subscript", end: sql.length, terminated: false };
 }
 
 /**
@@ -387,14 +448,19 @@ export function readSqlSpan(sql: string, index: number, grammar: SqlGrammar = DE
   // though it is the one delimiter pair here that opens and closes with different
   // characters. SQL Server's escape is a doubled closing bracket.
   //
-  // ClickHouse spells an array with the same characters and nests them, so
-  // `[[1,2],[3,4]]` closes at the first single `]` under this reading and the rest
-  // is undeterminable. That costs a bound on a form which already lost it before
-  // this change (see the array note in `operative-keyword.ts`). Telling the two
-  // apart needs a BRACKET fact on the grammar record, which it does not carry yet
-  // - the record exists and reaches this reader, but issue #295 is what puts the
-  // second row on it.
-  if (ch === "[") return readBracketed(sql, index);
+  // ClickHouse spells an array with the same characters and nests them, and there
+  // the name reading is wrong in both of its rules at once: `m['a]b']` is a
+  // subscript whose key carries a close bracket (the name reading ends the run at
+  // that bracket, and the CTE element around it can then not be crossed), and
+  // `[[1,2],[3,4]]` ends with a doubled bracket that the name reading takes for an
+  // escape, so the run never closes at all. Both cost the statement its bound. The
+  // grammar record answers it (#295): the two readings are mutually exclusive, so
+  // the dialect picks, and a caller that named none keeps the name reading - which
+  // is where the corrupted-statement shape `SELECT [a LIMIT 500--b] FROM t` lives,
+  // and it is the more expensive mistake of the two.
+  if (ch === "[") {
+    return grammar.bracket === "subscript" ? readSubscripted(sql, index, grammar) : readBracketed(sql, index);
+  }
 
   if (ch === "$") {
     const tagLength = measureDollarTag(sql, index);

--- a/src/lib/sql/spans.ts
+++ b/src/lib/sql/spans.ts
@@ -241,6 +241,48 @@ function readSubscripted(sql: string, index: number, grammar: SqlGrammar): SqlSp
 }
 
 /**
+ * A block comment under a grammar that NESTS: `/* a /* b *\/ c *\/` is one run.
+ *
+ * Depth is counted rather than matched, and both characters of every delimiter are
+ * consumed before the next look, so `/*\/` is one opener and no closer (the shared
+ * slash belongs to the opener) and the scan cannot see a delimiter twice. It is a
+ * single forward pass over the comment, so it stays linear on an adversarial nest -
+ * the property `leading-keyword.ts` records three measured regex failures for.
+ *
+ * Nothing inside a comment is a literal, here or in the engines this reads for: a
+ * `/*` written inside quotes in comment text is still an opener and a `*\/` inside
+ * them still closes. Looking for literals in there is the plausible wrong fix - it
+ * would make `/* it's /* deep *\/ still *\/` unterminated - so a fixture pins it.
+ *
+ * A run whose depth never returns to zero is reported undeterminable rather than
+ * closed at the last delimiter it saw. That is the fail-safe direction this module
+ * keeps everywhere: it costs the statement its bound (an over-large read) and, since
+ * #297, a confirmation prompt - where the guess would hide a write behind text the
+ * reader claimed to have read.
+ */
+function readNestedBlockComment(sql: string, index: number): SqlSpan {
+  let depth = 0;
+  let i = index;
+
+  while (i + 1 < sql.length) {
+    if (sql[i] === "/" && sql[i + 1] === "*") {
+      depth++;
+      i += 2;
+      continue;
+    }
+    if (sql[i] === "*" && sql[i + 1] === "/") {
+      depth--;
+      i += 2;
+      if (depth === 0) return { kind: "block-comment", end: i, terminated: true };
+      continue;
+    }
+    i++;
+  }
+
+  return { kind: "block-comment", end: sql.length, terminated: false };
+}
+
+/**
  * The closer Oracle pairs with an alternate-quote opener, or the opener itself.
  *
  * From node-oracledb's own SQL tokenizer (`lib/thin/statement.js`,
@@ -413,7 +455,20 @@ export function readSqlSpan(sql: string, index: number, grammar: SqlGrammar = DE
     return { kind: "line-comment", end: newline === -1 ? sql.length : newline + 1, terminated: true };
   }
 
+  // A `/*` written INSIDE a block comment opens a second one in PostgreSQL, SQL
+  // Server and ClickHouse and means nothing at all in MySQL, SQLite and Oracle, so
+  // the two readings put the comment's end in different places - and everything
+  // between the first `*\/` and the real end is either comment text or the
+  // statement's own code depending on which one applies. Read flat where the
+  // dialect nests, a `)` written in that region closed a CTE body that was still
+  // open, so the statement was typed by a keyword the operator had commented out:
+  // `WITH t AS (\n /* a /* b *\/ ) SELECT 1 *\/\n SELECT id FROM logs\n) INSERT …`
+  // was typed a read and handed a bound, which on PostgreSQL commits part of the
+  // insert. The grammar record answers it now (#300), and the flat reading survives
+  // as MySQL's, SQLite's, Oracle's and what a caller that named no dialect gets.
   if (ch === "/" && sql[index + 1] === "*") {
+    if (grammar.blockComment === "nesting") return readNestedBlockComment(sql, index);
+
     const close = sql.indexOf("*/", index + 2);
     if (close === -1) return { kind: "block-comment", end: sql.length, terminated: false };
     return { kind: "block-comment", end: close + 2, terminated: true };

--- a/src/lib/sql/spans.ts
+++ b/src/lib/sql/spans.ts
@@ -30,7 +30,14 @@
  *   suggestion; here a wrong literal boundary costs a bound on a write.
  *
  * This module is what every NEW reader builds on, so the count does not grow.
+ *
+ * Where the dialects genuinely disagree about a character, the reading comes from
+ * the caller's grammar record (`grammar.ts`) rather than from this file taking one
+ * engine's side. A call that names no dialect keeps the reading this module had
+ * before the record existed.
  */
+
+import { DEFAULT_SQL_GRAMMAR, type SqlGrammar } from "./grammar";
 
 /**
  * What kind of non-code run a span is.
@@ -75,6 +82,24 @@ function isWhitespace(ch: string): boolean {
 /** The characters that turn a `#` into a PostgreSQL operator rather than a comment. */
 function isHashOperatorTail(ch: string | undefined): boolean {
   return ch === ">" || ch === "-" || ch === "#";
+}
+
+/**
+ * Whether a line comment opens at `index`.
+ *
+ * `--` opens one in every dialect here and needs no grammar. `#` is the one this
+ * module could not answer on its own, so it asks the grammar record: MySQL and
+ * ClickHouse open a comment on any `#`, PostgreSQL, Oracle, SQL Server and SQLite
+ * open none, and a caller that named no dialect keeps the hybrid reading this
+ * module used to apply to everyone (see `DEFAULT_SQL_GRAMMAR`).
+ */
+function opensLineComment(sql: string, index: number, grammar: SqlGrammar): boolean {
+  const ch = sql[index];
+  if (ch === "-") return sql[index + 1] === "-";
+  if (ch !== "#") return false;
+  if (grammar.hash === "code") return false;
+  if (grammar.hash === "comment") return true;
+  return !isHashOperatorTail(sql[index + 1]);
 }
 
 /**
@@ -200,8 +225,12 @@ function measureDollarTag(sql: string, index: number): number {
  *
  * Callers walk a statement by asking at every position: is this a span? If yes,
  * jump to `end`; if no, this character is the statement's own code.
+ *
+ * `grammar` is the dialect's reading of the characters the engines disagree about.
+ * Omitting it is a real answer, not a missing one: it means "no dialect was
+ * named", and the compatibility default applies.
  */
-export function readSqlSpan(sql: string, index: number): SqlSpan | null {
+export function readSqlSpan(sql: string, index: number, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): SqlSpan | null {
   const ch = sql[index];
   if (ch === undefined) return null;
 
@@ -211,27 +240,21 @@ export function readSqlSpan(sql: string, index: number): SqlSpan | null {
     return { kind: "whitespace", end, terminated: true };
   }
 
-  // `#` is MySQL's and MariaDB's second line-comment marker. Unlike
-  // `leading-keyword.ts`, which only ever looks at a statement's LEADING trivia,
-  // this reader is asked about every position - and mid-statement `#` is a live
-  // PostgreSQL operator: `#>` and `#>>` walk a jsonb path, `#-` deletes one, `##`
-  // is geometric. Reading `SELECT meta #> '{a}'` as a comment swallows the rest of
-  // the line and costs an everyday jsonb query its bound, so a `#` that opens one
-  // of those operators is code.
+  // `#` is MySQL's, MariaDB's and ClickHouse's second line-comment marker, and it
+  // is ordinary code in PostgreSQL, Oracle, SQL Server and SQLite - a jsonb or
+  // geometric operator (`#>`, `#>>`, `#-`, `##`), an identifier character, a temp
+  // table, a bind-variable prefix. Unlike `leading-keyword.ts`, which only ever
+  // looks at a statement's LEADING trivia, this reader is asked about every
+  // position, so mid-statement `#` is exactly where the disagreement bites.
   //
-  // The trade is stated exactly, because this is the one place the module takes a
-  // dialect's SIDE instead of reporting that the dialects disagree. A MySQL comment
-  // whose first character is one of those (`#- note`) reads as code here, so the
-  // rest of that line is read as SQL where MySQL reads it as comment - and if that
-  // text contains a paren, the two readings end a construct in different places.
-  // `WITH t AS (\n #- note )\n SELECT 1) DELETE FROM users` is a DELETE in MySQL and
-  // reads as a SELECT here, which is the direction `operative-keyword.ts` otherwise
-  // promises to avoid. Reporting it undeterminable would close that, at the price of
-  // every PostgreSQL jsonb-operator CTE losing its bound: a certain cost against a
-  // contrived one. So the reading stands, the gap is recorded rather than hidden
-  // (`operative-keyword.ts`, and a test pins it), and `# note` - how comments are
-  // actually written - is unaffected either way.
-  if ((ch === "-" && sql[index + 1] === "-") || (ch === "#" && !isHashOperatorTail(sql[index + 1]))) {
+  // This used to be resolved here, by taking PostgreSQL's side: a `#` that opens
+  // one of those operators is code. That kept `SELECT meta #> '{a}'` bounded and
+  // cost the other direction - a MySQL comment written `#- note` read as SQL, so a
+  // `)` inside it ended a CTE body early and `WITH t AS (\n #- note )\n SELECT 1)
+  // DELETE FROM users` was typed a read and handed a bound, which MySQL applies to
+  // the rows the DELETE removes. The grammar record answers it now (#292), and the
+  // hybrid survives only as what a caller that named no dialect gets.
+  if (opensLineComment(sql, index, grammar)) {
     const newline = sql.indexOf("\n", index);
     // The newline belongs to the comment: it is what closes it.
     return { kind: "line-comment", end: newline === -1 ? sql.length : newline + 1, terminated: true };
@@ -267,8 +290,10 @@ export function readSqlSpan(sql: string, index: number): SqlSpan | null {
   // ClickHouse spells an array with the same characters and nests them, so
   // `[[1,2],[3,4]]` closes at the first single `]` under this reading and the rest
   // is undeterminable. That costs a bound on a form which already lost it before
-  // this change (see the array note in `operative-keyword.ts`); telling the two
-  // apart needs the dialect, which this module does not have.
+  // this change (see the array note in `operative-keyword.ts`). Telling the two
+  // apart needs a BRACKET fact on the grammar record, which it does not carry yet
+  // - the record exists and reaches this reader, but issue #295 is what puts the
+  // second row on it.
   if (ch === "[") return readBracketed(sql, index);
 
   if (ch === "$") {

--- a/src/lib/sql/spans.ts
+++ b/src/lib/sql/spans.ts
@@ -21,8 +21,12 @@
  * to change:
  *
  * - `statement-splitter.ts` inlines the same scan, wound together with the line
- *   counting it needs, and treats `#` as ordinary code - so a MySQL hash comment
- *   containing a `;` still splits there. Reusing this module would move statement
+ *   counting it needs, and knows neither of the dialect facts below: it treats `#`
+ *   as ordinary code, so a MySQL hash comment containing a `;` still splits there,
+ *   and it has no alternate-quoting branch, so an Oracle `q'{a'b;c}'` body splits
+ *   at that `;` while every reader over this module sees one literal. Both
+ *   divergences are safe in the same direction - the fragments lose a bound rather
+ *   than gaining a misplaced one - and reusing this module would move statement
  *   boundaries: a separate bug with its own tests.
  * - `alias-extractor.ts:134-135` blanks literals with a regex that honours
  *   BACKSLASH escapes, which this module reports as undeterminable instead (see
@@ -168,6 +172,82 @@ function readBracketed(sql: string, index: number): SqlSpan {
   return { kind: "quoted-identifier", end: sql.length, terminated: false };
 }
 
+/**
+ * The closer Oracle pairs with an alternate-quote opener, or the opener itself.
+ *
+ * From node-oracledb's own SQL tokenizer (`lib/thin/statement.js`,
+ * `_parseQstring`): the four bracket forms close with their partner, and every
+ * other delimiter closes with itself.
+ */
+const ALTERNATE_QUOTE_CLOSERS: Record<string, string> = { "[": "]", "{": "}", "(": ")", "<": ">" };
+
+/**
+ * The length of an alternate-quote tag at `index`, or 0 when none opens there.
+ *
+ * `q'` and `Q'` open one, and the same form spelled `nq'` / `NQ'` (any case
+ * mixture) is the national-character-set literal - Oracle's SQL Language
+ * Reference gives `nq'#…#'` as the NCHAR/NVARCHAR2 spelling. Both are read,
+ * because the body rules are identical and reading only one of them would leave
+ * the other's body walked as code, which is the defect this branch exists to fix.
+ */
+function measureAlternateQuoteTag(sql: string, index: number): number {
+  let i = index;
+  if (sql[i] === "n" || sql[i] === "N") i++;
+  if (sql[i] !== "q" && sql[i] !== "Q") return 0;
+  if (sql[i + 1] !== "'") return 0;
+  return i + 2 - index;
+}
+
+/**
+ * An Oracle alternate-quoted literal: `q'{it's}'`, `Q'<body>'`, `nq'!body!'`.
+ *
+ * The delimiter after the tag opens the body and the matching one FOLLOWED BY a
+ * quote closes it, which is what lets the body carry apostrophes - and the
+ * delimiter character itself (`q'{a}b}'` is one literal) - with nothing escaped.
+ * So there is no doubling rule and no backslash question here: the search is for
+ * the two characters that end it.
+ *
+ * Any character may be the delimiter, which needs no check of its own: Oracle
+ * refuses a whitespace delimiter where this reads a literal - and an opaque span
+ * moves the reading around it, so such a body can also swallow a `)` or a write
+ * keyword - but only in text Oracle rejects outright, so nothing that reaches a
+ * server depends on it. Half of a surrogate pair can never match its own closer, so
+ * that body reads as unterminated: the answer that costs a bound rather than
+ * misplacing one.
+ */
+function readAlternateQuoted(sql: string, index: number, tagLength: number): SqlSpan {
+  const body = index + tagLength + 1;
+  const opener = sql[index + tagLength];
+  // The tag at the very end of the input: no delimiter, so nothing can close it.
+  if (opener === undefined) return { kind: "string", end: sql.length, terminated: false };
+
+  const close = sql.indexOf(`${ALTERNATE_QUOTE_CLOSERS[opener] ?? opener}'`, body);
+  if (close === -1) return { kind: "string", end: sql.length, terminated: false };
+  return { kind: "string", end: close + 2, terminated: true };
+}
+
+/**
+ * Whether the character before `index` continues a word, i.e. `index` is inside
+ * one.
+ *
+ * Only the alternate-quote tag needs this: it is the one span whose first
+ * character is also an identifier character. Oracle's lexer reads a name greedily,
+ * so `freq'x'` there is a name followed by an ordinary string, and without the
+ * check the two kinds of reader in this folder would disagree about such text as
+ * well - the ones that read whole words step over the name and never ask here,
+ * while the ones that walk character by character would ask at its last letter.
+ * Two readings of one construct is what this folder exists to stop.
+ *
+ * node-oracledb's tokenizer has no equivalent check (it parses a q-string at any
+ * `'` preceded by `q`/`Q`), so this is deliberately stricter than the driver and
+ * closer to the server. What it excludes is text no dialect here accepts, and it
+ * excludes it in the safe direction: an ordinary string reading, as today.
+ */
+function continuesWord(sql: string, index: number): boolean {
+  const before = index === 0 ? undefined : sql[index - 1];
+  return before !== undefined && (IDENTIFIER_PART.test(before) || before === "$");
+}
+
 function readQuoted(sql: string, index: number, quote: string, kind: SqlSpanKind, backslashEscapes: boolean): SqlSpan {
   let i = index + 1;
 
@@ -229,6 +309,11 @@ function measureDollarTag(sql: string, index: number): number {
  * `grammar` is the dialect's reading of the characters the engines disagree about.
  * Omitting it is a real answer, not a missing one: it means "no dialect was
  * named", and the compatibility default applies.
+ *
+ * Pass the whole statement, not a suffix of it: the alternate-quote branch looks at
+ * the character BEFORE `index` to tell a tag from the tail of a name, so a slice
+ * that cuts a name in half can answer differently than the same text in place. A
+ * PREFIX slice is safe, which is what the callers here take (`sql.slice(0, end)`).
  */
 export function readSqlSpan(sql: string, index: number, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): SqlSpan | null {
   const ch = sql[index];
@@ -264,6 +349,21 @@ export function readSqlSpan(sql: string, index: number, grammar: SqlGrammar = DE
     const close = sql.indexOf("*/", index + 2);
     if (close === -1) return { kind: "block-comment", end: sql.length, terminated: false };
     return { kind: "block-comment", end: close + 2, terminated: true };
+  }
+
+  // Oracle writes a literal that carries apostrophes as `q'{it's}'` (`nq'…'` for
+  // the national character set), and it is the only dialect here with the form.
+  // Read as code - all any reader here could do before it was told the dialect -
+  // the first apostrophe INSIDE the body opens a string and everything after it is
+  // read one construct out of step, which costs in both of this folder's
+  // directions: a `)` in the body ended a CTE body early, so the statement was
+  // typed by a keyword written inside the literal and lost its bound, and a `--` in
+  // the body made the rest of the literal look like trailing trivia, so the bound
+  // was inserted INSIDE the literal and the statement Oracle received was corrupt
+  // while the caller was told it was limited (#292).
+  if (grammar.alternateQuoting) {
+    const tagLength = measureAlternateQuoteTag(sql, index);
+    if (tagLength > 0 && !continuesWord(sql, index)) return readAlternateQuoted(sql, index, tagLength);
   }
 
   if (ch === "'") return readQuoted(sql, index, "'", "string", true);

--- a/src/lib/sql/statement-end.ts
+++ b/src/lib/sql/statement-end.ts
@@ -31,6 +31,7 @@
  * failures of exactly that kind.
  */
 
+import { DEFAULT_SQL_GRAMMAR, hashRunIsAmbiguous, type SqlGrammar } from "./grammar";
 import { readSqlSpan } from "./spans";
 
 export interface StatementEnd {
@@ -92,31 +93,37 @@ function isTrailingSpace(ch: string): boolean {
  *    never closes.) Inserting on a guess emits `… 'O\'Brien'; LIMIT 500`, a bound
  *    after the statement's own `;`, which is a syntax error rather than too many
  *    rows.
- * 2. **A `#` line comment in the trailing run.** `spans.ts` reads `#` as MySQL's
- *    second comment marker, but it is ordinary code in three other dialects this
- *    project supports - `#tmp` is a T-SQL temp table, `ID#` a legal Oracle
- *    identifier, `flags # 5` a PostgreSQL XOR - and nothing in the text tells the
- *    two apart (`#note` and `#tmp` are the same characters). Cutting there emits
- *    `SELECT * FROM LIMIT 500 #tmp`. The `#` run is reported as part of the
- *    statement rather than trimmed off it, because the reading that costs least
- *    when wrong is the LONGER one: a bound written after a `#` is then still
- *    found (`… FROM #tmp ORDER BY id FETCH NEXT 10 ROWS ONLY` is a bounded T-SQL
- *    page, and a caller that could not see that bound would add a second), while
- *    the opposite mistake only reports a bound the caller responds to by leaving
- *    the statement alone - which is what it does here anyway.
+ * 2. **A `#` line comment in the trailing run, and ONLY where no dialect was
+ *    named.** `#` is a comment marker in MySQL, MariaDB and ClickHouse and
+ *    ordinary code in the rest - `#tmp` is a T-SQL temp table, `ID#` a legal
+ *    Oracle identifier, `flags # 5` a PostgreSQL XOR, `#id` a SQLite bind
+ *    variable - and nothing in the TEXT tells the two apart (`#note` and `#tmp`
+ *    are the same characters). Cutting on the wrong one emits
+ *    `SELECT * FROM LIMIT 500 #tmp`. A caller that names its dialect has told
+ *    them apart, so this refusal applies to the dialect-less reading alone
+ *    (#292); there the `#` run is reported as part of the statement rather than
+ *    trimmed off it, because the reading that costs least when wrong is the
+ *    LONGER one: a bound written after a `#` is then still found
+ *    (`… FROM #tmp ORDER BY id FETCH NEXT 10 ROWS ONLY` is a bounded T-SQL page,
+ *    and a caller that could not see that bound would add a second), while the
+ *    opposite mistake only reports a bound the caller responds to by leaving the
+ *    statement alone - which is what it does here anyway.
  *
  * A `#` comment with code after it on a later line is unaffected: the end then
  * advances past it, and inserting at the end of the statement is correct under
  * both readings.
  */
-export function readStatementEnd(sql: string): StatementEnd {
+export function readStatementEnd(sql: string, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): StatementEnd {
   let end = 0;
   let i = 0;
-  // Whether the run since the last code character contains a `#` line comment.
+  // Whether the run since the last code character contains a `#` line comment
+  // whose meaning is undecided. Under a named dialect there is nothing to be
+  // wrong about: the comment is a comment (cut before it) or the run is the
+  // statement's own code (the end has already advanced past it).
   let hashInTrailingRun = false;
 
   while (i < sql.length) {
-    const span = readSqlSpan(sql, i);
+    const span = readSqlSpan(sql, i, grammar);
 
     if (span !== null) {
       if (!span.terminated) return { end: endBeforeTerminator(sql), rewritable: false };
@@ -126,7 +133,7 @@ export function readStatementEnd(sql: string): StatementEnd {
       if (span.kind === "string" || span.kind === "quoted-identifier" || span.kind === "dollar-string") {
         end = span.end;
         hashInTrailingRun = false;
-      } else if (span.kind === "line-comment" && sql[i] === "#") {
+      } else if (span.kind === "line-comment" && sql[i] === "#" && hashRunIsAmbiguous(grammar)) {
         hashInTrailingRun = true;
       }
       i = span.end;

--- a/src/lib/sql/statement-end.ts
+++ b/src/lib/sql/statement-end.ts
@@ -32,7 +32,7 @@
  */
 
 import { DEFAULT_SQL_GRAMMAR, hashRunIsAmbiguous, type SqlGrammar } from "./grammar";
-import { readSqlSpan } from "./spans";
+import { readSqlSpan, type SqlSpanKind } from "./spans";
 
 export interface StatementEnd {
   /**
@@ -72,6 +72,23 @@ function endBeforeTerminator(sql: string): number {
 /** Whitespace as the terminator strip counts it, matching `String.prototype.trim`. */
 function isTrailingSpace(ch: string): boolean {
   return ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "\f" || ch === "\v";
+}
+
+/**
+ * Whether a span is the statement's own text rather than trivia between tokens.
+ *
+ * Everything but a comment and whitespace is: a literal, a quoted name and a
+ * bracketed subscript are all tokens the statement is made of, so the end has to
+ * advance past them. Reading one as trivia would leave the end at the last code
+ * character BEFORE it, and the insert-before-trivia rewrite then splices the bound
+ * into the middle of the statement - `SELECT [1,2]` emitted as
+ * `SELECT LIMIT 500 [1,2]`, `SELECT m['k']` as `SELECT m LIMIT 500['k']` - a
+ * corrupted statement rather than a missed bound. Both examples END with the run on
+ * purpose: with code after it the end reaches the same index under either reading,
+ * which is why the fixtures that pin this all end with the run.
+ */
+function isStatementText(kind: SqlSpanKind): boolean {
+  return kind === "string" || kind === "quoted-identifier" || kind === "dollar-string" || kind === "subscript";
 }
 
 /**
@@ -130,7 +147,7 @@ export function readStatementEnd(sql: string, grammar: SqlGrammar = DEFAULT_SQL_
       // A literal is the statement's own text; trivia is not. Both are skipped
       // whole, which is what keeps a `;` or a `--` written inside one from
       // looking like the end of the statement.
-      if (span.kind === "string" || span.kind === "quoted-identifier" || span.kind === "dollar-string") {
+      if (isStatementText(span.kind)) {
         end = span.end;
         hashInTrailingRun = false;
       } else if (span.kind === "line-comment" && sql[i] === "#" && hashRunIsAmbiguous(grammar)) {

--- a/src/lib/sql/words.ts
+++ b/src/lib/sql/words.ts
@@ -19,6 +19,7 @@
  * or one word at a time cannot backtrack at all.
  */
 
+import { DEFAULT_SQL_GRAMMAR, type SqlGrammar } from "./grammar";
 import { IDENTIFIER_PART, IDENTIFIER_START, readSqlSpan } from "./spans";
 
 /** A word (identifier or keyword) and where it ends. */
@@ -70,13 +71,24 @@ export interface CodeWord {
  * different places, the text is a syntax error under one of them, and guessing here
  * would answer for words inside a literal under the other. Pinned by a test in
  * `tests/unit/sql/words.test.ts`.
+ *
+ * WHICH runs are not code is the dialect's answer for one character: a write
+ * written after a `#` is commented out in MySQL and the statement's own code in
+ * PostgreSQL, and the safety predicate above this reader has to prompt in the
+ * second case and not the first (#292). Omitting `grammar` keeps the reading a
+ * dialect-less call always had.
  */
-export function findCodeWord(sql: string, word: string, from = 0): CodeWord | null {
+export function findCodeWord(
+  sql: string,
+  word: string,
+  from = 0,
+  grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR,
+): CodeWord | null {
   const target = word.toUpperCase();
   let i = from;
 
   while (i < sql.length) {
-    const span = readSqlSpan(sql, i);
+    const span = readSqlSpan(sql, i, grammar);
     if (span !== null) {
       i = span.end;
       continue;

--- a/src/lib/sql/words.ts
+++ b/src/lib/sql/words.ts
@@ -72,6 +72,12 @@ export interface CodeWord {
  * would answer for words inside a literal under the other. Pinned by a test in
  * `tests/unit/sql/words.test.ts`.
  *
+ * So a caller that must not be silent about such text asks about it separately
+ * rather than reading this reader's `null` as "the word is not there": the
+ * confirmation gate calls `hasUnterminatedSpan` and prompts on it (#297). This
+ * reader's answer stays what it is - where the word was FOUND - because the readers
+ * that walk a statement to rewrite it need exactly that.
+ *
  * WHICH runs are not code is the dialect's answer for one character: a write
  * written after a `#` is commented out in MySQL and the statement's own code in
  * PostgreSQL, and the safety predicate above this reader has to prompt in the

--- a/src/lib/storage/providers/postgres.ts
+++ b/src/lib/storage/providers/postgres.ts
@@ -35,6 +35,15 @@ export class PostgresStorageProvider implements ServerStorageProvider {
       ssl: this.buildSSLConfig(),
     });
 
+    // An idle client the server drops has no query to reject, so `pg` destroys it and
+    // emits on the pool; an `error` event with no listener is an uncaught exception. This
+    // pool is long-lived and serves every request while STORAGE_PROVIDER=postgres, so
+    // without this handler a dropped idle connection crashes the server (#298). The
+    // client is already gone — log it and let the pool open a fresh one on next acquire.
+    this.pool.on("error", (error: unknown) => {
+      logger.error("PostgreSQL storage pool client error", error, { provider: "postgres" });
+    });
+
     // Create table
     try {
       await this.pool.query(`

--- a/src/workspace/hooks/use-query-adapter.ts
+++ b/src/workspace/hooks/use-query-adapter.ts
@@ -75,7 +75,10 @@ export function useQueryAdapter({
       }
 
       // Safety check for dangerous queries (skip for force-execute via forceExecuteQuery)
-      if (isDangerousQuery(queryToExecute)) {
+      // Read under the active connection's dialect, as the standalone path does
+      // (#292): the same characters are a comment in one engine and code in
+      // another, and only the connection says which.
+      if (isDangerousQuery(queryToExecute, activeConnection.type)) {
         setSafetyCheckQuery(queryToExecute);
         return;
       }

--- a/tests/api/db/multi-query.test.ts
+++ b/tests/api/db/multi-query.test.ts
@@ -402,6 +402,29 @@ describe("POST /api/db/multi-query", () => {
       expect(mockProvider.prepareQuery).not.toHaveBeenCalled();
       expect(mockProvider.query).toHaveBeenCalledWith(finalStatement);
     });
+
+    // The route resolves its connection before it asks the classifier, so it asks
+    // under THAT connection's dialect (#292). Without the dialect this statement
+    // types `SELECT` - the `#-` reads as a PostgreSQL jsonb operator, so the `)`
+    // inside the comment closes the CTE body early - and the route would hand a
+    // `DELETE` to `prepareQuery`. Pinned here because this is the one caller layer
+    // where the route, not the provider, decides whether the statement is a read.
+    test("the final statement is classified under the connection's own dialect", async () => {
+      const finalStatement = "WITH t AS (\n  #- drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
+
+      const req = createMockRequest("/api/db/multi-query", {
+        method: "POST",
+        body: {
+          connection: { ...validConnection, type: "mysql" },
+          sql: `SELECT 1;\n${finalStatement}`,
+        },
+      });
+
+      await POST(req as never);
+
+      expect(mockProvider.prepareQuery).not.toHaveBeenCalled();
+      expect(mockProvider.query).toHaveBeenCalledWith(finalStatement);
+    });
   });
 
   test("QueryError from getOrCreateProvider returns 400", async () => {

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -934,23 +934,28 @@ describe("isDangerousQuery", () => {
   });
 
   /**
-   * The cost reaches past the backslash class, and it is pinned here rather than
-   * left to be discovered: a dialect at the compatibility BRACKET reading (#295
-   * established the subscript rule for ClickHouse only) cannot close a PostgreSQL
-   * nested array or a subscript key carrying a `]`, so those read-only statements
-   * ask before they run. `docs/providers/postgres.md` records the same cost on the
-   * limiter side - a lost bound - and now records this half too.
-   *
-   * Ordinary subscripts and array literals resolve, which is what keeps the class
-   * narrow: it is nested brackets and `]`-bearing keys, not every `[`.
+   * PostgreSQL reads `[…]` as a subscript, so none of these is unresolvable and an
+   * everyday read does not ask. The rule was established from the manual (4.2.3
+   * Subscripts, 4.2.12 Array Constructors, whose own example is
+   * `SELECT ARRAY[[1,2],[3,4]]`) after the dialect was briefly left at the
+   * compatibility NAME reading, which could not close a nested array or a key
+   * carrying a `]` and therefore prompted on ordinary statements. A confirmation
+   * the operator learns to click through protects nothing, so a false prompt on
+   * everyday syntax is not the cheap direction it looks like.
    */
-  test.each<[string, string, boolean]>([
-    ["a nested array", "SELECT ARRAY[[1,2],[3,4]] AS a FROM t", true],
-    ["a subscript key holding a close bracket", "SELECT j['a]b'] FROM t", true],
-    ["a nested subscript", "SELECT t.data[idx[0]] FROM t", true],
-    ["an ordinary subscript and array literal", "SELECT a[1], ARRAY[1,2] FROM t", false],
-  ])("answers %s on PostgreSQL with %p", (_label, query, expected) => {
-    expect(isDangerousQuery(query, "postgres")).toBe(expected);
+  test.each<[string, string]>([
+    ["a nested array", "SELECT ARRAY[[1,2],[3,4]] AS a FROM t"],
+    ["a subscript key holding a close bracket", "SELECT j['a]b'] FROM t"],
+    ["a nested subscript", "SELECT t.data[idx[0]] FROM t"],
+    ["an ordinary subscript and array literal", "SELECT a[1], ARRAY[1,2] FROM t"],
+  ])("does not prompt for %s on PostgreSQL", (_label, query) => {
+    expect(isDangerousQuery(query, "postgres")).toBe(false);
+  });
+
+  // The reading is a reading, not a licence: a subscript run that never closes is
+  // still unresolvable, and a write inside one still asks.
+  test("still prompts where a PostgreSQL subscript run does not close", () => {
+    expect(isDangerousQuery("SELECT ARRAY[[1,2] AS a FROM t", "postgres")).toBe(true);
   });
 
   /**
@@ -964,17 +969,29 @@ describe("isDangerousQuery", () => {
   });
 
   /**
-   * Both execution paths ask about every query text, so the rule reaches the two
-   * non-SQL providers as well: a Mongo document or a Redis command whose escaped
-   * quote this SQL span reader reports as undeterminable prompts, and the dialog
-   * tells the operator the text could not be fully read - which is true, though the
-   * grammar it could not read it under is not the one the text is written in. The
-   * fail-safe direction and one click, stated rather than implied.
+   * Both execution paths ask about whatever is in the editor, so this predicate is
+   * handed MongoDB documents and Redis commands too - and the unresolvable-run rule
+   * must not fire on them. Their text is not SQL, so a SQL span reader's verdict
+   * about it is not evidence of anything: the escaped quote below closes perfectly
+   * in JSON and in Redis's own argument parsing, and the dialog would have said
+   * "part of this statement could not be read" about text that reads fine.
+   *
+   * The rule that keeps this honest is the one the repo already applies to
+   * behaviour that differs by database: ask the single type-to-facts table
+   * (`readsSqlText`), never a type test written here.
    */
-  test("prompts for non-SQL query text whose escaped quote cannot be resolved", () => {
-    expect(isDangerousQuery('{"operation":"find","filter":{"msg":"say \\"hi\\""}}', "mongodb")).toBe(true);
+  test("does not prompt for non-SQL query text whose escaped quote a SQL reader cannot resolve", () => {
+    expect(isDangerousQuery('{"operation":"find","filter":{"msg":"say \\"hi\\""}}', "mongodb")).toBe(false);
     expect(isDangerousQuery('{"operation":"find","filter":{"msg":"hi"}}', "mongodb")).toBe(false);
-    expect(isDangerousQuery('SET k "a\\"b"', "redis")).toBe(true);
+    expect(isDangerousQuery('SET k "a\\"b"', "redis")).toBe(false);
+  });
+
+  // Only the unresolvable-run half was narrowed. The keyword half still reads the
+  // text it is given, whatever connection it is about to run on - not realistic
+  // Mongo input, but it is what pins that the predicate was not switched off
+  // wholesale for these two types.
+  test("still prompts for a destructive keyword under a non-SQL type", () => {
+    expect(isDangerousQuery("DROP TABLE users", "mongodb")).toBe(true);
   });
 
   // ── The dialect decides what the statement says (#292) ──────────────────

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -594,6 +594,121 @@ describe("QuerySafetyDialog", () => {
     const highButton = result2.queryByText("Proceed with Caution")!.closest("button");
     expect(highButton?.className).toContain("bg-red-600");
   });
+
+  // ── Honesty about text the reading could not resolve (#297) ────────────────
+  //
+  // The gate now opens this dialog for a statement carrying a run no reader can
+  // resolve, and a silent `true` would be only half of the bar: the operator is
+  // then reading a risk analysis produced from text whose reading stopped early.
+  // So the dialog says which of the two situations it is in.
+
+  const UNREADABLE_QUERY = "SELECT '\\';\nUPDATE t SET x = 1";
+
+  const SAFE_PAYLOAD = {
+    riskLevel: "safe",
+    summary: "Read-only query.",
+    warnings: [],
+    affectedRows: "none",
+    cascadeEffects: "none",
+    recommendation: "Proceed.",
+  };
+
+  test("says part of the statement could not be read, and that this is why it asks", async () => {
+    globalThis.fetch = mock(async () =>
+      createStreamResponse({ chunks: [JSON.stringify(SAFE_PAYLOAD)] }),
+    ) as unknown as typeof fetch;
+
+    const { queryByText } = render(
+      <QuerySafetyDialog
+        isOpen
+        query={UNREADABLE_QUERY}
+        schemaContext=""
+        databaseType="postgres"
+        onClose={onClose}
+        onProceed={onProceed}
+      />,
+    );
+
+    // Said immediately, without waiting on the analysis: the reason for asking is
+    // this client-side reading, not anything the model returns.
+    expect(queryByText("Part of this statement could not be read")).not.toBeNull();
+    expect(queryByText(/never closes/)).not.toBeNull();
+    expect(queryByText(/why you are being asked/)).not.toBeNull();
+
+    // And it goes on saying so BESIDE a verdict that read the statement as safe.
+    // The analysis was produced from text whose reading stopped early, so a "Safe"
+    // answer is not allowed to be the last thing the operator sees.
+    await waitFor(() => {
+      expect(queryByText("Safe")).not.toBeNull();
+    });
+    expect(queryByText("Part of this statement could not be read")).not.toBeNull();
+  });
+
+  test("says nothing of the kind for a statement it read whole", async () => {
+    globalThis.fetch = mock(async () =>
+      createStreamResponse({ chunks: [JSON.stringify(SAFE_PAYLOAD)] }),
+    ) as unknown as typeof fetch;
+
+    const { queryByText } = render(
+      <QuerySafetyDialog
+        isOpen
+        query="DELETE FROM users WHERE id = 5"
+        schemaContext=""
+        databaseType="postgres"
+        onClose={onClose}
+        onProceed={onProceed}
+      />,
+    );
+
+    expect(queryByText("Part of this statement could not be read")).toBeNull();
+
+    await waitFor(() => {
+      expect(queryByText("Safe")).not.toBeNull();
+    });
+    expect(queryByText("Part of this statement could not be read")).toBeNull();
+  });
+
+  /**
+   * The notice is the DIALECT's answer, like the gate that opened the dialog: the
+   * component already receives the connection's type, so it resolves the grammar
+   * itself rather than being told what to say.
+   */
+  test("reads the statement under the dialect it was given", async () => {
+    globalThis.fetch = mock(async () =>
+      createStreamResponse({ chunks: [JSON.stringify(SAFE_PAYLOAD)] }),
+    ) as unknown as typeof fetch;
+
+    // An Oracle alternate-quoted literal: an unresolvable run to a reader that does
+    // not have the form, one closed literal to Oracle's.
+    const alternateQuoted = "SELECT q'{it's}' FROM dual";
+
+    const { queryByText, unmount } = render(
+      <QuerySafetyDialog
+        isOpen
+        query={alternateQuoted}
+        schemaContext=""
+        databaseType="postgres"
+        onClose={onClose}
+        onProceed={onProceed}
+      />,
+    );
+    expect(queryByText("Part of this statement could not be read")).not.toBeNull();
+
+    unmount();
+    cleanup();
+
+    const onOracle = render(
+      <QuerySafetyDialog
+        isOpen
+        query={alternateQuoted}
+        schemaContext=""
+        databaseType="oracle"
+        onClose={onClose}
+        onProceed={onProceed}
+      />,
+    );
+    expect(onOracle.queryByText("Part of this statement could not be read")).toBeNull();
+  });
 });
 
 describe("isDangerousQuery", () => {
@@ -680,12 +795,19 @@ describe("isDangerousQuery", () => {
   });
 
   /**
-   * A `WITH` whose list never closes cannot be read, so the destructive keyword
+   * A `WITH` whose list never closes cannot be TYPED, so the destructive keyword
    * inside it is not reported. No dialect accepts the text either, so what the
    * server receives is a syntax error rather than a dropped table - pinned so the
    * gap stays a decision.
+   *
+   * This is the boundary of #297's rule, which is about text no reader can RESOLVE:
+   * here every character was read, and the shape it spells is an incomplete
+   * statement rather than a run hiding what is written inside it. The keyword inside
+   * the unclosed list is a CTE-body write, which the row above pins as not prompting
+   * even when the list DOES close - so the answer is inherited from that gap, not
+   * from the reading stopping early.
    */
-  test("does not prompt when the statement's shape cannot be read at all", () => {
+  test("does not prompt when the statement's shape cannot be typed", () => {
     expect(isDangerousQuery("WITH t AS (DELETE FROM x")).toBe(false);
   });
 
@@ -702,9 +824,117 @@ describe("isDangerousQuery", () => {
     ["a DELETE hidden in a CTE body", "WITH gone AS (DELETE FROM t RETURNING *) SELECT * FROM gone", false],
     ["a DROP after a leading SELECT", "SELECT 1; DROP TABLE users", false],
     ["an UPDATE after a leading SELECT", "SELECT 1;\nUPDATE t SET x = 1", true],
-    ["a write behind an undeterminable literal", "SELECT '\\';\nUPDATE t SET x = 1", false],
   ])("answers %s with %p", (_label, query, expected) => {
     expect(isDangerousQuery(query)).toBe(expected);
+  });
+
+  // ── Text no reader can resolve asks instead of staying silent (#297) ──────
+  //
+  // Every OTHER reader in `src/lib/sql/` errs toward not ACTING on text it cannot
+  // resolve, and that is the safe direction for them: their mistake is a row bound
+  // appended to a write, i.e. a partial commit. Here the costs are reversed - a
+  // false prompt costs one click, silence costs an unconfirmed destructive
+  // statement - so this predicate reads the span reader's `terminated: false` as
+  // its own answer rather than discarding it.
+
+  test("prompts for a write hidden behind an undeterminable literal", () => {
+    // `'\'` closes the string under PostgreSQL's reading and continues it under
+    // MySQL's, so `spans.ts` declines to guess and everything after the quote is
+    // invisible to a reader walking code words. The write is the second statement
+    // of a script node-postgres sends through the simple query protocol.
+    expect(isDangerousQuery("SELECT '\\';\nUPDATE t SET x = 1")).toBe(true);
+    // Not only the unanchored probe's vocabulary: a DROP written there was
+    // invisible too, and this predicate never looked for it past the leading word.
+    expect(isDangerousQuery("SELECT '\\';\nDROP TABLE users")).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["a literal that never closes", "SELECT 'unclosed FROM t"],
+    ["a block comment that never closes", "SELECT 1 /* unclosed"],
+    ["a dollar-quoted body that never closes", "SELECT $fn$ begin"],
+    ["a bracket-quoted name that never closes", "SELECT [name FROM t"],
+    ["a double-quoted name that never closes", 'SELECT "name FROM t'],
+  ])("prompts for %s", (_label, query) => {
+    expect(isDangerousQuery(query)).toBe(true);
+  });
+
+  /**
+   * The cost of asking, bounded by assertion rather than by hope.
+   *
+   * The reason this predicate stayed silent was the false prompts the honest answer
+   * buys: `spans.ts` reports an undeterminable literal for any closing quote behind
+   * an ODD backslash run, and a legitimate PostgreSQL literal ending in a backslash
+   * is exactly that shape. What must NOT happen is a prompt for every statement
+   * that merely CONTAINS a backslash, which is what a text-level backslash test
+   * would have produced.
+   */
+  test.each<[string, string]>([
+    ["a backslash inside a literal", "SELECT 'a\\nb' FROM t"],
+    ["a literal ending in a doubled backslash", "SELECT 'C:\\\\Users\\\\me' FROM files"],
+    ["an escaped LIKE wildcard", "SELECT * FROM t WHERE p LIKE 'a\\_b'"],
+    ["a backslash in a comment", "-- C:\\\nSELECT 1"],
+  ])("never prompts for %s, whose runs all resolve", (_label, query) => {
+    expect(isDangerousQuery(query)).toBe(false);
+  });
+
+  /**
+   * The most frequent prompt this rule buys, named rather than left to be
+   * discovered: `\'` is MySQL's OWN escape for an apostrophe, and `spans.ts` reports
+   * any closing quote behind an odd backslash run as undeterminable whatever the
+   * dialect - backslash semantics are deliberately not a fact the grammar record
+   * carries yet, because fixtures across this milestone rest on the undeterminable
+   * reading. So an everyday MySQL read asks, and naming the dialect does not narrow
+   * it: this is the one cost the channel cannot resolve today.
+   */
+  test("prompts for a literal escaping its apostrophe with a backslash, under either dialect", () => {
+    const everyday = "SELECT * FROM t WHERE name = 'it\\'s'";
+
+    expect(isDangerousQuery(everyday, "mysql")).toBe(true);
+    expect(isDangerousQuery(everyday, "postgres")).toBe(true);
+  });
+
+  /**
+   * The cost reaches past the backslash class, and it is pinned here rather than
+   * left to be discovered: a dialect at the compatibility BRACKET reading (#295
+   * established the subscript rule for ClickHouse only) cannot close a PostgreSQL
+   * nested array or a subscript key carrying a `]`, so those read-only statements
+   * ask before they run. `docs/providers/postgres.md` records the same cost on the
+   * limiter side - a lost bound - and now records this half too.
+   *
+   * Ordinary subscripts and array literals resolve, which is what keeps the class
+   * narrow: it is nested brackets and `]`-bearing keys, not every `[`.
+   */
+  test.each<[string, string, boolean]>([
+    ["a nested array", "SELECT ARRAY[[1,2],[3,4]] AS a FROM t", true],
+    ["a subscript key holding a close bracket", "SELECT j['a]b'] FROM t", true],
+    ["a nested subscript", "SELECT t.data[idx[0]] FROM t", true],
+    ["an ordinary subscript and array literal", "SELECT a[1], ARRAY[1,2] FROM t", false],
+  ])("answers %s on PostgreSQL with %p", (_label, query, expected) => {
+    expect(isDangerousQuery(query, "postgres")).toBe(expected);
+  });
+
+  /**
+   * The same class on SQLite, because the shared name reading honours SQL Server's
+   * doubled `]` for it: the escape swallows the real closer, so the run never
+   * terminates and the statement asks. SQLite rejects the text either way - recorded
+   * in `docs/providers/sqlite.md` beside the bound that divergence already cost.
+   */
+  test("prompts for a SQLite name whose doubled bracket swallows its closer", () => {
+    expect(isDangerousQuery("SELECT [a]] FROM t", "sqlite")).toBe(true);
+  });
+
+  /**
+   * Both execution paths ask about every query text, so the rule reaches the two
+   * non-SQL providers as well: a Mongo document or a Redis command whose escaped
+   * quote this SQL span reader reports as undeterminable prompts, and the dialog
+   * tells the operator the text could not be fully read - which is true, though the
+   * grammar it could not read it under is not the one the text is written in. The
+   * fail-safe direction and one click, stated rather than implied.
+   */
+  test("prompts for non-SQL query text whose escaped quote cannot be resolved", () => {
+    expect(isDangerousQuery('{"operation":"find","filter":{"msg":"say \\"hi\\""}}', "mongodb")).toBe(true);
+    expect(isDangerousQuery('{"operation":"find","filter":{"msg":"hi"}}', "mongodb")).toBe(false);
+    expect(isDangerousQuery('SET k "a\\"b"', "redis")).toBe(true);
   });
 
   // ── The dialect decides what the statement says (#292) ──────────────────
@@ -742,27 +972,31 @@ describe("isDangerousQuery", () => {
   // The bracket grammar reaches this predicate for the same reason (#295): under
   // ClickHouse's reading a nested array closes, so the keyword after the CTE list
   // is read and asked about, where the quoted-name reading took the closing `]]`
-  // for an escape, never closed the run, and left everything after it invisible.
-  test("prompts for a DELETE a nested array hid, once the dialect is named", () => {
+  // for an escape and never closed the run.
+  //
+  // Both readings ask now, and for two different reasons - ClickHouse's because it
+  // read the `DELETE`, the name reading because it could not read the statement at
+  // all (#297), which is also what the dialog then tells the operator. Which
+  // reading resolves that text is pinned in tests/unit/sql/spans.test.ts.
+  test("prompts for a DELETE a nested array hid, whether or not the dialect is named", () => {
     const query = "WITH [[1,2],[3,4]] AS x DELETE FROM t";
 
-    expect(isDangerousQuery(query)).toBe(false);
+    expect(isDangerousQuery(query)).toBe(true);
     expect(isDangerousQuery(query, "clickhouse")).toBe(true);
   });
 
   /**
-   * KNOWN NARROWING, pinned rather than left to be discovered: bracket text that
-   * does not balance is undeterminable under the subscript reading, and this
-   * predicate still answers "not dangerous" for text it cannot read - the one input
-   * class #297 is filed to change. Under the name reading the same text happened to
-   * close its run at the inner `]` and answer true, so naming the dialect LOSES
-   * this prompt. The text is a syntax error in ClickHouse either way.
+   * The narrowing #295 recorded here, now closed by #297's rule rather than left
+   * pinned: bracket text that does not balance is undeterminable under the subscript
+   * reading, so naming ClickHouse used to LOSE this prompt (the name reading happened
+   * to close its run at the inner `]` and read the `DELETE`). Both readings ask now -
+   * one because it read the statement, the other because it could not.
    */
-  test("still answers false for bracket text no reader can resolve", () => {
+  test("asks for bracket text no reader can resolve, under either reading", () => {
     const query = "WITH [[1,2] AS x DELETE FROM t";
 
     expect(isDangerousQuery(query)).toBe(true);
-    expect(isDangerousQuery(query, "clickhouse")).toBe(false);
+    expect(isDangerousQuery(query, "clickhouse")).toBe(true);
   });
 
   // ── Shape of the scan ───────────────────────────────────────────────────

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -739,6 +739,32 @@ describe("isDangerousQuery", () => {
     expect(isDangerousQuery("SELECT * FROM users", "mysql")).toBe(false);
   });
 
+  // The bracket grammar reaches this predicate for the same reason (#295): under
+  // ClickHouse's reading a nested array closes, so the keyword after the CTE list
+  // is read and asked about, where the quoted-name reading took the closing `]]`
+  // for an escape, never closed the run, and left everything after it invisible.
+  test("prompts for a DELETE a nested array hid, once the dialect is named", () => {
+    const query = "WITH [[1,2],[3,4]] AS x DELETE FROM t";
+
+    expect(isDangerousQuery(query)).toBe(false);
+    expect(isDangerousQuery(query, "clickhouse")).toBe(true);
+  });
+
+  /**
+   * KNOWN NARROWING, pinned rather than left to be discovered: bracket text that
+   * does not balance is undeterminable under the subscript reading, and this
+   * predicate still answers "not dangerous" for text it cannot read - the one input
+   * class #297 is filed to change. Under the name reading the same text happened to
+   * close its run at the inner `]` and answer true, so naming the dialect LOSES
+   * this prompt. The text is a syntax error in ClickHouse either way.
+   */
+  test("still answers false for bracket text no reader can resolve", () => {
+    const query = "WITH [[1,2] AS x DELETE FROM t";
+
+    expect(isDangerousQuery(query)).toBe(true);
+    expect(isDangerousQuery(query, "clickhouse")).toBe(false);
+  });
+
   // ── Shape of the scan ───────────────────────────────────────────────────
 
   /**

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -707,6 +707,38 @@ describe("isDangerousQuery", () => {
     expect(isDangerousQuery(query)).toBe(expected);
   });
 
+  // ── The dialect decides what the statement says (#292) ──────────────────
+  //
+  // This predicate is the last check before a destructive statement runs, and it
+  // was reading `#` by a rule that belongs to PostgreSQL. On MySQL that rule let
+  // a comment hide the `)` that closes a CTE body, so the reader reported the
+  // `SELECT` inside the comment's reach and the `DELETE` after the list ran with
+  // no confirmation at all. Both callers hold the active connection's type, so
+  // the predicate is told which dialect it is reading.
+
+  test("prompts for a DELETE a hash comment hid, once the dialect is named", () => {
+    const query = "WITH t AS (\n  #- drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
+
+    expect(isDangerousQuery(query)).toBe(false);
+    expect(isDangerousQuery(query, "mysql")).toBe(true);
+  });
+
+  // The other direction, which is why the dialect and not a blanket "a hash is a
+  // comment" is the fix: in MySQL the write really is commented out and prompting
+  // would be a false alarm, while in PostgreSQL those characters are an operator
+  // and the write is the statement's own code.
+  test("reads a write written after a hash as the dialect reads it", () => {
+    const query = "SELECT 1 # UPDATE t SET x = 1";
+
+    expect(isDangerousQuery(query, "mysql")).toBe(false);
+    expect(isDangerousQuery(query, "postgres")).toBe(true);
+  });
+
+  test("a dialect changes nothing for a statement carrying no hash", () => {
+    expect(isDangerousQuery("DROP TABLE users", "postgres")).toBe(true);
+    expect(isDangerousQuery("SELECT * FROM users", "mysql")).toBe(false);
+  });
+
   // ── Shape of the scan ───────────────────────────────────────────────────
 
   /**

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -709,6 +709,46 @@ describe("QuerySafetyDialog", () => {
     );
     expect(onOracle.queryByText("Part of this statement could not be read")).toBeNull();
   });
+
+  /**
+   * The nesting fact reaches the notice as well (#300), and the two halves of that
+   * issue's dialog bar are visible here side by side: a nested comment that never
+   * closes is text the reader could not resolve and the notice says so, while a
+   * balanced one was read WHOLE - the dialog is open because the statement really
+   * is a `DROP`, and claiming the text could not be read would be the false half.
+   */
+  test("says so for a nested comment that never closes, and nothing for one that does", async () => {
+    globalThis.fetch = mock(async () =>
+      createStreamResponse({ chunks: [JSON.stringify(SAFE_PAYLOAD)] }),
+    ) as unknown as typeof fetch;
+
+    const unclosed = render(
+      <QuerySafetyDialog
+        isOpen
+        query="/* outer /* inner */ DROP TABLE users"
+        schemaContext=""
+        databaseType="postgres"
+        onClose={onClose}
+        onProceed={onProceed}
+      />,
+    );
+    expect(unclosed.queryByText("Part of this statement could not be read")).not.toBeNull();
+
+    unclosed.unmount();
+    cleanup();
+
+    const balanced = render(
+      <QuerySafetyDialog
+        isOpen
+        query="/* outer /* inner */ still a note */ DROP TABLE users"
+        schemaContext=""
+        databaseType="postgres"
+        onClose={onClose}
+        onProceed={onProceed}
+      />,
+    );
+    expect(balanced.queryByText("Part of this statement could not be read")).toBeNull();
+  });
 });
 
 describe("isDangerousQuery", () => {
@@ -997,6 +1037,84 @@ describe("isDangerousQuery", () => {
 
     expect(isDangerousQuery(query)).toBe(true);
     expect(isDangerousQuery(query, "clickhouse")).toBe(true);
+  });
+
+  // ── Where a block comment ends decides what this predicate reads (#300) ──
+  //
+  // The third grammar fact, and the one that reaches this predicate through the
+  // KEYWORD rather than through unresolvable text: with the comment closed at its
+  // first `*/`, the word after it answers for the statement, and a word an
+  // operator commented out is never in the dangerous set. So a destructive
+  // statement written after a nested comment ran with no confirmation at all on
+  // every dialect that nests - which is PostgreSQL, SQL Server and ClickHouse.
+
+  test.each<["postgres" | "mssql" | "clickhouse"]>([
+    ["postgres"],
+    ["mssql"],
+    ["clickhouse"],
+  ])("prompts on %s for a destructive statement a nested comment hid", (type) => {
+    const query = "/* outer /* inner */ still a note */ DROP TABLE users";
+
+    expect(isDangerousQuery(query, type)).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["a DELETE", "DELETE FROM users WHERE id = 1"],
+    ["a TRUNCATE", "TRUNCATE TABLE users"],
+    ["a write inside a CTE list", "WITH t AS (UPDATE users SET seen = true RETURNING id) SELECT * FROM t"],
+  ])("prompts for %s hidden behind a nested comment under a nesting grammar", (_label, statement) => {
+    expect(isDangerousQuery(`/* outer /* inner */ still a note */ ${statement}`, "postgres")).toBe(true);
+  });
+
+  // The answer a flat grammar requires, pinned rather than left to the
+  // implementation: MySQL closes the comment at the first `*/`, so `still` really
+  // is the word that follows it and `*/ DROP …` is text MySQL rejects outright.
+  // Staying silent there is the dialect's own reading, not a missed prompt.
+  test("stays silent under a flat grammar, where the same text is a syntax error", () => {
+    const query = "/* outer /* inner */ still a note */ DROP TABLE users";
+
+    expect(isDangerousQuery(query)).toBe(false);
+    expect(isDangerousQuery(query, "mysql")).toBe(false);
+    expect(isDangerousQuery(query, "sqlite")).toBe(false);
+  });
+
+  // One opener too many: the comment never closes under a nesting grammar, so the
+  // statement is unreadable rather than misread - and unresolvable text asks
+  // (#297). The two halves of #300's dialog bar meet here: whichever way the text
+  // goes, a null keyword no longer means silence.
+  test("asks where the nested comment never closes, because the text cannot be read", () => {
+    const query = "/* outer /* inner */ DROP TABLE users";
+
+    expect(isDangerousQuery(query, "postgres")).toBe(true);
+    // Flat, the comment closed and the DROP is the statement's own leading keyword.
+    expect(isDangerousQuery(query, "mysql")).toBe(true);
+  });
+
+  /**
+   * The trivia alphabet the reader shares with the rest of the folder is ASCII, and the
+   * LEADING scan's is deliberately wider (JS `\s`) - the alphabet the pattern it
+   * replaced used, so the conversion answers what that pattern answered.
+   *
+   * On one engine the narrower reading would cost this prompt rather than merely
+   * differ: a `latin1` MySQL connection reads byte 0xA0 as a space and executes the
+   * statement behind it (verified on MySQL 26.7 through mysql2 - a row comes back under
+   * `charset=latin1`, and the same text is rejected under the `utf8mb4` the provider
+   * negotiates by default), and a connection string is where that charset comes from.
+   * U+2028 is here for the compatibility rule alone; no engine tried accepts it.
+   */
+  test.each<[string, string]>([
+    ["a no-break space", " DROP TABLE users"],
+    ["a line separator", " DROP TABLE users"],
+  ])("still prompts for a destructive statement behind %s", (_label, query) => {
+    expect(isDangerousQuery(query, "mysql")).toBe(true);
+    expect(isDangerousQuery(query)).toBe(true);
+  });
+
+  test("ordinary comments keep their answers under a nesting grammar", () => {
+    expect(isDangerousQuery("/* note */ DROP TABLE users", "postgres")).toBe(true);
+    expect(isDangerousQuery("/* a */ /* b */ SELECT * FROM users", "postgres")).toBe(false);
+    expect(isDangerousQuery("/* was a DELETE once */ SELECT 1", "postgres")).toBe(false);
+    expect(isDangerousQuery("/* a * b */ SELECT 1", "postgres")).toBe(false);
   });
 
   // ── Shape of the scan ───────────────────────────────────────────────────

--- a/tests/hooks/use-query-adapter.test.ts
+++ b/tests/hooks/use-query-adapter.test.ts
@@ -375,6 +375,31 @@ describe("useQueryAdapter", () => {
   });
 
   /**
+   * The embedded path's half of #300: the default connection here is PostgreSQL,
+   * where block comments NEST, so a comment carrying a second opener runs past the
+   * `*\/` a flat reading stops at. Read flat, the word after that marker answered
+   * for the statement - one the operator commented out, never in the dangerous set -
+   * so the `DROP` reached the host application's executor with no confirmation. The
+   * two shapes ask for different reasons: the balanced one because the `DROP` is now
+   * read, the unbalanced one because the text cannot be resolved at all.
+   */
+  test.each<[string, string]>([
+    ["a balanced nested comment", "/* outer /* inner */ still a note */ DROP TABLE users"],
+    ["a nested comment that never closes", "/* outer /* inner */ DROP TABLE users"],
+  ])("executeQuery sets safetyCheckQuery for a destructive statement behind %s", async (_label, hidden) => {
+    const params = makeHookParams();
+
+    const { result } = renderHook(() => useQueryAdapter(params));
+
+    await act(async () => {
+      await result.current.executeQuery(hidden);
+    });
+
+    expect(result.current.safetyCheckQuery).toBe(hidden);
+    expect(params.onQueryExecute).not.toHaveBeenCalled();
+  });
+
+  /**
    * The embedded path's half of #297: a write hidden behind a run the reader cannot
    * resolve reaches the dialog instead of the server.
    *

--- a/tests/hooks/use-query-adapter.test.ts
+++ b/tests/hooks/use-query-adapter.test.ts
@@ -353,6 +353,27 @@ describe("useQueryAdapter", () => {
     expect(params.onQueryExecute).not.toHaveBeenCalled();
   });
 
+  /**
+   * The gate reads the statement under the ACTIVE CONNECTION's dialect (#292).
+   *
+   * This file uses the real predicate, so it is where the embedded path's dialect
+   * channel is provable end to end: the same text is a commented-out note under
+   * one connection's grammar and a `DELETE` the statement operates under
+   * another's, and only the connection says which.
+   */
+  test("executeQuery reads the statement under the active connection's dialect", async () => {
+    const hidden = "WITH t AS (\n  #- drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
+
+    const onMysql = makeHookParams({ activeConnection: makeConnection({ type: "mysql" }) });
+    const { result: mysql } = renderHook(() => useQueryAdapter(onMysql));
+    await act(async () => {
+      await mysql.current.executeQuery(hidden);
+    });
+
+    expect(mysql.current.safetyCheckQuery).toBe(hidden);
+    expect(onMysql.onQueryExecute).not.toHaveBeenCalled();
+  });
+
   // ── executeQuery leaves other tabs untouched ────────────────────────────────
 
   test("executeQuery updates only the target tab when multiple tabs exist", async () => {

--- a/tests/hooks/use-query-adapter.test.ts
+++ b/tests/hooks/use-query-adapter.test.ts
@@ -374,6 +374,49 @@ describe("useQueryAdapter", () => {
     expect(onMysql.onQueryExecute).not.toHaveBeenCalled();
   });
 
+  /**
+   * The embedded path's half of #297: a write hidden behind a run the reader cannot
+   * resolve reaches the dialog instead of the server.
+   *
+   * This file uses the REAL predicate, so this is where the new rule is provable on
+   * the packaged execution path rather than only in the predicate's unit tests. The
+   * script is two statements under PostgreSQL's reading of `'\'` and one under
+   * MySQL's; the gate cannot tell which, and it is the second statement that writes.
+   */
+  test("executeQuery sets safetyCheckQuery for a write hidden behind an unresolvable literal", async () => {
+    const params = makeHookParams();
+
+    const { result } = renderHook(() => useQueryAdapter(params));
+
+    const hidden = "SELECT '\\';\nUPDATE t SET x = 1";
+    await act(async () => {
+      await result.current.executeQuery(hidden);
+    });
+
+    expect(result.current.safetyCheckQuery).toBe(hidden);
+    expect(params.onQueryExecute).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The other side of the same rule, on the same path: a statement whose runs all
+   * resolve executes without a prompt even though it carries a backslash. The cost
+   * of the rule above is a prompt for text that cannot be read, not for text that
+   * contains an escape.
+   */
+  test("executeQuery runs a read whose literal resolves, backslash and all", async () => {
+    const params = makeHookParams();
+
+    const { result } = renderHook(() => useQueryAdapter(params));
+
+    const escaped = "SELECT 'a\\nb' FROM t";
+    await act(async () => {
+      await result.current.executeQuery(escaped);
+    });
+
+    expect(result.current.safetyCheckQuery).toBeNull();
+    expect(params.onQueryExecute).toHaveBeenCalledWith("conn-1", escaped);
+  });
+
   // ── executeQuery leaves other tabs untouched ────────────────────────────────
 
   test("executeQuery updates only the target tab when multiple tabs exist", async () => {

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -280,7 +280,10 @@ describe("useQueryExecution", () => {
       await result.current.executeQuery(annotated);
     });
 
-    expect(isDangerousQueryMock).toHaveBeenCalledWith(annotated);
+    // The active connection's type travels with the text: the predicate reads a
+    // statement per dialect (#292), and this call site is one of the two places
+    // that knows which dialect the statement is about to run on.
+    expect(isDangerousQueryMock).toHaveBeenCalledWith(annotated, "postgres");
     expect(result.current.safetyCheckQuery).toBe(annotated);
   });
 

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -287,6 +287,33 @@ describe("useQueryExecution", () => {
     expect(result.current.safetyCheckQuery).toBe(annotated);
   });
 
+  /**
+   * The standalone path's half of #297, in this file's division of labour: a script
+   * whose reading cannot be resolved is handed to the gate whole - the unresolvable
+   * literal included, on the line where the user wrote it - and a positive answer
+   * opens the dialog instead of executing.
+   *
+   * What the REAL predicate answers for this exact text is pinned in
+   * tests/components/QuerySafetyDialog.test.tsx (it asks); the embedded adapter
+   * exercises the real predicate end to end in tests/hooks/use-query-adapter.test.ts.
+   * Here the stub answers on the DELETE, so what is provable is the call site: the
+   * gate sees the script as written and its answer decides whether anything runs.
+   */
+  test("asks the safety gate about a script whose literal cannot be resolved", async () => {
+    mockGlobalFetch({});
+    const params = createDefaultParams();
+
+    const { result } = renderHook(() => useQueryExecution(params));
+
+    const hidden = "SELECT '\\';\nDELETE FROM t WHERE id = 1";
+    await act(async () => {
+      await result.current.executeQuery(hidden);
+    });
+
+    expect(isDangerousQueryMock).toHaveBeenCalledWith(hidden, "postgres");
+    expect(result.current.safetyCheckQuery).toBe(hidden);
+  });
+
   test("executeQuery sets safetyCheckQuery for DELETE queries", async () => {
     mockGlobalFetch({});
     const params = createDefaultParams();

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -959,18 +959,63 @@ describe("ClickHouseProvider query preparation", () => {
     expect(prepared.wasLimited).toBe(true);
   });
 
-  // Fixture discipline: a hash beside ClickHouse's array literal, which the span
-  // reader models as SQL Server's bracket-quoted NAME rather than as an array —
-  // two constructs it does not model as a unit. The bound must land before the
-  // comment and leave the array untouched; a bound spliced into `[…]` is the
-  // statement-corrupting shape this suite exists to catch. (A NESTED array still
-  // costs the statement its bound: that is the bracket grammar, issue #295, and
-  // this asserts today's answer rather than pretending it is closed.)
+  // Fixture discipline: a hash beside ClickHouse's array literal — two facts of
+  // the same grammar record meeting inside one statement. The bound must land
+  // before the comment and leave the array untouched; a bound spliced into `[…]`
+  // is the statement-corrupting shape this suite exists to catch.
   test("bounds a statement carrying an array literal and a trailing hash comment", () => {
     const prepared = provider().prepareQuery("SELECT [1,2] AS a FROM t # daily", { limit: 25 });
 
     expect(prepared.query).toBe("SELECT [1,2] AS a FROM t LIMIT 25 # daily");
     expect(prepared.wasLimited).toBe(true);
+  });
+
+  // ── `[…]` is an array here, not a quoted name (#295) ──────────────────────
+  //
+  // The shared span reader used to read every bracketed run as SQL Server's
+  // quoted identifier: the run ended at the first unpaired `]` and a doubled one
+  // was an escape. Both are wrong for ClickHouse, where `[…]` nests and nothing
+  // inside it is escaped, and both cost the statement its bound — a `]` inside a
+  // subscript key ended the run early (so the CTE element could not be crossed and
+  // the statement typed OTHER), and a nested array's `]]` was read as an escape,
+  // so the run never closed and the end was not cuttable. Named, the dialect gets
+  // the array reading; SQL Server and SQLite keep the name one.
+  test.each<[string, string]>([
+    ["a nested array in the select list", "SELECT [[1,2],[3,4]] AS a FROM t"],
+    ["a map subscript whose key carries a close bracket", "WITH m['a]b'] AS v SELECT v FROM t"],
+    ["a nested array CTE element", "WITH [[1,2],[3,4]] AS a SELECT arrayJoin(a)"],
+    ["an array holding a close bracket in a literal", "WITH ['a]', 'b'] AS a SELECT a"],
+    // Syntax the reader models as neither of its two bracket shapes: a lambda
+    // inside an array, a map literal whose key carries a close bracket, and a
+    // chained subscript.
+    ["a lambda inside an array", "WITH arrayMap(x -> x, [[1],[2]]) AS a SELECT a"],
+    ["a map literal subscripted by a bracketed key", "WITH map('a]b', 1)['a]b'] AS v SELECT v"],
+    ["a subscript chain", "SELECT m['k']['j]'] AS v FROM t"],
+    // The rows where the run is the statement's LAST token are the ones that pin
+    // it as the statement's own TEXT: with code after the run, the end reaches the
+    // input's length whether the run is read as text or as trivia, so the emitted
+    // SQL is the same either way. Read as trivia, these three come back as
+    // `SELECT LIMIT 25 [1,2]` and `SELECT m LIMIT 25['a]b']` — a corrupted
+    // statement reported as limited. Reported by review on this task.
+    ["an array literal that ends the statement", "SELECT [1,2]"],
+    ["a nested array that ends the statement", "SELECT [[1,2],[3,4]]"],
+    ["a subscript that ends the statement", "SELECT m['a]b']"],
+  ])("bounds %s, emitted intact", (_label, sql) => {
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(`${sql} LIMIT 25`);
+    expect(prepared.wasLimited).toBe(true);
+  });
+
+  test("refuses to rewrite a statement whose array literal never closes", () => {
+    // The fail-safe direction is unchanged: a run the reader cannot close is
+    // undeterminable, and an undeterminable end is not cut.
+    const sql = "SELECT [[1,2] AS a FROM t";
+
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(sql);
+    expect(prepared.wasLimited).toBe(false);
   });
 
   // ── Expression-form CTEs (#291) ───────────────────────────────────────────

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -1018,6 +1018,40 @@ describe("ClickHouseProvider query preparation", () => {
     expect(prepared.wasLimited).toBe(false);
   });
 
+  // ── Block comments NEST here too (#300) ───────────────────────────────────
+  //
+  // ClickHouse's syntax reference states C-style comments can be nested and gives
+  // a nested example. Read flat, the run between the inner `*/` and the comment's
+  // real end reaches the readers as code, which costs a statement carrying one its
+  // bound - the entire cost on this engine, which has no data-modifying CTE.
+
+  test.each<[string, string]>([
+    ["a leading nested comment", "/* a /* b */ x */ SELECT arrayJoin([1, 2]) AS n"],
+    ["a nested comment inside a CTE element", "WITH /* a /* b */ x */ 1 AS one SELECT one FROM events"],
+    ["a nested comment carrying a close bracket and a paren", "SELECT /* a /* ] ) */ x */ [1,2] AS a FROM t"],
+  ])("bounds a statement carrying %s, emitted intact", (_label, sql) => {
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(`${sql} LIMIT 25`);
+    expect(prepared.wasLimited).toBe(true);
+  });
+
+  test("places the bound before a trailing nested comment, not inside it", () => {
+    const prepared = provider().prepareQuery("SELECT n FROM events /* a /* b */ c */", { limit: 25 });
+
+    expect(prepared.query).toBe("SELECT n FROM events LIMIT 25 /* a /* b */ c */");
+    expect(prepared.wasLimited).toBe(true);
+  });
+
+  test("refuses to rewrite a statement whose nested comment never closes", () => {
+    const sql = "/* a /* b */ SELECT n FROM events";
+
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(sql);
+    expect(prepared.wasLimited).toBe(false);
+  });
+
   // ── Expression-form CTEs (#291) ───────────────────────────────────────────
   //
   // `WITH <expr> AS <alias>` is how a CTE is ordinarily written here, and it is

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -936,6 +936,43 @@ describe("ClickHouseProvider query preparation", () => {
     expect(prepared.wasLimited).toBe(true);
   });
 
+  // ── The `#` grammar is ClickHouse's here (#292) ────────────────────────────
+  //
+  // ClickHouse's syntax reference lists `#` and `#!` alongside `--` as line
+  // comments. The shared reader had to guess, and the rule it guessed was
+  // PostgreSQL's - a hash followed by an operator character is code - so a
+  // ClickHouse comment written that way was read as SQL, and an ordinary one at
+  // the end of a statement made the bound unplaceable. Named, the dialect gets
+  // the bound written before the comment, exactly as the `--` form does.
+
+  test.each<[string, string, string]>([
+    ["a plain hash comment", "SELECT * FROM users # daily check", "SELECT * FROM users LIMIT 25 # daily check"],
+    ["a hashbang comment", "SELECT * FROM users #! daily check", "SELECT * FROM users LIMIT 25 #! daily check"],
+    // The clause commented out with a hash is not a clause: reading it as one
+    // would leave the statement unbounded, and reading the comment as code would
+    // put the bound after a `FORMAT` this provider refuses to write past.
+    ["a commented-out FORMAT", "SELECT * FROM users # FORMAT TSV", "SELECT * FROM users LIMIT 25 # FORMAT TSV"],
+  ])("bounds a statement ending in %s, before the comment", (_label, sql, expected) => {
+    const prepared = provider().prepareQuery(sql, { limit: 25 });
+
+    expect(prepared.query).toBe(expected);
+    expect(prepared.wasLimited).toBe(true);
+  });
+
+  // Fixture discipline: a hash beside ClickHouse's array literal, which the span
+  // reader models as SQL Server's bracket-quoted NAME rather than as an array —
+  // two constructs it does not model as a unit. The bound must land before the
+  // comment and leave the array untouched; a bound spliced into `[…]` is the
+  // statement-corrupting shape this suite exists to catch. (A NESTED array still
+  // costs the statement its bound: that is the bracket grammar, issue #295, and
+  // this asserts today's answer rather than pretending it is closed.)
+  test("bounds a statement carrying an array literal and a trailing hash comment", () => {
+    const prepared = provider().prepareQuery("SELECT [1,2] AS a FROM t # daily", { limit: 25 });
+
+    expect(prepared.query).toBe("SELECT [1,2] AS a FROM t LIMIT 25 # daily");
+    expect(prepared.wasLimited).toBe(true);
+  });
+
   // ── Expression-form CTEs (#291) ───────────────────────────────────────────
   //
   // `WITH <expr> AS <alias>` is how a CTE is ordinarily written here, and it is

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -807,6 +807,140 @@ describe("MSSQLProvider", () => {
       });
     });
 
+    // ── A statement that already carries a page (#293) ───────────────────────
+    //
+    // `TOP` and `OFFSET … FETCH` may not both appear in one query expression, so
+    // adding a row-count clause to a statement that already carries a page does
+    // not return too many rows - SQL Server rejects the statement outright
+    // (Msg 10741) while this method reports `wasLimited: true`. Two shapes reach
+    // that, and neither of them is the hash #292 closed at the root:
+    //
+    // 1. The statement's end may not be CUT. The already-bounded probes in the
+    //    shared limiter are anchored at the end of the statement's own text, and
+    //    where the cut is refused that text still carries the trailing trivia -
+    //    so a real page written BEFORE a trailing comment sits away from the
+    //    anchor and reads as absent.
+    // 2. `OFFSET n ROWS` with no `FETCH` tail is a complete T-SQL page that the
+    //    shared probes do not recognise at all: they want a `FETCH … ROWS ONLY`
+    //    tail or a bare `OFFSET n` at the very end, and this form is neither.
+    describe("statements that already carry a page", () => {
+      // Shape 1. Every row carries a real page AND real trailing trivia; what
+      // differs is only the reason the end cannot be cut. The emitted text is
+      // asserted whole, because what this closes is an emitted statement the
+      // server refuses rather than one that returns too many rows.
+      test.each<[string, string]>([
+        [
+          "a literal whose end is undeterminable",
+          "SELECT id FROM users WHERE path = 'C:\\' ORDER BY id OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY -- daily",
+        ],
+        [
+          "an unterminated block comment",
+          "SELECT id FROM users ORDER BY id OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY /* daily",
+        ],
+        [
+          "an unterminated bracket-quoted name",
+          "SELECT [abc FROM users ORDER BY id OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY -- daily",
+        ],
+      ])("adds no TOP to a paged read whose end cannot be cut for %s", (_label, sql) => {
+        const result = provider.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+        expect(result.query).not.toMatch(/\bTOP\b/i);
+      });
+
+      // Shape 2. The `#tmp` row is this task's fixture-discipline input: a
+      // temp-table name and a block comment after the page, two constructs the
+      // shared scanner reads only because this provider names its dialect.
+      test.each<[string, string]>([
+        ["with no FETCH tail", "SELECT * FROM users ORDER BY id OFFSET 10 ROWS"],
+        ["spelled ROW rather than ROWS", "SELECT * FROM users ORDER BY id OFFSET 1 ROW"],
+        ["before a trailing line comment", "SELECT * FROM users ORDER BY id OFFSET 10 ROWS -- daily"],
+        ["before a terminator", "SELECT * FROM users ORDER BY id OFFSET 10 ROWS;"],
+        ["with a FETCH tail", "SELECT * FROM users ORDER BY id OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY"],
+        ["on a temp table, before a block comment", "SELECT * FROM #tmp ORDER BY id OFFSET 10 ROWS /* daily */"],
+      ])("recognises a T-SQL page %s and adds no clause beside it", (_label, sql) => {
+        const result = provider.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+        expect(result.query).not.toMatch(/\bTOP\b/i);
+      });
+
+      // The pagination branch reaches the same statement, and appending there
+      // emits `… OFFSET 10 ROWS OFFSET 10 ROWS FETCH NEXT 50 ROWS ONLY`.
+      test("appends no second page to a T-SQL page when an offset is requested", () => {
+        const sql = "SELECT * FROM users ORDER BY id OFFSET 10 ROWS";
+
+        const result = provider.prepareQuery(sql, { limit: 50, offset: 10 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+
+      // The page probe is anchored at the end of the statement, exactly as the
+      // shared ones are: an `OFFSET` belonging to a subquery is a different query
+      // expression, which a `TOP` on the outer one may legally join, and one
+      // written in text the statement merely carries is no page at all.
+      test.each<[string, string, string]>([
+        [
+          "an OFFSET inside a subquery",
+          "SELECT * FROM (SELECT id FROM t ORDER BY id OFFSET 10 ROWS) x",
+          "SELECT TOP 50 * FROM (SELECT id FROM t ORDER BY id OFFSET 10 ROWS) x",
+        ],
+        [
+          "a page spelled inside a trailing comment",
+          "SELECT * FROM users -- OFFSET 10 ROWS",
+          "SELECT TOP 50 * FROM users -- OFFSET 10 ROWS",
+        ],
+        [
+          "a page spelled inside a bracket-quoted name",
+          "SELECT [OFFSET 5 ROWS] FROM users",
+          "SELECT TOP 50 [OFFSET 5 ROWS] FROM users",
+        ],
+        [
+          "a column whose name merely begins with the word",
+          "SELECT offset_id FROM users WHERE path = 'C:\\'",
+          "SELECT TOP 50 offset_id FROM users WHERE path = 'C:\\'",
+        ],
+      ])("still bounds a read carrying %s", (_label, sql, expected) => {
+        const result = provider.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(expected);
+        expect(result.wasLimited).toBe(true);
+      });
+
+      // A head `TOP` is found by a probe anchored at the statement's own
+      // `SELECT`, so no trailing trivia and no unreadable tail can hide it. This
+      // is today's answer on both rows; it is asserted because the refusal added
+      // here must not turn a recognised bound into a silent second one.
+      test.each<[string, string]>([
+        ["before a trailing comment", "SELECT TOP 10 * FROM users -- daily"],
+        ["in a statement whose end cannot be cut", "SELECT TOP 10 id FROM users WHERE path = 'C:\\'"],
+      ])("keeps a head TOP %s and collects no second clause", (_label, sql) => {
+        const result = provider.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+        expect(result.query.match(/\bTOP\b/gi)).toHaveLength(1);
+      });
+
+      // The blunt half of the rule, pinned so it stays a decision rather than a
+      // surprise: where the end cannot be cut, no anchor is trustworthy, so the
+      // WORD alone is enough to decline - and a statement that merely names a
+      // column `offset` beside an unreadable literal loses its bound. It is
+      // reported honestly (`wasLimited: false`), which is the trade every reader
+      // in `src/lib/sql/` makes for text it cannot resolve.
+      test("declines where an unreadable end sits beside a column named like a clause", () => {
+        const sql = "SELECT [offset] FROM users WHERE path = 'C:\\'";
+
+        const result = provider.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+    });
+
     // The honesty invariant behind all of the above, asserted directly: there is no
     // input for which this path claims a limit while handing back the statement it
     // was given. A CTE is the case that is NOT rewritable here - `TOP` belongs to

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -765,6 +765,36 @@ describe("MSSQLProvider", () => {
           expect(result.query).toBe("SELECT TOP 50 [a#b] FROM #tmp");
           expect(result.wasLimited).toBe(true);
         });
+
+        // ── `[…]` stays a quoted NAME here (#295) ───────────────────────────
+        //
+        // The bracket grammar is now the dialect's answer, and T-SQL's is the one
+        // the shared reader always applied: everything between the brackets is the
+        // name — an apostrophe, a comment marker, a semicolon — and a doubled `]`
+        // is how a bracket inside one is written, which is exactly what this
+        // provider's own `escapeIdentifier` emits. ClickHouse gets the array
+        // reading instead, and teaching THIS scan to step over string literals is
+        // what would break the first row below.
+        test.each<[string, string, string]>([
+          ["an apostrophe", "SELECT [it's] FROM users", "SELECT TOP 50 [it's] FROM users"],
+          ["a doubled close bracket", "SELECT [a]]b] FROM users", "SELECT TOP 50 [a]]b] FROM users"],
+          ["a comment marker", "SELECT [a--b] FROM users", "SELECT TOP 50 [a--b] FROM users"],
+          ["a semicolon", "SELECT [a;b] FROM users", "SELECT TOP 50 [a;b] FROM users"],
+        ])("splices TOP ahead of a bracket-quoted name carrying %s", (_label, sql, expected) => {
+          const result = provider.prepareQuery(sql, { limit: 50 });
+
+          expect(result.query).toBe(expected);
+          expect(result.wasLimited).toBe(true);
+        });
+
+        test("pages a bracket-quoted name carrying an apostrophe, appending at the real end", () => {
+          // The tail branch is where a misread name costs more than a bound: the
+          // page has to land after the whole name, not inside it.
+          const result = provider.prepareQuery("SELECT [it's] FROM users ORDER BY id", { limit: 50, offset: 10 });
+
+          expect(result.query).toBe("SELECT [it's] FROM users ORDER BY id OFFSET 10 ROWS FETCH NEXT 50 ROWS ONLY");
+          expect(result.wasLimited).toBe(true);
+        });
       });
 
       test("appends OFFSET FETCH to a commented SELECT, which needs no head rewrite", () => {

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -807,6 +807,58 @@ describe("MSSQLProvider", () => {
       });
     });
 
+    // ── Block comments NEST here (#300) ──────────────────────────────────────
+    //
+    // T-SQL supports nested comments: a `/*` anywhere inside a comment opens a
+    // nested one and needs its own `*/` ("Slash Star (Block Comment)"). Read flat,
+    // the text between the inner `*/` and the comment's real end reaches the
+    // readers as code - and on THIS provider that is worse than a lost bound,
+    // because the `TOP` splice writes into the head at an index that reading
+    // chose. The first row below is the shape it emitted: a `TOP` placed after a
+    // `DISTINCT` that is inside the comment, so SQL Server saw
+    // `SELECT name FROM t` - unbounded - while this method reported a limit.
+    describe("nested block comments", () => {
+      test("splices TOP before the whole comment rather than into it", () => {
+        const result = provider.prepareQuery("SELECT /* a /* b */ DISTINCT */ name FROM t", { limit: 50 });
+
+        expect(result.query).toBe("SELECT TOP 50 /* a /* b */ DISTINCT */ name FROM t");
+        expect(result.wasLimited).toBe(true);
+      });
+
+      test("still keeps TOP after a DISTINCT that follows the whole comment", () => {
+        const result = provider.prepareQuery("SELECT /* a /* b */ c */ DISTINCT name FROM t", { limit: 50 });
+
+        expect(result.query).toBe("SELECT /* a /* b */ c */ DISTINCT TOP 50 name FROM t");
+        expect(result.wasLimited).toBe(true);
+      });
+
+      test("bounds a read behind a leading nested comment", () => {
+        const result = provider.prepareQuery("/* a /* b */ x */ SELECT name FROM t", { limit: 50 });
+
+        expect(result.query).toBe("/* a /* b */ x */ SELECT TOP 50 name FROM t");
+        expect(result.wasLimited).toBe(true);
+      });
+
+      test("adds no clause to a write a nested comment hid inside a CTE list", () => {
+        const sql =
+          "WITH recent AS (\n  /* outer /* inner */ ) SELECT 1 */\n  SELECT id FROM logs\n)\nINSERT INTO archive (id) SELECT id FROM recent";
+
+        const result = provider.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+
+      test("adds no clause where the nested comment never closes", () => {
+        const sql = "/* a /* b */ SELECT name FROM t";
+
+        const result = provider.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+    });
+
     // ── A statement that already carries a page (#293) ───────────────────────
     //
     // `TOP` and `OFFSET … FETCH` may not both appear in one query expression, so

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -701,20 +701,68 @@ describe("MSSQLProvider", () => {
           expect(result.wasLimited).toBe(false);
         });
 
-        test.each<[string, string]>([
-          ["a temp table", "SELECT * FROM #tmp ORDER BY id"],
-          ["a literal whose end is undeterminable", "SELECT id FROM users WHERE path = 'C:\\';"],
-        ])("the offset branch declines on %s, which it cannot append to", (_label, sql) => {
+        test("the offset branch declines on a literal whose end is undeterminable", () => {
+          const sql = "SELECT id FROM users WHERE path = 'C:\\';";
+
           const result = provider.prepareQuery(sql, { limit: 50, offset: 10 });
 
           expect(result.query).toBe(sql);
           expect(result.wasLimited).toBe(false);
         });
 
+        // A temp table used to reach the same refusal, and it no longer does: this
+        // provider now tells the shared reader that `#` is code in T-SQL (#292), so
+        // `#tmp` is the statement's own text, the end is cuttable and the page is
+        // appended where T-SQL wants it. The refusal was never about temp tables
+        // being unsafe to page - it was the price of a reader that could not tell
+        // `#tmp` from `# note`.
+        test("the offset branch now pages a temp-table read, which T-SQL accepts", () => {
+          const result = provider.prepareQuery("SELECT * FROM #tmp ORDER BY id", { limit: 50, offset: 10 });
+
+          expect(result.query).toBe("SELECT * FROM #tmp ORDER BY id OFFSET 10 ROWS FETCH NEXT 50 ROWS ONLY");
+          expect(result.wasLimited).toBe(true);
+        });
+
         test("the TOP head splice is unchanged by a trailing comment", () => {
           const result = provider.prepareQuery("SELECT * FROM users -- daily check", { limit: 50 });
 
           expect(result.query).toBe("SELECT TOP 50 * FROM users -- daily check");
+          expect(result.wasLimited).toBe(true);
+        });
+
+        // ── The `#` grammar is T-SQL's here (#292) ──────────────────────────
+        //
+        // This block records the shape the trailing-comment note above had to
+        // leave open: put trivia AFTER the bound of a temp-table page and the
+        // whole line vanished into a "comment" that starts at `#tmp`, so the
+        // end-anchored probe saw no bound and a `TOP` was spliced alongside an
+        // `OFFSET … FETCH` that SQL Server rejects outright (Msg 10741). Naming
+        // the dialect closes it at the root: `#` is never a comment in T-SQL.
+        test.each<[string, string]>([
+          ["a trailing line comment", "SELECT * FROM #tmp ORDER BY id OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY -- daily"],
+          [
+            "a trailing block comment",
+            "SELECT * FROM #tmp ORDER BY id OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY /* daily */",
+          ],
+          [
+            "a terminator and a comment",
+            "SELECT * FROM #tmp ORDER BY id OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY; -- daily",
+          ],
+        ])("does not splice TOP into an already-paged temp-table read carrying %s", (_label, sql) => {
+          const result = provider.prepareQuery(sql, { limit: 50 });
+
+          expect(result.query).toBe(sql);
+          expect(result.wasLimited).toBe(false);
+        });
+
+        // Fixture discipline: a bracket-quoted NAME carrying a hash, read from a
+        // temp table - two constructs the scanner does not model as a unit. The
+        // emitted text is asserted whole, because the failure mode this milestone
+        // shipped last time was a bound spliced INTO a bracketed name.
+        test("splices TOP ahead of a bracket-quoted name carrying a hash", () => {
+          const result = provider.prepareQuery("SELECT [a#b] FROM #tmp", { limit: 50 });
+
+          expect(result.query).toBe("SELECT TOP 50 [a#b] FROM #tmp");
           expect(result.wasLimited).toBe(true);
         });
       });

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -1,4 +1,5 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { EventEmitter } from "node:events";
 
 // ---------------------------------------------------------------------------
 // Mock mssql BEFORE importing the provider
@@ -7,6 +8,8 @@ import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 let mockQueryFn: (sql: string) => Promise<unknown>;
 let capturedInputs: Array<{ name: string; value: unknown }> = [];
 let cancelShouldThrow = false;
+/** The pool handed to the most recently constructed provider. */
+let lastPool: EventEmitter | undefined;
 
 class MockRequest {
   private _transaction: unknown;
@@ -41,13 +44,20 @@ class MockTransaction {
   async rollback() {}
 }
 
-class MockConnectionPool {
+/**
+ * A real EventEmitter, because `mssql`'s ConnectionPool is one and emits `error` for a
+ * background connection failure (a non-ESOCKET tedious error) as well as for a failed
+ * acquire. An `error` event with no listener is an uncaught exception (#298), so an inert
+ * `on` in the mock would hide the crash instead of pinning it.
+ */
+class MockConnectionPool extends EventEmitter {
   private _config: unknown;
   public size = 10;
   public available = 7;
   public pending = 0;
 
   constructor(config: unknown) {
+    super();
     this._config = config;
   }
 
@@ -62,10 +72,20 @@ class MockConnectionPool {
   }
 }
 
+/**
+ * The provider does `new mssql.ConnectionPool(config)`; recording the instance here lets a
+ * test emit on the very emitter the provider attached its listener to.
+ */
+function ConnectionPoolFactory(config: unknown): MockConnectionPool {
+  const pool = new MockConnectionPool(config);
+  lastPool = pool;
+  return pool;
+}
+
 mock.module("mssql", () => {
   return {
     default: {
-      ConnectionPool: MockConnectionPool,
+      ConnectionPool: ConnectionPoolFactory,
       Transaction: MockTransaction,
       Request: MockRequest,
     },
@@ -474,6 +494,30 @@ describe("MSSQLProvider", () => {
       await provider.connect();
       await provider.connect(); // should not throw
       expect(provider.isConnected()).toBe(true);
+    });
+
+    // ── Pool error events (#298) ─────────────────────────────────────────────
+
+    test("a pool error is logged and does not escalate past the provider", async () => {
+      await provider.connect();
+      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        expect(() => lastPool?.emit("error", new Error("socket hang up"))).not.toThrow();
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        const logged = errorSpy.mock.calls[0].join(" ");
+        expect(logged).toContain("[MSSQL]");
+        expect(logged).toContain("socket hang up");
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    test("the pool carries exactly one error listener, and a repeat connect adds none", async () => {
+      await provider.connect();
+      await provider.connect();
+
+      expect(lastPool?.listenerCount("error")).toBe(1);
     });
   });
 

--- a/tests/integration/db/mysql-provider.test.ts
+++ b/tests/integration/db/mysql-provider.test.ts
@@ -959,10 +959,11 @@ describe("MySQLProvider", () => {
       expect(result.wasLimited).toBe(false);
     });
 
-    // `#` is MySQL's own second line-comment marker, and it is the reason the shared
-    // trivia pattern in `lib/sql/leading-keyword.ts` recognises one at all: without it
-    // a `# note`-led SELECT classified as an unknown statement type and reached the
-    // server with no LIMIT, which is #275's reported symptom on this provider.
+    // `#` is MySQL's own second line-comment marker, and it is the reason
+    // `lib/sql/leading-keyword.ts` skips such a run at all - on every dialect, since
+    // none of them can OPEN a statement with one. Without it a `# note`-led SELECT
+    // classified as an unknown statement type and reached the server with no LIMIT,
+    // which is #275's reported symptom on this provider.
     test.each<[string, string]>([
       ["a hash comment", "# note\nSELECT * FROM users"],
       ["a line comment", "-- note\nSELECT * FROM users"],

--- a/tests/integration/db/mysql-provider.test.ts
+++ b/tests/integration/db/mysql-provider.test.ts
@@ -984,6 +984,49 @@ describe("MySQLProvider", () => {
       expect(result.query).toBe(sql);
       expect(result.wasLimited).toBe(false);
     });
+
+    // ── The `#` grammar is MySQL's here (#292) ────────────────────────────
+    //
+    // The shared readers used to decide `#` from the characters alone, and the
+    // rule they settled on was PostgreSQL's: a hash whose next character makes a
+    // jsonb/geometric operator is code. On THIS provider that reading is simply
+    // wrong - every `#` opens a comment - and it cost a write its typing. The
+    // provider now tells the readers which dialect they are reading, so these
+    // assertions go through `prepareQuery`, the real caller, and pin the emitted
+    // text rather than "a bound was added".
+
+    describe("hash comments (#292)", () => {
+      test("a comment hiding a paren does not retype the DELETE it precedes", () => {
+        provider = new MySQLProvider(makeMySQLConfig());
+        // `#-` reads as a jsonb operator to a dialect-blind scan, so the `)` inside
+        // the comment closed the CTE body early and `SELECT` answered for the whole
+        // statement - a bound on a DELETE, which MySQL 8 accepts and commits.
+        const sql = "WITH t AS (\n  #- drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
+
+        const result = provider.prepareQuery(sql, { limit: 50 });
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+
+      test("a bound written after a hash is commented out, so a real one is added before it", () => {
+        provider = new MySQLProvider(makeMySQLConfig());
+
+        const result = provider.prepareQuery("SELECT * FROM t # LIMIT 10", { limit: 50 });
+
+        expect(result.query).toBe("SELECT * FROM t LIMIT 50 # LIMIT 10");
+        expect(result.wasLimited).toBe(true);
+      });
+
+      test("a hash inside a backtick-quoted name is part of the name", () => {
+        provider = new MySQLProvider(makeMySQLConfig());
+
+        const result = provider.prepareQuery("SELECT `a#b` FROM t", { limit: 50 });
+
+        expect(result.query).toBe("SELECT `a#b` FROM t LIMIT 50");
+        expect(result.wasLimited).toBe(true);
+      });
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -678,6 +678,61 @@ describe("OracleProvider", () => {
         expect(result.wasLimited).toBe(true);
       });
 
+      // ── Alternate quoting is a literal here (#292) ──────────────────────
+      //
+      // `q'{it's}'` is how Oracle writes a literal that carries apostrophes, and
+      // the shared span reader had no branch for the form: the body was walked as
+      // code, so the first apostrophe inside it opened a string and everything
+      // after it read one construct out of step. Two costs, both real today: a `)`
+      // in the body ends a CTE body early, so the statement is typed by a keyword
+      // that is inside the literal and loses its bound; and a `--` in the body
+      // makes the rest of the literal look like trailing trivia, so #280's
+      // insert-before-trivia rewrite splices the clause INSIDE the literal and
+      // emits SQL Oracle rejects. `prepareQuery` passes its own type, and Oracle's
+      // grammar has the form - node-oracledb's own tokenizer
+      // (`lib/thin/statement.js`, `_parseQstring`) pairs `[ ] { } ( ) < >` and
+      // closes every other delimiter with itself.
+      test.each<[string, string]>([
+        ["a CTE body holding an apostrophe", "WITH T AS (SELECT q'{it's}' AS S FROM DUAL) SELECT * FROM T"],
+        [
+          "a literal holding a close paren and a write keyword",
+          "WITH T AS (SELECT q'{it's ) DELETE FROM USERS}' AS S FROM DUAL) SELECT * FROM T",
+        ],
+        ["a literal holding a comment marker", "SELECT q'[it's a -- note )]' AS S FROM DUAL"],
+        ["an upper-case tag", "SELECT Q'<it's>' AS S FROM DUAL"],
+        ["a delimiter that closes with itself", "SELECT q'!it's!' AS S FROM DUAL"],
+        // The national-charset spelling of the same form (`nq'…'`, Oracle's SQL
+        // Language Reference). Its comment-marker shape is the corrupting one
+        // above, so it is asserted here rather than left to the reader's charity.
+        ["a national-charset literal", "SELECT nq'{it's}' AS S FROM DUAL"],
+        ["a national-charset literal holding a comment marker", "SELECT nq'[it's a -- note )]' AS S FROM DUAL"],
+        [
+          "an upper-case national-charset literal in a CTE body",
+          "WITH T AS (SELECT NQ'{it's ) SELECT X}' AS S FROM DUAL) SELECT * FROM T",
+        ],
+      ])("bounds %s, with the clause after the literal", (_label, sql) => {
+        const result = provider.prepareQuery(sql);
+
+        expect(result.query).toBe(`${sql} FETCH FIRST 500 ROWS ONLY`);
+        expect(result.wasLimited).toBe(true);
+      });
+
+      // Where the form itself cannot be read to its end there is no honest place
+      // for the clause, so the statement is returned as it came.
+      test.each<[string, string]>([
+        ["an alternate literal that never closes", "SELECT q'{it's FROM DUAL"],
+        ["a national-charset literal that never closes", "SELECT nq'{it's FROM DUAL"],
+        // A name that merely ends in the tag's letters is a name: Oracle reads it
+        // greedily and so does this reader, which leaves the apostrophe after it
+        // opening an ordinary string that never closes.
+        ["a name ending in the tag's letters", "SELECT FREQ'{it's}' AS S FROM DUAL"],
+      ])("returns %s untouched rather than bounding it on a guess", (_label, sql) => {
+        const result = provider.prepareQuery(sql);
+
+        expect(result.query).toBe(sql);
+        expect(result.wasLimited).toBe(false);
+      });
+
       test("a real FETCH FIRST before a comment is still honoured", () => {
         const sql = "SELECT * FROM USERS FETCH FIRST 10 ROWS ONLY -- deliberate";
 

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -649,20 +649,33 @@ describe("OracleProvider", () => {
         expect(result.query).toBe("SELECT * FROM USERS FETCH FIRST 500 ROWS ONLY; -- daily check");
       });
 
-      test.each<[string, string]>([
-        // A quote behind an odd backslash run: Oracle and MySQL close that
-        // literal in different places, so there is no honest place for the
-        // clause. Appending on a guess would put it after the terminator.
-        ["a literal whose end is undeterminable", "SELECT * FROM USERS WHERE PATH = 'C:\\';"],
-        // `#` is legal in an Oracle identifier and is MySQL's comment marker, and
-        // nothing in the text tells them apart. Appending would have emitted
-        // `... WHERE ID FETCH FIRST 500 ROWS ONLY# = 1`.
-        ["an identifier carrying a hash", "SELECT * FROM EMP WHERE ID# = 1"],
-      ])("returns %s untouched rather than bounding it on a guess", (_label, sql) => {
+      // A quote behind an odd backslash run: Oracle and MySQL close that literal
+      // in different places, so there is no honest place for the clause.
+      // Appending on a guess would put it after the terminator.
+      test("returns a literal whose end is undeterminable untouched rather than bounding it on a guess", () => {
+        const sql = "SELECT * FROM USERS WHERE PATH = 'C:\\';";
+
         const result = provider.prepareQuery(sql);
 
         expect(result.query).toBe(sql);
         expect(result.wasLimited).toBe(false);
+      });
+
+      // ── The `#` grammar is Oracle's here (#292) ─────────────────────────
+      //
+      // `#` is a legal identifier character in Oracle and opens no comment there
+      // - node-oracledb's own SQL tokenizer accepts it inside a name and starts
+      // comments on `--` and `/*` only. While the shared reader had to guess, it
+      // read `ID#` as MySQL would and declined to bound the statement at all;
+      // told which dialect it is reading, it bounds it where Oracle wants it.
+      test.each<[string, string]>([
+        ["a bare identifier carrying a hash", "SELECT * FROM EMP WHERE ID# = 1"],
+        ["a hash at the end of a table name", "SELECT * FROM EMP#"],
+      ])("bounds %s instead of declining", (_label, sql) => {
+        const result = provider.prepareQuery(sql);
+
+        expect(result.query).toBe(`${sql} FETCH FIRST 500 ROWS ONLY`);
+        expect(result.wasLimited).toBe(true);
       });
 
       test("a real FETCH FIRST before a comment is still honoured", () => {

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -1786,5 +1786,47 @@ describe("PostgresProvider", () => {
       expect(result.query).toBe(sql);
       expect(result.wasLimited).toBe(false);
     });
+
+    // ── Block comments NEST here (#300) ────────────────────────────────────
+    //
+    // PostgreSQL's manual (4.1.5) says block comments nest "as specified in the SQL
+    // standard but unlike C", so a `/*` written inside one opens a second comment
+    // and the run continues past the next `*/`. Read flat, everything between that
+    // `*/` and the comment's real end reaches the readers as code - and this is the
+    // provider where that costs the most, because `WITH … INSERT` really writes and
+    // a bound appended to it commits part of the write.
+
+    test.each<[string, string]>([
+      ["an INSERT … SELECT", "INSERT INTO archive (id) SELECT id FROM recent"],
+      ["an UPDATE … SET", "UPDATE archive SET seen = true WHERE id IN (SELECT id FROM recent)"],
+    ])("leaves %s hidden behind a nested comment unbounded, emitted intact", (_label, write) => {
+      provider = new PostgresProvider(makePgConfig());
+      const sql = `WITH recent AS (\n  /* outer /* inner */ ) SELECT 1 */\n  SELECT id FROM logs\n)\n${write}`;
+
+      const result = provider.prepareQuery(sql, { limit: 50 });
+
+      expect(result.query).toBe(sql);
+      expect(result.wasLimited).toBe(false);
+    });
+
+    test("bounds a read behind a nested comment, and emits the comment intact", () => {
+      provider = new PostgresProvider(makePgConfig());
+      const sql = "/* outer /* inner */ still a note */ SELECT id FROM logs";
+
+      const result = provider.prepareQuery(sql, { limit: 50 });
+
+      expect(result.query).toBe(`${sql} LIMIT 50`);
+      expect(result.wasLimited).toBe(true);
+    });
+
+    test("leaves a statement whose nested comment never closes untouched", () => {
+      provider = new PostgresProvider(makePgConfig());
+      const sql = "/* outer /* inner */ SELECT id FROM logs";
+
+      const result = provider.prepareQuery(sql, { limit: 50 });
+
+      expect(result.query).toBe(sql);
+      expect(result.wasLimited).toBe(false);
+    });
   });
 });

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -1711,4 +1711,41 @@ describe("PostgresProvider", () => {
       expect(activity[0].query).toBe("SELECT * FROM test_table");
     });
   });
+
+  // --------------------------------------------------------------------------
+  // prepareQuery() — the `#` grammar is PostgreSQL's here (#292)
+  // --------------------------------------------------------------------------
+  //
+  // PostgreSQL has exactly two comment forms, `--` and `/* */`; `#` is an
+  // operator character (`#>`, `#>>`, `#-` walk or delete a jsonb path, `#` is
+  // integer XOR). The shared readers used to approximate that with "a hash is a
+  // comment unless the next character makes an operator", which reads `# note` on
+  // this provider as a comment and stops the statement there. Asserted through
+  // the provider's own `prepareQuery`, with the emitted text pinned whole.
+
+  describe("prepareQuery()", () => {
+    test.each<[string, string]>([
+      ["a jsonb path operator", "SELECT meta #> '{a}' FROM docs"],
+      ["a jsonb path-as-text operator", "SELECT meta #>> '{a}' FROM docs"],
+      ["an integer XOR operator", "SELECT flags # 5 AS x FROM t"],
+      ["a dollar-quoted body carrying a hash and a paren", "SELECT $fn$ # ) DELETE $fn$ AS body FROM t"],
+    ])("bounds a statement carrying %s, emitted intact", (_label, sql) => {
+      provider = new PostgresProvider(makePgConfig());
+
+      const result = provider.prepareQuery(sql, { limit: 50 });
+
+      expect(result.query).toBe(`${sql} LIMIT 50`);
+      expect(result.wasLimited).toBe(true);
+    });
+
+    test("a write is still a write, hash or no hash", () => {
+      provider = new PostgresProvider(makePgConfig());
+      const sql = "UPDATE t SET flags = flags # 5";
+
+      const result = provider.prepareQuery(sql, { limit: 50 });
+
+      expect(result.query).toBe(sql);
+      expect(result.wasLimited).toBe(false);
+    });
+  });
 });

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -3,7 +3,8 @@
  * Uses mock.module() to intercept pg before provider import.
  */
 
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { EventEmitter } from "node:events";
 import type { DatabaseConnection } from "@/lib/types";
 import { DatabaseConfigError } from "@/lib/db/errors";
 
@@ -25,17 +26,31 @@ const mockClient = {
   release: () => {},
 };
 
-const mockPool = {
-  connect: async () => mockClient,
-  end: async () => {},
-  totalCount: 10,
-  idleCount: 7,
-  waitingCount: 0,
-};
+/**
+ * The pool mock is a real EventEmitter, and a fresh instance per construction, because
+ * that is what `pg` hands back. An `error` event with no listener is an uncaught
+ * exception (#298), so a plain object carrying an inert `on` could not tell a pool whose
+ * idle-client failure is handled from one that takes the process down with it.
+ */
+class MockPool extends EventEmitter {
+  public totalCount = 10;
+  public idleCount = 7;
+  public waitingCount = 0;
+
+  async connect() {
+    return mockClient;
+  }
+
+  async end() {}
+}
+
+/** The pool handed to the most recently constructed provider. */
+let lastPool: MockPool | undefined;
 
 mock.module("pg", () => ({
   Pool: function () {
-    return mockPool;
+    lastPool = new MockPool();
+    return lastPool;
   },
 }));
 
@@ -1635,6 +1650,40 @@ describe("PostgresProvider", () => {
       expect(stats.length).toBeGreaterThanOrEqual(1);
       const walEntry = stats.find((s) => s.name === "WAL");
       expect(walEntry).toBeUndefined();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Pool Error Events (#298)
+  // --------------------------------------------------------------------------
+
+  describe("pool error events", () => {
+    test("an idle client error is logged and does not escalate past the provider", async () => {
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+      const pool = lastPool;
+      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        // `pg` has already removed and destroyed the client by the time it emits on the
+        // POOL; with no listener that emit is an uncaught exception, i.e. a dead server.
+        expect(() => pool?.emit("error", new Error("Connection terminated unexpectedly"))).not.toThrow();
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        const logged = errorSpy.mock.calls[0].join(" ");
+        expect(logged).toContain("[Postgres]");
+        expect(logged).toContain("Connection terminated unexpectedly");
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    test("the pool carries exactly one error listener, and a repeat connect adds none", async () => {
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+      // connect() is a no-op once a pool exists, so listeners cannot accumulate.
+      await provider.connect();
+
+      expect(lastPool?.listenerCount("error")).toBe(1);
     });
   });
 

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -1753,8 +1753,8 @@ describe("PostgresProvider", () => {
     // PostgreSQL subscripts arrays and jsonb with `[…]`, but no first-party source
     // for that rule was established here, so the reader keeps SQL Server's quoted-
     // NAME reading rather than guessing from ClickHouse's. These fixtures pin what
-    // that costs, because `docs/providers/postgres.md` now states it: a lost bound,
-    // never a misplaced clause. Ordinary subscripts are unaffected.
+    // that costs the LIMITER, because `docs/providers/postgres.md` states it: a lost
+    // bound, never a misplaced clause. Ordinary subscripts are unaffected.
     test.each<[string, string]>([
       ["an ordinary subscript", "SELECT a[1] FROM t"],
       ["a flat array constructor", "SELECT ARRAY[1,2] FROM t"],
@@ -1767,6 +1767,11 @@ describe("PostgresProvider", () => {
       expect(result.wasLimited).toBe(true);
     });
 
+    // The two shapes below cost their statements a confirmation prompt as well
+    // (#297): a run the reader cannot resolve is text the safety gate cannot read
+    // either, so an everyday read asks before it runs. That half is pinned in
+    // `tests/components/QuerySafetyDialog.test.tsx`, where the predicate lives, and
+    // stated in `docs/providers/postgres.md` beside the lost bound.
     test.each<[string, string]>([
       // The closing `]]` is read as SQL Server's escape, so the run never closes.
       ["a nested array constructor", "SELECT ARRAY[[1,2],[3,4]] AS a FROM t"],

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -1797,17 +1797,29 @@ describe("PostgresProvider", () => {
       expect(result.wasLimited).toBe(false);
     });
 
-    // ── The bracket fact is left UNDECIDED for this dialect (#295) ──────────
+    // ── `[…]` is a SUBSCRIPT here (#295) ────────────────────────────────────
     //
-    // PostgreSQL subscripts arrays and jsonb with `[…]`, but no first-party source
-    // for that rule was established here, so the reader keeps SQL Server's quoted-
-    // NAME reading rather than guessing from ClickHouse's. These fixtures pin what
-    // that costs the LIMITER, because `docs/providers/postgres.md` states it: a lost
-    // bound, never a misplaced clause. Ordinary subscripts are unaffected.
+    // Established from the manual: `expression[subscript]` and
+    // `expression[lower:upper]` are an element and a slice (4.2.3), array
+    // constructors nest and the manual's own example is `SELECT ARRAY[[1,2],[3,4]]`
+    // (4.2.12), and identifiers are quoted with double quotes (4.1.1) - so `[` is
+    // never a name quote in this dialect and the NAME reading it briefly inherited
+    // from SQL Server could not close a nested array or a key carrying a `]`. That
+    // cost a bound on everyday syntax and, once #297 landed, a confirmation prompt
+    // on an ordinary read.
+    //
+    // The last row is the one the reader could get wrong silently: the statement
+    // ENDS with the bracketed run, so nothing after it would catch a bound placed
+    // by a reader that lost track of where the run closes. A fixture can only pin a
+    // reading where the two readings disagree.
     test.each<[string, string]>([
       ["an ordinary subscript", "SELECT a[1] FROM t"],
       ["a flat array constructor", "SELECT ARRAY[1,2] FROM t"],
-    ])("still bounds %s", (_label, sql) => {
+      ["a nested array constructor", "SELECT ARRAY[[1,2],[3,4]] AS a FROM t"],
+      ["a jsonb subscript whose key carries a close bracket", "SELECT j['a]b'] FROM t"],
+      ["a nested subscript", "SELECT t.data[idx[0]] FROM t"],
+      ["a statement that ENDS with a nested array", "SELECT ARRAY[[1,2],[3,4]]"],
+    ])("bounds %s, appending the clause after the run", (_label, sql) => {
       provider = new PostgresProvider(makePgConfig());
 
       const result = provider.prepareQuery(sql, { limit: 50 });
@@ -1816,19 +1828,12 @@ describe("PostgresProvider", () => {
       expect(result.wasLimited).toBe(true);
     });
 
-    // The two shapes below cost their statements a confirmation prompt as well
-    // (#297): a run the reader cannot resolve is text the safety gate cannot read
-    // either, so an everyday read asks before it runs. That half is pinned in
-    // `tests/components/QuerySafetyDialog.test.tsx`, where the predicate lives, and
-    // stated in `docs/providers/postgres.md` beside the lost bound.
-    test.each<[string, string]>([
-      // The closing `]]` is read as SQL Server's escape, so the run never closes.
-      ["a nested array constructor", "SELECT ARRAY[[1,2],[3,4]] AS a FROM t"],
-      // The `]` inside the key ends the run early, and the rest of the key then
-      // reads as an unterminated literal.
-      ["a jsonb subscript whose key carries a close bracket", "SELECT j['a]b'] FROM t"],
-    ])("leaves %s unbounded, and emits it untouched", (_label, sql) => {
+    // A reading is not a licence to guess: a subscript run short of its closer is
+    // still undeterminable, so the statement keeps its text and loses its bound
+    // rather than collecting a clause inside the run.
+    test("leaves an unclosed subscript run unbounded, and emits it untouched", () => {
       provider = new PostgresProvider(makePgConfig());
+      const sql = "SELECT ARRAY[[1,2] AS a FROM t";
 
       const result = provider.prepareQuery(sql, { limit: 50 });
 

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -1747,5 +1747,39 @@ describe("PostgresProvider", () => {
       expect(result.query).toBe(sql);
       expect(result.wasLimited).toBe(false);
     });
+
+    // ── The bracket fact is left UNDECIDED for this dialect (#295) ──────────
+    //
+    // PostgreSQL subscripts arrays and jsonb with `[…]`, but no first-party source
+    // for that rule was established here, so the reader keeps SQL Server's quoted-
+    // NAME reading rather than guessing from ClickHouse's. These fixtures pin what
+    // that costs, because `docs/providers/postgres.md` now states it: a lost bound,
+    // never a misplaced clause. Ordinary subscripts are unaffected.
+    test.each<[string, string]>([
+      ["an ordinary subscript", "SELECT a[1] FROM t"],
+      ["a flat array constructor", "SELECT ARRAY[1,2] FROM t"],
+    ])("still bounds %s", (_label, sql) => {
+      provider = new PostgresProvider(makePgConfig());
+
+      const result = provider.prepareQuery(sql, { limit: 50 });
+
+      expect(result.query).toBe(`${sql} LIMIT 50`);
+      expect(result.wasLimited).toBe(true);
+    });
+
+    test.each<[string, string]>([
+      // The closing `]]` is read as SQL Server's escape, so the run never closes.
+      ["a nested array constructor", "SELECT ARRAY[[1,2],[3,4]] AS a FROM t"],
+      // The `]` inside the key ends the run early, and the rest of the key then
+      // reads as an unterminated literal.
+      ["a jsonb subscript whose key carries a close bracket", "SELECT j['a]b'] FROM t"],
+    ])("leaves %s unbounded, and emits it untouched", (_label, sql) => {
+      provider = new PostgresProvider(makePgConfig());
+
+      const result = provider.prepareQuery(sql, { limit: 50 });
+
+      expect(result.query).toBe(sql);
+      expect(result.wasLimited).toBe(false);
+    });
   });
 });

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -669,6 +669,22 @@ describe("SQLiteProvider", () => {
       expect(result.query).toBe(sql);
       expect(result.wasLimited).toBe(false);
     });
+
+    // ── The `#` grammar is SQLite's here (#292) ──────────────────────────
+    //
+    // SQLite has two comment forms, `--` and `/* */`. Its own tokenizer (the
+    // bundled amalgamation classifies `#` as `CC_VARALPHA`) reads `#name` as a
+    // bind variable, i.e. code. The shared reader used to guess MySQL's rule
+    // here, which swallowed the rest of the line and cost the statement its
+    // bound; naming the dialect bounds it instead, emitted text intact.
+    test("bounds a statement carrying a hash-prefixed bind variable", () => {
+      provider = new SQLiteProvider(makeSQLiteConfig());
+
+      const result = provider.prepareQuery("SELECT * FROM users WHERE id = #id");
+
+      expect(result.query).toBe("SELECT * FROM users WHERE id = #id LIMIT 500");
+      expect(result.wasLimited).toBe(true);
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -685,6 +685,47 @@ describe("SQLiteProvider", () => {
       expect(result.query).toBe("SELECT * FROM users WHERE id = #id LIMIT 500");
       expect(result.wasLimited).toBe(true);
     });
+
+    // ── `[…]` is a quoted name here too (#295) ───────────────────────────
+    //
+    // SQLite accepts Microsoft-style bracket identifiers: its own tokenizer (the
+    // bundled amalgamation classifies `[` as `CC_QUOTE2`, "`[...]` style quoted
+    // ids") reads everything up to the close bracket as the name. So the bracket
+    // fact for this dialect is the name reading, not ClickHouse's array one, and a
+    // scan that stepped over string literals inside the run would lose the first
+    // row below. The emitted text is asserted whole: a bound spliced INTO a
+    // bracketed name is the corrupted-statement shape, not a missing bound.
+    test.each<[string, string, string]>([
+      ["an apostrophe", "SELECT [it's] FROM users", "SELECT [it's] FROM users LIMIT 500"],
+      ["a comment marker", "SELECT [a--b] FROM users", "SELECT [a--b] FROM users LIMIT 500"],
+      [
+        "a comment marker before real trailing trivia",
+        "SELECT [a--b] FROM users -- daily",
+        "SELECT [a--b] FROM users LIMIT 500 -- daily",
+      ],
+    ])("bounds a statement whose bracket-quoted name carries %s", (_label, sql, expected) => {
+      provider = new SQLiteProvider(makeSQLiteConfig());
+
+      const result = provider.prepareQuery(sql);
+
+      expect(result.query).toBe(expected);
+      expect(result.wasLimited).toBe(true);
+    });
+
+    // KNOWN DIVERGENCE, asserted so it is a decision: SQLite has no escape inside
+    // a bracket identifier - its tokenizer stops at the FIRST `]` - while this
+    // reader honours SQL Server's doubled bracket, so it reads `[a]]b]` as one
+    // name where SQLite reads `[a]` followed by junk. SQLite rejects that text
+    // either way, so the longer reading only ever costs a bound on a statement the
+    // server refuses.
+    test("reads a doubled close bracket as part of the name, which SQLite itself does not", () => {
+      provider = new SQLiteProvider(makeSQLiteConfig());
+
+      const result = provider.prepareQuery("SELECT [a]]b] FROM users");
+
+      expect(result.query).toBe("SELECT [a]]b] FROM users LIMIT 500");
+      expect(result.wasLimited).toBe(true);
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/tests/isolated/query-safety-gate-standalone.test.ts
+++ b/tests/isolated/query-safety-gate-standalone.test.ts
@@ -1,0 +1,138 @@
+import "../setup-dom";
+import "../helpers/mock-sonner";
+import "../helpers/mock-navigation";
+
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import { mockGlobalFetch, restoreGlobalFetch } from "../helpers/mock-fetch";
+import { storage } from "@/lib/storage";
+
+import { useQueryExecution } from "@/hooks/use-query-execution";
+import type { DatabaseConnection, QueryTab } from "@/lib/types";
+
+// ── The standalone execution path against the REAL confirmation gate (#297) ──
+//
+// Isolated, and this is the whole reason the file exists: tests/hooks/
+// use-query-execution.test.ts stubs `@/components/QuerySafetyDialog` with
+// `mock.module`, which is process-wide in bun, so no test that shares a process
+// with it can observe what the real predicate answers. That stub is deliberate -
+// it is what lets that file's UPDATE and DDL cases execute without a
+// confirmation - but it also means the standalone path's half of #297 cannot be
+// proved there: the stub answers on a substring, so a test written against it
+// would pass with the fix reverted.
+//
+// The embedded adapter needs no such file (tests/hooks/use-query-adapter.test.ts
+// already uses the real predicate). This one covers the other path: a script
+// whose reading cannot be resolved must reach the dialog rather than the server,
+// with nothing between the gate and the assertion.
+
+const connection: DatabaseConnection = {
+  id: "gate-pg-1",
+  name: "Test PostgreSQL",
+  type: "postgres",
+  host: "localhost",
+  port: 5432,
+  user: "testuser",
+  password: "testpass",
+  database: "testdb",
+  createdAt: new Date("2025-01-01T00:00:00Z"),
+  environment: "development",
+};
+
+const tab: QueryTab = {
+  id: "tab-1",
+  name: "Query 1",
+  query: "SELECT 1",
+  result: null,
+  isExecuting: false,
+  type: "sql",
+};
+
+function params() {
+  return {
+    activeConnection: connection,
+    // No provider metadata: the gate runs before anything reads capabilities, so a
+    // null one keeps this file to the one thing it is here to prove.
+    metadata: null,
+    tabs: [tab],
+    activeTabId: "tab-1",
+    currentTab: tab,
+    setTabs: mock((fn: unknown) => {
+      if (typeof fn === "function") (fn as (prev: QueryTab[]) => QueryTab[])([tab]);
+    }),
+    transactionActive: false,
+    playgroundMode: false,
+    fetchSchema: mock(async () => {}),
+    queryEditorRef: { current: null },
+  };
+}
+
+describe("useQueryExecution: the real safety gate", () => {
+  let addToHistorySpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    addToHistorySpy = spyOn(storage, "addToHistory").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    addToHistorySpy.mockRestore();
+    restoreGlobalFetch();
+  });
+
+  /**
+   * `'\'` closes the string under PostgreSQL's reading and continues it under
+   * MySQL's, so the span reader declines to resolve it and everything after the
+   * quote is invisible to a reader walking code words - which is why this script
+   * used to execute with no confirmation at all. The write is its second
+   * statement, and node-postgres sends both through the simple query protocol.
+   */
+  test("opens the dialog for a write hidden behind an unresolvable literal", async () => {
+    const fetchMock = mockGlobalFetch({});
+    const { result } = renderHook(() => useQueryExecution(params()));
+
+    const hidden = "SELECT '\\';\nUPDATE t SET x = 1";
+    await act(async () => {
+      await result.current.executeQuery(hidden);
+    });
+
+    expect(result.current.safetyCheckQuery).toBe(hidden);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The cost of the rule above, on this path too: a statement whose runs all
+   * resolve executes even though it carries a backslash. A prompt for every
+   * escape would be the "cries wolf" outcome the issue weighed.
+   */
+  test("runs a read whose literal resolves, backslash and all", async () => {
+    const fetchMock = mockGlobalFetch({
+      "/api/db/query": { ok: true, json: { rows: [{ id: 1 }], fields: ["id"], rowCount: 1, executionTime: 3 } },
+    });
+    const { result } = renderHook(() => useQueryExecution(params()));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT 'a\\nb' FROM t");
+    });
+
+    expect(result.current.safetyCheckQuery).toBeNull();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  /**
+   * And the #294 fixture on the real predicate here as well: a note above a
+   * destructive statement is the most ordinary habit there is, and it used to
+   * skip the dialog entirely.
+   */
+  test("opens the dialog for a destructive statement behind a comment", async () => {
+    const fetchMock = mockGlobalFetch({});
+    const { result } = renderHook(() => useQueryExecution(params()));
+
+    const annotated = "-- cleanup\nDROP TABLE users";
+    await act(async () => {
+      await result.current.executeQuery(annotated);
+    });
+
+    expect(result.current.safetyCheckQuery).toBe(annotated);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/isolated/query-safety-gate-standalone.test.ts
+++ b/tests/isolated/query-safety-gate-standalone.test.ts
@@ -119,6 +119,30 @@ describe("useQueryExecution: the real safety gate", () => {
   });
 
   /**
+   * #300's dialog half on this path: the connection is PostgreSQL, where block
+   * comments NEST, so a comment carrying a second opener runs past the `*\/` a flat
+   * reading stops at. Read flat, the word after that marker answered for the
+   * statement - a word the operator commented out, never in the dangerous set - so
+   * the `DROP` reached the server with no confirmation. Both shapes are asserted
+   * because they ask for different reasons: the balanced one because the reader now
+   * reads the `DROP`, the unbalanced one because the text cannot be resolved at all.
+   */
+  test.each<[string, string]>([
+    ["a balanced nested comment", "/* outer /* inner */ still a note */ DROP TABLE users"],
+    ["a nested comment that never closes", "/* outer /* inner */ DROP TABLE users"],
+  ])("opens the dialog for a destructive statement behind %s", async (_label, hidden) => {
+    const fetchMock = mockGlobalFetch({});
+    const { result } = renderHook(() => useQueryExecution(params()));
+
+    await act(async () => {
+      await result.current.executeQuery(hidden);
+    });
+
+    expect(result.current.safetyCheckQuery).toBe(hidden);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  /**
    * And the #294 fixture on the real predicate here as well: a note above a
    * destructive statement is the most ordinary habit there is, and it used to
    * skip the dialog entirely.

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -23,7 +23,10 @@ set -e
 
 PASS=0
 FAIL=0
-TOTAL_GROUPS=21
+# Count the `run_group` CALLS below when adding one (not the definition) - this is the
+# number the final summary reports, and it had already drifted by one before Group 0e
+# was added.
+TOTAL_GROUPS=23
 EXTRA_BUN_ARGS=("$@")
 GROUP_INDEX=0
 COVERAGE_MODE=0
@@ -99,6 +102,13 @@ run_group "Group 0c: Exports shim" --nocov \
 # module chain without rendering it.
 run_group "Group 0d: Monaco loader wiring" --nocov \
   tests/isolated/monaco-loader-wiring.test.ts
+
+# Group 0e: The standalone execution path against the REAL confirmation gate
+# (isolated — tests/hooks/use-query-execution.test.ts stubs
+# @/components/QuerySafetyDialog with mock.module, which is process-wide, so a
+# test sharing that process cannot observe what the real predicate answers).
+run_group "Group 0e: Query safety gate (standalone path)" \
+  tests/isolated/query-safety-gate-standalone.test.ts
 
 # Group 1: Studio (isolated — mocks almost every child component)
 run_group "Group 1/6: Studio" \

--- a/tests/unit/db/query-limiter.test.ts
+++ b/tests/unit/db/query-limiter.test.ts
@@ -945,3 +945,107 @@ describe("applyQueryLimit: bracket-quoted identifiers", () => {
     expect(applyQueryLimit("SELECT [a--b] FROM t -- daily", 500).sql).toBe("SELECT [a--b] FROM t LIMIT 500 -- daily");
   });
 });
+
+// ─── The dialect channel (#292) ──────────────────────────────────────────────
+//
+// Every reading above is a call that names NO dialect, and the point of the
+// compatibility default is that those answers do not move: the readers do exactly
+// what they did before this channel existed. A caller that DOES name its dialect
+// gets that dialect's grammar, and the shapes below are the ones where the two
+// answers differ - each asserted on BOTH sides, so the default is a decision
+// rather than whatever the implementation happened to do.
+
+describe("a named dialect changes the reading; naming none does not", () => {
+  // The bad direction this family exists to prevent: a hash comment whose first
+  // character makes a PostgreSQL operator hides a `)`, the CTE body ends early,
+  // and a statement that DELETEs is typed SELECT and bounded. MySQL 8 accepts
+  // both `WITH … DELETE` and a `LIMIT` on a `DELETE`, so that bound would commit a
+  // partial delete while the UI reported a truncated result set.
+  const HIDDEN_DELETE = "WITH t AS (\n  #- drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
+
+  test("without a dialect the hidden DELETE keeps today's (wrong) type", () => {
+    expect(analyzeQuery(HIDDEN_DELETE).type).toBe("SELECT");
+  });
+
+  test("under MySQL's grammar it is typed as the DELETE it operates and gets no bound", () => {
+    expect(analyzeQuery(HIDDEN_DELETE, "mysql").type).toBe("DELETE");
+
+    const result = applyQueryLimit(HIDDEN_DELETE, 500, 0, {}, "mysql");
+    expect(result.sql).toBe(HIDDEN_DELETE);
+    expect(result.wasLimited).toBe(false);
+  });
+
+  // The read-side face of the same ambiguity: a bound written after a hash is
+  // read as a real one today, so the statement is left unbounded. Under MySQL's
+  // grammar the bound is commented out, so a real one is added - and it is added
+  // BEFORE the comment, or it would land inside it.
+  test("a bound commented out with a hash is real without a dialect and commented out under MySQL's", () => {
+    const sql = "SELECT * FROM t # LIMIT 10";
+
+    expect(analyzeQuery(sql).hasLimit).toBe(true);
+    expect(applyQueryLimit(sql, 500).sql).toBe(sql);
+
+    expect(analyzeQuery(sql, "mysql").hasLimit).toBe(false);
+    expect(applyQueryLimit(sql, 500, 0, {}, "mysql")).toMatchObject({
+      sql: "SELECT * FROM t LIMIT 500 # LIMIT 10",
+      wasLimited: true,
+    });
+  });
+
+  // The other side: under a code grammar the run is part of the statement, so the
+  // cut is no longer refused and an ordinary temp-table read is bounded.
+  test.each<[string, string, "mssql" | "oracle" | "postgres" | "sqlite", string]>([
+    ["a T-SQL temp table", "SELECT * FROM #tmp", "mssql", "SELECT * FROM #tmp LIMIT 500"],
+    [
+      "an Oracle identifier carrying a hash",
+      "SELECT * FROM EMP WHERE ID# = 1",
+      "oracle",
+      "SELECT * FROM EMP WHERE ID# = 1 LIMIT 500",
+    ],
+    ["a PostgreSQL XOR operator", "SELECT flags # 5 AS x FROM t", "postgres", "SELECT flags # 5 AS x FROM t LIMIT 500"],
+    ["a SQLite bind variable", "SELECT * FROM t WHERE id = #id", "sqlite", "SELECT * FROM t WHERE id = #id LIMIT 500"],
+  ])("%s is bounded under a code grammar and left alone without one", (_label, sql, type, expected) => {
+    expect(applyQueryLimit(sql, 500).wasLimited).toBe(false);
+
+    const result = applyQueryLimit(sql, 500, 0, {}, type);
+    expect(result.sql).toBe(expected);
+    expect(result.wasLimited).toBe(true);
+  });
+
+  // Fixture discipline: input built from syntax these readers do not model as a
+  // unit - a hash INSIDE a quoted name, and a dollar-quoted body carrying both a
+  // hash and a close paren. The emitted text is asserted whole, because "a bound
+  // was added" would pass while the bound sat inside the name.
+  test.each<[string, string, "mysql" | "postgres" | "mssql", string]>([
+    ["a backtick name carrying a hash", "SELECT `a#b` FROM t", "mysql", "SELECT `a#b` FROM t LIMIT 500"],
+    [
+      "a bracket name carrying a hash, from a temp table",
+      "SELECT [a#b] FROM #tmp",
+      "mssql",
+      "SELECT [a#b] FROM #tmp LIMIT 500",
+    ],
+    [
+      "a dollar-quoted body carrying a hash and a paren",
+      "SELECT $fn$ # ) DELETE $fn$ AS body FROM t",
+      "postgres",
+      "SELECT $fn$ # ) DELETE $fn$ AS body FROM t LIMIT 500",
+    ],
+  ])("%s is emitted intact", (_label, sql, type, expected) => {
+    const result = applyQueryLimit(sql, 500, 0, {}, type);
+
+    expect(result.sql).toBe(expected);
+    expect(result.wasLimited).toBe(true);
+  });
+
+  test("isSelectQuery takes the dialect too, so the multi-statement route agrees with the provider", () => {
+    expect(isSelectQuery(HIDDEN_DELETE)).toBe(true);
+    expect(isSelectQuery(HIDDEN_DELETE, "mysql")).toBe(false);
+  });
+
+  // A dialect with no established `#` rule keeps the default reading, and that is
+  // an answer this milestone owes its readers rather than an accident.
+  test("a dialect left at the compatibility default answers as a dialect-less call does", () => {
+    expect(analyzeQuery(HIDDEN_DELETE, "druid").type).toBe("SELECT");
+    expect(applyQueryLimit("SELECT * FROM t # note", 500, 0, {}, "couchbase").wasLimited).toBe(false);
+  });
+});

--- a/tests/unit/db/query-limiter.test.ts
+++ b/tests/unit/db/query-limiter.test.ts
@@ -1037,6 +1037,35 @@ describe("a named dialect changes the reading; naming none does not", () => {
     expect(result.wasLimited).toBe(true);
   });
 
+  // Oracle's alternate quoting (`q'{it's}'`) is the second grammar this channel
+  // carries, and the only dialect that has the form is the only one that reads it.
+  // Both inputs below are Oracle text, so the dialect-less answers are what
+  // reading Oracle as something else costs: the first loses its bound, and the
+  // second - whose literal also carries a `--` - has the clause placed before what
+  // that reading calls a trailing comment, i.e. inside the literal. That answer is
+  // correct FOR the grammar being read (there `q` is a name and `'[it'` a string)
+  // and wrong for the statement, which is the whole point of naming the dialect.
+  test.each<[string, string, string, string]>([
+    [
+      "a CTE body holding an apostrophe",
+      "WITH t AS (SELECT q'{it's}' AS s FROM dual) SELECT * FROM t",
+      "WITH t AS (SELECT q'{it's}' AS s FROM dual) SELECT * FROM t",
+      "WITH t AS (SELECT q'{it's}' AS s FROM dual) SELECT * FROM t LIMIT 500",
+    ],
+    [
+      "a literal holding an apostrophe and a comment marker",
+      "SELECT q'[it's a -- note )]' AS s FROM dual",
+      "SELECT q'[it's a LIMIT 500 -- note )]' AS s FROM dual",
+      "SELECT q'[it's a -- note )]' AS s FROM dual LIMIT 500",
+    ],
+  ])("%s is read as a literal under Oracle's grammar only", (_label, sql, withoutDialect, underOracle) => {
+    expect(applyQueryLimit(sql, 500).sql).toBe(withoutDialect);
+
+    const result = applyQueryLimit(sql, 500, 0, {}, "oracle");
+    expect(result.sql).toBe(underOracle);
+    expect(result.wasLimited).toBe(true);
+  });
+
   test("isSelectQuery takes the dialect too, so the multi-statement route agrees with the provider", () => {
     expect(isSelectQuery(HIDDEN_DELETE)).toBe(true);
     expect(isSelectQuery(HIDDEN_DELETE, "mysql")).toBe(false);

--- a/tests/unit/db/query-limiter.test.ts
+++ b/tests/unit/db/query-limiter.test.ts
@@ -946,6 +946,93 @@ describe("applyQueryLimit: bracket-quoted identifiers", () => {
   });
 });
 
+// ─── `[…]` is read per dialect (#295) ────────────────────────────────────────
+//
+// The reading above is a NAME, which is right for SQL Server and SQLite and wrong
+// for ClickHouse, where the same characters are an array or a subscript: they nest
+// and nothing inside them is escaped. Read as a name, a `]` written inside a
+// string ends the run early and the CTE element around it cannot be crossed, so
+// the statement loses its bound - on the engine whose whole point is scanning more
+// rows than a browser can hold. The two readings are mutually exclusive, so this
+// is the dialect's answer and both sides are asserted on the emitted text.
+
+describe("applyQueryLimit: the bracket grammar", () => {
+  test.each<[string, string, "clickhouse", string]>([
+    [
+      "a map subscript whose key carries a close bracket",
+      "WITH m['a]b'] AS v SELECT v FROM t",
+      "clickhouse",
+      "WITH m['a]b'] AS v SELECT v FROM t LIMIT 500",
+    ],
+    [
+      "a nested array element",
+      "WITH [[1,2],[3,4]] AS a SELECT arrayJoin(a)",
+      "clickhouse",
+      "WITH [[1,2],[3,4]] AS a SELECT arrayJoin(a) LIMIT 500",
+    ],
+    [
+      "a nested array in the select list",
+      "SELECT [[1,2],[3,4]] AS a FROM t",
+      "clickhouse",
+      "SELECT [[1,2],[3,4]] AS a FROM t LIMIT 500",
+    ],
+    // The bound goes after the run and before the trailing comment: a subscript is
+    // the statement's own text, not trivia, so an end read before it would splice
+    // the clause into the middle of the statement. The rows where the run is the
+    // statement's LAST token are what make that assertable at all - with code after
+    // the run, both readings put the end in the same place (reported by review).
+    [
+      "an array literal before a trailing hash comment",
+      "SELECT [[1,2],[3]] AS a FROM t # daily",
+      "clickhouse",
+      "SELECT [[1,2],[3]] AS a FROM t LIMIT 500 # daily",
+    ],
+    ["a subscript that ends the statement", "SELECT m['a]b']", "clickhouse", "SELECT m['a]b'] LIMIT 500"],
+    [
+      "a nested array that ends the statement, before a comment",
+      "SELECT [[1,2],[3,4]] # daily",
+      "clickhouse",
+      "SELECT [[1,2],[3,4]] LIMIT 500 # daily",
+    ],
+  ])("%s is bounded under the subscript grammar, emitted intact", (_label, sql, type, expected) => {
+    const result = applyQueryLimit(sql, 500, 0, {}, type);
+
+    expect(result.sql).toBe(expected);
+    expect(result.wasLimited).toBe(true);
+    // Without the dialect the same text keeps today's answer, which for every
+    // shape here is no bound at all: the name reading either cannot cross the
+    // element or cannot close the run.
+    expect(applyQueryLimit(sql, 500).sql).not.toBe(expected);
+  });
+
+  test.each<[string, string, "mssql" | "sqlite", string]>([
+    ["an apostrophe inside the name", "SELECT [it's] FROM t", "mssql", "SELECT [it's] FROM t LIMIT 500"],
+    ["a doubled close bracket", "SELECT [a]]b] FROM t", "mssql", "SELECT [a]]b] FROM t LIMIT 500"],
+    ["a comment marker inside the name", "SELECT [a--b] FROM t", "sqlite", "SELECT [a--b] FROM t LIMIT 500"],
+    ["a name carrying a semicolon", "SELECT [a;b] FROM t -- daily", "sqlite", "SELECT [a;b] FROM t LIMIT 500 -- daily"],
+  ])("a bracket-quoted name with %s stays one name under the name grammar", (_label, sql, type, expected) => {
+    const result = applyQueryLimit(sql, 500, 0, {}, type);
+
+    expect(result.sql).toBe(expected);
+    expect(result.wasLimited).toBe(true);
+  });
+
+  test("a subscript with no literal in it, and a literal with no close bracket, keep their answers", () => {
+    // Neither reading moves for these, and that is worth pinning: it is what says
+    // the change is confined to the runs where the two grammars disagree.
+    expect(applyQueryLimit("SELECT a[1] FROM t", 500, 0, {}, "clickhouse").sql).toBe("SELECT a[1] FROM t LIMIT 500");
+    expect(applyQueryLimit("SELECT a[1] FROM t", 500).sql).toBe("SELECT a[1] FROM t LIMIT 500");
+    expect(applyQueryLimit("SELECT 'a[b' FROM t", 500, 0, {}, "clickhouse").sql).toBe("SELECT 'a[b' FROM t LIMIT 500");
+    expect(applyQueryLimit("SELECT 'a[b' FROM t", 500).sql).toBe("SELECT 'a[b' FROM t LIMIT 500");
+  });
+
+  test("a run the subscript grammar cannot close is not rewritten", () => {
+    const sql = "SELECT [1,2 AS a FROM t";
+
+    expect(applyQueryLimit(sql, 500, 0, {}, "clickhouse")).toMatchObject({ sql, wasLimited: false });
+  });
+});
+
 // ─── The dialect channel (#292) ──────────────────────────────────────────────
 //
 // Every reading above is a call that names NO dialect, and the point of the

--- a/tests/unit/db/query-limiter.test.ts
+++ b/tests/unit/db/query-limiter.test.ts
@@ -1165,3 +1165,94 @@ describe("a named dialect changes the reading; naming none does not", () => {
     expect(applyQueryLimit("SELECT * FROM t # note", 500, 0, {}, "couchbase").wasLimited).toBe(false);
   });
 });
+
+// ─── Where a block comment ends is the dialect's answer too (#300) ───────────
+//
+// The third grammar this channel carries, and the one whose cost is the same as
+// the `#` row's worst case: a comment that NESTS ends later than the flat reading
+// thinks, so a `)` written between the first `*/` and the comment's real end
+// closes a CTE body that is still open. The statement is then typed by a keyword
+// the operator commented out, and a bound appended to a write on PostgreSQL
+// commits part of it.
+
+describe("a nested block comment under the dialect that reads it", () => {
+  // The `)` and the `SELECT` both sit AFTER the inner `*/`, which is the region a
+  // flat reading hands over as code. With the whole comment read as one comment,
+  // the CTE body runs to its real `)` and the statement is the write it operates.
+  const hiddenWrite = (write: string) =>
+    `WITH recent AS (\n  /* outer /* inner */ ) SELECT 1 */\n  SELECT id FROM logs\n)\n${write}`;
+
+  test.each<[string, string, ParsedQueryInfo["type"]]>([
+    ["an INSERT … SELECT", "INSERT INTO archive (id) SELECT id FROM recent", "INSERT"],
+    ["an UPDATE … SET", "UPDATE archive SET seen = true WHERE id IN (SELECT id FROM recent)", "UPDATE"],
+  ])("%s hidden behind a nested comment is typed as the write it is, and not bounded", (_label, write, type) => {
+    const sql = hiddenWrite(write);
+
+    // Today's answer without the dialect, kept: the flat reading really is what
+    // MySQL does, and the statement is a syntax error there.
+    expect(analyzeQuery(sql).type).toBe("SELECT");
+    expect(analyzeQuery(sql, "mysql").type).toBe("SELECT");
+
+    expect(analyzeQuery(sql, "postgres").type).toBe(type);
+
+    const result = applyQueryLimit(sql, 500, 0, {}, "postgres");
+    expect(result.sql).toBe(sql);
+    expect(result.wasLimited).toBe(false);
+  });
+
+  // The read side of the same fact: with the comment read whole, the statement
+  // behind it is an ordinary SELECT and collects its bound - and the bound goes
+  // after the statement, never inside the comment.
+  test("a read behind a nested comment is bounded, and the comment is emitted intact", () => {
+    const sql = "/* outer /* inner */ still a note */ SELECT id FROM logs";
+
+    expect(applyQueryLimit(sql, 500).wasLimited).toBe(false);
+
+    expect(applyQueryLimit(sql, 500, 0, {}, "postgres")).toMatchObject({
+      sql: "/* outer /* inner */ still a note */ SELECT id FROM logs LIMIT 500",
+      wasLimited: true,
+    });
+  });
+
+  // Fixture discipline (the milestone's rule): a nested comment written where no
+  // reader models it as a unit - inside a dollar-quoted body, and inside a trailing
+  // comment run - with the emitted text asserted whole rather than "a bound was
+  // added".
+  test.each<[string, string, string]>([
+    [
+      "a dollar-quoted body carrying a nested comment and a paren",
+      "SELECT $fn$ /* a /* b */ ) $fn$ AS body FROM t",
+      "SELECT $fn$ /* a /* b */ ) $fn$ AS body FROM t LIMIT 500",
+    ],
+    [
+      "a trailing nested comment, where the bound goes before it",
+      "SELECT id FROM logs /* a /* b */ c */",
+      "SELECT id FROM logs LIMIT 500 /* a /* b */ c */",
+    ],
+  ])("%s is emitted intact under a nesting grammar", (_label, sql, expected) => {
+    const result = applyQueryLimit(sql, 500, 0, {}, "postgres");
+
+    expect(result.sql).toBe(expected);
+    expect(result.wasLimited).toBe(true);
+  });
+
+  // One opener too many is undeterminable rather than guessed, so nothing is
+  // rewritten - the fail-safe direction this folder keeps everywhere.
+  test("a nested comment that never closes is not rewritten under a nesting grammar", () => {
+    const sql = "/* outer /* inner */ SELECT id FROM logs";
+
+    expect(applyQueryLimit(sql, 500, 0, {}, "postgres")).toMatchObject({ sql, wasLimited: false });
+  });
+
+  // Ordinary comments answer the same under both readings, which is what says the
+  // change is confined to the runs where the grammars disagree.
+  test.each<[string, string, string]>([
+    ["one block comment", "/* note */ SELECT 1", "/* note */ SELECT 1 LIMIT 500"],
+    ["adjacent block comments", "/*a*//*b*/SELECT 1", "/*a*//*b*/SELECT 1 LIMIT 500"],
+    ["a comment holding a lone star", "/* a * b */ SELECT 1", "/* a * b */ SELECT 1 LIMIT 500"],
+    ["a multi-line comment", "/* one\n   two */ SELECT 1", "/* one\n   two */ SELECT 1 LIMIT 500"],
+  ])("%s keeps its answer under both readings", (_label, sql, expected) => {
+    expect(applyQueryLimit(sql, 500).sql).toBe(expected);
+    expect(applyQueryLimit(sql, 500, 0, {}, "postgres").sql).toBe(expected);
+  });
+});

--- a/tests/unit/lib/explain/clickhouse-json.test.ts
+++ b/tests/unit/lib/explain/clickhouse-json.test.ts
@@ -243,6 +243,21 @@ describe("clickhouseJsonStrategy", () => {
     );
   });
 
+  // Block comments nest in ClickHouse too (#300), so this strategy reads the statement
+  // under ClickHouse's grammar. Nothing here executes - ClickHouse's EXPLAIN describes
+  // without running, unlike PostgreSQL's ANALYZE - so what this buys is an honest
+  // classification rather than a write prevented: a statement whose real keyword is a
+  // write no longer gets an Explain built for it, and a read hidden behind a nested
+  // comment does.
+  test("buildSql reads a nested comment the way ClickHouse does", () => {
+    expect(
+      clickhouseJsonStrategy.buildSql("/* a /* b */ SELECT 1 */ ALTER TABLE users DELETE WHERE id = 1", "estimate"),
+    ).toBeNull();
+
+    const read = "/* a /* b */ x */ SELECT 1";
+    expect(clickhouseJsonStrategy.buildSql(read, "estimate")).toBe(`EXPLAIN json = 1, indexes = 1 ${read}`);
+  });
+
   test("buildSql returns null for non-SELECT statements in both modes", () => {
     expect(clickhouseJsonStrategy.buildSql("INSERT INTO users FORMAT Values (1)", "estimate")).toBeNull();
     expect(

--- a/tests/unit/lib/explain/postgres-json.test.ts
+++ b/tests/unit/lib/explain/postgres-json.test.ts
@@ -57,6 +57,41 @@ describe("postgresJsonStrategy", () => {
     expect(postgresJsonStrategy.buildSql(sql, "estimate")).toBeNull();
   });
 
+  /**
+   * The nested-comment shape, and the reason this strategy has to read the statement
+   * under PostgreSQL's own grammar rather than the shared default (#300).
+   *
+   * Block comments NEST here, so `/* a /* b *\/ SELECT 1 *\/ DELETE FROM users` is a
+   * comment followed by a DELETE - while a flat reading sees the comment end at the
+   * inner `*\/` and reports `SELECT` as the leading keyword. This path skips the
+   * confirmation gate entirely (an explain run is not a dangerous-query check), and
+   * `ANALYZE` executes what it explains, so the flat reading really did delete the
+   * rows: live-verified on PostgreSQL 18, `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)`
+   * over that statement against a 3-row table left 0 rows behind. Refusing to build
+   * is the only honest answer - the statement is a DELETE, and this strategy explains
+   * reads.
+   */
+  test.each<[string, string]>([
+    ["a DELETE", "/* a /* b */ SELECT 1 */ DELETE FROM users"],
+    ["an UPDATE", "/* a /* b */ SELECT 1 */ UPDATE users SET x = 1"],
+    ["a TRUNCATE", "/* a /* b */ SELECT 1 */ TRUNCATE users"],
+  ])("buildSql refuses %s that a nested comment made look like a SELECT", (_label, sql) => {
+    expect(postgresJsonStrategy.buildSql(sql, "analyze")).toBeNull();
+    expect(postgresJsonStrategy.buildSql(sql, "estimate")).toBeNull();
+  });
+
+  test("buildSql still explains a read behind a nested comment", () => {
+    const sql = "/* a /* b */ x */ SELECT 1";
+
+    expect(postgresJsonStrategy.buildSql(sql, "analyze")).toBe(`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${sql}`);
+  });
+
+  test("buildSql refuses a statement whose nested comment never closes", () => {
+    // Undeterminable text: the comment never returns to depth zero, so there is no
+    // leading keyword to classify and nothing to wrap.
+    expect(postgresJsonStrategy.buildSql("/* a /* b */ SELECT 1", "analyze")).toBeNull();
+  });
+
   // The over-reach, pinned at the STRATEGY boundary rather than only on the helper.
   // The screen is textual, so a keyword inside a string literal counts and this
   // harmless read-only CTE loses its Explain button. That is the direction this has to

--- a/tests/unit/lib/explain/select-prefix.test.ts
+++ b/tests/unit/lib/explain/select-prefix.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { classifySelectPrefix, hasDataModifyingStatement } from "@/lib/explain/select-prefix";
 
 describe("classifySelectPrefix", () => {
@@ -20,8 +21,11 @@ describe("classifySelectPrefix", () => {
   });
 
   // The `#` case above is a DELIBERATE widening, not inherited behaviour: it arrived
-  // when the query limiter needed the same comment tolerance (#275) and `#` went into
-  // the shared trivia pattern for MySQL's and MariaDB's sake. It answered `null` here
+  // when the query limiter needed the same comment tolerance (#275) and a leading `#`
+  // run became trivia in the shared reader for MySQL's and MariaDB's sake - which it
+  // still is on every dialect, because none can open a statement with one, and that
+  // is the one reading in `lib/sql/leading-keyword.ts` the dialect does not
+  // decide (#300). It answered `null` here
   // before, so all six strategies used to hide the Explain button for a `#`-annotated
   // statement and now build one.
   //
@@ -72,6 +76,27 @@ describe("classifySelectPrefix", () => {
     ["a comment that never closes before the keyword", "-- SELECT 1"],
   ])("returns null for %s", (_label, sql) => {
     expect(classifySelectPrefix(sql)).toBeNull();
+  });
+
+  /**
+   * The classifier takes a grammar too, because one caller's EXPLAIN executes what it
+   * explains (#300).
+   *
+   * `classifySelectPrefix` is dialect-blind by default and stays that way: the shared
+   * reading is the flat one, and for five of the six strategies a misread comment costs
+   * at most a refused Explain button. PostgreSQL's is the exception — `EXPLAIN
+   * (ANALYZE, …)` runs the statement and that path skips the confirmation gate — so
+   * that strategy passes PostgreSQL's grammar, under which a nested comment is read
+   * whole and the statement below is seen for the write it is.
+   */
+  test("reads leading trivia under the grammar it is given", () => {
+    const hiddenWrite = "/* a /* b */ SELECT 1 */ DELETE FROM users";
+
+    expect(classifySelectPrefix(hiddenWrite)).toBe("select");
+    expect(classifySelectPrefix(hiddenWrite, resolveSqlGrammar("postgres"))).toBeNull();
+
+    const read = "/* a /* b */ x */ SELECT 1";
+    expect(classifySelectPrefix(read, resolveSqlGrammar("postgres"))).toBe("select");
   });
 
   /**

--- a/tests/unit/lib/storage/providers/postgres.test.ts
+++ b/tests/unit/lib/storage/providers/postgres.test.ts
@@ -1,5 +1,7 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { EventEmitter } from "node:events";
 import type { ServerStorageProvider } from "@/lib/storage/types";
+import { logger } from "@/lib/logger";
 
 // ── Mock pg ──────────────────────────────────────────────────────────────────
 
@@ -13,13 +15,26 @@ const mockClient = {
   release: mockRelease,
 };
 
-const mockPool: Record<string, any> = {
-  query: mockQuery,
-  connect: mock(async () => mockClient),
-  end: mockEnd,
-};
+/**
+ * A real EventEmitter, fresh per construction, mirroring what `pg` hands back. An `error`
+ * event with no listener is an uncaught exception (#298), and this pool is long-lived —
+ * it serves every request while STORAGE_PROVIDER=postgres — so an inert `on` in the mock
+ * would hide exactly the crash this suite has to pin.
+ */
+function createMockPool(): EventEmitter & Record<string, any> {
+  const pool = new EventEmitter() as EventEmitter & Record<string, any>;
+  pool.query = mockQuery;
+  pool.connect = mock(async () => mockClient);
+  pool.end = mockEnd;
+  return pool;
+}
 
-const mockPoolConstructor = mock(() => mockPool);
+let mockPool = createMockPool();
+
+const mockPoolConstructor = mock(() => {
+  mockPool = createMockPool();
+  return mockPool;
+});
 
 mock.module("pg", () => ({
   Pool: mockPoolConstructor,
@@ -307,5 +322,35 @@ describe("PostgresStorageProvider", () => {
   test("ensurePool throws when not initialized", async () => {
     const freshProvider = new PostgresStorageProvider("postgresql://localhost/test");
     await expect(freshProvider.getAllData("test@test.com")).rejects.toThrow("not initialized");
+  });
+
+  // ── Pool error events (#298) ───────────────────────────────────────────────
+
+  test("an idle client error on the storage pool is logged and does not escalate", async () => {
+    await provider.initialize();
+    const idleFailure = new Error("Connection terminated unexpectedly");
+    const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
+    // Another test file replaces `@/lib/logger` wholesale, and spying on a method that is
+    // already a mock reuses that mock — call history from the rest of the process comes
+    // with it. Clear it so the count below is this test's own.
+    errorSpy.mockClear();
+
+    try {
+      // `pg` destroys the idle client and emits on the POOL; an `error` event with no
+      // listener is an uncaught exception, i.e. a dead server process.
+      expect(() => mockPool.emit("error", idleFailure)).not.toThrow();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const [message, loggedError, context] = errorSpy.mock.calls[0] as [string, unknown, unknown];
+      expect(message).toContain("pool");
+      expect(loggedError).toBe(idleFailure);
+      expect(context).toEqual({ provider: "postgres" });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("the storage pool carries exactly one error listener", async () => {
+    await provider.initialize();
+    expect(mockPool.listenerCount("error")).toBe(1);
   });
 });

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from "bun:test";
+import { DEFAULT_SQL_GRAMMAR, hashRunIsAmbiguous, resolveSqlGrammar } from "@/lib/sql/grammar";
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * The one place a database type becomes a set of grammar facts (#292).
+ *
+ * This test pins the TABLE, not the implementation: every row below was
+ * established from an authoritative source, and a row that was NOT established
+ * has to stay at the compatibility default rather than be guessed from a
+ * neighbouring dialect. Both halves are asserted, because "which dialects were
+ * left undecided" is part of the answer this milestone owes its readers.
+ */
+describe("resolveSqlGrammar", () => {
+  // ── `#`: established readings ────────────────────────────────────────────
+  //
+  // - MySQL/MariaDB: `#` opens a line comment. The repo already encodes this in
+  //   `leading-keyword.ts`'s trivia pattern and pins it in the MySQL provider
+  //   suite (`# note\nSELECT …` is bounded), which is what #275 closed.
+  // - ClickHouse: `#` and `#!` open a line comment (ClickHouse syntax reference).
+  // - PostgreSQL: the only comment forms are `--` and `/* */`; `#` is an operator
+  //   character (`#>`, `#-`, `##`, integer XOR).
+  // - Oracle: node-oracledb's own SQL tokenizer (`lib/thin/statement.js`) accepts
+  //   `#` as an identifier character and opens comments on `--` and `/*` only.
+  // - SQLite: the bundled SQLite amalgamation classifies `#` as `CC_VARALPHA`
+  //   (a bind-variable prefix, i.e. code) and opens comments on `--` and `/*`.
+
+  test.each<[DatabaseType, "comment" | "code"]>([
+    ["mysql", "comment"],
+    ["clickhouse", "comment"],
+    ["postgres", "code"],
+    ["oracle", "code"],
+    ["mssql", "code"],
+    ["sqlite", "code"],
+  ])("%s reads `#` as %s", (type, hash) => {
+    expect(resolveSqlGrammar(type).hash).toBe(hash);
+  });
+
+  // ── Dialects deliberately left undecided ────────────────────────────────
+  //
+  // No authoritative offline source was established for these, and guessing a
+  // dialect's rule from a neighbouring one is exactly what this milestone forbids.
+  // They keep today's reading, which costs them nothing they had.
+
+  test.each<DatabaseType>([
+    "couchbase",
+    "druid",
+    "libredb",
+    "mongodb",
+    "redis",
+  ])("%s is left at the compatibility default", (type) => {
+    expect(resolveSqlGrammar(type)).toBe(DEFAULT_SQL_GRAMMAR);
+  });
+
+  test("a call that names no dialect gets the compatibility default", () => {
+    expect(resolveSqlGrammar(undefined)).toBe(DEFAULT_SQL_GRAMMAR);
+  });
+
+  test("the compatibility default is today's reading, not one of the honest two", () => {
+    expect(DEFAULT_SQL_GRAMMAR.hash).toBe("comment-unless-operator");
+  });
+});
+
+describe("hashRunIsAmbiguous", () => {
+  test("is true only where the reading is the undecided one", () => {
+    expect(hashRunIsAmbiguous(DEFAULT_SQL_GRAMMAR)).toBe(true);
+    expect(hashRunIsAmbiguous(resolveSqlGrammar("mysql"))).toBe(false);
+    expect(hashRunIsAmbiguous(resolveSqlGrammar("mssql"))).toBe(false);
+  });
+});

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -56,6 +56,22 @@ describe("resolveSqlGrammar", () => {
     expect(resolveSqlGrammar(undefined)).toBe(DEFAULT_SQL_GRAMMAR);
   });
 
+  /**
+   * A string that is not a database type at all gets the default too, prototype
+   * keys included. The packaged confirmation dialog resolves its own grammar from an
+   * optional prop a HOST application fills in as a plain string (#297), so this
+   * lookup is reached with text nothing in this repo validated; a bare index would
+   * answer `Object.prototype.constructor` for one of these - not a grammar.
+   */
+  test.each([
+    "constructor",
+    "toString",
+    "hasOwnProperty",
+    "not-a-database",
+  ])("resolves %p to the compatibility default rather than a prototype value", (key) => {
+    expect(resolveSqlGrammar(key as DatabaseType)).toBe(DEFAULT_SQL_GRAMMAR);
+  });
+
   test("the compatibility default is today's reading, not one of the honest two", () => {
     expect(DEFAULT_SQL_GRAMMAR.hash).toBe("comment-unless-operator");
   });

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -4,6 +4,7 @@ import {
   type BracketGrammar,
   DEFAULT_SQL_GRAMMAR,
   hashRunIsAmbiguous,
+  readsSqlText,
   resolveSqlGrammar,
 } from "@/lib/sql/grammar";
 import type { DatabaseType } from "@/lib/types";
@@ -126,24 +127,28 @@ describe("resolveSqlGrammar", () => {
   //   no doubling escape; identifiers there are quoted with backticks or double
   //   quotes (`identifier.ts` falls back to the standard form for it). So the two
   //   readings are mutually exclusive rather than two spellings of one rule.
-
+  // - PostgreSQL: `expression[subscript]` and `expression[lower:upper]` are how it
+  //   reads an element and a slice (manual 4.2.3 Subscripts), and array
+  //   constructors nest - the manual's own example is `SELECT ARRAY[[1,2],[3,4]]`
+  //   (4.2.12 Array Constructors). Identifiers there are quoted with double quotes
+  //   (4.1.1), so `[` is never a name quote and the subscript reading is the only
+  //   one the dialect has.
   test.each<[DatabaseType, BracketGrammar]>([
     ["mssql", "quoted-identifier"],
     ["sqlite", "quoted-identifier"],
     ["clickhouse", "subscript"],
+    ["postgres", "subscript"],
   ])("%s reads `[…]` as %s", (type, bracket) => {
     expect(resolveSqlGrammar(type).bracket).toBe(bracket);
   });
 
   // A dialect established for ONE character can be undecided about another, so
   // the default is per fact rather than per dialect. `[` is not an identifier
-  // quote in MySQL, PostgreSQL or Oracle and no authoritative reading of it was
-  // established for them, so they keep the one they had.
-  test.each<DatabaseType>([
-    "mysql",
-    "postgres",
-    "oracle",
-  ])("%s is left at the compatibility default for `[…]`", (type) => {
+  // quote in MySQL or Oracle either, but neither has a SUBSCRIPT rule to read it
+  // under - MySQL gives the characters no meaning outside a JSON path written in a
+  // string, Oracle none outside an alternate-quote delimiter - so no authoritative
+  // reading was established for them and they keep the one they had.
+  test.each<DatabaseType>(["mysql", "oracle"])("%s is left at the compatibility default for `[…]`", (type) => {
     expect(resolveSqlGrammar(type).bracket).toBe(DEFAULT_SQL_GRAMMAR.bracket);
   });
 
@@ -200,5 +205,49 @@ describe("hashRunIsAmbiguous", () => {
     expect(hashRunIsAmbiguous(DEFAULT_SQL_GRAMMAR)).toBe(true);
     expect(hashRunIsAmbiguous(resolveSqlGrammar("mysql"))).toBe(false);
     expect(hashRunIsAmbiguous(resolveSqlGrammar("mssql"))).toBe(false);
+  });
+});
+
+/**
+ * Whether the query text is SQL at all - the question that comes BEFORE which SQL
+ * grammar to read it under.
+ *
+ * `resolveSqlGrammar` answers the second question and has an answer for every
+ * input, so a MongoDB document or a Redis command gets the compatibility grammar
+ * and is then read as SQL. That is what the readers under `src/lib/sql/` do to
+ * text no dialect here describes, and for the confirmation gate it produced a
+ * prompt on ordinary reads: the escaped quote in a Mongo filter or a Redis value
+ * is an unresolvable literal to a SQL span reader and a perfectly closed one in
+ * the grammar the text is actually written in.
+ *
+ * Same shape as the grammar table and for the same reason: ONE place maps a
+ * database type to the answer, so no reader grows a type test of its own.
+ */
+describe("readsSqlText", () => {
+  test.each<DatabaseType>([
+    "postgres",
+    "mysql",
+    "sqlite",
+    "oracle",
+    "mssql",
+    "clickhouse",
+    "druid",
+    "couchbase",
+    "libredb",
+  ])("%s writes its queries in SQL", (type) => {
+    expect(readsSqlText(type)).toBe(true);
+  });
+
+  test.each<DatabaseType>(["mongodb", "redis"])("%s does not", (type) => {
+    expect(readsSqlText(type)).toBe(false);
+  });
+
+  test("a call that names no dialect is read as SQL", () => {
+    // The compatibility default once more. A caller that named nothing was reading
+    // SQL before this question existed, and the published dialog takes the type as
+    // a plain string from a host application - an unrecognised one must not turn
+    // the SQL checks off.
+    expect(readsSqlText()).toBe(true);
+    expect(readsSqlText("not-a-database" as DatabaseType)).toBe(true);
   });
 });

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -59,6 +59,35 @@ describe("resolveSqlGrammar", () => {
   test("the compatibility default is today's reading, not one of the honest two", () => {
     expect(DEFAULT_SQL_GRAMMAR.hash).toBe("comment-unless-operator");
   });
+
+  // ── `q'…'`: Oracle's alternate quoting ──────────────────────────────────
+  //
+  // Unlike `#`, this fact is not two engines disagreeing about a character: only
+  // Oracle has the form at all, so every other dialect's reading of that text is
+  // "a name followed by an ordinary string". Established from node-oracledb's own
+  // SQL tokenizer (`lib/thin/statement.js`, `_parseQstring`), which parses a `'`
+  // preceded by `q`/`Q` as a q-string, and from Oracle's SQL Language Reference
+  // for the delimiter pairing and the `nq'…'` spelling.
+
+  test("oracle is the only dialect that reads `q'…'` as a literal", () => {
+    expect(resolveSqlGrammar("oracle").alternateQuoting).toBe(true);
+  });
+
+  test.each<DatabaseType>([
+    "mysql",
+    "clickhouse",
+    "postgres",
+    "mssql",
+    "sqlite",
+  ])("%s does not read `q'…'` as a literal", (type) => {
+    expect(resolveSqlGrammar(type).alternateQuoting).toBe(false);
+  });
+
+  test("a call that names no dialect does not read the form either", () => {
+    // The compatibility default: before the channel existed no reader here had a
+    // branch for the form, so keeping it out is what keeps those answers still.
+    expect(DEFAULT_SQL_GRAMMAR.alternateQuoting).toBe(false);
+  });
 });
 
 describe("hashRunIsAmbiguous", () => {

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -223,23 +223,60 @@ describe("hashRunIsAmbiguous", () => {
  * Same shape as the grammar table and for the same reason: ONE place maps a
  * database type to the answer, so no reader grows a type test of its own.
  */
-describe("readsSqlText", () => {
-  test.each<DatabaseType>([
-    "postgres",
-    "mysql",
-    "sqlite",
-    "oracle",
-    "mssql",
-    "clickhouse",
-    "druid",
-    "couchbase",
-    "libredb",
-  ])("%s writes its queries in SQL", (type) => {
-    expect(readsSqlText(type)).toBe(true);
-  });
+/**
+ * The two maps below are the real checklist for a new provider, in the shape this
+ * repo already uses for the other type-keyed tables (`PICKER_COVERAGE`,
+ * `MODIFIED_COLUMN_COVERAGE`): a `Record<DatabaseType, …>` the compiler refuses to
+ * accept until the new id is listed.
+ *
+ * Neither table in `grammar.ts` can enforce this on its own - `SQL_GRAMMARS` is a
+ * `Partial<Record<…>>` because "absent" is a meaningful answer, and the non-SQL set
+ * is a set. So a provider added without touching that file silently inherits the
+ * compatibility grammar and is silently declared to write SQL, and nothing fails.
+ * Deciding is mandatory; deciding "leave it at the default" is a fine decision.
+ */
+const GRAMMAR_COVERAGE: Record<DatabaseType, "established" | "default"> = {
+  postgres: "established",
+  mysql: "established",
+  sqlite: "established",
+  oracle: "established",
+  mssql: "established",
+  clickhouse: "established",
+  // No authoritative source was established for these, so they read as SQL under
+  // the compatibility grammar. See the module doc in `grammar.ts`.
+  couchbase: "default",
+  druid: "default",
+  libredb: "default",
+  // Not SQL at all - see SQL_TEXT_COVERAGE below.
+  mongodb: "default",
+  redis: "default",
+};
 
-  test.each<DatabaseType>(["mongodb", "redis"])("%s does not", (type) => {
-    expect(readsSqlText(type)).toBe(false);
+describe("every database type has a recorded grammar decision", () => {
+  test.each(Object.entries(GRAMMAR_COVERAGE))("%s is %s", (type, expected) => {
+    const isDefault = resolveSqlGrammar(type as DatabaseType) === DEFAULT_SQL_GRAMMAR;
+
+    expect(isDefault ? "default" : "established").toBe(expected);
+  });
+});
+
+const SQL_TEXT_COVERAGE: Record<DatabaseType, boolean> = {
+  postgres: true,
+  mysql: true,
+  sqlite: true,
+  oracle: true,
+  mssql: true,
+  clickhouse: true,
+  couchbase: true,
+  druid: true,
+  libredb: true,
+  mongodb: false,
+  redis: false,
+};
+
+describe("readsSqlText", () => {
+  test.each(Object.entries(SQL_TEXT_COVERAGE))("%s writes SQL: %s", (type, expected) => {
+    expect(readsSqlText(type as DatabaseType)).toBe(expected);
   });
 
   test("a call that names no dialect is read as SQL", () => {

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from "bun:test";
-import { type BracketGrammar, DEFAULT_SQL_GRAMMAR, hashRunIsAmbiguous, resolveSqlGrammar } from "@/lib/sql/grammar";
+import {
+  type BlockCommentGrammar,
+  type BracketGrammar,
+  DEFAULT_SQL_GRAMMAR,
+  hashRunIsAmbiguous,
+  resolveSqlGrammar,
+} from "@/lib/sql/grammar";
 import type { DatabaseType } from "@/lib/types";
 
 /**
@@ -14,9 +20,11 @@ import type { DatabaseType } from "@/lib/types";
 describe("resolveSqlGrammar", () => {
   // ── `#`: established readings ────────────────────────────────────────────
   //
-  // - MySQL/MariaDB: `#` opens a line comment. The repo already encodes this in
-  //   `leading-keyword.ts`'s trivia pattern and pins it in the MySQL provider
-  //   suite (`# note\nSELECT …` is bounded), which is what #275 closed.
+  // - MySQL/MariaDB: `#` opens a line comment. The repo already skipped such a run
+  //   in a statement's LEADING trivia before this record existed - and still does,
+  //   on every dialect, because none of them can open a statement with one - and it
+  //   pins that in the MySQL provider suite (`# note\nSELECT …` is bounded), which
+  //   is what #275 closed.
   // - ClickHouse: `#` and `#!` open a line comment (ClickHouse syntax reference).
   // - PostgreSQL: the only comment forms are `--` and `/* */`; `#` is an operator
   //   character (`#>`, `#-`, `##`, integer XOR).
@@ -144,6 +152,46 @@ describe("resolveSqlGrammar", () => {
     // #291/#299 fixtures assert, and the corrupted-statement shape those closed
     // (`SELECT [a LIMIT 500--b] FROM t`) is what a code reading brings back.
     expect(DEFAULT_SQL_GRAMMAR.bracket).toBe("quoted-identifier");
+  });
+
+  // ── `/* … /* … */ … */`: where a block comment ENDS (#300) ────────────────
+  //
+  // The one grammar fact that moves the end of a construct the reader is
+  // otherwise happy with: a second opener written inside a comment is either part
+  // of the comment (so the run continues past the next `*/`) or it is nothing at
+  // all (so the run ends there and everything after it is the statement's code).
+  //
+  // - PostgreSQL: block comments nest, "as specified in the SQL standard but
+  //   unlike C" (PostgreSQL manual, 4.1.5 Comments).
+  // - SQL Server: nested comments are supported - a `/*` anywhere inside a comment
+  //   opens a nested one and needs its own `*/` (T-SQL "Slash Star (Block
+  //   Comment)").
+  // - ClickHouse: C-style comments can be nested (ClickHouse SQL syntax
+  //   reference, which gives a nested example).
+  // - MySQL/MariaDB: nested comments are NOT supported and are deprecated (MySQL
+  //   reference manual, 11.7 Comments), so the first `*/` ends the run.
+  // - SQLite: the bundled amalgamation's tokenizer (`case CC_SLASH`) scans for the
+  //   first `*/` with no depth count at all.
+  // - Oracle: node-oracledb's own tokenizer (`_parseMultiLineComment`) stops at the
+  //   first `*/`, and Oracle's PL/SQL reference states one multiline comment
+  //   cannot contain another.
+
+  test.each<[DatabaseType, BlockCommentGrammar]>([
+    ["postgres", "nesting"],
+    ["mssql", "nesting"],
+    ["clickhouse", "nesting"],
+    ["mysql", "flat"],
+    ["sqlite", "flat"],
+    ["oracle", "flat"],
+  ])("%s closes a block comment the %s way", (type, blockComment) => {
+    expect(resolveSqlGrammar(type).blockComment).toBe(blockComment);
+  });
+
+  test("the compatibility default does not nest block comments", () => {
+    // Today's reading again: every fixture written for #275, #280, #287, #291 and
+    // #294 calls these readers without a dialect, and `indexOf("*/")` is what they
+    // were written against.
+    expect(DEFAULT_SQL_GRAMMAR.blockComment).toBe("flat");
   });
 });
 

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { DEFAULT_SQL_GRAMMAR, hashRunIsAmbiguous, resolveSqlGrammar } from "@/lib/sql/grammar";
+import { type BracketGrammar, DEFAULT_SQL_GRAMMAR, hashRunIsAmbiguous, resolveSqlGrammar } from "@/lib/sql/grammar";
 import type { DatabaseType } from "@/lib/types";
 
 /**
@@ -87,6 +87,47 @@ describe("resolveSqlGrammar", () => {
     // The compatibility default: before the channel existed no reader here had a
     // branch for the form, so keeping it out is what keeps those answers still.
     expect(DEFAULT_SQL_GRAMMAR.alternateQuoting).toBe(false);
+  });
+
+  // ── `[…]`: two readings that cannot both apply (#295) ────────────────────
+  //
+  // - SQL Server: `[name]` is a delimited identifier and a `]` inside it is
+  //   written doubled. This repo's own quoter emits exactly that
+  //   (`src/lib/sql/identifier.ts`), and the MSSQL provider's
+  //   `escapeIdentifier` is pinned on it.
+  // - SQLite: the SQLite amalgamation bundled with `better-sqlite3` classifies
+  //   `[` as `CC_QUOTE2` - "`[...]` style quoted ids", the Microsoft-style form -
+  //   so it is a name there too.
+  // - ClickHouse: `[…]` is an array literal or a subscript, it NESTS, and it has
+  //   no doubling escape; identifiers there are quoted with backticks or double
+  //   quotes (`identifier.ts` falls back to the standard form for it). So the two
+  //   readings are mutually exclusive rather than two spellings of one rule.
+
+  test.each<[DatabaseType, BracketGrammar]>([
+    ["mssql", "quoted-identifier"],
+    ["sqlite", "quoted-identifier"],
+    ["clickhouse", "subscript"],
+  ])("%s reads `[…]` as %s", (type, bracket) => {
+    expect(resolveSqlGrammar(type).bracket).toBe(bracket);
+  });
+
+  // A dialect established for ONE character can be undecided about another, so
+  // the default is per fact rather than per dialect. `[` is not an identifier
+  // quote in MySQL, PostgreSQL or Oracle and no authoritative reading of it was
+  // established for them, so they keep the one they had.
+  test.each<DatabaseType>([
+    "mysql",
+    "postgres",
+    "oracle",
+  ])("%s is left at the compatibility default for `[…]`", (type) => {
+    expect(resolveSqlGrammar(type).bracket).toBe(DEFAULT_SQL_GRAMMAR.bracket);
+  });
+
+  test("the compatibility default reads `[…]` as a quoted name", () => {
+    // Today's reading, kept for the same reason as the `#` row: it is what the
+    // #291/#299 fixtures assert, and the corrupted-statement shape those closed
+    // (`SELECT [a LIMIT 500--b] FROM t`) is what a code reading brings back.
+    expect(DEFAULT_SQL_GRAMMAR.bracket).toBe("quoted-identifier");
   });
 });
 

--- a/tests/unit/sql/leading-keyword.test.ts
+++ b/tests/unit/sql/leading-keyword.test.ts
@@ -1,10 +1,11 @@
 import { describe, test, expect } from "bun:test";
+import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function keywordOf(sql: string): string | null {
-  return readLeadingKeyword(sql)?.keyword ?? null;
+function keywordOf(sql: string, grammar?: SqlGrammar): string | null {
+  return readLeadingKeyword(sql, grammar)?.keyword ?? null;
 }
 
 // ─── readLeadingKeyword ─────────────────────────────────────────────────────
@@ -27,6 +28,21 @@ describe("readLeadingKeyword", () => {
       ["a MySQL hash line comment", "# note\nSELECT 1"],
       ["an empty hash comment", "#\nSELECT 1"],
       ["stacked comments of all three styles", "# a\n-- b\n/* c */\nSELECT 1"],
+      // Whitespace here is JS `\s`, which is WIDER than the ASCII set `spans.ts`
+      // reads as a whitespace span. It is the alphabet the pattern this scan replaced
+      // used, so keeping it is what makes the conversion answer-for-answer identical -
+      // and on one engine the narrower reading would cost more than a difference: a
+      // `latin1` MySQL connection reads byte 0xA0 as a space and runs the statement
+      // behind it (verified on MySQL 26.7 through mysql2: a row comes back under
+      // `charset=latin1`, and the statement is rejected under the `utf8mb4` the
+      // provider negotiates by default, as U+2028, U+3000 and a BOM are under every
+      // charset tried; PostgreSQL 18 rejects all four). The gate's half of that is
+      // pinned in tests/components/QuerySafetyDialog.test.tsx.
+      ["a no-break space", " SELECT 1"],
+      ["a byte-order mark", "﻿SELECT 1"],
+      ["an ideographic space", "　SELECT 1"],
+      ["a line separator", " SELECT 1"],
+      ["unicode whitespace between comments", "-- a\n /* b */ SELECT 1"],
     ])("finds the keyword behind %s", (_label, sql) => {
       expect(keywordOf(sql)).toBe("SELECT");
     });
@@ -39,6 +55,87 @@ describe("readLeadingKeyword", () => {
     // there only changes which error the server reports, never a result.
     test("treats a hash comment as trivia on every dialect, because a statement cannot open with one", () => {
       expect(keywordOf("# note\nUPDATE t SET a = 1")).toBe("UPDATE");
+    });
+  });
+
+  // ── Where the leading comment ENDS is the dialect's answer (#300) ────────
+  //
+  // The trivia scan is `readSqlSpan`'s now, so this reader and the ones that walk
+  // the rest of the statement read a comment the same way - which they did not
+  // before, and the difference was invisible until a dialect that NESTS block
+  // comments met a statement carrying one.
+
+  describe("reads leading trivia under the grammar it is given", () => {
+    const POSTGRES = resolveSqlGrammar("postgres");
+    const MSSQL = resolveSqlGrammar("mssql");
+    const MYSQL = resolveSqlGrammar("mysql");
+
+    // The word after the inner `*/` is what a flat reading reports, and it is not a
+    // keyword the statement has - it is a word the operator commented out.
+    const NESTED = "/* note /* inner */ still a note */ DROP TABLE users";
+
+    test.each<[string, SqlGrammar]>([
+      ["postgres", POSTGRES],
+      ["mssql", MSSQL],
+    ])("a nesting grammar (%s) reads past the whole comment to the real keyword", (_label, grammar) => {
+      expect(keywordOf(NESTED, grammar)).toBe("DROP");
+    });
+
+    test.each<[string, SqlGrammar | undefined]>([
+      ["mysql", MYSQL],
+      ["no dialect at all", undefined],
+    ])("a flat grammar (%s) keeps reporting the word inside the comment tail", (_label, grammar) => {
+      // Not a regression and not a guess: MySQL closes the comment at the first
+      // `*/`, so `still a note */ DROP …` really is what follows it there - text
+      // MySQL rejects outright. The answer is pinned so the flat reading stays a
+      // decision rather than whatever the scan happens to do.
+      expect(keywordOf(NESTED, grammar)).toBe("STILL");
+    });
+
+    test("a nested comment that never closes answers null under a nesting grammar", () => {
+      expect(readLeadingKeyword("/* note /* inner */ DROP TABLE users", POSTGRES)).toBeNull();
+    });
+
+    /**
+     * `#` in LEADING trivia stays dialect-blind, on purpose.
+     *
+     * It is a comment marker in MySQL and ClickHouse and ordinary code in the rest,
+     * but no dialect here can OPEN a statement with one - `#tmp`, `#>` and `ID#` are
+     * all mid-statement forms - so skipping the run costs nothing anywhere and
+     * keeps every dialect's annotated statement bounded, which is what #275 fixed.
+     * Reading it as code instead would have taken the bound back off a
+     * `# note`-led SELECT on SQL Server and PostgreSQL.
+     */
+    test.each<[string, SqlGrammar | undefined]>([
+      ["postgres", POSTGRES],
+      ["mssql", MSSQL],
+      ["mysql", MYSQL],
+      ["no dialect at all", undefined],
+    ])("skips a leading hash comment under %s", (_label, grammar) => {
+      expect(keywordOf("# note\nSELECT 1", grammar)).toBe("SELECT");
+      expect(keywordOf("#- note\nSELECT 1", grammar)).toBe("SELECT");
+    });
+
+    // A literal is the statement's own text, not trivia, so the scan stops at one
+    // rather than stepping over it looking for a word. The edge matters because
+    // `readSqlSpan` answers for literals too, and treating every span as trivia
+    // would report `UPDATE` for `'x' UPDATE t SET …`.
+    test.each<[string, string]>([
+      ["a string", "'x' SELECT 1"],
+      ["a backtick-quoted name", "`x` SELECT 1"],
+      ["a dollar-quoted body", "$fn$ x $fn$ SELECT 1"],
+      ["a bracket-quoted name", "[x] SELECT 1"],
+    ])("answers null when %s precedes the first word", (_label, sql) => {
+      expect(readLeadingKeyword(sql)).toBeNull();
+    });
+
+    // The same rule under Oracle's grammar, where one more form is a literal: the
+    // alternate-quote tag opens with a letter, so a reader without the form answers
+    // `Q` for this input and Oracle's answers null - the literal is the statement's
+    // own text, and a statement cannot open with one.
+    test("answers null for an Oracle alternate-quoted literal, under Oracle's grammar only", () => {
+      expect(keywordOf("q'{x}' FROM dual")).toBe("Q");
+      expect(keywordOf("q'{x}' FROM dual", resolveSqlGrammar("oracle"))).toBeNull();
     });
   });
 
@@ -163,28 +260,34 @@ describe("readLeadingKeyword", () => {
     });
   });
 
-  // ── Shape of the pattern ────────────────────────────────────────────────
+  // ── Shape of the scan ───────────────────────────────────────────────────
 
   /**
-   * Regression guard on the SHAPE of the trivia pattern, not on what it accepts.
+   * Regression guard on the SHAPE of the trivia scan, not on what it accepts.
    *
-   * The pattern travelled here from `lib/explain/select-prefix.ts`, where all three
-   * ambiguities below were measured on real predecessors and one was found by CodeQL
-   * rather than by a guard like this one. Each is a different way of matching the
-   * same text twice inside a `*` quantifier, which is what lets a NON-matching input
-   * backtrack:
+   * The scan is `readSqlSpan`'s now (#300) - one span or one character at a time, so
+   * it cannot backtrack at all - and this guard is what keeps it that way: a reader
+   * that goes back to a pattern over the same trivia grammar would reintroduce one of
+   * the three ambiguities below and this test would fail on time rather than on an
+   * answer.
+   *
+   * The pattern this replaced travelled here from `lib/explain/select-prefix.ts`,
+   * where all three ambiguities were measured on real predecessors and one was found
+   * by CodeQL rather than by a guard like this one. Each is a different way of
+   * matching the same text twice inside a `*` quantifier, which is what lets a
+   * NON-matching input backtrack:
    *
    *   a leading `\s*` beside a `\s` alternative      quadratic    958ms / 20k spaces
    *   a lazy `[\s\S]*?\*\/` spanning two comments    quadratic    852ms / 4 KB
    *   `--[^\n]*` with no `(?:\n|$)` tail             EXPONENTIAL  634ms / 49 chars
    *
-   * The hash alternative carries the same anchor requirement as the dash one, and a
+   * The hash alternative carried the same anchor requirement as the dash one, and a
    * run of single `#` characters partitions even more freely than a run of `--`
    * pairs, so it is guarded on the same shapes.
    *
    * EVERY input here ends in a character that cannot open a word, which is what makes
-   * this a TIMING guard rather than a correctness one: the match has to fail, so a
-   * broken pattern is forced to try every partition of the trivia. That tail is
+   * this a TIMING guard rather than a correctness one: the read has to fail, so a
+   * pattern-shaped reader is forced to try every partition of the trivia. That tail is
    * load-bearing and easy to get wrong. Measured against the anchorless
    * `--[^\n]*` mutation while writing this guard:
    *
@@ -193,18 +296,19 @@ describe("readLeadingKeyword", () => {
    *
    * With a letter tail the mutation finds a keyword immediately and never searches,
    * so only the null assertion below would catch it. A guard that cannot fail on
-   * time is not a guard on the shape.
+   * time is not a guard on the shape. (The scanner answers every input here in
+   * well under a millisecond, so the numbers below are the failure mode's, not its.)
    *
    * Both engine numbers are recorded because they differ by two orders of magnitude
    * and the SMALLER one is what this suite sees: JSC caps backtracking (it plateaus
    * near 0.7s from ~20 dash pairs upward), while V8 grows cleanly exponentially past
    * a minute. Anyone re-measuring under `bun test` and finding "only" 0.7s has not
-   * found an exaggeration - it still clears the bound below by 3x, and the correct
-   * pattern answers that same input in 0.001ms, five orders of magnitude away.
+   * found an exaggeration - it still clears the bound below by 3x, and the scanner
+   * answers that same input in 0.001ms, five orders of magnitude away.
    *
-   * The bound is loose on purpose (three orders of magnitude above what the correct
-   * pattern needs) so it cannot flake on a slow runner while still failing outright
-   * if any of the three ambiguities returns.
+   * The bound is loose on purpose (three orders of magnitude above what the scan
+   * needs) so it cannot flake on a slow runner while still failing outright if any of
+   * the three ambiguities returns.
    */
   test("does not backtrack on long comment or whitespace runs that never reach a keyword", () => {
     const BOUND_MS = 200;
@@ -229,6 +333,34 @@ describe("readLeadingKeyword", () => {
 
       // A correct answer AND a bounded one: a fast wrong answer is not a pass.
       expect(result).toBeNull();
+      expect(elapsed, `${label} took ${elapsed.toFixed(1)}ms`).toBeLessThan(BOUND_MS);
+    }
+  });
+
+  /**
+   * The same guard under a grammar that NESTS block comments (#300).
+   *
+   * Counting depth is what could have reintroduced the cost the pattern above was
+   * shaped to avoid, so it is asserted rather than assumed: the scan is a single
+   * forward pass that consumes each comment once, and an adversarial nest - a run
+   * of openers that never closes, and a deeply balanced one - stays linear.
+   */
+  test("stays bounded under a nesting grammar, on nests that never close and nests that do", () => {
+    const BOUND_MS = 200;
+    const POSTGRES = resolveSqlGrammar("postgres");
+    const adversarial: [string, string, string | null][] = [
+      ["20k unclosed openers", `${"/*".repeat(20000)}(`, null],
+      ["20k balanced levels", `${"/*".repeat(20000)}${"*/".repeat(20000)}(`, null],
+      ["4 KB of empty block comments", `${"/**/".repeat(1000)}(1)`, null],
+      ["1k nested pairs, reaching a keyword", `${"/*a/*b*/c*/".repeat(1000)}SELECT 1`, "SELECT"],
+    ];
+
+    for (const [label, sql, expected] of adversarial) {
+      const started = performance.now();
+      const result = readLeadingKeyword(sql, POSTGRES);
+      const elapsed = performance.now() - started;
+
+      expect(result?.keyword ?? null).toBe(expected);
       expect(elapsed, `${label} took ${elapsed.toFixed(1)}ms`).toBeLessThan(BOUND_MS);
     }
   });

--- a/tests/unit/sql/operative-keyword.test.ts
+++ b/tests/unit/sql/operative-keyword.test.ts
@@ -297,11 +297,35 @@ describe("readOperativeKeyword", () => {
   // someone closed a gap, which is welcome - update the expectation and say so.
 
   describe("known gaps that answer SELECT for a statement that writes", () => {
-    // Oracle's alternative quoting is not a literal to `readSqlSpan`, so the `)`
-    // inside this one closes the CTE body early. Unreachable in Oracle itself,
-    // which has no `WITH … DELETE`, and no other dialect here has the form.
-    test("walks an Oracle q-quoted literal as code", () => {
+    // Oracle's alternate quoting is not a literal under a grammar that does not
+    // have the form - which is every dialect but Oracle, and the compatibility
+    // default - so the `)` inside this one closes the CTE body early and the
+    // `SELECT` written inside the literal answers for the whole statement.
+    test("walks an Oracle q-quoted literal as code where the grammar has no such form", () => {
       expect(operativeOf("WITH t AS (SELECT q'{it's ) SELECT x}' FROM dual) DELETE FROM users")).toBe("SELECT");
+    });
+
+    // …and that closes under Oracle's own grammar (#292). This is the direction
+    // that matters: read as code, the statement types `SELECT` and the limiter
+    // appends a bound to a `DELETE`; read as the literal it is, the keyword after
+    // the CTE list is the one the statement operates.
+    test("an alternate-quoting grammar reads the q-quoted body as the literal it is", () => {
+      const oracle = resolveSqlGrammar("oracle");
+
+      expect(operativeOf("WITH t AS (SELECT q'{it's ) SELECT x}' FROM dual) DELETE FROM users", oracle)).toBe("DELETE");
+      expect(operativeOf("WITH t AS (SELECT q'{it's}' AS s FROM dual) SELECT * FROM t", oracle)).toBe("SELECT");
+    });
+
+    // The national-charset spelling reads the same way, asserted on the direction
+    // that costs a partial write rather than a bound: a `SELECT` written inside the
+    // literal must not answer for a statement that DELETEs.
+    test("the national-charset spelling is read as a literal too", () => {
+      const oracle = resolveSqlGrammar("oracle");
+
+      expect(operativeOf("WITH t AS (SELECT nq'{it's ) SELECT x}' FROM dual) DELETE FROM users", oracle)).toBe(
+        "DELETE",
+      );
+      expect(operativeOf("WITH t AS (SELECT NQ'{it's}' AS s FROM dual) SELECT * FROM t", oracle)).toBe("SELECT");
     });
 
     // `#-` is a PostgreSQL jsonb operator and a MySQL comment opener at once.

--- a/tests/unit/sql/operative-keyword.test.ts
+++ b/tests/unit/sql/operative-keyword.test.ts
@@ -447,6 +447,44 @@ describe("readOperativeKeyword", () => {
     });
   });
 
+  // ── The block-comment grammar (#300) ────────────────────────────────────
+  //
+  // A comment that NESTS ends later than a flat reading thinks, and everything in
+  // between is handed to this walker as code. A `)` written in that region closes
+  // the CTE body early, so the statement is typed by a keyword the operator
+  // commented out - and on PostgreSQL, where a `WITH … INSERT` really writes, the
+  // bound that follows commits part of it.
+
+  describe("a nested comment inside a CTE list", () => {
+    const POSTGRES = resolveSqlGrammar("postgres");
+    const MYSQL = resolveSqlGrammar("mysql");
+
+    const HIDDEN_WRITE = (write: string) =>
+      `WITH recent AS (\n  /* outer /* inner */ ) SELECT 1 */\n  SELECT id FROM logs\n)\n${write}`;
+
+    test.each<[string, string]>([
+      ["an INSERT", "INSERT INTO archive (id) SELECT id FROM recent"],
+      ["an UPDATE", "UPDATE archive SET seen = true WHERE id IN (SELECT id FROM recent)"],
+      ["a DELETE", "DELETE FROM archive WHERE id IN (SELECT id FROM recent)"],
+    ])("reports %s under a nesting grammar, where the whole comment is a comment", (_label, write) => {
+      expect(operativeOf(HIDDEN_WRITE(write), POSTGRES)).toBe(write.split(" ")[0]);
+    });
+
+    test("reports the keyword written inside the comment under a flat grammar", () => {
+      // MySQL closes the comment at the first `*/`, so the `)` after it really does
+      // end the CTE body there and `SELECT` really is the next word. The text is a
+      // syntax error on MySQL either way; what matters is that the answer is the
+      // dialect's own reading rather than a shared guess.
+      expect(operativeOf(HIDDEN_WRITE("INSERT INTO archive (id) SELECT id FROM recent"), MYSQL)).toBe("SELECT");
+    });
+
+    test("reports null under a nesting grammar when the nested comment never closes", () => {
+      const unclosed = "WITH recent AS (\n  /* outer /* inner */\n  SELECT id FROM logs\n) DELETE FROM users";
+
+      expect(operativeOf(unclosed, POSTGRES)).toBeNull();
+    });
+  });
+
   // ── Bounded time ────────────────────────────────────────────────────────
   //
   // The CTE-list scan is a character scanner rather than a regex over

--- a/tests/unit/sql/operative-keyword.test.ts
+++ b/tests/unit/sql/operative-keyword.test.ts
@@ -1,10 +1,11 @@
 import { describe, test, expect } from "bun:test";
+import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function operativeOf(sql: string): string | null {
-  return readOperativeKeyword(sql)?.keyword ?? null;
+function operativeOf(sql: string, grammar?: SqlGrammar): string | null {
+  return readOperativeKeyword(sql, grammar)?.keyword ?? null;
 }
 
 // ─── readOperativeKeyword ───────────────────────────────────────────────────
@@ -322,6 +323,25 @@ describe("readOperativeKeyword", () => {
       const sql = "WITH t AS (\n  # drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
 
       expect(operativeOf(sql)).toBe("DELETE");
+    });
+
+    // …and the gap CLOSES for a caller that names its dialect (#292). This is the
+    // one shape in this family that costs a partially committed write - MySQL 8
+    // accepts both `WITH … DELETE` and a `LIMIT` on a `DELETE` - so it is asserted
+    // in both directions: the write is typed as a write under MySQL's grammar, and
+    // the jsonb operator that the hybrid reading exists to protect still reads as
+    // code under PostgreSQL's.
+    test("a comment grammar reads the same statement as the DELETE it operates", () => {
+      const sql = "WITH t AS (\n  #- drop the ) SELECT here\n  SELECT id FROM logs\n) DELETE FROM users";
+
+      expect(operativeOf(sql, resolveSqlGrammar("mysql"))).toBe("DELETE");
+    });
+
+    test("a code grammar keeps a jsonb-operator CTE readable", () => {
+      const postgres = resolveSqlGrammar("postgres");
+
+      expect(operativeOf("WITH t AS (SELECT meta #> '{a}' AS v FROM docs) SELECT * FROM t", postgres)).toBe("SELECT");
+      expect(operativeOf("WITH t AS (SELECT meta #- '{a}' AS v FROM docs) DELETE FROM users", postgres)).toBe("DELETE");
     });
 
     // Reading an expression means knowing where it ends only by its `AS`, so any

--- a/tests/unit/sql/operative-keyword.test.ts
+++ b/tests/unit/sql/operative-keyword.test.ts
@@ -387,6 +387,66 @@ describe("readOperativeKeyword", () => {
     });
   });
 
+  // ── The bracket grammar (#295) ──────────────────────────────────────────
+  //
+  // `[…]` is a quoted NAME in SQL Server and SQLite and a nestable array or
+  // subscript in ClickHouse, and the two readings are mutually exclusive: the
+  // name reading ends the run at the first unpaired `]` (so one written inside a
+  // string ends it early) while the subscript reading steps over literals and
+  // counts depth (so a doubled `]` closes it rather than escaping). Each element
+  // the walker cannot cross costs the statement its bound, which on ClickHouse -
+  // the engine whose whole point is scanning more rows than a browser can hold -
+  // is the entire cost.
+
+  describe("a bracketed run under the dialect that owns it", () => {
+    const CLICKHOUSE = resolveSqlGrammar("clickhouse");
+    const MSSQL = resolveSqlGrammar("mssql");
+
+    test.each<[string, string]>([
+      ["a map subscript whose key text carries a close bracket", "WITH m['a]b'] AS v SELECT v"],
+      ["a nested array element", "WITH [[1,2],[3,4]] AS a SELECT arrayJoin(a)"],
+      ["an array holding a close bracket in a literal", "WITH ['a]', 'b'] AS a SELECT a"],
+      ["a subscript chain", "WITH m['k']['j]'] AS v SELECT v"],
+      // Syntax the reader models as neither of its two shapes: a lambda inside an
+      // array literal, and a map literal whose key carries a close bracket.
+      ["a lambda inside an array", "WITH arrayMap(x -> x, [1,2]) AS a SELECT a"],
+      ["a map literal subscripted by a bracketed key", "WITH map('a]b', 1)['a]b'] AS v SELECT v"],
+    ])("crosses %s and reports the operative keyword", (_label, sql) => {
+      expect(operativeOf(sql, CLICKHOUSE)).toBe("SELECT");
+    });
+
+    test("still reads a bracket-quoted name as one name under the SQL Server grammar", () => {
+      // The constraint that makes the naive fix wrong: everything between the
+      // brackets is the NAME there, apostrophe included, and a doubled `]` is how
+      // a bracket inside one is written. A scan that stepped over literals would
+      // lose both.
+      expect(operativeOf("WITH [it's] AS (SELECT 1) SELECT 1", MSSQL)).toBe("SELECT");
+      expect(operativeOf("WITH [my]]cte] AS (SELECT 1) SELECT 1", MSSQL)).toBe("SELECT");
+      expect(operativeOf("WITH [my cte] AS (SELECT 1) DELETE FROM users", MSSQL)).toBe("DELETE");
+    });
+
+    test("reports null where a subscript never closes", () => {
+      // The fail-safe direction is unchanged: a run the reader cannot close is
+      // undeterminable, so the statement is not typed as a read.
+      expect(operativeOf("WITH [1,2 AS a SELECT 1", CLICKHOUSE)).toBeNull();
+      expect(operativeOf("WITH [[1,2] AS a SELECT 1", CLICKHOUSE)).toBeNull();
+      expect(operativeOf("WITH m['a] AS v SELECT v", CLICKHOUSE)).toBeNull();
+    });
+
+    test("crosses a deeply nested subscript in bounded time", () => {
+      // Depth is counted, not matched by a regex: the scan advances one span or
+      // one bracket at a time and cannot backtrack.
+      const sql = `WITH ${"[".repeat(20000)}1${"]".repeat(20000)} AS a SELECT 1`;
+
+      const started = performance.now();
+      const keyword = operativeOf(sql, CLICKHOUSE);
+      const elapsed = performance.now() - started;
+
+      expect(keyword).toBe("SELECT");
+      expect(elapsed, `took ${elapsed.toFixed(1)}ms`).toBeLessThan(200);
+    });
+  });
+
   // ── Bounded time ────────────────────────────────────────────────────────
   //
   // The CTE-list scan is a character scanner rather than a regex over

--- a/tests/unit/sql/spans.test.ts
+++ b/tests/unit/sql/spans.test.ts
@@ -271,6 +271,95 @@ describe("readSqlSpan", () => {
     });
   });
 
+  // ── Alternate quoting (Oracle's `q'…'`) ─────────────────────────────────
+  //
+  // The form exists so that a literal can carry apostrophes without doubling
+  // them, which is exactly what makes reading it as code so damaging: the first
+  // apostrophe INSIDE the body opens a string, and everything after it is read one
+  // construct out of step. A `)` there ends a CTE body early and a `--` there
+  // turns the rest of the literal into what looks like trailing trivia (#292).
+  //
+  // Oracle is the only dialect here with the form, so the branch is reached only
+  // under its grammar; every other dialect reads the same characters as a name
+  // followed by an ordinary string, which is what they are there.
+
+  describe("alternate quoting (`q'…'`, Oracle)", () => {
+    const ORACLE = resolveSqlGrammar("oracle");
+
+    // The delimiter pairs node-oracledb's own tokenizer accepts: the four bracket
+    // forms close with their partner, every other character with itself.
+    test.each<[string, string, string]>([
+      ["a brace-delimited body", "q'{it's}' x", "string|q'{it's}'"],
+      ["a bracket-delimited body", "q'[it's]' x", "string|q'[it's]'"],
+      ["a paren-delimited body", "q'(it's)' x", "string|q'(it's)'"],
+      ["an angle-delimited body", "q'<it's>' x", "string|q'<it's>'"],
+      ["an arbitrary delimiter closing with itself", "q'!it's!' x", "string|q'!it's!'"],
+      ["an upper-case tag", "Q'{it's}' x", "string|Q'{it's}'"],
+      // The national-character-set spelling of the same form, whose body rules are
+      // identical - Oracle's SQL Language Reference gives `nq'#…#'` for NCHAR.
+      ["the national-charset tag", "nq'{it's}' x", "string|nq'{it's}'"],
+      ["an upper-case national-charset tag", "NQ'{it's}' x", "string|NQ'{it's}'"],
+      ["a mixed-case national-charset tag", "nQ'{it's}' x", "string|nQ'{it's}'"],
+    ])("reads %s as one literal", (_label, sql, expected) => {
+      expect(spanOf(sql, 0, ORACLE)).toBe(expected);
+    });
+
+    // The closer ends the body only where a quote follows it, which is what lets
+    // the delimiter character itself appear inside the literal.
+    test("a closing delimiter with no quote after it does not end the body", () => {
+      expect(spanOf("q'{a}b}' x", 0, ORACLE)).toBe("string|q'{a}b}'");
+      expect(spanOf("q'!a!b!' x", 0, ORACLE)).toBe("string|q'!a!b!'");
+    });
+
+    test("a paren, a comment marker and a write keyword inside the body belong to the body", () => {
+      expect(spanOf("q'{it's ) -- DELETE FROM users}' x", 0, ORACLE)).toBe("string|q'{it's ) -- DELETE FROM users}'");
+    });
+
+    // A body that never closes hides whatever follows it, so the reader says so
+    // rather than picking one of the two places the literal could end.
+    test.each<[string, string, number]>([
+      ["a body that never closes", "q'{abc", 6],
+      ["a tag with nothing after it", "q'", 2],
+      ["a national-charset body that never closes", "nq'{abc", 7],
+    ])("reports %s as undeterminable", (_label, sql, end) => {
+      expect(readSqlSpan(sql, 0, ORACLE)).toEqual({ kind: "string", end, terminated: false });
+    });
+
+    test.each<[string, string]>([
+      ["the plain tag", "q'{it's}' x"],
+      ["the national-charset tag", "nq'{it's}' x"],
+    ])("a grammar without the form reads %s as code", (_label, sql) => {
+      expect(readSqlSpan(sql, 0)).toBeNull();
+      expect(readSqlSpan(sql, 0, resolveSqlGrammar("postgres"))).toBeNull();
+    });
+
+    // The tag has to START a token. Oracle's lexer reads a name greedily, so
+    // `freq'x'` is a name followed by a string there too - and without the check
+    // the two kinds of reader in this folder would disagree about it: the ones that
+    // read whole words step over the name and never ask here, while the ones that
+    // walk character by character would ask at its last letter.
+    test.each<[string, string, number]>([
+      ["inside a longer name", "SELECT freq'{x}'", 10],
+      ["whose national-charset spelling sits inside a longer name", "SELECT frenq'{x}'", 10],
+      ["at the `q` of a national-charset tag, which the span starts one earlier", "nq'{it's}'", 1],
+    ])("a tag %s does not open the form", (_label, sql, index) => {
+      expect(readSqlSpan(sql, index, ORACLE)).toBeNull();
+    });
+
+    // The body search is an `indexOf` for two characters, so it cannot backtrack -
+    // and this guard is what stops anyone replacing it with a pattern that can.
+    test("answers in bounded time on a long body that never closes", () => {
+      const sql = `q'{${"a".repeat(20000)}`;
+
+      const started = performance.now();
+      const span = readSqlSpan(sql, 0, ORACLE);
+      const elapsed = performance.now() - started;
+
+      expect(span).toEqual({ kind: "string", end: sql.length, terminated: false });
+      expect(elapsed, `took ${elapsed.toFixed(1)}ms`).toBeLessThan(200);
+    });
+  });
+
   // ── Bounded time ────────────────────────────────────────────────────────
   //
   // This module exists partly because the regex alternative is a ReDoS trap:

--- a/tests/unit/sql/spans.test.ts
+++ b/tests/unit/sql/spans.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
-import { readSqlSpan } from "@/lib/sql/spans";
+import { hasUnterminatedSpan, readSqlSpan } from "@/lib/sql/spans";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -497,5 +497,88 @@ describe("readSqlSpan: bracketed subscripts", () => {
     // statement inside a literal.
     expect(readSqlSpan("['a", 0, CLICKHOUSE)).toEqual({ kind: "subscript", end: 3, terminated: false });
     expect(readSqlSpan("['a\\'] AS v", 0, CLICKHOUSE)?.terminated).toBe(false);
+  });
+});
+
+// ─── Text no reader can resolve (#297) ───────────────────────────────────────
+//
+// Every reader over this module discards `terminated: false` after acting on it:
+// the limiter declines to rewrite, `findCodeWord` reports the word it could not
+// see as absent. The confirmation gate needs the signal ITSELF - a span that never
+// closes hides whatever is written inside it, and answering "not dangerous" for
+// text a reader cannot read is the one direction that costs more than a click.
+
+describe("hasUnterminatedSpan", () => {
+  test.each<[string, string]>([
+    ["a plain read", "SELECT * FROM users"],
+    ["a closed literal", "SELECT name FROM users WHERE name = 'O''Brien'"],
+    ["a backslash inside a literal", "SELECT 'a\\nb' FROM t"],
+    ["a literal ending in a doubled backslash", "SELECT 'C:\\\\Users\\\\me' FROM files"],
+    ["stacked comments", "-- one\n/* two */\n-- three\nSELECT 1"],
+    ["a line comment closed by the end of the input", "SELECT 1 -- note"],
+    ["a dollar-quoted body", "SELECT $fn$ begin end $fn$"],
+    ["a bracket-quoted name", "SELECT [a--b] FROM t"],
+    ["a backtick-quoted name", "SELECT `a b` FROM t"],
+    ["text holding no span at all", "1+1"],
+    ["nothing", ""],
+  ])("answers false for %s", (_label, sql) => {
+    expect(hasUnterminatedSpan(sql)).toBe(false);
+  });
+
+  test.each<[string, string]>([
+    ["a quote behind an odd backslash run", "SELECT '\\';\nUPDATE t SET x = 1"],
+    ["a literal that never closes", "SELECT 'unclosed FROM t"],
+    ["a block comment that never closes", "SELECT 1 /* unclosed"],
+    ["a dollar-quoted body that never closes", "SELECT $fn$ begin"],
+    ["a bracket-quoted name that never closes", "SELECT [name FROM t"],
+    ["a double-quoted name that never closes", 'SELECT "name FROM t'],
+  ])("answers true for %s", (_label, sql) => {
+    expect(hasUnterminatedSpan(sql)).toBe(true);
+  });
+
+  // The signal is the GRAMMAR's answer, not this module's: the same characters are
+  // resolvable under one dialect's reading and not under another's, which is the
+  // whole reason the dialect reaches these readers (#292, #295).
+
+  test("the dialect decides whether a bracketed run resolves", () => {
+    // Under the name reading this closes at the inner `]`; under ClickHouse's
+    // array reading the depth never returns to zero.
+    const unbalanced = "WITH [[1,2] AS x DELETE FROM t";
+
+    expect(hasUnterminatedSpan(unbalanced)).toBe(false);
+    expect(hasUnterminatedSpan(unbalanced, resolveSqlGrammar("clickhouse"))).toBe(true);
+
+    // And the other direction on a nested array that IS balanced: the name reading
+    // takes the trailing `]]` for an escape and never closes the run, while
+    // ClickHouse's counts depth and closes it. This is the reason the confirmation
+    // gate answers the same for both readings of this text and for different
+    // reasons - one read the statement, the other could not.
+    const nested = "WITH [[1,2],[3,4]] AS x DELETE FROM t";
+
+    expect(hasUnterminatedSpan(nested)).toBe(true);
+    expect(hasUnterminatedSpan(nested, resolveSqlGrammar("clickhouse"))).toBe(false);
+  });
+
+  test("the dialect decides whether an alternate-quoted literal resolves", () => {
+    // Read as ordinary code the apostrophe inside the body opens a string that
+    // swallows the rest of the input; under Oracle's grammar the form closes.
+    const alternateQuoted = "SELECT q'{it's}' FROM dual";
+
+    expect(hasUnterminatedSpan(alternateQuoted)).toBe(true);
+    expect(hasUnterminatedSpan(alternateQuoted, resolveSqlGrammar("oracle"))).toBe(false);
+  });
+
+  test("answers in bounded time on a large input", () => {
+    // The gate that consumes this runs on the editor's execute path, where a
+    // pasted migration script is ordinary. A scanner that advances one span at a
+    // time cannot backtrack - the property this asserts is kept, not assumed.
+    const many = `SELECT ${"'lit' /* note */ -- line\n".repeat(20000)}1`;
+
+    const started = performance.now();
+    const unresolved = hasUnterminatedSpan(many);
+    const elapsed = performance.now() - started;
+
+    expect(unresolved).toBe(false);
+    expect(elapsed, `took ${elapsed.toFixed(1)}ms`).toBeLessThan(200);
   });
 });

--- a/tests/unit/sql/spans.test.ts
+++ b/tests/unit/sql/spans.test.ts
@@ -157,6 +157,112 @@ describe("readSqlSpan", () => {
     });
   });
 
+  // ── A second opener inside a comment is the dialect's answer (#300) ───────
+  //
+  // The cases above all call without a dialect and keep the reading this module
+  // always had: the first `*/` closes the run. Where a dialect NESTS them, that
+  // reading hands the text between the first `*/` and the comment's real end to
+  // the readers above as code - and both of them are then wrong at once, because
+  // a `)` in there ends a CTE body early (so the statement is typed by a keyword
+  // written inside a comment) and the keyword the confirmation gate reads is one
+  // the operator commented out.
+
+  describe("a named dialect decides where a block comment ends", () => {
+    const POSTGRES = resolveSqlGrammar("postgres");
+    const MSSQL = resolveSqlGrammar("mssql");
+    const CLICKHOUSE_G = resolveSqlGrammar("clickhouse");
+    const MYSQL = resolveSqlGrammar("mysql");
+    const SQLITE = resolveSqlGrammar("sqlite");
+    const ORACLE_G = resolveSqlGrammar("oracle");
+
+    const NESTED = "/* a /* b */ c */ SELECT 1";
+
+    test.each<[string, SqlGrammar]>([
+      ["postgres", POSTGRES],
+      ["mssql", MSSQL],
+      ["clickhouse", CLICKHOUSE_G],
+    ])("a nesting grammar (%s) reads the inner comment as part of the outer one", (_label, grammar) => {
+      expect(spanOf(NESTED, 0, grammar)).toBe("block-comment|/* a /* b */ c */");
+    });
+
+    test.each<[string, SqlGrammar | undefined]>([
+      ["mysql", MYSQL],
+      ["sqlite", SQLITE],
+      ["oracle", ORACLE_G],
+      ["no dialect at all", undefined],
+    ])("a flat grammar (%s) closes it at the first delimiter", (_label, grammar) => {
+      expect(spanOf(NESTED, 0, grammar)).toBe("block-comment|/* a /* b */");
+    });
+
+    // The fail-safe half of the nesting reading: one opener too many means the
+    // comment never closes, so the span is undeterminable rather than guessed -
+    // which costs a bound and, since #297, asks for a confirmation.
+    test("a nesting grammar reports an unclosed nested comment as undeterminable", () => {
+      expect(readSqlSpan("/* a /* b */ DROP TABLE t", 0, POSTGRES)).toEqual({
+        kind: "block-comment",
+        end: 25,
+        terminated: false,
+      });
+    });
+
+    test("depth is counted, not matched: three levels close in order", () => {
+      expect(spanOf("/*1 /*2 /*3 */ 2*/ 1*/ SELECT", 0, POSTGRES)).toBe("block-comment|/*1 /*2 /*3 */ 2*/ 1*/");
+    });
+
+    test.each<[string, string]>([
+      ["an empty comment", "/**/"],
+      ["a comment holding a lone star", "/* a * b */"],
+      ["a comment with a body", "/*a*/"],
+    ])("a nesting grammar answers %s exactly as the flat reading does", (_label, sql) => {
+      expect(spanOf(`${sql} SELECT 1`, 0, POSTGRES)).toBe(`block-comment|${sql}`);
+      expect(spanOf(`${sql} SELECT 1`, 0)).toBe(`block-comment|${sql}`);
+    });
+
+    // Adjacent comments do not nest into each other: the first closes at depth zero,
+    // and the second is a separate span. Worth asserting because a depth counter that
+    // kept scanning past a zero crossing would swallow both.
+    test("a nesting grammar ends the first of two adjacent comments at its own closer", () => {
+      expect(spanOf("/*a*//*b*/SELECT 1", 0, POSTGRES)).toBe("block-comment|/*a*/");
+      expect(spanOf("/*a*//*b*/SELECT 1", 5, POSTGRES)).toBe("block-comment|/*b*/");
+    });
+
+    // An empty nested comment is the smallest input where the two readings differ,
+    // so it belongs here rather than in the list above: the nesting reading needs
+    // both closers, the flat one stops at the first.
+    test("the two readings of an empty nested comment differ by its second closer", () => {
+      expect(spanOf("/*/**/*/ SELECT 1", 0, POSTGRES)).toBe("block-comment|/*/**/*/");
+      expect(spanOf("/*/**/*/ SELECT 1", 0)).toBe("block-comment|/*/**/");
+    });
+
+    // `/*/` is one opener and no closer: the slash the two delimiters share is
+    // consumed by the opener, so this never closes under either reading.
+    test.each<[string, SqlGrammar | undefined]>([
+      ["a nesting grammar", POSTGRES],
+      ["the default", undefined],
+    ])("%s leaves `/*/` unterminated", (_label, grammar) => {
+      expect(readSqlSpan("/*/", 0, grammar)).toEqual({ kind: "block-comment", end: 3, terminated: false });
+    });
+
+    // Inside a comment there are no literals, in this reader and in the engines it
+    // is reading for: a `/*` written inside a quoted-looking run is still an
+    // opener, and a `*/` inside one still closes. Asserted because the opposite
+    // guess - looking for literals inside comment text - is the plausible wrong fix.
+    test("a quote inside comment text neither opens a literal nor hides a delimiter", () => {
+      expect(spanOf("/* it's /* deep */ still */ SELECT 1", 0, POSTGRES)).toBe(
+        "block-comment|/* it's /* deep */ still */",
+      );
+    });
+
+    // A comment is trivia, so a nested one cannot be part of a statement's text -
+    // but a nested comment INSIDE a bracketed subscript is crossed by the run that
+    // contains it, and that run has to stay one span (#295).
+    test("a nested comment inside a ClickHouse subscript is crossed with the run", () => {
+      expect(spanOf("[1 /* ] /* deep */ still */, 2] x", 0, CLICKHOUSE_G)).toBe(
+        "subscript|[1 /* ] /* deep */ still */, 2]",
+      );
+    });
+  });
+
   // ── Literals ────────────────────────────────────────────────────────────
 
   describe("single-quoted strings", () => {
@@ -557,6 +663,37 @@ describe("hasUnterminatedSpan", () => {
 
     expect(hasUnterminatedSpan(nested)).toBe(true);
     expect(hasUnterminatedSpan(nested, resolveSqlGrammar("clickhouse"))).toBe(false);
+  });
+
+  test("the dialect decides whether a nested comment resolves", () => {
+    // One opener too many: flat reading closes at the first `*/` and reads the
+    // rest as code, while a nesting dialect is still inside the comment when the
+    // input runs out - so the same text is resolvable under one and not the other,
+    // and the gate asks only where it cannot be read (#300).
+    const unclosed = "/* a /* b */ DROP TABLE users";
+
+    expect(hasUnterminatedSpan(unclosed)).toBe(false);
+    expect(hasUnterminatedSpan(unclosed, resolveSqlGrammar("mysql"))).toBe(false);
+    expect(hasUnterminatedSpan(unclosed, resolveSqlGrammar("postgres"))).toBe(true);
+
+    // Balanced, so a nesting dialect resolves it - and the gate then has to find
+    // the DROP by reading the statement rather than by giving up on the text.
+    const balanced = "/* a /* b */ c */ DROP TABLE users";
+
+    expect(hasUnterminatedSpan(balanced, resolveSqlGrammar("postgres"))).toBe(false);
+  });
+
+  test("answers in bounded time on a deeply nested comment", () => {
+    // The depth count is a single forward pass, so an adversarial nest is linear.
+    // Unbalanced on purpose: the answer has to be reached by scanning to the end.
+    const deep = `${"/*".repeat(20000)} SELECT 1`;
+
+    const started = performance.now();
+    const unresolved = hasUnterminatedSpan(deep, resolveSqlGrammar("postgres"));
+    const elapsed = performance.now() - started;
+
+    expect(unresolved).toBe(true);
+    expect(elapsed, `took ${elapsed.toFixed(1)}ms`).toBeLessThan(200);
   });
 
   test("the dialect decides whether an alternate-quoted literal resolves", () => {

--- a/tests/unit/sql/spans.test.ts
+++ b/tests/unit/sql/spans.test.ts
@@ -438,3 +438,64 @@ describe("readSqlSpan: bracket-quoted identifiers", () => {
     expect(span?.end).toBe(4);
   });
 });
+
+// ─── Bracketed subscripts (#295) ─────────────────────────────────────────────
+//
+// The same characters are an array literal or a subscript in ClickHouse, where
+// they NEST and nothing is escaped, so the name reading above ends the run at the
+// wrong place twice over: at a `]` written inside a string (`m['a]b']`) and at the
+// first `]` of a nested array (`[[1,2],[3,4]]`, whose `]]` the name reading then
+// takes for an escape and never closes). Both cost the statement its bound. The
+// two grammars are mutually exclusive - teaching the name scan to step over
+// literals would break a legal SQL Server name like `[it's]` - so the reading
+// comes from the dialect.
+
+describe("readSqlSpan: bracketed subscripts", () => {
+  const CLICKHOUSE = resolveSqlGrammar("clickhouse");
+  const MSSQL = resolveSqlGrammar("mssql");
+
+  test("reads an array literal as one span", () => {
+    expect(spanOf("[1,2] AS a", 0, CLICKHOUSE)).toBe("subscript|[1,2]");
+    expect(spanOf("m['k'] FROM t", 1, CLICKHOUSE)).toBe("subscript|['k']");
+  });
+
+  test("nests, so an inner array does not end the outer one", () => {
+    expect(spanOf("[[1,2],[3,4]] AS a", 0, CLICKHOUSE)).toBe("subscript|[[1,2],[3,4]]");
+    expect(spanOf("[[[1]]] x", 0, CLICKHOUSE)).toBe("subscript|[[[1]]]");
+  });
+
+  test("a close bracket inside a literal does not end the run", () => {
+    expect(spanOf("['a]b'] AS v", 0, CLICKHOUSE)).toBe("subscript|['a]b']");
+    expect(spanOf('["a]b"] AS v', 0, CLICKHOUSE)).toBe('subscript|["a]b"]');
+  });
+
+  test("a close bracket inside a comment does not end it either", () => {
+    expect(spanOf("[1 /* ] */, 2] x", 0, CLICKHOUSE)).toBe("subscript|[1 /* ] */, 2]");
+    // `#` is a comment in ClickHouse, which is the T1a row of the same record:
+    // the two facts have to hold at once inside one run.
+    expect(spanOf("[1 # ]\n, 2] x", 0, CLICKHOUSE)).toBe("subscript|[1 # ]\n, 2]");
+  });
+
+  test("a doubled close bracket is not an escape here", () => {
+    // The mutually exclusive half, asserted on one input: `]]` closes the run
+    // under the subscript reading (it is how a nested array ends) and escapes a
+    // name character under SQL Server's.
+    expect(spanOf("[a]]b] x", 0, CLICKHOUSE)).toBe("subscript|[a]");
+    expect(spanOf("[a]]b] x", 0, MSSQL)).toBe("quoted-identifier|[a]]b]");
+  });
+
+  test("reports an unterminated subscript rather than guessing where it ends", () => {
+    expect(readSqlSpan("[1,2", 0, CLICKHOUSE)).toEqual({ kind: "subscript", end: 4, terminated: false });
+    // Depth is counted, so a run that closes one bracket short is unterminated too.
+    expect(readSqlSpan("[[1,2]", 0, CLICKHOUSE)).toEqual({ kind: "subscript", end: 6, terminated: false });
+  });
+
+  test("a literal inside that cannot be resolved makes the whole run unterminated", () => {
+    // The span reader reports a quote behind an odd backslash run as
+    // undeterminable, and a run built on top of one cannot be more certain than
+    // what it contains. Answering `terminated` here would put the end of the
+    // statement inside a literal.
+    expect(readSqlSpan("['a", 0, CLICKHOUSE)).toEqual({ kind: "subscript", end: 3, terminated: false });
+    expect(readSqlSpan("['a\\'] AS v", 0, CLICKHOUSE)?.terminated).toBe(false);
+  });
+});

--- a/tests/unit/sql/spans.test.ts
+++ b/tests/unit/sql/spans.test.ts
@@ -1,11 +1,12 @@
 import { describe, test, expect } from "bun:test";
+import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readSqlSpan } from "@/lib/sql/spans";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 /** The span at index 0, as `kind|text` (or `null`), which is what most cases assert. */
-function spanOf(sql: string, index = 0): string | null {
-  const span = readSqlSpan(sql, index);
+function spanOf(sql: string, index = 0, grammar?: SqlGrammar): string | null {
+  const span = readSqlSpan(sql, index, grammar);
   return span === null ? null : `${span.kind}|${sql.slice(index, span.end)}`;
 }
 
@@ -100,6 +101,42 @@ describe("readSqlSpan", () => {
 
     test("an empty line comment is still a span", () => {
       expect(spanOf("--\nSELECT")).toBe("line-comment|--\n");
+    });
+  });
+
+  // ── The `#` reading is the dialect's, when a dialect is named (#292) ─────
+  //
+  // Every case above is a call that names NO dialect, and all of them keep their
+  // answers: the default is today's hybrid reading, pinned as a decision in
+  // `grammar.test.ts`. A call that DOES name one gets that dialect's rule, which
+  // is what removes the "the module takes one engine's side" trade above - not
+  // for the default, but for every caller that knows which engine it is talking
+  // to, and after #292 that is all of them.
+
+  describe("a named dialect decides what `#` means", () => {
+    const MYSQL = resolveSqlGrammar("mysql");
+    const POSTGRES = resolveSqlGrammar("postgres");
+
+    test("a comment grammar reads an operator-tailed hash as a comment", () => {
+      expect(spanOf("#- note\nSELECT 1", 0, MYSQL)).toBe("line-comment|#- note\n");
+      expect(spanOf("SELECT 1 #> note", 9, MYSQL)).toBe("line-comment|#> note");
+    });
+
+    test("a code grammar reads even a plainly-written hash comment as code", () => {
+      expect(readSqlSpan("# note\nSELECT 1", 0, POSTGRES)).toBeNull();
+      expect(readSqlSpan("SELECT * FROM #tmp", 14, POSTGRES)).toBeNull();
+    });
+
+    test("a dialect changes nothing about the `--` comment, which no dialect disputes", () => {
+      expect(spanOf("-- note\nSELECT 1", 0, POSTGRES)).toBe("line-comment|-- note\n");
+      expect(spanOf("-- note\nSELECT 1", 0, MYSQL)).toBe("line-comment|-- note\n");
+    });
+
+    // A `#` inside a literal is the literal's, whatever the dialect says about a
+    // bare one - the branch order has to keep the quote reader in front.
+    test("a hash inside a quoted run is not read as a comment under any grammar", () => {
+      expect(spanOf("`a#b` FROM t", 0, MYSQL)).toBe("quoted-identifier|`a#b`");
+      expect(spanOf("'# not a comment'", 0, POSTGRES)).toBe("string|'# not a comment'");
     });
   });
 

--- a/tests/unit/sql/statement-end.test.ts
+++ b/tests/unit/sql/statement-end.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from "bun:test";
+import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
+import type { DatabaseType } from "@/lib/types";
 
 /**
  * `[statement, trailing]` - the split this reader exists to produce.
@@ -8,8 +10,8 @@ import { readStatementEnd } from "@/lib/sql/statement-end";
  * readable and pins BOTH sides: a reader that loses characters would still return
  * a plausible-looking number.
  */
-function split(sql: string): [string, string] {
-  const { end } = readStatementEnd(sql);
+function split(sql: string, grammar?: SqlGrammar): [string, string] {
+  const { end } = readStatementEnd(sql, grammar);
   return [sql.slice(0, end), sql.slice(end)];
 }
 
@@ -141,6 +143,40 @@ describe("readStatementEnd", () => {
     ])("refuses a cut but reports the whole statement for %s", (_label, sql, statement) => {
       expect(readStatementEnd(sql).rewritable).toBe(false);
       expect(split(sql)[0]).toBe(statement);
+    });
+
+    // ── …unless the caller says which dialect it is (#292) ────────────────
+    //
+    // The refusal above exists because "nothing in the text tells them apart".
+    // A caller that names its dialect has told them apart, so the refusal is
+    // lifted in BOTH directions - and the two directions produce different
+    // ends, which is why each is asserted whole rather than by its flag.
+
+    test("a comment grammar cuts before the trailing hash comment", () => {
+      const mysql = resolveSqlGrammar("mysql");
+
+      expect(readStatementEnd("SELECT 1 # note", mysql)).toEqual({ end: 8, rewritable: true });
+      expect(split("SELECT 1 # note", mysql)).toEqual(["SELECT 1", " # note"]);
+      expect(split("SELECT 1 # note\n;", mysql)).toEqual(["SELECT 1", " # note\n;"]);
+    });
+
+    test.each<[string, string, DatabaseType]>([
+      ["a T-SQL temp table", "SELECT * FROM #tmp", "mssql"],
+      ["an Oracle identifier carrying a hash", "SELECT * FROM EMP WHERE ID# = 1", "oracle"],
+      ["a PostgreSQL XOR operator", "SELECT flags # 5 AS x FROM t", "postgres"],
+      ["a SQLite bind variable", "SELECT * FROM t WHERE id = #id", "sqlite"],
+    ])("a code grammar keeps %s as the statement's own text and allows the cut", (_label, sql, type) => {
+      expect(readStatementEnd(sql, resolveSqlGrammar(type))).toEqual({ end: sql.length, rewritable: true });
+    });
+
+    test("a code grammar still splits off the trivia that dialect does have", () => {
+      const mssql = resolveSqlGrammar("mssql");
+
+      expect(split("SELECT * FROM #tmp -- daily", mssql)).toEqual(["SELECT * FROM #tmp", " -- daily"]);
+      expect(split("SELECT * FROM #t FETCH NEXT 10 ROWS ONLY;", mssql)).toEqual([
+        "SELECT * FROM #t FETCH NEXT 10 ROWS ONLY",
+        ";",
+      ]);
     });
   });
 

--- a/tests/unit/sql/statement-end.test.ts
+++ b/tests/unit/sql/statement-end.test.ts
@@ -178,6 +178,43 @@ describe("readStatementEnd", () => {
         ";",
       ]);
     });
+
+    // ── A bracketed run is the statement's own text under both readings ────
+    //
+    // A quoted name and an array literal are both TOKENS, so the end has to
+    // advance past either of them. Treating the subscript reading (#295) as
+    // trivia instead would put the end back at the last code character BEFORE
+    // the run, and the insert-before-trivia rewrite then splices the bound into
+    // the middle of the statement - `SELECT [1,2]` emitted as
+    // `SELECT LIMIT 500 [1,2]` - which is the corrupted-statement class, not a
+    // missed bound.
+    // Only a row where the run is the LAST token decides that: with code after the
+    // run the end reaches the input's length under either reading, so the first
+    // three rows below say nothing about it. Reported by review on this task.
+    test.each<[string, string, DatabaseType]>([
+      ["an array literal", "SELECT [1,2] AS a", "clickhouse"],
+      ["a map subscript whose key carries a close bracket", "SELECT m['a]b'] AS v", "clickhouse"],
+      ["a bracket-quoted name", "SELECT [a--b] FROM t", "mssql"],
+      ["an array literal that ENDS the statement", "SELECT [1,2]", "clickhouse"],
+      ["a nested array that ends the statement", "SELECT [[1,2],[3,4]]", "clickhouse"],
+      ["a subscript that ends the statement", "SELECT m['a]b']", "clickhouse"],
+      ["a bracket-quoted name that ends the statement", "SELECT [a--b]", "mssql"],
+    ])("keeps %s inside the statement and allows the cut", (_label, sql, type) => {
+      expect(readStatementEnd(sql, resolveSqlGrammar(type))).toEqual({ end: sql.length, rewritable: true });
+    });
+
+    test("splits the trailing trivia off after a bracketed run, not before it", () => {
+      const clickhouse = resolveSqlGrammar("clickhouse");
+
+      expect(split("SELECT [1,2] AS a -- daily", clickhouse)).toEqual(["SELECT [1,2] AS a", " -- daily"]);
+      expect(split("SELECT [[1,2],[3,4]] AS a;", clickhouse)).toEqual(["SELECT [[1,2],[3,4]] AS a", ";"]);
+    });
+
+    test("refuses the cut where a subscript never closes", () => {
+      const clickhouse = resolveSqlGrammar("clickhouse");
+
+      expect(readStatementEnd("SELECT [1,2 AS a", clickhouse).rewritable).toBe(false);
+    });
   });
 
   // ── Bounded time ────────────────────────────────────────────────────────

--- a/tests/unit/sql/words.test.ts
+++ b/tests/unit/sql/words.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { findCodeWord, readSqlWord } from "@/lib/sql/words";
 
 /** The word at an index as its text alone - the shape most assertions want. */
@@ -119,6 +120,20 @@ describe("findCodeWord", () => {
     ["an unterminated block comment", "SELECT 1 /* note\nUPDATE t SET y = 1"],
   ])("does not read code past %s", (_label, sql) => {
     expect(findAt(sql, "UPDATE")).toBe(-1);
+  });
+
+  // ── What counts as "not code" is the dialect's answer (#292) ────────────
+  //
+  // The safety predicate is this module's caller, and a `#` decides whether a
+  // write after it is the statement's own code. Both directions matter here: in
+  // MySQL the write really is commented out and prompting would be a false alarm,
+  // while in PostgreSQL those characters are an operator and the write is real.
+
+  test("a hash hides a write under a comment grammar and does not under a code grammar", () => {
+    const sql = "SELECT 1 # UPDATE t SET x";
+
+    expect(findCodeWord(sql, "UPDATE", 0, resolveSqlGrammar("mysql"))).toBeNull();
+    expect(findCodeWord(sql, "UPDATE", 0, resolveSqlGrammar("postgres"))).toEqual({ start: 11, end: 17 });
   });
 
   // ── Shape of the scan ──────────────────────────────────────────────────


### PR DESCRIPTION
One shortage seen from five sides, plus one unrelated crash.

Everything under `src/lib/sql/` read a statement from characters alone and resolved four genuinely
dialect-dependent grammars by taking one engine's side. The consequences were not cosmetic: a write
could be typed as a read and collect an automatic row bound (a partial commit), a bound could be
spliced *inside* a comment or a literal (a statement the server refuses, reported as limited), and a
destructive statement could reach execution without the confirmation the product promises.

## What changes

1. **A dialect channel (#292).** New `src/lib/sql/grammar.ts` holds one declarative table of grammar
   facts and exactly one resolver from a database type to it; readers accept the resolved record and
   never a type id, so no dialect test exists below the resolver. Threaded to eleven call sites in
   five layers — five provider `prepareQuery` paths, the shared limiter, the multi-statement route,
   both client hooks, the confirmation predicate. `#` is now per dialect: a comment in MySQL and
   ClickHouse, code in PostgreSQL, Oracle, SQL Server and SQLite.
2. **Oracle alternate quoting (#292).** `q'{…}'` / `nq'{…}'` is read as the literal it is under the
   Oracle grammar, with the delimiter pairs Oracle accepts. It previously cost such a statement its
   bound and — where the body held a `--` — spliced the clause inside the literal.
3. **Bracketed runs per dialect (#295).** `[…]` is a quoted identifier (mssql, sqlite) or a nestable
   array/subscript (clickhouse); the subscript scan counts depth and consults `readSqlSpan`, so a
   literal inside is stepped over whole.
4. **MSSQL pages (#293).** No row-count clause is added beside a page the probes cannot see: the
   guard sits before the `TOP` / pagination split, and the provider now recognises T-SQL's own
   `OFFSET n ROWS` page form.
5. **The confirmation gate is honest (#297).** A run no reader can resolve was already detected and
   then discarded; the gate now asks on it, and the dialog says why with a distinct "Part of this
   statement could not be read" notice rather than the risk copy it shows for text it did read. No
   published prop was added or broken.
6. **Block comments nest where their dialect nests them (#300).** All six dialect facts were
   established from first-party sources, and `readLeadingKeyword` was converted from its own regex
   trivia grammar to `readSqlSpan`, so there is one reading of a comment in the folder. This is where
   the sharpest defect surfaced: a nested comment made `classifySelectPrefix` type a `DELETE` as a
   `SELECT`, explain runs skip the confirmation gate, and PostgreSQL's `EXPLAIN (ANALYZE, …)`
   executes what it explains — live-verified on PostgreSQL 18, 3 rows before, 0 after.
7. **No pool crashes the server (#298).** `error` listeners at both PostgreSQL pool sites — the
   database provider and the storage provider, a second process-lifetime pool — plus mssql. mysql2
   and oracledb were audited from their installed packages: neither has a pool-level `error` event,
   and each `connect()` records that. Visible in the close-out smoke run itself: an idle pool client
   error logged five times while the server kept serving.

Docs move with the code in every commit: `docs/editor/query-optimization.md` (the behaviour doc for
all six issues), `docs/ADDING_A_PROVIDER.md`, `docs/STORAGE.md`, and the provider docs plus
integration suites for every provider whose reading changed.

## On the tests

The previous sweep shipped a regression that emitted corrupted SQL (`SELECT [a--b] FROM t` came back
as `SELECT [a LIMIT 500--b] FROM t`) and it passed the local gate, CI, 100% line coverage and five
fresh-context reviews — because every fixture had been written from input the reader already read
correctly. So each dialect taught here also carries a fixture built from syntax the reader does not
model at all, asserted through the real `prepareQuery` with the emitted statement text asserted
byte-intact rather than "a bound was added".

That was still not sufficient on its own. Review of the bracket work found that every fixture placed
code *after* the bracketed run, so the `subscript` disjunct in `isStatementText` was pinned by
nothing: deleting it emitted `SELECT [1,2]` as `SELECT LIMIT 500 [1,2]` and zero tests failed. Line
coverage cannot see a missing disjunct in a one-line predicate. Fixed with ends-with-run fixtures at
three levels; the same mutation now fails eight tests. The general rule, recorded in the code: a
fixture can only pin a reader's answer where the two readings disagree.

## Not in scope, and where it went

Grammar facts that could not be established from an authoritative source were left at the
compatibility default rather than guessed, and which ones those are is stated in
`docs/editor/query-optimization.md` and in `grammar.ts` itself rather than implied. A call that names
no dialect keeps exactly today's reading, pinned by its own tests, so every fixture written for #275,
#280, #287, #291 and #294 still asserts what it was written for.

The adjacent defects found while doing this work — including a second dialect-blind scanner that can
hand the multi-statement route a bare `DROP` — are recorded in the new `docs/BACKLOG.md` rather than
folded in here.

## Verification

- `./loop/scripts/gate.sh` — green (format, lint 0 errors, typecheck, knip, test, build).
- `bun run test:coverage && bun run coverage:check` — 100.00% (29133/29133 lines).
- `./loop/scripts/functional-smoke.sh` — green (login, PostgreSQL connection through the real modal,
  query, rows render).

Closes #292, #293, #295, #297, #298, #300 at merge.
