### PR TITLE
feat(auth): let a public instance offer one-click demo access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,24 @@ JWT_SECRET=your_32_character_random_string_here
 # AUTH_COOKIE_SECURE=false
 
 # ============================================
+# PUBLIC DEMO ACCESS (off by default)
+# ============================================
+# For a public showcase instance only. Set BOTH to the credentials of an account
+# you have already configured above (normally USER_EMAIL/USER_PASSWORD) and the
+# login screen gains an "Explore the live demo" button that signs visitors in
+# with one click — no signup, no credentials to type.
+#
+# This is not an authentication bypass: POST /api/auth/demo resolves these against
+# the same user table as the normal login and grants only that account's role.
+# With either half unset the button is not rendered and the route answers 404, so
+# a private deployment is unaffected.
+#
+# Do NOT enable on an instance holding real data — anyone on the internet gets
+# that account's access. Point it at a throwaway instance with sample databases.
+# DEMO_EMAIL=user@libredb.org
+# DEMO_PASSWORD=the_same_value_as_USER_PASSWORD
+
+# ============================================
 # AUTHENTICATION PROVIDER
 # ============================================
 # "local" (default) = email/password login (ADMIN_EMAIL/ADMIN_PASSWORD, USER_EMAIL/USER_PASSWORD)

--- a/.env.example
+++ b/.env.example
@@ -66,20 +66,22 @@ JWT_SECRET=your_32_character_random_string_here
 # ============================================
 # PUBLIC DEMO ACCESS (off by default)
 # ============================================
-# For a public showcase instance only. Set BOTH to the credentials of an account
-# you have already configured above (normally USER_EMAIL/USER_PASSWORD) and the
-# login screen gains an "Explore the live demo" button that signs visitors in
-# with one click — no signup, no credentials to type.
+# For a public showcase instance only. Set DEMO_MODE and the login screen gains
+# an "Explore the live demo" button that opens a session in one click — no
+# signup, no credentials to type.
 #
-# This is not an authentication bypass: POST /api/auth/demo resolves these against
-# the same user table as the normal login and grants only that account's role.
-# With either half unset the button is not rendered and the route answers 404, so
-# a private deployment is unaffected.
+# There is deliberately no demo password: nobody types one, so it would be a
+# constant shared between two variables on the same server rather than a check.
+# The switch is the gate. Unset, the button is not rendered and
+# POST /api/auth/demo answers 404, so a private deployment is unaffected.
 #
-# Do NOT enable on an instance holding real data — anyone on the internet gets
-# that account's access. Point it at a throwaway instance with sample databases.
-# DEMO_EMAIL=user@libredb.org
-# DEMO_PASSWORD=the_same_value_as_USER_PASSWORD
+# Do NOT enable on an instance holding real data — anyone on the internet gets a
+# session. Point it at a throwaway instance with sample databases.
+# DEMO_MODE=true
+#
+# Role a demo visitor receives. Defaults to "user"; anything not understood also
+# reads as "user". Only set this to "admin" if you mean it.
+# DEMO_ROLE=user
 
 # ============================================
 # AUTHENTICATION PROVIDER

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -21,22 +21,57 @@ live instance should not have: it can be wiped and rebuilt at any time.
 
 ## One-time setup
 
-Render needs to be told, once, which repo and file to read. After that the
-instance is repo-driven.
+Render needs to be told, once, which repo and file to read, and the domain has
+to be pointed at it. None of this happens automatically. After it, every change
+to the demo — sample data, the AI assistant, the plan — is a commit to
+`deploy/demo/render.yaml`.
+
+- [ ] **1.** Create the Render service from `deploy/demo/render.yaml` — *not* the root `render.yaml`
+- [ ] **2.** Supply a `JWT_SECRET` when prompted
+- [ ] **3.** Add the custom domain `demo.libredb.org` in Render
+- [ ] **4.** Add the Cloudflare CNAME **as DNS-only (grey cloud)** and set SSL/TLS to Full
+- [ ] **5.** Wait for Render to report the certificate valid, then switch to Proxied
+- [ ] **6.** Repoint the "Try Live Demo" CTA on libredb.org to `demo.libredb.org`
+- [ ] **7.** Verify in a private window, and confirm `app.libredb.org` is unchanged
+
+### 1–2. Create the service
 
 1. Render Dashboard → **New** → **Blueprint**
-2. Repository: `libredb/libredb-studio`
-3. Blueprint file path: **`deploy/demo/render.yaml`**
-   (Render defaults to `render.yaml` at the root; custom paths are set here or
-   later from the Blueprint's Settings page.)
-4. When prompted, provide `JWT_SECRET` — 32+ characters, `openssl rand -base64 32`.
-   It is the only value not in the file, because a committed session-signing
-   secret is a committed session-signing secret.
-5. Point `demo.libredb.org` at the new service and update the "Try Live Demo"
-   button on libredb.org.
+2. Repository: `libredb/libredb-studio`, branch `main`
+3. Blueprint file path: **`deploy/demo/render.yaml`**. Render defaults to
+   `render.yaml` at the root, which is the wrong file — it is the public
+   "Deploy to Render" recipe and carries no demo access. Custom paths are set
+   here, or later from the Blueprint's Settings page.
+4. When prompted, provide `JWT_SECRET` — 32+ characters,
+   `openssl rand -base64 32`. It is the only value not in the file, because a
+   committed session-signing secret is a committed session-signing secret.
 
-From then on, every change to the demo — sample data, the AI assistant, the
-plan — is a commit to `deploy/demo/render.yaml`.
+### 3–5. Custom domain
+
+The service works on its `onrender.com` URL, but this is the link that goes on
+Hacker News, Reddit and Product Hunt, and a vendor subdomain reads as a weekend
+deployment. Use the real one.
+
+1. Render → the demo service → **Settings** → **Custom Domains** → add
+   `demo.libredb.org`
+2. Cloudflare → DNS → `CNAME demo → libredb-studio-demo.onrender.com`,
+   **Proxy status: DNS only (grey cloud)**
+3. Cloudflare → SSL/TLS → encryption mode **Full**
+4. Wait for Render to report the certificate issued and valid. The grey cloud
+   above is not a detail to skip: a proxied record can block issuance, and the
+   failure surfaces later as an unrelated TLS error.
+5. Once the certificate is valid, optionally switch the record to **Proxied
+   (orange cloud)** for Cloudflare's caching and WAF.
+
+Per [Render's Cloudflare guide](https://render.com/docs/configure-cloudflare-dns).
+
+### 6. Point the site at it
+
+Update the "Try Live Demo" CTA on libredb.org to `https://demo.libredb.org`.
+It currently points at `app.libredb.org`, which redirects to `/login` — a
+visitor with no account cannot get past it, which is the problem this instance
+exists to solve. Leaving the CTA where it is ships the fix and keeps the
+symptom.
 
 ## What a visitor gets
 

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -68,10 +68,11 @@ Per [Render's Cloudflare guide](https://render.com/docs/configure-cloudflare-dns
 ### 6. Point the site at it
 
 Update the "Try Live Demo" CTA on libredb.org to `https://demo.libredb.org`.
-It currently points at `app.libredb.org`, which redirects to `/login` — a
-visitor with no account cannot get past it, which is the problem this instance
-exists to solve. Leaving the CTA where it is ships the fix and keeps the
-symptom.
+It currently points at `app.libredb.org`, which redirects to `/login`: a button
+promising a live demo that opens an SSO prompt. Whether a stranger can complete
+that prompt depends on how the identity provider is configured, but a visitor
+evaluating the product should not have to find out. Leaving the CTA where it is
+ships the fix and keeps the symptom.
 
 ## What a visitor gets
 

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -1,0 +1,60 @@
+# The public demo instance
+
+Everything about the showcase instance lives in
+[`render.yaml`](render.yaml) next to this file, so it is changed by editing the
+repo rather than by clicking through a dashboard.
+
+## Why it is not the root Blueprint
+
+The repository root `render.yaml` is what the README's "Deploy to Render" button
+deploys, and services created from it redeploy on every commit here. A
+`DEMO_MODE` value in that file would therefore switch on public demo access for
+other people's deployments. The demo keeps its own Blueprint so nobody inherits
+it.
+
+## Why it is a separate service from app.libredb.org
+
+Re-pointing an existing Blueprint reconciles that service's environment against
+the new file, which would disturb whatever is currently set on the live
+instance. A separate service leaves it alone, and gives the demo something the
+live instance should not have: it can be wiped and rebuilt at any time.
+
+## One-time setup
+
+Render needs to be told, once, which repo and file to read. After that the
+instance is repo-driven.
+
+1. Render Dashboard → **New** → **Blueprint**
+2. Repository: `libredb/libredb-studio`
+3. Blueprint file path: **`deploy/demo/render.yaml`**
+   (Render defaults to `render.yaml` at the root; custom paths are set here or
+   later from the Blueprint's Settings page.)
+4. When prompted, provide `JWT_SECRET` — 32+ characters, `openssl rand -base64 32`.
+   It is the only value not in the file, because a committed session-signing
+   secret is a committed session-signing secret.
+5. Point `demo.libredb.org` at the new service and update the "Try Live Demo"
+   button on libredb.org.
+
+From then on, every change to the demo — sample data, the AI assistant, the
+plan — is a commit to `deploy/demo/render.yaml`.
+
+## What a visitor gets
+
+`DEMO_MODE=true` puts an **Explore the live demo** button on the login screen
+that opens a session in one click, with the `user` role: query execution, no
+admin area (`src/proxy.ts` enforces it).
+
+They land on the two built-in sample connections, **Sample (LibreDB)** and
+**Sample (Employees)**, which the server seeds on first start. Storage is
+browser-scoped, so each visitor gets their own workspace and cannot disturb the
+next one's.
+
+## Before a launch
+
+- **Do not leave it on a free instance.** Free services spin down when idle and
+  cold-start for roughly a minute. Launch traffic arrives in one burst, and the
+  first visitors are the ones who decide whether the post gets upvoted.
+- **Consider richer seed data.** The two embedded samples are small; the grid
+  and the ER diagram are more convincing against realistic volume. See
+  [`docs/SEED_CONNECTIONS.md`](../../docs/SEED_CONNECTIONS.md).
+- **Never point this at real data.** Anyone who reaches the URL gets a session.

--- a/deploy/demo/render.yaml
+++ b/deploy/demo/render.yaml
@@ -1,0 +1,96 @@
+# Render Blueprint — the public showcase instance, and only that instance.
+#
+# This file is deliberately NOT the repository root `render.yaml`. That one is
+# the target of the README's "Deploy to Render" button and redeploys every
+# service created from it on each commit, so a `DEMO_MODE` value there would
+# open a public demo on other people's deployments. Keeping the demo's config
+# in its own Blueprint file means everything about the showcase instance is
+# managed from this repo, and nobody else inherits it.
+#
+# Render reads a custom Blueprint path set when the Blueprint is created (or
+# changed later from its Settings page): point it at `deploy/demo/render.yaml`.
+#
+# Deliberately a SEPARATE service from app.libredb.org rather than a re-point
+# of it: re-pointing an existing Blueprint reconciles the service's environment
+# against the new file, which would disturb whatever is set on the live
+# instance. A new service leaves it untouched and can be wiped freely.
+
+services:
+  - type: web
+    name: libredb-studio-demo
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    healthCheckPath: /api/db/health
+    autoDeployTrigger: commit
+
+    # A demo that cold-starts for 50 seconds converts nobody. Free instances
+    # spin down when idle, which is exactly wrong for a launch: the traffic
+    # arrives in one burst and the first visitors meet a spinner. Use a paid
+    # instance for the launch window, then downgrade if you like.
+    plan: starter
+
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: "3000"
+
+      # --- What makes this the demo -------------------------------------
+      # One-click entry for visitors with no account. Safe HERE and nowhere
+      # else: this service holds nothing but sample data.
+      - key: DEMO_MODE
+        value: "true"
+      # Explicit rather than relying on the default, so the privilege a
+      # stranger receives is stated in the file rather than inferred.
+      - key: DEMO_ROLE
+        value: user
+
+      # --- Auth ----------------------------------------------------------
+      # Password auth rather than SSO: a demo visitor has no account at an
+      # identity provider, so OIDC would leave them exactly as stuck as the
+      # login wall this instance exists to remove. The admin password is
+      # generated on first boot (AUTH_BOOTSTRAP) and never needed by visitors,
+      # who arrive through DEMO_MODE.
+      - key: NEXT_PUBLIC_AUTH_PROVIDER
+        value: local
+      # Prompted once at create time; 32+ characters. Without it the bootstrap
+      # generates one, but it would then change on every redeploy of an
+      # instance with no disk, logging every visitor out mid-session.
+      - key: JWT_SECRET
+        sync: false
+
+      # --- Storage --------------------------------------------------------
+      # Browser-scoped on purpose. Server-side storage would put every visitor
+      # in one shared namespace, where anyone can rename or delete the
+      # connections the next visitor is about to open. "local" gives each
+      # browser its own workspace, needs no disk, and survives redeploys.
+      - key: STORAGE_PROVIDER
+        value: local
+
+      # --- Sample data ----------------------------------------------------
+      # Both are on by default; stated explicitly because an empty demo is a
+      # worse advertisement than no demo. They provide the "Sample (LibreDB)"
+      # and "Sample (Employees)" connections a visitor lands on.
+      - key: LIBREDB_EMBEDDED_SAMPLE
+        value: "true"
+      - key: SQLITE_EMBEDDED_SAMPLE
+        value: "true"
+
+      # --- Richer seed connections (optional, recommended before launch) ---
+      # The two embedded samples are small. A visitor arriving from Hacker
+      # News judges the product on what the grid and the ER diagram look like
+      # with realistic volume. To point the demo at real Postgres/Mongo/Redis
+      # instances, mount a seed config and set the credentials it references.
+      # See docs/SEED_CONNECTIONS.md.
+      # - key: SEED_CONFIG_PATH
+      #   value: /app/config/seed-connections.yaml
+
+      # --- AI assistant (optional) ----------------------------------------
+      # NL2SQL is one of the strongest things to show. Enabling it here spends
+      # real tokens on anonymous traffic, so weigh that against launch volume.
+      # - key: LLM_PROVIDER
+      #   value: gemini
+      # - key: LLM_MODEL
+      #   value: gemini-2.5-flash
+      # - key: LLM_API_KEY
+      #   sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -55,6 +55,18 @@ services:
       # - key: OIDC_ADMIN_ROLES
       #   value: admin
 
+      # --- Public demo access (optional) ---------------------------------
+      # Turns the login screen into a one-click way in for visitors who have
+      # no account, for a public showcase instance. Deliberately left
+      # commented and without a value: this Blueprint is the target of the
+      # README's "Deploy to Render" button and redeploys on every commit, so
+      # a value here would open every service deployed from it. Set it in the
+      # Render dashboard (Environment tab) on the one instance that wants it.
+      # Never enable it on a service holding real data - anyone reaching the
+      # URL gets a session.
+      # - key: DEMO_MODE
+      #   value: "true"
+
       # --- AI query assistance (optional) --------------------------------
       # Fully opt-in: uncomment and provide a key to enable. See the README
       # configuration section for supported providers/models.

--- a/src/app/api/auth/demo/route.ts
+++ b/src/app/api/auth/demo/route.ts
@@ -8,7 +8,7 @@ import { logger } from "@/lib/logger";
 /**
  * One-click sign-in for a public demo instance.
  *
- * Gated solely by `DEMO_MODE`, because there is no visitor to authenticate — a
+ * Gated solely by `DEMO_MODE`, because there is nobody to authenticate — a
  * demo password would be a constant shared between two variables on the same
  * server, not a check. Requiring a real account instead would mean enabling
  * password login on an SSO-only deployment, which is a worse trade.

--- a/src/app/api/auth/demo/route.ts
+++ b/src/app/api/auth/demo/route.ts
@@ -1,0 +1,55 @@
+import { login } from "@/lib/auth";
+import { AuthConfigError } from "@/lib/auth-errors";
+import { getAuthUsers } from "@/lib/local-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { createErrorResponse } from "@/lib/api/errors";
+import { logger } from "@/lib/logger";
+
+/**
+ * One-click sign-in for a public demo instance.
+ *
+ * This is not an authentication bypass: it resolves `DEMO_EMAIL`/`DEMO_PASSWORD`
+ * against the same user table as `POST /api/auth/login` and mints no role of its
+ * own, so a demo visitor gets exactly the account the operator configured — and
+ * nothing when the pair is absent, which is the default.
+ */
+export async function POST(_request: NextRequest) {
+  const email = process.env.DEMO_EMAIL;
+  const password = process.env.DEMO_PASSWORD;
+
+  // Off unless both are set. 404 rather than 403 so a server without a demo
+  // account does not advertise that the route exists at all.
+  if (!email || !password) {
+    return NextResponse.json({ success: false, message: "Demo access is not enabled on this server" }, { status: 404 });
+  }
+
+  try {
+    const matched = getAuthUsers().find((u) => u.email === email && u.password === password);
+
+    if (!matched) {
+      // The visitor pressed a button; they cannot have got this wrong. Report it
+      // as the operator error it is instead of "invalid email or password".
+      logger.error("Demo access is misconfigured", new Error("DEMO_EMAIL does not match a configured account"), {
+        route: "POST /api/auth/demo",
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            "Demo access is misconfigured: DEMO_EMAIL and DEMO_PASSWORD do not match a configured account. " +
+            "Point them at the ADMIN_EMAIL/ADMIN_PASSWORD or USER_EMAIL/USER_PASSWORD pair and restart the server.",
+        },
+        { status: 503 },
+      );
+    }
+
+    await login(matched.role, matched.email);
+    return NextResponse.json({ success: true, role: matched.role });
+  } catch (error) {
+    if (error instanceof AuthConfigError) {
+      logger.error("Authentication is not configured", error, { route: "POST /api/auth/demo" });
+      return NextResponse.json({ success: false, message: error.message }, { status: 503 });
+    }
+    return createErrorResponse(error, { route: "POST /api/auth/demo" });
+  }
+}

--- a/src/app/api/auth/demo/route.ts
+++ b/src/app/api/auth/demo/route.ts
@@ -1,6 +1,6 @@
 import { login } from "@/lib/auth";
 import { AuthConfigError } from "@/lib/auth-errors";
-import { getAuthUsers } from "@/lib/local-auth";
+import { DEMO_ACCOUNT_EMAIL, getDemoRole, isDemoEnabled } from "@/lib/demo-access";
 import { NextRequest, NextResponse } from "next/server";
 import { createErrorResponse } from "@/lib/api/errors";
 import { logger } from "@/lib/logger";
@@ -8,43 +8,22 @@ import { logger } from "@/lib/logger";
 /**
  * One-click sign-in for a public demo instance.
  *
- * This is not an authentication bypass: it resolves `DEMO_EMAIL`/`DEMO_PASSWORD`
- * against the same user table as `POST /api/auth/login` and mints no role of its
- * own, so a demo visitor gets exactly the account the operator configured — and
- * nothing when the pair is absent, which is the default.
+ * Gated solely by `DEMO_MODE`, because there is no visitor to authenticate — a
+ * demo password would be a constant shared between two variables on the same
+ * server, not a check. Requiring a real account instead would mean enabling
+ * password login on an SSO-only deployment, which is a worse trade.
  */
 export async function POST(_request: NextRequest) {
-  const email = process.env.DEMO_EMAIL;
-  const password = process.env.DEMO_PASSWORD;
-
-  // Off unless both are set. 404 rather than 403 so a server without a demo
-  // account does not advertise that the route exists at all.
-  if (!email || !password) {
+  // 404 rather than 403 so a server without demo access does not advertise that
+  // the route exists at all.
+  if (!isDemoEnabled()) {
     return NextResponse.json({ success: false, message: "Demo access is not enabled on this server" }, { status: 404 });
   }
 
   try {
-    const matched = getAuthUsers().find((u) => u.email === email && u.password === password);
-
-    if (!matched) {
-      // The visitor pressed a button; they cannot have got this wrong. Report it
-      // as the operator error it is instead of "invalid email or password".
-      logger.error("Demo access is misconfigured", new Error("DEMO_EMAIL does not match a configured account"), {
-        route: "POST /api/auth/demo",
-      });
-      return NextResponse.json(
-        {
-          success: false,
-          message:
-            "Demo access is misconfigured: DEMO_EMAIL and DEMO_PASSWORD do not match a configured account. " +
-            "Point them at the ADMIN_EMAIL/ADMIN_PASSWORD or USER_EMAIL/USER_PASSWORD pair and restart the server.",
-        },
-        { status: 503 },
-      );
-    }
-
-    await login(matched.role, matched.email);
-    return NextResponse.json({ success: true, role: matched.role });
+    const role = getDemoRole();
+    await login(role, DEMO_ACCOUNT_EMAIL);
+    return NextResponse.json({ success: true, role });
   } catch (error) {
     if (error instanceof AuthConfigError) {
       logger.error("Authentication is not configured", error, { route: "POST /api/auth/demo" });

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -6,19 +6,39 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { ExternalLink, Lock, Mail, ShieldCheck, Zap, Globe, Shield, Layers } from "lucide-react";
+import { ExternalLink, Lock, Mail, PlayCircle, ShieldCheck, Zap, Globe, Shield, Layers } from "lucide-react";
 import { toast } from "sonner";
 import LibreDBLogo from "@/components/libredb-logo";
 import { CommunitySection } from "@/components/community-section";
 
-function LoginFormInner({ authProvider }: { authProvider: string }) {
+function LoginFormInner({ authProvider, demoEnabled = false }: { authProvider: string; demoEnabled?: boolean }) {
   const isOIDC = authProvider === "oidc";
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isDemoLoading, setIsDemoLoading] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
   const oidcError = searchParams.get("error");
+
+  const handleDemoLogin = async () => {
+    setIsDemoLoading(true);
+    try {
+      const response = await fetch("/api/auth/demo", { method: "POST" });
+      const data = await response.json();
+
+      if (data.success) {
+        router.push(data.role === "admin" ? "/admin" : "/");
+        router.refresh();
+      } else {
+        toast.error(data.message || "The demo is unavailable right now");
+      }
+    } catch {
+      toast.error("An error occurred. Please try again.");
+    } finally {
+      setIsDemoLoading(false);
+    }
+  };
 
   const handleLogin = async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
@@ -279,6 +299,34 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
                   </form>
                 </>
               )}
+
+              {/* Public-demo escape hatch: a first-time visitor who has no
+                  account must still be able to see the product. Rendered only
+                  when the server has a demo account configured. */}
+              {demoEnabled && (
+                <div className="space-y-3">
+                  <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                      <span className="w-full border-t border-muted-foreground/15" />
+                    </div>
+                    <div className="relative flex justify-center">
+                      <span className="bg-card px-2 text-xs text-muted-foreground">or</span>
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    className="w-full h-11 text-base font-medium active:scale-[0.98] transition-all gap-2"
+                    onClick={handleDemoLogin}
+                    disabled={isDemoLoading}
+                  >
+                    <PlayCircle strokeWidth={1.5} className="h-4 w-4" />
+                    {isDemoLoading ? "Opening the demo..." : "Explore the live demo"}
+                  </Button>
+                  <p className="text-xs text-muted-foreground text-center">
+                    No account needed. Sample databases, reset regularly.
+                  </p>
+                </div>
+              )}
             </CardContent>
 
             <CardFooter className="pt-0 pb-6 flex flex-col items-center gap-2">
@@ -311,10 +359,10 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
   );
 }
 
-export default function LoginForm({ authProvider }: { authProvider: string }) {
+export default function LoginForm({ authProvider, demoEnabled }: { authProvider: string; demoEnabled?: boolean }) {
   return (
     <Suspense>
-      <LoginFormInner authProvider={authProvider} />
+      <LoginFormInner authProvider={authProvider} demoEnabled={demoEnabled} />
     </Suspense>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,5 +7,9 @@ export const dynamic = "force-dynamic";
 
 export default function LoginPage() {
   const authProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER || "local";
-  return <LoginForm authProvider={authProvider} />;
+  // Server-side only: the demo account's credentials never reach the browser,
+  // only the fact that a demo exists. Absent either half, the button is not
+  // rendered and POST /api/auth/demo answers 404.
+  const demoEnabled = Boolean(process.env.DEMO_EMAIL && process.env.DEMO_PASSWORD);
+  return <LoginForm authProvider={authProvider} demoEnabled={demoEnabled} />;
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 import LoginForm from "./login-form";
+import { isDemoEnabled } from "@/lib/demo-access";
 
 // Force dynamic rendering so env vars are read at runtime, not build time.
 // This is critical for Docker deployments where NEXT_PUBLIC_AUTH_PROVIDER
@@ -7,9 +8,7 @@ export const dynamic = "force-dynamic";
 
 export default function LoginPage() {
   const authProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER || "local";
-  // Server-side only: the demo account's credentials never reach the browser,
-  // only the fact that a demo exists. Absent either half, the button is not
-  // rendered and POST /api/auth/demo answers 404.
-  const demoEnabled = Boolean(process.env.DEMO_EMAIL && process.env.DEMO_PASSWORD);
-  return <LoginForm authProvider={authProvider} demoEnabled={demoEnabled} />;
+  // Read through the same switch the route uses, so the button and the endpoint
+  // can never disagree about whether this server offers a demo.
+  return <LoginForm authProvider={authProvider} demoEnabled={isDemoEnabled()} />;
 }

--- a/src/lib/demo-access.ts
+++ b/src/lib/demo-access.ts
@@ -1,0 +1,31 @@
+/**
+ * Public demo access — a single opt-in switch for showcase instances.
+ *
+ * A visitor arriving at a public instance has no account and no way to see the
+ * product. `DEMO_MODE` opens a one-click session for them. It is deliberately
+ * not a credential: there is nobody to authenticate, so a password would be a
+ * shared constant between two variables on the same server rather than a check.
+ * The gate is the switch, and the switch is off unless an operator turns it on.
+ */
+import type { Role } from "@/lib/auth";
+
+// Same vocabulary as AUTH_COOKIE_SECURE and AUTH_BOOTSTRAP.
+const ENABLED_VALUES = new Set(["on", "true", "1"]);
+
+/** The identity a demo session carries. Not an account — nothing authenticates against it. */
+export const DEMO_ACCOUNT_EMAIL = "demo@libredb.org";
+
+/** True when this server offers public demo access. Off unless DEMO_MODE says otherwise. */
+export function isDemoEnabled(): boolean {
+  const raw = process.env.DEMO_MODE?.trim().toLowerCase();
+  return raw !== undefined && ENABLED_VALUES.has(raw);
+}
+
+/**
+ * The role a demo visitor receives. `user` unless an operator deliberately asks
+ * for `admin` — an unrecognized value is not worth failing a boot over, and the
+ * safe reading of "I do not understand this" is the lower privilege.
+ */
+export function getDemoRole(): Role {
+  return process.env.DEMO_ROLE?.trim().toLowerCase() === "admin" ? "admin" : "user";
+}

--- a/src/lib/demo-access.ts
+++ b/src/lib/demo-access.ts
@@ -1,11 +1,14 @@
 /**
  * Public demo access — a single opt-in switch for showcase instances.
  *
- * A visitor arriving at a public instance has no account and no way to see the
- * product. `DEMO_MODE` opens a one-click session for them. It is deliberately
- * not a credential: there is nobody to authenticate, so a password would be a
- * shared constant between two variables on the same server rather than a check.
- * The gate is the switch, and the switch is off unless an operator turns it on.
+ * A visitor arriving at a public instance is asked for an identity before they
+ * see anything — a password they were never given, or a round trip through an
+ * identity provider. `DEMO_MODE` opens a one-click session instead of asking.
+ *
+ * The switch is deliberately not a credential. There is nobody to authenticate,
+ * so a demo password would be a constant shared between two variables on the
+ * same server rather than a check. The gate is the switch, and the switch is
+ * off unless an operator turns it on.
  */
 import type { Role } from "@/lib/auth";
 

--- a/tests/api/auth/demo.test.ts
+++ b/tests/api/auth/demo.test.ts
@@ -17,14 +17,17 @@ mock.module("@/lib/auth", () => ({
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 const { POST } = await import("@/app/api/auth/demo/route");
 
+const post = () => POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 describe("POST /api/auth/demo", () => {
-  const MUTATED_ENV_KEYS = ["DEMO_EMAIL", "DEMO_PASSWORD", "ADMIN_PASSWORD", "USER_PASSWORD"] as const;
+  const MUTATED_ENV_KEYS = ["DEMO_MODE", "DEMO_ROLE", "ADMIN_PASSWORD", "USER_PASSWORD"] as const;
   const envSnapshot: Record<string, string | undefined> = {};
 
   beforeEach(() => {
     mockLogin.mockClear();
     for (const key of MUTATED_ENV_KEYS) envSnapshot[key] = process.env[key];
+    delete process.env.DEMO_ROLE;
   });
 
   afterEach(() => {
@@ -35,11 +38,10 @@ describe("POST /api/auth/demo", () => {
     }
   });
 
-  test("returns 404 when DEMO_EMAIL is not set — the feature is off by default", async () => {
-    delete process.env.DEMO_EMAIL;
-    process.env.DEMO_PASSWORD = "LibreDB.2026";
+  test("returns 404 when DEMO_MODE is unset — off by default", async () => {
+    delete process.env.DEMO_MODE;
 
-    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const res = await post();
     const data = await parseResponseJSON<{ success: boolean; message: string }>(res);
 
     expect(res.status).toBe(404);
@@ -48,70 +50,62 @@ describe("POST /api/auth/demo", () => {
     expect(mockLogin).not.toHaveBeenCalled();
   });
 
-  test("returns 404 when DEMO_PASSWORD is not set", async () => {
-    process.env.DEMO_EMAIL = "user@libredb.org";
-    delete process.env.DEMO_PASSWORD;
+  test("returns 404 for a value that does not read as on", async () => {
+    process.env.DEMO_MODE = "yes-please";
 
-    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
-
-    expect(res.status).toBe(404);
+    expect((await post()).status).toBe(404);
     expect(mockLogin).not.toHaveBeenCalled();
   });
 
-  test("signs the visitor in as the configured demo account", async () => {
-    process.env.DEMO_EMAIL = "user@libredb.org";
-    process.env.DEMO_PASSWORD = "LibreDB.2026";
-    process.env.USER_PASSWORD = "LibreDB.2026";
+  test.each(["true", "on", "1", " TRUE ", "On"])("opens a demo session when DEMO_MODE is %p", async (value) => {
+    process.env.DEMO_MODE = value;
 
-    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const res = await post();
     const data = await parseResponseJSON<{ success: boolean; role: string }>(res);
 
     expect(res.status).toBe(200);
     expect(data.success).toBe(true);
     expect(data.role).toBe("user");
-    expect(mockLogin).toHaveBeenCalledWith("user", "user@libredb.org");
+    expect(mockLogin).toHaveBeenCalledWith("user", "demo@libredb.org");
   });
 
-  test("grants only the role the demo account already has — no privilege of its own", async () => {
-    // The route never mints a role: it resolves DEMO_EMAIL against the same user
-    // table as /api/auth/login. Pointing DEMO_EMAIL at the admin account is an
-    // operator decision, visible here rather than hidden behind a bypass path.
-    process.env.DEMO_EMAIL = "admin@libredb.org";
-    process.env.DEMO_PASSWORD = "LibreDB.2026";
-    process.env.ADMIN_PASSWORD = "LibreDB.2026";
+  test("needs no account, no password and no ADMIN_PASSWORD to work", async () => {
+    // The whole point of the switch: a public instance running OIDC has no local
+    // accounts at all, and demo visitors must still get in.
+    delete process.env.ADMIN_PASSWORD;
+    delete process.env.USER_PASSWORD;
+    process.env.DEMO_MODE = "true";
 
-    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
-    const data = await parseResponseJSON<{ role: string }>(res);
+    expect((await post()).status).toBe(200);
+  });
+
+  test("grants admin only when an operator explicitly asks for it", async () => {
+    process.env.DEMO_MODE = "true";
+    process.env.DEMO_ROLE = "admin";
+
+    const data = await parseResponseJSON<{ role: string }>(await post());
 
     expect(data.role).toBe("admin");
+    expect(mockLogin).toHaveBeenCalledWith("admin", "demo@libredb.org");
   });
 
-  test("returns 503 with an actionable message when the demo credentials match no account", async () => {
-    process.env.DEMO_EMAIL = "demo@libredb.org";
-    process.env.DEMO_PASSWORD = "not-the-configured-password";
+  test("falls back to the lower privilege when DEMO_ROLE is not understood", async () => {
+    process.env.DEMO_MODE = "true";
+    process.env.DEMO_ROLE = "superuser";
 
-    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
-    const data = await parseResponseJSON<{ success: boolean; message: string }>(res);
+    const data = await parseResponseJSON<{ role: string }>(await post());
 
-    // Operator misconfiguration, not a visitor error: never show the visitor
-    // "invalid credentials" for a button they cannot type into.
-    expect(res.status).toBe(503);
-    expect(data.success).toBe(false);
-    expect(data.message).toContain("DEMO_EMAIL");
-    expect(mockLogin).not.toHaveBeenCalled();
+    expect(data.role).toBe("user");
   });
 
   test("surfaces a JWT_SECRET config error as a 503 with its message", async () => {
-    process.env.DEMO_EMAIL = "user@libredb.org";
-    process.env.DEMO_PASSWORD = "LibreDB.2026";
-    process.env.USER_PASSWORD = "LibreDB.2026";
-
+    process.env.DEMO_MODE = "true";
     const jwtMessage = "Login is unavailable: the server's JWT_SECRET is not configured.";
     mockLogin.mockImplementationOnce(async () => {
       throw new AuthConfigError(jwtMessage);
     });
 
-    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const res = await post();
     const data = await parseResponseJSON<{ success: boolean; message: string }>(res);
 
     expect(res.status).toBe(503);
@@ -119,16 +113,13 @@ describe("POST /api/auth/demo", () => {
   });
 
   test("returns 500 when signing the session fails for an unexpected reason", async () => {
-    process.env.DEMO_EMAIL = "user@libredb.org";
-    process.env.DEMO_PASSWORD = "LibreDB.2026";
-    process.env.USER_PASSWORD = "LibreDB.2026";
-
+    process.env.DEMO_MODE = "true";
     mockLogin.mockImplementationOnce(async () => {
       throw new Error("cookie store unavailable");
     });
 
-    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
-    const data = await parseResponseJSON<{ code: string; statusCode: number }>(res);
+    const res = await post();
+    const data = await parseResponseJSON<{ code: string }>(res);
 
     expect(res.status).toBe(500);
     expect(data.code).toBe("INTERNAL_ERROR");

--- a/tests/api/auth/demo.test.ts
+++ b/tests/api/auth/demo.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { createMockRequest, parseResponseJSON } from "../../helpers/mock-next";
+import { AuthConfigError } from "@/lib/auth-errors";
+
+// ─── Mock @/lib/auth BEFORE importing the route ─────────────────────────────
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mockLogin = mock(async (_role: string, _email?: string) => {});
+
+mock.module("@/lib/auth", () => ({
+  login: mockLogin,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  getSession: mock(async () => null),
+  logout: mock(async () => {}),
+}));
+
+// ─── Import route handler AFTER mocking ─────────────────────────────────────
+const { POST } = await import("@/app/api/auth/demo/route");
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+describe("POST /api/auth/demo", () => {
+  const MUTATED_ENV_KEYS = ["DEMO_EMAIL", "DEMO_PASSWORD", "ADMIN_PASSWORD", "USER_PASSWORD"] as const;
+  const envSnapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    mockLogin.mockClear();
+    for (const key of MUTATED_ENV_KEYS) envSnapshot[key] = process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of MUTATED_ENV_KEYS) {
+      const value = envSnapshot[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  test("returns 404 when DEMO_EMAIL is not set — the feature is off by default", async () => {
+    delete process.env.DEMO_EMAIL;
+    process.env.DEMO_PASSWORD = "LibreDB.2026";
+
+    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const data = await parseResponseJSON<{ success: boolean; message: string }>(res);
+
+    expect(res.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.message).toBe("Demo access is not enabled on this server");
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when DEMO_PASSWORD is not set", async () => {
+    process.env.DEMO_EMAIL = "user@libredb.org";
+    delete process.env.DEMO_PASSWORD;
+
+    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+
+    expect(res.status).toBe(404);
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  test("signs the visitor in as the configured demo account", async () => {
+    process.env.DEMO_EMAIL = "user@libredb.org";
+    process.env.DEMO_PASSWORD = "LibreDB.2026";
+    process.env.USER_PASSWORD = "LibreDB.2026";
+
+    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const data = await parseResponseJSON<{ success: boolean; role: string }>(res);
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.role).toBe("user");
+    expect(mockLogin).toHaveBeenCalledWith("user", "user@libredb.org");
+  });
+
+  test("grants only the role the demo account already has — no privilege of its own", async () => {
+    // The route never mints a role: it resolves DEMO_EMAIL against the same user
+    // table as /api/auth/login. Pointing DEMO_EMAIL at the admin account is an
+    // operator decision, visible here rather than hidden behind a bypass path.
+    process.env.DEMO_EMAIL = "admin@libredb.org";
+    process.env.DEMO_PASSWORD = "LibreDB.2026";
+    process.env.ADMIN_PASSWORD = "LibreDB.2026";
+
+    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const data = await parseResponseJSON<{ role: string }>(res);
+
+    expect(data.role).toBe("admin");
+  });
+
+  test("returns 503 with an actionable message when the demo credentials match no account", async () => {
+    process.env.DEMO_EMAIL = "demo@libredb.org";
+    process.env.DEMO_PASSWORD = "not-the-configured-password";
+
+    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const data = await parseResponseJSON<{ success: boolean; message: string }>(res);
+
+    // Operator misconfiguration, not a visitor error: never show the visitor
+    // "invalid credentials" for a button they cannot type into.
+    expect(res.status).toBe(503);
+    expect(data.success).toBe(false);
+    expect(data.message).toContain("DEMO_EMAIL");
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  test("surfaces a JWT_SECRET config error as a 503 with its message", async () => {
+    process.env.DEMO_EMAIL = "user@libredb.org";
+    process.env.DEMO_PASSWORD = "LibreDB.2026";
+    process.env.USER_PASSWORD = "LibreDB.2026";
+
+    const jwtMessage = "Login is unavailable: the server's JWT_SECRET is not configured.";
+    mockLogin.mockImplementationOnce(async () => {
+      throw new AuthConfigError(jwtMessage);
+    });
+
+    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const data = await parseResponseJSON<{ success: boolean; message: string }>(res);
+
+    expect(res.status).toBe(503);
+    expect(data.message).toBe(jwtMessage);
+  });
+
+  test("returns 500 when signing the session fails for an unexpected reason", async () => {
+    process.env.DEMO_EMAIL = "user@libredb.org";
+    process.env.DEMO_PASSWORD = "LibreDB.2026";
+    process.env.USER_PASSWORD = "LibreDB.2026";
+
+    mockLogin.mockImplementationOnce(async () => {
+      throw new Error("cookie store unavailable");
+    });
+
+    const res = await POST(createMockRequest("/api/auth/demo", { method: "POST" }) as never);
+    const data = await parseResponseJSON<{ code: string; statusCode: number }>(res);
+
+    expect(res.status).toBe(500);
+    expect(data.code).toBe("INTERNAL_ERROR");
+  });
+});

--- a/tests/components/LoginPageDemo.test.tsx
+++ b/tests/components/LoginPageDemo.test.tsx
@@ -1,0 +1,112 @@
+import "../setup-dom";
+import React from "react";
+import { mockRouterPush, mockRouterRefresh } from "../helpers/mock-navigation";
+import { mockToastError } from "../helpers/mock-sonner";
+import { mock } from "bun:test";
+
+const { default: LoginForm } = await import("@/app/login/login-form");
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const DEMO_LABEL = "Explore the live demo";
+
+function mockFetchOnce(body: unknown, ok = true) {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(new Response(JSON.stringify(body), { status: ok ? 200 : 503 })),
+  ) as never;
+}
+
+describe("LoginPage — live demo button", () => {
+  beforeEach(() => {
+    mockRouterPush.mockClear();
+    mockRouterRefresh.mockClear();
+    mockToastError.mockClear();
+    mockFetchOnce({ success: true, role: "user" });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("is absent when the server has no demo account configured", () => {
+    const { queryByText } = render(<LoginForm authProvider="local" />);
+    expect(queryByText(DEMO_LABEL)).toBeNull();
+  });
+
+  test("is rendered in local auth mode when a demo account is configured", () => {
+    const { getByText } = render(<LoginForm authProvider="local" demoEnabled />);
+    expect(getByText(DEMO_LABEL)).not.toBeNull();
+  });
+
+  test("is rendered in OIDC mode too — a visitor without an IdP account still needs a way in", () => {
+    const { getByText } = render(<LoginForm authProvider="oidc" demoEnabled />);
+    expect(getByText(DEMO_LABEL)).not.toBeNull();
+  });
+
+  test("signs the visitor in and routes to the workspace", async () => {
+    const user = userEvent.setup();
+    const { getByText } = render(<LoginForm authProvider="oidc" demoEnabled />);
+
+    await user.click(getByText(DEMO_LABEL));
+
+    await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith("/"));
+    expect(mockRouterRefresh).toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/auth/demo", { method: "POST" });
+  });
+
+  test("routes an admin demo account to the admin area", async () => {
+    mockFetchOnce({ success: true, role: "admin" });
+    const user = userEvent.setup();
+    const { getByText } = render(<LoginForm authProvider="local" demoEnabled />);
+
+    await user.click(getByText(DEMO_LABEL));
+
+    await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith("/admin"));
+  });
+
+  test("surfaces the server's message when the demo is misconfigured", async () => {
+    mockFetchOnce({ success: false, message: "Demo access is misconfigured: DEMO_EMAIL ..." }, false);
+    const user = userEvent.setup();
+    const { getByText } = render(<LoginForm authProvider="local" demoEnabled />);
+
+    await user.click(getByText(DEMO_LABEL));
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("Demo access is misconfigured: DEMO_EMAIL ..."));
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  test("falls back to a generic message when the server sends none", async () => {
+    mockFetchOnce({ success: false }, false);
+    const user = userEvent.setup();
+    const { getByText } = render(<LoginForm authProvider="local" demoEnabled />);
+
+    await user.click(getByText(DEMO_LABEL));
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("The demo is unavailable right now"));
+  });
+
+  test("shows an error toast when the request itself fails", async () => {
+    globalThis.fetch = mock(() => Promise.reject(new Error("network down"))) as never;
+    const user = userEvent.setup();
+    const { getByText } = render(<LoginForm authProvider="local" demoEnabled />);
+
+    await user.click(getByText(DEMO_LABEL));
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("An error occurred. Please try again."));
+  });
+
+  test("shows a pending label while the demo session is being created", async () => {
+    let release: (value: Response) => void = () => {};
+    globalThis.fetch = mock(() => new Promise<Response>((resolve) => (release = resolve))) as never;
+    const user = userEvent.setup();
+    const { getByText, queryByText } = render(<LoginForm authProvider="local" demoEnabled />);
+
+    await user.click(getByText(DEMO_LABEL));
+
+    await waitFor(() => expect(queryByText("Opening the demo...")).not.toBeNull());
+    release(new Response(JSON.stringify({ success: true, role: "user" })));
+    await waitFor(() => expect(queryByText(DEMO_LABEL)).not.toBeNull());
+  });
+});

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -181,6 +181,7 @@ run_group "Group 11/12: Smoke tests" \
   tests/components/Page.test.tsx \
   tests/components/LoginPage.test.tsx \
   tests/components/LoginPageOIDC.test.tsx \
+  tests/components/LoginPageDemo.test.tsx \
   tests/components/CommunitySection.test.tsx \
   tests/components/MonitoringPage.test.tsx \
   tests/components/monitoring/MetricChart.test.tsx


### PR DESCRIPTION
## Why

A visitor who lands on a public showcase instance meets a login screen before they see anything. Whether that screen can be passed at all depends on the deployment: an SSO instance may let a stranger through its identity provider, a password instance will not. Either way the first thing the product asks of someone evaluating it is an identity round trip. Most of them leave instead.

This adds an opt-in demo entry point for instances that want one, plus the repo-managed Blueprint for the instance that will use it.

## What

- `POST /api/auth/demo` opens a demo session, gated solely by `DEMO_MODE`.
- The login screen gains an "Explore the live demo" button in **both** local and OIDC mode , a visitor with no account at the configured IdP is exactly who needs it.
- `src/lib/demo-access.ts` holds the switch, so the page and the route cannot disagree about whether this server offers a demo.
- `deploy/demo/render.yaml` defines the showcase instance itself, so it is managed by commits rather than dashboard visits.

## Why no demo password

The first cut required `DEMO_EMAIL`/`DEMO_PASSWORD` to resolve against the local user table. That authenticated nobody. A visitor presses a button and types nothing, so the password was a constant shared between two variables on the same server. It charged real costs for that: it required a matching local account, which meant enabling password login on an SSO-only deployment, and it added a drift failure where `USER_PASSWORD` and `DEMO_PASSWORD` could fall out of step and answer 503.

`DEMO_MODE` is the gate instead, using the same vocabulary as `AUTH_BOOTSTRAP` and `AUTH_COOKIE_SECURE` (`on`/`true`/`1`). Because it is not a secret, it lives in committed deploy config rather than a secret store. `DEMO_ROLE` picks the role, defaulting to `user`; an unrecognized value also reads as `user` rather than failing a boot.

## Off by default

Unset, the button is not rendered and the route answers 404, so existing deployments are unaffected. The root `render.yaml` deliberately carries `DEMO_MODE` only as a commented note: that file backs the README's "Deploy to Render" button and redeploys every service created from it, so a value there would open a public demo on other people's deployments.

## Verification

Six gates pass locally: `format`, `lint`, `typecheck`, `knip`, `test`, `build`. Coverage stays at 29316/29316 lines (100%).

Checked against a running production server in OIDC mode with `DEMO_MODE` as the **only** variable set (no `ADMIN_PASSWORD`, no `USER_PASSWORD`):

| Case | Result |
| --- | --- |
| Button on `/login` | rendered |
| `POST /api/auth/demo` | 200, `role: user` |
| `GET /api/auth/me` with that cookie | authenticated as the demo session |
| Demo session against `/admin` | 307 away, RBAC holds |
| `DEMO_MODE` unset | no button, route answers 404 |

---

# Deploying the demo , for whoever has the Render account

**Merging this changes nothing in production.** Everything below is manual, and the demo is not live until all of it is done. It is one-time setup; afterwards the instance is driven by `deploy/demo/render.yaml` and changing it means committing to this repo, not visiting a dashboard.

**`app.libredb.org` is not touched by any of this.** The demo is a separate Render service, so the live instance keeps its current environment and is left alone.

## The manual checklist

- [ ] **1.** Create the Render service from `deploy/demo/render.yaml`, *not* the root `render.yaml`
- [ ] **2.** Supply a `JWT_SECRET` when prompted
- [ ] **3.** Add the custom domain `demo.libredb.org` in Render
- [ ] **4.** Add the Cloudflare CNAME **as DNS-only (grey cloud)** and set SSL/TLS to Full
- [ ] **5.** Wait for Render to report the certificate valid, then switch the record to Proxied
- [ ] **6.** Repoint the "Try Live Demo" CTA on libredb.org to `demo.libredb.org`
- [ ] **7.** Verify in a private window, and confirm `app.libredb.org` is unchanged

Details for each below.

### 1–2. Create the service (~2 minutes)

1. Render Dashboard → **New** → **Blueprint**
2. Repository: `libredb/libredb-studio`, branch `main`
3. **Blueprint file path: `deploy/demo/render.yaml`**. This is the step that matters. Render defaults to `render.yaml` at the repo root, which is the wrong file: it is the public "Deploy to Render" recipe and carries no demo access.
4. When prompted for `JWT_SECRET`, paste 32+ characters from `openssl rand -base64 32`. It is the only value not in the file, because a committed session-signing secret is not a secret. Without it the bootstrap generates one that changes on every redeploy, logging visitors out mid-session.
5. Deploy. The service comes up at `libredb-studio-demo.onrender.com` with the demo button live.

`plan: starter` is set on purpose. Free services spin down when idle and cold-start for roughly a minute; launch traffic arrives in one burst and the first visitors are the ones who decide whether a post gets upvoted.

### 3–5. Custom domain: `demo.libredb.org`

The service works on its `onrender.com` URL, but the demo is what gets linked from Hacker News, Reddit and Product Hunt, and a vendor subdomain reads as a weekend deployment. Use the real one.

1. Render → the demo service → **Settings** → **Custom Domains** → add `demo.libredb.org`
2. Cloudflare → DNS → `CNAME demo → libredb-studio-demo.onrender.com`, **Proxy status: DNS only (grey cloud)**
3. Cloudflare → SSL/TLS → encryption mode **Full**
4. Wait for the Render dashboard to report the certificate issued and valid

   **The grey cloud in step 2 is not a detail to skip.** A proxied record can block Render's certificate issuance, and the failure looks like an unrelated TLS error later.
5. Once the certificate is valid, optionally switch the record to **Proxied (orange cloud)** for Cloudflare's caching and WAF

Per [Render's Cloudflare guide](https://render.com/docs/configure-cloudflare-dns).

### 6. Point the site at it

Update the "Try Live Demo" CTA on libredb.org to `https://demo.libredb.org`. Today it points at `app.libredb.org`, which redirects to `/login` , a button promising a live demo that opens an SSO prompt, which is the friction this PR exists to remove. Leaving the CTA where it is means shipping the fix and keeping the symptom.

### 7. Verify before announcing anything

- Open `https://demo.libredb.org` in a private window. The **Explore the live demo** button must be on the login screen, and one click must land in the workspace.
- The workspace must show the **Sample (LibreDB)** and **Sample (Employees)** connections. An empty demo is worse than none.
- Confirm `app.libredb.org` still behaves exactly as before. It should; nothing here touches it.

## Two things to be deliberate about

- **Never set `DEMO_MODE` on an instance holding real data.** Anyone who reaches the URL gets a session with the `user` role. This is safe on the demo service because it holds nothing but sample data.
- **The built-in samples are small.** The grid and the ER diagram are more convincing against realistic volume. `deploy/demo/render.yaml` has a commented `SEED_CONFIG_PATH` block for pointing the demo at real Postgres/Mongo/Redis instances, worth doing before any launch push. See `docs/SEED_CONNECTIONS.md`.


