### PR TITLE
docs(rancher): refresh the SUSE catalog listing content to the granted certification

### DIFF
--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -7,17 +7,30 @@ the single source for the catalog text; the partner-charts `app-readme.md` overl
 refreshed from it during the Phase-2 resubmission (see `E2E_VALIDATION_TASK.md` for the
 validation side).
 
+The listing is live at https://www.suse.com/pcsc/viewVersionPage?versionID=26969 (SUSE
+published it on 2026-08-05 from an earlier revision of this file). Edits here do not
+propagate automatically — SUSE owns the page, so any change has to be mailed to the
+partner contact.
+
+> **Accuracy gate — engine count.** The wording below says ten engines. That is true
+> from the first release containing ClickHouse and Apache Druid onwards; both are merged
+> on `main` but unreleased as of **0.9.66**, which ships eight (PostgreSQL, MySQL,
+> Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase). The catalog entry is
+> version-scoped, so do not publish the ten-engine wording against a version older than
+> that — send the eight-engine variant instead, or cut the release first.
+
 ## Listing facts
 
 | Field | Value |
 |-------|-------|
 | Product name | LibreDB Studio |
-| Vendor (public listing) | LibreDB |
+| Vendor (public listing) | LibreDB — as published, the page heads the partner as **Sekoya** with the product as LibreDB Studio |
 | Partner of record (legal entity) | Sekoya Grup Bilisim ve Teknoloji Ltd. Sti., Istanbul, Turkiye |
-| Category | Database / Developer Tools |
+| Category | Data Management & Analysis (assigned by SUSE; we had proposed Database / Developer Tools) |
 | License | MIT (open source) |
 | Specialization | SUSE One — INNOVATE |
-| Certification | SUSE Ready for Rancher (in progress) |
+| Certification | SUSE Ready, Platform: SUSE Rancher — granted, live since 2026-08-05 |
+| Catalog listing | https://www.suse.com/pcsc/viewVersionPage?versionID=26969 |
 | Website | https://libredb.org |
 | Source | https://github.com/libredb/libredb-studio |
 | Helm repository | https://libredb.org/libredb-studio/ (also OCI: `oci://ghcr.io/libredb/charts/libredb-studio`) |
@@ -28,16 +41,17 @@ validation side).
 ## Short description (one sentence)
 
 LibreDB Studio is an MIT-licensed, AI-assisted open source SQL IDE that connects to
-PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis directly from the
-browser.
+PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse and
+Apache Druid directly from the browser.
 
 ## Long description
 
 LibreDB Studio brings a full SQL IDE to Rancher-managed Kubernetes clusters: browse
 schemas, run queries, and manage data across PostgreSQL, MySQL, Oracle, SQL Server,
-SQLite, MongoDB and Redis from a single web interface, with no desktop client to
-install. An optional AI assistant (bring your own key: Gemini, OpenAI, or a local
-model) writes and explains SQL from natural language and stays off unless configured.
+SQLite, MongoDB, Redis, Couchbase, ClickHouse and Apache Druid from a single web
+interface, with no desktop client to install. An optional AI assistant (bring your own
+key: Gemini, OpenAI, or a local model) writes and explains SQL from natural language and
+stays off unless configured.
 
 The Helm chart installs from the Rancher Apps catalog with default values: first-run
 admin credentials are generated automatically and printed to the pod log, so a working
@@ -49,8 +63,8 @@ versions are documented and validated for every release.
 
 ## Key features (bullet form, if the catalog template asks for them)
 
-- Seven database engines in one browser-based IDE: PostgreSQL, MySQL, Oracle,
-  SQL Server, SQLite, MongoDB, Redis
+- Ten database engines in one browser-based IDE: PostgreSQL, MySQL, Oracle,
+  SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid
 - One-click install from the Rancher Apps catalog — deployable with default values,
   zero configuration required
 - Optional AI query assistance (Gemini, OpenAI, or a self-hosted model; off by
@@ -61,16 +75,33 @@ versions are documented and validated for every release.
 - Multi-arch images (amd64/arm64), documented supported-version matrix, fully
   automated and self-verifying release pipeline
 
+## Outstanding corrections to the published page
+
+Checked against the live page on 2026-08-07. These are deltas between what SUSE
+published and what is true today; batch them into one mail to the partner contact rather
+than sending them one at a time.
+
+| Field on the page | Published value | Should be |
+|---|---|---|
+| Version | LibreDB Studio 0.9.44 | the current release (0.9.66 or later), with the release link updated to match |
+| Key features | "Seven database engines" | see the accuracy gate above — eight today, ten once ClickHouse and Druid ship |
+| Hardware Architecture | x86-64 | x86-64 and Arm64 (`ghcr.io/libredb/libredb-studio` is linux/amd64 + linux/arm64) |
+
+Two open questions for the same mail: whether the version field can track the latest
+release or whether certification is bound to a specific version, and which exact
+certification wording and imagery we may reuse in our own README, docs and website.
+Until that is answered, our public copy states only what the listing itself states and
+links to it — no badge, no logo.
+
 ## Delivery note
 
-Troy Topnik (SUSE) offered to lift the listing content from the website, the GitHub
-README, or the PR's `app-readme.md`. Hand him this file's Short description, Long
-description, and Listing facts instead — it is the reviewed, canonical wording. Any
-future edit happens here first, then propagates to the partner-charts overlay.
+The content above was delivered to Troy Topnik (SUSE) and published on 2026-08-05; he
+fitted as much of the long description as the page template allows. This file stays the
+canonical wording: any future edit happens here first, then goes to SUSE by mail and to
+the partner-charts `app-readme.md` overlay.
 
-Vendor naming: our preference is that the public listing shows the vendor as
-**LibreDB** (the brand users see on the chart, the Helm repo, and GitHub), while the
-certification and partner record are attached to the legal entity, Sekoya Grup Bilisim
-ve Teknoloji Ltd. Sti. This mirrors the accepted pattern in rancher/partner-charts
-(e.g. OpenBao listed under the brand while the certification is held by the backing
-company).
+Vendor naming, as settled: the page heads the partner as **Sekoya** (the legal entity,
+Sekoya Grup Bilisim ve Teknoloji Ltd. Sti.) with the product named **LibreDB Studio**.
+We had asked for the vendor line to read LibreDB; the split SUSE applied achieves the
+same thing — brand on the product, certification on the company — so it is accepted and
+not worth re-litigating.

--- a/docs/RANCHER.md
+++ b/docs/RANCHER.md
@@ -6,6 +6,11 @@ instance, and first-run admin credentials are generated automatically. This
 document describes the supported Rancher, Kubernetes, and distribution
 versions, how to install through Rancher, and the combinations we validate.
 
+LibreDB Studio is listed in the SUSE Partner Certification & Solutions
+Catalog: [LibreDB Studio](https://www.suse.com/pcsc/viewVersionPage?versionID=26969),
+where the listing records the platform as SUSE Rancher and the certification
+as SUSE Ready.
+
 ## Supported versions
 
 These are the SUSE Rancher and Rancher Kubernetes distribution versions


### PR DESCRIPTION
The SUSE Ready certification is granted and the PCSC listing is live, but `deploy/rancher/CATALOG_LISTING.md` still described the pre-certification state and a seven-engine product. That file is the canonical source for both the catalog text SUSE publishes and the partner-charts `app-readme.md` overlay, so the drift would have propagated into the upstream PR refresh.

## What changed

- **Certification status**: `SUSE Ready for Rancher (in progress)` becomes the granted state (SUSE Ready, platform SUSE Rancher, live since 2026-08-05), plus a row for the listing URL.
- **Engine list**: seven becomes ten across the short description, long description and feature bullets (Couchbase, ClickHouse, Apache Druid).
- **Accuracy gate on that count**: 0.9.66 ships eight engines — ClickHouse and Druid are merged on `main` but unreleased. The catalog entry is version-scoped, so the file now states explicitly that the ten-engine wording must not be published against a version older than the release that carries them.
- **As-published reality**: the category SUSE assigned (Data Management & Analysis) and the vendor split it applied (partner Sekoya, product LibreDB Studio) are recorded as settled, instead of the request we originally sent.
- **Outstanding corrections table**: the three deltas between the live page and today's truth (version 0.9.44, seven-engine bullet, x86-64-only architecture), to batch into one mail rather than sending piecemeal.
- **docs/RANCHER.md**: links the catalog listing, stating only what the listing itself states — no badge and no logo until SUSE confirms what wording and imagery we may reuse.

## Notes

Documentation only; no runtime code touched. Does not touch rancher/partner-charts#1158 — that PR is refreshed around 2026-08-17 at SUSE's request.