### PR TITLE
docs: invite a star where the installs actually land

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -158,4 +158,14 @@ Health check endpoint: `GET /api/db/health` · Container HTTP port: `3000`.
 - **DeepWiki docs:** <https://deepwiki.com/libredb/libredb-studio>
 - **License:** MIT
 
+---
+
+## Star the project
+
+LibreDB Studio is open source under the MIT license and free to use, with no paid tier gating any feature on this page. If it is useful to you, a star on GitHub is the clearest signal that the work is worth continuing.
+
+<a href="https://github.com/libredb/libredb-studio"><img src="https://img.shields.io/github/stars/libredb/libredb-studio?style=social" alt="GitHub stars"></a>
+
+Repository: <https://github.com/libredb/libredb-studio>
+
 <sub>This page mirrors <a href="https://github.com/libredb/libredb-studio/blob/main/DOCKERHUB.md">DOCKERHUB.md</a> in the GitHub repository.</sub>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/libredb/libredb-studio"><img src="https://img.shields.io/github/stars/libredb/libredb-studio?style=social" alt="GitHub stars"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://sonarcloud.io/project/overview?id=libredb_libredb-studio"><img src="https://sonarcloud.io/api/project_badges/measure?project=libredb_libredb-studio&metric=alert_status" alt="Quality Gate"></a>
   <a href="#testing"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen" alt="Coverage 100%"></a>


### PR DESCRIPTION
## The measured problem

The image gets roughly 590 Docker pulls per day, while the GitHub repository page sees only about 15 unique visitors per day. The gap is not a conversion problem on the repo page — it is that almost nobody who installs the project ever arrives there. The two surfaces that installs actually land on carried no invitation to visit or star the repository.

## What changes

- **README.md** — adds a GitHub stars badge as the first badge in the top badge group, matching the surrounding `<a href><img alt></a>` markup. Stars are the social-proof signal, so they lead the row.
- **DOCKERHUB.md** — adds a short closing `## Star the project` section. It states plainly that the project is open source and free, invites a star if the tool is useful, and carries the same stars badge plus a plain link to the repository. Tone matches the rest of the file: calm and factual, no hard sell.

Documentation only. No source, version, or chart changes.

## Verification

- `bun run format` — pass (782 files checked, no fixes applied)
- `bun run lint` — pass (exit 0, pre-existing warnings only)
- `bun run knip` — pass (exit 0)
- Both badge and repository URLs return HTTP 200.
