### PR TITLE
chore(release): 0.9.67 - ClickHouse and Apache Druid

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.28
-appVersion: "0.9.66"
+version: 0.1.29
+appVersion: "0.9.67"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.66
+      image: ghcr.io/libredb/libredb-studio:0.9.67
       platforms:
         - linux/amd64
         - linux/arm64
@@ -43,9 +43,11 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Application updated to 0.9.66 - Couchbase is now a supported database, speaking SQL++ over the Query and management REST APIs; it adds no driver dependency, so the image size is unchanged"
-    - "Couchbase support covers the bucket, scope and collection explorer with INFER-derived column types, EXPLAIN plans, read-your-writes query consistency, and the monitoring and maintenance surfaces the other providers expose"
-    - "No chart template changes - the rendered manifests are identical to 0.1.27"
+    - "Application updated to 0.9.67 - ClickHouse and Apache Druid are now supported databases, both spoken over their HTTP interfaces, so neither adds a driver dependency and the image size is unchanged"
+    - "ClickHouse support covers the explorer, EXPLAIN plans, and the monitoring and maintenance surfaces the other providers expose; Apache Druid adds datasource browsing and plan reading over Druid SQL"
+    - "Every SQL statement is now read with its own dialect's grammar, so statement boundaries, identifier quoting and row-limit injection stay correct on all ten engines"
+    - "Inline row edits and CSV imports bind their values instead of interpolating them"
+    - "No chart template changes - the rendered manifests are identical to 0.1.28"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.28 \
+  --version 0.1.29 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -21,8 +21,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Database, Developer Tools
-    containerImage: ghcr.io/libredb/libredb-studio-operator:0.9.66
-    createdAt: "2026-08-03T09:31:18Z"
+    containerImage: ghcr.io/libredb/libredb-studio-operator:0.9.67
+    createdAt: "2026-08-07T17:38:03Z"
     description: Open-source web-based SQL IDE for PostgreSQL, MySQL, Oracle, SQL
       Server, SQLite, MongoDB and Redis, with AI-powered query assistance.
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
@@ -33,7 +33,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: libredb-studio-operator.v0.9.66
+  name: libredb-studio-operator.v0.9.67
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -255,7 +255,7 @@ spec:
                 - --leader-elect
                 - --leader-election-id=libredb-studio-operator
                 - --health-probe-bind-address=:8081
-                image: ghcr.io/libredb/libredb-studio-operator:0.9.66
+                image: ghcr.io/libredb/libredb-studio-operator:0.9.67
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -360,4 +360,4 @@ spec:
   provider:
     name: LibreDB
     url: https://libredb.org
-  version: 0.9.66
+  version: 0.9.67

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/libredb/libredb-studio-operator
-  newTag: 0.9.66
+  newTag: 0.9.67

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.28
-appVersion: "0.9.66"
+version: 0.1.29
+appVersion: "0.9.67"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -31,7 +31,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.9.66
+      image: ghcr.io/libredb/libredb-studio:0.9.67
       platforms:
         - linux/amd64
         - linux/arm64
@@ -43,9 +43,11 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Application updated to 0.9.66 - Couchbase is now a supported database, speaking SQL++ over the Query and management REST APIs; it adds no driver dependency, so the image size is unchanged"
-    - "Couchbase support covers the bucket, scope and collection explorer with INFER-derived column types, EXPLAIN plans, read-your-writes query consistency, and the monitoring and maintenance surfaces the other providers expose"
-    - "No chart template changes - the rendered manifests are identical to 0.1.27"
+    - "Application updated to 0.9.67 - ClickHouse and Apache Druid are now supported databases, both spoken over their HTTP interfaces, so neither adds a driver dependency and the image size is unchanged"
+    - "ClickHouse support covers the explorer, EXPLAIN plans, and the monitoring and maintenance surfaces the other providers expose; Apache Druid adds datasource browsing and plan reading over Druid SQL"
+    - "Every SQL statement is now read with its own dialect's grammar, so statement boundaries, identifier quoting and row-limit injection stay correct on all ten engines"
+    - "Inline row edits and CSV imports bind their values instead of interpolating them"
+    - "No chart template changes - the rendered manifests are identical to 0.1.28"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.28 \
+  --version 0.1.29 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.9.66",
+  "version": "0.9.67",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Version bump for the 0.9.67 release. Two new engines shipped since 0.9.66 (ClickHouse #270, Apache Druid #271) but neither has been in a release yet, which left README, BRAND_MESSAGING and the SUSE catalog copy claiming ten engines against a released product that has eight. This closes that gap.

## Bump contents

- `package.json` 0.9.66 -> 0.9.67
- `bun run chart:bump`: chart 0.1.28 -> **0.1.29**, appVersion 0.9.67, image tag, chart README, operator chart copy
- `artifacthub.io/changes` rewritten by hand for 0.1.29 (chart:bump does not touch it), then chart:bump re-run so the operator chart copy carries the new annotation
- `make -C operator bundle`: CSV `libredb-studio-operator.v0.9.67` and controller image tag

No chart template changes — the rendered manifests are identical to 0.1.28.

## Local gates

| Gate | Result |
|---|---|
| format / lint / typecheck / knip | pass (lint: 0 errors, 76 pre-existing warnings) |
| test | pass, all 23 groups |
| build | pass |
| test:coverage + coverage:check | pass, 29254/29254 lines (100.00%) |
| chart:check | OK, chart 0.1.29 / appVersion 0.9.67 in sync |
| helm lint --strict | 1 chart linted, 0 failed |
| operator bundle freshness after commit | FRESH |

Release notes are written and the draft release goes up after this lands; the tag is pushed against the bump commit.