### PR TITLE
fix(agent): bound one model call, and make four log lines say what happened

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -108,7 +108,25 @@ database would investigate the seed and report on it as though it were the one o
 
 A run emits a closed set of **semantic events**, and they are the whole of what the UI renders:
 `run-started`, `context-captured`, `statement-drafted`, `tool-invoked`, `tool-completed`,
-`tool-refused`, `report-composed`, `run-finished`.
+`tool-refused`, `report-composed`, `closing-statement`, `run-finished`.
+
+**`closing-statement` is the model's closing prose, and it is deliberately not a report.** It carries
+no citations and claims none, which is why it has its own kind rather than a lenient
+`report-composed`: a claim without evidence is inexpressible by design, and planning mode — which has
+no tools and so can never produce evidence — could therefore never say anything at all. Its whole
+output is one of these. An agent run's is an aside, except when it is the only thing the run left
+behind, which is exactly when it is worth seeing. It is written only when the prose is non-empty.
+
+**`run-finished` carries how the loop ended**, as `stopReason`: `report-composed`, `model-stopped`,
+`cancelled`, `deadline-exceeded`, `model-timeout` or `turn-limit`. This is what separates *succeeded*
+from *answered* — a run that stopped because the model composed a cited report and one that stopped
+because the model had nothing more to say are both `succeeded`, and only this says which. The rail
+reads it and states the difference. What it still cannot do is put that difference in the STATUS
+itself; the vocabulary for that arrives with M3's goal verifiers (`docs/BACKLOG.md` B24).
+
+`stopReason` sits beside `reason`, which says why a drive died before or outside the loop. They
+answer different questions and are mutually exclusive in practice; when both are present, `reason`
+is the one a user reads, because a dead drive is the more specific account of an ending.
 
 ## Durability and resume
 
@@ -468,6 +486,8 @@ declared-target allowlist, the statement guard and the role's own grants are the
   markup.
 - **B23** — seed eligibility is decided against the browser's last descriptor fetch, so a seed
   repointed server-side mid-session is not seen until the next fetch.
+- **B24** — a run that ends without a cited report is still `succeeded`; the timeline says so, the
+  status cannot, and the vocabulary that would (`needs_input`) arrives with M3's goal verifiers.
 
 ## Related documentation
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -225,8 +225,17 @@ agent's privileges.
 | `maxResultRows` / `maxResultBytes` | 200 / 256 KiB | Compared after the driver has materialised the rows, so an oversized read is refused but still paid for at the database. |
 | `maxConcurrentExecutions` | 1 | The loop is sequential; a run cannot fan out. |
 | Run deadline | 300 s | **Wall clock**, including model latency. |
+| One model call | 90 s | Whichever of this and the run's remaining time is smaller applies. |
 | Repair attempts | 3 | Statements that failed **at the database**. |
 | Model turns per drive | 16 | A backstop for a loop that never reaches the database. |
+
+**The per-call ceiling exists because the run deadline used to be the only bound on a single
+request.** A measured run ended at exactly 300.0 s with a two-event ledger: one call never answered
+and spent a budget meant to cover a whole investigation, while the rail showed nothing moving for
+five minutes. Turns on this workload land in seconds, so a call that reaches 90 s is not coming back.
+The two bounds stay distinct in what they report — `model-timeout` says a request never returned and
+starting again is reasonable; `deadline-exceeded` says the run used its time — and when less than the
+ceiling remains, the run's own reason is the one given.
 
 **The run deadline** is a monotonic per-run clock with an injected time source, and it answers two
 questions before every call: may this call start (`INSUFFICIENT_TIME_REMAINING` if its minimum

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1383,3 +1383,29 @@ Done when the run-start route validates the descriptor the browser believed it w
 a fingerprint sent with the request and compared server-side, refusing with a distinct reason when it
 has moved — rather than the client's snapshot being the only check. Until then `docs/AGENT.md` says
 the comparison is against the last fetch, not against the live descriptor.
+
+### B24. A run that answers nothing is still `succeeded`, and the vocabulary to say otherwise belongs to M3
+
+`AgentRunTerminalStatus` is `succeeded | failed | cancelled`. Nothing in it can say "this run
+finished, and did not answer". So an agent run that inspects the schema, executes its reads and then
+stops without calling `compose_report` ends `succeeded` — which is what nine live runs on 2026-08-12
+did, none of them producing a report.
+
+The user-facing half of this is closed. A run now records its `stopReason` and its closing prose, so
+the rail states plainly that "the model stopped without composing a cited report" and shows what the
+model actually said. What remains is the status word, and deliberately so:
+
+- **`failed` would be wrong for planning mode.** That mode has no tools and can never produce
+  evidence; a planning run that returned a good plan did exactly what the mode is for.
+- **Changing ledger semantics twice is the expensive kind of change.** Every past run is re-read
+  under the new meaning, so it is worth doing once, with the right vocabulary.
+- **The rule is not knowable yet.** M3 asks for goal verifiers *per template*, which implies the
+  answer differs by workflow type rather than being one predicate over every run.
+
+This is a hand-off, not a deferral: **#330 already owns it.** Its acceptance criteria name
+`needs_input` — a status this codebase does not have — and its policy unit gates require "citation
+present for every final finding". The verifier that decides whether a run answered is M3's work, and
+the vocabulary extension arrives with it.
+
+Done when a run that ends without a cited report says so in its STATUS as well as its timeline,
+under whatever term M3 ratifies, and every earlier ending still folds to the same meaning it had.

--- a/src/app/api/db/disconnect/route.ts
+++ b/src/app/api/db/disconnect/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    logger.error("[DB] Error disconnecting provider", { error: String(error) });
+    logger.error("[DB] Error disconnecting provider", error, { route: "POST /api/db/disconnect" });
     return NextResponse.json({ success: false, error: "Failed to disconnect" }, { status: 500 });
   }
 }

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -414,6 +414,26 @@ export function AgentRail({
         </ol>
 
         {/*
+          Said where the results are listed, and keyed on this run having stored any
+          plus the HOST's ability to show one — so it appears exactly when it explains
+          something: while the run is live it states the bound in advance, and once the
+          run has ended it says why the controls that were there are gone
+          (`docs/BACKLOG.md` B15).
+
+          It used to live inside the report section, which meant only a run that
+          composed a report ever explained itself. The runs that most need the sentence
+          compose nothing: a cancelled run observed on 2026-08-12 listed six stored
+          results, offered no control on any of them, and said nothing about why. The
+          bound belongs to the run's rows, not to its report.
+        */}
+        {onShowArtifact !== undefined && run.timeline.items.some((item) => item.artifactId !== undefined) && (
+          <p data-testid="agent-report-retention" className="px-3 pb-2 text-[0.625rem] text-zinc-600">
+            A run&apos;s stored rows are released when the run ends, so a result can be shown only while its run is
+            still going.
+          </p>
+        )}
+
+        {/*
           The run's conclusion, and the one place a user can check it: every claim
           is the model's own prose — quoted, never narrated as the app speaking —
           and every citation names something this run's ledger holds. The server
@@ -424,19 +444,6 @@ export function AgentRail({
         {run.timeline.report !== null && (
           <section data-testid="agent-report" className="border-t border-white/5 p-2 space-y-2">
             <h2 className="px-1 text-xs font-medium text-zinc-300">Report</h2>
-            {/*
-              Said where the controls would be, and deliberately keyed on the HOST's
-              ability to show a result rather than on this run's — so it is present
-              exactly when it explains something: while the run is live it states the
-              bound in advance, and once the run has ended it says why the controls
-              that were there are gone (`docs/BACKLOG.md` B15).
-            */}
-            {onShowArtifact !== undefined && (
-              <p data-testid="agent-report-retention" className="px-1 text-[0.625rem] text-zinc-600">
-                A run&apos;s stored rows are released when the run ends, so a result can be shown only while its run is
-                still going.
-              </p>
-            )}
             {run.timeline.report.claims.map((claim) => (
               <div key={claim.id} data-testid="agent-report-claim" className="rounded p-2 hover:bg-white/5">
                 <pre className="overflow-x-auto rounded bg-black/40 p-1.5 font-mono text-[0.625rem] text-zinc-300 whitespace-pre-wrap">

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -207,6 +207,7 @@ const STOP_SENTENCES = {
   "model-stopped": "The model stopped without composing a cited report.",
   cancelled: "Stopped because it was cancelled.",
   "deadline-exceeded": "The run reached its time limit before it finished.",
+  "model-timeout": "The model did not answer in time. Starting the run again is reasonable.",
   "turn-limit": "The run reached its step limit before it finished. What it had gathered is above.",
 } as const satisfies Record<AgentRunStopReason, string | null>;
 

--- a/src/hooks/use-connection-manager.ts
+++ b/src/hooks/use-connection-manager.ts
@@ -77,9 +77,8 @@ export function useConnectionManager(storageReady = false) {
         );
       } catch (error) {
         // Foreign keys / indexes are non-essential for browsing — log and move on.
-        logger.error("Failed to load schema relations (FK/indexes); table list unaffected", {
+        logger.error("Failed to load schema relations (FK/indexes); table list unaffected", error, {
           route: "use-connection-manager",
-          error: error instanceof Error ? error.message : String(error),
         });
       }
     },

--- a/src/lib/agent/execution-policy.ts
+++ b/src/lib/agent/execution-policy.ts
@@ -82,6 +82,23 @@ export const AGENT_EXECUTION_POLICY: ExecutionPolicy = Object.freeze({
 export const AGENT_RUN_DEADLINE_MS = 300_000;
 
 /**
+ * The longest ONE model call may take before the loop stops waiting for it.
+ *
+ * The run deadline used to be the only bound on a single request, and a measured run
+ * showed what that costs: an unanswered call ended a run at exactly 300.0s with a
+ * two-event ledger, having spent a budget meant to cover a whole investigation — and
+ * a user watched it do so with no feedback. Turns on this workload land in seconds,
+ * so a ceiling this far above them is only ever reached by a call that is not coming
+ * back.
+ *
+ * It bounds ONE call, never the run: the deadline is still the authority the loop
+ * reads between turns, and whichever is smaller applies. A run with less time left
+ * than this gets the run's own reason, because "this request never returned" and
+ * "this run used its time" are different things to tell a user.
+ */
+export const AGENT_MODEL_TURN_TIMEOUT_MS = 90_000;
+
+/**
  * The least time a single call could plausibly need. Below this, the deadline
  * refuses to start the call rather than beginning one it cannot finish. Kept well
  * under `statementTimeoutMs`, which `AgentRunDeadline.admit` requires: a minimum

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -46,7 +46,7 @@
 import { createHash } from "node:crypto";
 import { type ModelMessage, type ToolSet, streamText, tool } from "ai";
 import { captureContextSnapshot, packContextForTask, reusableSnapshot } from "./context-snapshot";
-import { AGENT_MAX_MODEL_TURNS } from "./execution-policy";
+import { AGENT_MAX_MODEL_TURNS, AGENT_MODEL_TURN_TIMEOUT_MS } from "./execution-policy";
 import { type AgentModel, mapAgentModelError } from "./model-adapter";
 import {
   type AgentRunInvocation,
@@ -78,6 +78,8 @@ export interface AgentInvestigationOptions {
   readonly resources: AgentToolResources;
   /** Backstop on model turns; defaults to `AGENT_MAX_MODEL_TURNS`. */
   readonly maxTurns?: number;
+  /** Ceiling on ONE model call; defaults to `AGENT_MODEL_TURN_TIMEOUT_MS`. */
+  readonly turnTimeoutMs?: number;
 }
 
 /**
@@ -464,6 +466,7 @@ export async function runInvestigation(
 ): Promise<AgentInvestigationResult> {
   const { service, model, resources } = options;
   const maxTurns = options.maxTurns ?? AGENT_MAX_MODEL_TURNS;
+  const turnTimeoutMs = options.turnTimeoutMs ?? AGENT_MODEL_TURN_TIMEOUT_MS;
 
   // Refuses a run that has ended, and tells us what the previous process left
   // behind. A queued run is one nothing has driven yet; a running one is a resume.
@@ -577,9 +580,12 @@ export async function runInvestigation(
     // cancelled or already out of time ends without reading a catalog first.
     if (!contextEstablished) await establishContext();
     turns += 1;
-    const turn = await takeTurn(model, instructions, messages, tools, remainingMs);
+    // Whichever bound is smaller applies, and which one it was decides what the user
+    // is told: a call that never returned is not a run that used its time.
+    const turnBudgetMs = Math.min(remainingMs, turnTimeoutMs);
+    const turn = await takeTurn(model, instructions, messages, tools, turnBudgetMs);
     text = turn.text;
-    if (turn.aborted) return conclude("failed", "deadline-exceeded");
+    if (turn.aborted) return conclude("failed", turnBudgetMs < remainingMs ? "model-timeout" : "deadline-exceeded");
     if (turn.toolCalls.length === 0) return conclude("succeeded", "model-stopped");
 
     messages.push(...turn.assistantMessages);

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -116,6 +116,8 @@ export type AgentRunStopReason =
   | "cancelled"
   /** The wall-clock budget ran out. */
   | "deadline-exceeded"
+  /** One model call did not return within its own ceiling. Retrying is reasonable. */
+  | "model-timeout"
   /** The model-turn ceiling was reached with work still in flight. */
   | "turn-limit";
 

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -559,7 +559,7 @@ export function registerShutdownHandlers(): void {
       await clearProviderCache();
       logger.info("[DB] All database connections closed gracefully");
     } catch (error) {
-      logger.error("[DB] Error during graceful shutdown", { error: String(error) });
+      logger.error("[DB] Error during graceful shutdown", error, { route: "db/factory" });
     }
     process.exit(0);
   };

--- a/src/lib/seed/credential-resolver.ts
+++ b/src/lib/seed/credential-resolver.ts
@@ -53,10 +53,9 @@ export function resolveAllCredentials(connections: SeedConnection[]): SeedConnec
     try {
       results.push(resolveConnectionCredentials(conn));
     } catch (err) {
-      logger.error("Seed connection skipped due to credential resolution failure", {
+      logger.error("Seed connection skipped due to credential resolution failure", err, {
         route: "seed/credential-resolver",
         connectionId: conn.id,
-        error: (err as Error).message,
       });
     }
   }

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -956,6 +956,35 @@ describe("AgentRail", () => {
       expect(queryAllByTestId("agent-apply-statement")).toHaveLength(0);
     });
 
+    /*
+      The note used to live inside the report section, which meant it appeared only
+      for runs that composed one — and the runs that most need it compose nothing.
+      Observed on 2026-08-12: a cancelled run showed six "Result stored" entries, no
+      "Show result" control on any of them, and no sentence anywhere saying why. A
+      user who watched the controls disappear was left to guess.
+
+      The bound is a property of the RUN's stored rows, not of its report, so the note
+      belongs wherever those rows are listed.
+    */
+    test("a run that ended without a report still says why its results cannot be shown", async () => {
+      mockAgentFetch([OPENED_LINE, STARTED_LINE, COMPLETED_LINE, CANCELLED_LINE, FINISHED_LINE]);
+      const { findByTestId, queryByTestId } = await runWith({ onShowArtifact: mock(() => {}) });
+
+      const note = await findByTestId("agent-report-retention");
+      expect(note.textContent).toContain("released when the run ends");
+      // No report was composed, which is exactly the case that had no explanation.
+      expect(queryByTestId("agent-report")).toBeNull();
+    });
+
+    test("a run that stored nothing says nothing about retention", async () => {
+      // Nothing was held, so there is no absence to explain.
+      mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE]);
+      const { findByTestId, queryByTestId } = await runWith({ onShowArtifact: mock(() => {}) });
+
+      await findByTestId("agent-run-status");
+      expect(queryByTestId("agent-report-retention")).toBeNull();
+    });
+
     test("with no way to show a result, the retention note is not shown either", async () => {
       mockAgentFetch([OPENED_LINE, STARTED_LINE, COMPLETED_LINE, REPORT_LINE, FINISHED_LINE]);
       const { findByTestId, queryByTestId } = await runWith({});

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -176,6 +176,20 @@ interface Turn {
 }
 
 /**
+ * A call that never answers, and ends the only way a real one can: when the transport
+ * is aborted.
+ *
+ * A promise that simply never settles would be an unfaithful double — a real `fetch`
+ * rejects when its signal fires, and a fixture that ignores the signal tests a
+ * transport nobody ships. It also hangs the test rather than failing it, which reads
+ * as "the ceiling does not work" whatever the code does.
+ */
+const unansweredCall = (turn: Turn): Promise<Response> =>
+  new Promise((_resolve, reject) => {
+    turn.signal?.addEventListener("abort", () => reject(new DOMException("The operation was aborted", "AbortError")));
+  });
+
+/**
  * A model whose every turn is a function of what it was actually sent.
  *
  * A turn may answer asynchronously: the cancellation test needs one that records a
@@ -966,6 +980,60 @@ describe("the run loop is bounded", () => {
     expect(result.status).toBe("failed");
     expect(result.stopReason).toBe("turn-limit");
     expect(result.turns).toBe(2);
+  });
+
+  /*
+    A model call that never answers used to cost the whole run.
+
+    Measured, not assumed: one planning run on 2026-08-12 ended at 300.0s — exactly
+    `AGENT_RUN_DEADLINE_MS` — with a two-event ledger. The deadline did its job
+    perfectly; the problem is that it was the ONLY bound on a single call, so one
+    unanswered request spent a five-minute budget that was meant to cover a whole
+    investigation, and the user watched a spinner for all of it.
+
+    A turn ceiling makes the failure cheap and, more importantly, nameable: the run
+    ends `model-timeout` rather than `deadline-exceeded`, because "this one request
+    never came back" and "this run used its time" are different things to be told.
+  */
+  test("one unanswered model call ends the turn, not the whole run budget", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "planning");
+    // Never resolves: only the turn ceiling can end this.
+    const script = scriptedModel(unansweredCall);
+
+    const started = Date.now();
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+      turnTimeoutMs: 200,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.stopReason).toBe("model-timeout");
+    // The run deadline is five minutes; this cost a fifth of a second.
+    expect(Date.now() - started).toBeLessThan(AGENT_RUN_DEADLINE_MS);
+
+    const finished = (await eventsOf(b.store, run.runId)).find((event) => event.kind === "run-finished");
+    expect(finished).toMatchObject({ status: "failed", stopReason: "model-timeout" });
+  });
+
+  test("a run that runs out of time is still reported as out of time, not as a slow call", async () => {
+    // The turn ceiling must not relabel the run deadline: when less time remains than
+    // a turn is allowed, the shorter bound is the run's own, and the reason follows it.
+    const b = boot(freshDataDir(), { spentMs: AGENT_RUN_DEADLINE_MS - 100 });
+    const run = await startRun(b, "planning");
+    const script = scriptedModel(unansweredCall);
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+      turnTimeoutMs: 60_000,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.stopReason).toBe("deadline-exceeded");
   });
 
   test("a spent deadline ends the run without asking the model anything", async () => {

--- a/tests/unit/logger-call-shape.test.ts
+++ b/tests/unit/logger-call-shape.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `logger.error` takes the error SECOND and the context THIRD.
+ *
+ * Passing the context where the error belongs compiles, runs, and produces a log line
+ * that names neither: `error?: unknown` accepts anything by design — you can throw a
+ * string — so the compiler cannot object, and the formatter renders the object as
+ * `Unknown: [object Object]` while the `context` slot stays empty, so the route and
+ * the ids that were carefully assembled never appear either.
+ *
+ * That is not hypothetical. Four call sites had it, and the loudest of them fired on
+ * every managed-connections request:
+ *
+ *     [ERROR] Seed connection skipped due to credential resolution failure | Unknown: [object Object]
+ *
+ * The connection id and the reason were both in the object being swallowed. An
+ * operator meeting that line learns only that something, somewhere, was skipped.
+ *
+ * A grep is a blunt instrument, and it is the right one here: the mistake is a shape
+ * the type system deliberately permits, so nothing but a reader — or this — will catch
+ * the fifth occurrence.
+ */
+
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "../..");
+
+/** `logger.error("...", {` — an object literal in the argument reserved for the error. */
+const CONTEXT_AS_ERROR = /logger\.error\(\s*(["'`])(?:(?!\1).)*\1\s*,\s*\{/;
+
+describe("logger.error is called with the error second and the context third", () => {
+  const files = [...new Bun.Glob("src/**/*.{ts,tsx}").scanSync(ROOT)];
+
+  test("the scan found source files (an empty scan would pass for the wrong reason)", () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  test("no call site passes a context object where the error belongs", async () => {
+    const offenders: string[] = [];
+    for (const relative of files) {
+      const source = await Bun.file(path.join(ROOT, relative)).text();
+      if (!source.includes("logger.error(")) continue;
+      const lines = source.split("\n");
+      for (const [index, line] of lines.entries()) {
+        // Anchored on the line the call STARTS on, so a wrapped call is reported once
+        // and at the line a reader would go to. The next line joins it because the
+        // context object commonly begins there.
+        if (!line.includes("logger.error(")) continue;
+        const window = `${line} ${(lines[index + 1] ?? "").trim()}`;
+        if (CONTEXT_AS_ERROR.test(window)) offenders.push(`${relative}:${index + 1}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Phase A4 and A5 from the roadmap. Both are about a user or an operator being told something true.

## A4 — a per-call ceiling, and a correction to the record

The roadmap recorded a **"398-second hang"**. Measuring it from the ledger instead of from my own polling shows the run ended at **300.0 seconds — exactly `AGENT_RUN_DEADLINE_MS`**. The deadline worked perfectly. 398 was when I *looked*, not when it happened, and reporting it as the run's duration was wrong.

What is real is narrower and still worth fixing: the run deadline was the **only** bound on a single model call, so one unanswered request spent a five-minute budget meant to cover a whole investigation — with nothing moving in the rail for all of it.

`AGENT_MODEL_TURN_TIMEOUT_MS` (90 s) bounds one call; whichever of it and the run's remaining time is smaller applies. Turns on this workload land in seconds, so a call that reaches the ceiling is not coming back.

The two bounds stay distinct in what they report, which is the point of splitting them:

| Stop reason | What it means |
|---|---|
| `model-timeout` | This request never returned. Starting the run again is reasonable. |
| `deadline-exceeded` | This run used its time. |

When less than the ceiling remains, the run's own reason wins — pinned by a test, because relabelling the deadline as a slow call is the easy mistake.

**On the test double:** an unanswered call rejects on the transport's abort signal rather than never settling. The harness already exposed `turn.signal` for exactly this — a fixture that ignores it tests a transport nobody ships, and *hangs* the test instead of failing it, which reads as "the ceiling does not work" whatever the code does.

## A5 — the argument that swallowed four log lines

`logger.error(message, error?, context?)` takes the error second. Four call sites passed their **context object** there, so the formatter rendered `Unknown: [object Object]` and the `context` slot stayed empty — losing both halves at once. The loudest fired on every managed-connections request:

```
Seed connection skipped due to credential resolution failure | Unknown: [object Object]
```

The connection id and the reason were both inside the object being swallowed. Verified live, it now reads:

```
{route=seed/credential-resolver, connId=employee-demo} Seed connection skipped due to
credential resolution failure | Error: Environment variable DEMO_DB_PASSWORD is not
defined (required by seed connection "employee-demo" field "password")
```

`error?: unknown` accepts anything by design — you can throw a string — so the compiler cannot object to the shape. A scanning test guards the class instead: a grep is a blunt instrument, and the right one when the mistake is a shape the type system deliberately permits.

## Checks

Six local gates green, coverage 100% (33719/33719).