### PR TITLE
feat(db): canonical database operations, risk classes and fail-closed policy layer (#328)

### DIFF
--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -847,6 +847,8 @@ Both require an **admin** role (enforced in-handler in addition to the middlewar
 
 Returns audit events. Optional query params: `type` (filter by event type), `limit` (default 100). Response: `{ "events": [], "total": 0 }`. `POST /api/admin/audit` appends an event (user auto-filled from the session).
 
+Events of type `agent_operation` come from the agent execution path (#328) and additionally carry `correlationId` — the id joining one execution's policy-decision event to its execution-outcome event (a refused operation emits the decision event only, with an `agent_*` reason code). It is opaque and per execution: it identifies neither a user nor a session. On the authoritative stdout line the same value appears as `correlation_id`, and it is omitted entirely from every event that does not set it.
+
 #### POST /api/admin/fleet-health
 
 Body `{ "connections": [...] }`; returns per-connection health `{ "results": [{ connectionId, status, latencyMs, ... }] }`. `400` if `connections` is missing. `401` with no session, `403` with a session that is not an admin — see the note above.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -705,3 +705,21 @@ write is refused, so a zero-byte file can still appear at any path the server pr
 callback, which `bun:sqlite` does not expose at all. Done when a control exists on both adapters,
 or when agent SQLite targets are constrained to an allowlisted directory (related: the base-dir
 allowlist proposed in issue #125).
+
+### A3. Out-of-scope READS have no database-native control on either provider
+
+Both agent profiles bound what a statement can WRITE with a database-native control. What it can
+READ is bounded only by the policy layer's declared-target allowlist plus the input-stage statement
+guard - and both of those read SQL, which this milestone treats as defense in depth rather than a
+boundary:
+
+- SQLite: `ATTACH` of an *existing* file succeeds on a read-only handle and its rows become
+  readable. No authorizer exists on `bun:sqlite`, so there is nothing engine-side to stop it
+  (docs/providers/sqlite.md section 12.3).
+- PostgreSQL: the read-only role can read every table its grants allow, whatever catalog or schema
+  the request declared. Per-table `SELECT` grants are the only real bound
+  (docs/providers/postgres.md section 12.3).
+
+Done when out-of-scope reads are refused by something that does not read SQL - a per-target grant
+set generated for the agent role, an allowlisted directory for SQLite targets, or an authorizer both
+adapters expose.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -675,3 +675,33 @@ reading the stored row before every write and preserving an existing envelope wh
 value is absent - which would also silently resurrect a password the user deliberately cleared, a
 worse bug than the one it fixes. Done when a design is found that distinguishes "the client never
 had this value" from "the client cleared this value" without adding a field to the stored shape.
+
+---
+
+## Agent M1 deferrals (#328)
+
+Each of these was decided while building the operation/policy layer, not overlooked. Delete an
+entry when the work lands.
+
+### A1. A SQLite agent statement can block the runtime for its whole duration
+
+`src/lib/db/providers/sql/sqlite.ts`'s `queryReadOnly` enforces `statementTimeoutMs` as a
+post-execution deadline: the result of an overrunning statement is refused, but the statement is
+never preempted. SQLite has no transaction-local statement timeout, and neither `bun:sqlite` nor
+`node:sqlite` exposes `sqlite3_interrupt` or a progress handler, so there is nothing to preempt it
+with. Because both drivers are synchronous, a hostile recursive CTE therefore blocks the whole
+runtime while it runs. This is the same property as the normal SQLite query path, but the input
+source is different in kind: there the SQL comes from an authenticated operator, here it comes from
+an agent. Done when either driver exposes an interrupt/progress hook, or agent SQLite execution
+moves to a worker that can be killed on deadline.
+
+### A2. `VACUUM INTO` can create an empty file at an agent-chosen path
+
+The SQLite agent profile's read-only open governs the target database file only; `VACUUM INTO
+'<path>'` writes to a *different* file and is refused by `PRAGMA query_only`, which the profile
+re-asserts and verifies before every statement. SQLite creates the destination file before the
+write is refused, so a zero-byte file can still appear at any path the server process can write to
+(no data reaches it - asserted on both adapters by file size). Closing this needs an authorizer
+callback, which `bun:sqlite` does not expose at all. Done when a control exists on both adapters,
+or when agent SQLite targets are constrained to an allowlisted directory (related: the base-dir
+allowlist proposed in issue #125).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -723,3 +723,42 @@ boundary:
 Done when out-of-scope reads are refused by something that does not read SQL - a per-target grant
 set generated for the agent role, an allowlisted directory for SQLite targets, or an authorizer both
 adapters expose.
+
+### A4. No wall-clock deadline bounds an agent run
+
+`maxTotalRunMs` bounds the DATABASE time a run consumes: the execution layer reports each completed
+call's elapsed time and the tracker sums them. Nothing bounds the run's wall clock. Time between
+calls is not counted, so a run that spends minutes in model latency or waiting on a caller stays
+inside its budget indefinitely; parallel calls each contribute their own duration, so the sum can
+exceed real elapsed time; and a call admitted just under the limit can still overrun it by up to one
+statement timeout.
+
+This is deliberate at this layer. `ExecutionBudgetTracker` has no clock so that budget accounting
+stays deterministic under test, and database time is the bound that actually protects the database.
+The missing control is a run-level one: a runaway agent is bounded by how long it may run, not by
+how much database time it used.
+
+Done when the run loop owns a monotonic deadline per run, refuses to admit a call that cannot finish
+inside the remaining time, and clamps each effective statement timeout to what is left. That belongs
+with the WorkflowAgent run loop in M2 (#329), which is the first component that owns a run's
+lifetime.
+
+### A5. The PostgreSQL profile's regression tests model the server rather than run one
+
+`tests/integration/db/postgres-provider.test.ts` proves the read-only profile against a stateful
+hand-written engine mock. Every rule it models was verified against a live PostgreSQL 18 while the
+profile was built - read-only transaction rejection by engine state, the extended-protocol refusal of
+multi-command strings, `SET TRANSACTION READ WRITE` really relaxing the transaction, advisory locks
+surviving rollback - and the mock encodes them faithfully enough that bypass attempts fail on real
+modeled behavior (a write actually landing) rather than on protocol metadata.
+
+What it cannot catch is a future regression on the other side of the seam: a driver change, a server
+version that behaves differently, or a `pg` option that stops meaning what it meant. The assertions
+would stay green because the mock, not the server, defines the semantics. The repository's
+integration suites are mock-based by convention and CI runs no database service; the only real
+engine in the pipeline today is the throwaway PostgreSQL container behind
+`loop/scripts/functional-smoke.sh`.
+
+Done when a container-backed test proves, against a supported PostgreSQL, that a direct write and a
+multi-command escape are rejected through the profile under the resolved role. The cheapest path is
+extending the functional-smoke container rather than adding a service to every CI test job.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -43,6 +43,7 @@ Two consequences worth stating before the table:
 | 3.2 | Every authoritative (server-generated) audit event is emitted as one structured JSON line on stdout | Implemented | [`src/lib/audit.ts`](../src/lib/audit.ts) | [`tests/security/audit-redaction.test.ts`](../tests/security/audit-redaction.test.ts), [`tests/security/audit-type-safety.test.ts`](../tests/security/audit-type-safety.test.ts) |
 | 3.3 | This page is checked against the repository on every build | Implemented | [`scripts/security-check.mjs`](../scripts/security-check.mjs) | [`tests/unit/security-check.test.ts`](../tests/unit/security-check.test.ts) |
 | 3.4 | A statement submitted on the agent execution path cannot write, change schema, reach another database, load code, or run the executing form of EXPLAIN | Partial | [`src/lib/db/operations/policy.ts`](../src/lib/db/operations/policy.ts), [`src/lib/db/operations/statement-guard.ts`](../src/lib/db/operations/statement-guard.ts), [`src/lib/db/providers/sql/postgres.ts`](../src/lib/db/providers/sql/postgres.ts), [`src/lib/db/providers/sql/sqlite.ts`](../src/lib/db/providers/sql/sqlite.ts) | [`tests/security/agent-statement-boundary.test.ts`](../tests/security/agent-statement-boundary.test.ts), [`tests/integration/db/postgres-provider.test.ts`](../tests/integration/db/postgres-provider.test.ts), [`tests/integration/db/sqlite-provider.test.ts`](../tests/integration/db/sqlite-provider.test.ts) |
+| 3.5 | Every agent-path operation — allowed, denied, or held for approval — is audited under one correlation id, and its result is released with the run | Partial | [`src/lib/db/operations/execution.ts`](../src/lib/db/operations/execution.ts), [`src/lib/db/operations/artifacts.ts`](../src/lib/db/operations/artifacts.ts), [`src/lib/audit.ts`](../src/lib/audit.ts) | [`tests/security/agent-execution-audit.test.ts`](../tests/security/agent-execution-audit.test.ts), [`tests/unit/db/operations/execution.test.ts`](../tests/unit/db/operations/execution.test.ts), [`tests/unit/db/operations/artifacts.test.ts`](../tests/unit/db/operations/artifacts.test.ts), [`tests/api/db/query.test.ts`](../tests/api/db/query.test.ts) |
 
 ## Notes on individual rows
 
@@ -86,6 +87,17 @@ READS have no database-native control on either provider (only the declared-targ
 statement guard, and whatever the role's grants bound — see
 [`docs/BACKLOG.md`](./BACKLOG.md) A3), and no route or agent runtime reaches this layer yet, so it
 governs nothing in a shipped release until the agent surface lands.
+
+**3.5.** Each execution emits a decision event and, once allowed, an execution-outcome event
+sharing one server-generated correlation id; a denial emits the decision event alone with a typed
+`agent_*` reason. The decision is recorded **before** the provider is called and the emission is not
+wrapped in a try/catch, so an execution that cannot be audited does not run. What the events carry
+is deliberately narrow: the registry-resolved operation id, an `agent:<role>` actor label, the
+outcome, the reason code, the elapsed time and the correlation id — never the statement, the
+agent-supplied operation id, the session identifier or a driver message. Results live in an
+in-process artifact store released with the run (TTL and an entry cap are backstops), so no agent
+result is written at rest. **Partial** for the same two reasons as 3.4: no route reaches this layer
+yet, and the in-app ring buffer is per-process — the stdout line remains the authoritative record.
 
 ## Known limits
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -42,6 +42,7 @@ Two consequences worth stating before the table:
 | 3.1 | Credentials are encrypted at rest in the server-side store | Implemented | [`src/lib/storage/encryption.ts`](../src/lib/storage/encryption.ts), [`src/lib/storage/connection-secrets.ts`](../src/lib/storage/connection-secrets.ts), [`src/lib/storage/encrypting-provider.ts`](../src/lib/storage/encrypting-provider.ts), [`src/lib/storage/factory.ts`](../src/lib/storage/factory.ts) | [`tests/security/credential-at-rest.test.ts`](../tests/security/credential-at-rest.test.ts), [`tests/isolated/factory-singleton.test.ts`](../tests/isolated/factory-singleton.test.ts), [`tests/integration/storage/sqlite-credential-encryption.test.ts`](../tests/integration/storage/sqlite-credential-encryption.test.ts) |
 | 3.2 | Every authoritative (server-generated) audit event is emitted as one structured JSON line on stdout | Implemented | [`src/lib/audit.ts`](../src/lib/audit.ts) | [`tests/security/audit-redaction.test.ts`](../tests/security/audit-redaction.test.ts), [`tests/security/audit-type-safety.test.ts`](../tests/security/audit-type-safety.test.ts) |
 | 3.3 | This page is checked against the repository on every build | Implemented | [`scripts/security-check.mjs`](../scripts/security-check.mjs) | [`tests/unit/security-check.test.ts`](../tests/unit/security-check.test.ts) |
+| 3.4 | A statement submitted on the agent execution path cannot write, change schema, reach another database, load code, or run the executing form of EXPLAIN | Partial | [`src/lib/db/operations/policy.ts`](../src/lib/db/operations/policy.ts), [`src/lib/db/operations/statement-guard.ts`](../src/lib/db/operations/statement-guard.ts), [`src/lib/db/providers/sql/postgres.ts`](../src/lib/db/providers/sql/postgres.ts), [`src/lib/db/providers/sql/sqlite.ts`](../src/lib/db/providers/sql/sqlite.ts) | [`tests/security/agent-statement-boundary.test.ts`](../tests/security/agent-statement-boundary.test.ts), [`tests/integration/db/postgres-provider.test.ts`](../tests/integration/db/postgres-provider.test.ts), [`tests/integration/db/sqlite-provider.test.ts`](../tests/integration/db/sqlite-provider.test.ts) |
 
 ## Notes on individual rows
 
@@ -75,6 +76,16 @@ close that gap; `postgres` deployments do not share this exposure by default. Fu
 **3.2.** `POST /api/admin/audit` is the one writer that reaches the in-app buffer without reaching
 stdout, and that is deliberate: its body is client-supplied, so giving it the authoritative channel
 would let an admin session forge an indistinguishable log line.
+
+**3.4.** WRITES are refused by the database itself — a PostgreSQL read-only transaction carrying
+exactly one statement, run by a role verified at open to hold neither superuser nor any
+server-file/program privilege (a read-only transaction does not stop `COPY … TO PROGRAM`); and a
+separate SQLite read-only open with `PRAGMA query_only` re-asserted before every statement. Reading
+the SQL is defense in depth only, never the boundary. **Partial** for two reasons: out-of-scope
+READS have no database-native control on either provider (only the declared-target allowlist, the
+statement guard, and whatever the role's grants bound — see
+[`docs/BACKLOG.md`](./BACKLOG.md) A3), and no route or agent runtime reaches this layer yet, so it
+governs nothing in a shipped release until the agent surface lands.
 
 ## Known limits
 

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -348,19 +348,21 @@ nothing to switch on and nothing to configure.
 
 ### What is encrypted
 
-Six fields, all on a saved connection:
+Seven fields, all on a saved connection:
 
 | Field | What it is |
 |-------|------------|
 | `password` | The database password |
 | `connectionString` | A URL that can embed `user:password@` |
+| `agentPassword` | The optional least-privilege agent-profile password (#328) |
 | `ssl.clientKey` | The TLS client private key |
 | `sshTunnel.password` | The SSH password |
 | `sshTunnel.privateKey` | The SSH private key |
 | `sshTunnel.passphrase` | The passphrase that unlocks the key above |
 
-Everything else stays readable, deliberately: `host`, `port`, `user`, `database`, `name` and the
-TLS certificates (`ssl.caCert`, `ssl.clientCert` — certificates are public by construction). An
+Everything else stays readable, deliberately: `host`, `port`, `user`, `agentUser`, `database`,
+`name` and the TLS certificates (`ssl.caCert`, `ssl.clientCert` — certificates are public by
+construction). An
 operator holding a dump has to be able to answer "which of my databases is in here"; that is
 incident response, not a leak. No other collection is touched — `history` and `saved_queries` hold
 SQL text, which is the product's data rather than its secrets.

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -17,6 +17,7 @@
 | **Connection string** | Supported (`postgres://` / `postgresql://`) |
 | **Transactions** | Yes — explicit `BEGIN`/`COMMIT`/`ROLLBACK` with auto-rollback timeout |
 | **Query cancellation** | Yes — PID tracking + `pg_cancel_backend` |
+| **Agent read-only profile** | Yes — `BEGIN READ ONLY` + extended-protocol single statement (#328, §12) |
 | **Source** | [`src/lib/db/providers/sql/postgres.ts`](../../src/lib/db/providers/sql/postgres.ts) |
 | **Base** | [`src/lib/db/providers/sql/sql-base.ts`](../../src/lib/db/providers/sql/sql-base.ts) |
 | **Tests** | [`tests/integration/db/postgres-provider.test.ts`](../../tests/integration/db/postgres-provider.test.ts) |
@@ -502,9 +503,71 @@ syntax errors.
 
 ---
 
-## 12. Testing
+## 12. Agent read-only execution profile (#328)
 
-### 12.1 How the tests work
+The agent programme (epic #325) never talks to the shared, fully-privileged provider. It acquires
+a **dedicated provider keyed by (connection id, execution profile)** and runs every statement
+through `queryReadOnly()`, where the DATABASE — not a SQL parser — is the boundary.
+
+### 12.1 Acquisition (`acquireExecutionProfileProvider`, [factory.ts](../../src/lib/db/factory.ts))
+
+- The profiled cache is physically separate from `getOrCreateProvider`'s cache: an agent
+  acquisition never returns, inserts, or touches a shared writable entry (unit-tested in both
+  directions), so an agent execution can never be handed the editor's pool — and vice versa.
+- Provider types without a database-native read-only wrapper are refused with
+  `PROFILE_UNSUPPORTED_BY_PROVIDER`; there is no fallback to `query()`.
+- Optional least-privilege credential: `agentUser` / `agentPassword` on the connection
+  (`agentPassword` is secret-classified and sealed at rest by
+  [connection-secrets](../../src/lib/storage/connection-secrets.ts)). Resolution fails closed:
+
+  | Configuration | Outcome |
+  |---|---|
+  | Neither field set | Connection's own credentials, still inside the read-only transaction |
+  | Both set, password resolves | Profile pool authenticates as `agentUser` |
+  | Only one field set | `AGENT_CREDENTIAL_UNRESOLVABLE` — never a silent fallback to the more privileged default |
+  | Sealed password that does not open | `AGENT_CREDENTIAL_UNRESOLVABLE` |
+  | Combined with `connectionString` | `AGENT_CREDENTIAL_WITH_CONNECTION_STRING` — the pool config would silently drop the credential |
+
+- Lifecycle: profiled providers idle out on the same 30-minute sweep, are removed alongside
+  `removeProvider(connectionId)`, and share the connection's SSH tunnel (closed only once nothing
+  serves the connection anymore).
+
+### 12.2 Per-statement execution (`queryReadOnly`, [postgres.ts](../../src/lib/db/providers/sql/postgres.ts))
+
+Each call runs:
+
+```sql
+BEGIN READ ONLY;
+SET LOCAL statement_timeout = <budget.statementTimeoutMs>;  -- dies with the transaction
+-- the single statement, sent on the extended query protocol
+ROLLBACK;                                                   -- always; the profile never commits
+```
+
+Two server-enforced properties carry the security claim:
+
+1. **Writes are rejected by PostgreSQL itself** (SQLSTATE `25006`, *cannot execute … in a
+   read-only transaction*). No SQL classification happens in this path.
+2. **Single-statement is protocol-enforced**: the statement is sent with `queryMode: 'extended'`
+   (pg ≥ 8.11), and the server refuses multi-command strings in a Parse message (SQLSTATE `42601`)
+   before executing anything — so `SELECT 1; COMMIT; INSERT …` cannot commit its way out of the
+   read-only transaction the way it could on the simple protocol.
+
+A lone hostile statement cannot escape either: `SET TRANSACTION READ WRITE` would be the
+transaction's only statement before `ROLLBACK`; a session-level `SET` reverts with the rollback
+(GUC changes are transactional); a bare `COMMIT` merely ends an empty read-only transaction. A
+client whose `ROLLBACK` fails is destroyed (`release(error)`), never returned to the pool
+mid-transaction.
+
+The `ReadOnlyStatementBudget` (`statementTimeoutMs`, `maxResultRows`, `maxResultBytes`,
+[types.ts](../../src/lib/db/types.ts)) is validated as positive integers before any client is
+acquired — the timeout is interpolated into `SET LOCAL`, which takes no bind parameters — and the
+row/byte caps are enforced result-side after the statement returns.
+
+---
+
+## 13. Testing
+
+### 13.1 How the tests work
 
 Integration tests live in
 [`tests/integration/db/postgres-provider.test.ts`](../../tests/integration/db/postgres-provider.test.ts).
@@ -521,7 +584,7 @@ server.
 > process isolation via `tests/run-core.sh`); the coverage workflow uses `bun run test:coverage`
 > (also per-file). See [`CLAUDE.md`](../../CLAUDE.md).
 
-### 12.2 Coverage
+### 13.2 Coverage
 
 The suite (60+ tests) covers: validation (incl. connection-string bypass), connect/disconnect
 idempotency, **every SSL precedence branch**, query + PID tracking + error mapping, query
@@ -533,7 +596,7 @@ formatting, performance (incl. checkpoint fallback), slow queries (extension + `
 fallback), active sessions,
 table/index/storage stats, pool stats, capabilities, and `pg_stat_activity` passthrough.
 
-### 12.3 Run it
+### 13.3 Run it
 
 ```bash
 bun test tests/integration/db/postgres-provider.test.ts   # just this file (single process — safe)
@@ -541,7 +604,7 @@ bun run test:ci                                            # CI publish gate —
 bun run test:coverage                                      # CI coverage workflow — per-file core + components
 ```
 
-### 12.4 Optional: verifying against a live PostgreSQL
+### 13.4 Optional: verifying against a live PostgreSQL
 
 The committed tests are mock-based by design. To smoke-test against a real server:
 
@@ -554,9 +617,9 @@ The E2E suite (`e2e/`) has been verified against PostgreSQL 18.x.
 
 ---
 
-## 13. Usage examples
+## 14. Usage examples
 
-### 13.1 Programmatic (via the factory)
+### 14.1 Programmatic (via the factory)
 
 ```ts
 import { createDatabaseProvider } from '@/lib/db/factory';
@@ -574,7 +637,7 @@ const rels = await provider.getSchemaRelations();      // FKs + indexes to merge
 await provider.disconnect();
 ```
 
-### 13.2 Over the API
+### 14.2 Over the API
 
 - `POST /api/db/query` — run SQL (see [`API_DOCS.md`](../API_DOCS.md#post-apidbquery)).
 - `POST /api/db/schema/list` and `POST /api/db/schema/relations` — two-phase schema.
@@ -584,7 +647,7 @@ await provider.disconnect();
 
 ---
 
-## 14. Known limitations & future work
+## 15. Known limitations & future work
 
 - **`transactionsPerSecond` / `queriesPerSecond` are not reported** (`undefined`) — they require
   time-based sampling of `pg_stat_database`, which the single-shot metric call doesn't do.
@@ -604,7 +667,7 @@ await provider.disconnect();
 
 ---
 
-## 15. References
+## 16. References
 
 - Driver: [`pg` (node-postgres)](https://github.com/brianc/node-postgres)
 - Source: [`src/lib/db/providers/sql/postgres.ts`](../../src/lib/db/providers/sql/postgres.ts)

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -515,7 +515,11 @@ through `queryReadOnly()`, where the DATABASE — not a SQL parser — is the bo
   acquisition never returns, inserts, or touches a shared writable entry (unit-tested in both
   directions), so an agent execution can never be handed the editor's pool — and vice versa.
 - Provider types without a database-native read-only wrapper are refused with
-  `PROFILE_UNSUPPORTED_BY_PROVIDER`; there is no fallback to `query()`.
+  `PROFILE_UNSUPPORTED_BY_PROVIDER`; there is no fallback to `query()`. A provider that supports the
+  profile but cannot apply it to *this* target refuses with `PROFILE_UNSUPPORTED_TARGET` (SQLite
+  does this for `:memory:` — see [sqlite.md §12.3](./sqlite.md#123-per-statement-execution-queryreadonly)).
+  Every refusal is an `ExecutionProfileError` carrying an `ExecutionProfileDenyCode`
+  ([errors.ts](../../src/lib/db/errors.ts)), so callers branch on the code, never on a message.
 - Optional least-privilege credential: `agentUser` / `agentPassword` on the connection
   (`agentPassword` is secret-classified and sealed at rest by
   [connection-secrets](../../src/lib/storage/connection-secrets.ts)). Resolution fails closed:

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -520,13 +520,16 @@ through `queryReadOnly()`, where the DATABASE — not a SQL parser — is the bo
   does this for `:memory:` — see [sqlite.md §12.3](./sqlite.md#123-per-statement-execution-queryreadonly)).
   Every refusal is an `ExecutionProfileError` carrying an `ExecutionProfileDenyCode`
   ([errors.ts](../../src/lib/db/errors.ts)), so callers branch on the code, never on a message.
+- **The role is verified at open, not assumed** (see §12.3): a profile provider only connects if
+  its role is genuinely least-privilege. This applies whichever credential resolves below, because
+  an `agentUser` can be pointed at a superuser just as easily as a connection's own user can be one.
 - Optional least-privilege credential: `agentUser` / `agentPassword` on the connection
   (`agentPassword` is secret-classified and sealed at rest by
   [connection-secrets](../../src/lib/storage/connection-secrets.ts)). Resolution fails closed:
 
   | Configuration | Outcome |
   |---|---|
-  | Neither field set | Connection's own credentials, still inside the read-only transaction |
+  | Neither field set | Connection's own credentials — which must themselves pass the role check in §12.3 |
   | Both set, password resolves | Profile pool authenticates as `agentUser` |
   | Only one field set | `AGENT_CREDENTIAL_UNRESOLVABLE` — never a silent fallback to the more privileged default |
   | Sealed password that does not open | `AGENT_CREDENTIAL_UNRESOLVABLE` |
@@ -545,7 +548,14 @@ BEGIN READ ONLY;
 SET LOCAL statement_timeout = <budget.statementTimeoutMs>;  -- dies with the transaction
 -- the single statement, sent on the extended query protocol
 ROLLBACK;                                                   -- always; the profile never commits
+DISCARD ALL;                                                -- session state a rollback keeps
 ```
+
+`DISCARD ALL` is there because a rollback is not a full reset: an advisory lock taken inside the
+transaction survives it (verified on PostgreSQL 18), and nothing on the agent path is *required* to
+release one, so a pooled client would otherwise carry it into every later execution. It runs after the
+rollback because it cannot run inside a transaction block. A client that fails either step is
+destroyed rather than returned to the pool.
 
 Two server-enforced properties carry the security claim:
 
@@ -556,16 +566,71 @@ Two server-enforced properties carry the security claim:
    before executing anything — so `SELECT 1; COMMIT; INSERT …` cannot commit its way out of the
    read-only transaction the way it could on the simple protocol.
 
-A lone hostile statement cannot escape either: `SET TRANSACTION READ WRITE` would be the
-transaction's only statement before `ROLLBACK`; a session-level `SET` reverts with the rollback
-(GUC changes are transactional); a bare `COMMIT` merely ends an empty read-only transaction. A
-client whose `ROLLBACK` fails is destroyed (`release(error)`), never returned to the pool
-mid-transaction.
+A lone hostile statement cannot escape either — and the first of these is not theoretical:
+`SET TRANSACTION READ WRITE` **is accepted inside `BEGIN READ ONLY` and does relax the transaction**
+(verified on 18: a following `INSERT` committed), so what contains it is that it can only ever be
+the transaction's only statement before the `ROLLBACK`. A session-level `SET` reverts with the
+rollback (GUC changes are transactional); a bare `COMMIT` merely ends an empty read-only
+transaction. A client whose cleanup fails is destroyed (`release(error)`), never returned to the
+pool mid-transaction.
 
 The `ReadOnlyStatementBudget` (`statementTimeoutMs`, `maxResultRows`, `maxResultBytes`,
 [types.ts](../../src/lib/db/types.ts)) is validated as positive integers before any client is
 acquired — the timeout is interpolated into `SET LOCAL`, which takes no bind parameters — and the
 row/byte caps are enforced result-side after the statement returns.
+
+`queryReadOnly()` exists only on a provider opened under the profile: called on an ordinary
+provider it throws, because such a provider has had no role verification and would serve agent
+semantics without the boundary that makes them true.
+
+### 12.3 What the read-only transaction does NOT cover — and the role that does
+
+A read-only transaction forbids changing the **database**. It does not forbid a statement from
+reaching the **server**. Verified on PostgreSQL 18, all three of these succeeded inside
+`BEGIN READ ONLY` as a superuser:
+
+| Statement | What it did |
+|---|---|
+| `COPY (…) TO '<path>'` | wrote query results to an arbitrary server-side file |
+| `COPY (…) TO PROGRAM '<cmd>'` | ran a shell command as the server's OS user |
+| `SELECT pg_read_file('<path>')` | read an arbitrary server-side file |
+
+As a role with only `CONNECT`/`USAGE`/`SELECT`, the same three are refused — by **privileges**
+(`pg_write_server_files`, `pg_execute_server_program`, `pg_read_server_files` or superuser), not by
+the transaction. Two consequences the profile implements rather than documents as advice:
+
+1. **Opening the profile probes the role** and refuses with `PROFILE_PRIVILEGES_TOO_BROAD` unless
+   superuser and all three predefined-role memberships read back false
+   (`assertAgentRoleIsUnprivileged`, [postgres.ts](../../src/lib/db/providers/sql/postgres.ts)). The
+   probe uses `to_regrole`, so a server missing a predefined role answers `false` rather than
+   erroring. A server that answers nothing, or answers non-booleans, is refused too — an unproven
+   boundary is not a boundary.
+
+   What the probe proves is **non-membership and non-superuser**, not the absence of the capability:
+   a role directly granted `EXECUTE` on `pg_read_file()` answers false to all four flags and can
+   still read server files. That is why the recipe below says grant nothing else. The probe also
+   runs **once, at open** — a profiled provider stays cached until the idle sweep, so a role granted
+   new privileges afterwards keeps serving from the already-verified pool until it is evicted or
+   `removeProvider` runs.
+2. **`SET TRANSACTION READ WRITE` really works** inside `BEGIN READ ONLY` (also verified on 18: the
+   following `INSERT` committed). What contains it is that it can only ever be the transaction's
+   ONLY statement, after which the profile rolls back — so the single-statement rule in §12.2 is
+   load-bearing, not decorative.
+
+Recommended role for an agent target:
+
+```sql
+CREATE ROLE libredb_agent LOGIN PASSWORD '<secret>';
+GRANT CONNECT ON DATABASE <db> TO libredb_agent;
+GRANT USAGE ON SCHEMA <schema> TO libredb_agent;
+GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO libredb_agent;
+-- Grant nothing else. In particular do NOT grant pg_read_server_files,
+-- pg_write_server_files, pg_execute_server_program, or superuser.
+```
+
+Per-table `SELECT` grants are also what bound which rows an agent can READ: the policy layer's
+catalog/schema allowlist screens the *declared* target, and only the grants bound what a hostile
+statement could reach instead.
 
 ---
 

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -604,7 +604,10 @@ the transaction. Two consequences the profile implements rather than documents a
    (`assertAgentRoleIsUnprivileged`, [postgres.ts](../../src/lib/db/providers/sql/postgres.ts)). The
    probe uses `to_regrole`, so a server missing a predefined role answers `false` rather than
    erroring. A server that answers nothing, or answers non-booleans, is refused too — an unproven
-   boundary is not a boundary.
+   boundary is not a boundary. Every catalog function the probe calls is written `pg_catalog`-
+   qualified: `pg_catalog` is searched implicitly first only while it is not named in `search_path`,
+   so a path that names it explicitly behind another schema lets a shadow `pg_has_role()` answer
+   false for a superuser and defeat this check.
 
    What the probe proves is **non-membership and non-superuser**, not the absence of the capability:
    a role directly granted `EXECUTE` on `pg_read_file()` answers false to all four flags and can

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -20,6 +20,7 @@
 | **Transactions** | ❌ no explicit begin/commit/rollback API |
 | **Query cancellation** | ❌ none (synchronous, embedded) |
 | **Pooling** | ❌ none (single connection) |
+| **Agent read-only profile** | Yes — separate read-only OPEN (no file create) + verified `query_only` (#328, §12) |
 | **Source** | [`src/lib/db/providers/sql/sqlite.ts`](../../src/lib/db/providers/sql/sqlite.ts) |
 | **Tests** | [`tests/integration/db/sqlite-provider.test.ts`](../../tests/integration/db/sqlite-provider.test.ts) |
 
@@ -128,12 +129,16 @@ The driver is imported lazily via `loadSQLiteDriver()`
 ### Registration
 
 ```ts
-// factory.ts:72
+// factory.ts
 case "sqlite": {
   const { SQLiteProvider } = await import("./providers/sql/sqlite");
-  return new SQLiteProvider(connection, options);
+  return new SQLiteProvider(connection, options, execution);
 }
 ```
+
+`execution` is the server-injected [`ProviderExecutionContext`](../../src/lib/db/types.ts) — empty
+on the normal path, and carrying the read-only flag only when
+`acquireExecutionProfileProvider` builds an agent provider ([§12](#12-agent-read-only-execution-profile-328)).
 
 ---
 
@@ -159,7 +164,9 @@ directories are created on connect.
 `connect()` opens the file with `{ create: true, readwrite: true }` and sets
 `PRAGMA foreign_keys = ON`, `journal_mode = WAL`, `synchronous = NORMAL`
 ([sqlite.ts:104](../../src/lib/db/providers/sql/sqlite.ts)) — FK enforcement on, WAL for better
-concurrency, NORMAL sync for a speed/durability balance.
+concurrency, NORMAL sync for a speed/durability balance. The agent read-only profile runs a
+different open sequence entirely — `journal_mode = WAL` is itself a write and fails on a read-only
+handle ([§12.1](#121-where-the-boundary-is)).
 
 ### 3.3 Read vs write dispatch
 
@@ -399,11 +406,14 @@ SQLite is the **only** provider whose integration tests run against a **real eng
 - **bun driver** — the main suite opens a `bun:sqlite` **`:memory:`** database in-process (tests
   run under Bun).
 - **node driver** — Bun cannot load any non-bun SQLite driver in-process, so the core CRUD /
-  schema / maintenance / error-mapping cases run in a real **`node` subprocess**:
+  schema / maintenance / error-mapping cases **and the agent read-only profile contract** run in a
+  real **`node` subprocess**:
   [`sqlite-node-harness.ts`](../../tests/integration/db/sqlite-node-harness.ts) is bundled with
   `bun build --target=node` and executed with `LIBREDB_SQLITE_DRIVER=node` against a temp on-disk
-  file (`mkdtempSync`). The subprocess test skips (with a warning) if `node` with `node:sqlite` is
-  unavailable.
+  file (`mkdtempSync`), reporting its results as JSON on stdout. The subprocess test skips (with a
+  warning) if `node` with `node:sqlite` is unavailable. This subprocess is the only place an
+  adapter that accepted the read-only open flag and ignored it would be caught, so the profile
+  cases are duplicated there deliberately rather than trusted from the bun run.
 - **driver selection** — `resolveSQLiteDriverName()` is tested directly (runtime default, `bun`/
   `node` overrides, invalid-value fallback), restoring `LIBREDB_SQLITE_DRIVER` after each test.
 
@@ -419,7 +429,12 @@ SQL execution, schema PRAGMAs, maintenance, and monitoring end-to-end.
 Validation, connect/disconnect, path handling (NUL rejection, `..` acceptance), query (read +
 write), capabilities, `getSchema` (columns/PKs/FKs/indexes), health, maintenance
 (vacuum/analyze/reindex/check), overview, performance, active sessions, slow queries,
-table/index/storage stats, `getMonitoringData`, `prepareQuery`, and labels.
+table/index/storage stats, `getMonitoringData`, `prepareQuery`, and labels. For the agent profile
+([§12](#12-agent-read-only-execution-profile-328)): rejected write / schema change / file create,
+`query_only` read-back, the pragma-bypass case, row/byte/time budgets, multi-statement tail
+suppression, `:memory:` refusal, and the refusal to run `queryReadOnly` on a writable handle — each
+asserted behaviorally (did the write land? does the file exist?) rather than by driver error code,
+since bun and node report read-only violations differently.
 
 ### 11.3 Run it
 
@@ -431,7 +446,94 @@ bun run test:coverage                                    # CI coverage workflow
 
 ---
 
-## 12. Usage examples
+## 12. Agent read-only execution profile (#328)
+
+The agent programme (epic #325) never talks to the shared, writable provider. It acquires a
+**dedicated provider keyed by (connection id, execution profile)** via
+`acquireExecutionProfileProvider` ([factory.ts](../../src/lib/db/factory.ts)) and runs every
+statement through `queryReadOnly()`. See [postgres.md §12](./postgres.md#12-agent-read-only-execution-profile-328)
+for the acquisition/caching rules, which are provider-independent; this section is the SQLite half.
+
+### 12.1 Where the boundary is
+
+PostgreSQL establishes read-only enforcement **per transaction**. SQLite has no such construct, so
+it is established **at open time** instead — the profile opens a second, physically separate handle
+to the same file with SQLite's own read-only flag (`readonly` under bun:sqlite, `readOnly` under
+node:sqlite; the [driver adapter](../../src/lib/db/providers/sql/sqlite-driver.ts) maps between
+them). Every write and DDL against the target database is refused by the engine, and a missing file
+is not created — with no SQL inspected on the way.
+
+The read-only open governs **the target database file, and only that file**. It does not stop a
+statement that writes to a *different* file: `VACUUM INTO '<path>'` copies the whole database to an
+arbitrary server path from a read-only handle on both adapters. That route is closed by the second
+control below, which is why the profile does not rest on the open alone.
+
+Because the flag is an open option rather than a runtime call, the intent has to reach the
+constructor. It travels in `ProviderExecutionContext` ([types.ts](../../src/lib/db/types.ts)) — a
+*server-injected* third constructor argument, deliberately **not** a member of `ProviderOptions`:
+that object is caller-supplied and flows into `getOrCreateProvider`, so a profile flag living there
+could be set — or cleared — by whoever assembles options for a request. Only
+`acquireExecutionProfileProvider` passes it, and a test pins that the shared path stays writable
+when a caller tries to smuggle the flag through options.
+
+The read-only open deliberately skips the shared `connect()` sequence
+([§3.2](#32-pragmas-on-connect)): no parent directory is created, no `create` flag is passed, and
+the `journal_mode = WAL` pragma — itself a write, which fails outright on a read-only handle — is
+not run. None of it applies to a connection that cannot write.
+
+### 12.2 `query_only`, re-asserted before every statement
+
+A read-only open does **not** imply `PRAGMA query_only`: it reads back `0` on both adapters until
+set explicitly. The profile sets it and verifies the read-back — at open *and before every
+statement* — refusing the handle otherwise (`assertQueryOnlyEnabled`).
+
+Per statement, not once at open, for two reasons. The profiled provider is **pooled and reused**
+across an agent run, and a statement is free to run `PRAGMA query_only = false` (nothing parses
+it), which would otherwise persist for every later call on that connection. Re-asserting closes
+that: `prepare()` compiles exactly one statement, so the disable and the write it would enable can
+never ride in the same call, and the next call re-enables the pragma before running anything.
+
+So the two controls cover different ground and neither is redundant — the open refuses writes to
+the target database, `query_only` refuses writes to anything else. The suite asserts both,
+including the `VACUUM INTO` case with `query_only` deliberately disabled first.
+
+**Known limitation — empty files at an agent-chosen path.** SQLite creates the destination file
+*before* refusing the `VACUUM INTO` copy, so an agent can still cause a zero-byte file to appear at
+any path the server process can write to. No data reaches it (asserted on both adapters by file
+size, not by existence). Closing this would need an authorizer callback, which `bun:sqlite` does
+not expose at all.
+
+### 12.3 Per-statement execution (`queryReadOnly`)
+
+| Budget field | How SQLite honors it |
+|---|---|
+| `maxResultRows` | Result-side: rows are counted after execution; over budget throws, never truncates |
+| `maxResultBytes` | Result-side, same rule (serialized size) |
+| `statementTimeoutMs` | **Post-execution deadline only** — see the limitation below |
+
+Statements are compiled with `prepare()`, never `exec()`. `exec()` runs *every* statement of a
+multi-statement string; `prepare()` compiles only the first and drops the tail, so a smuggled
+trailing write is never executed. Rejecting multi-statement input outright remains the policy
+pipeline's job — silent truncation is not treated as a pass.
+
+An in-memory (`:memory:`) target is refused under this profile: a read-only open of an anonymous
+database can only ever yield an empty one (node:sqlite) or fail outright (bun:sqlite), so vending
+it would hand the agent a silently useless target. The refusal is an `ExecutionProfileError` with
+reason code **`PROFILE_UNSUPPORTED_TARGET`** ([errors.ts](../../src/lib/db/errors.ts)) — the same
+typed deny surface acquisition uses for `UNSUPPORTED_PROFILE` /
+`PROFILE_UNSUPPORTED_BY_PROVIDER`, so a caller can branch on the code instead of a message, and
+`connect()` deliberately does not wrap it into a generic `ConnectionError`.
+
+**Known limitation — the timeout cannot preempt.** SQLite has no transaction-local statement
+timeout, and neither adapter exposes `sqlite3_interrupt` or a progress handler. `statementTimeoutMs`
+is therefore enforced as a deadline *check*: an overrunning statement runs to completion and its
+result is then refused, rather than being returned as if it had been within budget. Since the
+drivers are synchronous, such a statement also blocks the runtime while it runs — the same property
+as the normal SQLite query path ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
+
+---
+
+## 13. Usage examples
 
 ```ts
 import { createDatabaseProvider } from '@/lib/db/factory';
@@ -453,7 +555,7 @@ not apply to SQLite ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
 
 ---
 
-## 13. Known limitations & future work
+## 14. Known limitations & future work
 
 - **Server-local file only.** No network protocol; a hosted/SaaS user cannot reach a SQLite file on
   their own machine. SQLite-as-target suits self-hosted / local-dev / edge and zero-config trials.
@@ -485,7 +587,7 @@ not apply to SQLite ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
 
 ---
 
-## 14. References
+## 15. References
 
 - Drivers: [`bun:sqlite`](https://bun.sh/docs/api/sqlite) (Bun built-in) · [`node:sqlite`](https://nodejs.org/api/sqlite.html) (Node built-in)
 - Driver adapter: [`src/lib/db/providers/sql/sqlite-driver.ts`](../../src/lib/db/providers/sql/sqlite-driver.ts)

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -524,6 +524,18 @@ typed deny surface acquisition uses for `UNSUPPORTED_PROFILE` /
 `PROFILE_UNSUPPORTED_BY_PROVIDER`, so a caller can branch on the code instead of a message, and
 `connect()` deliberately does not wrap it into a generic `ConnectionError`.
 
+**Known limitation — `ATTACH` contains writes, not reads.** Attaching a *missing* file fails and
+creates nothing, and an *existing* file attaches with the read-only mode inherited, so writes
+through it are refused (both asserted in the integration suite). Its **rows do become readable**,
+and neither adapter offers a database-native control that would stop that — `bun:sqlite` exposes no
+authorizer callback at all, and `node:sqlite`'s `setAuthorizer` is therefore not usable as a
+cross-adapter control. Out-of-scope reads through `ATTACH` are consequently held off by the
+input-stage denial in the operations layer
+([statement-guard.ts](../../src/lib/db/operations/statement-guard.ts)) — defense in depth carrying a
+gap the engine leaves, which is the honest description rather than a boundary claim. Residual risk:
+a statement that reached the profile with that layer bypassed could read any SQLite file the server
+process can open.
+
 **Known limitation — the timeout cannot preempt.** SQLite has no transaction-local statement
 timeout, and neither adapter exposes `sqlite3_interrupt` or a progress handler. `statementTimeoutMs`
 is therefore enforced as a deadline *check*: an overrunning statement runs to completion and its

--- a/scripts/security-check.mjs
+++ b/scripts/security-check.mjs
@@ -60,6 +60,7 @@ export const PROGRAMME_CONTROL_IDS = [
   "3.2",
   "3.3",
   "3.4",
+  "3.5",
 ];
 
 export const STATUSES = new Set(["Implemented", "Partial", "Not implemented"]);

--- a/scripts/security-check.mjs
+++ b/scripts/security-check.mjs
@@ -59,6 +59,7 @@ export const PROGRAMME_CONTROL_IDS = [
   "3.1",
   "3.2",
   "3.3",
+  "3.4",
 ];
 
 export const STATUSES = new Set(["Implemented", "Partial", "Not implemented"]);

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,7 +34,7 @@ sonar.sourceEncoding=UTF-8
 # TestDataGenerator: Math.random there only produces fake sample rows (names,
 # addresses, lorem ipsum) to populate dev/test tables. No security, crypto, or
 # token use, so a CSPRNG is unwarranted. Suppress the rule for that file only.
-sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria=e1,e2,e3
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S2245
 sonar.issue.ignore.multicriteria.e1.resourceKey=src/components/TestDataGenerator.tsx
 
@@ -45,3 +45,11 @@ sonar.issue.ignore.multicriteria.e1.resourceKey=src/components/TestDataGenerator
 # localeCompare would be a bug. Suppress S2871 for this file only.
 sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S2871
 sonar.issue.ignore.multicriteria.e2.resourceKey=src/lib/schema-diff/diff-engine.ts
+
+# Same rule, same reason, in the agent operation registry: registeredIds() sorts
+# internal operation ids for a deterministic enumeration that tests assert by
+# exact array equality. Nothing here is user-facing text, and localeCompare would
+# make the order depend on the host locale, so it would be a bug rather than a
+# fix. Suppress S2871 for this file only.
+sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S2871
+sonar.issue.ignore.multicriteria.e3.resourceKey=src/lib/db/operations/registry.ts

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -8,6 +8,14 @@ export type AuditEventType =
   | "connection_test"
   | "query_execution"
   | "managed_connection"
+  /**
+   * An agent-path operation: one event for the policy decision and, when that
+   * decision allowed execution, one for its outcome. Distinct from
+   * `query_execution` on purpose — an operator filtering the log needs to
+   * separate what a human ran in the editor from what an agent was permitted
+   * to run (#328).
+   */
+  | "agent_operation"
   // Phase 1 auth events
   | "login_success"
   | "login_failure"
@@ -31,7 +39,29 @@ export type AuditReason =
   | "oidc_state_invalid"
   | "oidc_no_claims"
   | "oidc_failed"
-  | "oidc_config";
+  | "oidc_config"
+  // Agent execution path (#328). The thirteen `agent_*` codes below mirror
+  // `PolicyDenyCode` one-for-one, plus the two outcomes that are not policy
+  // denials: an operation that may only ever require approval, and a provider
+  // that failed after the decision allowed it. The mirror is not maintained by
+  // hand — `DENY_REASONS` in src/lib/db/operations/execution.ts is typed
+  // `Record<PolicyDenyCode, AuditReason>`, so a new deny code with no reason
+  // here, or a reason renamed here, fails to compile.
+  | "agent_unknown_operation"
+  | "agent_ambiguous_operation"
+  | "agent_malformed_policy_context"
+  | "agent_invalid_actor"
+  | "agent_target_out_of_scope"
+  | "agent_input_validation_failed"
+  | "agent_capability_unsupported"
+  | "agent_role_forbidden"
+  | "agent_mode_forbidden"
+  | "agent_risk_exceeds_policy"
+  | "agent_concurrency_budget_exceeded"
+  | "agent_statement_budget_exceeded"
+  | "agent_total_run_budget_exceeded"
+  | "agent_approval_required"
+  | "agent_execution_failed";
 
 export interface AuditEvent {
   id: string;
@@ -57,6 +87,15 @@ export interface AuditEvent {
    * call for a different operator response, but would otherwise read identically.
    */
   bucket?: string;
+  /**
+   * Joins the events of ONE agent execution: the policy decision and, when the
+   * decision allowed it, the execution outcome. Server-generated per execution
+   * (src/lib/db/operations/execution.ts) and opaque — it identifies an
+   * execution, never a session, a user or a token, so it stays safe to log
+   * while remaining the key an operator groups by. Only `agent_operation`
+   * events set it.
+   */
+  correlationId?: string;
 }
 
 const MAX_EVENTS = 1000;
@@ -346,6 +385,7 @@ interface AuditLogLine {
   connection?: string;
   duration_ms?: number;
   bucket?: string;
+  correlation_id?: string;
 }
 
 function toAuditLine(event: AuditEvent): AuditLogLine {
@@ -362,6 +402,7 @@ function toAuditLine(event: AuditEvent): AuditLogLine {
     ...(event.ip && event.ip !== UNKNOWN_ADDRESS ? { ip: event.ip } : {}),
     ...(event.connectionName ? { connection: event.connectionName } : {}),
     ...(event.bucket ? { bucket: event.bucket } : {}),
+    ...(event.correlationId ? { correlation_id: event.correlationId } : {}),
     // Number.isFinite excludes NaN and +/-Infinity: JSON.stringify(NaN) silently produces `null`,
     // which would flip duration_ms from a number to null for that one line in a contract parsers
     // depend on. Omitting it entirely keeps the field's type stable instead.

--- a/src/lib/db/errors.ts
+++ b/src/lib/db/errors.ts
@@ -147,6 +147,43 @@ export class QueryCancelledError extends DatabaseError {
 }
 
 // ============================================================================
+// Execution-profile errors (#328)
+// ============================================================================
+
+/**
+ * Why an execution-profile acquisition was refused. Every refusal carries one:
+ * a caller that has to parse a message to learn why it was denied cannot fail
+ * closed on the reason.
+ */
+export type ExecutionProfileDenyCode =
+  | "UNSUPPORTED_PROFILE"
+  | "PROFILE_UNSUPPORTED_BY_PROVIDER"
+  | "PROFILE_UNSUPPORTED_TARGET"
+  | "AGENT_CREDENTIAL_UNRESOLVABLE"
+  | "AGENT_CREDENTIAL_WITH_CONNECTION_STRING";
+
+/**
+ * Raised when a provider cannot be vended under a requested execution profile.
+ * It lives here, with the other database errors, rather than in the factory:
+ * providers themselves raise it (SQLite refuses an in-memory target), and a
+ * provider must not have to import the factory to state why it fails closed.
+ *
+ * Kept a plain Error rather than a DatabaseError subclass for now — nothing
+ * maps it to an API response yet, and the route surface that eventually will
+ * (#329+) is where that decision belongs.
+ */
+export class ExecutionProfileError extends Error {
+  constructor(
+    message: string,
+    public readonly reasonCode: ExecutionProfileDenyCode,
+  ) {
+    super(message);
+    this.name = "ExecutionProfileError";
+    Object.setPrototypeOf(this, ExecutionProfileError.prototype);
+  }
+}
+
+// ============================================================================
 // Type Guards
 // ============================================================================
 

--- a/src/lib/db/errors.ts
+++ b/src/lib/db/errors.ts
@@ -159,6 +159,8 @@ export type ExecutionProfileDenyCode =
   | "UNSUPPORTED_PROFILE"
   | "PROFILE_UNSUPPORTED_BY_PROVIDER"
   | "PROFILE_UNSUPPORTED_TARGET"
+  /** The role the profile would run as holds privileges no read-only boundary can contain. */
+  | "PROFILE_PRIVILEGES_TOO_BROAD"
   | "AGENT_CREDENTIAL_UNRESOLVABLE"
   | "AGENT_CREDENTIAL_WITH_CONNECTION_STRING";
 

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -6,7 +6,8 @@
 
 import { type DatabaseProvider, type DatabaseConnection, type ProviderOptions } from "./types";
 import { DatabaseConfigError } from "./errors";
-import { createSSHTunnel, closeSSHTunnel } from "@/lib/ssh/tunnel";
+import { createSSHTunnel, closeSSHTunnel, hasTunnel } from "@/lib/ssh/tunnel";
+import { readSecret } from "@/lib/storage/encryption";
 import { logger } from "@/lib/logger";
 
 // ============================================================================
@@ -145,6 +146,30 @@ interface CachedProvider {
 
 const providerCache = new Map<string, CachedProvider>();
 
+// ============================================================================
+// Execution-profile provider cache (#328)
+// ----------------------------------------------------------------------------
+// Physically separate from providerCache on purpose: an agent acquisition must
+// be able to prove it never read from nor wrote to the shared writable cache.
+// Keyed by (connection id, execution profile).
+// ============================================================================
+
+interface ProfiledCachedProvider extends CachedProvider {
+  connectionId: string;
+}
+
+const profiledProviderCache = new Map<string, ProfiledCachedProvider>();
+
+function profiledCacheKey(connectionId: string, profile: ExecutionProfile): string {
+  return `${profile}::${connectionId}`;
+}
+
+/** True when any provider — shared or profiled — still serves this connection. */
+function connectionStillServed(connectionId: string): boolean {
+  if (providerCache.has(connectionId)) return true;
+  return Array.from(profiledProviderCache.values()).some((entry) => entry.connectionId === connectionId);
+}
+
 /** Idle timeout: evict providers unused for 30 minutes */
 const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 /** Sweep interval: check for idle providers every 5 minutes */
@@ -171,18 +196,46 @@ export async function evictIdleProviders(maxIdleMs: number = IDLE_TIMEOUT_MS): P
         logger.warn(`[DB] Error disconnecting idle provider ${id}`, { connectionId: id, error: String(error) });
       }
       providerCache.delete(id);
-      // Also close SSH tunnel
-      try {
-        await closeSSHTunnel(id);
-      } catch {
-        /* ignore */
+      // Close the shared tunnel only when nothing serves the connection
+      // anymore — a live profiled provider still needs it.
+      if (!connectionStillServed(id)) {
+        try {
+          await closeSSHTunnel(id);
+        } catch {
+          /* ignore */
+        }
       }
       evicted++;
     }
   }
 
-  // Stop sweeping if cache is empty
-  if (providerCache.size === 0 && sweepTimer) {
+  // Profiled providers idle out on the same clock. The tunnel is shared per
+  // connection id, so it is closed only once nothing serves that connection.
+  for (const [key, entry] of profiledProviderCache) {
+    if (now - entry.lastUsed >= maxIdleMs) {
+      logger.info(`[DB] Evicting idle profiled provider: ${key}`);
+      try {
+        await entry.provider.disconnect();
+      } catch (error) {
+        logger.warn(`[DB] Error disconnecting idle profiled provider ${key}`, {
+          connectionId: entry.connectionId,
+          error: String(error),
+        });
+      }
+      profiledProviderCache.delete(key);
+      if (!connectionStillServed(entry.connectionId)) {
+        try {
+          await closeSSHTunnel(entry.connectionId);
+        } catch {
+          /* ignore */
+        }
+      }
+      evicted++;
+    }
+  }
+
+  // Stop sweeping if both caches are empty
+  if (providerCache.size === 0 && profiledProviderCache.size === 0 && sweepTimer) {
     clearInterval(sweepTimer);
     sweepTimer = null;
   }
@@ -223,8 +276,13 @@ export async function getOrCreateProvider(
     return cached.provider;
   }
 
-  // If SSH tunnel is configured, create tunnel first and rewrite connection
+  // If SSH tunnel is configured, create tunnel first and rewrite connection.
+  // createSSHTunnel returns a pre-existing tunnel for the same connection id,
+  // so remember whether this call actually created it — only a fresh tunnel
+  // may be torn down on failure (a pre-existing one may still serve an
+  // execution-profile provider).
   let effectiveConnection = connection;
+  const tunnelPreexisted = hasTunnel(connection.id);
   let tunnel: Awaited<ReturnType<typeof createSSHTunnel>> | null = null;
   if (connection.sshTunnel?.enabled && connection.host && connection.port) {
     tunnel = await createSSHTunnel(connection.id, connection.sshTunnel, connection.host, connection.port);
@@ -241,8 +299,8 @@ export async function getOrCreateProvider(
   try {
     await provider.connect();
   } catch (error) {
-    // Clean up SSH tunnel if provider connect fails to prevent FD leak
-    if (tunnel) {
+    // Clean up a freshly created SSH tunnel if provider connect fails to prevent FD leak
+    if (tunnel && !tunnelPreexisted) {
       await tunnel.close().catch(() => {});
     }
     throw error;
@@ -257,8 +315,144 @@ export async function getOrCreateProvider(
   return provider;
 }
 
+// ============================================================================
+// Execution-profile provider acquisition (#328)
+// ============================================================================
+
 /**
- * Remove a provider from cache and disconnect
+ * The execution profiles this factory can vend. Exactly one exists today; an
+ * unknown profile string is refused, never defaulted (fail closed).
+ */
+export type ExecutionProfile = "agent-read-only";
+
+const EXECUTION_PROFILES: ReadonlySet<string> = new Set<ExecutionProfile>(["agent-read-only"]);
+
+export type ExecutionProfileDenyCode =
+  | "UNSUPPORTED_PROFILE"
+  | "PROFILE_UNSUPPORTED_BY_PROVIDER"
+  | "AGENT_CREDENTIAL_UNRESOLVABLE"
+  | "AGENT_CREDENTIAL_WITH_CONNECTION_STRING";
+
+export class ExecutionProfileError extends Error {
+  constructor(
+    message: string,
+    public readonly reasonCode: ExecutionProfileDenyCode,
+  ) {
+    super(message);
+    this.name = "ExecutionProfileError";
+    Object.setPrototypeOf(this, ExecutionProfileError.prototype);
+  }
+}
+
+/**
+ * Resolves the optional least-privilege agent credential from the connection
+ * (the connection-secrets seam: `agentPassword` may arrive sealed and is
+ * opened with readSecret). Fail closed on every misconfiguration:
+ *
+ * - both fields absent → null (the profile runs under the connection's own
+ *   credentials, still inside the database-native read-only boundary);
+ * - only one field present → deny; a half-configured credential must not
+ *   silently degrade to the more privileged default;
+ * - a sealed password that does not open → deny, never a plaintext fallback;
+ * - combined with a connection string → deny: buildPoolConfig ignores
+ *   user/password fields when a connection string is present, so the
+ *   credential would be silently dropped and the agent would run as the more
+ *   privileged embedded user.
+ */
+function resolveAgentCredential(connection: DatabaseConnection): { user: string; password: string } | null {
+  const { agentUser, agentPassword } = connection;
+  if (agentUser === undefined && agentPassword === undefined) return null;
+  if (connection.connectionString) {
+    throw new ExecutionProfileError(
+      `Connection "${connection.id}" configures an agent credential alongside a connection string; the credential cannot be applied, so acquisition is refused`,
+      "AGENT_CREDENTIAL_WITH_CONNECTION_STRING",
+    );
+  }
+  if (!agentUser || !agentPassword) {
+    throw new ExecutionProfileError(
+      `Connection "${connection.id}" configures an incomplete agent credential (user and password are both required)`,
+      "AGENT_CREDENTIAL_UNRESOLVABLE",
+    );
+  }
+  const read = readSecret(agentPassword);
+  if (read.kind === "undecryptable") {
+    throw new ExecutionProfileError(
+      `Connection "${connection.id}" configures an agent credential that cannot be resolved`,
+      "AGENT_CREDENTIAL_UNRESOLVABLE",
+    );
+  }
+  return { user: agentUser, password: read.value };
+}
+
+/**
+ * Acquire a provider for (connection id, execution profile). Never touches
+ * the shared writable cache in either direction: the profiled provider has
+ * its own keyed lifecycle, so an agent execution can never be handed the
+ * editor's fully-privileged pool, and an editor request can never be handed a
+ * read-only one. Providers whose type has no database-native read-only
+ * wrapper are refused rather than silently served `query()` (fail closed).
+ */
+export async function acquireExecutionProfileProvider(
+  connection: DatabaseConnection,
+  profile: ExecutionProfile,
+  options: ProviderOptions = {},
+): Promise<DatabaseProvider> {
+  if (!EXECUTION_PROFILES.has(profile)) {
+    throw new ExecutionProfileError(`Unknown execution profile: ${String(profile)}`, "UNSUPPORTED_PROFILE");
+  }
+
+  const cacheKey = profiledCacheKey(connection.id, profile);
+  const cached = profiledProviderCache.get(cacheKey);
+  if (cached?.provider.isConnected()) {
+    cached.lastUsed = Date.now();
+    return cached.provider;
+  }
+
+  const credential = resolveAgentCredential(connection);
+  let effectiveConnection: DatabaseConnection = credential
+    ? { ...connection, user: credential.user, password: credential.password }
+    : connection;
+
+  // The SSH tunnel is keyed by connection id and shared with the writable
+  // provider (createSSHTunnel returns the existing one). Only a tunnel this
+  // acquisition freshly created may be torn down on failure.
+  const tunnelPreexisted = hasTunnel(connection.id);
+  let tunnel: Awaited<ReturnType<typeof createSSHTunnel>> | null = null;
+  if (connection.sshTunnel?.enabled && connection.host && connection.port) {
+    tunnel = await createSSHTunnel(connection.id, connection.sshTunnel, connection.host, connection.port);
+    effectiveConnection = { ...effectiveConnection, host: tunnel.localHost, port: tunnel.localPort };
+  }
+
+  const closeFreshTunnel = async () => {
+    if (tunnel && !tunnelPreexisted) await tunnel.close().catch(() => {});
+  };
+
+  const provider = await createDatabaseProvider(effectiveConnection, options);
+  if (typeof provider.queryReadOnly !== "function") {
+    await closeFreshTunnel();
+    throw new ExecutionProfileError(
+      `Provider type "${connection.type}" has no database-native read-only execution profile`,
+      "PROFILE_UNSUPPORTED_BY_PROVIDER",
+    );
+  }
+
+  try {
+    await provider.connect();
+  } catch (error) {
+    await closeFreshTunnel();
+    throw error;
+  }
+
+  profiledProviderCache.set(cacheKey, { provider, lastUsed: Date.now(), connectionId: connection.id });
+  startIdleSweep();
+
+  return provider;
+}
+
+/**
+ * Remove a provider from cache and disconnect. Also removes the connection's
+ * execution-profile providers: a deleted or re-credentialed connection must
+ * not leave a stale agent pool running under the old configuration.
  */
 export async function removeProvider(connectionId: string): Promise<void> {
   const cached = providerCache.get(connectionId);
@@ -272,6 +466,16 @@ export async function removeProvider(connectionId: string): Promise<void> {
     providerCache.delete(connectionId);
   }
 
+  for (const [key, entry] of profiledProviderCache) {
+    if (entry.connectionId !== connectionId) continue;
+    try {
+      await entry.provider.disconnect();
+    } catch (error) {
+      logger.warn(`Error disconnecting profiled provider ${key}`, { connectionId, error: String(error) });
+    }
+    profiledProviderCache.delete(key);
+  }
+
   // Close SSH tunnel if exists
   try {
     await closeSSHTunnel(connectionId);
@@ -281,7 +485,7 @@ export async function removeProvider(connectionId: string): Promise<void> {
 }
 
 /**
- * Clear all cached providers
+ * Clear all cached providers (shared and execution-profile)
  */
 export async function clearProviderCache(): Promise<void> {
   // Stop idle sweep
@@ -299,9 +503,17 @@ export async function clearProviderCache(): Promise<void> {
       }),
     );
   }
+  for (const [key, entry] of profiledProviderCache) {
+    disconnectPromises.push(
+      entry.provider.disconnect().catch((error) => {
+        console.error(`[DB] Error disconnecting profiled provider ${key}:`, error);
+      }),
+    );
+  }
 
   await Promise.all(disconnectPromises);
   providerCache.clear();
+  profiledProviderCache.clear();
 }
 
 /**
@@ -311,6 +523,17 @@ export function getProviderCacheStats(): { size: number; connections: string[] }
   return {
     size: providerCache.size,
     connections: Array.from(providerCache.keys()),
+  };
+}
+
+/**
+ * Execution-profile cache statistics (observability for the isolation
+ * invariant: agent acquisitions must never appear in getProviderCacheStats).
+ */
+export function getExecutionProfileCacheStats(): { size: number; connections: string[] } {
+  return {
+    size: profiledProviderCache.size,
+    connections: Array.from(profiledProviderCache.values(), (entry) => entry.connectionId),
   };
 }
 

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -72,7 +72,7 @@ export async function createDatabaseProvider(
     // SQL Databases - dynamically imported to reduce memory
     case "postgres": {
       const { PostgresProvider } = await import("./providers/sql/postgres");
-      return new PostgresProvider(connection, options);
+      return new PostgresProvider(connection, options, execution);
     }
 
     case "mysql": {

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -4,8 +4,13 @@
  * Uses dynamic imports to reduce memory footprint - providers are loaded on demand
  */
 
-import { type DatabaseProvider, type DatabaseConnection, type ProviderOptions } from "./types";
-import { DatabaseConfigError } from "./errors";
+import {
+  type DatabaseProvider,
+  type DatabaseConnection,
+  type ProviderOptions,
+  type ProviderExecutionContext,
+} from "./types";
+import { DatabaseConfigError, ExecutionProfileError } from "./errors";
 import { createSSHTunnel, closeSSHTunnel, hasTunnel } from "@/lib/ssh/tunnel";
 import { readSecret } from "@/lib/storage/encryption";
 import { logger } from "@/lib/logger";
@@ -20,6 +25,10 @@ import { logger } from "@/lib/logger";
  *
  * @param connection - Database connection configuration
  * @param options - Optional provider options (pooling, timeout, etc.)
+ * @param execution - Server-injected execution context (#328). Never built
+ *   from caller-supplied options; only acquireExecutionProfileProvider passes
+ *   it. Providers whose read-only boundary is established at OPEN time read it
+ *   (SQLite); the rest establish theirs per statement and ignore it.
  * @returns Promise<DatabaseProvider> instance
  * @throws DatabaseConfigError if connection type is not supported
  *
@@ -53,6 +62,7 @@ import { logger } from "@/lib/logger";
 export async function createDatabaseProvider(
   connection: DatabaseConnection,
   options: ProviderOptions = {},
+  execution: ProviderExecutionContext = {},
 ): Promise<DatabaseProvider> {
   // Sanitize user-controlled values to prevent log injection
   const sanitize = (v: string) => v.replace(/[\r\n]/g, " ").replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
@@ -72,7 +82,7 @@ export async function createDatabaseProvider(
 
     case "sqlite": {
       const { SQLiteProvider } = await import("./providers/sql/sqlite");
-      return new SQLiteProvider(connection, options);
+      return new SQLiteProvider(connection, options, execution);
     }
 
     case "oracle": {
@@ -325,24 +335,16 @@ export async function getOrCreateProvider(
  */
 export type ExecutionProfile = "agent-read-only";
 
-const EXECUTION_PROFILES: ReadonlySet<string> = new Set<ExecutionProfile>(["agent-read-only"]);
+/**
+ * What each profile means to a provider that establishes its read-only
+ * boundary at open time. Single source of truth for the profile list, so a new
+ * profile cannot be accepted without stating the context it is opened under.
+ */
+const PROFILE_EXECUTION_CONTEXT: Record<ExecutionProfile, ProviderExecutionContext> = {
+  "agent-read-only": { readOnly: true },
+};
 
-export type ExecutionProfileDenyCode =
-  | "UNSUPPORTED_PROFILE"
-  | "PROFILE_UNSUPPORTED_BY_PROVIDER"
-  | "AGENT_CREDENTIAL_UNRESOLVABLE"
-  | "AGENT_CREDENTIAL_WITH_CONNECTION_STRING";
-
-export class ExecutionProfileError extends Error {
-  constructor(
-    message: string,
-    public readonly reasonCode: ExecutionProfileDenyCode,
-  ) {
-    super(message);
-    this.name = "ExecutionProfileError";
-    Object.setPrototypeOf(this, ExecutionProfileError.prototype);
-  }
-}
+const EXECUTION_PROFILES: ReadonlySet<string> = new Set(Object.keys(PROFILE_EXECUTION_CONTEXT));
 
 /**
  * Resolves the optional least-privilege agent credential from the connection
@@ -427,7 +429,7 @@ export async function acquireExecutionProfileProvider(
     if (tunnel && !tunnelPreexisted) await tunnel.close().catch(() => {});
   };
 
-  const provider = await createDatabaseProvider(effectiveConnection, options);
+  const provider = await createDatabaseProvider(effectiveConnection, options, PROFILE_EXECUTION_CONTEXT[profile]);
   if (typeof provider.queryReadOnly !== "function") {
     await closeFreshTunnel();
     throw new ExecutionProfileError(

--- a/src/lib/db/operations/artifacts.ts
+++ b/src/lib/db/operations/artifacts.ts
@@ -1,0 +1,143 @@
+/**
+ * Run-scoped execution artifacts (#328).
+ *
+ * An allowed agent execution produces a result that a later turn may want to
+ * reference without re-running the statement. Those results live here, in
+ * process memory only: nothing is written through a storage provider, so this
+ * milestone adds no new place where result data rests on disk and no new schema
+ * to migrate. That is a deliberate limit, not an omission — persisting agent
+ * results at rest raises encryption, retention and tenancy questions #328 does
+ * not answer.
+ *
+ * Three bounds keep the map from growing without limit, in decreasing order of
+ * determinism:
+ *
+ * 1. `releaseRun` — the normal path, called with the budget tracker's `endRun`
+ *    when a run finishes. Everything that run produced is gone at that moment.
+ * 2. TTL — the backstop for a run that never ends (an agent process dies, a
+ *    caller forgets to release). An expired artifact is never served, whether
+ *    or not anything has swept it yet, and `put` sweeps before it stores.
+ * 3. `maxArtifacts` — a memory bound, evicting the oldest entry first. It is
+ *    explicitly NOT a security control: dropping an artifact loses a result,
+ *    it never grants access to one. (Contrast the rate limiter's capacity
+ *    eviction, which `budgets.ts` rejected for budget accounting because
+ *    restarting a counter at zero fails open.) It bounds the entry COUNT, so
+ *    the worst-case footprint is `maxArtifacts` times whatever the execution
+ *    profile's `maxResultBytes` admitted — the byte cap is enforced where the
+ *    rows are read, not here.
+ *
+ * There is no clock in this module, for the same reason `ExecutionBudgetTracker`
+ * has none: every time-dependent method takes the caller's `nowMs`, which keeps
+ * expiry deterministic under test instead of sleep-dependent.
+ */
+
+export class ArtifactStoreError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArtifactStoreError";
+    Object.setPrototypeOf(this, ArtifactStoreError.prototype);
+  }
+}
+
+export interface ExecutionArtifact<T = unknown> {
+  /** The audit correlation id of the execution that produced it — the join key. */
+  readonly correlationId: string;
+  readonly runId: string;
+  /** Registry-resolved operation id; never a caller-supplied string. */
+  readonly operationId: string;
+  readonly createdAtMs: number;
+  readonly value: T;
+}
+
+export interface ExecutionArtifactStoreOptions {
+  readonly ttlMs: number;
+  readonly maxArtifacts: number;
+}
+
+function assertPositiveInteger(value: number, label: string): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new ArtifactStoreError(`${label} must be a positive integer, got ${String(value)}`);
+  }
+  return value;
+}
+
+function assertIdentifier(value: string, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ArtifactStoreError(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+export class ExecutionArtifactStore<T = unknown> {
+  private readonly artifacts = new Map<string, ExecutionArtifact<T>>();
+  private readonly ttlMs: number;
+  private readonly maxArtifacts: number;
+
+  constructor(options: ExecutionArtifactStoreOptions) {
+    this.ttlMs = assertPositiveInteger(options.ttlMs, "ttlMs");
+    this.maxArtifacts = assertPositiveInteger(options.maxArtifacts, "maxArtifacts");
+  }
+
+  put(artifact: ExecutionArtifact<T>, nowMs: number): void {
+    assertIdentifier(artifact.correlationId, "correlationId");
+    assertIdentifier(artifact.runId, "runId");
+    if (typeof artifact.createdAtMs !== "number" || !Number.isFinite(artifact.createdAtMs)) {
+      throw new ArtifactStoreError(`createdAtMs must be a finite number, got ${String(artifact.createdAtMs)}`);
+    }
+    // Sweep before the uniqueness check, not after: an entry that has already
+    // expired is not a live artifact, so it must not be what refuses a new one.
+    this.sweep(nowMs);
+    if (this.artifacts.has(artifact.correlationId)) {
+      throw new ArtifactStoreError(`artifact "${artifact.correlationId}" already exists — correlation ids are unique`);
+    }
+    // Map iteration is insertion order, and executions are stored as they
+    // finish, so keys arrive oldest-first. Deleting the entry the loop is
+    // currently on is well-defined for a Map iterator, and the size check
+    // leads rather than follows so a store already under the cap deletes
+    // nothing.
+    for (const oldest of this.artifacts.keys()) {
+      if (this.artifacts.size < this.maxArtifacts) break;
+      this.artifacts.delete(oldest);
+    }
+    this.artifacts.set(artifact.correlationId, artifact);
+  }
+
+  /** Pure read: an expired artifact is invisible here and reclaimed by `sweep`. */
+  get(correlationId: string, nowMs: number): ExecutionArtifact<T> | undefined {
+    const artifact = this.artifacts.get(correlationId);
+    if (!artifact) return undefined;
+    return this.hasExpired(artifact, nowMs) ? undefined : artifact;
+  }
+
+  /** Deterministic cleanup: everything one run produced, released together. */
+  releaseRun(runId: string): number {
+    const id = assertIdentifier(runId, "runId");
+    let released = 0;
+    for (const [correlationId, artifact] of this.artifacts) {
+      if (artifact.runId === id) {
+        this.artifacts.delete(correlationId);
+        released += 1;
+      }
+    }
+    return released;
+  }
+
+  sweep(nowMs: number): number {
+    let swept = 0;
+    for (const [correlationId, artifact] of this.artifacts) {
+      if (this.hasExpired(artifact, nowMs)) {
+        this.artifacts.delete(correlationId);
+        swept += 1;
+      }
+    }
+    return swept;
+  }
+
+  get size(): number {
+    return this.artifacts.size;
+  }
+
+  private hasExpired(artifact: ExecutionArtifact<T>, nowMs: number): boolean {
+    return nowMs - artifact.createdAtMs >= this.ttlMs;
+  }
+}

--- a/src/lib/db/operations/budgets.ts
+++ b/src/lib/db/operations/budgets.ts
@@ -4,11 +4,21 @@
  * The five budget dimensions pinned by the acceptance bar all live here:
  * statement count (`maxStatementsPerRun`), per-statement timeout
  * (`statementTimeoutMs`), row/byte caps (`maxResultRows`/`maxResultBytes`),
- * concurrency (`maxConcurrentExecutions`), and total-run wall clock
- * (`maxTotalRunMs`). Concurrency, statement count, and total-run are gate
- * checks the policy pipeline evaluates against a run's usage; timeout and
+ * concurrency (`maxConcurrentExecutions`), and total execution time
+ * (`maxTotalRunMs`). Concurrency, statement count, and total execution time are
+ * gate checks the policy pipeline evaluates against a run's usage; timeout and
  * row/byte caps are enforcement parameters the execution profiles apply
  * database-side (transaction-local timeout) and result-side.
+ *
+ * `maxTotalRunMs` bounds the DATABASE time a run consumes — the sum of the
+ * elapsed times the execution layer reports for completed calls. It is not a
+ * wall-clock deadline for the run: time between calls is not counted, parallel
+ * calls each contribute their own duration, and a call admitted just under the
+ * limit can still overrun it by up to one statement timeout. That is the useful
+ * bound at this layer (it limits load on the database), and a real wall-clock
+ * deadline needs a clock this tracker deliberately does not have — see the
+ * determinism note below. Bounding an agent run's wall clock belongs to the run
+ * loop that M2 introduces; tracked in docs/BACKLOG.md.
  *
  * `src/lib/api/rate-limit.ts` was evaluated for reuse and deliberately not
  * used: its counters are fixed-window and monotonic (no decrement, so

--- a/src/lib/db/operations/budgets.ts
+++ b/src/lib/db/operations/budgets.ts
@@ -1,0 +1,122 @@
+/**
+ * Execution budgets and run-scoped usage accounting (#328).
+ *
+ * The five budget dimensions pinned by the acceptance bar all live here:
+ * statement count (`maxStatementsPerRun`), per-statement timeout
+ * (`statementTimeoutMs`), row/byte caps (`maxResultRows`/`maxResultBytes`),
+ * concurrency (`maxConcurrentExecutions`), and total-run wall clock
+ * (`maxTotalRunMs`). Concurrency, statement count, and total-run are gate
+ * checks the policy pipeline evaluates against a run's usage; timeout and
+ * row/byte caps are enforcement parameters the execution profiles apply
+ * database-side (transaction-local timeout) and result-side.
+ *
+ * `src/lib/api/rate-limit.ts` was evaluated for reuse and deliberately not
+ * used: its counters are fixed-window and monotonic (no decrement, so
+ * concurrency release is inexpressible) and its capacity eviction fails OPEN
+ * by design (an evicted key restarts at zero) — correct for rate limiting,
+ * a bypass for a security budget. This tracker is run-scoped, decrements on
+ * release, and fails loud on accounting corruption instead of guessing.
+ */
+
+/**
+ * Effective budget attached to every policy decision. Enforceable policies
+ * carry positive integers in every field; the all-zero budget exists only on
+ * malformed-context denials, where nothing is executable.
+ */
+export interface ExecutionBudget {
+  readonly maxConcurrentExecutions: number;
+  readonly maxStatementsPerRun: number;
+  readonly maxTotalRunMs: number;
+  readonly statementTimeoutMs: number;
+  readonly maxResultRows: number;
+  readonly maxResultBytes: number;
+}
+
+/** Snapshot of a run's consumption, evaluated by the policy pipeline's budget stage. */
+export interface ExecutionUsage {
+  readonly activeExecutions: number;
+  readonly executedStatements: number;
+  readonly totalElapsedMs: number;
+}
+
+export class BudgetAccountingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BudgetAccountingError";
+    Object.setPrototypeOf(this, BudgetAccountingError.prototype);
+  }
+}
+
+interface RunAccount {
+  activeExecutions: number;
+  executedStatements: number;
+  totalElapsedMs: number;
+}
+
+function assertRunId(runId: string): string {
+  if (typeof runId !== "string" || runId.trim().length === 0) {
+    throw new BudgetAccountingError("run id must be a non-empty string");
+  }
+  return runId;
+}
+
+/**
+ * Per-run execution accounting. There is no clock in here: elapsed time is
+ * whatever the execution layer measured and reported, which keeps the tracker
+ * deterministic under test. Every accounting error throws instead of clamping —
+ * an unbalanced release that silently clamped to zero would under-count
+ * concurrency and fail open.
+ */
+export class ExecutionBudgetTracker {
+  private readonly runs = new Map<string, RunAccount>();
+
+  beginExecution(runId: string): void {
+    const id = assertRunId(runId);
+    const account = this.runs.get(id) ?? { activeExecutions: 0, executedStatements: 0, totalElapsedMs: 0 };
+    account.activeExecutions += 1;
+    this.runs.set(id, account);
+  }
+
+  endExecution(runId: string, outcome: { readonly statements: number; readonly elapsedMs: number }): void {
+    const id = assertRunId(runId);
+    const { statements, elapsedMs } = outcome;
+    if (!Number.isInteger(statements) || statements < 0) {
+      throw new BudgetAccountingError(`statements must be a non-negative integer, got ${String(statements)}`);
+    }
+    if (typeof elapsedMs !== "number" || !Number.isFinite(elapsedMs) || elapsedMs < 0) {
+      throw new BudgetAccountingError(`elapsedMs must be a non-negative finite number, got ${String(elapsedMs)}`);
+    }
+    const account = this.runs.get(id);
+    if (!account || account.activeExecutions === 0) {
+      throw new BudgetAccountingError(`unbalanced endExecution for run "${id}" — no live execution to release`);
+    }
+    account.activeExecutions -= 1;
+    account.executedStatements += statements;
+    account.totalElapsedMs += elapsedMs;
+  }
+
+  usage(runId: string): ExecutionUsage {
+    const account = this.runs.get(assertRunId(runId));
+    if (!account) return { activeExecutions: 0, executedStatements: 0, totalElapsedMs: 0 };
+    return {
+      activeExecutions: account.activeExecutions,
+      executedStatements: account.executedStatements,
+      totalElapsedMs: account.totalElapsedMs,
+    };
+  }
+
+  /**
+   * Releases a finished run's accounting. Idempotent for finished runs, but a
+   * run with live executions cannot be ended: dropping live usage would reset
+   * the concurrency and total-run budgets mid-flight.
+   */
+  endRun(runId: string): void {
+    const id = assertRunId(runId);
+    const account = this.runs.get(id);
+    if (!account) return;
+    if (account.activeExecutions > 0) {
+      throw new BudgetAccountingError(`cannot end run "${id}" while ${account.activeExecutions} execution(s) are live`);
+    }
+    this.runs.delete(id);
+  }
+}

--- a/src/lib/db/operations/descriptors.ts
+++ b/src/lib/db/operations/descriptors.ts
@@ -32,7 +32,8 @@ const PLAN_EXECUTION_ID: ExplainOperationId = "sql.explain.analyze";
  */
 const BOUNDED_READ_BOUNDARY =
   "PostgreSQL: single statement inside BEGIN READ ONLY with transaction-local timeout, rolled back and released; " +
-  "SQLite: separate read-only open (no file creation) with PRAGMA query_only verified at open";
+  "SQLite: separate read-only open governing the target file (no file creation), plus PRAGMA query_only " +
+  "re-asserted and verified before every statement to refuse writes to other files (VACUUM INTO)";
 
 export const sqlQueryReadDescriptor: RegistrableOperationDescriptor = {
   id: "sql.query.read",

--- a/src/lib/db/operations/descriptors.ts
+++ b/src/lib/db/operations/descriptors.ts
@@ -1,0 +1,88 @@
+/**
+ * Canonical Phase 1 operation descriptors (#328, epic #325).
+ *
+ * Exactly three operations exist: bounded read, plan inspection, plan
+ * execution. Plan inspection and plan execution are DISTINCT descriptors whose
+ * ids are derived from the explain seam's modes (`ExplainMode`,
+ * src/lib/explain) — renaming a mode breaks these ids at compile time — and
+ * the executing variant is default-denied because EXPLAIN ANALYZE runs the
+ * statement (epic #325 product decision).
+ */
+
+import { z } from "zod";
+import type { ExplainMode } from "@/lib/explain";
+import { OperationRegistry } from "./registry";
+import type { RegistrableOperationDescriptor } from "./types";
+
+/**
+ * Exactly one SQL statement string; unknown keys are rejected (fail closed).
+ * Single-statement and read-only guarantees come from the database-native
+ * execution profiles, not from this schema.
+ */
+const sqlStatementInput = z.strictObject({ sql: z.string().min(1) });
+
+type ExplainOperationId = `sql.explain.${ExplainMode}`;
+const PLAN_INSPECTION_ID: ExplainOperationId = "sql.explain.estimate";
+const PLAN_EXECUTION_ID: ExplainOperationId = "sql.explain.analyze";
+
+/**
+ * Verification markers cite the boundary pinned by issue #328 / epic #325 and
+ * implemented by this milestone's execution profiles: the database engine, not
+ * a parser, rejects anything but a bounded read through the agent path.
+ */
+const BOUNDED_READ_BOUNDARY =
+  "PostgreSQL: single statement inside BEGIN READ ONLY with transaction-local timeout, rolled back and released; " +
+  "SQLite: separate read-only open (no file creation) with PRAGMA query_only verified at open";
+
+export const sqlQueryReadDescriptor: RegistrableOperationDescriptor = {
+  id: "sql.query.read",
+  riskClass: 1,
+  accessLevel: "data-read",
+  requiredCapabilities: [],
+  resourceCost: "heavy",
+  supportsDryRun: false,
+  requiresApproval: false,
+  inputSchema: sqlStatementInput,
+  verification: {
+    reviewedBy: "issue #328 acceptance bar (epic #325 product decisions)",
+    boundary: BOUNDED_READ_BOUNDARY,
+    verifiedOn: "2026-08-10",
+  },
+};
+
+export const sqlExplainEstimateDescriptor: RegistrableOperationDescriptor = {
+  id: PLAN_INSPECTION_ID,
+  riskClass: 0,
+  accessLevel: "metadata-read",
+  requiredCapabilities: ["supportsExplain"],
+  resourceCost: "light",
+  supportsDryRun: false,
+  requiresApproval: false,
+  inputSchema: sqlStatementInput,
+};
+
+export const sqlExplainAnalyzeDescriptor: RegistrableOperationDescriptor = {
+  id: PLAN_EXECUTION_ID,
+  riskClass: 1,
+  accessLevel: "data-read",
+  requiredCapabilities: ["supportsExplain"],
+  resourceCost: "heavy",
+  supportsDryRun: false,
+  // Default-denied: EXPLAIN ANALYZE executes the statement, so it can only
+  // ever reach require-approval, never a plain allow (epic #325).
+  requiresApproval: true,
+  inputSchema: sqlStatementInput,
+  verification: {
+    reviewedBy: "issue #328 acceptance bar (epic #325 product decisions)",
+    boundary: `Plan execution runs under the same database-native profile as bounded reads: ${BOUNDED_READ_BOUNDARY}`,
+    verifiedOn: "2026-08-10",
+  },
+};
+
+export function createCanonicalOperationRegistry(): OperationRegistry {
+  const registry = new OperationRegistry();
+  registry.register(sqlQueryReadDescriptor);
+  registry.register(sqlExplainEstimateDescriptor);
+  registry.register(sqlExplainAnalyzeDescriptor);
+  return registry;
+}

--- a/src/lib/db/operations/descriptors.ts
+++ b/src/lib/db/operations/descriptors.ts
@@ -9,17 +9,10 @@
  * statement (epic #325 product decision).
  */
 
-import { z } from "zod";
 import type { ExplainMode } from "@/lib/explain";
 import { OperationRegistry } from "./registry";
+import { agentPlanExecutionSqlInput, agentReadSqlInput } from "./statement-guard";
 import type { RegistrableOperationDescriptor } from "./types";
-
-/**
- * Exactly one SQL statement string; unknown keys are rejected (fail closed).
- * Single-statement and read-only guarantees come from the database-native
- * execution profiles, not from this schema.
- */
-const sqlStatementInput = z.strictObject({ sql: z.string().min(1) });
 
 type ExplainOperationId = `sql.explain.${ExplainMode}`;
 const PLAN_INSPECTION_ID: ExplainOperationId = "sql.explain.estimate";
@@ -31,7 +24,9 @@ const PLAN_EXECUTION_ID: ExplainOperationId = "sql.explain.analyze";
  * a parser, rejects anything but a bounded read through the agent path.
  */
 const BOUNDED_READ_BOUNDARY =
-  "PostgreSQL: single statement inside BEGIN READ ONLY with transaction-local timeout, rolled back and released; " +
+  "PostgreSQL: single statement inside BEGIN READ ONLY with transaction-local timeout, rolled back and released, " +
+  "as a least-privilege role verified at open — the transaction alone does not stop server-side file access or " +
+  "program execution (COPY TO PROGRAM), only the role does; " +
   "SQLite: separate read-only open governing the target file (no file creation), plus PRAGMA query_only " +
   "re-asserted and verified before every statement to refuse writes to other files (VACUUM INTO)";
 
@@ -43,7 +38,7 @@ export const sqlQueryReadDescriptor: RegistrableOperationDescriptor = {
   resourceCost: "heavy",
   supportsDryRun: false,
   requiresApproval: false,
-  inputSchema: sqlStatementInput,
+  inputSchema: agentReadSqlInput,
   verification: {
     reviewedBy: "issue #328 acceptance bar (epic #325 product decisions)",
     boundary: BOUNDED_READ_BOUNDARY,
@@ -59,7 +54,10 @@ export const sqlExplainEstimateDescriptor: RegistrableOperationDescriptor = {
   resourceCost: "light",
   supportsDryRun: false,
   requiresApproval: false,
-  inputSchema: sqlStatementInput,
+  // The inspecting variant takes the read schema, so `EXPLAIN ANALYZE` smuggled
+  // into a plan-inspection request is refused at the input stage rather than
+  // becoming a plan execution that never asked for approval.
+  inputSchema: agentReadSqlInput,
 };
 
 export const sqlExplainAnalyzeDescriptor: RegistrableOperationDescriptor = {
@@ -72,7 +70,7 @@ export const sqlExplainAnalyzeDescriptor: RegistrableOperationDescriptor = {
   // Default-denied: EXPLAIN ANALYZE executes the statement, so it can only
   // ever reach require-approval, never a plain allow (epic #325).
   requiresApproval: true,
-  inputSchema: sqlStatementInput,
+  inputSchema: agentPlanExecutionSqlInput,
   verification: {
     reviewedBy: "issue #328 acceptance bar (epic #325 product decisions)",
     boundary: `Plan execution runs under the same database-native profile as bounded reads: ${BOUNDED_READ_BOUNDARY}`,

--- a/src/lib/db/operations/execution.ts
+++ b/src/lib/db/operations/execution.ts
@@ -1,0 +1,233 @@
+/**
+ * Audit correlation and artifact lifecycle for the agent execution path (#328).
+ *
+ * This is the glue that turns a policy decision into an accountable execution:
+ * every attempt — allowed, denied, or held for approval — leaves an entry in
+ * the SHIPPED audit layer (`src/lib/audit.ts`, reused rather than rebuilt), and
+ * an allowed one leaves a run-scoped artifact that `releaseExecutionRun`
+ * deletes when the run ends.
+ *
+ * Three properties are load-bearing:
+ *
+ * 1. **A denial is audited.** A decision that leaves no trace is the wrong
+ *    default for a security layer: the log is how an operator learns an agent
+ *    probed for something it could not have.
+ * 2. **The decision event precedes the provider call.** Emission is not wrapped
+ *    in a try/catch, so ANY audit-sink failure propagates and the provider is
+ *    never invoked — the path fails closed on an unauditable execution rather
+ *    than running it silently. (`src/proxy.ts` makes the opposite trade for a
+ *    403 it has already decided; there, swallowing the sink error protects an
+ *    answer that is not about to touch a database.)
+ * 3. **Only closed vocabularies are logged.** The audited action is the
+ *    registry-RESOLVED descriptor id, never the caller's raw operation string,
+ *    and the actor is a `mode:role` label built only from values the pipeline
+ *    validated. No SQL, no input, no driver message, no session identifier
+ *    reaches an audit field — `src/lib/audit.ts` forbids exactly those, and the
+ *    correlation id is what makes them unnecessary.
+ *
+ * No route wiring lives here: #328 builds the enforcement layer, and the agent
+ * surface that calls it lands in a later milestone.
+ */
+
+import { randomUUID } from "node:crypto";
+import { type AuditReason, emitAuditEvent } from "@/lib/audit";
+import type { ExecutionArtifactStore } from "./artifacts";
+import type { ExecutionBudget, ExecutionBudgetTracker } from "./budgets";
+import type { ExecutionActor, PolicyDecision, PolicyDenyCode, PolicyEvaluationParams } from "./policy";
+import { evaluateOperation, isValidActor } from "./policy";
+
+/**
+ * Every policy denial mapped to its audit reason. Typed as a total record, so
+ * a new `PolicyDenyCode` cannot reach production without a reason code an
+ * operator can filter on — the compiler is the mirror, not a convention.
+ */
+export const DENY_REASONS: Record<PolicyDenyCode, AuditReason> = {
+  UNKNOWN_OPERATION: "agent_unknown_operation",
+  AMBIGUOUS_OPERATION: "agent_ambiguous_operation",
+  MALFORMED_POLICY_CONTEXT: "agent_malformed_policy_context",
+  INVALID_ACTOR: "agent_invalid_actor",
+  TARGET_OUT_OF_SCOPE: "agent_target_out_of_scope",
+  INPUT_VALIDATION_FAILED: "agent_input_validation_failed",
+  CAPABILITY_UNSUPPORTED: "agent_capability_unsupported",
+  ROLE_FORBIDDEN: "agent_role_forbidden",
+  MODE_FORBIDDEN: "agent_mode_forbidden",
+  RISK_EXCEEDS_POLICY: "agent_risk_exceeds_policy",
+  CONCURRENCY_BUDGET_EXCEEDED: "agent_concurrency_budget_exceeded",
+  STATEMENT_BUDGET_EXCEEDED: "agent_statement_budget_exceeded",
+  TOTAL_RUN_BUDGET_EXCEEDED: "agent_total_run_budget_exceeded",
+};
+
+/** `target` on the audit event (`route` on the stdout line) — the phase, not a URL. */
+const DECISION_TARGET = "agent/operations/decision";
+const EXECUTION_TARGET = "agent/operations/execution";
+/** Logged instead of an operation id the registry refused to resolve. */
+const UNRESOLVED_OPERATION = "unresolved";
+/** Logged instead of a `mode:role` label the pipeline never validated. */
+const UNKNOWN_ACTOR = "agent:unknown";
+
+export interface AuditedExecutionContext<T = unknown> {
+  /** Server-generated run id; the budget tracker and artifact store key on it. */
+  readonly runId: string;
+  readonly tracker: ExecutionBudgetTracker;
+  readonly artifacts: ExecutionArtifactStore<T>;
+  /** Injected so elapsed time is deterministic under test, as in `budgets.ts`. */
+  readonly clock?: () => number;
+}
+
+type AllowDecision = Extract<PolicyDecision, { kind: "allow" }>;
+type RefusedDecision = Exclude<PolicyDecision, AllowDecision>;
+
+export type AuditedExecutionResult<T> =
+  | { readonly kind: "denied"; readonly correlationId: string; readonly decision: RefusedDecision }
+  | { readonly kind: "executed"; readonly correlationId: string; readonly decision: AllowDecision; readonly result: T };
+
+/**
+ * `mode:role`, but only when policy.ts's own actor validation accepts the
+ * actor — otherwise `mode` and `role` are unvalidated caller text and have no
+ * place in a log field. Asking `isValidActor` directly (rather than inferring
+ * validity from the deny code) keeps this correct even if a future stage is
+ * inserted ahead of the actor stage, and keeps the role/mode vocabulary in one
+ * module.
+ */
+function actorLabel(actor: ExecutionActor): string {
+  return isValidActor(actor) ? `${actor.mode}:${actor.role}` : UNKNOWN_ACTOR;
+}
+
+/**
+ * Clamped: `Date.now` is the default clock and is not monotonic, and the budget
+ * tracker refuses a negative or non-finite elapsed time — which would strand
+ * the run's concurrency slot rather than merely mis-measure it, because the
+ * statement has already run by the time it is accounted for. `Math.max` alone
+ * is not enough: `Math.max(0, NaN)` is `NaN`.
+ */
+function elapsedSince(startedAtMs: number, clock: () => number): number {
+  const elapsed = clock() - startedAtMs;
+  return Number.isFinite(elapsed) ? Math.max(0, elapsed) : 0;
+}
+
+function refusalReason(decision: RefusedDecision): AuditReason {
+  return decision.kind === "deny" ? DENY_REASONS[decision.reasonCode] : "agent_approval_required";
+}
+
+/**
+ * Evaluates the request, audits the decision, and executes only on a plain
+ * allow. The provider callback is unreachable on a denial or an approval
+ * requirement (the spy-provider invariant `executeWithPolicy` pins, re-asserted
+ * here because this entry point owns the audit and accounting around it — the
+ * reason it is a separate function rather than a wrapper: there is no seam
+ * between decision and invocation in `executeWithPolicy`).
+ *
+ * A provider failure is audited and rethrown untouched: the caller sees its own
+ * error, and the audit line carries only the typed reason, never the message.
+ */
+export async function executeAuditedOperation<T>(
+  params: Omit<PolicyEvaluationParams, "usage">,
+  context: AuditedExecutionContext<T>,
+  invoke: (execution: { readonly validatedInput: unknown; readonly budget: ExecutionBudget }) => Promise<T>,
+): Promise<AuditedExecutionResult<T>> {
+  const { runId, tracker, artifacts } = context;
+  const clock = context.clock ?? Date.now;
+  const correlationId = randomUUID();
+
+  // Usage is read from the tracker rather than supplied by the caller — a
+  // caller-passed snapshot could be stale or optimistic — and it is read BEFORE
+  // this execution is registered, so a run's first execution cannot deny itself
+  // on the concurrency budget.
+  //
+  // INVARIANT: nothing between this read and `beginExecution` below may await.
+  // An await in that span would let two concurrent executions of the same run
+  // both observe `activeExecutions: 0` and both pass the concurrency gate.
+  const evaluation: PolicyEvaluationParams = { ...params, usage: tracker.usage(runId) };
+  const decision = evaluateOperation(evaluation);
+
+  // Resolved independently of the pipeline (resolution is pure and cheap): the
+  // decision carries an operation id only when it allows or requires approval,
+  // and a denial still has to name what was attempted.
+  const resolution = params.registry.resolve(params.request?.operationId as string);
+  const action = resolution.kind === "resolved" ? resolution.descriptor.id : UNRESOLVED_OPERATION;
+  const user = actorLabel(params.actor);
+
+  if (decision.kind !== "allow") {
+    emitAuditEvent({
+      type: "agent_operation",
+      action,
+      target: DECISION_TARGET,
+      user,
+      result: "failure",
+      reason: refusalReason(decision),
+      correlationId,
+    });
+    return { kind: "denied", correlationId, decision };
+  }
+
+  emitAuditEvent({
+    type: "agent_operation",
+    action,
+    target: DECISION_TARGET,
+    user,
+    result: "success",
+    correlationId,
+  });
+
+  const startedAtMs = clock();
+  tracker.beginExecution(runId);
+
+  // The try covers the provider call ONLY. Everything after it is this module's
+  // own bookkeeping, and a compensating release that also covered it would call
+  // endExecution twice — the tracker fails loud on the second, which would
+  // replace whatever really went wrong and suppress the outcome event.
+  let result: T;
+  try {
+    result = await invoke({ validatedInput: decision.validatedInput, budget: decision.effectiveBudget });
+  } catch (error) {
+    const failedAfterMs = elapsedSince(startedAtMs, clock);
+    tracker.endExecution(runId, { statements: 1, elapsedMs: failedAfterMs });
+    emitAuditEvent({
+      type: "agent_operation",
+      action,
+      target: EXECUTION_TARGET,
+      user,
+      result: "failure",
+      reason: "agent_execution_failed",
+      duration: failedAfterMs,
+      correlationId,
+    });
+    throw error;
+  }
+
+  const elapsedMs = elapsedSince(startedAtMs, clock);
+  // Accounting, then the audit line, then the artifact. The statement ran, so
+  // the trail is recorded before this module's in-memory store gets a say: a
+  // store that refuses the result must not also erase the record that it ran.
+  tracker.endExecution(runId, { statements: 1, elapsedMs });
+  emitAuditEvent({
+    type: "agent_operation",
+    action,
+    target: EXECUTION_TARGET,
+    user,
+    result: "success",
+    duration: elapsedMs,
+    correlationId,
+  });
+  // `createdAtMs` is the START instant, so the TTL is measured from when the
+  // statement began, not from when it returned.
+  artifacts.put(
+    { correlationId, runId, operationId: decision.operationId, createdAtMs: startedAtMs, value: result },
+    startedAtMs + elapsedMs,
+  );
+  return { kind: "executed", correlationId, decision, result };
+}
+
+/**
+ * Ends a run: its artifacts and its budget accounting are released together, so
+ * neither outlives the other. This is the deterministic cleanup path — the
+ * artifact TTL exists only for runs that never reach it.
+ *
+ * The tracker goes first because it is the step that can refuse: `endRun`
+ * throws while any execution is still live, and destroying the artifacts before
+ * learning that would leave a live run with its results already gone.
+ */
+export function releaseExecutionRun(context: Pick<AuditedExecutionContext, "runId" | "tracker" | "artifacts">): void {
+  context.tracker.endRun(context.runId);
+  context.artifacts.releaseRun(context.runId);
+}

--- a/src/lib/db/operations/policy.ts
+++ b/src/lib/db/operations/policy.ts
@@ -1,0 +1,353 @@
+/**
+ * Fail-closed policy decision pipeline (#328).
+ *
+ * Fixed evaluation order: actor/session → classification (registry
+ * resolution) → immutable target scope → schema-validated input → provider
+ * capability → risk/mode/role policy → budgets. The six spec stages run in
+ * their pinned order with actor/session literally first; classification slots
+ * immediately after it because every descriptor-dependent stage (input schema,
+ * capabilities, risk class, approval flag) needs the resolved descriptor,
+ * while the actor stage reads nothing from it. First denial wins. Every
+ * outcome is a typed allow / deny / require-approval carrying a reason code,
+ * the policy version, and the effective budget — and on anything but a plain
+ * allow the provider callback is never invoked (`executeWithPolicy`).
+ *
+ * The pipeline reads only modeled descriptor fields (id, riskClass,
+ * requiredCapabilities, requiresApproval, inputSchema) — never a spread of the
+ * descriptor object — so unmodeled fields smuggled past the registry types
+ * cannot influence a decision. Capabilities arrive as data, not as a provider
+ * instance: they are a fast deny signal and stay a UI-affordance contract; the
+ * security boundary is database-native (the T3/T4 execution profiles).
+ *
+ * `requiresApproval` is resolved AFTER all deny stages pass: an approval-
+ * flagged request that is also over budget denies — approval must never be a
+ * channel around a denial. Server-side context integrity (policy, usage,
+ * scope) is a precondition checked before the stages; a malformed context
+ * denies with `MALFORMED_POLICY_CONTEXT` because a NaN budget limit or junk
+ * usage would otherwise compare permissively and fail open.
+ */
+
+import type { Role } from "@/lib/auth";
+import type { ProviderCapabilities } from "@/lib/db/types";
+import type { ExecutionBudget, ExecutionUsage } from "./budgets";
+import type { OperationRegistry } from "./registry";
+
+/**
+ * Execution modes this layer serves today. The normal editor path is
+ * deliberately NOT a mode: it stays un-gated by this pipeline (#328 keeps the
+ * editor/API write path regression-unchanged). New modes are added here only
+ * when a policy decision admits them — an unknown mode is an invalid actor,
+ * never a permissive default.
+ */
+type ExecutionMode = "agent";
+
+/**
+ * Runtime vocabularies for actor validation. `Role` is compile-time coupled to
+ * the auth seam (`src/lib/auth.ts`); this set intentionally does NOT widen
+ * automatically if a new role is added there — a new role stays denied by this
+ * layer until policy work admits it explicitly (fail closed).
+ */
+const ROLES: ReadonlySet<unknown> = new Set<Role>(["admin", "user"]);
+const MODES: ReadonlySet<unknown> = new Set<ExecutionMode>(["agent"]);
+
+export interface ExecutionActor {
+  readonly sessionId: string;
+  readonly role: Role;
+  readonly mode: ExecutionMode;
+}
+
+/** Server-injected target scope. Build via `createTargetScope`; never caller-chosen. */
+export interface TargetScope {
+  readonly connectionId: string;
+  /** When present, the request must name a member. An empty list is deny-all. */
+  readonly catalogAllowlist?: readonly string[];
+  readonly schemaAllowlist?: readonly string[];
+}
+
+export interface OperationRequest {
+  readonly operationId: string;
+  /** Caller-declared target; every present field must fall inside the scope. */
+  readonly target?: {
+    readonly connectionId?: string;
+    readonly catalog?: string;
+    readonly schema?: string;
+  };
+  readonly input: unknown;
+}
+
+export interface ExecutionPolicy {
+  readonly version: string;
+  readonly maxRiskClass: 0 | 1;
+  readonly allowedRoles: readonly Role[];
+  readonly allowedModes: readonly ExecutionMode[];
+  readonly budgets: ExecutionBudget;
+}
+
+export interface PolicyEvaluationParams {
+  readonly registry: OperationRegistry;
+  readonly policy: ExecutionPolicy;
+  readonly actor: ExecutionActor;
+  readonly scope: TargetScope;
+  readonly request: OperationRequest;
+  readonly capabilities: ProviderCapabilities;
+  readonly usage: ExecutionUsage;
+}
+
+export type PolicyDenyCode =
+  | "UNKNOWN_OPERATION"
+  | "AMBIGUOUS_OPERATION"
+  | "MALFORMED_POLICY_CONTEXT"
+  | "INVALID_ACTOR"
+  | "TARGET_OUT_OF_SCOPE"
+  | "INPUT_VALIDATION_FAILED"
+  | "CAPABILITY_UNSUPPORTED"
+  | "ROLE_FORBIDDEN"
+  | "MODE_FORBIDDEN"
+  | "RISK_EXCEEDS_POLICY"
+  | "CONCURRENCY_BUDGET_EXCEEDED"
+  | "STATEMENT_BUDGET_EXCEEDED"
+  | "TOTAL_RUN_BUDGET_EXCEEDED";
+
+interface PolicyDecisionBase {
+  readonly policyVersion: string;
+  readonly effectiveBudget: ExecutionBudget;
+}
+
+interface PolicyAllowDecision extends PolicyDecisionBase {
+  readonly kind: "allow";
+  readonly reasonCode: "ALLOWED";
+  readonly operationId: string;
+  /** The schema-parsed input snapshot — execution consumes this, never the raw request input. */
+  readonly validatedInput: unknown;
+}
+
+interface PolicyApprovalDecision extends PolicyDecisionBase {
+  readonly kind: "require-approval";
+  readonly reasonCode: "APPROVAL_REQUIRED";
+  readonly operationId: string;
+}
+
+interface PolicyDenyDecision extends PolicyDecisionBase {
+  readonly kind: "deny";
+  readonly reasonCode: PolicyDenyCode;
+}
+
+export type PolicyDecision = PolicyAllowDecision | PolicyApprovalDecision | PolicyDenyDecision;
+
+export class TargetScopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TargetScopeError";
+    Object.setPrototypeOf(this, TargetScopeError.prototype);
+  }
+}
+
+/** Nothing is executable under this budget; attached to malformed-context denials. */
+const ZERO_BUDGET: ExecutionBudget = Object.freeze({
+  maxConcurrentExecutions: 0,
+  maxStatementsPerRun: 0,
+  maxTotalRunMs: 0,
+  statementTimeoutMs: 0,
+  maxResultRows: 0,
+  maxResultBytes: 0,
+});
+
+const BUDGET_FIELDS = [
+  "maxConcurrentExecutions",
+  "maxStatementsPerRun",
+  "maxTotalRunMs",
+  "statementTimeoutMs",
+  "maxResultRows",
+  "maxResultBytes",
+] as const;
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isValidAllowlist(list: readonly string[] | undefined): boolean {
+  return list === undefined || (Array.isArray(list) && list.every(isNonBlankString));
+}
+
+function frozenAllowlist(entries: readonly string[], label: string): readonly string[] {
+  if (!entries.every(isNonBlankString)) {
+    throw new TargetScopeError(`every ${label} allowlist entry must be a non-empty string`);
+  }
+  return Object.freeze([...entries]);
+}
+
+/**
+ * Builds the immutable, server-injected target scope. Construction is a
+ * trusted server-side act and fails loud, mirroring `OperationRegistry.register`.
+ */
+export function createTargetScope(
+  connectionId: string,
+  allowlists: { readonly catalogs?: readonly string[]; readonly schemas?: readonly string[] } = {},
+): TargetScope {
+  if (!isNonBlankString(connectionId)) {
+    throw new TargetScopeError("connectionId must be a non-empty string");
+  }
+  const scope: TargetScope = {
+    connectionId,
+    ...(allowlists.catalogs === undefined ? {} : { catalogAllowlist: frozenAllowlist(allowlists.catalogs, "catalog") }),
+    ...(allowlists.schemas === undefined ? {} : { schemaAllowlist: frozenAllowlist(allowlists.schemas, "schema") }),
+  };
+  return Object.freeze(scope);
+}
+
+function isValidBudget(budgets: ExecutionBudget): boolean {
+  if (typeof budgets !== "object" || budgets === null) return false;
+  return BUDGET_FIELDS.every((field) => {
+    const value = budgets[field];
+    return typeof value === "number" && Number.isInteger(value) && value >= 1;
+  });
+}
+
+function isValidPolicy(policy: ExecutionPolicy): boolean {
+  if (typeof policy !== "object" || policy === null) return false;
+  if (!isNonBlankString(policy.version)) return false;
+  if (policy.maxRiskClass !== 0 && policy.maxRiskClass !== 1) return false;
+  if (!Array.isArray(policy.allowedRoles) || !policy.allowedRoles.every((role) => ROLES.has(role))) return false;
+  if (!Array.isArray(policy.allowedModes) || !policy.allowedModes.every((mode) => MODES.has(mode))) return false;
+  return isValidBudget(policy.budgets);
+}
+
+function isValidUsage(usage: ExecutionUsage): boolean {
+  if (typeof usage !== "object" || usage === null) return false;
+  const { activeExecutions, executedStatements, totalElapsedMs } = usage;
+  if (!Number.isInteger(activeExecutions) || activeExecutions < 0) return false;
+  if (!Number.isInteger(executedStatements) || executedStatements < 0) return false;
+  return typeof totalElapsedMs === "number" && Number.isFinite(totalElapsedMs) && totalElapsedMs >= 0;
+}
+
+function isValidScope(scope: TargetScope): boolean {
+  if (typeof scope !== "object" || scope === null) return false;
+  return (
+    isNonBlankString(scope.connectionId) &&
+    isValidAllowlist(scope.catalogAllowlist) &&
+    isValidAllowlist(scope.schemaAllowlist)
+  );
+}
+
+function isValidActor(actor: ExecutionActor): boolean {
+  if (typeof actor !== "object" || actor === null) return false;
+  return isNonBlankString(actor.sessionId) && ROLES.has(actor.role) && MODES.has(actor.mode);
+}
+
+/** An absent allowlist leaves the dimension unconstrained beyond the connection boundary. */
+function withinAllowlist(allowlist: readonly string[] | undefined, requested: string | undefined): boolean {
+  if (allowlist === undefined) return true;
+  return requested !== undefined && allowlist.includes(requested);
+}
+
+/** Explicit-field frozen copy: unmodeled fields on a caller's budget object never propagate. */
+function freezeBudget(budgets: ExecutionBudget): ExecutionBudget {
+  return Object.freeze({
+    maxConcurrentExecutions: budgets.maxConcurrentExecutions,
+    maxStatementsPerRun: budgets.maxStatementsPerRun,
+    maxTotalRunMs: budgets.maxTotalRunMs,
+    statementTimeoutMs: budgets.statementTimeoutMs,
+    maxResultRows: budgets.maxResultRows,
+    maxResultBytes: budgets.maxResultBytes,
+  });
+}
+
+export function evaluateOperation(params: PolicyEvaluationParams): PolicyDecision {
+  const { registry, policy, actor, scope, request, capabilities, usage } = params;
+
+  // Precondition — server-side context integrity. A NaN budget limit or junk
+  // usage would compare permissively below, so a malformed context can only deny.
+  if (!isValidPolicy(policy) || !isValidUsage(usage) || !isValidScope(scope)) {
+    return {
+      kind: "deny",
+      reasonCode: "MALFORMED_POLICY_CONTEXT",
+      policyVersion: isNonBlankString(policy?.version) ? policy.version : "invalid",
+      effectiveBudget: ZERO_BUDGET,
+    };
+  }
+
+  const policyVersion = policy.version;
+  const effectiveBudget = freezeBudget(policy.budgets);
+  const deny = (reasonCode: PolicyDenyCode): PolicyDenyDecision => ({
+    kind: "deny",
+    reasonCode,
+    policyVersion,
+    effectiveBudget,
+  });
+
+  // Stage 1 — actor/session (spec-pinned first stage).
+  if (!isValidActor(actor)) return deny("INVALID_ACTOR");
+
+  // Classification. Unknown and alias-shaped ids are typed denials; every
+  // descriptor-dependent stage below needs the resolved descriptor.
+  const resolution = registry.resolve(request?.operationId as string);
+  if (resolution.kind === "denied") return deny(resolution.reasonCode);
+  const { descriptor } = resolution;
+
+  // Stage 2 — immutable target scope. The scope's connection id is server-
+  // injected; a caller-named connection may only restate it, never change it.
+  const target = request.target ?? {};
+  if (target.connectionId !== undefined && target.connectionId !== scope.connectionId) {
+    return deny("TARGET_OUT_OF_SCOPE");
+  }
+  if (!withinAllowlist(scope.catalogAllowlist, target.catalog)) return deny("TARGET_OUT_OF_SCOPE");
+  if (!withinAllowlist(scope.schemaAllowlist, target.schema)) return deny("TARGET_OUT_OF_SCOPE");
+
+  // Stage 3 — schema-validated input.
+  const parsed = descriptor.inputSchema.safeParse(request.input);
+  if (!parsed.success) return deny("INPUT_VALIDATION_FAILED");
+
+  // Stage 4 — provider capability (fast deny; never the security boundary).
+  const capabilityView: Partial<ProviderCapabilities> = capabilities ?? {};
+  if (!descriptor.requiredCapabilities.every((key) => capabilityView[key] === true)) {
+    return deny("CAPABILITY_UNSUPPORTED");
+  }
+
+  // Stage 5 — risk/mode/role policy.
+  if (!policy.allowedRoles.includes(actor.role)) return deny("ROLE_FORBIDDEN");
+  if (!policy.allowedModes.includes(actor.mode)) return deny("MODE_FORBIDDEN");
+  if (descriptor.riskClass > policy.maxRiskClass) return deny("RISK_EXCEEDS_POLICY");
+
+  // Stage 6 — budgets. This request counts as one statement: the input model
+  // admits exactly one statement string, and the execution profiles enforce
+  // single-statement database-natively.
+  if (usage.activeExecutions >= effectiveBudget.maxConcurrentExecutions) return deny("CONCURRENCY_BUDGET_EXCEEDED");
+  if (usage.executedStatements + 1 > effectiveBudget.maxStatementsPerRun) return deny("STATEMENT_BUDGET_EXCEEDED");
+  if (usage.totalElapsedMs >= effectiveBudget.maxTotalRunMs) return deny("TOTAL_RUN_BUDGET_EXCEEDED");
+
+  if (descriptor.requiresApproval) {
+    return {
+      kind: "require-approval",
+      reasonCode: "APPROVAL_REQUIRED",
+      operationId: descriptor.id,
+      policyVersion,
+      effectiveBudget,
+    };
+  }
+  return {
+    kind: "allow",
+    reasonCode: "ALLOWED",
+    operationId: descriptor.id,
+    validatedInput: parsed.data,
+    policyVersion,
+    effectiveBudget,
+  };
+}
+
+/**
+ * Evaluates the request and invokes the provider callback ONLY on a plain
+ * allow — the spy-provider invariant: on any deny or require-approval the
+ * callback is never reached. Provider failures propagate untouched.
+ */
+export async function executeWithPolicy<T>(
+  params: PolicyEvaluationParams,
+  invoke: (execution: { readonly validatedInput: unknown; readonly budget: ExecutionBudget }) => Promise<T>,
+): Promise<
+  | { readonly decision: PolicyApprovalDecision | PolicyDenyDecision }
+  | { readonly decision: PolicyAllowDecision; readonly result: T }
+> {
+  const decision = evaluateOperation(params);
+  if (decision.kind !== "allow") return { decision };
+  const result = await invoke({ validatedInput: decision.validatedInput, budget: decision.effectiveBudget });
+  return { decision, result };
+}

--- a/src/lib/db/operations/policy.ts
+++ b/src/lib/db/operations/policy.ts
@@ -229,7 +229,13 @@ function isValidScope(scope: TargetScope): boolean {
   );
 }
 
-function isValidActor(actor: ExecutionActor): boolean {
+/**
+ * Exported for the audit glue (`execution.ts`), which may only put an actor's
+ * `mode`/`role` into a log field once this has accepted them: before that they
+ * are unvalidated caller text. Keeping the check here keeps the role/mode
+ * vocabulary in one module.
+ */
+export function isValidActor(actor: ExecutionActor): boolean {
   if (typeof actor !== "object" || actor === null) return false;
   return isNonBlankString(actor.sessionId) && ROLES.has(actor.role) && MODES.has(actor.mode);
 }

--- a/src/lib/db/operations/registry.ts
+++ b/src/lib/db/operations/registry.ts
@@ -1,0 +1,120 @@
+/**
+ * Fail-closed operation registry (#328).
+ *
+ * Registration is a build-time act and fails loud (typed throw); resolution
+ * handles untrusted runtime input and never throws — every lookup returns a
+ * typed resolved/denied result with a reason code, so a caller cannot ignore
+ * a denial by accident. The registry never guesses: an id that only
+ * case/whitespace-normalizes to a registered one is denied as ambiguous
+ * rather than helpfully corrected (alias-shaped bypass attempts stay denials).
+ */
+
+import type { RegistrableOperationDescriptor } from "./types";
+
+/** Two or more lowercase alphanumeric segments separated by single dots. */
+const CANONICAL_ID_PATTERN = /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)+$/;
+
+const ACCESS_LEVELS: ReadonlySet<unknown> = new Set(["metadata-read", "data-read"]);
+const RESOURCE_COSTS: ReadonlySet<unknown> = new Set(["light", "moderate", "heavy"]);
+
+type OperationRegistrationDenyCode =
+  | "INVALID_OPERATION_ID"
+  | "UNREGISTRABLE_RISK_CLASS"
+  | "UNVERIFIED_RISK_CLASS"
+  | "MALFORMED_DESCRIPTOR"
+  | "DUPLICATE_OPERATION_ID";
+
+type OperationResolutionDenyCode = "UNKNOWN_OPERATION" | "AMBIGUOUS_OPERATION";
+
+type OperationResolution =
+  | { readonly kind: "resolved"; readonly descriptor: RegistrableOperationDescriptor }
+  | { readonly kind: "denied"; readonly reasonCode: OperationResolutionDenyCode; readonly requestedId: string };
+
+export class OperationRegistrationError extends Error {
+  constructor(
+    message: string,
+    public readonly reasonCode: OperationRegistrationDenyCode,
+  ) {
+    super(message);
+    this.name = "OperationRegistrationError";
+    Object.setPrototypeOf(this, OperationRegistrationError.prototype);
+  }
+}
+
+function isSubstantiveVerification(marker: unknown): boolean {
+  if (typeof marker !== "object" || marker === null) return false;
+  const { reviewedBy, boundary, verifiedOn } = marker as Record<string, unknown>;
+  return [reviewedBy, boundary, verifiedOn].every((field) => typeof field === "string" && field.trim().length > 0);
+}
+
+/**
+ * Shape checks for callers that bypass the compile-time model. Capability keys
+ * are validated as non-empty strings only — an unknown key is not widened away
+ * here because the capability stage treats it as unsupported, which fails
+ * closed on its own.
+ */
+function isWellFormed(descriptor: RegistrableOperationDescriptor): boolean {
+  const { accessLevel, requiredCapabilities, resourceCost, supportsDryRun, requiresApproval, inputSchema } = descriptor;
+  if (!ACCESS_LEVELS.has(accessLevel) || !RESOURCE_COSTS.has(resourceCost)) return false;
+  if (typeof supportsDryRun !== "boolean" || typeof requiresApproval !== "boolean") return false;
+  if (!Array.isArray(requiredCapabilities)) return false;
+  if (!requiredCapabilities.every((key) => typeof key === "string" && key.length > 0)) return false;
+  return typeof (inputSchema as { safeParse?: unknown } | undefined)?.safeParse === "function";
+}
+
+export class OperationRegistry {
+  private readonly descriptors = new Map<string, RegistrableOperationDescriptor>();
+
+  register(descriptor: RegistrableOperationDescriptor): void {
+    const { id, riskClass } = descriptor;
+    if (typeof id !== "string" || !CANONICAL_ID_PATTERN.test(id)) {
+      throw new OperationRegistrationError(
+        `Operation id ${JSON.stringify(id)} is not canonical (lowercase dot-separated segments)`,
+        "INVALID_OPERATION_ID",
+      );
+    }
+    if (riskClass !== 0 && riskClass !== 1) {
+      throw new OperationRegistrationError(
+        `Operation "${id}" declares risk class ${String(riskClass)}; classes above 1 have no registrable representation`,
+        "UNREGISTRABLE_RISK_CLASS",
+      );
+    }
+    if (riskClass === 1 && !isSubstantiveVerification(descriptor.verification)) {
+      throw new OperationRegistrationError(
+        `Operation "${id}" is risk class 1 without a substantive verification marker`,
+        "UNVERIFIED_RISK_CLASS",
+      );
+    }
+    if (!isWellFormed(descriptor)) {
+      throw new OperationRegistrationError(`Operation "${id}" descriptor is malformed`, "MALFORMED_DESCRIPTOR");
+    }
+    if (this.descriptors.has(id)) {
+      throw new OperationRegistrationError(`Operation "${id}" is already registered`, "DUPLICATE_OPERATION_ID");
+    }
+    // Frozen snapshot: a reference retained by the registering caller must not
+    // be able to rewrite policy-relevant fields after registration.
+    const requiredCapabilities = Object.freeze([...descriptor.requiredCapabilities]);
+    const snapshot: RegistrableOperationDescriptor =
+      descriptor.riskClass === 1
+        ? { ...descriptor, requiredCapabilities, verification: Object.freeze({ ...descriptor.verification }) }
+        : { ...descriptor, requiredCapabilities };
+    this.descriptors.set(id, Object.freeze(snapshot));
+  }
+
+  resolve(requestedId: string): OperationResolution {
+    if (typeof requestedId !== "string") {
+      return { kind: "denied", reasonCode: "UNKNOWN_OPERATION", requestedId: String(requestedId) };
+    }
+    const descriptor = this.descriptors.get(requestedId);
+    if (descriptor) return { kind: "resolved", descriptor };
+    const normalized = requestedId.trim().toLowerCase();
+    if (normalized !== requestedId && this.descriptors.has(normalized)) {
+      return { kind: "denied", reasonCode: "AMBIGUOUS_OPERATION", requestedId };
+    }
+    return { kind: "denied", reasonCode: "UNKNOWN_OPERATION", requestedId };
+  }
+
+  registeredIds(): readonly string[] {
+    return [...this.descriptors.keys()].sort();
+  }
+}

--- a/src/lib/db/operations/registry.ts
+++ b/src/lib/db/operations/registry.ts
@@ -114,6 +114,10 @@ export class OperationRegistry {
     return { kind: "denied", reasonCode: "UNKNOWN_OPERATION", requestedId };
   }
 
+  // Default (code-point) sort, NOT localeCompare: these are internal operation
+  // ids, never user-facing text, and callers depend on the order being identical
+  // on every host. localeCompare would tie it to the host locale. S2871 is
+  // suppressed for this file in sonar-project.properties for exactly this reason.
   registeredIds(): readonly string[] {
     return [...this.descriptors.keys()].sort();
   }

--- a/src/lib/db/operations/statement-guard.ts
+++ b/src/lib/db/operations/statement-guard.ts
@@ -1,0 +1,272 @@
+/**
+ * Input-stage statement-shape guard for the agent path (#328).
+ *
+ * DEFENSE IN DEPTH, NEVER THE BOUNDARY. The boundary is database-native: a
+ * PostgreSQL read-only transaction under a least-privilege role, and a SQLite
+ * read-only open with `query_only` re-asserted per statement (see the execution
+ * profiles in `providers/sql/postgres.ts` / `sqlite.ts`). This guard exists
+ * because those controls are scoped to what they protect and because silent
+ * truncation is not a refusal: `prepare()` drops the tail of a multi-statement
+ * string rather than rejecting it, and an operation that asked to run two
+ * statements should be told no, not partly obeyed.
+ *
+ * Everything here reads the shared SQL readers in `src/lib/sql` rather than
+ * matching text. That matters in both directions:
+ *
+ * - a keyword a statement merely MENTIONS — inside a string, a quoted
+ *   identifier, a comment, a dollar-quoted body — is not the statement doing it
+ *   (`words.ts` records four defects of exactly that kind), so a legitimate
+ *   read like `SELECT 'insert into t' AS note` must stay allowed;
+ * - a keyword hidden BEHIND trivia or a CTE list is still the statement doing
+ *   it, so `/* SELECT *\/ INSERT …` and `WITH x AS (…) UPDATE …` must be
+ *   refused. `readOperativeKeyword` answers the second one by walking the CTE
+ *   grammar instead of searching the text.
+ *
+ * The reading is dialect-less (`DEFAULT_SQL_GRAMMAR`): the descriptor's input
+ * contract is evaluated before a provider is chosen. Where the dialects disagree
+ * about a run's meaning, the default reading is not automatically the safe one —
+ * two forms disagree about where the STATEMENT ENDS, and reading them the
+ * default way would admit a second statement rather than refuse a read:
+ *
+ * - `$tag$…$tag$` is a literal in PostgreSQL and a bind parameter followed by
+ *   ordinary code in SQLite, so a `;` written inside one really terminates the
+ *   statement there;
+ * - `#` opens a comment in MySQL/ClickHouse, is an operator in PostgreSQL and
+ *   prefixes a bind variable in SQLite.
+ *
+ * Both are therefore refused outright (`DIALECT_AMBIGUOUS_TEXT`) instead of
+ * being read under one dialect's rules. A third form was considered and left
+ * alone: `[…]` is a quoted identifier under this grammar and an array subscript
+ * whose contents are CODE in PostgreSQL, so `SELECT a[1 ; DROP TABLE t]` reads
+ * as one statement here and as two there. It stays admitted because it is not
+ * exploitable on either engine this milestone serves — PostgreSQL takes one
+ * command per Parse message and rejects that text outright, and SQLite really
+ * does read the run as an identifier.
+ *
+ * The one direction this layer accepts being wrong is over-refusal, and it costs
+ * real queries:
+ *
+ * - PostgreSQL's jsonb path operators `#>` and `#>>` are refused with everything
+ *   else carrying a `#`. Use `->` / `->>` or `jsonb_extract_path()` instead.
+ * - a bare non-reserved keyword used as an identifier (`SELECT copy FROM ads`,
+ *   `SELECT set FROM t`) is refused; quoting it (`SELECT "set" FROM t`) is the
+ *   escape hatch.
+ * - a dollar-quoted literal (`SELECT $$x$$`) is refused; ordinary quotes are not.
+ *
+ * That trade is deliberate — a refused read is re-runnable, a missed write is not.
+ */
+
+import { z } from "zod";
+import { DEFAULT_SQL_GRAMMAR } from "@/lib/sql/grammar";
+import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
+import { hasUnterminatedSpan, readSqlSpan, type SqlSpanKind } from "@/lib/sql/spans";
+import { readSqlWord } from "@/lib/sql/words";
+
+export type AgentStatementViolation =
+  /** Text carrying a literal or comment that never closes — unreadable, so refused. */
+  | "UNDETERMINABLE_TEXT"
+  /** A run the engines read differently, and differently about where the statement ends. */
+  | "DIALECT_AMBIGUOUS_TEXT"
+  /** A second statement follows a terminator; the agent path admits exactly one. */
+  | "MULTIPLE_STATEMENTS"
+  /** No statement to read (only trivia), or a shape the CTE reader cannot cross. */
+  | "NO_STATEMENT"
+  /** The keyword that operates the statement is not a bounded read. */
+  | "NON_READ_STATEMENT"
+  /** A read-shaped statement carrying a side effect (a writing CTE, a setter function). */
+  | "SIDE_EFFECT_KEYWORD";
+
+/**
+ * Keywords that may operate a statement on the agent path. An allowlist, so an
+ * unknown, misspelled or novel command is refused by default rather than
+ * needing an entry in a list of forbidden ones.
+ *
+ * `EXPLAIN` is here because plan inspection is a registered operation; the
+ * executing form is caught by `ANALYZE` below rather than by a second allowlist.
+ */
+const READ_STATEMENTS: ReadonlySet<string> = new Set(["SELECT", "VALUES", "TABLE", "EXPLAIN"]);
+
+/**
+ * Words no bounded read may contain in its own code, whatever it leads with.
+ *
+ * Two families, and both are needed because the allowlist above is about the
+ * statement's HEAD:
+ *
+ * - `INSERT` / `UPDATE` / `DELETE` / `MERGE` can ride inside a CTE body, where
+ *   the operative keyword is still the `SELECT` that reads the CTE. Those four
+ *   and no others carry a data-modifying CTE — verified on PostgreSQL 18 and
+ *   recorded in `lib/explain/select-prefix.ts`.
+ * - the statement commands can ride behind an allowed `EXPLAIN`, which prefixes
+ *   any statement in both engines this milestone serves.
+ *
+ * `REPLACE` is deliberately absent: it is a scalar function in both engines
+ * (`replace(v, 'a', 'b')`), and SQLite's `REPLACE INTO` leads a statement, so
+ * the allowlist already refuses it. `COMMIT`, `ROLLBACK` and `BEGIN` are absent
+ * for the same reason — they can only appear as a head or after a terminator,
+ * and both are refused above.
+ */
+const SIDE_EFFECT_WORDS: ReadonlySet<string> = new Set([
+  "INSERT",
+  "UPDATE",
+  "DELETE",
+  "MERGE",
+  "TRUNCATE",
+  "CREATE",
+  "DROP",
+  "ALTER",
+  "GRANT",
+  "REVOKE",
+  "ATTACH",
+  "DETACH",
+  "PRAGMA",
+  "VACUUM",
+  "REINDEX",
+  "COPY",
+  "CALL",
+  "DO",
+  "SET",
+  "LOCK",
+  "LOAD_EXTENSION",
+  // A SELECT-headed statement that writes: PostgreSQL's `SELECT … INTO <table>`
+  // creates one, MySQL's `INTO OUTFILE` writes a server-side file. Costs no
+  // legitimate read on either supported engine, since `INSERT INTO` and
+  // `MERGE INTO` are already refused by the rules above.
+  "INTO",
+]);
+
+/**
+ * SQLite exposes pragmas as table-valued functions too, and some accept the
+ * value as an argument — `pragma_query_only(0)` is the setter form found while
+ * reviewing the SQLite profile. A prefix rule covers the whole family; matching
+ * `PRAGMA` alone would not, because the function name is one word.
+ */
+const PRAGMA_FUNCTION_PREFIX = "PRAGMA_";
+
+/**
+ * Permitted only for the plan-EXECUTION descriptor; a bare `ANALYZE` writes
+ * statistics in both engines.
+ *
+ * BOTH spellings, because PostgreSQL accepts `ANALYSE` as a full synonym and it
+ * executes the statement just the same. Knowing one spelling would let plan
+ * execution be requested through the risk-class-0, approval-free plan-INSPECTION
+ * descriptor — a whole risk class and its approval gate bypassed by a vowel.
+ */
+const PLAN_EXECUTION_WORDS: ReadonlySet<string> = new Set(["ANALYZE", "ANALYSE"]);
+
+export interface AgentStatementOptions {
+  /** true only for the approval-gated plan-execution descriptor (`sql.explain.analyze`). */
+  readonly allowPlanExecution?: boolean;
+}
+
+/**
+ * Whether a span is the statement's own text rather than trivia between tokens.
+ * The same four kinds `statement-end.ts` treats as statement text — a literal, a
+ * quoted name and a bracketed subscript are tokens a statement is made of.
+ */
+function isStatementText(kind: SqlSpanKind): boolean {
+  return kind === "string" || kind === "quoted-identifier" || kind === "dollar-string" || kind === "subscript";
+}
+
+/**
+ * One walk answering both questions about where this statement ends: whether
+ * anything but trivia follows a terminator, and whether the text carries a run
+ * the engines would terminate the statement at differently.
+ *
+ * A `;` inside a literal, a quoted name or a comment is not a terminator, which
+ * is why this walks spans rather than splitting on the character. Trailing
+ * `;`s, whitespace and comments are not a second statement.
+ */
+function scanStatementShape(sql: string): { dialectAmbiguous: boolean; statementTail: boolean } {
+  let terminated = false;
+  let statementTail = false;
+  let dialectAmbiguous = false;
+  let i = 0;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i, DEFAULT_SQL_GRAMMAR);
+    if (span !== null) {
+      // A `$…$` run read as a literal here is code in SQLite; a `#` run read as
+      // a comment here is an operator in PostgreSQL. Either way this reader
+      // cannot say where the statement ends, so it says so.
+      if (span.kind === "dollar-string" || sql[i] === "#") dialectAmbiguous = true;
+      if (terminated && isStatementText(span.kind)) statementTail = true;
+      i = span.end;
+      continue;
+    }
+
+    if (sql[i] === ";") terminated = true;
+    else if (sql[i] === "#") dialectAmbiguous = true;
+    else if (terminated && !/\s/.test(sql[i])) statementTail = true;
+    i++;
+  }
+
+  return { dialectAmbiguous, statementTail };
+}
+
+/** The first forbidden word in this statement's own code, or null. */
+function findSideEffectWord(sql: string, allowPlanExecution: boolean): string | null {
+  let i = 0;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i, DEFAULT_SQL_GRAMMAR);
+    if (span !== null) {
+      i = span.end;
+      continue;
+    }
+
+    const word = readSqlWord(sql, i);
+    if (word === null) {
+      i++;
+      continue;
+    }
+    if (SIDE_EFFECT_WORDS.has(word.text) || word.text.startsWith(PRAGMA_FUNCTION_PREFIX)) return word.text;
+    if (PLAN_EXECUTION_WORDS.has(word.text) && !allowPlanExecution) return word.text;
+    i = word.end;
+  }
+
+  return null;
+}
+
+/**
+ * Why this statement may not run on the agent path, or `null` when the guard
+ * has no objection. `null` is NOT a safety claim — it means this layer found
+ * nothing; the database-native profile still has to refuse whatever it missed.
+ *
+ * Checks run cheapest-and-most-certain first, and the first one that fires is
+ * the reported violation: unreadable text, then text no single reading settles,
+ * then a second statement, then the statement's own shape, then what its code
+ * carries.
+ */
+export function inspectAgentStatement(
+  sql: string,
+  options: AgentStatementOptions = {},
+): AgentStatementViolation | null {
+  if (hasUnterminatedSpan(sql, DEFAULT_SQL_GRAMMAR)) return "UNDETERMINABLE_TEXT";
+
+  const shape = scanStatementShape(sql);
+  if (shape.dialectAmbiguous) return "DIALECT_AMBIGUOUS_TEXT";
+  if (shape.statementTail) return "MULTIPLE_STATEMENTS";
+
+  const operative = readOperativeKeyword(sql, DEFAULT_SQL_GRAMMAR);
+  if (operative === null) return "NO_STATEMENT";
+  if (!READ_STATEMENTS.has(operative.keyword)) return "NON_READ_STATEMENT";
+
+  return findSideEffectWord(sql, options.allowPlanExecution === true) === null ? null : "SIDE_EFFECT_KEYWORD";
+}
+
+/**
+ * Exactly one SQL statement string, shaped like a bounded read. Unknown keys
+ * are rejected (fail closed), and the violation travels as the issue message so
+ * a denial can be diagnosed without re-running the guard.
+ */
+function agentSqlInput(options: AgentStatementOptions) {
+  return z.strictObject({ sql: z.string().min(1) }).superRefine((value, ctx) => {
+    const violation = inspectAgentStatement(value.sql, options);
+    if (violation !== null) {
+      ctx.addIssue({ code: "custom", message: `agent statement refused: ${violation}`, path: ["sql"] });
+    }
+  });
+}
+
+export const agentReadSqlInput = agentSqlInput({});
+export const agentPlanExecutionSqlInput = agentSqlInput({ allowPlanExecution: true });

--- a/src/lib/db/operations/types.ts
+++ b/src/lib/db/operations/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Canonical database-operation descriptor model (#328, epic #325).
+ *
+ * Risk classes R0-R6 grade operations by blast radius; Phase 1 gives only two
+ * of them a registrable meaning — R0 (bounded metadata read) and R1 (bounded
+ * data read, individually verified against a database-native boundary).
+ * Classes 2-6 deliberately have NO registrable representation, not even a
+ * disabled slot: `RegistrableOperationDescriptor` structurally cannot express
+ * them, and the registry refuses them at runtime for callers that bypass the
+ * types. Database-native enforcement (PostgreSQL read-only transaction, SQLite
+ * query_only) is the security boundary — nothing in this model trusts a parser.
+ */
+
+import type { z } from "zod";
+import type { ProviderCapabilities } from "@/lib/db/types";
+
+/** Full R0-R6 risk scale. Only 0 and 1 are registrable — see module doc. */
+export type RiskClass = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/** Registrable access levels. Write/admin levels intentionally do not exist. */
+type OperationAccessLevel = "metadata-read" | "data-read";
+
+/** Coarse cost tier consumed by execution budgets (statement/row/concurrency). */
+type OperationResourceCost = "light" | "moderate" | "heavy";
+
+/**
+ * ProviderCapabilities keys usable as required-capability gates: the boolean
+ * affordance flags only. Capabilities stay a UI-affordance contract and a fast
+ * deny signal — never the security boundary.
+ */
+type BooleanProviderCapability = {
+  [K in keyof ProviderCapabilities]-?: ProviderCapabilities[K] extends boolean | undefined ? K : never;
+}[keyof ProviderCapabilities];
+
+/**
+ * Explicit per-descriptor verification marker required to register any
+ * risk-class-1 descriptor: who reviewed it and which database-native boundary
+ * bounds it. An R1 descriptor without a substantive marker is refused exactly
+ * like a class-2+ one.
+ */
+export interface RiskVerification {
+  readonly reviewedBy: string;
+  /** The database-native mechanism that bounds the operation (never a parser). */
+  readonly boundary: string;
+  /** ISO date (YYYY-MM-DD) the verification was recorded. */
+  readonly verifiedOn: string;
+}
+
+interface OperationDescriptorBase {
+  /** Canonical id: two or more lowercase dot-separated segments, e.g. "sql.query.read". */
+  readonly id: string;
+  readonly accessLevel: OperationAccessLevel;
+  readonly requiredCapabilities: readonly BooleanProviderCapability[];
+  readonly resourceCost: OperationResourceCost;
+  readonly supportsDryRun: boolean;
+  /**
+   * true = default-denied: the decision pipeline may answer require-approval
+   * for this operation, never a plain allow.
+   */
+  readonly requiresApproval: boolean;
+  /** Input contract enforced before any policy evaluation (fail closed). */
+  readonly inputSchema: z.ZodType<unknown>;
+}
+
+/**
+ * The only descriptor shapes that can exist in a registry. R1 requires the
+ * verification marker structurally; classes 2-6 are inexpressible.
+ */
+export type RegistrableOperationDescriptor =
+  | (OperationDescriptorBase & { readonly riskClass: 0; readonly verification?: never })
+  | (OperationDescriptorBase & { readonly riskClass: 1; readonly verification: RiskVerification });

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -524,15 +524,30 @@ const STORAGE_WAL_SQL = `
  * `to_regrole` keeps the query safe on a server where a predefined role is
  * absent (it yields NULL, and `COALESCE` makes that a `false` rather than an
  * error), so the check does not depend on the server's major version.
+ *
+ * Every catalog FUNCTION is schema-qualified because this query decides a
+ * security boundary. `pg_catalog` is searched implicitly first only while it is
+ * not named in `search_path`; once it is named explicitly, any schema ahead of
+ * it shadows built-ins, so `search_path = attacker_schema, pg_catalog` plus a
+ * shadow `pg_has_role()` would answer four falses for a superuser and defeat
+ * the one check meant to catch that role. `COALESCE` and `current_user` need no
+ * qualification (and accept none): they are SQL constructs the parser resolves,
+ * not functions that name resolution can redirect.
  */
 const AGENT_ROLE_PRIVILEGE_SQL = `
-        SELECT current_setting('is_superuser') = 'on' AS is_superuser,
-               COALESCE(pg_has_role(current_user, to_regrole('pg_read_server_files'), 'USAGE'), false)
-                 AS reads_server_files,
-               COALESCE(pg_has_role(current_user, to_regrole('pg_write_server_files'), 'USAGE'), false)
-                 AS writes_server_files,
-               COALESCE(pg_has_role(current_user, to_regrole('pg_execute_server_program'), 'USAGE'), false)
-                 AS executes_programs
+        SELECT pg_catalog.current_setting('is_superuser') = 'on' AS is_superuser,
+               COALESCE(
+                 pg_catalog.pg_has_role(current_user, pg_catalog.to_regrole('pg_read_server_files'), 'USAGE'),
+                 false
+               ) AS reads_server_files,
+               COALESCE(
+                 pg_catalog.pg_has_role(current_user, pg_catalog.to_regrole('pg_write_server_files'), 'USAGE'),
+                 false
+               ) AS writes_server_files,
+               COALESCE(
+                 pg_catalog.pg_has_role(current_user, pg_catalog.to_regrole('pg_execute_server_program'), 'USAGE'),
+                 false
+               ) AS executes_programs
       `;
 
 const AGENT_ROLE_FORBIDDEN_CAPABILITIES = [
@@ -660,14 +675,18 @@ export class PostgresProvider extends SQLBaseProvider {
       this.setConnected(true);
     } catch (error) {
       this.setError(error instanceof Error ? error : new Error(String(error)));
+      // The pool is built before anything that can fail here — the borrow, and
+      // under the profile the role probe. Whatever went wrong, the caller ends
+      // up without a usable provider, and `acquireExecutionProfileProvider`
+      // drops it WITHOUT calling disconnect(), so a pool left open here leaks
+      // its idle socket and timers with no reference left to close them. End it
+      // on every failed connect, not just the typed refusal.
+      const failedPool = this.pool;
+      this.pool = null;
+      await failedPool?.end().catch(() => {});
       // A typed profile refusal keeps its identity: wrapping it would strip the
       // deny reason code callers branch on.
       if (error instanceof ExecutionProfileError) {
-        // The pool was built before the refusal; leaving it would leak the
-        // sockets of a provider the caller can never use.
-        const refusedPool = this.pool;
-        this.pool = null;
-        await refusedPool?.end().catch(() => {});
         throw error;
       }
       throw new ConnectionError(

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -3,7 +3,7 @@
  * Full PostgreSQL support with connection pooling
  */
 
-import { Pool, type PoolClient, type PoolConfig as PgPoolConfig } from "pg";
+import { Pool, type PoolClient, type PoolConfig as PgPoolConfig, type QueryConfig } from "pg";
 import { SQLBaseProvider } from "./sql-base";
 import {
   type DatabaseConnection,
@@ -15,6 +15,7 @@ import {
   type MaintenanceResult,
   type ProviderOptions,
   type ProviderCapabilities,
+  type ReadOnlyStatementBudget,
   type SlowQuery,
   type ActiveSession,
   type DatabaseOverview,
@@ -505,6 +506,32 @@ const STORAGE_WAL_SQL = `
         `;
 
 // ============================================================================
+// Read-only execution budget validation (#328)
+// ============================================================================
+
+/** PostgreSQL's statement_timeout is a 32-bit millisecond setting. */
+const MAX_STATEMENT_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Refuses the whole call unless every budget field is a positive integer in
+ * range (fail closed). The timeout bound matters doubly: the value is
+ * interpolated into `SET LOCAL statement_timeout = N` (SET takes no bind
+ * parameters), so nothing that is not a positive integer may pass.
+ */
+function assertReadOnlyBudget(budget: ReadOnlyStatementBudget): void {
+  const fields: Array<[name: string, value: unknown, max: number]> = [
+    ["statementTimeoutMs", budget?.statementTimeoutMs, MAX_STATEMENT_TIMEOUT_MS],
+    ["maxResultRows", budget?.maxResultRows, Number.MAX_SAFE_INTEGER],
+    ["maxResultBytes", budget?.maxResultBytes, Number.MAX_SAFE_INTEGER],
+  ];
+  for (const [name, value, max] of fields) {
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > max) {
+      throw new QueryError(`Read-only execution budget field ${name} must be a positive integer <= ${max}`, "postgres");
+    }
+  }
+}
+
+// ============================================================================
 // PostgreSQL Provider
 // ============================================================================
 
@@ -725,6 +752,89 @@ export class PostgresProvider extends SQLBaseProvider {
       console.error("[Postgres] Failed to cancel query:", error);
       return false;
     }
+  }
+
+  // ============================================================================
+  // Agent Read-Only Execution Profile (#328)
+  // ============================================================================
+
+  /**
+   * Runs exactly one statement inside `BEGIN READ ONLY` with a
+   * transaction-local timeout, then rolls back and releases the client. The
+   * DATABASE is the boundary, twice over:
+   *
+   * - The read-only transaction makes the server itself reject any write that
+   *   reaches it (SQLSTATE 25006) — no SQL classification happens here.
+   * - The statement travels on the extended query protocol (`queryMode:
+   *   "extended"`, pg >= 8.11), whose Parse message the server refuses for
+   *   multi-command strings (SQLSTATE 42601) BEFORE executing anything. That
+   *   is what stops `SELECT 1; COMMIT; INSERT ...` from committing its way out
+   *   of the read-only transaction — on the simple protocol the server would
+   *   execute each command in turn, honoring the smuggled COMMIT.
+   *
+   * A single hostile statement cannot escape either: `SET TRANSACTION READ
+   * WRITE` would be the transaction's only statement before ROLLBACK, a lone
+   * COMMIT merely ends an empty read-only transaction, and a session-level
+   * `SET` reverts with the rollback (GUC changes are transactional).
+   *
+   * The row/byte caps are enforced result-side after the statement returns;
+   * the timeout is `SET LOCAL`, so it dies with the transaction.
+   */
+  public async queryReadOnly(sql: string, budget: ReadOnlyStatementBudget): Promise<QueryResult> {
+    this.ensureConnected();
+    assertReadOnlyBudget(budget);
+
+    return this.trackQuery(async () => {
+      const { result, executionTime } = await this.measureExecution(async () => {
+        const client = await this.pool!.connect();
+        try {
+          await client.query("BEGIN READ ONLY");
+          // SET cannot take bind parameters; the value is proven a positive
+          // integer by assertReadOnlyBudget above, so no text can pass through.
+          await client.query(`SET LOCAL statement_timeout = ${budget.statementTimeoutMs}`);
+          // @types/pg does not model queryMode yet; the runtime supports it
+          // since pg 8.11 (node_modules/pg/lib/query.js requiresPreparation).
+          const extendedQuery = { text: sql, queryMode: "extended" } as QueryConfig & { queryMode: "extended" };
+          return await client.query(extendedQuery);
+        } catch (error) {
+          throw mapDatabaseError(error, "postgres", sql);
+        } finally {
+          // The profile never commits. A client that cannot roll back is
+          // destroyed (release(error)), never returned to the pool mid-transaction.
+          try {
+            await client.query("ROLLBACK");
+            client.release();
+          } catch (rollbackError) {
+            client.release(rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)));
+          }
+        }
+      });
+
+      if (result.rows.length > budget.maxResultRows) {
+        throw new QueryError(
+          `Read-only execution exceeded the row budget: ${result.rows.length} rows > ${budget.maxResultRows} allowed`,
+          "postgres",
+          sql,
+        );
+      }
+      const resultBytes = Buffer.byteLength(
+        JSON.stringify(result.rows, (_key, value: unknown) => (typeof value === "bigint" ? value.toString() : value)),
+      );
+      if (resultBytes > budget.maxResultBytes) {
+        throw new QueryError(
+          `Read-only execution exceeded the byte budget: ${resultBytes} bytes > ${budget.maxResultBytes} allowed`,
+          "postgres",
+          sql,
+        );
+      }
+
+      return {
+        rows: result.rows,
+        fields: result.fields?.map((f) => f.name) ?? [],
+        rowCount: result.rowCount ?? 0,
+        executionTime,
+      };
+    });
   }
 
   // ============================================================================

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -15,6 +15,7 @@ import {
   type MaintenanceResult,
   type ProviderOptions,
   type ProviderCapabilities,
+  type ProviderExecutionContext,
   type ReadOnlyStatementBudget,
   type SlowQuery,
   type ActiveSession,
@@ -26,7 +27,13 @@ import {
   type IndexStats,
   type StorageStats,
 } from "../../types";
-import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
+import {
+  DatabaseConfigError,
+  ConnectionError,
+  ExecutionProfileError,
+  QueryError,
+  mapDatabaseError,
+} from "../../errors";
 import { assertReadOnlyBudget, measureResultBytes } from "./read-only-budget";
 import { formatBytes } from "../../utils/pool-manager";
 
@@ -507,6 +514,67 @@ const STORAGE_WAL_SQL = `
         `;
 
 // ============================================================================
+// Agent read-only execution profile (#328)
+// ============================================================================
+
+/**
+ * The capabilities a read-only TRANSACTION cannot contain, asked of the role
+ * the profile would run as.
+ *
+ * `to_regrole` keeps the query safe on a server where a predefined role is
+ * absent (it yields NULL, and `COALESCE` makes that a `false` rather than an
+ * error), so the check does not depend on the server's major version.
+ */
+const AGENT_ROLE_PRIVILEGE_SQL = `
+        SELECT current_setting('is_superuser') = 'on' AS is_superuser,
+               COALESCE(pg_has_role(current_user, to_regrole('pg_read_server_files'), 'USAGE'), false)
+                 AS reads_server_files,
+               COALESCE(pg_has_role(current_user, to_regrole('pg_write_server_files'), 'USAGE'), false)
+                 AS writes_server_files,
+               COALESCE(pg_has_role(current_user, to_regrole('pg_execute_server_program'), 'USAGE'), false)
+                 AS executes_programs
+      `;
+
+const AGENT_ROLE_FORBIDDEN_CAPABILITIES = [
+  "is_superuser",
+  "reads_server_files",
+  "writes_server_files",
+  "executes_programs",
+] as const;
+
+/**
+ * Refuses a role whose privileges reach past the read-only transaction.
+ *
+ * `BEGIN READ ONLY` forbids changing the DATABASE. It does not forbid writing
+ * somewhere else: verified on PostgreSQL 18, a superuser session inside a
+ * read-only transaction still ran `COPY (…) TO '<path>'` (an arbitrary
+ * server-side file write), `COPY (…) TO PROGRAM '<cmd>'` (command execution as
+ * the server's OS user) and `pg_read_file()` (an arbitrary server-side file
+ * read). Only privileges refuse those — the same lesson the SQLite profile
+ * learned from `VACUUM INTO`: a control is a claim about one resource, so the
+ * question is always what else the statement can reach.
+ *
+ * Hence a least-privilege agent role is part of this profile's boundary rather
+ * than a recommendation, and it is VERIFIED at open instead of assumed from
+ * configuration: an admin can point `agentUser` at a superuser, and a
+ * connection's own user very often is one.
+ *
+ * Fails closed on anything it cannot read as four explicit `false`s — a server
+ * that answers nothing, or answers something else, leaves the boundary
+ * unproven.
+ */
+function assertAgentRoleIsUnprivileged(rows: unknown[]): void {
+  const row = rows[0] as Record<string, unknown> | undefined;
+  const held = AGENT_ROLE_FORBIDDEN_CAPABILITIES.filter((capability) => row?.[capability] !== false);
+  if (held.length > 0) {
+    throw new ExecutionProfileError(
+      `The agent read-only execution profile requires a least-privilege PostgreSQL role; this role is unverified or too broad (${held.join(", ")}). A read-only transaction does not stop server-side file access or program execution.`,
+      "PROFILE_PRIVILEGES_TOO_BROAD",
+    );
+  }
+}
+
+// ============================================================================
 // PostgreSQL Provider
 // ============================================================================
 
@@ -519,8 +587,15 @@ export class PostgresProvider extends SQLBaseProvider {
   private txTimeout: ReturnType<typeof setTimeout> | null = null;
   private static readonly TX_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
-  constructor(config: DatabaseConnection, options: ProviderOptions = {}) {
+  /** True when this instance was opened under the agent read-only profile. */
+  private readonly readOnlyProfile: boolean;
+
+  constructor(config: DatabaseConnection, options: ProviderOptions = {}, execution: ProviderExecutionContext = {}) {
     super(config, options);
+    // Server-injected only (see ProviderExecutionContext): the editor path
+    // builds providers from caller-supplied ProviderOptions, which has no route
+    // to this flag in either direction.
+    this.readOnlyProfile = execution.readOnly === true;
     this.validate();
   }
 
@@ -572,11 +647,29 @@ export class PostgresProvider extends SQLBaseProvider {
       this.attachPoolErrorListener(this.pool);
 
       const client = await this.pool.connect();
-      client.release();
+      try {
+        // Under the profile, the role itself is part of the boundary — verify it
+        // on the same client this connect already borrowed.
+        if (this.readOnlyProfile) {
+          assertAgentRoleIsUnprivileged((await client.query(AGENT_ROLE_PRIVILEGE_SQL)).rows);
+        }
+      } finally {
+        client.release();
+      }
 
       this.setConnected(true);
     } catch (error) {
       this.setError(error instanceof Error ? error : new Error(String(error)));
+      // A typed profile refusal keeps its identity: wrapping it would strip the
+      // deny reason code callers branch on.
+      if (error instanceof ExecutionProfileError) {
+        // The pool was built before the refusal; leaving it would leak the
+        // sockets of a provider the caller can never use.
+        const refusedPool = this.pool;
+        this.pool = null;
+        await refusedPool?.end().catch(() => {});
+        throw error;
+      }
       throw new ConnectionError(
         `Failed to connect to PostgreSQL: ${error instanceof Error ? error.message : error}`,
         "postgres",
@@ -758,6 +851,17 @@ export class PostgresProvider extends SQLBaseProvider {
   public async queryReadOnly(sql: string, budget: ReadOnlyStatementBudget): Promise<QueryResult> {
     this.ensureConnected();
     assertReadOnlyBudget(budget, "postgres");
+    if (!this.readOnlyProfile) {
+      // A provider opened outside the profile has had no role verification, so
+      // its session may be able to write server files or run programs from
+      // inside a read-only transaction. Refuse rather than serve agent
+      // semantics without the boundary that makes them true.
+      throw new QueryError(
+        "Read-only execution requires a provider opened under the agent read-only profile",
+        "postgres",
+        sql,
+      );
+    }
 
     return this.trackQuery(async () => {
       const { result, executionTime } = await this.measureExecution(async () => {
@@ -774,13 +878,19 @@ export class PostgresProvider extends SQLBaseProvider {
         } catch (error) {
           throw mapDatabaseError(error, "postgres", sql);
         } finally {
-          // The profile never commits. A client that cannot roll back is
+          // The profile never commits. A client that cannot be reset is
           // destroyed (release(error)), never returned to the pool mid-transaction.
           try {
             await client.query("ROLLBACK");
+            // Session state a rollback does NOT undo: an advisory lock taken
+            // inside the transaction survives it (verified on PostgreSQL 18) and
+            // no statement the agent path admits could release it, so a pooled
+            // client would carry it into every later execution. DISCARD ALL
+            // cannot run inside a transaction block, hence after the ROLLBACK.
+            await client.query("DISCARD ALL");
             client.release();
-          } catch (rollbackError) {
-            client.release(rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)));
+          } catch (cleanupError) {
+            client.release(cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError)));
           }
         }
       });

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -27,6 +27,7 @@ import {
   type StorageStats,
 } from "../../types";
 import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
+import { assertReadOnlyBudget, measureResultBytes } from "./read-only-budget";
 import { formatBytes } from "../../utils/pool-manager";
 
 // ============================================================================
@@ -506,32 +507,6 @@ const STORAGE_WAL_SQL = `
         `;
 
 // ============================================================================
-// Read-only execution budget validation (#328)
-// ============================================================================
-
-/** PostgreSQL's statement_timeout is a 32-bit millisecond setting. */
-const MAX_STATEMENT_TIMEOUT_MS = 2_147_483_647;
-
-/**
- * Refuses the whole call unless every budget field is a positive integer in
- * range (fail closed). The timeout bound matters doubly: the value is
- * interpolated into `SET LOCAL statement_timeout = N` (SET takes no bind
- * parameters), so nothing that is not a positive integer may pass.
- */
-function assertReadOnlyBudget(budget: ReadOnlyStatementBudget): void {
-  const fields: Array<[name: string, value: unknown, max: number]> = [
-    ["statementTimeoutMs", budget?.statementTimeoutMs, MAX_STATEMENT_TIMEOUT_MS],
-    ["maxResultRows", budget?.maxResultRows, Number.MAX_SAFE_INTEGER],
-    ["maxResultBytes", budget?.maxResultBytes, Number.MAX_SAFE_INTEGER],
-  ];
-  for (const [name, value, max] of fields) {
-    if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > max) {
-      throw new QueryError(`Read-only execution budget field ${name} must be a positive integer <= ${max}`, "postgres");
-    }
-  }
-}
-
-// ============================================================================
 // PostgreSQL Provider
 // ============================================================================
 
@@ -782,7 +757,7 @@ export class PostgresProvider extends SQLBaseProvider {
    */
   public async queryReadOnly(sql: string, budget: ReadOnlyStatementBudget): Promise<QueryResult> {
     this.ensureConnected();
-    assertReadOnlyBudget(budget);
+    assertReadOnlyBudget(budget, "postgres");
 
     return this.trackQuery(async () => {
       const { result, executionTime } = await this.measureExecution(async () => {
@@ -817,9 +792,7 @@ export class PostgresProvider extends SQLBaseProvider {
           sql,
         );
       }
-      const resultBytes = Buffer.byteLength(
-        JSON.stringify(result.rows, (_key, value: unknown) => (typeof value === "bigint" ? value.toString() : value)),
-      );
+      const resultBytes = measureResultBytes(result.rows);
       if (resultBytes > budget.maxResultBytes) {
         throw new QueryError(
           `Read-only execution exceeded the byte budget: ${resultBytes} bytes > ${budget.maxResultBytes} allowed`,

--- a/src/lib/db/providers/sql/read-only-budget.ts
+++ b/src/lib/db/providers/sql/read-only-budget.ts
@@ -1,0 +1,43 @@
+/**
+ * Read-only execution budget validation (#328).
+ *
+ * Shared by every provider that implements `queryReadOnly`, so the agent
+ * execution profile cannot end up with one provider validating its budget and
+ * another trusting it. The check is fail-closed: the whole call is refused
+ * unless every field is a positive integer in range.
+ *
+ * The upper bound matters doubly on PostgreSQL, where the timeout is
+ * interpolated into `SET LOCAL statement_timeout = N` (SET takes no bind
+ * parameters), so nothing that is not a positive integer may reach it.
+ */
+
+import type { DatabaseType, ReadOnlyStatementBudget } from "../../types";
+import { QueryError } from "../../errors";
+
+/** PostgreSQL's statement_timeout is a 32-bit millisecond setting; the same
+ * ceiling is applied everywhere — a timeout beyond ~24 days is not a budget. */
+const MAX_STATEMENT_TIMEOUT_MS = 2_147_483_647;
+
+export function assertReadOnlyBudget(budget: ReadOnlyStatementBudget, provider: DatabaseType): void {
+  const fields: Array<[name: string, value: unknown, max: number]> = [
+    ["statementTimeoutMs", budget?.statementTimeoutMs, MAX_STATEMENT_TIMEOUT_MS],
+    ["maxResultRows", budget?.maxResultRows, Number.MAX_SAFE_INTEGER],
+    ["maxResultBytes", budget?.maxResultBytes, Number.MAX_SAFE_INTEGER],
+  ];
+  for (const [name, value, max] of fields) {
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > max) {
+      throw new QueryError(`Read-only execution budget field ${name} must be a positive integer <= ${max}`, provider);
+    }
+  }
+}
+
+/**
+ * Byte size of a result set as it would be serialized to the caller. BigInt
+ * values (node:sqlite and pg both emit them for 64-bit integers) have no JSON
+ * representation, so they are measured as their decimal text.
+ */
+export function measureResultBytes(rows: unknown[]): number {
+  return Buffer.byteLength(
+    JSON.stringify(rows, (_key, value: unknown) => (typeof value === "bigint" ? value.toString() : value)),
+  );
+}

--- a/src/lib/db/providers/sql/sqlite-driver.ts
+++ b/src/lib/db/providers/sql/sqlite-driver.ts
@@ -33,7 +33,14 @@ export type SQLiteDatabase = {
   close(): void;
 };
 
-export type SQLiteOpenOptions = { create?: boolean; readwrite?: boolean };
+/**
+ * Open options in the bun:sqlite spelling (this surface is bun-shaped; the
+ * node adapter below translates). `readonly` opens the database under SQLite's
+ * own read-only enforcement — writes are refused by the engine and a missing
+ * file is NOT created — which is the SQLite half of the agent execution
+ * profile (#328).
+ */
+export type SQLiteOpenOptions = { create?: boolean; readwrite?: boolean; readonly?: boolean };
 
 export type SQLiteConstructor = new (path: string, options?: SQLiteOpenOptions) => SQLiteDatabase;
 
@@ -51,7 +58,11 @@ export type NodeDatabaseSyncLike = {
   prepare(sql: string): NodeStatementLike;
   close(): void;
 };
-export type NodeSQLiteModule = { DatabaseSync: new (path: string) => NodeDatabaseSyncLike };
+/** node:sqlite's own open options — only the ones this adapter maps. */
+export type NodeSQLiteOpenOptions = { readOnly?: boolean };
+export type NodeSQLiteModule = {
+  DatabaseSync: new (path: string, options?: NodeSQLiteOpenOptions) => NodeDatabaseSyncLike;
+};
 
 const loadedDrivers = new Map<SQLiteDriverName, SQLiteConstructor>();
 const driverLoadErrors = new Map<SQLiteDriverName, Error>();
@@ -85,7 +96,10 @@ async function loadBunDriver(): Promise<SQLiteConstructor> {
  * the bridges below keep behaviour byte-compatible with bun:sqlite:
  * - node:sqlite opens read-write and creates missing files by default,
  *   matching the `{ create: true, readwrite: true }` options the provider
- *   passes to bun:sqlite, so open options are accepted and ignored.
+ *   passes to bun:sqlite, so those two flags need no translation. The
+ *   read-only flag DOES: node spells it `readOnly`, bun spells it `readonly`,
+ *   and an adapter that dropped it would silently hand an agent execution
+ *   profile a fully writable database handle (#328).
  * - `get()` returns `undefined` on a miss where bun:sqlite returns `null`.
  * - `run()` reports `changes` as `number | bigint`; normalize to `number`.
  *
@@ -96,8 +110,8 @@ export function createNodeSQLiteDriver(DatabaseSyncCtor: NodeSQLiteModule["Datab
   class NodeSQLiteDatabase implements SQLiteDatabase {
     private readonly db: NodeDatabaseSyncLike;
 
-    constructor(dbPath: string, _options?: SQLiteOpenOptions) {
-      this.db = new DatabaseSyncCtor(dbPath);
+    constructor(dbPath: string, options?: SQLiteOpenOptions) {
+      this.db = new DatabaseSyncCtor(dbPath, { readOnly: options?.readonly === true });
     }
 
     exec(sql: string): void {

--- a/src/lib/db/providers/sql/sqlite.ts
+++ b/src/lib/db/providers/sql/sqlite.ts
@@ -19,6 +19,8 @@ import {
   type MaintenanceType,
   type MaintenanceResult,
   type ProviderOptions,
+  type ProviderExecutionContext,
+  type ReadOnlyStatementBudget,
   type ProviderCapabilities,
   type DatabaseOverview,
   type PerformanceMetrics,
@@ -28,7 +30,14 @@ import {
   type IndexStats,
   type StorageStats,
 } from "../../types";
-import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
+import {
+  DatabaseConfigError,
+  ConnectionError,
+  ExecutionProfileError,
+  QueryError,
+  mapDatabaseError,
+} from "../../errors";
+import { assertReadOnlyBudget, measureResultBytes } from "./read-only-budget";
 import { formatBytes } from "../../utils/pool-manager";
 import { loadSQLiteDriver, type SQLiteDatabase } from "./sqlite-driver";
 import * as fs from "fs";
@@ -115,14 +124,54 @@ const STATS_INDEXES_SQL = `
     `;
 
 // ============================================================================
+// Agent read-only execution profile (#328)
+// ============================================================================
+
+const QUERY_ONLY_PRAGMA_SQL = "PRAGMA query_only = true";
+const QUERY_ONLY_READBACK_SQL = "PRAGMA query_only";
+
+/**
+ * Refuses a read-only handle whose `query_only` pragma does not read back
+ * enabled.
+ *
+ * A read-only OPEN does not imply `query_only` on either adapter (it reads
+ * back 0 until explicitly set), so the profile sets it and verifies it — at
+ * open AND before every statement.
+ *
+ * The two controls cover different things and neither is redundant. The
+ * read-only open governs the TARGET database file: writes to it are refused
+ * and a missing file is not created. It does NOT govern writes to OTHER
+ * files — `VACUUM INTO '<path>'` copies the whole database to an arbitrary
+ * server path from a read-only handle on both adapters. That is what
+ * `query_only` refuses, and why it is re-asserted per statement rather than
+ * only at open: a statement can turn it off, but `prepare()` compiles exactly
+ * one statement, so the disable and the write can never ride in the same call.
+ */
+export function assertQueryOnlyEnabled(readback: unknown[]): void {
+  const value = (readback[0] as { query_only?: unknown } | undefined)?.query_only;
+  if (value !== 1) {
+    throw new ConnectionError(
+      `SQLite read-only profile could not enable query_only (read back ${JSON.stringify(value ?? null)})`,
+      "sqlite",
+    );
+  }
+}
+
+// ============================================================================
 // SQLite Provider
 // ============================================================================
 
 export class SQLiteProvider extends SQLBaseProvider {
   private db: SQLiteDatabase | null = null;
+  /** True when this instance was opened under the agent read-only profile. */
+  private readonly readOnlyProfile: boolean;
 
-  constructor(config: DatabaseConnection, options: ProviderOptions = {}) {
+  constructor(config: DatabaseConnection, options: ProviderOptions = {}, execution: ProviderExecutionContext = {}) {
     super(config, options);
+    // Server-injected only (see ProviderExecutionContext): the shared editor
+    // path builds providers from caller-supplied ProviderOptions, which has no
+    // route to this flag in either direction.
+    this.readOnlyProfile = execution.readOnly === true;
     this.validate();
   }
 
@@ -172,6 +221,11 @@ export class SQLiteProvider extends SQLBaseProvider {
 
       const dbPath = this.getDatabasePath();
 
+      if (this.readOnlyProfile) {
+        this.connectReadOnly(SQLiteDB, dbPath);
+        return;
+      }
+
       if (dbPath !== ":memory:") {
         const dir = path.dirname(dbPath);
         if (!fs.existsSync(dir)) {
@@ -193,7 +247,9 @@ export class SQLiteProvider extends SQLBaseProvider {
     } catch (error) {
       this.setError(error instanceof Error ? error : new Error(String(error)));
 
-      if (error instanceof DatabaseConfigError) {
+      // Typed refusals keep their own identity: wrapping them would strip the
+      // config diagnosis / the profile's deny reason code.
+      if (error instanceof DatabaseConfigError || error instanceof ExecutionProfileError) {
         throw error;
       }
 
@@ -202,6 +258,48 @@ export class SQLiteProvider extends SQLBaseProvider {
         "sqlite",
       );
     }
+  }
+
+  /**
+   * Open the agent read-only handle (#328). Deliberately NOT the shared
+   * sequence above:
+   *
+   * - no directory is created and no `create` flag is passed, so a missing
+   *   target leaves the filesystem untouched (the read-only open itself
+   *   refuses to create the file on both adapters);
+   * - `PRAGMA journal_mode = WAL` is a write and fails outright on a read-only
+   *   handle, so the shared pragma trio is skipped — none of it applies to a
+   *   connection that cannot write;
+   * - `query_only` is set and verified (a read-only open does not imply it).
+   *
+   * An in-memory target is refused: a read-only open of an anonymous database
+   * can only ever yield an empty one (node:sqlite) or fail (bun:sqlite), so
+   * vending it would hand the agent a silently useless target.
+   */
+  private connectReadOnly(SQLiteDB: Awaited<ReturnType<typeof loadSQLiteDriver>>, dbPath: string): void {
+    if (dbPath === ":memory:") {
+      throw new ExecutionProfileError(
+        "The agent read-only execution profile cannot target an in-memory SQLite database",
+        "PROFILE_UNSUPPORTED_TARGET",
+      );
+    }
+
+    this.db = new SQLiteDB(dbPath, { readonly: true });
+    try {
+      this.enforceQueryOnly();
+    } catch (error) {
+      this.db.close();
+      this.db = null;
+      throw error;
+    }
+
+    this.setConnected(true);
+  }
+
+  /** Set `query_only` and refuse to continue unless it reads back enabled. */
+  private enforceQueryOnly(): void {
+    this.db!.exec(QUERY_ONLY_PRAGMA_SQL);
+    assertQueryOnlyEnabled(this.db!.prepare(QUERY_ONLY_READBACK_SQL).all());
   }
 
   public async disconnect(): Promise<void> {
@@ -274,6 +372,84 @@ export class SQLiteProvider extends SQLBaseProvider {
         rows: result.rows,
         fields: result.fields,
         rowCount: result.rows.length || result.changes,
+        executionTime,
+      };
+    });
+  }
+
+  /**
+   * Execute exactly one statement under SQLite's own read-only enforcement
+   * (#328).
+   *
+   * The boundary is the database's own enforcement, not any inspection of
+   * `sql`: a write reaching this method is executed and rejected by the
+   * engine (see `assertQueryOnlyEnabled` for which control covers what). It is
+   * therefore refused outright on a provider that was not opened under the
+   * profile — a writable handle has no boundary to enforce, and silently
+   * running the statement there would be exactly the fail-open this layer
+   * exists to prevent.
+   *
+   * Statements are compiled with `prepare()`, never `exec()`: `exec()` runs
+   * every statement of a multi-statement string, while `prepare()` compiles
+   * only the first. Rejecting multi-statement input is the policy pipeline's
+   * job — this method only guarantees the tail is never executed.
+   */
+  public async queryReadOnly(sql: string, budget: ReadOnlyStatementBudget): Promise<QueryResult> {
+    this.ensureConnected();
+    assertReadOnlyBudget(budget, "sqlite");
+    if (!this.readOnlyProfile) {
+      throw new QueryError(
+        "Read-only execution requires a provider opened under the agent read-only profile",
+        "sqlite",
+        sql,
+      );
+    }
+    // Per statement, not just at open: the profiled provider is pooled and
+    // reused, so a previous statement's `PRAGMA query_only = false` would
+    // otherwise persist for every later call on this connection.
+    this.enforceQueryOnly();
+
+    return this.trackQuery(async () => {
+      const { result, executionTime } = await this.measureExecution(async () => {
+        try {
+          return this.db!.prepare(sql).all() as Record<string, unknown>[];
+        } catch (error) {
+          throw mapDatabaseError(error, "sqlite", sql);
+        }
+      });
+
+      if (result.length > budget.maxResultRows) {
+        throw new QueryError(
+          `Read-only execution exceeded the row budget: ${result.length} rows > ${budget.maxResultRows} allowed`,
+          "sqlite",
+          sql,
+        );
+      }
+      const resultBytes = measureResultBytes(result);
+      if (resultBytes > budget.maxResultBytes) {
+        throw new QueryError(
+          `Read-only execution exceeded the byte budget: ${resultBytes} bytes > ${budget.maxResultBytes} allowed`,
+          "sqlite",
+          sql,
+        );
+      }
+      // SQLite has no transaction-local statement timeout, and neither adapter
+      // exposes sqlite3_interrupt or a progress handler, so the budget's
+      // timeout is a post-execution deadline: an overrunning statement is not
+      // preempted, but its result is refused rather than returned as if it had
+      // been within budget. Recorded as such in docs/providers/sqlite.md.
+      if (executionTime > budget.statementTimeoutMs) {
+        throw new QueryError(
+          `Read-only execution exceeded the time budget: ${executionTime}ms > ${budget.statementTimeoutMs}ms allowed`,
+          "sqlite",
+          sql,
+        );
+      }
+
+      return {
+        rows: result,
+        fields: result.length > 0 ? Object.keys(result[0]) : [],
+        rowCount: result.length,
         executionTime,
       };
     });

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -158,6 +158,19 @@ export interface ProviderLabels {
   vacuumGlobalDesc: string;
 }
 
+/**
+ * Enforcement caps for a single statement executed through an agent read-only
+ * execution profile (#328). The timeout is enforced database-side
+ * (transaction-local), the row/byte caps result-side after the statement
+ * returns. Every field must be a positive integer — queryReadOnly refuses the
+ * whole call otherwise (fail closed).
+ */
+export interface ReadOnlyStatementBudget {
+  statementTimeoutMs: number;
+  maxResultRows: number;
+  maxResultBytes: number;
+}
+
 export interface PreparedQuery {
   query: string;
   wasLimited: boolean;
@@ -204,6 +217,16 @@ export interface DatabaseProvider {
    * @returns Query result with rows, fields, and execution time
    */
   query(sql: string, params?: unknown[]): Promise<QueryResult>;
+
+  /**
+   * Execute exactly one statement under the DATABASE's own read-only
+   * enforcement (#328): the engine, not a parser, rejects writes through this
+   * path. Optional on purpose — only providers with a verified database-native
+   * boundary implement it, and execution-profile acquisition
+   * (`acquireExecutionProfileProvider` in factory.ts) refuses provider types
+   * that lack it rather than falling back to `query()` (fail closed).
+   */
+  queryReadOnly?(sql: string, budget: ReadOnlyStatementBudget): Promise<QueryResult>;
 
   /**
    * Get full database schema

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -346,6 +346,23 @@ export interface ProviderOptions {
   timezone?: string;
 }
 
+/**
+ * Server-injected construction context for an execution-profile provider
+ * (#328). Deliberately NOT a member of `ProviderOptions`: that object is
+ * caller-supplied and flows all the way into `getOrCreateProvider`, so a
+ * profile flag living there could be set — or cleared — by whoever builds the
+ * options for a request. Only `acquireExecutionProfileProvider` passes this.
+ */
+export interface ProviderExecutionContext {
+  /**
+   * Open the connection under the database's own read-only enforcement.
+   * Only providers whose read-only boundary is established at OPEN time read
+   * this (SQLite); PostgreSQL establishes it per transaction inside
+   * `queryReadOnly` instead, so its provider ignores the context.
+   */
+  readOnly?: boolean;
+}
+
 // ============================================================================
 // Internal Types
 // ============================================================================

--- a/src/lib/storage/connection-secrets.ts
+++ b/src/lib/storage/connection-secrets.ts
@@ -37,6 +37,8 @@ export const CONNECTION_FIELDS: Record<keyof DatabaseConnection, FieldClass> = {
   instanceName: "public",
   managed: "public",
   seedId: "public",
+  agentUser: "public",
+  agentPassword: "secret",
 };
 
 export const SSL_FIELDS: Record<keyof SSLConfig, FieldClass> = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,6 +70,8 @@ export interface DatabaseConnection {
   instanceName?: string; // MSSQL: named instance (e.g. SQLEXPRESS)
   managed?: boolean; // true = admin-controlled, read-only in UI
   seedId?: string; // stable reference to seed config ID
+  agentUser?: string; // optional least-privilege role for the agent read-only execution profile (#328)
+  agentPassword?: string; // password for agentUser; secret-classified, sealed at rest by connection-secrets
 }
 
 export interface TableSchema {

--- a/tests/api/db/query.test.ts
+++ b/tests/api/db/query.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { createMockRequest, parseResponseJSON } from "../../helpers/mock-next";
 import { createMockProvider } from "../../helpers/mock-provider";
+import { discoverRoutes } from "../../security/helpers/discover-routes";
 import { clearRateLimitState } from "@/lib/api/rate-limit";
+import { agentReadSqlInput } from "@/lib/db/operations/statement-guard";
 import {
   QueryError,
   TimeoutError,
@@ -421,5 +425,84 @@ describe("POST /api/db/query", () => {
 
     expect(res.status).toBe(499);
     expect(data.code).toBe("QUERY_CANCELLED");
+  });
+});
+
+/**
+ * Regression for #328: the agent enforcement layer must not have followed the
+ * operator into the editor. Everything #328 built — the read-only execution
+ * profiles, the statement guard, the policy pipeline, the audited execution
+ * glue — applies to the AGENT path only; a human running a write in the editor
+ * is the product's primary use, and gating it would be a silent regression
+ * that no test in the operations layer could see.
+ */
+describe("POST /api/db/query — the editor path stays outside the agent policy layer", () => {
+  const writeStatement = "UPDATE orders SET status = 'shipped' WHERE id = 42";
+
+  beforeEach(() => {
+    clearRateLimitState();
+    mockGetOrCreateProvider.mockClear();
+    mockGetSession.mockClear();
+    mockGetSession.mockImplementation(
+      async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+    );
+  });
+
+  test("executes a write the agent input contract refuses, through the shared provider", async () => {
+    // The same statement, judged by both paths. If these ever agree, one of the
+    // two is wrong: the agent contract must refuse it, the editor must run it.
+    expect(agentReadSqlInput.safeParse({ sql: writeStatement }).success).toBe(false);
+
+    const writeProvider = createMockProvider({
+      prepareQueryResult: { query: writeStatement, wasLimited: false, limit: 0, offset: 0 },
+    });
+    mockGetOrCreateProvider.mockResolvedValueOnce(writeProvider as never);
+
+    const req = createMockRequest("/api/db/query", {
+      method: "POST",
+      body: { connection: validConnection, sql: writeStatement },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(200);
+    // Reached the driver verbatim: not refused, not rewritten, not downgraded.
+    expect(writeProvider.query).toHaveBeenCalledWith(writeStatement, undefined);
+    // The shared, fully-privileged provider cache - never an execution profile.
+    expect(mockGetOrCreateProvider).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Read from disk rather than asserted through a behaviour, deliberately. The
+   * behavioural version of this check would be "the route emits no
+   * agent_operation audit event", and it cannot fail: `bun run test` runs this
+   * directory in one process with tests/api/db/maintenance.test.ts, whose
+   * `mock.module("@/lib/audit")` replaces `emitAuditEvent` itself
+   * process-wide, so no destination — buffer or stdout — would see an emission
+   * even if the glue WERE wired in. A source-level invariant has no such hole.
+   *
+   * `discoverRoutes` is reused rather than re-walked here (it lives under
+   * tests/security/helpers because the security enumerations were its first
+   * callers): it recurses, so it sees `db/schema/list` and `db/schema/relations`
+   * alongside `db/schema` — the exact case its own doc comment names, and the
+   * one a single-level listing silently drops. Its route keys map back to files
+   * deterministically, which is all this assertion needs.
+   */
+  const DB_ROUTES_DIR = join(import.meta.dir, "..", "..", "..", "src", "app", "api", "db");
+
+  const dbRouteFiles = discoverRoutes(DB_ROUTES_DIR).map(([routeKey]) =>
+    join(DB_ROUTES_DIR, ...routeKey.split("/"), "route.ts"),
+  );
+
+  test("the route enumeration finds every one of today's sixteen /api/db routes", () => {
+    // An enumeration bug that found nothing - or that missed the nested schema
+    // routes - would make the next test quietly narrower than it claims.
+    expect(dbRouteFiles.length).toBeGreaterThanOrEqual(16);
+    expect(dbRouteFiles.every((file) => existsSync(file))).toBe(true);
+  });
+
+  test("no /api/db route imports the agent operations layer", () => {
+    const gated = dbRouteFiles.filter((file) => readFileSync(file, "utf8").includes("@/lib/db/operations"));
+    expect(gated).toEqual([]);
   });
 });

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -7,7 +7,7 @@ import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:
 import { EventEmitter } from "node:events";
 import type { DatabaseConnection } from "@/lib/types";
 import type { ReadOnlyStatementBudget } from "@/lib/db/types";
-import { DatabaseConfigError, ExecutionProfileError } from "@/lib/db/errors";
+import { ConnectionError, DatabaseConfigError, ExecutionProfileError } from "@/lib/db/errors";
 
 // ============================================================================
 // Mock pg BEFORE importing the provider
@@ -1992,6 +1992,10 @@ describe("PostgresProvider", () => {
       /** Rows the probe returns; overridable to model a server that answers nothing. */
       privilegeRows: Array<Record<string, unknown>> | null = null;
       privilegeProbes = 0;
+      /** The probe's SQL, kept so a test can assert how it names its built-ins. */
+      privilegeProbeText: string | null = null;
+      /** Set to model the probe itself failing (dropped socket, protocol error). */
+      privilegeProbeFailure: Error | null = null;
       /** Session-level statement_timeout, and the value to restore on rollback. */
       sessionTimeout = 30_000;
       private sessionTimeoutBeforeTx: number | null = null;
@@ -2047,6 +2051,8 @@ describe("PostgresProvider", () => {
         // as "what one queryReadOnly call sent".
         if (keyword === "SELECT" && /is_superuser/i.test(text)) {
           this.privilegeProbes++;
+          this.privilegeProbeText = text;
+          if (this.privilegeProbeFailure) throw this.privilegeProbeFailure;
           return this.rows(this.privilegeRows ?? [{ ...this.privileges }]);
         }
         this.statements.push({ text: text.trim(), protocol });
@@ -2309,6 +2315,45 @@ describe("PostgresProvider", () => {
       // The probe is part of opening the profile, not of every statement.
       expect(engine.privilegeProbes).toBe(1);
       expect(provider.isConnected()).toBe(true);
+    });
+
+    test("schema-qualifies every built-in the privilege probe calls", () => {
+      // pg_catalog is searched implicitly FIRST only while it is NOT named in
+      // search_path; once it is named explicitly, a schema ahead of it shadows
+      // built-ins. So `search_path = attacker_schema, pg_catalog` plus a shadow
+      // pg_has_role()/current_setting() makes this probe answer four falses for
+      // a superuser — defeating the one check meant to catch exactly that role.
+      // Whoever can plant prompt-injection text in a table can often also create
+      // a function, so the two reach the same attacker. Qualifying costs nothing.
+      // Only real catalog FUNCTIONS are shadowable, so only they are listed:
+      // COALESCE and CURRENT_USER are SQL constructs the parser handles, cannot
+      // be schema-qualified at all, and no user function can intercept them.
+      const probe = engine.privilegeProbeText;
+      expect(probe).toBeTruthy();
+      for (const builtin of ["current_setting", "pg_has_role", "to_regrole"]) {
+        expect(probe).not.toMatch(new RegExp(String.raw`(?<!pg_catalog\.)\b${builtin}\s*\(`, "i"));
+      }
+    });
+
+    test("ends the pool when the privilege probe itself fails", async () => {
+      // The typed refusal path already ends the pool. This is the other way out
+      // of connect() after the pool exists: the probe query rejecting on a
+      // dropped socket or protocol error. The factory does not disconnect a
+      // provider whose connect() threw, so a pool left open here leaks its idle
+      // socket and timers with nothing holding a reference to close them.
+      engine.privilegeProbeFailure = new Error("connection terminated unexpectedly");
+      const failing = new PostgresProvider(makePgConfig(), {}, { readOnly: true });
+      const endSpy = spyOn(MockPool.prototype, "end");
+
+      const error = await failing.connect().then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(ConnectionError);
+      expect(failing.isConnected()).toBe(false);
+      expect(endSpy).toHaveBeenCalled();
+      endSpy.mockRestore();
+      engine.privilegeProbeFailure = null;
     });
 
     test.each([

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -6,6 +6,7 @@
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { DatabaseConnection } from "@/lib/types";
+import type { ReadOnlyStatementBudget } from "@/lib/db/types";
 import { DatabaseConfigError } from "@/lib/db/errors";
 
 // ============================================================================
@@ -23,7 +24,9 @@ let mockQueryFn: (
 
 const mockClient = {
   query: (sql: string, params?: unknown[]) => mockQueryFn(sql, params),
-  release: () => {},
+  // Real pg signature: release(err?) — an error argument destroys the client
+  // instead of returning it to the pool, which queryReadOnly relies on.
+  release: (_destroy?: Error) => {},
 };
 
 /**
@@ -1881,6 +1884,282 @@ describe("PostgresProvider", () => {
 
       expect(result.query).toBe(sql);
       expect(result.wasLimited).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // queryReadOnly — agent read-only execution profile (#328)
+  // --------------------------------------------------------------------------
+
+  describe("queryReadOnly (agent read-only execution profile)", () => {
+    /** Reads the first keyword the way the server would: past whitespace and comments. */
+    function engineLeadingKeyword(text: string): string {
+      let rest = text;
+      for (;;) {
+        const trimmed = rest.trimStart();
+        if (trimmed.startsWith("--")) {
+          const newline = trimmed.indexOf("\n");
+          rest = newline === -1 ? "" : trimmed.slice(newline + 1);
+          continue;
+        }
+        if (trimmed.startsWith("/*")) {
+          const close = trimmed.indexOf("*/");
+          rest = close === -1 ? "" : trimmed.slice(close + 2);
+          continue;
+        }
+        return (/^[A-Za-z]+/.exec(trimmed)?.[0] ?? "").toUpperCase();
+      }
+    }
+
+    function pgServerError(message: string, code: string): Error {
+      return Object.assign(new Error(message), { code });
+    }
+
+    /** The server executes each semicolon-separated command of a simple-protocol string in turn. */
+    function splitCommands(text: string): string[] {
+      // Naive split is faithful enough for this suite's corpus (no ';' inside literals).
+      return text
+        .split(";")
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+    }
+
+    type EngineProtocol = "simple" | "extended";
+
+    /**
+     * Stateful engine mock modeling the PostgreSQL behaviors this profile's
+     * security rests on, so the assertions hold even when product-side
+     * classification is bypassed:
+     *
+     * - a write executed inside a READ ONLY transaction fails with 25006 based
+     *   on the ENGINE's transaction state, no matter what the text looks like;
+     * - the extended query protocol refuses multi-command strings with 42601
+     *   before executing anything;
+     * - the simple protocol EXECUTES multi-command strings sequentially and
+     *   honors transaction control, so an implementation that regressed to the
+     *   simple protocol would really COMMIT out of the read-only transaction
+     *   and apply the smuggled write — `appliedWrites` catches that.
+     *
+     * Protocol detection mirrors pg's requiresPreparation()
+     * (node_modules/pg/lib/query.js): named, extended-mode, or valued queries
+     * prepare; a bare string with no values stays on the simple protocol.
+     */
+    class ReadOnlyEngineMock {
+      txState: "none" | "read-only" | "read-write" | "aborted" = "none";
+      readonly statements: Array<{ text: string; protocol: EngineProtocol }> = [];
+      readonly appliedWrites: string[] = [];
+      readonly localTimeouts: number[] = [];
+      selectRows: Array<Record<string, unknown>> = [{ ok: 1 }];
+      failRollback = false;
+
+      static protocolOf(arg: unknown, params?: unknown[]): { text: string; protocol: EngineProtocol } {
+        if (typeof arg === "string") {
+          const extended = Array.isArray(params) && params.length > 0;
+          return { text: arg, protocol: extended ? "extended" : "simple" };
+        }
+        const config = arg as { text: string; name?: string; values?: unknown[]; queryMode?: string };
+        const extended =
+          config.queryMode === "extended" ||
+          Boolean(config.name) ||
+          (Array.isArray(config.values) && config.values.length > 0);
+        return { text: config.text, protocol: extended ? "extended" : "simple" };
+      }
+
+      async query(arg: unknown, params?: unknown[]) {
+        const { text, protocol } = ReadOnlyEngineMock.protocolOf(arg, params);
+        if (protocol === "extended") {
+          if (splitCommands(text).length > 1) {
+            throw pgServerError("cannot insert multiple commands into a prepared statement", "42601");
+          }
+          return this.execute(text, protocol);
+        }
+        let last: ReturnType<ReadOnlyEngineMock["execute"]> = { rows: [], fields: [], rowCount: 0 };
+        for (const command of splitCommands(text)) {
+          last = this.execute(command, protocol);
+        }
+        return last;
+      }
+
+      private execute(text: string, protocol: EngineProtocol) {
+        this.statements.push({ text: text.trim(), protocol });
+        const keyword = engineLeadingKeyword(text);
+        if (this.txState === "aborted" && keyword !== "ROLLBACK" && keyword !== "COMMIT") {
+          throw pgServerError(
+            "current transaction is aborted, commands ignored until end of transaction block",
+            "25P02",
+          );
+        }
+        switch (keyword) {
+          case "BEGIN":
+          case "START":
+            // Inside a transaction the server only warns; state is unchanged.
+            if (this.txState === "none") {
+              this.txState = /read\s+only/i.test(text) ? "read-only" : "read-write";
+            }
+            return { rows: [], fields: [], rowCount: 0 };
+          case "COMMIT":
+          case "END":
+            this.txState = "none";
+            return { rows: [], fields: [], rowCount: 0 };
+          case "ROLLBACK":
+            if (this.failRollback) {
+              throw pgServerError("server closed the connection unexpectedly", "08006");
+            }
+            this.txState = "none";
+            return { rows: [], fields: [], rowCount: 0 };
+          case "SET": {
+            const local = /^set\s+local\s+statement_timeout\s*=\s*(\d+)$/i.exec(text.trim());
+            if (local) this.localTimeouts.push(Number(local[1]));
+            return { rows: [], fields: [], rowCount: 0 };
+          }
+          case "SELECT":
+          case "EXPLAIN":
+          case "SHOW":
+            return {
+              rows: this.selectRows,
+              fields: Object.keys(this.selectRows[0] ?? {}).map((name) => ({ name })),
+              rowCount: this.selectRows.length,
+            };
+          default:
+            // Everything else counts as a write attempt (conservative server model).
+            if (this.txState === "read-only") {
+              this.txState = "aborted";
+              throw pgServerError(`cannot execute ${keyword} in a read-only transaction`, "25006");
+            }
+            this.appliedWrites.push(text.trim());
+            return { rows: [], fields: [], rowCount: 1 };
+        }
+      }
+    }
+
+    function roBudget(overrides: Partial<ReadOnlyStatementBudget> = {}): ReadOnlyStatementBudget {
+      return { statementTimeoutMs: 4500, maxResultRows: 100, maxResultBytes: 1_000_000, ...overrides };
+    }
+
+    let engine: ReadOnlyEngineMock;
+    let releaseSpy: ReturnType<typeof spyOn<typeof mockClient, "release">>;
+
+    beforeEach(async () => {
+      engine = new ReadOnlyEngineMock();
+      mockQueryFn = (sql: string, params?: unknown[]) => engine.query(sql, params);
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+      // Installed after connect() so the counts below are wrapper-only.
+      releaseSpy = spyOn(mockClient, "release");
+    });
+
+    afterEach(() => {
+      releaseSpy.mockRestore();
+    });
+
+    test("runs exactly one statement inside BEGIN READ ONLY with a transaction-local timeout, then rolls back and releases", async () => {
+      const result = await provider.queryReadOnly("SELECT 1 AS ok", roBudget());
+
+      expect(result.rows).toEqual([{ ok: 1 }]);
+      expect(result.fields).toEqual(["ok"]);
+      expect(result.rowCount).toBe(1);
+      expect(result.executionTime).toBeGreaterThanOrEqual(0);
+      expect(engine.statements.map((s) => s.text)).toEqual([
+        "BEGIN READ ONLY",
+        "SET LOCAL statement_timeout = 4500",
+        "SELECT 1 AS ok",
+        "ROLLBACK",
+      ]);
+      // The statement itself travels on the extended protocol — that is what
+      // makes single-statement a server-enforced property (42601), not a parse.
+      expect(engine.statements[2]?.protocol).toBe("extended");
+      expect(engine.localTimeouts).toEqual([4500]);
+      expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("the database itself rejects a write attempted through the agent path", async () => {
+      await expect(provider.queryReadOnly("INSERT INTO t (id) VALUES (1)", roBudget())).rejects.toThrow(
+        /read-only transaction/,
+      );
+
+      expect(engine.appliedWrites).toEqual([]);
+      expect(engine.statements.at(-1)?.text).toBe("ROLLBACK");
+      expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("the normal editor path on the same connection still writes", async () => {
+      const result = await provider.query("INSERT INTO t (id) VALUES (1)");
+
+      expect(result.rowCount).toBe(1);
+      expect(engine.appliedWrites).toEqual(["INSERT INTO t (id) VALUES (1)"]);
+    });
+
+    test("multi-statement input cannot smuggle transaction control past the read-only boundary", async () => {
+      await expect(
+        provider.queryReadOnly("SELECT 1; COMMIT; INSERT INTO t (id) VALUES (1)", roBudget()),
+      ).rejects.toThrow(/multiple commands/);
+
+      expect(engine.appliedWrites).toEqual([]);
+      // The server refused at parse time: nothing ran between SET LOCAL and ROLLBACK.
+      expect(engine.statements.map((s) => s.text)).toEqual([
+        "BEGIN READ ONLY",
+        "SET LOCAL statement_timeout = 4500",
+        "ROLLBACK",
+      ]);
+    });
+
+    test("a transaction-control statement as the single statement leaves no residue", async () => {
+      const result = await provider.queryReadOnly("COMMIT", roBudget());
+
+      expect(result.rows).toEqual([]);
+      expect(engine.appliedWrites).toEqual([]);
+      expect(engine.txState).toBe("none");
+      expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("rejects a malformed budget before any statement reaches the session", async () => {
+      const hostileTimeouts = [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648, "50; COMMIT"];
+      for (const statementTimeoutMs of hostileTimeouts) {
+        await expect(
+          provider.queryReadOnly("SELECT 1", roBudget({ statementTimeoutMs: statementTimeoutMs as never })),
+        ).rejects.toThrow(/budget/i);
+      }
+      await expect(provider.queryReadOnly("SELECT 1", roBudget({ maxResultRows: 0 }))).rejects.toThrow(/budget/i);
+      await expect(provider.queryReadOnly("SELECT 1", roBudget({ maxResultBytes: -5 }))).rejects.toThrow(/budget/i);
+
+      expect(engine.statements).toEqual([]);
+      expect(releaseSpy).not.toHaveBeenCalled();
+    });
+
+    test("enforces the row budget result-side", async () => {
+      engine.selectRows = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+      await expect(provider.queryReadOnly("SELECT id FROM t", roBudget({ maxResultRows: 2 }))).rejects.toThrow(
+        /row budget/i,
+      );
+      expect(engine.statements.at(-1)?.text).toBe("ROLLBACK");
+      expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("enforces the byte budget result-side", async () => {
+      engine.selectRows = [{ blob: "x".repeat(64) }];
+
+      await expect(provider.queryReadOnly("SELECT blob FROM t", roBudget({ maxResultBytes: 16 }))).rejects.toThrow(
+        /byte budget/i,
+      );
+      expect(engine.statements.at(-1)?.text).toBe("ROLLBACK");
+    });
+
+    test("a client that cannot roll back is destroyed, never returned to the pool", async () => {
+      engine.failRollback = true;
+
+      const result = await provider.queryReadOnly("SELECT 1 AS ok", roBudget());
+
+      expect(result.rows).toEqual([{ ok: 1 }]);
+      expect(releaseSpy).toHaveBeenCalledTimes(1);
+      expect(releaseSpy.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    });
+
+    test("requires a connected provider", async () => {
+      const cold = new PostgresProvider(makePgConfig());
+
+      await expect(cold.queryReadOnly("SELECT 1", roBudget())).rejects.toThrow(/connect/i);
+      expect(engine.statements).toEqual([]);
     });
   });
 });

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -7,7 +7,7 @@ import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:
 import { EventEmitter } from "node:events";
 import type { DatabaseConnection } from "@/lib/types";
 import type { ReadOnlyStatementBudget } from "@/lib/db/types";
-import { DatabaseConfigError } from "@/lib/db/errors";
+import { DatabaseConfigError, ExecutionProfileError } from "@/lib/db/errors";
 
 // ============================================================================
 // Mock pg BEFORE importing the provider
@@ -1927,12 +1927,41 @@ describe("PostgresProvider", () => {
     type EngineProtocol = "simple" | "extended";
 
     /**
+     * A data-modifying CTE, the only shape that can carry a write under a `WITH`.
+     *
+     * A whole-text pattern, which `lib/sql/operative-keyword.ts` documents as the
+     * wrong reading for PRODUCTION code — deliberately kept here, where being
+     * stricter than the server only ever makes a hostile fixture easier to
+     * refuse. A read-only CTE that merely quotes a write keyword would be modeled
+     * as a write, so a future fixture of that shape must not be read as proof of
+     * anything.
+     */
+    function withCarriesWrite(text: string): boolean {
+      return /\b(?:INSERT|UPDATE|DELETE|MERGE)\b/i.test(text);
+    }
+
+    /**
      * Stateful engine mock modeling the PostgreSQL behaviors this profile's
      * security rests on, so the assertions hold even when product-side
-     * classification is bypassed:
+     * classification is bypassed. Every rule below was verified against a live
+     * PostgreSQL 18 rather than assumed:
      *
      * - a write executed inside a READ ONLY transaction fails with 25006 based
-     *   on the ENGINE's transaction state, no matter what the text looks like;
+     *   on the ENGINE's transaction state, no matter what the text looks like —
+     *   including a data-modifying CTE, which the server refuses while naming
+     *   the top-level statement ("cannot execute SELECT in a read-only
+     *   transaction"), and a write behind a comment;
+     * - `SET TRANSACTION READ WRITE` really DOES relax the transaction — it is
+     *   accepted inside `BEGIN READ ONLY` and a following write then commits.
+     *   That is why the profile's one-statement-per-transaction rule is
+     *   load-bearing rather than decorative, and modeling it faithfully is what
+     *   makes the pollution tests below mean something;
+     * - a session-level `SET` inside the transaction is reverted by ROLLBACK
+     *   (GUC changes are transactional), so it cannot leak into the next
+     *   execution on a pooled client;
+     * - `COPY … TO <file>` / `TO PROGRAM` are NOT refused by a read-only
+     *   transaction. Only privileges refuse them, which is why the profile
+     *   verifies the role at open;
      * - the extended query protocol refuses multi-command strings with 42601
      *   before executing anything;
      * - the simple protocol EXECUTES multi-command strings sequentially and
@@ -1949,8 +1978,25 @@ describe("PostgresProvider", () => {
       readonly statements: Array<{ text: string; protocol: EngineProtocol }> = [];
       readonly appliedWrites: string[] = [];
       readonly localTimeouts: number[] = [];
+      /** Files/programs a COPY reached — empty unless privileges allowed it. */
+      readonly serverFileWrites: string[] = [];
       selectRows: Array<Record<string, unknown>> = [{ ok: 1 }];
       failRollback = false;
+      /** What the role-privilege probe answers. All false = a least-privilege agent role. */
+      privileges: Record<string, boolean> = {
+        is_superuser: false,
+        reads_server_files: false,
+        writes_server_files: false,
+        executes_programs: false,
+      };
+      /** Rows the probe returns; overridable to model a server that answers nothing. */
+      privilegeRows: Array<Record<string, unknown>> | null = null;
+      privilegeProbes = 0;
+      /** Session-level statement_timeout, and the value to restore on rollback. */
+      sessionTimeout = 30_000;
+      private sessionTimeoutBeforeTx: number | null = null;
+      /** Advisory locks held by the session. These survive ROLLBACK (verified on 18). */
+      readonly advisoryLocks: number[] = [];
 
       static protocolOf(arg: unknown, params?: unknown[]): { text: string; protocol: EngineProtocol } {
         if (typeof arg === "string") {
@@ -1980,9 +2026,30 @@ describe("PostgresProvider", () => {
         return last;
       }
 
+      private rows(data: Array<Record<string, unknown>>) {
+        return { rows: data, fields: Object.keys(data[0] ?? {}).map((name) => ({ name })), rowCount: data.length };
+      }
+
+      /** A write attempt: refused by the transaction's access mode, else applied. */
+      private write(text: string, named: string) {
+        if (this.txState === "read-only") {
+          this.txState = "aborted";
+          throw pgServerError(`cannot execute ${named} in a read-only transaction`, "25006");
+        }
+        this.appliedWrites.push(text.trim());
+        return { rows: [], fields: [], rowCount: 1 };
+      }
+
       private execute(text: string, protocol: EngineProtocol) {
-        this.statements.push({ text: text.trim(), protocol });
         const keyword = engineLeadingKeyword(text);
+        // The role-privilege probe the read-only profile runs at OPEN. Counted
+        // separately rather than pushed onto `statements`, which the tests read
+        // as "what one queryReadOnly call sent".
+        if (keyword === "SELECT" && /is_superuser/i.test(text)) {
+          this.privilegeProbes++;
+          return this.rows(this.privilegeRows ?? [{ ...this.privileges }]);
+        }
+        this.statements.push({ text: text.trim(), protocol });
         if (this.txState === "aborted" && keyword !== "ROLLBACK" && keyword !== "COMMIT") {
           throw pgServerError(
             "current transaction is aborted, commands ignored until end of transaction block",
@@ -1995,39 +2062,86 @@ describe("PostgresProvider", () => {
             // Inside a transaction the server only warns; state is unchanged.
             if (this.txState === "none") {
               this.txState = /read\s+only/i.test(text) ? "read-only" : "read-write";
+              this.sessionTimeoutBeforeTx = this.sessionTimeout;
             }
             return { rows: [], fields: [], rowCount: 0 };
           case "COMMIT":
           case "END":
             this.txState = "none";
+            this.sessionTimeoutBeforeTx = null;
             return { rows: [], fields: [], rowCount: 0 };
           case "ROLLBACK":
             if (this.failRollback) {
               throw pgServerError("server closed the connection unexpectedly", "08006");
             }
             this.txState = "none";
+            // GUC changes are transactional: a session-level SET made inside the
+            // transaction is undone here.
+            if (this.sessionTimeoutBeforeTx !== null) this.sessionTimeout = this.sessionTimeoutBeforeTx;
+            this.sessionTimeoutBeforeTx = null;
             return { rows: [], fields: [], rowCount: 0 };
           case "SET": {
             const local = /^set\s+local\s+statement_timeout\s*=\s*(\d+)$/i.exec(text.trim());
-            if (local) this.localTimeouts.push(Number(local[1]));
+            if (local) {
+              this.localTimeouts.push(Number(local[1]));
+              return { rows: [], fields: [], rowCount: 0 };
+            }
+            const session = /^set\s+statement_timeout\s*=\s*(\d+)$/i.exec(text.trim());
+            if (session) {
+              this.sessionTimeout = Number(session[1]);
+              return { rows: [], fields: [], rowCount: 0 };
+            }
+            // Live-verified on PostgreSQL 18: accepted inside BEGIN READ ONLY,
+            // and the transaction really becomes writable.
+            if (/^set\s+transaction\s+read\s+write$/i.test(text.trim())) {
+              if (this.txState === "read-only") this.txState = "read-write";
+              return { rows: [], fields: [], rowCount: 0 };
+            }
             return { rows: [], fields: [], rowCount: 0 };
           }
-          case "SELECT":
+          case "COPY": {
+            // A read-only transaction does not refuse these; privileges do.
+            const toProgram = /\bto\s+program\b/i.test(text);
+            const privileged = toProgram ? this.privileges.executes_programs : this.privileges.writes_server_files;
+            if (!privileged) {
+              this.txState = "aborted";
+              throw pgServerError(
+                toProgram
+                  ? "permission denied to COPY to or from an external program"
+                  : "permission denied to COPY to a file",
+                "42501",
+              );
+            }
+            this.serverFileWrites.push(text.trim());
+            return { rows: [], fields: [], rowCount: 1 };
+          }
+          case "DISCARD":
+            // Session state a rollback does not undo. Cannot run inside a
+            // transaction block, which is why the profile issues it after the
+            // ROLLBACK rather than instead of it.
+            this.advisoryLocks.length = 0;
+            return { rows: [], fields: [], rowCount: 0 };
+          case "WITH":
+            // The CTE list is a preamble: a `WITH` that carries a write is a
+            // write, and one that does not is an ordinary read.
+            return withCarriesWrite(text) ? this.write(text, "SELECT") : this.rows(this.selectRows);
+          case "SELECT": {
+            // An advisory lock is session state, not transaction state: taking
+            // one inside a read-only transaction succeeds and outlives the
+            // rollback.
+            const lock = /pg_advisory_lock\(\s*(\d+)\s*\)/i.exec(text);
+            if (lock) {
+              this.advisoryLocks.push(Number(lock[1]));
+              return this.rows([{ pg_advisory_lock: "" }]);
+            }
+            return this.rows(this.selectRows);
+          }
           case "EXPLAIN":
           case "SHOW":
-            return {
-              rows: this.selectRows,
-              fields: Object.keys(this.selectRows[0] ?? {}).map((name) => ({ name })),
-              rowCount: this.selectRows.length,
-            };
+            return this.rows(this.selectRows);
           default:
             // Everything else counts as a write attempt (conservative server model).
-            if (this.txState === "read-only") {
-              this.txState = "aborted";
-              throw pgServerError(`cannot execute ${keyword} in a read-only transaction`, "25006");
-            }
-            this.appliedWrites.push(text.trim());
-            return { rows: [], fields: [], rowCount: 1 };
+            return this.write(text, keyword);
         }
       }
     }
@@ -2042,7 +2156,11 @@ describe("PostgresProvider", () => {
     beforeEach(async () => {
       engine = new ReadOnlyEngineMock();
       mockQueryFn = (sql: string, params?: unknown[]) => engine.query(sql, params);
-      provider = new PostgresProvider(makePgConfig());
+      // The third argument is the server-injected execution context: `queryReadOnly`
+      // exists only on a provider opened under the profile, so that the role
+      // verification below can never be skipped by reaching for the method on an
+      // ordinary provider.
+      provider = new PostgresProvider(makePgConfig(), {}, { readOnly: true });
       await provider.connect();
       // Installed after connect() so the counts below are wrapper-only.
       releaseSpy = spyOn(mockClient, "release");
@@ -2064,6 +2182,8 @@ describe("PostgresProvider", () => {
         "SET LOCAL statement_timeout = 4500",
         "SELECT 1 AS ok",
         "ROLLBACK",
+        // Session state the rollback does not undo (see the advisory-lock case).
+        "DISCARD ALL",
       ]);
       // The statement itself travels on the extended protocol — that is what
       // makes single-statement a server-enforced property (42601), not a parse.
@@ -2078,15 +2198,33 @@ describe("PostgresProvider", () => {
       );
 
       expect(engine.appliedWrites).toEqual([]);
-      expect(engine.statements.at(-1)?.text).toBe("ROLLBACK");
+      expect(engine.statements.at(-1)?.text).toBe("DISCARD ALL");
       expect(releaseSpy).toHaveBeenCalledTimes(1);
     });
 
     test("the normal editor path on the same connection still writes", async () => {
-      const result = await provider.query("INSERT INTO t (id) VALUES (1)");
+      // The editor holds its own, unprofiled provider (getOrCreateProvider's
+      // cache entry) — the regression pin for #328: gating the agent path must
+      // not gate the editor.
+      const editor = new PostgresProvider(makePgConfig());
+      await editor.connect();
+      const result = await editor.query("INSERT INTO t (id) VALUES (1)");
 
       expect(result.rowCount).toBe(1);
       expect(engine.appliedWrites).toEqual(["INSERT INTO t (id) VALUES (1)"]);
+      await editor.disconnect();
+    });
+
+    test("refuses queryReadOnly on a provider that was not opened under the profile", async () => {
+      const unprofiled = new PostgresProvider(makePgConfig());
+      await unprofiled.connect();
+
+      // Fail closed, and for the reason the SQLite profile fails closed too: a
+      // provider opened outside the profile has had no role verification, so
+      // running the statement there would be the fail-open this layer prevents.
+      await expect(unprofiled.queryReadOnly("SELECT 1", roBudget())).rejects.toThrow(/read-only profile/i);
+      expect(engine.statements).toEqual([]);
+      await unprofiled.disconnect();
     });
 
     test("multi-statement input cannot smuggle transaction control past the read-only boundary", async () => {
@@ -2100,6 +2238,7 @@ describe("PostgresProvider", () => {
         "BEGIN READ ONLY",
         "SET LOCAL statement_timeout = 4500",
         "ROLLBACK",
+        "DISCARD ALL",
       ]);
     });
 
@@ -2132,7 +2271,7 @@ describe("PostgresProvider", () => {
       await expect(provider.queryReadOnly("SELECT id FROM t", roBudget({ maxResultRows: 2 }))).rejects.toThrow(
         /row budget/i,
       );
-      expect(engine.statements.at(-1)?.text).toBe("ROLLBACK");
+      expect(engine.statements.at(-1)?.text).toBe("DISCARD ALL");
       expect(releaseSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -2142,7 +2281,7 @@ describe("PostgresProvider", () => {
       await expect(provider.queryReadOnly("SELECT blob FROM t", roBudget({ maxResultBytes: 16 }))).rejects.toThrow(
         /byte budget/i,
       );
-      expect(engine.statements.at(-1)?.text).toBe("ROLLBACK");
+      expect(engine.statements.at(-1)?.text).toBe("DISCARD ALL");
     });
 
     test("a client that cannot roll back is destroyed, never returned to the pool", async () => {
@@ -2156,10 +2295,156 @@ describe("PostgresProvider", () => {
     });
 
     test("requires a connected provider", async () => {
-      const cold = new PostgresProvider(makePgConfig());
+      const cold = new PostgresProvider(makePgConfig(), {}, { readOnly: true });
 
       await expect(cold.queryReadOnly("SELECT 1", roBudget())).rejects.toThrow(/connect/i);
       expect(engine.statements).toEqual([]);
+    });
+
+    // ------------------------------------------------------------------------
+    // What the read-only TRANSACTION does not cover (verified on PostgreSQL 18)
+    // ------------------------------------------------------------------------
+
+    test("verifies at open that the agent role holds no server-file or program privilege", async () => {
+      // The probe is part of opening the profile, not of every statement.
+      expect(engine.privilegeProbes).toBe(1);
+      expect(provider.isConnected()).toBe(true);
+    });
+
+    test.each([
+      ["a superuser", "is_superuser"],
+      ["a role that can read server files", "reads_server_files"],
+      ["a role that can write server files", "writes_server_files"],
+      ["a role that can run server programs", "executes_programs"],
+    ])("refuses to open the profile for %s", async (_label, capability) => {
+      // A read-only transaction forbids changing the DATABASE. It does not stop
+      // `COPY … TO '<path>'`, `COPY … TO PROGRAM '<cmd>'` or `pg_read_file()` —
+      // all three succeeded inside BEGIN READ ONLY as a superuser on PostgreSQL
+      // 18. Only privileges refuse them, so a role that holds any of these has
+      // no read-only boundary and the profile refuses to vend it.
+      engine.privileges = { ...engine.privileges, [capability]: true };
+      const privileged = new PostgresProvider(makePgConfig(), {}, { readOnly: true });
+      // The pool is constructed inside connect(), so the spy goes on the
+      // prototype rather than on an instance that does not exist yet.
+      const endSpy = spyOn(MockPool.prototype, "end");
+
+      const error = await privileged.connect().then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(ExecutionProfileError);
+      expect((error as ExecutionProfileError).reasonCode).toBe("PROFILE_PRIVILEGES_TOO_BROAD");
+      expect(privileged.isConnected()).toBe(false);
+      // The pool exists before the refusal; leaving it would leak its sockets
+      // for a provider the caller can never use.
+      expect(endSpy).toHaveBeenCalled();
+      endSpy.mockRestore();
+    });
+
+    test.each([
+      ["no rows", []],
+      ["a row without the expected fields", [{ ok: 1 }]],
+      ["a row whose flags are not booleans", [{ is_superuser: "off" }]],
+    ])("fails closed when the privilege probe answers %s", async (_label, rows) => {
+      engine.privilegeRows = rows as Array<Record<string, unknown>>;
+      const unverifiable = new PostgresProvider(makePgConfig(), {}, { readOnly: true });
+
+      await expect(unverifiable.connect()).rejects.toThrow(ExecutionProfileError);
+      expect(unverifiable.isConnected()).toBe(false);
+    });
+
+    test("the profile only ever exists for a role the engine refuses COPY to", async () => {
+      // Together with the refusals above, this is the whole story for the
+      // exfiltration family: the engine permits COPY under a read-only
+      // transaction, so the control is the role — and for a role that reached
+      // the profile, the engine itself denies it.
+      await expect(provider.queryReadOnly("COPY (SELECT 1) TO PROGRAM 'sh -c id'", roBudget())).rejects.toThrow(
+        /permission denied/i,
+      );
+      await expect(provider.queryReadOnly("COPY (SELECT 1) TO '/tmp/stolen.txt'", roBudget())).rejects.toThrow(
+        /permission denied/i,
+      );
+
+      expect(engine.serverFileWrites).toEqual([]);
+      expect(engine.appliedWrites).toEqual([]);
+    });
+
+    test("a data-modifying CTE is rejected by the engine while a read-only CTE succeeds", async () => {
+      engine.selectRows = [{ n: 1 }];
+      const read = await provider.queryReadOnly(
+        "WITH recent AS (SELECT id FROM t) SELECT count(*) AS n FROM recent",
+        roBudget(),
+      );
+      expect(read.rows).toEqual([{ n: 1 }]);
+
+      await expect(
+        provider.queryReadOnly(
+          "WITH moved AS (INSERT INTO archive SELECT * FROM t RETURNING id) SELECT count(*) FROM moved",
+          roBudget(),
+        ),
+      ).rejects.toThrow(/read-only transaction/);
+
+      // The pair is the point: a mock that blanket-refused every `WITH` would
+      // pass the second assertion for the wrong reason and fail the first.
+      expect(engine.appliedWrites).toEqual([]);
+    });
+
+    test("a write hidden behind a comment is rejected by the engine, not by inspecting the text", async () => {
+      await expect(provider.queryReadOnly("/* SELECT */ INSERT INTO t (id) VALUES (1)", roBudget())).rejects.toThrow(
+        /read-only transaction/,
+      );
+      await expect(provider.queryReadOnly("-- SELECT 1\nUPDATE t SET id = 2", roBudget())).rejects.toThrow(
+        /read-only transaction/,
+      );
+
+      expect(engine.appliedWrites).toEqual([]);
+    });
+
+    test("relaxing the transaction access mode cannot reach a second statement", async () => {
+      // The escape is real: this statement genuinely makes the transaction
+      // writable (live-verified). What stops it is that it is the transaction's
+      // ONLY statement — the next execution begins its own READ ONLY
+      // transaction on the pooled client.
+      await provider.queryReadOnly("SET TRANSACTION READ WRITE", roBudget());
+      expect(engine.txState).toBe("none");
+
+      await expect(provider.queryReadOnly("INSERT INTO t (id) VALUES (1)", roBudget())).rejects.toThrow(
+        /read-only transaction/,
+      );
+      expect(engine.appliedWrites).toEqual([]);
+      expect(engine.statements.filter((s) => s.text === "BEGIN READ ONLY")).toHaveLength(2);
+    });
+
+    test("a session-level SET does not survive into the next execution on the pooled client", async () => {
+      await provider.queryReadOnly("SET statement_timeout = 0", roBudget());
+
+      // The first assertion documents the model (GUCs are transactional, so the
+      // ROLLBACK restored the session value); the load-bearing one is the
+      // second — the next execution installs its own transaction-local timeout
+      // from the budget whatever the session carries.
+      expect(engine.sessionTimeout).toBe(30_000);
+      await provider.queryReadOnly("SELECT 1 AS ok", roBudget({ statementTimeoutMs: 1234 }));
+      expect(engine.localTimeouts).toEqual([4500, 1234]);
+    });
+
+    test("session state a rollback does NOT undo is discarded before the client goes back to the pool", async () => {
+      // Verified on PostgreSQL 18: an advisory lock taken inside BEGIN READ ONLY
+      // survives the ROLLBACK, and nothing on the agent path is REQUIRED to
+      // release it (`pg_advisory_unlock_all()` would, but a hostile statement has
+      // no reason to send it), so a pooled client would otherwise carry the lock
+      // into every later execution. `DISCARD ALL` — which cannot run inside a
+      // transaction block, hence after the rollback — makes "rolled back and
+      // released" true for session state too, without relying on goodwill.
+      await provider.queryReadOnly("SELECT pg_advisory_lock(101)", roBudget());
+
+      expect(engine.advisoryLocks).toEqual([]);
+      expect(engine.statements.map((s) => s.text)).toEqual([
+        "BEGIN READ ONLY",
+        "SET LOCAL statement_timeout = 4500",
+        "SELECT pg_advisory_lock(101)",
+        "ROLLBACK",
+        "DISCARD ALL",
+      ]);
     });
   });
 });

--- a/tests/integration/db/sqlite-node-harness.ts
+++ b/tests/integration/db/sqlite-node-harness.ts
@@ -12,8 +12,11 @@
  * stdout for the test to assert on. Any failure exits non-zero.
  */
 
+import { existsSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { SQLiteProvider } from "../../../src/lib/db/providers/sql/sqlite";
 import type { DatabaseConnection } from "../../../src/lib/types";
+import type { ReadOnlyStatementBudget } from "../../../src/lib/db/types";
 
 async function main(): Promise<void> {
   const dbPath = process.argv[2];
@@ -100,7 +103,113 @@ async function main(): Promise<void> {
   await provider.disconnect();
   report.disconnected = !provider.isConnected();
 
+  await runAgentReadOnlyProfile(dbPath, report);
+
   console.log(JSON.stringify(report));
+}
+
+/**
+ * Agent read-only execution profile contract (#328) on the node:sqlite
+ * adapter. The bun adapter is covered in-process by sqlite-provider.test.ts;
+ * these are the same behavioral assertions run against the real node driver,
+ * because an adapter that accepts the read-only open flag and ignores it would
+ * otherwise hand the agent a fully writable handle and no in-process test
+ * could see it.
+ */
+async function runAgentReadOnlyProfile(dbPath: string, report: Record<string, unknown>): Promise<void> {
+  const budget: ReadOnlyStatementBudget = {
+    statementTimeoutMs: 5_000,
+    maxResultRows: 100,
+    maxResultBytes: 64 * 1024,
+  };
+  const agentConfig: DatabaseConnection = {
+    id: "node-driver-harness-agent",
+    name: "Node Driver Harness (agent read-only)",
+    type: "sqlite",
+    database: dbPath,
+    createdAt: new Date(),
+  };
+
+  const agent = new SQLiteProvider(agentConfig, {}, { readOnly: true });
+  await agent.connect();
+  report.agentConnected = agent.isConnected();
+
+  // query_only must be verified at open — a read-only open does not imply it.
+  report.agentQueryOnly = (await agent.queryReadOnly("PRAGMA query_only", budget)).rows;
+
+  // A legitimate read still works.
+  report.agentSelectRows = (await agent.queryReadOnly("SELECT id, name FROM users ORDER BY id", budget)).rows;
+
+  // prepare() compiles one statement and drops the tail on this adapter too;
+  // the verification read below proves the smuggled insert never ran.
+  report.agentMultiStatementRows = (
+    await agent.queryReadOnly("SELECT id FROM users; INSERT INTO users (id, name) VALUES (97, 'tail')", budget)
+  ).rows;
+
+  // Write and schema change: rejected by the database, not by a classifier.
+  report.agentWriteRejected = await rejects(() =>
+    agent.queryReadOnly("INSERT INTO users (id, name) VALUES (99, 'agent')", budget),
+  );
+  report.agentSchemaChangeRejected = await rejects(() =>
+    agent.queryReadOnly("CREATE TABLE injected (id INTEGER)", budget),
+  );
+
+  // A statement that disables query_only must not leave it disabled for the
+  // next one — the provider is pooled and reused across an agent run.
+  await agent.queryReadOnly("PRAGMA query_only = false", budget);
+  report.agentQueryOnlyAfterDisable = (await agent.queryReadOnly("PRAGMA query_only", budget)).rows;
+  report.agentWriteRejectedAfterDisable = await rejects(() =>
+    agent.queryReadOnly("INSERT INTO users (id, name) VALUES (98, 'bypass')", budget),
+  );
+
+  // The read-only open governs the target file only; VACUUM INTO writes to
+  // ANOTHER file and is refused by query_only. The engine still creates the
+  // target before refusing, so assert on content, not existence.
+  const stolen = join(dirname(dbPath), "node-agent-stolen.db");
+  await agent.queryReadOnly("PRAGMA query_only = false", budget);
+  report.agentVacuumIntoRejected = await rejects(() => agent.queryReadOnly(`VACUUM INTO '${stolen}'`, budget));
+  report.agentStolenBytes = existsSync(stolen) ? statSync(stolen).size : 0;
+
+  await agent.disconnect();
+
+  // Nothing landed: re-read with a writable handle.
+  const verifier = new SQLiteProvider({ ...agentConfig, id: "node-driver-harness-verify" });
+  await verifier.connect();
+  report.agentRowsAfterRejectedWrites = (await verifier.query("SELECT id, name FROM users ORDER BY id")).rows;
+  report.agentTablesAfterRejectedWrites = (
+    await verifier.query("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+  ).rows;
+  await verifier.disconnect();
+
+  // A missing file in an EXISTING directory must not be created (the shared
+  // editor path would create it), and a missing directory must not be either.
+  const missingFile = join(dirname(dbPath), "node-agent-never-created.db");
+  const missingFileProvider = new SQLiteProvider(
+    { ...agentConfig, id: "node-driver-harness-missing-file", database: missingFile },
+    {},
+    { readOnly: true },
+  );
+  report.agentMissingOpenRejected = await rejects(() => missingFileProvider.connect());
+  report.agentMissingFileCreated = existsSync(missingFile);
+
+  const missingDir = join(dirname(dbPath), "node-agent-not-created");
+  const missingDirProvider = new SQLiteProvider(
+    { ...agentConfig, id: "node-driver-harness-missing-dir", database: join(missingDir, "absent.db") },
+    {},
+    { readOnly: true },
+  );
+  report.agentMissingDirOpenRejected = await rejects(() => missingDirProvider.connect());
+  report.agentMissingDirCreated = existsSync(missingDir);
+}
+
+/** True when the thunk rejects; false when it resolves. */
+async function rejects(fn: () => Promise<unknown>): Promise<boolean> {
+  try {
+    await fn();
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 main().catch((error: unknown) => {

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -9,13 +9,14 @@
 
 import { describe, test, expect, afterEach, beforeAll, afterAll } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
-import { SQLiteProvider } from "@/lib/db/providers/sql/sqlite";
+import { SQLiteProvider, assertQueryOnlyEnabled } from "@/lib/db/providers/sql/sqlite";
 import { resolveSQLiteDriverName } from "@/lib/db/providers/sql/sqlite-driver";
 import type { DatabaseConnection } from "@/lib/types";
-import { DatabaseConfigError } from "@/lib/db/errors";
+import type { ReadOnlyStatementBudget } from "@/lib/db/types";
+import { ConnectionError, DatabaseConfigError, ExecutionProfileError, QueryError } from "@/lib/db/errors";
 
 // ============================================================================
 // Helpers
@@ -770,6 +771,294 @@ describe("SQLiteProvider", () => {
 });
 
 // ============================================================================
+// Agent read-only execution profile (#328) — bun driver, in-process
+//
+// The security boundary asserted here is the DATABASE's own read-only open,
+// never a SQL classifier: every rejection case drives hostile SQL straight
+// through the profile and then re-reads the data with a writable handle to
+// prove nothing landed. Assertions are behavioral on purpose — bun and node
+// report read-only violations with different codes and messages, so a test
+// that asserted either would pass on one adapter and fail on the other.
+// ============================================================================
+
+const AGENT_BUDGET: ReadOnlyStatementBudget = {
+  statementTimeoutMs: 5_000,
+  maxResultRows: 100,
+  maxResultBytes: 64 * 1024,
+};
+
+describe("SQLiteProvider agent read-only execution profile (#328)", () => {
+  let agentTmpDir: string;
+  let seeded = 0;
+  let agent: SQLiteProvider | null = null;
+  let writable: SQLiteProvider | null = null;
+
+  beforeAll(() => {
+    agentTmpDir = mkdtempSync(join(tmpdir(), "libredb-sqlite-agent-"));
+  });
+
+  afterAll(() => {
+    rmSync(agentTmpDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    for (const p of [agent, writable]) {
+      try {
+        if (p?.isConnected()) await p.disconnect();
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+    agent = null;
+    writable = null;
+  });
+
+  /** Create a real on-disk database with one seeded row, then close the writer. */
+  async function seedDatabase(): Promise<string> {
+    const dbPath = join(agentTmpDir, `agent-${++seeded}.db`);
+    const seed = new SQLiteProvider(makeSQLiteConfig({ database: dbPath }));
+    await seed.connect();
+    await seed.query("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+    await seed.query("INSERT INTO t (id, v) VALUES (1, 'seeded')");
+    await seed.disconnect();
+    return dbPath;
+  }
+
+  /** Rows currently in `t`, read back through an independent writable handle. */
+  async function readBack(dbPath: string): Promise<Record<string, unknown>[]> {
+    const reader = new SQLiteProvider(makeSQLiteConfig({ database: dbPath }));
+    await reader.connect();
+    try {
+      return (await reader.query("SELECT id, v FROM t ORDER BY id")).rows;
+    } finally {
+      await reader.disconnect();
+    }
+  }
+
+  async function openAgent(dbPath: string): Promise<SQLiteProvider> {
+    agent = new SQLiteProvider(makeSQLiteConfig({ database: dbPath }), {}, { readOnly: true });
+    await agent.connect();
+    return agent;
+  }
+
+  test("returns rows for a legitimate SELECT", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    const result = await profile.queryReadOnly("SELECT id, v FROM t ORDER BY id", AGENT_BUDGET);
+
+    expect(result.rows).toEqual([{ id: 1, v: "seeded" }]);
+    expect(result.fields).toEqual(["id", "v"]);
+    expect(result.rowCount).toBe(1);
+  });
+
+  test("the database itself rejects a write through the profile", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    await expect(profile.queryReadOnly("INSERT INTO t (id, v) VALUES (2, 'agent')", AGENT_BUDGET)).rejects.toThrow();
+
+    expect(await readBack(dbPath)).toEqual([{ id: 1, v: "seeded" }]);
+  });
+
+  test("the database itself rejects a schema change through the profile", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    await expect(profile.queryReadOnly("CREATE TABLE injected (id INTEGER)", AGENT_BUDGET)).rejects.toThrow();
+    await expect(profile.queryReadOnly("DROP TABLE t", AGENT_BUDGET)).rejects.toThrow();
+
+    const tables = await profile.queryReadOnly("SELECT name FROM sqlite_master WHERE type = 'table'", AGENT_BUDGET);
+    expect(tables.rows).toEqual([{ name: "t" }]);
+  });
+
+  test("a missing file in an existing directory is not created", async () => {
+    // The sharp no-create case: the shared editor path would create this file
+    // (it passes `create: true` and mkdirs first), so a read-only open that
+    // silently fell back to read-write would leave the file behind.
+    const missingFile = join(agentTmpDir, "never-created.db");
+
+    const profile = new SQLiteProvider(makeSQLiteConfig({ database: missingFile }), {}, { readOnly: true });
+    await expect(profile.connect()).rejects.toThrow();
+
+    expect(profile.isConnected()).toBe(false);
+    expect(existsSync(missingFile)).toBe(false);
+  });
+
+  test("a missing parent directory is not created either", async () => {
+    const missingDir = join(agentTmpDir, "not-created");
+    const missingFile = join(missingDir, "absent.db");
+
+    const profile = new SQLiteProvider(makeSQLiteConfig({ database: missingFile }), {}, { readOnly: true });
+    await expect(profile.connect()).rejects.toThrow();
+
+    expect(existsSync(missingDir)).toBe(false);
+  });
+
+  test("PRAGMA query_only reads back enabled after open", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    const pragma = await profile.queryReadOnly("PRAGMA query_only", AGENT_BUDGET);
+
+    expect(pragma.rows).toEqual([{ query_only: 1 }]);
+  });
+
+  test("query_only is re-asserted before every statement, so a disable cannot persist", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    // The statement itself succeeds — nothing parses it — but it cannot leave
+    // the session disabled for the next call, because the profiled provider is
+    // pooled and reused across an agent run.
+    await profile.queryReadOnly("PRAGMA query_only = false", AGENT_BUDGET);
+
+    expect((await profile.queryReadOnly("PRAGMA query_only", AGENT_BUDGET)).rows).toEqual([{ query_only: 1 }]);
+    await expect(profile.queryReadOnly("INSERT INTO t (id, v) VALUES (2, 'bypass')", AGENT_BUDGET)).rejects.toThrow();
+    expect(await readBack(dbPath)).toEqual([{ id: 1, v: "seeded" }]);
+  });
+
+  test("VACUUM INTO cannot copy the database to another path, even after disabling query_only", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+    const stolen = join(agentTmpDir, `stolen-${seeded}.db`);
+
+    // A read-only OPEN only governs the target database file: on a handle
+    // whose query_only is off, this statement copies the whole database to an
+    // arbitrary server path on BOTH adapters (verified). query_only is what
+    // refuses it, which is why it is re-asserted per statement.
+    await profile.queryReadOnly("PRAGMA query_only = false", AGENT_BUDGET);
+    await expect(profile.queryReadOnly(`VACUUM INTO '${stolen}'`, AGENT_BUDGET)).rejects.toThrow();
+
+    // KNOWN LIMITATION: the engine creates the target file before refusing the
+    // copy, so an empty file can still appear at an agent-chosen path. What
+    // must never happen is readable data landing in it.
+    expect(existsSync(stolen) ? statSync(stolen).size : 0).toBe(0);
+  });
+
+  test("executes only the first statement of multi-statement input; the tail never runs", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    // prepare() compiles a single statement and drops the tail on both
+    // adapters. The profile must therefore never reach exec(), which would run
+    // every statement. Silent truncation is not an acceptable pass either —
+    // input-stage denial of multi-statement text is the policy pipeline's job.
+    const result = await profile.queryReadOnly("SELECT id FROM t; INSERT INTO t VALUES (2, 'tail')", AGENT_BUDGET);
+
+    expect(result.rows).toEqual([{ id: 1 }]);
+    expect(await readBack(dbPath)).toEqual([{ id: 1, v: "seeded" }]);
+  });
+
+  test("a writable provider on the same file still writes while the profile is open", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    writable = new SQLiteProvider(makeSQLiteConfig({ database: dbPath }));
+    await writable.connect();
+    const insert = await writable.query("INSERT INTO t (id, v) VALUES (2, 'editor')");
+
+    expect(insert.rowCount).toBe(1);
+    expect(await profile.queryReadOnly("SELECT COUNT(*) AS c FROM t", AGENT_BUDGET)).toMatchObject({
+      rows: [{ c: 2 }],
+    });
+  });
+
+  test("refuses queryReadOnly on a provider that was not opened read-only (fail closed)", async () => {
+    const dbPath = await seedDatabase();
+    writable = new SQLiteProvider(makeSQLiteConfig({ database: dbPath }));
+    await writable.connect();
+
+    await expect(writable.queryReadOnly("SELECT 1 AS one", AGENT_BUDGET)).rejects.toThrow(QueryError);
+    // The refusal is what keeps the writable handle from becoming an agent
+    // path: the statement must not have run at all.
+    await expect(writable.queryReadOnly("INSERT INTO t (id, v) VALUES (3, 'x')", AGENT_BUDGET)).rejects.toThrow(
+      QueryError,
+    );
+    expect(await readBack(dbPath)).toEqual([{ id: 1, v: "seeded" }]);
+  });
+
+  test("refuses an in-memory database under the read-only profile", async () => {
+    const profile = new SQLiteProvider(makeSQLiteConfig({ database: ":memory:" }), {}, { readOnly: true });
+
+    // A read-only open of an anonymous database can only ever yield an empty
+    // one (node) or fail outright (bun); vending it would be a silently
+    // useless agent target. The refusal carries a deny code, and connect()
+    // must not wrap it into a generic ConnectionError.
+    const error = await profile.connect().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(ExecutionProfileError);
+    expect((error as ExecutionProfileError).reasonCode).toBe("PROFILE_UNSUPPORTED_TARGET");
+    expect(profile.isConnected()).toBe(false);
+  });
+
+  test("enforces the row budget with a typed error instead of truncating", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    const rows = await profile.queryReadOnly("SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3", {
+      ...AGENT_BUDGET,
+      maxResultRows: 3,
+    });
+    expect(rows.rowCount).toBe(3);
+
+    await expect(
+      profile.queryReadOnly("SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3", {
+        ...AGENT_BUDGET,
+        maxResultRows: 2,
+      }),
+    ).rejects.toThrow(QueryError);
+  });
+
+  test("enforces the byte budget with a typed error instead of truncating", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    await expect(
+      profile.queryReadOnly("SELECT 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' AS big", { ...AGENT_BUDGET, maxResultBytes: 8 }),
+    ).rejects.toThrow(QueryError);
+  });
+
+  test("rejects a statement that overruns the timeout budget", async () => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    // Neither adapter exposes sqlite3_interrupt or a progress handler, so the
+    // timeout is a post-execution deadline: the statement is not preempted,
+    // but its result is refused. See docs/providers/sqlite.md section 12.
+    await expect(
+      profile.queryReadOnly(
+        "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM c WHERE x < 400000) SELECT COUNT(*) AS n FROM c",
+        { ...AGENT_BUDGET, statementTimeoutMs: 1 },
+      ),
+    ).rejects.toThrow(QueryError);
+  });
+
+  test.each([
+    ["statementTimeoutMs", { statementTimeoutMs: 0 }],
+    ["maxResultRows", { maxResultRows: -1 }],
+    ["maxResultBytes", { maxResultBytes: 1.5 }],
+  ])("refuses the whole call when budget field %s is not a positive integer", async (_field, override) => {
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    await expect(
+      profile.queryReadOnly("SELECT 1 AS one", { ...AGENT_BUDGET, ...override } as ReadOnlyStatementBudget),
+    ).rejects.toThrow(QueryError);
+  });
+
+  test("refuses a handle whose query_only pragma does not read back enabled", () => {
+    // The happy path is covered by every test above; these pin the refusal for
+    // a driver that accepts `PRAGMA query_only = true` and ignores it.
+    expect(() => assertQueryOnlyEnabled([{ query_only: 1 }])).not.toThrow();
+    expect(() => assertQueryOnlyEnabled([{ query_only: 0 }])).toThrow(ConnectionError);
+    expect(() => assertQueryOnlyEnabled([])).toThrow(ConnectionError);
+  });
+});
+
+// ============================================================================
 // Driver selection (sqlite-driver adapter)
 // ============================================================================
 
@@ -925,5 +1214,29 @@ describe.skipIf(!nodeDriverTestable)("SQLiteProvider with LIBREDB_SQLITE_DRIVER=
     // Error mapping (same mapDatabaseError path as the bun driver)
     expect(report.queryErrorName).toBe("DatabaseError");
     expect(report.queryErrorMessage).toContain("no such table");
+
+    // ------------------------------------------------------------------
+    // Agent read-only execution profile (#328) on the node:sqlite adapter.
+    // These fail on an adapter that accepts the read-only open flag and
+    // ignores it: the write would land and the file would be created.
+    // ------------------------------------------------------------------
+    expect(report.agentConnected).toBe(true);
+    expect(report.agentQueryOnly).toEqual([{ query_only: 1 }]);
+    expect(report.agentSelectRows).toEqual([{ id: 1, name: "Alice" }]);
+    expect(report.agentMultiStatementRows).toEqual([{ id: 1 }]);
+    expect(report.agentWriteRejected).toBe(true);
+    expect(report.agentSchemaChangeRejected).toBe(true);
+    // query_only is re-asserted per statement, and VACUUM INTO — the one route
+    // a read-only open does not cover — leaks nothing.
+    expect(report.agentQueryOnlyAfterDisable).toEqual([{ query_only: 1 }]);
+    expect(report.agentWriteRejectedAfterDisable).toBe(true);
+    expect(report.agentVacuumIntoRejected).toBe(true);
+    expect(report.agentStolenBytes).toBe(0);
+    expect(report.agentRowsAfterRejectedWrites).toEqual([{ id: 1, name: "Alice" }]);
+    expect(report.agentTablesAfterRejectedWrites).toEqual([{ name: "books" }, { name: "users" }]);
+    expect(report.agentMissingOpenRejected).toBe(true);
+    expect(report.agentMissingFileCreated).toBe(false);
+    expect(report.agentMissingDirOpenRejected).toBe(true);
+    expect(report.agentMissingDirCreated).toBe(false);
   });
 });

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -1049,6 +1049,37 @@ describe("SQLiteProvider agent read-only execution profile (#328)", () => {
     ).rejects.toThrow(QueryError);
   });
 
+  test("attaching a second database creates nothing and cannot be written through", async () => {
+    const dbPath = await seedDatabase();
+    const otherPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+    const absent = join(agentTmpDir, `attach-absent-${seeded}.db`);
+
+    // A missing file is not created by ATTACH either — same no-create property
+    // as the profile's own open.
+    await expect(profile.queryReadOnly(`ATTACH DATABASE '${absent}' AS absent`, AGENT_BUDGET)).rejects.toThrow();
+    expect(existsSync(absent)).toBe(false);
+
+    // An EXISTING file attaches successfully: the read-only mode is inherited,
+    // so writes through it are refused...
+    await profile.queryReadOnly(`ATTACH DATABASE '${otherPath}' AS other`, AGENT_BUDGET);
+    await expect(profile.queryReadOnly("INSERT INTO other.t (id, v) VALUES (2, 'x')", AGENT_BUDGET)).rejects.toThrow();
+    expect(await readBack(otherPath)).toEqual([{ id: 1, v: "seeded" }]);
+
+    // ...but its ROWS become readable, and neither adapter offers a
+    // database-native control that would stop that (bun:sqlite exposes no
+    // authorizer at all). This is asserted rather than wished away: the only
+    // control for out-of-scope READS through ATTACH is the input-stage denial in
+    // the operations layer (tests/security/agent-statement-boundary.test.ts),
+    // which is why that denial exists. Recorded as a known limitation in
+    // docs/providers/sqlite.md section 12 and docs/BACKLOG.md.
+    const leaked = await profile.queryReadOnly("SELECT v FROM other.t", AGENT_BUDGET);
+    expect(leaked.rows).toEqual([{ v: "seeded" }]);
+
+    await profile.queryReadOnly("DETACH DATABASE other", AGENT_BUDGET);
+    await expect(profile.queryReadOnly("DETACH DATABASE main", AGENT_BUDGET)).rejects.toThrow();
+  });
+
   test("refuses a handle whose query_only pragma does not read back enabled", () => {
     // The happy path is covered by every test above; these pin the refusal for
     // a driver that accepts `PRAGMA query_only = true` and ignores it.

--- a/tests/security/agent-execution-audit.test.ts
+++ b/tests/security/agent-execution-audit.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { getServerAuditBuffer } from "@/lib/audit";
+import { ExecutionArtifactStore } from "@/lib/db/operations/artifacts";
+import type { ExecutionBudget } from "@/lib/db/operations/budgets";
+import { ExecutionBudgetTracker } from "@/lib/db/operations/budgets";
+import { createCanonicalOperationRegistry } from "@/lib/db/operations/descriptors";
+import { DENY_REASONS, executeAuditedOperation } from "@/lib/db/operations/execution";
+import type { ExecutionActor, ExecutionPolicy, OperationRequest } from "@/lib/db/operations/policy";
+import { createTargetScope } from "@/lib/db/operations/policy";
+import type { ProviderCapabilities } from "@/lib/db/types";
+
+/**
+ * Control 3.5 — accountability of the agent execution path (#328).
+ *
+ * Two threats, one suite:
+ *
+ * (a) An execution nobody can see. An agent path whose denials are silent
+ *     tells an operator nothing about what was attempted, and an allowed
+ *     execution that is unauditable must not run at all — the fail-closed
+ *     direction, asserted here by breaking the sink.
+ * (b) The audit trail itself becoming the leak. Everything reaching this layer
+ *     — statement text, agent-supplied operation ids, session identifiers,
+ *     driver error messages — is exactly what `src/lib/audit.ts` forbids
+ *     recording. The sentinel sweep below scans the WHOLE serialized output of
+ *     both destinations (ring buffer and the authoritative stdout line) rather
+ *     than naming fields, so a value smuggled into a field this test never
+ *     heard of still fails it.
+ */
+
+const budgets: ExecutionBudget = {
+  maxConcurrentExecutions: 2,
+  maxStatementsPerRun: 10,
+  maxTotalRunMs: 60_000,
+  statementTimeoutMs: 5_000,
+  maxResultRows: 1_000,
+  maxResultBytes: 1_048_576,
+};
+
+const policy: ExecutionPolicy = {
+  version: "test-policy.1",
+  maxRiskClass: 1,
+  allowedRoles: ["admin", "user"],
+  allowedModes: ["agent"],
+  budgets,
+};
+
+const capabilities: ProviderCapabilities = {
+  queryLanguage: "sql",
+  supportsExplain: true,
+  explainFormat: "postgres-json",
+  supportsExternalQueryLimiting: true,
+  supportsCreateTable: true,
+  supportsInlineRowEdit: true,
+  supportsMaintenance: false,
+  maintenanceOperations: [],
+  supportsConnectionString: true,
+  defaultPort: 5432,
+  schemaRefreshPattern: "manual",
+};
+
+/** Distinctive values that must never appear in either audit destination. */
+const SQL_SENTINEL = "zt7q_salary_column_sentinel";
+const SESSION_SENTINEL = "eyJhbGciOiJIUzI1NiJ9.sentinel-session-token";
+const OPERATION_SENTINEL = "sql.query.read.zt7q_forged_operation";
+
+const actor: ExecutionActor = { sessionId: SESSION_SENTINEL, role: "user", mode: "agent" };
+const scope = createTargetScope("conn-1");
+
+function params(request: OperationRequest) {
+  return { registry: createCanonicalOperationRegistry(), policy, actor, scope, request, capabilities };
+}
+
+function context() {
+  return {
+    runId: "run-1",
+    tracker: new ExecutionBudgetTracker(),
+    artifacts: new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 }),
+    clock: (() => {
+      let tick = 0;
+      return () => {
+        tick += 10;
+        return tick;
+      };
+    })(),
+  };
+}
+
+let consoleSpy: ReturnType<typeof spyOn<Console, "log">>;
+
+/** Everything both destinations recorded, as one string to scan. */
+function auditedText(): string {
+  const lines = consoleSpy.mock.calls.map((call) => String(call[0])).join("\n");
+  return `${JSON.stringify(getServerAuditBuffer().getAll())}\n${lines}`;
+}
+
+beforeEach(() => {
+  getServerAuditBuffer().clear();
+  consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleSpy.mockRestore();
+});
+
+describe("agent execution audit — what must never be recorded", () => {
+  test("an allowed execution records no statement text and no session identifier", async () => {
+    await executeAuditedOperation(
+      params({ operationId: "sql.query.read", target: {}, input: { sql: `SELECT ${SQL_SENTINEL} FROM staff` } }),
+      context(),
+      mock(async () => ({ rows: [{ [SQL_SENTINEL]: 90_000 }] })),
+    );
+
+    const recorded = auditedText();
+    expect(recorded).not.toContain(SQL_SENTINEL);
+    expect(recorded).not.toContain(SESSION_SENTINEL);
+    // The result rows stay in the in-memory artifact; only the correlation id
+    // and the elapsed time describe them in the log.
+    expect(recorded).toContain("agent_operation");
+  });
+
+  test("a denied request records neither its statement nor the operation id it invented", async () => {
+    await executeAuditedOperation(
+      params({ operationId: OPERATION_SENTINEL, target: {}, input: { sql: `SELECT ${SQL_SENTINEL}` } }),
+      context(),
+      mock(async () => ({ rows: [] })),
+    );
+
+    const recorded = auditedText();
+    expect(recorded).not.toContain(SQL_SENTINEL);
+    expect(recorded).not.toContain(SESSION_SENTINEL);
+    // An agent-chosen id is caller text, so it is refused a place in the log
+    // exactly like the statement is - the reason code says what happened.
+    expect(recorded).not.toContain("zt7q_forged_operation");
+    expect(recorded).toContain("agent_unknown_operation");
+  });
+
+  test("a provider failure records the typed reason, never the driver's message", async () => {
+    await expect(
+      executeAuditedOperation(
+        params({ operationId: "sql.query.read", target: {}, input: { sql: "SELECT 1" } }),
+        context(),
+        mock(async () => {
+          throw new Error(`relation ${SQL_SENTINEL} does not exist at 10.1.2.3:5432`);
+        }),
+      ),
+    ).rejects.toThrow();
+
+    const recorded = auditedText();
+    expect(recorded).not.toContain(SQL_SENTINEL);
+    expect(recorded).not.toContain("10.1.2.3");
+    expect(recorded).toContain("agent_execution_failed");
+  });
+});
+
+describe("agent execution audit — what every attempt records", () => {
+  test("an allowed execution leaves a decision event and an execution event", async () => {
+    const outcome = await executeAuditedOperation(
+      params({ operationId: "sql.query.read", target: {}, input: { sql: "SELECT 1" } }),
+      context(),
+      mock(async () => ({ rows: [] })),
+    );
+
+    const [decision, execution] = getServerAuditBuffer().getAll();
+    expect(decision.type).toBe("agent_operation");
+    expect(execution.type).toBe("agent_operation");
+    expect(decision.correlationId).toBe(outcome.correlationId);
+    expect(execution.correlationId).toBe(outcome.correlationId);
+
+    // The decision is recorded BEFORE the provider runs, so a statement that
+    // never returns still leaves a trace that it was authorized and started.
+    expect(decision.target).toBe("agent/operations/decision");
+    expect(execution.target).toBe("agent/operations/execution");
+    expect(decision.result).toBe("success");
+    expect(execution.result).toBe("success");
+    expect(decision.reason).toBeUndefined();
+
+    // The action is the registry-RESOLVED id; the actor is a closed-vocabulary
+    // label. Neither field can carry caller-supplied text.
+    expect(decision.action).toBe("sql.query.read");
+    expect(execution.action).toBe("sql.query.read");
+    expect(decision.user).toBe("agent:user");
+    // Elapsed time comes from the injected clock, not a real one.
+    expect(execution.duration).toBe(10);
+  });
+
+  test("a denial leaves exactly one event carrying its reason code", async () => {
+    const denyingPolicy: ExecutionPolicy = { ...policy, allowedRoles: ["admin"] };
+    const outcome = await executeAuditedOperation(
+      { ...params({ operationId: "sql.query.read", target: {}, input: { sql: "SELECT 1" } }), policy: denyingPolicy },
+      context(),
+      mock(async () => ({ rows: [] })),
+    );
+
+    const events = getServerAuditBuffer().getAll();
+    expect(events).toHaveLength(1);
+    expect(events[0].target).toBe("agent/operations/decision");
+    expect(events[0].result).toBe("failure");
+    expect(events[0].reason).toBe("agent_role_forbidden");
+    expect(events[0].correlationId).toBe(outcome.correlationId);
+  });
+
+  test("an approval requirement is recorded as its own reason, not as a plain denial", async () => {
+    await executeAuditedOperation(
+      params({ operationId: "sql.explain.analyze", target: {}, input: { sql: "EXPLAIN ANALYZE SELECT 1" } }),
+      context(),
+      mock(async () => ({ rows: [] })),
+    );
+
+    const events = getServerAuditBuffer().getAll();
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe("agent_approval_required");
+    expect(events[0].action).toBe("sql.explain.analyze");
+  });
+
+  test("records that the statement ran even when the artifact store refuses its result", async () => {
+    const storeFailure = new Error("artifact store rejected the result");
+    const refusingStore = {
+      put: () => {
+        throw storeFailure;
+      },
+      releaseRun: () => 0,
+    } as unknown as ExecutionArtifactStore;
+
+    // The audit line is emitted BEFORE the in-memory store gets a say. A store
+    // that refuses the result must not also erase the record that the database
+    // executed something - the trail is the part that cannot be reconstructed.
+    await expect(
+      executeAuditedOperation(
+        params({ operationId: "sql.query.read", target: {}, input: { sql: "SELECT 1" } }),
+        { ...context(), artifacts: refusingStore },
+        mock(async () => ({ rows: [] })),
+      ),
+    ).rejects.toThrow(storeFailure);
+
+    const events = getServerAuditBuffer().getAll();
+    expect(events).toHaveLength(2);
+    expect(events[1].target).toBe("agent/operations/execution");
+    expect(events[1].result).toBe("success");
+  });
+
+  test("an actor the pipeline never validated is recorded as unknown", async () => {
+    await executeAuditedOperation(
+      {
+        ...params({ operationId: "sql.query.read", target: {}, input: { sql: "SELECT 1" } }),
+        actor: { sessionId: SESSION_SENTINEL, role: "root" as never, mode: "agent" },
+      },
+      context(),
+      mock(async () => ({ rows: [] })),
+    );
+
+    const [event] = getServerAuditBuffer().getAll();
+    expect(event.reason).toBe("agent_invalid_actor");
+    // Not "agent:root": the label is built only from values policy.ts accepted.
+    expect(event.user).toBe("agent:unknown");
+  });
+});
+
+describe("agent execution audit — the authoritative stdout line", () => {
+  test("carries the correlation id joining an execution's two events", async () => {
+    const outcome = await executeAuditedOperation(
+      params({ operationId: "sql.query.read", target: {}, input: { sql: "SELECT 1" } }),
+      context(),
+      mock(async () => ({ rows: [] })),
+    );
+
+    const lines = consoleSpy.mock.calls.map((call) => JSON.parse(String(call[0])) as Record<string, unknown>);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(line.schema).toBe("libredb.audit.v1");
+      expect(line.event).toBe("agent_operation");
+      expect(line.correlation_id).toBe(outcome.correlationId);
+      expect(line.actor).toBe("agent:user");
+    }
+    expect(lines[0].route).toBe("agent/operations/decision");
+    expect(lines[1].route).toBe("agent/operations/execution");
+  });
+
+  test("omits the correlation id entirely for events that do not carry one", async () => {
+    // Regression guard for the optional-field convention in toAuditLine: a
+    // non-agent event must not gain a null or empty correlation_id key, which
+    // would change the fixed shape downstream parsers depend on.
+    const { emitAuditEvent } = await import("@/lib/audit");
+    emitAuditEvent({
+      type: "logout",
+      action: "logout",
+      target: "POST /api/auth/logout",
+      user: "admin",
+      result: "success",
+    });
+
+    const line = JSON.parse(String(consoleSpy.mock.calls[0][0])) as Record<string, unknown>;
+    expect("correlation_id" in line).toBe(false);
+  });
+});
+
+describe("agent execution audit — fail closed", () => {
+  test("does not invoke the provider when the decision cannot be recorded", async () => {
+    const invoke = mock(async () => ({ rows: [] }));
+    // The sink is forced to throw to pin a structural property, not to model a
+    // specific outage: `emitAuditEvent` is called with no try/catch around it
+    // and before the provider, so ANY emission failure stops the execution
+    // instead of letting it run unrecorded. (`src/proxy.ts` makes the opposite
+    // trade for a 403 it has already decided; tests/api/auth/login.test.ts pins
+    // that one with the same forced-sink technique.)
+    consoleSpy.mockImplementation(() => {
+      throw new Error("audit sink unavailable");
+    });
+
+    await expect(
+      executeAuditedOperation(
+        params({ operationId: "sql.query.read", target: {}, input: { sql: "SELECT 1" } }),
+        context(),
+        invoke,
+      ),
+    ).rejects.toThrow("audit sink unavailable");
+
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe("agent execution audit — the deny vocabulary", () => {
+  test("maps every policy deny code to a distinct agent reason code", () => {
+    const codes = Object.keys(DENY_REASONS);
+    const reasons = Object.values(DENY_REASONS);
+
+    // Totality is enforced by the compiler (Record<PolicyDenyCode, AuditReason>);
+    // what a test can still add is that the mapping is injective and namespaced,
+    // so two different denials never read identically in the log.
+    expect(new Set(reasons).size).toBe(codes.length);
+    expect(reasons.every((reason) => reason.startsWith("agent_"))).toBe(true);
+    expect(codes.length).toBeGreaterThanOrEqual(13);
+  });
+});

--- a/tests/security/agent-statement-boundary.test.ts
+++ b/tests/security/agent-statement-boundary.test.ts
@@ -1,0 +1,378 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExecutionBudget, ExecutionUsage } from "@/lib/db/operations/budgets";
+import { createCanonicalOperationRegistry } from "@/lib/db/operations/descriptors";
+import {
+  type ExecutionActor,
+  type ExecutionPolicy,
+  type PolicyDenyCode,
+  type PolicyEvaluationParams,
+  createTargetScope,
+  evaluateOperation,
+  executeWithPolicy,
+} from "@/lib/db/operations/policy";
+import { SQLiteProvider } from "@/lib/db/providers/sql/sqlite";
+import type { ProviderCapabilities, ReadOnlyStatementBudget } from "@/lib/db/types";
+import type { DatabaseConnection } from "@/lib/types";
+
+/**
+ * Threat: an agent (or anything that reaches the agent path) submits SQL crafted
+ * to write, to change schema, to touch a second database, to load code, or to
+ * run the executing form of EXPLAIN — using obfuscation to get past whatever
+ * inspects the text.
+ *
+ * Every case is asserted on BOTH layers, because they fail differently:
+ *
+ * (a) the policy pipeline denies it at the input stage with a reason code and
+ *     the provider is never invoked. This layer is DEFENSE IN DEPTH — it reads
+ *     SQL, so it can be wrong.
+ * (b) the same statement is driven STRAIGHT AT the read-only profile, as if (a)
+ *     had been bypassed entirely, and the database itself refuses it. This is
+ *     the load-bearing assertion (#328): a case that only asserts (a) is not a
+ *     security test.
+ *
+ * The (b) side runs against a real SQLite file (bun:sqlite, in-process, no
+ * mocks). PostgreSQL's engine-level half lives in
+ * tests/integration/db/postgres-provider.test.ts, where the pg driver mock is,
+ * and SQLite's provider-specific plumbing (ATTACH containment, adapter contract)
+ * in tests/integration/db/sqlite-provider.test.ts, per the provider triad rule.
+ *
+ * The fixtures are chosen so that nothing here can pass by keyword matching:
+ * the legitimate control statements mention write keywords inside literals,
+ * identifiers and comments, and the hostile ones hide the write behind
+ * comments, CTEs, function calls and statement terminators.
+ */
+
+/**
+ * One scratch directory for the whole file, created at import time so the
+ * hostile corpus below can name paths INSIDE it: a statement that writes
+ * elsewhere then leaves evidence where this suite can see it.
+ */
+const SCRATCH = mkdtempSync(join(tmpdir(), "libredb-agent-security-"));
+const TARGET_DB = join(SCRATCH, "target.db");
+/** Paths the corpus tries to create. Nothing may ever exist at them. */
+const ATTACK_PATHS = [join(SCRATCH, "attached.db"), join(SCRATCH, "copied.txt"), join(SCRATCH, "extension.so")];
+
+// ─── Layer (a): the policy pipeline ─────────────────────────────────────────
+
+const budgets: ExecutionBudget = {
+  maxConcurrentExecutions: 2,
+  maxStatementsPerRun: 50,
+  maxTotalRunMs: 60_000,
+  statementTimeoutMs: 5_000,
+  maxResultRows: 1_000,
+  maxResultBytes: 1_048_576,
+};
+
+const policy: ExecutionPolicy = {
+  version: "agent-m1.security",
+  maxRiskClass: 1,
+  allowedRoles: ["admin", "user"],
+  allowedModes: ["agent"],
+  budgets,
+};
+
+const actor: ExecutionActor = { sessionId: "session-security", role: "user", mode: "agent" };
+
+const capabilities: ProviderCapabilities = {
+  queryLanguage: "sql",
+  supportsExplain: true,
+  explainFormat: "sqlite-queryplan",
+  supportsExternalQueryLimiting: true,
+  supportsCreateTable: true,
+  supportsInlineRowEdit: true,
+  supportsMaintenance: true,
+  maintenanceOperations: [],
+  supportsConnectionString: false,
+  defaultPort: null,
+  schemaRefreshPattern: "manual",
+};
+
+const idleUsage: ExecutionUsage = { activeExecutions: 0, executedStatements: 0, totalElapsedMs: 0 };
+
+function pipelineParams(operationId: string, sql: string): PolicyEvaluationParams {
+  return {
+    registry: createCanonicalOperationRegistry(),
+    policy,
+    actor,
+    scope: createTargetScope("conn-security"),
+    request: { operationId, target: {}, input: { sql } },
+    capabilities,
+    usage: idleUsage,
+  };
+}
+
+/** Denies with `expected` AND proves the provider callback was never reached. */
+async function expectPipelineDeny(operationId: string, sql: string, expected: PolicyDenyCode): Promise<void> {
+  const decision = evaluateOperation(pipelineParams(operationId, sql));
+  expect(decision.kind).toBe("deny");
+  if (decision.kind === "deny") expect(decision.reasonCode).toBe(expected);
+
+  let invocations = 0;
+  const outcome = await executeWithPolicy(pipelineParams(operationId, sql), async () => {
+    invocations++;
+    return "executed";
+  });
+  expect(invocations).toBe(0);
+  expect(outcome.decision.kind).toBe("deny");
+}
+
+// ─── The attack corpus, shared by both layers ───────────────────────────────
+
+/**
+ * How SQLite's own enforcement answers a statement that reached the profile
+ * with classification bypassed:
+ *
+ * - `rejected` — the engine refuses it outright;
+ * - `first-statement-only` — `prepare()` compiles one statement, so the tail
+ *   never runs (silent truncation is not a pass on its own, which is why the
+ *   same input is denied at the input stage above).
+ */
+type EngineOutcome = "rejected" | "first-statement-only";
+
+interface Attack {
+  readonly label: string;
+  readonly sql: string;
+  readonly deny: PolicyDenyCode;
+  /** Absent when the construct is PostgreSQL-only (asserted in the pg suite). */
+  readonly sqlite?: EngineOutcome;
+}
+
+const ATTACKS: readonly Attack[] = [
+  {
+    label: "a write hidden behind a block comment",
+    sql: "/* SELECT */ INSERT INTO t (id, v) VALUES (2, 'obfuscated')",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "a write hidden behind a line comment and newlines",
+    sql: "\n\t-- SELECT id FROM t\n   UPDATE t SET v = 'obfuscated'\n",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "a data-modifying CTE",
+    sql: "WITH src AS (SELECT 2 AS id) INSERT INTO t (id, v) SELECT id, 'cte' FROM src",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "a nested CTE whose inner element writes",
+    sql: "WITH outer_cte AS (WITH inner_cte AS (SELECT 2 AS id) SELECT id FROM inner_cte) DELETE FROM t WHERE id IN (SELECT id FROM outer_cte)",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "multi-statement input smuggling a write after a legitimate read",
+    sql: "SELECT id FROM t; INSERT INTO t (id, v) VALUES (2, 'tail')",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "first-statement-only",
+  },
+  {
+    label: "a mutating pragma",
+    sql: "PRAGMA user_version = 42",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    // A journal-mode CHANGE, not a restatement: setting the mode a database is
+    // already in is a no-op the engine answers with the current value, so a test
+    // that used the current mode would prove nothing. The seeded database is in
+    // WAL (the shared editor path sets it at open), hence DELETE here.
+    label: "a journal-mode change",
+    sql: "PRAGMA journal_mode = DELETE",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "attaching a second database that does not exist yet",
+    sql: `ATTACH DATABASE '${ATTACK_PATHS[0]}' AS stolen`,
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "detaching the target database",
+    sql: "DETACH DATABASE main",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "loading an extension through a function call",
+    sql: `SELECT load_extension('${ATTACK_PATHS[2]}')`,
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "a temp table used as writable scratch space",
+    sql: "CREATE TEMP TABLE scratch (id INTEGER)",
+    deny: "INPUT_VALIDATION_FAILED",
+    sqlite: "rejected",
+  },
+  {
+    label: "a server-side file write (PostgreSQL COPY)",
+    sql: `COPY (SELECT v FROM t) TO '${ATTACK_PATHS[1]}'`,
+    deny: "INPUT_VALIDATION_FAILED",
+  },
+  {
+    label: "a server-side program execution (PostgreSQL COPY TO PROGRAM)",
+    sql: "COPY (SELECT v FROM t) TO PROGRAM 'sh -c id'",
+    deny: "INPUT_VALIDATION_FAILED",
+  },
+  {
+    label: "an attempt to leave the read-only transaction",
+    sql: "SET TRANSACTION READ WRITE",
+    deny: "INPUT_VALIDATION_FAILED",
+  },
+];
+
+/** Reads that MENTION write keywords where the statement does not execute them. */
+const LEGITIMATE_READS: readonly string[] = [
+  "SELECT id, v FROM t ORDER BY id",
+  "SELECT 'insert into t values (1)' AS note, id FROM t",
+  "SELECT id FROM t -- delete from t\n",
+  "WITH recent AS (SELECT id, v FROM t) SELECT * FROM recent",
+];
+
+describe("agent statement boundary — layer (a): the policy pipeline denies before the provider is reached", () => {
+  test.each(ATTACKS.map((attack) => [attack.label, attack] as const))("denies %s", async (_label, attack) => {
+    await expectPipelineDeny("sql.query.read", attack.sql, attack.deny);
+  });
+
+  test.each([...LEGITIMATE_READS])("allows the legitimate read %#, which merely mentions write keywords", (sql) => {
+    const decision = evaluateOperation(pipelineParams("sql.query.read", sql));
+    expect(decision.kind).toBe("allow");
+  });
+});
+
+describe("agent statement boundary — plan execution cannot be reached by aliasing or obfuscation", () => {
+  test.each([
+    ["SQL.EXPLAIN.ANALYZE", "AMBIGUOUS_OPERATION"],
+    [" sql.explain.analyze ", "AMBIGUOUS_OPERATION"],
+    ["sql.explain.analyse", "UNKNOWN_OPERATION"],
+    ["sql_explain_analyze", "UNKNOWN_OPERATION"],
+  ] as const)("denies the aliased operation id %s", async (operationId, expected) => {
+    await expectPipelineDeny(operationId, "SELECT 1", expected);
+  });
+
+  test.each([
+    "EXPLAIN ANALYZE SELECT id FROM t",
+    "EXPLAIN (ANALYZE, BUFFERS) SELECT id FROM t",
+    "EXPLAIN /* plan */ ANALYZE SELECT id FROM t",
+    // PostgreSQL accepts ANALYSE as a full synonym and it executes the
+    // statement, so a single-spelling check would launder plan execution
+    // through this risk-class-0, approval-free descriptor.
+    "EXPLAIN ANALYSE SELECT id FROM t",
+    "EXPLAIN (ANALYSE, BUFFERS) SELECT id FROM t",
+  ])("denies plan EXECUTION requested through the plan-inspection descriptor: %s", async (sql) => {
+    await expectPipelineDeny("sql.explain.estimate", sql, "INPUT_VALIDATION_FAILED");
+  });
+
+  test("the plan-execution descriptor itself can only ever reach require-approval", () => {
+    const decision = evaluateOperation(pipelineParams("sql.explain.analyze", "EXPLAIN ANALYZE SELECT id FROM t"));
+    expect(decision.kind).toBe("require-approval");
+    if (decision.kind === "require-approval") expect(decision.reasonCode).toBe("APPROVAL_REQUIRED");
+  });
+
+  test("a write carried by an approved plan execution is still denied at the input stage", async () => {
+    await expectPipelineDeny(
+      "sql.explain.analyze",
+      "EXPLAIN ANALYZE WITH w AS (INSERT INTO t (id, v) VALUES (2, 'x') RETURNING id) SELECT * FROM w",
+      "INPUT_VALIDATION_FAILED",
+    );
+  });
+});
+
+// ─── Layer (b): the database itself, with classification bypassed ────────────
+
+const AGENT_BUDGET: ReadOnlyStatementBudget = {
+  statementTimeoutMs: 5_000,
+  maxResultRows: 100,
+  maxResultBytes: 1_000_000,
+};
+
+describe("agent statement boundary — layer (b): SQLite refuses the same statements with the pipeline bypassed", () => {
+  let profile: SQLiteProvider;
+
+  function config(database: string): DatabaseConnection {
+    return { id: "conn-security", name: "Security SQLite", type: "sqlite", database, createdAt: new Date() };
+  }
+
+  async function tableState(): Promise<Record<string, unknown>[]> {
+    const reader = new SQLiteProvider(config(TARGET_DB));
+    await reader.connect();
+    try {
+      return (await reader.query("SELECT id, v FROM t ORDER BY id")).rows;
+    } finally {
+      await reader.disconnect();
+    }
+  }
+
+  beforeAll(async () => {
+    const seed = new SQLiteProvider(config(TARGET_DB));
+    await seed.connect();
+    await seed.query("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+    await seed.query("INSERT INTO t (id, v) VALUES (1, 'seeded')");
+    await seed.disconnect();
+
+    profile = new SQLiteProvider(config(TARGET_DB), {}, { readOnly: true });
+    await profile.connect();
+  });
+
+  afterAll(async () => {
+    if (profile?.isConnected()) await profile.disconnect();
+    rmSync(SCRATCH, { recursive: true, force: true });
+  });
+
+  const sqliteAttacks = ATTACKS.filter((attack) => attack.sqlite !== undefined);
+
+  test.each(
+    sqliteAttacks.map((attack) => [attack.label, attack] as const),
+  )("the engine — not a parser — refuses %s", async (_label, attack) => {
+    const before = await tableState();
+
+    if (attack.sqlite === "rejected") {
+      await expect(profile.queryReadOnly(attack.sql, AGENT_BUDGET)).rejects.toThrow();
+    } else {
+      // Only the leading statement is compiled; the smuggled tail never runs.
+      const result = await profile.queryReadOnly(attack.sql, AGENT_BUDGET);
+      expect(result.rows).toEqual([{ id: 1 }]);
+    }
+
+    expect(await tableState()).toEqual(before);
+  });
+
+  test("a pragma function cannot turn query_only off for a later statement", async () => {
+    // The setter form is refused by this build, and the profile re-asserts the
+    // pragma before every statement regardless — so neither the disable nor a
+    // write behind it can survive into the next call.
+    await expect(profile.queryReadOnly("SELECT * FROM pragma_query_only(0)", AGENT_BUDGET)).rejects.toThrow();
+
+    expect((await profile.queryReadOnly("PRAGMA query_only", AGENT_BUDGET)).rows).toEqual([{ query_only: 1 }]);
+    await expect(profile.queryReadOnly("INSERT INTO t (id, v) VALUES (3, 'after')", AGENT_BUDGET)).rejects.toThrow();
+  });
+
+  test("legitimate reads still work through the profile after the whole hostile corpus", async () => {
+    for (const sql of LEGITIMATE_READS) {
+      const result = await profile.queryReadOnly(sql, AGENT_BUDGET);
+      expect(result.rows.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("nothing was written anywhere else in the scratch directory", async () => {
+    // The T4 lesson generalized: a read-only open protects the file it opened,
+    // not the filesystem. The corpus above names paths inside this directory for
+    // the statements that write ELSEWHERE (ATTACH of a new database, extension
+    // load, both COPY forms), so their evidence would land here.
+    for (const attacked of ATTACK_PATHS) {
+      expect(existsSync(attacked)).toBe(false);
+    }
+    // Only the target database and its own journal sidecars may exist. Sizes are
+    // not asserted: a writable reader legitimately churns the WAL files.
+    const unexpected = readdirSync(SCRATCH).filter((name) => !name.startsWith("target.db"));
+    expect(unexpected).toEqual([]);
+    expect(await tableState()).toEqual([{ id: 1, v: "seeded" }]);
+  });
+});

--- a/tests/security/audit-redaction.test.ts
+++ b/tests/security/audit-redaction.test.ts
@@ -25,6 +25,7 @@ const ALLOWED_KEYS = new Set([
   "connection",
   "duration_ms",
   "bucket",
+  "correlation_id",
 ]);
 
 function captureLine(emit: () => void): Record<string, unknown> {
@@ -70,6 +71,30 @@ describe("emitAuditEvent", () => {
     expect(line.route).toBe("POST /api/auth/login");
     expect(line.reason).toBe("bad_credentials");
     expect(line.ip).toBe("203.0.113.9");
+  });
+
+  test("holds an agent event's correlation id to the same key allowlist and the same bound", () => {
+    // The agent execution path (#328) is the only writer that sets
+    // correlationId, so without a case that emits one the new key would sit
+    // outside the invariant this file exists to enforce. A correlation id is
+    // server-generated, but it is a string field like every other, so it goes
+    // through the same allowlist and the same MAX_AUDIT_FIELD_LENGTH bound.
+    const line = captureLine(() =>
+      emitAuditEvent({
+        type: "agent_operation",
+        action: "sql.query.read",
+        target: "agent/operations/decision",
+        user: "agent:user",
+        result: "success",
+        correlationId: "c".repeat(10_000),
+      }),
+    );
+
+    for (const key of Object.keys(line)) {
+      expect({ key, allowed: ALLOWED_KEYS.has(key) }).toEqual({ key, allowed: true });
+    }
+    expect(line.event).toBe("agent_operation");
+    expect(String(line.correlation_id).length).toBe(254);
   });
 
   test("cannot be made to forge a second log line through the actor field", () => {

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -213,10 +213,12 @@ const mockCreateSSHTunnel = mock(async () => ({
 
 const mockCloseSSHTunnel = mock(async () => {});
 
+const mockHasTunnel = mock(() => false);
+
 mock.module("@/lib/ssh/tunnel", () => ({
   createSSHTunnel: mockCreateSSHTunnel,
   closeSSHTunnel: mockCloseSSHTunnel,
-  hasTunnel: mock(() => false),
+  hasTunnel: mockHasTunnel,
   getTunnelInfo: mock(() => undefined),
 }));
 
@@ -240,6 +242,9 @@ const {
   getProviderCacheStats,
   evictIdleProviders,
   registerShutdownHandlers,
+  acquireExecutionProfileProvider,
+  getExecutionProfileCacheStats,
+  ExecutionProfileError,
 } = await import("@/lib/db/factory");
 if (nodeEnvBefore === undefined) {
   delete (process.env as Record<string, string>).NODE_ENV;
@@ -433,6 +438,31 @@ describe("getOrCreateProvider", () => {
     expect(mockCreateSSHTunnel).toHaveBeenCalledTimes(1);
     const tunnel = (await mockCreateSSHTunnel.mock.results[0]?.value) as { close: ReturnType<typeof mock> } | undefined;
     expect(tunnel?.close).toHaveBeenCalledTimes(1);
+    expect(getProviderCacheStats().size).toBe(0);
+  });
+
+  test("does not close a pre-existing tunnel when provider connect fails", async () => {
+    // createSSHTunnel returns the existing tunnel for the connection id, so a
+    // failed connect must not tear down a tunnel another provider (e.g. an
+    // execution-profile one) is still using.
+    const conn = makeConnection("sqlite", {
+      id: "ssh-connect-fail-shared",
+      database: "bad\u0000path.db",
+      sshTunnel: {
+        enabled: true,
+        host: "bastion.example.com",
+        port: 22,
+        username: "admin",
+        authMethod: "password",
+        password: "secret",
+      },
+    } as Partial<DatabaseConnection>);
+    mockHasTunnel.mockReturnValueOnce(true);
+
+    await expect(getOrCreateProvider(conn)).rejects.toThrow(/NUL bytes/);
+
+    const tunnel = (await mockCreateSSHTunnel.mock.results[0]?.value) as { close: ReturnType<typeof mock> } | undefined;
+    expect(tunnel?.close).not.toHaveBeenCalled();
     expect(getProviderCacheStats().size).toBe(0);
   });
 });
@@ -685,5 +715,289 @@ describe("shutdown signal handlers", () => {
       provider.disconnect = realDisconnect;
       await clearProviderCache();
     }
+  });
+});
+
+// ─── acquireExecutionProfileProvider — agent read-only profile (#328) ──────
+
+describe("acquireExecutionProfileProvider", () => {
+  const pgConn = (overrides: Partial<DatabaseConnection> = {}) =>
+    makeConnection("postgres", { id: "pg-profile", ...overrides });
+
+  test("acquires a dedicated provider without touching the shared writable cache", async () => {
+    const shared = await getOrCreateProvider(pgConn());
+    const statsBefore = getProviderCacheStats();
+
+    const agent = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+
+    expect(agent).not.toBe(shared);
+    expect(getProviderCacheStats()).toEqual(statsBefore);
+    expect(getExecutionProfileCacheStats().size).toBe(1);
+  });
+
+  test("caches per (connection id, profile) and reuses the dedicated instance", async () => {
+    const first = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+    const second = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+
+    expect(second).toBe(first);
+    expect(getExecutionProfileCacheStats()).toEqual({ size: 1, connections: ["pg-profile"] });
+    expect(getProviderCacheStats().size).toBe(0);
+  });
+
+  test("shared-cache acquisitions leave the profile cache untouched", async () => {
+    await getOrCreateProvider(pgConn());
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("re-acquires when the cached profile provider is disconnected", async () => {
+    const first = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+    await first.disconnect();
+
+    const second = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+
+    expect(second).not.toBe(first);
+    expect(second.isConnected()).toBe(true);
+  });
+
+  test("refuses an unknown execution profile (fail closed)", async () => {
+    const error: unknown = await acquireExecutionProfileProvider(pgConn(), "agent-read-write" as never).catch(
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(ExecutionProfileError);
+    expect((error as InstanceType<typeof ExecutionProfileError>).reasonCode).toBe("UNSUPPORTED_PROFILE");
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("refuses a provider type without a database-native read-only wrapper", async () => {
+    const error: unknown = await acquireExecutionProfileProvider(
+      makeConnection("redis", { id: "redis-profile" }),
+      "agent-read-only",
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ExecutionProfileError);
+    expect((error as InstanceType<typeof ExecutionProfileError>).reasonCode).toBe("PROFILE_UNSUPPORTED_BY_PROVIDER");
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("uses the least-privilege agent credential for the profile provider only", async () => {
+    const conn = pgConn({ id: "pg-cred", agentUser: "agent_ro", agentPassword: "agent-secret" });
+
+    const agent = await acquireExecutionProfileProvider(conn, "agent-read-only");
+    const shared = await getOrCreateProvider(conn);
+
+    expect(agent.config.user).toBe("agent_ro");
+    expect(agent.config.password).toBe("agent-secret");
+    expect(shared.config.user).toBe("test");
+  });
+
+  test("denies when the agent credential is configured but unresolvable (fail closed)", async () => {
+    // "v9:a:b" carries an envelope version tag this build does not recognise —
+    // readSecret classifies it undecryptable, never plaintext.
+    const conn = pgConn({ id: "pg-bad-cred", agentUser: "agent_ro", agentPassword: "v9:a:b" });
+
+    const error: unknown = await acquireExecutionProfileProvider(conn, "agent-read-only").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ExecutionProfileError);
+    expect((error as InstanceType<typeof ExecutionProfileError>).reasonCode).toBe("AGENT_CREDENTIAL_UNRESOLVABLE");
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("denies an agent user without a password (fail closed)", async () => {
+    const conn = pgConn({ id: "pg-user-only", agentUser: "agent_ro" });
+
+    const error: unknown = await acquireExecutionProfileProvider(conn, "agent-read-only").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ExecutionProfileError);
+    expect((error as InstanceType<typeof ExecutionProfileError>).reasonCode).toBe("AGENT_CREDENTIAL_UNRESOLVABLE");
+  });
+
+  test("denies an agent password without a user (fail closed)", async () => {
+    const conn = pgConn({ id: "pg-password-only", agentPassword: "agent-secret" });
+
+    const error: unknown = await acquireExecutionProfileProvider(conn, "agent-read-only").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ExecutionProfileError);
+    expect((error as InstanceType<typeof ExecutionProfileError>).reasonCode).toBe("AGENT_CREDENTIAL_UNRESOLVABLE");
+  });
+
+  test("denies an agent credential on a connection-string connection", async () => {
+    // buildPoolConfig ignores user/password fields when a connection string is
+    // present, so the credential would be silently dropped — running the agent
+    // as the MORE privileged embedded user. Denying is the fail-closed choice.
+    const conn = pgConn({
+      id: "pg-cs-cred",
+      connectionString: "postgresql://app:pw@db.internal:5432/prod",
+      agentUser: "agent_ro",
+      agentPassword: "agent-secret",
+    });
+
+    const error: unknown = await acquireExecutionProfileProvider(conn, "agent-read-only").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ExecutionProfileError);
+    expect((error as InstanceType<typeof ExecutionProfileError>).reasonCode).toBe(
+      "AGENT_CREDENTIAL_WITH_CONNECTION_STRING",
+    );
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("does not cache a profile provider whose connection failed", async () => {
+    const originalConnect = mockPgPool.connect;
+    mockPgPool.connect = async () => {
+      throw new Error("connection refused");
+    };
+    try {
+      await expect(acquireExecutionProfileProvider(pgConn(), "agent-read-only")).rejects.toThrow(
+        /connection refused|Failed to connect/,
+      );
+      expect(getExecutionProfileCacheStats().size).toBe(0);
+    } finally {
+      mockPgPool.connect = originalConnect;
+    }
+  });
+
+  test("creates the connection's SSH tunnel and connects the profile provider through it", async () => {
+    const conn = pgConn({
+      id: "pg-tunnel-profile",
+      host: "remote-db.example.com",
+      sshTunnel: {
+        enabled: true,
+        host: "bastion.example.com",
+        port: 22,
+        username: "admin",
+        authMethod: "password",
+        password: "secret",
+      },
+    });
+
+    const agent = await acquireExecutionProfileProvider(conn, "agent-read-only");
+
+    expect(mockCreateSSHTunnel).toHaveBeenCalledTimes(1);
+    expect(agent.config.host).toBe("127.0.0.1");
+    expect(agent.config.port).toBe(54321);
+  });
+
+  test("tears down a freshly created tunnel when the profile connection fails", async () => {
+    const conn = pgConn({
+      id: "pg-tunnel-fail",
+      sshTunnel: {
+        enabled: true,
+        host: "bastion.example.com",
+        port: 22,
+        username: "admin",
+        authMethod: "password",
+        password: "secret",
+      },
+    });
+    const originalConnect = mockPgPool.connect;
+    mockPgPool.connect = async () => {
+      throw new Error("connection refused");
+    };
+    try {
+      await expect(acquireExecutionProfileProvider(conn, "agent-read-only")).rejects.toThrow(
+        /connection refused|Failed to connect/,
+      );
+      const tunnel = (await mockCreateSSHTunnel.mock.results[0]?.value) as
+        | { close: ReturnType<typeof mock> }
+        | undefined;
+      expect(tunnel?.close).toHaveBeenCalledTimes(1);
+      expect(getExecutionProfileCacheStats().size).toBe(0);
+    } finally {
+      mockPgPool.connect = originalConnect;
+    }
+  });
+
+  test("evicting an idle shared provider keeps the tunnel of a live profile provider", async () => {
+    await getOrCreateProvider(pgConn());
+    // The profiled provider arrives later, so only the shared entry is idle
+    // beyond the threshold below (margins sized against CI scheduling jitter).
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+    mockCloseSSHTunnel.mockClear();
+
+    const evicted = await evictIdleProviders(30);
+
+    expect(evicted).toBe(1);
+    expect(getProviderCacheStats().size).toBe(0);
+    expect(getExecutionProfileCacheStats().size).toBe(1);
+    expect(mockCloseSSHTunnel).not.toHaveBeenCalled();
+  });
+
+  test("evicting an idle profile provider keeps the tunnel of a still-served connection", async () => {
+    await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+    // The writable provider arrives later, so only the profiled entry is idle
+    // beyond the threshold below (margins sized against CI scheduling jitter).
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    await getOrCreateProvider(pgConn());
+    mockCloseSSHTunnel.mockClear();
+
+    const evicted = await evictIdleProviders(30);
+
+    expect(evicted).toBe(1);
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+    expect(getProviderCacheStats().size).toBe(1);
+    expect(mockCloseSSHTunnel).not.toHaveBeenCalled();
+  });
+
+  test("eviction logs and continues when a profile provider disconnect fails", async () => {
+    const agent = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+    agent.disconnect = async () => {
+      throw new Error("disconnect failed");
+    };
+
+    const evicted = await evictIdleProviders(0);
+
+    expect(evicted).toBe(1);
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("removeProvider logs and continues when a profile provider disconnect fails", async () => {
+    const agent = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+    agent.disconnect = async () => {
+      throw new Error("disconnect failed");
+    };
+
+    await removeProvider("pg-profile");
+
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("clearProviderCache logs and continues when a profile provider disconnect rejects", async () => {
+    const agent = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+    agent.disconnect = async () => {
+      throw new Error("disconnect failed");
+    };
+
+    await clearProviderCache();
+
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("removeProvider also removes the connection's profile providers", async () => {
+    const agent = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+
+    await removeProvider("pg-profile");
+
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+    expect(agent.isConnected()).toBe(false);
+  });
+
+  test("evictIdleProviders sweeps idle profile providers and closes the connection's tunnel", async () => {
+    await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+
+    const evicted = await evictIdleProviders(0);
+
+    expect(evicted).toBe(1);
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+    expect(mockCloseSSHTunnel).toHaveBeenCalledWith("pg-profile");
+  });
+
+  test("clearProviderCache clears the profile cache too", async () => {
+    const agent = await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+
+    await clearProviderCache();
+
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+    expect(agent.isConnected()).toBe(false);
   });
 });

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -1,5 +1,16 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test";
-import type { DatabaseConnection } from "@/lib/db/types";
+import { describe, test, expect, mock, beforeEach, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DatabaseConnection, ReadOnlyStatementBudget } from "@/lib/db/types";
+import { ExecutionProfileError } from "@/lib/db/errors";
+
+/** Enforcement caps for the sqlite agent-profile assertions below. */
+const AGENT_BUDGET: ReadOnlyStatementBudget = {
+  statementTimeoutMs: 5_000,
+  maxResultRows: 100,
+  maxResultBytes: 64 * 1024,
+};
 
 // ============================================================================
 // Helper: build a minimal DatabaseConnection for a given type
@@ -244,7 +255,6 @@ const {
   registerShutdownHandlers,
   acquireExecutionProfileProvider,
   getExecutionProfileCacheStats,
-  ExecutionProfileError,
 } = await import("@/lib/db/factory");
 if (nodeEnvBefore === undefined) {
   delete (process.env as Record<string, string>).NODE_ENV;
@@ -999,5 +1009,72 @@ describe("acquireExecutionProfileProvider", () => {
 
     expect(getExecutionProfileCacheStats().size).toBe(0);
     expect(agent.isConnected()).toBe(false);
+  });
+
+  // ─── SQLite: read-only intent is injected server-side, never by a caller ──
+  // sqlite runs on the real driver here (no mock), so these assert the actual
+  // database boundary rather than factory bookkeeping.
+
+  describe("sqlite", () => {
+    let sqliteTmpDir: string;
+    let seeded = 0;
+
+    beforeAll(() => {
+      sqliteTmpDir = mkdtempSync(join(tmpdir(), "libredb-factory-sqlite-"));
+    });
+
+    afterAll(() => {
+      rmSync(sqliteTmpDir, { recursive: true, force: true });
+    });
+
+    /** A real on-disk sqlite connection with one seeded row. */
+    async function seedFileConnection(): Promise<DatabaseConnection> {
+      const conn = makeConnection("sqlite", {
+        id: `sqlite-agent-${++seeded}`,
+        database: join(sqliteTmpDir, `agent-${seeded}.db`),
+      });
+      const writer = await getOrCreateProvider(conn);
+      await writer.query("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+      await writer.query("INSERT INTO t (id, v) VALUES (1, 'seeded')");
+      await removeProvider(conn.id);
+      return conn;
+    }
+
+    test("acquires a sqlite agent provider whose writes the database rejects", async () => {
+      const conn = await seedFileConnection();
+
+      const agent = await acquireExecutionProfileProvider(conn, "agent-read-only");
+
+      expect(await agent.queryReadOnly!("SELECT v FROM t", { ...AGENT_BUDGET })).toMatchObject({
+        rows: [{ v: "seeded" }],
+      });
+      await expect(agent.queryReadOnly!("INSERT INTO t (id, v) VALUES (2, 'agent')", AGENT_BUDGET)).rejects.toThrow();
+      expect(getExecutionProfileCacheStats()).toEqual({ size: 1, connections: [conn.id] });
+      expect(getProviderCacheStats().size).toBe(0);
+    });
+
+    test("a caller-supplied options object cannot put the shared provider into the read-only profile", async () => {
+      const conn = await seedFileConnection();
+
+      // ProviderOptions is caller-supplied and flows through getOrCreateProvider;
+      // the execution profile must be unreachable from it in either direction.
+      const shared = await getOrCreateProvider(conn, { readOnly: true } as never);
+
+      const insert = await shared.query("INSERT INTO t (id, v) VALUES (2, 'editor')");
+      expect(insert.rowCount).toBe(1);
+      expect(getExecutionProfileCacheStats().size).toBe(0);
+    });
+
+    test("refuses an in-memory sqlite target for the agent profile (fail closed)", async () => {
+      const conn = makeConnection("sqlite", { id: "sqlite-memory-agent", database: ":memory:" });
+
+      // Refused for being an in-memory target, not for the provider type
+      // lacking a read-only profile — the deny code has to say which.
+      const error: unknown = await acquireExecutionProfileProvider(conn, "agent-read-only").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ExecutionProfileError);
+      expect((error as ExecutionProfileError).reasonCode).toBe("PROFILE_UNSUPPORTED_TARGET");
+      expect(getExecutionProfileCacheStats().size).toBe(0);
+    });
   });
 });

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -36,9 +36,27 @@ function makeConnection(type: string, overrides: Partial<DatabaseConnection> = {
 // We do NOT mock provider module paths — that would poison other test files.
 // ============================================================================
 
+/**
+ * The privileges the mocked PostgreSQL role reports to the agent profile's
+ * open-time check. All false = a least-privilege role, which is what the profile
+ * requires: a read-only transaction does not stop server-side file access or
+ * program execution, so the role is part of that boundary (#328).
+ */
+let mockPgRolePrivileges: Record<string, boolean> = {
+  is_superuser: false,
+  reads_server_files: false,
+  writes_server_files: false,
+  executes_programs: false,
+};
+
+const mockPgQuery = async (sql?: string) =>
+  typeof sql === "string" && /is_superuser/i.test(sql)
+    ? { rows: [{ ...mockPgRolePrivileges }], fields: [] }
+    : { rows: [], fields: [] };
+
 const mockPgPool = {
-  query: async () => ({ rows: [], fields: [] }),
-  connect: async () => ({ query: async () => ({ rows: [], fields: [] }), release: () => {} }),
+  query: mockPgQuery,
+  connect: async () => ({ query: mockPgQuery, release: () => {} }),
   end: async () => {},
   on: () => {},
 };
@@ -788,6 +806,30 @@ describe("acquireExecutionProfileProvider", () => {
     expect(error).toBeInstanceOf(ExecutionProfileError);
     expect((error as InstanceType<typeof ExecutionProfileError>).reasonCode).toBe("PROFILE_UNSUPPORTED_BY_PROVIDER");
     expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("refuses to vend a PostgreSQL profile whose role is too privileged, and caches nothing", async () => {
+    // The provider verifies the role at open (a read-only transaction does not
+    // stop COPY TO PROGRAM or pg_read_file), and the refusal has to reach the
+    // caller intact — not as a generic connection failure — with no half-built
+    // entry left in the profiled cache.
+    mockPgRolePrivileges = { ...mockPgRolePrivileges, executes_programs: true };
+    try {
+      const error: unknown = await acquireExecutionProfileProvider(pgConn({ id: "pg-privileged" }), "agent-read-only")
+        .then(() => null)
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ExecutionProfileError);
+      expect((error as InstanceType<typeof ExecutionProfileError>).reasonCode).toBe("PROFILE_PRIVILEGES_TOO_BROAD");
+      expect(getExecutionProfileCacheStats().size).toBe(0);
+    } finally {
+      mockPgRolePrivileges = { ...mockPgRolePrivileges, executes_programs: false };
+    }
+
+    // The same connection is still usable on the editor path: the profile's
+    // requirement must not gate ordinary queries.
+    const shared = await getOrCreateProvider(pgConn({ id: "pg-privileged" }));
+    expect(shared.isConnected()).toBe(true);
   });
 
   test("uses the least-privilege agent credential for the profile provider only", async () => {

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -752,6 +752,39 @@ describe("acquireExecutionProfileProvider", () => {
   const pgConn = (overrides: Partial<DatabaseConnection> = {}) =>
     makeConnection("postgres", { id: "pg-profile", ...overrides });
 
+  /**
+   * Deterministic clock for the two cross-cache eviction assertions below.
+   *
+   * Those tests need one cache entry to be older than `evictIdleProviders`'
+   * threshold while the other is younger. Sleeping for the gap makes that a race
+   * with CI scheduling jitter from BOTH sides: any delay between the second
+   * acquisition and the evict call ages the younger entry past the threshold too,
+   * and then both entries evict for a reason unrelated to the invariant under
+   * test. Both cache entries are stamped from `Date.now()` (the `set` calls in
+   * `getOrCreateProvider` and `acquireExecutionProfileProvider`) and compared
+   * against it in `evictIdleProviders`, so freezing it makes the age gap exact
+   * instead of probable — and keeps a security-relevant suite free of a flake
+   * class that would train maintainers to re-run it.
+   *
+   * This does NOT control the idle sweep: `startIdleSweep` runs on a real
+   * `setInterval` and is unaffected. Deliberately a local patch rather than
+   * bun:test's `setSystemTime`, which also moves `new Date()` — the narrower
+   * blast radius matches this file's other stub-and-restore helpers.
+   */
+  function installFakeClock(): { advance: (ms: number) => void; restore: () => void } {
+    const realNow = Date.now;
+    let current = realNow();
+    Date.now = () => current;
+    return {
+      advance: (ms: number) => {
+        current += ms;
+      },
+      restore: () => {
+        Date.now = realNow;
+      },
+    };
+  }
+
   test("acquires a dedicated provider without touching the shared writable cache", async () => {
     const shared = await getOrCreateProvider(pgConn());
     const statsBefore = getProviderCacheStats();
@@ -960,35 +993,45 @@ describe("acquireExecutionProfileProvider", () => {
   });
 
   test("evicting an idle shared provider keeps the tunnel of a live profile provider", async () => {
-    await getOrCreateProvider(pgConn());
-    // The profiled provider arrives later, so only the shared entry is idle
-    // beyond the threshold below (margins sized against CI scheduling jitter).
-    await new Promise((resolve) => setTimeout(resolve, 60));
-    await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
-    mockCloseSSHTunnel.mockClear();
+    const clock = installFakeClock();
+    try {
+      await getOrCreateProvider(pgConn());
+      // The profiled provider arrives later, so only the shared entry is idle
+      // beyond the threshold below. The gap is injected, never slept for.
+      clock.advance(60);
+      await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+      mockCloseSSHTunnel.mockClear();
 
-    const evicted = await evictIdleProviders(30);
+      const evicted = await evictIdleProviders(30);
 
-    expect(evicted).toBe(1);
-    expect(getProviderCacheStats().size).toBe(0);
-    expect(getExecutionProfileCacheStats().size).toBe(1);
-    expect(mockCloseSSHTunnel).not.toHaveBeenCalled();
+      expect(evicted).toBe(1);
+      expect(getProviderCacheStats().size).toBe(0);
+      expect(getExecutionProfileCacheStats().size).toBe(1);
+      expect(mockCloseSSHTunnel).not.toHaveBeenCalled();
+    } finally {
+      clock.restore();
+    }
   });
 
   test("evicting an idle profile provider keeps the tunnel of a still-served connection", async () => {
-    await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
-    // The writable provider arrives later, so only the profiled entry is idle
-    // beyond the threshold below (margins sized against CI scheduling jitter).
-    await new Promise((resolve) => setTimeout(resolve, 60));
-    await getOrCreateProvider(pgConn());
-    mockCloseSSHTunnel.mockClear();
+    const clock = installFakeClock();
+    try {
+      await acquireExecutionProfileProvider(pgConn(), "agent-read-only");
+      // The writable provider arrives later, so only the profiled entry is idle
+      // beyond the threshold below. The gap is injected, never slept for.
+      clock.advance(60);
+      await getOrCreateProvider(pgConn());
+      mockCloseSSHTunnel.mockClear();
 
-    const evicted = await evictIdleProviders(30);
+      const evicted = await evictIdleProviders(30);
 
-    expect(evicted).toBe(1);
-    expect(getExecutionProfileCacheStats().size).toBe(0);
-    expect(getProviderCacheStats().size).toBe(1);
-    expect(mockCloseSSHTunnel).not.toHaveBeenCalled();
+      expect(evicted).toBe(1);
+      expect(getExecutionProfileCacheStats().size).toBe(0);
+      expect(getProviderCacheStats().size).toBe(1);
+      expect(mockCloseSSHTunnel).not.toHaveBeenCalled();
+    } finally {
+      clock.restore();
+    }
   });
 
   test("eviction logs and continues when a profile provider disconnect fails", async () => {

--- a/tests/unit/db/operations/artifacts.test.ts
+++ b/tests/unit/db/operations/artifacts.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { ArtifactStoreError, ExecutionArtifactStore } from "@/lib/db/operations/artifacts";
+
+/**
+ * Run-scoped execution artifacts (#328 T6). The store holds an allowed agent
+ * execution's result in memory so a later agent turn can reference it without
+ * re-running the statement, and it is bounded three ways: an explicit release
+ * when the run ends (the deterministic path), a TTL for runs that never end,
+ * and a hard entry cap so a flood of abandoned runs cannot grow without limit.
+ *
+ * There is no clock inside the store, exactly as `ExecutionBudgetTracker` has
+ * none: every time-dependent method takes the caller's `nowMs`, so the TTL is
+ * asserted here by arithmetic rather than by sleeping.
+ */
+
+const artifact = (correlationId: string, runId: string, createdAtMs: number, value: unknown = { rows: [] }) => ({
+  correlationId,
+  runId,
+  operationId: "sql.query.read",
+  createdAtMs,
+  value,
+});
+
+describe("ExecutionArtifactStore construction", () => {
+  test.each([
+    ["ttlMs of zero", { ttlMs: 0, maxArtifacts: 4 }],
+    ["a fractional ttlMs", { ttlMs: 1.5, maxArtifacts: 4 }],
+    ["a NaN ttlMs", { ttlMs: Number.NaN, maxArtifacts: 4 }],
+    ["maxArtifacts of zero", { ttlMs: 1_000, maxArtifacts: 0 }],
+    ["a fractional maxArtifacts", { ttlMs: 1_000, maxArtifacts: 2.5 }],
+  ])("refuses %s instead of silently disabling the bound", (_label, options) => {
+    expect(() => new ExecutionArtifactStore(options)).toThrow(ArtifactStoreError);
+  });
+});
+
+describe("ExecutionArtifactStore lifecycle", () => {
+  test("stores an artifact and serves it back within its TTL", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 1_000, maxArtifacts: 4 });
+    store.put(artifact("corr-1", "run-1", 5_000, { rows: [1, 2] }), 5_000);
+
+    const found = store.get("corr-1", 5_999);
+    expect(found?.value).toEqual({ rows: [1, 2] });
+    expect(found?.runId).toBe("run-1");
+    expect(store.size).toBe(1);
+  });
+
+  test("never serves an artifact past its TTL, even before a sweep reclaims it", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 1_000, maxArtifacts: 4 });
+    store.put(artifact("corr-1", "run-1", 5_000), 5_000);
+
+    // Expiry is decided by the deadline, not by whether anything has swept yet:
+    // a stale result must not be readable just because no later call happened.
+    expect(store.get("corr-1", 6_000)).toBeUndefined();
+    expect(store.size).toBe(1);
+
+    expect(store.sweep(6_000)).toBe(1);
+    expect(store.size).toBe(0);
+  });
+
+  test("returns undefined for a correlation id it never held", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 1_000, maxArtifacts: 4 });
+    expect(store.get("corr-absent", 1)).toBeUndefined();
+  });
+
+  test("refuses a second artifact under a correlation id it already holds", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 1_000, maxArtifacts: 4 });
+    store.put(artifact("corr-1", "run-1", 5_000, { rows: ["first"] }), 5_000);
+
+    // Overwriting would let one execution's result be served as another's, which
+    // is precisely what a correlation id exists to prevent.
+    expect(() => store.put(artifact("corr-1", "run-1", 5_100, { rows: ["second"] }), 5_100)).toThrow(
+      ArtifactStoreError,
+    );
+    expect(store.get("corr-1", 5_100)?.value).toEqual({ rows: ["first"] });
+  });
+
+  test("lets a new artifact take the correlation id of an expired one", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 1_000, maxArtifacts: 4 });
+    store.put(artifact("corr-1", "run-1", 1_000, { rows: ["first"] }), 1_000);
+
+    // An expired entry is not a live artifact, so it must not be what refuses a
+    // replacement - the sweep has to run before the uniqueness check, not after.
+    // (Unreachable with real UUID keys; asserted because the ORDER is the
+    // behaviour, and both orders execute the same lines.)
+    store.put(artifact("corr-1", "run-1", 2_000, { rows: ["second"] }), 2_000);
+
+    expect(store.get("corr-1", 2_000)?.value).toEqual({ rows: ["second"] });
+    expect(store.size).toBe(1);
+  });
+
+  test.each([
+    ["a blank correlation id", artifact("   ", "run-1", 1)],
+    ["a blank run id", artifact("corr-1", "", 1)],
+    ["a non-finite creation time", artifact("corr-1", "run-1", Number.POSITIVE_INFINITY)],
+  ])("refuses %s", (_label, candidate) => {
+    const store = new ExecutionArtifactStore({ ttlMs: 1_000, maxArtifacts: 4 });
+    expect(() => store.put(candidate, 1)).toThrow(ArtifactStoreError);
+  });
+
+  test("releases every artifact of one run and leaves the others alone", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 10_000, maxArtifacts: 8 });
+    store.put(artifact("corr-1", "run-1", 1_000), 1_000);
+    store.put(artifact("corr-2", "run-1", 1_100), 1_100);
+    store.put(artifact("corr-3", "run-2", 1_200), 1_200);
+
+    expect(store.releaseRun("run-1")).toBe(2);
+    expect(store.get("corr-1", 1_300)).toBeUndefined();
+    expect(store.get("corr-2", 1_300)).toBeUndefined();
+    expect(store.get("corr-3", 1_300)?.runId).toBe("run-2");
+    expect(store.size).toBe(1);
+  });
+
+  test("releasing a run that holds nothing is a no-op, not an error", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 10_000, maxArtifacts: 8 });
+    expect(store.releaseRun("run-never-seen")).toBe(0);
+  });
+
+  test("refuses a blank run id on release rather than sweeping something unintended", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 10_000, maxArtifacts: 8 });
+    expect(() => store.releaseRun("  ")).toThrow(ArtifactStoreError);
+  });
+
+  test("sweeps expired artifacts on write, so an abandoned run cannot accumulate", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 1_000, maxArtifacts: 8 });
+    store.put(artifact("corr-1", "abandoned-run", 1_000), 1_000);
+    store.put(artifact("corr-2", "abandoned-run", 1_500), 1_500);
+
+    store.put(artifact("corr-3", "live-run", 2_600), 2_600);
+
+    expect(store.size).toBe(1);
+    expect(store.get("corr-3", 2_600)?.runId).toBe("live-run");
+  });
+
+  test("evicts the oldest artifact when the entry cap is reached", () => {
+    const store = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 2 });
+    store.put(artifact("corr-1", "run-1", 1_000), 1_000);
+    store.put(artifact("corr-2", "run-1", 1_100), 1_100);
+    store.put(artifact("corr-3", "run-1", 1_200), 1_200);
+
+    expect(store.size).toBe(2);
+    expect(store.get("corr-1", 1_200)).toBeUndefined();
+    expect(store.get("corr-2", 1_200)?.correlationId).toBe("corr-2");
+    expect(store.get("corr-3", 1_200)?.correlationId).toBe("corr-3");
+  });
+});

--- a/tests/unit/db/operations/budgets.test.ts
+++ b/tests/unit/db/operations/budgets.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from "bun:test";
+import { BudgetAccountingError, ExecutionBudgetTracker } from "@/lib/db/operations/budgets";
+import type { ExecutionBudget, ExecutionUsage } from "@/lib/db/operations/budgets";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+// Consumes the budget model type so the six budget dimensions pinned by #328
+// (statement count, timeout, row/byte, concurrency, total-run) stay compile-checked.
+const budgetShape: ExecutionBudget = {
+  maxConcurrentExecutions: 2,
+  maxStatementsPerRun: 10,
+  maxTotalRunMs: 60_000,
+  statementTimeoutMs: 5_000,
+  maxResultRows: 1_000,
+  maxResultBytes: 1_048_576,
+};
+
+const zeroUsage: ExecutionUsage = { activeExecutions: 0, executedStatements: 0, totalElapsedMs: 0 };
+
+// ─── usage ──────────────────────────────────────────────────────────────────
+
+describe("ExecutionBudgetTracker.usage", () => {
+  test("a run that never began has zero usage", () => {
+    const tracker = new ExecutionBudgetTracker();
+    expect(tracker.usage("run-1")).toEqual(zeroUsage);
+    expect(budgetShape.maxStatementsPerRun).toBeGreaterThan(0);
+  });
+
+  test("returns a snapshot copy — mutating it never reaches the tracker", () => {
+    const tracker = new ExecutionBudgetTracker();
+    tracker.beginExecution("run-1");
+    const snapshot = tracker.usage("run-1") as { activeExecutions: number };
+    snapshot.activeExecutions = 99;
+    expect(tracker.usage("run-1").activeExecutions).toBe(1);
+  });
+
+  test("refuses a blank run id", () => {
+    const tracker = new ExecutionBudgetTracker();
+    expect(() => tracker.usage("")).toThrow(BudgetAccountingError);
+    expect(() => tracker.usage("   ")).toThrow(BudgetAccountingError);
+  });
+});
+
+// ─── beginExecution / endExecution ──────────────────────────────────────────
+
+describe("ExecutionBudgetTracker accounting", () => {
+  test("begin increments concurrency; end decrements it and accumulates statements and elapsed time", () => {
+    const tracker = new ExecutionBudgetTracker();
+    tracker.beginExecution("run-1");
+    tracker.beginExecution("run-1");
+    expect(tracker.usage("run-1").activeExecutions).toBe(2);
+    tracker.endExecution("run-1", { statements: 1, elapsedMs: 120.5 });
+    tracker.endExecution("run-1", { statements: 1, elapsedMs: 79.5 });
+    expect(tracker.usage("run-1")).toEqual({ activeExecutions: 0, executedStatements: 2, totalElapsedMs: 200 });
+  });
+
+  test("tracks runs independently", () => {
+    const tracker = new ExecutionBudgetTracker();
+    tracker.beginExecution("run-a");
+    tracker.beginExecution("run-b");
+    tracker.endExecution("run-b", { statements: 1, elapsedMs: 5 });
+    expect(tracker.usage("run-a")).toEqual({ activeExecutions: 1, executedStatements: 0, totalElapsedMs: 0 });
+    expect(tracker.usage("run-b")).toEqual({ activeExecutions: 0, executedStatements: 1, totalElapsedMs: 5 });
+  });
+
+  test("an unbalanced end fails loud — silently clamping would under-count concurrency (fail open)", () => {
+    const tracker = new ExecutionBudgetTracker();
+    expect(() => tracker.endExecution("run-1", { statements: 0, elapsedMs: 0 })).toThrow(BudgetAccountingError);
+    tracker.beginExecution("run-1");
+    tracker.endExecution("run-1", { statements: 1, elapsedMs: 1 });
+    expect(() => tracker.endExecution("run-1", { statements: 1, elapsedMs: 1 })).toThrow(BudgetAccountingError);
+  });
+
+  test("refuses corrupt outcome accounting instead of poisoning the run totals", () => {
+    const tracker = new ExecutionBudgetTracker();
+    const invalidOutcomes = [
+      { statements: -1, elapsedMs: 0 },
+      { statements: 1.5, elapsedMs: 0 },
+      { statements: Number.NaN, elapsedMs: 0 },
+      { statements: 0, elapsedMs: -1 },
+      { statements: 0, elapsedMs: Number.NaN },
+      { statements: 0, elapsedMs: Number.POSITIVE_INFINITY },
+    ];
+    for (const outcome of invalidOutcomes) {
+      tracker.beginExecution("run-1");
+      expect(() => tracker.endExecution("run-1", outcome)).toThrow(BudgetAccountingError);
+      // The refused outcome must not have decremented concurrency or accumulated totals.
+      expect(tracker.usage("run-1").executedStatements).toBe(0);
+      tracker.endExecution("run-1", { statements: 0, elapsedMs: 0 });
+    }
+  });
+
+  test("refuses blank run ids on both begin and end", () => {
+    const tracker = new ExecutionBudgetTracker();
+    expect(() => tracker.beginExecution(" ")).toThrow(BudgetAccountingError);
+    expect(() => tracker.endExecution("", { statements: 0, elapsedMs: 0 })).toThrow(BudgetAccountingError);
+  });
+});
+
+// ─── endRun ─────────────────────────────────────────────────────────────────
+
+describe("ExecutionBudgetTracker.endRun", () => {
+  test("releases a finished run's accounting and is idempotent", () => {
+    const tracker = new ExecutionBudgetTracker();
+    tracker.beginExecution("run-1");
+    tracker.endExecution("run-1", { statements: 3, elapsedMs: 42 });
+    tracker.endRun("run-1");
+    expect(tracker.usage("run-1")).toEqual(zeroUsage);
+    tracker.endRun("run-1");
+    expect(tracker.usage("run-1")).toEqual(zeroUsage);
+  });
+
+  test("refuses to end a run with live executions — dropping live usage would reset the budget mid-flight", () => {
+    const tracker = new ExecutionBudgetTracker();
+    tracker.beginExecution("run-1");
+    expect(() => tracker.endRun("run-1")).toThrow(BudgetAccountingError);
+    expect(tracker.usage("run-1").activeExecutions).toBe(1);
+  });
+
+  test("refuses a blank run id", () => {
+    const tracker = new ExecutionBudgetTracker();
+    expect(() => tracker.endRun("")).toThrow(BudgetAccountingError);
+  });
+});

--- a/tests/unit/db/operations/descriptors.test.ts
+++ b/tests/unit/db/operations/descriptors.test.ts
@@ -47,6 +47,12 @@ describe("sql.query.read", () => {
     // assertions above were satisfied by that false wording too.
     expect(sqlQueryReadDescriptor.verification?.boundary).toContain("before every statement");
     expect(sqlQueryReadDescriptor.verification?.boundary).toContain("other files");
+    // Same correction on the PostgreSQL half: a read-only transaction forbids
+    // changing the database, not writing server files or running programs
+    // (verified on 18), so the least-privilege role is part of the boundary and
+    // the marker has to say so.
+    expect(sqlQueryReadDescriptor.verification?.boundary).toContain("least-privilege role verified at open");
+    expect(sqlQueryReadDescriptor.verification?.boundary).toContain("program execution");
   });
 });
 

--- a/tests/unit/db/operations/descriptors.test.ts
+++ b/tests/unit/db/operations/descriptors.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "bun:test";
+import {
+  createCanonicalOperationRegistry,
+  sqlExplainAnalyzeDescriptor,
+  sqlExplainEstimateDescriptor,
+  sqlQueryReadDescriptor,
+} from "@/lib/db/operations/descriptors";
+
+const canonicalDescriptors = [sqlQueryReadDescriptor, sqlExplainEstimateDescriptor, sqlExplainAnalyzeDescriptor];
+
+describe("canonical operation registry", () => {
+  test("registers exactly the three canonical descriptors — no write, DDL, or admin operation exists", () => {
+    const registry = createCanonicalOperationRegistry();
+    expect(registry.registeredIds()).toEqual(["sql.explain.analyze", "sql.explain.estimate", "sql.query.read"]);
+  });
+
+  test("resolves every canonical id to its descriptor", () => {
+    const registry = createCanonicalOperationRegistry();
+    for (const descriptor of canonicalDescriptors) {
+      const resolution = registry.resolve(descriptor.id);
+      expect(resolution.kind).toBe("resolved");
+      if (resolution.kind === "resolved") expect(resolution.descriptor.id).toBe(descriptor.id);
+    }
+  });
+
+  test("denies unregistered operations with a reason code", () => {
+    const registry = createCanonicalOperationRegistry();
+    const resolution = registry.resolve("sql.query.write");
+    expect(resolution).toEqual({ kind: "denied", reasonCode: "UNKNOWN_OPERATION", requestedId: "sql.query.write" });
+  });
+});
+
+describe("sql.query.read", () => {
+  test("is a verified bounded read: risk class 1 with a substantive verification marker", () => {
+    expect(sqlQueryReadDescriptor.id).toBe("sql.query.read");
+    expect(sqlQueryReadDescriptor.riskClass).toBe(1);
+    expect(sqlQueryReadDescriptor.accessLevel).toBe("data-read");
+    expect(sqlQueryReadDescriptor.resourceCost).toBe("heavy");
+    expect(sqlQueryReadDescriptor.supportsDryRun).toBe(false);
+    expect(sqlQueryReadDescriptor.requiresApproval).toBe(false);
+    expect(sqlQueryReadDescriptor.verification?.reviewedBy.trim().length).toBeGreaterThan(0);
+    expect(sqlQueryReadDescriptor.verification?.boundary).toContain("READ ONLY");
+    expect(sqlQueryReadDescriptor.verification?.boundary).toContain("query_only");
+  });
+});
+
+describe("plan inspection vs plan execution", () => {
+  test("are distinct descriptors aligned with the explain seam's estimate/analyze modes", () => {
+    expect(sqlExplainEstimateDescriptor.id).toBe("sql.explain.estimate");
+    expect(sqlExplainAnalyzeDescriptor.id).toBe("sql.explain.analyze");
+    expect(sqlExplainEstimateDescriptor.id).not.toBe(sqlExplainAnalyzeDescriptor.id);
+  });
+
+  test("plan inspection is metadata-only risk class 0 and needs no approval", () => {
+    expect(sqlExplainEstimateDescriptor.riskClass).toBe(0);
+    expect(sqlExplainEstimateDescriptor.accessLevel).toBe("metadata-read");
+    expect(sqlExplainEstimateDescriptor.requiresApproval).toBe(false);
+    expect(sqlExplainEstimateDescriptor.requiredCapabilities).toContain("supportsExplain");
+  });
+
+  test("plan execution is default-denied: verified risk class 1 that always requires approval", () => {
+    expect(sqlExplainAnalyzeDescriptor.riskClass).toBe(1);
+    expect(sqlExplainAnalyzeDescriptor.accessLevel).toBe("data-read");
+    expect(sqlExplainAnalyzeDescriptor.requiresApproval).toBe(true);
+    expect(sqlExplainAnalyzeDescriptor.requiredCapabilities).toContain("supportsExplain");
+    expect(sqlExplainAnalyzeDescriptor.verification?.boundary.trim().length).toBeGreaterThan(0);
+  });
+});
+
+describe("canonical input schemas", () => {
+  test("accept exactly one non-empty SQL statement string", () => {
+    for (const descriptor of canonicalDescriptors) {
+      expect(descriptor.inputSchema.safeParse({ sql: "SELECT 1" }).success).toBe(true);
+    }
+  });
+
+  test("reject missing, empty, or non-string sql and any unknown key (fail closed)", () => {
+    const hostileInputs = [
+      {},
+      { sql: "" },
+      { sql: 1 },
+      { sql: "SELECT 1", extra: true },
+      "SELECT 1",
+      null,
+      undefined,
+      [],
+    ];
+    for (const descriptor of canonicalDescriptors) {
+      for (const input of hostileInputs) {
+        expect(descriptor.inputSchema.safeParse(input).success).toBe(false);
+      }
+    }
+  });
+});

--- a/tests/unit/db/operations/descriptors.test.ts
+++ b/tests/unit/db/operations/descriptors.test.ts
@@ -41,6 +41,12 @@ describe("sql.query.read", () => {
     expect(sqlQueryReadDescriptor.verification?.reviewedBy.trim().length).toBeGreaterThan(0);
     expect(sqlQueryReadDescriptor.verification?.boundary).toContain("READ ONLY");
     expect(sqlQueryReadDescriptor.verification?.boundary).toContain("query_only");
+    // The marker must state what each SQLite control actually covers. An
+    // earlier version claimed the read-only open alone was the boundary, which
+    // was false for writes to OTHER files (VACUUM INTO) — and the two
+    // assertions above were satisfied by that false wording too.
+    expect(sqlQueryReadDescriptor.verification?.boundary).toContain("before every statement");
+    expect(sqlQueryReadDescriptor.verification?.boundary).toContain("other files");
   });
 });
 

--- a/tests/unit/db/operations/execution.test.ts
+++ b/tests/unit/db/operations/execution.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { ExecutionArtifactStore } from "@/lib/db/operations/artifacts";
+import type { ExecutionBudget } from "@/lib/db/operations/budgets";
+import { ExecutionBudgetTracker } from "@/lib/db/operations/budgets";
+import { createCanonicalOperationRegistry } from "@/lib/db/operations/descriptors";
+import { executeAuditedOperation, releaseExecutionRun } from "@/lib/db/operations/execution";
+import type { ExecutionActor, ExecutionPolicy, OperationRequest, TargetScope } from "@/lib/db/operations/policy";
+import { createTargetScope } from "@/lib/db/operations/policy";
+import type { ProviderCapabilities } from "@/lib/db/types";
+
+/**
+ * Audit + artifact glue for the agent execution path (#328 T6) — the execution
+ * MECHANICS: what the caller is told, what the budget tracker records, what the
+ * artifact store holds, and that a refused request never reaches the provider.
+ *
+ * What the audit TRAIL contains is asserted in
+ * `tests/security/agent-execution-audit.test.ts` instead, and deliberately not
+ * here. `bun run test` runs tests/unit, tests/api and tests/integration in one
+ * process, and `tests/api/db/maintenance.test.ts` replaces `@/lib/audit`
+ * wholesale via `mock.module` — which is process-wide, so whether an assertion
+ * in this directory sees the real ring buffer depends on file ordering
+ * (CLAUDE.md's coverage-isolation note; `tests/api/auth/login.test.ts` carries
+ * the same warning). tests/security is its own `bun test` invocation with no
+ * such stub, so the audit assertions are deterministic there. Do not "restore"
+ * event assertions to this file.
+ */
+
+const budgets: ExecutionBudget = {
+  maxConcurrentExecutions: 2,
+  maxStatementsPerRun: 10,
+  maxTotalRunMs: 60_000,
+  statementTimeoutMs: 5_000,
+  maxResultRows: 1_000,
+  maxResultBytes: 1_048_576,
+};
+
+const policy: ExecutionPolicy = {
+  version: "test-policy.1",
+  maxRiskClass: 1,
+  allowedRoles: ["admin", "user"],
+  allowedModes: ["agent"],
+  budgets,
+};
+
+const actor: ExecutionActor = { sessionId: "session-1", role: "user", mode: "agent" };
+
+const capabilities: ProviderCapabilities = {
+  queryLanguage: "sql",
+  supportsExplain: true,
+  explainFormat: "postgres-json",
+  supportsExternalQueryLimiting: true,
+  supportsCreateTable: true,
+  supportsInlineRowEdit: true,
+  supportsMaintenance: false,
+  maintenanceOperations: [],
+  supportsConnectionString: true,
+  defaultPort: 5432,
+  schemaRefreshPattern: "manual",
+};
+
+const readRequest: OperationRequest = {
+  operationId: "sql.query.read",
+  target: {},
+  input: { sql: "SELECT id FROM orders" },
+};
+
+const scope: TargetScope = createTargetScope("conn-1");
+
+/** Deterministic clock: each call returns the next pinned instant. */
+function stubClock(...instants: number[]): () => number {
+  let index = 0;
+  return () => {
+    const value = instants[Math.min(index, instants.length - 1)];
+    index += 1;
+    return value;
+  };
+}
+
+function baseParams(overrides: Partial<Parameters<typeof executeAuditedOperation>[0]> = {}) {
+  return {
+    registry: createCanonicalOperationRegistry(),
+    policy,
+    actor,
+    scope,
+    request: readRequest,
+    capabilities,
+    ...overrides,
+  };
+}
+
+let consoleSpy: ReturnType<typeof spyOn<Console, "log">>;
+
+beforeEach(() => {
+  // Only to keep the authoritative stdout line out of the test output; nothing
+  // here reads it (see the header note on where the audit trail is asserted).
+  consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleSpy.mockRestore();
+});
+
+describe("executeAuditedOperation — allowed execution", () => {
+  test("reports the allow decision and the provider result to its caller", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore<{ rows: { id: number }[] }>({ ttlMs: 60_000, maxArtifacts: 8 });
+    const invoke = mock(async () => ({ rows: [{ id: 1 }] }));
+
+    const outcome = await executeAuditedOperation(
+      baseParams(),
+      { runId: "run-1", tracker, artifacts, clock: stubClock(1_000, 1_042) },
+      invoke,
+    );
+
+    expect(outcome.kind).toBe("executed");
+    expect(outcome.decision.reasonCode).toBe("ALLOWED");
+    expect(outcome.correlationId).toMatch(/^[0-9a-f-]{36}$/);
+    if (outcome.kind === "executed") expect(outcome.result).toEqual({ rows: [{ id: 1 }] });
+  });
+
+  test("gives every execution its own correlation id", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+    const invoke = mock(async () => ({ rows: [] }));
+    const context = { runId: "run-1", tracker, artifacts, clock: stubClock(1_000, 1_001) };
+
+    const first = await executeAuditedOperation(baseParams(), context, invoke);
+    const second = await executeAuditedOperation(baseParams(), context, invoke);
+
+    expect(first.correlationId).not.toBe(second.correlationId);
+  });
+
+  test("stores the result as a run-scoped artifact keyed by the correlation id", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore<{ rows: unknown[] }>({ ttlMs: 60_000, maxArtifacts: 8 });
+    const invoke = mock(async () => ({ rows: [{ id: 7 }] }));
+
+    const outcome = await executeAuditedOperation(
+      baseParams(),
+      { runId: "run-1", tracker, artifacts, clock: stubClock(2_000, 2_010) },
+      invoke,
+    );
+
+    const stored = artifacts.get(outcome.correlationId, 2_010);
+    expect(stored?.value).toEqual({ rows: [{ id: 7 }] });
+    expect(stored?.runId).toBe("run-1");
+    expect(stored?.operationId).toBe("sql.query.read");
+    expect(stored?.createdAtMs).toBe(2_000);
+  });
+
+  test("accounts the statement against the run and releases the concurrency slot", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+
+    await executeAuditedOperation(
+      baseParams(),
+      { runId: "run-1", tracker, artifacts, clock: stubClock(0, 25) },
+      mock(async () => ({ rows: [] })),
+    );
+
+    expect(tracker.usage("run-1")).toEqual({ activeExecutions: 0, executedStatements: 1, totalElapsedMs: 25 });
+  });
+
+  test("does not count its own in-flight execution against the concurrency budget", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+    // A budget of one: if usage were read after beginExecution, the very first
+    // execution of a run would deny itself.
+    const params = baseParams({ policy: { ...policy, budgets: { ...budgets, maxConcurrentExecutions: 1 } } });
+
+    const outcome = await executeAuditedOperation(
+      params,
+      { runId: "run-1", tracker, artifacts, clock: stubClock(0, 5) },
+      mock(async () => ({ rows: [] })),
+    );
+
+    expect(outcome.kind).toBe("executed");
+  });
+
+  test("passes the validated input and the frozen effective budget to the provider callback", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+    const invoke = mock(async (_execution: { validatedInput: unknown; budget: ExecutionBudget }) => ({ rows: [] }));
+
+    await executeAuditedOperation(baseParams(), { runId: "run-1", tracker, artifacts, clock: stubClock(0, 1) }, invoke);
+
+    const execution = invoke.mock.calls[0][0];
+    expect(execution.validatedInput).toEqual({ sql: "SELECT id FROM orders" });
+    expect(execution.budget.statementTimeoutMs).toBe(5_000);
+    expect(Object.isFrozen(execution.budget)).toBe(true);
+  });
+});
+
+describe("executeAuditedOperation — refused execution", () => {
+  test("never reaches the provider on a denial, and consumes nothing", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+    const invoke = mock(async () => ({ rows: [] }));
+    const params = baseParams({ policy: { ...policy, allowedRoles: ["admin"] } });
+
+    const outcome = await executeAuditedOperation(
+      params,
+      { runId: "run-1", tracker, artifacts, clock: stubClock(0, 1) },
+      invoke,
+    );
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(outcome.kind).toBe("denied");
+    expect(outcome.decision.reasonCode).toBe("ROLE_FORBIDDEN");
+    // A refused request consumes no statement and leaves no artifact behind.
+    expect(tracker.usage("run-1").executedStatements).toBe(0);
+    expect(artifacts.size).toBe(0);
+  });
+
+  test("never reaches the provider on an approval requirement", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+    const invoke = mock(async () => ({ rows: [] }));
+    const params = baseParams({
+      request: { operationId: "sql.explain.analyze", target: {}, input: { sql: "EXPLAIN ANALYZE SELECT 1" } },
+    });
+
+    const outcome = await executeAuditedOperation(
+      params,
+      { runId: "run-1", tracker, artifacts, clock: stubClock(0, 1) },
+      invoke,
+    );
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(outcome.kind).toBe("denied");
+    expect(outcome.decision.reasonCode).toBe("APPROVAL_REQUIRED");
+    expect(artifacts.size).toBe(0);
+  });
+});
+
+describe("executeAuditedOperation — provider failure", () => {
+  test("keeps no artifact, releases the slot, and rethrows the provider's error", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+    const failure = new Error("connection reset by peer");
+    const invoke = mock(async () => {
+      throw failure;
+    });
+
+    await expect(
+      executeAuditedOperation(baseParams(), { runId: "run-1", tracker, artifacts, clock: stubClock(100, 160) }, invoke),
+    ).rejects.toThrow(failure);
+
+    // A failed statement still consumed the database's time, so it is accounted
+    // for; only the result it never produced is absent.
+    expect(artifacts.size).toBe(0);
+    expect(tracker.usage("run-1")).toEqual({ activeExecutions: 0, executedStatements: 1, totalElapsedMs: 60 });
+  });
+
+  test("reports a failing artifact store's own error, without releasing the slot twice", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const storeFailure = new Error("artifact store rejected the result");
+    const artifacts = {
+      put: () => {
+        throw storeFailure;
+      },
+      releaseRun: () => 0,
+    } as unknown as ExecutionArtifactStore<{ rows: unknown[] }>;
+
+    // Only the provider call belongs in the recovery path. A compensating
+    // release that also covered post-execution bookkeeping would call
+    // endExecution a second time, and the BudgetAccountingError that raises
+    // would replace the error that actually happened.
+    await expect(
+      executeAuditedOperation(
+        baseParams(),
+        { runId: "run-1", tracker, artifacts, clock: stubClock(0, 30) },
+        mock(async () => ({ rows: [] })),
+      ),
+    ).rejects.toThrow(storeFailure);
+
+    expect(tracker.usage("run-1")).toEqual({ activeExecutions: 0, executedStatements: 1, totalElapsedMs: 30 });
+  });
+
+  test("survives a clock that steps backwards mid-execution", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+
+    // `Date.now()` is the default clock and is not monotonic (an NTP step, a VM
+    // clock sync). budgets.ts rejects a negative elapsedMs, so an unclamped
+    // subtraction would strand the run's concurrency slot at 1 forever - the
+    // run could then never be released.
+    const outcome = await executeAuditedOperation(
+      baseParams(),
+      { runId: "run-1", tracker, artifacts, clock: stubClock(1_000, 400) },
+      mock(async () => ({ rows: [] })),
+    );
+
+    expect(outcome.kind).toBe("executed");
+    expect(tracker.usage("run-1")).toEqual({ activeExecutions: 0, executedStatements: 1, totalElapsedMs: 0 });
+    releaseExecutionRun({ runId: "run-1", tracker, artifacts });
+  });
+
+  test("survives a clock that reports a non-finite instant", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+
+    // `Math.max(0, NaN)` is NaN, and the tracker refuses a non-finite elapsed
+    // time - which would strand the slot exactly as a backwards step did. The
+    // clamp has to reject non-finite values, not just negative ones.
+    const outcome = await executeAuditedOperation(
+      baseParams(),
+      { runId: "run-1", tracker, artifacts, clock: stubClock(0, Number.NaN) },
+      mock(async () => ({ rows: [] })),
+    );
+
+    expect(outcome.kind).toBe("executed");
+    expect(tracker.usage("run-1")).toEqual({ activeExecutions: 0, executedStatements: 1, totalElapsedMs: 0 });
+    releaseExecutionRun({ runId: "run-1", tracker, artifacts });
+  });
+});
+
+describe("releaseExecutionRun", () => {
+  test("drops the run's artifacts and its budget accounting together", async () => {
+    const tracker = new ExecutionBudgetTracker();
+    const artifacts = new ExecutionArtifactStore({ ttlMs: 60_000, maxArtifacts: 8 });
+    const context = { runId: "run-1", tracker, artifacts, clock: stubClock(0, 1) };
+
+    const outcome = await executeAuditedOperation(
+      baseParams(),
+      context,
+      mock(async () => ({ rows: [] })),
+    );
+    expect(artifacts.size).toBe(1);
+
+    releaseExecutionRun(context);
+
+    expect(artifacts.get(outcome.correlationId, 2)).toBeUndefined();
+    expect(artifacts.size).toBe(0);
+    expect(tracker.usage("run-1")).toEqual({ activeExecutions: 0, executedStatements: 0, totalElapsedMs: 0 });
+  });
+});

--- a/tests/unit/db/operations/policy.test.ts
+++ b/tests/unit/db/operations/policy.test.ts
@@ -1,0 +1,530 @@
+import { describe, test, expect } from "bun:test";
+import { z } from "zod";
+import type { ProviderCapabilities } from "@/lib/db/types";
+import type { ExecutionBudget, ExecutionUsage } from "@/lib/db/operations/budgets";
+import { createCanonicalOperationRegistry } from "@/lib/db/operations/descriptors";
+import { OperationRegistry } from "@/lib/db/operations/registry";
+import { TargetScopeError, createTargetScope, evaluateOperation, executeWithPolicy } from "@/lib/db/operations/policy";
+import type {
+  ExecutionActor,
+  ExecutionPolicy,
+  OperationRequest,
+  PolicyDecision,
+  PolicyDenyCode,
+  PolicyEvaluationParams,
+  TargetScope,
+} from "@/lib/db/operations/policy";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const budgets: ExecutionBudget = {
+  maxConcurrentExecutions: 2,
+  maxStatementsPerRun: 10,
+  maxTotalRunMs: 60_000,
+  statementTimeoutMs: 5_000,
+  maxResultRows: 1_000,
+  maxResultBytes: 1_048_576,
+};
+
+const policy: ExecutionPolicy = {
+  version: "test-policy.1",
+  maxRiskClass: 1,
+  allowedRoles: ["admin", "user"],
+  allowedModes: ["agent"],
+  budgets,
+};
+
+const actor: ExecutionActor = { sessionId: "session-1", role: "user", mode: "agent" };
+
+const capabilities: ProviderCapabilities = {
+  queryLanguage: "sql",
+  supportsExplain: true,
+  explainFormat: "postgres-json",
+  supportsExternalQueryLimiting: true,
+  supportsCreateTable: true,
+  supportsInlineRowEdit: true,
+  supportsMaintenance: false,
+  maintenanceOperations: [],
+  supportsConnectionString: true,
+  defaultPort: 5432,
+  schemaRefreshPattern: "manual",
+};
+
+const idleUsage: ExecutionUsage = { activeExecutions: 0, executedStatements: 0, totalElapsedMs: 0 };
+
+const readRequest: OperationRequest = {
+  operationId: "sql.query.read",
+  target: {},
+  input: { sql: "SELECT 1" },
+};
+
+function params(overrides: Partial<PolicyEvaluationParams> = {}): PolicyEvaluationParams {
+  return {
+    registry: createCanonicalOperationRegistry(),
+    policy,
+    actor,
+    scope: createTargetScope("conn-1"),
+    request: readRequest,
+    capabilities,
+    usage: idleUsage,
+    ...overrides,
+  };
+}
+
+function expectDeny(decision: PolicyDecision, reasonCode: PolicyDenyCode): void {
+  expect(decision.kind).toBe("deny");
+  if (decision.kind === "deny") expect(decision.reasonCode).toBe(reasonCode);
+}
+
+// ─── Allow path ─────────────────────────────────────────────────────────────
+
+describe("evaluateOperation — allow", () => {
+  test("allows a valid bounded read with reason code, policy version, effective budget, and validated input", () => {
+    const decision = evaluateOperation(params());
+    expect(decision.kind).toBe("allow");
+    if (decision.kind === "allow") {
+      expect(decision.reasonCode).toBe("ALLOWED");
+      expect(decision.operationId).toBe("sql.query.read");
+      expect(decision.policyVersion).toBe("test-policy.1");
+      expect(decision.effectiveBudget).toEqual(budgets);
+      expect(Object.isFrozen(decision.effectiveBudget)).toBe(true);
+      expect(decision.validatedInput).toEqual({ sql: "SELECT 1" });
+    }
+  });
+
+  test("a caller-named target inside the scope is allowed; absent target fields defer to the server-injected scope", () => {
+    const scoped = params({
+      scope: createTargetScope("conn-1", { catalogs: ["main"], schemas: ["public"] }),
+      request: { ...readRequest, target: { connectionId: "conn-1", catalog: "main", schema: "public" } },
+    });
+    expect(evaluateOperation(scoped).kind).toBe("allow");
+    const unrestricted = params({ request: { ...readRequest, target: { catalog: "anything" } } });
+    expect(evaluateOperation(unrestricted).kind).toBe("allow");
+    const noTarget = params({ request: { operationId: "sql.query.read", input: { sql: "SELECT 1" } } });
+    expect(evaluateOperation(noTarget).kind).toBe("allow");
+  });
+
+  test("the effective budget is a snapshot — mutating the policy afterwards never changes an issued decision", () => {
+    const localPolicy: ExecutionPolicy = { ...policy, budgets: { ...budgets } };
+    const decision = evaluateOperation(params({ policy: localPolicy }));
+    (localPolicy.budgets as { maxResultRows: number }).maxResultRows = 999_999;
+    if (decision.kind === "allow") expect(decision.effectiveBudget.maxResultRows).toBe(1_000);
+    expect(decision.kind).toBe("allow");
+  });
+});
+
+// ─── Stage 0: classification ────────────────────────────────────────────────
+
+describe("evaluateOperation — classification", () => {
+  test("denies an unknown operation id with the registry's reason code and full decision envelope", () => {
+    const decision = evaluateOperation(params({ request: { ...readRequest, operationId: "sql.query.write" } }));
+    expectDeny(decision, "UNKNOWN_OPERATION");
+    expect(decision.policyVersion).toBe("test-policy.1");
+    expect(decision.effectiveBudget).toEqual(budgets);
+  });
+
+  test("denies an alias-shaped id as ambiguous — never helpfully corrected", () => {
+    const decision = evaluateOperation(params({ request: { ...readRequest, operationId: "SQL.Query.Read" } }));
+    expectDeny(decision, "AMBIGUOUS_OPERATION");
+  });
+
+  test("actor/session precedes classification: an invalid actor wins over an unknown operation (spec-pinned order)", () => {
+    const decision = evaluateOperation(
+      params({
+        request: { ...readRequest, operationId: "nope.op" },
+        actor: { ...actor, sessionId: "" },
+      }),
+    );
+    expectDeny(decision, "INVALID_ACTOR");
+  });
+});
+
+// ─── Stage 1: actor/session ─────────────────────────────────────────────────
+
+describe("evaluateOperation — actor stage", () => {
+  test("denies a missing or malformed actor: blank session, unknown role, unknown mode", () => {
+    const hostileActors = [
+      undefined,
+      null,
+      { ...actor, sessionId: "" },
+      { ...actor, sessionId: "   " },
+      { ...actor, sessionId: 42 },
+      { ...actor, role: "root" },
+      { ...actor, mode: "editor" },
+    ];
+    for (const hostile of hostileActors) {
+      const decision = evaluateOperation(params({ actor: hostile as unknown as ExecutionActor }));
+      expectDeny(decision, "INVALID_ACTOR");
+    }
+  });
+});
+
+// ─── Stage 2: immutable target scope ────────────────────────────────────────
+
+describe("evaluateOperation — target scope stage", () => {
+  test("denies a caller-chosen connection id that differs from the server-injected scope", () => {
+    const decision = evaluateOperation(params({ request: { ...readRequest, target: { connectionId: "conn-2" } } }));
+    expectDeny(decision, "TARGET_OUT_OF_SCOPE");
+  });
+
+  test("denies a catalog outside the allowlist, and an undeclared catalog when an allowlist exists", () => {
+    const scope = createTargetScope("conn-1", { catalogs: ["main"] });
+    expectDeny(
+      evaluateOperation(params({ scope, request: { ...readRequest, target: { catalog: "other" } } })),
+      "TARGET_OUT_OF_SCOPE",
+    );
+    expectDeny(evaluateOperation(params({ scope, request: readRequest })), "TARGET_OUT_OF_SCOPE");
+  });
+
+  test("denies a schema outside the allowlist, and an undeclared schema when an allowlist exists", () => {
+    const scope = createTargetScope("conn-1", { schemas: ["public"] });
+    expectDeny(
+      evaluateOperation(params({ scope, request: { ...readRequest, target: { schema: "pg_catalog" } } })),
+      "TARGET_OUT_OF_SCOPE",
+    );
+    expectDeny(evaluateOperation(params({ scope, request: readRequest })), "TARGET_OUT_OF_SCOPE");
+  });
+
+  test("an empty allowlist is deny-all for that dimension", () => {
+    const scope = createTargetScope("conn-1", { catalogs: [] });
+    expectDeny(
+      evaluateOperation(params({ scope, request: { ...readRequest, target: { catalog: "main" } } })),
+      "TARGET_OUT_OF_SCOPE",
+    );
+  });
+});
+
+describe("createTargetScope", () => {
+  test("returns a deeply frozen scope: the object and both allowlists are immutable", () => {
+    const scope = createTargetScope("conn-1", { catalogs: ["main"], schemas: ["public"] });
+    expect(Object.isFrozen(scope)).toBe(true);
+    expect(Object.isFrozen(scope.catalogAllowlist)).toBe(true);
+    expect(Object.isFrozen(scope.schemaAllowlist)).toBe(true);
+    expect(scope.connectionId).toBe("conn-1");
+  });
+
+  test("later mutation of the caller's allowlist array never reaches the scope", () => {
+    const catalogs = ["main"];
+    const scope = createTargetScope("conn-1", { catalogs });
+    catalogs.push("smuggled");
+    expect(scope.catalogAllowlist).toEqual(["main"]);
+  });
+
+  test("refuses a blank connection id and blank or non-string allowlist entries", () => {
+    expect(() => createTargetScope("")).toThrow(TargetScopeError);
+    expect(() => createTargetScope("  ")).toThrow(TargetScopeError);
+    expect(() => createTargetScope("conn-1", { catalogs: [""] })).toThrow(TargetScopeError);
+    expect(() => createTargetScope("conn-1", { schemas: [" "] })).toThrow(TargetScopeError);
+    expect(() => createTargetScope("conn-1", { catalogs: [42 as unknown as string] })).toThrow(TargetScopeError);
+  });
+});
+
+// ─── Stage 3: schema-validated input ────────────────────────────────────────
+
+describe("evaluateOperation — input stage", () => {
+  test("denies input the descriptor schema rejects: missing sql, empty sql, unknown keys, non-object input", () => {
+    const hostileInputs = [undefined, null, "SELECT 1", {}, { sql: "" }, { sql: 42 }, { sql: "SELECT 1", extra: true }];
+    for (const input of hostileInputs) {
+      const decision = evaluateOperation(params({ request: { ...readRequest, input } }));
+      expectDeny(decision, "INPUT_VALIDATION_FAILED");
+    }
+  });
+});
+
+// ─── Stage 4: provider capability ───────────────────────────────────────────
+
+describe("evaluateOperation — capability stage", () => {
+  const estimateRequest: OperationRequest = { ...readRequest, operationId: "sql.explain.estimate" };
+
+  test("denies an operation whose required capability the provider reports false", () => {
+    const decision = evaluateOperation(
+      params({ request: estimateRequest, capabilities: { ...capabilities, supportsExplain: false } }),
+    );
+    expectDeny(decision, "CAPABILITY_UNSUPPORTED");
+  });
+
+  test("an absent capability flag is unsupported — fail closed, never a permissive default", () => {
+    const { supportsExplain: _dropped, ...withoutExplain } = capabilities;
+    const decision = evaluateOperation(
+      params({ request: estimateRequest, capabilities: withoutExplain as ProviderCapabilities }),
+    );
+    expectDeny(decision, "CAPABILITY_UNSUPPORTED");
+  });
+});
+
+// ─── Stage 5: risk/mode/role policy ─────────────────────────────────────────
+
+describe("evaluateOperation — risk/mode/role stage", () => {
+  test("denies a risk class above the policy maximum", () => {
+    const decision = evaluateOperation(params({ policy: { ...policy, maxRiskClass: 0 } }));
+    expectDeny(decision, "RISK_EXCEEDS_POLICY");
+  });
+
+  test("denies a role the policy does not allow", () => {
+    const decision = evaluateOperation(params({ policy: { ...policy, allowedRoles: ["admin"] } }));
+    expectDeny(decision, "ROLE_FORBIDDEN");
+  });
+
+  test("denies a mode the policy does not allow", () => {
+    const decision = evaluateOperation(params({ policy: { ...policy, allowedModes: [] } }));
+    expectDeny(decision, "MODE_FORBIDDEN");
+  });
+
+  test("an approval-flagged descriptor yields require-approval, never a plain allow", () => {
+    const decision = evaluateOperation(params({ request: { ...readRequest, operationId: "sql.explain.analyze" } }));
+    expect(decision.kind).toBe("require-approval");
+    if (decision.kind === "require-approval") {
+      expect(decision.reasonCode).toBe("APPROVAL_REQUIRED");
+      expect(decision.operationId).toBe("sql.explain.analyze");
+      expect(decision.policyVersion).toBe("test-policy.1");
+      expect(decision.effectiveBudget).toEqual(budgets);
+    }
+  });
+});
+
+// ─── Stage 6: budgets ───────────────────────────────────────────────────────
+
+describe("evaluateOperation — budget stage", () => {
+  test("denies at the concurrency limit and allows just below it", () => {
+    expectDeny(
+      evaluateOperation(params({ usage: { ...idleUsage, activeExecutions: 2 } })),
+      "CONCURRENCY_BUDGET_EXCEEDED",
+    );
+    expect(evaluateOperation(params({ usage: { ...idleUsage, activeExecutions: 1 } })).kind).toBe("allow");
+  });
+
+  test("denies when the run's statement budget is spent and allows the final statement within it", () => {
+    expectDeny(
+      evaluateOperation(params({ usage: { ...idleUsage, executedStatements: 10 } })),
+      "STATEMENT_BUDGET_EXCEEDED",
+    );
+    expect(evaluateOperation(params({ usage: { ...idleUsage, executedStatements: 9 } })).kind).toBe("allow");
+  });
+
+  test("denies when the total-run time budget is exhausted and allows just below it", () => {
+    expectDeny(
+      evaluateOperation(params({ usage: { ...idleUsage, totalElapsedMs: 60_000 } })),
+      "TOTAL_RUN_BUDGET_EXCEEDED",
+    );
+    expect(evaluateOperation(params({ usage: { ...idleUsage, totalElapsedMs: 59_999.5 } })).kind).toBe("allow");
+  });
+
+  test("a budget denial beats require-approval — approval is never a channel around budgets", () => {
+    const decision = evaluateOperation(
+      params({
+        request: { ...readRequest, operationId: "sql.explain.analyze" },
+        usage: { ...idleUsage, activeExecutions: 2 },
+      }),
+    );
+    expectDeny(decision, "CONCURRENCY_BUDGET_EXCEEDED");
+  });
+});
+
+// ─── Malformed server-side context (fail-closed preconditions) ──────────────
+
+describe("evaluateOperation — malformed policy context", () => {
+  test("denies on a blank policy version, reporting the version as invalid with an all-zero budget", () => {
+    const decision = evaluateOperation(params({ policy: { ...policy, version: "  " } }));
+    expectDeny(decision, "MALFORMED_POLICY_CONTEXT");
+    expect(decision.policyVersion).toBe("invalid");
+    expect(decision.effectiveBudget).toEqual({
+      maxConcurrentExecutions: 0,
+      maxStatementsPerRun: 0,
+      maxTotalRunMs: 0,
+      statementTimeoutMs: 0,
+      maxResultRows: 0,
+      maxResultBytes: 0,
+    });
+    expect(Object.isFrozen(decision.effectiveBudget)).toBe(true);
+  });
+
+  test("denies every non-positive, non-integer, or non-numeric budget field — a NaN limit would otherwise fail open", () => {
+    const budgetFields = Object.keys(budgets) as Array<keyof ExecutionBudget>;
+    for (const field of budgetFields) {
+      for (const bad of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, "5"]) {
+        const decision = evaluateOperation(
+          params({ policy: { ...policy, budgets: { ...budgets, [field]: bad as unknown as number } } }),
+        );
+        expectDeny(decision, "MALFORMED_POLICY_CONTEXT");
+        expect(decision.policyVersion).toBe("test-policy.1");
+      }
+    }
+  });
+
+  test("denies a policy with unknown roles or modes, or non-array role/mode lists", () => {
+    const hostilePolicies = [
+      { ...policy, allowedRoles: ["root"] },
+      { ...policy, allowedRoles: "admin" },
+      { ...policy, allowedModes: ["editor"] },
+      { ...policy, allowedModes: "agent" },
+      { ...policy, maxRiskClass: 2 },
+      { ...policy, budgets: undefined },
+      null,
+    ];
+    for (const hostile of hostilePolicies) {
+      const decision = evaluateOperation(params({ policy: hostile as unknown as ExecutionPolicy }));
+      expectDeny(decision, "MALFORMED_POLICY_CONTEXT");
+    }
+  });
+
+  test("denies malformed usage accounting: negative, fractional-count, or non-finite values", () => {
+    const hostileUsages = [
+      { ...idleUsage, activeExecutions: -1 },
+      { ...idleUsage, activeExecutions: 1.5 },
+      { ...idleUsage, executedStatements: Number.NaN },
+      { ...idleUsage, totalElapsedMs: -5 },
+      { ...idleUsage, totalElapsedMs: Number.POSITIVE_INFINITY },
+      undefined,
+    ];
+    for (const hostile of hostileUsages) {
+      const decision = evaluateOperation(params({ usage: hostile as unknown as ExecutionUsage }));
+      expectDeny(decision, "MALFORMED_POLICY_CONTEXT");
+    }
+  });
+
+  test("denies a hand-built scope that bypassed createTargetScope with a blank connection id or junk allowlist", () => {
+    const hostileScopes = [
+      { connectionId: "" },
+      { connectionId: "conn-1", catalogAllowlist: ["main", ""] },
+      { connectionId: "conn-1", schemaAllowlist: "public" },
+      undefined,
+    ];
+    for (const hostile of hostileScopes) {
+      const decision = evaluateOperation(params({ scope: hostile as unknown as TargetScope }));
+      expectDeny(decision, "MALFORMED_POLICY_CONTEXT");
+    }
+  });
+});
+
+// ─── Fixed evaluation order ─────────────────────────────────────────────────
+
+describe("evaluateOperation — fixed evaluation order", () => {
+  test("fixing each failure surfaces exactly the next stage's denial, ending in allow", () => {
+    const registry = new OperationRegistry();
+    registry.register({
+      id: "test.cascade.read",
+      riskClass: 1,
+      accessLevel: "data-read",
+      requiredCapabilities: ["supportsExplain"],
+      resourceCost: "moderate",
+      supportsDryRun: false,
+      requiresApproval: false,
+      inputSchema: z.strictObject({ sql: z.string().min(1) }),
+      verification: {
+        reviewedBy: "policy pipeline order test",
+        boundary: "database-native read-only enforcement (test fixture)",
+        verifiedOn: "2026-08-10",
+      },
+    });
+    let p: PolicyEvaluationParams = {
+      registry,
+      policy: { ...policy, maxRiskClass: 0 },
+      actor: { ...actor, sessionId: "" },
+      scope: createTargetScope("conn-1", { catalogs: ["main"] }),
+      request: { operationId: "test.unknown.op", target: { connectionId: "conn-2", catalog: "other" }, input: {} },
+      capabilities: { ...capabilities, supportsExplain: false },
+      usage: { activeExecutions: 2, executedStatements: 10, totalElapsedMs: 60_000 },
+    };
+    const expectStage = (reasonCode: PolicyDenyCode) => expectDeny(evaluateOperation(p), reasonCode);
+
+    expectStage("INVALID_ACTOR");
+    p = { ...p, actor };
+    expectStage("UNKNOWN_OPERATION");
+    p = { ...p, request: { ...p.request, operationId: "test.cascade.read" } };
+    expectStage("TARGET_OUT_OF_SCOPE");
+    p = { ...p, request: { ...p.request, target: { connectionId: "conn-1", catalog: "main" } } };
+    expectStage("INPUT_VALIDATION_FAILED");
+    p = { ...p, request: { ...p.request, input: { sql: "SELECT 1" } } };
+    expectStage("CAPABILITY_UNSUPPORTED");
+    p = { ...p, capabilities };
+    expectStage("RISK_EXCEEDS_POLICY");
+    p = { ...p, policy };
+    expectStage("CONCURRENCY_BUDGET_EXCEEDED");
+    p = { ...p, usage: { ...p.usage, activeExecutions: 0 } };
+    expectStage("STATEMENT_BUDGET_EXCEEDED");
+    p = { ...p, usage: { ...p.usage, executedStatements: 0 } };
+    expectStage("TOTAL_RUN_BUDGET_EXCEEDED");
+    p = { ...p, usage: idleUsage };
+    expect(evaluateOperation(p).kind).toBe("allow");
+  });
+});
+
+// ─── executeWithPolicy: the spy-provider invariant ──────────────────────────
+
+describe("executeWithPolicy", () => {
+  const denyScenarios: ReadonlyArray<[PolicyDenyCode, Partial<PolicyEvaluationParams>]> = [
+    ["UNKNOWN_OPERATION", { request: { ...readRequest, operationId: "nope.op" } }],
+    ["AMBIGUOUS_OPERATION", { request: { ...readRequest, operationId: "SQL.Query.Read" } }],
+    ["MALFORMED_POLICY_CONTEXT", { policy: { ...policy, version: " " } }],
+    ["INVALID_ACTOR", { actor: { ...actor, sessionId: "" } }],
+    ["TARGET_OUT_OF_SCOPE", { request: { ...readRequest, target: { connectionId: "conn-2" } } }],
+    ["INPUT_VALIDATION_FAILED", { request: { ...readRequest, input: {} } }],
+    [
+      "CAPABILITY_UNSUPPORTED",
+      {
+        request: { ...readRequest, operationId: "sql.explain.estimate" },
+        capabilities: { ...capabilities, supportsExplain: false },
+      },
+    ],
+    ["ROLE_FORBIDDEN", { policy: { ...policy, allowedRoles: [] } }],
+    ["MODE_FORBIDDEN", { policy: { ...policy, allowedModes: [] } }],
+    ["RISK_EXCEEDS_POLICY", { policy: { ...policy, maxRiskClass: 0 } }],
+    ["CONCURRENCY_BUDGET_EXCEEDED", { usage: { ...idleUsage, activeExecutions: 2 } }],
+    ["STATEMENT_BUDGET_EXCEEDED", { usage: { ...idleUsage, executedStatements: 10 } }],
+    ["TOTAL_RUN_BUDGET_EXCEEDED", { usage: { ...idleUsage, totalElapsedMs: 60_000 } }],
+  ];
+
+  test("the provider callback is never invoked on ANY deny", async () => {
+    for (const [reasonCode, overrides] of denyScenarios) {
+      let calls = 0;
+      const outcome = await executeWithPolicy(params(overrides), async () => {
+        calls += 1;
+        return "never";
+      });
+      expect(calls).toBe(0);
+      expect(outcome.decision.kind).toBe("deny");
+      if (outcome.decision.kind === "deny") expect(outcome.decision.reasonCode).toBe(reasonCode);
+      expect("result" in outcome).toBe(false);
+    }
+  });
+
+  test("the provider callback is never invoked on require-approval", async () => {
+    let calls = 0;
+    const outcome = await executeWithPolicy(
+      params({ request: { ...readRequest, operationId: "sql.explain.analyze" } }),
+      async () => {
+        calls += 1;
+        return "never";
+      },
+    );
+    expect(calls).toBe(0);
+    expect(outcome.decision.kind).toBe("require-approval");
+    expect("result" in outcome).toBe(false);
+  });
+
+  test("on allow the callback is invoked exactly once with the validated input and the effective budget", async () => {
+    let calls = 0;
+    let seenInput: unknown;
+    let seenBudget: ExecutionBudget | undefined;
+    const outcome = await executeWithPolicy(params(), async (execution) => {
+      calls += 1;
+      seenInput = execution.validatedInput;
+      seenBudget = execution.budget;
+      return ["row-1"];
+    });
+    expect(calls).toBe(1);
+    expect(seenInput).toEqual({ sql: "SELECT 1" });
+    expect(seenBudget).toEqual(budgets);
+    expect(outcome.decision.kind).toBe("allow");
+    if ("result" in outcome) expect(outcome.result).toEqual(["row-1"]);
+    expect("result" in outcome).toBe(true);
+  });
+
+  test("a provider failure propagates — the guard never swallows execution errors", async () => {
+    await expect(
+      executeWithPolicy(params(), async () => {
+        throw new Error("connection reset");
+      }),
+    ).rejects.toThrow("connection reset");
+  });
+});

--- a/tests/unit/db/operations/registry.test.ts
+++ b/tests/unit/db/operations/registry.test.ts
@@ -1,0 +1,228 @@
+import { describe, test, expect } from "bun:test";
+import { z } from "zod";
+import { OperationRegistry, OperationRegistrationError } from "@/lib/db/operations/registry";
+import type { RegistrableOperationDescriptor, RiskClass, RiskVerification } from "@/lib/db/operations/types";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const verification: RiskVerification = {
+  reviewedBy: "registry unit test",
+  boundary: "database-native read-only enforcement (test fixture)",
+  verifiedOn: "2026-08-10",
+};
+
+function readDescriptor(overrides: Partial<Record<string, unknown>> = {}): RegistrableOperationDescriptor {
+  // The cast lets tests hand the registry descriptors TypeScript structurally
+  // forbids (risk class 2+, missing verification) — runtime refusal of exactly
+  // those shapes is the behavior under test.
+  return {
+    id: "test.operation.read",
+    riskClass: 0,
+    accessLevel: "metadata-read",
+    requiredCapabilities: [],
+    resourceCost: "light",
+    supportsDryRun: false,
+    requiresApproval: false,
+    inputSchema: z.strictObject({}),
+    ...overrides,
+  } as unknown as RegistrableOperationDescriptor;
+}
+
+function captureRefusal(fn: () => void): OperationRegistrationError {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(OperationRegistrationError);
+    return error as OperationRegistrationError;
+  }
+  throw new Error("expected the registration to be refused");
+}
+
+// ─── register ───────────────────────────────────────────────────────────────
+
+describe("OperationRegistry.register", () => {
+  test("registers a risk-class-0 descriptor and resolves it by exact id", () => {
+    const registry = new OperationRegistry();
+    registry.register(readDescriptor());
+    const resolution = registry.resolve("test.operation.read");
+    expect(resolution.kind).toBe("resolved");
+    if (resolution.kind === "resolved") {
+      expect(resolution.descriptor.id).toBe("test.operation.read");
+      expect(resolution.descriptor.riskClass).toBe(0);
+    }
+  });
+
+  test("registers a verified risk-class-1 descriptor", () => {
+    const registry = new OperationRegistry();
+    registry.register(readDescriptor({ riskClass: 1, verification }));
+    const resolution = registry.resolve("test.operation.read");
+    expect(resolution.kind).toBe("resolved");
+    if (resolution.kind === "resolved") {
+      expect(resolution.descriptor.riskClass).toBe(1);
+      expect(resolution.descriptor.verification).toEqual(verification);
+    }
+  });
+
+  test("refuses every risk class above 1 and stores nothing", () => {
+    const refusedClasses: RiskClass[] = [2, 3, 4, 5, 6];
+    for (const riskClass of refusedClasses) {
+      const registry = new OperationRegistry();
+      const refusal = captureRefusal(() => registry.register(readDescriptor({ riskClass, verification })));
+      expect(refusal.reasonCode).toBe("UNREGISTRABLE_RISK_CLASS");
+      const resolution = registry.resolve("test.operation.read");
+      expect(resolution.kind).toBe("denied");
+      if (resolution.kind === "denied") expect(resolution.reasonCode).toBe("UNKNOWN_OPERATION");
+    }
+  });
+
+  test("refuses risk classes outside the 0-6 scale and non-integer classes", () => {
+    for (const riskClass of [-1, 7, 1.5, Number.NaN, "1", null, undefined]) {
+      const registry = new OperationRegistry();
+      const refusal = captureRefusal(() => registry.register(readDescriptor({ riskClass, verification })));
+      expect(refusal.reasonCode).toBe("UNREGISTRABLE_RISK_CLASS");
+    }
+  });
+
+  test("refuses an unverified risk-class-1 descriptor exactly like class 2+: error thrown, nothing stored", () => {
+    const registry = new OperationRegistry();
+    const refusal = captureRefusal(() => registry.register(readDescriptor({ riskClass: 1 })));
+    expect(refusal.reasonCode).toBe("UNVERIFIED_RISK_CLASS");
+    expect(registry.resolve("test.operation.read").kind).toBe("denied");
+  });
+
+  test("refuses a risk-class-1 descriptor whose verification marker is blank or partial", () => {
+    const blankMarkers = [
+      { reviewedBy: " ", boundary: "b", verifiedOn: "2026-08-10" },
+      { reviewedBy: "r", boundary: "", verifiedOn: "2026-08-10" },
+      { reviewedBy: "r", boundary: "b", verifiedOn: "   " },
+      { reviewedBy: "r", boundary: "b" },
+      "verified",
+    ];
+    for (const marker of blankMarkers) {
+      const registry = new OperationRegistry();
+      const refusal = captureRefusal(() => registry.register(readDescriptor({ riskClass: 1, verification: marker })));
+      expect(refusal.reasonCode).toBe("UNVERIFIED_RISK_CLASS");
+      expect(registry.resolve("test.operation.read").kind).toBe("denied");
+    }
+  });
+
+  test("refuses non-canonical operation ids", () => {
+    const invalidIds = [
+      "",
+      "sql",
+      "SQL.Query.Read",
+      " sql.query.read",
+      "sql.query.read ",
+      "sql..read",
+      "sql_query.read",
+      "sql.query.",
+      7,
+    ];
+    for (const id of invalidIds) {
+      const registry = new OperationRegistry();
+      const refusal = captureRefusal(() => registry.register(readDescriptor({ id })));
+      expect(refusal.reasonCode).toBe("INVALID_OPERATION_ID");
+    }
+  });
+
+  test("refuses malformed descriptors: non-boolean flags, unknown levels or costs, bad capability lists, missing input schema", () => {
+    const malformed: Array<Record<string, unknown>> = [
+      { supportsDryRun: "no" },
+      { requiresApproval: undefined },
+      { accessLevel: "root" },
+      { resourceCost: "free" },
+      { requiredCapabilities: "supportsExplain" },
+      { requiredCapabilities: [""] },
+      { requiredCapabilities: [42] },
+      { inputSchema: undefined },
+      { inputSchema: { safeParse: "not-a-function" } },
+    ];
+    for (const overrides of malformed) {
+      const registry = new OperationRegistry();
+      const refusal = captureRefusal(() => registry.register(readDescriptor(overrides)));
+      expect(refusal.reasonCode).toBe("MALFORMED_DESCRIPTOR");
+      expect(registry.resolve("test.operation.read").kind).toBe("denied");
+    }
+  });
+
+  test("refuses a duplicate id and keeps the original descriptor untouched", () => {
+    const registry = new OperationRegistry();
+    registry.register(readDescriptor());
+    const refusal = captureRefusal(() => registry.register(readDescriptor({ requiresApproval: true })));
+    expect(refusal.reasonCode).toBe("DUPLICATE_OPERATION_ID");
+    const resolution = registry.resolve("test.operation.read");
+    expect(resolution.kind).toBe("resolved");
+    if (resolution.kind === "resolved") expect(resolution.descriptor.requiresApproval).toBe(false);
+  });
+
+  test("stores an immutable snapshot: later mutation of the caller's object never reaches the registry", () => {
+    const registry = new OperationRegistry();
+    const original = readDescriptor({ riskClass: 1, verification: { ...verification } });
+    registry.register(original);
+    (original as unknown as { requiresApproval: boolean }).requiresApproval = true;
+    (original.verification as { boundary: string }).boundary = "tampered";
+    const resolution = registry.resolve("test.operation.read");
+    expect(resolution.kind).toBe("resolved");
+    if (resolution.kind === "resolved") {
+      expect(resolution.descriptor.requiresApproval).toBe(false);
+      expect(resolution.descriptor.verification?.boundary).toBe(verification.boundary);
+      expect(Object.isFrozen(resolution.descriptor)).toBe(true);
+      expect(Object.isFrozen(resolution.descriptor.requiredCapabilities)).toBe(true);
+      expect(Object.isFrozen(resolution.descriptor.verification)).toBe(true);
+    }
+  });
+});
+
+// ─── resolve ────────────────────────────────────────────────────────────────
+
+describe("OperationRegistry.resolve", () => {
+  test("denies an unknown id with a reason code — never undefined, never a throw", () => {
+    const registry = new OperationRegistry();
+    const resolution = registry.resolve("sql.query.write");
+    expect(resolution).toEqual({ kind: "denied", reasonCode: "UNKNOWN_OPERATION", requestedId: "sql.query.write" });
+  });
+
+  test("denies as ambiguous an id that only normalizes to a registered one — the registry never guesses", () => {
+    const registry = new OperationRegistry();
+    registry.register(readDescriptor());
+    for (const requestedId of [
+      "Test.Operation.Read",
+      "TEST.OPERATION.READ",
+      " test.operation.read ",
+      "test.operation.read\n",
+    ]) {
+      const resolution = registry.resolve(requestedId);
+      expect(resolution.kind).toBe("denied");
+      if (resolution.kind === "denied") {
+        expect(resolution.reasonCode).toBe("AMBIGUOUS_OPERATION");
+        expect(resolution.requestedId).toBe(requestedId);
+      }
+    }
+  });
+
+  test("denies normalized non-matches as unknown, not ambiguous", () => {
+    const registry = new OperationRegistry();
+    registry.register(readDescriptor());
+    const resolution = registry.resolve("Test Operation Read");
+    expect(resolution.kind).toBe("denied");
+    if (resolution.kind === "denied") expect(resolution.reasonCode).toBe("UNKNOWN_OPERATION");
+  });
+
+  test("denies the empty string and non-string input without throwing", () => {
+    const registry = new OperationRegistry();
+    registry.register(readDescriptor());
+    expect(registry.resolve("").kind).toBe("denied");
+    for (const hostile of [null, undefined, 42, { id: "test.operation.read" }]) {
+      const resolution = registry.resolve(hostile as unknown as string);
+      expect(resolution.kind).toBe("denied");
+      if (resolution.kind === "denied") expect(resolution.reasonCode).toBe("UNKNOWN_OPERATION");
+    }
+  });
+
+  test("lists registered ids deterministically sorted", () => {
+    const registry = new OperationRegistry();
+    registry.register(readDescriptor({ id: "test.zeta.read" }));
+    registry.register(readDescriptor({ id: "test.alpha.read" }));
+    expect(registry.registeredIds()).toEqual(["test.alpha.read", "test.zeta.read"]);
+  });
+});

--- a/tests/unit/db/operations/statement-guard.test.ts
+++ b/tests/unit/db/operations/statement-guard.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect } from "bun:test";
+import {
+  agentPlanExecutionSqlInput,
+  agentReadSqlInput,
+  inspectAgentStatement,
+} from "@/lib/db/operations/statement-guard";
+
+/**
+ * The guard is defense in depth, so both directions matter and neither is a
+ * "nice to have": a miss lets hostile text reach the database-native boundary
+ * (which is what actually refuses it), while a false positive refuses a
+ * legitimate agent read. The cases below are therefore chosen to be
+ * unanswerable by substring matching in EITHER direction — every legitimate
+ * fixture mentions a write keyword somewhere the statement does not execute it.
+ */
+
+describe("inspectAgentStatement — legitimate bounded reads", () => {
+  test.each([
+    ["a plain select", "SELECT 1"],
+    ["lowercase and unaligned whitespace", "  select\n\tid\nfrom t\nwhere id = 1  "],
+    ["a read-only CTE", "WITH recent AS (SELECT id FROM t) SELECT * FROM recent"],
+    ["a recursive CTE", "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM c WHERE x < 5) SELECT * FROM c"],
+    ["a VALUES list", "VALUES (1), (2)"],
+    ["PostgreSQL TABLE shorthand", "TABLE inventory"],
+    ["plan inspection", "EXPLAIN SELECT 1"],
+    ["a leading block comment", "/* daily report */ SELECT 1"],
+    ["a leading line comment", "-- daily report\nSELECT 1"],
+    ["a trailing terminator", "SELECT 1;"],
+    ["repeated trailing terminators and trivia", "SELECT 1 ; ; -- done\n"],
+  ])("allows %s", (_label, sql) => {
+    expect(inspectAgentStatement(sql)).toBeNull();
+  });
+
+  test.each([
+    ["a write keyword inside a string literal", "SELECT 'insert into t values (1)' AS note"],
+    ["a write keyword inside a quoted identifier", 'SELECT "delete" FROM audit'],
+    ["a write keyword as part of a longer identifier", "SELECT insert_count, updated_at FROM insert_log"],
+    ["a write keyword inside a line comment", "SELECT id FROM t -- delete from t\n"],
+    ["a write keyword inside a block comment", "SELECT id FROM t /* update t set x = 1 */"],
+    ["a semicolon inside a string literal", "SELECT ';' AS semi, 'a;b' AS pair"],
+  ])("allows a read that merely mentions %s", (_label, sql) => {
+    expect(inspectAgentStatement(sql)).toBeNull();
+  });
+});
+
+describe("inspectAgentStatement — text the engines read differently", () => {
+  test.each([
+    // `$tag$…$tag$` is a literal in PostgreSQL and a BIND PARAMETER followed by
+    // ordinary code in SQLite, so a `;` written inside one really terminates the
+    // statement there. Reading it as a literal would admit a second statement.
+    ["a dollar-quoted body", "SELECT $tag$ drop table t $tag$ AS body"],
+    ["a semicolon inside a dollar-quoted body", "SELECT $x$ ; ATTACH DATABASE '/tmp/x.db' AS y $x$"],
+    // `#` starts a comment in MySQL/ClickHouse, is an operator in PostgreSQL and
+    // prefixes a bind variable in SQLite — the same disagreement about where the
+    // statement ends.
+    ["a hash run", "SELECT 1 #; DROP TABLE t"],
+    ["a hash operator", "SELECT flags # 5 AS x FROM t"],
+    ["a dollar-quoted code block", "DO $$ BEGIN PERFORM 1; END $$"],
+  ])("denies %s rather than picking a dialect", (_label, sql) => {
+    expect(inspectAgentStatement(sql)).toBe("DIALECT_AMBIGUOUS_TEXT");
+  });
+});
+
+describe("inspectAgentStatement — multi-statement input", () => {
+  test.each([
+    ["a smuggled write", "SELECT 1; INSERT INTO t VALUES (1)"],
+    ["no whitespace after the terminator", "SELECT 1;SELECT 2"],
+    ["transaction control between reads", "SELECT 1; COMMIT; SELECT 2"],
+    ["a literal after the terminator", "SELECT 1; 'tail'"],
+    ["a leading terminator", "; SELECT 1"],
+    ["a comment hiding the terminator's tail", "SELECT 1; -- x\nDROP TABLE t"],
+  ])("denies %s", (_label, sql) => {
+    expect(inspectAgentStatement(sql)).toBe("MULTIPLE_STATEMENTS");
+  });
+});
+
+describe("inspectAgentStatement — statements that are not bounded reads", () => {
+  test.each([
+    ["a bare write", "INSERT INTO t VALUES (1)"],
+    ["a schema change", "CREATE TABLE injected (id INTEGER)"],
+    ["a mutating pragma", "PRAGMA journal_mode = WAL"],
+    ["a pragma read (still not a read statement)", "PRAGMA query_only"],
+    ["an attach", "ATTACH DATABASE '/etc/passwd' AS stolen"],
+    ["a detach", "DETACH DATABASE stolen"],
+    ["a vacuum that writes elsewhere", "VACUUM INTO '/tmp/copy.db'"],
+    ["a server-side file write", "COPY (SELECT 1) TO '/tmp/copy.txt'"],
+    ["a server-side program execution", "COPY (SELECT 1) TO PROGRAM 'sh -c id'"],
+    ["a write hidden behind a block comment", "/* SELECT */ INSERT INTO t VALUES (1)"],
+    ["a write hidden behind a line comment", "-- SELECT 1\nDROP TABLE t"],
+    // The string-bodied form: the dollar-quoted one is refused a step earlier,
+    // as text the engines read differently (see the dialect group).
+    ["an anonymous code block", "DO 'BEGIN PERFORM 1; END'"],
+    // A CTE list is a preamble: `readOperativeKeyword` walks it and answers the
+    // keyword that actually operates the statement, so a write AFTER the list is
+    // reported here rather than as a keyword hidden inside a read.
+    ["a write after the CTE list", "WITH src AS (SELECT 1 AS id) UPDATE t SET id = src.id FROM src"],
+  ])("denies %s", (_label, sql) => {
+    expect(inspectAgentStatement(sql)).toBe("NON_READ_STATEMENT");
+  });
+});
+
+describe("inspectAgentStatement — side effects hidden inside a read-shaped statement", () => {
+  test.each([
+    [
+      "a data-modifying CTE",
+      "WITH moved AS (INSERT INTO archive SELECT * FROM t RETURNING id) SELECT count(*) FROM moved",
+    ],
+    [
+      "a data-modifying CTE behind a read-only one",
+      "WITH a AS (SELECT 1 AS x), b AS (DELETE FROM t RETURNING id) SELECT * FROM a JOIN b ON true",
+    ],
+    ["SQLite extension loading through a function call", "SELECT load_extension('/tmp/evil.so')"],
+    ["a pragma function used as a setter", "SELECT * FROM pragma_query_only(0)"],
+    ["a locking read that takes row locks", "SELECT id FROM t FOR UPDATE"],
+    ["a merge inside a CTE", "WITH m AS (MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE) SELECT 1"],
+    // A SELECT-headed statement that WRITES: PostgreSQL's SELECT INTO creates a
+    // table, and MySQL's INTO OUTFILE writes a server-side file.
+    ["a table-creating SELECT INTO", "SELECT * INTO stolen FROM t"],
+    ["a file-writing SELECT", "SELECT v FROM t INTO OUTFILE '/tmp/stolen.csv'"],
+  ])("denies %s", (_label, sql) => {
+    expect(inspectAgentStatement(sql)).toBe("SIDE_EFFECT_KEYWORD");
+  });
+});
+
+describe("inspectAgentStatement — text with no readable statement", () => {
+  test.each([
+    ["only a line comment", "-- nothing here\n"],
+    ["only a block comment", "/* nothing here */"],
+    ["only whitespace", "   \n\t"],
+    ["a CTE list that cannot be read", "WITH t AS NOT LAZY (SELECT 1) SELECT 2"],
+  ])("denies %s", (_label, sql) => {
+    expect(inspectAgentStatement(sql)).toBe("NO_STATEMENT");
+  });
+
+  test.each([
+    ["an unterminated string literal", "SELECT 'oops"],
+    ["an unterminated block comment", "SELECT 1 /* oops"],
+  ])("denies %s as undeterminable text", (_label, sql) => {
+    expect(inspectAgentStatement(sql)).toBe("UNDETERMINABLE_TEXT");
+  });
+});
+
+describe("inspectAgentStatement — plan inspection versus plan execution", () => {
+  test("refuses EXPLAIN ANALYZE unless plan execution is explicitly permitted", () => {
+    expect(inspectAgentStatement("EXPLAIN ANALYZE SELECT 1")).toBe("SIDE_EFFECT_KEYWORD");
+    expect(inspectAgentStatement("EXPLAIN (ANALYZE, BUFFERS) SELECT 1")).toBe("SIDE_EFFECT_KEYWORD");
+    // Obfuscation of the same request must not slip past the inspect variant.
+    expect(inspectAgentStatement("EXPLAIN /* plan */ ANALYZE SELECT 1")).toBe("SIDE_EFFECT_KEYWORD");
+  });
+
+  test("refuses the British spelling too — PostgreSQL accepts ANALYSE and it executes", () => {
+    // One spelling is not the keyword: `EXPLAIN ANALYSE` runs the statement on
+    // PostgreSQL exactly as ANALYZE does, so a guard that knew only one spelling
+    // would launder plan EXECUTION through the risk-class-0, approval-free
+    // plan-INSPECTION descriptor.
+    expect(inspectAgentStatement("EXPLAIN ANALYSE SELECT 1")).toBe("SIDE_EFFECT_KEYWORD");
+    expect(inspectAgentStatement("EXPLAIN (ANALYSE, BUFFERS) SELECT 1")).toBe("SIDE_EFFECT_KEYWORD");
+    expect(inspectAgentStatement("EXPLAIN ANALYSE SELECT 1", { allowPlanExecution: true })).toBeNull();
+  });
+
+  test("permits ANALYZE only for the plan-execution variant, and still refuses a write it carries", () => {
+    expect(inspectAgentStatement("EXPLAIN ANALYZE SELECT 1", { allowPlanExecution: true })).toBeNull();
+    expect(
+      inspectAgentStatement("EXPLAIN ANALYZE WITH w AS (INSERT INTO t VALUES (1) RETURNING id) SELECT * FROM w", {
+        allowPlanExecution: true,
+      }),
+    ).toBe("SIDE_EFFECT_KEYWORD");
+    // A bare ANALYZE is a statistics write in both engines, not a plan read.
+    expect(inspectAgentStatement("ANALYZE t", { allowPlanExecution: true })).toBe("NON_READ_STATEMENT");
+  });
+});
+
+describe("agent SQL input schemas", () => {
+  test("the read schema accepts exactly one non-empty bounded read and nothing else", () => {
+    expect(agentReadSqlInput.safeParse({ sql: "SELECT 1" }).success).toBe(true);
+    for (const input of [{}, { sql: "" }, { sql: 1 }, { sql: "SELECT 1", extra: true }, null, "SELECT 1", []]) {
+      expect(agentReadSqlInput.safeParse(input).success).toBe(false);
+    }
+  });
+
+  test("the read schema reports the violation as the issue message, keyed to the sql field", () => {
+    const parsed = agentReadSqlInput.safeParse({ sql: "SELECT 1; DROP TABLE t" });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]?.message).toContain("MULTIPLE_STATEMENTS");
+      expect(parsed.error.issues[0]?.path).toEqual(["sql"]);
+    }
+  });
+
+  test("only the plan-execution schema admits EXPLAIN ANALYZE", () => {
+    expect(agentReadSqlInput.safeParse({ sql: "EXPLAIN ANALYZE SELECT 1" }).success).toBe(false);
+    expect(agentPlanExecutionSqlInput.safeParse({ sql: "EXPLAIN ANALYZE SELECT 1" }).success).toBe(true);
+    expect(agentPlanExecutionSqlInput.safeParse({ sql: "DROP TABLE t" }).success).toBe(false);
+  });
+});

--- a/tests/unit/db/sqlite-driver.test.ts
+++ b/tests/unit/db/sqlite-driver.test.ts
@@ -13,10 +13,12 @@ import {
 class StubDatabaseSync implements NodeDatabaseSyncLike {
   static lastInstance: StubDatabaseSync | undefined;
   readonly path: string;
+  readonly options: { readOnly?: boolean } | undefined;
   readonly calls: string[] = [];
 
-  constructor(path: string) {
+  constructor(path: string, options?: { readOnly?: boolean }) {
     this.path = path;
+    this.options = options;
     StubDatabaseSync.lastInstance = this;
   }
 
@@ -67,7 +69,7 @@ describe("sqlite-driver", () => {
   });
 
   describe("createNodeSQLiteDriver() adapter semantics", () => {
-    test("bridges exec/prepare/close and ignores bun-style open options", () => {
+    test("bridges exec/prepare/close", () => {
       const Driver = createNodeSQLiteDriver(StubDatabaseSync);
       const db = new Driver("/tmp/adapter.db", { create: true, readwrite: true });
       const stub = StubDatabaseSync.lastInstance!;
@@ -98,6 +100,26 @@ describe("sqlite-driver", () => {
 
       expect(stmt.run("bigint")).toEqual({ changes: 3 });
       expect(stmt.run("number")).toEqual({ changes: 1 });
+    });
+
+    // The read-only open flag is the SQLite half of the agent execution
+    // profile's security boundary (#328). The two runtimes spell it
+    // differently — bun `readonly`, node `readOnly` — so an adapter that
+    // forwards nothing (or forwards the bun spelling verbatim) would hand the
+    // agent a fully writable handle. These pin the mapping at the seam; the
+    // node harness in tests/integration/db proves the real driver honors it.
+    test("maps the read-only open flag onto node:sqlite's readOnly option", () => {
+      const Driver = createNodeSQLiteDriver(StubDatabaseSync);
+      new Driver("/tmp/agent.db", { readonly: true });
+
+      expect(StubDatabaseSync.lastInstance!.options).toEqual({ readOnly: true });
+    });
+
+    test("opens read-write when no read-only flag is given (the shared editor path)", () => {
+      const Driver = createNodeSQLiteDriver(StubDatabaseSync);
+      new Driver("/tmp/editor.db", { create: true, readwrite: true });
+
+      expect(StubDatabaseSync.lastInstance!.options).toEqual({ readOnly: false });
     });
   });
 

--- a/tests/unit/lib/storage/connection-secrets.test.ts
+++ b/tests/unit/lib/storage/connection-secrets.test.ts
@@ -40,6 +40,8 @@ function fullConnection(): DatabaseConnection {
     database: "prod",
     connectionString: "postgres://app:CANARY-IN-URL@db.internal:5432/prod",
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    agentUser: "agent-ro",
+    agentPassword: "CANARY-AGENT-PASSWORD",
     ssl: {
       mode: "verify-full",
       caCert: "-----BEGIN CERTIFICATE-----CA-----END CERTIFICATE-----",
@@ -67,6 +69,7 @@ const CANARIES = [
   "CANARY-SSH-PASSWORD",
   "CANARY-SSH-PRIVATE-KEY",
   "CANARY-SSH-PASSPHRASE",
+  "CANARY-AGENT-PASSWORD",
 ];
 
 describe("the classification is exhaustive by construction", () => {
@@ -79,6 +82,8 @@ describe("the classification is exhaustive by construction", () => {
 
     expect(classified).toEqual(
       [
+        "agentPassword",
+        "agentUser",
         "color",
         "connectionString",
         "createdAt",
@@ -102,7 +107,7 @@ describe("the classification is exhaustive by construction", () => {
     );
   });
 
-  test("exactly the six credential-bearing fields are classified secret", () => {
+  test("exactly the seven credential-bearing fields are classified secret", () => {
     const secrets = [
       ...Object.keys(CONNECTION_FIELDS).filter((k) => CONNECTION_FIELDS[k as never] === "secret"),
       ...Object.keys(SSL_FIELDS)
@@ -115,6 +120,7 @@ describe("the classification is exhaustive by construction", () => {
 
     expect(secrets).toEqual(
       [
+        "agentPassword",
         "connectionString",
         "password",
         "ssl.clientKey",
@@ -146,6 +152,7 @@ describe("encryptConnections", () => {
 
     expect(encrypted.password?.startsWith(prefix)).toBe(true);
     expect(encrypted.connectionString?.startsWith(prefix)).toBe(true);
+    expect(encrypted.agentPassword?.startsWith(prefix)).toBe(true);
     expect(encrypted.ssl?.clientKey?.startsWith(prefix)).toBe(true);
     expect(encrypted.sshTunnel?.password?.startsWith(prefix)).toBe(true);
     expect(encrypted.sshTunnel?.privateKey?.startsWith(prefix)).toBe(true);
@@ -158,6 +165,7 @@ describe("encryptConnections", () => {
     expect(encrypted.host).toBe("db.internal");
     expect(encrypted.user).toBe("app");
     expect(encrypted.database).toBe("prod");
+    expect(encrypted.agentUser).toBe("agent-ro");
     expect(encrypted.ssl?.caCert).toContain("BEGIN CERTIFICATE");
   });
 
@@ -251,8 +259,8 @@ describe("decryptConnections", () => {
     resetStorageEncryptionKey();
     const result = decryptConnections(encrypted);
 
-    // Six unreadable fields on one record.
-    expect(result.undecryptable).toBe(6);
+    // Seven unreadable fields on one record.
+    expect(result.undecryptable).toBe(7);
     // The record SURVIVES. Dropping it would be persisted as a deletion by the write-through
     // cache on the next sync, destroying ciphertext a restored key could still have opened.
     expect(result.connections).toHaveLength(1);
@@ -270,7 +278,7 @@ describe("decryptConnections", () => {
     process.env.JWT_SECRET = "a-different-secret-that-cannot-open-it";
     resetStorageEncryptionKey();
 
-    expect(decryptConnections(encrypted).undecryptable).toBe(12);
+    expect(decryptConnections(encrypted).undecryptable).toBe(14);
   });
 
   test("an empty list is not an error", () => {


### PR DESCRIPTION
Implements #328 — the canonical database-operation layer the agent programme (epic #325) is built on: typed operation descriptors with risk classes, a fail-closed policy pipeline with execution budgets, and database-native read-only execution profiles for PostgreSQL and SQLite.

No route reaches this layer yet. That wiring is #329 (M2) and later; this PR adds the enforcement layer and its tests only, with no new runtime dependency and no AI SDK or Node 24 coupling.

## What this adds

- **Operation descriptors and a fail-closed registry** (`src/lib/db/operations/{types,registry,descriptors}.ts`). Risk classes 2-6 are structurally inexpressible rather than flagged off: the registrable-descriptor type is a union of class 0 and verified class 1 members only, so there is no disabled slot for anyone to enable later. `register()` throws (registration is a trusted build-time act that must fail loudly); `resolve()` never throws and returns a typed resolved/denied union, so a caller cannot ignore a denial. Ids that merely case- or whitespace-normalize to a registered id are denied as ambiguous rather than helpfully corrected.
- **A fail-closed decision pipeline with execution budgets** (`policy.ts`, `budgets.ts`). Stages evaluate in a pinned order — actor/session, classification, target scope, schema-validated input, provider capability, risk/mode/role, budgets — and the first denial wins. Every outcome is a typed allow / deny / require-approval carrying a reason code, a policy version and a frozen effective budget. On any deny the provider is never invoked, asserted with a spy provider. The existing rate-limit primitives were evaluated for budget accounting and rejected with reasons (fixed-window, monotonic, eviction fails open — correct for rate limiting, a bypass for a security budget).
- **A PostgreSQL read-only execution profile** (`factory.ts`, `postgres.ts`). Agent execution acquires a provider from a physically separate cache keyed by profile plus connection id, never a `getOrCreateProvider` entry, and runs one statement per `BEGIN READ ONLY` transaction with a transaction-local timeout, then rolls back, runs `DISCARD ALL` and releases. Single-statement is enforced by the server through the extended query protocol, never by parsing.
- **A SQLite read-only execution profile** (`sqlite.ts`, `sqlite-driver.ts`). A separate read-only open that creates neither file nor directory and skips the shared path's write-implying pragmas, with `query_only` re-asserted and re-verified before every statement. The driver contract gained read-only support on both adapters, with contract tests that fail on an adapter that silently ignores the flags — which the Node adapter did before this PR.
- **A negative security suite** (`tests/security/agent-statement-boundary.test.ts` plus both provider integration files) covering comment and whitespace obfuscation, nested and data-modifying CTEs, multi-statement input, mutating pragmas, attach and detach, extension loading, and plan-execution bypass attempts. Each case asserts the pipeline decision where classification catches it and, more importantly, that the database-native boundary still holds when classification is bypassed.
- **Audit correlation and artifact lifecycle** (`execution.ts`, `artifacts.ts`, `audit.ts`). Two correlated events per allowed execution and one per refusal, joined by a correlation id. An unauditable execution fails closed: the audit call is deliberately not wrapped in a try/catch, because this path is about to touch a database.

## Two real security defects were found and fixed while building this

Both were found by probing running engines, not by reading code, and neither was visible to the test gate.

1. **SQLite: a read-only open protects only the file it opened.** With `query_only` off, `VACUUM INTO '<path>'` wrote a readable copy of the database, seeded secret included, to an arbitrary server path. The first implementation set the pragma once at open, and its own test asserted the pragma could be turned back off — so the profile shipped an exfiltration primitive that its tests documented as acceptable. Fixed by re-asserting and re-verifying the pragma before every statement, which is unbypassable because `prepare()` compiles exactly one statement: the disable and the write it would enable can never ride in the same call.
2. **PostgreSQL: `BEGIN READ ONLY` forbids changing the database and nothing else.** Inside that transaction as a privileged user, `COPY (...) TO '/path'` wrote files, `COPY (...) TO PROGRAM 'cmd'` executed shell commands as the postgres OS user, and `pg_read_file()` read arbitrary files. Agent credentials had been optional with a fallback to the connection's own user, which in most deployments is exactly such a user. Fixed by verifying the role at profile open — refused unless the role is not a superuser and not a member of `pg_read_server_files`, `pg_write_server_files` or `pg_execute_server_program`. Requiring configured agent credentials was considered and rejected: configuration is not proof, since an admin can point them at a superuser.

The lesson generalizes and is worth carrying into future provider work: a boundary claim is always about a specific resource. Before asserting that the engine enforces something, name the control's scope object, then look for a statement that writes or reads somewhere else. Neither original test suite could have caught these, because both only attempted writes to the target database, which is precisely where the control does work.

A related bypass is worth calling out: PostgreSQL accepts `ANALYSE` as a full synonym for `ANALYZE` and executes it, so a guard that knew one spelling let plan execution through the approval-free plan-inspection descriptor. A risk class and its approval gate were bypassed by one vowel, and the test passed because all its fixtures used the same spelling.

## Known limitations, recorded rather than hidden

These are documented in `docs/BACKLOG.md` (A1-A3), the provider docs and `docs/SECURITY.md` rather than covered by tests that would imply a boundary the engines do not provide:

- Out-of-scope **reads** have no database-native control on either provider. SQLite `ATTACH` of an existing file succeeds on a read-only handle; bun:sqlite exposes no authorizer and node:sqlite's exists but is therefore not usable as a cross-adapter control. Attach is denied at the input stage only.
- SQLite `statementTimeoutMs` is a post-execution deadline, not preemption: neither adapter exposes an interrupt, and the synchronous drivers mean an overrunning statement blocks the runtime.
- Row and byte caps buffer the full result before refusing, on both providers, so the residual risk is memory rather than disclosure. Streaming enforcement would mean partial-result semantics this milestone deliberately deferred.
- `docs/SECURITY.md` rows 3.4 and 3.5 are marked **Partial** on purpose, since no route reaches this layer yet.

## Verification

Built test-first throughout, one task per commit, each with its own green gate and a fresh-context adversarial review. Three of the seven tasks were blocked by that review on real security defects the gate could not see.

- `./loop/scripts/gate.sh` green (format, lint, typecheck, knip, test, build)
- Coverage 100 percent (30788/30788 lines) via `test:coverage` and `coverage:check`
- Functional smoke green: the real app booted against a throwaway PostgreSQL container, login through connection creation to query results rendering
- Provider triad respected: provider code, `docs/providers/<id>.md` and the integration tests move together, PostgreSQL and SQLite only

## Reviewer note

The role verification in the PostgreSQL profile changes the credential matrix introduced earlier in this same branch: agent credentials stay optional, but the resolved role is now verified at open and refused if it is privileged. Nothing consumes this layer yet, so no existing behavior changes.

Closes #328
