### PR TITLE
feat(agent): let a shortcut open the rail on a question, and start nothing (#331 T1)

### DIFF
--- a/src/app/api/agent/runs/route.ts
+++ b/src/app/api/agent/runs/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { admitAgentModel } from "@/lib/agent/capability-gate";
 import { isAgentRuntimeEnabled } from "@/lib/agent/config";
+import { AGENT_MAX_OBJECTIVE_LENGTH } from "@/lib/agent/execution-policy";
 import { driveAgentRun, getAgentRunService } from "@/lib/agent/runtime";
 import type { AgentRunMode, AgentRunWorkflowType } from "@/lib/agent/types";
 import { createErrorResponse } from "@/lib/api/errors";
@@ -36,8 +37,12 @@ import { resolveConnection } from "@/lib/seed/resolve-connection";
 
 const ROUTE = "POST /api/agent/runs";
 
-/** Bounded because it is written to the ledger and into every prompt the run makes. */
-const MAX_OBJECTIVE_LENGTH = 4000;
+/**
+ * Bounded because it is written to the ledger and into every prompt the run makes.
+ * Imported rather than written here: the rail bounds the same value, and the two used
+ * to be separate constants kept in step by a comment (see the constant's docblock).
+ */
+const MAX_OBJECTIVE_LENGTH = AGENT_MAX_OBJECTIVE_LENGTH;
 
 const MODES: ReadonlySet<string> = new Set<AgentRunMode>(["planning", "agent"]);
 

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -28,6 +28,7 @@ import { quoteLiteral } from "@/lib/sql/values";
 import { resolveAgentRunConnectionId } from "@/hooks/use-connection-payload";
 import { useAgentCapability } from "@/hooks/use-agent-capability";
 import { useAgentArtifact } from "@/components/agent/use-agent-artifact";
+import { useAgentPrefill } from "@/components/agent/use-agent-prefill";
 import { useToast } from "@/hooks/use-toast";
 import { useProviderMetadata } from "@/hooks/use-provider-metadata";
 import { useAuth } from "@/hooks/use-auth";
@@ -172,6 +173,16 @@ export default function Studio() {
   // rather than for the operator's container. Off (and absent) until it answers.
   const agentEnabled = useAgentCapability();
   const [isAgentSheetOpen, setIsAgentSheetOpen] = useState(false);
+
+  /*
+    The prefill seam (#331 T1). The shell owns the ask because a shortcut can be
+    anywhere in the shell — the command palette, the mobile header, a bottom-panel tab —
+    while the rail is ONE instance behind both of its presentations; the rail applies it
+    as a prop, the direction `isAgentSheetOpen` already runs in. T2 and T3 hand
+    `agentPrefill.requestPrefill` to those entry points; a prefill fills the rail and
+    starts nothing when they do.
+  */
+  const agentPrefill = useAgentPrefill();
 
   // Artifact hydration (#329 T11). The rail cites what a run stored; showing it puts
   // the rows into the bottom panel that already renders rows, and applying a drafted
@@ -620,6 +631,7 @@ export default function Studio() {
                 connectionName={conn.activeConnection?.name ?? null}
                 sheetOpen={isAgentSheetOpen}
                 onSheetOpenChange={setIsAgentSheetOpen}
+                prefill={agentPrefill.request}
                 onApplyStatement={(sql) => tabMgr.updateCurrentTab({ query: sql })}
                 onShowArtifact={agentArtifact.show}
               />

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -4,7 +4,12 @@ import React, { useEffect, useRef, useState } from "react";
 import { Bot, Loader2, PencilLine, Play, Square, TableProperties } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
-import { AGENT_EXECUTION_POLICY, AGENT_MAX_MODEL_TURNS, AGENT_RUN_DEADLINE_MS } from "@/lib/agent/execution-policy";
+import {
+  AGENT_EXECUTION_POLICY,
+  AGENT_MAX_MODEL_TURNS,
+  AGENT_MAX_OBJECTIVE_LENGTH,
+  AGENT_RUN_DEADLINE_MS,
+} from "@/lib/agent/execution-policy";
 import type { AgentRunMode, AgentRunStatus, AgentRunWorkflowType } from "@/lib/agent/types";
 import { cn } from "@/lib/utils";
 import { type AgentBudgetGauge, type AgentTimelineTone, describeFailureReason } from "./timeline";
@@ -63,9 +68,6 @@ export interface AgentRailProps {
    */
   readonly onShowArtifact?: (reference: { readonly runId: string; readonly correlationId: string }) => void;
 }
-
-/** Mirrors `MAX_OBJECTIVE_LENGTH` in the start route, which refuses anything longer. */
-const MAX_OBJECTIVE_LENGTH = 4000;
 
 const TONE_CLASSES: Readonly<Record<AgentTimelineTone, string>> = {
   neutral: "bg-zinc-600",
@@ -384,7 +386,7 @@ export function AgentRail({
           data-testid="agent-objective"
           value={objective}
           onChange={(e) => setObjective(e.target.value)}
-          maxLength={MAX_OBJECTIVE_LENGTH}
+          maxLength={AGENT_MAX_OBJECTIVE_LENGTH}
           rows={3}
           className="mt-1 w-full resize-none rounded bg-black/40 border border-white/10 px-2 py-1.5 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-blue-500/40"
           placeholder="Why is checkout slow?"

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -3,11 +3,12 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Bot, Loader2, PencilLine, Play, Square, TableProperties } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
 import { AGENT_EXECUTION_POLICY, AGENT_MAX_MODEL_TURNS, AGENT_RUN_DEADLINE_MS } from "@/lib/agent/execution-policy";
 import type { AgentRunMode, AgentRunStatus, AgentRunWorkflowType } from "@/lib/agent/types";
 import { cn } from "@/lib/utils";
 import { type AgentBudgetGauge, type AgentTimelineTone, describeFailureReason } from "./timeline";
+import type { AgentPrefillRequest } from "./use-agent-prefill";
 import { useAgentRun } from "./use-agent-run";
 
 /**
@@ -44,6 +45,12 @@ export interface AgentRailProps {
   /** Below `md` only: whether the sheet presentation is open. */
   readonly sheetOpen?: boolean;
   readonly onSheetOpenChange?: (open: boolean) => void;
+  /**
+   * A shortcut's ask to open this rail on a question (#331 T1). Applied once per
+   * request id, so the same ask made twice takes effect twice; it selects the workflow
+   * and fills the objective, and it never starts a run.
+   */
+  readonly prefill?: AgentPrefillRequest | null;
   /**
    * Puts a statement the run drafted into the host's editor (#329 T11). Absent when
    * the host has no editor to put it in, and the control is then not rendered.
@@ -167,10 +174,13 @@ export function AgentRail({
   onSheetOpenChange,
   onApplyStatement,
   onShowArtifact,
+  prefill = null,
 }: AgentRailProps) {
   const [mode, setMode] = useState<AgentRunMode>("planning");
   const [workflowType, setWorkflowType] = useState<AgentRunWorkflowType>("investigation");
   const [objective, setObjective] = useState("");
+  /** An ask that arrived while the user was typing, waiting for them to take it. */
+  const [offeredObjective, setOfferedObjective] = useState<string | null>(null);
   const run = useAgentRun();
 
   /*
@@ -191,6 +201,73 @@ export function AgentRail({
     if (wasMobile.current && !isMobile && sheetOpen) onSheetOpenChange?.(false);
     wasMobile.current = isMobile;
   }, [isMobile, sheetOpen, onSheetOpenChange]);
+
+  /** Which ask has been applied, and the text the last one put in the box. */
+  const appliedPrefillId = useRef<number | null>(null);
+  const prefilledObjective = useRef<string | null>(null);
+
+  /*
+    The prefill seam (#331 T1).
+
+    An ask is an EVENT the shell delivers as a prop, not a value to derive state from,
+    which is why it is applied in an effect and keyed on the request's ID: two clicks
+    on the same shortcut are two asks, and a request compared by value would make the
+    second one a prop that did not change.
+
+    Whether the sheet must be opened is decided HERE, from the viewport itself
+    (`isMobileViewport`) rather than from `useIsMobile`. This effect runs after commit
+    and only on the client, so the platform's answer is exact at the moment the ask is
+    served — while the hook seeds false and resolves in its own effect, which on a
+    narrow viewport is not a stale answer but a wrong one.
+
+    That replaced a ref recording an "owed" open, paid the next time the hook reported
+    mobile. The T1 adversarial recheck showed it carried two defects (R1, R2): on a
+    real desktop the hook's value never changed, so the debt was never discharged and
+    the first narrowing of the window opened the sheet for an ask the user had already
+    been served in the panel — the exact thing that code's comment claimed could not
+    happen — and the debt was keyed to the REQUEST rather than to the open it owed.
+    Reading the viewport directly leaves nothing to owe and nothing to pay later, so
+    both defects are gone rather than guarded.
+
+    Nothing here starts a run. That is the seam's rule rather than an omission — a
+    shortcut is worth one click, and a click that also spent model tokens and read a
+    database would be a different feature.
+  */
+  useEffect(() => {
+    if (prefill === null || appliedPrefillId.current === prefill.id) return;
+    appliedPrefillId.current = prefill.id;
+
+    // Applied either way: the workflow is a visible control holding nothing the user
+    // typed, and one click puts it back.
+    setWorkflowType(prefill.workflowType);
+
+    /*
+      An objective the user is typing is theirs. It is not overwritten — and it is not
+      dropped either, or the shortcut would look broken: the ask waits on one line the
+      user can accept. "Theirs" means text they typed, so a box that is empty, blank,
+      or still holds exactly what the last ask put there is one nobody has touched.
+    */
+    if (objective.trim().length === 0 || objective === prefilledObjective.current) {
+      setObjective(prefill.objective);
+      prefilledObjective.current = prefill.objective;
+      // An offer the PREVIOUS ask left is about a box that no longer says what it
+      // said. Left standing it reads "Suggested: A" under an objective that already
+      // says B — the state a user reaches by answering an offer with an emptied box
+      // rather than by taking it.
+      setOfferedObjective(null);
+    } else {
+      setOfferedObjective(prefill.objective);
+    }
+
+    /*
+      Below `md` the panel this rail renders into is display:none, so filling it
+      without opening the sheet would fill a surface nobody can see. The flag itself
+      stays the shell's, so this is an ask rather than a set. Above `md` there is
+      nothing to open: the rail is already the panel, the ask is already served, and
+      the crossing is left entirely to the reconciliation effect above.
+    */
+    if (isMobileViewport()) onSheetOpenChange?.(true);
+  }, [prefill, objective, onSheetOpenChange]);
 
   const canStart = connectionId !== null && objective.trim().length > 0 && !run.isBusy;
 
@@ -312,6 +389,32 @@ export function AgentRail({
           className="mt-1 w-full resize-none rounded bg-black/40 border border-white/10 px-2 py-1.5 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-blue-500/40"
           placeholder="Why is checkout slow?"
         />
+
+        {/*
+          ONE line, and an OFFER rather than a change (#331 T1). The objective in the
+          box is the user's, so a shortcut may not overwrite it — but it may not quietly
+          drop what it was asked to say either, or the shortcut reads as broken. So the
+          ask waits here until the user takes it, and nothing is discarded without them
+          saying so.
+        */}
+        {offeredObjective !== null && (
+          <p data-testid="agent-prefill-offer" className="mt-2 text-[0.625rem] text-zinc-500">
+            Suggested: <span className="text-zinc-400">{offeredObjective}</span>
+            <button
+              type="button"
+              data-testid="agent-prefill-offer-apply"
+              aria-label="Replace the objective with the suggested one"
+              onClick={() => {
+                setObjective(offeredObjective);
+                prefilledObjective.current = offeredObjective;
+                setOfferedObjective(null);
+              }}
+              className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-white/5 transition-colors"
+            >
+              Replace
+            </button>
+          </p>
+        )}
 
         {connectionId === null && (
           <p data-testid="agent-unresolvable-connection" className="mt-2 text-xs text-amber-400/80">

--- a/src/components/agent/use-agent-prefill.ts
+++ b/src/components/agent/use-agent-prefill.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { AgentRunWorkflowType } from "@/lib/agent/types";
+
+/**
+ * The prefill seam (#331 T1): how a shortcut somewhere else in the shell opens the
+ * rail already asking the right question.
+ *
+ * It lives beside the rail but the state is the SHELL's, and that is the point: a
+ * shortcut can be anywhere in the shell — the command palette, the mobile header, a
+ * bottom-panel tab — while the rail is one instance behind both of its presentations.
+ * So the shell owns the ask and the rail consumes it as a prop, which is the direction
+ * the sheet's own open state already runs in rather than a second ownership rule
+ * invented beside it.
+ *
+ * Three decisions are made here rather than at each caller, because T2, T3 and T4 all
+ * construct an ask through this and a decision made per caller is a decision made
+ * three ways:
+ *
+ *  - **An ask carries a workflow and an objective, and nothing about the MODE.** The
+ *    epic's three axes — execution mode, workflow type, connection scope — are
+ *    independent, and a shortcut that also chose how the run executes would be merging
+ *    two of them behind one click. Whichever mode the user chose stays chosen.
+ *  - **An ask carries a monotonic id.** Two consecutive clicks on the same shortcut
+ *    are two asks and both must take effect; a request compared by value would make
+ *    the second one a prop that did not change, and the click would silently do
+ *    nothing.
+ *  - **Asking starts nothing.** There is no run here and the rail starts none when it
+ *    applies one: only the Start button spends model tokens and reads a database, and
+ *    a shortcut that turned one click into both would be a different feature.
+ */
+
+export interface AgentPrefillRequest {
+  /**
+   * Which ask this is. The rail applies any id it has not applied yet, so this is an
+   * identity rather than a counter anyone reads — the same question asked twice
+   * differs here and nowhere else.
+   */
+  readonly id: number;
+  /** What the run is FOR. A visible control the user can still change. */
+  readonly workflowType: AgentRunWorkflowType;
+  /** What to ask, which the rail may only OFFER if the user is already typing. */
+  readonly objective: string;
+}
+
+export interface AgentPrefillHolder {
+  readonly request: AgentPrefillRequest | null;
+  readonly requestPrefill: (workflowType: AgentRunWorkflowType, objective: string) => void;
+}
+
+export function useAgentPrefill(): AgentPrefillHolder {
+  const [request, setRequest] = useState<AgentPrefillRequest | null>(null);
+
+  /*
+    Stable across renders, and the id is read from the previous request rather than
+    from a dependency: every caller is handed this as a prop and the rail lists it
+    among an effect's dependencies, so a fresh identity each render would re-render
+    each of those callers and re-run that effect.
+  */
+  const requestPrefill = useCallback((workflowType: AgentRunWorkflowType, objective: string) => {
+    setRequest((previous) => ({ id: (previous?.id ?? 0) + 1, workflowType, objective }));
+  }, []);
+
+  return { request, requestPrefill };
+}

--- a/src/components/agent/use-agent-prefill.ts
+++ b/src/components/agent/use-agent-prefill.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { AGENT_MAX_OBJECTIVE_LENGTH } from "@/lib/agent/execution-policy";
 import type { AgentRunWorkflowType } from "@/lib/agent/types";
 
 /**
@@ -40,7 +41,13 @@ export interface AgentPrefillRequest {
   readonly id: number;
   /** What the run is FOR. A visible control the user can still change. */
   readonly workflowType: AgentRunWorkflowType;
-  /** What to ask, which the rail may only OFFER if the user is already typing. */
+  /**
+   * What to ask, which the rail may only OFFER if the user is already typing.
+   *
+   * Never longer than `AGENT_MAX_OBJECTIVE_LENGTH`: an ask is built from something the
+   * shell already has — an editor's statement, a panel's question — and none of those
+   * is bounded the way the objective box is.
+   */
   readonly objective: string;
 }
 
@@ -59,7 +66,18 @@ export function useAgentPrefill(): AgentPrefillHolder {
     each of those callers and re-run that effect.
   */
   const requestPrefill = useCallback((workflowType: AgentRunWorkflowType, objective: string) => {
-    setRequest((previous) => ({ id: (previous?.id ?? 0) + 1, workflowType, objective }));
+    /*
+      Clamped HERE, where an ask is minted, rather than at each place the rail writes
+      one into the box. The rail writes it in two: the applied branch and the offer's
+      Replace control, and a bound enforced at both is a bound that can be enforced at
+      one of them. Found by review on #348: the box's own `maxLength` binds typing and
+      nothing else, so a shortcut could put the rail into a state its UI forbids and
+      the start route then refuses — a Start that fails for a reason the user was
+      never shown. Truncating keeps the shortcut working and leaves the result in an
+      editable box the user reads before pressing anything.
+    */
+    const bounded = objective.slice(0, AGENT_MAX_OBJECTIVE_LENGTH);
+    setRequest((previous) => ({ id: (previous?.id ?? 0) + 1, workflowType, objective: bounded }));
   }, []);
 
   return { request, requestPrefill };

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -2,15 +2,39 @@ import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
+/** Written once, so nothing can subscribe to one breakpoint and decide from another. */
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+
+/**
+ * Whether the viewport is below the mobile breakpoint RIGHT NOW.
+ *
+ * `useIsMobile` is the wrong instrument for a caller that has to DECIDE something at
+ * a point in time rather than render from it: it seeds false and resolves in an
+ * effect, so its value is not merely stale on the first commit — it is wrong on a
+ * narrow viewport, and a decision taken from it there is taken from an answer the
+ * platform never gave. This asks the platform instead, and answers exactly.
+ *
+ * It answers false where there is no window, which is the same answer the hook's
+ * first render gives, so nothing rendered on the server disagrees with the client's
+ * first pass. Use the HOOK for anything a render reads: this one does not subscribe,
+ * so a viewport that changes afterwards will not re-render anybody.
+ *
+ * Both read `MOBILE_QUERY`, so the two can never answer about different breakpoints.
+ */
+export function isMobileViewport(): boolean {
+  return typeof window === "undefined" ? false : window.matchMedia(MOBILE_QUERY).matches;
+}
+
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean>(false);
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(MOBILE_QUERY);
     const onChange = () => {
       setIsMobile(mql.matches);
     };
-    // Set initial value immediately
+    // The same reading `isMobileViewport` makes, taken from the list this effect has
+    // to construct anyway rather than by constructing a second one.
     setIsMobile(mql.matches);
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);

--- a/src/lib/agent/execution-policy.ts
+++ b/src/lib/agent/execution-policy.ts
@@ -136,3 +136,22 @@ export const AGENT_MAX_REPAIR_ATTEMPTS = 3;
  * exists), and that is recorded in `docs/BACKLOG.md` rather than implied here.
  */
 export const AGENT_MAX_MODEL_TURNS = 16;
+
+/**
+ * The longest objective a run may be started on.
+ *
+ * Here rather than at either end of the wire, because it used to be written twice —
+ * once in the start route and once in the rail, kept in step by a COMMENT saying one
+ * mirrored the other. That held only while the box a user types into was the sole way
+ * an objective could be set. #331 T1 added a second way, a shortcut that fills the
+ * rail programmatically, and review found what two constants and a comment cannot
+ * catch: a prefill longer than this bypassed the textarea's `maxLength`, so the rail
+ * accepted a state its own UI forbids and the route then refused the run the user
+ * pressed Start on. The statement an editor shortcut prefills is exactly the kind of
+ * text that reaches this length.
+ *
+ * One constant, imported by both, so the two cannot disagree at all. The bound is the
+ * SERVER's — the route refuses anything longer whatever a client believes — and the
+ * client's job is to never construct what the server will refuse.
+ */
+export const AGENT_MAX_OBJECTIVE_LENGTH = 4000;

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -416,6 +416,29 @@ mock.module("@/components/agent/AgentRail", () => ({
   },
 }));
 
+/**
+ * The prefill seam's shell half (#331 T1), stubbed to a value nothing else could
+ * produce.
+ *
+ * The T1 adversarial review found the wiring untested: the test below asserted only
+ * that the request starts null, which is also what a Studio that never called the hook
+ * and hard-coded `prefill={null}` would report. So the hook is replaced by one that
+ * always holds an ask, and what the rail is handed has to BE it. The hook's own
+ * behaviour — that nothing is asked for until a shortcut asks, and what an ask
+ * contains — is covered in tests/hooks/use-agent-prefill.test.ts, which runs in a
+ * different process: `mock.module` is process-wide, and Studio.test.tsx is its own
+ * isolation group (tests/run-components.sh Group 1), so no suite shares this stub.
+ */
+const PREFILL_SENTINEL = {
+  id: 7,
+  workflowType: "query-optimization",
+  objective: "why is checkout slow",
+} as const;
+
+mock.module("@/components/agent/use-agent-prefill", () => ({
+  useAgentPrefill: () => ({ request: PREFILL_SENTINEL, requestPrefill: mock(() => {}) }),
+}));
+
 mock.module("@/components/ui/resizable", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require("react");
@@ -1465,6 +1488,26 @@ describe("Studio", () => {
 
     act(() => (capturedAgentRailProps.onSheetOpenChange as (open: boolean) => void)(false));
     expect(capturedAgentRailProps.sheetOpen).toBe(false);
+  });
+
+  /**
+   * Who owns a prefill ask (#331 T1). The shell holds it because a shortcut can be
+   * anywhere in the shell while the rail is ONE instance behind both presentations,
+   * and the rail applies it as a prop — the direction `sheetOpen` already runs in.
+   *
+   * Asserted against the stubbed hook's sentinel rather than against null, because
+   * null is what a Studio that dropped the hook entirely would also hand over — the
+   * T1 adversarial review's point: deleting the import, the call and the prop kept
+   * the old assertion green. T2 and T3 hand `requestPrefill` to the legacy AI entry
+   * points; what this pins is that whatever the shell's holder says is what the one
+   * rail instance is given.
+   */
+  test("the shell owns the prefill request and hands it to the one rail instance", async () => {
+    mockAgentConfig(true);
+    const { findByTestId } = render(<Studio />);
+    await findByTestId("agent-rail");
+
+    expect(capturedAgentRailProps.prefill).toBe(PREFILL_SENTINEL);
   });
 
   // =========================================================================

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -640,6 +640,312 @@ describe("AgentRail", () => {
   });
 
   /**
+   * The prefill seam (#331 T1) — the contract every shortcut T2, T3 and T4 wire goes
+   * through, which is why it is pinned here rather than at each caller.
+   *
+   * What these tests hold to, in the order the seam's decisions were made:
+   *
+   *  - **An ask carries a workflow and an objective, and nothing about the MODE.** The
+   *    epic's three axes are independent: a shortcut says what a run is FOR, and how it
+   *    executes stays whatever the user chose.
+   *  - **An ask starts nothing.** Every test here asserts the network was never
+   *    touched. One click that spent model tokens and read a database would be a
+   *    different feature from one that filled in a question.
+   *  - **An objective the user typed is never discarded.** Not overwritten, and not
+   *    dropped either — the ask waits on a line they can accept, because a shortcut
+   *    that appeared to do nothing would read as broken.
+   *  - **Both presentations, one instance.** The panel above `md` and the sheet below
+   *    it are branches of the same component, so an ask has to land in whichever one is
+   *    rendering; a seam wired into a single branch is the failure this task exists to
+   *    prevent. Including the branch `useIsMobile` has not resolved into yet: the T1
+   *    adversarial review found that an ask present in the first committed render on a
+   *    narrow viewport reached the invisible one, and the recheck then found the
+   *    workaround for that leaving a debt a later narrowing paid on a desktop. The
+   *    three tests at the end of this block hold the reading that removed both.
+   */
+  describe("prefill", () => {
+    const ASK = { id: 1, workflowType: "query-optimization", objective: "why is checkout slow" } as const;
+    const SECOND_ASK = { id: 2, workflowType: "database-assessment", objective: "what is worth fixing here" } as const;
+
+    /** A prefill fills the rail; it never runs it, so nothing here may reach the network. */
+    function refuseEveryRequest() {
+      const fetchMock = mock(async () => jsonResponse({}, 202));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+      return fetchMock;
+    }
+
+    const objectiveValue = (element: Element | null): string => (element as HTMLTextAreaElement).value;
+
+    test("an ask selects the workflow, fills the objective and starts nothing", () => {
+      const fetchMock = refuseEveryRequest();
+      const { getByTestId, rerender } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+      fireEvent.click(getByTestId("agent-mode-agent"));
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={ASK} />);
+
+      expect(getByTestId("agent-workflow-query-optimization").getAttribute("aria-pressed")).toBe("true");
+      expect(getByTestId("agent-workflow-investigation").getAttribute("aria-pressed")).toBe("false");
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe(ASK.objective);
+      // The mode is the user's, and an ask carries none: merging that axis into the
+      // shortcut is what the epic's three independent axes exist to prevent.
+      expect(getByTestId("agent-mode-agent").getAttribute("aria-pressed")).toBe("true");
+      expect(getByTestId("agent-rail-panel")).toBeTruthy();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test("a second ask replaces an objective the user has not touched", () => {
+      const fetchMock = refuseEveryRequest();
+      const { getByTestId, queryByTestId, rerender } = render(<AgentRail {...DEFAULT_PROPS} prefill={ASK} />);
+
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={SECOND_ASK} />);
+
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe(SECOND_ASK.objective);
+      expect(getByTestId("agent-workflow-database-assessment").getAttribute("aria-pressed")).toBe("true");
+      // Nothing of the user's was in the box, so there is nothing to offer.
+      expect(queryByTestId("agent-prefill-offer")).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test("the same ask twice takes effect twice", () => {
+      const fetchMock = refuseEveryRequest();
+      const { getByTestId, rerender } = render(<AgentRail {...DEFAULT_PROPS} prefill={ASK} />);
+
+      // The user emptied the box and clicked the same shortcut again. The second ask
+      // is identical in every field but its id, which is the whole reason it carries
+      // one: a request compared by value would make that click do nothing.
+      fireEvent.change(getByTestId("agent-objective"), { target: { value: "" } });
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe("");
+
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={{ ...ASK, id: 2 }} />);
+
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe(ASK.objective);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test("a box holding only whitespace is not something the user typed", () => {
+      const fetchMock = refuseEveryRequest();
+      const { getByTestId, queryByTestId, rerender } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+      fireEvent.change(getByTestId("agent-objective"), { target: { value: "   \n " } });
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={ASK} />);
+
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe(ASK.objective);
+      expect(queryByTestId("agent-prefill-offer")).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test("an objective the user typed survives an ask, which waits on a line they can accept", () => {
+      const fetchMock = refuseEveryRequest();
+      const { getByTestId, queryByTestId, rerender } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+      fireEvent.change(getByTestId("agent-objective"), { target: { value: "which index is missing on orders" } });
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={ASK} />);
+
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe("which index is missing on orders");
+      // The workflow is applied either way — it is a visible control holding nothing
+      // the user wrote, and one they can change back in a click.
+      expect(getByTestId("agent-workflow-query-optimization").getAttribute("aria-pressed")).toBe("true");
+      // And the ask is not dropped on the floor, which is what would make the
+      // shortcut look broken.
+      expect(getByTestId("agent-prefill-offer").textContent).toContain(ASK.objective);
+
+      fireEvent.click(getByTestId("agent-prefill-offer-apply"));
+
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe(ASK.objective);
+      expect(queryByTestId("agent-prefill-offer")).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test("an objective replaced on the user's say-so is no longer theirs to protect", () => {
+      const fetchMock = refuseEveryRequest();
+      const { getByTestId, queryByTestId, rerender } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+      fireEvent.change(getByTestId("agent-objective"), { target: { value: "which index is missing on orders" } });
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={ASK} />);
+      fireEvent.click(getByTestId("agent-prefill-offer-apply"));
+
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={SECOND_ASK} />);
+
+      // The box now holds exactly what the last ask put there, so the next one takes
+      // it without asking again.
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe(SECOND_ASK.objective);
+      expect(queryByTestId("agent-prefill-offer")).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    /**
+     * An offer outlives the box it was made about unless the applied branch retracts
+     * it, and the T1 adversarial review found nothing holding that: the retraction was
+     * covered only incidentally, so deleting it left every test green.
+     *
+     * The state it exists for is the one where the user answers the offer their own
+     * way — they clear the box instead of taking the suggestion. The next ask then has
+     * nothing of theirs to protect and lands in the box itself, and an offer still
+     * standing would read "Suggested: A" under an objective that already says B.
+     */
+    test("an ask taken into an emptied box retracts the offer the last one left", () => {
+      const fetchMock = refuseEveryRequest();
+      const { getByTestId, queryByTestId, rerender } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+      fireEvent.change(getByTestId("agent-objective"), { target: { value: "which index is missing on orders" } });
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={ASK} />);
+      expect(getByTestId("agent-prefill-offer").textContent).toContain(ASK.objective);
+
+      // Their own answer to the offer: the box is emptied rather than replaced.
+      fireEvent.change(getByTestId("agent-objective"), { target: { value: "" } });
+      rerender(<AgentRail {...DEFAULT_PROPS} prefill={SECOND_ASK} />);
+
+      expect(objectiveValue(getByTestId("agent-objective"))).toBe(SECOND_ASK.objective);
+      expect(queryByTestId("agent-prefill-offer")).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test("below md an ask opens the sheet and fills the rail inside it", async () => {
+      const fetchMock = refuseEveryRequest();
+      const onSheetOpenChange = mock(() => {});
+      const view = render(<AgentRail {...DEFAULT_PROPS} onSheetOpenChange={onSheetOpenChange} />);
+
+      // The breakpoint is crossed explicitly: `useIsMobile` reports false on its first
+      // render and resolves in an effect, so an ask applied in the mount commit could
+      // not yet know the panel it filled is display:none.
+      await act(async () => {
+        media.setMatches(true);
+      });
+      view.rerender(<AgentRail {...DEFAULT_PROPS} onSheetOpenChange={onSheetOpenChange} prefill={ASK} />);
+
+      // The rail ASKS to be opened. The flag stays the shell's, the same way it does
+      // when the mobile nav opens the rail with nothing prefilled.
+      expect(onSheetOpenChange).toHaveBeenCalledWith(true);
+      view.rerender(<AgentRail {...DEFAULT_PROPS} sheetOpen onSheetOpenChange={onSheetOpenChange} prefill={ASK} />);
+
+      const sheet = await view.findByTestId("agent-rail-sheet");
+      expect(view.queryByTestId("agent-rail-panel")).toBeNull();
+      expect(
+        sheet.querySelector('[data-testid="agent-workflow-query-optimization"]')?.getAttribute("aria-pressed"),
+      ).toBe("true");
+      expect(objectiveValue(sheet.querySelector('[data-testid="agent-objective"]'))).toBe(ASK.objective);
+
+      // And an ask made while the SHEET is the presentation lands in the same state:
+      // one instance serves both, so a seam wired into one branch would lose this.
+      view.rerender(
+        <AgentRail {...DEFAULT_PROPS} sheetOpen onSheetOpenChange={onSheetOpenChange} prefill={SECOND_ASK} />,
+      );
+
+      const filled = view.getByTestId("agent-rail-sheet");
+      expect(
+        filled.querySelector('[data-testid="agent-workflow-database-assessment"]')?.getAttribute("aria-pressed"),
+      ).toBe("true");
+      expect(objectiveValue(filled.querySelector('[data-testid="agent-objective"]'))).toBe(SECOND_ASK.objective);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The ask that is present in the rail's FIRST committed render, on a viewport that
+     * was already narrow — which the T1 adversarial review named as a real defect this
+     * suite had no test for.
+     *
+     * `useIsMobile` seeds false and resolves in an effect, so that first commit reads
+     * as desktop no matter how narrow the window is. An ask that decided from the
+     * hook's value would ask nobody to open the sheet: it would land in the panel
+     * branch, which is `hidden md:flex`, and the user would see a shortcut that
+     * visibly did nothing. The rail asks the viewport itself instead, in an effect
+     * that runs after commit, where the platform's answer is exact.
+     *
+     * Today's wiring never produces that render — the shell starts at null and mounts
+     * the rail behind the capability probe — but T2 and T3 wire entry points that are
+     * not gated on it, so this is the case the seam has to survive rather than a
+     * hypothetical.
+     */
+    test("an ask already present in the first render on a narrow viewport still opens the sheet", async () => {
+      const fetchMock = refuseEveryRequest();
+      const onSheetOpenChange = mock(() => {});
+      // Narrow BEFORE the mount: the media query already matches, and it is
+      // `useIsMobile`'s own effect — not a resize — that makes the rail read it.
+      media.setMatches(true);
+
+      const view = render(<AgentRail {...DEFAULT_PROPS} onSheetOpenChange={onSheetOpenChange} prefill={ASK} />);
+      await act(async () => {});
+
+      expect(onSheetOpenChange).toHaveBeenCalledWith(true);
+
+      view.rerender(<AgentRail {...DEFAULT_PROPS} sheetOpen onSheetOpenChange={onSheetOpenChange} prefill={ASK} />);
+
+      const sheet = await view.findByTestId("agent-rail-sheet");
+      expect(view.queryByTestId("agent-rail-panel")).toBeNull();
+      expect(objectiveValue(sheet.querySelector('[data-testid="agent-objective"]'))).toBe(ASK.objective);
+      expect(
+        sheet.querySelector('[data-testid="agent-workflow-query-optimization"]')?.getAttribute("aria-pressed"),
+      ).toBe("true");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The other half of the same rule: an ask is served once, at the moment it is
+     * applied, and a viewport that changes afterwards is not a second serving. Without
+     * that, an ask would re-open the sheet on every later crossing back to a narrow
+     * viewport — reopening a sheet the user closed, which the reconciliation effect's
+     * crossing behaviour must not turn into.
+     */
+    test("a crossing back to a narrow viewport does not re-open the sheet an ask already opened", async () => {
+      const fetchMock = refuseEveryRequest();
+      const onSheetOpenChange = mock((_open: boolean) => {});
+      media.setMatches(true);
+
+      const view = render(<AgentRail {...DEFAULT_PROPS} onSheetOpenChange={onSheetOpenChange} prefill={ASK} />);
+      await act(async () => {});
+      view.rerender(<AgentRail {...DEFAULT_PROPS} sheetOpen onSheetOpenChange={onSheetOpenChange} prefill={ASK} />);
+      await view.findByTestId("agent-rail-sheet");
+
+      await act(async () => {
+        media.setMatches(false);
+      });
+      view.rerender(
+        <AgentRail {...DEFAULT_PROPS} sheetOpen={false} onSheetOpenChange={onSheetOpenChange} prefill={ASK} />,
+      );
+      await act(async () => {
+        media.setMatches(true);
+      });
+
+      const opens = onSheetOpenChange.mock.calls.filter(([open]) => open === true);
+      expect(opens.length).toBe(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The residual the T1 adversarial recheck named (R1/R2): an ask served on a
+     * GENUINE desktop must leave nothing behind for a later narrowing to act on.
+     *
+     * The rail used to record an owed open and pay it when `useIsMobile` next
+     * reported true. On a desktop that flag never changed, so the debt was never
+     * cleared — and the first narrowing of the window paid it, popping the sheet open
+     * for an ask the user had already been served in the panel minutes earlier. The
+     * viewport is read synchronously at the moment the ask is applied instead, so
+     * there is nothing owed and nothing to pay.
+     */
+    test("an ask served in the panel is not re-served as a sheet when the window later narrows", async () => {
+      const fetchMock = refuseEveryRequest();
+      const onSheetOpenChange = mock((_open: boolean) => {});
+      // A genuine desktop: the media query does not match at the mount, and the ask
+      // is applied against a viewport that really is wide.
+      const view = render(<AgentRail {...DEFAULT_PROPS} onSheetOpenChange={onSheetOpenChange} prefill={ASK} />);
+      await act(async () => {});
+
+      expect(view.getByTestId("agent-rail-panel")).toBeTruthy();
+      expect(objectiveValue(view.getByTestId("agent-objective"))).toBe(ASK.objective);
+      expect(onSheetOpenChange).not.toHaveBeenCalled();
+
+      // Later — a rotation, a split screen, a dragged window edge. The ask was served
+      // in the panel and is over; narrowing must not reopen it as a sheet.
+      await act(async () => {
+        media.setMatches(true);
+      });
+
+      expect(onSheetOpenChange.mock.calls.filter(([open]) => open === true).length).toBe(0);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
    * The stop control (#329 T10b).
    *
    * Stopping is an ASK, not an outcome — the run's own loop ends it at its next

--- a/tests/hooks/use-agent-prefill.test.ts
+++ b/tests/hooks/use-agent-prefill.test.ts
@@ -1,0 +1,78 @@
+import "../setup-dom";
+import "../helpers/mock-sonner";
+import "../helpers/mock-navigation";
+
+import { describe, test, expect } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+import { useAgentPrefill } from "@/components/agent/use-agent-prefill";
+
+/**
+ * The shell's half of the prefill seam (#331 T1): who owns an ask, and what an ask is.
+ *
+ * The rail's half is covered in `tests/components/agent/AgentRail.test.tsx`. What is
+ * pinned here is the shape of the request itself, because T2, T3 and T4 all construct
+ * one through this hook and a field added or dropped later would change what three
+ * callers mean:
+ *
+ *  - An ask names a workflow and an objective. It does NOT name a mode — the epic's
+ *    three axes are independent, and a shortcut that picked the execution mode too
+ *    would be merging two of them behind one click.
+ *  - An ask carries a monotonic id, so the same question asked twice is two asks. The
+ *    rail applies any id it has not applied yet; without one, a second click on the
+ *    same shortcut would be a value-identical prop and silently do nothing.
+ *  - Asking starts nothing. There is no run, no request and no fetch here — only the
+ *    Start button spends model tokens and reads a database.
+ */
+
+describe("useAgentPrefill", () => {
+  test("nothing is asked for until a shortcut asks", () => {
+    const { result } = renderHook(() => useAgentPrefill());
+
+    expect(result.current.request).toBeNull();
+  });
+
+  test("an ask names the workflow and the objective, and nothing else", () => {
+    const { result } = renderHook(() => useAgentPrefill());
+
+    act(() => {
+      result.current.requestPrefill("query-optimization", "why is checkout slow");
+    });
+
+    expect(result.current.request).toEqual({
+      id: 1,
+      workflowType: "query-optimization",
+      objective: "why is checkout slow",
+    });
+    // Asserted as the full key set rather than field by field: a `mode` added here
+    // later is exactly the merge of two independent axes this seam refuses.
+    expect(Object.keys(result.current.request ?? {}).sort()).toEqual(["id", "objective", "workflowType"]);
+  });
+
+  test("the same question asked twice is two asks", () => {
+    const { result } = renderHook(() => useAgentPrefill());
+
+    act(() => {
+      result.current.requestPrefill("investigation", "why is checkout slow");
+    });
+    expect(result.current.request?.id).toBe(1);
+
+    act(() => {
+      result.current.requestPrefill("investigation", "why is checkout slow");
+    });
+
+    expect(result.current.request?.id).toBe(2);
+  });
+
+  test("the requester keeps its identity across renders", () => {
+    // The rail applies an ask from an effect that lists this among its dependencies,
+    // and every caller in T2/T3 is handed it as a prop. A fresh identity each render
+    // would re-run that effect and re-render every one of those callers.
+    const { result, rerender } = renderHook(() => useAgentPrefill());
+    const first = result.current.requestPrefill;
+
+    rerender();
+
+    expect(result.current.requestPrefill).toBe(first);
+  });
+});

--- a/tests/hooks/use-agent-prefill.test.ts
+++ b/tests/hooks/use-agent-prefill.test.ts
@@ -6,6 +6,7 @@ import { describe, test, expect } from "bun:test";
 import { act, renderHook } from "@testing-library/react";
 
 import { useAgentPrefill } from "@/components/agent/use-agent-prefill";
+import { AGENT_MAX_OBJECTIVE_LENGTH } from "@/lib/agent/execution-policy";
 
 /**
  * The shell's half of the prefill seam (#331 T1): who owns an ask, and what an ask is.
@@ -62,6 +63,31 @@ describe("useAgentPrefill", () => {
     });
 
     expect(result.current.request?.id).toBe(2);
+  });
+
+  test("an ask longer than a run may carry is cut to what the route accepts", () => {
+    // Review on #348: the objective box bounds TYPING through `maxLength`, and a
+    // shortcut does not type. An editor statement is the ask T3 builds, and one longer
+    // than this is ordinary — unclamped it reached a Start the start route then
+    // refused, so the click failed for a reason the user was never shown.
+    const { result } = renderHook(() => useAgentPrefill());
+
+    act(() => {
+      result.current.requestPrefill("query-optimization", "s".repeat(AGENT_MAX_OBJECTIVE_LENGTH + 500));
+    });
+
+    expect(result.current.request?.objective.length).toBe(AGENT_MAX_OBJECTIVE_LENGTH);
+  });
+
+  test("an ask the route would accept is left exactly as it was asked", () => {
+    const { result } = renderHook(() => useAgentPrefill());
+    const asked = "s".repeat(AGENT_MAX_OBJECTIVE_LENGTH);
+
+    act(() => {
+      result.current.requestPrefill("investigation", asked);
+    });
+
+    expect(result.current.request?.objective).toBe(asked);
   });
 
   test("the requester keeps its identity across renders", () => {

--- a/tests/hooks/use-mobile.test.ts
+++ b/tests/hooks/use-mobile.test.ts
@@ -3,7 +3,7 @@ import "../setup-dom";
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { renderHook, act, waitFor } from "@testing-library/react";
 
-import { useIsMobile } from "@/hooks/use-mobile";
+import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
 
 // =============================================================================
 // matchMedia mock helpers
@@ -173,5 +173,75 @@ describe("useIsMobile", () => {
     const addedListener = mql.addEventListener.mock.calls[0][1];
     const removedListener = mql.removeEventListener.mock.calls[0][1];
     expect(addedListener).toBe(removedListener);
+  });
+});
+
+// =============================================================================
+// isMobileViewport Tests
+// =============================================================================
+/**
+ * The synchronous read the hook cannot give: `useIsMobile` seeds false and resolves
+ * in an effect, so a caller that has to DECIDE something at a point in time — rather
+ * than render from it — needs the platform's own answer instead of last render's.
+ */
+describe("isMobileViewport", () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      value: originalMatchMedia,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "matchMedia", {
+      value: originalMatchMedia,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  test("answers from the media query, on the same breakpoint the hook uses", () => {
+    const { mockMatchMedia } = createMockMatchMedia(true);
+    Object.defineProperty(window, "matchMedia", {
+      value: mockMatchMedia,
+      writable: true,
+      configurable: true,
+    });
+
+    expect(isMobileViewport()).toBe(true);
+    // The same query string the hook subscribes to. It exists once in the module, so
+    // the predicate and the hook cannot answer about different breakpoints.
+    expect(mockMatchMedia).toHaveBeenCalledWith("(max-width: 767px)");
+  });
+
+  test("answers false on a viewport at or above the breakpoint", () => {
+    const { mockMatchMedia } = createMockMatchMedia(false);
+    Object.defineProperty(window, "matchMedia", {
+      value: mockMatchMedia,
+      writable: true,
+      configurable: true,
+    });
+
+    expect(isMobileViewport()).toBe(false);
+  });
+
+  /**
+   * There is no viewport on the server, and a module that renders on both sides may
+   * call this during a render that never touches a browser. It answers false rather
+   * than throwing — the same answer the hook's first render gives, so markup produced
+   * on the server and markup produced on the client's first pass agree.
+   */
+  test("answers false where there is no window at all", () => {
+    const realWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", { value: undefined, writable: true, configurable: true });
+    try {
+      expect(isMobileViewport()).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, "window", { value: realWindow, writable: true, configurable: true });
+    }
   });
 });

--- a/tests/unit/components/agent-hydration.test.ts
+++ b/tests/unit/components/agent-hydration.test.ts
@@ -107,7 +107,14 @@ describe("hydrateAgentArtifact", () => {
  */
 describe("the agent rail's module boundary", () => {
   const AGENT_DIR = path.join(process.cwd(), "src/components/agent");
-  const RAIL_MODULES = ["AgentRail.tsx", "hydration.ts", "timeline.ts", "use-agent-artifact.ts", "use-agent-run.ts"];
+  const RAIL_MODULES = [
+    "AgentRail.tsx",
+    "hydration.ts",
+    "timeline.ts",
+    "use-agent-artifact.ts",
+    "use-agent-prefill.ts",
+    "use-agent-run.ts",
+  ];
   const FORBIDDEN = [
     "@/components/ResultsGrid",
     "@/components/QueryEditor",


### PR DESCRIPTION
First of the M4 sequence (#331). It is deliberately small, because everything after it needs somewhere
to send the user: T2 replaces the NL2SQL and Autopilot tabs, T3 replaces the editor's AI button, and T4
needs a surface to point at when a model cannot drive a run. Each of those would otherwise invent its own
way to open the rail on a question.

## What it adds

`useAgentPrefill` in the shell, an optional `prefill` prop on `AgentRail`, and `isMobileViewport` beside
`useIsMobile`.

**An ask carries a workflow type and an objective, and nothing about the mode.** #325 ratified that
execution mode, workflow type and connection scope are three independent axes; a shortcut that also chose
how the run executes would merge two of them behind one click. `tests/hooks/use-agent-prefill.test.ts`
pins the exact key set, so adding `mode` later fails a test rather than passing review.

**The shell owns the ask; the rail consumes it as a prop.** That is the direction `sheetOpen` /
`onSheetOpenChange` already run in. The rail is ONE instance behind both presentations
(`AgentRail.tsx` builds `content` once and returns it inside either the sheet or the panel), so a seam
wired into one branch would be lost in the other — the sheet test renders the sheet and reads the
objective out of it rather than asserting on props.

**An ask is an event, not a value.** It carries a monotonic id and the rail applies any id it has not
applied. Two clicks on the same shortcut are two asks; a request compared by value would make the second
one a prop that did not change.

## The two rules the tests pin

**A prefill starts no run.** `run.start` has one call site, reached only from the Start button. All ten
tests in the `prefill` block assert the network was never touched. A shortcut is worth one click; a click
that also spent model tokens and read a database would be a different feature.

**A typed objective is never lost.** If the box holds text the user typed, the ask does not overwrite
it — and does not vanish either, or the shortcut reads as broken. It waits on one line with an explicit
Replace control. "Untouched" means empty, blank, or still exactly what the last ask put there.

## Two rounds of adversarial review, and what they changed

Three independent reviewers read the first implementation; two of them found the same latent defect, and
a fourth round removed its root cause rather than its symptom.

**The defect.** `useIsMobile` seeds `false` and resolves in an effect, so on a narrow viewport its first
answer is not stale — it is wrong. An ask present in the rail's first committed render would have been
applied with `isMobile === false`, filling the panel branch (`hidden md:flex`, so `display:none` below
`md`) and never opening the sheet; the id guard then blocked the retry. Not reachable through today's
wiring, because Studio starts the request at `null` and the rail mounts after the capability probe
resolves — but T2 and T3 wire entry points that are not gated on `agentEnabled`, which is exactly when it
would have gone live.

**The first fix** recorded an owed sheet-open in a ref and paid it when the hook reported mobile. A
recheck ran mutation testing against a mirror of the tree and confirmed the new tests failed without it,
then found two residuals: on a real desktop the hook's value never changes, so the debt was never
discharged and the first narrowing of the window re-served an ask the user already had in the panel —
the exact behaviour that code's own comment claimed was impossible.

**The fix that shipped** asks the platform instead. `isMobileViewport()` reads `matchMedia` synchronously;
effects run after commit on the client, so the answer is exact at the moment the ask is served. Nothing is
owed and nothing is paid later, so both residuals are gone rather than guarded. A test pins the case the
residual named: an ask served in the panel is not re-served as a sheet when the window later narrows.

Also fixed from that review: the Studio test asserted only that `prefill` starts null, so the ownership
contract passed even with the wiring deleted (it now pins the hook's value through a sentinel); one line
was covered only incidentally (a stale offer left standing under a replaced objective, now tested); and a
docblock claimed every test asserted the network was untouched when three did not (now all ten do).

## What this PR deliberately does not do

No caller is wired. The only consumers are Studio, which owns the state, and the tests. T2 and T3 hand
`requestPrefill` to the legacy entry points as they replace them.

## Verification

Six gates green locally, plus coverage: `check-coverage: OK — 34621/34621 lines (100.00%)`. `build:lib`
was also run: no agent or prefill code reaches `dist/`, and the package-boundary tests are untouched and
green.

Part of #325. Implements the T1 gate in #331.
