### PR TITLE
feat(agent): say what a refused model can still do (#331 T4)

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -515,6 +515,43 @@ shape what that costs:
 - **The cache key is the model's identity**, so a configuration change misses it by construction:
   there is no invalidation hook to forget and no TTL to tune.
 
+### What a refused model looks like in the app
+
+The `422` carries the probe's sentence as `error` and the shortfall as `missing` — the identifiers
+`toolCalling`, `structuredOutput`, `streaming`. The rail reads the STATUS, not the words, to tell this
+apart from every other refused start, and renders a state of its own rather than the generic error
+line: what the probe could not establish, in this build's own labels; the server's sentence, which is
+the only place the model's name and the endpoint's own words appear; and what still works. A name this
+build has no label for is dropped rather than shown, because our field names are not the user's
+vocabulary — the labels live in `capability-labels.ts` so the sentence the server writes and the list
+the browser renders cannot drift apart, and so the rail can name a capability without importing the
+AI SDK into the page.
+
+**A verdict is about one mode**, and the rail shows it only over that mode. The gate admits planning
+on its first line, so a refusal is a statement about the agent run that was asked for and about
+nothing else; a refusal raised for one mode left standing over the other would be the rail asserting
+what the server never said. The mode travels with the verdict (`AgentModelRefusal.mode`) rather than
+being assumed.
+
+**#325's ratified fallback is superseded** (#331 T4). That epic decided a model failing the probe
+"falls back explicitly to chat/NL2SQL"; T2 removed NL2SQL and T3 removed the in-editor chat, so
+neither destination exists. What that reading missed — and what the rail wrongly told users for the
+length of one review cycle, as "There is nothing toolless to fall back to" — is that a toolless
+surface DID survive T2 and T3: this rail's own planning mode. It is never probed, so it runs on
+exactly the model that was just refused, and it is one click away in the same panel.
+
+So the state is not a dead end and no longer claims to be. It says the model cannot drive an AGENT
+run and which capabilities the probe could not establish; that plan mode needs no tools and still
+works, offering a control that SELECTS that mode and starts nothing; and that a different model is
+what buys a run that reads the database. Offering is honest and deciding is not — the same rule
+T1's shortcut follows, for the same reason: a click that spent model budget would be a different
+feature. What plan mode cannot do is left plainly stated rather than implied, because a toolless run
+reaches no database and a user pointed at it deserves to know that before they ask.
+
+The offer is not an argument from the code: on 2026-08-13 an `ollama` endpoint serving `gemma3:270m`
+refused an agent start with exactly that `422`, and the same model then ran a planning run to
+`succeeded` in the same rail, on the same connection and the same objective, one click later.
+
 ## Whether the run answered
 
 Everything above describes a run that *ran*. Whether it **answered** is a different
@@ -736,6 +773,7 @@ src/lib/agent/
 ├── plan-summary.ts       # how an engine reaches its rows, read from an ESTIMATING plan
 ├── table-profile.ts      # composed per-table aggregates, and the findings derived from them
 ├── capability-probe.ts   # tool calling / structured output / streaming, established positively
+├── capability-labels.ts  # what those three are called in front of a user; shared with the rail
 ├── drive-token.ts        # the single-purpose credential the resume seam verifies
 └── untrusted-content.ts  # the prompt-side fence for database content
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -517,15 +517,26 @@ shape what that costs:
 
 ### What a refused model looks like in the app
 
-The `422` carries the probe's sentence as `error` and the shortfall as `missing` — the identifiers
-`toolCalling`, `structuredOutput`, `streaming`. The rail reads the STATUS, not the words, to tell this
-apart from every other refused start, and renders a state of its own rather than the generic error
-line: what the probe could not establish, in this build's own labels; the server's sentence, which is
-the only place the model's name and the endpoint's own words appear; and what still works. A name this
-build has no label for is dropped rather than shown, because our field names are not the user's
-vocabulary — the labels live in `capability-labels.ts` so the sentence the server writes and the list
-the browser renders cannot drift apart, and so the rail can name a capability without importing the
-AI SDK into the page.
+The `422` carries the probe's sentence as `error`, the shortfall as `missing`, and what the probe
+watched fail as `disproved` — all in the identifiers `toolCalling`, `structuredOutput`, `streaming`.
+The rail reads the STATUS, not the words, to tell this apart from every other refused start, and
+renders a state of its own rather than the generic error line: what the probe could not establish, in
+this build's own labels; the server's sentence, which is the only place the model's name and the
+endpoint's own words appear; and what is still worth trying. A name this build has no label for is
+dropped rather than shown, because our field names are not the user's vocabulary — the labels live in
+`capability-labels.ts` so the sentence the server writes and the list the browser renders cannot drift
+apart, and so the rail can name a capability without importing the AI SDK into the page.
+
+**`missing` and `disproved` are not the same fact.** `missing` is what this run needed and did not
+get, which is all a refusal needs; `disproved` is the half the probe actually observed failing. They
+come apart most sharply on streaming. An endpoint that refuses the tool request answers with a status
+before any stream exists, so streaming is *unobserved* — on 2026-08-13 an `ollama` endpoint serving
+`gemma3:270m` refused exactly that way and the same model then drove a planning run to `succeeded`. An
+endpoint that ignores `stream: true` and returns one buffered body has been *watched* not streaming:
+the SDK's SSE parser finds no frames in it, nothing the model did is readable, and a planning run over
+it — driven through the real run loop — ends `succeeded` with empty text and writes no closing
+statement. Both produce `missing: ["toolCalling", "structuredOutput", "streaming"]`. Only `disproved`
+separates the model that can still plan from the endpoint that will answer nothing at all.
 
 **A verdict is about one mode**, and the rail shows it only over that mode. The gate admits planning
 on its first line, so a refusal is a statement about the agent run that was asked for and about
@@ -537,20 +548,35 @@ being assumed.
 "falls back explicitly to chat/NL2SQL"; T2 removed NL2SQL and T3 removed the in-editor chat, so
 neither destination exists. What that reading missed — and what the rail wrongly told users for the
 length of one review cycle, as "There is nothing toolless to fall back to" — is that a toolless
-surface DID survive T2 and T3: this rail's own planning mode. It is never probed, so it runs on
-exactly the model that was just refused, and it is one click away in the same panel.
+surface DID survive T2 and T3: this rail's own planning mode. It is never probed, so it is REACHABLE
+with exactly the model that was just refused, one click away in the same panel — which is not the same
+as it working, and the next paragraph is about the difference.
 
-So the state is not a dead end and no longer claims to be. It says the model cannot drive an AGENT
-run and which capabilities the probe could not establish; that plan mode needs no tools and still
-works, offering a control that SELECTS that mode and starts nothing; and that a different model is
-what buys a run that reads the database. Offering is honest and deciding is not — the same rule
-T1's shortcut follows, for the same reason: a click that spent model budget would be a different
-feature. What plan mode cannot do is left plainly stated rather than implied, because a toolless run
-reaches no database and a user pointed at it deserves to know that before they ask.
+So the state is not a dead end and no longer claims to be. It says the model cannot drive an AGENT run
+and which capabilities the probe could not establish; that plan mode needs no tools and **may** still
+work, offering a control that SELECTS that mode and starts nothing; and that a different model is what
+buys a run that reads the database. Offering is honest and deciding is not — the same rule T1's
+shortcut follows, for the same reason: a click that spent model budget would be a different feature.
+What plan mode cannot do is left plainly stated rather than implied, because a toolless run reaches no
+database and a user pointed at it deserves to know that before they ask.
 
-The offer is not an argument from the code: on 2026-08-13 an `ollama` endpoint serving `gemma3:270m`
+**The offer is an invitation, not a guarantee, and it is withdrawn where the probe contradicts it.**
+Admission without probing is not proof of compatibility: the gate skips planning because planning
+needs no tools, which says nothing about whether this endpoint would serve a toolless request. So the
+copy says "may still work" and asks the user to try it — and where `disproved` names `streaming`, the
+offer is not made at all. A planning turn consumes the same `streamText().fullStream` an agent turn
+does (`investigation.ts`), so an endpoint watched answering without a stream would produce a run that
+reports `succeeded` and contains nothing; pointing a refused user at that is a second, quieter
+failure. The state says so instead, and names an endpoint that streams alongside a different model as
+the way out. The alternative — teaching the loop to read a buffered body — was rejected: the SDK
+discards it before the loop sees anything, so tolerating it means a second, non-streaming path through
+the run loop for the sake of an endpoint that ignores the protocol it was asked to speak.
+
+None of this is an argument from the code. On 2026-08-13 an `ollama` endpoint serving `gemma3:270m`
 refused an agent start with exactly that `422`, and the same model then ran a planning run to
-`succeeded` in the same rail, on the same connection and the same objective, one click later.
+`succeeded` in the same rail, on the same connection and the same objective, one click later; and a
+planning run driven over an endpoint that answers a streamed request with one buffered body produced
+the empty `succeeded` run described above.
 
 ## Whether the run answered
 

--- a/src/app/api/agent/runs/route.ts
+++ b/src/app/api/agent/runs/route.ts
@@ -112,7 +112,14 @@ export async function POST(req: Request) {
     */
     const gate = await admitAgentModel(mode as AgentRunMode);
     if (gate.kind === "refused") {
-      return NextResponse.json({ error: gate.refusal.message, missing: gate.refusal.missing }, { status: 422 });
+      // `disproved` travels beside `missing` because they answer different questions.
+      // `missing` is what this run needed and did not get; `disproved` is what the
+      // probe watched fail, which is the only half that says anything about what ELSE
+      // the same model could be asked to do (#331 T4 review).
+      return NextResponse.json(
+        { error: gate.refusal.message, missing: gate.refusal.missing, disproved: gate.refusal.disproved },
+        { status: 422 },
+      );
     }
 
     const service = await getAgentRunService();

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -116,6 +116,35 @@ function readGauge(gauge: AgentBudgetGauge): string {
 const gaugeFraction = (gauge: AgentBudgetGauge): number => Math.min(100, (gauge.used / gauge.limit) * 100);
 
 /**
+ * What a user whose model was refused can still do — in three registers, because a
+ * refusal supports three different true statements (#331 T4 review).
+ *
+ * Each line is written out in full rather than composed from clauses: this is the copy a
+ * user reads at the moment the product told them no, and a sentence assembled from
+ * fragments is the kind that ends up claiming something no branch intended.
+ *
+ *  - Plan mode is on the table. Said as an invitation, never as a guarantee: the probe
+ *    only ever sends a request WITH tools, so no refusal it can reach establishes that a
+ *    toolless one would be served. "Still works with this model" was the claim before,
+ *    and it was one the probe could not keep.
+ *  - The endpoint was watched failing to stream. Then plan mode is not on the table —
+ *    it reads the same `streamText().fullStream` — and saying so is more use than an
+ *    offer that would end in a `succeeded` run with nothing in it.
+ *  - Neither: a verdict raised for plan mode itself, which only a server that probes
+ *    planning could produce. Pointing that user at the mode they are in says nothing, so
+ *    the line is what remains true.
+ */
+function refusalActionText(planModeOffered: boolean, streamingDisproved: boolean): string {
+  if (planModeOffered) {
+    return "Plan mode needs no tools, so it may still work with this model: it reasons about your question and drafts an approach without reading the database. Try it, or configure a different model — one that passes the probe — for a run that reads the database.";
+  }
+  if (streamingDisproved) {
+    return "This endpoint answered without streaming, and plan mode reads the same stream, so it would produce nothing here either. A different model, or an endpoint that streams, is what gets an answer.";
+  }
+  return "A different model, one that passes the probe, is what gets a run that reads the database.";
+}
+
+/**
  * What one entry lets a user do with what the run produced (#329 T11).
  *
  * Rendered only where the ledger recorded something to act on AND the host can act
@@ -318,6 +347,30 @@ export function AgentRail({
   const modelRefusal = run.refusal !== null && run.refusal.mode === mode ? run.refusal : null;
 
   /*
+    Whether plan mode is still worth offering with this model (#331 T4 review).
+
+    The offer used to hang on nothing at all, and read as a guarantee: "plan mode still
+    works with this model". It does not always. A planning turn consumes the same
+    `streamText().fullStream` an agent turn does (`investigation.ts`), and an endpoint
+    that answers a streamed request with one buffered body yields no incremental part at
+    all — driven through the real run loop on 2026-08-13, such a planning run ends
+    `succeeded` with empty text and writes no closing statement. Offering it would be
+    the rail sending a user from one failure into a quieter one.
+
+    `missing` cannot tell those apart: it names streaming in that case AND in the case
+    where the endpoint refused the tool request before a stream could exist — the live
+    `gemma3:270m` refusal, whose model then completed a planning run. `disproved` is the
+    half that can, so the offer hangs on it: withdrawn only where the probe WATCHED the
+    endpoint fail to stream, and left standing where streaming was merely never seen.
+
+    It is still an invitation and not a promise, and the copy says so, because the probe
+    always sends tools: no refusal it can reach establishes that a TOOLLESS request
+    would be served.
+  */
+  const streamingDisproved = modelRefusal !== null && modelRefusal.disproved.includes("streaming");
+  const planModeOffered = modelRefusal !== null && modelRefusal.mode !== "planning" && !streamingDisproved;
+
+  /*
     An artifact is named by a correlation id, and the route that serves its rows is
     scoped to the run that recorded it — so the run id is bound here rather than
     threaded through every item.
@@ -504,17 +557,22 @@ export function AgentRail({
           T3 removed both of those surfaces, so that decision is void — but the earlier
           reading of this state, that nothing toolless survived them, was FALSE, and the
           rail said so to users. The toolless surface that survived is this rail's own
-          planning mode: `admitAgentModel` admits it without probing, so it works with
-          exactly the model just refused, one click away, in this panel. Driven live on
-          2026-08-13 — an `ollama` endpoint serving `gemma3:270m` refused the agent start
-          below, and the same model then ran a planning run to `succeeded`.
+          planning mode, one click away, in this panel. Driven live on 2026-08-13 — an
+          `ollama` endpoint serving `gemma3:270m` refused the agent start below, and the
+          same model then ran a planning run to `succeeded`.
+
+          That `admitAgentModel` admits planning without probing is why the mode is
+          REACHABLE with a refused model; it is not evidence that it WORKS with one. The
+          gate skips the probe because planning needs no tools, which answers nothing
+          about whether this endpoint would serve a toolless request — see
+          `planModeOffered` above for the one observation that settles it the other way.
 
           So the state says what is true instead. An AGENT run is what this model cannot
-          drive, and why; plan mode still works and is offered; a different model is what
-          buys a run that reads the database. The offer only SELECTS the mode — the user
-          decides whether to ask anything of it, the same rule T1's shortcut follows, and
-          for the same reason: a click that spent model budget would be a different
-          feature.
+          drive, and why; plan mode is offered where nothing the probe saw rules it out;
+          a different model is what buys a run that reads the database. The offer only
+          SELECTS the mode — the user decides whether to ask anything of it, the same
+          rule T1's shortcut follows, and for the same reason: a click that spent model
+          budget would be a different feature.
 
           Three registers, on purpose. The verdict is a heading; the shortfall is the
           structured `missing` rendered AS structure, one item per capability, so it can
@@ -523,6 +581,10 @@ export function AgentRail({
           report do name the same capabilities — driven live on 2026-08-13, that reads as
           a summary above its detail, and the alternative is a browser that either parses
           the server's sentence apart or renders `missing` decoratively.
+
+          The small print is `text-zinc-400` rather than `text-zinc-500`, which computes
+          to 3.98:1 on this panel's `#0a0a0a` under the alert's own tint — short of WCAG
+          AA at a size the large-text allowance does not cover (#100, #331 T4 review).
         */}
         {modelRefusal !== null && (
           <div
@@ -533,7 +595,7 @@ export function AgentRail({
             <p className="text-xs text-red-300">This model cannot drive an agent run.</p>
             {modelRefusal.missing.length > 0 && (
               <div data-testid="agent-model-refusal-missing" className="flex flex-wrap items-center gap-1">
-                <span className="text-[0.625rem] text-zinc-500">The probe could not establish:</span>
+                <span className="text-[0.625rem] text-zinc-400">The probe could not establish:</span>
                 {modelRefusal.missing.map((capability) => (
                   <span key={capability} className="px-1 py-0.5 rounded bg-red-500/10 text-[0.625rem] text-red-200/90">
                     {describeAgentCapability(capability)}
@@ -544,17 +606,15 @@ export function AgentRail({
             <p data-testid="agent-model-refusal-report" className="text-[0.625rem] text-zinc-400">
               {modelRefusal.message}
             </p>
-            <p data-testid="agent-model-refusal-action" className="text-[0.625rem] text-zinc-500">
-              Plan mode needs no tools, so it still works with this model: it reasons about your question and drafts an
-              approach without reading the database. A different model, one that passes the probe, is what gets a run
-              that reads it.
+            <p data-testid="agent-model-refusal-action" className="text-[0.625rem] text-zinc-400">
+              {refusalActionText(planModeOffered, streamingDisproved)}
             </p>
             {/*
-              Offered only where it means something. A verdict raised FOR planning could
-              only come from a server that probes it, and pointing such a user at the
-              mode they are already in would be the offer saying nothing.
+              Offered only where it means something: not to a user already in plan mode,
+              and not over an endpoint the probe watched fail to stream, which is the one
+              observation that also rules the offered mode out.
             */}
-            {modelRefusal.mode !== "planning" && (
+            {planModeOffered && (
               <button
                 type="button"
                 data-testid="agent-model-refusal-use-planning"

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Bot, Loader2, PencilLine, Play, Square, TableProperties } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
+import { describeAgentCapability } from "@/lib/agent/capability-labels";
 import {
   AGENT_EXECUTION_POLICY,
   AGENT_MAX_MODEL_TURNS,
@@ -300,6 +301,23 @@ export function AgentRail({
     run.runId !== null && LIVE_STATUSES.has(run.timeline.status) && !run.timeline.stopRequested && !run.isStopping;
 
   /*
+    A verdict about the model is a verdict about ONE mode (#331 T4).
+
+    `admitAgentModel` returns `allowed` for planning on its first line: the mode is
+    toolless by contract, so tool calling is not among the capabilities it needs and it
+    is never probed. A refusal is therefore only ever true of the mode it was raised
+    for, and showing it above another mode would be the rail stating something the
+    server did not — most visibly right after the user takes the way out this state
+    itself points at.
+
+    Scoped here rather than cleared in the hook: the hook reports what the server said,
+    and which of it applies to the surface's current selection is the surface's
+    question. Switching back to agent mode is not a new fact and re-asking to learn it
+    would spend a model round trip on an answer already given.
+  */
+  const modelRefusal = run.refusal !== null && run.refusal.mode === mode ? run.refusal : null;
+
+  /*
     An artifact is named by a correlation id, and the route that serves its rows is
     scoped to the run that recorded it — so the run id is bound here rather than
     threaded through every item.
@@ -476,6 +494,78 @@ export function AgentRail({
             </button>
           </div>
         </div>
+
+        {/*
+          The refused model (#331 T4). A start refused because the model was ESTABLISHED
+          as unable to drive an agent run is not the generic red line: nothing here can
+          be retried, and what has to change is not in this panel at all.
+
+          #325 ratified that such a model "falls back explicitly to chat/NL2SQL". T2 and
+          T3 removed both of those surfaces, so that decision is void — but the earlier
+          reading of this state, that nothing toolless survived them, was FALSE, and the
+          rail said so to users. The toolless surface that survived is this rail's own
+          planning mode: `admitAgentModel` admits it without probing, so it works with
+          exactly the model just refused, one click away, in this panel. Driven live on
+          2026-08-13 — an `ollama` endpoint serving `gemma3:270m` refused the agent start
+          below, and the same model then ran a planning run to `succeeded`.
+
+          So the state says what is true instead. An AGENT run is what this model cannot
+          drive, and why; plan mode still works and is offered; a different model is what
+          buys a run that reads the database. The offer only SELECTS the mode — the user
+          decides whether to ask anything of it, the same rule T1's shortcut follows, and
+          for the same reason: a click that spent model budget would be a different
+          feature.
+
+          Three registers, on purpose. The verdict is a heading; the shortfall is the
+          structured `missing` rendered AS structure, one item per capability, so it can
+          be scanned rather than read; the report is the server's prose, the only place
+          the model's name and the endpoint's own words appear. The shortfall and the
+          report do name the same capabilities — driven live on 2026-08-13, that reads as
+          a summary above its detail, and the alternative is a browser that either parses
+          the server's sentence apart or renders `missing` decoratively.
+        */}
+        {modelRefusal !== null && (
+          <div
+            role="alert"
+            data-testid="agent-model-refusal"
+            className="mt-2 p-2 rounded border border-red-500/30 bg-red-500/5 space-y-1"
+          >
+            <p className="text-xs text-red-300">This model cannot drive an agent run.</p>
+            {modelRefusal.missing.length > 0 && (
+              <div data-testid="agent-model-refusal-missing" className="flex flex-wrap items-center gap-1">
+                <span className="text-[0.625rem] text-zinc-500">The probe could not establish:</span>
+                {modelRefusal.missing.map((capability) => (
+                  <span key={capability} className="px-1 py-0.5 rounded bg-red-500/10 text-[0.625rem] text-red-200/90">
+                    {describeAgentCapability(capability)}
+                  </span>
+                ))}
+              </div>
+            )}
+            <p data-testid="agent-model-refusal-report" className="text-[0.625rem] text-zinc-400">
+              {modelRefusal.message}
+            </p>
+            <p data-testid="agent-model-refusal-action" className="text-[0.625rem] text-zinc-500">
+              Plan mode needs no tools, so it still works with this model: it reasons about your question and drafts an
+              approach without reading the database. A different model, one that passes the probe, is what gets a run
+              that reads it.
+            </p>
+            {/*
+              Offered only where it means something. A verdict raised FOR planning could
+              only come from a server that probes it, and pointing such a user at the
+              mode they are already in would be the offer saying nothing.
+            */}
+            {modelRefusal.mode !== "planning" && (
+              <button
+                type="button"
+                data-testid="agent-model-refusal-use-planning"
+                onClick={() => setMode("planning")}
+                className="px-1.5 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-white/5 transition-colors"
+              >
+                Switch to Plan mode
+              </button>
+            )}
+          </div>
+        )}
 
         {run.error !== null && (
           <p role="alert" data-testid="agent-error" className="mt-2 text-xs text-red-400">

--- a/src/components/agent/use-agent-run.ts
+++ b/src/components/agent/use-agent-run.ts
@@ -1,6 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { isAgentModelCapability } from "@/lib/agent/capability-labels";
+// Type-only, so nothing of the probe — or of the AI SDK it runs — reaches this bundle.
+import type { AgentModelCapability } from "@/lib/agent/capability-probe";
 import type { AgentLedgerEntry } from "@/lib/agent/run-store";
 import type { AgentRunMode, AgentRunWorkflowType } from "@/lib/agent/types";
 import { foldLedgerEntries, parseLedgerLine, type AgentRunTimeline } from "./timeline";
@@ -53,6 +56,17 @@ export interface AgentRunFollower {
   readonly timeline: AgentRunTimeline;
   /** The app's own words about why the last attempt did not continue. */
   readonly error: string | null;
+  /**
+   * The one start failure that is a verdict about the MODEL rather than about the
+   * attempt (#331 T4). Set only for the capability gate's `422`; every other refused
+   * start, and every failure of a run that did open, stays in `error` or in the
+   * ledger's own failure reason.
+   *
+   * It carries the mode it was raised for, because it is not true of every mode: the
+   * gate admits planning without probing at all. A surface offering both modes must
+   * check that field before showing this — see `AgentRail`.
+   */
+  readonly refusal: AgentModelRefusal | null;
   readonly start: (input: AgentRunStartInput) => Promise<void>;
   /**
    * Asks the run to stop. It is an ASK: the run's own loop ends it at its next
@@ -65,6 +79,56 @@ export interface AgentRunFollower {
 interface StartResponse {
   readonly runId?: unknown;
   readonly error?: unknown;
+  readonly missing?: unknown;
+}
+
+/**
+ * What the capability gate established about the configured model.
+ *
+ * `message` is the server's own sentence: it names the model and quotes what the
+ * endpoint said, neither of which crosses the wire in any other field. `missing` is the
+ * structured half, so a surface can state the shortfall in its own words instead of
+ * parsing that sentence back apart.
+ */
+export interface AgentModelRefusal {
+  readonly message: string;
+  /** Empty when the server named a shortfall this build has no words for; never invented. */
+  readonly missing: readonly AgentModelCapability[];
+  /**
+   * The mode the refused start asked for, and the only mode this verdict is about.
+   *
+   * The gate probes a model because an AGENT run needs tools; planning is toolless by
+   * contract and returns `allowed` on its first line (`capability-gate.ts`), so it is
+   * never probed and never refused. A verdict left standing over a mode it was never
+   * about would be a false statement, which is why it is recorded rather than assumed.
+   */
+  readonly mode: AgentRunMode;
+}
+
+/**
+ * The status the capability gate refuses with. 422 rather than 400 because the request
+ * was well-formed and it is the server's own configuration that cannot honour it
+ * (`src/app/api/agent/runs/route.ts`).
+ */
+const CAPABILITY_REFUSED_STATUS = 422;
+
+/**
+ * Carries the verdict out through the same exit the other start failures take, so the
+ * rule about what may be reported after an abort is written once. Its `message` is the
+ * server's sentence, which is also what `messageFor` would produce: a reader that loses
+ * the `instanceof` below degrades to the generic line rather than to nothing.
+ */
+class ModelRefusedError extends Error {
+  readonly refusal: AgentModelRefusal;
+
+  constructor(refusal: AgentModelRefusal) {
+    super(refusal.message);
+    this.refusal = refusal;
+  }
+}
+
+function readMissingCapabilities(value: unknown): readonly AgentModelCapability[] {
+  return Array.isArray(value) ? value.filter(isAgentModelCapability) : [];
 }
 
 function messageFor(error: unknown): string {
@@ -77,6 +141,7 @@ export function useAgentRun(): AgentRunFollower {
   const [isBusy, setIsBusy] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [refusal, setRefusal] = useState<AgentModelRefusal | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(
@@ -133,6 +198,9 @@ export function useAgentRun(): AgentRunFollower {
       setIsBusy(true);
       setIsStopping(false);
       setError(null);
+      // A verdict is about the model that was configured when it was reached; an
+      // operator who changed it and started again is owed the new answer, not the old one.
+      setRefusal(null);
       setEntries([]);
       setRunId(null);
 
@@ -146,7 +214,20 @@ export function useAgentRun(): AgentRunFollower {
         });
         const body = (await res.json().catch(() => ({}))) as StartResponse;
         if (!res.ok) {
-          throw new Error(typeof body.error === "string" ? body.error : `The run could not be started (${res.status})`);
+          const said = typeof body.error === "string" ? body.error : `The run could not be started (${res.status})`;
+          // The status is what makes this a verdict, not the words. Only the capability
+          // gate answers 422, and it answers it only for an incapability it POSITIVELY
+          // established: a bad key, a quota, a 5xx or a dropped socket all open a run and
+          // are reported by the drive in its own vocabulary, so nothing that merely went
+          // wrong can be read here as a statement about the model.
+          if (res.status === CAPABILITY_REFUSED_STATUS) {
+            throw new ModelRefusedError({
+              message: said,
+              missing: readMissingCapabilities(body.missing),
+              mode: input.mode,
+            });
+          }
+          throw new Error(said);
         }
         if (typeof body.runId !== "string") {
           throw new Error("The server opened a run without naming it");
@@ -154,7 +235,8 @@ export function useAgentRun(): AgentRunFollower {
         openedRunId = body.runId;
       } catch (startError) {
         if (!controller.signal.aborted) {
-          setError(messageFor(startError));
+          if (startError instanceof ModelRefusedError) setRefusal(startError.refusal);
+          else setError(messageFor(startError));
           setIsBusy(false);
         }
         return;
@@ -204,5 +286,5 @@ export function useAgentRun(): AgentRunFollower {
     }
   }, [runId]);
 
-  return { runId, isBusy, isStopping, timeline: foldLedgerEntries(entries), error, start, cancel };
+  return { runId, isBusy, isStopping, timeline: foldLedgerEntries(entries), error, refusal, start, cancel };
 }

--- a/src/components/agent/use-agent-run.ts
+++ b/src/components/agent/use-agent-run.ts
@@ -80,6 +80,7 @@ interface StartResponse {
   readonly runId?: unknown;
   readonly error?: unknown;
   readonly missing?: unknown;
+  readonly disproved?: unknown;
 }
 
 /**
@@ -94,6 +95,17 @@ export interface AgentModelRefusal {
   readonly message: string;
   /** Empty when the server named a shortfall this build has no words for; never invented. */
   readonly missing: readonly AgentModelCapability[];
+  /**
+   * The subset of `missing` the probe WATCHED fail, as against what it never got to see.
+   *
+   * The two are not interchangeable outside the run that was refused. An endpoint that
+   * refused the tool request establishes nothing about streaming; one that answered a
+   * streamed request with a buffered body establishes that it does not stream, and a
+   * toolless run over it would produce silence. Both arrive as `missing: [..."streaming"]`,
+   * so a surface offering the user another mode reads this field, never `missing`
+   * (#331 T4 review, `capability-probe.ts`).
+   */
+  readonly disproved: readonly AgentModelCapability[];
   /**
    * The mode the refused start asked for, and the only mode this verdict is about.
    *
@@ -127,7 +139,8 @@ class ModelRefusedError extends Error {
   }
 }
 
-function readMissingCapabilities(value: unknown): readonly AgentModelCapability[] {
+/** Names this build has words for, and nothing else: an unknown one is dropped, never shown. */
+function readCapabilities(value: unknown): readonly AgentModelCapability[] {
   return Array.isArray(value) ? value.filter(isAgentModelCapability) : [];
 }
 
@@ -223,7 +236,8 @@ export function useAgentRun(): AgentRunFollower {
           if (res.status === CAPABILITY_REFUSED_STATUS) {
             throw new ModelRefusedError({
               message: said,
-              missing: readMissingCapabilities(body.missing),
+              missing: readCapabilities(body.missing),
+              disproved: readCapabilities(body.disproved),
               mode: input.mode,
             });
           }

--- a/src/lib/agent/capability-labels.ts
+++ b/src/lib/agent/capability-labels.ts
@@ -1,0 +1,39 @@
+import type { AgentModelCapability } from "./capability-probe";
+
+/**
+ * What each probed capability is called in front of a user (#331 T4).
+ *
+ * It lives apart from `capability-probe.ts` because both ends of a refusal need these
+ * words and only one end can import that module: the probe runs the AI SDK, and the
+ * rail is a client component, so importing the probe from the browser would ship `ai`
+ * and the provider packages into the page. The type import above is erased, so nothing
+ * of the probe reaches a bundle through this file.
+ *
+ * One map, two readers: the sentence the server writes into the `422` and the list the
+ * rail composes from `missing` name the same three things by construction rather than by
+ * two authors happening to agree.
+ *
+ * The field names are this repository's own identifiers. Reading `structuredOutput` back
+ * to someone leaks our vocabulary into their error message, and "schema-valid tool
+ * arguments" is also the more accurate claim — it is precisely what the probe measured.
+ */
+const CAPABILITY_LABELS: Readonly<Record<AgentModelCapability, string>> = Object.freeze({
+  toolCalling: "tool calling",
+  structuredOutput: "schema-valid tool arguments",
+  streaming: "streaming",
+});
+
+export function describeAgentCapability(capability: AgentModelCapability): string {
+  return CAPABILITY_LABELS[capability];
+}
+
+/**
+ * Whether a name that arrived over the wire is one this build has words for.
+ *
+ * A server newer than the page it is serving may probe a capability this bundle has
+ * never heard of. Rendering that identifier raw is exactly the leak the labels exist to
+ * prevent, so the browser drops what it cannot name rather than inventing a label for it.
+ */
+export function isAgentModelCapability(value: unknown): value is AgentModelCapability {
+  return typeof value === "string" && Object.hasOwn(CAPABILITY_LABELS, value);
+}

--- a/src/lib/agent/capability-probe.ts
+++ b/src/lib/agent/capability-probe.ts
@@ -89,6 +89,22 @@ export interface AgentCapabilityRefusal {
    * precedes the body, so a refused request has established nothing at all.
    */
   readonly missing: readonly AgentModelCapability[];
+  /**
+   * The subset of `missing` that this probe watched FAIL, as against the ones it
+   * never got to look at. Often empty, and that is not a defect: an endpoint which
+   * refused the request outright answered no question about the model at all.
+   *
+   * The distinction exists because `missing` is honest for exactly one purpose —
+   * refusing an agent run, which needs all three — and misleading for every other.
+   * "Streaming not established" covers both an endpoint that never streamed because
+   * it refused the tool request (verified live on 2026-08-13: `gemma3:270m` on
+   * `ollama` refused with HTTP 400 and then drove a planning run to `succeeded`) and
+   * an endpoint that answered one buffered body, where a toolless run would produce
+   * silence. A surface that offers the user something ELSE to do with the same model
+   * has to be able to tell those apart, so the probe records which it saw rather than
+   * leaving each reader to guess (#331 T4 review).
+   */
+  readonly disproved: readonly AgentModelCapability[];
   readonly detail?: string;
   /** User-facing: what could not be established, and that another model is the way forward. */
   readonly message: string;
@@ -309,12 +325,46 @@ function classifyProbeFailure(failure: unknown, provider: LLMProviderType): Prob
   return { conclusive: true, detail: endpointRefusalDetail(status, failure.message) };
 }
 
+/**
+ * Which of the unestablished capabilities the endpoint's OWN ANSWER contradicted.
+ *
+ * Three cases, and the order they are written in is the order they exclude each other:
+ *
+ *  - **The request was refused** (`answered: false`). The status precedes the body, so
+ *    nothing was read and nothing is disproved — the model may be able to do all three
+ *    things and never got the chance to show any of them.
+ *  - **The endpoint answered, but not as a stream.** Then the only thing observed is
+ *    the transport: the SDK's SSE parser finds no frames in a buffered body, so a tool
+ *    call inside one is invisible too, and reading the silence as "this model does not
+ *    call tools" would be the probe inventing a diagnosis.
+ *  - **The endpoint streamed.** Then what the model did was readable, and each missing
+ *    capability was genuinely watched failing — except `structuredOutput` when no tool
+ *    was called at all: a model that called nothing showed no arguments to validate,
+ *    which is unexercised rather than absent.
+ */
+function disprovedBy(
+  capabilities: AgentModelCapabilities,
+  missing: readonly AgentModelCapability[],
+  answered: boolean,
+): readonly AgentModelCapability[] {
+  if (!answered) return [];
+  if (!capabilities.streaming) return ["streaming"];
+  return missing.filter((capability) => capability !== "structuredOutput" || capabilities.toolCalling);
+}
+
+interface RefusalContext {
+  /** The endpoint returned an answer, rather than refusing the request with a status. */
+  readonly answered: boolean;
+  readonly detail?: string;
+}
+
 function refuse(
   agentModel: AgentModel,
   capabilities: AgentModelCapabilities,
-  detail?: string,
+  context: RefusalContext,
 ): AgentCapabilityProbeResult {
   const missing = REQUIRED_CAPABILITIES.filter((capability) => !capabilities[capability]);
+  const { answered, detail } = context;
 
   return {
     supported: false,
@@ -323,6 +373,7 @@ function refuse(
       modelId: agentModel.modelId,
       capabilities,
       missing,
+      disproved: disprovedBy(capabilities, missing, answered),
       detail,
       message: refusalMessage(agentModel.provider, agentModel.modelId, missing, detail),
     },
@@ -358,7 +409,9 @@ export async function probeAgentModel(
     // A stream that broke after a complete tool call is still inconclusive: the
     // transport just failed, and starting a run on it would fail next.
     if (!verdict.conclusive) throw verdict.error;
-    return refuse(agentModel, capabilities, verdict.detail);
+    // `answered: false` — the endpoint declined to serve the request, so nothing it
+    // sent is evidence about the model beyond its unwillingness to take this tool.
+    return refuse(agentModel, capabilities, { answered: false, detail: verdict.detail });
   }
 
   if (capabilities.toolCalling && capabilities.structuredOutput && capabilities.streaming) {
@@ -366,5 +419,7 @@ export async function probeAgentModel(
   }
 
   const detail = observation.unknownToolName === undefined ? undefined : unknownToolDetail(observation.unknownToolName);
-  return refuse(agentModel, capabilities, detail);
+  // The endpoint ran the request to completion; whatever it sent is what the model,
+  // or its transport, actually did.
+  return refuse(agentModel, capabilities, { answered: true, ...(detail === undefined ? {} : { detail }) });
 }

--- a/src/lib/agent/capability-probe.ts
+++ b/src/lib/agent/capability-probe.ts
@@ -52,6 +52,9 @@
 import { APICallError, streamText, tool } from "ai";
 import { z } from "zod";
 import { type LLMProviderType, LLMError, LLMStreamError } from "@/lib/llm/types";
+// The labels moved out so the rail can name a missing capability without importing
+// this module — and with it the AI SDK — into the browser (#331 T4).
+import { describeAgentCapability } from "./capability-labels";
 import { type AgentModel, mapAgentModelError } from "./model-adapter";
 
 /** What one probe established. Every field is an observation, not a vendor claim. */
@@ -117,18 +120,6 @@ const PROBE_PROMPT = `Call the ${PROBE_TOOL_NAME} tool once with acknowledged se
 /** Order is the order a refusal lists them in, so the message reads the same way twice. */
 const REQUIRED_CAPABILITIES: readonly AgentModelCapability[] = ["toolCalling", "structuredOutput", "streaming"];
 
-/**
- * What each capability is called in front of a user. The field names are this
- * module's own identifiers; reading `structuredOutput` back to someone is leaking
- * our vocabulary into their error message, and "schema-valid tool arguments" is
- * also the more accurate claim — that is precisely what the probe measured.
- */
-const CAPABILITY_LABELS: Readonly<Record<AgentModelCapability, string>> = Object.freeze({
-  toolCalling: "tool calling",
-  structuredOutput: "schema-valid tool arguments",
-  streaming: "streaming",
-});
-
 /** How much untrusted text may reach a user-facing message. */
 const DETAIL_LIMIT = 200;
 
@@ -143,19 +134,26 @@ const DETAIL_LIMIT = 200;
 //
 // The message names the shortfall and ONE action, and no other surface (#331 T2).
 // It used to send the user to the NL2SQL panel and the AI Assistant as toolless
-// alternatives. That is the wrong advice independently of which of those surfaces
+// alternatives, which is the wrong advice independently of which of those surfaces
 // still ships: the user asked for an agent run, and a toolless surface cannot
 // answer that question - it has no way to reach the database at all. A refusal
-// that redirects to a surface which cannot do the refused thing turns one clear
-// failure into a second, slower one. What remains is the true half: the probe
-// could not establish these capabilities, and a different model is the way forward.
+// that answers the refused question with a surface which cannot do the refused
+// thing turns one clear failure into a second, slower one. What remains is the true
+// half: the probe could not establish these capabilities, and a different model is
+// the way forward.
+//
+// This is why the sentence names no surface even though one survives (#331 T4): the
+// rail does offer planning mode, and that is an offer of a DIFFERENT question the
+// user may choose to ask, not this question answered elsewhere. Which surfaces exist
+// is also the client's fact, not this module's - the same message is read by anything
+// that reaches the run route.
 const refusalMessage = (
   provider: LLMProviderType,
   modelId: string,
   missing: readonly AgentModelCapability[],
   detail?: string,
 ): string => {
-  const shortfall = missing.map((capability) => CAPABILITY_LABELS[capability]).join(", ");
+  const shortfall = missing.map(describeAgentCapability).join(", ");
   // Its own statement rather than a template inside the template below: a nested one
   // reads as part of the sentence while being a separate expression, which is why the
   // rule against them exists.

--- a/tests/api/agent/runs.test.ts
+++ b/tests/api/agent/runs.test.ts
@@ -177,6 +177,7 @@ describe("POST /api/agent/runs", () => {
         modelId: "some-model",
         capabilities: { toolCalling: false, structuredOutput: false, streaming: true },
         missing: ["toolCalling"],
+        disproved: ["toolCalling"],
         message: "This model does not call tools. Configure a different model and start the run again.",
       },
     }));
@@ -189,6 +190,36 @@ describe("POST /api/agent/runs", () => {
     expect(body.missing).toEqual(["toolCalling"]);
     expect(mockStart).not.toHaveBeenCalled();
     expect(mockDriveAgentRun).not.toHaveBeenCalled();
+  });
+
+  /*
+    What the probe WATCHED fail travels too, because `missing` alone cannot answer the
+    question the rail asks of it. An endpoint that refused the tool request establishes
+    nothing about streaming; one that answered a streamed request with a buffered body
+    establishes that it does not stream, and a toolless run over the same endpoint would
+    produce silence. Both arrive here as `missing: [… "streaming"]`, so the browser
+    would have to guess which — and a browser that guesses wrong offers a mode that
+    cannot answer (#331 T4 review).
+  */
+  test("the refusal carries what was DISPROVED, not only what was unestablished", async () => {
+    mockAdmitAgentModel.mockImplementation(async () => ({
+      kind: "refused",
+      refusal: {
+        provider: "ollama",
+        modelId: "gemma3:270m",
+        capabilities: { toolCalling: false, structuredOutput: false, streaming: false },
+        missing: ["toolCalling", "structuredOutput", "streaming"],
+        disproved: ["streaming"],
+        message: "This endpoint ignored stream:true.",
+      },
+    }));
+
+    const body = await parseResponseJSON<{ missing: string[]; disproved: string[] }>(
+      await POST(startRequest(VALID_BODY)),
+    );
+
+    expect(body.missing).toEqual(["toolCalling", "structuredOutput", "streaming"]);
+    expect(body.disproved).toEqual(["streaming"]);
   });
 
   test("opens a run for the session's own actor and reports it queued", async () => {

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -358,7 +358,7 @@ describe("AgentRail", () => {
 
   test("a refusal with no message of its own still says something true", async () => {
     globalThis.fetch = mock(async () => jsonResponse({}, 500)) as unknown as typeof fetch;
-    const { getByTestId, findByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
 
     fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
     await act(async () => {
@@ -366,6 +366,229 @@ describe("AgentRail", () => {
     });
 
     expect((await findByTestId("agent-error")).textContent).toContain("500");
+    expect(queryByTestId("agent-model-refusal")).toBeNull();
+  });
+
+  /**
+   * The refused model (#331 T4).
+   *
+   * A `422` is the one start failure that is a verdict about the MODEL: the capability
+   * gate refuses only what the probe positively established, so everything that merely
+   * went wrong — a bad key, a quota, a 5xx — starts a run and is reported by the drive
+   * instead. The body below is the one a real refusal produced on 2026-08-13, from an
+   * Ollama endpoint serving `gemma3:270m`.
+   *
+   * #325 ratified that a model failing the probe falls back to chat/NL2SQL. T2 and T3
+   * deleted both surfaces — but the toolless surface that SURVIVED is in this rail:
+   * `admitAgentModel` returns `allowed` for planning mode without probing at all, so
+   * the mode one click away works with exactly the model that was just refused. The
+   * rail therefore may not claim there is nothing toolless left; what it owes the user
+   * is which capability is missing, that an AGENT run is what this model cannot drive,
+   * that plan mode still works, and that another model is what reads the database.
+   */
+  test("a model established as unable to drive a run is refused, and the shortfall is named", async () => {
+    const fetchMock = mock(async () =>
+      jsonResponse(
+        {
+          error:
+            'The model "gemma3:270m" (ollama) cannot drive an agent run: the capability probe could not establish tool calling, schema-valid tool arguments, streaming. The endpoint refused the tool request with HTTP 400: registry.ollama.ai/library/gemma3:270m does not support tools. Configure a different model and start the run again.',
+          missing: ["toolCalling", "structuredOutput", "streaming"],
+        },
+        422,
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    expect((await findByTestId("agent-model-refusal")).textContent).toContain("cannot drive an agent run");
+
+    const missing = getByTestId("agent-model-refusal-missing").textContent ?? "";
+    expect(missing).toContain("tool calling");
+    expect(missing).toContain("schema-valid tool arguments");
+    expect(missing).toContain("streaming");
+    // Our field names are not the user's vocabulary, and the probe's own message rule
+    // says so; a rail rendering `missing` raw would reintroduce exactly that leak.
+    expect(missing).not.toContain("toolCalling");
+    expect(missing).not.toContain("structuredOutput");
+
+    // The endpoint's own words survive the trip: they name the true cause, and nothing
+    // this browser composes could have known them.
+    expect(getByTestId("agent-model-refusal-report").textContent).toContain("does not support tools");
+    expect(getByTestId("agent-model-refusal-action").textContent).toContain("model");
+
+    // Not the generic red line, and nothing was followed.
+    expect(queryByTestId("agent-error")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The false statement this state used to make. It read "There is nothing toolless to
+   * fall back to", which the capability gate contradicts on its second line: planning
+   * mode is never probed and never refused, so the same model drives a plan today.
+   */
+  test("the refusal names plan mode as the way this model still works", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: "no", missing: ["toolCalling"] }, 422),
+    ) as unknown as typeof fetch;
+    const { getByTestId, findByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    const action = (await findByTestId("agent-model-refusal-action")).textContent ?? "";
+    expect(action).toContain("Plan mode");
+    expect(action).toContain("no tools");
+    // The claim that was false. It cannot come back in any of its wordings.
+    expect(action).not.toContain("nothing toolless");
+    expect(action).not.toContain("nothing to fall back to");
+    // And a different model is still what buys a run that reads the database.
+    expect(action).toContain("different model");
+  });
+
+  /**
+   * Offering is honest, deciding is not — and a shortcut that spent model budget is the
+   * thing #331 T1 already refused to build. So the control SELECTS the mode and does
+   * nothing else: no second request leaves the browser.
+   */
+  test("the refusal's control selects plan mode and starts nothing", async () => {
+    const fetchMock = mock(async () =>
+      jsonResponse({ error: "no", missing: ["toolCalling"] }, 422),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    await act(async () => {
+      fireEvent.click(await findByTestId("agent-model-refusal-use-planning"));
+    });
+
+    expect(getByTestId("agent-mode-planning").getAttribute("aria-pressed")).toBe("true");
+    expect(getByTestId("agent-mode-agent").getAttribute("aria-pressed")).toBe("false");
+    // The refused start, and nothing after it.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(queryByTestId("agent-run-id")?.textContent).toBe("");
+    // The objective is the user's and the offer did not touch it.
+    expect((getByTestId("agent-objective") as HTMLTextAreaElement).value).toBe("why is checkout slow");
+  });
+
+  /**
+   * A verdict is about the mode it was raised for. Once the copy points at plan mode,
+   * a refusal still standing above the mode the user just took would name a way
+   * forward and then deny the user took it.
+   */
+  test("a refusal raised for an agent run does not stand over plan mode", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: "no", missing: ["toolCalling"] }, 422),
+    ) as unknown as typeof fetch;
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+    expect(await findByTestId("agent-model-refusal")).toBeTruthy();
+
+    fireEvent.click(getByTestId("agent-mode-planning"));
+    expect(queryByTestId("agent-model-refusal")).toBeNull();
+
+    // Still true of the mode it was about, and nothing was re-asked to learn that.
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    expect(getByTestId("agent-model-refusal")).toBeTruthy();
+  });
+
+  /**
+   * The gate admits planning without probing, so only a server that probes it could
+   * refuse one. Should that ever arrive, the state still explains itself — but it does
+   * not offer the mode the user is already in, because an offer that changes nothing
+   * is an offer saying nothing.
+   */
+  test("a verdict raised for plan mode explains itself and offers no switch to plan mode", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: "no", missing: ["streaming"] }, 422),
+    ) as unknown as typeof fetch;
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    expect((await findByTestId("agent-model-refusal-missing")).textContent).toContain("streaming");
+    expect(queryByTestId("agent-model-refusal-use-planning")).toBeNull();
+  });
+
+  test("a verdict whose body carries nothing else is still a verdict rather than a generic failure", async () => {
+    globalThis.fetch = mock(async () => jsonResponse({}, 422)) as unknown as typeof fetch;
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    expect((await findByTestId("agent-model-refusal")).textContent).toContain("422");
+    // Nothing is claimed about which capability is absent, because nothing was said.
+    expect(queryByTestId("agent-model-refusal-missing")).toBeNull();
+    expect(queryByTestId("agent-error")).toBeNull();
+  });
+
+  // A newer server may probe a capability this build has never heard of. Rendering the
+  // identifier raw is the one thing the labels exist to prevent, so it is dropped.
+  test("a capability this build has no words for is not read back at the user", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: "no", missing: ["toolCalling", "telepathy"] }, 422),
+    ) as unknown as typeof fetch;
+    const { getByTestId, findByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    const missing = (await findByTestId("agent-model-refusal-missing")).textContent ?? "";
+    expect(missing).toContain("tool calling");
+    expect(missing).not.toContain("telepathy");
+  });
+
+  // An operator fixes the configuration and starts again: the verdict was about the
+  // model that was configured then, so it cannot outlive the next attempt.
+  test("a refusal does not survive the next start", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: "no", missing: ["toolCalling"] }, 422),
+    ) as unknown as typeof fetch;
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+    expect(await findByTestId("agent-model-refusal")).toBeTruthy();
+
+    mockAgentFetch([OPENED_LINE, STARTED_LINE]);
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    expect((await findByTestId("agent-run-id")).textContent).toBe("arun_1");
+    expect(queryByTestId("agent-model-refusal")).toBeNull();
   });
 
   // An accepted start whose body names no run leaves nothing to follow: the stream
@@ -555,6 +778,31 @@ describe("AgentRail", () => {
     expect((await findByTestId("agent-failure-reason")).textContent).toBe(
       "The model provider is not configured or could not be reached.",
     );
+  });
+
+  /**
+   * The failure this state must NOT swallow (#331 T4). A quota is not a verdict about
+   * what the model can do: the run opened, the drive classified it, and the ledger says
+   * so in the words `describeFailureReason` owns. Reporting it as an incapable model
+   * would send an operator to change a model that is fine.
+   */
+  test("a drive that ran out of quota keeps the quota's own words, not the incapable-model state", async () => {
+    const failedLine = `${JSON.stringify({
+      kind: "event",
+      event: { kind: "run-finished", atMs: 1_002, status: "failed", reason: "model-rate-limited" },
+    })}\n`;
+    mockAgentFetch([OPENED_LINE, failedLine]);
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    expect((await findByTestId("agent-failure-reason")).textContent).toBe(
+      "The model provider is limiting this key's requests. Waiting a minute usually clears it.",
+    );
+    expect(queryByTestId("agent-model-refusal")).toBeNull();
   });
 
   test("an ending the server gave no reason for claims none", async () => {

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -431,10 +431,15 @@ describe("AgentRail", () => {
    * The false statement this state used to make. It read "There is nothing toolless to
    * fall back to", which the capability gate contradicts on its second line: planning
    * mode is never probed and never refused, so the same model drives a plan today.
+   *
+   * The offer is an invitation rather than a promise, and that is not hedging: the
+   * probe always sends tools, so a refusal that establishes nothing about a TOOLLESS
+   * request cannot establish that one would work either. What it can do is not
+   * contradict it — see the two tests below for the case where it does.
    */
-  test("the refusal names plan mode as the way this model still works", async () => {
+  test("the refusal offers plan mode where nothing the probe saw rules it out", async () => {
     globalThis.fetch = mock(async () =>
-      jsonResponse({ error: "no", missing: ["toolCalling"] }, 422),
+      jsonResponse({ error: "no", missing: ["toolCalling"], disproved: ["toolCalling"] }, 422),
     ) as unknown as typeof fetch;
     const { getByTestId, findByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
 
@@ -444,14 +449,104 @@ describe("AgentRail", () => {
       fireEvent.click(getByTestId("agent-start"));
     });
 
-    const action = (await findByTestId("agent-model-refusal-action")).textContent ?? "";
+    expect(await findByTestId("agent-model-refusal-use-planning")).toBeTruthy();
+    const action = getByTestId("agent-model-refusal-action").textContent ?? "";
     expect(action).toContain("Plan mode");
     expect(action).toContain("no tools");
+    // Offered, not guaranteed: the probe never sent a toolless request.
+    expect(action).toMatch(/\btry\b|\bmay\b/i);
     // The claim that was false. It cannot come back in any of its wordings.
     expect(action).not.toContain("nothing toolless");
     expect(action).not.toContain("nothing to fall back to");
     // And a different model is still what buys a run that reads the database.
     expect(action).toContain("different model");
+  });
+
+  /**
+   * The distinction this state turns on (#331 T4 review).
+   *
+   * `missing` names what the probe could not ESTABLISH, and "streaming" lands there for
+   * two opposite reasons. Here the endpoint refused the tool request outright — the
+   * live `gemma3:270m` case of 2026-08-13 — so no stream ever existed to observe, and
+   * the same model then drove a planning run to `succeeded`. Nothing was disproved, so
+   * the offer stands even though `missing` names streaming.
+   */
+  test("streaming merely unobserved does not withdraw the offer", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: "no", missing: ["toolCalling", "structuredOutput", "streaming"], disproved: [] }, 422),
+    ) as unknown as typeof fetch;
+    const { getByTestId, findByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    expect((await findByTestId("agent-model-refusal-missing")).textContent).toContain("streaming");
+    expect(getByTestId("agent-model-refusal-use-planning")).toBeTruthy();
+  });
+
+  /**
+   * The other reason, and the one that made the old copy a false promise. An endpoint
+   * that answered the probe with one buffered body was WATCHED failing to stream, and
+   * plan mode consumes the same `streamText().fullStream` an agent run does
+   * (`investigation.ts`). Driven through the real run loop on 2026-08-13: a planning
+   * run over such an endpoint ends `succeeded` with empty text and writes no closing
+   * statement — the user gets a run that claims to have worked and says nothing.
+   *
+   * So the rail does not offer it. Pinned on the DISPROOF rather than on `missing`,
+   * which is identical in this case and in the one above.
+   */
+  test("an endpoint watched failing to stream is not offered a mode that reads the same stream", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse(
+        { error: "no", missing: ["toolCalling", "structuredOutput", "streaming"], disproved: ["streaming"] },
+        422,
+      ),
+    ) as unknown as typeof fetch;
+    const { getByTestId, findByTestId, queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    expect(await findByTestId("agent-model-refusal")).toBeTruthy();
+    expect(queryByTestId("agent-model-refusal-use-planning")).toBeNull();
+
+    const action = getByTestId("agent-model-refusal-action").textContent ?? "";
+    // The promise that cannot be kept here, in any of its wordings.
+    expect(action).not.toContain("still work");
+    expect(action).not.toContain("Try");
+    // What is true instead: the endpoint did not stream, and that is what plan mode
+    // would read too.
+    expect(action).toContain("streaming");
+    expect(action).toContain("different model");
+  });
+
+  /**
+   * Small print is print (#100). `text-zinc-500` on this rail's `#0a0a0a`, under the
+   * alert's own `bg-red-500/5`, computes to 3.98:1 against WCAG AA's 4.5:1 — measured
+   * from the installed Tailwind 4 palette, not estimated — and this text is 10px, so
+   * the large-text allowance does not apply. `text-zinc-400` is 7.33:1.
+   */
+  test("the refusal's small print is not written in a colour that fails AA", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: "no", missing: ["toolCalling"], disproved: ["toolCalling"] }, 422),
+    ) as unknown as typeof fetch;
+    const { getByTestId, findByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.click(getByTestId("agent-mode-agent"));
+    fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(getByTestId("agent-start"));
+    });
+
+    const missing = await findByTestId("agent-model-refusal-missing");
+    expect(missing.querySelector("span")?.className).not.toContain("text-zinc-500");
+    expect(getByTestId("agent-model-refusal-action").className).not.toContain("text-zinc-500");
   });
 
   /**

--- a/tests/isolated/agent-capability-gate.test.ts
+++ b/tests/isolated/agent-capability-gate.test.ts
@@ -56,6 +56,9 @@ const REFUSAL = {
     modelId: "gemini-3.5-flash-lite",
     capabilities: { toolCalling: false, structuredOutput: false, streaming: true },
     missing: ["toolCalling" as const],
+    // The model streamed prose instead of calling the tool, so this shortfall was
+    // watched rather than merely unobserved (`capability-probe.ts`).
+    disproved: ["toolCalling" as const],
     message: "This model does not call tools. Configure a different model and start the run again.",
   },
 };

--- a/tests/isolated/agent-capability-probe.test.ts
+++ b/tests/isolated/agent-capability-probe.test.ts
@@ -307,6 +307,62 @@ describe("a model that cannot demonstrate a capability is refused", () => {
   });
 });
 
+// ─── what was DISPROVED, as against what was never seen ─────────────────────
+
+/**
+ * `missing` is what the probe could not establish, and that is two different facts
+ * wearing one name: a capability the endpoint's own answer contradicted, and one the
+ * probe never got to look at. Both are honest as a refusal for an agent run — neither
+ * is a demonstration — but they support opposite claims about anything ELSE the model
+ * might be asked to do, and a surface that offers a toolless mode is exactly such a
+ * claim.
+ *
+ * Driven, not argued (2026-08-13): an `ollama` endpoint serving `gemma3:270m` refused
+ * the tool request with HTTP 400 and then completed a planning run, because the refusal
+ * came before any stream existed. And a planning run over `chatBufferedCompletion`
+ * through the real run loop ends `succeeded` with empty text and no closing statement —
+ * the buffered body is dropped by the SDK's SSE parser, so the same "streaming not
+ * established" hides a mode that works and a mode that silently produces nothing.
+ *
+ * So the refusal records which of the two it is, and these tests pin the distinction.
+ */
+describe("a refusal separates what was disproved from what was never observed", () => {
+  test("an endpoint that refused the request disproves nothing", async () => {
+    // The status precedes the body: no answer was read, so `missing` here is the
+    // absence of an observation rather than a verdict about anything but tools.
+    const { result } = await probe(OPENAI_CONFIG, endpointError(400, "this model does not support tools"));
+
+    expect(refusalOf(result).disproved).toEqual([]);
+  });
+
+  test("an endpoint that answered without streaming disproves streaming, and only streaming", async () => {
+    // The SDK's SSE parser finds no frames in a buffered body, so nothing the MODEL
+    // did was readable — the endpoint's transport is the one thing this run observed.
+    const { result } = await probe(OPENAI_CONFIG, chatBufferedCompletion("here is your answer"));
+
+    expect(refusalOf(result).disproved).toEqual(["streaming"]);
+  });
+
+  test("a model that streamed prose instead of calling the tool disproves tool calling", async () => {
+    const { result } = await probe(OPENAI_CONFIG, chatTextStream("no tools here"));
+
+    const refusal = refusalOf(result);
+    expect(refusal.missing).toEqual(["toolCalling", "structuredOutput"]);
+    // Structured output was never exercised: a model that called nothing showed no
+    // arguments to validate, so it is unobserved rather than absent.
+    expect(refusal.disproved).toEqual(["toolCalling"]);
+  });
+
+  test("arguments the schema rejected are a disproof, because the probe watched them fail", async () => {
+    const { result } = await probe(
+      OPENAI_CONFIG,
+      chatToolCallStream(PROBE_TOOL_NAME, JSON.stringify({ acknowledged: "yes" })),
+    );
+
+    expect(refusalOf(result).disproved).toEqual(["structuredOutput"]);
+  });
+});
+
 // ─── a failure that says nothing about the model reaches no verdict ─────────
 
 describe("a failure that is not about the model is inconclusive, never a refusal", () => {


### PR DESCRIPTION
The start route already answered `422 { error, missing }` when the capability gate established that the
configured model cannot drive a run. The rail threw the useful half away: `useAgentRun` read only
`body.error`, so "this model cannot drive a run" was rendered identically to "the run could not be
started".

## What it says now

The rail names what the probe could not establish — tool calling, schema-valid tool arguments, streaming —
carries the probe's own sentence (the only place the model's name and the endpoint's own words appear), and
says what to do about it. The capability labels live in one module both ends import, so the server's
sentence and the browser's list cannot drift, and a capability name this build has no words for is dropped
rather than rendered raw.

It does **not** swallow the failures that are not verdicts about the model. The gate refuses only an
*established* incapability; a bad key, a quota or a 5xx start the run and are reported by the drive as
`model-unauthorized` / `model-rate-limited` / `model-unavailable`, each of which already has a sentence.
A scripted 500 and a scripted rate-limited drive failure both assert the new state is absent.

## This milestone's framing of T4 was wrong, and the PR corrects it rather than implementing it

#331 wrote T4 as "a dead end that explains itself", because T2 and T3 removed chat and NL2SQL. They did —
but the toolless surface that survived is **the rail's own planning mode**. `capability-gate.ts:74` reads:

```ts
if (mode === "planning") return { kind: "allowed" };
```

Planning runs are never probed and never refused. It is toolless by contract, it is one click away in the
same rail, and it works with exactly the model that was just refused. So the first version's action line —
"There is nothing toolless to fall back to" — was a **false statement the product would have shown a
user**. It now says:

> Plan mode needs no tools, so it still works with this model: it reasons about your question and drafts an
> approach without reading the database. A different model, one that passes the probe, is what gets a run
> that reads it.

with a control whose entire body is `setMode("planning")`. It selects the mode and **starts nothing** —
asserted by counting requests, not by reading the code. Offering is honest; deciding for the user is not.

## Driven, not argued

A real Ollama endpoint serving `gemma3:270m` produced the refusal (`missing: ["toolCalling",
"structuredOutput", "streaming"]`, detail *"the endpoint refused the tool request with HTTP 400: … does not
support tools"*), the browser rendered the state above, and clicking the offer then **completed a planning
run with the same refused model** (`arun_b70baae5…`, `succeeded`). The control model `qwen3.5:4b` is
admitted, so the gate discriminates rather than blanket-refusing.

That last run also disproved a plausible worry raised in review: the probe reported `streaming` as not
established, which looks like it should break planning too. It does not — **"not established" is the
absence of an observation, not a verdict.** The tool request was refused before any stream could be seen.

## A refusal no longer outlives the mode it was about

It carries the mode it was raised for, and the rail shows it only there. Otherwise a verdict about an agent
run stood over a plan mode that would start normally with the same model — and once the copy points at plan
mode, that would have been a state naming a way forward and then still standing there after the user took
it.

## One thing to fix in the issue

#331's T4 gate sentence still asks for "a control that reaches NL2SQL". It contradicts its own task body
three bullets above ("Do not invent a substitute surface") and names a surface #349 deleted. It was not
implemented; #331's status block records the correction.

## Verification

`format` · `lint` (0 errors) · `typecheck` · `knip` · `run-core.sh` (274 files) · `test:components`
(28 groups) · `build`, all green after rebasing onto `main` (which now carries #352). Coverage was
`34107/34107 (100.00%)` pre-rebase and is re-running.

Part of #325. Implements the T4 gate in #331.
