### PR TITLE
feat(agent): refuse an incapable model at the start, not at its first tool call

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -293,7 +293,24 @@ A **capability probe** exists to establish, positively, that a configured model 
 the schema its tool arguments are declared against, and streams. It reports only what it observed on
 the wire — there is no capability table keyed on model names, because for `ollama` and `custom` kinds
 the model is whatever the operator is serving — and a failure that says nothing about the model (a
-bad key, a quota, a 5xx) reaches no verdict at all. It is not yet wired into the start path (B18).
+bad key, a quota, a 5xx) reaches no verdict at all.
+
+**The start path consults it before opening an agent run** (`capability-gate.ts`), and four decisions
+shape what that costs:
+
+- **Planning runs are not probed.** That mode is toolless by contract, so tool calling is not among
+  the capabilities it needs.
+- **Only an established incapability refuses**, with `422` and the probe's own sentence. Everything
+  the probe merely failed on starts as before, so the start path gained no new way to fail — and since
+  a drive now reports `model-rate-limited`, `model-unauthorized` or `model-unavailable`, those runs
+  say what happened rather than sitting at `queued`.
+- **Positive verdicts are cached for the life of the process; refusals are not.** A model that called
+  a tool keeps calling tools, so that round trip is paid once. A refusal is re-probed because an
+  operator can fix the server without changing the model id — an `ollama` endpoint serving something
+  else under the same name — and re-probing costs a round trip only to someone whose runs are already
+  failing.
+- **The cache key is the model's identity**, so a configuration change misses it by construction:
+  there is no invalidation hook to forget and no TTL to tune.
 
 ## HTTP surface
 
@@ -308,7 +325,7 @@ that *is* its answer, and the drive route verifies a machine credential instead 
 | Route | Purpose |
 | --- | --- |
 | `GET /api/agent/config` | Whether this server runs agents. Session-verified; answers the flag only, never the backend or the model. |
-| `POST /api/agent/runs` | Opens a run (mode, objective, `connectionId`) and returns `202` with the run id. An inline connection in the body is refused. |
+| `POST /api/agent/runs` | Opens a run (mode, objective, `connectionId`) and returns `202` with the run id. An inline connection in the body is refused. An agent run whose model was established as unable to call tools is refused `422` before any run is opened. |
 | `GET /api/agent/runs/{runId}` | The run record, folded from its ledger. |
 | `DELETE /api/agent/runs/{runId}` | Requests a stop. Cancellation is enforced by the run loop's own persisted state, not by a driver cancel propagating — so this is "asked to stop", not "has stopped". |
 | `GET /api/agent/runs/{runId}/stream` | The ledger as NDJSON, one entry per line. |
@@ -476,8 +493,6 @@ declared-target allowlist, the statement guard and the role's own grants are the
 - **B16** — the opt-in `@workflow/world-postgres` backend is not present in the standalone payload,
   so it cannot load in the container image or the npx payload.
 - **B17** — table profiling and monitoring tools are deferred; the M2 tool set is the four above.
-- **B18** — nothing calls the capability probe, so a model that cannot call tools is discovered at its
-  first tool call rather than refused at start.
 - **B19** — the agent endpoints are described here but are absent from
   [`docs/API_DOCS.md`](./API_DOCS.md).
 - **B20** — a Gemini deployment behind a proxy is not configurable: `LLM_API_URL` is unread for that

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1293,25 +1293,6 @@ tool is added to the read-class set. Done, for monitoring, only after a decision
 operation set grows a fourth descriptor for non-SQL metadata reads — which drags the verification
 marker, the provider triad and the security matrix with it, and is a human product call.
 
-### B18. Nothing calls the capability probe, so an incapable model is discovered at its first tool call
-
-`probeAgentModel` (`src/lib/agent/capability-probe.ts`) establishes positively that a configured model
-calls tools, honours the schema its tool arguments are declared against, and streams — and it has no
-caller in `src/`. The consequence is not a security gap (a model that cannot call tools simply does
-nothing) but a diagnosis gap: instead of a typed refusal at start pointing the user at the chat and
-NL2SQL surfaces that do work, the run opens, spends a drive, and ends with a model that answered in
-prose.
-
-It was left unwired for a real reason rather than by omission: a mandatory live probe on every run
-start adds a model round trip and a failure mode to the start path, and whether to pay that (per
-start, per configuration change, or cached with what invalidation) is a product decision T9's bar did
-not carry. There is a second, narrower limit worth stating in the same place: for the `ollama` and
-`custom` kinds the probe can only report what it observed on the wire, because the model is whatever
-the operator is serving — so "not established" there means "not observed", never "not supported".
-
-Done when the start path refuses a model whose capabilities were established as absent, with the
-refusal surfaced in the rail, and with the caching decision recorded rather than implied.
-
 ### B19. The agent endpoints are absent from docs/API_DOCS.md
 
 `docs/API_DOCS.md` documents every other route family (auth, database, AI, storage, connections,

--- a/src/app/api/agent/runs/route.ts
+++ b/src/app/api/agent/runs/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { admitAgentModel } from "@/lib/agent/capability-gate";
 import { isAgentRuntimeEnabled } from "@/lib/agent/config";
 import { driveAgentRun, getAgentRunService } from "@/lib/agent/runtime";
 import type { AgentRunMode } from "@/lib/agent/types";
@@ -75,6 +76,21 @@ export async function POST(req: Request) {
     }
 
     const connection = await resolveConnection({ connectionId }, guard.session);
+
+    /*
+      Before a run exists, not after one has failed. A model that cannot call tools
+      would otherwise open a run, spend a drive and end having answered in prose — the
+      diagnosis gap `docs/BACKLOG.md` B18 describes. The gate refuses only what the
+      probe positively ESTABLISHED, so nothing that merely went wrong (a quota, a bad
+      key, an unreachable endpoint) reaches here as a refusal; those still start, and
+      the drive reports them in its own vocabulary. 422 rather than 400: the request is
+      well-formed, and it is the server's configuration that cannot honour it.
+    */
+    const gate = await admitAgentModel(mode as AgentRunMode);
+    if (gate.kind === "refused") {
+      return NextResponse.json({ error: gate.refusal.message, missing: gate.refusal.missing }, { status: 422 });
+    }
+
     const service = await getAgentRunService();
     const record = await service.start({
       mode: mode as AgentRunMode,

--- a/src/lib/agent/capability-gate.ts
+++ b/src/lib/agent/capability-gate.ts
@@ -1,0 +1,117 @@
+/**
+ * Whether a configured model may drive an agent run (`docs/BACKLOG.md` B18).
+ *
+ * `capability-probe.ts` has always been able to answer "can this model call tools",
+ * and its docblock has always said "the run service asks this module first" — which
+ * was aspiration, not description. Nothing called it, so a model that answers in prose
+ * was discovered at its first tool call: the run opened, spent a drive and ended having
+ * established nothing. This module is the caller, and it sits on the start path so a
+ * refusal arrives before a run exists rather than as a run that failed.
+ *
+ * Four decisions, stated because B18 asks for them to be recorded rather than implied:
+ *
+ * **Planning mode is not probed.** It is toolless by contract (`types.ts`), so tool
+ * calling is not among the capabilities it needs, and probing would spend a model round
+ * trip answering a question the mode does not ask. The probe's own docblock leaves this
+ * choice to the caller; this is the caller making it.
+ *
+ * **Only an ESTABLISHED incapability refuses.** The probe throws — in this
+ * repository's `LLMError` vocabulary — for a bad key, a quota, an unpaid account, a
+ * 5xx or a dropped socket, none of which say anything about what the model can do.
+ * Those are let through. B18's own reservation was that a mandatory probe "adds a
+ * failure mode to the start path", and this is the answer to it: the start path gains
+ * no new way to fail, because the only new refusal is one the probe positively
+ * established. What happens to those runs is no longer a mystery either — since Phase A
+ * a drive reports `model-rate-limited`, `model-unauthorized` or `model-unavailable`
+ * rather than sitting at `queued`.
+ *
+ * **Positive verdicts are cached, and nothing else is.** A model that called a tool
+ * will keep calling tools, so that round trip is worth paying once — the alternative is
+ * a preflight on every run, which is the sort of cost that gets features turned off. A
+ * refusal is deliberately NOT cached: an operator can fix the server without changing
+ * the model id (an `ollama` endpoint serving something else under the same name is the
+ * case the probe's docblock already warns about), so a cached refusal would outlive the
+ * problem. Re-probing costs a round trip to someone whose runs are already failing.
+ *
+ * **The cache key is the model's identity**, so a configuration change misses by
+ * construction. There is no invalidation hook to forget to call, and no TTL to tune:
+ * the thing that would change the answer also changes the key. The one case it cannot
+ * see is a server swapped behind an unchanged id, which is exactly why refusals are not
+ * cached.
+ */
+
+import type { AgentRunMode } from "./types";
+import type { AgentCapabilityRefusal } from "./capability-probe";
+import { probeAgentModel } from "./capability-probe";
+import { type AgentModel, createAgentModel } from "./model-adapter";
+import { logger } from "@/lib/logger";
+
+export type AgentCapabilityGateVerdict =
+  | { readonly kind: "allowed" }
+  | { readonly kind: "refused"; readonly refusal: AgentCapabilityRefusal };
+
+/**
+ * Model identities established as able to drive a run. Process-scoped on purpose: a
+ * restarted server re-establishes it, which costs one round trip and is the honest
+ * answer to "was that still true after the restart".
+ */
+const established = new Set<string>();
+
+const identityOf = (model: AgentModel): string => `${model.provider}:${model.modelId}`;
+
+/** Test seam. A process-wide cache is exactly the state a suite must be able to clear. */
+export function resetAgentCapabilityCache(): void {
+  established.clear();
+}
+
+/**
+ * The model is built here rather than taken as an argument, and a construction failure
+ * is swallowed for the same reason a probe failure is: an unconfigured provider is not
+ * a statement about a model's capabilities, and the start path must not gain a new way
+ * to fail. The drive builds its own model moments later and reports that honestly.
+ */
+export async function admitAgentModel(mode: AgentRunMode): Promise<AgentCapabilityGateVerdict> {
+  if (mode === "planning") return { kind: "allowed" };
+
+  let model: AgentModel;
+  try {
+    model = await createAgentModel();
+  } catch (error) {
+    logger.warn("Model could not be built for the capability gate; starting the run anyway", {
+      route: "agent/capability-gate",
+      error: error instanceof Error ? error.name : "unknown",
+    });
+    return { kind: "allowed" };
+  }
+
+  const identity = identityOf(model);
+  if (established.has(identity)) return { kind: "allowed" };
+
+  let result: Awaited<ReturnType<typeof probeAgentModel>>;
+  try {
+    result = await probeAgentModel(model);
+  } catch (error) {
+    // Not a verdict about the model. Logged rather than surfaced, because the run is
+    // about to be started and its own failure will carry the reason.
+    logger.warn("Model capability probe was inconclusive; starting the run anyway", {
+      route: "agent/capability-gate",
+      provider: model.provider,
+      modelId: model.modelId,
+      error: error instanceof Error ? error.name : "unknown",
+    });
+    return { kind: "allowed" };
+  }
+
+  if (result.supported) {
+    established.add(identity);
+    return { kind: "allowed" };
+  }
+
+  logger.warn("Model refused an agent run: its capabilities were established as absent", {
+    route: "agent/capability-gate",
+    provider: result.refusal.provider,
+    modelId: result.refusal.modelId,
+    missing: result.refusal.missing.join(","),
+  });
+  return { kind: "refused", refusal: result.refusal };
+}

--- a/src/lib/api/agent-run-access.ts
+++ b/src/lib/api/agent-run-access.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { isAgentRuntimeEnabled } from "@/lib/agent/config";
 import type { AgentRunService, AgentRunStatusReport } from "@/lib/agent/run-service";
+import { AgentRunStoreError } from "@/lib/agent/run-store";
 import { getAgentRunService } from "@/lib/agent/runtime";
 import { guardRoute } from "@/lib/api/require-session";
 import type { UserPayload } from "@/lib/auth";
@@ -45,7 +46,26 @@ export async function accessAgentRun(opts: {
   if (!isAgentRuntimeEnabled()) return { response: notFound() };
 
   const service = await getAgentRunService();
-  const report = await service.status(opts.runId);
+
+  /*
+    A run id the LEDGER cannot name joins the same bucket. The store refuses one before
+    it touches anything (`AGENT_RUN_ID_PATTERN` — a run id becomes a stream name), which
+    is the guard doing its job; what was missing is that the refusal had no HTTP
+    meaning, so asking for `../../etc/passwd` produced a bodyless 500 instead of an
+    answer. It cannot exist, so it answers like a run that does not — the same reason a
+    run belonging to somebody else does. Only THAT reason is caught: a malformed ledger
+    or a backend that is genuinely broken must still surface as a server error.
+  */
+  let report: AgentRunStatusReport | null;
+  try {
+    report = await service.status(opts.runId);
+  } catch (error) {
+    if (error instanceof AgentRunStoreError && error.reasonCode === "INVALID_RUN_ID") {
+      return { response: notFound() };
+    }
+    throw error;
+  }
+
   if (report === null || report.record.actor.sessionId !== guard.session.username) {
     return { response: notFound() };
   }

--- a/tests/api/agent/runs.test.ts
+++ b/tests/api/agent/runs.test.ts
@@ -14,6 +14,7 @@ import { AgentRunServiceError } from "@/lib/agent/run-service";
 import { clearRateLimitState } from "@/lib/api/rate-limit";
 import * as realAuth from "@/lib/auth";
 import * as realSeed from "@/lib/seed/resolve-connection";
+import * as realGate from "@/lib/agent/capability-gate";
 
 const { SeedConnectionError } = realSeed;
 
@@ -24,6 +25,8 @@ const mockGetSession = mock(
 );
 
 // ─── The connection the run is opened against ───────────────────────────────
+
+const mockAdmitAgentModel = mock<typeof realGate.admitAgentModel>(async () => ({ kind: "allowed" }));
 
 const mockResolveConnection = mock(async (body: { connectionId?: string }) => ({
   id: body.connectionId ?? "seed:sales",
@@ -99,6 +102,9 @@ function installMocks(): void {
   // replacement stays installed for the rest of the process and breaks the next
   // file that imports an export this one forgot.
   mock.module("@/lib/auth", () => ({ ...realAuth, getSession: mockGetSession }));
+  // The gate would otherwise build a real model and, where a key is configured, put a
+  // live probe call inside this suite.
+  mock.module("@/lib/agent/capability-gate", () => ({ ...realGate, admitAgentModel: mockAdmitAgentModel }));
   mock.module("@/lib/seed/resolve-connection", () => ({ ...realSeed, resolveConnection: mockResolveConnection }));
   mock.module("@/lib/agent/runtime", () => ({
     getAgentRunService: mock(async () => ({
@@ -137,11 +143,43 @@ beforeEach(() => {
   mockGetSession.mockResolvedValue({ role: "user", username: "ada" });
   process.env[AGENT_ENABLED_ENV] = "true";
   mockDriveAgentRun.mockClear();
+  mockAdmitAgentModel.mockClear();
+  mockAdmitAgentModel.mockImplementation(async () => ({ kind: "allowed" }));
   mockStart.mockClear();
   mockResolveConnection.mockClear();
 });
 
 describe("POST /api/agent/runs", () => {
+  /*
+    A model that cannot call tools is refused BEFORE a run exists, which is the whole
+    point of the gate (`docs/BACKLOG.md` B18): otherwise the run opens, spends a drive
+    and ends having answered in prose, and the user is left reading a failed run to
+    learn something the server could have said at the start. 422 because the request is
+    well-formed — it is the configuration that cannot honour it — and no ledger is
+    written for a run that never began.
+  */
+  test("a model established as unable to drive a run is refused before one is opened", async () => {
+    mockAdmitAgentModel.mockImplementation(async () => ({
+      kind: "refused",
+      refusal: {
+        provider: "gemini",
+        modelId: "some-model",
+        capabilities: { toolCalling: false, structuredOutput: false, streaming: true },
+        missing: ["toolCalling"],
+        message: "This model does not call tools. Use the AI Assistant or Natural Language Query instead.",
+      },
+    }));
+
+    const res = await POST(startRequest(VALID_BODY));
+    const body = await parseResponseJSON<{ error: string; missing: string[] }>(res);
+
+    expect(res.status).toBe(422);
+    expect(body.error).toContain("does not call tools");
+    expect(body.missing).toEqual(["toolCalling"]);
+    expect(mockStart).not.toHaveBeenCalled();
+    expect(mockDriveAgentRun).not.toHaveBeenCalled();
+  });
+
   test("opens a run for the session's own actor and reports it queued", async () => {
     const res = await POST(startRequest(VALID_BODY));
     const body = await parseResponseJSON<{ runId: string; status: string; mode: string }>(res);

--- a/tests/api/agent/runs.test.ts
+++ b/tests/api/agent/runs.test.ts
@@ -15,6 +15,7 @@ import { clearRateLimitState } from "@/lib/api/rate-limit";
 import * as realAuth from "@/lib/auth";
 import * as realSeed from "@/lib/seed/resolve-connection";
 import * as realGate from "@/lib/agent/capability-gate";
+import { AgentRunStoreError } from "@/lib/agent/run-store";
 
 const { SeedConnectionError } = realSeed;
 
@@ -327,6 +328,33 @@ describe("GET /api/agent/runs/[runId]", () => {
     const res = await GET(createMockRequest("/api/agent/runs/arun_9"), params("arun_9"));
 
     expect(res.status).toBe(404);
+  });
+
+  /*
+    A run id the LEDGER cannot name is a run that cannot exist, so it answers like one.
+
+    Found by asking the running server for `../../etc/passwd`: the store's id guard
+    refused it before touching the filesystem — which is the guard working — but the
+    error reached no HTTP mapping and fell through as a bodyless 500. A malformed id is
+    the caller's mistake, and this module's own rule is that "no such run", "not yours"
+    and "runtime off" answer identically; teaching a caller the id grammar through a
+    different status would undo that.
+  */
+  test("a run id the ledger cannot name answers exactly like a run that does not exist", async () => {
+    // Once: a persistent replacement would outlive this test, because `mock.module`
+    // installs it for the whole process.
+    mockStatus.mockImplementationOnce(async (runId: string) => {
+      throw new AgentRunStoreError(
+        "INVALID_RUN_ID",
+        `agent run id "${runId}" is not usable as a ledger name: expected 1-64 characters of [A-Za-z0-9_]`,
+      );
+    });
+
+    const res = await GET(createMockRequest("/api/agent/runs/arun-with-hyphens"), params("arun-with-hyphens"));
+    const body = await parseResponseJSON<{ error: string }>(res);
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("No such agent run");
   });
 
   test("an unauthenticated caller is refused", async () => {

--- a/tests/isolated/agent-capability-gate.test.ts
+++ b/tests/isolated/agent-capability-gate.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The start path's model gate (`docs/BACKLOG.md` B18).
+ *
+ * `probeAgentModel` establishes positively that a configured model calls tools, honours
+ * the schema its arguments are declared against, and streams — and until now nothing
+ * called it. Its own docblock claimed "the run service asks this module first", which
+ * was aspiration rather than description: an incapable model was discovered at its
+ * first tool call, after a run had opened and spent a drive answering in prose.
+ *
+ * Four decisions are pinned here, because B18 asks for them to be recorded rather than
+ * implied:
+ *
+ *  1. **Planning mode is not probed.** That mode is toolless by contract, so tool
+ *     calling is not a capability it needs. Probing it would spend a model round trip
+ *     to answer a question the mode does not ask.
+ *  2. **Only an ESTABLISHED incapability refuses.** The probe THROWS for a bad key, a
+ *     quota, a 5xx or a dropped socket — none of which say anything about the model —
+ *     and the gate lets those through rather than adding a failure mode to the start
+ *     path. The drive then reports them honestly (`model-rate-limited`,
+ *     `model-unavailable`), which it did not do before Phase A and does now.
+ *  3. **Positive verdicts are cached; nothing else is.** A model that called a tool
+ *     will keep calling tools, so paying for that round trip once is enough. A refusal
+ *     is not cached because an operator can fix the server without changing the model
+ *     id — an `ollama` endpoint serving something else under the same name is the case
+ *     — and the cost of re-probing falls only on someone whose runs are already
+ *     failing.
+ *  4. **The key is the model's identity**, so a configuration change misses the cache
+ *     by construction instead of needing an invalidation hook.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { LLMConfigError, LLMRateLimitError } from "@/lib/llm/types";
+import type { AgentModel } from "@/lib/agent/model-adapter";
+import type { AgentCapabilityProbeResult } from "@/lib/agent/capability-probe";
+
+const probeAgentModel = mock<(model: AgentModel) => Promise<AgentCapabilityProbeResult>>(async () => ({
+  supported: true,
+  capabilities: { toolCalling: true, structuredOutput: true, streaming: true },
+}));
+
+mock.module("@/lib/agent/capability-probe", () => ({ probeAgentModel }));
+
+const model = (modelId = "gemini-3.5-flash-lite"): AgentModel =>
+  ({ provider: "gemini", modelId, model: {} }) as unknown as AgentModel;
+
+const createAgentModel = mock<() => Promise<AgentModel>>(async () => model());
+
+mock.module("@/lib/agent/model-adapter", () => ({ createAgentModel }));
+
+const { admitAgentModel, resetAgentCapabilityCache } = await import("@/lib/agent/capability-gate");
+
+const REFUSAL = {
+  supported: false as const,
+  refusal: {
+    provider: "gemini" as const,
+    modelId: "gemini-3.5-flash-lite",
+    capabilities: { toolCalling: false, structuredOutput: false, streaming: true },
+    missing: ["toolCalling" as const],
+    message: "This model does not call tools. Use the AI Assistant or Natural Language Query instead.",
+  },
+};
+
+beforeEach(() => {
+  resetAgentCapabilityCache();
+  probeAgentModel.mockClear();
+  createAgentModel.mockClear();
+  createAgentModel.mockImplementation(async () => model());
+  probeAgentModel.mockImplementation(async () => ({
+    supported: true,
+    capabilities: { toolCalling: true, structuredOutput: true, streaming: true },
+  }));
+});
+
+afterEach(() => {
+  resetAgentCapabilityCache();
+});
+
+describe("the model gate on the start path", () => {
+  test("a planning run is admitted without spending a model call", async () => {
+    const verdict = await admitAgentModel("planning");
+
+    expect(verdict.kind).toBe("allowed");
+    expect(probeAgentModel).not.toHaveBeenCalled();
+  });
+
+  test("an agent run is probed, and admitted when the model can drive one", async () => {
+    const verdict = await admitAgentModel("agent");
+
+    expect(verdict.kind).toBe("allowed");
+    expect(probeAgentModel).toHaveBeenCalledTimes(1);
+  });
+
+  test("a model established as unable to call tools is refused, with the probe's own words", async () => {
+    probeAgentModel.mockImplementation(async () => REFUSAL);
+
+    const verdict = await admitAgentModel("agent");
+
+    expect(verdict).toMatchObject({ kind: "refused", refusal: { missing: ["toolCalling"] } });
+  });
+
+  test("a probe that says nothing about the model admits the run", async () => {
+    // A quota is not a capability. Refusing here would replace an honest run-level
+    // failure with a start-level one, for a condition that clears itself.
+    probeAgentModel.mockImplementation(async () => {
+      throw new LLMRateLimitError("quota exceeded", "gemini");
+    });
+
+    const verdict = await admitAgentModel("agent");
+
+    expect(verdict.kind).toBe("allowed");
+  });
+
+  test("a capable model is probed once, however many runs follow", async () => {
+    await admitAgentModel("agent");
+    await admitAgentModel("agent");
+    await admitAgentModel("agent");
+
+    expect(probeAgentModel).toHaveBeenCalledTimes(1);
+  });
+
+  test("a refusal is re-probed, because the operator may have fixed the server", async () => {
+    probeAgentModel.mockImplementation(async () => REFUSAL);
+    expect((await admitAgentModel("agent")).kind).toBe("refused");
+
+    probeAgentModel.mockImplementation(async () => ({
+      supported: true,
+      capabilities: { toolCalling: true, structuredOutput: true, streaming: true },
+    }));
+    expect((await admitAgentModel("agent")).kind).toBe("allowed");
+    expect(probeAgentModel).toHaveBeenCalledTimes(2);
+  });
+
+  test("a different model is a different question", async () => {
+    // The cache key IS the configuration, so changing the model misses it without any
+    // invalidation hook — which is the point of keying it that way.
+    createAgentModel.mockImplementationOnce(async () => model("gemini-3.5-pro"));
+    await admitAgentModel("agent");
+    await admitAgentModel("agent");
+
+    expect(probeAgentModel).toHaveBeenCalledTimes(2);
+  });
+
+  test("a model that cannot even be built admits the run", async () => {
+    // An unconfigured provider says nothing about a model's capabilities, and the start
+    // path must not gain a way to fail that it did not have.
+    createAgentModel.mockImplementationOnce(async () => {
+      throw new LLMConfigError("Gemini API key is required", "gemini");
+    });
+
+    const verdict = await admitAgentModel("agent");
+
+    expect(verdict.kind).toBe("allowed");
+    expect(probeAgentModel).not.toHaveBeenCalled();
+  });
+});

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -136,6 +136,13 @@ run_group "Group 0g: Agent runtime composition" \
 run_group "Group 0h: Agent end-to-end investigation" \
   tests/isolated/agent-investigation-e2e.test.ts
 
+# Group 0i: The start path's model gate. Its own group, NOT part of 0f: it mocks
+# @/lib/agent/capability-probe and @/lib/agent/model-adapter, and mock.module is
+# process-wide — 0f contains the suites for both of those modules, so sharing its
+# process would hand them the stubs written for this one.
+run_group "Group 0i: Agent capability gate" \
+  tests/isolated/agent-capability-gate.test.ts
+
 # Group 1: Studio (isolated — mocks almost every child component)
 run_group "Group 1/6: Studio" \
   tests/components/Studio.test.tsx


### PR DESCRIPTION
Closes backlog **B18**, and wires up a module that has been able to answer this question since M2 while nothing asked it. `capability-probe.ts`'s own docblock said *"the run service asks this module first"* — aspiration, not description. Until now a model that cannot call tools was discovered by opening a run, spending a drive and ending with prose where an investigation should have been.

B18 asked for four decisions to be **recorded rather than implied**, so they are — in the module, in the tests, and in `docs/AGENT.md`:

### Planning runs are not probed
That mode is toolless by contract, so tool calling is not among the capabilities it needs. Probing would spend a model round trip answering a question the mode does not ask.

### Only an ESTABLISHED incapability refuses
`422`, with the probe's own sentence. The probe throws for a bad key, a quota, an unpaid account, a 5xx or a dropped socket — none of which say anything about what a model can do — and the gate lets all of those start.

That is the direct answer to B18's own reservation, that a mandatory probe *"adds a failure mode to the start path"*: it adds none. It also only became reasonable **after Phase A**, which is why it lands now — those runs used to sit at `queued`, and now report `model-rate-limited`, `model-unauthorized` or `model-unavailable` themselves.

### Positive verdicts are cached for the process's life; nothing else is
A model that called a tool keeps calling tools, so the round trip is paid once — a preflight on every run is the kind of cost that gets a feature turned off.

Refusals are deliberately **not** cached: an operator can fix the server without changing the model id (an `ollama` endpoint serving something else under the same name is the case the probe already warns about), so a cached refusal would outlive the problem. Re-probing costs a round trip only to someone whose runs are already failing.

### The cache key is the model's identity
A configuration change misses it by construction — no invalidation hook to forget, no TTL to tune. The one thing it cannot see is a server swapped behind an unchanged id, which is exactly why refusals are not cached.

---

The refusal happens **before `service.start`**, so a rejected run leaves no ledger behind: there is no failed run to explain, because no run began.

**A note on the test wiring worth reading:** the new isolated suite needed its own group in `run-components.sh`. Without one it was in *no* group — `bun run test` never ran it, and the **coverage gate is what noticed**, reporting the whole module as uncovered. It cannot join Group 0f, which contains the suites for the two modules it mocks.

Six local gates green, coverage 100% (33761/33761).