### PR TITLE
fix(agent): tell the model what a citation is (#350)

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -163,6 +163,13 @@ rather than instead of it (B24).
 answer different questions and are mutually exclusive in practice; when both are present, `reason`
 is the one a user reads, because a dead drive is the more specific account of an ending.
 
+**What a `stopReason` MEANS depends on the mode**, and `model-stopped` is where the two part company.
+In agent mode it is a shortfall: the model had a report tool and did not use it. In planning mode it
+is the successful ending — planning is toolless, `compose_report` does not exist there, and stopping
+once the plan is written is the only way a good planning run can end. The rail therefore words that
+one ending per mode (#350); every other ending is a shortfall in either mode, because a planning run
+that ran out of time produced no plan either.
+
 ## Durability and resume
 
 A run has **no mutable row anywhere**. It *is* an append-only ledger on the durable backend, and the
@@ -246,6 +253,19 @@ never the shared writable connection cache.
 | `run_read_query` | `sql.query.read` | The statement (a bounded read). |
 | `inspect_plan` | `sql.explain.estimate` | The statement to explain. The *estimating* form only. |
 | `compose_report` | — | Claims and the evidence references backing them. Reaches no database. |
+
+**An evidence reference is one object, and the model is told which** — in the tool description, in
+the rules the run is opened with, and again each time an id changes hands:
+`{"source":"artifact","correlationId":"…"}` for a result the run read, or
+`{"source":"context-snapshot","fingerprint":"…"}` for the inventory it captured. Saying only that a
+claim must cite is not enough: live runs reached the point of reporting knowing they had to cite,
+holding the correlation id they needed, and spent their remaining turns guessing at the shape — one
+run's ledger records the model asking itself whether an evidence item is "an array of table row
+objects or strings?" and sending a statement with nothing to learn in it while it worked that out
+(#350). The same words are also what a REFUSAL says: a model that got the shape wrong is the one that
+most needs to be shown it. A server-composed citation is never a suggestion the model has to decode —
+`composeReportTool` verifies every reference against the run's own event log and refuses a claim it
+cannot resolve.
 
 Two consequences worth stating:
 

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -7,6 +7,7 @@ import type {
   AgentReportClaim,
   AgentRunEvent,
   AgentRunFailureReason,
+  AgentRunMode,
   AgentRunStatus,
   AgentRunStopReason,
   AgentRunWorkflowType,
@@ -246,11 +247,24 @@ const WORKFLOW_WORDS: Readonly<Record<AgentRunWorkflowType, string>> = {
  * the durable contract cannot reach a user as an unlabelled ending.
  *
  * `report-composed` has no sentence: the report itself is already in the timeline
- * above, and a line repeating that it exists would be noise. The rest are all cases
- * where the run stopped WITHOUT answering, which is precisely what a reader cannot
- * otherwise tell from `succeeded` or `failed` alone.
+ * above, and a line repeating that it exists would be noise.
+ *
+ * **What an ending MEANS depends on the mode**, which is why this is keyed on it
+ * (#350). The wording below was written for agent mode, where a run that stops with
+ * no report has fallen short. In planning mode the same exit is the SUCCESSFUL one:
+ * planning is toolless by contract, `compose_report` does not exist there, and
+ * stopping once the plan is written is exactly how a good planning run ends. A live
+ * planning run on 2026-08-12 was recorded `answered` by its own verifier and the
+ * rail rendered "Run answered" above "The model stopped without composing a cited
+ * report." — a headline and a sentence about the same run that contradicted each
+ * other. The earlier docblock here asserted the assumption that broke ("the rest are
+ * all cases where the run stopped WITHOUT answering"); it held for one mode and was
+ * stated for both.
+ *
+ * Only `model-stopped` differs. Every other ending is a shortfall in either mode: a
+ * planning run that ran out of time or was cancelled produced no plan either.
  */
-const STOP_SENTENCES = {
+const AGENT_STOP_SENTENCES = {
   "report-composed": null,
   "model-stopped": "The model stopped without composing a cited report.",
   cancelled: "Stopped because it was cancelled.",
@@ -259,6 +273,14 @@ const STOP_SENTENCES = {
   "turn-limit": "The run reached its step limit before it finished. What it had gathered is above.",
 } as const satisfies Record<AgentRunStopReason, string | null>;
 
+const STOP_SENTENCES: Readonly<Record<AgentRunMode, Record<AgentRunStopReason, string | null>>> = {
+  agent: AGENT_STOP_SENTENCES,
+  planning: {
+    ...AGENT_STOP_SENTENCES,
+    "model-stopped": "The model finished its plan and stopped. Planning mode has no tools, so it composed no report.",
+  },
+};
+
 /**
  * The one sentence an ending gets, from at most one of its two accounts.
  *
@@ -266,11 +288,15 @@ const STOP_SENTENCES = {
  * specific thing to have happened than any way the loop can exit. Neither present is
  * the normal case for a ledger written before these fields existed, and it yields no
  * detail rather than an invented one.
+ *
+ * The verdict's shortfall still wins over the stop reason in BOTH modes, so a
+ * planning run that produced no plan is told that rather than told it stopped.
  */
 function describeEnding(
   reason: AgentRunFailureReason | undefined,
   stopReason: AgentRunStopReason | undefined,
   verdict: AgentGoalVerdictRecord | undefined,
+  mode: AgentRunMode,
 ): { detail?: string } {
   if (reason !== undefined) return { detail: FAILURE_SENTENCES[reason] };
   // What the run was missing, when a verifier said. More specific than the stop
@@ -279,8 +305,14 @@ function describeEnding(
   const shortfall = verdict?.unmet?.map((code) => SHORTFALL_SENTENCES[code]).join(" ");
   if (shortfall !== undefined && shortfall.length > 0) return { detail: shortfall };
   if (stopReason === undefined) return {};
-  const sentence = STOP_SENTENCES[stopReason];
-  return sentence === null ? {} : { detail: sentence };
+  // BOTH indexes are optional, and for the same reason. `parseLedgerLine` checks the
+  // entry kind and deliberately nothing else, so a mode and a stop reason alike are
+  // whatever a possibly-newer server wrote — the unions describe what this bundle
+  // knows, not what the line holds. An unrecognised value in either position yields
+  // no sentence, which is a run read without a line under it rather than a rail torn
+  // down mid-read.
+  const sentence = STOP_SENTENCES[mode]?.[stopReason];
+  return sentence === null || sentence === undefined ? {} : { detail: sentence };
 }
 
 /** The verdict as the ledger carries it. Optional everywhere, like the fields beside it. */
@@ -333,7 +365,7 @@ function describeRefusal(refusal: AgentToolRefusal): Omit<AgentTimelineItem, "id
   }
 }
 
-function describeEvent(event: AgentRunEvent): Omit<AgentTimelineItem, "id" | "atMs"> {
+function describeEvent(event: AgentRunEvent, mode: AgentRunMode): Omit<AgentTimelineItem, "id" | "atMs"> {
   switch (event.kind) {
     case "run-started":
       return { tone: "neutral", headline: `Run started in ${event.mode} mode` };
@@ -431,12 +463,12 @@ function describeEvent(event: AgentRunEvent): Omit<AgentTimelineItem, "id" | "at
         // would be this component inventing a cause for every ending that had none.
         // `reason` wins when both are present: a drive that died outside the loop is
         // a more specific account of the ending than the loop's own exit.
-        ...describeEnding(event.reason, event.stopReason, event.goalVerdict),
+        ...describeEnding(event.reason, event.stopReason, event.goalVerdict, mode),
       };
   }
 }
 
-function describeEntry(entry: AgentLedgerEntry): Omit<AgentTimelineItem, "id"> {
+function describeEntry(entry: AgentLedgerEntry, mode: AgentRunMode): Omit<AgentTimelineItem, "id"> {
   switch (entry.kind) {
     case "run-opened":
       return {
@@ -452,7 +484,7 @@ function describeEntry(entry: AgentLedgerEntry): Omit<AgentTimelineItem, "id"> {
         quoted: entry.objective,
       };
     case "event":
-      return { atMs: entry.event.atMs, ...describeEvent(entry.event) };
+      return { atMs: entry.event.atMs, ...describeEvent(entry.event, mode) };
     default:
       return {
         atMs: entry.atMs,
@@ -582,12 +614,28 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
   const statementsByStep = new Map<string, string>();
   const captures = new Map<string, number>();
 
+  /*
+    What an ending MEANS depends on this (#350), so it is folded like the status is
+    and read from whichever of the two entries carries it — the header a run is
+    opened with, or the `run-started` event, since a stream can be joined after the
+    header has gone past.
+
+    `agent` is the default rather than an absence, and deliberately so: a fold that
+    never saw either has always shown the agent wording, and this must not change
+    what such a ledger reads as. The default is only reachable for a ledger whose
+    beginning the rail does not hold.
+  */
+  let mode: AgentRunMode = "agent";
+
   entries.forEach((entry, index) => {
     if (entry.kind === "cancellation-requested") stopRequested = true;
+    if (entry.kind === "run-opened") mode = entry.mode;
     if (entry.kind === "event") {
       const { event } = entry;
-      if (event.kind === "run-started") status = "running";
-      else if (event.kind === "run-finished") {
+      if (event.kind === "run-started") {
+        status = "running";
+        mode = event.mode;
+      } else if (event.kind === "run-finished") {
         status = event.status;
         failureReason = event.reason ?? null;
       } else if (event.kind === "context-captured") captures.set(event.fingerprint, event.tableCount);
@@ -608,7 +656,7 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
     }
     // Indexed, because two entries can legitimately be identical in content and
     // timestamp (a resumed run replaying a step), and React needs distinct keys.
-    items.push({ id: `entry-${index}`, ...describeEntry(entry) });
+    items.push({ id: `entry-${index}`, ...describeEntry(entry, mode) });
   });
 
   const budgets = AGENT_EXECUTION_POLICY.budgets;

--- a/src/lib/agent/context-snapshot.ts
+++ b/src/lib/agent/context-snapshot.ts
@@ -453,13 +453,20 @@ function renderTable(table: TableSchema): string {
  * Table and column names are DATABASE CONTENT and are therefore fenced as untrusted
  * input, exactly like rows: a column comment or a table name is writable by whoever
  * can write to the database.
+ *
+ * A `preface` is the SERVER's own sentence, placed ahead of the fence — a caller that
+ * needs to say something about the inventory (how to cite it, say) cannot say it
+ * inside a region the model is told to treat as data. It is a parameter rather than
+ * something a caller concatenates because the bound is this function's to keep:
+ * anything prepended outside would overrun it silently, by exactly its own length.
  */
 export function packContextForTask(
   snapshot: AgentContextSnapshot,
   objective: string,
-  options: { readonly maxChars?: number } = {},
+  options: { readonly maxChars?: number; readonly preface?: string } = {},
 ): string {
-  const maxChars = options.maxChars ?? AGENT_CONTEXT_PACK_MAX_CHARS;
+  const lead = options.preface === undefined ? "" : `${options.preface}\n`;
+  const maxChars = (options.maxChars ?? AGENT_CONTEXT_PACK_MAX_CHARS) - lead.length;
   const source = {
     label: "schema inventory",
     operationId: "agent/context-snapshot",
@@ -471,7 +478,7 @@ export function packContextForTask(
   // schema" would take it for the schema as it is now.
   const header = `Schema inventory for this run — fingerprint ${snapshot.fingerprint}, ${snapshot.tables.length} table(s) read at epoch ${snapshot.capturedAtMs}ms and not re-read since, most task-relevant first.`;
   if (snapshot.tables.length === 0) {
-    return fenceUntrustedContent(`${header}\nThis database reported no tables.`, source);
+    return `${lead}${fenceUntrustedContent(`${header}\nThis database reported no tables.`, source)}`;
   }
 
   const terms = taskTerms(objective);
@@ -494,5 +501,5 @@ export function packContextForTask(
     shown += 1;
   }
 
-  return fenceUntrustedContent(close(body, ranked.length - shown), source);
+  return `${lead}${fenceUntrustedContent(close(body, ranked.length - shown), source)}`;
 }

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -57,12 +57,15 @@ import {
 } from "./run-service";
 import type { AgentSettledStepEvent } from "./run-store";
 import {
+  AGENT_EVIDENCE_CONTRACT,
   AGENT_TOOL_DEFINITIONS,
   type AgentToolContext,
   type AgentToolName,
   type AgentToolOutcome,
+  citeSnapshot,
   comparePlansTool,
   composeReportTool,
+  handoverText,
   inspectPlanTool,
   planTableProfile,
   profileTableTool,
@@ -156,12 +159,24 @@ const SHARED_RULES = [
   "Never claim anything you have not established in this run.",
 ].join(" ");
 
+/**
+ * The rules an agent-mode run is opened with.
+ *
+ * The closing rule states the evidence contract in `tools.ts`'s own words rather
+ * than in a second wording of it (#350). Saying only "every claim must cite" is
+ * exactly what these rules used to say, and two live runs on 2026-08-12 show what it
+ * cost: the model reached `compose_report` knowing it had to, could not work out what
+ * an evidence item looked like, and spent five of seven turns guessing — one of them
+ * a `SELECT 1` sent to the database purely to keep thinking — while holding the
+ * correlation id it needed. The example object costs one line.
+ */
 const AGENT_RULES = [
   "You investigate a database read-only, through the tools you were given.",
   "Every statement you send is bounded and read-only; writes and DDL are refused before the database is reached.",
   "If a statement fails, draft a DIFFERENT one: the same statement is refused rather than retried, and your repair attempts are limited.",
   "A refusal that names a policy decision is a boundary, not a defect in your SQL. Rewording will not change it.",
   "Finish by calling compose_report. Every claim must cite an artifact this run read or the schema snapshot it captured.",
+  AGENT_EVIDENCE_CONTRACT,
 ].join(" ");
 
 const PLANNING_RULES = [
@@ -232,6 +247,28 @@ function systemPrompt(record: AgentRunRecord): string {
 // ============================================================================
 
 /**
+ * What a captured snapshot says about itself, in the server's own voice (#350).
+ *
+ * The inventory reaches the model FENCED, and a fence is a region the model is told
+ * to treat as data and never as instruction — so the sentence telling it how to cite
+ * the inventory cannot live inside one. It goes immediately before it instead, which
+ * is also where the fence's own header already speaks. The fingerprint is a
+ * server-computed `ctx_…` digest, so nothing untrusted is spliced in.
+ */
+const snapshotHandoverText = (fingerprint: string): string =>
+  `Cite that inventory in a claim as ${citeSnapshot(fingerprint)}.`;
+
+/**
+ * The packed inventory, with the sentence that says how to cite it in front of it.
+ *
+ * Handed to `packContextForTask` as its preface rather than concatenated here, so the
+ * sentence is INSIDE the bound that function keeps rather than added on top of it.
+ */
+function packSnapshotMessage(snapshot: AgentContextSnapshot, objective: string): string {
+  return packContextForTask(snapshot, objective, { preface: snapshotHandoverText(snapshot.fingerprint) });
+}
+
+/**
  * The schema's relations, as its own fenced block beside the inventory.
  *
  * Separate rather than folded into the inventory, for a reason the packing code
@@ -269,7 +306,10 @@ function toolsByStep(events: readonly AgentRunEvent[]): ReadonlyMap<string, stri
 function describeSettled(event: AgentSettledStepEvent, toolName: string): string {
   if (event.kind === "tool-completed") {
     const { correlationId, operationId, summary } = event.artifact;
-    return `Step ${event.stepId} (${toolName}) completed: operation ${operationId}, artifact ${correlationId}, ${summary.rowCount} row(s). The rows themselves are not delivered again — cite the artifact, or draft a different statement if you need to see them.`;
+    // The citation form, not merely the id (#350): a resumed run is told about work
+    // whose rows it will never see again, so this text IS its only route to citing
+    // that step, and "cite the artifact" left the how unsaid exactly as the rules did.
+    return `Step ${event.stepId} (${toolName}) completed: operation ${operationId}, ${summary.rowCount} row(s). ${handoverText(correlationId)} The rows themselves are not delivered again — cite it, or draft a different statement if you need to see them.`;
   }
 
   const { refusal } = event;
@@ -303,7 +343,9 @@ function describePriorProgress(record: AgentRunRecord): string | null {
 
   for (const event of record.events) {
     if (event.kind === "context-captured") {
-      lines.push(`A schema snapshot was captured: fingerprint ${event.fingerprint}, ${event.tableCount} table(s).`);
+      lines.push(
+        `A schema snapshot was captured: ${event.tableCount} table(s). ${snapshotHandoverText(event.fingerprint)}`,
+      );
     } else if (event.kind === "statement-drafted") {
       lines.push(`Step ${event.stepId}: you drafted ${event.sql} (${event.rationale}).`);
     } else if (event.kind === "tool-completed" || event.kind === "tool-refused") {
@@ -691,7 +733,7 @@ export async function runInvestigation(
 
     const recorded = reusableSnapshot(record.events, record.connectionId);
     if (recorded !== null) {
-      messages.push({ role: "user", content: packContextForTask(recorded, record.objective) });
+      messages.push({ role: "user", content: packSnapshotMessage(recorded, record.objective) });
       messages.push({ role: "user", content: packRelations(recorded, record.workflowType) });
       return;
     }
@@ -708,7 +750,7 @@ export async function runInvestigation(
       tableCount: snapshot.tables.length,
       snapshot,
     });
-    messages.push({ role: "user", content: packContextForTask(snapshot, record.objective) });
+    messages.push({ role: "user", content: packSnapshotMessage(snapshot, record.objective) });
     messages.push({ role: "user", content: packRelations(snapshot, record.workflowType) });
   };
 

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -275,6 +275,46 @@ const evidenceSchema = z.discriminatedUnion("source", [
   }),
 ]);
 
+/**
+ * ONE citation, rendered as the object the schema above accepts (#350).
+ *
+ * A function rather than a pair of string constants, because the same two calls
+ * produce both things that have to agree: the EXAMPLE a description shows, with a
+ * placeholder where the id goes, and the CONCRETE citation a completed step hands
+ * over with the id filled in. A model that copies what it was shown is producing
+ * what the parser was going to accept, because the same code wrote both.
+ *
+ * `satisfies AgentEvidenceReference` is what ties them to the durable contract, and
+ * `tests/unit/lib/agent/tools.test.ts` closes the loop from the other side: it lifts
+ * every literal object out of each description and parses it through that tool's own
+ * `inputSchema`, so a description offering a shape the schema refuses fails there
+ * rather than in a run.
+ *
+ * Why it exists at all: the evidence contract is a two-arm discriminated union, and
+ * two live runs (#350) inferred it wrong from the serialized JSON schema alone — the
+ * ledger records the model asking itself whether an evidence item is "an array of
+ * table row objects or strings?" and spending a database round trip on the question.
+ * Nothing it was TOLD named `source`, `correlationId` or `fingerprint`.
+ */
+const citeArtifact = (correlationId: string): string =>
+  JSON.stringify({ source: "artifact", correlationId } satisfies AgentEvidenceReference);
+
+export const citeSnapshot = (fingerprint: string): string =>
+  JSON.stringify({ source: "context-snapshot", fingerprint } satisfies AgentEvidenceReference);
+
+/**
+ * The evidence contract in one sentence, said identically wherever it is said.
+ *
+ * Exported because `investigation.ts` states it too — in the run's opening rules —
+ * and two wordings of the same contract would be two things to keep equal, with the
+ * one that drifted being the one a model followed into a refusal.
+ */
+export const AGENT_EVIDENCE_CONTRACT = [
+  `Each evidence item is ONE object: ${citeArtifact("<the artifact id a completed step reported>")} for a result this run read,`,
+  `or ${citeSnapshot("<the fingerprint of the schema snapshot this run captured>")} for that inventory.`,
+  'Add "locator" only to point at a part of it.',
+].join(" ");
+
 const reportSchema = z.strictObject({
   claims: z.array(z.strictObject({ claim: z.string().min(1), evidence: z.array(evidenceSchema).min(1) })).min(1),
 });
@@ -349,14 +389,12 @@ export const AGENT_TOOL_DEFINITIONS: Readonly<Record<AgentToolName, AgentToolDef
   },
   recommend_change: {
     name: "recommend_change",
-    description:
-      "Propose one index or one rewrite for the user to apply themselves. The statement is never executed by this run; it is offered to the user's editor. Every recommendation must cite evidence this run produced.",
+    description: `Propose one index or one rewrite for the user to apply themselves. The statement is never executed by this run; it is offered to the user's editor. Every recommendation must cite evidence this run produced. ${AGENT_EVIDENCE_CONTRACT}`,
     inputSchema: recommendationSchema,
   },
   compose_report: {
     name: "compose_report",
-    description:
-      "Compose the run's findings. Every claim must cite at least one artifact this run read or the schema snapshot it captured; an uncited claim is refused.",
+    description: `Compose the run's findings and finish. Every claim must cite at least one artifact this run read or the schema snapshot it captured; an uncited claim is refused. ${AGENT_EVIDENCE_CONTRACT}`,
     inputSchema: reportSchema,
   },
 } satisfies Record<AgentToolName, AgentToolDefinition>);
@@ -432,10 +470,13 @@ export function selectAgentTools(run: Pick<AgentRunRecord, "mode" | "workflowTyp
 const UNAVAILABLE_TEXT: Readonly<Record<AgentToolUnavailableCode, string>> = Object.freeze({
   MODE_HAS_NO_TOOLS:
     "This run is in planning mode, which has no tools at all. Produce a plan in prose; no database call is possible from here.",
+  // Said by every tool, including the two that reach no database and compose no SQL,
+  // so it may not promise a statement (#350). `recommend_change` and `compose_report`
+  // shared a sentence written for the SQL-composing tools, and a model that got an
+  // evidence object wrong was answered with a sentence about statements.
   INVALID_TOOL_INPUT:
-    "The arguments could not be turned into a statement this layer will run. Correct them and call the tool again.",
-  UNVERIFIABLE_EVIDENCE:
-    "At least one evidence reference does not match anything this run produced. Cite an artifact this run actually read, or the schema snapshot it captured.",
+    "The arguments did not match the shape this tool declares, so nothing was done. Correct them and call the tool again.",
+  UNVERIFIABLE_EVIDENCE: `At least one evidence reference does not match anything this run produced. Cite an artifact this run actually read, or the schema snapshot it captured. ${AGENT_EVIDENCE_CONTRACT}`,
   UNVERIFIABLE_PLAN:
     "At least one of those references is not an estimated plan this run produced. Inspect the plan of each statement first, then compare the two artifacts those inspections returned.",
   TABLE_NOT_INVENTORIED:
@@ -545,6 +586,28 @@ function unavailable(
 ): AgentToolOutcome & { kind: "unavailable" } {
   const base = UNAVAILABLE_TEXT[reasonCode];
   return { kind: "unavailable", reasonCode, modelText: detail === undefined ? base : `${base} (${detail})` };
+}
+
+/**
+ * The bad-input refusal the two evidence-bearing tools give, with the contract in it.
+ *
+ * `INVALID_TOOL_INPUT` is shared by every tool, and a selector this layer could not
+ * read has nothing to do with citing — so the contract is added HERE, at the two call
+ * sites where the arguments that failed to parse carried evidence, rather than to the
+ * shared sentence.
+ *
+ * Why a refusal restates something the description already said (#350): a description
+ * is read by a model that is not yet confused, and a refusal is read by one that
+ * demonstrably is. It got the shape wrong, and this reply is the next thing it reads.
+ * `UNVERIFIABLE_EVIDENCE` carries the contract in `UNAVAILABLE_TEXT` itself, because
+ * only these same two tools can produce it.
+ */
+function invalidEvidenceInput(): AgentToolOutcome & { kind: "unavailable" } {
+  return {
+    kind: "unavailable",
+    reasonCode: "INVALID_TOOL_INPUT",
+    modelText: `${UNAVAILABLE_TEXT.INVALID_TOOL_INPUT} ${AGENT_EVIDENCE_CONTRACT}`,
+  };
 }
 
 /**
@@ -855,13 +918,23 @@ export async function executeAgentOperation(
   return {
     kind: "completed",
     artifact,
-    modelText: fenceUntrustedContent(renderRows(result.rows), {
+    // The handover sentence comes FIRST, in the server's own voice, before the
+    // fence (#350). This is the moment the id changes hands, and it is where the
+    // model needs the form: the live runs that failed were HOLDING the correlation
+    // id and still never produced the object, so naming an id is demonstrably not
+    // the same as saying how to cite it. The id is a server-minted UUID, so nothing
+    // untrusted is spliced into this sentence.
+    modelText: `${handoverText(artifact.correlationId)}\n${fenceUntrustedContent(renderRows(result.rows), {
       label: `${request.label ?? "result"}, ${result.rowCount} row(s)`,
       operationId: artifact.operationId,
       reference: artifact.correlationId,
-    }),
+    })}`,
   };
 }
+
+/** What a completed reach says about the artifact it just produced. */
+export const handoverText = (correlationId: string): string =>
+  `Stored as artifact ${correlationId}. To use it in a claim, cite it as ${citeArtifact(correlationId)}.`;
 
 // ============================================================================
 // The four tools
@@ -1254,7 +1327,7 @@ export async function profileTableTool(
     // into a sentence the model reads as the server speaking. Found by review on
     // #345: an identifier is exactly as untrusted as a row value.
     modelText: [
-      `Profiled a table: ${profile.rowCount} row(s), columns ${plan.from + 1}-${plan.from + columns.length} at ${depth} depth, ${findings.length} finding(s), artifact ${outcome.artifact.correlationId}.`,
+      `Profiled a table: ${profile.rowCount} row(s), columns ${plan.from + 1}-${plan.from + columns.length} at ${depth} depth, ${findings.length} finding(s). ${handoverText(outcome.artifact.correlationId)}`,
       plan.remaining === 0
         ? "Every column of that table is covered."
         : `${plan.remaining} further column(s) are NOT covered by this profile; call profile_table again with fromColumn=${plan.from + columns.length} to reach them.`,
@@ -1326,7 +1399,7 @@ export function recommendChangeTool(
   }
 
   const parsed = parseToolInput(recommendationSchema, input);
-  if (!parsed.ok) return unavailable("INVALID_TOOL_INPUT");
+  if (!parsed.ok) return invalidEvidenceInput();
   if (!matchesCard(parsed.value.change, parsed.value.statement)) {
     return unavailable("RECOMMENDATION_SHAPE_MISMATCH");
   }
@@ -1405,7 +1478,7 @@ export function composeReportTool(
   }
 
   const parsed = parseToolInput(reportSchema, input);
-  if (!parsed.ok) return unavailable("INVALID_TOOL_INPUT");
+  if (!parsed.ok) return invalidEvidenceInput();
 
   const claims: AgentReportClaim[] = [];
   for (const claim of parsed.value.claims) {

--- a/tests/evals/injection.test.ts
+++ b/tests/evals/injection.test.ts
@@ -256,7 +256,12 @@ describe("a hostile table name in a profile", () => {
 
     expect(drive.kinds).not.toContain("table-profiled");
     expect(drive.modelStatements).toEqual([]);
-    expect(drive.transcripts[1]).toContain("could not be turned into a statement");
+    // The refusal is the shared bad-input one carrying the COMPOSER's reason code,
+    // which is what "this never became a statement" looks like from the model's side.
+    // The sentence itself no longer promises a statement, because `compose_report`
+    // and `recommend_change` say it too and run none (#350).
+    expect(drive.transcripts[1]).toContain("did not match the shape this tool declares");
+    expect(drive.transcripts[1]).toContain("INVALID_SELECTOR");
   });
 });
 

--- a/tests/evals/query-optimization.test.ts
+++ b/tests/evals/query-optimization.test.ts
@@ -65,7 +65,7 @@ async function open(engine: EvalEngine): Promise<EvalRun> {
 const comparesPlans =
   () =>
   (turn: Turn): Response => {
-    const [before, after] = [...new Set(correlationIdsIn(turn.transcript))];
+    const [before, after] = correlationIdsIn(turn.transcript);
     if (before === undefined || after === undefined) {
       throw new Error(
         `expected two plan artifacts in the transcript, got ${JSON.stringify(correlationIdsIn(turn.transcript))}`,

--- a/tests/evals/real-model.ts
+++ b/tests/evals/real-model.ts
@@ -23,7 +23,7 @@
 
 import { createAgentModel } from "@/lib/agent/model-adapter";
 import { LLMRateLimitError } from "@/lib/llm/types";
-import { type EvalEngine, type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
+import { DEPARTMENTS, type EvalEngine, type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
 import type { EvalDrive } from "../isolated/fixtures/agent-eval-harness";
 
 interface RealModelCase {
@@ -53,7 +53,63 @@ const HEADCOUNTS = [
   { department: "support", headcount: 17 },
 ];
 
+/** A count per department table, so a statement that names some gets those. */
+const COUNTS: Readonly<Record<string, number>> = {
+  engineering: 41,
+  sales: 22,
+  support: 17,
+  finance: 12,
+  legal: 5,
+  people: 9,
+  marketing: 14,
+  research: 31,
+};
+
+/**
+ * A scripted engine whose answers AGREE with the inventory the run captured.
+ *
+ * The three cases below hand back the same three rows whatever they are asked,
+ * against an inventory of eight department tables of `(id, name)`. A scripted model
+ * never notices — it does not read the inventory — but a real one does, and #350's
+ * measurement showed what that costs: the model counts the eight tables, is answered
+ * about three departments it did not ask about, disbelieves the result, and probes
+ * to the turn ceiling. The run never gets as far as composing anything, so those
+ * cases cannot measure a REPORT at all, whatever the report contract says. Left as
+ * they are on purpose — they are #341's observed corpus, and re-shaping them is its
+ * own change with its own evidence to produce — but a case that needs the run to
+ * reach the end needs an engine that lets it.
+ */
+const countsFor = async (sql: string) => {
+  const named = DEPARTMENTS.filter((table) => new RegExp(`\\b${table}\\b`, "i").test(sql));
+  const tables = named.length > 0 ? named : DEPARTMENTS;
+  const counted = tables
+    .map((table) => ({ department: table, headcount: COUNTS[table] ?? 0 }))
+    .sort((left, right) => right.headcount - left.headcount);
+  return rows(counted, ["department", "headcount"]);
+};
+
 const CASES: readonly RealModelCase[] = [
+  {
+    /*
+      #350's scenario, and the one case here that measures the REPORT.
+
+      The other cases end wherever the model chooses to stop; this one is scored on
+      whether the run WROTE DOWN what it found. That is the thing #350 is about: the
+      live runs that motivated it read the answer, held the artifact id, and composed
+      nothing, spending their remaining turns on statements with nothing to learn in
+      them (`SELECT 1 as x;`, `SELECT sqlite_version();`) while working out how to
+      cite what they already had. `claims` in the table below is the column that
+      shows it — a run can be `succeeded` with zero.
+
+      This case is a MEASUREMENT harness, not evidence by itself: what a given model
+      does with it belongs in the run that measured it, not in this comment.
+    */
+    name: "cited-report",
+    engine: "sqlite",
+    objective: "Which department has the most employees?",
+    expectation: "composes a report citing an artifact it read, rather than re-reading to the turn ceiling",
+    answer: countsFor,
+  },
   {
     name: "one-query-answer",
     engine: "postgres",
@@ -93,6 +149,8 @@ interface CaseOutcome {
   readonly stopReason: string;
   readonly turns: number;
   readonly statements: number;
+  /** Claims the run wrote down, each carrying a citation the server verified. */
+  readonly claims: number;
   readonly note: string;
 }
 
@@ -104,6 +162,12 @@ function summarise(name: string, drive: EvalDrive, expectation: string): CaseOut
     stopReason: drive.stopReason,
     turns: drive.turns,
     statements: drive.modelStatements.length,
+    // Reported alongside the verdict because #350 is about this number being zero:
+    // a run can read seven times, hold the answer, and write down none of it.
+    claims: drive.events.reduce(
+      (total, event) => (event.kind === "report-composed" ? total + event.claims.length : total),
+      0,
+    ),
     note: expectation,
   };
 }
@@ -131,6 +195,7 @@ async function runCase(testCase: RealModelCase): Promise<CaseOutcome> {
       stopReason: "-",
       turns: 0,
       statements: 0,
+      claims: 0,
       note: error instanceof Error ? error.message : String(error),
     };
   } finally {
@@ -156,11 +221,11 @@ async function main(): Promise<void> {
   }
 
   const lines = [
-    "| case | verdict | status | stop reason | turns | statements | what a good run does |",
-    "| --- | --- | --- | --- | --- | --- | --- |",
+    "| case | verdict | status | stop reason | turns | statements | claims | what a good run does |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- |",
     ...outcomes.map(
       (outcome) =>
-        `| ${outcome.name} | ${outcome.verdict} | ${outcome.status} | ${outcome.stopReason} | ${outcome.turns} | ${outcome.statements} | ${outcome.note} |`,
+        `| ${outcome.name} | ${outcome.verdict} | ${outcome.status} | ${outcome.stopReason} | ${outcome.turns} | ${outcome.statements} | ${outcome.claims} | ${outcome.note} |`,
     ),
   ];
   console.log(lines.join("\n"));

--- a/tests/evals/report-citation.test.ts
+++ b/tests/evals/report-citation.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
+import {
+  answersProse,
+  callsTool,
+  offeredCitationsIn,
+  promptText,
+  reportCitingWhatWasOffered,
+} from "../isolated/fixtures/agent-scripted-model";
+
+/**
+ * The citation contract, driven end to end (#350).
+ *
+ * **This is a regression guard, and it is NOT the evidence the issue asks for.** A
+ * scripted model already knows the contract, so it can never be confused by one —
+ * which is precisely why the defect survived a green suite and a hundred-per-cent
+ * coverage gate. The evidence is a live run, and it lives in the PR body.
+ *
+ * What this CAN hold still is the property a live model depends on and no prose
+ * assertion covers: **the object the server puts in front of the model is one the
+ * server will then accept.** Four things have to agree for that — `evidenceSchema`,
+ * the tool descriptions, `AGENT_RULES`, and the handover text a completed step and a
+ * captured snapshot write — and they are in three files. The model here copies what
+ * it was offered and nothing else, so if any of the four drifts, the run stops
+ * answering here instead of in production.
+ *
+ * The complementary halves are elsewhere and are deliberately not repeated:
+ * `tests/unit/lib/agent/tools.test.ts` parses each description's literal objects
+ * through that tool's own schema, and `tests/isolated/agent-investigation.test.ts`
+ * asserts the shape reaches all three places a model looks.
+ */
+
+const runs: EvalRun[] = [];
+let consoleSpy: ReturnType<typeof spyOn<Console, "log">>;
+
+beforeEach(() => {
+  consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleSpy.mockRestore();
+  for (const run of runs.splice(0)) run.dispose();
+});
+
+async function open(options: Parameters<typeof openEvalRun>[0] = {}): Promise<EvalRun> {
+  const run = await openEvalRun(options);
+  runs.push(run);
+  return run;
+}
+
+const AGGREGATE = "SELECT department, count(*) AS headcount FROM employees GROUP BY department ORDER BY 2 DESC";
+
+describe("a run can cite using only what it was shown", () => {
+  test("a model that copies the offered citation answers, on both engines", async () => {
+    for (const engine of ["postgres", "sqlite"] as const) {
+      const run = await open({ engine });
+      const drive = await run.drive([
+        callsTool("run_read_query", { sql: AGGREGATE, rationale: "count by department" }),
+        reportCitingWhatWasOffered("Engineering has the most employees."),
+      ]);
+
+      expect(drive.verdict.outcome, engine).toBe("answered");
+      expect(drive.stopReason, engine).toBe("report-composed");
+      expect(drive.kinds, engine).toContain("report-composed");
+    }
+  });
+
+  test("the citation it copied is the artifact the run actually produced", async () => {
+    const run = await open();
+    const drive = await run.drive([
+      callsTool("run_read_query", { sql: AGGREGATE, rationale: "count by department" }),
+      reportCitingWhatWasOffered("Engineering has the most employees."),
+    ]);
+
+    const completed = drive.events.find((event) => event.kind === "tool-completed");
+    const report = drive.events.find((event) => event.kind === "report-composed");
+    if (completed?.kind !== "tool-completed" || report?.kind !== "report-composed") {
+      throw new Error(`expected a completed read and a report, got ${drive.kinds.join(", ")}`);
+    }
+
+    // Every reference is one the run minted, not one the fixture invented — the
+    // server verified them against its own ledger before recording this entry.
+    expect(report.claims[0]?.evidence).toContainEqual({
+      source: "artifact",
+      correlationId: completed.artifact.correlationId,
+    });
+  });
+
+  test("the snapshot is citable from the first turn, before any statement is sent", async () => {
+    // A run whose answer is in the inventory itself never reads anything, so the
+    // snapshot's fingerprint is the ONLY thing it can cite. Without the handover
+    // sentence, such a run has no way to compose a report at all.
+    const run = await open({ objective: "Which tables does this database have?" });
+    const drive = await run.drive([reportCitingWhatWasOffered("The database has eight department tables.")]);
+
+    expect(drive.verdict.outcome).toBe("answered");
+    expect(drive.modelStatements).toEqual([]);
+
+    const captured = drive.events.find((event) => event.kind === "context-captured");
+    const report = drive.events.find((event) => event.kind === "report-composed");
+    if (captured?.kind !== "context-captured" || report?.kind !== "report-composed") {
+      throw new Error(`expected a capture and a report, got ${drive.kinds.join(", ")}`);
+    }
+    expect(report.claims[0]?.evidence).toContainEqual({
+      source: "context-snapshot",
+      fingerprint: captured.fingerprint,
+    });
+  });
+
+  test("a planning run is offered no citation, because it can produce none", async () => {
+    const offered: unknown[][] = [];
+    const run = await open({ mode: "planning" });
+    await run.drive([
+      (turn) => {
+        offered.push(offeredCitationsIn(turn));
+        return answersProse("First, read the plan of the report query.")(turn);
+      },
+    ]);
+
+    expect(offered).toEqual([[]]);
+  });
+
+  test("the placeholder in the rules is not mistaken for a real id", async () => {
+    // The rules carry `{"source":"artifact","correlationId":"<the artifact id …>"}`
+    // as a template. A fixture that copied THAT would compose a report citing
+    // something no run ever produced — so the extractor drops the placeholders, and
+    // this asserts they were there to be dropped.
+    const prompts: string[] = [];
+    const run = await open();
+    await run.drive([
+      (turn) => {
+        prompts.push(promptText(turn));
+        return answersProse("nothing to do")(turn);
+      },
+    ]);
+
+    expect(prompts[0]).toContain('{"source":"artifact","correlationId":"<');
+    expect(prompts[0]).toContain('{"source":"context-snapshot","fingerprint":"<');
+  });
+});

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -27,6 +27,7 @@ import {
   callsTool,
   correlationIdIn,
   modelOver,
+  promptText,
   reportOn,
   scriptedModel,
   unansweredCall,
@@ -471,6 +472,141 @@ describe("a fresh run drives the investigation arc", () => {
     expect(messages.filter((message) => message.role === "user").map((message) => message.content)).toContain(
       OBJECTIVE,
     );
+  });
+});
+
+/*
+  #350. Both places that told the model to cite said only that a claim must cite.
+  Neither said what a citation IS, and two live runs spent five of seven turns
+  guessing at it — one of them sending `SELECT 1` purely to keep thinking — while
+  holding the correlation id they needed.
+
+  These assertions are about the PROMPT, which is unusual here and is the point: a
+  scripted model already knows the contract and can never be confused by it, so no
+  behavioural test in this suite can see this defect. What CAN be pinned mechanically
+  is that the shape appears in each of the three places a model looks — the rules it
+  is opened with, the moment an id changes hands, and the summary a resumed run is
+  given — and that what appears there is the shape the parser accepts.
+*/
+describe("the model is told what a citation IS, not only that it must cite (#350)", () => {
+  /** Every literal evidence object in a prompt, as the model would lift one out. */
+  const offeredObjects = (text: string): { source: string; correlationId?: string; fingerprint?: string }[] =>
+    [...text.matchAll(/\{"source":"[a-z-]+","[A-Za-z]+":"[^"]*"\}/g)].map((match) => JSON.parse(match[0]));
+
+  /** The rules the run was opened with, on their own — not the messages beside them. */
+  const rulesOf = (turn: Turn): string => {
+    const messages = (turn.body.messages ?? []) as { role?: string; content?: unknown }[];
+    const system = messages.find((message) => message.role === "system");
+    return typeof system?.content === "string" ? system.content : "";
+  };
+
+  test("the run's rules carry both arms of the evidence contract", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(answersProse("ok"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    expect(
+      offeredObjects(rulesOf(script.turns[0] as Turn))
+        .map((object) => object.source)
+        .sort(),
+    ).toEqual(["artifact", "context-snapshot"]);
+  });
+
+  test("the snapshot's own fingerprint is offered as a citation when it is captured", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(answersProse("ok"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const captured = (await eventsOf(b.store, run.runId)).find((event) => event.kind === "context-captured");
+    if (captured?.kind !== "context-captured") throw new Error("this drive captured no snapshot");
+    // Not the placeholder from the rules: the run's OWN fingerprint, ready to copy.
+    expect(offeredObjects(promptText(script.turns[0] as Turn))).toContainEqual({
+      source: "context-snapshot",
+      fingerprint: captured.fingerprint,
+    });
+  });
+
+  test("a completed read offers its own id in the shape a claim takes", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "size it" }),
+      answersProse("done"),
+    );
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const completed = (await eventsOf(b.store, run.runId)).find((event) => event.kind === "tool-completed");
+    if (completed?.kind !== "tool-completed") throw new Error("this drive completed no tool call");
+    // The SECOND turn is where the tool's answer reached the model.
+    expect(offeredObjects(promptText(script.turns[1] as Turn))).toContainEqual({
+      source: "artifact",
+      correlationId: completed.artifact.correlationId,
+    });
+  });
+
+  test("a resumed run is offered the same shapes for what it already established", async () => {
+    const dataDir = freshDataDir();
+    const first = boot(dataDir);
+    const run = await startRun(first);
+    // One completed read, then the driving process stops answering.
+    const died = scriptedModel(callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "size it" }));
+    await expect(
+      runInvestigation(run.runId, {
+        service: first.service,
+        model: await modelOver(died.fetch),
+        resources: first.resources,
+      }),
+    ).rejects.toThrow();
+
+    const second = boot(dataDir);
+    const resumed = scriptedModel(answersProse("ok"));
+    await runInvestigation(run.runId, {
+      service: second.service,
+      model: await modelOver(resumed.fetch),
+      resources: second.resources,
+    });
+
+    const events = await eventsOf(second.store, run.runId);
+    const completed = events.find((event) => event.kind === "tool-completed");
+    const captured = events.find((event) => event.kind === "context-captured");
+    if (completed?.kind !== "tool-completed" || captured?.kind !== "context-captured") {
+      throw new Error("the resumed run has no prior progress to be told about");
+    }
+
+    const offered = offeredObjects(promptText(resumed.turns[0] as Turn));
+    expect(offered).toContainEqual({ source: "artifact", correlationId: completed.artifact.correlationId });
+    expect(offered).toContainEqual({ source: "context-snapshot", fingerprint: captured.fingerprint });
+  });
+
+  test("planning mode is not told to cite anything, because it has nothing to cite", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "planning");
+    const script = scriptedModel(answersProse("a plan"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    expect(offeredObjects(promptText(script.turns[0] as Turn))).toEqual([]);
   });
 });
 

--- a/tests/isolated/fixtures/agent-scripted-model.ts
+++ b/tests/isolated/fixtures/agent-scripted-model.ts
@@ -120,11 +120,25 @@ export function correlationIdIn(transcript: string): string {
   return match[0];
 }
 
-/** Every correlation id in the transcript, oldest first. */
+/**
+ * Every DISTINCT correlation id in the transcript, oldest first.
+ *
+ * Deduplicated here rather than at each call site (#350). One artifact now reaches
+ * the model three times in one handover — in the fence header, in "Stored as
+ * artifact …", and inside the citation object — so occurrences stopped being ids the
+ * moment the handover text was added, and a caller that destructures `[before,
+ * after]` would silently get one artifact twice. Both call sites already wanted a
+ * set and wrapped this in `new Set`; making that the function's contract removes the
+ * trap rather than leaving it for the next caller to step in.
+ */
 export function correlationIdsIn(transcript: string): string[] {
-  return [...transcript.matchAll(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g)].map(
-    (match) => match[0],
-  );
+  return [
+    ...new Set(
+      [...transcript.matchAll(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g)].map(
+        (match) => match[0],
+      ),
+    ),
+  ];
 }
 
 /** A report citing the FIRST result this run produced. */
@@ -139,11 +153,52 @@ export const reportOn =
       "call_report",
     );
 
+/**
+ * The prompt as prose: every message's text, in order.
+ *
+ * `turn.transcript` is the messages JSON-encoded, so a JSON object embedded in a
+ * message's text appears there escaped and cannot be lifted back out. This is what
+ * the MODEL reads.
+ */
+export function promptText(turn: Turn): string {
+  const messages = (turn.body.messages ?? []) as { content?: unknown }[];
+  return messages.map((message) => (typeof message.content === "string" ? message.content : "")).join("\n");
+}
+
+/**
+ * Every evidence object the SERVER offered in this prompt, lifted verbatim (#350).
+ *
+ * The regex matches canonical JSON with no spaces, which is what `JSON.stringify`
+ * produces in `tools.ts` — deliberately coupled, so a citation the server renders
+ * some other way stops being found here rather than being silently tolerated.
+ */
+export function offeredCitationsIn(turn: Turn): unknown[] {
+  return [...promptText(turn).matchAll(/\{"source":"[a-z-]+","[A-Za-z]+":"[^"]*"\}/g)]
+    .map((match) => JSON.parse(match[0]) as { correlationId?: string; fingerprint?: string })
+    .filter((citation) => !(citation.correlationId ?? citation.fingerprint ?? "").startsWith("<"));
+}
+
+/**
+ * A report that cites ONLY what the prompt offered, copied exactly as offered.
+ *
+ * The regression guard for #350: it asks nothing of the model's understanding, only
+ * that the object the server put in front of it is one the server will then accept.
+ * If the description, the rules, the handover text and `evidenceSchema` ever drift
+ * apart, this fixture composes a report the tool refuses.
+ */
+export const reportCitingWhatWasOffered =
+  (claim: string): ScriptedTurn =>
+  (turn: Turn): Response => {
+    const evidence = offeredCitationsIn(turn);
+    if (evidence.length === 0) throw new Error(`the prompt offered no citation: ${promptText(turn).slice(0, 600)}`);
+    return chatToolCallStream("compose_report", JSON.stringify({ claims: [{ claim, evidence }] }), "call_report");
+  };
+
 /** A report citing EVERY result this run produced, which is what an empty-evidence fixture needs. */
 export const reportOnAll =
   (claim: string): ScriptedTurn =>
   (turn: Turn): Response => {
-    const ids = [...new Set(correlationIdsIn(turn.transcript))];
+    const ids = correlationIdsIn(turn.transcript);
     if (ids.length === 0) throw new Error(`no artifact reference in the transcript: ${turn.transcript.slice(0, 400)}`);
     return chatToolCallStream(
       "compose_report",

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -1152,3 +1152,153 @@ describe("an ending says whether the run ANSWERED, not only how it stopped (B24)
     expect(view.items[1]?.detail).toContain("stopped without composing a cited report");
   });
 });
+
+/*
+  #350's second finding, and the reason it survived every existing assertion: the
+  headline and the sentence under it were each pinned alone, and the defect is only
+  visible in the PAIR. A planning run that ended exactly as planning runs are meant
+  to ended `model-stopped`, and the rail rendered "Run answered" with "The model
+  stopped without composing a cited report." directly beneath it — a verdict and a
+  shortfall about the same run, in the same breath, one of them false.
+
+  Every test here therefore reads BOTH fields of one ending. Asserting either half
+  on its own is what let the contradiction through the first time.
+*/
+describe("the verdict and the sentence beneath it are read as one pair (#350)", () => {
+  const openedIn = (mode: "agent" | "planning"): AgentLedgerEntry => ({ ...OPENED, mode });
+
+  const stoppedAnswering = (verifier: string): AgentLedgerEntry =>
+    event({
+      kind: "event",
+      event: {
+        kind: "run-finished",
+        atMs: 9,
+        status: "succeeded",
+        stopReason: "model-stopped",
+        goalVerdict: { outcome: "answered", verifier },
+      },
+    } as AgentLedgerEntry & { kind: "event" });
+
+  test("a planning run that answered is not also told it composed no report", () => {
+    // Planning is TOOLLESS by contract: `compose_report` does not exist in that
+    // mode, so stopping without one is how a good planning run ends.
+    const view = foldLedgerEntries([openedIn("planning"), stoppedAnswering("agent-planning.1")]);
+    const ending = view.items[1];
+
+    expect(ending?.headline).toBe("Run answered");
+    expect(ending?.detail ?? "").not.toContain("without composing a cited report");
+    // And it is not merely silent: the pair still says what happened.
+    expect(ending?.detail).toContain("plan");
+  });
+
+  test("an agent run that answered nothing still reads as the shortfall it is", () => {
+    const view = foldLedgerEntries([
+      openedIn("agent"),
+      event({
+        kind: "event",
+        event: {
+          kind: "run-finished",
+          atMs: 9,
+          status: "succeeded",
+          stopReason: "model-stopped",
+          goalVerdict: { outcome: "unanswered", verifier: "agent-investigation.1", unmet: ["no-report"] },
+        },
+      } as AgentLedgerEntry & { kind: "event" }),
+    ]);
+    const ending = view.items[1];
+
+    expect(ending?.headline).toBe("Run did not answer");
+    expect(ending?.detail).toContain("without composing a cited report");
+  });
+
+  test("a planning run that fell short says what it lacked, not how the loop exited", () => {
+    const view = foldLedgerEntries([
+      openedIn("planning"),
+      event({
+        kind: "event",
+        event: {
+          kind: "run-finished",
+          atMs: 9,
+          status: "succeeded",
+          stopReason: "model-stopped",
+          goalVerdict: { outcome: "unanswered", verifier: "agent-planning.1", unmet: ["no-plan"] },
+        },
+      } as AgentLedgerEntry & { kind: "event" }),
+    ]);
+    const ending = view.items[1];
+
+    expect(ending?.headline).toBe("Run did not answer");
+    expect(ending?.detail).toContain("no plan at all");
+  });
+
+  test("a planning run's other endings are still the failures they were", () => {
+    const view = foldLedgerEntries([
+      openedIn("planning"),
+      event({
+        kind: "event",
+        event: { kind: "run-finished", atMs: 9, status: "failed", stopReason: "deadline-exceeded" },
+      } as AgentLedgerEntry & { kind: "event" }),
+    ]);
+
+    expect(view.items[1]?.detail).toContain("time limit");
+  });
+
+  test("a ledger whose header the rail never read keeps the agent-mode reading", () => {
+    // A stream joined after the header — the fold has no mode to go on, and the
+    // agent wording is what this component has always shown.
+    const view = foldLedgerEntries([stoppedAnswering("agent-investigation.1")]);
+
+    expect(view.items[0]?.detail).toContain("without composing a cited report");
+  });
+
+  test("the mode is taken from a run-started event when that is all there is", () => {
+    const view = foldLedgerEntries([
+      event({ kind: "event", event: { kind: "run-started", atMs: 2, mode: "planning" } } as AgentLedgerEntry & {
+        kind: "event";
+      }),
+      stoppedAnswering("agent-planning.1"),
+    ]);
+
+    expect(view.items[1]?.detail ?? "").not.toContain("without composing a cited report");
+  });
+
+  /*
+    Keying the sentence on the mode made a two-level lookup out of a one-level one,
+    and the second index is the one that throws. `parseLedgerLine` validates the
+    entry KIND and deliberately nothing else — its own docblock says a newer server
+    may write things this bundle has never heard of, and that is not a reason to
+    tear down a timeline a user is already reading. A mode is exactly such a thing:
+    it arrives off parsed JSON, so `AgentRunMode` describes what this bundle knows,
+    not what the line contains.
+
+    The rail must therefore degrade for an unknown mode the way it already degrades
+    for an unknown stop reason — no sentence, everything else intact — rather than
+    blanking the run.
+  */
+  test("a mode this bundle has never heard of does not tear down the timeline", () => {
+    const line = JSON.stringify({ ...OPENED, mode: "supervised" });
+    const parsed = parseLedgerLine(line);
+    if (parsed === null) throw new Error("the header itself must still parse: its kind is one this bundle knows");
+
+    const view = foldLedgerEntries([parsed, stoppedAnswering("agent-supervised.1")]);
+
+    // The run is still readable, and the ending still carries its verdict.
+    expect(view.items).toHaveLength(2);
+    expect(view.items[1]?.headline).toBe("Run answered");
+    // No invented sentence: unknown mode degrades exactly like an unknown stop
+    // reason, which yields no detail rather than another mode's wording.
+    expect(view.items[1]?.detail).toBeUndefined();
+  });
+
+  test("an unknown stop reason still degrades to no sentence, in a mode this bundle knows", () => {
+    const view = foldLedgerEntries([
+      openedIn("agent"),
+      event({
+        kind: "event",
+        event: { kind: "run-finished", atMs: 9, status: "succeeded", stopReason: "abandoned-by-operator" },
+      } as unknown as AgentLedgerEntry & { kind: "event" }),
+    ]);
+
+    expect(view.items[1]?.detail).toBeUndefined();
+  });
+});

--- a/tests/unit/lib/agent/context-snapshot.test.ts
+++ b/tests/unit/lib/agent/context-snapshot.test.ts
@@ -463,6 +463,30 @@ describe("packContextForTask", () => {
     expect(packed).toContain("omitted");
   });
 
+  /*
+    A preface is the server's own voice ahead of the fence — the sentence telling the
+    model how to cite the inventory cannot live INSIDE a region the model is told to
+    treat as data (#350). Passed here rather than concatenated by the caller because
+    the bound is this function's to keep: text prepended outside it would overrun the
+    bound the docblock above states, silently and by exactly its own length.
+  */
+  test("a preface is inside the bound, not added to it", () => {
+    const preface = `Cite that inventory in a claim as ${"x".repeat(300)}.`;
+    const packed = packContextForTask(wideSnapshot(200, 40), "Why is the orders report slow?", { preface });
+
+    expect(packed.startsWith(`${preface}\n`)).toBe(true);
+    expect(packed.length).toBeLessThanOrEqual(AGENT_CONTEXT_PACK_MAX_CHARS);
+  });
+
+  test("a preface stays outside the fenced region", () => {
+    const preface = 'Cite that inventory as {"source":"context-snapshot","fingerprint":"ctx_0"}.';
+    const packed = packContextForTask(wideSnapshot(0, 0), "anything", { preface });
+
+    // Before the fence opens, so nothing tells the model to read it as data.
+    expect(packed).toContain(preface);
+    expect(packed.indexOf(preface)).toBeLessThan(packed.indexOf(UNTRUSTED_CONTENT_BEGIN));
+  });
+
   test("selects the tables the task is about, most relevant first", () => {
     const snapshot: AgentContextSnapshot = {
       ...wideSnapshot(40, 4),

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -283,6 +283,162 @@ describe("selectAgentTools — the server decides, from the persisted mode and w
   });
 });
 
+/*
+  #350: two live runs called `run_read_query` seven times and `compose_report`
+  zero times, and the ledger's rationales say why — "evidence (array of table row
+  objects or strings? …)". Both places the model is told about citing said a claim
+  must cite; neither said what a citation IS. So the contract is asserted here as
+  the model reads it: the description carries the object, and the object it carries
+  is one the schema beside it accepts.
+*/
+describe("a tool that demands a citation says what a citation IS (#350)", () => {
+  /** Every literal evidence object the description offers, as the model would lift it. */
+  const offeredObjects = (description: string): unknown[] =>
+    [...description.matchAll(/\{"source":"[a-z-]+","[A-Za-z]+":"[^"]*"\}/g)].map((match) => JSON.parse(match[0]));
+
+  for (const name of ["compose_report", "recommend_change"] as const) {
+    test(`${name} shows both arms of the evidence contract`, () => {
+      const objects = offeredObjects(AGENT_TOOL_DEFINITIONS[name].description);
+
+      expect(objects.map((object) => (object as { source: string }).source).sort()).toEqual([
+        "artifact",
+        "context-snapshot",
+      ]);
+    });
+
+    test(`${name} accepts the very objects its own description offers`, () => {
+      // The point of asserting through the SCHEMA rather than on the prose: a
+      // description that showed a shape the parser refuses would be worse than one
+      // that showed nothing, and only this fails when the two drift apart.
+      for (const evidence of offeredObjects(AGENT_TOOL_DEFINITIONS[name].description)) {
+        const input =
+          name === "compose_report"
+            ? { claims: [{ claim: "a claim", evidence: [evidence] }] }
+            : { change: "index", statement: "CREATE INDEX i ON t (c)", rationale: "why", evidence: [evidence] };
+
+        expect(AGENT_TOOL_DEFINITIONS[name].inputSchema.safeParse(input).success, JSON.stringify(evidence)).toBe(true);
+      }
+    });
+  }
+
+  test("a completed read hands over a citation the report tool will accept", async () => {
+    // The moment the id changes hands. The live run was HOLDING the correlation id
+    // it needed and still never produced the object, so naming the id is not enough:
+    // the text has to carry the form.
+    const h = harness();
+
+    const outcome = await runReadQueryTool(h.context, { sql: "SELECT id FROM orders" });
+    if (outcome.kind !== "completed") throw new Error(`expected a completed read, got ${outcome.kind}`);
+
+    const offered = offeredObjects(outcome.modelText);
+    expect(offered).toEqual([{ source: "artifact", correlationId: outcome.artifact.correlationId }]);
+
+    // And it verifies against the run's own ledger, which is the check that
+    // actually refuses a report.
+    const events: AgentRunEvent[] = [{ kind: "tool-completed", atMs: 1, stepId: "step_1", artifact: outcome.artifact }];
+    const report = composeReportTool(
+      h.context,
+      { runId: h.context.runId, events },
+      {
+        claims: [{ claim: "orders has rows", evidence: offered }],
+      },
+    );
+
+    expect(report.kind).toBe("composed");
+  });
+
+  /*
+    The two readings that matter most, and the two the contract skipped.
+
+    A description and a set of opening rules are read by a model that is not yet
+    confused. A REFUSAL is read by one that already is — it got the shape wrong, and
+    the answer it gets back is its best chance to get it right. `INVALID_TOOL_INPUT`
+    said "could not be turned into a statement this layer will run", which is written
+    for a tool that composes SQL and is simply untrue of `compose_report`, and
+    `UNVERIFIABLE_EVIDENCE` named the two SOURCES without ever showing the object.
+  */
+  describe("a refusal restates the contract, because that is who reads it", () => {
+    const bothArms = (text: string): string[] =>
+      offeredObjects(text)
+        .map((object) => (object as { source: string }).source)
+        .sort();
+
+    const artifactEvent: AgentRunEvent = {
+      kind: "tool-completed",
+      atMs: 1,
+      stepId: "step_1",
+      artifact: {
+        correlationId: "corr-real",
+        operationId: "sql.query.read",
+        connectionId: "conn-1",
+        createdAtMs: 1,
+        summary: { rowCount: 1, columns: ["id"], truncated: false },
+      },
+    } as unknown as AgentRunEvent;
+
+    test("compose_report tells a wrong-shaped citation what the shape is", () => {
+      const h = harness();
+
+      // Evidence as bare strings: the exact guess the live ledger recorded the
+      // model making ("array of table row objects or strings?").
+      const outcome = composeReportTool(
+        h.context,
+        { runId: h.context.runId, events: [artifactEvent] },
+        { claims: [{ claim: "Engineering is largest.", evidence: ["corr-real"] }] },
+      );
+
+      if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+      expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
+      expect(bothArms(outcome.modelText)).toEqual(["artifact", "context-snapshot"]);
+    });
+
+    test("recommend_change tells a wrong-shaped citation what the shape is", () => {
+      const h = harness();
+
+      const outcome = recommendChangeTool(
+        h.context,
+        { runId: h.context.runId, events: [artifactEvent] },
+        {
+          change: "index",
+          statement: "CREATE INDEX i ON orders (id)",
+          rationale: "the read scans",
+          evidence: ["corr-real"],
+        },
+      );
+
+      if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+      expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
+      expect(bothArms(outcome.modelText)).toEqual(["artifact", "context-snapshot"]);
+    });
+
+    test("a citation that resolves to nothing is shown the object, not only the sources", () => {
+      const h = harness();
+
+      const outcome = composeReportTool(
+        h.context,
+        { runId: h.context.runId, events: [artifactEvent] },
+        { claims: [{ claim: "Invented", evidence: [{ source: "artifact", correlationId: "corr-invented" }] }] },
+      );
+
+      if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+      expect(outcome.reasonCode).toBe("UNVERIFIABLE_EVIDENCE");
+      expect(bothArms(outcome.modelText)).toEqual(["artifact", "context-snapshot"]);
+    });
+
+    test("the bad-input refusal no longer promises a statement to a tool that runs none", () => {
+      // `compose_report` and `recommend_change` reach no database and compose no SQL,
+      // and they share this code with the tools that do. The shared sentence has to
+      // be true of all of them.
+      const h = harness();
+
+      const outcome = composeReportTool(h.context, { runId: h.context.runId, events: [] }, { claims: [] });
+
+      if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+      expect(outcome.modelText).not.toContain("statement this layer will run");
+    });
+  });
+});
+
 describe("runReadQueryTool — the allowed path", () => {
   test("reaches the database once, through the agent read-only profile", async () => {
     const h = harness();


### PR DESCRIPTION
Closes #350.

M4 removed the legacy AI surfaces, so the agent is now the product's only AI story. Driving it in a browser
against a real model showed that story does not yet hold: **two agent runs found their answer and neither
wrote it down**, both ending `unmet: ["no-report"]` after calling `run_read_query` repeatedly and
`compose_report` zero times.

## Why, in the model's own words

The ledger records a rationale per statement. Verbatim, from `arun_c7511f8b…`:

> **Wait, `compose_report` schema requires claims as an array of objects, each having `claim` (string) and
> `evidence` (array of table row objects or strings? Ah, evidence items are usually the exact JSON objects
> returned by read queries or table snapshots).**

> **Wait, evidence can be strings or query results.** … Let's do a single claim with reference
> `19b9f458-…` — and the statement it sent that turn was `SELECT 1`.

Five of seven turns went into guessing the shape of an evidence item, including a database round trip that
existed only to buy thinking time. It was holding the correlation id it needed and still never produced
`{"source":"artifact","correlationId":"…"}` — because **nothing it was told ever named those fields**. The
tool description and `AGENT_RULES` both said a claim must cite; neither said what a citation IS.

## The change

`citeArtifact` / `citeSnapshot` render the citation object, and `AGENT_EVIDENCE_CONTRACT` states it in one
wording used in every place the model reads:

- the `compose_report` and `recommend_change` descriptions;
- `AGENT_RULES`, the rules a run opens with;
- **the moment an artifact id changes hands** — a completed step now says how to cite the id it just gave;
- beside the schema snapshot's own fingerprint.

The example a description shows and the concrete citation a step hands over are produced by **the same
code**, so a model that copies what it was shown is producing what the parser was going to accept. A test
lifts every literal object out of every description and parses it through that tool's own `inputSchema`,
so a description offering a shape the schema refuses fails in CI rather than in a run.

**The handover sentence sits outside the fence around database content.** A fence is a region the model is
told to treat as data and never as instruction — an instruction inside one is an instruction the model is
right to ignore.

It also reaches the two places a confused model only sees *because* it is confused, which the first round
missed: the wrong-shaped-input refusal (whose text used to promise "a statement this layer will run", for
tools that run none) and the unresolvable-citation refusal.

## Measured, not argued

Run by the orchestrator rather than reported by the implementer, because the first A/B was not reproducible
from anything preserved. Same scenario, same model, same key, on the final code; only the prompt wording
differs between sides. Six runs, logs kept:

| side | verdict | stop reason | turns | claims |
| --- | --- | --- | --- | --- |
| before (`origin/main` wording) ×3 | `unanswered (no-report)` | `turn-limit` | 16 | 0 |
| after ×3 | `answered` | `report-composed` | 2 | 1 |

A passing run's claim:

```json
{"claim": "The engineering department has the most employees, with 41 employees.",
 "evidence": [{"source":"artifact","correlationId":"f6df23a2-…"},
              {"source":"context-snapshot","fingerprint":"ctx_22cc994b…"}]}
```

The model produced **both** arms of the union correctly, including reaching for `context-snapshot`
unprompted — which it had never done in any failing run. That is why the union was kept: it was never what
cost the runs; nothing naming its fields was.

## The second finding from the same drive

A planning run ended correctly — `goalVerdict: {outcome: "answered", verifier: "agent-planning.1"}` — and
the rail rendered **"Run answered"** directly above **"The model stopped without composing a cited
report."** Planning is toolless by contract; `compose_report` does not exist there, and stopping without
one is how a good planning run ends. The stop sentences are now keyed by mode.

Review then caught that the two-level lookup **threw** on a mode this bundle does not know, blanking a
timeline the user was reading — against the file's own stated rule that a newer server's vocabulary is not
a reason to tear one down. It degrades now, and a test feeds an unknown mode to prove it.

## Not fixed here, and it matters for T7

Three of the harness's real-model cases are **not sound instruments**: their scripted engine answers every
statement with the same three rows while handing out an inventory of eight tables, so a real model — which
reads the inventory, as a scripted one does not — never believes the result and probes to the ceiling.
Those cases cannot reach the report step whatever the report contract says. They are #341's observed
corpus, and reshaping them needs its own evidence.

## Verification

`format` · `lint` (0 errors) · `typecheck` · `knip` · `run-core.sh` (274 files) · `test:components`
(28 groups) · `build`, all green after rebasing onto `main`. Coverage re-running.
