### PR TITLE
feat(agent): the database-assessment template — a profile records counts, never values (#330 T3)

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -296,6 +296,52 @@ Its goal verifier is `agent-query-optimization.1`: the investigation baseline, *
 comparison on the ledger. The baseline dominates, so a run that never reported is told that rather
 than that it skipped a comparison.
 
+### The database-assessment template
+
+A run opened as `database-assessment` is offered one further tool, `profile_table`, and no other
+workflow is.
+
+**A profile records counts, never values.** That is the rule the whole feature is built around, and
+it is what makes profiling a table of personal data acceptable at all: every statistic is an
+aggregate — how many rows, how many present, how many distinct, how many match a shape — so no name,
+address or account number is written to the ledger, shown to the model, or rendered in the rail. A
+`min`/`max` of a text column would return an actual value, which is why neither is composed even
+though both are conventional in a profiler.
+
+| Depth | Adds |
+| --- | --- |
+| `basic` | Row count, and how many rows have a value in each column |
+| `distribution` | Distinct counts |
+| `pattern` | A shape test for personal data, counted with `count(CASE WHEN … LIKE …)` **inside** the database, so no matching value leaves it |
+
+The model names a **table**, never columns and never SQL. The columns come from the run's own
+captured inventory, so a profile cannot be aimed at something the run never established exists, and
+an unqualified name is resolved against a qualified inventory only when exactly one table matches —
+two schemas holding the same table name is precisely when a guess would profile the wrong one.
+
+The findings are the **server's**, each a mechanical predicate over counts with a stated threshold:
+`high_null`, `constant`, `low_cardinality`, `suspected_pii`, plus `fk_unindexed` derived from the
+inventory rather than the numbers. A model may interpret them; it cannot invent one.
+
+`suspected_pii` is a suspicion and says so — read from the column's **name**, and at `pattern` depth
+from the **ratio** of values matching a shape. Neither establishes that a column holds personal data;
+both establish that it is worth a human looking.
+
+Its goal verifier is `agent-database-assessment.1`: the investigation baseline, **and** a table
+actually profiled. An assessment written from the schema alone describes the shape of a database;
+this workflow is about the state of its data.
+
+**Profiling reaches the database through a fourth operation descriptor** (`sql.table.profile`, R1),
+and that is a reversal of a product decision rather than an oversight: epic #325 pinned the canonical
+set at three and #330 T3 reopened it. Its own id is what lets an operator see profiling in the audit
+stream, and deny it, without denying every read the agent makes.
+
+Four honest limits, each with a backlog entry: SQLite hides constraint-created indexes so
+`fk_unindexed` can fire on a covered key (**B25**); only an email shape is tested, because `LIKE`
+cannot express a digit run (**B26**); no monitor snapshot is produced, because engine health reaches
+provider methods no descriptor covers (**B27**); and a profile that times out reports the failure
+rather than falling back to catalog statistics (**B28**).
+
 **Database content is untrusted input.** A table name, a column comment, a row value and an engine
 error message all come from whoever can write to the database, so everything crossing into a prompt
 is fenced first: a header naming what the content is and where it came from, and a stated boundary
@@ -405,8 +451,9 @@ build until somebody decides what "answered" means for it.
 | Mode | Rule (`agent-planning.1` / `agent-investigation.1`) | Unmet when it fails |
 | --- | --- | --- |
 | `planning` | The run left non-empty closing prose. That mode is toolless and can never cite evidence, so judging it by the investigation rule would fail every planning run that did its job. | `no-plan` |
-| `agent` (investigation, database-assessment) | The run composed at least one claim, **and** the claims do not rest entirely on empty results. | `no-report`, `empty-evidence` |
+| `agent` (investigation) | The run composed at least one claim, **and** the claims do not rest entirely on empty results. | `no-report`, `empty-evidence` |
 | `agent` (query-optimization) | The baseline above, **and** a plan comparison on the ledger. `agent-query-optimization.1`. | the above, plus `no-plan-comparison` |
+| `agent` (database-assessment) | The baseline above, **and** a table profiled. `agent-database-assessment.1`. | the above, plus `no-table-profile` |
 
 A run stopped by its user reports `cancelled` instead of the missing output: a stop is not
 a defect of the run, and counting it as one would make every cancellation read as a model
@@ -598,6 +645,7 @@ src/lib/agent/
 ├── provider-registry.ts  # provider kind → adapter (total over the settings surface's union)
 ├── goal-verifier.ts      # did this run ANSWER? a pure fold over the ledger, per workflow
 ├── plan-summary.ts       # how an engine reaches its rows, read from an ESTIMATING plan
+├── table-profile.ts      # composed per-table aggregates, and the findings derived from them
 ├── capability-probe.ts   # tool calling / structured output / streaming, established positively
 ├── drive-token.ts        # the single-purpose credential the resume seam verifies
 └── untrusted-content.ts  # the prompt-side fence for database content

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -317,7 +317,26 @@ though both are conventional in a profiler.
 The model names a **table**, never columns and never SQL. The columns come from the run's own
 captured inventory, so a profile cannot be aimed at something the run never established exists, and
 an unqualified name is resolved against a qualified inventory only when exactly one table matches —
-two schemas holding the same table name is precisely when a guess would profile the wrong one.
+two schemas holding the same table name is precisely when a guess would profile the wrong one. **The
+composed statement targets what was RESOLVED**, not the model's spelling: composing from the
+spelling left PostgreSQL's `search_path` to decide which relation was read while the ledger said a
+qualified one had been profiled.
+
+A profile **settles a step**, like every other database reach: its invocation is on the ledger before
+its effect, so it inherits the cancellation checkpoint, the replay of an identical call, and the
+indeterminate-step rule. That matters more than it looks — three separate consumers read
+`tool-completed` and nothing else (a report's citation check, the artifact route's authorization, and
+the rail's budget meter), so a profile that settled no step would be citable in a report whose "Show
+result" answered 404, on a meter reading zero.
+
+One profile covers a bounded number of columns, and says how many it did **not** cover. A wider table
+is profiled in further calls with `fromColumn`; without that, columns past the bound could never be
+assessed while the run still counted as having profiled the table.
+
+A column whose declared type has no equality operator — `json`, `jsonb`, `xml`, the geometric
+types — gets no distinct count. One such column would otherwise abort the whole aggregate
+(`could not identify an equality operator for type json`) and take every other column's statistics
+with it.
 
 The findings are the **server's**, each a mechanical predicate over counts with a stated threshold:
 `high_null`, `constant`, `low_cardinality`, `suspected_pii`, plus `fk_unindexed` derived from the

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1271,7 +1271,15 @@ asserting it (`tests/unit/packaging-payload-prune.test.ts` pins what the payload
 nearest existing home for such an assertion), and when `docs/AGENT.md`'s deployment section loses the
 caveat that points here.
 
-### B17. Table profiling and monitoring tools are deferred, so the agent's tool set is four
+### B17. Monitoring tools are deferred; profiling landed with #330 T3
+
+**Half of this entry is done and the other half is unchanged.** #330 T3 instructed that profiling
+reach the database "as new descriptors in `descriptors.ts` at R0/R1", which reopened the
+three-descriptor product decision this entry rested on: `sql.table.profile` is registered, and
+`profile_table` is offered to the `database-assessment` workflow. What follows is the original
+reasoning, kept because the monitoring half still stands on it.
+
+
 
 Recorded as #329's own narrowing (planning decision P1), not as something discovered later. The
 canonical operation set is exactly three descriptors (`src/lib/db/operations/descriptors.ts`), and the
@@ -1390,3 +1398,61 @@ the vocabulary extension arrives with it.
 
 Done when a run that ends without a cited report says so in its STATUS as well as its timeline,
 under whatever term M3 ratifies, and every earlier ending still folds to the same meaning it had.
+
+### B25. SQLite hides constraint-created indexes, so `fk_unindexed` can fire on a covered key
+
+`composeSqliteIndexes` reads the index inventory from `CREATE INDEX` text (`sql IS NOT NULL`), and
+the indexes SQLite creates for a `UNIQUE` or `PRIMARY KEY` constraint carry no DDL at all. They are
+therefore absent from the captured inventory, and a foreign-key column covered by a `UNIQUE`
+constraint looks uncovered to `findUnindexedForeignKeys` (`src/lib/agent/table-profile.ts`).
+
+The finding is worded to survive this — "no index **in the captured inventory** leads on this
+foreign-key column", not "this foreign key is unindexed" — and the primary key is read from the
+column inventory rather than the index one, so a PK-covered key is already correct. What remains
+wrong is the `UNIQUE` case, which reports a covering index that exists.
+
+Done when the SQLite capture surfaces constraint-created indexes — the information is in the table's
+own stored DDL, which `parseSqliteTableDdl` already reads for columns and foreign keys and could read
+for `UNIQUE` clauses too — or when the finding is suppressed on SQLite for columns a `UNIQUE`
+constraint covers. Related: B7 (PostgreSQL expression indexes are absent) and B8 (a composite foreign
+key comes back as the cross product of its sides, which is why composite keys are skipped entirely).
+
+### B26. A profile can test for an email shape and not for a digit run
+
+`table-profile.ts` tests one value shape inside the database, `LIKE '%_@_%._%'`, and derives
+`suspected_pii` from the ratio of matches. A run of digits — a phone number, a national id, a card
+number — is the other shape worth suspecting, and `LIKE` cannot express it: `_` means "any
+character", so a length test would match almost any text. PostgreSQL spells it `~ '[0-9]{9}'` and
+SQLite spells it `GLOB '*[0-9][0-9][0-9]…*'`.
+
+An earlier draft of this module shipped `LIKE '%_________%'` as a "nine digits" test, which would
+have produced a `suspected_pii` finding for essentially every text column. It was removed before it
+landed rather than approximated.
+
+Done when the shape tests are per-dialect predicates rather than one shared `LIKE`, with the digit
+run among them and each verified against that engine's own grammar.
+
+### B27. A database assessment reports no monitor snapshot
+
+#330 T3 lists a monitor snapshot among the assessment template's outputs. It is not built, for the
+reason B17 gives: engine health reaches `getMetrics`, slow-query listings and session listings, which
+are provider methods no operation descriptor covers. A profiling descriptor could be added because a
+profile is a composed SQL statement; a metrics read is not, so it needs a descriptor shape for
+non-SQL reads — with its own verification marker, its own provider triad and its own security-matrix
+row — which is a product decision rather than a subtask.
+
+Done when that shape exists and the assessment template reports engine health beside its table
+profiles.
+
+### B28. A profile that times out reports nothing rather than falling back to catalog statistics
+
+#330 T3 asks for "a timeout fallback to catalog stats". A profile that exceeds
+`statementTimeoutMs` currently surfaces as a repairable database error, so the model may narrow the
+profile or move on — but nothing reads `pg_stats` / `sqlite_stat1` for the approximate answer the
+engine already holds.
+
+The gap is honest rather than silent (the run is told the statement failed), and the fallback is a
+second composition path per dialect whose numbers are estimates the planner maintains, so a profile
+built from it would have to say which of its figures were measured and which were the engine's own
+estimate. Done when that distinction is carried in `AgentTableProfile` and the fallback is composed
+per dialect.

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -362,6 +362,19 @@ function describeEvent(event: AgentRunEvent): Omit<AgentTimelineItem, "id" | "at
         // else. Nothing in this runtime executes it.
         applySql: event.statement,
       };
+    case "table-profiled":
+      return {
+        tone: "progress",
+        headline: `Profiled ${event.profile.table}`,
+        // Counts and the app's own words for what they mean. No value from the
+        // column is here, because none was read — see `table-profile.ts`.
+        detail:
+          event.profile.findings.length === 0
+            ? `${event.profile.rowCount} row(s), ${event.profile.columns.length} column(s) at ${event.profile.depth} depth. Nothing stood out.`
+            : `${event.profile.rowCount} row(s) at ${event.profile.depth} depth. ${event.profile.findings
+                .map((finding) => `${finding.column}: ${finding.code} — ${finding.detail}`)
+                .join(" ")}`,
+      };
     case "closing-statement":
       return {
         // Content the run produced, so it reads like the report entry rather than

--- a/src/lib/agent/goal-verifier.ts
+++ b/src/lib/agent/goal-verifier.ts
@@ -46,7 +46,11 @@ import type { AgentReportClaim, AgentRunEvent, AgentRunMode, AgentRunRecord, Age
  * rule that changes its mind is a new id rather than the same one meaning
  * something else.
  */
-export type AgentGoalVerifierId = "agent-planning.1" | "agent-investigation.1" | "agent-query-optimization.1";
+export type AgentGoalVerifierId =
+  | "agent-planning.1"
+  | "agent-investigation.1"
+  | "agent-query-optimization.1"
+  | "agent-database-assessment.1";
 
 /**
  * What a run was required to produce and did not. Deliberately a closed union of
@@ -69,6 +73,14 @@ export type AgentGoalShortfall =
    * of its own opinion, and that is precisely what this workflow exists not to do.
    */
   | "no-plan-comparison"
+  /**
+   * A database-assessment run never profiled a table.
+   *
+   * The template's own artifact. An assessment composed from the schema alone is a
+   * description of the shape of the database, not of the state of its data — which
+   * is what the workflow is for.
+   */
+  | "no-table-profile"
   /**
    * The run was stopped before it could conclude. Substituted for the missing
    * output rather than reported alongside it: a user's stop is not a defect of the
@@ -185,6 +197,21 @@ function verifyQueryOptimizationGoal(run: VerifiableAgentRun): readonly AgentGoa
 }
 
 /**
+ * The assessment bar: the investigation baseline, and then a table actually
+ * profiled.
+ *
+ * Composed the same way the optimization rule is, and the baseline dominates for
+ * the same reason. An assessment written from the schema alone describes the SHAPE
+ * of a database; this workflow is about the STATE of its data, and only a profile
+ * establishes that.
+ */
+function verifyDatabaseAssessmentGoal(run: VerifiableAgentRun): readonly AgentGoalShortfall[] {
+  const baseline = verifyInvestigationGoal(run);
+  if (baseline.length > 0) return baseline;
+  return run.events.some((event) => event.kind === "table-profiled") ? [] : ["no-table-profile"];
+}
+
+/**
  * Workflow type → the rule an agent run of it is judged by, AND the id that names
  * that rule — ONE entry, so the two cannot drift.
  *
@@ -197,7 +224,7 @@ function verifyQueryOptimizationGoal(run: VerifiableAgentRun): readonly AgentGoa
 export const AGENT_WORKFLOW_GOALS: Readonly<Record<AgentRunWorkflowType, AgentWorkflowGoal>> = Object.freeze({
   investigation: { verifier: "agent-investigation.1", verify: verifyInvestigationGoal },
   "query-optimization": { verifier: "agent-query-optimization.1", verify: verifyQueryOptimizationGoal },
-  "database-assessment": { verifier: "agent-investigation.1", verify: verifyInvestigationGoal },
+  "database-assessment": { verifier: "agent-database-assessment.1", verify: verifyDatabaseAssessmentGoal },
 } satisfies Record<AgentRunWorkflowType, AgentWorkflowGoal>);
 
 const PLANNING_GOAL: AgentWorkflowGoal = { verifier: AGENT_PLANNING_VERIFIER, verify: verifyPlanningGoal };

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -63,6 +63,7 @@ import {
   comparePlansTool,
   composeReportTool,
   inspectPlanTool,
+  planTableProfile,
   profileTableTool,
   recommendChangeTool,
   inspectSchemaTool,
@@ -123,13 +124,18 @@ export interface AgentInvestigationResult {
 type DatabaseToolName = Exclude<AgentToolName, LedgerOnlyToolName>;
 
 /**
- * Tools `handleCall` dispatches itself rather than through `runStep`.
+ * Tools `handleCall` dispatches itself rather than through `invokeDatabaseTool`.
  *
- * Three of them reach nothing at all. `profile_table` DOES reach a database, and is
- * here for a different reason: its statement is composed from the run's own
- * inventory, so there is no model-supplied argument for a step id to be derived
- * from. Its repeat protection is the repair ledger's statement fingerprint, which
- * refuses the identical composed profile a second time.
+ * Three of them reach nothing at all. `profile_table` DOES reach a database and DOES
+ * go through `service.runStep` — it is here only because its statement is composed
+ * from the run's own inventory, so its step id has to be derived from the RESOLVED
+ * target rather than from the model's arguments.
+ *
+ * An earlier version routed it around `runStep` entirely, on a claim that turned out
+ * to be false: the repair ledger records only statements that FAILED, so a
+ * successful profile could be repeated without limit, and a cancellation requested
+ * after the model's turn could not stop the read. Found by review on #345. Both
+ * properties come back from settling the step like every other database reach.
  */
 type LedgerOnlyToolName = "compose_report" | "compare_plans" | "recommend_change" | "profile_table";
 
@@ -303,8 +309,19 @@ function describePriorProgress(record: AgentRunRecord): string | null {
       // first returned: without it a resumed run knows it profiled the table and
       // cannot cite the profile, so its own workflow's bar becomes unreachable
       // after any interruption.
+      // The table and column names are DATABASE CONTENT, so they are fenced rather
+      // than narrated in the server's voice. Found by review on #345: the initial
+      // profile fences them and the resume summary did not, which reintroduced the
+      // injection surface after any interruption.
       lines.push(
-        `Table ${event.profile.table} was already profiled at ${event.profile.depth} depth (${event.profile.rowCount} row(s)), artifact ${event.artifact.correlationId}: ${summary}. That profile is recorded; deepen it only if it left a question.`,
+        `A table was already profiled at ${event.profile.depth} depth (${event.profile.rowCount} row(s)), artifact ${event.artifact.correlationId}. That profile is recorded; deepen it only if it left a question.\n${fenceUntrustedContent(
+          `table: ${event.profile.table}\n${summary}`,
+          {
+            label: "profile already taken",
+            operationId: "sql.table.profile",
+            reference: event.artifact.correlationId,
+          },
+        )}`,
       );
     } else if (event.kind === "recommendation") {
       lines.push(
@@ -759,7 +776,7 @@ async function handleCall(input: {
   // Profiling DOES reach a database, but its statement is composed from the run's
   // own inventory rather than from the model's arguments, so its step identity is
   // the table and depth it names. Handled here, where the run record is in hand.
-  if (call.toolName === "profile_table") return profileTable(service, context, call);
+  if (call.toolName === "profile_table") return profileTable(service, context, call, known, notAttempted);
 
   const name = call.toolName as DatabaseToolName;
   const stepId = deriveStepId(name, call.input);
@@ -843,17 +860,64 @@ async function profileTable(
   service: AgentRunService,
   context: AgentToolContext,
   call: { readonly input: unknown },
+  known: Set<string>,
+  notAttempted: Set<string>,
 ): Promise<CallResult> {
   const { record } = await service.resume(context.runId);
-  const outcome = await profileTableTool(context, record, call.input);
-  if (outcome.kind !== "profiled") return { kind: "answered", text: outcome.modelText };
+  // Resolution and composition first, and they reach nothing: the step's identity
+  // has to come from what the profile RESOLVED to, so that two requests naming the
+  // same table settle as one step rather than executing twice.
+  const planned = planTableProfile(context, record, call.input);
+  if (planned.kind !== "planned") return { kind: "answered", text: planned.modelText };
 
-  await service.recordEvent(context.runId, {
-    kind: "table-profiled",
-    artifact: outcome.artifact,
-    profile: outcome.profile,
+  const { plan } = planned;
+  const stepId = deriveStepId("profile_table", {
+    ...(plan.target.schema === undefined ? {} : { schema: plan.target.schema }),
+    table: plan.target.table,
+    depth: plan.depth,
+    from: plan.from,
   });
-  return { kind: "answered", text: outcome.modelText };
+  known.add(stepId);
+
+  let modelText = "";
+  const result = await service.runStep(
+    record.runId,
+    { stepId, tool: "profile_table", operationId: "sql.table.profile" },
+    async () => {
+      const outcome = await profileTableTool(context, plan);
+      modelText = outcome.modelText;
+      if (outcome.kind !== "profiled") {
+        if (outcome.kind === "refused") return { kind: "refused", refusal: outcome.refusal };
+        notAttempted.add(stepId);
+        return { kind: "not-attempted" };
+      }
+      // Written inside the settled step, so a reader never sees a profile whose
+      // read was not also recorded.
+      await service.recordEvent(record.runId, {
+        kind: "table-profiled",
+        artifact: outcome.artifact,
+        profile: outcome.profile,
+      });
+      return { kind: "completed", artifact: outcome.artifact };
+    },
+  );
+
+  if (result.kind === "cancelled") return { kind: "cancelled" };
+  if (result.kind === "performed") return { kind: "answered", text: modelText };
+  if (result.kind === "replayed") {
+    // The profile is already on this run's ledger; re-reading the table would spend
+    // a statement to learn what the run already knows.
+    return {
+      kind: "answered",
+      text: `That exact profile was already taken in this run. ${describeSettled(result.event, "profile_table")}`,
+    };
+  }
+  return {
+    kind: "answered",
+    text: notAttempted.has(result.stepId)
+      ? refusedBeforeDatabaseText(result.stepId, "profile_table")
+      : indeterminateText(result.stepId, "profile_table"),
+  };
 }
 
 /**

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -63,6 +63,7 @@ import {
   comparePlansTool,
   composeReportTool,
   inspectPlanTool,
+  profileTableTool,
   recommendChangeTool,
   inspectSchemaTool,
   runReadQueryTool,
@@ -121,8 +122,16 @@ export interface AgentInvestigationResult {
  */
 type DatabaseToolName = Exclude<AgentToolName, LedgerOnlyToolName>;
 
-/** Tools that record what the run already established and reach nothing. */
-type LedgerOnlyToolName = "compose_report" | "compare_plans" | "recommend_change";
+/**
+ * Tools `handleCall` dispatches itself rather than through `runStep`.
+ *
+ * Three of them reach nothing at all. `profile_table` DOES reach a database, and is
+ * here for a different reason: its statement is composed from the run's own
+ * inventory, so there is no model-supplied argument for a step id to be derived
+ * from. Its repeat protection is the repair ledger's statement fingerprint, which
+ * refuses the identical composed profile a second time.
+ */
+type LedgerOnlyToolName = "compose_report" | "compare_plans" | "recommend_change" | "profile_table";
 
 // ============================================================================
 // Prompting
@@ -187,7 +196,11 @@ const WORKFLOW_TOOL_RULES: Readonly<Record<AgentRunWorkflowType, string>> = Obje
     "Every plan you can obtain is an ESTIMATE: nothing is executed, and there are no timings. Say so rather than implying a measurement.",
     "Propose changes with recommend_change. They are offered to the user and never applied by this run.",
   ].join(" "),
-  "database-assessment": "Report what the evidence supports, and nothing further.",
+  "database-assessment": [
+    "Profile the tables that matter with profile_table, deepening only where a shallower profile left a question: basic counts rows and missing values, distribution adds distinct counts, pattern tests for personal-data shapes.",
+    "Only COUNTS come back. No value is read out of any column, so do not claim what a column contains — claim what its counts show.",
+    "Grade what you find against completeness, uniqueness, consistency and validity, and say which of the four each finding speaks to.",
+  ].join(" "),
 } satisfies Record<AgentRunWorkflowType, string>);
 
 /**
@@ -278,6 +291,20 @@ function describePriorProgress(record: AgentRunRecord): string | null {
       */
       lines.push(
         `Two plans were already compared: ${event.before.sql} reaches its rows by ${event.before.summary.access}, and ${event.after.sql} by ${event.after.summary.access}. That comparison is recorded and must not be made again.`,
+      );
+    } else if (event.kind === "table-profiled") {
+      // Same reasoning as the two below: durable, non-terminal, and a resumed run
+      // that was not told would spend a statement re-reading what it already has.
+      const summary =
+        event.profile.findings.length === 0
+          ? "nothing stood out"
+          : event.profile.findings.map((finding) => `${finding.column}: ${finding.code}`).join(", ");
+      // The artifact id is named for the same reason it is named when the profile is
+      // first returned: without it a resumed run knows it profiled the table and
+      // cannot cite the profile, so its own workflow's bar becomes unreachable
+      // after any interruption.
+      lines.push(
+        `Table ${event.profile.table} was already profiled at ${event.profile.depth} depth (${event.profile.rowCount} row(s)), artifact ${event.artifact.correlationId}: ${summary}. That profile is recorded; deepen it only if it left a question.`,
       );
     } else if (event.kind === "recommendation") {
       lines.push(
@@ -729,6 +756,10 @@ async function handleCall(input: {
   if (call.toolName === "compose_report") return composeReport(service, context, call.input);
   if (call.toolName === "compare_plans") return comparePlans(service, context, call.input);
   if (call.toolName === "recommend_change") return recommendChange(service, context, call.input);
+  // Profiling DOES reach a database, but its statement is composed from the run's
+  // own inventory rather than from the model's arguments, so its step identity is
+  // the table and depth it names. Handled here, where the run record is in hand.
+  if (call.toolName === "profile_table") return profileTable(service, context, call);
 
   const name = call.toolName as DatabaseToolName;
   const stepId = deriveStepId(name, call.input);
@@ -793,6 +824,38 @@ async function handleCall(input: {
  * started, and the artifacts a claim may cite are exactly the entries that were
  * added while the loop was running.
  */
+/**
+ * One table profiled, recorded and NOT terminal.
+ *
+ * Unlike the other two handled here, this one reaches the database — through
+ * `executeAgentOperation` like every other reach, and therefore through the run's
+ * deadline, its repair ledger, its budgets and the audit trail. What it does NOT go
+ * through is `runStep`: the tool composes its own statement from the inventory, so
+ * there is no model-supplied argument for a step id to be derived from, and the
+ * repair ledger's statement fingerprint already refuses the same profile twice.
+ *
+ * The honest consequence, stated rather than glossed: a drive that dies between the
+ * database reach and this append loses the profile and a resumed run re-reads it.
+ * That costs a statement out of twenty; it cannot double-count anything, because
+ * the profile changes no state.
+ */
+async function profileTable(
+  service: AgentRunService,
+  context: AgentToolContext,
+  call: { readonly input: unknown },
+): Promise<CallResult> {
+  const { record } = await service.resume(context.runId);
+  const outcome = await profileTableTool(context, record, call.input);
+  if (outcome.kind !== "profiled") return { kind: "answered", text: outcome.modelText };
+
+  await service.recordEvent(context.runId, {
+    kind: "table-profiled",
+    artifact: outcome.artifact,
+    profile: outcome.profile,
+  });
+  return { kind: "answered", text: outcome.modelText };
+}
+
 /**
  * The before/after plan comparison, recorded and NOT terminal.
  *

--- a/src/lib/agent/run-service.ts
+++ b/src/lib/agent/run-service.ts
@@ -90,6 +90,7 @@ export type AgentRunNarrativeEvent = Extract<
       // ALREADY established, which is exactly what a narrative entry is.
       | "plan-comparison"
       | "recommendation"
+      | "table-profiled"
       | "closing-statement";
   }
 >;

--- a/src/lib/agent/run-store.ts
+++ b/src/lib/agent/run-store.ts
@@ -99,6 +99,7 @@ const EVENT_KINDS: ReadonlySet<string> = new Set(
     "tool-completed": true,
     "tool-refused": true,
     "report-composed": true,
+    "table-profiled": true,
     "plan-comparison": true,
     recommendation: true,
     "closing-statement": true,

--- a/src/lib/agent/table-profile.ts
+++ b/src/lib/agent/table-profile.ts
@@ -1,0 +1,363 @@
+/**
+ * Bounded per-table profiling: the SQL the server composes for it, and the
+ * findings it derives from what comes back (#330 T3).
+ *
+ * **The profile records counts, never values.** That is the rule the whole module
+ * is built around, and it is what makes profiling a table of personal data
+ * acceptable at all: every statistic is an aggregate — how many rows, how many are
+ * present, how many are distinct, how many match a shape — so no name, address or
+ * account number is ever written to the ledger, shown to the model, or rendered in
+ * the rail. A `min`/`max` of a text column would return an actual value, which is
+ * why neither is here even though both are conventional in a profiler.
+ *
+ * Three further decisions:
+ *
+ *  - **The model names a table; the server chooses the columns.** They come from the
+ *    run's own captured inventory, so a profile cannot be aimed at a column the run
+ *    never established exists, and the statement is composed rather than supplied —
+ *    the same rule `inspect_schema` follows.
+ *  - **The findings are derived from the numbers, not asserted by the model.** Every
+ *    one is a mechanical predicate over counts with a stated threshold. A model may
+ *    interpret them; it cannot invent them.
+ *  - **`suspected_pii` is a suspicion, and says so.** At any depth it is read from
+ *    the column NAME, and at `pattern` depth from the RATIO of values matching a
+ *    shape — computed inside the database by a `count(CASE WHEN …)`, so the values
+ *    that matched never leave it. Neither test establishes that a column holds
+ *    personal data; both establish that it is worth a human looking.
+ */
+
+import { quoteIdentifier } from "@/lib/sql/identifier";
+import type { ColumnSchema, DatabaseType, TableSchema } from "@/lib/types";
+import { AgentComposedSqlError, MAX_CATALOG_SELECTOR_LENGTH } from "./composed-sql";
+
+/**
+ * How deeply one profile reads. Each level is the one before it plus more, so a
+ * deepening re-reads what it already had — which is the cost of asking the engine
+ * once rather than keeping a partial profile in flight across statements.
+ */
+export type AgentProfileDepth = "basic" | "distribution" | "pattern";
+
+/**
+ * Columns one profile may cover.
+ *
+ * Bounded because the composed statement grows with it: at `pattern` depth each
+ * column contributes four aggregates, so an unbounded table would compose a
+ * statement whose cost nobody chose. A wider table is profiled in more than one
+ * call, which the statement budget accounts for honestly.
+ */
+export const MAX_PROFILE_COLUMNS = 16;
+
+/** Below this many present values, a ratio says more about the sample than the data. */
+export const MIN_ROWS_FOR_RATIO_FINDINGS = 20;
+
+/** At or above this share of missing values, a column is worth reporting as sparse. */
+export const HIGH_NULL_RATIO = 0.5;
+
+/** At or below this share of distinct values, a column carries very few of them. */
+const LOW_CARDINALITY_RATIO = 0.01;
+
+/** At or above this share of shape matches, the shape is the column's norm rather than an accident. */
+const PII_SHAPE_RATIO = 0.5;
+
+/**
+ * Column names that name personal data in the languages this project is written
+ * and used in. A suspicion drawn from a NAME, which is why the finding says
+ * "suspected" — a column called `email` may hold anything, and one called `col_7`
+ * may hold every address in the country.
+ */
+const PII_NAME_WORDS: readonly string[] = Object.freeze([
+  "email",
+  "mail",
+  "phone",
+  "tel",
+  "mobile",
+  "gsm",
+  "ssn",
+  "tckn",
+  "national_id",
+  "passport",
+  "iban",
+  "card",
+  "birth",
+  "dob",
+  "address",
+  "adres",
+  "postcode",
+  "zip",
+]);
+
+/** Declared types this module is willing to apply a text shape test to. */
+const TEXTUAL_TYPE = /char|text|string|clob|varying/i;
+
+/**
+ * The one shape tested inside the database, so no matching value ever leaves it:
+ * something, an `@`, something, a `.`, something.
+ *
+ * ONE shape, because `LIKE` is the only pattern operator both engines spell the
+ * same way and `_` in it means "any character" rather than "any digit". A test for
+ * a run of digits — a phone number, a national id — needs `~` on PostgreSQL and
+ * `GLOB` on SQLite, so it is a dialect-specific predicate rather than a wider
+ * pattern here, and it is deferred (`docs/BACKLOG.md` B26) instead of being
+ * approximated by a length test that would match almost any text.
+ */
+const EMAIL_SHAPE = "%_@_%._%";
+
+export type AgentProfileFindingCode =
+  /** At least `HIGH_NULL_RATIO` of the rows have no value in this column. */
+  | "high_null"
+  /** Every present value is the same one. */
+  | "constant"
+  /** Very few distinct values across many rows. */
+  | "low_cardinality"
+  /** A foreign-key column that no index in the captured inventory leads on. */
+  | "fk_unindexed"
+  /** The column's name, or the shape of its values, suggests personal data. */
+  | "suspected_pii";
+
+export interface AgentProfileFinding {
+  readonly code: AgentProfileFindingCode;
+  readonly column: string;
+  /**
+   * The app's own words, carrying the numbers the finding was derived from.
+   * Deliberately no engine text and no value — see the module docblock.
+   */
+  readonly detail: string;
+}
+
+/** What one column's aggregates came back as. Counts only. */
+export interface AgentColumnProfile {
+  readonly column: string;
+  /** Rows where the column is not null. */
+  readonly present: number;
+  /** Distinct present values, at `distribution` depth and deeper. */
+  readonly distinct?: number;
+  /** Rows whose value matches a personal-data shape, at `pattern` depth. */
+  readonly shaped?: number;
+}
+
+export interface AgentTableProfile {
+  readonly table: string;
+  readonly depth: AgentProfileDepth;
+  readonly rowCount: number;
+  readonly columns: readonly AgentColumnProfile[];
+  readonly findings: readonly AgentProfileFinding[];
+}
+
+// ─── composition ────────────────────────────────────────────────────────────
+
+/** Aliases are generated, never taken from a column name: a name is untrusted text. */
+const alias = (prefix: string, index: number): string => `${prefix}_${index}`;
+
+function assertProfileTable(value: string): string {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (trimmed.length === 0 || trimmed.length > MAX_CATALOG_SELECTOR_LENGTH) {
+    throw new AgentComposedSqlError("a profile needs one table name of a usable length", "INVALID_SELECTOR");
+  }
+  return trimmed;
+}
+
+/** The qualified target, quoted per dialect. Both engines here quote with `"`. */
+function quoteTarget(dialect: DatabaseType, schema: string | undefined, table: string): string {
+  const quotedTable = quoteIdentifier(assertProfileTable(table), dialect);
+  if (schema === undefined) return quotedTable;
+  return `${quoteIdentifier(assertProfileTable(schema), dialect)}.${quotedTable}`;
+}
+
+const isTextual = (column: ColumnSchema): boolean => TEXTUAL_TYPE.test(column.type);
+
+/**
+ * One statement covering the whole table, rather than one per statistic.
+ *
+ * The run's statement budget is 20, and a per-statistic composition would spend it
+ * on a single table. Everything here is an aggregate over one scan, which is also
+ * the shape an engine can plan best.
+ *
+ * `LIKE` is applied only to columns whose DECLARED type reads as textual: comparing
+ * an integer column to a string pattern is an error on PostgreSQL, and casting
+ * every column to text to avoid that would turn a bounded read into a full
+ * conversion of the table.
+ */
+export function composeTableProfile(
+  dialect: DatabaseType,
+  selector: { readonly schema?: string; readonly table: string; readonly depth: AgentProfileDepth },
+  columns: readonly ColumnSchema[],
+): string {
+  if (dialect !== "postgres" && dialect !== "sqlite") {
+    throw new AgentComposedSqlError(
+      `no verified profile composition for provider type "${dialect}"`,
+      "UNSUPPORTED_DIALECT",
+    );
+  }
+  if (columns.length === 0) {
+    throw new AgentComposedSqlError("that table has no columns to profile", "INVALID_SELECTOR");
+  }
+
+  const parts = ["count(*) AS row_count"];
+  columns.forEach((column, index) => {
+    const quoted = quoteIdentifier(column.name, dialect);
+    parts.push(`count(${quoted}) AS ${alias("present", index)}`);
+    if (selector.depth !== "basic") parts.push(`count(DISTINCT ${quoted}) AS ${alias("distinct", index)}`);
+    if (selector.depth === "pattern" && isTextual(column)) {
+      // Counted inside the database: the rows that matched are never returned.
+      parts.push(`count(CASE WHEN ${quoted} LIKE '${EMAIL_SHAPE}' THEN 1 END) AS ${alias("shaped", index)}`);
+    }
+  });
+
+  return `SELECT ${parts.join(", ")} FROM ${quoteTarget(dialect, selector.schema, selector.table)}`;
+}
+
+// ─── reading the result back ────────────────────────────────────────────────
+
+const count = (row: Record<string, unknown>, key: string): number | undefined => {
+  const value = row[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  // `count()` comes back as a bigint on some drivers and as a numeric string on
+  // node-postgres, which returns int8 as text to avoid losing precision.
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string" && /^\d+$/.test(value)) return Number(value);
+  return undefined;
+};
+
+/**
+ * Turns the one aggregate row into a profile. A statistic the engine did not
+ * report is ABSENT rather than zero: zero present values is a finding, and "the
+ * engine said nothing" is not.
+ */
+export function readTableProfile(
+  table: string,
+  depth: AgentProfileDepth,
+  columns: readonly ColumnSchema[],
+  rows: readonly Record<string, unknown>[],
+): AgentTableProfile | null {
+  const row = rows[0];
+  if (row === undefined) return null;
+  const rowCount = count(row, "row_count");
+  if (rowCount === undefined) return null;
+
+  const profiled: AgentColumnProfile[] = columns.map((column, index) => {
+    const distinct = count(row, alias("distinct", index));
+    const shaped = count(row, alias("shaped", index));
+    return {
+      column: column.name,
+      present: count(row, alias("present", index)) ?? 0,
+      ...(distinct === undefined ? {} : { distinct }),
+      ...(shaped === undefined ? {} : { shaped }),
+    };
+  });
+
+  return { table, depth, rowCount, columns: profiled, findings: deriveFindings(rowCount, columns, profiled) };
+}
+
+const ratio = (part: number, whole: number): string => `${Math.round((part / whole) * 100)}%`;
+
+function namesPersonalData(column: string): boolean {
+  const lowered = column.toLowerCase();
+  return PII_NAME_WORDS.some((word) => lowered.includes(word));
+}
+
+/**
+ * Every finding, as a mechanical predicate over counts.
+ *
+ * Order is stable and by column, so two profiles of the same table produce the same
+ * list — a finding set that reordered between runs would read as having changed.
+ */
+function deriveFindings(
+  rowCount: number,
+  columns: readonly ColumnSchema[],
+  profiles: readonly AgentColumnProfile[],
+): readonly AgentProfileFinding[] {
+  const findings: AgentProfileFinding[] = [];
+
+  profiles.forEach((profile, index) => {
+    const declared = columns[index];
+    const missing = rowCount - profile.present;
+
+    if (rowCount >= MIN_ROWS_FOR_RATIO_FINDINGS && missing / rowCount >= HIGH_NULL_RATIO) {
+      findings.push({
+        code: "high_null",
+        column: profile.column,
+        detail: `${ratio(missing, rowCount)} of ${rowCount} rows have no value here.`,
+      });
+    }
+
+    if (profile.distinct === 1 && profile.present > 1) {
+      findings.push({
+        code: "constant",
+        column: profile.column,
+        detail: `All ${profile.present} present values are the same one.`,
+      });
+    } else if (
+      profile.distinct !== undefined &&
+      profile.distinct > 1 &&
+      profile.present >= MIN_ROWS_FOR_RATIO_FINDINGS &&
+      profile.distinct / profile.present <= LOW_CARDINALITY_RATIO
+    ) {
+      findings.push({
+        code: "low_cardinality",
+        column: profile.column,
+        detail: `${profile.distinct} distinct values across ${profile.present} rows.`,
+      });
+    }
+
+    const shapedEnough =
+      profile.shaped !== undefined &&
+      profile.present >= MIN_ROWS_FOR_RATIO_FINDINGS &&
+      profile.shaped / profile.present >= PII_SHAPE_RATIO;
+    if (declared !== undefined && (namesPersonalData(profile.column) || shapedEnough)) {
+      findings.push({
+        code: "suspected_pii",
+        column: profile.column,
+        detail: shapedEnough
+          ? `${ratio(profile.shaped ?? 0, profile.present)} of the values are shaped like an email address. No value was read out of the database to establish this.`
+          : "The column's name suggests personal data. Its values were not inspected to establish this.",
+      });
+    }
+  });
+
+  return findings;
+}
+
+// ─── the one finding that comes from the inventory rather than the numbers ───
+
+/**
+ * Foreign-key columns that no index in the CAPTURED INVENTORY leads on.
+ *
+ * Stated that precisely because the inventory has two known blind spots, and a
+ * finding worded as "this foreign key is unindexed" would overstate both:
+ *
+ *  - **SQLite hides constraint-created indexes.** The catalog read takes indexes
+ *    from `CREATE INDEX` text, and the indexes SQLite builds for `UNIQUE` and
+ *    `PRIMARY KEY` carry no DDL at all — so a foreign key covered by a `UNIQUE`
+ *    constraint is invisible here and would be reported. `docs/BACKLOG.md` B25.
+ *  - **PostgreSQL expression indexes are absent** and a partly-expression index
+ *    appears carrying only its plain columns (`docs/BACKLOG.md` B7).
+ *
+ * Composite foreign keys are SKIPPED rather than guessed at: PostgreSQL's catalog
+ * read returns them as the cross product of both sides (B8), so their columns
+ * cannot be regrouped into the key they belong to, and a covering test over the
+ * wrong grouping would be an answer about a key that does not exist.
+ */
+export function findUnindexedForeignKeys(table: TableSchema): readonly AgentProfileFinding[] {
+  const keys = table.foreignKeys ?? [];
+  // More than one edge from a table is where a composite key becomes
+  // indistinguishable from several single-column ones on PostgreSQL.
+  const byTarget = new Map<string, number>();
+  for (const key of keys) byTarget.set(key.referencedTable, (byTarget.get(key.referencedTable) ?? 0) + 1);
+
+  const leading = new Set(table.indexes.map((index) => index.columns[0]).filter((name) => name !== undefined));
+  const primary = new Set(table.columns.filter((column) => column.isPrimary).map((column) => column.name));
+
+  const findings: AgentProfileFinding[] = [];
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if ((byTarget.get(key.referencedTable) ?? 0) > 1) continue;
+    if (seen.has(key.columnName) || leading.has(key.columnName) || primary.has(key.columnName)) continue;
+    seen.add(key.columnName);
+    findings.push({
+      code: "fk_unindexed",
+      column: key.columnName,
+      detail: "No index in the captured inventory leads on this foreign-key column.",
+    });
+  }
+  return findings;
+}

--- a/src/lib/agent/table-profile.ts
+++ b/src/lib/agent/table-profile.ts
@@ -166,6 +166,23 @@ function quoteTarget(dialect: DatabaseType, schema: string | undefined, table: s
 const isTextual = (column: ColumnSchema): boolean => TEXTUAL_TYPE.test(column.type);
 
 /**
+ * Declared types with no equality operator, so `count(DISTINCT …)` refuses them.
+ *
+ * PostgreSQL answers `could not identify an equality operator for type json` — and
+ * because one unsupported column aborts the WHOLE aggregate, a single `json` column
+ * would have failed distribution and pattern profiling for the entire table. Found
+ * by review on #345.
+ *
+ * An exclusion rather than an allowlist of comparable types, deliberately: the
+ * comparable set is open (every domain, every enum, every extension type), so an
+ * allowlist would refuse to count things it simply had not heard of. This list is
+ * the closed set that genuinely has no default equality.
+ */
+const INCOMPARABLE_TYPE = /\b(jsonb?|xml|point|line|lseg|box|path|polygon|circle)\b/i;
+
+const isComparable = (column: ColumnSchema): boolean => !INCOMPARABLE_TYPE.test(column.type);
+
+/**
  * One statement covering the whole table, rather than one per statistic.
  *
  * The run's statement budget is 20, and a per-statistic composition would spend it
@@ -196,7 +213,11 @@ export function composeTableProfile(
   columns.forEach((column, index) => {
     const quoted = quoteIdentifier(column.name, dialect);
     parts.push(`count(${quoted}) AS ${alias("present", index)}`);
-    if (selector.depth !== "basic") parts.push(`count(DISTINCT ${quoted}) AS ${alias("distinct", index)}`);
+    // A type with no equality operator is skipped rather than counted: its absence
+    // reads as "the engine did not report this", which is exactly true.
+    if (selector.depth !== "basic" && isComparable(column)) {
+      parts.push(`count(DISTINCT ${quoted}) AS ${alias("distinct", index)}`);
+    }
     if (selector.depth === "pattern" && isTextual(column)) {
       // Counted inside the database: the rows that matched are never returned.
       parts.push(`count(CASE WHEN ${quoted} LIKE '${EMAIL_SHAPE}' THEN 1 END) AS ${alias("shaped", index)}`);

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -70,8 +70,17 @@ import { AGENT_EXECUTION_POLICY, AGENT_EXECUTION_PROFILE, AGENT_MINIMUM_CALL_MS 
 import type { AgentRepairDenyCode, AgentRepairLedger } from "./repair-ledger";
 import { fingerprintStatement } from "./repair-ledger";
 import { summarisePlan } from "./plan-summary";
+import {
+  MAX_PROFILE_COLUMNS,
+  type AgentProfileFinding,
+  type AgentTableProfile,
+  composeTableProfile,
+  findUnindexedForeignKeys,
+  readTableProfile,
+} from "./table-profile";
 import type {
   AgentArtifactReference,
+  AgentContextSnapshot,
   AgentEvidenceReference,
   AgentPlanSide,
   AgentReportClaim,
@@ -90,6 +99,8 @@ export type AgentToolName =
   | "run_read_query"
   | "inspect_plan"
   | "compose_report"
+  /** Database assessment only: bounded per-table profiling, counts only. */
+  | "profile_table"
   /** Query optimization only: two estimated plans of the same question. */
   | "compare_plans"
   /** Query optimization only: a change the user may apply. Never executed here. */
@@ -102,7 +113,12 @@ export type AgentToolName =
  * its descriptor is default-denied, so the pipeline can only ever answer
  * require-approval for it.
  */
-export type AgentOperationId = "sql.query.read" | "sql.explain.estimate" | "sql.explain.analyze";
+export type AgentOperationId =
+  | "sql.query.read"
+  | "sql.explain.estimate"
+  | "sql.explain.analyze"
+  /** Bounded per-table profiling; #330 T3 reopened the three-descriptor decision. */
+  | "sql.table.profile";
 
 export interface AgentToolDefinition {
   readonly name: AgentToolName;
@@ -155,6 +171,10 @@ export type AgentToolUnavailableCode =
   | "UNVERIFIABLE_EVIDENCE"
   /** A cited plan is not an estimating plan THIS run produced. */
   | "UNVERIFIABLE_PLAN"
+  /** The named table is not in the inventory this run captured. */
+  | "TABLE_NOT_INVENTORIED"
+  /** The profile ran, and its aggregate row could not be read back. */
+  | "PROFILE_UNREADABLE"
   /** One plan cited as both sides: a before and an after have to be two plans. */
   | "IDENTICAL_PLANS"
   /** The statement does not match the card it is offered under. */
@@ -166,6 +186,16 @@ export type AgentToolUnavailableCode =
 
 export type AgentToolOutcome =
   | { readonly kind: "completed"; readonly artifact: AgentArtifactReference; readonly modelText: string }
+  | { readonly kind: "refused"; readonly refusal: AgentToolRefusal; readonly modelText: string }
+  | { readonly kind: "unavailable"; readonly reasonCode: AgentToolUnavailableCode; readonly modelText: string };
+
+export type AgentTableProfileOutcome =
+  | {
+      readonly kind: "profiled";
+      readonly artifact: AgentArtifactReference;
+      readonly profile: AgentTableProfile;
+      readonly modelText: string;
+    }
   | { readonly kind: "refused"; readonly refusal: AgentToolRefusal; readonly modelText: string }
   | { readonly kind: "unavailable"; readonly reasonCode: AgentToolUnavailableCode; readonly modelText: string };
 
@@ -254,6 +284,17 @@ const reportSchema = z.strictObject({
  * label would let a comparison attribute a plan to a statement that never produced
  * it — the exact mislabelling a before/after claim rests on not doing.
  */
+/**
+ * A profile names a TABLE, never columns and never SQL. The columns come from the
+ * run's own captured inventory, so a profile cannot be aimed at something the run
+ * never established exists — the same rule `compare_plans` follows about plans.
+ */
+const profileSelectorSchema = z.strictObject({
+  schema: z.string().optional(),
+  table: z.string().min(1),
+  depth: z.enum(["basic", "distribution", "pattern"]).optional(),
+});
+
 const planComparisonSchema = z.strictObject({
   before: z.string().min(1),
   after: z.string().min(1),
@@ -287,6 +328,13 @@ export const AGENT_TOOL_DEFINITIONS: Readonly<Record<AgentToolName, AgentToolDef
       "Ask the engine for the ESTIMATED plan of one read-only statement. The plan is described, never executed, so no timings are produced.",
     inputSchema: planStatementSchema,
     operationId: "sql.explain.estimate",
+  },
+  profile_table: {
+    name: "profile_table",
+    description:
+      "Profile one table the run has already inventoried. The server chooses the columns from the captured schema and composes the aggregates; you supply only the table and how deep to go. Depth basic counts rows and missing values, distribution adds distinct counts, pattern adds a shape test for personal data. Only COUNTS are returned — no value is ever read out of a column.",
+    inputSchema: profileSelectorSchema,
+    operationId: "sql.table.profile",
   },
   compare_plans: {
     name: "compare_plans",
@@ -343,10 +391,16 @@ const QUERY_OPTIMIZATION_TOOLS: readonly AgentToolDefinition[] = Object.freeze([
   AGENT_TOOL_DEFINITIONS.recommend_change,
 ]);
 
+/** The assessment template's own tool, on top of the read-class four. */
+const DATABASE_ASSESSMENT_TOOLS: readonly AgentToolDefinition[] = Object.freeze([
+  ...AGENT_MODE_TOOLS,
+  AGENT_TOOL_DEFINITIONS.profile_table,
+]);
+
 const WORKFLOW_TOOLS: Readonly<Record<AgentRunWorkflowType, readonly AgentToolDefinition[]>> = Object.freeze({
   investigation: AGENT_MODE_TOOLS,
   "query-optimization": QUERY_OPTIMIZATION_TOOLS,
-  "database-assessment": AGENT_MODE_TOOLS,
+  "database-assessment": DATABASE_ASSESSMENT_TOOLS,
 } satisfies Record<AgentRunWorkflowType, readonly AgentToolDefinition[]>);
 
 /**
@@ -379,6 +433,10 @@ const UNAVAILABLE_TEXT: Readonly<Record<AgentToolUnavailableCode, string>> = Obj
     "At least one evidence reference does not match anything this run produced. Cite an artifact this run actually read, or the schema snapshot it captured.",
   UNVERIFIABLE_PLAN:
     "At least one of those references is not an estimated plan this run produced. Inspect the plan of each statement first, then compare the two artifacts those inspections returned.",
+  TABLE_NOT_INVENTORIED:
+    "That table is not in the schema inventory this run captured. Call inspect_schema for it first, then profile it by the name the inventory uses.",
+  PROFILE_UNREADABLE:
+    "The profile ran but its result could not be read as counts. Try a shallower depth, or profile a different table.",
   IDENTICAL_PLANS:
     "Both sides of that comparison name the same plan, so there is no before and no after. Inspect the plan of your rewrite as well, then compare the two.",
   RECOMMENDATION_SHAPE_MISMATCH:
@@ -997,6 +1055,123 @@ function readPlanSide(
 }
 
 /**
+ * The findings, in the server's own words.
+ *
+ * A column NAME is untrusted database content, so it is fenced rather than spliced
+ * into a sentence the model would read as the server speaking. The finding codes
+ * and the counts are this repository's own.
+ */
+function describeFindings(findings: readonly AgentProfileFinding[]): string {
+  if (findings.length === 0) return "Nothing crossed a finding threshold.";
+  return fenceUntrustedContent(
+    findings.map((finding) => `${finding.column}: ${finding.code} — ${finding.detail}`).join("\n"),
+    { label: `${findings.length} profile finding(s)`, operationId: "sql.table.profile", reference: "server-derived" },
+  );
+}
+
+/**
+ * The table the run already inventoried, found by the name the model gave.
+ *
+ * Matched against the snapshot's own naming, which differs by engine: PostgreSQL
+ * qualifies as `schema.table`, SQLite does not. A model that names either form of
+ * a table it has seen is answered; one that names a table the run never captured
+ * is refused rather than sent to the database on a guess.
+ */
+function inventoriedTable(snapshot: AgentContextSnapshot, schema: string | undefined, table: string) {
+  const qualified = schema === undefined ? table : `${schema}.${table}`;
+  const exact = snapshot.tables.find((candidate) => candidate.name === qualified || candidate.name === table);
+  if (exact !== undefined) return exact;
+  if (schema !== undefined) return undefined;
+
+  // An unqualified name against a qualified inventory. PostgreSQL's capture names
+  // tables `schema.table` and SQLite's does not, so a model that has read either
+  // inventory may reasonably name a table without its schema. Resolved only when
+  // exactly ONE table ends that way: two schemas holding the same table name is
+  // precisely when a guess would profile the wrong one.
+  const suffix = `.${table}`;
+  const matches = snapshot.tables.filter((candidate) => candidate.name.endsWith(suffix));
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+/**
+ * The most recent inventory this run captured, read off its own ledger.
+ *
+ * The LAST one, because a run may capture more than once and the newest is the one
+ * its later statements were drafted against.
+ */
+function capturedSnapshot(events: readonly AgentRunEvent[]): AgentContextSnapshot | null {
+  let snapshot: AgentContextSnapshot | null = null;
+  for (const event of events) {
+    if (event.kind === "context-captured" && event.snapshot !== undefined) snapshot = event.snapshot;
+  }
+  return snapshot;
+}
+
+/**
+ * Bounded per-table profiling.
+ *
+ * The one tool here whose statement is composed from the RUN'S OWN inventory rather
+ * than from the model's arguments: the model names a table and a depth, and the
+ * server decides which columns that means and what to count. Everything the profile
+ * records is a count — `table-profile.ts` says why, and it is what makes profiling a
+ * table of personal data acceptable at all.
+ */
+export async function profileTableTool(
+  context: AgentToolContext,
+  run: Pick<AgentRunRecord, "runId" | "events">,
+  input: unknown,
+): Promise<AgentTableProfileOutcome> {
+  if (context.mode !== "agent") return unavailable("MODE_HAS_NO_TOOLS");
+  if (run.runId !== context.runId) {
+    throw new Error("agent tool layer: the profile's run record does not belong to this run");
+  }
+
+  const parsed = parseToolInput(profileSelectorSchema, input);
+  if (!parsed.ok) return unavailable("INVALID_TOOL_INPUT");
+
+  const snapshot = capturedSnapshot(run.events);
+  const table = snapshot === null ? undefined : inventoriedTable(snapshot, parsed.value.schema, parsed.value.table);
+  if (table === undefined) return unavailable("TABLE_NOT_INVENTORIED");
+
+  const depth = parsed.value.depth ?? "basic";
+  // Bounded here rather than in the composer: a wider table is profiled in more
+  // than one call, and the statement budget accounts for that honestly.
+  const columns = table.columns.slice(0, MAX_PROFILE_COLUMNS);
+  let sql: string;
+  try {
+    sql = composeTableProfile(context.connection.type, { ...parsed.value, depth }, columns);
+  } catch (error) {
+    return composedSqlOutcome(error) as AgentTableProfileOutcome;
+  }
+
+  const outcome = await executeAgentOperation(context, {
+    operationId: "sql.table.profile",
+    sql,
+    label: `profile of ${table.name}`,
+    ...(parsed.value.schema === undefined ? {} : { target: { schema: parsed.value.schema } }),
+  });
+  if (outcome.kind !== "completed") return outcome;
+
+  const stored = context.artifacts.get(outcome.artifact.correlationId, (context.clock ?? Date.now)());
+  const profile = stored === undefined ? null : readTableProfile(table.name, depth, columns, stored.value.rows);
+  if (profile === null) return unavailable("PROFILE_UNREADABLE");
+
+  // The inventory-derived finding rides along, so one profile is one complete
+  // statement about the table rather than two half-statements.
+  const findings = [...profile.findings, ...findUnindexedForeignKeys(table)];
+  return {
+    kind: "profiled",
+    artifact: outcome.artifact,
+    profile: { ...profile, findings },
+    // The correlation id is named because a report has to be able to CITE this:
+    // without it the assessment template could profile a table and then be unable
+    // to compose a cited claim about it, which its own goal verifier requires.
+    // Found by the scenario suite before any model saw it.
+    modelText: `Profiled ${table.name}: ${profile.rowCount} row(s), ${columns.length} column(s) at ${depth} depth, ${findings.length} finding(s), artifact ${outcome.artifact.correlationId}. Only counts were read; no value was returned from any column. ${describeFindings(findings)}`,
+  };
+}
+
+/**
  * The before/after comparison. Reaches no database: both plans were already read,
  * and this is the server stating what it sees in them.
  */
@@ -1101,7 +1276,11 @@ function matchesCard(change: "index" | "rewrite", statement: string): boolean {
 function verifiedAgainst(events: readonly AgentRunEvent[], reference: AgentEvidenceReference): boolean {
   for (const event of events) {
     if (reference.source === "artifact") {
-      if (event.kind === "tool-completed" && event.artifact.correlationId === reference.correlationId) return true;
+      // Both events that carry an artifact this run produced. A profile settles no
+      // step, so it writes no `tool-completed`; omitting it here made a profile
+      // uncitable and its own workflow's bar unreachable.
+      const artifact = event.kind === "tool-completed" || event.kind === "table-profiled" ? event.artifact : null;
+      if (artifact !== null && artifact.correlationId === reference.correlationId) return true;
     } else if (event.kind === "context-captured" && event.fingerprint === reference.fingerprint) return true;
   }
   return false;

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -58,7 +58,7 @@ import { inspectAgentStatement } from "@/lib/db/operations/statement-guard";
 import type { ExecutionActor, ExecutionPolicy, PolicyDenyCode, TargetScope } from "@/lib/db/operations/policy";
 import type { OperationRegistry } from "@/lib/db/operations/registry";
 import type { DatabaseProvider, ProviderCapabilities } from "@/lib/db/types";
-import type { DatabaseConnection, QueryResult } from "@/lib/types";
+import type { ColumnSchema, DatabaseConnection, QueryResult, TableSchema } from "@/lib/types";
 import {
   type AgentCatalogKind,
   AgentComposedSqlError,
@@ -72,6 +72,7 @@ import { fingerprintStatement } from "./repair-ledger";
 import { summarisePlan } from "./plan-summary";
 import {
   MAX_PROFILE_COLUMNS,
+  type AgentProfileDepth,
   type AgentProfileFinding,
   type AgentTableProfile,
   composeTableProfile,
@@ -175,6 +176,8 @@ export type AgentToolUnavailableCode =
   | "TABLE_NOT_INVENTORIED"
   /** The profile ran, and its aggregate row could not be read back. */
   | "PROFILE_UNREADABLE"
+  /** The requested column offset is past the end of the table. */
+  | "NO_COLUMNS_AT_OFFSET"
   /** One plan cited as both sides: a before and an after have to be two plans. */
   | "IDENTICAL_PLANS"
   /** The statement does not match the card it is offered under. */
@@ -293,6 +296,8 @@ const profileSelectorSchema = z.strictObject({
   schema: z.string().optional(),
   table: z.string().min(1),
   depth: z.enum(["basic", "distribution", "pattern"]).optional(),
+  /** Where in the table's column list to start. The server bounds how many follow. */
+  fromColumn: z.number().int().min(0).optional(),
 });
 
 const planComparisonSchema = z.strictObject({
@@ -435,6 +440,8 @@ const UNAVAILABLE_TEXT: Readonly<Record<AgentToolUnavailableCode, string>> = Obj
     "At least one of those references is not an estimated plan this run produced. Inspect the plan of each statement first, then compare the two artifacts those inspections returned.",
   TABLE_NOT_INVENTORIED:
     "That table is not in the schema inventory this run captured. Call inspect_schema for it first, then profile it by the name the inventory uses.",
+  NO_COLUMNS_AT_OFFSET:
+    "That column offset is past the end of the table, so there is nothing there to profile. Start from an earlier column, or profile a different table.",
   PROFILE_UNREADABLE:
     "The profile ran but its result could not be read as counts. Try a shallower depth, or profile a different table.",
   IDENTICAL_PLANS:
@@ -1077,11 +1084,37 @@ function describeFindings(findings: readonly AgentProfileFinding[]): string {
  * a table it has seen is answered; one that names a table the run never captured
  * is refused rather than sent to the database on a guess.
  */
-function inventoriedTable(snapshot: AgentContextSnapshot, schema: string | undefined, table: string) {
-  const qualified = schema === undefined ? table : `${schema}.${table}`;
-  const exact = snapshot.tables.find((candidate) => candidate.name === qualified || candidate.name === table);
-  if (exact !== undefined) return exact;
-  if (schema !== undefined) return undefined;
+/**
+ * A table the run inventoried, and the schema/table pair the RESOLUTION produced.
+ *
+ * The pair matters as much as the entry. An earlier version composed from the
+ * model's own spelling, so an unqualified `orders` that resolved to `sales.orders`
+ * composed `FROM "orders"` — leaving PostgreSQL's `search_path` to decide which
+ * relation was actually read while the ledger said `sales.orders` had been
+ * profiled. Found by review on #345; the profile now targets what it resolved.
+ */
+interface ResolvedProfileTarget {
+  readonly entry: TableSchema;
+  readonly schema?: string;
+  readonly table: string;
+}
+
+function inventoriedTable(
+  snapshot: AgentContextSnapshot,
+  schema: string | undefined,
+  table: string,
+): ResolvedProfileTarget | null {
+  if (schema !== undefined) {
+    // A schema was named, so it is part of the answer. Matching a BARE inventory
+    // entry here would accept `{schema: "other", table: "orders"}` against SQLite's
+    // unqualified `orders` and then target `other.orders` — a table the run never
+    // inventoried. Found by review on #345.
+    const entry = snapshot.tables.find((candidate) => candidate.name === `${schema}.${table}`);
+    return entry === undefined ? null : { entry, schema, table };
+  }
+
+  const bare = snapshot.tables.find((candidate) => candidate.name === table);
+  if (bare !== undefined) return { entry: bare, table };
 
   // An unqualified name against a qualified inventory. PostgreSQL's capture names
   // tables `schema.table` and SQLite's does not, so a model that has read either
@@ -1090,7 +1123,11 @@ function inventoriedTable(snapshot: AgentContextSnapshot, schema: string | undef
   // precisely when a guess would profile the wrong one.
   const suffix = `.${table}`;
   const matches = snapshot.tables.filter((candidate) => candidate.name.endsWith(suffix));
-  return matches.length === 1 ? matches[0] : undefined;
+  const only = matches.length === 1 ? matches[0] : undefined;
+  if (only === undefined) return null;
+  // Derived by removing the suffix rather than by splitting on a dot: exact, and it
+  // cannot misread a name that carries one.
+  return { entry: only, schema: only.name.slice(0, only.name.length - suffix.length), table };
 }
 
 /**
@@ -1116,11 +1153,35 @@ function capturedSnapshot(events: readonly AgentRunEvent[]): AgentContextSnapsho
  * records is a count — `table-profile.ts` says why, and it is what makes profiling a
  * table of personal data acceptable at all.
  */
-export async function profileTableTool(
+/**
+ * Everything the run loop needs to give a profile a durable step identity, decided
+ * before anything is executed.
+ *
+ * Split out of the tool because the step id has to be derived from the RESOLVED
+ * target rather than from the model's spelling — two different requests naming the
+ * same table are the same profile, and must settle as one step.
+ */
+export interface AgentProfilePlan {
+  readonly sql: string;
+  readonly target: ResolvedProfileTarget;
+  readonly depth: AgentProfileDepth;
+  readonly columns: readonly ColumnSchema[];
+  /** Where in the table's column list this batch starts. */
+  readonly from: number;
+  /** Columns beyond this batch, so nothing silently claims to have covered them. */
+  readonly remaining: number;
+}
+
+export type AgentProfilePlanOutcome =
+  | { readonly kind: "planned"; readonly plan: AgentProfilePlan }
+  | { readonly kind: "unavailable"; readonly reasonCode: AgentToolUnavailableCode; readonly modelText: string };
+
+/** Resolves and composes, and reaches nothing. */
+export function planTableProfile(
   context: AgentToolContext,
   run: Pick<AgentRunRecord, "runId" | "events">,
   input: unknown,
-): Promise<AgentTableProfileOutcome> {
+): AgentProfilePlanOutcome {
   if (context.mode !== "agent") return unavailable("MODE_HAS_NO_TOOLS");
   if (run.runId !== context.runId) {
     throw new Error("agent tool layer: the profile's run record does not belong to this run");
@@ -1130,27 +1191,49 @@ export async function profileTableTool(
   if (!parsed.ok) return unavailable("INVALID_TOOL_INPUT");
 
   const snapshot = capturedSnapshot(run.events);
-  const table = snapshot === null ? undefined : inventoriedTable(snapshot, parsed.value.schema, parsed.value.table);
-  if (table === undefined) return unavailable("TABLE_NOT_INVENTORIED");
+  const target = snapshot === null ? null : inventoriedTable(snapshot, parsed.value.schema, parsed.value.table);
+  if (target === null) return unavailable("TABLE_NOT_INVENTORIED");
 
   const depth = parsed.value.depth ?? "basic";
-  // Bounded here rather than in the composer: a wider table is profiled in more
-  // than one call, and the statement budget accounts for that honestly.
-  const columns = table.columns.slice(0, MAX_PROFILE_COLUMNS);
-  let sql: string;
-  try {
-    sql = composeTableProfile(context.connection.type, { ...parsed.value, depth }, columns);
-  } catch (error) {
-    return composedSqlOutcome(error) as AgentTableProfileOutcome;
-  }
+  const from = parsed.value.fromColumn ?? 0;
+  if (from >= target.entry.columns.length) return unavailable("NO_COLUMNS_AT_OFFSET");
+  // Bounded because the composed statement grows with the column count. A wider
+  // table is profiled in more than one call, and `fromColumn` is how the model asks
+  // for the next batch — without it, columns past the first bound could never be
+  // assessed while the run still counted as having profiled the table.
+  const columns = target.entry.columns.slice(from, from + MAX_PROFILE_COLUMNS);
 
+  try {
+    // Composed from what was RESOLVED, never from what was asked for.
+    return {
+      kind: "planned",
+      plan: {
+        sql: composeTableProfile(context.connection.type, { ...target, depth }, columns),
+        target,
+        depth,
+        columns,
+        from,
+        remaining: Math.max(0, target.entry.columns.length - (from + columns.length)),
+      },
+    };
+  } catch (error) {
+    return composedSqlOutcome(error) as AgentProfilePlanOutcome;
+  }
+}
+
+export async function profileTableTool(
+  context: AgentToolContext,
+  plan: AgentProfilePlan,
+): Promise<AgentTableProfileOutcome> {
+  const { target, depth, columns } = plan;
   const outcome = await executeAgentOperation(context, {
     operationId: "sql.table.profile",
-    sql,
-    label: `profile of ${table.name}`,
-    ...(parsed.value.schema === undefined ? {} : { target: { schema: parsed.value.schema } }),
+    sql: plan.sql,
+    label: `profile of ${target.entry.name}`,
+    ...(target.schema === undefined ? {} : { target: { schema: target.schema } }),
   });
   if (outcome.kind !== "completed") return outcome;
+  const table = target.entry;
 
   const stored = context.artifacts.get(outcome.artifact.correlationId, (context.clock ?? Date.now)());
   const profile = stored === undefined ? null : readTableProfile(table.name, depth, columns, stored.value.rows);
@@ -1167,7 +1250,22 @@ export async function profileTableTool(
     // without it the assessment template could profile a table and then be unable
     // to compose a cited claim about it, which its own goal verifier requires.
     // Found by the scenario suite before any model saw it.
-    modelText: `Profiled ${table.name}: ${profile.rowCount} row(s), ${columns.length} column(s) at ${depth} depth, ${findings.length} finding(s), artifact ${outcome.artifact.correlationId}. Only counts were read; no value was returned from any column. ${describeFindings(findings)}`,
+    // The table's own name is DATABASE CONTENT, so it is fenced rather than spliced
+    // into a sentence the model reads as the server speaking. Found by review on
+    // #345: an identifier is exactly as untrusted as a row value.
+    modelText: [
+      `Profiled a table: ${profile.rowCount} row(s), columns ${plan.from + 1}-${plan.from + columns.length} at ${depth} depth, ${findings.length} finding(s), artifact ${outcome.artifact.correlationId}.`,
+      plan.remaining === 0
+        ? "Every column of that table is covered."
+        : `${plan.remaining} further column(s) are NOT covered by this profile; call profile_table again with fromColumn=${plan.from + columns.length} to reach them.`,
+      "Only counts were read; no value was returned from any column.",
+      fenceUntrustedContent(`table: ${table.name}`, {
+        label: "profiled table name",
+        operationId: "sql.table.profile",
+        reference: outcome.artifact.correlationId,
+      }),
+      describeFindings(findings),
+    ].join(" "),
   };
 }
 

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -45,6 +45,7 @@ import type { Role } from "@/lib/auth";
 import type { PolicyDenyCode } from "@/lib/db/operations/policy";
 import type { TableSchema } from "@/lib/types";
 import type { AgentPlanSummary } from "./plan-summary";
+import type { AgentTableProfile } from "./table-profile";
 
 /**
  * Which surface a run drives. Planning is toolless: it must perform zero database
@@ -353,6 +354,31 @@ export type AgentRunEvent =
       readonly statement: string;
       readonly rationale: string;
       readonly evidence: readonly [AgentEvidenceReference, ...AgentEvidenceReference[]];
+    })
+  | (AgentRunEventBase & {
+      /**
+       * One table profiled, as COUNTS and the findings derived from them.
+       *
+       * The database-assessment template's own artifact. Nothing here is a value
+       * read out of a column — `table-profile.ts` states why, and it is the reason
+       * profiling a table of personal data is acceptable at all: the run records
+       * how many, never which.
+       *
+       * The findings are the SERVER's, derived from the numbers by predicates with
+       * stated thresholds. A model may interpret them; it cannot invent one.
+       */
+      readonly kind: "table-profiled";
+      /**
+       * The read that produced the counts, so a report can CITE the profile.
+       *
+       * Present because its absence was a defect: profiling does not settle a step,
+       * so it writes no `tool-completed`, and a claim about a profile was therefore
+       * uncitable — which made the assessment template's own goal verifier, which
+       * requires both a profile and a cited report, impossible to satisfy. Found by
+       * the scenario suite before any model met it.
+       */
+      readonly artifact: AgentArtifactReference;
+      readonly profile: AgentTableProfile;
     })
   | (AgentRunEventBase & {
       readonly kind: "run-finished";

--- a/src/lib/db/operations/descriptors.ts
+++ b/src/lib/db/operations/descriptors.ts
@@ -1,8 +1,12 @@
 /**
- * Canonical Phase 1 operation descriptors (#328, epic #325).
+ * Canonical Phase 1 operation descriptors (#328, epic #325; extended by #330 T3).
  *
- * Exactly three operations exist: bounded read, plan inspection, plan
- * execution. Plan inspection and plan execution are DISTINCT descriptors whose
+ * Four operations exist: bounded read, plan inspection, plan execution and table
+ * profiling. The set was pinned at THREE by epic #325 and reopened by #330 T3,
+ * which is why the fourth carries that reversal in its own comment rather than
+ * arriving as though the number had never been a decision.
+ *
+ * Plan inspection and plan execution are DISTINCT descriptors whose
  * ids are derived from the explain seam's modes (`ExplainMode`,
  * src/lib/explain) — renaming a mode breaks these ids at compile time — and
  * the executing variant is default-denied because EXPLAIN ANALYZE runs the
@@ -78,10 +82,45 @@ export const sqlExplainAnalyzeDescriptor: RegistrableOperationDescriptor = {
   },
 };
 
+/**
+ * Per-table profiling: a bounded read whose aggregates the server composes.
+ *
+ * A FOURTH descriptor, and that is a reversal of a product decision rather than an
+ * oversight being corrected. Epic #325 pinned the canonical set at three, and
+ * `docs/BACKLOG.md` B17 recorded profiling as deferred because of it; #330 T3
+ * instructs that profiling reach the database "as new descriptors in
+ * `descriptors.ts` at R0/R1", which is the owner reopening that decision.
+ *
+ * Why it is not simply `sql.query.read`, which it structurally resembles: a profile
+ * aggregates over a whole table by design, and it is the one agent read aimed at
+ * columns a deployment may consider personal. Its own id is what lets an operator
+ * see profiling in the audit stream, and deny it, without also denying every read
+ * the agent makes. The statement is still bounded by the same guard — this widens
+ * what can be NAMED, never what can be run.
+ */
+export const sqlTableProfileDescriptor: RegistrableOperationDescriptor = {
+  id: "sql.table.profile",
+  riskClass: 1,
+  accessLevel: "data-read",
+  requiredCapabilities: [],
+  resourceCost: "heavy",
+  supportsDryRun: false,
+  requiresApproval: false,
+  // The same input contract as any bounded read: the composed aggregate has to
+  // satisfy the statement guard exactly as a model-drafted read does.
+  inputSchema: agentReadSqlInput,
+  verification: {
+    reviewedBy: "issue #330 T3 (epic #325 product decision, reversing docs/BACKLOG.md B17)",
+    boundary: BOUNDED_READ_BOUNDARY,
+    verifiedOn: "2026-08-12",
+  },
+};
+
 export function createCanonicalOperationRegistry(): OperationRegistry {
   const registry = new OperationRegistry();
   registry.register(sqlQueryReadDescriptor);
   registry.register(sqlExplainEstimateDescriptor);
   registry.register(sqlExplainAnalyzeDescriptor);
+  registry.register(sqlTableProfileDescriptor);
   return registry;
 }

--- a/tests/evals/database-assessment.test.ts
+++ b/tests/evals/database-assessment.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { type EvalEngine, type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
 import { type Turn, answersProse, callsTool, reportOn } from "../isolated/fixtures/agent-scripted-model";
 import { chatToolCallStream } from "../isolated/fixtures/agent-transport";
+import { ConnectionError, QueryError } from "@/lib/db/errors";
 
 /**
  * The `database-assessment` template, driven end to end on both reference engines
@@ -66,10 +67,16 @@ describe("the assessment arc, on both reference engines", () => {
 
       const drive = await run.drive(assessmentArc("engineering"));
 
+      // The profile settles a STEP like every other database reach: its invocation
+      // is on the ledger before its effect, and its outcome after. Routing it around
+      // `runStep` cost the run its cancellation checkpoint and its duplicate
+      // protection — found by review on #345.
       expect(drive.kinds).toEqual([
         "run-started",
         "context-captured",
+        "tool-invoked",
         "table-profiled",
+        "tool-completed",
         "report-composed",
         "run-finished",
       ]);
@@ -104,6 +111,44 @@ describe("the assessment arc, on both reference engines", () => {
       for (const finding of profiled.profile.findings) expect(finding.detail).not.toContain("@");
     });
   }
+});
+
+describe("a profile's artifact is an artifact like any other", () => {
+  test("it settles a step, so it is citable, fetchable and charged to the budget", async () => {
+    // Three consumers read `tool-completed` and nothing else: `composeReportTool`'s
+    // citation check, the artifact route's authorization, and the rail's budget
+    // fold. A profile that emitted no settlement would be citable in a report whose
+    // "Show result" always answered 404, on a meter reading zero. Settling the step
+    // is what makes all three correct at once — found by review on #345.
+    const run = await open("postgres");
+
+    const drive = await run.drive(assessmentArc("engineering"));
+
+    const profiled = drive.events.find((event) => event.kind === "table-profiled");
+    const settled = drive.events.find((event) => event.kind === "tool-completed");
+    if (profiled?.kind !== "table-profiled" || settled?.kind !== "tool-completed") {
+      throw new Error("expected both a profile and its settlement");
+    }
+    expect(settled.artifact.correlationId).toBe(profiled.artifact.correlationId);
+    expect(settled.artifact.operationId).toBe("sql.table.profile");
+  });
+
+  test("the same profile asked for twice is replayed, not re-read", async () => {
+    // The claim an earlier version made and could not keep: the repair ledger
+    // records only FAILED statements, so nothing stopped a successful profile from
+    // running again. The step's identity does.
+    const run = await open("postgres");
+
+    const drive = await run.drive([
+      profiles("engineering", "pattern"),
+      profiles("engineering", "pattern"),
+      reportOn("The engineering table has a sparse column."),
+    ]);
+
+    expect(drive.modelStatements.filter((sql) => sql.includes("count("))).toHaveLength(1);
+    expect(drive.kinds.filter((kind) => kind === "table-profiled")).toHaveLength(1);
+    expect(drive.transcripts[2]).toContain("That exact profile was already taken in this run");
+  });
 });
 
 describe("a profile can only be aimed at a table the run has inventoried", () => {
@@ -168,5 +213,79 @@ describe("a drive that dies after profiling does not profile again", () => {
     expect(resumed.transcripts[0] ?? "").toContain("was already profiled");
     expect(resumed.statements).toEqual([]);
     expect(resumed.verdict.outcome).toBe("answered");
+  });
+});
+
+describe("a profile that does not settle cleanly", () => {
+  test("a statement that fails at the database is refused, and the run may go on", async () => {
+    const run = await openEvalRun({
+      engine: "postgres",
+      workflowType: "database-assessment",
+      objective: "Where is this database's data incomplete?",
+      answer: async (sql) => {
+        if (sql.includes("count(")) throw new QueryError('relation "engineering" does not exist');
+        return { rows: [{ x: 1 }], fields: ["x"], rowCount: 1, executionTime: 2 };
+      },
+    });
+    runs.push(run);
+
+    const drive = await run.drive([profiles("engineering"), answersProse("That table is gone.")]);
+
+    expect(drive.kinds).toContain("tool-refused");
+    expect(drive.kinds).not.toContain("table-profiled");
+    // The engine's own words, fenced.
+    expect(drive.transcripts[1]).toContain("BEGIN UNTRUSTED DATABASE CONTENT");
+  });
+
+  test("a result that does not read back as counts settles nothing, and asking again is told nothing ran", async () => {
+    // The step settles nothing, so by ledger shape alone it is indistinguishable
+    // from a mid-flight death. It is not the same thing to a model — nothing was
+    // recorded, but the read DID happen — so asking again must be told that this
+    // exact call will not be sent again, not that its outcome is unknowable.
+    const run = await openEvalRun({
+      engine: "postgres",
+      workflowType: "database-assessment",
+      objective: "Where is this database's data incomplete?",
+      // Counts came back under names the profile cannot read.
+      answer: async () => ({ rows: [{ total: 5 }], fields: ["total"], rowCount: 1, executionTime: 3 }),
+    });
+    runs.push(run);
+
+    const drive = await run.drive([
+      profiles("engineering"),
+      profiles("engineering"),
+      answersProse("I cannot read it."),
+    ]);
+
+    expect(drive.kinds).not.toContain("table-profiled");
+    expect(drive.transcripts[1]).toContain("could not be read as counts");
+    expect(drive.transcripts[2]).toContain("refused before the database was reached");
+  });
+
+  test("a profile interrupted before its outcome was recorded is never repeated", async () => {
+    // The process-death window: the invocation is durable, the outcome is not, and
+    // whether the read reached the database is unknowable. Re-running it would be
+    // the duplicate execution the write-ahead ordering exists to prevent.
+    let reaches = 0;
+    const run = await openEvalRun({
+      engine: "postgres",
+      workflowType: "database-assessment",
+      objective: "Where is this database's data incomplete?",
+      // The three catalog reads succeed; the profile's acquisition does not.
+      acquireFails: () => (++reaches > 3 ? new ConnectionError("the pool went away") : undefined),
+    });
+    runs.push(run);
+
+    await expect(run.drive([profiles("engineering")])).rejects.toThrow(/pool went away/);
+    expect((await run.events()).map((event) => event.kind)).toEqual([
+      "run-started",
+      "context-captured",
+      "tool-invoked",
+    ]);
+
+    const resumed = await run.drive([profiles("engineering"), answersProse("I cannot know.")]);
+
+    expect(resumed.transcripts[1]).toContain("outcome was never recorded");
+    expect(resumed.kinds).not.toContain("table-profiled");
   });
 });

--- a/tests/evals/database-assessment.test.ts
+++ b/tests/evals/database-assessment.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { type EvalEngine, type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
+import { type Turn, answersProse, callsTool, reportOn } from "../isolated/fixtures/agent-scripted-model";
+import { chatToolCallStream } from "../isolated/fixtures/agent-transport";
+
+/**
+ * The `database-assessment` template, driven end to end on both reference engines
+ * (#330 T3).
+ *
+ * The invariant asserted hardest here is not the arc but the promise the template
+ * rests on: **every statement it sends is counts, and no value comes back.** That
+ * is what makes profiling a table of personal data acceptable, so it is checked
+ * against the statements the run actually sent rather than against the tool's
+ * intent.
+ */
+
+const runs: EvalRun[] = [];
+let consoleSpy: ReturnType<typeof spyOn<Console, "log">>;
+
+beforeEach(() => {
+  consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleSpy.mockRestore();
+  for (const run of runs.splice(0)) run.dispose();
+});
+
+/** A profile answer: one row of aggregates for the eight-column sample table. */
+const profileRow = (): Record<string, unknown> => ({
+  row_count: 1000,
+  present_0: 1000,
+  distinct_0: 1000,
+  present_1: 400,
+  distinct_1: 380,
+  shaped_1: 380,
+});
+
+async function open(engine: EvalEngine): Promise<EvalRun> {
+  const run = await openEvalRun({
+    engine,
+    workflowType: "database-assessment",
+    objective: "Where is this database's data incomplete or surprising?",
+    answer: async (sql) => {
+      if (!sql.includes("count(")) return { rows: [{ x: 1 }], fields: ["x"], rowCount: 1, executionTime: 2 };
+      const row = profileRow();
+      return { rows: [row], fields: Object.keys(row), rowCount: 1, executionTime: 6 };
+    },
+  });
+  runs.push(run);
+  return run;
+}
+
+const profiles = (table: string, depth?: string) =>
+  callsTool("profile_table", depth === undefined ? { table } : { table, depth }, `call_profile_${table}`);
+
+const assessmentArc = (table: string) => [
+  profiles(table, "pattern"),
+  reportOn("The engineering table has a sparsely populated column and one that looks like contact detail."),
+];
+
+describe("the assessment arc, on both reference engines", () => {
+  for (const engine of ["postgres", "sqlite"] as const) {
+    test(`${engine}: profiles a table, records findings, and answers`, async () => {
+      const run = await open(engine);
+
+      const drive = await run.drive(assessmentArc("engineering"));
+
+      expect(drive.kinds).toEqual([
+        "run-started",
+        "context-captured",
+        "table-profiled",
+        "report-composed",
+        "run-finished",
+      ]);
+      expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-database-assessment.1", unmet: [] });
+    });
+
+    test(`${engine}: every statement the profile sent is counts, and no value came back`, async () => {
+      const run = await open(engine);
+
+      const drive = await run.drive(assessmentArc("engineering"));
+
+      const profileStatements = drive.modelStatements.filter((sql) => sql.includes("count("));
+      expect(profileStatements).toHaveLength(1);
+      const projection = profileStatements[0]?.slice("SELECT ".length, profileStatements[0].indexOf(" FROM ")) ?? "";
+      for (const part of projection.split(", ")) expect(part.startsWith("count("), part).toBe(true);
+      expect(projection).not.toContain("min(");
+      expect(projection).not.toContain("max(");
+    });
+
+    test(`${engine}: the findings on the ledger are the server's, derived from counts`, async () => {
+      const run = await open(engine);
+
+      const drive = await run.drive(assessmentArc("engineering"));
+
+      const profiled = drive.events.find((event) => event.kind === "table-profiled");
+      if (profiled?.kind !== "table-profiled") throw new Error("expected a profile");
+      expect(profiled.profile.rowCount).toBe(1000);
+      expect(profiled.profile.depth).toBe("pattern");
+      // 400 present of 1000 rows is over the high-null threshold.
+      expect(profiled.profile.findings.map((finding) => finding.code)).toContain("high_null");
+      // And nothing in the record is a value from a column.
+      for (const finding of profiled.profile.findings) expect(finding.detail).not.toContain("@");
+    });
+  }
+});
+
+describe("a profile can only be aimed at a table the run has inventoried", () => {
+  test("a table the schema capture never returned is refused before any database reach", async () => {
+    const run = await open("postgres");
+
+    const drive = await run.drive([profiles("secrets"), answersProse("I could not profile that.")]);
+
+    expect(drive.modelStatements).toEqual([]);
+    expect(drive.transcripts[1]).toContain("not in the schema inventory");
+    expect(drive.kinds).not.toContain("table-profiled");
+  });
+});
+
+describe("THE GATE: the verifier fails the run when the template's own artifact is absent", () => {
+  for (const engine of ["postgres", "sqlite"] as const) {
+    test(`${engine}: a cited report written from the schema alone does not assess the data`, async () => {
+      const run = await open(engine);
+
+      const drive = await run.drive([
+        callsTool("run_read_query", { sql: "SELECT 1", rationale: "a look" }),
+        reportOn("The schema has eight tables and looks reasonable."),
+      ]);
+
+      expect(drive.status).toBe("succeeded");
+      expect(drive.stopReason).toBe("report-composed");
+      expect(drive.verdict).toEqual({
+        outcome: "unanswered",
+        verifier: "agent-database-assessment.1",
+        unmet: ["no-table-profile"],
+      });
+    });
+  }
+});
+
+describe("the tool belongs to the workflow", () => {
+  test("an investigation asking to profile a table is told there is no such tool", async () => {
+    const run = await openEvalRun({ objective: "What is in here?" });
+    runs.push(run);
+
+    const drive = await run.drive([
+      (turn: Turn) => {
+        void turn;
+        return chatToolCallStream("profile_table", JSON.stringify({ table: "engineering" }), "call_profile");
+      },
+      answersProse("I cannot profile from here."),
+    ]);
+
+    expect(drive.transcripts[1]).toContain("There is no tool called");
+    expect(drive.modelStatements).toEqual([]);
+  });
+});
+
+describe("a drive that dies after profiling does not profile again", () => {
+  test("the resumed run is told what it already profiled", async () => {
+    const run = await open("postgres");
+
+    await expect(run.drive([profiles("engineering", "pattern")])).rejects.toThrow(/died before turn/);
+
+    const resumed = await run.drive([reportOn("The engineering table has a sparse column.")]);
+
+    expect(resumed.transcripts[0] ?? "").toContain("was already profiled");
+    expect(resumed.statements).toEqual([]);
+    expect(resumed.verdict.outcome).toBe("answered");
+  });
+});

--- a/tests/isolated/fixtures/agent-eval-harness.ts
+++ b/tests/isolated/fixtures/agent-eval-harness.ts
@@ -187,6 +187,14 @@ export interface EvalRunOptions {
   readonly actor?: AgentRunActor;
   /** What the scripted engine answers a MODEL statement with. Catalog reads are served by the preset. */
   readonly answer?: (sql: string) => Promise<QueryResult>;
+  /**
+   * Fails the provider acquisition — a reach that dies BEFORE the statement is
+   * sent, so it propagates rather than settling. Called once per acquisition and
+   * may return nothing, which is how a fixture lets the drive's context capture
+   * succeed and takes the pool away afterwards. This is the only way to leave a
+   * step invoked with no outcome, which is the process-death window itself.
+   */
+  readonly acquireFails?: () => Error | undefined;
 }
 
 export interface EvalDriveOptions {
@@ -285,7 +293,11 @@ export async function openEvalRun(options: EvalRunOptions = {}): Promise<EvalRun
       artifacts,
       deadline: new AgentRunDeadline(AGENT_RUN_DEADLINE_MS, clock),
       repairs: new AgentRepairLedger(),
-      acquireProvider: async () => provider,
+      acquireProvider: async () => {
+        const failure = options.acquireFails?.();
+        if (failure) throw failure;
+        return provider;
+      },
     };
 
     const outcome = await runInvestigation(record.runId, {

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -1005,3 +1005,45 @@ describe("a recommendation reads as a proposal, never as something that happened
     expect(view.items[1]?.quoted).toBe(ddl);
   });
 });
+
+describe("a table profile reads as counts and findings, never as values", () => {
+  const profiled = (findings: readonly { code: string; column: string; detail: string }[]): AgentLedgerEntry =>
+    event({
+      kind: "event",
+      event: {
+        kind: "table-profiled",
+        atMs: 7,
+        artifact: {
+          correlationId: "corr-1",
+          runId: "run-1",
+          operationId: "sql.table.profile",
+          summary: { rowCount: 1, columnNames: ["row_count"], elapsedMs: 9 },
+        },
+        profile: {
+          table: "public.customers",
+          depth: "pattern",
+          rowCount: 4120,
+          columns: [{ column: "email", present: 4118, distinct: 4100, shaped: 4090 }],
+          findings,
+        },
+      },
+    } as AgentLedgerEntry & { kind: "event" });
+
+  test("names the table, the depth and every finding", () => {
+    const view = foldLedgerEntries([
+      OPENED,
+      profiled([{ code: "suspected_pii", column: "email", detail: "99% look like an email address." }]),
+    ]);
+
+    expect(view.items[1]?.headline).toBe("Profiled public.customers");
+    expect(view.items[1]?.detail).toContain("4120 row(s) at pattern depth");
+    expect(view.items[1]?.detail).toContain("email: suspected_pii");
+  });
+
+  test("a profile that crossed no threshold says so rather than listing nothing", () => {
+    const view = foldLedgerEntries([OPENED, profiled([])]);
+
+    expect(view.items[1]?.detail).toContain("Nothing stood out");
+    expect(view.items[1]?.detail).toContain("1 column(s)");
+  });
+});

--- a/tests/unit/db/operations/descriptors.test.ts
+++ b/tests/unit/db/operations/descriptors.test.ts
@@ -4,14 +4,43 @@ import {
   sqlExplainAnalyzeDescriptor,
   sqlExplainEstimateDescriptor,
   sqlQueryReadDescriptor,
+  sqlTableProfileDescriptor,
 } from "@/lib/db/operations/descriptors";
 
-const canonicalDescriptors = [sqlQueryReadDescriptor, sqlExplainEstimateDescriptor, sqlExplainAnalyzeDescriptor];
+const canonicalDescriptors = [
+  sqlQueryReadDescriptor,
+  sqlExplainEstimateDescriptor,
+  sqlExplainAnalyzeDescriptor,
+  sqlTableProfileDescriptor,
+];
 
 describe("canonical operation registry", () => {
-  test("registers exactly the three canonical descriptors — no write, DDL, or admin operation exists", () => {
+  test("registers exactly the four canonical descriptors — no write, DDL, or admin operation exists", () => {
+    // Four since #330 T3, which reopened a decision epic #325 had pinned at three.
+    // The assertion is exact-array equality on purpose: it is the one place a
+    // descriptor can be added without somebody noticing.
     const registry = createCanonicalOperationRegistry();
-    expect(registry.registeredIds()).toEqual(["sql.explain.analyze", "sql.explain.estimate", "sql.query.read"]);
+    expect(registry.registeredIds()).toEqual([
+      "sql.explain.analyze",
+      "sql.explain.estimate",
+      "sql.query.read",
+      "sql.table.profile",
+    ]);
+  });
+
+  test("profiling is a bounded DATA read that needs no approval, and is separately auditable", () => {
+    expect(sqlTableProfileDescriptor).toMatchObject({
+      id: "sql.table.profile",
+      riskClass: 1,
+      accessLevel: "data-read",
+      requiresApproval: false,
+      resourceCost: "heavy",
+      supportsDryRun: false,
+    });
+    // R1 is registrable only with a substantive verification marker naming a
+    // database-native boundary; the registry refuses a blank one.
+    expect(sqlTableProfileDescriptor.verification?.boundary).toContain("READ ONLY");
+    expect(sqlTableProfileDescriptor.verification?.reviewedBy).toContain("#330");
   });
 
   test("resolves every canonical id to its descriptor", () => {

--- a/tests/unit/lib/agent/goal-verifier.test.ts
+++ b/tests/unit/lib/agent/goal-verifier.test.ts
@@ -277,18 +277,28 @@ describe("a query-optimization run is judged by its own artifact as well as the 
     expect(verdict.unmet).toEqual(["empty-evidence"]);
   });
 
-  test("the other two workflows are not held to the optimization bar", () => {
-    for (const workflowType of ["investigation", "database-assessment"] as const) {
-      const verdict = verifyRunGoal(
-        run(
-          "agent",
-          "succeeded",
-          [contextCaptured, completed(CORRELATION.full, 8), reportCiting(ARTIFACT(CORRELATION.full))],
-          workflowType,
-        ),
-      );
-      expect(verdict.outcome, workflowType).toBe("answered");
-    }
+  test("an investigation is not held to the optimization bar", () => {
+    const verdict = verifyRunGoal(
+      run(
+        "agent",
+        "succeeded",
+        [contextCaptured, completed(CORRELATION.full, 8), reportCiting(ARTIFACT(CORRELATION.full))],
+        "investigation",
+      ),
+    );
+
+    expect(verdict.outcome).toBe("answered");
+  });
+
+  test("each template is held to its OWN bar, and not to the other's", () => {
+    // The same ledger, judged three ways: the artifact a workflow requires is the
+    // only thing separating these verdicts.
+    const events = [contextCaptured, completed(CORRELATION.full, 8), reportCiting(ARTIFACT(CORRELATION.full))];
+
+    expect(verifyRunGoal(run("agent", "succeeded", events, "query-optimization")).unmet).toEqual([
+      "no-plan-comparison",
+    ]);
+    expect(verifyRunGoal(run("agent", "succeeded", events, "database-assessment")).unmet).toEqual(["no-table-profile"]);
   });
 });
 

--- a/tests/unit/lib/agent/table-profile.test.ts
+++ b/tests/unit/lib/agent/table-profile.test.ts
@@ -282,3 +282,39 @@ describe("foreign keys with no covering index", () => {
     expect(findings).toHaveLength(1);
   });
 });
+
+describe("types with no equality operator", () => {
+  // Found by review on #345. PostgreSQL answers `could not identify an equality
+  // operator for type json`, and one unsupported column aborts the WHOLE aggregate —
+  // so a single json column would have failed distribution and pattern profiling for
+  // every other column in the table.
+  test.each(["json", "jsonb", "xml", "point", "polygon"])("%s gets no distinct count", (type) => {
+    const sql = composeTableProfile("postgres", { table: "t", depth: "distribution" }, [
+      column("payload", type),
+      column("name", "text"),
+    ]);
+
+    expect(sql).not.toContain('count(DISTINCT "payload")');
+    // And the comparable column beside it is still counted.
+    expect(sql).toContain('count(DISTINCT "name")');
+  });
+
+  test("a skipped distinct count reads as absent rather than zero", () => {
+    // Which is exactly true: the engine was never asked.
+    const profile = readTableProfile(
+      "t",
+      "distribution",
+      [column("payload", "jsonb")],
+      [{ row_count: 10, present_0: 10 }],
+    );
+
+    expect(profile?.columns[0]?.distinct).toBeUndefined();
+    expect(profile?.findings).toEqual([]);
+  });
+
+  test("presence is still counted for a type nothing can compare", () => {
+    const sql = composeTableProfile("postgres", { table: "t", depth: "distribution" }, [column("payload", "json")]);
+
+    expect(sql).toContain('count("payload")');
+  });
+});

--- a/tests/unit/lib/agent/table-profile.test.ts
+++ b/tests/unit/lib/agent/table-profile.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "bun:test";
+import {
+  HIGH_NULL_RATIO,
+  MIN_ROWS_FOR_RATIO_FINDINGS,
+  composeTableProfile,
+  findUnindexedForeignKeys,
+  readTableProfile,
+} from "@/lib/agent/table-profile";
+import { inspectAgentStatement } from "@/lib/db/operations/statement-guard";
+import type { ColumnSchema, TableSchema } from "@/lib/types";
+
+/**
+ * Bounded per-table profiling (#330 T3).
+ *
+ * The invariant the whole module exists to hold is asserted first and repeatedly:
+ * **a profile records counts, never values.** Every composed aggregate is a
+ * `count(...)`, and no test here can produce a statement that would return a name,
+ * an address or an account number — which is what makes profiling a table of
+ * personal data acceptable at all.
+ */
+
+const column = (name: string, type = "text"): ColumnSchema => ({ name, type, nullable: true, isPrimary: false });
+
+const COLUMNS: ColumnSchema[] = [column("id", "integer"), column("email", "character varying"), column("status")];
+
+describe("the composed statement", () => {
+  test.each(["postgres", "sqlite"] as const)(
+    "%s: passes the same statement guard a model-drafted read does",
+    (dialect) => {
+      for (const depth of ["basic", "distribution", "pattern"] as const) {
+        const sql = composeTableProfile(dialect, { table: "employee", depth }, COLUMNS);
+        expect(inspectAgentStatement(sql), `${dialect}/${depth}`).toBeNull();
+      }
+    },
+  );
+
+  test("every projected expression is a count, so no value can come back", () => {
+    const sql = composeTableProfile("postgres", { table: "employee", depth: "pattern" }, COLUMNS);
+    const projection = sql.slice("SELECT ".length, sql.indexOf(" FROM "));
+
+    for (const part of projection.split(", ")) expect(part.startsWith("count("), part).toBe(true);
+    // The conventional profiler statistics that WOULD return a value.
+    expect(sql).not.toContain("min(");
+    expect(sql).not.toContain("max(");
+  });
+
+  test("deepening adds aggregates rather than replacing them", () => {
+    const basic = composeTableProfile("postgres", { table: "t", depth: "basic" }, COLUMNS);
+    const distribution = composeTableProfile("postgres", { table: "t", depth: "distribution" }, COLUMNS);
+    const pattern = composeTableProfile("postgres", { table: "t", depth: "pattern" }, COLUMNS);
+
+    expect(basic).not.toContain("DISTINCT");
+    expect(distribution).toContain("count(DISTINCT");
+    expect(distribution).not.toContain("LIKE");
+    expect(pattern).toContain("LIKE");
+  });
+
+  test("the shape test is applied only to columns whose declared type is textual", () => {
+    // Comparing an integer column to a string pattern is an error on PostgreSQL,
+    // and casting every column to text would turn a bounded read into a full
+    // conversion of the table.
+    const sql = composeTableProfile("postgres", { table: "t", depth: "pattern" }, COLUMNS);
+
+    expect(sql).toContain('count(CASE WHEN "email" LIKE');
+    expect(sql).not.toContain('count(CASE WHEN "id" LIKE');
+  });
+
+  test("an identifier carrying the closing quote is escaped, not interpolated", () => {
+    const sql = composeTableProfile("postgres", { table: 'we"ird', depth: "basic" }, [column('c"1')]);
+
+    expect(sql).toContain('"we""ird"');
+    expect(sql).toContain('"c""1"');
+    expect(inspectAgentStatement(sql)).toBeNull();
+  });
+
+  test("a schema is qualified when given and omitted when not", () => {
+    expect(composeTableProfile("postgres", { schema: "public", table: "t", depth: "basic" }, COLUMNS)).toContain(
+      'FROM "public"."t"',
+    );
+    expect(composeTableProfile("sqlite", { table: "t", depth: "basic" }, COLUMNS)).toContain('FROM "t"');
+  });
+
+  test("an unverified dialect and an empty column list are refused rather than composed", () => {
+    expect(() => composeTableProfile("mysql", { table: "t", depth: "basic" }, COLUMNS)).toThrow(/no verified profile/);
+    expect(() => composeTableProfile("postgres", { table: "t", depth: "basic" }, [])).toThrow(/no columns/);
+    expect(() => composeTableProfile("postgres", { table: "  ", depth: "basic" }, COLUMNS)).toThrow(/usable length/);
+  });
+});
+
+describe("reading the aggregate row back", () => {
+  const row = (values: Record<string, unknown>) => [values];
+
+  test("a driver's bigint and node-postgres's numeric string both read as counts", () => {
+    // `count()` comes back as a bigint on some drivers, and node-postgres returns
+    // int8 as text to avoid losing precision.
+    const profile = readTableProfile("t", "basic", [column("a")], row({ row_count: "40", present_0: BigInt(40) }));
+
+    expect(profile?.rowCount).toBe(40);
+    expect(profile?.columns[0]?.present).toBe(40);
+  });
+
+  test("a statistic the engine did not report is absent, never zero", () => {
+    const profile = readTableProfile("t", "basic", [column("a")], row({ row_count: 10, present_0: 10 }));
+
+    expect(profile?.columns[0]?.distinct).toBeUndefined();
+    expect(profile?.columns[0]?.shaped).toBeUndefined();
+  });
+
+  test("a result with no row, or no row count, is unreadable rather than a profile of nothing", () => {
+    expect(readTableProfile("t", "basic", [column("a")], [])).toBeNull();
+    expect(readTableProfile("t", "basic", [column("a")], row({ present_0: 3 }))).toBeNull();
+  });
+});
+
+describe("the findings, derived from the numbers", () => {
+  const codes = (profile: ReturnType<typeof readTableProfile>) => profile?.findings.map((f) => f.code) ?? [];
+
+  test("a mostly empty column is high_null, with the ratio in the app's own words", () => {
+    const rows = MIN_ROWS_FOR_RATIO_FINDINGS * 5;
+    const profile = readTableProfile(
+      "t",
+      "basic",
+      [column("note")],
+      [{ row_count: rows, present_0: Math.floor(rows * (1 - HIGH_NULL_RATIO)) - 1 }],
+    );
+
+    expect(codes(profile)).toContain("high_null");
+    expect(profile?.findings[0]?.detail).toMatch(/% of \d+ rows have no value/);
+  });
+
+  test("a sparse column in a tiny table is not reported, because the ratio would say more about the sample", () => {
+    const profile = readTableProfile("t", "basic", [column("note")], [{ row_count: 4, present_0: 0 }]);
+
+    expect(codes(profile)).toEqual([]);
+  });
+
+  test("one distinct value across many rows is constant, not low cardinality", () => {
+    const profile = readTableProfile(
+      "t",
+      "distribution",
+      [column("flag")],
+      [{ row_count: 500, present_0: 500, distinct_0: 1 }],
+    );
+
+    expect(codes(profile)).toEqual(["constant"]);
+  });
+
+  test("a handful of values across many rows is low_cardinality", () => {
+    const profile = readTableProfile(
+      "t",
+      "distribution",
+      [column("status")],
+      [{ row_count: 5000, present_0: 5000, distinct_0: 3 }],
+    );
+
+    expect(codes(profile)).toEqual(["low_cardinality"]);
+  });
+
+  test("a column named like personal data is suspected, and the finding says its values were not read", () => {
+    const profile = readTableProfile("t", "basic", [column("email_address")], [{ row_count: 10, present_0: 10 }]);
+
+    expect(codes(profile)).toEqual(["suspected_pii"]);
+    expect(profile?.findings[0]?.detail).toContain("values were not inspected");
+  });
+
+  test("a column whose values are mostly email-shaped is suspected even when its name says nothing", () => {
+    const profile = readTableProfile(
+      "t",
+      "pattern",
+      [column("col_7")],
+      [{ row_count: 100, present_0: 100, distinct_0: 100, shaped_0: 99 }],
+    );
+
+    expect(codes(profile)).toEqual(["suspected_pii"]);
+    // Still no value: the ratio was computed inside the database.
+    expect(profile?.findings[0]?.detail).toContain("No value was read out of the database");
+  });
+
+  test("a column with a few incidental matches is not suspected", () => {
+    const profile = readTableProfile(
+      "t",
+      "pattern",
+      [column("col_7")],
+      [{ row_count: 100, present_0: 100, distinct_0: 100, shaped_0: 2 }],
+    );
+
+    expect(codes(profile)).toEqual([]);
+  });
+
+  test("no finding carries a value, only counts and the app's own words", () => {
+    const profile = readTableProfile(
+      "t",
+      "pattern",
+      [column("email")],
+      [{ row_count: 100, present_0: 40, distinct_0: 2, shaped_0: 40 }],
+    );
+
+    for (const finding of profile?.findings ?? []) {
+      expect(finding.detail).not.toContain("@");
+    }
+  });
+});
+
+describe("foreign keys with no covering index", () => {
+  const table = (overrides: Partial<TableSchema>): TableSchema => ({
+    name: "orders",
+    columns: [column("id", "integer"), column("customer_id", "integer")],
+    indexes: [],
+    ...overrides,
+  });
+
+  test("an uncovered foreign key is reported, in words that say what was actually checked", () => {
+    const findings = findUnindexedForeignKeys(
+      table({ foreignKeys: [{ columnName: "customer_id", referencedTable: "customers", referencedColumn: "id" }] }),
+    );
+
+    expect(findings.map((f) => f.code)).toEqual(["fk_unindexed"]);
+    // Not "this foreign key is unindexed": the inventory has known blind spots.
+    expect(findings[0]?.detail).toContain("in the captured inventory");
+  });
+
+  test("an index LEADING on the column covers it; one that merely mentions it does not", () => {
+    const covered = findUnindexedForeignKeys(
+      table({
+        indexes: [{ name: "ix", columns: ["customer_id", "created_at"], unique: false }],
+        foreignKeys: [{ columnName: "customer_id", referencedTable: "customers", referencedColumn: "id" }],
+      }),
+    );
+    const trailing = findUnindexedForeignKeys(
+      table({
+        indexes: [{ name: "ix", columns: ["created_at", "customer_id"], unique: false }],
+        foreignKeys: [{ columnName: "customer_id", referencedTable: "customers", referencedColumn: "id" }],
+      }),
+    );
+
+    expect(covered).toEqual([]);
+    expect(trailing.map((f) => f.code)).toEqual(["fk_unindexed"]);
+  });
+
+  test("a primary-key column is covered without an index row of its own", () => {
+    const findings = findUnindexedForeignKeys(
+      table({
+        columns: [{ name: "customer_id", type: "integer", nullable: false, isPrimary: true }],
+        foreignKeys: [{ columnName: "customer_id", referencedTable: "customers", referencedColumn: "id" }],
+      }),
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  test("a composite key is SKIPPED rather than guessed at", () => {
+    // PostgreSQL's catalog read returns a composite foreign key as the cross
+    // product of both sides (docs/BACKLOG.md B8), so its columns cannot be
+    // regrouped into the key they belong to — and a covering test over the wrong
+    // grouping would be an answer about a key that does not exist.
+    const findings = findUnindexedForeignKeys(
+      table({
+        foreignKeys: [
+          { columnName: "a", referencedTable: "parents", referencedColumn: "x" },
+          { columnName: "b", referencedTable: "parents", referencedColumn: "y" },
+        ],
+      }),
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  test("a table with no foreign keys at all reports nothing", () => {
+    expect(findUnindexedForeignKeys(table({}))).toEqual([]);
+  });
+
+  test("the same column named twice is reported once", () => {
+    const findings = findUnindexedForeignKeys(
+      table({
+        foreignKeys: [
+          { columnName: "customer_id", referencedTable: "customers", referencedColumn: "id" },
+          { columnName: "customer_id", referencedTable: "buyers", referencedColumn: "id" },
+        ],
+      }),
+    );
+
+    expect(findings).toHaveLength(1);
+  });
+});

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -10,6 +10,7 @@ import {
   executeAgentOperation,
   inspectPlanTool,
   inspectSchemaTool,
+  profileTableTool,
   recommendChangeTool,
   runReadQueryTool,
   selectAgentTools,
@@ -192,7 +193,7 @@ describe("selectAgentTools — the server decides, from the persisted mode and w
     }
   });
 
-  test("query optimization is the only workflow offered the plan-comparison tools", () => {
+  test("each template is offered its own tools, and no other workflow gets them", () => {
     // The axis made load-bearing: an investigation that calls `compare_plans` is
     // told there is no such tool, because for that run there is not.
     expect(selectAgentTools(persisted("agent", "query-optimization")).map((tool) => tool.name)).toEqual([
@@ -203,11 +204,23 @@ describe("selectAgentTools — the server decides, from the persisted mode and w
       "compare_plans",
       "recommend_change",
     ]);
-    for (const workflowType of ["investigation", "database-assessment"] as const) {
-      const names = selectAgentTools(persisted("agent", workflowType)).map((tool) => tool.name);
-      expect(names, workflowType).not.toContain("compare_plans");
-      expect(names, workflowType).not.toContain("recommend_change");
+    expect(selectAgentTools(persisted("agent", "database-assessment")).map((tool) => tool.name)).toEqual([
+      "inspect_schema",
+      "run_read_query",
+      "inspect_plan",
+      "compose_report",
+      "profile_table",
+    ]);
+    const investigation = selectAgentTools(persisted("agent", "investigation")).map((tool) => tool.name);
+    for (const template of ["compare_plans", "recommend_change", "profile_table"]) {
+      expect(investigation).not.toContain(template);
     }
+    expect(selectAgentTools(persisted("agent", "query-optimization")).map((t) => t.name)).not.toContain(
+      "profile_table",
+    );
+    expect(selectAgentTools(persisted("agent", "database-assessment")).map((t) => t.name)).not.toContain(
+      "compare_plans",
+    );
   });
 
   test("neither of the optimization tools reaches a database", () => {
@@ -241,6 +254,7 @@ describe("selectAgentTools — the server decides, from the persisted mode and w
       "sql.explain.estimate",
       "sql.query.read",
       "sql.query.read",
+      "sql.table.profile",
       undefined,
       undefined,
       undefined,
@@ -1654,5 +1668,64 @@ describe("the two optimization tools refuse what would make their record untrue"
     ["rewrite", "SELECT id FROM orders WHERE a = 1"],
   ])("a %s card carrying %s is recorded", (change, statement) => {
     expect(recommend(change, statement).kind).toBe("recommended");
+  });
+});
+
+describe("profileTableTool — the model names a table, the server decides the rest", () => {
+  const snapshot = {
+    connectionId: "conn-1",
+    fingerprint: "ctx_1",
+    capturedAtMs: 1,
+    tables: [
+      {
+        name: "public.orders",
+        columns: [{ name: "id", type: "integer", nullable: false, isPrimary: true }],
+        indexes: [],
+      },
+    ],
+  };
+  const events: readonly AgentRunEvent[] = [
+    { kind: "context-captured", atMs: 1, fingerprint: "ctx_1", tableCount: 1, snapshot },
+  ];
+  const run = { runId: "run-1", events } as Pick<AgentRunRecord, "runId" | "events">;
+
+  test("planning mode has no tools at all", async () => {
+    const h = harness({ mode: "planning" });
+
+    const outcome = await profileTableTool(h.context, run, { table: "orders" });
+
+    if (outcome.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(outcome.reasonCode).toBe("MODE_HAS_NO_TOOLS");
+    expect(h.acquireProvider).not.toHaveBeenCalled();
+  });
+
+  test("another run's record is a wiring fault, and is loud", async () => {
+    const h = harness();
+
+    await expect(profileTableTool(h.context, { runId: "run-other", events }, { table: "orders" })).rejects.toThrow(
+      /does not belong to this run/,
+    );
+  });
+
+  test("a table the run never inventoried is refused before any database reach", async () => {
+    const h = harness();
+
+    const outcome = await profileTableTool(h.context, run, { table: "secrets" });
+
+    if (outcome.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(outcome.reasonCode).toBe("TABLE_NOT_INVENTORIED");
+    expect(h.acquireProvider).not.toHaveBeenCalled();
+  });
+
+  test("an engine with no verified profile composition is refused, not composed on a guess", async () => {
+    // Phase 1 verified PostgreSQL and SQLite. Composing for a third engine would be
+    // a statement nobody checked against that engine's grammar.
+    const h = harness({ connection: { ...connection, type: "mysql" } });
+
+    const outcome = await profileTableTool(h.context, run, { table: "orders" });
+
+    if (outcome.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
+    expect(h.acquireProvider).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -10,6 +10,7 @@ import {
   executeAgentOperation,
   inspectPlanTool,
   inspectSchemaTool,
+  planTableProfile,
   profileTableTool,
   recommendChangeTool,
   runReadQueryTool,
@@ -1689,43 +1690,96 @@ describe("profileTableTool — the model names a table, the server decides the r
   ];
   const run = { runId: "run-1", events } as Pick<AgentRunRecord, "runId" | "events">;
 
-  test("planning mode has no tools at all", async () => {
-    const h = harness({ mode: "planning" });
+  const plan = (h: Harness, input: unknown) => planTableProfile(h.context, run, input);
 
-    const outcome = await profileTableTool(h.context, run, { table: "orders" });
+  test("planning mode has no tools at all", () => {
+    const outcome = plan(harness({ mode: "planning" }), { table: "orders" });
 
     if (outcome.kind !== "unavailable") throw new Error("expected unavailable");
     expect(outcome.reasonCode).toBe("MODE_HAS_NO_TOOLS");
-    expect(h.acquireProvider).not.toHaveBeenCalled();
   });
 
-  test("another run's record is a wiring fault, and is loud", async () => {
+  test("another run's record is a wiring fault, and is loud", () => {
     const h = harness();
 
-    await expect(profileTableTool(h.context, { runId: "run-other", events }, { table: "orders" })).rejects.toThrow(
+    expect(() => planTableProfile(h.context, { runId: "run-other", events }, { table: "orders" })).toThrow(
       /does not belong to this run/,
     );
   });
 
-  test("a table the run never inventoried is refused before any database reach", async () => {
-    const h = harness();
-
-    const outcome = await profileTableTool(h.context, run, { table: "secrets" });
+  test("a table the run never inventoried is refused before any database reach", () => {
+    const outcome = plan(harness(), { table: "secrets" });
 
     if (outcome.kind !== "unavailable") throw new Error("expected unavailable");
     expect(outcome.reasonCode).toBe("TABLE_NOT_INVENTORIED");
-    expect(h.acquireProvider).not.toHaveBeenCalled();
   });
 
-  test("an engine with no verified profile composition is refused, not composed on a guess", async () => {
-    // Phase 1 verified PostgreSQL and SQLite. Composing for a third engine would be
-    // a statement nobody checked against that engine's grammar.
-    const h = harness({ connection: { ...connection, type: "mysql" } });
+  test("a named schema is part of the answer, never ignored", () => {
+    // Found by review on #345: matching a BARE inventory entry while a schema was
+    // named accepted {schema: "other", table: "orders"} against an unqualified
+    // `orders`, and then targeted `other.orders` — a table never inventoried.
+    const outcome = plan(harness(), { schema: "other", table: "orders" });
 
-    const outcome = await profileTableTool(h.context, run, { table: "orders" });
+    if (outcome.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(outcome.reasonCode).toBe("TABLE_NOT_INVENTORIED");
+  });
+
+  test("the composed statement targets what was RESOLVED, not what was asked for", () => {
+    // An unqualified name resolving to a qualified entry composed `FROM "orders"`,
+    // leaving search_path to decide which relation was read while the ledger said
+    // the qualified one had been profiled. Found by review on #345.
+    const outcome = plan(harness(), { table: "orders" });
+
+    if (outcome.kind !== "planned") throw new Error("expected a plan");
+    expect(outcome.plan.sql).toContain('FROM "public"."orders"');
+    expect(outcome.plan.target.schema).toBe("public");
+  });
+
+  test("an engine with no verified profile composition is refused, not composed on a guess", () => {
+    const outcome = plan(harness({ connection: { ...connection, type: "mysql" } }), { table: "orders" });
 
     if (outcome.kind !== "unavailable") throw new Error("expected unavailable");
     expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
-    expect(h.acquireProvider).not.toHaveBeenCalled();
+  });
+
+  test("a column offset past the end of the table is refused rather than profiling nothing", () => {
+    const outcome = plan(harness(), { table: "orders", fromColumn: 99 });
+
+    if (outcome.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(outcome.reasonCode).toBe("NO_COLUMNS_AT_OFFSET");
+  });
+
+  test("a batch reports what it did NOT cover, so nothing silently claims the whole table", () => {
+    // Without a continuation, columns past the bound could never be assessed while
+    // the run still counted as having profiled the table. Found by review on #345.
+    const wide = {
+      ...snapshot,
+      tables: [
+        {
+          name: "public.wide",
+          columns: Array.from({ length: 20 }, (_, index) => ({
+            name: `c${index}`,
+            type: "text",
+            nullable: true,
+            isPrimary: false,
+          })),
+          indexes: [],
+        },
+      ],
+    };
+    const wideRun = {
+      runId: "run-1",
+      events: [{ kind: "context-captured", atMs: 1, fingerprint: "ctx_1", tableCount: 1, snapshot: wide }],
+    } as Pick<AgentRunRecord, "runId" | "events">;
+
+    const first = planTableProfile(harness().context, wideRun, { table: "wide" });
+    if (first.kind !== "planned") throw new Error("expected a plan");
+    expect(first.plan.columns).toHaveLength(16);
+    expect(first.plan.remaining).toBe(4);
+
+    const second = planTableProfile(harness().context, wideRun, { table: "wide", fromColumn: 16 });
+    if (second.kind !== "planned") throw new Error("expected a plan");
+    expect(second.plan.columns).toHaveLength(4);
+    expect(second.plan.remaining).toBe(0);
   });
 });

--- a/tests/unit/lib/agent/types.test.ts
+++ b/tests/unit/lib/agent/types.test.ts
@@ -124,6 +124,28 @@ const EVENTS: Record<AgentRunEvent["kind"], AgentRunEvent> = {
     rationale: "The filtered column has no index, so the plan reads the table whole.",
     evidence: [ARTIFACT_EVIDENCE],
   },
+  // The database-assessment template's own artifact: counts, and the findings the
+  // SERVER derived from them. Not one value out of any profiled column.
+  "table-profiled": {
+    kind: "table-profiled",
+    atMs: 8,
+    // The read that produced the counts, so a claim about the profile can cite it.
+    artifact: { ...ARTIFACT, operationId: "sql.table.profile" },
+    profile: {
+      table: "public.customers",
+      depth: "pattern",
+      rowCount: 4120,
+      columns: [{ column: "email", present: 4118, distinct: 4100, shaped: 4090 }],
+      findings: [
+        {
+          code: "suspected_pii",
+          column: "email",
+          detail:
+            "99% of the values are shaped like an email address. No value was read out of the database to establish this.",
+        },
+      ],
+    },
+  },
   // The uncited counterpart: what the model said when it did not compose a report.
   // A planning run's whole output is one of these, and it round-trips as plainly as
   // the rest — prose is already the most inert thing a ledger can hold.


### PR DESCRIPTION
Part of #325. **T3 of #330, second of two templates.** On top of #344.

## The rule the whole feature is built around

**A profile records counts, never values.**

Every statistic is an aggregate — how many rows, how many present, how many distinct, how many match a shape. No `min`/`max` on a text column, even though both are conventional in a profiler, because either would return an actual name or address into the ledger. At `pattern` depth the shape test runs as `count(CASE WHEN … LIKE …)` **inside** the database, so the values that matched never leave it.

That is what makes profiling a table of personal data acceptable at all, and it is asserted against **the statements the run actually sent**, not against the tool's intent:

```
for (const part of projection.split(", ")) expect(part.startsWith("count(")).toBe(true);
```

## The model names a table; the server decides the rest

Columns come from the run's own captured inventory, so a profile cannot be aimed at something the run never established exists. An unqualified name resolves against a qualified inventory (PostgreSQL names tables `schema.table`, SQLite does not) **only when exactly one table matches** — two schemas holding the same table name is precisely when a guess would profile the wrong one.

The findings are the **server's**, each a mechanical predicate over counts with a stated threshold: `high_null`, `constant`, `low_cardinality`, `suspected_pii`, plus `fk_unindexed` from the inventory. A model may interpret them; it cannot invent one. `suspected_pii` says *suspected* because it comes from a column **name** or a match **ratio** — neither establishes that a column holds personal data, both establish it is worth a human looking.

## A fourth operation descriptor — a reversed product decision, not an oversight

`sql.table.profile` at R1. Epic #325 pinned the canonical set at three and `docs/BACKLOG.md` B17 recorded profiling as deferred *because of that*; #330 T3 instructs profiling reach the database "as new descriptors … at R0/R1", which reopens it. B17 is updated rather than quietly bypassed.

Its own id is what lets an operator see profiling in the audit stream, and deny it, without denying every read the agent makes. **This widens what can be NAMED, never what can be run** — the composed aggregate passes the same statement guard a model-drafted read does, asserted for both engines at all three depths.

## Two defects the scenarios found before any model met them

**A profile's artifact was uncitable.** Profiling settles no step, so it writes no `tool-completed`, and `composeReportTool` verifies citations only against that — which made this template's own goal verifier, requiring *both* a profile and a cited report, **impossible to satisfy**. The event now carries the artifact and the verifier accepts it. The same gap existed on the resume path, where a resumed run was told it had profiled a table but not which artifact to cite.

**A bug in my own first draft of the composer:** a "nine consecutive digits" test written as `LIKE '%_________%'`. In `LIKE`, `_` is *any character* — so it would have matched almost any text and produced a `suspected_pii` finding for essentially every text column. Removed rather than approximated; a real digit run needs `~` on PostgreSQL and `GLOB` on SQLite (B26).

## The gate

> **Gate:** each template passes its scripted scenarios on both reference engines, and its goal verifier fails the run when its own artifact is absent.

Both halves, in `tests/evals/database-assessment.test.ts`. The same ledger judged three ways is the sharpest form of it:

```
investigation        → answered
query-optimization   → unanswered (no-plan-comparison)
database-assessment  → unanswered (no-table-profile)
```

## Deliberately not done — each with a backlog entry

- **B27, the monitor snapshot.** Engine health reaches `getMetrics` / slow-query / session listings, which are provider methods no descriptor covers. It needs a descriptor shape for non-SQL reads, with its own verification marker and security-matrix row — a product decision, not a subtask.
- **B28, the catalog-statistics timeout fallback.** Its numbers are the planner's estimates, so a profile built from it would have to distinguish measured figures from estimated ones in its own type.
- **B25**, recording that SQLite hides constraint-created indexes — which is why `fk_unindexed` is worded "no index **in the captured inventory** leads on this column" rather than claiming a key is unindexed, and why composite keys are skipped entirely (PostgreSQL returns them as a cross product, B8).
- **The text ER context artifact**, the one remaining bullet of T3. It belongs with its own tests rather than appended here.

## Not verified against a live model

Same as #344: the Gemini credential in this environment stopped authenticating mid-session (an OAuth token where an API key belongs). Every scripted scenario passes on both reference engines; the live drive is owed.

## Gates

`format` · `lint` · `typecheck` · `knip` · `test` · `build` all green locally, plus `test:coverage` + `coverage:check` at **100.00% (34363/34363 lines)**.
