### PR TITLE
fix: carry the result channels through both dropped paths, and gate the admin maintenance controls (#285, #282)

### DIFF
--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -762,8 +762,8 @@ a target; `analyze` does not.
 | `kill` | `KILL QUERY WHERE query_id = '<target>' SYNC` | `SYNC` so the result is reported after the query has actually stopped, not after the kill was merely queued |
 
 `vacuum`, `reindex` and `check` have no ClickHouse equivalent, so they are absent from
-`maintenanceOperations` and the monitoring Tables tab never offers them (#272); the admin Operations
-tab still does not read capabilities ([#282](https://github.com/libredb/libredb-studio/issues/282)).
+`maintenanceOperations` and neither tab that offers maintenance renders them — the monitoring Tables
+tab since #272, the admin Operations tab since #282.
 Calling `runMaintenance` with one directly throws a `QueryError` naming the three supported
 operations. A target is qualified through
 `escapeIdentifier()` (`"database"."table"`, defaulting the database to the pinned one when the

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -599,8 +599,8 @@ connection ceiling over REST, so the denominator is a constant while the numerat
 | `kill` | `DELETE FROM system:active_requests WHERE requestId = $1` | Target is the request id shown in active sessions |
 
 `vacuum`, `optimize` and `check` have no Couchbase equivalent, so they are absent from
-`maintenanceOperations` and the monitoring Tables tab never offers them (#272); the admin Operations
-tab still does not read capabilities ([#282](https://github.com/libredb/libredb-studio/issues/282)).
+`maintenanceOperations` and neither tab that offers maintenance renders them — the monitoring Tables
+tab since #272, the admin Operations tab since #282.
 Calling `runMaintenance` with one directly throws a `QueryError` naming the three supported
 operations.
 

--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -1168,13 +1168,14 @@ the declared operations where it is `true`, and none at all until the metadata h
 never Druid-specific: `libredb.ts` also sets `supportsMaintenance: false` and had exactly the same
 dead buttons, so the fix landed once in shared UI for every provider.
 
-**The admin Operations tab still has the same gap.** `src/components/admin/tabs/OperationsTab.tsx`
-renders its global `Run Analyze` / `Run Vacuum` / `Run Reindex` controls and its per-table
-Analyze/Vacuum buttons without reading `getCapabilities()`, so those still answer 400 here. #272's
-bar covers the monitoring Tables tab only; the Operations tab is tracked as
-[#282](https://github.com/libredb/libredb-studio/issues/282). Stated
-explicitly because a doc claiming "no control offers any operation" would be describing the intent
-instead of the software.
+**The admin Operations tab closed the same gap (issue #282).** It rendered its global
+`Run Analyze` / `Run Vacuum` / `Run Reindex` controls and its per-table Analyze/Vacuum buttons
+without reading `getCapabilities()`, so all of them answered 400 here. `OperationsTab.tsx` now
+resolves the selected connection's capabilities through `useProviderMetadata` and hides the whole
+Global Operations group where `supportsMaintenance` is `false`, each individual control whose
+`MaintenanceType` is absent from `maintenanceOperations`, and everything until the metadata has
+resolved. So for Druid no maintenance control renders in either place — the statement above now
+describes the software rather than the intent.
 
 `runMaintenance(type)` ([index.ts:471](../../src/lib/db/providers/sql/druid/index.ts)) exists because
 the `DatabaseProvider` interface obliges every provider to implement it, and **not** because any

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -454,11 +454,11 @@ QueryError: Maintenance operation "<type>" is not supported for LibreDB
 ```
 
 This is reflected in `getCapabilities().supportsMaintenance = false` and
-`maintenanceOperations = []`. The monitoring **Tables** tab hides the maintenance actions for this
-provider: it renders no per-row maintenance control when a provider declares maintenance unsupported
-(issue #272). The admin **Operations** tab does not read capabilities yet, so its maintenance buttons
-still appear here and answer HTTP 400 — tracked as
-[#282](https://github.com/libredb/libredb-studio/issues/282), outside #272's bar.
+`maintenanceOperations = []`. Both tabs that offer maintenance now hide it for this provider: the
+monitoring **Tables** tab renders no per-row control when a provider declares maintenance
+unsupported (issue #272), and the admin **Operations** tab hides its whole Global Operations group
+and its per-table buttons on the same reading (issue #282). Neither offers a control that could only
+answer HTTP 400.
 
 ---
 

--- a/src/app/api/db/multi-query/route.ts
+++ b/src/app/api/db/multi-query/route.ts
@@ -5,7 +5,8 @@ import { isSelectQuery } from "@/lib/db/utils/query-limiter";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { getSession } from "@/lib/auth";
-import type { QueryWarning } from "@/lib/types";
+import type { DatabaseType, QueryWarning } from "@/lib/types";
+import type { DatabaseProvider } from "@/lib/db/types";
 
 export interface StatementResult {
   index: number;
@@ -26,6 +27,77 @@ export interface StatementResult {
    */
   warnings?: QueryWarning[];
   columnTypes?: Record<string, string>;
+}
+
+/**
+ * The channels a result carries beyond its rows, kept absent when the source has
+ * none — the grid decides whether to render a section from the field's presence
+ * alone, so an empty array would announce one with nothing in it (#285).
+ *
+ * Shared by the per-statement result and the main one, which is why it takes the
+ * fields rather than a whole result: both shapes have exactly these two.
+ */
+function carriedChannels(source: Pick<StatementResult, "warnings" | "columnTypes"> | undefined) {
+  return {
+    ...(source?.warnings && { warnings: source.warnings }),
+    ...(source?.columnTypes && { columnTypes: source.columnTypes }),
+  };
+}
+
+/**
+ * Run one statement of the script and describe the outcome, including the error
+ * when it failed — the loop decides what to do about it.
+ *
+ * Extracted from `POST` rather than inlined: with the two channels added, the
+ * handler carried the whole per-statement dance (limiter decision, execution,
+ * error shaping) inside its own control flow and crossed the cognitive-complexity
+ * bar (PR #308 review).
+ */
+async function runStatement(
+  provider: DatabaseProvider,
+  stmt: { sql: string; startLine: number },
+  index: number,
+  isLast: boolean,
+  dialect: DatabaseType,
+  options: Record<string, unknown>,
+): Promise<StatementResult> {
+  const startTime = performance.now();
+  const identity = { index, sql: stmt.sql, startLine: stmt.startLine };
+
+  try {
+    // For the last statement that is a SELECT, apply limit. "Last statement
+    // only" is this route's own policy; whether the statement IS a SELECT is
+    // not — that reading is shared, and this route used to re-derive it with
+    // `/^\s*SELECT\b/i`. `splitStatements` keeps each statement's leading
+    // comments, so an annotated final SELECT failed that pattern and reached
+    // the engine unprepared, which is the unbounded read the shared classifier
+    // was made comment-tolerant to close (#281, #275). The shared reading also
+    // types a `WITH` by the keyword its CTE list operates (#287), so a
+    // read-only CTE is bounded here and a data-modifying one is not.
+    const prepared =
+      isLast && isSelectQuery(stmt.sql, dialect)
+        ? provider.prepareQuery(stmt.sql, options)
+        : { query: stmt.sql, wasLimited: false, limit: 0, offset: 0 };
+
+    const result = await provider.query(prepared.query);
+
+    return {
+      ...identity,
+      status: "success",
+      rows: result.rows,
+      fields: result.fields,
+      rowCount: result.rowCount,
+      executionTime: Math.round(performance.now() - startTime),
+      ...carriedChannels(result),
+    };
+  } catch (error) {
+    return {
+      ...identity,
+      status: "error",
+      executionTime: Math.round(performance.now() - startTime),
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -55,57 +127,19 @@ export async function POST(req: NextRequest) {
     let totalExecutionTime = 0;
 
     for (let i = 0; i < statements.length; i++) {
-      const stmt = statements[i];
-      const startTime = performance.now();
+      const outcome = await runStatement(
+        provider,
+        statements[i],
+        i,
+        i === statements.length - 1,
+        connection.type,
+        options,
+      );
+      totalExecutionTime += outcome.executionTime;
+      results.push(outcome);
 
-      try {
-        // For the last statement that is a SELECT, apply limit. "Last statement
-        // only" is this route's own policy; whether the statement IS a SELECT is
-        // not — that reading is shared, and this route used to re-derive it with
-        // `/^\s*SELECT\b/i`. `splitStatements` keeps each statement's leading
-        // comments, so an annotated final SELECT failed that pattern and reached
-        // the engine unprepared, which is the unbounded read the shared classifier
-        // was made comment-tolerant to close (#281, #275). The shared reading also
-        // types a `WITH` by the keyword its CTE list operates (#287), so a
-        // read-only CTE is bounded here and a data-modifying one is not.
-        const isLastSelect = i === statements.length - 1 && isSelectQuery(stmt.sql, connection.type);
-        const prepared = isLastSelect
-          ? provider.prepareQuery(stmt.sql, options)
-          : { query: stmt.sql, wasLimited: false, limit: 0, offset: 0 };
-
-        const result = await provider.query(prepared.query);
-        const executionTime = Math.round(performance.now() - startTime);
-        totalExecutionTime += executionTime;
-
-        results.push({
-          index: i,
-          sql: stmt.sql,
-          startLine: stmt.startLine,
-          status: "success",
-          rows: result.rows,
-          fields: result.fields,
-          rowCount: result.rowCount,
-          executionTime,
-          ...(result.warnings && { warnings: result.warnings }),
-          ...(result.columnTypes && { columnTypes: result.columnTypes }),
-        });
-      } catch (error) {
-        const executionTime = Math.round(performance.now() - startTime);
-        totalExecutionTime += executionTime;
-        const errorMessage = error instanceof Error ? error.message : "Unknown error";
-
-        results.push({
-          index: i,
-          sql: stmt.sql,
-          startLine: stmt.startLine,
-          status: "error",
-          executionTime,
-          error: errorMessage,
-        });
-
-        // Stop execution on error
-        break;
-      }
+      // Stop execution on error
+      if (outcome.status === "error") break;
     }
 
     // Return the last successful result with rows as the main result (for ResultsGrid)
@@ -123,8 +157,7 @@ export async function POST(req: NextRequest) {
       // The main result shows one statement's rows, so it carries that statement's
       // notices and declared types and no others. Merging every statement's
       // warnings here would attribute one run's notice to another run's rows.
-      ...(lastResultWithRows?.warnings && { warnings: lastResultWithRows.warnings }),
-      ...(lastResultWithRows?.columnTypes && { columnTypes: lastResultWithRows.columnTypes }),
+      ...carriedChannels(lastResultWithRows),
       // Multi-statement metadata
       multiStatement: true,
       statementCount: statements.length,

--- a/src/app/api/db/multi-query/route.ts
+++ b/src/app/api/db/multi-query/route.ts
@@ -5,6 +5,7 @@ import { isSelectQuery } from "@/lib/db/utils/query-limiter";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { getSession } from "@/lib/auth";
+import type { QueryWarning } from "@/lib/types";
 
 export interface StatementResult {
   index: number;
@@ -16,6 +17,15 @@ export interface StatementResult {
   rowCount?: number;
   executionTime: number;
   error?: string;
+  /**
+   * The two additive channels #273 gave the shared result, carried per statement
+   * because that is where they are attributable: a notice belongs to the run that
+   * produced it, and a declared type describes that run's own projection. Absent
+   * when the engine reported none, never empty — the grid decides whether to
+   * render anything from the field's presence alone (#285).
+   */
+  warnings?: QueryWarning[];
+  columnTypes?: Record<string, string>;
 }
 
 export async function POST(req: NextRequest) {
@@ -76,6 +86,8 @@ export async function POST(req: NextRequest) {
           fields: result.fields,
           rowCount: result.rowCount,
           executionTime,
+          ...(result.warnings && { warnings: result.warnings }),
+          ...(result.columnTypes && { columnTypes: result.columnTypes }),
         });
       } catch (error) {
         const executionTime = Math.round(performance.now() - startTime);
@@ -108,6 +120,11 @@ export async function POST(req: NextRequest) {
       fields: lastResultWithRows?.fields || [],
       rowCount: lastResultWithRows?.rowCount || 0,
       executionTime: totalExecutionTime,
+      // The main result shows one statement's rows, so it carries that statement's
+      // notices and declared types and no others. Merging every statement's
+      // warnings here would attribute one run's notice to another run's rows.
+      ...(lastResultWithRows?.warnings && { warnings: lastResultWithRows.warnings }),
+      ...(lastResultWithRows?.columnTypes && { columnTypes: lastResultWithRows.columnTypes }),
       // Multi-statement metadata
       multiStatement: true,
       statementCount: statements.length,

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -37,7 +37,8 @@ import { useMonitoringData } from "@/hooks/use-monitoring-data";
 import { storage } from "@/lib/storage";
 import { useAllConnections } from "@/hooks/use-all-connections";
 import type { DatabaseConnection } from "@/lib/types";
-import type { ActiveSessionDetails } from "@/lib/db/types";
+import type { ActiveSessionDetails, MaintenanceType } from "@/lib/db/types";
+import { useProviderMetadata } from "@/hooks/use-provider-metadata";
 
 interface OperationLogEntry {
   id: string;
@@ -63,6 +64,17 @@ export function OperationsTab() {
     selectedConnection,
     monitoringOptions,
   );
+
+  // Offer only the maintenance the connected provider declares it can perform:
+  // /api/db/maintenance rejects everything else with 400, so an ungated control can
+  // only produce an error (#282, the twin of the #272 gate on the monitoring Tables
+  // tab). Unknown capabilities hide the controls rather than showing them —
+  // `metadata` is also null when /api/db/provider-meta fails, and failing open
+  // would put the dead buttons back on exactly the connections this gate is for.
+  const { metadata } = useProviderMetadata(selectedConnection);
+  const canRun = (type: MaintenanceType) =>
+    metadata?.capabilities.supportsMaintenance === true && metadata.capabilities.maintenanceOperations.includes(type);
+  const anyMaintenance = canRun("analyze") || canRun("vacuum") || canRun("reindex");
 
   const { connections: allConns } = useAllConnections();
   useEffect(() => {
@@ -224,88 +236,98 @@ export function OperationsTab() {
         <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-4 text-red-400 text-sm">{error}</div>
       )}
 
-      {/* Global Operations */}
-      <div>
-        <div className="flex items-center gap-2 mb-3">
-          <ShieldAlert className="h-4 w-4 text-blue-400" />
-          <h3 className="text-sm font-bold text-zinc-300">Global Operations</h3>
+      {/* Global Operations — hidden entirely where the provider declares none */}
+      {anyMaintenance && (
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <ShieldAlert className="h-4 w-4 text-blue-400" />
+            <h3 className="text-sm font-bold text-zinc-300">Global Operations</h3>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            {/* Analyze */}
+            {canRun("analyze") && (
+              <div className="p-4 rounded-xl border border-white/5 bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
+                <div className="flex items-start justify-between mb-3">
+                  <div className="w-8 h-8 rounded-lg bg-yellow-500/10 border border-yellow-500/20 flex items-center justify-center">
+                    <Zap className="w-4 h-4 text-yellow-500" />
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs border-white/10 hover:bg-yellow-500/10 hover:text-yellow-500"
+                    onClick={() => handleRunMaintenance("analyze")}
+                    disabled={!!actionLoading || !selectedConnection}
+                  >
+                    {actionLoading === "analyze-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
+                    Run Analyze
+                  </Button>
+                </div>
+                <h4 className="text-sm font-bold text-zinc-200 mb-1">Update Statistics</h4>
+                <p className="text-xs text-zinc-500 leading-relaxed">
+                  Updates query planner statistics for all tables.
+                </p>
+              </div>
+            )}
+
+            {/* Vacuum */}
+            {canRun("vacuum") && (
+              <div className="p-4 rounded-xl border border-white/5 bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
+                <div className="flex items-start justify-between mb-3">
+                  <div className="w-8 h-8 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-center">
+                    <HardDrive className="w-4 h-4 text-blue-500" />
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs border-white/10 hover:bg-blue-500/10 hover:text-blue-500"
+                    onClick={() => handleRunMaintenance("vacuum")}
+                    disabled={!!actionLoading || !selectedConnection}
+                  >
+                    {actionLoading === "vacuum-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
+                    Run Vacuum
+                  </Button>
+                </div>
+                <h4 className="text-sm font-bold text-zinc-200 mb-1">Reclaim Space</h4>
+                <p className="text-xs text-zinc-500 leading-relaxed">Removes dead rows and returns space to the OS.</p>
+              </div>
+            )}
+
+            {/* Reindex */}
+            {canRun("reindex") && (
+              <div className="p-4 rounded-xl border border-white/5 bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
+                <div className="flex items-start justify-between mb-3">
+                  <div className="w-8 h-8 rounded-lg bg-purple-500/10 border border-purple-500/20 flex items-center justify-center">
+                    <RefreshCw className="w-4 h-4 text-purple-500" />
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs border-white/10 hover:bg-purple-500/10 hover:text-purple-500"
+                    onClick={() => handleRunMaintenance("reindex")}
+                    disabled={!!actionLoading || !selectedConnection}
+                  >
+                    {actionLoading === "reindex-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
+                    Run Reindex
+                  </Button>
+                </div>
+                <h4 className="text-sm font-bold text-zinc-200 mb-1">Rebuild Indexes</h4>
+                <p className="text-xs text-zinc-500 leading-relaxed">Reconstructs all indexes in the database.</p>
+              </div>
+            )}
+
+            {/* Warning Card */}
+            <div className="p-4 rounded-xl border border-red-500/10 bg-red-500/5 flex flex-col justify-center">
+              <div className="flex items-center gap-2 text-red-400 mb-2">
+                <ShieldAlert className="w-4 h-4" />
+                <span className="text-xs font-bold uppercase tracking-wider">Warning</span>
+              </div>
+              <p className="text-xs text-red-400/70 leading-relaxed italic">
+                These operations can be resource-intensive. Avoid running them during peak traffic hours.
+              </p>
+            </div>
+          </div>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          {/* Analyze */}
-          <div className="p-4 rounded-xl border border-white/5 bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
-            <div className="flex items-start justify-between mb-3">
-              <div className="w-8 h-8 rounded-lg bg-yellow-500/10 border border-yellow-500/20 flex items-center justify-center">
-                <Zap className="w-4 h-4 text-yellow-500" />
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs border-white/10 hover:bg-yellow-500/10 hover:text-yellow-500"
-                onClick={() => handleRunMaintenance("analyze")}
-                disabled={!!actionLoading || !selectedConnection}
-              >
-                {actionLoading === "analyze-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
-                Run Analyze
-              </Button>
-            </div>
-            <h4 className="text-sm font-bold text-zinc-200 mb-1">Update Statistics</h4>
-            <p className="text-xs text-zinc-500 leading-relaxed">Updates query planner statistics for all tables.</p>
-          </div>
-
-          {/* Vacuum */}
-          <div className="p-4 rounded-xl border border-white/5 bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
-            <div className="flex items-start justify-between mb-3">
-              <div className="w-8 h-8 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-center">
-                <HardDrive className="w-4 h-4 text-blue-500" />
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs border-white/10 hover:bg-blue-500/10 hover:text-blue-500"
-                onClick={() => handleRunMaintenance("vacuum")}
-                disabled={!!actionLoading || !selectedConnection}
-              >
-                {actionLoading === "vacuum-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
-                Run Vacuum
-              </Button>
-            </div>
-            <h4 className="text-sm font-bold text-zinc-200 mb-1">Reclaim Space</h4>
-            <p className="text-xs text-zinc-500 leading-relaxed">Removes dead rows and returns space to the OS.</p>
-          </div>
-
-          {/* Reindex */}
-          <div className="p-4 rounded-xl border border-white/5 bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
-            <div className="flex items-start justify-between mb-3">
-              <div className="w-8 h-8 rounded-lg bg-purple-500/10 border border-purple-500/20 flex items-center justify-center">
-                <RefreshCw className="w-4 h-4 text-purple-500" />
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs border-white/10 hover:bg-purple-500/10 hover:text-purple-500"
-                onClick={() => handleRunMaintenance("reindex")}
-                disabled={!!actionLoading || !selectedConnection}
-              >
-                {actionLoading === "reindex-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
-                Run Reindex
-              </Button>
-            </div>
-            <h4 className="text-sm font-bold text-zinc-200 mb-1">Rebuild Indexes</h4>
-            <p className="text-xs text-zinc-500 leading-relaxed">Reconstructs all indexes in the database.</p>
-          </div>
-
-          {/* Warning Card */}
-          <div className="p-4 rounded-xl border border-red-500/10 bg-red-500/5 flex flex-col justify-center">
-            <div className="flex items-center gap-2 text-red-400 mb-2">
-              <ShieldAlert className="w-4 h-4" />
-              <span className="text-xs font-bold uppercase tracking-wider">Warning</span>
-            </div>
-            <p className="text-xs text-red-400/70 leading-relaxed italic">
-              These operations can be resource-intensive. Avoid running them during peak traffic hours.
-            </p>
-          </div>
-        </div>
-      </div>
+      )}
 
       {/* Tables + Sessions Split */}
       <div className="grid gap-6 md:grid-cols-2">
@@ -353,34 +375,38 @@ export function OperationsTab() {
                       </div>
                     </div>
                     <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="w-7 h-7 text-zinc-500 hover:text-yellow-500"
-                        title="Analyze"
-                        onClick={() => handleRunMaintenance("analyze", table.tableName)}
-                        disabled={!!actionLoading}
-                      >
-                        {actionLoading === `analyze-${table.tableName}` ? (
-                          <Loader2 className="w-3 h-3 animate-spin" />
-                        ) : (
-                          <Search className="w-3 h-3" />
-                        )}
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="w-7 h-7 text-zinc-500 hover:text-blue-500"
-                        title="Vacuum"
-                        onClick={() => handleRunMaintenance("vacuum", table.tableName)}
-                        disabled={!!actionLoading}
-                      >
-                        {actionLoading === `vacuum-${table.tableName}` ? (
-                          <Loader2 className="w-3 h-3 animate-spin" />
-                        ) : (
-                          <HardDrive className="w-3 h-3" />
-                        )}
-                      </Button>
+                      {canRun("analyze") && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="w-7 h-7 text-zinc-500 hover:text-yellow-500"
+                          title="Analyze"
+                          onClick={() => handleRunMaintenance("analyze", table.tableName)}
+                          disabled={!!actionLoading}
+                        >
+                          {actionLoading === `analyze-${table.tableName}` ? (
+                            <Loader2 className="w-3 h-3 animate-spin" />
+                          ) : (
+                            <Search className="w-3 h-3" />
+                          )}
+                        </Button>
+                      )}
+                      {canRun("vacuum") && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="w-7 h-7 text-zinc-500 hover:text-blue-500"
+                          title="Vacuum"
+                          onClick={() => handleRunMaintenance("vacuum", table.tableName)}
+                          disabled={!!actionLoading}
+                        >
+                          {actionLoading === `vacuum-${table.tableName}` ? (
+                            <Loader2 className="w-3 h-3 animate-spin" />
+                          ) : (
+                            <HardDrive className="w-3 h-3" />
+                          )}
+                        </Button>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/src/workspace/hooks/use-query-adapter.ts
+++ b/src/workspace/hooks/use-query-adapter.ts
@@ -7,6 +7,32 @@ import type { BottomPanelMode } from "@/components/studio/BottomPanel";
 import { useToast } from "@/hooks/use-toast";
 import { isDangerousQuery } from "@/components/QuerySafetyDialog";
 
+/**
+ * The channels a host result carries beyond rows and counts (#285).
+ *
+ * The adapter used to build its tab result from an explicit five-key list, so
+ * anything the host attached beyond those keys was dropped and the embedding saw
+ * neither the query warnings nor the declared column types the standalone app
+ * shows. Both are read straight off `result` by `ResultsGrid`, so carrying them is
+ * the whole fix — and the declared types go into the contract's existing
+ * `columns[].type` slot rather than a second shape for the same information.
+ *
+ * Both stay ABSENT when the host sent nothing: the grid decides whether to render
+ * from the field's presence, so an empty array would announce a section with
+ * nothing in it.
+ */
+function carriedChannels(result: WorkspaceQueryResult): Pick<QueryTab["result"] & object, "warnings" | "columnTypes"> {
+  // A column the host declared without a type contributes no entry rather than an
+  // undefined one every reader would have to test for.
+  const declared = (result.columns ?? []).filter((column) => column.type !== undefined);
+  return {
+    ...(result.warnings && { warnings: result.warnings }),
+    ...(declared.length > 0 && {
+      columnTypes: Object.fromEntries(declared.map((column) => [column.name, column.type as string])),
+    }),
+  };
+}
+
 interface UseQueryAdapterParams {
   activeConnection: DatabaseConnection | null;
   onQueryExecute: (
@@ -120,6 +146,7 @@ export function useQueryAdapter({
                 rowCount: result.rowCount,
                 executionTime,
                 pagination: result.pagination,
+                ...carriedChannels(result),
               },
               allRows: result.rows,
               currentOffset: result.rows.length,
@@ -202,6 +229,7 @@ export function useQueryAdapter({
                   rowCount: result.rowCount,
                   executionTime,
                   pagination: result.pagination,
+                  ...carriedChannels(result),
                 },
                 allRows: result.rows,
                 currentOffset: result.rows.length,

--- a/src/workspace/types.ts
+++ b/src/workspace/types.ts
@@ -1,5 +1,5 @@
 // src/workspace/types.ts
-import type { DatabaseType, TableSchema, SavedQuery } from "@/lib/types";
+import type { DatabaseType, TableSchema, SavedQuery, QueryWarning } from "@/lib/types";
 
 // === Connection (platform → studio) ===
 
@@ -22,9 +22,25 @@ export interface WorkspaceUser {
 export interface WorkspaceQueryResult {
   rows: Record<string, unknown>[];
   fields: string[];
+  /**
+   * The declared type of each column, as the engine spells it. Optional per
+   * column, because a computed projection often has none. The adapter turns this
+   * into the grid's `columnTypes` map (#285).
+   */
   columns?: { name: string; type?: string }[];
   rowCount: number;
   executionTime: number;
+  /**
+   * Notices the engine attached to this run — an analytics engine answering 200
+   * with rows missing, a query service returning advice about the statement. The
+   * grid renders them from the field's presence, so a host that has none should
+   * omit the field rather than send an empty array (#285).
+   *
+   * Additive and optional: this interface is published (`src/exports/workspace.ts`)
+   * and implemented outside this repo, so a required field would stop every
+   * existing host from compiling.
+   */
+  warnings?: QueryWarning[];
   pagination?: {
     limit: number;
     offset: number;

--- a/tests/api/db/multi-query.test.ts
+++ b/tests/api/db/multi-query.test.ts
@@ -161,6 +161,95 @@ describe("POST /api/db/multi-query", () => {
     expect(data.fields).toBeDefined();
   });
 
+  // ── Warnings and declared column types travel with their statement (#285) ──
+  //
+  // #273 gave the shared result both channels and the providers fill them, but
+  // this route builds each statement result from an explicit field list, so both
+  // stopped here. Silent field-dropping is only caught by asserting the far end.
+
+  test("carries each statement's warnings and column types onto that statement", async () => {
+    let call = 0;
+    (mockProvider.query as ReturnType<typeof mock>).mockImplementation(async () => {
+      call++;
+      return {
+        rows: [{ id: call }],
+        fields: ["id"],
+        rowCount: 1,
+        executionTime: 5,
+        warnings: [{ message: `notice ${call}`, code: call }],
+        columnTypes: { id: call === 1 ? "BIGINT" : "INTEGER" },
+      };
+    });
+
+    const req = createMockRequest("/api/db/multi-query", {
+      method: "POST",
+      body: { connection: validConnection, sql: "SELECT 1; SELECT 2" },
+    });
+
+    const res = await POST(req as never);
+    const data = await parseResponseJSON<{
+      statements: Array<{
+        warnings?: { message: string; code?: number | string }[];
+        columnTypes?: Record<string, string>;
+      }>;
+    }>(res);
+
+    expect(data.statements[0].warnings).toEqual([{ message: "notice 1", code: 1 }]);
+    expect(data.statements[0].columnTypes).toEqual({ id: "BIGINT" });
+    expect(data.statements[1].warnings).toEqual([{ message: "notice 2", code: 2 }]);
+    expect(data.statements[1].columnTypes).toEqual({ id: "INTEGER" });
+  });
+
+  test("the main result carries the channels of the statement whose rows it shows", async () => {
+    // The main result is the last statement that returned rows, so those rows and
+    // these notices come from the same run. Merging every statement's warnings
+    // would attribute one statement's notice to another's rows.
+    let call = 0;
+    (mockProvider.query as ReturnType<typeof mock>).mockImplementation(async () => {
+      call++;
+      return call === 1
+        ? { rows: [{ id: 1 }], fields: ["id"], rowCount: 1, executionTime: 5, warnings: [{ message: "first" }] }
+        : {
+            rows: [{ total: 2 }],
+            fields: ["total"],
+            rowCount: 1,
+            executionTime: 5,
+            warnings: [{ message: "second" }],
+            columnTypes: { total: "BIGINT" },
+          };
+    });
+
+    const req = createMockRequest("/api/db/multi-query", {
+      method: "POST",
+      body: { connection: validConnection, sql: "SELECT 1; SELECT count(*) AS total FROM t" },
+    });
+
+    const res = await POST(req as never);
+    const data = await parseResponseJSON<{
+      warnings?: { message: string }[];
+      columnTypes?: Record<string, string>;
+    }>(res);
+
+    expect(data.warnings).toEqual([{ message: "second" }]);
+    expect(data.columnTypes).toEqual({ total: "BIGINT" });
+  });
+
+  test("omits both channels when the engine reported neither", async () => {
+    // Absent rather than empty: the grid decides whether to render anything from
+    // the field's presence alone.
+    const req = createMockRequest("/api/db/multi-query", {
+      method: "POST",
+      body: { connection: validConnection, sql: "SELECT 1; SELECT 2" },
+    });
+
+    const res = await POST(req as never);
+    const data = await parseResponseJSON<Record<string, unknown>>(res);
+
+    expect("warnings" in data).toBe(false);
+    expect("columnTypes" in data).toBe(false);
+    expect("warnings" in (data.statements as Record<string, unknown>[])[0]).toBe(false);
+  });
+
   test("multiple statements are all executed", async () => {
     let callCount = 0;
     (mockProvider.query as ReturnType<typeof mock>).mockImplementation(async () => {

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -28,6 +28,13 @@ let mockConnectionsList: Record<string, unknown>[] = [
 ];
 let mockActiveConnectionId: string | null = "c1";
 
+// The capabilities the selected connection's provider declares. `null` is the
+// state before `/api/db/provider-meta` answers, and the state it stays in when
+// that request fails (#282).
+let mockMetadata: { capabilities: Record<string, unknown> } | null = {
+  capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze", "vacuum", "reindex"] },
+};
+
 const defaultSessions = [
   {
     pid: 1234,
@@ -64,6 +71,10 @@ mock.module("@/hooks/use-monitoring-data", () => ({
     runMaintenance: mockRunMaintenance,
     ...monitoringOverride,
   })),
+}));
+
+mock.module("@/hooks/use-provider-metadata", () => ({
+  useProviderMetadata: mock(() => ({ metadata: mockMetadata, isLoading: false })),
 }));
 
 mock.module("@/lib/storage", () => ({
@@ -167,6 +178,9 @@ describe("OperationsTab", () => {
       },
     ];
     mockActiveConnectionId = "c1";
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze", "vacuum", "reindex"] },
+    };
 
     // Clear mocks
     mockRefresh.mockClear();
@@ -234,6 +248,69 @@ describe("OperationsTab", () => {
     expect(queryByText("Run Analyze")).not.toBeNull();
     expect(queryByText("Run Vacuum")).not.toBeNull();
     expect(queryByText("Run Reindex")).not.toBeNull();
+  });
+
+  // ── Maintenance controls are gated on declared capability (#282) ──────────
+  //
+  // `/api/db/maintenance` short-circuits on the capability, so an ungated button
+  // can only ever answer HTTP 400. This is the same gate #272 put on the
+  // monitoring Tables tab; this tab is its untouched twin, and the affected set is
+  // broad — Druid and the embedded engine declare no maintenance at all, and
+  // MySQL, MSSQL, ClickHouse, Oracle and Redis declare neither vacuum nor reindex.
+
+  test("renders only the operations the provider declares", async () => {
+    mockMetadata = { capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze"] } };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Run Analyze")).not.toBeNull();
+    expect(queryByText("Run Vacuum")).toBeNull();
+    expect(queryByText("Run Reindex")).toBeNull();
+  });
+
+  test("hides the whole maintenance group when the provider declares none", async () => {
+    mockMetadata = { capabilities: { supportsMaintenance: false, maintenanceOperations: [] } };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Global Operations")).toBeNull();
+    expect(queryByText("Run Analyze")).toBeNull();
+    expect(queryByText("Run Vacuum")).toBeNull();
+    expect(queryByText("Run Reindex")).toBeNull();
+  });
+
+  test("hides the controls while the capabilities are unknown", async () => {
+    // Undefined covers both the moment before /api/db/provider-meta answers and
+    // the case where it failed. Failing open would put the dead buttons back on
+    // exactly the connections this gate exists for, which is how #272 reasoned.
+    mockMetadata = null;
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Run Analyze")).toBeNull();
+    expect(queryByText("Global Operations")).toBeNull();
+  });
+
+  test("hides the per-table maintenance buttons the provider does not declare", async () => {
+    mockMetadata = { capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze"] } };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { container } = renderResult!;
+
+    const titles = Array.from(container.querySelectorAll("button")).map((b) => b.getAttribute("title"));
+    expect(titles).toContain("Analyze");
+    expect(titles).not.toContain("Vacuum");
   });
 
   test("warning card present", async () => {

--- a/tests/hooks/use-query-adapter.test.ts
+++ b/tests/hooks/use-query-adapter.test.ts
@@ -89,6 +89,90 @@ describe("useQueryAdapter", () => {
     mockToastError.mockClear();
   });
 
+  // ── The two additive result channels reach the grid (#285) ────────────────
+  //
+  // The adapter built its tab result from an explicit five-key list, so anything
+  // the host attached beyond those keys was dropped — which made the query
+  // warnings and declared column types of #273 invisible in the npm-package
+  // embedding while the standalone app showed them. `ResultsGrid` reads
+  // `result.warnings` and `result.columnTypes`, so a passthrough is the whole fix.
+
+  test("executeQuery carries host warnings through to the tab result", async () => {
+    const params = makeHookParams({
+      onQueryExecute: mock(() =>
+        Promise.resolve(makeQueryResult({ warnings: [{ message: "1 document exceeded the limit", code: 3000 }] })),
+      ),
+    });
+    const { result } = renderHook(() => useQueryAdapter(params as never));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT 1");
+    });
+
+    expect(params.tabs[0].result?.warnings).toEqual([{ message: "1 document exceeded the limit", code: 3000 }]);
+  });
+
+  test("executeQuery fills columnTypes from the contract's existing columns slot", async () => {
+    // `WorkspaceQueryResult.columns[].type` was already declared and unused;
+    // filling it beats inventing a second shape for the same information.
+    const params = makeHookParams({
+      onQueryExecute: mock(() =>
+        Promise.resolve(
+          makeQueryResult({
+            columns: [{ name: "id", type: "BIGINT" }, { name: "name", type: "Nullable(String)" }, { name: "extra" }],
+          }),
+        ),
+      ),
+    });
+    const { result } = renderHook(() => useQueryAdapter(params as never));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT 1");
+    });
+
+    // A column the host declared without a type contributes no entry, rather than
+    // an undefined one the grid would have to test for.
+    expect(params.tabs[0].result?.columnTypes).toEqual({ id: "BIGINT", name: "Nullable(String)" });
+  });
+
+  test("executeQuery leaves both channels absent when the host sent neither", async () => {
+    const params = makeHookParams();
+    const { result } = renderHook(() => useQueryAdapter(params as never));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT 1");
+    });
+
+    expect(params.tabs[0].result?.warnings).toBeUndefined();
+    expect(params.tabs[0].result?.columnTypes).toBeUndefined();
+  });
+
+  test("forceExecuteQuery carries both channels too", async () => {
+    // The confirm-and-run path builds its own result object, so it drops the same
+    // keys unless it is fixed with the first one.
+    const params = makeHookParams({
+      onQueryExecute: mock(() =>
+        Promise.resolve(
+          makeQueryResult({
+            warnings: [{ message: "truncated" }],
+            columns: [{ name: "id", type: "INTEGER" }],
+          }),
+        ),
+      ),
+    });
+    const { result } = renderHook(() => useQueryAdapter(params as never));
+
+    await act(async () => {
+      result.current.forceExecuteQuery("DELETE FROM users");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(params.tabs[0].result?.warnings).toEqual([{ message: "truncated" }]);
+    expect(params.tabs[0].result?.columnTypes).toEqual({ id: "INTEGER" });
+  });
+
   // ── executeQuery calls onQueryExecute with correct connectionId and sql ────
 
   test("executeQuery calls onQueryExecute with correct connectionId and sql", async () => {


### PR DESCRIPTION
Closes #285. Closes #282.

Two capability-honesty defects from the same sweep, both of the shape "the software knows something and the surface does not say it". Different files, no overlap, one review context.

## #285 — warnings and declared column types stopped at two paths

#273 gave the shared result two additive channels (`warnings`, `columnTypes`) and the providers fill them. `/api/db/query` spreads the whole result, so the standalone single-statement path was intact end to end. The other two paths build their result from an explicit field list, so everything beyond those keys was dropped.

**The embedded workspace adapter** is the one that reached users: `ResultsGrid` reads `result.warnings` and `result.columnTypes`, so the npm-package embedding (`libredb-platform`) showed neither while the standalone app showed both. Fixed in both of its result-building sites — `executeQuery` and `forceExecuteQuery`.

- The declared types go into the contract's existing `columns[].type` slot rather than a second shape for the same information. That slot was already declared and unused.
- A column the host declared without a type contributes no entry, rather than an undefined one every reader would have to test for.
- `WorkspaceQueryResult` gains a `warnings` slot — **additive and optional**, since the interface is published via `src/exports/workspace.ts` and implemented outside this repo. `QueryWarning` was already exported.

**The multi-statement route** carries both channels per statement, because that is where they are attributable: a notice belongs to the run that produced it.

The issue deliberately left one question open — whose warnings the main result should show. It carries the channels of **the statement whose rows it is showing** (the last one that returned rows). Those rows and those notices come from the same run; merging every statement's warnings would attribute one run's notice to another run's rows, and showing none would reintroduce the defect for the multi-statement path.

Both channels stay **absent** when the engine reported nothing, never empty — the grid decides whether to render a section from the field's presence alone.

## #282 — the admin Operations tab ignored capabilities

The same defect #272 fixed in the monitoring Tables tab, in its untouched twin. `OperationsTab.tsx` contained no capability information at all, so its three global controls and its per-table Analyze/Vacuum buttons were offered for every connection while `/api/db/maintenance` short-circuits on the capability and answers 400. That is guaranteed on Druid and the embedded engine (no maintenance at all), and on MySQL, MSSQL, ClickHouse, Oracle and Redis for vacuum and reindex.

It now resolves the selected connection's capabilities through `useProviderMetadata` — the tab already held `selectedConnection` — and hides:

- the whole Global Operations group where `supportsMaintenance` is not `true`,
- each individual control whose `MaintenanceType` is absent from `maintenanceOperations`,
- everything while the capabilities are unknown.

Unknown hides rather than shows, following #272's reasoning: `metadata` is also null when `/api/db/provider-meta` fails, and failing open would put the dead buttons back on exactly the connections this gate exists for.

## Docs move with the code

Four provider docs asserted the old state in prose: `druid.md` described the gap at length ("The admin Operations tab still has the same gap"), and `couchbase.md`, `clickhouse.md` and `libredb.md` each said the Operations tab "still does not read capabilities". All four now describe the software rather than the intent.

`/api/db/multi-query` is documented as an internal route ("consult the route handlers"), so `API_DOCS.md` needs no change; `WorkspaceQueryResult` is its own documentation and the new field is commented there.

## Verification

`bun run format` · `bun run lint` (0 errors) · `bun run typecheck` · `bun run knip` · `bun run test` (exit 0) · `bun run build` · `bun run build:lib` + `bun run attw` · `bun run coverage:check` → **29244/29244 lines (100.00%)**.

Every behaviour change landed test-first. The passthrough defect class is only caught by asserting the far end, so each path has a test that puts a warning and a declared type in at the provider/host and reads it out at the consumer, plus one asserting both stay absent when nothing was reported.
