### PR TITLE
fix(ci): let the arm-ttk gate decide the azure package job, not the error stream

### DIFF
--- a/.github/workflows/azure-marketplace-package.yml
+++ b/.github/workflows/azure-marketplace-package.yml
@@ -52,10 +52,36 @@ jobs:
           # The release zip carries a top-level arm-ttk/ folder, so extracting
           # into arm-ttk/ nests the module one level deeper (verified 2026-08-05).
           Import-Module ./arm-ttk/arm-ttk/arm-ttk/arm-ttk.psd1
-          $results = Test-AzMarketplacePackage -TemplatePath "dist/azure/package"
+
+          # arm-ttk's individual tests report through the ERROR stream, and
+          # Test-AzTemplate collects that stream into each result's .Errors /
+          # .Warnings (`. $myModule $TheTest @testInput 2>&1 3>&1`). GitHub's pwsh
+          # shell runs with $ErrorActionPreference = 'Stop', which turns the first
+          # such write into a TERMINATING error - so the run died inside the toolkit
+          # and the gate below never executed. A test arm-ttk itself classifies as a
+          # warning was therefore indistinguishable from a failure, and this job
+          # could not pass while any warning existed. Let the toolkit finish; the
+          # gate decides the outcome.
+          $ErrorActionPreference = 'Continue'
+          $results = Test-AzMarketplacePackage -TemplatePath "dist/azure/package" 2>$null
           $results | Format-List
-          $failed = $results | Where-Object { $_.Errors }
-          if ($failed) { Write-Error "arm-ttk reported $($failed.Count) failing test(s)"; exit 1 }
+
+          # A wrong -TemplatePath or a half-imported module yields an empty result
+          # set, which would otherwise sail through the gate as "nothing failed".
+          if (-not $results -or $results.Count -eq 0) {
+            Write-Error "arm-ttk produced no results at all - the package path or the module import is wrong"
+            exit 1
+          }
+
+          $failed = @($results | Where-Object { $_.Errors })
+          $warned = @($results | Where-Object { $_.Warnings -and -not $_.Errors })
+          Write-Host "arm-ttk: $($results.Count) tests, $($failed.Count) failed, $($warned.Count) warned"
+          foreach ($w in $warned) { Write-Host "::warning title=arm-ttk::$($w.Name): $($w.Warnings -join '; ')" }
+          if ($failed.Count -gt 0) {
+            foreach ($f in $failed) { Write-Host "::error title=arm-ttk::$($f.Name): $($f.Errors -join '; ')" }
+            Write-Error "arm-ttk reported $($failed.Count) failing test(s)"
+            exit 1
+          }
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## What

The first real dispatch of the **Azure Marketplace Package** workflow after #307 merged [failed](https://github.com/libredb/libredb-studio/actions/runs/31169983574) — and not on anything wrong with the package. arm-ttk reported `35 tests, 0 failed, 1 warning`, which is the expected result.

arm-ttk's individual tests report through the **error stream**, and `Test-AzTemplate` collects that stream into each result's `.Errors` / `.Warnings` (`. $myModule $TheTest @testInput 2>&1 3>&1`). GitHub's `shell: pwsh` runs with `$ErrorActionPreference = 'Stop'`, so the first such write became a **terminating** error inside the toolkit at `Test-AzTemplate.ps1:253`, and the job's own gate —

```powershell
$failed = $results | Where-Object { $_.Errors }
if ($failed) { … exit 1 }
```

— never executed. A finding arm-ttk itself classifies as a *warning* was therefore indistinguishable from a failure: **this job could not have passed while any warning existed.**

## Why the fix is in the job, not the template

The warning is `URIs Should Be Properly Constructed` on `applicationUrl`. Silencing it at the template is not the right move:

- the test's own source carries the comment `# commenting out the test due to # 417`;
- it reports an empty function name (`Function ''`) — the regex does not even capture it;
- `format` is on its `$FunctionNotAllowedInUri` list alongside `concat`, so rewriting the output as `format(...)` would not clear it either;
- arm-ttk classifies the result as a warning with `Errors` empty. The job should agree with it.

## The change

`$ErrorActionPreference = 'Continue'` before the call, so the toolkit finishes and the declared gate decides. Plus two things the original step lacked:

- each finding is surfaced as a GitHub annotation (`::warning` / `::error`) with the test name;
- an **empty** result set now fails. A wrong `-TemplatePath` or a half-imported module would otherwise sail through the gate as "nothing failed".

## Verification

The step's `run:` block was extracted from the workflow file itself — not retyped — and executed under the same shell semantics (`$ErrorActionPreference = 'stop'` prepended, `pwsh -command ". 'file'"`) against the pinned toolkit release:

| package | exit code | output |
|---|---|---|
| the real one | **0** | `arm-ttk: 35 tests, 0 failed, 1 warned` |
| with a planted `securestring` `defaultValue` | **1** | `::error … Secure String Parameters Cannot Have Default` |

The second row matters more than the first: a gate that was just loosened has to be shown to still fail.

Then dispatched for real on this branch — [run 31170797677](https://github.com/libredb/libredb-studio/actions/runs/31170797677): **success**, every step green, `arm-ttk: 35 tests, 0 failed, 1 warned`, artifact uploaded (15 KB, the two-file package zip).

## Note on the earlier verification

The local check in #307 reported arm-ttk's verdict accurately but ran in a plain container, where `$ErrorActionPreference` defaults to `Continue` — so it could not predict the job's outcome. Reproducing the *tool* is not the same as reproducing the *job*; this PR's check does the latter.
