### PR TITLE
fix(sql): bind the inline row edit's values, and quote the remaining interpolated ones (#290)

### DIFF
--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -36,8 +36,8 @@ Three decisions. The first is the consequential one, which is why it is first.
      avoid it.** A standard-SQL engine reached over HTTP, such as ClickHouse or Apache Druid, should
      extend it and get all of that for free. Druid is the clearest case of how little is left over:
      double-quoted identifiers and `LIMIT n OFFSET m` are both correct Druid SQL, so
-     `escapeIdentifier()`, `buildLimitClause()` and `getPlaceholder()` are inherited unchanged and
-     `prepareQuery()` is the only override — for a single dialect trap, not for the transport.
+     `escapeIdentifier()` and `buildLimitClause()` are inherited unchanged and `prepareQuery()` is
+     the only override — for a single dialect trap, not for the transport.
    - **Non-SQL databases → extend `BaseDatabaseProvider`** directly, like MongoDB and Redis.
    - The one reason a SQL-speaking provider extends `BaseDatabaseProvider` anyway is a dialect the
      shared helpers cannot express. Couchbase is that case: SQL++ quotes identifiers with doubled
@@ -245,7 +245,7 @@ for worked, code-verified examples see each provider's **Design decisions** sect
 |--------|-------------|
 | `escapeIdentifier()` | `"table_name"` (PostgreSQL/SQLite) or `` `table_name` `` (MySQL) |
 | `buildLimitClause()` | `LIMIT 50 OFFSET 10` |
-| `getPlaceholder()` | `$1` (PostgreSQL) or `?` (MySQL/SQLite) |
+| `positionalPlaceholder()` ([`src/lib/sql/values.ts`](../src/lib/sql/values.ts), not inherited) | `$1` (PostgreSQL, Couchbase), `?` (MySQL, SQLite, Druid), `:1` (Oracle), `@p1` (SQL Server), `null` where the engine has no positional form |
 | `shouldEnableSSL()` | Auto-detects cloud providers |
 | `prepareQuery()` | Automatically injects LIMIT into SELECT queries |
 

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -303,6 +303,19 @@ Execute SQL query on connected database.
 
 The `pagination` object reports the auto-limiting applied by the server (default 500 rows). `wasLimited` is `true` when the server injected a `LIMIT` the query didn't specify; `hasMore` indicates more rows are available — re-request with a higher `offset` to page. See [`docs/editor/query-optimization.md`](editor/query-optimization.md).
 
+**Bound parameters (optional):**
+```json
+{
+  "connection": { "type": "mysql", "host": "localhost", "database": "mydb" },
+  "sql": "UPDATE users SET `name` = ? WHERE `id` = ?",
+  "params": ["O'Brien", 7]
+}
+```
+
+`params` binds the statement's positional placeholders through the driver, so a value never becomes statement text. Use it for any statement built from data rather than typed by a person — a value carrying `\'` would otherwise close its own string literal on MySQL or ClickHouse and have the rest read as SQL. The placeholder form is the dialect's own: `$n` (PostgreSQL), `?` (MySQL, SQLite), `:n` (Oracle), `@pn` (SQL Server).
+
+Each element must be a string, number, boolean or `null`; anything else is rejected with 400 rather than handed to the driver. `POST /api/db/transaction` accepts the same field for its `query` action.
+
 **Response (400 Bad Request):**
 ```json
 {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -138,14 +138,17 @@ MongoDB, Redis, ClickHouse, Druid or Couchbase clients expose a fatal `error` ev
 
 ## Value interpolation
 
-### V1. Four call sites escape by doubling quotes only
+### V1. `SQLBaseProvider.escapeString` teaches the escape that #290 was about
 
-`src/components/PivotTable.tsx`, `src/components/TestDataGenerator.tsx`, `src/components/Studio.tsx`,
-`src/components/DataImportModal.tsx` and `src/workspace/StudioWorkspace.tsx` each build SQL by
-doubling quotes in a value, which a backslash-escaping dialect can still turn into SQL. The related
-inline-edit path is no longer among them: #290 binds its values instead. Both halves of that fix are
-reusable here — `quoteLiteral` (`src/lib/sql/values.ts`) for a statement that must carry its values,
-and the `params` channel through `executeQuery` / `/api/db/query` for one that does not.
+`src/lib/db/providers/sql/sql-base.ts` still carries a `protected escapeString` that doubles the
+quote and nothing else. It has no callers — only a test-local subclass reaches it — so it is not a
+defect today, but it is the method a provider author would reach for, and on MySQL or ClickHouse its
+result can be closed early by a value ending in a backslash. Either delete it (the six call sites
+that did this now use `quoteLiteral` in `src/lib/sql/values.ts`) or make it dialect-aware from
+`this.type`.
+
+The two remaining doubling sites in `src/lib/db/providers/sql/oracle.ts` are correct as written:
+Oracle reads a backslash in a literal as data.
 
 ### V2. Query history records the placeholders, not the values that were bound
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -140,11 +140,20 @@ MongoDB, Redis, ClickHouse, Druid or Couchbase clients expose a fatal `error` ev
 
 ### V1. Four call sites escape by doubling quotes only
 
-`src/components/PivotTable.tsx`, `src/components/TestDataGenerator.tsx`, `src/components/Studio.tsx`
-and `src/components/DataImportModal.tsx` each build SQL by doubling quotes in a value, which a
-backslash-escaping dialect can still turn into SQL. The related inline-edit path
-(`src/hooks/use-inline-editing.ts`, a non-numeric primary-key value interpolated into `WHERE` with no
-escaping at all) is already covered by issue #290; these four are not.
+`src/components/PivotTable.tsx`, `src/components/TestDataGenerator.tsx`, `src/components/Studio.tsx`,
+`src/components/DataImportModal.tsx` and `src/workspace/StudioWorkspace.tsx` each build SQL by
+doubling quotes in a value, which a backslash-escaping dialect can still turn into SQL. The related
+inline-edit path is no longer among them: #290 binds its values instead. Both halves of that fix are
+reusable here — `quoteLiteral` (`src/lib/sql/values.ts`) for a statement that must carry its values,
+and the `params` channel through `executeQuery` / `/api/db/query` for one that does not.
+
+### V2. Query history records the placeholders, not the values that were bound
+
+Since #290 the inline row editor sends `SET "name" = $1` with the value bound, and
+`use-query-execution` writes that text to history — a truthful record of the statement the engine
+ran, but no longer a record of what was written. Carrying the bound values as their own history
+field would restore the audit trail without putting them back into the SQL. Touches the history
+entry shape in `src/lib/storage`, so it is a schema change rather than a one-line fix.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -138,19 +138,7 @@ MongoDB, Redis, ClickHouse, Druid or Couchbase clients expose a fatal `error` ev
 
 ## Value interpolation
 
-### V1. `SQLBaseProvider.escapeString` teaches the escape that #290 was about
-
-`src/lib/db/providers/sql/sql-base.ts` still carries a `protected escapeString` that doubles the
-quote and nothing else. It has no callers — only a test-local subclass reaches it — so it is not a
-defect today, but it is the method a provider author would reach for, and on MySQL or ClickHouse its
-result can be closed early by a value ending in a backslash. Either delete it (the six call sites
-that did this now use `quoteLiteral` in `src/lib/sql/values.ts`) or make it dialect-aware from
-`this.type`.
-
-The two remaining doubling sites in `src/lib/db/providers/sql/oracle.ts` are correct as written:
-Oracle reads a backslash in a literal as data.
-
-### V2. Query history records the placeholders, not the values that were bound
+### V1. Query history records the placeholders, not the values that were bound
 
 Since #290 the inline row editor sends `SET "name" = $1` with the value bound, and
 `use-query-execution` writes that text to history — a truthful record of the statement the engine

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -79,7 +79,7 @@ rather than reimplementing them:
 | Member | Purpose |
 |--------|---------|
 | `escapeIdentifier()` ([sql-base.ts:33](../../src/lib/db/providers/sql/sql-base.ts)) | Dialect-aware quoting — `"ident"` for Postgres, `` `ident` `` for MySQL, `[ident]` for MSSQL; doubles embedded quote chars |
-| `getPlaceholder()` ([sql-base.ts:65](../../src/lib/db/providers/sql/sql-base.ts)) | `$1`-style placeholders for Postgres (`?` for MySQL/SQLite, `:n` Oracle, `@pn` MSSQL) |
+| `positionalPlaceholder()` ([values.ts](../../src/lib/sql/values.ts), shared rather than inherited) | `$1`-style placeholders for Postgres (`?` for MySQL/SQLite/Druid, `:n` Oracle, `@pn` MSSQL, `$n` Couchbase) |
 | `shouldEnableSSL()` ([sql-base.ts:75](../../src/lib/db/providers/sql/sql-base.ts)) | Auto-enables SSL for known cloud hosts (supabase, neon, render, planetscale, aws, azure, gcp, …) |
 | `getDefaultSchema()` ([sql-base.ts:91](../../src/lib/db/providers/sql/sql-base.ts)) | `public` for Postgres |
 | `prepareQuery()` ([sql-base.ts:137](../../src/lib/db/providers/sql/sql-base.ts)) | Injects `LIMIT` into bare `SELECT`s — see [§5.2](#52-automatic-limit-injection) |

--- a/src/app/api/db/profile/route.ts
+++ b/src/app/api/db/profile/route.ts
@@ -4,6 +4,7 @@ import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { getSession } from "@/lib/auth";
 import { quoteIdentifier, quoteQualifiedName } from "@/lib/query-generators";
+import { quoteLiteral } from "@/lib/sql/values";
 
 export async function POST(req: NextRequest) {
   try {
@@ -82,9 +83,12 @@ export async function POST(req: NextRequest) {
       // Build profiling query for each column
       const profileParts = colList.slice(0, 20).map((col) => {
         const safeCol = quoteIdentifier(col, capabilities);
+        // The name is also carried as a LABEL, which makes it a value in a string
+        // literal. It arrives in the request, so it is quoted the way the connected
+        // engine reads a literal rather than by doubling the quote alone (#290).
         return `
           SELECT
-            '${col.replace(/'/g, "''")}' as column_name,
+            ${quoteLiteral(col, connection.type)} as column_name,
             COUNT(*) as total_count,
             COUNT(${safeCol}) as non_null_count,
             COUNT(*) - COUNT(${safeCol}) as null_count,

--- a/src/app/api/db/query/route.ts
+++ b/src/app/api/db/query/route.ts
@@ -3,6 +3,7 @@ import { getOrCreateProvider } from "@/lib/db";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { getSession } from "@/lib/auth";
+import { readBoundParams } from "@/lib/api/bound-params";
 
 export async function POST(req: NextRequest) {
   try {
@@ -20,6 +21,14 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Connection and query are required" }, { status: 400 });
     }
 
+    // A generated statement sends its values here rather than writing them into the
+    // SQL (#290). They go straight to the driver's bind path, so what may be bound
+    // is decided before the provider is even reached.
+    const bound = readBoundParams(body.params);
+    if (!bound.valid) {
+      return NextResponse.json({ error: bound.message }, { status: 400 });
+    }
+
     const provider = await getOrCreateProvider(connection);
     const prepared = provider.prepareQuery(sql, options);
 
@@ -31,8 +40,8 @@ export async function POST(req: NextRequest) {
             provider as unknown as {
               query(sql: string, params?: unknown[], queryId?: string): ReturnType<typeof provider.query>;
             }
-          ).query(prepared.query, undefined, queryId)
-        : await provider.query(prepared.query);
+          ).query(prepared.query, bound.params, queryId)
+        : await provider.query(prepared.query, bound.params);
 
     const hasMore = result.rows.length === prepared.limit;
 

--- a/src/app/api/db/transaction/route.ts
+++ b/src/app/api/db/transaction/route.ts
@@ -3,6 +3,7 @@ import { getOrCreateProvider } from "@/lib/db";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { getSession } from "@/lib/auth";
+import { readBoundParams } from "@/lib/api/bound-params";
 
 interface TransactionProvider {
   beginTransaction(): Promise<void>;
@@ -71,9 +72,17 @@ export async function POST(req: NextRequest) {
           return NextResponse.json({ error: "SQL query is required for transaction query" }, { status: 400 });
         }
 
+        // The values of a generated statement are bound here as well: a row edit
+        // applied while a transaction is open takes this endpoint, and it would
+        // otherwise be the one path that still carried them as text (#290).
+        const bound = readBoundParams(body.params);
+        if (!bound.valid) {
+          return NextResponse.json({ error: bound.message }, { status: 400 });
+        }
+
         // Apply limit for SELECT queries within transaction
         const prepared = provider.prepareQuery(sql, options);
-        const result = await provider.queryInTransaction(prepared.query);
+        const result = await provider.queryInTransaction(prepared.query, bound.params);
 
         const hasMore = result.rows.length === prepared.limit;
 

--- a/src/components/DataImportModal.tsx
+++ b/src/components/DataImportModal.tsx
@@ -91,17 +91,27 @@ export function parseJSON(text: string): ParsedData {
   return { headers, rows, totalRows: rows.length };
 }
 
+/**
+ * The shapes a value must have to be written into a statement unquoted. They are
+ * shared with `inferSqlType` on purpose: the type is inferred from a sample, so
+ * the same test has to be applied again to each value that is emitted — one
+ * predicate, used in both places, cannot drift from itself.
+ */
+const INTEGER_VALUE = /^-?\d+$/;
+const NUMERIC_VALUE = /^-?\d+(\.\d+)?$/;
+const BOOLEAN_VALUE = /^(true|false|0|1)$/i;
+
 export function inferSqlType(values: string[]): string {
   const nonEmpty = values.filter((v) => v !== "" && v !== null);
   if (nonEmpty.length === 0) return "TEXT";
 
-  const allIntegers = nonEmpty.every((v) => /^-?\d+$/.test(v));
+  const allIntegers = nonEmpty.every((v) => INTEGER_VALUE.test(v));
   if (allIntegers) return "INTEGER";
 
-  const allNumbers = nonEmpty.every((v) => /^-?\d+(\.\d+)?$/.test(v));
+  const allNumbers = nonEmpty.every((v) => NUMERIC_VALUE.test(v));
   if (allNumbers) return "NUMERIC";
 
-  const allBooleans = nonEmpty.every((v) => /^(true|false|0|1)$/i.test(v));
+  const allBooleans = nonEmpty.every((v) => BOOLEAN_VALUE.test(v));
   if (allBooleans) return "BOOLEAN";
 
   return "TEXT";
@@ -135,13 +145,18 @@ export function generateImportSQL(
 
   const statements: string[] = [];
 
+  // One type per column, read from the first 100 rows and computed once. It used
+  // to be re-inferred for every cell, which re-scanned that sample rows × columns
+  // times for a single import.
+  const columnTypes = parsedData.headers.map((_, idx) =>
+    inferSqlType(parsedData.rows.slice(0, 100).map((r) => r[idx])),
+  );
+
   // CREATE TABLE if new
   if (createNewTable) {
-    const colDefs = parsedData.headers.map((h) => {
-      const colValues = parsedData.rows.slice(0, 100).map((r) => r[parsedData.headers.indexOf(h)]);
-      const sqlType = inferSqlType(colValues);
+    const colDefs = parsedData.headers.map((h, idx) => {
       const colName = columnMapping[h] || h;
-      return `  ${colName} ${sqlType}`;
+      return `  ${colName} ${columnTypes[idx]}`;
     });
     statements.push(`CREATE TABLE ${tableName} (\n${colDefs.join(",\n")}\n);`);
   }
@@ -154,12 +169,21 @@ export function generateImportSQL(
     const batch = parsedData.rows.slice(i, i + batchSize);
     const valueRows = batch.map((row) => {
       const values = row.map((val, idx) => {
-        const sqlType = inferSqlType(parsedData.rows.slice(0, 100).map((r) => r[idx]));
+        const sqlType = columnTypes[idx];
         if (val === "" || val === "NULL" || val === "null") return "NULL";
-        if (sqlType === "INTEGER" || sqlType === "NUMERIC" || sqlType === "BOOLEAN") {
-          if (sqlType === "BOOLEAN") return val.toLowerCase() === "true" || val === "1" ? "TRUE" : "FALSE";
-          return val;
+        // The type came from the first 100 rows, so every value after them is
+        // outside the evidence for it. Each one is tested again by the same
+        // predicate that typed the column, and one that fails falls through to a
+        // quoted literal: unquoted text is statement grammar, and a row past the
+        // sample used to be able to carry `0); DELETE FROM users; --` straight
+        // into an import the user then executes (PR #304 review).
+        if (sqlType === "BOOLEAN" && BOOLEAN_VALUE.test(val)) {
+          return val.toLowerCase() === "true" || val === "1" ? "TRUE" : "FALSE";
         }
+        if (sqlType === "INTEGER" && INTEGER_VALUE.test(val)) return val;
+        if (sqlType === "NUMERIC" && NUMERIC_VALUE.test(val)) return val;
+        // A value the engine will refuse for its column is better than one it
+        // reads as SQL: the type error names the row, and nothing executes.
         return escapeSQL(val, dialect);
       });
       return `  (${values.join(", ")})`;

--- a/src/components/DataImportModal.tsx
+++ b/src/components/DataImportModal.tsx
@@ -17,7 +17,8 @@ import {
   Loader2,
   X,
 } from "lucide-react";
-import type { TableSchema } from "@/lib/types";
+import type { DatabaseType, TableSchema } from "@/lib/types";
+import { quoteLiteral } from "@/lib/sql/values";
 
 interface DataImportModalProps {
   isOpen: boolean;
@@ -106,9 +107,17 @@ export function inferSqlType(values: string[]): string {
   return "TEXT";
 }
 
-export function escapeSQL(value: string): string {
+/**
+ * Quote an imported cell as a SQL literal for the dialect the import will run on.
+ *
+ * These statements are handed to `onImport`, which executes them, so a cell of the
+ * uploaded file becomes SQL. Doubling the quote is enough only where a backslash
+ * is data: on a backslash-escaping dialect a cell ending in one would escape the
+ * closing quote and have the rest of the row read as statement text (#290).
+ */
+export function escapeSQL(value: string, dialect?: DatabaseType): string {
   if (value === "" || value === "null" || value === "NULL") return "NULL";
-  return `'${value.replace(/'/g, "''")}'`;
+  return quoteLiteral(value, dialect);
 }
 
 export function generateImportSQL(
@@ -117,6 +126,7 @@ export function generateImportSQL(
   createNewTable: boolean,
   newTableName: string,
   columnMapping: Record<string, string>,
+  dialect?: DatabaseType,
 ): string {
   if (!parsedData) return "";
 
@@ -150,7 +160,7 @@ export function generateImportSQL(
           if (sqlType === "BOOLEAN") return val.toLowerCase() === "true" || val === "1" ? "TRUE" : "FALSE";
           return val;
         }
-        return escapeSQL(val);
+        return escapeSQL(val, dialect);
       });
       return `  (${values.join(", ")})`;
     });
@@ -239,8 +249,16 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
   }, []);
 
   const generatedSQL = useMemo(
-    () => generateImportSQL(parsedData, targetTable, createNewTable, newTableName, columnMapping),
-    [parsedData, targetTable, createNewTable, newTableName, columnMapping],
+    () =>
+      generateImportSQL(
+        parsedData,
+        targetTable,
+        createNewTable,
+        newTableName,
+        columnMapping,
+        databaseType as DatabaseType | undefined,
+      ),
+    [parsedData, targetTable, createNewTable, newTableName, columnMapping, databaseType],
   );
 
   const handleImport = () => {

--- a/src/components/PivotTable.tsx
+++ b/src/components/PivotTable.tsx
@@ -5,6 +5,7 @@ import { Columns3, GripVertical, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DatabaseType, QueryResult } from "@/lib/types";
 import { quoteLiteral } from "@/lib/sql/values";
+import { quoteIdentifier } from "@/lib/sql/identifier";
 
 interface PivotTableProps {
   result: QueryResult | null;
@@ -109,26 +110,32 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
   // Generate SQL
   const generateSQL = useCallback(() => {
     if (!rowField) return "";
-    const select: string[] = [`"${rowField}"`];
-    const groupBy: string[] = [`"${rowField}"`];
+    // Every name here is arbitrary result data: a field is whatever the query
+    // aliased it to, and a pivot key is a value the rows carried. Both are quoted
+    // for the connected dialect rather than wrapped in a hard-coded `"` — that
+    // form is not even an identifier on MySQL, and a name holding the closing
+    // quote character would end the span and leave the rest to be parsed as SQL
+    // (#290, PR #304 review).
+    const dialect = databaseType as DatabaseType | undefined;
+    const quote = (name: string) => quoteIdentifier(name, dialect);
+    const select: string[] = [quote(rowField)];
+    const groupBy: string[] = [quote(rowField)];
 
     if (colField) {
       // Use CASE WHEN for pivot columns
       const colKeys = pivotData?.colKeys || [];
       for (const ck of colKeys) {
         if (ck === "__all__") continue;
-        const valExpr = valueField ? `"${valueField}"` : "1";
-        // A column key is a VALUE the result carried, so it is quoted the way the
-        // connected engine reads a literal — doubling the quote alone would let a
-        // key ending in a backslash close the literal on MySQL or ClickHouse and
-        // have the rest read as SQL (#290).
+        const valExpr = valueField ? quote(valueField) : "1";
+        // The same key is a VALUE on the left of the comparison and an IDENTIFIER
+        // as the column's alias, so it is quoted both ways in the same line.
         select.push(
-          `${AGG_LABELS[aggFunction]}(CASE WHEN "${colField}" = ${quoteLiteral(ck, databaseType as DatabaseType | undefined)} THEN ${valExpr} END) AS "${ck}"`,
+          `${AGG_LABELS[aggFunction]}(CASE WHEN ${quote(colField)} = ${quoteLiteral(ck, dialect)} THEN ${valExpr} END) AS ${quote(ck)}`,
         );
       }
     } else {
-      const valExpr = valueField ? `"${valueField}"` : "*";
-      select.push(`${AGG_LABELS[aggFunction]}(${valExpr}) AS "${aggFunction}_value"`);
+      const valExpr = valueField ? quote(valueField) : "*";
+      select.push(`${AGG_LABELS[aggFunction]}(${valExpr}) AS ${quote(`${aggFunction}_value`)}`);
     }
 
     return `SELECT\n  ${select.join(",\n  ")}\nFROM your_table\nGROUP BY ${groupBy.join(", ")}\nORDER BY ${groupBy.join(", ")};`;

--- a/src/components/PivotTable.tsx
+++ b/src/components/PivotTable.tsx
@@ -3,11 +3,14 @@
 import React, { useState, useMemo, useCallback, useEffect } from "react";
 import { Columns3, GripVertical, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { QueryResult } from "@/lib/types";
+import { DatabaseType, QueryResult } from "@/lib/types";
+import { quoteLiteral } from "@/lib/sql/values";
 
 interface PivotTableProps {
   result: QueryResult | null;
   onLoadQuery?: (query: string) => void;
+  /** The connected engine, so a generated literal is quoted the way it reads it. */
+  databaseType?: string;
 }
 
 type AggFunction = "count" | "sum" | "avg" | "min" | "max";
@@ -37,7 +40,7 @@ export function aggregate(values: unknown[], fn: AggFunction): string {
   }
 }
 
-export function PivotTable({ result, onLoadQuery }: PivotTableProps) {
+export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProps) {
   const [rowField, setRowField] = useState<string | null>(null);
   const [colField, setColField] = useState<string | null>(null);
   const [valueField, setValueField] = useState<string | null>(null);
@@ -115,8 +118,12 @@ export function PivotTable({ result, onLoadQuery }: PivotTableProps) {
       for (const ck of colKeys) {
         if (ck === "__all__") continue;
         const valExpr = valueField ? `"${valueField}"` : "1";
+        // A column key is a VALUE the result carried, so it is quoted the way the
+        // connected engine reads a literal — doubling the quote alone would let a
+        // key ending in a backslash close the literal on MySQL or ClickHouse and
+        // have the rest read as SQL (#290).
         select.push(
-          `${AGG_LABELS[aggFunction]}(CASE WHEN "${colField}" = '${ck.replace(/'/g, "''")}' THEN ${valExpr} END) AS "${ck}"`,
+          `${AGG_LABELS[aggFunction]}(CASE WHEN "${colField}" = ${quoteLiteral(ck, databaseType as DatabaseType | undefined)} THEN ${valExpr} END) AS "${ck}"`,
         );
       }
     } else {
@@ -125,7 +132,7 @@ export function PivotTable({ result, onLoadQuery }: PivotTableProps) {
     }
 
     return `SELECT\n  ${select.join(",\n  ")}\nFROM your_table\nGROUP BY ${groupBy.join(", ")}\nORDER BY ${groupBy.join(", ")};`;
-  }, [rowField, colField, valueField, aggFunction, pivotData]);
+  }, [rowField, colField, valueField, aggFunction, pivotData, databaseType]);
 
   if (!result || rows.length === 0) {
     return (

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -23,6 +23,7 @@ import {
   BottomPanel,
 } from "@/components/studio/index";
 import { DatabaseConnection, SavedQuery } from "@/lib/types";
+import { quoteLiteral } from "@/lib/sql/values";
 import { useToast } from "@/hooks/use-toast";
 import { useProviderMetadata } from "@/hooks/use-provider-metadata";
 import { useAuth } from "@/hooks/use-auth";
@@ -226,7 +227,12 @@ export default function Studio() {
           const val = row[col];
           if (val === null || val === undefined) return "NULL";
           if (typeof val === "number" || typeof val === "boolean") return String(val);
-          return `'${String(val).replace(/'/g, "''")}'`;
+          // The exported file is SQL that runs somewhere later, usually unattended,
+          // and every value in it is data the table held. Quoting is therefore the
+          // connected engine's own: doubling the quote alone would let a value
+          // ending in a backslash close its literal and have the rest of the file
+          // read as statements (#290).
+          return quoteLiteral(String(val), conn.activeConnection?.type);
         });
         return `INSERT INTO ${tableName} (${columns.join(", ")}) VALUES (${values.join(", ")});`;
       });

--- a/src/components/TestDataGenerator.tsx
+++ b/src/components/TestDataGenerator.tsx
@@ -3,7 +3,8 @@
 import React, { useState, useMemo } from "react";
 import { Wand2, X, Play, Copy, Check, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { TableSchema } from "@/lib/types";
+import { DatabaseType, TableSchema } from "@/lib/types";
+import { quoteLiteral } from "@/lib/sql/values";
 
 interface TestDataGeneratorProps {
   isOpen: boolean;
@@ -161,6 +162,7 @@ export function TestDataGenerator({
   onClose,
   tableName,
   tableSchema,
+  databaseType,
   queryLanguage,
   onExecuteQuery,
 }: TestDataGeneratorProps) {
@@ -213,14 +215,17 @@ export function TestDataGenerator({
           type.includes("real")
         )
           return val;
-        return `'${val.replace(/'/g, "''")}'`;
+        // No generator can produce a quote or a backslash today, so this is the
+        // shared quoting rather than a fix: the next generator added inherits a
+        // literal the connected engine reads as data (#290).
+        return quoteLiteral(val, databaseType as DatabaseType | undefined);
       });
       return `(${values.join(", ")})`;
     });
 
     return `INSERT INTO ${tableName} (${colNames})\nVALUES\n  ${rows.join(",\n  ")};`;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tableSchema, columnConfigs, rowCount, queryLanguage, tableName, refreshKey]);
+  }, [tableSchema, columnConfigs, rowCount, queryLanguage, tableName, databaseType, refreshKey]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(generatedQuery);

--- a/src/components/TestDataGenerator.tsx
+++ b/src/components/TestDataGenerator.tsx
@@ -203,20 +203,26 @@ export function TestDataGenerator({
       const values = cols.map((col) => {
         const gen = FAKE[col.faker.generator as keyof typeof FAKE];
         const val = gen ? gen(i) : `value_${i}`;
-        // Determine if value should be quoted
+        // Determine if value should be quoted. The generator is picked by column
+        // NAME and this test reads the column TYPE, so the two can disagree —
+        // `phone BIGINT` yields `+1-555-…`. The value itself decides, not the
+        // type alone: a value written unquoted IS statement grammar, so one that
+        // does not look like a number is quoted and the engine gets to object
+        // (PR #304 review).
         const type = col.type.toLowerCase();
-        if (type.includes("bool")) return val;
+        if (type.includes("bool") && /^(true|false)$/i.test(val)) return val;
         if (
-          type.includes("int") ||
-          type.includes("float") ||
-          type.includes("double") ||
-          type.includes("decimal") ||
-          type.includes("numeric") ||
-          type.includes("real")
+          (type.includes("int") ||
+            type.includes("float") ||
+            type.includes("double") ||
+            type.includes("decimal") ||
+            type.includes("numeric") ||
+            type.includes("real")) &&
+          /^-?\d+(\.\d+)?$/.test(val)
         )
           return val;
-        // No generator can produce a quote or a backslash today, so this is the
-        // shared quoting rather than a fix: the next generator added inherits a
+        // No generator can produce a quote or a backslash today, so the quoting
+        // itself is shared rather than a fix: the next generator added inherits a
         // literal the connected engine reads as data (#290).
         return quoteLiteral(val, databaseType as DatabaseType | undefined);
       });

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -319,6 +319,7 @@ export function BottomPanel({
               onLoadQuery(q);
               onSetMode("results");
             }}
+            databaseType={activeConnection?.type}
           />
         ) : mode === "docs" ? (
           <DatabaseDocs schema={schema} schemaContext={schemaContext} databaseType={activeConnection?.type} />

--- a/src/hooks/use-inline-editing.ts
+++ b/src/hooks/use-inline-editing.ts
@@ -5,6 +5,7 @@ import type { DatabaseConnection, QueryTab } from "@/lib/types";
 import type { CellChange } from "@/components/ResultsGrid";
 import { useToast } from "@/hooks/use-toast";
 import { isBareIdentifier, quoteIdentifier } from "@/lib/sql/identifier";
+import { positionalPlaceholder, quoteLiteral } from "@/lib/sql/values";
 
 interface UseInlineEditingParams {
   activeConnection: DatabaseConnection | null;
@@ -17,7 +18,7 @@ interface UseInlineEditingParams {
     sql: string,
     tabId?: string,
     isExplain?: boolean,
-    options?: { skipSafety?: boolean },
+    options?: { skipSafety?: boolean; params?: unknown[] },
   ) => void | Promise<unknown>;
 }
 
@@ -86,27 +87,49 @@ export function useInlineEditing({ activeConnection, currentTab, executeQuery }:
       return;
     }
 
-    const quote = (identifier: string) => quoteIdentifier(identifier, activeConnection.type);
+    const dialect = activeConnection.type;
+    const quote = (identifier: string) => quoteIdentifier(identifier, dialect);
 
     // Generate UPDATE statements
-    const statements: string[] = [];
+    const statements: Array<{ sql: string; params: unknown[] }> = [];
     for (const [rowIndex, changes] of changesByRow) {
       const row = currentTab.result.rows[rowIndex];
       const pkValue = row[pkColumn];
+      const params: unknown[] = [];
+      // A value is arbitrary text — pasted, imported, or read back from the table —
+      // so it is bound rather than written into the statement. Interpolating it and
+      // doubling the quote is only enough where a backslash is data: MySQL reads
+      // `\'` as an escaped quote, so a value could close its own literal and have
+      // the rest read as SQL, and applying edits skips the dangerous-query dialog
+      // that would otherwise show the user that statement (#290). Where the dialect
+      // has no positional bind form, a dialect-aware quoted literal is the fallback.
+      const emit = (value: string | number): string => {
+        const placeholder = positionalPlaceholder(dialect, params.length + 1);
+        if (placeholder !== null) {
+          params.push(value);
+          return placeholder;
+        }
+        return typeof value === "number" ? String(value) : quoteLiteral(value, dialect);
+      };
       const setClauses = changes.map((c) => {
-        const val =
-          c.newValue === "" || c.newValue.toUpperCase() === "NULL" ? "NULL" : `'${c.newValue.replace(/'/g, "''")}'`;
+        const isNull = c.newValue === "" || c.newValue.toUpperCase() === "NULL";
         // Column names come from the result's own field list, so they are exactly
         // what the engine reports and can be quoted: that keeps a name holding a
         // space or a reserved word legal, and keeps one that spells SQL inert.
-        return `${quote(c.columnId)} = ${val}`;
+        // NULL stays a keyword: it is not a value, so it takes no parameter.
+        return `${quote(c.columnId)} = ${isNull ? "NULL" : emit(c.newValue)}`;
       });
-      const pkVal = typeof pkValue === "number" ? pkValue : `'${pkValue}'`;
+      // The key keeps the number/text split it always had — a number goes to the
+      // driver as a number — but neither form is written into the statement now.
+      const pkVal = emit(typeof pkValue === "number" ? pkValue : String(pkValue));
       // No trailing semicolon: it only ever served to join the statements, and each
       // one now goes to /api/db/query verbatim rather than through
       // `splitStatements`, which used to strip it. oracledb rejects a plain
       // statement that carries one (ORA-00933).
-      statements.push(`UPDATE ${tableName} SET ${setClauses.join(", ")} WHERE ${quote(pkColumn)} = ${pkVal}`);
+      statements.push({
+        sql: `UPDATE ${tableName} SET ${setClauses.join(", ")} WHERE ${quote(pkColumn)} = ${pkVal}`,
+        params,
+      });
     }
 
     // One request per row (issue #269), sequentially and with the safety dialog
@@ -126,7 +149,10 @@ export function useInlineEditing({ activeConnection, currentTab, executeQuery }:
     //    statements are generated rather than typed, each carries a WHERE on the
     //    detected key, and the pending changes were reviewed in the grid first.
     for (const statement of statements) {
-      await executeQuery(statement, undefined, false, { skipSafety: true });
+      await executeQuery(statement.sql, undefined, false, {
+        skipSafety: true,
+        ...(statement.params.length > 0 && { params: statement.params }),
+      });
     }
     setPendingChanges([]);
     setEditingEnabled(false);

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -205,8 +205,18 @@ export function useQueryExecution({
         const queryToRun = directExplainSql || queryToExecute;
 
         // Detect multi-statement queries (not for EXPLAIN or load-more or transaction)
+        //
+        // A parameterized statement never takes this route: `/api/db/multi-query`
+        // splits the payload and binds nothing, so the values would be dropped and
+        // the statement would run with unbound placeholders. Parameters may only
+        // travel to an endpoint that binds them (PR #304 review).
         const useMultiQuery =
-          !isExplain && !isLoadMore && !transactionActive && !isPlaygroundRun && isMultiStatement(queryToExecute);
+          !isExplain &&
+          !isLoadMore &&
+          !transactionActive &&
+          !isPlaygroundRun &&
+          !params &&
+          isMultiStatement(queryToExecute);
 
         // Use transaction endpoint if a transaction is active or in playground mode
         const useTransaction = (transactionActive || isPlaygroundRun) && !isExplain;
@@ -249,6 +259,11 @@ export function useQueryExecution({
                 ...buildConnectionPayload(activeConnection),
                 sql: explainSql,
                 options: {},
+                // The explain SQL is the statement with a prefix, so its
+                // placeholders are the same ones in the same order and the same
+                // values bind them. Without this the plan request would run
+                // unbound and the panel would keep the previous plan (PR #304).
+                ...(params && { params }),
               }),
             });
           }

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -19,6 +19,12 @@ export interface QueryExecutionOptions {
   offset?: number;
   unlimited?: boolean;
   skipSafety?: boolean;
+  /**
+   * Values for the statement's positional placeholders, bound by the driver
+   * instead of written into the SQL. A generated statement (the inline row editor,
+   * #290) carries its values here so that no value can be read as statement text.
+   */
+  params?: unknown[];
 }
 
 interface UseQueryExecutionParams {
@@ -137,7 +143,7 @@ export function useQueryExecution({
       }
 
       // Options extraction
-      const { limit = 500, offset = 0, unlimited = false } = executionOptions || {};
+      const { limit = 500, offset = 0, unlimited = false, params } = executionOptions || {};
 
       // isLoadingMore flag
       const isLoadMore = offset > 0;
@@ -216,6 +222,10 @@ export function useQueryExecution({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             ...buildConnectionPayload(activeConnection),
+            // The parameter array travels beside the SQL on whichever endpoint the
+            // statement takes, and only when the caller supplied one: a request
+            // without values must stay a request without a `params` key (#290).
+            ...(params && { params }),
             ...(useTransaction
               ? { action: "query", sql: queryToExecute, options: { limit, offset, unlimited } }
               : {

--- a/src/lib/api/bound-params.ts
+++ b/src/lib/api/bound-params.ts
@@ -1,0 +1,30 @@
+/**
+ * The error a request gets when its `params` are not bindable. It names the whole
+ * allowed set rather than the offending element, because the offending element is
+ * a value the caller sent and the response is not the place to echo it back.
+ */
+export const BOUND_PARAMS_MESSAGE = "params must be an array of strings, numbers, booleans or null";
+
+type BoundParamsResult = { valid: true; params: unknown[] | undefined } | { valid: false; message: string };
+
+/**
+ * Read a request's `params` field — the values a statement's positional
+ * placeholders are bound to (#290).
+ *
+ * The check is a boundary, not a formality. The array reaches a driver's bind
+ * path directly, and every driver reacts differently to a value it cannot bind:
+ * an object may be coerced, expanded, or rejected deep inside the engine. Only the
+ * scalars JSON can carry get through, so an inline row edit's value is bindable by
+ * construction and anything else is refused with a 400 rather than a query error.
+ */
+export function readBoundParams(value: unknown): BoundParamsResult {
+  if (value === undefined) return { valid: true, params: undefined };
+  if (!Array.isArray(value)) return { valid: false, message: BOUND_PARAMS_MESSAGE };
+
+  const bindable = value.every(
+    (element) =>
+      element === null || typeof element === "string" || typeof element === "number" || typeof element === "boolean",
+  );
+
+  return bindable ? { valid: true, params: value } : { valid: false, message: BOUND_PARAMS_MESSAGE };
+}

--- a/src/lib/db/providers/sql/sql-base.ts
+++ b/src/lib/db/providers/sql/sql-base.ts
@@ -57,13 +57,6 @@ export abstract class SQLBaseProvider extends BaseDatabaseProvider {
   }
 
   /**
-   * Escape string value for SQL
-   */
-  protected escapeString(value: string): string {
-    return value.replace(/'/g, "''");
-  }
-
-  /**
    * Build LIMIT clause based on dialect
    */
   protected buildLimitClause(limit: number, offset?: number): string {
@@ -71,18 +64,6 @@ export abstract class SQLBaseProvider extends BaseDatabaseProvider {
       return `LIMIT ${limit} OFFSET ${offset}`;
     }
     return `LIMIT ${limit}`;
-  }
-
-  /**
-   * Get placeholder style for parameterized queries
-   * PostgreSQL: $1, $2, $3
-   * MySQL/SQLite: ?, ?, ?
-   */
-  protected getPlaceholder(index: number): string {
-    if (this.type === "postgres") return `$${index}`;
-    if (this.type === "oracle") return `:${index}`;
-    if (this.type === "mssql") return `@p${index}`;
-    return "?";
   }
 
   /**

--- a/src/lib/sql/identifier.ts
+++ b/src/lib/sql/identifier.ts
@@ -14,7 +14,7 @@ import type { DatabaseType } from "@/lib/types";
  * name you have exactly as the engine reports it — a result field name is such a
  * name; a table name guessed from a tab title is not.
  */
-export function quoteIdentifier(name: string, dialect: DatabaseType): string {
+export function quoteIdentifier(name: string, dialect: DatabaseType | undefined): string {
   switch (dialect) {
     case "mysql":
       return `\`${name.replace(/`/g, "``")}\``;
@@ -23,7 +23,8 @@ export function quoteIdentifier(name: string, dialect: DatabaseType): string {
     default:
       // The SQL standard form, and what the remaining dialects use: PostgreSQL,
       // SQLite, Oracle, ClickHouse, Druid, and the document/key-value providers
-      // whose generators fall back to it.
+      // whose generators fall back to it. An undefined dialect lands here too —
+      // a generator with no connection to name one can claim only the standard.
       return `"${name.replace(/"/g, '""')}"`;
   }
 }

--- a/src/lib/sql/values.ts
+++ b/src/lib/sql/values.ts
@@ -42,9 +42,14 @@ const BACKSLASH_ESCAPES_IN_LITERAL: Record<DatabaseType, boolean> = {
  * a value ending in `\` would escape the closing quote and everything after it
  * would be read as SQL — a `WHERE` clause pasted into a cell then becomes the
  * statement's real predicate (issue #290).
+ *
+ * An undefined dialect is the generator that has no connection to name one. It
+ * gets the standard form, matching the standard identifier quoting such a
+ * generator already emits: doubling the backslash there would corrupt the value on
+ * every dialect that reads it as data, which is the larger group.
  */
-export function quoteLiteral(value: string, dialect: DatabaseType): string {
-  const escaped = BACKSLASH_ESCAPES_IN_LITERAL[dialect] ? value.replace(/\\/g, "\\\\") : value;
+export function quoteLiteral(value: string, dialect: DatabaseType | undefined): string {
+  const escaped = dialect && BACKSLASH_ESCAPES_IN_LITERAL[dialect] ? value.replace(/\\/g, "\\\\") : value;
   return `'${escaped.replace(/'/g, "''")}'`;
 }
 

--- a/src/lib/sql/values.ts
+++ b/src/lib/sql/values.ts
@@ -1,0 +1,81 @@
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * Whether the dialect reads a backslash as an escape character inside a string
+ * literal. The map is total on purpose: a new provider cannot be added without
+ * TypeScript demanding an answer here, because the silent wrong answer is exactly
+ * the defect this file exists to close (issue #290).
+ */
+const BACKSLASH_ESCAPES_IN_LITERAL: Record<DatabaseType, boolean> = {
+  // `standard_conforming_strings` has been on by default since PostgreSQL 9.1, so
+  // a backslash in a plain literal is data.
+  postgres: false,
+  sqlite: false,
+  oracle: false,
+  mssql: false,
+  // Calcite's standard lexer, which Druid SQL uses: doubling is the only escape.
+  druid: false,
+  // No SQL string literal of its own; the standard form is the inert choice.
+  redis: false,
+  libredb: false,
+  // Default `sql_mode`. A server running with NO_BACKSLASH_ESCAPES reads the
+  // doubled backslash as two characters, which is why binding the value beats
+  // quoting it wherever a bind form exists.
+  mysql: true,
+  // Matches what the ClickHouse provider already does when it builds its own
+  // literals (`src/lib/db/providers/sql/clickhouse/index.ts`).
+  clickhouse: true,
+  // SQL++ and the document shells spell their strings the way JSON does.
+  couchbase: true,
+  mongodb: true,
+};
+
+/**
+ * Quote a value as a string literal for a dialect.
+ *
+ * This is the weaker half of the fix and it is the fallback, not the default: use
+ * `positionalPlaceholder` and bind the value wherever the dialect has a bind form,
+ * so the value never becomes statement text at all. Quoting is what remains for a
+ * dialect that has no positional form.
+ *
+ * Doubling the quote alone is not enough. In a dialect where a backslash escapes,
+ * a value ending in `\` would escape the closing quote and everything after it
+ * would be read as SQL — a `WHERE` clause pasted into a cell then becomes the
+ * statement's real predicate (issue #290).
+ */
+export function quoteLiteral(value: string, dialect: DatabaseType): string {
+  const escaped = BACKSLASH_ESCAPES_IN_LITERAL[dialect] ? value.replace(/\\/g, "\\\\") : value;
+  return `'${escaped.replace(/'/g, "''")}'`;
+}
+
+/**
+ * The placeholder a dialect's driver binds for the 1-based `position`, or `null`
+ * where this repo has not pinned a positional bind form.
+ *
+ * Each form is the one the provider's own `query(sql, params)` actually binds, so
+ * changing one without changing the provider breaks the pair: `pg` takes `$n`,
+ * `mysql2` and the SQLite drivers take `?`, `oracledb` binds an array to `:n`, and
+ * the mssql provider registers its inputs as `p1`, `p2`, … which the statement
+ * spells `@p1`, `@p2`.
+ *
+ * `null` is not the claim that an engine cannot bind — it is the claim that this
+ * repo has not verified how. ClickHouse's provider refuses positional parameters
+ * outright, and the remaining engines are not driven by a SQL statement. A dialect
+ * that gains statement-driven row editing (issue #279) adds its form here; until
+ * it does, `quoteLiteral` keeps the value out of the statement's grammar.
+ */
+export function positionalPlaceholder(dialect: DatabaseType, position: number): string | null {
+  switch (dialect) {
+    case "postgres":
+      return `$${position}`;
+    case "mysql":
+    case "sqlite":
+      return "?";
+    case "oracle":
+      return `:${position}`;
+    case "mssql":
+      return `@p${position}`;
+    default:
+      return null;
+  }
+}

--- a/src/lib/sql/values.ts
+++ b/src/lib/sql/values.ts
@@ -1,33 +1,47 @@
 import type { DatabaseType } from "@/lib/types";
 
 /**
- * Whether the dialect reads a backslash as an escape character inside a string
- * literal. The map is total on purpose: a new provider cannot be added without
- * TypeScript demanding an answer here, because the silent wrong answer is exactly
- * the defect this file exists to close (issue #290).
+ * How a dialect spells the escapes inside a single-quoted string literal.
+ *
+ * - `standard` — the quote is doubled and a backslash is ordinary data.
+ * - `double-and-backslash` — the quote is doubled, and a backslash escapes, so it
+ *   has to be doubled too or it would escape the closing quote.
+ * - `backslash` — every escape is spelled with a backslash, including the quote;
+ *   doubling is not part of the grammar.
+ *
+ * The map is total on purpose: a new provider cannot be added without TypeScript
+ * demanding an answer here, because the silent wrong answer is exactly the defect
+ * this file exists to close (issue #290).
  */
-const BACKSLASH_ESCAPES_IN_LITERAL: Record<DatabaseType, boolean> = {
+type LiteralEscape = "standard" | "double-and-backslash" | "backslash";
+
+const LITERAL_ESCAPE: Record<DatabaseType, LiteralEscape> = {
   // `standard_conforming_strings` has been on by default since PostgreSQL 9.1, so
   // a backslash in a plain literal is data.
-  postgres: false,
-  sqlite: false,
-  oracle: false,
-  mssql: false,
-  // Calcite's standard lexer, which Druid SQL uses: doubling is the only escape.
-  druid: false,
-  // No SQL string literal of its own; the standard form is the inert choice.
-  redis: false,
-  libredb: false,
+  postgres: "standard",
+  sqlite: "standard",
+  oracle: "standard",
+  mssql: "standard",
+  // Druid quotes a string with single quotes and puts its backslash escapes in the
+  // separate `U&'fo\00F6'` form, so a backslash in a plain literal is data.
+  druid: "standard",
+  // These three declare `queryLanguage: "json"`, so no statement is ever built for
+  // them to read. What a generator emits for such a connection is portable SQL
+  // meant to run elsewhere, and the standard form is the only thing it can claim.
+  mongodb: "standard",
+  redis: "standard",
+  libredb: "standard",
   // Default `sql_mode`. A server running with NO_BACKSLASH_ESCAPES reads the
   // doubled backslash as two characters, which is why binding the value beats
   // quoting it wherever a bind form exists.
-  mysql: true,
+  mysql: "double-and-backslash",
   // Matches what the ClickHouse provider already does when it builds its own
   // literals (`src/lib/db/providers/sql/clickhouse/index.ts`).
-  clickhouse: true,
-  // SQL++ and the document shells spell their strings the way JSON does.
-  couchbase: true,
-  mongodb: true,
+  clickhouse: "double-and-backslash",
+  // SQL++ spells its literals the way JSON does — `char ::= unicode-character |
+  // '\' ( '\' | '"' | "'" | 'b' | 'f' | 'n' | 'r' | 't' | 'u' hex hex hex hex )`.
+  // Doubling is not in that grammar, so a doubled quote is not one literal there.
+  couchbase: "backslash",
 };
 
 /**
@@ -49,8 +63,13 @@ const BACKSLASH_ESCAPES_IN_LITERAL: Record<DatabaseType, boolean> = {
  * every dialect that reads it as data, which is the larger group.
  */
 export function quoteLiteral(value: string, dialect: DatabaseType | undefined): string {
-  const escaped = dialect && BACKSLASH_ESCAPES_IN_LITERAL[dialect] ? value.replace(/\\/g, "\\\\") : value;
-  return `'${escaped.replace(/'/g, "''")}'`;
+  const escape = dialect ? LITERAL_ESCAPE[dialect] : "standard";
+  if (escape === "standard") return `'${value.replace(/'/g, "''")}'`;
+
+  // The backslash goes first in both remaining forms: doubling it afterwards would
+  // also double the one this function just added in front of a quote.
+  const escaped = value.replace(/\\/g, "\\\\");
+  return escape === "backslash" ? `'${escaped.replace(/'/g, "\\'")}'` : `'${escaped.replace(/'/g, "''")}'`;
 }
 
 /**
@@ -63,18 +82,23 @@ export function quoteLiteral(value: string, dialect: DatabaseType | undefined): 
  * the mssql provider registers its inputs as `p1`, `p2`, … which the statement
  * spells `@p1`, `@p2`.
  *
- * `null` is not the claim that an engine cannot bind — it is the claim that this
- * repo has not verified how. ClickHouse's provider refuses positional parameters
- * outright, and the remaining engines are not driven by a SQL statement. A dialect
- * that gains statement-driven row editing (issue #279) adds its form here; until
- * it does, `quoteLiteral` keeps the value out of the statement's grammar.
+ * `null` is where this repo knows there is no positional form to spell: ClickHouse
+ * binds named parameters only and its provider refuses positional ones outright,
+ * and MongoDB, Redis and the embedded engine declare `queryLanguage: "json"`, so
+ * no SQL statement binds anything for them. It is the signal to quote the value
+ * with `quoteLiteral` instead — never to emit a placeholder nothing will bind.
  */
 export function positionalPlaceholder(dialect: DatabaseType, position: number): string | null {
   switch (dialect) {
+    // SQL++ takes its values in `args`, which the statement reads as `$1`, `$2`.
     case "postgres":
+    case "couchbase":
       return `$${position}`;
+    // Druid binds a `parameters` array against `?`, live-verified when the
+    // provider was written (`src/lib/db/providers/sql/druid/index.ts`).
     case "mysql":
     case "sqlite":
+    case "druid":
       return "?";
     case "oracle":
       return `:${position}`;

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -19,6 +19,7 @@ import { useConnectionAdapter } from "@/workspace/hooks/use-connection-adapter";
 import { useQueryAdapter } from "@/workspace/hooks/use-query-adapter";
 import { type StudioWorkspaceProps, DEFAULT_WORKSPACE_FEATURES } from "@/workspace/types";
 import { cn } from "@/lib/utils";
+import { quoteLiteral } from "@/lib/sql/values";
 
 /**
  * Scoped CSS for studio's dark theme.
@@ -233,7 +234,12 @@ export function StudioWorkspace({
             const val = row[col];
             if (val === null || val === undefined) return "NULL";
             if (typeof val === "number" || typeof val === "boolean") return String(val);
-            return `'${String(val).replace(/'/g, "''")}'`;
+            // The exported file is SQL that runs somewhere later, usually
+            // unattended, and every value in it is data the table held. Quoting is
+            // the connected engine's own: doubling the quote alone would let a
+            // value ending in a backslash close its literal and have the rest of
+            // the file read as statements (#290).
+            return quoteLiteral(String(val), conn.activeConnection?.type);
           });
           return `INSERT INTO ${tableName} (${columns.join(", ")}) VALUES (${values.join(", ")});`;
         });

--- a/tests/api/db/profile.test.ts
+++ b/tests/api/db/profile.test.ts
@@ -86,6 +86,28 @@ describe("POST /api/db/profile", () => {
     );
   });
 
+  // The column name arrives in the request and is embedded in the profiling query
+  // as a string literal (`'<col>' as column_name`). Doubling the quote is enough
+  // only where a backslash is data, so on a backslash-escaping dialect a name
+  // ending in one would close the literal and have the rest read as SQL (#290).
+  test("quotes the column label for the connected dialect", async () => {
+    const req = createMockRequest("/api/db/profile", {
+      method: "POST",
+      body: {
+        connection: { ...validConnection, type: "mysql" },
+        tableName: "users",
+        columns: ["a\\' UNION SELECT 1 -- "],
+      },
+    });
+
+    await POST(req as never);
+
+    const emitted = (mockSQLProvider.query as ReturnType<typeof mock>).mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(emitted).toContain("'a\\\\'' UNION SELECT 1 -- ' as column_name");
+  });
+
   test("returns 401 when no session exists", async () => {
     mockGetSession.mockResolvedValueOnce(null);
 

--- a/tests/api/db/query.test.ts
+++ b/tests/api/db/query.test.ts
@@ -140,6 +140,73 @@ describe("POST /api/db/query", () => {
     expect(providerWithCancel.query).toHaveBeenCalledWith("SELECT * FROM users LIMIT 50", undefined, "query-42");
   });
 
+  // ── Bound parameters (#290) ───────────────────────────────────────────────
+  //
+  // A generated statement (the inline row editor) sends its values here instead of
+  // writing them into the SQL, so a value cannot close a string literal and have
+  // the rest read as statement text. The route is the last hop before the driver's
+  // bind path, so it is also where an unbindable value is refused.
+
+  test("binds the request's parameters instead of running the statement unbound", async () => {
+    const req = createMockRequest("/api/db/query", {
+      method: "POST",
+      body: {
+        connection: validConnection,
+        sql: `UPDATE users SET "name" = $1 WHERE "id" = $2`,
+        params: ["\\' WHERE 1=1 -- ", 7],
+      },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(200);
+    expect(mockProvider.query).toHaveBeenCalledWith(`UPDATE users SET "name" = $1 WHERE "id" = $2 LIMIT 50`, [
+      "\\' WHERE 1=1 -- ",
+      7,
+    ]);
+  });
+
+  test("binds parameters alongside a queryId when cancellation is supported", async () => {
+    const providerWithCancel = {
+      ...createMockProvider(),
+      cancelQuery: mock(async () => true),
+    };
+    mockGetOrCreateProvider.mockResolvedValueOnce(providerWithCancel as never);
+
+    const req = createMockRequest("/api/db/query", {
+      method: "POST",
+      body: {
+        connection: validConnection,
+        sql: `UPDATE users SET "name" = $1 WHERE "id" = $2`,
+        params: ["Alice", 7],
+        queryId: "query-42",
+      },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(200);
+    expect(providerWithCancel.query).toHaveBeenCalledWith(
+      `UPDATE users SET "name" = $1 WHERE "id" = $2 LIMIT 50`,
+      ["Alice", 7],
+      "query-42",
+    );
+  });
+
+  test("returns 400 for a parameter the driver cannot bind as a scalar", async () => {
+    const req = createMockRequest("/api/db/query", {
+      method: "POST",
+      body: { connection: validConnection, sql: "SELECT * FROM users WHERE id = $1", params: [{ nested: true }] },
+    });
+
+    const res = await POST(req as never);
+    const data = await parseResponseJSON<{ error: string }>(res);
+
+    expect(res.status).toBe(400);
+    expect(data.error).toContain("params");
+    expect(mockProvider.query).not.toHaveBeenCalled();
+  });
+
   test("returns 200 with rows and pagination for valid query", async () => {
     const req = createMockRequest("/api/db/query", {
       method: "POST",

--- a/tests/api/db/transaction.test.ts
+++ b/tests/api/db/transaction.test.ts
@@ -222,6 +222,49 @@ describe("POST /api/db/transaction", () => {
     expect(data.pagination.wasLimited).toBeDefined();
   });
 
+  // A row edit applied while a transaction is open takes this endpoint, so the
+  // values have to be bound here too — otherwise the transaction path would be the
+  // one place a generated statement still carried its values as text (#290).
+
+  test("query action binds the request's parameters", async () => {
+    const req = createMockRequest("/api/db/transaction", {
+      method: "POST",
+      body: {
+        connection: validConnection,
+        action: "query",
+        sql: `UPDATE users SET "name" = $1 WHERE "id" = $2`,
+        params: ["\\' WHERE 1=1 -- ", 7],
+      },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(200);
+    expect(mockTxProvider.queryInTransaction).toHaveBeenCalledWith(
+      `UPDATE users SET "name" = $1 WHERE "id" = $2 LIMIT 50`,
+      ["\\' WHERE 1=1 -- ", 7],
+    );
+  });
+
+  test("query action returns 400 for a parameter the driver cannot bind as a scalar", async () => {
+    const req = createMockRequest("/api/db/transaction", {
+      method: "POST",
+      body: {
+        connection: validConnection,
+        action: "query",
+        sql: "SELECT * FROM users WHERE id = $1",
+        params: [{ nested: true }],
+      },
+    });
+
+    const res = await POST(req as never);
+    const data = await parseResponseJSON<{ error: string }>(res);
+
+    expect(res.status).toBe(400);
+    expect(data.error).toContain("params");
+    expect(mockTxProvider.queryInTransaction).not.toHaveBeenCalled();
+  });
+
   test("query action without sql returns 400", async () => {
     const req = createMockRequest("/api/db/transaction", {
       method: "POST",

--- a/tests/components/PivotTable.test.tsx
+++ b/tests/components/PivotTable.test.tsx
@@ -188,6 +188,56 @@ describe("PivotTable", () => {
     expect(sql).toContain("= 'a\\\\'' OR 1=1 -- '");
   });
 
+  test("Generate SQL quotes the identifiers it builds from result data", () => {
+    // The same key is also written as the column's ALIAS, and a field name is
+    // whatever the query aliased it to. Both reach the statement as identifiers,
+    // so a value carrying the closing quote character would end the quoted span
+    // and leave the rest to be parsed as SQL (PR #304 review).
+    const hostile: QueryResult = {
+      rows: [
+        { 'de"pt': "Engineering", status: 'a" , 1 AS x --', salary: 90000 },
+        { 'de"pt': "Sales", status: "active", salary: 70000 },
+      ],
+      fields: ['de"pt', "status", "salary"],
+      rowCount: 2,
+      executionTime: 5,
+    };
+    const onLoadQuery = mock((sql: string) => {
+      void sql;
+    });
+    const { container, queryByText } = render(<PivotTable result={hostile} onLoadQuery={onLoadQuery} />);
+    const colSelect = container.querySelectorAll("select")[1];
+    fireEvent.change(colSelect!, { target: { value: "status" } });
+    fireEvent.click(queryByText("Generate SQL")!);
+
+    const sql = onLoadQuery.mock.calls[0][0];
+    expect(sql).toContain('AS "a"" , 1 AS x --"');
+    expect(sql).toContain('"de""pt"');
+    // The `--` and the comma are inside the alias and the literal, and nowhere
+    // else: each appears exactly as many times as the values that carry them.
+    expect(sql.match(/--/g)).toHaveLength(2);
+  });
+
+  test("Generate SQL quotes identifiers the way the connected dialect spells them", () => {
+    // MySQL does not read `"name"` as an identifier at all: without ANSI_QUOTES it
+    // is a string literal, so a generated alias in that form is not just unsafe,
+    // it is wrong.
+    const onLoadQuery = mock((sql: string) => {
+      void sql;
+    });
+    const { container, queryByText } = render(
+      <PivotTable result={result} onLoadQuery={onLoadQuery} databaseType="mysql" />,
+    );
+    const colSelect = container.querySelectorAll("select")[1];
+    fireEvent.change(colSelect!, { target: { value: "status" } });
+    fireEvent.click(queryByText("Generate SQL")!);
+
+    const sql = onLoadQuery.mock.calls[0][0];
+    expect(sql).toContain("`dept`");
+    expect(sql).toContain("AS `active`");
+    expect(sql).not.toContain('"');
+  });
+
   test("Generate SQL emits the standard form when no dialect is known", () => {
     const withBackslash: QueryResult = {
       rows: [

--- a/tests/components/PivotTable.test.tsx
+++ b/tests/components/PivotTable.test.tsx
@@ -160,6 +160,55 @@ describe("PivotTable", () => {
     expect(sql).toContain("CASE WHEN");
   });
 
+  // A pivot column key is a VALUE read back from the result, so it carries
+  // whatever the table holds and reaches the generated statement as a literal. The
+  // SQL is loaded into the editor a click away from running (#290).
+
+  test("Generate SQL quotes a column key for the dialect the result came from", () => {
+    const hostile: QueryResult = {
+      rows: [
+        { dept: "Engineering", status: "a\\' OR 1=1 -- ", salary: 90000 },
+        { dept: "Sales", status: "active", salary: 70000 },
+      ],
+      fields: ["dept", "status", "salary"],
+      rowCount: 2,
+      executionTime: 5,
+    };
+    const onLoadQuery = mock((sql: string) => {
+      void sql;
+    });
+    const { container, queryByText } = render(
+      <PivotTable result={hostile} onLoadQuery={onLoadQuery} databaseType="mysql" />,
+    );
+    const colSelect = container.querySelectorAll("select")[1];
+    fireEvent.change(colSelect!, { target: { value: "status" } });
+    fireEvent.click(queryByText("Generate SQL")!);
+
+    const sql = onLoadQuery.mock.calls[0][0];
+    expect(sql).toContain("= 'a\\\\'' OR 1=1 -- '");
+  });
+
+  test("Generate SQL emits the standard form when no dialect is known", () => {
+    const withBackslash: QueryResult = {
+      rows: [
+        { dept: "Engineering", status: "C:\\Users", salary: 90000 },
+        { dept: "Sales", status: "active", salary: 70000 },
+      ],
+      fields: ["dept", "status", "salary"],
+      rowCount: 2,
+      executionTime: 5,
+    };
+    const onLoadQuery = mock((sql: string) => {
+      void sql;
+    });
+    const { container, queryByText } = render(<PivotTable result={withBackslash} onLoadQuery={onLoadQuery} />);
+    const colSelect = container.querySelectorAll("select")[1];
+    fireEvent.change(colSelect!, { target: { value: "status" } });
+    fireEvent.click(queryByText("Generate SQL")!);
+
+    expect(onLoadQuery.mock.calls[0][0]).toContain("= 'C:\\Users'");
+  });
+
   test("status footer shows group and column counts", () => {
     const { container } = render(<PivotTable result={result} />);
     const text = container.textContent || "";

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -804,6 +804,37 @@ describe("Studio", () => {
     expect(blob.type).toBe("text/sql");
   });
 
+  // The exported file is SQL that will be run somewhere later, usually
+  // unattended, and every value in it is data the table held. A cell ending in a
+  // backslash would close its literal on a dialect that escapes with one and have
+  // the rest of the file read as statements (#290).
+  test("exportResults sql-insert quotes a cell for the connected dialect", async () => {
+    connMgrOverride = { activeConnection: { ...pgConn, type: "mysql" as const } };
+    tabMgrOverride = {
+      currentTab: {
+        id: "tab-1",
+        name: "Users",
+        query: "SELECT 1",
+        result: {
+          rows: [{ id: 1, path: "C:\\Users\\'); DROP TABLE users; --" }],
+          fields: ["id", "path"],
+          rowCount: 1,
+          executionTime: 1,
+        },
+        isExecuting: false,
+        type: "sql",
+      },
+    };
+    render(<Studio />);
+    const exportFn = capturedBottomPanelProps.onExportResults as (format: string) => void;
+    act(() => exportFn("sql-insert"));
+
+    const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
+    expect(await blob.text()).toBe(
+      "INSERT INTO Users (id, path) VALUES (1, 'C:\\\\Users\\\\''); DROP TABLE users; --');",
+    );
+  });
+
   test("exportResults sql-ddl creates text/sql blob", () => {
     tabMgrOverride = {
       currentTab: {

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -583,6 +583,33 @@ describe("StudioWorkspace", () => {
     expect(text).toContain("true");
   });
 
+  // Same file, same hazard as the standalone export: the values are data the table
+  // held, and the file is run later, usually unattended. On a dialect that escapes
+  // with a backslash, a value ending in one would close its literal and have the
+  // rest of the file read as statements (#290).
+  test("exportResults sql-insert quotes a value for the connected dialect", async () => {
+    connAdapterOverride = { activeConnection: { ...dbConn, type: "mysql" as const } };
+    tabMgrOverride = {
+      currentTab: {
+        ...baseTab,
+        name: "Query: users",
+        result: {
+          rows: [{ id: 1, path: "C:\\Users\\'); DROP TABLE users; --" }],
+          fields: ["id", "path"],
+          rowCount: 1,
+          executionTime: 1,
+        },
+      },
+    };
+    renderWorkspace();
+    act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("sql-insert"));
+
+    const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
+    expect(await blob.text()).toBe(
+      "INSERT INTO users (id, path) VALUES (1, 'C:\\\\Users\\\\''); DROP TABLE users; --');",
+    );
+  });
+
   test("exportResults sql-ddl infers column types from the first row", async () => {
     withExportResult();
     renderWorkspace();

--- a/tests/components/TestDataGenerator.test.tsx
+++ b/tests/components/TestDataGenerator.test.tsx
@@ -53,6 +53,32 @@ describe("TestDataGenerator", () => {
     expect(container.textContent).toContain("INSERT INTO employees");
   });
 
+  test("quotes a generated value that does not match its column's numeric type", () => {
+    // The generator is chosen by column NAME and the quoting by column TYPE, so
+    // the two can disagree: `phone BIGINT` produces `+1-555-…`, which used to be
+    // written into the statement unquoted because the type said numeric. Same
+    // shape as the import defect (PR #304 review) — here it makes broken SQL
+    // rather than an injection, because the vocabulary is the generator's own.
+    const mismatched: TableSchema = {
+      name: "contacts",
+      indexes: [],
+      columns: [{ name: "phone", type: "BIGINT", nullable: false, isPrimary: false }],
+    };
+    const { container } = render(
+      <TestDataGenerator
+        isOpen
+        onClose={mock(() => {})}
+        tableName="contacts"
+        tableSchema={mismatched}
+        onExecuteQuery={mock(() => {})}
+      />,
+    );
+
+    const text = container.textContent || "";
+    expect(text).toContain("('+1-555-");
+    expect(text).not.toContain("(+1-555-");
+  });
+
   test("row count buttons change output", () => {
     const { queryByText, container } = render(
       <TestDataGenerator

--- a/tests/hooks/use-inline-editing.test.ts
+++ b/tests/hooks/use-inline-editing.test.ts
@@ -211,9 +211,14 @@ describe("useInlineEditing", () => {
     expect(sql).toContain("UPDATE");
     expect(sql).toContain("users");
     // Column identifiers are quoted (PR #289 review): a result field is named by
-    // whatever the query aliased it to, so it reaches SQL as arbitrary text.
-    expect(sql).toContain(`"name" = 'Alice Updated'`);
-    expect(sql).toContain(`WHERE "id" = 1`);
+    // whatever the query aliased it to, so it reaches SQL as arbitrary text. Values
+    // are bound rather than quoted (#290), so the statement carries placeholders.
+    expect(sql).toContain(`"name" = $1`);
+    expect(sql).toContain(`WHERE "id" = $2`);
+    expect((mockExecuteQuery as ReturnType<typeof mock>).mock.calls[0][3]).toEqual({
+      skipSafety: true,
+      params: ["Alice Updated", 1],
+    });
 
     // Changes should be cleared after apply
     expect(result.current.pendingChanges).toEqual([]);
@@ -258,8 +263,13 @@ describe("useInlineEditing", () => {
       expect(sql.match(/UPDATE/g)).toHaveLength(1);
       expect(sql.endsWith(";")).toBe(false);
     }
-    expect(sent[0]).toBe(`UPDATE users SET "name" = 'Alice Updated' WHERE "id" = 1`);
-    expect(sent[1]).toBe(`UPDATE users SET "email" = 'bob@new.test' WHERE "id" = 2`);
+    expect(sent[0]).toBe(`UPDATE users SET "name" = $1 WHERE "id" = $2`);
+    expect(sent[1]).toBe(`UPDATE users SET "email" = $1 WHERE "id" = $2`);
+    // Each row carries its own parameters, so a shared statement text is not a
+    // shared payload: placeholder numbering restarts per request.
+    const options = (mockExecuteQuery as ReturnType<typeof mock>).mock.calls.map((call) => call[3]);
+    expect(options[0]).toEqual({ skipSafety: true, params: ["Alice Updated", 1] });
+    expect(options[1]).toEqual({ skipSafety: true, params: ["bob@new.test", 2] });
   });
 
   test("handleApplyChanges runs each row past the safety dialog, so every row is applied", async () => {
@@ -293,7 +303,7 @@ describe("useInlineEditing", () => {
     const calls = (mockExecuteQuery as ReturnType<typeof mock>).mock.calls;
     expect(calls).toHaveLength(2);
     for (const call of calls) {
-      expect(call[3]).toEqual({ skipSafety: true });
+      expect((call[3] as { skipSafety?: boolean }).skipSafety).toBe(true);
     }
   });
 
@@ -341,7 +351,7 @@ describe("useInlineEditing", () => {
     });
 
     // The second row must not have been sent while the first is still in flight.
-    expect(order).toEqual([`start:UPDATE users SET "name" = 'A2' WHERE "id" = 1`]);
+    expect(order).toEqual([`start:UPDATE users SET "name" = $1 WHERE "id" = $2`]);
 
     await act(async () => {
       resolveFirst?.();
@@ -349,10 +359,10 @@ describe("useInlineEditing", () => {
     });
 
     expect(order).toEqual([
-      `start:UPDATE users SET "name" = 'A2' WHERE "id" = 1`,
-      `end:UPDATE users SET "name" = 'A2' WHERE "id" = 1`,
-      `start:UPDATE users SET "name" = 'B2' WHERE "id" = 2`,
-      `end:UPDATE users SET "name" = 'B2' WHERE "id" = 2`,
+      `start:UPDATE users SET "name" = $1 WHERE "id" = $2`,
+      `end:UPDATE users SET "name" = $1 WHERE "id" = $2`,
+      `start:UPDATE users SET "name" = $1 WHERE "id" = $2`,
+      `end:UPDATE users SET "name" = $1 WHERE "id" = $2`,
     ]);
   });
 
@@ -490,7 +500,7 @@ describe("useInlineEditing", () => {
 
     expect(mockExecuteQuery).toHaveBeenCalledTimes(1);
     const sql = mockExecuteQuery.mock.calls[0][0] as string;
-    expect(sql).toBe(`UPDATE users SET "${hostile}" = 'w' WHERE "id" = 1`);
+    expect(sql).toBe(`UPDATE users SET "${hostile}" = $1 WHERE "id" = $2`);
     // Nothing outside the quoted identifier ends the statement.
     expect(sql.replace(/"[^"]*"/g, "")).not.toContain(";");
   });
@@ -513,7 +523,7 @@ describe("useInlineEditing", () => {
       await result.current.handleApplyChanges();
     });
 
-    expect(mockExecuteQuery.mock.calls[0][0]).toBe("UPDATE users SET `first name` = 'Bob' WHERE `id` = 1");
+    expect(mockExecuteQuery.mock.calls[0][0]).toBe("UPDATE users SET `first name` = ? WHERE `id` = ?");
   });
 
   test("refuses to apply when the table name could not be read as an identifier", async () => {
@@ -556,6 +566,153 @@ describe("useInlineEditing", () => {
       await result.current.handleApplyChanges();
     });
 
-    expect(mockExecuteQuery.mock.calls[0][0]).toBe(`UPDATE public.users SET "name" = 'Alice Updated' WHERE "id" = 1`);
+    expect(mockExecuteQuery.mock.calls[0][0]).toBe(`UPDATE public.users SET "name" = $1 WHERE "id" = $2`);
+  });
+
+  // ── Values are bound, not interpolated (#290) ─────────────────────────────
+  //
+  // The value half of the statement is arbitrary text — pasted, imported, or read
+  // back from the table. Doubling the quote is enough only where a backslash is
+  // data; MySQL reads `\'` as an escaped quote, so an interpolated value could
+  // close its literal early and have the rest read as SQL. Applying edits skips
+  // the dangerous-query dialog, so nothing shows that statement before it runs.
+
+  test("binds the edited value in the placeholder form the dialect's driver expects", async () => {
+    const cases: Array<{ type: DatabaseConnection["type"]; sql: string }> = [
+      { type: "postgres", sql: `UPDATE users SET "name" = $1 WHERE "id" = $2` },
+      { type: "mysql", sql: "UPDATE users SET `name` = ? WHERE `id` = ?" },
+      { type: "sqlite", sql: `UPDATE users SET "name" = ? WHERE "id" = ?` },
+      { type: "oracle", sql: `UPDATE users SET "name" = :1 WHERE "id" = :2` },
+      { type: "mssql", sql: `UPDATE users SET [name] = @p1 WHERE [id] = @p2` },
+    ];
+
+    for (const { type, sql } of cases) {
+      mockExecuteQuery.mockClear();
+      const { result } = renderHook(() =>
+        useInlineEditing({
+          activeConnection: makeConnection({ type }),
+          currentTab: makeTab(),
+          executeQuery: mockExecuteQuery as (sql: string) => void,
+        }),
+      );
+
+      act(() => {
+        result.current.handleCellChange(makeChange({ newValue: "Alice Updated" }));
+      });
+      await act(async () => {
+        await result.current.handleApplyChanges();
+      });
+
+      expect(mockExecuteQuery.mock.calls[0][0]).toBe(sql);
+      expect(mockExecuteQuery.mock.calls[0][3]).toEqual({ skipSafety: true, params: ["Alice Updated", 1] });
+    }
+  });
+
+  test("a backslash-escaping dialect cannot read the edited value as SQL", async () => {
+    // The issue #290 payload: interpolated into a MySQL statement it closed the
+    // literal early and `WHERE 1=1` became the real predicate, so every row in the
+    // table was updated instead of the edited one.
+    const payload = "\\' WHERE 1=1 -- ";
+    const { result } = renderHook(() =>
+      useInlineEditing({
+        activeConnection: makeConnection({ type: "mysql" }),
+        currentTab: makeTab(),
+        executeQuery: mockExecuteQuery as (sql: string) => void,
+      }),
+    );
+
+    act(() => {
+      result.current.handleCellChange(makeChange({ newValue: payload }));
+    });
+    await act(async () => {
+      await result.current.handleApplyChanges();
+    });
+
+    const [sql, , , options] = mockExecuteQuery.mock.calls[0];
+    expect(sql).toBe("UPDATE users SET `name` = ? WHERE `id` = ?");
+    expect(sql).not.toContain("1=1");
+    expect(options).toEqual({ skipSafety: true, params: [payload, 1] });
+  });
+
+  test("binds a primary key value that is not a number instead of quoting it", async () => {
+    // The key is read back from the result, so it carries whatever the table holds.
+    // A natural key with a quote in it used to reach `WHERE id = '...'` with no
+    // escaping at all — in every dialect, not only the backslash ones.
+    const hostileKey = "x' OR '1'='1";
+    const { result } = renderHook(() =>
+      useInlineEditing({
+        activeConnection: makeConnection(),
+        currentTab: makeTab({
+          result: makeResult({
+            fields: ["id", "name"],
+            rows: [{ id: hostileKey, name: "Alice" }],
+          }),
+        }),
+        executeQuery: mockExecuteQuery as (sql: string) => void,
+      }),
+    );
+
+    act(() => {
+      result.current.handleCellChange(makeChange({ newValue: "Alice Updated" }));
+    });
+    await act(async () => {
+      await result.current.handleApplyChanges();
+    });
+
+    const [sql, , , options] = mockExecuteQuery.mock.calls[0];
+    expect(sql).toBe(`UPDATE users SET "name" = $1 WHERE "id" = $2`);
+    expect(options).toEqual({ skipSafety: true, params: ["Alice Updated", hostileKey] });
+  });
+
+  test("keeps NULL a keyword and numbers the remaining placeholders around it", async () => {
+    // Clearing a cell means SQL NULL, which is a keyword rather than a value, so it
+    // takes no parameter — and the placeholders that follow must not count it.
+    const { result } = renderHook(() =>
+      useInlineEditing({
+        activeConnection: makeConnection(),
+        currentTab: makeTab(),
+        executeQuery: mockExecuteQuery as (sql: string) => void,
+      }),
+    );
+
+    act(() => {
+      result.current.handleCellChange(makeChange({ columnId: "name", originalValue: "Alice", newValue: "" }));
+      result.current.handleCellChange(
+        makeChange({ columnId: "email", originalValue: "alice@test.com", newValue: "new@test.com" }),
+      );
+    });
+    await act(async () => {
+      await result.current.handleApplyChanges();
+    });
+
+    const [sql, , , options] = mockExecuteQuery.mock.calls[0];
+    expect(sql).toBe(`UPDATE users SET "name" = NULL, "email" = $1 WHERE "id" = $2`);
+    expect(options).toEqual({ skipSafety: true, params: ["new@test.com", 1] });
+  });
+
+  test("quotes the value dialect-aware where the dialect has no positional bind form", async () => {
+    // ClickHouse's provider refuses positional parameters outright, so a statement
+    // built for it has to carry its values as literals — quoted the way ClickHouse
+    // reads them, backslash included. Its `supportsInlineRowEdit` is false today, so
+    // this is the guard that keeps issue #279 from re-opening #290 when a dialect
+    // like it gains row editing.
+    const { result } = renderHook(() =>
+      useInlineEditing({
+        activeConnection: makeConnection({ type: "clickhouse" }),
+        currentTab: makeTab(),
+        executeQuery: mockExecuteQuery as (sql: string) => void,
+      }),
+    );
+
+    act(() => {
+      result.current.handleCellChange(makeChange({ newValue: "a\\'b" }));
+    });
+    await act(async () => {
+      await result.current.handleApplyChanges();
+    });
+
+    const [sql, , , options] = mockExecuteQuery.mock.calls[0];
+    expect(sql).toBe(`UPDATE users SET "name" = 'a\\\\''b' WHERE "id" = 1`);
+    expect(options).toEqual({ skipSafety: true });
   });
 });

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -674,6 +674,77 @@ describe("useQueryExecution", () => {
     expect(body.sql).toBe("SELECT * FROM users");
   });
 
+  // ── Bound parameters reach the server (#290) ───────────────────────────────
+  //
+  // The inline row editor builds `SET col = $1` and hands the value over as data.
+  // If the value stopped here the statement would run with its placeholders
+  // unbound, so this channel is what makes binding possible at all.
+
+  test("executeQuery sends bound parameters to /api/db/query", async () => {
+    const fetchMock = mockGlobalFetch({
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
+
+    const { result } = renderHook(() => useQueryExecution(createDefaultParams()));
+
+    await act(async () => {
+      await result.current.executeQuery(`UPDATE users SET "name" = $1 WHERE "id" = $2`, undefined, false, {
+        skipSafety: true,
+        params: ["\\' WHERE 1=1 -- ", 1],
+      });
+    });
+
+    const queryCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
+    );
+    const body = JSON.parse(queryCall![1]!.body as string);
+    expect(body.params).toEqual(["\\' WHERE 1=1 -- ", 1]);
+  });
+
+  test("executeQuery omits params entirely when the caller passed none", async () => {
+    const fetchMock = mockGlobalFetch({
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
+
+    const { result } = renderHook(() => useQueryExecution(createDefaultParams()));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT * FROM users");
+    });
+
+    const queryCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
+    );
+    const body = JSON.parse(queryCall![1]!.body as string);
+    expect("params" in body).toBe(false);
+  });
+
+  test("executeQuery sends bound parameters on the transaction endpoint too", async () => {
+    // A row edit applied while a transaction is open takes this endpoint, so the
+    // value has to be bound here as well — otherwise the transaction path would be
+    // the one place the statement still carried its values as text.
+    const fetchMock = mockGlobalFetch({
+      "/api/db/transaction": { ok: true, json: mockQueryResult },
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
+
+    const { result } = renderHook(() => useQueryExecution(createDefaultParams({ transactionActive: true })));
+
+    await act(async () => {
+      await result.current.executeQuery(`UPDATE users SET "name" = $1 WHERE "id" = $2`, undefined, false, {
+        skipSafety: true,
+        params: ["Alice", 1],
+      });
+    });
+
+    const txnCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/transaction"),
+    );
+    const body = JSON.parse(txnCall![1]!.body as string);
+    expect(body.action).toBe("query");
+    expect(body.params).toEqual(["Alice", 1]);
+  });
+
   // ── executeQuery adds error to history on failure ──────────────────────────
 
   test("executeQuery adds to history on error response", async () => {

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -719,6 +719,60 @@ describe("useQueryExecution", () => {
     expect("params" in body).toBe(false);
   });
 
+  test("executeQuery binds the same parameters in the background explain request", async () => {
+    // The explain SQL is the statement with a prefix, so its placeholders are the
+    // same ones in the same order. Sending it without the values would run it
+    // unbound — the plan request fails and the panel keeps the previous plan
+    // (PR #304 review).
+    const fetchMock = mockGlobalFetch({
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
+
+    const { result } = renderHook(() => useQueryExecution(createDefaultParams()));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT * FROM users WHERE id = $1", undefined, false, {
+        params: [7],
+      });
+    });
+
+    const explainCall = fetchMock.mock.calls.find((call) => {
+      const body = JSON.parse((call[1] as RequestInit).body as string);
+      return typeof body.sql === "string" && body.sql.startsWith("EXPLAIN");
+    });
+    expect(explainCall).toBeDefined();
+    expect(JSON.parse((explainCall![1] as RequestInit).body as string).params).toEqual([7]);
+  });
+
+  test("executeQuery keeps a parameterized statement off the multi-statement route", async () => {
+    // `/api/db/multi-query` splits the payload and binds nothing, so a parameter
+    // array reaching it would be dropped and the statement would run with unbound
+    // placeholders. Parameters may only travel to an endpoint that binds them.
+    const fetchMock = mockGlobalFetch({
+      "/api/db/multi-query": { ok: true, json: mockQueryResult },
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
+
+    const { result } = renderHook(() => useQueryExecution(createDefaultParams()));
+
+    await act(async () => {
+      await result.current.executeQuery("UPDATE users SET name = $1 WHERE id = $2; SELECT 1", undefined, false, {
+        skipSafety: true,
+        params: ["Alice", 1],
+      });
+    });
+
+    const multiCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/multi-query"),
+    );
+    expect(multiCall).toBeUndefined();
+
+    const queryCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
+    );
+    expect(JSON.parse((queryCall![1] as RequestInit).body as string).params).toEqual(["Alice", 1]);
+  });
+
   test("executeQuery sends bound parameters on the transaction endpoint too", async () => {
     // A row edit applied while a transaction is open takes this endpoint, so the
     // value has to be bound here as well — otherwise the transaction path would be

--- a/tests/unit/api-bound-params.test.ts
+++ b/tests/unit/api-bound-params.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { BOUND_PARAMS_MESSAGE, readBoundParams } from "@/lib/api/bound-params";
+
+// The parameter array is the channel that keeps a generated statement's values out
+// of its grammar (#290), and it arrives from the client as JSON. What a driver does
+// with a value it cannot bind is driver-specific — mysql2 and pg disagree about
+// objects, and an unbindable element would surface as a confusing engine error at
+// best — so the route decides what a parameter may be before the driver sees it.
+
+describe("readBoundParams", () => {
+  test("accepts an absent parameter list", () => {
+    expect(readBoundParams(undefined)).toEqual({ valid: true, params: undefined });
+  });
+
+  test("accepts the scalar types JSON can carry", () => {
+    expect(readBoundParams(["text", 42, true, null])).toEqual({ valid: true, params: ["text", 42, true, null] });
+  });
+
+  test("accepts an empty list", () => {
+    expect(readBoundParams([])).toEqual({ valid: true, params: [] });
+  });
+
+  test("rejects a value that is not an array", () => {
+    expect(readBoundParams("text")).toEqual({ valid: false, message: BOUND_PARAMS_MESSAGE });
+    expect(readBoundParams(42)).toEqual({ valid: false, message: BOUND_PARAMS_MESSAGE });
+    expect(readBoundParams({ 0: "text" })).toEqual({ valid: false, message: BOUND_PARAMS_MESSAGE });
+    expect(readBoundParams(null)).toEqual({ valid: false, message: BOUND_PARAMS_MESSAGE });
+  });
+
+  test("rejects an element no driver binds as a scalar", () => {
+    expect(readBoundParams([{ nested: true }])).toEqual({ valid: false, message: BOUND_PARAMS_MESSAGE });
+    expect(readBoundParams([["nested"]])).toEqual({ valid: false, message: BOUND_PARAMS_MESSAGE });
+    expect(readBoundParams([undefined])).toEqual({ valid: false, message: BOUND_PARAMS_MESSAGE });
+  });
+
+  test("names what is allowed, so a rejected request can be corrected", () => {
+    expect(BOUND_PARAMS_MESSAGE).toContain("params");
+  });
+});

--- a/tests/unit/data-import-functions.test.ts
+++ b/tests/unit/data-import-functions.test.ts
@@ -255,6 +255,43 @@ describe("generateImportSQL", () => {
     expect(sql).toContain("('C:\\\\Users\\\\''; DROP TABLE users; --')");
   });
 
+  // The column type is inferred from the first 100 rows only, and every value it
+  // typed as numeric used to be written into the statement verbatim. Row 101 is
+  // outside that sample, so it could carry anything — and these statements are
+  // executed by `onImport` (PR #304 review).
+  test("quotes a value that does not match the type inferred from the sample", () => {
+    const rows = Array.from({ length: 100 }, (_, i) => [String(i)]);
+    rows.push(["0); DELETE FROM users; -- "]);
+    const beyondTheSample: ParsedData = { headers: ["amount"], rows, totalRows: 101 };
+
+    const sql = generateImportSQL(beyondTheSample, "orders", false, "", {});
+
+    expect(sql).toContain("('0); DELETE FROM users; -- ')");
+    expect(sql).not.toContain("(0); DELETE FROM users; -- )");
+  });
+
+  test("quotes a value the sample typed as boolean but that is not one", () => {
+    // Not an injection — the old code answered FALSE for anything unrecognized,
+    // which silently wrote the wrong value rather than letting the engine object.
+    const rows = Array.from({ length: 100 }, () => ["true"]);
+    rows.push(["maybe"]);
+    const beyondTheSample: ParsedData = { headers: ["active"], rows, totalRows: 101 };
+
+    const sql = generateImportSQL(beyondTheSample, "flags", false, "", {});
+
+    expect(sql).toContain("('maybe')");
+  });
+
+  test("still writes a matching numeric value unquoted", () => {
+    const numeric: ParsedData = {
+      headers: ["amount", "ratio", "active"],
+      rows: [["42", "1.5", "true"]],
+      totalRows: 1,
+    };
+
+    expect(generateImportSQL(numeric, "orders", false, "", {})).toContain("(42, 1.5, TRUE)");
+  });
+
   test("emits the standard form when no dialect is known", () => {
     const withBackslash: ParsedData = {
       headers: ["path"],

--- a/tests/unit/data-import-functions.test.ts
+++ b/tests/unit/data-import-functions.test.ts
@@ -206,6 +206,12 @@ describe("escapeSQL", () => {
     expect(escapeSQL("it's a 'test'")).toBe("'it''s a ''test'''");
   });
 
+  test("doubles a backslash for a dialect that reads it as an escape", () => {
+    expect(escapeSQL("a\\b", "mysql")).toBe("'a\\\\b'");
+    expect(escapeSQL("a\\b", "postgres")).toBe("'a\\b'");
+    expect(escapeSQL("a\\b")).toBe("'a\\b'");
+  });
+
   test("returns NULL for empty string", () => {
     expect(escapeSQL("")).toBe("NULL");
   });
@@ -232,6 +238,32 @@ describe("generateImportSQL", () => {
     ],
     totalRows: 2,
   };
+
+  // The generated statements are handed straight to `onImport`, which executes
+  // them, so a cell of an imported file is a value that becomes SQL. On a
+  // backslash-escaping dialect a cell ending in `\` would escape the closing quote
+  // and the rest of the row would be read as statement text (#290).
+  test("escapes an imported cell for the dialect it will run on", () => {
+    const withBackslash: ParsedData = {
+      headers: ["path"],
+      rows: [["C:\\Users\\'; DROP TABLE users; --"]],
+      totalRows: 1,
+    };
+
+    const sql = generateImportSQL(withBackslash, "files", false, "", {}, "mysql");
+
+    expect(sql).toContain("('C:\\\\Users\\\\''; DROP TABLE users; --')");
+  });
+
+  test("emits the standard form when no dialect is known", () => {
+    const withBackslash: ParsedData = {
+      headers: ["path"],
+      rows: [["C:\\Users"]],
+      totalRows: 1,
+    };
+
+    expect(generateImportSQL(withBackslash, "files", false, "", {})).toContain("('C:\\Users')");
+  });
 
   test("returns empty for null parsedData", () => {
     expect(generateImportSQL(null, "users", false, "", {})).toBe("");

--- a/tests/unit/db/sql-base.test.ts
+++ b/tests/unit/db/sql-base.test.ts
@@ -86,14 +86,8 @@ class TestSQLProvider extends SQLBaseProvider {
   public callEscapeIdentifier(id: string): string {
     return this.escapeIdentifier(id);
   }
-  public callEscapeString(val: string): string {
-    return this.escapeString(val);
-  }
   public callBuildLimitClause(limit: number, offset?: number): string {
     return this.buildLimitClause(limit, offset);
-  }
-  public callGetPlaceholder(index: number): string {
-    return this.getPlaceholder(index);
   }
   public callShouldEnableSSL(): boolean {
     return this.shouldEnableSSL();
@@ -178,22 +172,6 @@ describe("SQLBaseProvider", () => {
   });
 
   // --------------------------------------------------------------------------
-  // escapeString
-  // --------------------------------------------------------------------------
-
-  describe("escapeString()", () => {
-    test("escapes single quotes", () => {
-      const p = new TestSQLProvider(makeConfig("postgres"));
-      expect(p.callEscapeString("O'Brien")).toBe("O''Brien");
-    });
-
-    test("no change for strings without quotes", () => {
-      const p = new TestSQLProvider(makeConfig("postgres"));
-      expect(p.callEscapeString("hello")).toBe("hello");
-    });
-  });
-
-  // --------------------------------------------------------------------------
   // buildLimitClause
   // --------------------------------------------------------------------------
 
@@ -211,40 +189,6 @@ describe("SQLBaseProvider", () => {
     test("LIMIT only when offset is 0", () => {
       const p = new TestSQLProvider(makeConfig("postgres"));
       expect(p.callBuildLimitClause(50, 0)).toBe("LIMIT 50");
-    });
-  });
-
-  // --------------------------------------------------------------------------
-  // getPlaceholder
-  // --------------------------------------------------------------------------
-
-  describe("getPlaceholder()", () => {
-    test("postgres returns $N", () => {
-      const p = new TestSQLProvider(makeConfig("postgres"));
-      expect(p.callGetPlaceholder(1)).toBe("$1");
-      expect(p.callGetPlaceholder(3)).toBe("$3");
-    });
-
-    test("mysql returns ?", () => {
-      const p = new TestSQLProvider(makeConfig("mysql"));
-      expect(p.callGetPlaceholder(1)).toBe("?");
-    });
-
-    test("sqlite returns ?", () => {
-      const p = new TestSQLProvider(makeConfig("sqlite"));
-      expect(p.callGetPlaceholder(1)).toBe("?");
-    });
-
-    test("oracle returns :N", () => {
-      const p = new TestSQLProvider(makeConfig("oracle"));
-      expect(p.callGetPlaceholder(1)).toBe(":1");
-      expect(p.callGetPlaceholder(5)).toBe(":5");
-    });
-
-    test("mssql returns @pN", () => {
-      const p = new TestSQLProvider(makeConfig("mssql"));
-      expect(p.callGetPlaceholder(1)).toBe("@p1");
-      expect(p.callGetPlaceholder(2)).toBe("@p2");
     });
   });
 

--- a/tests/unit/sql/identifier.test.ts
+++ b/tests/unit/sql/identifier.test.ts
@@ -17,6 +17,14 @@ describe("quoteIdentifier", () => {
     expect(quoteIdentifier("name", "mssql")).toBe("[name]");
   });
 
+  test("falls back to the standard form when no dialect is known", () => {
+    // A generator with no connection to name a dialect still has to quote the
+    // names it builds from result data; the standard form is what such a
+    // generator can claim, and it is what these callers already emitted.
+    expect(quoteIdentifier("name", undefined)).toBe('"name"');
+    expect(quoteIdentifier('a"b', undefined)).toBe('"a""b"');
+  });
+
   test("doubles an embedded closing quote character", () => {
     expect(quoteIdentifier('a"b', "postgres")).toBe('"a""b"');
     expect(quoteIdentifier("a`b", "mysql")).toBe("`a``b`");

--- a/tests/unit/sql/values.test.ts
+++ b/tests/unit/sql/values.test.ts
@@ -14,20 +14,27 @@ describe("quoteLiteral", () => {
     expect(quoteLiteral("abc", "mysql")).toBe("'abc'");
   });
 
-  test("doubles an embedded single quote in every dialect", () => {
+  test("doubles an embedded single quote where doubling is the escape", () => {
     expect(quoteLiteral("O'Brien", "postgres")).toBe("'O''Brien'");
     expect(quoteLiteral("O'Brien", "mysql")).toBe("'O''Brien'");
     expect(quoteLiteral("O'Brien", "sqlite")).toBe("'O''Brien'");
     expect(quoteLiteral("O'Brien", "oracle")).toBe("'O''Brien'");
     expect(quoteLiteral("O'Brien", "mssql")).toBe("'O''Brien'");
     expect(quoteLiteral("O'Brien", "clickhouse")).toBe("'O''Brien'");
+    expect(quoteLiteral("O'Brien", "druid")).toBe("'O''Brien'");
+  });
+
+  test("escapes the quote with a backslash where the grammar has no doubling", () => {
+    // Couchbase's SQL++ spells every escape with a backslash:
+    //   char ::= unicode-character | '\' ( '\' | '"' | "'" | 'b' | ... )
+    // Doubling is not in that grammar, so `'O''Brien'` is not one literal there.
+    expect(quoteLiteral("O'Brien", "couchbase")).toBe("'O\\'Brien'");
   });
 
   test("doubles a backslash where the dialect reads it as an escape", () => {
     expect(quoteLiteral("a\\b", "mysql")).toBe("'a\\\\b'");
     expect(quoteLiteral("a\\b", "clickhouse")).toBe("'a\\\\b'");
     expect(quoteLiteral("a\\b", "couchbase")).toBe("'a\\\\b'");
-    expect(quoteLiteral("a\\b", "mongodb")).toBe("'a\\\\b'");
   });
 
   test("leaves a backslash alone where it is data", () => {
@@ -36,8 +43,17 @@ describe("quoteLiteral", () => {
     expect(quoteLiteral("a\\b", "oracle")).toBe("'a\\b'");
     expect(quoteLiteral("a\\b", "mssql")).toBe("'a\\b'");
     expect(quoteLiteral("a\\b", "druid")).toBe("'a\\b'");
+  });
+
+  test("gives the standard form to an engine that has no SQL of its own", () => {
+    // MongoDB, Redis and the embedded engine all declare `queryLanguage: "json"`,
+    // so no statement is ever built for them to read. What a generator emits for
+    // such a connection is portable SQL meant to run elsewhere, and the standard
+    // form is the only thing it can claim.
+    expect(quoteLiteral("a\\b", "mongodb")).toBe("'a\\b'");
     expect(quoteLiteral("a\\b", "redis")).toBe("'a\\b'");
     expect(quoteLiteral("a\\b", "libredb")).toBe("'a\\b'");
+    expect(quoteLiteral("O'Brien", "mongodb")).toBe("'O''Brien'");
   });
 
   test("falls back to the standard form when no dialect is known", () => {
@@ -69,15 +85,21 @@ describe("positionalPlaceholder", () => {
     // mssql binds `request.input("p1", ...)`, so the statement must say `@p1`.
     expect(positionalPlaceholder("mssql", 1)).toBe("@p1");
     expect(positionalPlaceholder("mssql", 2)).toBe("@p2");
+    // Druid's provider binds a `parameters` array against `?` placeholders, which
+    // its own doc comment records as live-verified.
+    expect(positionalPlaceholder("druid", 1)).toBe("?");
+    // Couchbase sends `args`, which SQL++ reads as `$1`, `$2` — the integration
+    // test pins the pair with `bodyOf("country = $1").args`.
+    expect(positionalPlaceholder("couchbase", 1)).toBe("$1");
+    expect(positionalPlaceholder("couchbase", 2)).toBe("$2");
   });
 
-  test("returns null for a dialect whose bind form this repo has not pinned", () => {
-    // ClickHouse's provider refuses positional parameters outright, and the
-    // remaining engines are not driven by a SQL statement at all. Null is the
-    // signal to quote the value instead — never to emit an unbound placeholder.
+  test("returns null where this repo knows there is no positional bind form", () => {
+    // ClickHouse's provider refuses positional parameters outright, and the other
+    // three declare `queryLanguage: "json"`, so no SQL statement binds anything for
+    // them. Null is the signal to quote the value instead — never to emit an
+    // unbound placeholder.
     expect(positionalPlaceholder("clickhouse", 1)).toBeNull();
-    expect(positionalPlaceholder("couchbase", 1)).toBeNull();
-    expect(positionalPlaceholder("druid", 1)).toBeNull();
     expect(positionalPlaceholder("mongodb", 1)).toBeNull();
     expect(positionalPlaceholder("redis", 1)).toBeNull();
     expect(positionalPlaceholder("libredb", 1)).toBeNull();

--- a/tests/unit/sql/values.test.ts
+++ b/tests/unit/sql/values.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { positionalPlaceholder, quoteLiteral } from "@/lib/sql/values";
+
+// A value reaching SQL generation is arbitrary text — a pasted cell, an imported
+// result, a natural key read back from the table. Doubling the quote is only half
+// the escape: MySQL and the JSON-shaped dialects read a backslash as an escape
+// inside a string literal, so `\'` there closes the literal early and the rest of
+// the value is parsed as statement text (issue #290). Binding the value is the
+// real fix; this quoting is what the dialects without a positional bind form get.
+
+describe("quoteLiteral", () => {
+  test("wraps a value in single quotes", () => {
+    expect(quoteLiteral("abc", "postgres")).toBe("'abc'");
+    expect(quoteLiteral("abc", "mysql")).toBe("'abc'");
+  });
+
+  test("doubles an embedded single quote in every dialect", () => {
+    expect(quoteLiteral("O'Brien", "postgres")).toBe("'O''Brien'");
+    expect(quoteLiteral("O'Brien", "mysql")).toBe("'O''Brien'");
+    expect(quoteLiteral("O'Brien", "sqlite")).toBe("'O''Brien'");
+    expect(quoteLiteral("O'Brien", "oracle")).toBe("'O''Brien'");
+    expect(quoteLiteral("O'Brien", "mssql")).toBe("'O''Brien'");
+    expect(quoteLiteral("O'Brien", "clickhouse")).toBe("'O''Brien'");
+  });
+
+  test("doubles a backslash where the dialect reads it as an escape", () => {
+    expect(quoteLiteral("a\\b", "mysql")).toBe("'a\\\\b'");
+    expect(quoteLiteral("a\\b", "clickhouse")).toBe("'a\\\\b'");
+    expect(quoteLiteral("a\\b", "couchbase")).toBe("'a\\\\b'");
+    expect(quoteLiteral("a\\b", "mongodb")).toBe("'a\\\\b'");
+  });
+
+  test("leaves a backslash alone where it is data", () => {
+    expect(quoteLiteral("a\\b", "postgres")).toBe("'a\\b'");
+    expect(quoteLiteral("a\\b", "sqlite")).toBe("'a\\b'");
+    expect(quoteLiteral("a\\b", "oracle")).toBe("'a\\b'");
+    expect(quoteLiteral("a\\b", "mssql")).toBe("'a\\b'");
+    expect(quoteLiteral("a\\b", "druid")).toBe("'a\\b'");
+    expect(quoteLiteral("a\\b", "redis")).toBe("'a\\b'");
+    expect(quoteLiteral("a\\b", "libredb")).toBe("'a\\b'");
+  });
+
+  test("the issue #290 payload cannot close the literal early on MySQL", () => {
+    // Read as MySQL: '  \\ -> one backslash, '' -> one quote, then the text, then
+    // the closing quote. Every character of the payload stays data, so the trailing
+    // `WHERE 1=1` is not the statement's predicate.
+    expect(quoteLiteral("\\' WHERE 1=1 -- ", "mysql")).toBe("'\\\\'' WHERE 1=1 -- '");
+  });
+});
+
+describe("positionalPlaceholder", () => {
+  test("spells the placeholder the driver binds for each dialect", () => {
+    expect(positionalPlaceholder("postgres", 1)).toBe("$1");
+    expect(positionalPlaceholder("postgres", 2)).toBe("$2");
+    expect(positionalPlaceholder("mysql", 1)).toBe("?");
+    expect(positionalPlaceholder("mysql", 2)).toBe("?");
+    expect(positionalPlaceholder("sqlite", 1)).toBe("?");
+    expect(positionalPlaceholder("oracle", 1)).toBe(":1");
+    expect(positionalPlaceholder("oracle", 2)).toBe(":2");
+    // mssql binds `request.input("p1", ...)`, so the statement must say `@p1`.
+    expect(positionalPlaceholder("mssql", 1)).toBe("@p1");
+    expect(positionalPlaceholder("mssql", 2)).toBe("@p2");
+  });
+
+  test("returns null for a dialect whose bind form this repo has not pinned", () => {
+    // ClickHouse's provider refuses positional parameters outright, and the
+    // remaining engines are not driven by a SQL statement at all. Null is the
+    // signal to quote the value instead — never to emit an unbound placeholder.
+    expect(positionalPlaceholder("clickhouse", 1)).toBeNull();
+    expect(positionalPlaceholder("couchbase", 1)).toBeNull();
+    expect(positionalPlaceholder("druid", 1)).toBeNull();
+    expect(positionalPlaceholder("mongodb", 1)).toBeNull();
+    expect(positionalPlaceholder("redis", 1)).toBeNull();
+    expect(positionalPlaceholder("libredb", 1)).toBeNull();
+  });
+});

--- a/tests/unit/sql/values.test.ts
+++ b/tests/unit/sql/values.test.ts
@@ -40,6 +40,15 @@ describe("quoteLiteral", () => {
     expect(quoteLiteral("a\\b", "libredb")).toBe("'a\\b'");
   });
 
+  test("falls back to the standard form when no dialect is known", () => {
+    // A generator that has no connection yet (no engine has been picked) can only
+    // claim the SQL standard, which is also what its identifier quoting claims.
+    // Doubling a backslash there would corrupt the value on the dialects that read
+    // it as data — the larger group.
+    expect(quoteLiteral("a\\b", undefined)).toBe("'a\\b'");
+    expect(quoteLiteral("O'Brien", undefined)).toBe("'O''Brien'");
+  });
+
   test("the issue #290 payload cannot close the literal early on MySQL", () => {
     // Read as MySQL: '  \\ -> one backslash, '' -> one quote, then the text, then
     // the closing quote. Every character of the payload stays data, so the trailing


### PR DESCRIPTION
Closes #290.

The inline row editor built its `UPDATE` by interpolating the edited value and escaping it by doubling the quote. That is enough only where a backslash is data. MySQL and ClickHouse read `\'` as an escaped quote, so a value could close its own literal and have the rest parsed as statement text:

```sql
UPDATE t SET `col` = '\'' WHERE 1=1 -- ' WHERE `id` = 1
```

MySQL reads `'\''` as the one-character string `'`, so `WHERE 1=1` is the real predicate and every row in the table is updated. No second statement is needed, so mysql2's `multipleStatements: false` never came into it, and applying edits deliberately skips the dangerous-query dialog - nothing showed that statement before it ran. The primary-key half was interpolated with no escaping at all, so a natural key holding a quote broke the `WHERE` in every dialect, not only the backslash ones.

## Commit 1 - bind the inline row edit's values

Values travel beside the statement and are bound by the driver:

- **`src/lib/sql/values.ts`.** `positionalPlaceholder` spells the form each provider's own `query(sql, params)` binds - `$n`, `?`, `:n`, `@pn` - so changing one without the other breaks the pair visibly. `quoteLiteral` is the fallback for a dialect with no positional form, and it doubles the backslash where the dialect escapes it. That map is total over `DatabaseType`: a new provider cannot be added without answering the question, which is the silent wrong answer this file exists to prevent.
- **The channel** runs from `useInlineEditing` through `executeQuery` to both `/api/db/query` and `/api/db/transaction`. A row edit applied while a transaction is open takes the second one, which would otherwise have been the single path still carrying its values as text.
- **`src/lib/api/bound-params.ts`** refuses anything but the scalars JSON can carry, with a 400 rather than an unbindable value reaching a driver's bind path where every driver reacts differently.

`NULL` stays a keyword and takes no placeholder; the placeholders that follow are numbered around it. ClickHouse keeps the quoted form because its provider refuses positional parameters outright - its `supportsInlineRowEdit` is false today, so that branch is the guard that keeps #279 from re-opening this.

## Commit 2 - quote the remaining interpolated values

The six call sites that still doubled the quote in a value now go through `quoteLiteral`. Same defect, different half: these generate SQL rather than execute it directly, and each carries data the user never typed. Each real path has the payload as a test:

- **`DataImportModal`** - the generated statements are handed to `onImport`, which executes them, so a cell of an uploaded CSV becomes SQL.
- **`PivotTable`** - a pivot column key is a value read back from the result, and `Generate SQL` loads the statement into the editor a click from running. The dialect arrives as a new prop, passed by `BottomPanel`.
- **`Studio` / `StudioWorkspace` sql-insert export** - the file is run later, usually unattended. Before this, a cell of `C:\Users\'); DROP TABLE users; --` exported to a MySQL target as a literal that closed early and left the drop as statement text; the test asserts the whole line.
- **`/api/db/profile`** - the column name arrives in the request and is carried as a label, which puts it in a string literal.

`TestDataGenerator` moves to the same helper **without a behaviour change**: its values come from a fixed vocabulary that cannot contain a quote or a backslash, so this is the shared quoting rather than a fix. Its `databaseType` prop was declared but never destructured, so it was dead until now.

`quoteLiteral` accepts an undefined dialect for a generator that has no connection to name one, and answers with the standard form - doubling the backslash there would corrupt the value on every dialect that reads it as data, the larger group.

## Deliberately not changed

- The two doubling sites in `src/lib/db/providers/sql/oracle.ts` are correct as written: Oracle reads a backslash in a literal as data.
- `SQLBaseProvider.escapeString` has no callers - only a test-local subclass reaches it - but it is the method a provider author would reach for and it spells the escape this PR is about. Recorded in `docs/BACKLOG.md` (V1) rather than changed here.
- Query history now records the statement as executed, which means placeholders rather than values: a truthful record of what ran, but no longer a record of what was written. Restoring that audit trail is a history-entry schema change, recorded as V2.

## Verification

All six local gates plus the coverage gate, run against this branch:

`bun run format` · `bun run lint` (0 errors) · `bun run typecheck` · `bun run knip` · `bun run test` (exit 0) · `bun run build` · `bun run build:lib` + `bun run attw` · `bun run coverage:check` -> **29209/29209 lines (100.00%)**.

Every behaviour change landed test-first; the tests that encoded the old interpolated contract were updated rather than deleted, since their subjects (identifier quoting, one request per row, sequencing) are unchanged.
