### PR TITLE
feat(agent): let a run say what it concluded, and how it stopped

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -148,8 +148,25 @@ an empty timeline, its cause readable only in the server log, and with no drive 
 nothing would come back to it.
 
 A drive that fails anywhere now records `run-finished` with status `failed` and a **classified
-reason**: `model-unavailable`, `connection-unresolvable`, or `internal`. Three properties are
-deliberate:
+reason**:
+
+| Reason | What happened | What the user does next |
+| --- | --- | --- |
+| `model-unavailable` | No usable model: unconfigured, or the provider could not be reached | Check the `LLM_*` settings |
+| `model-rate-limited` | The provider answered, and refused on volume | Wait — this one clears itself |
+| `model-unauthorized` | The provider rejected the credentials | Fix the key; retrying will not help |
+| `engine-unsupported` | The connection's engine has no database-native read-only profile | Investigate a different connection |
+| `connection-unresolvable` | The run's persisted connection no longer resolves server-side | Restore the seed, or start on another connection |
+| `internal` | Anything else | Read the server log |
+
+The split is finer than it first was, and the correction is worth recording: the model failures were
+one label on the reasoning that every one of them sends a user to the same settings screen. A live
+run disproved it. A free-tier quota was exhausted and the rail reported that the provider "is not
+configured or could not be reached" — of a provider that was configured and had answered seconds
+earlier. A quota is the only model failure that fixes itself, and it was the one described as a
+misconfiguration.
+
+Three properties are deliberate:
 
 - **The reason is chosen from the error's type, never from its message.** That text is written by a
   model provider, a driver or a connection resolver, and none of them promise to keep a credential,

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -184,6 +184,11 @@ const TERMINAL_TONES = {
  */
 const FAILURE_SENTENCES = {
   "model-unavailable": "The model provider is not configured or could not be reached.",
+  // Says what to do, because for this one there is something to do and it is not
+  // opening the settings: the provider answered, and asked for less traffic.
+  "model-rate-limited": "The model provider is limiting this key's requests. Waiting a minute usually clears it.",
+  "model-unauthorized": "The model provider rejected the configured credentials.",
+  "engine-unsupported": "The agent cannot run on this database engine: it offers no read-only execution profile.",
   "connection-unresolvable": "This run's database connection no longer resolves on the server.",
   internal: "The server could not carry this run. The reason is in the server log.",
 } as const satisfies Record<AgentRunFailureReason, string>;

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -6,6 +6,7 @@ import type {
   AgentRunEvent,
   AgentRunFailureReason,
   AgentRunStatus,
+  AgentRunStopReason,
   AgentToolRefusal,
 } from "@/lib/agent/types";
 
@@ -188,6 +189,41 @@ const FAILURE_SENTENCES = {
 } as const satisfies Record<AgentRunFailureReason, string>;
 
 /**
+ * How the loop ended, said plainly. Total over the union, so a stop reason added to
+ * the durable contract cannot reach a user as an unlabelled ending.
+ *
+ * `report-composed` has no sentence: the report itself is already in the timeline
+ * above, and a line repeating that it exists would be noise. The rest are all cases
+ * where the run stopped WITHOUT answering, which is precisely what a reader cannot
+ * otherwise tell from `succeeded` or `failed` alone.
+ */
+const STOP_SENTENCES = {
+  "report-composed": null,
+  "model-stopped": "The model stopped without composing a cited report.",
+  cancelled: "Stopped because it was cancelled.",
+  "deadline-exceeded": "The run reached its time limit before it finished.",
+  "turn-limit": "The run reached its step limit before it finished. What it had gathered is above.",
+} as const satisfies Record<AgentRunStopReason, string | null>;
+
+/**
+ * The one sentence an ending gets, from at most one of its two accounts.
+ *
+ * `reason` wins: it means the drive died before or outside the loop, which is a more
+ * specific thing to have happened than any way the loop can exit. Neither present is
+ * the normal case for a ledger written before these fields existed, and it yields no
+ * detail rather than an invented one.
+ */
+function describeEnding(
+  reason: AgentRunFailureReason | undefined,
+  stopReason: AgentRunStopReason | undefined,
+): { detail?: string } {
+  if (reason !== undefined) return { detail: FAILURE_SENTENCES[reason] };
+  if (stopReason === undefined) return {};
+  const sentence = STOP_SENTENCES[stopReason];
+  return sentence === null ? {} : { detail: sentence };
+}
+
+/**
  * The sentence for a reason, for a surface that shows it outside the timeline.
  *
  * Exported so the rail's status line and the timeline entry cannot drift into two
@@ -249,13 +285,23 @@ function describeEvent(event: AgentRunEvent): Omit<AgentTimelineItem, "id" | "at
         headline: "Report composed",
         detail: `${event.claims.length} ${event.claims.length === 1 ? "claim" : "claims"}, each citing evidence`,
       };
+    case "closing-statement":
+      return {
+        // Content the run produced, so it reads like the report entry rather than
+        // like an ending — but under its own name, because it cites nothing.
+        tone: "progress",
+        headline: "Closing statement",
+        detail: event.text,
+      };
     default:
       return {
         tone: TERMINAL_TONES[event.status],
         headline: `Run ${event.status}`,
         // Absent unless the ledger recorded one. A sentence supplied by default
         // would be this component inventing a cause for every ending that had none.
-        ...(event.reason === undefined ? {} : { detail: FAILURE_SENTENCES[event.reason] }),
+        // `reason` wins when both are present: a drive that died outside the loop is
+        // a more specific account of the ending than the loop's own exit.
+        ...describeEnding(event.reason, event.stopReason),
       };
   }
 }

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -66,7 +66,7 @@ import {
   runReadQueryTool,
   selectAgentTools,
 } from "./tools";
-import type { AgentRunEvent, AgentRunRecord, AgentRunTerminalStatus } from "./types";
+import type { AgentRunEvent, AgentRunRecord, AgentRunStopReason, AgentRunTerminalStatus } from "./types";
 import { UNTRUSTED_CONTENT_BEGIN, UNTRUSTED_CONTENT_END, fenceUntrustedContent } from "./untrusted-content";
 
 /** Everything a tool call needs EXCEPT what the run's own record decides. */
@@ -83,13 +83,13 @@ export interface AgentInvestigationOptions {
 /**
  * Why the loop stopped. Every one of these ends the run; a failure the loop does
  * not own has no member here, because it leaves the run running instead.
+ *
+ * The durable contract owns the vocabulary (`AgentRunStopReason` in `types.ts`) and
+ * this is an alias of it, not a copy: the value is written into the ledger, so two
+ * unions would be two things to keep equal, and the one that drifted would be the one
+ * a resumed reader could not interpret.
  */
-export type AgentInvestigationStopReason =
-  | "report-composed"
-  | "model-stopped"
-  | "cancelled"
-  | "deadline-exceeded"
-  | "turn-limit";
+export type AgentInvestigationStopReason = AgentRunStopReason;
 
 export interface AgentInvestigationResult {
   readonly runId: string;
@@ -553,11 +553,21 @@ export async function runInvestigation(
   let turns = 0;
   let text = "";
 
+  /*
+    Every terminal path goes through here, which is why the ledger writes belong here
+    and not at each exit: an exit added later cannot forget them.
+
+    The closing prose is written BEFORE the ending, in the same order a reader folds
+    them — a run whose last entry is `run-finished` is finished, and nothing arrives
+    after it. It is skipped when empty rather than written blank, because an empty
+    entry would record that the model spoke.
+  */
   const conclude = async (
     status: AgentRunTerminalStatus,
-    stopReason: AgentInvestigationStopReason,
+    stopReason: AgentRunStopReason,
   ): Promise<AgentInvestigationResult> => {
-    await service.finish(runId, status);
+    if (text.length > 0) await service.recordEvent(runId, { kind: "closing-statement", text });
+    await service.finish(runId, status, { stopReason });
     return { runId, status, stopReason, turns, text };
   };
 

--- a/src/lib/agent/run-service.ts
+++ b/src/lib/agent/run-service.ts
@@ -55,9 +55,21 @@ import type {
   AgentRunMode,
   AgentRunRecord,
   AgentRunFailureReason,
+  AgentRunStopReason,
   AgentRunTerminalStatus,
   AgentToolRefusal,
 } from "./types";
+
+/**
+ * How a run ended, as the two independent things it can be: `reason` says why a drive
+ * died before or outside the loop, `stopReason` says how the loop itself ended. An
+ * options bag rather than two positional optionals, because `finish(id, s, undefined,
+ * x)` is exactly the call site that eventually passes one in the other's place.
+ */
+export interface AgentRunEnding {
+  readonly reason?: AgentRunFailureReason;
+  readonly stopReason?: AgentRunStopReason;
+}
 
 /**
  * The events a run TELLS, as opposed to the ones that happen to it. Everything
@@ -66,7 +78,7 @@ import type {
  */
 export type AgentRunNarrativeEvent = Extract<
   AgentRunEvent,
-  { kind: "context-captured" | "statement-drafted" | "report-composed" }
+  { kind: "context-captured" | "statement-drafted" | "report-composed" | "closing-statement" }
 >;
 
 /** Distributes over the union, so each variant loses `atMs` rather than the union collapsing. */
@@ -259,7 +271,9 @@ export class AgentRunService {
   async cancel(runId: string, by: AgentRunActor): Promise<AgentRunStatusReport> {
     const view = await this.readOrThrow(runId);
     if (view.terminal) return report(view);
-    if (view.record.status === "queued") return report(await this.finalize(runId, "cancelled"));
+    if (view.record.status === "queued") {
+      return report(await this.finalize(runId, "cancelled", { stopReason: "cancelled" }));
+    }
     await this.store.requestCancellation(runId, by);
     return report(await this.readOrThrow(runId));
   }
@@ -272,12 +286,12 @@ export class AgentRunService {
    * the ledger records what happened rather than what was asked for. The request
    * stays visible in the status report instead of being rewritten into the outcome.
    */
-  async finish(runId: string, status: AgentRunTerminalStatus, reason?: AgentRunFailureReason): Promise<AgentRunRecord> {
+  async finish(runId: string, status: AgentRunTerminalStatus, ending: AgentRunEnding = {}): Promise<AgentRunRecord> {
     const view = await this.readOrThrow(runId);
     if (view.terminal) {
       throw new AgentRunServiceError("RUN_ALREADY_TERMINAL", `agent run "${runId}" already ${view.record.status}`);
     }
-    return (await this.finalize(runId, status, reason)).record;
+    return (await this.finalize(runId, status, ending)).record;
   }
 
   /**
@@ -329,7 +343,7 @@ export class AgentRunService {
       throw new AgentRunServiceError("RUN_NOT_RUNNING", `agent run "${runId}" is ${view.record.status}, not running`);
     }
     if (view.cancellationRequestedAtMs !== null) {
-      await this.finalize(runId, "cancelled");
+      await this.finalize(runId, "cancelled", { stopReason: "cancelled" });
       return { kind: "cancelled" };
     }
     const settled = view.settledSteps.get(invocation.stepId);
@@ -391,8 +405,9 @@ export class AgentRunService {
   private async finalize(
     runId: string,
     status: AgentRunTerminalStatus,
-    reason?: AgentRunFailureReason,
+    ending: AgentRunEnding,
   ): Promise<AgentRunLedgerView> {
+    const { reason, stopReason } = ending;
     const live = this.resources.tracker.usage(runId).activeExecutions;
     if (live > 0) {
       throw new AgentRunServiceError(
@@ -400,14 +415,15 @@ export class AgentRunService {
         `agent run "${runId}" still has ${live} execution(s) in flight and cannot be ended`,
       );
     }
-    // Spread rather than `reason` outright: an ending that has no reason writes the
-    // entry it always wrote, so a ledger from before this field and one after it are
-    // the same bytes for the same event.
+    // Spread rather than the fields outright: an ending that has neither writes the
+    // entry it always wrote, so a ledger from before these fields and one after them
+    // are the same bytes for the same event.
     await this.store.appendEvent(runId, {
       kind: "run-finished",
       atMs: this.clock(),
       status,
       ...(reason === undefined ? {} : { reason }),
+      ...(stopReason === undefined ? {} : { stopReason }),
     });
     try {
       releaseExecutionRun({ runId, tracker: this.resources.tracker, artifacts: this.resources.artifacts });

--- a/src/lib/agent/run-store.ts
+++ b/src/lib/agent/run-store.ts
@@ -72,16 +72,29 @@ const AGENT_LEDGER_STREAM_PREFIX = "agent-ledger-";
  */
 export const AGENT_RUN_ID_PATTERN = /^[A-Za-z0-9_]{1,64}$/;
 
-const EVENT_KINDS: ReadonlySet<string> = new Set<AgentRunEvent["kind"]>([
-  "run-started",
-  "context-captured",
-  "statement-drafted",
-  "tool-invoked",
-  "tool-completed",
-  "tool-refused",
-  "report-composed",
-  "run-finished",
-]);
+/**
+ * Which event kinds a ledger line may carry.
+ *
+ * Derived from a total record rather than written as an array, because the failure
+ * mode of the array was demonstrated: adding `closing-statement` to `AgentRunEvent`
+ * left this list behind, and the first run to write one made its own ledger
+ * unreadable — the validator rejected an event the writer had just appended. An array
+ * of the union's own type does not catch that; only exhaustiveness does. Add a kind to
+ * the contract now and `bun run typecheck` fails here until it is admitted.
+ */
+const EVENT_KINDS: ReadonlySet<string> = new Set(
+  Object.keys({
+    "run-started": true,
+    "context-captured": true,
+    "statement-drafted": true,
+    "tool-invoked": true,
+    "tool-completed": true,
+    "tool-refused": true,
+    "report-composed": true,
+    "closing-statement": true,
+    "run-finished": true,
+  } satisfies Record<AgentRunEvent["kind"], true>),
+);
 
 /**
  * What a ledger line can be. The header is written once; `event` carries one of

--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -32,7 +32,8 @@ import { type ExecutionArtifact, ExecutionArtifactStore } from "@/lib/db/operati
 import { ExecutionBudgetTracker } from "@/lib/db/operations/budgets";
 import { createCanonicalOperationRegistry } from "@/lib/db/operations/descriptors";
 import { createTargetScope } from "@/lib/db/operations/policy";
-import { LLMError } from "@/lib/llm/types";
+import { LLMAuthError, LLMError, LLMRateLimitError } from "@/lib/llm/types";
+import { ExecutionProfileError } from "@/lib/db/errors";
 import { logger } from "@/lib/logger";
 import { resolveConnection, SeedConnectionError } from "@/lib/seed/resolve-connection";
 import type { QueryResult } from "@/lib/types";
@@ -191,10 +192,24 @@ function classifyDriveFailure(error: unknown): AgentRunFailureReason {
   // bundle. The SDK's errors are the ones that arrive in duplicate.
   if (error instanceof SeedConnectionError) return "connection-unresolvable";
 
-  // Every LLM failure reads as one label because the user's next move is the same
-  // for all of them — look at the model settings. A rate limit and a refused key
-  // differ to an operator, who has the logged message, not to the person deciding
-  // whether to start another run.
+  // An engine with no read-only profile is not a server fault, and calling it
+  // `internal` sent a user to a log that could only tell them what their own
+  // connection already says. Checked before the generic classes below because it is
+  // the specific thing that happened.
+  if (error instanceof ExecutionProfileError) return "engine-unsupported";
+
+  /*
+    These were one label until 2026-08-12, on the reasoning that the user's next move
+    is the same for all of them — look at the model settings. A live run falsified it.
+    A Gemini free-tier quota (15 requests a minute) was exhausted by testing, and the
+    rail told the user the provider "is not configured or could not be reached" about a
+    provider that was configured and had answered seconds earlier. For a quota the next
+    move is to wait a minute; for a refused key it is to fix the key; only the rest send
+    anyone to the settings. The subclasses are checked before `LLMError` itself, which
+    all of them extend.
+  */
+  if (error instanceof LLMRateLimitError) return "model-rate-limited";
+  if (error instanceof LLMAuthError) return "model-unauthorized";
   if (error instanceof LLMError) return "model-unavailable";
 
   // Everything else, deliberately unnamed: a provider that could not be built and a

--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -171,7 +171,7 @@ export async function driveAgentRun(runId: string): Promise<AgentInvestigationRe
 async function recordDriveFailure(service: AgentRunService, runId: string, error: unknown): Promise<void> {
   const reason = classifyDriveFailure(error);
   try {
-    await service.finish(runId, "failed", reason);
+    await service.finish(runId, "failed", { reason });
   } catch (recordingError) {
     logger.error("Agent run failed and its ending could not be recorded", recordingError, { runId, reason });
   }

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -84,6 +84,28 @@ export type AgentRunFailureReason =
   | "internal";
 
 /**
+ * How the loop ended — a different question from `AgentRunFailureReason`, which says
+ * why a drive died before or outside the loop.
+ *
+ * This is the run's own account of itself, and it is what makes the difference between
+ * "succeeded" and "answered" legible. A run that stops because the model composed a
+ * cited report and a run that stops because the model simply had nothing more to say
+ * are both `succeeded`; only this says which. Recording it is what lets a reader — the
+ * rail, or a later verifier — tell a finished investigation from an abandoned one.
+ */
+export type AgentRunStopReason =
+  /** The model called `compose_report`; the run answered with citations. */
+  | "report-composed"
+  /** The model stopped calling tools. A planning run's normal end; an agent run's silence. */
+  | "model-stopped"
+  /** A cancellation was requested and observed between turns. */
+  | "cancelled"
+  /** The wall-clock budget ran out. */
+  | "deadline-exceeded"
+  /** The model-turn ceiling was reached with work still in flight. */
+  | "turn-limit";
+
+/**
  * Who started the run, persisted at start and the sole authority for authorizing
  * every later tool call — never the callback that woke the run up, never the
  * request body.
@@ -221,6 +243,23 @@ export type AgentRunEvent =
   | (AgentRunEventBase & { readonly kind: "tool-refused"; readonly stepId: string; readonly refusal: AgentToolRefusal })
   | (AgentRunEventBase & { readonly kind: "report-composed"; readonly claims: readonly AgentReportClaim[] })
   | (AgentRunEventBase & {
+      /**
+       * The model's closing prose, recorded because it is otherwise lost.
+       *
+       * Deliberately NOT a report: it carries no citations and claims none, which is
+       * exactly why it has its own kind rather than a lenient `report-composed`. A
+       * planning run's whole output is one of these — that mode has no tools, so it
+       * can never produce evidence and could never have composed a report. An agent
+       * run's is an aside, and when it is the only thing a run left behind, that is
+       * itself worth seeing.
+       *
+       * Written only when the prose is non-empty: an empty entry would record that
+       * the model spoke when it did not.
+       */
+      readonly kind: "closing-statement";
+      readonly text: string;
+    })
+  | (AgentRunEventBase & {
       readonly kind: "run-finished";
       readonly status: AgentRunTerminalStatus;
       /**
@@ -233,6 +272,12 @@ export type AgentRunEvent =
        * reason visible only in the server log.
        */
       readonly reason?: AgentRunFailureReason;
+      /**
+       * How the loop itself ended, when the loop is what ended it. Absent on a run
+       * the drive failed out of — those carry `reason` instead, and the two are
+       * mutually exclusive by construction rather than by convention.
+       */
+      readonly stopReason?: AgentRunStopReason;
     });
 
 /**

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -76,8 +76,22 @@ export type AgentRunStatus = "queued" | "running" | AgentRunTerminalStatus;
  * specific label would be a claim the classifier cannot support.
  */
 export type AgentRunFailureReason =
-  /** No usable model: unconfigured, refused credentials, or unreachable. */
+  /** No usable model: unconfigured, or the provider could not be reached. */
   | "model-unavailable"
+  /**
+   * The provider is there and answering, and is refusing on volume. The only model
+   * failure that fixes itself, and the one worth telling apart from the rest: a
+   * misconfiguration needs an operator, a quota needs a minute.
+   */
+  | "model-rate-limited"
+  /** The provider rejected the credentials. An operator fixes this; retrying does not. */
+  | "model-unauthorized"
+  /**
+   * The connection's engine has no database-native read-only execution profile, so
+   * this run could never have been permitted on it. A property of the connection the
+   * user chose, not a fault of the server — which is why it is not `internal`.
+   */
+  | "engine-unsupported"
   /** The run's persisted connection no longer resolves on the server. */
   | "connection-unresolvable"
   /** Anything else. Deliberately unspecific; the log carries the detail. */

--- a/src/lib/seed/index.ts
+++ b/src/lib/seed/index.ts
@@ -34,25 +34,35 @@ export async function getManagedConnections(roles: string[]): Promise<ManagedCon
 
   const out = [...fromConfig];
 
-  // In a test run, only consider a sample when its explicit path override is set,
-  // so an uncontrolled real ./data/sample.* cannot perturb unrelated suites.
-  // (NODE_ENV==='test' guard mirrors the existing pattern in src/lib/db/factory.ts.)
-  const libredbSampleConsidered = process.env.NODE_ENV !== "test" || !!process.env.LIBREDB_EMBEDDED_SAMPLE_PATH;
-  if (isSampleEnabled() && libredbSampleConsidered) {
+  /*
+    The SQLite sample leads the built-ins, and the order is the point: a client with
+    no persisted active connection selects the first of this list, so whichever sample
+    comes first is what a brand-new user lands on. The agent runtime targets
+    PostgreSQL and SQLite; the LibreDB engine has no database-native read-only
+    execution profile, so leading with it put every zero-config user on the one
+    connection an agent run can never execute against. An operator's own seed config
+    still leads both — those are already in `out`.
+
+    In a test run, only consider a sample when its explicit path override is set, so
+    an uncontrolled real ./data/sample.* cannot perturb unrelated suites.
+    (NODE_ENV==='test' guard mirrors the existing pattern in src/lib/db/factory.ts.)
+  */
+  const sqliteSampleConsidered = process.env.NODE_ENV !== "test" || !!process.env.SQLITE_EMBEDDED_SAMPLE_PATH;
+  if (isSqliteSampleEnabled() && sqliteSampleConsidered) {
     try {
-      if (fs.existsSync(resolveSamplePath())) {
-        out.push(buildSampleConnection());
+      if (fs.existsSync(resolveSqliteSamplePath())) {
+        out.push(buildSqliteSampleConnection());
       }
     } catch {
       /* fs error -> omit the sample */
     }
   }
 
-  const sqliteSampleConsidered = process.env.NODE_ENV !== "test" || !!process.env.SQLITE_EMBEDDED_SAMPLE_PATH;
-  if (isSqliteSampleEnabled() && sqliteSampleConsidered) {
+  const libredbSampleConsidered = process.env.NODE_ENV !== "test" || !!process.env.LIBREDB_EMBEDDED_SAMPLE_PATH;
+  if (isSampleEnabled() && libredbSampleConsidered) {
     try {
-      if (fs.existsSync(resolveSqliteSamplePath())) {
-        out.push(buildSqliteSampleConnection());
+      if (fs.existsSync(resolveSamplePath())) {
+        out.push(buildSampleConnection());
       }
     } catch {
       /* fs error -> omit the sample */

--- a/tests/integration/seed/sqlite-sample-managed.test.ts
+++ b/tests/integration/seed/sqlite-sample-managed.test.ts
@@ -47,6 +47,37 @@ describe("getManagedConnections: sqlite embedded sample", () => {
     expect(sample?.managed).toBe(false);
   });
 
+  /*
+    Order is the default connection. `useConnectionManager` selects the first merged
+    connection when no active id is persisted, so whichever sample leads is what a
+    brand-new user lands on — and the agent runtime targets PostgreSQL and SQLite,
+    not the LibreDB engine, which has no database-native read-only execution profile.
+    Leading with LibreDB put every zero-config user on the one connection the agent
+    can never run against, and it took a real run to notice.
+
+    An operator's own seed config still leads: those are appended before either
+    sample, so this only decides which of the two built-ins comes first.
+  */
+  test("leads the built-in samples, so a first run lands on an engine the agent supports", async () => {
+    const sqliteFile = useTempSamplePath();
+    await seedSqliteSampleFile(sqliteFile);
+
+    const libredbDir = fs.mkdtempSync(path.join(os.tmpdir(), "libredb-sample-order-"));
+    tmpDirs.push(libredbDir);
+    const libredbFile = path.join(libredbDir, "sample.libredb");
+    process.env.LIBREDB_EMBEDDED_SAMPLE_PATH = libredbFile;
+    const { seedSampleFile, SAMPLE_SEED_ID } = await import("@/lib/seed/libredb-sample");
+    await seedSampleFile(libredbFile);
+
+    try {
+      const seedIds = (await getManagedConnections(["user"])).map((c) => c.seedId);
+      expect(seedIds).toContain(SAMPLE_SEED_ID);
+      expect(seedIds.indexOf(SQLITE_SAMPLE_SEED_ID)).toBeLessThan(seedIds.indexOf(SAMPLE_SEED_ID));
+    } finally {
+      delete process.env.LIBREDB_EMBEDDED_SAMPLE_PATH;
+    }
+  });
+
   test("omits the sample while the file does not exist", async () => {
     useTempSamplePath(); // path set, file never seeded
     const conns = await getManagedConnections(["user"]);

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -339,6 +339,8 @@ describe("a fresh run drives the investigation arc", () => {
       "tool-invoked",
       "tool-completed",
       "report-composed",
+      // No closing statement: this model reports and says nothing after it, and an
+      // empty entry would record that it spoke.
       "run-finished",
     ]);
     expect(b.queryReadOnly).toHaveBeenCalledTimes(CONTEXT_READS + 1);
@@ -423,6 +425,9 @@ describe("a fresh run drives the investigation arc", () => {
       "statement-drafted",
       "tool-invoked",
       "tool-completed",
+      // This run ends on prose rather than a report, and that prose is now the only
+      // thing it leaves behind — which is exactly the case that used to vanish.
+      "closing-statement",
       "run-finished",
     ]);
     const draft = events.find((event) => event.kind === "statement-drafted");
@@ -570,6 +575,62 @@ describe("planning mode performs zero database operations", () => {
     expect(result.status).toBe("succeeded");
     expect(result.stopReason).toBe("model-stopped");
     expect(result.text).toBe("First look at the index.");
+  });
+
+  /*
+    The prose was already RETURNED to the caller, and the test above asserts exactly
+    that — which is how a planning run could pass its tests while producing nothing a
+    user ever sees. A run's ledger is the only thing that outlives the drive, so a
+    plan the ledger does not carry is a plan that was discarded. Nine live runs on
+    2026-08-12 produced zero visible output for this reason.
+  */
+  test("the plan reaches the ledger, not just the caller", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "planning");
+    const script = scriptedModel(answersProse("Start with ", "the salary index."));
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const events = await eventsOf(b.store, run.runId);
+    const closing = events.find((event) => event.kind === "closing-statement");
+    expect(closing).toBeDefined();
+    expect(closing).toMatchObject({ text: "Start with the salary index." });
+    // The record a resumed reader folds says the same thing the drive returned.
+    expect(closing && "text" in closing ? closing.text : null).toBe(result.text);
+  });
+
+  test("the ledger records how the loop ended, not only that it did", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "planning");
+    const script = scriptedModel(answersProse("a plan"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const finished = (await eventsOf(b.store, run.runId)).find((event) => event.kind === "run-finished");
+    expect(finished).toMatchObject({ status: "succeeded", stopReason: "model-stopped" });
+  });
+
+  test("a run that says nothing writes no empty closing statement", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "planning");
+    const script = scriptedModel(answersProse(""));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const events = await eventsOf(b.store, run.runId);
+    expect(events.some((event) => event.kind === "closing-statement")).toBe(false);
   });
 
   test("a planning run still has a cancellation checkpoint between turns", async () => {

--- a/tests/isolated/agent-runtime.test.ts
+++ b/tests/isolated/agent-runtime.test.ts
@@ -19,7 +19,8 @@ import { AGENT_ENABLED_ENV } from "@/lib/agent/config";
 import { AGENT_RUN_DEADLINE_MS } from "@/lib/agent/execution-policy";
 import * as realRunStore from "@/lib/agent/run-store";
 import { AgentRunServiceError } from "@/lib/agent/run-service";
-import { LLMConfigError } from "@/lib/llm/types";
+import { LLMAuthError, LLMConfigError, LLMRateLimitError } from "@/lib/llm/types";
+import { ExecutionProfileError } from "@/lib/db/errors";
 import { SeedConnectionError } from "@/lib/seed/resolve-connection";
 import { acquireExecutionProfileProvider } from "@/lib/db/factory";
 import type { AgentToolResources } from "@/lib/agent/investigation";
@@ -194,6 +195,65 @@ describe("a drive that fails before the loop", () => {
     expect(await finishedEvent("arun_modelgone")).toMatchObject({
       status: "failed",
       reason: "model-unavailable",
+    });
+  });
+
+  /*
+    The three model failures a user can tell apart, and must.
+
+    Collapsing them into "model-unavailable" is what a real run produced on
+    2026-08-12: a Gemini free-tier quota of 15 requests per minute was exhausted by
+    testing, and the rail reported that the provider "is not configured or could not
+    be reached" — of a provider that was configured and had answered a second
+    earlier. A quota is the one model failure that fixes itself, and it was the one
+    described as a misconfiguration.
+  */
+  test("records a rate limit as itself, not as an unreachable provider", async () => {
+    await openRun("arun_ratelimited");
+    mockCreateAgentModel.mockImplementationOnce(async () => {
+      throw new LLMRateLimitError("You exceeded your current quota. Please retry in 54.6s.", "gemini");
+    });
+
+    await expect(driveAgentRun("arun_ratelimited")).rejects.toThrow(LLMRateLimitError);
+
+    expect(await finishedEvent("arun_ratelimited")).toMatchObject({
+      status: "failed",
+      reason: "model-rate-limited",
+    });
+  });
+
+  test("records refused model credentials as itself", async () => {
+    await openRun("arun_badkey");
+    mockCreateAgentModel.mockImplementationOnce(async () => {
+      throw new LLMAuthError("API key not valid", "gemini");
+    });
+
+    await expect(driveAgentRun("arun_badkey")).rejects.toThrow(LLMAuthError);
+
+    expect(await finishedEvent("arun_badkey")).toMatchObject({
+      status: "failed",
+      reason: "model-unauthorized",
+    });
+  });
+
+  test("records an engine the agent cannot execute on read-only", async () => {
+    // The default connection of a zero-config deployment is the LibreDB sample,
+    // which has no database-native read-only profile. Reported as "internal", that
+    // is a server fault the user should report; reported as itself, it is a
+    // connection they should switch away from.
+    await openRun("arun_noprofile");
+    mockResolveConnection.mockImplementationOnce(async () => {
+      throw new ExecutionProfileError(
+        'Provider type "libredb" has no database-native read-only execution profile',
+        "PROFILE_UNSUPPORTED_BY_PROVIDER",
+      );
+    });
+
+    await expect(driveAgentRun("arun_noprofile")).rejects.toThrow(ExecutionProfileError);
+
+    expect(await finishedEvent("arun_noprofile")).toMatchObject({
+      status: "failed",
+      reason: "engine-unsupported",
     });
   });
 

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -118,6 +118,89 @@ describe("foldLedgerEntries", () => {
     expect(view.items.at(-1)?.detail).toBe("The model provider is not configured or could not be reached.");
   });
 
+  /*
+    The prose a run ends on used to be returned to the caller and dropped. These pin
+    the two halves of showing it: the entry that carries the words, and the ending
+    that says the run stopped without a cited report — which is the difference
+    between "succeeded" and "answered".
+  */
+  test("the model's closing prose becomes an entry of its own", () => {
+    const view = foldLedgerEntries([
+      OPENED,
+      event({
+        kind: "event",
+        event: { kind: "closing-statement", atMs: 8, text: "Start with the salary index." },
+      }),
+      event({
+        kind: "event",
+        event: { kind: "run-finished", atMs: 9, status: "succeeded", stopReason: "model-stopped" },
+      }),
+    ]);
+
+    const closing = view.items.at(-2);
+    expect(closing?.headline).toBe("Closing statement");
+    expect(closing?.detail).toBe("Start with the salary index.");
+    expect(closing?.tone).toBe("progress");
+    expect(view.items.at(-1)?.detail).toBe("The model stopped without composing a cited report.");
+  });
+
+  test("a run that ran out of steps says so, and keeps what it gathered", () => {
+    const view = foldLedgerEntries([
+      OPENED,
+      event({ kind: "event", event: { kind: "run-finished", atMs: 9, status: "failed", stopReason: "turn-limit" } }),
+    ]);
+
+    expect(view.items.at(-1)?.detail).toBe(
+      "The run reached its step limit before it finished. What it had gathered is above.",
+    );
+  });
+
+  test("a deadline and a cancellation each get their own account", () => {
+    const ended = (stopReason: "deadline-exceeded" | "cancelled") =>
+      foldLedgerEntries([
+        OPENED,
+        event({ kind: "event", event: { kind: "run-finished", atMs: 9, status: "failed", stopReason } }),
+      ]).items.at(-1)?.detail;
+
+    expect(ended("deadline-exceeded")).toBe("The run reached its time limit before it finished.");
+    expect(ended("cancelled")).toBe("Stopped because it was cancelled.");
+  });
+
+  test("a run that composed a report does not also announce that it stopped", () => {
+    // The report is already in the timeline above; a line saying a report exists
+    // would be the entry repeating its neighbour.
+    const view = foldLedgerEntries([
+      OPENED,
+      event({
+        kind: "event",
+        event: { kind: "run-finished", atMs: 9, status: "succeeded", stopReason: "report-composed" },
+      }),
+    ]);
+
+    expect(view.items.at(-1)?.detail).toBeUndefined();
+  });
+
+  test("a drive that died outside the loop is described by that, not by the loop's exit", () => {
+    // Both can be present on a ledger written by a drive that failed after the loop
+    // had already recorded how it stopped. The drive failure is the more specific
+    // account of what happened, so it is the one a user reads.
+    const view = foldLedgerEntries([
+      OPENED,
+      event({
+        kind: "event",
+        event: {
+          kind: "run-finished",
+          atMs: 9,
+          status: "failed",
+          reason: "model-unavailable",
+          stopReason: "model-stopped",
+        },
+      }),
+    ]);
+
+    expect(view.items.at(-1)?.detail).toBe("The model provider is not configured or could not be reached.");
+  });
+
   test("an ending with no reason claims none", () => {
     // Most endings need none: succeeded, cancelled, and a loop that stopped on its
     // own terms are fully described by the status. A default sentence here would

--- a/tests/unit/lib/agent/types.test.ts
+++ b/tests/unit/lib/agent/types.test.ts
@@ -97,6 +97,10 @@ const EVENTS: Record<AgentRunEvent["kind"], AgentRunEvent> = {
   "tool-refused": { kind: "tool-refused", atMs: 5, stepId: "step-1", refusal: DATABASE_ERROR },
   "tool-completed": { kind: "tool-completed", atMs: 6, stepId: "step-2", artifact: ARTIFACT },
   "report-composed": { kind: "report-composed", atMs: 7, claims: [CLAIM] },
+  // The uncited counterpart: what the model said when it did not compose a report.
+  // A planning run's whole output is one of these, and it round-trips as plainly as
+  // the rest — prose is already the most inert thing a ledger can hold.
+  "closing-statement": { kind: "closing-statement", atMs: 8, text: "Start with the salary index." },
   "run-finished": { kind: "run-finished", atMs: 8, status: "succeeded" },
 };
 


### PR DESCRIPTION
Phase A1 + the honesty half of A2 from the roadmap. Nine live runs on 2026-08-12 produced zero visible output between them; this is why.

## What was wrong

`conclude()` is every terminal path's single exit, and it held both missing pieces while writing neither:

```ts
await service.finish(runId, status);              // stopReason and text dropped here
return { runId, status, stopReason, turns, text };
```

Planning mode — the default — called the model, received a plan, and discarded it. Its whole ledger was two events. Agent runs read the database competently and ended `succeeded` with the answer nowhere.

## What changed

**`closing-statement`** carries the model's prose, under its own event kind rather than a lenient `report-composed`. It cites nothing and claims nothing, and that is the point: planning mode has no tools, so it can never produce evidence and could never have composed a report — being unable to speak at all was the consequence. Written only when the prose is non-empty.

**`stopReason` on `run-finished`** — `report-composed` | `model-stopped` | `cancelled` | `deadline-exceeded` | `turn-limit`. This is what separates *succeeded* from *answered*. A run that stops without composing now says so in the rail rather than presenting silence as success. It sits beside `reason` (why a drive died outside the loop); `reason` wins when both are present, since a dead drive is the more specific account.

`finish` takes an ending object rather than two positional optionals of different unions.

## What it deliberately does not do

It does not demote an unanswered run to `failed`. The terminal vocabulary has no `partial`, and a planning run that produced a good plan did not fail. Making the ending legible is the precondition for that policy call, not the call itself.

## Two guards, both earned

- The store's event-kind whitelist was a hand-written array of the union's own type — which does not catch an omission. Adding `closing-statement` left it behind, and the first run to write one **made its own ledger unreadable**: the validator rejected an event the writer had just appended. Derived from a total record now, so the next kind fails typecheck instead.
- `STOP_SENTENCES` is total over the stop-reason union, so a reason added later cannot reach a user as an unlabelled ending.

## Verification

Live against the dev server with Gemini, planning mode:

```
Run opened in planning mode
Run started in planning mode
Closing statement — "To determine which departments have the highest average salary…
                    I would follow a systematic investigation plan: 1. Inspect the Schema…"
Run succeeded — "The model stopped without composing a cited report."
```

Six local gates green, coverage 100% (33711/33711).