### PR TITLE
security: close the remotely reachable holes and correct SECURITY.md (Phase 0)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,7 +78,8 @@ When using LibreDB Studio, please follow these security best practices:
   `USER_PASSWORD` environment variables and are compared directly; they are not stored in a
   database and are not hashed. Protect them the way you protect any other server environment
   variable, or use the OIDC provider instead.
-- Session tokens expire after a configurable period
+- Session tokens (the JWT and its cookie) have a fixed 24-hour lifetime; this is not configurable
+  today
 
 #### Database Connections
 - Connection details, including database passwords and SSH private keys, are stored unencrypted
@@ -93,7 +94,11 @@ When using LibreDB Studio, please follow these security best practices:
 #### API Security
 - All API endpoints require authentication except `/api/auth/*`, `/api/db/health` (for load
   balancer probes) and `/api/storage/config` (which returns the storage mode only)
-- SQL injection protection is handled by parameterized queries
+- Running arbitrary SQL against your connected database is the product's purpose, not an
+  injection surface. Where the application builds SQL of its own — generated starter queries,
+  schema browsing, inline cell edits — values are bound as parameters and identifiers such as
+  table and column names are quoted for the target dialect, since SQL has no parameter syntax
+  for identifiers
 - Rate limiting should be implemented at the infrastructure level
 
 #### AI/LLM Integration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -99,10 +99,12 @@ When using LibreDB Studio, please follow these security best practices:
   without one, the same as every other endpoint.
 - Running arbitrary SQL against your connected database is the product's purpose, not an
   injection surface. Where the application builds SQL of its own — generated starter queries,
-  schema browsing, inline cell edits — values are bound as parameters and identifiers such as
-  column names are quoted for the target dialect; a table name is validated instead of quoted
-  where quoting it would change its case semantics (for example on Oracle), since SQL has no
-  parameter syntax for identifiers
+  schema browsing, inline cell edits — values are bound as parameters, and identifiers the
+  application knows from schema metadata, column names and table names alike, are quoted for the
+  target dialect, since SQL has no parameter syntax for identifiers. The one identifier it infers
+  rather than knows — the table name behind an inline cell edit, read from a tab title or guessed
+  from the query text — is validated as a bare identifier instead, and the edit is refused when it
+  is not, because a guess cannot be safely quoted
 - Rate limiting should be implemented at the infrastructure level
 
 #### AI/LLM Integration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,13 +92,17 @@ When using LibreDB Studio, please follow these security best practices:
 - Connection pooling is used to prevent connection exhaustion
 
 #### API Security
-- All API endpoints require authentication except `/api/auth/*`, `/api/db/health` (for load
-  balancer probes) and `/api/storage/config` (which returns the storage mode only)
+- All API endpoints require authentication except `POST /api/auth/login`, `POST /api/auth/logout`,
+  `GET /api/auth/oidc/login`, `GET /api/auth/oidc/callback`, `GET /api/db/health` (for load
+  balancer probes), and `GET /api/storage/config` (which returns the storage mode only).
+  `GET /api/auth/me` and `POST /api/db/health` each check for a session themselves and return 401
+  without one, the same as every other endpoint.
 - Running arbitrary SQL against your connected database is the product's purpose, not an
   injection surface. Where the application builds SQL of its own — generated starter queries,
   schema browsing, inline cell edits — values are bound as parameters and identifiers such as
-  table and column names are quoted for the target dialect, since SQL has no parameter syntax
-  for identifiers
+  column names are quoted for the target dialect; a table name is validated instead of quoted
+  where quoting it would change its case semantics (for example on Oracle), since SQL has no
+  parameter syntax for identifiers
 - Rate limiting should be implemented at the infrastructure level
 
 #### AI/LLM Integration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,16 +74,25 @@ When using LibreDB Studio, please follow these security best practices:
 
 #### Authentication
 - LibreDB Studio uses JWT-based authentication
-- Passwords are hashed using industry-standard algorithms
+- Credentials for the built-in local login are supplied through the `ADMIN_PASSWORD` and
+  `USER_PASSWORD` environment variables and are compared directly; they are not stored in a
+  database and are not hashed. Protect them the way you protect any other server environment
+  variable, or use the OIDC provider instead.
 - Session tokens expire after a configurable period
 
 #### Database Connections
-- Connection strings are stored encrypted in browser localStorage
-- Database credentials are never logged or exposed in API responses
+- Connection details, including database passwords and SSH private keys, are stored unencrypted
+  in browser `localStorage`, and in the server-side store when `STORAGE_PROVIDER` is set to
+  `sqlite` or `postgres`. Treat both as secret material: anyone who can read that browser
+  profile or that database can read every configured credential.
+- Database credentials are not written to application logs, but they are returned in plaintext
+  to the authenticated owner through storage API responses (for example `GET /api/storage`),
+  because the app must be able to redisplay a saved connection's password for editing and reuse
 - Connection pooling is used to prevent connection exhaustion
 
 #### API Security
-- All API endpoints require authentication (except `/api/auth/login`)
+- All API endpoints require authentication except `/api/auth/*`, `/api/db/health` (for load
+  balancer probes) and `/api/storage/config` (which returns the storage mode only)
 - SQL injection protection is handled by parameterized queries
 - Rate limiting should be implemented at the infrastructure level
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -215,7 +215,7 @@ deprecated against this entry (#288): it becomes real, or goes away in a major, 
 
 ### A1. Three copies of the 401 response, with two different shapes
 
-`src/lib/api/require-session.ts:17` builds `{ error: "Authentication required" }` with status 401 —
+`src/lib/api/require-session.ts:24` builds `{ error: "Authentication required" }` with status 401 —
 the shared guard the security/phase-0-hotfix branch added for routes that reach a database or an
 LLM provider. `src/lib/api/schema-route.ts:31-34` and `src/app/api/db/health/route.ts:28-31` build
 the identical response inline, and both predate that branch: they were not converted to call the

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -211,6 +211,41 @@ deprecated against this entry (#288): it becomes real, or goes away in a major, 
 
 ---
 
+## Authentication and security headers
+
+### A1. Three copies of the 401 response, with two different shapes
+
+`src/lib/api/require-session.ts:17` builds `{ error: "Authentication required" }` with status 401 —
+the shared guard the security/phase-0-hotfix branch added for routes that reach a database or an
+LLM provider. `src/lib/api/schema-route.ts:31-34` and `src/app/api/db/health/route.ts:28-31` build
+the identical response inline, and both predate that branch: they were not converted to call the
+new guard.
+
+Separately, the storage routes (`src/app/api/storage/route.ts:21`,
+`src/app/api/storage/[collection]/route.ts:22`, `src/app/api/storage/migrate/route.ts:23`) answer
+`{ error: "Unauthorized" }` instead, so a client cannot rely on one error shape for "not logged in"
+across the whole API.
+
+Done when there is exactly one 401 response for this condition, built in one place, and every route
+that needs it (including the storage routes) calls it. Deferred to Phase 1 rather than folded into
+the hotfix: none of the three is wrong today, and consolidating them is a refactor, not a fix.
+
+### A2. Paths containing a dot bypass the security middleware entirely
+
+`src/proxy.ts:85`'s matcher excludes any path matching `.*\..*` so that static assets skip the auth
+redirect — `/((?!api/auth|api/db/health|api/storage/config|_next/static|_next/image|.*\..*).*)`.
+The exclusion is by design for auth (nothing under `public/` or `/monaco/vs/*.js` needs a login
+redirect), but it means `proxy()` never runs for those paths at all, not just skips the redirect.
+Phase 1's plan to add security headers (CSP and friends) inside `proxy()` would then miss every
+dot-containing path — `public/**` and the Monaco AMD bundle under `/monaco/vs/*.js` chief among
+them — leaving them without the new headers while every extensionless route gets them.
+
+Done when Phase 1's header work accounts for this gap: either give static assets their headers
+through a different mechanism (e.g. `next.config`'s `headers()`), or narrow the matcher exclusion
+so it still skips the auth redirect without skipping header injection.
+
+---
+
 ## Tests
 
 ### T1. Two disjuncts are pinned by almost nothing
@@ -229,6 +264,22 @@ Done when deleting any single disjunct of `isStatementText` fails a test.
 The test mocks `pg` with a shared inert pool while the storage provider caches `Pool` in a
 module-level variable, so in a shared process the first initialize decides which mock every later one
 gets. Related to the `mock.module()` isolation rules in `docs/TOOLCHAIN.md`.
+
+### T3. `tests/security/image-proxy.test.ts` asserts a configuration invariant, not the threat
+
+The design this test protects is: `/_next/image?url=http://169.254.169.254/` (or any other
+attacker-chosen URL) must be rejected, because `next/image`'s optimizer would otherwise perform an
+unauthenticated server-side fetch of it. What the test actually asserts is narrower —
+`nextConfig.images` is `undefined` — which is sufficient today only because nothing in `src/`
+imports `next/image` at all (verified: `next.config`'s `images` key is never set, and no component
+imports `next/image`), so the control is closed and correctly verified for the current codebase.
+
+The gap is that the assertion is a proxy for the threat, not the threat itself, and a future,
+strictly safer configuration would fail it: setting `images: { unoptimized: true }` (which disables
+the optimizer's fetch behaviour entirely, closing the same threat a different way) would still trip
+`toBeUndefined()`. The real assertion — that `GET /_next/image?url=<attacker URL>` is rejected —
+belongs with the Phase 1 Playwright work, which can make an actual HTTP request against a running
+server; a unit test importing `next.config` has no way to exercise the route itself.
 
 ---
 

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -330,7 +330,8 @@ Minimal by nature — SQLite keeps almost no server-style runtime statistics.
 
 ## 8. Maintenance
 
-`runMaintenance(type, target?)` ([sqlite.ts:377](../../src/lib/db/providers/sql/sqlite.ts)):
+`runMaintenance(type, target?)` ([sqlite.ts:377](../../src/lib/db/providers/sql/sqlite.ts)); `analyze`
+and `reindex` targets are quoted via `escapeIdentifier()`:
 
 | Type | Action |
 |------|--------|
@@ -340,7 +341,8 @@ Minimal by nature — SQLite keeps almost no server-style runtime statistics.
 | `check` | `PRAGMA integrity_check` (returns ok / failure detail) |
 
 `getCapabilities().maintenanceOperations = ['vacuum', 'analyze', 'reindex', 'check']`. There is no
-`kill` — SQLite has no sessions to terminate.
+`kill` — SQLite has no sessions to terminate. Quoting the target prevents identifier injection in
+`ANALYZE`/`REINDEX` statements (which cannot use bind parameters for object names).
 
 ---
 

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -330,7 +330,7 @@ Minimal by nature — SQLite keeps almost no server-style runtime statistics.
 
 ## 8. Maintenance
 
-`runMaintenance(type, target?)` ([sqlite.ts:377](../../src/lib/db/providers/sql/sqlite.ts)); `analyze`
+`runMaintenance(type, target?)` ([sqlite.ts:432](../../src/lib/db/providers/sql/sqlite.ts)); `analyze`
 and `reindex` targets are quoted via `escapeIdentifier()`:
 
 | Type | Action |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,30 @@ const eslintConfig = defineConfig([
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/purity": "warn",
       "react-hooks/incompatible-library": "warn",
+      // dangerouslySetInnerHTML is an XSS sink: the security hotfix branch removed the two that
+      // existed (LLM markdown now renders through src/components/rich-text.tsx's React-node
+      // renderer instead), and this rule is what keeps a third one from being added silently.
+      // Enforced here (ESLint / eslint-config-next), not in oxlint's .oxlintrc.json: this
+      // project's convention is that eslint-config-next owns React/JSX-semantics rules (see the
+      // "Strategy A" note below, and .oxlintrc.json's react/react-in-jsx-scope and
+      // react-hooks/exhaustive-deps entries, which are explicitly turned off there so they are
+      // not double-reported). oxlint's react plugin implements react/no-danger too, but leaves it
+      // off by default (it sits outside oxlint's correctness/suspicious categories, which are the
+      // only ones this project enables), so there is nothing to disable on that side — ESLint is
+      // already the sole enforcer.
+      "react/no-danger": "error",
+    },
+  },
+  {
+    // src/components/ui/chart.tsx is an upstream shadcn primitive that emits CSS custom
+    // properties (chart colors) from a developer-supplied typed config via
+    // dangerouslySetInnerHTML; it is kept upstream-pure by repository convention (see the
+    // src/components/ui/** overrides in .oxlintrc.json for the same policy) and is referenced
+    // nowhere else in the codebase. Scoped to this one file, not to src/components/ui/**, so a
+    // sink added to any other ui/* file still fails.
+    files: ["src/components/ui/chart.tsx"],
+    rules: {
+      "react/no-danger": "off",
     },
   },
   // Narrow type-aware safety net for the async-heavy code paths (API routes

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,18 +12,6 @@ const nextConfig: NextConfig = {
   // Externalize native modules to reduce bundle size and memory usage
   // These packages will be loaded from node_modules at runtime
   serverExternalPackages: ["pg", "mysql2", "mongodb", "better-sqlite3", "ssh2"],
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "**",
-      },
-      {
-        protocol: "http",
-        hostname: "**",
-      },
-    ],
-  },
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lint": "oxlint && eslint .",
     "lint:oxc": "oxlint",
     "typecheck": "tsc --noEmit",
-    "test": "bun test tests/unit tests/api tests/integration && bun test tests/hooks && bun run test:components",
+    "test": "bun test tests/unit tests/api tests/integration tests/security && bun test tests/hooks && bun run test:components",
     "test:ci": "bash tests/run-core.sh && bun run test:components",
     "test:unit": "bun test tests/unit",
     "test:integration": "bun test tests/integration",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lint": "oxlint && eslint .",
     "lint:oxc": "oxlint",
     "typecheck": "tsc --noEmit",
-    "test": "bun test tests/unit tests/api tests/integration tests/security && bun test tests/hooks && bun run test:components",
+    "test": "bun test tests/unit tests/api tests/integration && bun test tests/hooks && bun test tests/security && bun run test:components",
     "test:ci": "bash tests/run-core.sh && bun run test:components",
     "test:unit": "bun test tests/unit",
     "test:integration": "bun test tests/integration",

--- a/src/app/api/ai/autopilot/route.ts
+++ b/src/app/api/ai/autopilot/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { createLLMProvider } from "@/lib/llm";
 import { createErrorResponse } from "@/lib/api/errors";
+import { requireSession } from "@/lib/api/require-session";
 
 function buildAutopilotPrompt(databaseType: string): string {
   return `You are a Database Performance Autopilot for ${databaseType || "PostgreSQL"}. You combine slow query analysis, execution plans, table statistics, and index usage into a comprehensive optimization report.
@@ -44,6 +45,9 @@ GUIDELINES:
 }
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { slowQueries, indexStats, tableStats, performanceMetrics, overview, schemaContext, databaseType } =
       await req.json();

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { createLLMProvider } from "@/lib/llm";
 import { createErrorResponse } from "@/lib/api/errors";
+import { requireSession } from "@/lib/api/require-session";
 
 // ============================================================================
 // System Prompt Builder
@@ -91,6 +92,9 @@ GUIDELINES:
 // ============================================================================
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { prompt, schemaContext, databaseType, queryLanguage, conversationHistory } = await req.json();
 

--- a/src/app/api/ai/describe-schema/route.ts
+++ b/src/app/api/ai/describe-schema/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createLLMProvider } from "@/lib/llm";
 import { createErrorResponse } from "@/lib/api/errors";
+import { requireSession } from "@/lib/api/require-session";
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { schemaContext, databaseType, mode } = await req.json();
 

--- a/src/app/api/ai/explain/route.ts
+++ b/src/app/api/ai/explain/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createLLMProvider } from "@/lib/llm";
 import { createErrorResponse } from "@/lib/api/errors";
+import { requireSession } from "@/lib/api/require-session";
 
 function buildExplainSystemPrompt(databaseType: string, schemaContext: string): string {
   return `You are an Expert Database Performance Analyst specializing in query optimization for ${databaseType || "PostgreSQL"}.
@@ -40,6 +41,9 @@ GUIDELINES:
 }
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { query, explainPlan, schemaContext, databaseType } = await req.json();
 

--- a/src/app/api/ai/impact/route.ts
+++ b/src/app/api/ai/impact/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createLLMProvider } from "@/lib/llm";
 import { createErrorResponse } from "@/lib/api/errors";
+import { requireSession } from "@/lib/api/require-session";
 
 function buildImpactSystemPrompt(databaseType: string, schemaContext: string): string {
   return `You are a Schema Change Impact Analyst for ${databaseType || "PostgreSQL"}. You analyze DDL statements BEFORE they are executed and predict their impact.
@@ -60,6 +61,9 @@ GUIDELINES:
 }
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { query, schemaContext, databaseType } = await req.json();
 

--- a/src/app/api/ai/index-advisor/route.ts
+++ b/src/app/api/ai/index-advisor/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { createLLMProvider } from "@/lib/llm";
 import { createErrorResponse } from "@/lib/api/errors";
+import { requireSession } from "@/lib/api/require-session";
 
 function buildIndexAdvisorPrompt(databaseType: string): string {
   return `You are a Database Index Optimization Expert for ${databaseType || "PostgreSQL"}.
@@ -53,6 +54,9 @@ GUIDELINES:
 }
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { slowQueries, indexStats, tableStats, schemaContext, databaseType } = await req.json();
 

--- a/src/app/api/ai/nl2sql/route.ts
+++ b/src/app/api/ai/nl2sql/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createLLMProvider } from "@/lib/llm";
 import { createErrorResponse } from "@/lib/api/errors";
+import { requireSession } from "@/lib/api/require-session";
 
 function buildNL2SQLPrompt(databaseType: string, schemaContext: string, queryLanguage?: string): string {
   if (queryLanguage === "json") {
@@ -49,6 +50,9 @@ RULES:
 }
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { question, schemaContext, databaseType, queryLanguage, conversationHistory } = await req.json();
 

--- a/src/app/api/ai/query-safety/route.ts
+++ b/src/app/api/ai/query-safety/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createLLMProvider } from "@/lib/llm";
 import { createErrorResponse } from "@/lib/api/errors";
+import { requireSession } from "@/lib/api/require-session";
 
 function buildSafetySystemPrompt(databaseType: string, schemaContext: string): string {
   return `You are a Database Safety Analyst. Your job is to analyze SQL queries BEFORE they are executed and warn the user about potential dangers.
@@ -50,6 +51,9 @@ GUIDELINES:
 }
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { query, schemaContext, databaseType } = await req.json();
 

--- a/src/app/api/db/disconnect/route.ts
+++ b/src/app/api/db/disconnect/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { removeProvider } from "@/lib/db/factory";
+import { requireSession } from "@/lib/api/require-session";
 import { logger } from "@/lib/logger";
 
 export async function POST(req: NextRequest) {
+  const unauthorized = await requireSession();
+  if (unauthorized) return unauthorized;
+
   try {
     const { connectionId } = await req.json();
 

--- a/src/components/AIAutopilotPanel.tsx
+++ b/src/components/AIAutopilotPanel.tsx
@@ -4,6 +4,7 @@ import React, { useState, useRef } from "react";
 import { Loader2, Sparkles, RefreshCw, Play, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DatabaseConnection } from "@/lib/types";
+import { renderInlineBold } from "@/components/rich-text";
 
 interface AIAutopilotPanelProps {
   connection: DatabaseConnection | null;
@@ -181,27 +182,22 @@ export function AIAutopilotPanel({ connection, schemaContext, onExecuteQuery }: 
           </h3>,
         );
       } else if (line.startsWith("- ")) {
-        const content = line.slice(2).replace(/\*\*(.*?)\*\*/g, '<strong class="text-zinc-200">$1</strong>');
         elements.push(
-          <li
-            key={i}
-            className="text-xs text-zinc-400 ml-4 leading-relaxed"
-            dangerouslySetInnerHTML={{ __html: content }}
-          />,
+          <li key={i} className="text-xs text-zinc-400 ml-4 leading-relaxed">
+            {renderInlineBold(line.slice(2))}
+          </li>,
         );
       } else if (line.match(/^\d+\.\s/)) {
-        const content = line.replace(/\*\*(.*?)\*\*/g, '<strong class="text-zinc-200">$1</strong>');
         elements.push(
-          <li
-            key={i}
-            className="text-xs text-zinc-400 ml-4 leading-relaxed list-decimal"
-            dangerouslySetInnerHTML={{ __html: content }}
-          />,
+          <li key={i} className="text-xs text-zinc-400 ml-4 leading-relaxed list-decimal">
+            {renderInlineBold(line)}
+          </li>,
         );
       } else if (line.trim()) {
-        const content = line.replace(/\*\*(.*?)\*\*/g, '<strong class="text-zinc-200">$1</strong>');
         elements.push(
-          <p key={i} className="text-xs text-zinc-400 leading-relaxed" dangerouslySetInnerHTML={{ __html: content }} />,
+          <p key={i} className="text-xs text-zinc-400 leading-relaxed">
+            {renderInlineBold(line)}
+          </p>,
         );
       } else {
         elements.push(<div key={i} className="h-2" />);

--- a/src/components/DatabaseDocs.tsx
+++ b/src/components/DatabaseDocs.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { FileText, Loader2, Search, Sparkles, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TableSchema } from "@/lib/types";
+import { renderInlineBold } from "@/components/rich-text";
 
 interface DatabaseDocsProps {
   schema: TableSchema[];
@@ -138,29 +139,24 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
           </h3>
         );
       if (line.startsWith("- ")) {
-        const content = line.slice(2).replace(/\*\*(.*?)\*\*/g, '<strong class="text-zinc-200">$1</strong>');
         return (
-          <li
-            key={i}
-            className="text-xs text-zinc-400 ml-4 leading-relaxed"
-            dangerouslySetInnerHTML={{ __html: content }}
-          />
+          <li key={i} className="text-xs text-zinc-400 ml-4 leading-relaxed">
+            {renderInlineBold(line.slice(2))}
+          </li>
         );
       }
       if (line.match(/^\d+\.\s/)) {
-        const content = line.replace(/\*\*(.*?)\*\*/g, '<strong class="text-zinc-200">$1</strong>');
         return (
-          <li
-            key={i}
-            className="text-xs text-zinc-400 ml-4 leading-relaxed list-decimal"
-            dangerouslySetInnerHTML={{ __html: content }}
-          />
+          <li key={i} className="text-xs text-zinc-400 ml-4 leading-relaxed list-decimal">
+            {renderInlineBold(line)}
+          </li>
         );
       }
       if (line.trim()) {
-        const content = line.replace(/\*\*(.*?)\*\*/g, '<strong class="text-zinc-200">$1</strong>');
         return (
-          <p key={i} className="text-xs text-zinc-400 leading-relaxed" dangerouslySetInnerHTML={{ __html: content }} />
+          <p key={i} className="text-xs text-zinc-400 leading-relaxed">
+            {renderInlineBold(line)}
+          </p>
         );
       }
       return <div key={i} className="h-1.5" />;

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -8,6 +8,9 @@ import type { ReactNode } from "react";
  * monitoring data, both of which an attacker can influence, so it must never reach an HTML
  * parser. Returning React nodes makes escaping structural rather than a step someone can
  * forget to apply.
+ *
+ * Expects a single line: the `**bold**` pattern is matched without the `s` flag, so `**` cannot
+ * pair across a newline. Both callers split their input on `\n` before calling this per line.
  */
 export function renderInlineBold(text: string): ReactNode[] {
   const pattern = /\*\*(.*?)\*\*/g;

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+
+/**
+ * Renders `**bold**` spans as React nodes.
+ *
+ * Security: this replaces two string-concatenating renderers whose output was passed to
+ * dangerouslySetInnerHTML. The input is LLM output derived from database identifiers and
+ * monitoring data, both of which an attacker can influence, so it must never reach an HTML
+ * parser. Returning React nodes makes escaping structural rather than a step someone can
+ * forget to apply.
+ */
+export function renderInlineBold(text: string): ReactNode[] {
+  const pattern = /\*\*(.*?)\*\*/g;
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let key = 0;
+  let match = pattern.exec(text);
+
+  while (match !== null) {
+    if (match.index > cursor) {
+      nodes.push(text.slice(cursor, match.index));
+    }
+
+    nodes.push(
+      <strong key={key} className="text-zinc-200">
+        {match[1]}
+      </strong>,
+    );
+
+    key += 1;
+    cursor = match.index + match[0].length;
+    match = pattern.exec(text);
+  }
+
+  if (cursor < text.length) {
+    nodes.push(text.slice(cursor));
+  }
+
+  return nodes;
+}

--- a/src/lib/api/require-session.ts
+++ b/src/lib/api/require-session.ts
@@ -10,6 +10,12 @@ import { getSession } from "@/lib/auth";
  * reach a database or an LLM provider verify the session themselves.
  *
  * Returns null when the caller is authenticated, or the 401 response the handler should return.
+ *
+ * Callers invoke this outside their own try/catch, unlike the inline checks it replaces. That is
+ * safe because `getSession()` cannot throw: a missing auth-token cookie makes it return null
+ * directly, and otherwise it awaits `verifyJWT()`, whose try block wraps the JWT secret lookup
+ * (so a misconfigured `JWT_SECRET` raises `AuthConfigError` there, not outside it) and always
+ * degrades to a returned null rather than letting anything escape.
  */
 export async function requireSession(): Promise<NextResponse | null> {
   const session = await getSession();

--- a/src/lib/api/require-session.ts
+++ b/src/lib/api/require-session.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+
+/**
+ * Handler-level authentication guard.
+ *
+ * src/proxy.ts already redirects unauthenticated requests, but middleware is an optimisation,
+ * not an authorization boundary: a matcher gap (the matcher exempts any path containing a dot)
+ * or a framework-level bypass would expose every route that relies on it alone. Routes that
+ * reach a database or an LLM provider verify the session themselves.
+ *
+ * Returns null when the caller is authenticated, or the 401 response the handler should return.
+ */
+export async function requireSession(): Promise<NextResponse | null> {
+  const session = await getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/src/lib/db/providers/sql/sqlite.ts
+++ b/src/lib/db/providers/sql/sqlite.ts
@@ -440,10 +440,10 @@ export class SQLiteProvider extends SQLBaseProvider {
           sql = "VACUUM";
           break;
         case "analyze":
-          sql = target ? `ANALYZE "${target}"` : "ANALYZE";
+          sql = target ? `ANALYZE ${this.escapeIdentifier(target)}` : "ANALYZE";
           break;
         case "reindex":
-          sql = target ? `REINDEX "${target}"` : "REINDEX";
+          sql = target ? `REINDEX ${this.escapeIdentifier(target)}` : "REINDEX";
           break;
         case "check":
           const checkStmt = this.db!.prepare("PRAGMA integrity_check");

--- a/tests/api/ai/autopilot.test.ts
+++ b/tests/api/ai/autopilot.test.ts
@@ -75,6 +75,18 @@ mock.module("@/lib/llm/types", () => ({
   LLMStreamError: MockLLMStreamError,
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 
 const { POST } = await import("@/app/api/ai/autopilot/route");

--- a/tests/api/ai/chat.test.ts
+++ b/tests/api/ai/chat.test.ts
@@ -75,6 +75,18 @@ mock.module("@/lib/llm/types", () => ({
   LLMStreamError: MockLLMStreamError,
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 
 const { POST } = await import("@/app/api/ai/chat/route");

--- a/tests/api/ai/describe-schema.test.ts
+++ b/tests/api/ai/describe-schema.test.ts
@@ -75,6 +75,18 @@ mock.module("@/lib/llm/types", () => ({
   LLMStreamError: MockLLMStreamError,
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 
 const { POST } = await import("@/app/api/ai/describe-schema/route");

--- a/tests/api/ai/explain.test.ts
+++ b/tests/api/ai/explain.test.ts
@@ -75,6 +75,18 @@ mock.module("@/lib/llm/types", () => ({
   LLMStreamError: MockLLMStreamError,
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 
 const { POST } = await import("@/app/api/ai/explain/route");

--- a/tests/api/ai/impact.test.ts
+++ b/tests/api/ai/impact.test.ts
@@ -75,6 +75,18 @@ mock.module("@/lib/llm/types", () => ({
   LLMStreamError: MockLLMStreamError,
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 
 const { POST } = await import("@/app/api/ai/impact/route");

--- a/tests/api/ai/index-advisor.test.ts
+++ b/tests/api/ai/index-advisor.test.ts
@@ -75,6 +75,18 @@ mock.module("@/lib/llm/types", () => ({
   LLMStreamError: MockLLMStreamError,
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 
 const { POST } = await import("@/app/api/ai/index-advisor/route");

--- a/tests/api/ai/nl2sql.test.ts
+++ b/tests/api/ai/nl2sql.test.ts
@@ -75,6 +75,18 @@ mock.module("@/lib/llm/types", () => ({
   LLMStreamError: MockLLMStreamError,
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 
 const { POST } = await import("@/app/api/ai/nl2sql/route");

--- a/tests/api/ai/query-safety.test.ts
+++ b/tests/api/ai/query-safety.test.ts
@@ -75,6 +75,18 @@ mock.module("@/lib/llm/types", () => ({
   LLMStreamError: MockLLMStreamError,
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
 
 const { POST } = await import("@/app/api/ai/query-safety/route");

--- a/tests/api/db/disconnect.test.ts
+++ b/tests/api/db/disconnect.test.ts
@@ -60,6 +60,18 @@ mock.module("@/lib/logger", () => ({
   },
 }));
 
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
 const { POST } = await import("@/app/api/db/disconnect/route");
 
 beforeEach(() => {

--- a/tests/components/AIAutopilotPanel.test.tsx
+++ b/tests/components/AIAutopilotPanel.test.tsx
@@ -632,6 +632,30 @@ describe("AIAutopilotPanel", () => {
     });
   });
 
+  test("renders an autopilot report containing an HTML payload as text", async () => {
+    const payload = "<svg onload=alert(1)>";
+    globalThis.fetch = mock((url: string) => {
+      if (url === "/api/db/monitoring") {
+        return Promise.resolve(createJsonResponse({}));
+      }
+      return Promise.resolve(createStreamResponse(`- ${payload}`));
+    }) as never;
+
+    const { queryByText, container } = render(<AIAutopilotPanel {...defaultProps} />);
+
+    await act(async () => {
+      fireEvent.click(queryByText("Run Analysis")!.closest("button")!);
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(payload);
+    });
+    // Scoped to the rendered report itself: the panel's header and button always render
+    // legitimate Lucide <svg> icons, so a bare container-wide query would find those and
+    // pass regardless of whether the payload was escaped.
+    expect(container.querySelector(".prose svg")).toBeNull();
+  });
+
   // ── Bold in lists ───────────────────────────────────────────────────────
 
   test("renders bold text inside bullet list items", async () => {

--- a/tests/components/DatabaseDocs.test.tsx
+++ b/tests/components/DatabaseDocs.test.tsx
@@ -187,6 +187,21 @@ describe("DatabaseDocs", () => {
     });
   });
 
+  test("renders AI documentation containing an HTML payload as text", async () => {
+    const payload = '<img src=x onerror="steal()">';
+    const user = userEvent.setup();
+    globalThis.fetch = mockFetchStream(`- ${payload}`) as unknown as typeof fetch;
+
+    const { container, queryByText } = render(<DatabaseDocs schema={schema} schemaContext="[]" />);
+
+    await user.click(queryByText("AI Describe")!);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(payload);
+    });
+    expect(container.querySelector("img")).toBeNull();
+  });
+
   test("renders AI docs markdown: h2, h3, list items, paragraphs", async () => {
     const user = userEvent.setup();
     const mdContent = "## Section\n### Subsection\n- Item one\n1. Numbered item\nPlain text paragraph\n";

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -435,6 +435,33 @@ describe("SQLiteProvider", () => {
       expect(result.success).toBe(true);
       expect(result.message).toContain("REINDEX");
     });
+
+    test("analyze does not execute a statement smuggled through the target identifier", async () => {
+      provider = new SQLiteProvider(makeSQLiteConfig());
+      await provider.connect();
+      await provider.query("CREATE TABLE mt (id INTEGER PRIMARY KEY, v TEXT)");
+      await provider.query("CREATE TABLE victim (id INTEGER PRIMARY KEY)");
+
+      // The target is quoted, so a `"` inside it must be doubled rather than closing the
+      // identifier. Unescaped, this becomes: ANALYZE "mt"; DROP TABLE victim; --"
+      await provider.runMaintenance("analyze", 'mt"; DROP TABLE victim; --').catch(() => undefined);
+
+      const tables = await provider.query("SELECT name FROM sqlite_master WHERE type='table' AND name='victim'");
+      expect(tables.rows.length).toBe(1);
+    });
+
+    test("reindex does not execute a statement smuggled through the target identifier", async () => {
+      provider = new SQLiteProvider(makeSQLiteConfig());
+      await provider.connect();
+      await provider.query("CREATE TABLE mt (id INTEGER PRIMARY KEY, v TEXT)");
+      await provider.query("CREATE INDEX idx_mt_v ON mt(v)");
+      await provider.query("CREATE TABLE victim (id INTEGER PRIMARY KEY)");
+
+      await provider.runMaintenance("reindex", 'idx_mt_v"; DROP TABLE victim; --').catch(() => undefined);
+
+      const tables = await provider.query("SELECT name FROM sqlite_master WHERE type='table' AND name='victim'");
+      expect(tables.rows.length).toBe(1);
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/tests/run-core.sh
+++ b/tests/run-core.sh
@@ -31,7 +31,7 @@ for arg in "$@"; do
 done
 
 # Deterministic, sorted list of every core test file.
-mapfile -t FILES < <(find tests/unit tests/api tests/integration tests/hooks \
+mapfile -t FILES < <(find tests/unit tests/api tests/integration tests/hooks tests/security \
   -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | sort)
 
 if [ "${#FILES[@]}" -eq 0 ]; then

--- a/tests/security/image-proxy.test.ts
+++ b/tests/security/image-proxy.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import nextConfig from "../../next.config";
+
+describe("next image optimizer exposure", () => {
+  test("declares no remote image hosts", () => {
+    // `/_next/*` is public in src/proxy.ts, so any configured remote pattern turns
+    // /_next/image into an unauthenticated server-side fetch of an attacker-chosen URL.
+    // Nothing in the app imports next/image, so the correct configuration is none at all.
+    expect(nextConfig.images).toBeUndefined();
+  });
+});

--- a/tests/security/image-proxy.test.ts
+++ b/tests/security/image-proxy.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import nextConfig from "../../next.config";
 
 describe("next image optimizer exposure", () => {
-  test("declares no remote image hosts", () => {
+  test("declares no images configuration at all", () => {
     // `/_next/*` is public in src/proxy.ts, so any configured remote pattern turns
     // /_next/image into an unauthenticated server-side fetch of an attacker-chosen URL.
     // Nothing in the app imports next/image, so the correct configuration is none at all.

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+
+const mockGetSession = mock(
+  async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+);
+
+mock.module("@/lib/auth", () => ({
+  getSession: mockGetSession,
+  signJWT: mock(async () => "mock-token"),
+  verifyJWT: mock(async () => null),
+  login: mock(async () => {}),
+  logout: mock(async () => {}),
+}));
+
+const { requireSession } = await import("@/lib/api/require-session");
+
+describe("requireSession", () => {
+  beforeEach(() => {
+    mockGetSession.mockClear();
+    mockGetSession.mockImplementation(async () => ({ role: "admin", username: "admin" }));
+  });
+
+  test("returns null when a session exists", async () => {
+    expect(await requireSession()).toBeNull();
+  });
+
+  test("returns a 401 response when no session exists", async () => {
+    mockGetSession.mockImplementation(async () => null);
+
+    const res = await requireSession();
+
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(401);
+    expect(await res?.json()).toEqual({ error: "Authentication required" });
+  });
+});

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -12,6 +12,78 @@ mock.module("@/lib/auth", () => ({
   logout: mock(async () => {}),
 }));
 
+// ─── Mock @/lib/llm so a bypassed guard can never be mistaken for a working one ──
+//
+// Without this, a route that lost its guard would fall through to the real
+// createLLMProvider() (network call, needs a valid key) and, on some failure
+// modes, src/lib/api/errors.ts maps LLMAuthError to HTTP 401 — the exact status
+// this test expects from the guard. A status-only assertion could then pass for
+// the wrong reason. Making createLLMProvider throw a plain Error (not one of the
+// LLM* classes) means a bypassed guard can only produce a 500 (the "Generic
+// Error" branch in createErrorResponse), never a 401 — so 401 here can only mean
+// the guard actually ran. This also means the test makes no network call.
+
+class MockLLMError extends Error {
+  statusCode?: number;
+  constructor(msg: string, _provider?: string, code?: number) {
+    super(msg);
+    this.name = "LLMError";
+    this.statusCode = code;
+  }
+}
+class MockLLMConfigError extends MockLLMError {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "LLMConfigError";
+  }
+}
+class MockLLMAuthError extends MockLLMError {
+  constructor(msg: string) {
+    super(msg, undefined, 401);
+    this.name = "LLMAuthError";
+  }
+}
+class MockLLMRateLimitError extends MockLLMError {
+  constructor(msg: string) {
+    super(msg, undefined, 429);
+    this.name = "LLMRateLimitError";
+  }
+}
+class MockLLMSafetyError extends MockLLMError {
+  constructor(msg: string) {
+    super(msg, undefined, 400);
+    this.name = "LLMSafetyError";
+  }
+}
+class MockLLMStreamError extends MockLLMError {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "LLMStreamError";
+  }
+}
+
+const mockCreateLLMProvider = mock(async () => {
+  throw new Error("createLLMProvider must not be reached: the requireSession guard should have returned 401 first");
+});
+
+mock.module("@/lib/llm", () => ({
+  createLLMProvider: mockCreateLLMProvider,
+  LLMError: MockLLMError,
+  LLMConfigError: MockLLMConfigError,
+  LLMAuthError: MockLLMAuthError,
+  LLMRateLimitError: MockLLMRateLimitError,
+  LLMSafetyError: MockLLMSafetyError,
+}));
+
+mock.module("@/lib/llm/types", () => ({
+  LLMError: MockLLMError,
+  LLMConfigError: MockLLMConfigError,
+  LLMAuthError: MockLLMAuthError,
+  LLMRateLimitError: MockLLMRateLimitError,
+  LLMSafetyError: MockLLMSafetyError,
+  LLMStreamError: MockLLMStreamError,
+}));
+
 const { requireSession } = await import("@/lib/api/require-session");
 
 describe("requireSession", () => {
@@ -70,6 +142,7 @@ describe("routes that reach a provider require a session", () => {
       const res = await POST(req as never);
 
       expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: "Authentication required" });
     });
   }
 });

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test, mock, beforeEach } from "bun:test";
+import { readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
 
 const mockGetSession = mock(
   async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
@@ -109,17 +111,34 @@ describe("requireSession", () => {
 
 type RouteModule = { POST: (req: never) => Promise<Response> };
 
-// Each specifier is a literal inside its own arrow function: bun resolves the "@/" alias at
-// parse time, so a variable module path would not resolve here.
+// Enumerated from disk instead of hardcoded, so a route added under src/app/api/ai/ later is
+// checked automatically instead of silently escaping this test - that was the whole gap: a
+// hardcoded list only ever proves the routes someone remembered to add to it are guarded.
+//
+// The import specifier is a filesystem path computed at test-run time, not the "@/" alias used
+// elsewhere in this file: bun resolves "@/" only when the specifier is a literal string it can
+// see at parse time, and a path built from a directory listing is not one. A plain path (relative
+// or absolute) has no such restriction - bun's dynamic import() resolves it like any other
+// runtime module specifier, and the "@/" imports *inside* each route.ts still resolve normally
+// there, since that resolution happens in that file's own context, independent of how the
+// importer named it.
+const AI_ROUTES_DIR = join(import.meta.dir, "..", "..", "src", "app", "api", "ai");
+
+function discoverAiRoutes(): Array<[string, () => Promise<RouteModule>]> {
+  return readdirSync(AI_ROUTES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(AI_ROUTES_DIR, entry.name, "route.ts")))
+    .map((entry) => entry.name)
+    .sort()
+    .map((name): [string, () => Promise<RouteModule>] => [
+      `/api/ai/${name}`,
+      () => import(join(AI_ROUTES_DIR, name, "route.ts")) as Promise<RouteModule>,
+    ]);
+}
+
+const AI_ROUTES = discoverAiRoutes();
+
 const GUARDED_ROUTES: Array<[string, () => Promise<RouteModule>]> = [
-  ["/api/ai/autopilot", () => import("@/app/api/ai/autopilot/route")],
-  ["/api/ai/chat", () => import("@/app/api/ai/chat/route")],
-  ["/api/ai/describe-schema", () => import("@/app/api/ai/describe-schema/route")],
-  ["/api/ai/explain", () => import("@/app/api/ai/explain/route")],
-  ["/api/ai/impact", () => import("@/app/api/ai/impact/route")],
-  ["/api/ai/index-advisor", () => import("@/app/api/ai/index-advisor/route")],
-  ["/api/ai/nl2sql", () => import("@/app/api/ai/nl2sql/route")],
-  ["/api/ai/query-safety", () => import("@/app/api/ai/query-safety/route")],
+  ...AI_ROUTES,
   ["/api/db/disconnect", () => import("@/app/api/db/disconnect/route")],
 ];
 
@@ -127,6 +146,14 @@ describe("routes that reach a provider require a session", () => {
   beforeEach(() => {
     mockGetSession.mockClear();
     mockGetSession.mockImplementation(async () => null);
+  });
+
+  // A directory-listing bug that silently finds zero routes would make every test below
+  // vacuously pass (a `for` loop over an empty array runs no assertions). This is the guard
+  // that keeps the guard honest: today there are eight AI routes, and the enumeration must find
+  // at least that many, or this test suite is no longer proving what it claims to prove.
+  test("the filesystem enumeration finds at least today's eight AI routes", () => {
+    expect(AI_ROUTES.length).toBeGreaterThanOrEqual(8);
   });
 
   for (const [route, load] of GUARDED_ROUTES) {

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -34,3 +34,42 @@ describe("requireSession", () => {
     expect(await res?.json()).toEqual({ error: "Authentication required" });
   });
 });
+
+type RouteModule = { POST: (req: never) => Promise<Response> };
+
+// Each specifier is a literal inside its own arrow function: bun resolves the "@/" alias at
+// parse time, so a variable module path would not resolve here.
+const GUARDED_ROUTES: Array<[string, () => Promise<RouteModule>]> = [
+  ["/api/ai/autopilot", () => import("@/app/api/ai/autopilot/route")],
+  ["/api/ai/chat", () => import("@/app/api/ai/chat/route")],
+  ["/api/ai/describe-schema", () => import("@/app/api/ai/describe-schema/route")],
+  ["/api/ai/explain", () => import("@/app/api/ai/explain/route")],
+  ["/api/ai/impact", () => import("@/app/api/ai/impact/route")],
+  ["/api/ai/index-advisor", () => import("@/app/api/ai/index-advisor/route")],
+  ["/api/ai/nl2sql", () => import("@/app/api/ai/nl2sql/route")],
+  ["/api/ai/query-safety", () => import("@/app/api/ai/query-safety/route")],
+  ["/api/db/disconnect", () => import("@/app/api/db/disconnect/route")],
+];
+
+describe("routes that reach a provider require a session", () => {
+  beforeEach(() => {
+    mockGetSession.mockClear();
+    mockGetSession.mockImplementation(async () => null);
+  });
+
+  for (const [route, load] of GUARDED_ROUTES) {
+    test(`POST ${route} returns 401 without a session`, async () => {
+      const { POST } = await load();
+
+      const req = new Request(`http://localhost${route}`, {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const res = await POST(req as never);
+
+      expect(res.status).toBe(401);
+    });
+  }
+});

--- a/tests/security/xss-sinks.test.tsx
+++ b/tests/security/xss-sinks.test.tsx
@@ -1,0 +1,68 @@
+import "../setup-dom";
+
+import React from "react";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { renderInlineBold } from "@/components/rich-text";
+
+const IMG_PAYLOAD = '<img src=x onerror="steal()">';
+const SVG_PAYLOAD = "<svg onload=alert(1)>";
+
+afterEach(cleanup);
+
+describe("renderInlineBold", () => {
+  test("renders an HTML payload as text, never as an element", () => {
+    const { container } = render(<div>{renderInlineBold(IMG_PAYLOAD)}</div>);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe(IMG_PAYLOAD);
+  });
+
+  test("renders an HTML payload inside bold markers as text", () => {
+    const { container } = render(<div>{renderInlineBold(`**${SVG_PAYLOAD}**`)}</div>);
+
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelector("strong")?.textContent).toBe(SVG_PAYLOAD);
+  });
+
+  test("returns plain text unchanged when there are no bold markers", () => {
+    const { container } = render(<div>{renderInlineBold("plain line")}</div>);
+
+    expect(container.querySelector("strong")).toBeNull();
+    expect(container.textContent).toBe("plain line");
+  });
+
+  test("renders a bold span at the start with no leading text node", () => {
+    const { container } = render(<div>{renderInlineBold("**lead** tail")}</div>);
+
+    expect(container.querySelector("strong")?.textContent).toBe("lead");
+    expect(container.textContent).toBe("lead tail");
+  });
+
+  test("renders a bold span at the end with no trailing text node", () => {
+    const { container } = render(<div>{renderInlineBold("head **tail**")}</div>);
+
+    expect(container.querySelector("strong")?.textContent).toBe("tail");
+    expect(container.textContent).toBe("head tail");
+  });
+
+  test("renders multiple bold spans with the interleaved text between them", () => {
+    const { container } = render(<div>{renderInlineBold("a **b** c **d** e")}</div>);
+
+    const bold = container.querySelectorAll("strong");
+    expect(bold.length).toBe(2);
+    expect(bold[0].textContent).toBe("b");
+    expect(bold[1].textContent).toBe("d");
+    expect(container.textContent).toBe("a b c d e");
+  });
+
+  test("returns no nodes for an empty string", () => {
+    expect(renderInlineBold("")).toEqual([]);
+  });
+
+  test("applies the bold styling class the components rely on", () => {
+    const { container } = render(<div>{renderInlineBold("**x**")}</div>);
+
+    expect(container.querySelector("strong")?.className).toBe("text-zinc-200");
+  });
+});


### PR DESCRIPTION
Phase 0 of the security maturity programme: close the remotely reachable holes, and make `SECURITY.md` stop contradicting the code.

This is the first of four planned PRs. Phases 1 to 3 (security headers and CSP, rate limiting, supply-chain scanning, credential encryption at rest) follow on stacked branches.

## Why this is urgent

`src/components/DatabaseDocs.tsx` and `src/components/AIAutopilotPanel.tsx` rendered LLM output as raw HTML. Both fed on attacker-influenceable data, and database credentials are stored unencrypted in `localStorage`. The chain was complete:

1. An attacker creates a database object whose name carries an HTML payload, or runs a query that lands in the slow-query log.
2. A user opens that connection and requests AI Docs or Autopilot.
3. The identifier reaches the LLM as schema context and is echoed back.
4. It renders as live HTML. `<script>` does not execute through `innerHTML`, but `<img onerror>`, `<svg onload>` and `<iframe srcdoc>` do.
5. Every configured database credential is exfiltrated.

Affected versions include 0.9.67 and earlier, across all live distribution channels. **The npm package `@libredb/studio` is an affected artifact**: the two components are not in `src/exports/components.ts`, but they reach consumers through `src/exports/workspace.ts` -> `StudioWorkspace.tsx:14` -> `src/components/studio/BottomPanel.tsx:310,325`, so every embedder of the workspace was vulnerable.

## What changed

| Control | Change |
|---|---|
| XSS sinks | Both `dangerouslySetInnerHTML` sites replaced with a shared React-node renderer, `src/components/rich-text.tsx`. React escapes text nodes structurally, so the sink is removed rather than sanitised. |
| Open image proxy | Deleted the wildcard `images.remotePatterns` from `next.config.ts`. With `/_next` public in `src/proxy.ts`, it made `/_next/image?url=...` an unauthenticated server-side fetch of any URL. Nothing in `src/` imports `next/image`, so deletion is complete rather than a narrowing. |
| Handler-level auth | Eight `/api/ai/*` routes and `/api/db/disconnect` relied on middleware alone. All nine now call `requireSession()`. `src/proxy.ts:85`'s matcher exempts any path containing a dot, so middleware is an optimisation, not an authorization boundary. |
| `SECURITY.md` | Five false claims corrected: password hashing, encrypted `localStorage`, the public-endpoint list, session-token configurability, and credentials in API responses. |
| SQLite maintenance | `ANALYZE`/`REINDEX` targets are now escaped via the inherited `escapeIdentifier()`. Every sibling provider already did this; SQLite was the sole outlier. |
| Regression durability | `react/no-danger` is now an ESLint error, with a single path-scoped exception for the upstream `src/components/ui/chart.tsx`. A new `tests/security/` group holds threat-level tests. |

## Severity calibration

The SQLite escaping fix requires `role === "admin"` (`src/app/api/db/maintenance/route.ts:12`), and an admin can already execute arbitrary SQL through `/api/db/query`. It is a correctness and least-astonishment fix, **not** a privilege escalation, and should not be described as critical in release notes.

The image proxy and the missing handler auth are genuinely closed but sub-CVE: the image proxy allowed blind fetching only, and the AI routes were already covered by a middleware redirect, so the guard is defence in depth against a matcher gap.

## Advisory notes

- An advisory should describe the fix as **removing the two sinks**, not as hardening the application against XSS generally. Credentials remain plaintext in `localStorage` by design and CSP lands in Phase 1, so the impact statement stays fully severe for any sink found later.
- The GHSA ecosystem is **npm**, not only "application", per the export chain above.
- `package.json` is still `0.9.67`, the vulnerable version. The advisory cannot be published until a release lands and must name the shipped tag.
- Two things a scanner will surface, both correct outcomes: `src/components/ui/chart.tsx:74` still contains `dangerouslySetInnerHTML` (an unreferenced upstream shadcn primitive fed by a typed developer config, not exported from the package), and `SECURITY.md` now openly states that credentials are stored unencrypted.

## Verification

All eight gates pass at `f58b394`:

```
format      644 files checked, no fixes applied
lint        0 errors (76 pre-existing warnings)
typecheck   no diagnostics
knip        no unused files or exports
test        7062 passed, 0 failed, 23 groups
build       41 routes generated
coverage    100.00% (29299/29299 lines)
build:lib   + attw, all node16/bundler entries green
```

The `react/no-danger` rule was verified to actually fire rather than being configured and inert, by piping a snippet to ESLint under two filenames: it errors on a generic path and stays silent on `src/components/ui/chart.tsx`.

The sink inventory was re-derived independently rather than trusted: across `src/` the only remaining `dangerouslySetInnerHTML` is the sanctioned `ui/chart.tsx`. `src/components/VisualExplain.tsx` is a third LLM markdown renderer that was already React-node based and never vulnerable. Sweeps for `innerHTML`, `outerHTML`, `insertAdjacentHTML`, `document.write`, `srcdoc`, `DOMParser`, `createContextualFragment`, `eval` and `new Function` are clean.

## Deferred

Recorded in `docs/BACKLOG.md`: the `image-proxy` test asserts a configuration invariant rather than the design's specified threat assertion (the real check belongs with Phase 1's Playwright work); three copies of the 401 response now exist and the storage routes answer with a different body; and paths containing a dot bypass the proxy matcher, so Phase 1's headers will not reach static assets.
