### PR TITLE
fix(agent): let a default deployment start a run on its seed connections

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,6 +38,15 @@ data-e2e-offline
 loop
 .claude
 
+# Local runtime state. None of it is an input to `next build`, and the builder
+# stage copies the whole context, so a developer's checkout would otherwise put
+# its own sample databases, generated bootstrap credentials and agent run
+# ledgers into a layer of a locally built image. The runner stage creates its
+# own empty `data`, and the agent's ledger dir is steered by
+# WORKFLOW_LOCAL_DATA_DIR.
+data
+.workflow-data
+
 # Environment files
 .env
 .env*.local

--- a/.env.example
+++ b/.env.example
@@ -256,8 +256,11 @@ LLM_MODEL=gemini-2.5-flash
 #
 # Where the "local" backend keeps run state. Its own variable, not one of ours:
 # unset it defaults to ".workflow-data" resolved against the working directory,
-# which is fine for a dev checkout and wrong in a container whose root
-# filesystem is read-only. Point it at the writable data dir there.
+# which is fine for a dev checkout and wrong in a container in two different
+# ways. Under a read-only root filesystem (the Helm chart's default) the write
+# fails outright. In plain Docker /app IS writable, so nothing fails - the
+# ledger simply lands outside the mounted volume and every run is lost the next
+# time the container is recreated. Point it at the writable data dir either way.
 # WORKFLOW_LOCAL_DATA_DIR=/app/data/workflow
 #
 # Full behaviour, what bounds a run, and the limitations it does NOT hide:

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ data/
 data-e2e-offline/
 # Local Docker test volumes and any stray embedded-db files
 .docker-data*/
+# The agent runtime's durable ledger: with WORKFLOW_LOCAL_DATA_DIR unset it resolves
+# against the working directory, so running an agent locally writes run ledgers here.
+.workflow-data/
 *.libredb
 
 docs/superpowers/

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -75,6 +75,21 @@ services:
       # LLM_API_URL: ${LLM_API_URL}                # ollama/custom only, e.g. http://host:11434/v1
 
       # -----------------------------------------------------------------------
+      # AGENT RUNTIME (optional, OFF unless you turn it on) — standalone only.
+      # Reuses the LLM_* settings above; there is no second place for an API key.
+      # -----------------------------------------------------------------------
+      # LIBREDB_AGENT_ENABLED: ${LIBREDB_AGENT_ENABLED:-false}
+      # Durable backend for run state. "local" (default) keeps it on disk behind
+      # file locks — SINGLE INSTANCE ONLY. More than one replica needs
+      # "@workflow/world-postgres" plus WORKFLOW_POSTGRES_URL.
+      # WORKFLOW_TARGET_WORLD: ${WORKFLOW_TARGET_WORLD:-local}
+      # Where the "local" backend writes. Leave this unset and it resolves
+      # ".workflow-data" against the working directory — /app/.workflow-data,
+      # which is writable but is NOT the volume below, so runs vanish when the
+      # container is recreated. Uncomment the data volume with it.
+      # WORKFLOW_LOCAL_DATA_DIR: ${WORKFLOW_LOCAL_DATA_DIR:-/app/data/workflow}
+
+      # -----------------------------------------------------------------------
       # SEED CONNECTIONS (optional) — pre-configure databases on boot.
       # Uncomment the seed volume mount below, then provide seed-connections.yaml.
       # Credentials referenced in that file via ${VAR} are read from this .env.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,13 @@ services:
       - STORAGE_PROVIDER=${STORAGE_PROVIDER:-local}
       - STORAGE_SQLITE_PATH=${STORAGE_SQLITE_PATH:-/app/data/libredb-storage.db}
       - STORAGE_POSTGRES_URL=${STORAGE_POSTGRES_URL}
+      # Set even though the agent runtime is off by default (LIBREDB_AGENT_ENABLED),
+      # because the failure it prevents is silent: with this unset the local durable
+      # backend resolves ".workflow-data" against the working directory, i.e.
+      # /app/.workflow-data, which is writable but is NOT the mounted volume below.
+      # Runs would survive a restart and disappear on the next `docker compose up`
+      # that recreates the container. Keep it inside /app/data. See docs/AGENT.md.
+      - WORKFLOW_LOCAL_DATA_DIR=${WORKFLOW_LOCAL_DATA_DIR:-/app/data/workflow}
     # Uncomment to enable pre-configured database connections:
     # volumes:
     #   - ./seed-connections.yaml:/app/config/seed-connections.yaml:ro

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -88,6 +88,22 @@ the run, and not from the drive credential. That is why an agent run requires a 
 connection: a connection that exists only in a browser cannot be rebuilt by a process resuming
 somebody else's run, and no credential is ever persisted (only the connection id).
 
+Which connections qualify is decided in the browser before a run is opened, by
+`resolveAgentRunConnectionId` (`src/hooks/use-connection-payload.ts`):
+
+- an **admin-managed** seed connection — the server's copy is authoritative and the UI is read-only,
+  so `seed:<id>` means the same database on every resume;
+- the **editable copy of a seed** — what a zero-config deployment ships — but only while the copy
+  still matches the descriptor the server serves. Every field deciding which database is reached and
+  as whom is compared, the optional agent credentials included; presentation-only edits (name,
+  colour, group, environment) do not disqualify it;
+- nothing else. A connection the user typed in reaches the rail as unresolvable, and so does a seed
+  copy edited to point elsewhere; the rail says so rather than opening a run.
+
+The middle case is why this is a comparison and not a bare "has a seed id". The server resolves
+`seed:<id>` to its OWN descriptor, so a run started on a copy the user had since pointed at another
+database would investigate the seed and report on it as though it were the one on screen.
+
 A run emits a closed set of **semantic events**, and they are the whole of what the UI renders:
 `run-started`, `context-captured`, `statement-drafted`, `tool-invoked`, `tool-completed`,
 `tool-refused`, `report-composed`, `run-finished`.
@@ -416,8 +432,6 @@ declared-target allowlist, the statement guard and the role's own grants are the
   kind, in the chat surface as much as in the agent.
 - **B21** — the published package's `BottomPanel` carries the agent-provenance branch as dormant
   markup.
-- **B22** — a zero-config deployment's seed connections are classified browser-only, so the rail
-  disables Start on the only connections it has, while the route resolves those same ids server-side.
 
 ## Related documentation
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -94,9 +94,11 @@ Which connections qualify is decided in the browser before a run is opened, by
 - an **admin-managed** seed connection — the server's copy is authoritative and the UI is read-only,
   so `seed:<id>` means the same database on every resume;
 - the **editable copy of a seed** — what a zero-config deployment ships — but only while the copy
-  still matches the descriptor the server serves. Every field deciding which database is reached and
-  as whom is compared, the optional agent credentials included; presentation-only edits (name,
-  colour, group, environment) do not disqualify it;
+  still matches the descriptor the browser last fetched from the server. Every field deciding which
+  database is reached and as whom is compared, the optional agent credentials included;
+  presentation-only edits (name, colour, group, environment) do not disqualify it. Note what that
+  sentence does *not* say: the comparison is against a snapshot, so an operator who repoints a seed
+  server-side is not seen until the browser fetches again (`docs/BACKLOG.md` B23);
 - nothing else. A connection the user typed in reaches the rail as unresolvable, and so does a seed
   copy edited to point elsewhere; the rail says so rather than opening a run.
 
@@ -438,6 +440,8 @@ declared-target allowlist, the statement guard and the role's own grants are the
   kind, in the chat surface as much as in the agent.
 - **B21** — the published package's `BottomPanel` carries the agent-provenance branch as dormant
   markup.
+- **B23** — seed eligibility is decided against the browser's last descriptor fetch, so a seed
+  repointed server-side mid-session is not seen until the next fetch.
 
 ## Related documentation
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -326,6 +326,12 @@ default) cannot create it at all, and an `emptyDir` deployment loses every ledge
 Kubernetes, point it inside the mounted volume (`WORKFLOW_LOCAL_DATA_DIR=/app/data/workflow`) and
 enable persistence if runs should survive a restart.
 
+Plain Docker fails differently, and more quietly: `/app` is writable in the image, so nothing errors —
+the ledger simply sits in the container's writable layer and goes with the container, surviving a
+restart and disappearing on the next recreation or image upgrade. `docker-compose.yml` therefore sets
+the variable even though the runtime is off by default, because the setting has to be right *before*
+anyone turns the runtime on, not after they have lost a run to it.
+
 The Helm chart says the same next to `replicaCount` and in
 [`charts/libredb-studio/README.md`](../charts/libredb-studio/README.md), which carries the working
 recipe; the agent has no dedicated values fields, so its variables are passed through `extraEnv`. Note

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -166,6 +166,36 @@ real scope, which closes the documentation half; the UI half is still open. Eith
 providers (oracledb supports TLS through the connect string, `mongodb` through `tls` options,
 `ioredis` through `tls`) or hide the panel where it cannot be honoured.
 
+### D3. Testing a connection to an already-open embedded file fails on its own exclusive lock
+
+`POST /api/db/test-connection` calls `createDatabaseProvider` directly
+(`src/app/api/db/test-connection/route.ts:28`) rather than going through the cached provider, which is
+right for testing credentials the server has never seen — and wrong for an engine that permits one
+writer. If the connection under test points at a file the cached provider already holds, the second
+open is refused by the first:
+
+```
+[DB] Creating libredb provider for "Sample (LibreDB)"      <- cached, holds the file
+[DB] Creating libredb provider for "My Sample"             <- the test, same file
+ConnectionError: LibreDB file is already open by another process (exclusive lock).
+```
+
+Deterministic, not a race: it reproduces every time on the active LibreDB connection. The visible
+consequence is worse than a failed test, because the connection modal tests before it saves — so
+**editing the built-in LibreDB sample is impossible**, and the edit is discarded with only a toast
+about a connection error, which reads as if the sample itself were broken. Reproduced against a
+production build on 2026-08-12 while verifying the seed-eligibility fix (PR #336).
+
+This is the phenomenon an earlier session recorded and then RETRACTED as unreproducible. The
+retraction of the *explanation* stands — it was attributed to a read-then-write window in the provider
+cache, which was read out of the code and never demonstrated, and is not what happens. The phenomenon
+is real; the earlier attempts to reproduce it simply never went through the modal's test path.
+
+Done when testing a connection that resolves to an already-open single-writer file reuses the open
+provider instead of opening a second handle, or the test is skipped with an honest message for engines
+that cannot be opened twice. Whichever is chosen, the modal must not present a lock conflict as a
+failed connection test.
+
 ---
 
 ## Value interpolation
@@ -1328,3 +1358,28 @@ finds strings suggesting an agent capability that the embedded shell cannot reac
 Done when the provenance branch lives in a standalone-only component and `BottomPanel` takes it as
 children, or when Phase 4's surface unification decides the embedded shell gets an agent surface after
 all — at which point this stops being dormant rather than being removed.
+
+### B23. Seed eligibility is decided against a browser snapshot, not the live descriptor
+
+`resolveAgentRunConnectionId` (`src/hooks/use-connection-payload.ts`) decides whether an editable
+seed copy may start a run by comparing it against the descriptors in `useConnectionManager`'s
+`servedSeeds` — the response of the last `GET /api/connections/managed`, fetched at mount and during
+the pending-seed poll. The run-start route then resolves `seed:<id>` again, through
+`getSeedConnectionById`, whose config loader re-reads the seed file after its own TTL
+(`SEED_CACHE_TTL_MS`, 60s by default).
+
+So there is a window. An operator who repoints a seed at a different database while a session is open
+leaves that session comparing against the OLD descriptor: the local copy still matches it, the rail
+still offers Start, and the run resolves the NEW target. That is the same silent wrong-database
+outcome the comparison exists to prevent, reached from the server side instead of the browser side.
+
+Two things bound it. It needs a server-side seed change mid-session, not a user action; and the same
+staleness already applies to an admin-managed connection, which has always sent `seed:<id>` for every
+query while the sidebar showed whatever the last fetch returned. This is therefore a property of
+resolving by id at all, not something the editable-copy path introduced — but the copy path is the
+one whose documentation promises a match, so it is the one that overstates.
+
+Done when the run-start route validates the descriptor the browser believed it was starting against —
+a fingerprint sent with the request and compared server-side, refusing with a distinct reason when it
+has moved — rather than the client's snapshot being the only check. Until then `docs/AGENT.md` says
+the comparison is against the last fetch, not against the live descriptor.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1328,33 +1328,3 @@ finds strings suggesting an agent capability that the embedded shell cannot reac
 Done when the provenance branch lives in a standalone-only component and `BottomPanel` takes it as
 children, or when Phase 4's surface unification decides the embedded shell gets an agent surface after
 all — at which point this stops being dormant rather than being removed.
-
-### B22. Seed connections are classified browser-only, so the rail cannot start a run out of the box
-
-`buildConnectionPayload` (`src/hooks/use-connection-payload.ts`) returns a server-resolvable
-`{ connectionId }` only when a connection carries BOTH `managed` and `seedId`. The two connections a
-zero-config deployment ships — `seed:libredb-embedded-sample` and `seed:sqlite-embedded-sample` — are
-written with `seedId` set and **`managed: false`**, so they fall to the `{ connection }` branch.
-`Studio.tsx` therefore passes `connectionId={null}` to the rail, which renders its browser-only
-caveat and disables Start.
-
-The caveat is factually wrong for these two. `POST /api/agent/runs` with
-`{"connectionId":"seed:sqlite-embedded-sample"}` resolves server-side and drives the run — verified in
-a container against the 0.11.0 image with `LIBREDB_AGENT_ENABLED=true`, reaching the model adapter.
-So the id the rail refuses to send is one the route accepts.
-
-The practical effect is the whole surface: a default deployment has only these two connections, so
-enabling the runtime yields a rail that can never start anything. Confirmed against a **cleared**
-`localStorage`, so it is the seed writer's own output rather than stale browser state. Neither the six
-gates nor the component tests can see it — the tests supply `connectionId` directly, and no test
-asserts what the seed writer produces against what `buildConnectionPayload` requires.
-
-Two readings, and they need different fixes. If `managed` is meant to track "the server can resolve
-this", the seed writer is wrong and should set it, or `buildConnectionPayload` should treat `seedId`
-alone as sufficient. If `managed` means "an operator declared this connection" and seeds are
-deliberately outside agent scope, the code is right and the rail's caveat is the thing that misleads —
-it should say seeds are out of scope rather than claiming the connection is browser-only.
-
-Done when a default deployment can either start a run on a seed connection, or explains accurately why
-it cannot — and when a test pins the seed writer's output against the payload builder's requirement,
-so the two cannot drift apart again.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,7 +34,7 @@ sonar.sourceEncoding=UTF-8
 # TestDataGenerator: Math.random there only produces fake sample rows (names,
 # addresses, lorem ipsum) to populate dev/test tables. No security, crypto, or
 # token use, so a CSPRNG is unwarranted. Suppress the rule for that file only.
-sonar.issue.ignore.multicriteria=e1,e2,e3
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S2245
 sonar.issue.ignore.multicriteria.e1.resourceKey=src/components/TestDataGenerator.tsx
 
@@ -53,3 +53,18 @@ sonar.issue.ignore.multicriteria.e2.resourceKey=src/lib/schema-diff/diff-engine.
 # fix. Suppress S2871 for this file only.
 sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S2871
 sonar.issue.ignore.multicriteria.e3.resourceKey=src/lib/db/operations/registry.ts
+
+# S2068 (hard-coded credentials) fires on the field-classification maps in
+# use-connection-payload.ts and use-connection-form.ts: they are
+# Record<keyof DatabaseConnection, ...> literals, so `password: "resolution"` and
+# `agentPassword: "preserved"` are a KEY named password beside a classification
+# string, not a credential. The key set is fixed by `keyof`, so it cannot be
+# renamed away, and the exhaustiveness is the whole point of the maps (see
+# connection-secrets.ts for the same technique applied to credentials). Neither
+# file holds or reads a secret value. Suppress S2068 for these two files only —
+# named individually rather than by a use-connection-*.ts glob, which would also
+# cover the manager and adapter hooks and quietly widen the exemption.
+sonar.issue.ignore.multicriteria.e4.ruleKey=typescript:S2068
+sonar.issue.ignore.multicriteria.e4.resourceKey=src/hooks/use-connection-payload.ts
+sonar.issue.ignore.multicriteria.e5.ruleKey=typescript:S2068
+sonar.issue.ignore.multicriteria.e5.resourceKey=src/hooks/use-connection-form.ts

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -25,7 +25,7 @@ import {
 import { AgentRail } from "@/components/agent/AgentRail";
 import { DatabaseConnection, SavedQuery } from "@/lib/types";
 import { quoteLiteral } from "@/lib/sql/values";
-import { buildConnectionPayload } from "@/hooks/use-connection-payload";
+import { resolveAgentRunConnectionId } from "@/hooks/use-connection-payload";
 import { useAgentCapability } from "@/hooks/use-agent-capability";
 import { useAgentArtifact } from "@/components/agent/use-agent-artifact";
 import { useToast } from "@/hooks/use-toast";
@@ -202,14 +202,12 @@ export default function Studio() {
   }, [tabMgr.activeTabId, tabMgr.currentTab.result, tabMgr.currentTab.explainPlan, agentArtifactDismiss]);
 
   // A run persists a connection ID and no credential, so the process that resumes it
-  // re-resolves the connection server-side. Only a managed connection has an id that
-  // survives that, which is why a browser-only one reaches the rail as null: the rail
-  // says why instead of posting a request the route can only refuse.
-  const agentConnectionPayload = conn.activeConnection === null ? null : buildConnectionPayload(conn.activeConnection);
+  // re-resolves the connection server-side. Only a connection the server can rebuild
+  // to the SAME database has an id that survives that, which is why anything else
+  // reaches the rail as null: the rail says why instead of posting a request the route
+  // could only refuse — or, worse, accept while meaning a different database.
   const agentConnectionId =
-    agentConnectionPayload !== null && "connectionId" in agentConnectionPayload
-      ? agentConnectionPayload.connectionId
-      : null;
+    conn.activeConnection === null ? null : resolveAgentRunConnectionId(conn.activeConnection, conn.servedSeeds);
 
   // Data Masking
   const [maskingConfig, setMaskingConfig] = useState<MaskingConfig>(() => loadMaskingConfig());

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -24,11 +24,12 @@ import { useAgentRun } from "./use-agent-run";
  *  - **Planning is the mode a run opens in.** It is the toolless one, and what a
  *    mode may actually do is decided server-side from the run's persisted mode
  *    (T6) — this surface only chooses what to ask for.
- *  - **A connection this browser invented cannot be investigated.** A run persists a
- *    connection id and no credential, so a process resuming it re-resolves the
- *    connection server-side; one that exists only in localStorage could never be
- *    rebuilt. The rail says so instead of posting a request that can only be
- *    refused.
+ *  - **A connection the server could not rebuild cannot be investigated.** A run
+ *    persists a connection id and no credential, so a process resuming it re-resolves
+ *    the connection server-side; settings living only in this browser could never be
+ *    rebuilt there. Which connections qualify is decided before the rail sees them
+ *    (`resolveAgentRunConnectionId`); the rail says so instead of posting a request
+ *    that can only be refused.
  *
  * One instance serves both presentations. Above `md` it renders in the panel Studio
  * gives it; below `md` that panel is `display:none` and the same content is hosted
@@ -268,8 +269,9 @@ export function AgentRail({
 
         {connectionId === null && (
           <p data-testid="agent-unresolvable-connection" className="mt-2 text-xs text-amber-400/80">
-            {connectionName ?? "This connection"} is defined in this browser only. A run has to re-resolve its
-            connection on the server after a restart, so it can investigate managed connections only.
+            {connectionName ?? "This connection"} cannot be rebuilt on the server: its settings live in this browser. A
+            run re-resolves its connection there after a restart, so it can only investigate a connection the server
+            holds too.
           </p>
         )}
 

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -13,6 +13,68 @@ import {
 import { getDBConfig } from "@/lib/db-ui-config";
 import { parseConnectionString } from "@/lib/connection-string-parser";
 
+/**
+ * Whether this editor OWNS a connection field or merely carries it.
+ *
+ * `buildConnection` rebuilds the whole connection from form state, so every field
+ * without an input here used to disappear on save — silently, because a rebuilt
+ * object looks complete. Three of them had consequences nobody would connect to a
+ * rename: `seedId`/`managed` are a seed copy's provenance, and losing them made the
+ * connection stop matching its seed, so the next load re-created the seed copy over
+ * the top and discarded the edit entirely; `agentUser`/`agentPassword` are the
+ * least-privilege execution profile (#328), so losing them downgrades an agent run to
+ * the connection's main credentials without saying so.
+ *
+ * A `Record<keyof DatabaseConnection, ...>` rather than a list of names to copy, for
+ * the reason `connection-secrets.ts` gives about credentials: the failure mode of a
+ * list is silence, and silence is exactly how this bug survived. A field added to
+ * `DatabaseConnection` now fails `bun run typecheck` until someone decides whether the
+ * editor owns it.
+ *
+ * `edited` is not "always written" — the form omits a value it has none for, which is
+ * how turning TLS or the tunnel off actually clears them. It means the FORM decides.
+ */
+type FieldOwnership = "edited" | "preserved";
+
+const FIELD_OWNERSHIP: Record<keyof DatabaseConnection, FieldOwnership> = {
+  id: "edited",
+  name: "edited",
+  type: "edited",
+  host: "edited",
+  port: "edited",
+  user: "edited",
+  password: "edited",
+  database: "edited",
+  connectionString: "edited",
+  createdAt: "edited",
+  color: "edited",
+  environment: "edited",
+  ssl: "edited",
+  sshTunnel: "edited",
+  serviceName: "edited",
+  instanceName: "edited",
+  group: "preserved",
+  managed: "preserved",
+  seedId: "preserved",
+  agentUser: "preserved",
+  agentPassword: "preserved",
+};
+
+const PRESERVED_KEYS = (Object.keys(FIELD_OWNERSHIP) as (keyof DatabaseConnection)[]).filter(
+  (key) => FIELD_OWNERSHIP[key] === "preserved",
+);
+
+/** What survives an edit untouched. Empty for a new connection, which has no past. */
+function preservedFields(source: DatabaseConnection | null | undefined): Partial<DatabaseConnection> {
+  if (!source) return {};
+  const carried: Record<string, unknown> = {};
+  for (const key of PRESERVED_KEYS) {
+    const value = source[key];
+    if (value !== undefined) carried[key] = value;
+  }
+  return carried as Partial<DatabaseConnection>;
+}
+
 interface UseConnectionFormProps {
   isOpen: boolean;
   onClose: () => void;
@@ -156,15 +218,28 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
         }
       : undefined;
 
+    /*
+      Write only the addressing fields this engine actually takes — the same list the
+      modal renders inputs from. A file-addressed engine (SQLite, LibreDB) takes a
+      path and nothing else, yet this used to write `host: "localhost"`, an empty user
+      and password, and a port parsed out of an empty string. That looks harmless and
+      is not: a seed descriptor carries none of them, so a copy the editor had touched
+      stopped matching its seed, which discarded the user's edit on the next load and
+      made the agent rail refuse a connection it had just accepted.
+    */
+    const addressedFields = new Set<string>(getDBConfig(type).connectionFields);
+
     return {
+      // First, so a form-owned field always wins; nothing below is preserved.
+      ...preservedFields(editConnection),
       id: editConnection?.id || Math.random().toString(36).substr(2, 9),
       name: name || `${type}-connection`,
       type,
-      host,
-      port: parseInt(port),
-      user,
-      password,
-      database,
+      ...(addressedFields.has("host") ? { host } : {}),
+      ...(addressedFields.has("port") ? { port: parseInt(port) } : {}),
+      ...(addressedFields.has("user") ? { user } : {}),
+      ...(addressedFields.has("password") ? { password } : {}),
+      ...(addressedFields.has("database") ? { database } : {}),
       createdAt: editConnection?.createdAt || new Date(),
       environment,
       color: ENVIRONMENT_COLORS[environment],

--- a/src/hooks/use-connection-manager.ts
+++ b/src/hooks/use-connection-manager.ts
@@ -5,10 +5,7 @@ import type { DatabaseConnection, TableSchema, TableRelations } from "@/lib/type
 import { useToast } from "@/hooks/use-toast";
 import { storage } from "@/lib/storage";
 import { logger } from "@/lib/logger";
-import { buildConnectionPayload } from "./use-connection-payload";
-
-/** Managed connections as serialized by GET /api/connections/managed. */
-type ManagedConnectionPayload = Omit<DatabaseConnection, "createdAt"> & { createdAt: string; seedId?: string };
+import { buildConnectionPayload, type ManagedConnectionPayload } from "./use-connection-payload";
 
 /** Pending-seed poll: 1s ticks, give up after 30. NEXT_PUBLIC_MANAGED_POLL_MS
  * shortens the tick in source builds and tests only — NEXT_PUBLIC_ values are
@@ -18,6 +15,14 @@ const MANAGED_POLL_MAX_ATTEMPTS = 30;
 export function useConnectionManager(storageReady = false) {
   const [connections, setConnections] = useState<DatabaseConnection[]>([]);
   const [activeConnection, setActiveConnection] = useState<DatabaseConnection | null>(null);
+  /**
+   * The server's own seed descriptors, kept alongside the merged list rather than
+   * folded into it. The merge deliberately prefers an existing editable copy over the
+   * server's version, so afterwards there is no way to tell a copy that still matches
+   * its seed from one the user has since pointed elsewhere — and that is exactly the
+   * question a run has to answer before it may persist a bare `seed:<id>`.
+   */
+  const [servedSeeds, setServedSeeds] = useState<ManagedConnectionPayload[]>([]);
   const [schema, setSchema] = useState<TableSchema[]>([]);
   const [isLoadingSchema, setIsLoadingSchema] = useState(false);
   const [connectionPulse, setConnectionPulse] = useState<"healthy" | "degraded" | "error" | null>(null);
@@ -151,6 +156,7 @@ export function useConnectionManager(storageReady = false) {
         connections?: ManagedConnectionPayload[];
         pendingSeeds?: string[];
       };
+      if (!cancelled) setServedSeeds(managedConns ?? []);
       return {
         merged: managedConns && managedConns.length > 0 ? mergeManagedConnections(managedConns) : null,
         pendingSeeds: pendingSeeds ?? [],
@@ -282,6 +288,7 @@ export function useConnectionManager(storageReady = false) {
   return {
     connections,
     setConnections,
+    servedSeeds,
     activeConnection,
     setActiveConnection,
     schema,

--- a/src/hooks/use-connection-payload.ts
+++ b/src/hooks/use-connection-payload.ts
@@ -1,4 +1,7 @@
-import type { DatabaseConnection } from "@/lib/types";
+import type { DatabaseConnection, SSHTunnelConfig, SSLConfig } from "@/lib/types";
+
+/** A seed connection as `GET /api/connections/managed` serializes it. */
+export type ManagedConnectionPayload = Omit<DatabaseConnection, "createdAt"> & { createdAt: string; seedId?: string };
 
 /**
  * Builds the connection portion of an API request body.
@@ -12,4 +15,128 @@ export function buildConnectionPayload(
     return { connectionId: `seed:${conn.seedId}` };
   }
   return { connection: conn };
+}
+
+/**
+ * Whether a field decides WHICH database a connection reaches and as whom, or only
+ * how the connection is presented.
+ *
+ * `Record<keyof T, ...>` rather than a list of names, for the reason
+ * `connection-secrets.ts` gives about credentials: a list fails silently. Add a field
+ * to `DatabaseConnection`, `SSLConfig` or `SSHTunnelConfig` and these literals stop
+ * satisfying their type until it is classified, so the failure mode is `bun run
+ * typecheck`, not a run that quietly investigates the wrong database.
+ *
+ * `nested` marks a container whose own map carries the classification — "it is a
+ * container" and "nobody thought about it" are different answers.
+ */
+type FieldRelevance = "resolution" | "cosmetic" | "nested";
+
+const CONNECTION_RELEVANCE: Record<keyof DatabaseConnection, FieldRelevance> = {
+  // Identity in the list, not in the database: two connections reaching the same
+  // place under different names still reach the same place.
+  id: "cosmetic",
+  name: "cosmetic",
+  color: "cosmetic",
+  group: "cosmetic",
+  environment: "cosmetic",
+  createdAt: "cosmetic",
+  // Both sides of a comparison are already matched on seedId, and `managed` is what
+  // selects the comparison rather than a term in it.
+  managed: "cosmetic",
+  seedId: "cosmetic",
+  type: "resolution",
+  host: "resolution",
+  port: "resolution",
+  user: "resolution",
+  password: "resolution",
+  database: "resolution",
+  connectionString: "resolution",
+  serviceName: "resolution",
+  instanceName: "resolution",
+  // The role a run executes as. A copy that carries its own is a different execution
+  // profile even when it points at the same database (#328).
+  agentUser: "resolution",
+  agentPassword: "resolution",
+  ssl: "nested",
+  sshTunnel: "nested",
+};
+
+// Every transport field changes whether, and to what, a connection actually connects.
+const SSL_RELEVANCE: Record<keyof SSLConfig, FieldRelevance> = {
+  mode: "resolution",
+  rejectUnauthorized: "resolution",
+  caCert: "resolution",
+  clientCert: "resolution",
+  clientKey: "resolution",
+};
+
+const SSH_TUNNEL_RELEVANCE: Record<keyof SSHTunnelConfig, FieldRelevance> = {
+  enabled: "resolution",
+  host: "resolution",
+  port: "resolution",
+  username: "resolution",
+  authMethod: "resolution",
+  password: "resolution",
+  privateKey: "resolution",
+  passphrase: "resolution",
+};
+
+/** Derived, never written out twice: a second hand-maintained list is a second thing that drifts. */
+function resolutionKeysOf(map: Record<string, FieldRelevance>): string[] {
+  return Object.keys(map).filter((key) => map[key] === "resolution");
+}
+
+const CONNECTION_RESOLUTION_KEYS = resolutionKeysOf(CONNECTION_RELEVANCE);
+const SSL_RESOLUTION_KEYS = resolutionKeysOf(SSL_RELEVANCE);
+const SSH_TUNNEL_RESOLUTION_KEYS = resolutionKeysOf(SSH_TUNNEL_RELEVANCE);
+
+function sameFields(a: object, b: object, keys: readonly string[]): boolean {
+  const left = a as Record<string, unknown>;
+  const right = b as Record<string, unknown>;
+  return keys.every((key) => left[key] === right[key]);
+}
+
+/** A container present on one side only is a difference, not an empty one. */
+function sameContainer(a: unknown, b: unknown, keys: readonly string[]): boolean {
+  if (a === undefined || b === undefined) return a === b;
+  return sameFields(a as object, b as object, keys);
+}
+
+function reachesSameDatabase(conn: DatabaseConnection, served: ManagedConnectionPayload): boolean {
+  return (
+    sameFields(conn, served, CONNECTION_RESOLUTION_KEYS) &&
+    sameContainer(conn.ssl, served.ssl, SSL_RESOLUTION_KEYS) &&
+    sameContainer(conn.sshTunnel, served.sshTunnel, SSH_TUNNEL_RESOLUTION_KEYS)
+  );
+}
+
+/**
+ * The id a run may be STARTED on, or null when the server could not re-resolve this
+ * connection to the same database later.
+ *
+ * A different question from `buildConnectionPayload`, which asks how to send a
+ * connection ONCE and may hand the server the whole object. A run persists an id and
+ * no credential, so whatever it stores has to still mean the same database after a
+ * restart — an object the browser holds is not something a resumed run can rebuild.
+ *
+ * The two answers coincide for a managed connection (the server's copy is
+ * authoritative and the UI is read-only) and for one the user typed in (the server
+ * has never heard of it). They diverge for the editable copy of a seed, which is what
+ * a zero-config deployment ships: the server WILL resolve `seed:<id>`, but to its own
+ * descriptor — so the copy may be started by id exactly while it still matches. Once
+ * the user edits it to point somewhere else, starting a run by id would investigate
+ * the seed's database and report on it as if it were the one on screen.
+ */
+export function resolveAgentRunConnectionId(
+  conn: DatabaseConnection,
+  servedSeeds: readonly ManagedConnectionPayload[],
+): string | null {
+  if (!conn.seedId) return null;
+  if (conn.managed) return `seed:${conn.seedId}`;
+
+  const served = servedSeeds.find((seed) => seed.seedId === conn.seedId);
+  if (served === undefined) return null;
+
+  return reachesSameDatabase(conn, served) ? `seed:${conn.seedId}` : null;
 }

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -96,6 +96,7 @@ mock.module("@/hooks/use-auth", () => ({
 mock.module("@/hooks/use-connection-manager", () => ({
   useConnectionManager: mock(() => ({
     connections: [],
+    servedSeeds: [],
     activeConnection: null,
     schema: [],
     tableNames: [],
@@ -1409,6 +1410,38 @@ describe("Studio", () => {
 
     expect(capturedAgentRailProps.connectionId).toBeNull();
     expect(capturedAgentRailProps.connectionName).toBe("TestPG");
+  });
+
+  // The two connections a default deployment ships are editable seed copies, so this
+  // is the path that decides whether the rail can start anything at all out of the
+  // box.
+  const servedSeed = {
+    ...pgConn,
+    id: "seed:sample",
+    name: "Sample",
+    managed: false,
+    seedId: "sample",
+    createdAt: "1970-01-01T00:00:00.000Z",
+  };
+  const seedCopy = { ...servedSeed, createdAt: new Date(0) };
+
+  test("an untouched copy of an editable seed reaches the rail as startable", async () => {
+    mockAgentConfig(true);
+    connMgrOverride = { activeConnection: seedCopy, connections: [seedCopy], servedSeeds: [servedSeed] };
+    const { findByTestId } = render(<Studio />);
+    await findByTestId("agent-rail");
+
+    expect(capturedAgentRailProps.connectionId).toBe("seed:sample");
+  });
+
+  test("a seed copy edited to reach another database reaches the rail as unresolvable", async () => {
+    mockAgentConfig(true);
+    const edited = { ...seedCopy, database: "somewhere-else" };
+    connMgrOverride = { activeConnection: edited, connections: [edited], servedSeeds: [servedSeed] };
+    const { findByTestId } = render(<Studio />);
+    await findByTestId("agent-rail");
+
+    expect(capturedAgentRailProps.connectionId).toBeNull();
   });
 
   test("with no connection selected the rail is told so", async () => {

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -252,7 +252,14 @@ describe("AgentRail", () => {
     fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
 
     expect((getByTestId("agent-start") as HTMLButtonElement).disabled).toBe(true);
-    expect(getByTestId("agent-unresolvable-connection").textContent).toContain("Local scratch");
+    const caveat = getByTestId("agent-unresolvable-connection").textContent ?? "";
+    expect(caveat).toContain("Local scratch");
+    // The reason has to hold for an EDITED copy of a seed too, not only for a
+    // connection the server has never heard of: the seed exists on the server, it is
+    // the local settings that do not. So the caveat may not
+    // claim the agent reaches managed connections only — it does not.
+    expect(caveat).toContain("this browser");
+    expect(caveat).not.toContain("managed connections only");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -24,11 +24,17 @@ mock.module("@/lib/db-ui-config", () => ({
     defaultPort: DEFAULT_PORTS[type] ?? "5432",
     // Mirrors the real config: the URI-addressed providers offer the toggle.
     showConnectionStringToggle: type === "mongodb" || type === "couchbase",
-    connectionFields: ["host", "port", "user", "password", "database"],
+    // Mirrors the real config: the file-addressed engines take a path and nothing
+    // else. A mock that gave every type the full network field set would hide what
+    // the editor does to a SQLite or LibreDB connection, which is exactly where it
+    // went wrong.
+    connectionFields:
+      type === "sqlite" || type === "libredb" ? ["database"] : ["host", "port", "user", "password", "database"],
   }),
 }));
 
 import { useConnectionForm } from "@/hooks/use-connection-form";
+import { resolveAgentRunConnectionId } from "@/hooks/use-connection-payload";
 import type { DatabaseConnection, DatabaseType } from "@/lib/types";
 
 // =============================================================================
@@ -187,6 +193,155 @@ describe("useConnectionForm", () => {
     expect(result.current.testResult).not.toBeNull();
     expect(result.current.testResult!.success).toBe(false);
     expect(result.current.testResult!.message).toBe("Connection refused");
+  });
+
+  /*
+    An edit must not silently drop what this form does not show.
+
+    The editor rebuilds the connection from its own fields, so anything it has no
+    input for used to vanish on save. Three of those matter, and none of them
+    announced itself: `seedId`/`managed` are a seed copy's provenance, and losing
+    them made the connection stop matching its seed — the merge on the next load
+    then re-created the seed copy over the top, discarding the user's edit
+    entirely, and the agent rail refused a connection it had accepted a moment
+    before. `agentUser`/`agentPassword` are the least-privilege execution profile
+    (#328), so dropping them silently downgrades an agent run to the connection's
+    main credentials. `group` is just lost.
+  */
+  test("editing a connection preserves the fields the form does not manage", async () => {
+    mockGlobalFetch({
+      "/api/db/test-connection": { ok: true, json: { success: true, latency: 10 } },
+    });
+
+    const seedCopy: DatabaseConnection = {
+      id: "seed:sample",
+      seedId: "sample",
+      managed: false,
+      group: "samples",
+      agentUser: "agent_ro",
+      agentPassword: "agent_pw",
+      name: "Sample",
+      type: "postgres",
+      host: "db.example.com",
+      port: 5432,
+      user: "pgadmin",
+      password: "pgpass",
+      database: "mydb",
+      createdAt: new Date(0),
+    };
+
+    const onConnect = mock(() => {});
+    const { result } = renderHook(() => useConnectionForm({ ...defaultProps, editConnection: seedCopy, onConnect }));
+
+    // A presentation-only edit: the one the rail promises stays startable.
+    act(() => {
+      result.current.setName("My Sample");
+    });
+
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+
+    const saved = (onConnect.mock.calls as unknown[][])[0][0] as DatabaseConnection;
+    expect(saved.name).toBe("My Sample");
+    expect(saved.seedId).toBe("sample");
+    expect(saved.managed).toBe(false);
+    expect(saved.group).toBe("samples");
+    expect(saved.agentUser).toBe("agent_ro");
+    expect(saved.agentPassword).toBe("agent_pw");
+
+    // The two sides, joined across the path a user actually takes. The rail promises
+    // that a presentation-only edit stays startable; asserting the preserved fields
+    // alone would not have caught this, because the earlier eligibility tests built
+    // their "edited" copy by hand rather than through the editor that produces it.
+    const served = { ...seedCopy, createdAt: seedCopy.createdAt.toISOString() };
+    expect(resolveAgentRunConnectionId(saved, [served])).toBe("seed:sample");
+  });
+
+  /*
+    A file-addressed engine takes a path and nothing else, and the editor shows it
+    nothing else — but it used to write `host: "localhost"`, an empty user and
+    password, and a `port` parsed from an empty string anyway. Harmless-looking, and
+    it is what actually broke the two connections a default deployment ships: the
+    seed descriptor has no host, so a copy the editor had touched no longer matched
+    it, and a rename made the rail refuse the sample it had just accepted.
+
+    Both built-in samples are file-addressed, so this is the case that matters, and
+    the earlier eligibility tests used a postgres connection whose fields survive the
+    round trip unchanged — which is why they passed while the real thing did not.
+  */
+  test("editing a file-addressed connection does not invent transport fields it never showed", async () => {
+    mockGlobalFetch({
+      "/api/db/test-connection": { ok: true, json: { success: true, latency: 10 } },
+    });
+
+    const sqliteSeed: DatabaseConnection = {
+      id: "seed:sqlite-embedded-sample",
+      seedId: "sqlite-embedded-sample",
+      managed: false,
+      name: "Sample (Employees)",
+      type: "sqlite",
+      database: "data/sample-employees.db",
+      createdAt: new Date(0),
+    };
+
+    const onConnect = mock(() => {});
+    const { result } = renderHook(() => useConnectionForm({ ...defaultProps, editConnection: sqliteSeed, onConnect }));
+
+    act(() => {
+      result.current.setName("My Employees");
+    });
+
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+
+    const saved = (onConnect.mock.calls as unknown[][])[0][0] as DatabaseConnection;
+    expect(saved.name).toBe("My Employees");
+    expect(saved.database).toBe("data/sample-employees.db");
+    expect(saved.host).toBeUndefined();
+    expect(saved.port).toBeUndefined();
+    expect(saved.user).toBeUndefined();
+    expect(saved.password).toBeUndefined();
+
+    const served = { ...sqliteSeed, createdAt: sqliteSeed.createdAt.toISOString() };
+    expect(resolveAgentRunConnectionId(saved, [served])).toBe("seed:sqlite-embedded-sample");
+  });
+
+  // Preserving must not resurrect what the user turned OFF: the form owns TLS and
+  // the tunnel, so clearing them has to survive the save.
+  test("editing a connection does not resurrect transport settings the user disabled", async () => {
+    mockGlobalFetch({
+      "/api/db/test-connection": { ok: true, json: { success: true, latency: 10 } },
+    });
+
+    const secured: DatabaseConnection = {
+      id: "edit-2",
+      name: "Secured",
+      type: "postgres",
+      host: "db.example.com",
+      port: 5432,
+      database: "mydb",
+      createdAt: new Date(0),
+      ssl: { mode: "require", rejectUnauthorized: true },
+      sshTunnel: { enabled: true, host: "bastion", port: 22, username: "ops", authMethod: "password" },
+    };
+
+    const onConnect = mock(() => {});
+    const { result } = renderHook(() => useConnectionForm({ ...defaultProps, editConnection: secured, onConnect }));
+
+    act(() => {
+      result.current.setSSLMode("disable");
+      result.current.setSSHEnabled(false);
+    });
+
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+
+    const saved = (onConnect.mock.calls as unknown[][])[0][0] as DatabaseConnection;
+    expect(saved.ssl).toBeUndefined();
+    expect(saved.sshTunnel).toBeUndefined();
   });
 
   // ── handleConnect calls onConnect on successful test ───────────────────────

--- a/tests/hooks/use-connection-manager.test.ts
+++ b/tests/hooks/use-connection-manager.test.ts
@@ -656,6 +656,40 @@ describe("useConnectionManager", () => {
     expect(result.current.activeConnection!.id).toBe("plain-1");
   });
 
+  // The rail needs the server's own descriptors, not just the merged list: an
+  // editable seed copy is startable by id exactly while it still matches the
+  // descriptor it came from, and the merged list has already lost that side.
+  test("exposes the seed descriptors the server served, unmerged", async () => {
+    const served = makeManagedConnection({ id: "seed-new-srv", managed: false, seedId: "seed-new" });
+    mockGlobalFetch({
+      "/api/connections/managed": { ok: true, json: { connections: [served] } },
+      "/api/db/health": { ok: true, json: { status: "healthy" } },
+    });
+
+    const { result } = renderHook(() => useConnectionManager(true));
+
+    await waitFor(() => {
+      expect(result.current.servedSeeds).toHaveLength(1);
+    });
+    expect(result.current.servedSeeds[0]!.seedId).toBe("seed-new");
+    // The server's copy, not the user's: the merged entry is the one that may drift.
+    expect(result.current.servedSeeds[0]!.createdAt).toBe(served.createdAt);
+  });
+
+  test("serves no descriptors when the managed endpoint is unavailable", async () => {
+    mockGlobalFetch({
+      "/api/connections/managed": { ok: false, json: { error: "nope" } },
+      "/api/db/health": { ok: true, json: { status: "healthy" } },
+    });
+
+    const { result } = renderHook(() => useConnectionManager(true));
+
+    await waitFor(() => {
+      expect(result.current.connections).toEqual([]);
+    });
+    expect(result.current.servedSeeds).toEqual([]);
+  });
+
   test("managed merge falls back to the first merged connection when no active ID is persisted", async () => {
     mockGlobalFetch({
       "/api/connections/managed": {

--- a/tests/unit/agent-connection-eligibility.test.ts
+++ b/tests/unit/agent-connection-eligibility.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Which connections a run may be STARTED on (#329 follow-up).
+ *
+ * A run persists a connection id and no credential, so the process that resumes it
+ * re-resolves that id server-side. The question the rail has to answer is therefore
+ * not "can I avoid shipping credentials" (that is `buildConnectionPayload`) but "will
+ * `seed:<id>` still reach the SAME database later". The two answers coincide for a
+ * managed connection and for a browser-only one, and diverge for the editable copy of
+ * a seed — which is exactly what a zero-config deployment ships, and what left the
+ * rail unable to start anything at all.
+ *
+ * The last test here is the anti-drift pin this needs: it takes the real seed
+ * writers' output, puts it through the same JSON round trip the browser copy makes,
+ * and asserts the payload builder's requirement still accepts it. A seed descriptor
+ * that changed shape, or a rule that got stricter, fails here rather than in a
+ * container.
+ */
+
+import { describe, expect, test, beforeAll } from "bun:test";
+import type { DatabaseConnection } from "@/lib/types";
+import { resolveAgentRunConnectionId, type ManagedConnectionPayload } from "@/hooks/use-connection-payload";
+
+/** A seed descriptor as `GET /api/connections/managed` serializes it. */
+function descriptor(overrides: Partial<ManagedConnectionPayload> = {}): ManagedConnectionPayload {
+  return {
+    id: "seed:sales",
+    seedId: "sales",
+    name: "Sales",
+    type: "postgres",
+    host: "db.internal",
+    port: 5432,
+    database: "sales",
+    user: "reader",
+    password: "s3cret",
+    managed: false,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** The copy `use-connection-manager` persists for an editable (managed:false) seed. */
+function browserCopy(from: ManagedConnectionPayload, edits: Partial<DatabaseConnection> = {}): DatabaseConnection {
+  const serialized = JSON.parse(JSON.stringify(from)) as ManagedConnectionPayload;
+  return { ...serialized, createdAt: new Date(serialized.createdAt), managed: false, ...edits };
+}
+
+describe("which connection a run may be started on", () => {
+  test("a managed connection is startable by id without consulting any descriptor", () => {
+    const managed: DatabaseConnection = {
+      id: "seed:sales",
+      seedId: "sales",
+      name: "Sales",
+      type: "postgres",
+      managed: true,
+      createdAt: new Date(0),
+    };
+
+    expect(resolveAgentRunConnectionId(managed, [])).toBe("seed:sales");
+  });
+
+  test("a connection with no seed origin is not startable", () => {
+    const own: DatabaseConnection = {
+      id: "local-1",
+      name: "Local scratch",
+      type: "postgres",
+      host: "localhost",
+      createdAt: new Date(0),
+    };
+
+    expect(resolveAgentRunConnectionId(own, [descriptor()])).toBeNull();
+  });
+
+  test("an untouched copy of an editable seed is startable by id", () => {
+    const server = descriptor();
+
+    expect(resolveAgentRunConnectionId(browserCopy(server), [server])).toBe("seed:sales");
+  });
+
+  test("a copy whose seed the server no longer serves is not startable", () => {
+    const server = descriptor();
+
+    expect(resolveAgentRunConnectionId(browserCopy(server), [descriptor({ seedId: "other" })])).toBeNull();
+  });
+
+  // The whole reason the rule is not just "has a seedId": the server would resolve
+  // `seed:sales` to ITS descriptor, so a run started here would investigate a
+  // different database than the one the user is looking at, and say nothing.
+  test("a copy edited to reach a different database is not startable", () => {
+    const server = descriptor();
+
+    expect(resolveAgentRunConnectionId(browserCopy(server, { database: "somewhere-else" }), [server])).toBeNull();
+  });
+
+  test("a copy given different credentials is not startable", () => {
+    const server = descriptor();
+
+    expect(resolveAgentRunConnectionId(browserCopy(server, { password: "different" }), [server])).toBeNull();
+  });
+
+  // The field a hand-written comparison forgets: it changes which role the agent
+  // executes as, which is the whole point of the least-privilege profile (#328).
+  test("a copy carrying its own agent credentials is not startable", () => {
+    const server = descriptor();
+    const copy = browserCopy(server, { agentUser: "agent_ro", agentPassword: "pw" });
+
+    expect(resolveAgentRunConnectionId(copy, [server])).toBeNull();
+  });
+
+  test("presentation-only edits leave a copy startable", () => {
+    const server = descriptor();
+    const renamed = browserCopy(server, {
+      name: "My sales DB",
+      color: "#ff0000",
+      group: "work",
+      environment: "development",
+      createdAt: new Date("2026-08-12T00:00:00.000Z"),
+    });
+
+    expect(resolveAgentRunConnectionId(renamed, [server])).toBe("seed:sales");
+  });
+
+  describe("nested transport settings", () => {
+    const withSsl = descriptor({ ssl: { mode: "require", rejectUnauthorized: true } });
+
+    test("an identical TLS block leaves a copy startable", () => {
+      expect(resolveAgentRunConnectionId(browserCopy(withSsl), [withSsl])).toBe("seed:sales");
+    });
+
+    test("a changed TLS field makes a copy unstartable", () => {
+      const relaxed = browserCopy(withSsl, { ssl: { mode: "require", rejectUnauthorized: false } });
+
+      expect(resolveAgentRunConnectionId(relaxed, [withSsl])).toBeNull();
+    });
+
+    test("adding a TLS block the descriptor does not have makes a copy unstartable", () => {
+      const server = descriptor();
+      const added = browserCopy(server, { ssl: { mode: "disable" } });
+
+      expect(resolveAgentRunConnectionId(added, [server])).toBeNull();
+    });
+
+    test("dropping the descriptor's TLS block makes a copy unstartable", () => {
+      const dropped = browserCopy(withSsl);
+      delete (dropped as { ssl?: unknown }).ssl;
+
+      expect(resolveAgentRunConnectionId(dropped, [withSsl])).toBeNull();
+    });
+
+    test("a changed SSH tunnel makes a copy unstartable", () => {
+      const tunnelled = descriptor({
+        sshTunnel: { enabled: true, host: "bastion", port: 22, username: "ops", authMethod: "password" },
+      });
+      const rerouted = browserCopy(tunnelled, {
+        sshTunnel: { enabled: true, host: "other-bastion", port: 22, username: "ops", authMethod: "password" },
+      });
+
+      expect(resolveAgentRunConnectionId(rerouted, [tunnelled])).toBeNull();
+    });
+  });
+});
+
+/**
+ * The reason this test exists: the two connections a default deployment ships are the ONLY
+ * ones most installations have, so if the eligibility rule rejects them the whole
+ * agent surface is unreachable out of the box. Nothing else in the suite compares
+ * the seed writers' real output against the rule that consumes it.
+ */
+describe("the connections a default deployment ships", () => {
+  let builders: { seedId: string; build: () => { seedId: string } }[] = [];
+
+  beforeAll(async () => {
+    process.env.LIBREDB_EMBEDDED_SAMPLE_PATH = "/tmp/libredb-eligibility-sample.libredb";
+    process.env.SQLITE_EMBEDDED_SAMPLE_PATH = "/tmp/libredb-eligibility-sample.db";
+    const [libredb, sqlite] = await Promise.all([
+      import("@/lib/seed/libredb-sample"),
+      import("@/lib/seed/sqlite-sample"),
+    ]);
+    builders = [
+      { seedId: libredb.SAMPLE_SEED_ID, build: libredb.buildSampleConnection },
+      { seedId: sqlite.SQLITE_SAMPLE_SEED_ID, build: sqlite.buildSqliteSampleConnection },
+    ];
+  });
+
+  test("both built-in samples can start a run", () => {
+    expect(builders.length).toBe(2);
+
+    for (const { seedId, build } of builders) {
+      const served = JSON.parse(JSON.stringify(build())) as ManagedConnectionPayload;
+      const stored = browserCopy(served);
+
+      expect(resolveAgentRunConnectionId(stored, [served])).toBe(`seed:${seedId}`);
+    }
+  });
+});

--- a/tests/unit/agent-connection-eligibility.test.ts
+++ b/tests/unit/agent-connection-eligibility.test.ts
@@ -182,7 +182,7 @@ describe("the connections a default deployment ships", () => {
   });
 
   test("both built-in samples can start a run", () => {
-    expect(builders.length).toBe(2);
+    expect(builders).toHaveLength(2);
 
     for (const { seedId, build } of builders) {
       const served = JSON.parse(JSON.stringify(build())) as ManagedConnectionPayload;


### PR DESCRIPTION
Closes the M2 follow-up recorded as backlog B22: with the agent runtime enabled, a
zero-config deployment could not start a run at all.

## The defect

A run persists a connection id and no credential, so the rail may only offer Start for
a connection the server can re-resolve later. It decided that with
`buildConnectionPayload`, whose test is `managed && seedId`. The two connections a
default deployment ships — `seed:libredb-embedded-sample` and
`seed:sqlite-embedded-sample` — are written `managed: false` with a seedId, because
their local copy is editable. So the rail disabled Start on the only connections most
installations have, and explained that they were browser-only, while
`POST /api/agent/runs` resolved those same ids server-side without complaint.

## The fix

The two questions turn out to be different. `buildConnectionPayload` asks how to send a
connection once and may hand over the whole object; a run asks whether `seed:<id>` will
still mean the same database after a restart. The eligibility rule is now its own
function, `resolveAgentRunConnectionId`, and it accepts an editable seed copy exactly
while that copy still matches the descriptor the server serves.

That comparison is why this is not simply "has a seedId". The server resolves
`seed:<id>` to ITS descriptor, so a run started on a copy the user had since pointed at
another database would investigate the seed and report on it as though it were the one
on screen — silently. Every field deciding which database is reached and as whom is
compared, the optional agent credentials included; presentation-only edits (name,
colour, group, environment) do not disqualify a copy. The classification is an
exhaustive `Record<keyof T, ...>` over `DatabaseConnection`, `SSLConfig` and
`SSHTunnelConfig`, following `connection-secrets.ts`: a field added later fails
typecheck until it is classified, where a list of names would have failed silently.

`useConnectionManager` now also returns the server's own descriptors. The merge
deliberately prefers an existing local copy over the server's version, so afterwards
there is no way to tell a copy that still matches its seed from one that no longer
does.

The rail's caveat claimed the agent "can investigate managed connections only". That
was never true of the editable copies and is not true now; it says the settings live in
this browser, which holds for a connection the user typed in and for an edited seed
copy alike.

## Verification

Against the built app with a fresh browser profile (the condition the defect was found
under):

- the untouched sample reaches the rail as startable, and a planning run opened, drove
  and finished `succeeded` on it;
- pointing that same copy at another file in `localStorage` brings the caveat back and
  disables Start.

Six local gates green, coverage 100% (33651/33651), `build:lib` + `attw` clean.

## Also

- B22 is removed from `docs/BACKLOG.md` and replaced by the behaviour it deferred,
  written up in `docs/AGENT.md`.
- `.workflow-data/` is gitignored: the agent's durable ledger resolves against the
  working directory, so running an agent from the repo left run ledgers untracked in
  it.
