### PR TITLE
docs: correct two stale cut-release follow-ups, and record the glib advisory

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -150,7 +150,7 @@ Reading `distribution:check` after a release - what "clean" looks like:
 | Rows | Expected |
 |---|---|
 | `every_release` tier 0/1: github-release, docker-ghcr, docker-hub-mirror, npm, helm, homebrew, snap | **all OK at the new version.** Anything else here is a real chain failure |
-| `winget` | DRIFT at the previous version until its per-release manifest PR merges (see Phase 7) |
+| `winget` | DRIFT at the previous version until the auto-submitted manifest PR merges upstream (see Phase 7) |
 | tier 2/3 PaaS: caprover x3, railway, dokploy, cosmos, kubero, fly-io | DRIFT is normal - `on_demand` SLA |
 | linux-deb-rpm, appimage, flatpark, chocolatey, render, koyeb | SKIP by design, not a gap |
 
@@ -160,8 +160,7 @@ None of these belong in the bump commit or the chain; each needs the release to 
 
 | Follow-up | Why it waits |
 |---|---|
-| **winget manifest PR** | winget has no floating "latest" - every version needs its own manifests merged into `microsoft/winget-pkgs`. Not automated; `wingetcreate` against the published release is the least error-prone path |
-| **FlatPark metainfo + extra-data re-pin** | `tests/unit/flatpark-descriptor.test.ts` requires the metainfo's newest `<release>` to equal the version the manifest pins as extra-data, and that pin cannot move until the release's GUI `.deb` exists. So this is a post-release commit, never the bump commit |
+| **winget manifest PR - watch only, do not run `wingetcreate`** | winget has no floating "latest", so every version needs its own manifests in `microsoft/winget-pkgs` - but the `winget` job in `release-artifacts.yml` now submits that PR itself, from `needs: [guard, publish-release, channels]` so it runs strictly after publish (the validation pipeline downloads `InstallerUrl`, which is only public once published). Confirm it: `gh search prs --repo microsoft/winget-pkgs "LibreDB.Studio" --state open`. The job skips cleanly when winget's `update.ci_enabled` is false, when `WINGETCREATE_GITHUB_TOKEN` is missing (classic PAT with `public_repo`; wingetcreate rejects fine-grained PATs), when the package has no listing yet, or when the version is already upstream - so a green job is not by itself proof a PR was opened. Only a genuinely missing PR calls for a manual `wingetcreate` |
 | **PaaS template bumps** (caprover, railway, dokploy, cosmos, kubero, fly) | `on_demand` channels, several in upstream repos; batch them rather than blocking a release |
 | **OperatorHub / community-operators catalogs** | FBC ships in TWO upstream PRs - bundle first, then rendered catalogs. The second is bot-created only when the bundle directory carries a `release-config.yaml`, and `operator/bundle/` currently ships none, so that PR must be opened by hand |
 | **Chocolatey** | Gated off via `update.ci_enabled` in `distribution/channels.yaml` while the first push sits in community moderation |
@@ -199,7 +198,7 @@ true on a tag ref.
 | `artifacthub.io/changes` left stale | ArtifactHub shows the previous release's changelog for the new chart |
 | Chart version already released | Republishing rewrites the released chart's gh-pages index digest and OCI content (#167). `chart:check` blocks it; `force_republish` is the only escape hatch, for an asset-uploaded-but-index-failed run |
 | Unquoted `{}:[],&*#?\|-<>=!%@` in a changes entry | ArtifactHub hard-skips that chart version, permanently |
-| FlatPark metainfo bumped in the bump commit | `tests/unit/flatpark-descriptor.test.ts` fails - the metainfo's newest release must equal the version the manifest pins as extra-data, and that pin cannot move until the release's GUI `.deb` exists. Metainfo + extra-data re-pin belong to a post-release commit |
+| `packaging/flatpark/` bumped as part of a release | Do not touch it. FlatPark's bot has owned the pin since the 0.9.62 submission merged - it re-runs `resolve-update.sh` after each of our releases and rewrites its own copy, so this directory drifts by design (it still reads 0.9.62) and must stay out of release work. Bumping half of it fails `tests/unit/flatpark-descriptor.test.ts`, which requires the metainfo's newest `<release>` to equal the version the manifest pins as extra-data |
 | `gh release create --target <short-sha>` | Rejected ("target_commitish is invalid") - use `--target main` |
 | A `release-artifacts` run reporting `failure` | The release may still have published fine; check `Verify assets and publish release` before assuming otherwise |
 | Reusing a failed release's version after Snap published | Snap store revisions are immutable per version; bump the patch instead |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -204,6 +204,35 @@ gets. Related to the `mock.module()` isolation rules in `docs/TOOLCHAIN.md`.
 
 ---
 
+## Dependencies
+
+### P1. The desktop shell's `glib` advisory has no reachable fix while Tauri v2 targets GTK 3
+
+Dependabot alert 1 (GHSA-wrw7-89jp-8q8g, medium) reports unsoundness in the `Iterator` and
+`DoubleEndedIterator` impls of `glib::VariantStrIter`, affecting `>= 0.15.0, < 0.20.0`.
+`desktop/src-tauri/Cargo.lock` carries `glib 0.18.5`, and it cannot move:
+
+```
+glib 0.18.5  <-  gtk 0.18.2 (requires glib ^0.18)  <-  tauri 2.11.5
+```
+
+`cargo update -p glib@0.18.5 --precise 0.20.0` fails on that requirement. Upgrading Tauri does not
+help — 2.11.5 is the latest published version — and the `gtk` crate cannot deliver the fix either:
+0.18.2 is its latest release and it is published as UNMAINTAINED, directing users to `gtk4`. So the
+advisory closes only when Tauri's Linux backend moves off the GTK 3 bindings, which is upstream work
+on their side.
+
+Nothing in `desktop/src-tauri/` touches `glib`: the shell's direct dependencies are `tauri`,
+`serde_json` and `libc`, and no source file references `glib` or `Variant`. The exposure is whatever
+Tauri and GTK do with `VariantStrIter` internally, so the practical risk is low, but "we do not call
+it" is not the same as proving the code path is unreachable.
+
+Done when Tauri's dependency tree offers `glib >= 0.20` and the lock is updated, or when the alert is
+dismissed with this reasoning recorded on it. Re-check on each Tauri upgrade — a one-line
+`cargo tree -i glib` in `desktop/src-tauri/` answers it.
+
+---
+
 ## Documentation
 
 ### X1. Provider-doc line references are stale across the board


### PR DESCRIPTION
The 0.9.67 chain exercised the release runbook end to end and two Phase 7 entries turned out to describe work that is either automated or nobody's job any more. Both corrections are verified against the workflow and the packaging directory, not inferred.

## winget - was: run `wingetcreate` by hand

`release-artifacts.yml` carries a `winget` job (`needs: [guard, publish-release, channels]`) that submits the version-update PR itself, strictly after publish because the upstream validation pipeline downloads `InstallerUrl`. It opened [microsoft/winget-pkgs#413853](https://github.com/microsoft/winget-pkgs/pull/413853) for 0.9.67 without anyone asking. Following the old instruction would have produced a duplicate PR against a repo that does not deduplicate them.

The row now says watch rather than run, gives the search command, and enumerates the four conditions under which the job skips cleanly - `ci_enabled` false, missing `WINGETCREATE_GITHUB_TOKEN`, no listing yet, version already upstream - so a green job is not mistaken for proof that a PR was opened.

## FlatPark - was: post-release metainfo and extra-data re-pin

`packaging/flatpark/` has read 0.9.62 for five releases. `packaging/flatpark/README.md` explains why: FlatPark's bot has owned the pin since that submission merged, re-runs `resolve-update.sh` after each of our releases and rewrites its own copy, so the staged directory drifts by design. The follow-up the skill described has not been performed since 0.9.62 and does not need to be.

The row is removed from Phase 7. The part that is still true - bumping half the descriptor fails `tests/unit/flatpark-descriptor.test.ts`, which requires the metainfo's newest `<release>` to equal the extra-data pin - moves into the Traps table, reworded as leave the directory alone.

## Checked and left alone

The OperatorHub row's claim that `operator/bundle/` ships no `release-config.yaml`, so the second FBC PR must be opened by hand, is still accurate. Documentation only.

## Dependabot alert 1 (added in the second commit)

GHSA-wrw7-89jp-8q8g, medium: unsoundness in `glib::VariantStrIter`'s `Iterator` and `DoubleEndedIterator` impls, affecting `>= 0.15.0, < 0.20.0`. `desktop/src-tauri/Cargo.lock` carries 0.18.5.

**There is no upgrade path**, verified rather than assumed:

- `cargo update -p glib@0.18.5 --precise 0.20.0` fails: `gtk 0.18.2` requires `glib ^0.18`, and `tauri 2.11.5` requires that gtk.
- Upgrading Tauri does not help — 2.11.5 is the latest published version.
- The `gtk` crate cannot deliver the fix either: 0.18.2 is its latest release and it is published as UNMAINTAINED, pointing users at `gtk4`.

So the advisory closes only when Tauri's Linux backend moves off the GTK 3 bindings. Nothing in `desktop/src-tauri/` uses glib directly (its dependencies are `tauri`, `serde_json`, `libc`; no source file mentions `glib` or `Variant`), which makes the practical risk low without proving the path unreachable.

Recorded in `docs/BACKLOG.md` as **P1** under a new Dependencies section, with `cargo tree -i glib` as the re-check to run on each Tauri upgrade. The alert is deliberately left open rather than dismissed — dismissing it would need a reachability claim this evidence does not support. Say the word if you would rather dismiss it as tolerable risk.