### PR TITLE
docs: reject the unread workspace flag in the contract, and demote row editing to the backlog (#288, #279, #284)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -16,6 +16,10 @@ the time it was written down, but none of it has been filed as a GitHub issue.
   reading of a database's grammar that ought to be checked against a first-party source again.
 - Promote an entry to a GitHub issue whenever it needs discussion, an outside reporter, or a
   release note. This file is a holding area, not a competing tracker.
+- The reverse happens too. An issue that is understood, breaks nothing today and is not scheduled
+  belongs here rather than in a tracker where it only ages: it is closed with a pointer to its entry
+  and reopened if a consumer asks for it. A defect a user can hit stays an issue — closing one of
+  those hides a limitation instead of deferring it.
 
 ---
 
@@ -145,6 +149,37 @@ Since #290 the inline row editor sends `SET "name" = $1` with the value bound, a
 ran, but no longer a record of what was written. Carrying the bound values as their own history
 field would restore the audit trail without putting them back into the SQL. Touches the history
 entry shape in `src/lib/storage`, so it is a schema change rather than a one-line fix.
+
+---
+
+## Row editing
+
+### R1. Row editing is offered only where a shared `UPDATE` happens to fit (was #279)
+
+The results grid builds one statement shape for every engine —
+`UPDATE <table> SET <col> = <val> WHERE <pk> = <val>` in `src/hooks/use-inline-editing.ts` — so an
+engine that spells a row mutation differently cannot have the feature. #269 made that honest rather
+than broken: `supportsInlineRowEdit` hides the control wherever the shape does not fit, which is why
+this is deferred work and not a defect. Today it is true for PostgreSQL, MySQL, SQLite, Oracle and
+SQL Server, and false everywhere else.
+
+Making it work means moving statement generation into the provider, so each dialect owns its own
+form: the SQL providers keep the shape above, ClickHouse spells it `ALTER TABLE <t> UPDATE <col> =
+<val> WHERE ...`, MongoDB has no statement at all and would need the document-update path, and an
+append-only engine keeps declaring the capability false. The provider triad applies, so code,
+`docs/providers/<type-id>.md` and the provider's integration test move together, per provider.
+
+Two constraints come from #269 and do not go away:
+
+- **One request per edited row.** Several engines reject a multi-statement request, so the old
+  newline-joined payload cannot come back.
+- **Primary-key detection is heuristic.** The hook picks the key by looking for a result column named
+  `id` or ending in `_id`. That is acceptable for a control gated on an opt-in capability, but
+  per-dialect editing on real tables should derive the key from the schema instead.
+
+Whether row editing should be a universal feature at all is a product decision, not a mechanical one,
+which is the other half of why it is here. The published `WorkspaceFeatures.inlineEditing` flag is
+deprecated against this entry (#288): it becomes real, or goes away in a major, with this work.
 
 ---
 

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -1,3 +1,23 @@
+/**
+ * Migration SQL from a schema diff.
+ *
+ * **Only part of this generator is dialect-aware, and the rest emits one shape for
+ * everyone (#284).** Stated here because the difference is invisible from a call
+ * site: `generateMigrationSQL(diff, dialect)` takes a dialect either way.
+ *
+ * - Dialect-aware: the modified-column path, which branches per engine and names
+ *   the limitation in a comment where an engine has no such statement (#269).
+ * - Not yet: the transaction wrapper (`BEGIN;` / `COMMIT;`, which is only valid
+ *   for PostgreSQL and MySQL — MSSQL spells it `BEGIN TRANSACTION`, Oracle opens a
+ *   PL/SQL block and auto-commits DDL anyway, and six type ids have no
+ *   transactional DDL at all), `ADD COLUMN` and `DROP COLUMN`, and the index/FK
+ *   fallbacks that emit `DROP INDEX IF EXISTS`.
+ *
+ * So the output is correct for PostgreSQL, largely correct for MySQL and SQLite,
+ * and can be unrunnable elsewhere. Tracked rather than fixed here because the
+ * emitted forms want checking against a live MSSQL and Oracle before they are
+ * settled, the way #264 and #265 did.
+ */
 import type { DatabaseType } from "@/lib/types";
 // The shared quoter, which also escapes an embedded closing quote character — this
 // file used to carry its own copy that did not, so a schema object named with one

--- a/src/workspace/types.ts
+++ b/src/workspace/types.ts
@@ -59,6 +59,22 @@ export interface WorkspaceFeatures {
   testDataGenerator?: boolean;
   schemaDiagram?: boolean;
   dataImport?: boolean;
+  /**
+   * @deprecated Declared but not read: setting it has no effect (#288).
+   *
+   * The embedded workspace has no editing path to switch on. `StudioWorkspace`
+   * hard-codes `editingEnabled={false}` at both grid call sites, and the embedded
+   * query adapter's `executeQuery` takes no execution options, so it could not
+   * carry the `skipSafety` flag the standalone inline-edit path relies on (#269)
+   * even if a caller reached it.
+   *
+   * Kept rather than removed because this interface is published and implemented
+   * outside this repo, so deleting the field would stop a host that sets it from
+   * compiling. Saying so here is the honest half: a declared capability that is
+   * neither implemented nor rejected is the state to avoid, and this rejects it
+   * where a host reads the contract. It becomes real, or goes away in a major,
+   * with per-dialect row editing (#279).
+   */
   inlineEditing?: boolean;
   transactions?: boolean;
   connectionManagement?: boolean;
@@ -72,6 +88,9 @@ export const DEFAULT_WORKSPACE_FEATURES: Required<WorkspaceFeatures> = {
   testDataGenerator: true,
   schemaDiagram: true,
   dataImport: true,
+  // Deprecated and unread — see the field's note above (#288). It stays in the
+  // defaults because the type is `Required<WorkspaceFeatures>`, and `false` is
+  // the only value that matches what the embedded workspace actually does.
   inlineEditing: false,
   transactions: false,
   connectionManagement: false,


### PR DESCRIPTION
Closes #288. Closes #279.

Three deferred items, triaged by what each one costs a reader rather than by how much work it is. **No behaviour changes** — a deprecation tag, a backlog entry and a module header.

The context: these three are not scheduled while the product's attention is elsewhere. Leaving them open unanswered for months is its own cost, but so is closing a defect that still bites. So they are not treated the same way.

## #288 — the flag now says it does nothing

`WorkspaceFeatures.inlineEditing` is declared in a published interface, a host can set it, and nothing reads it: `StudioWorkspace` hard-codes `editingEnabled={false}` at both grid call sites, and the embedded query adapter's `executeQuery` takes no execution options, so it could not carry the `skipSafety` flag the standalone inline-edit path relies on (#269) even if a caller reached it.

The issue offered two resolutions — remove the field, or implement it. Both are wrong right now: removing it stops every host that sets it from compiling, and implementing it waits on #279. So this takes the option the issue was actually asking for. Its own words are that "a declared capability that is neither implemented nor rejected is the state to avoid" — this **rejects** it, explicitly, where a host reads the contract.

Verified in the built package rather than assumed: the tag lands on the field in `dist/workspace.d.ts`, so a host's editor strikes it through and says why.

## #279 — moved to `docs/BACKLOG.md` and closed

Deferred work, not a defect. #269 already made the software honest about it: the `supportsInlineRowEdit` capability hides the control wherever the shared `UPDATE <table> SET <col> = <val> WHERE <pk> = <val>` shape does not fit, so nothing is broken and no user is misled — the feature is simply absent on ClickHouse, Druid, MongoDB, Redis, Couchbase and the embedded engine.

The backlog entry keeps everything the issue knew: the per-provider forms (ClickHouse's `ALTER TABLE … UPDATE`, MongoDB's document path, append-only engines keeping the capability false), the provider-triad obligation, and the two constraints inherited from #269 — one request per edited row, and primary-key detection that should come from the schema rather than from column names. It also records that whether row editing should be universal at all is a product decision.

That is a **demotion**, the reverse of the file's documented promote-to-an-issue rule, so the rule now states both directions and where the line falls:

> An issue that is understood, breaks nothing today and is not scheduled belongs here rather than in a tracker where it only ages […] A defect a user can hit stays an issue — closing one of those hides a limitation instead of deferring it.

## #284 — stays open, and the generator now states its gap

Not closed, and not backlogged. The schema-diff generator can emit migration SQL that is unrunnable outside PostgreSQL — a `BEGIN;`/`COMMIT;` wrapper that MSSQL cannot parse and Oracle reads as a PL/SQL block, `ADD COLUMN`/`DROP COLUMN` in one shape for eleven type ids, and `DROP INDEX IF EXISTS` fallbacks Oracle rejects. A user meets that as broken SQL, so it keeps its issue; closing it would hide a limitation rather than defer it.

What it lacked was any statement of the gap where a developer meets it. `generateMigrationSQL(diff, dialect)` takes a dialect whether or not the path in question uses one, so the partial coverage is invisible from a call site. The module header now names the one path that is dialect-aware (the modified-column path, #269) and the four that are not.

The issue itself is getting a `help wanted` label and a comment recording that it is unscheduled, well specified, and that the emitted forms want checking against a live MSSQL and Oracle before they are settled — the way #264 and #265 were.

## Verification

`bun run format` · `bun run lint` (0 errors; no warning touches either changed source file) · `bun run typecheck` · `bun run knip` · `bun run test` (exit 0) · `bun run build` · `bun run build:lib` + `bun run attw` · `bun run coverage:check` → **29254/29254 lines (100.00%)**.

No tests were added: nothing executable changed. The one claim worth checking mechanically — that the deprecation reaches consumers — was checked against the built `dist/workspace.d.ts`.
