### PR TITLE
feat: ask for a star where the product has already proved itself

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -325,6 +325,13 @@ LLM_MODEL=gemini-2.5-flash
 # Optional template override (default: <cwd>/seed-assets/sqlite/employee.db):
 # SQLITE_EMBEDDED_SAMPLE_TEMPLATE=/app/seed-assets/sqlite/employee.db
 
+# ─── Startup Banner ──────────────────────────────────────────────────────────
+# On standalone startup the server prints one short block naming the version,
+# the local URL and the project repository. It is plain stdout for whoever reads
+# `docker logs` - nothing is sent anywhere. Set to "1" or "true" to print
+# nothing. Has no effect when embedded in libredb-platform.
+# LIBREDB_NO_BANNER=1
+
 # ─── Seed Connections (pre-configured databases) ─────────────────────────────
 # SEED_CONFIG_PATH=/app/config/seed-connections.yaml  # Path to seed config file
 # SEED_CACHE_TTL_MS=60000                              # Cache TTL in ms (default: 60s)

--- a/src/components/github-repo-link.tsx
+++ b/src/components/github-repo-link.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Github } from "lucide-react";
+import { REPO_URL } from "@/lib/community/repo";
+import { dismissStarPrompt } from "@/lib/community/star-prompt";
+import { cn } from "@/lib/utils";
+
+interface GitHubRepoLinkProps {
+  /**
+   * Spacing, sizing AND colour for the surrounding chrome. The colour is the
+   * caller's because this link sits in two very different surfaces: the studio
+   * headers are fixed dark chrome (zinc), while the sidebar follows the theme
+   * tokens the embedding host supplies. Merging two competing text colours here
+   * would depend on tailwind-merge resolving a custom token, which it silently
+   * does not.
+   */
+  className?: string;
+}
+
+/**
+ * The permanent way to the repository, sitting in the studio chrome beside the
+ * version string. A static icon and a static href: nothing here reads a star
+ * count or touches the network, so air-gapped installs and the CSP are unaffected.
+ *
+ * Following it also marks the one-shot star prompt handled - someone who has
+ * already been to the repository should not be asked again by the tenth-query
+ * toast. `dismissStarPrompt` is SSR-safe and swallows every storage failure, so
+ * this handler cannot throw or block the navigation.
+ */
+export function GitHubRepoLink({ className }: GitHubRepoLinkProps) {
+  return (
+    <a
+      href={REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="LibreDB Studio on GitHub"
+      title="LibreDB Studio on GitHub"
+      onClick={() => dismissStarPrompt()}
+      className={cn("inline-flex items-center justify-center transition-colors", className)}
+    >
+      <Github strokeWidth={1.5} className="w-3.5 h-3.5" />
+    </a>
+  );
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -7,6 +7,8 @@ import { Plus, Zap, Layers } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SchemaExplorer } from "@/components/schema-explorer";
+import { GitHubRepoLink } from "@/components/github-repo-link";
+import { getAppVersion } from "@/lib/app-version";
 import { ConnectionsList } from "./ConnectionsList";
 
 interface SidebarProps {
@@ -52,6 +54,8 @@ export function Sidebar({
   onGenerateCode,
   onGenerateTestData,
 }: SidebarProps) {
+  const appVersion = getAppVersion();
+
   return (
     <div className="flex w-full h-full border-r border-border flex-col bg-background select-none">
       <div className="h-14 px-4 flex items-center justify-between border-b border-border">
@@ -118,7 +122,16 @@ export function Sidebar({
             <div className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
             <span className="text-xs font-medium text-muted-foreground">Connected</span>
           </div>
-          <span className="text-xs font-mono text-muted-foreground/70">v1.2.5</span>
+          <div className="flex items-center gap-2">
+            {/*
+              The sidebar is the one piece of chrome BOTH modes render - the
+              standalone app and the embedded workspace, which supplies its own
+              header - so the invitation to the repository lives here to reach
+              every user rather than only the standalone ones.
+            */}
+            <GitHubRepoLink className="text-muted-foreground/70 hover:text-foreground" />
+            {appVersion && <span className="text-xs font-mono text-muted-foreground/70">v{appVersion}</span>}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/studio/StudioDesktopHeader.tsx
+++ b/src/components/studio/StudioDesktopHeader.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { GitHubRepoLink } from "@/components/github-repo-link";
 
 interface StudioDesktopHeaderProps {
   activeConnection: DatabaseConnection | null;
@@ -115,6 +116,7 @@ export function StudioDesktopHeader({
           strokeWidth={1.5}
           className="w-3.5 h-3.5 text-zinc-400 cursor-pointer hover:text-white transition-colors mx-2"
         />
+        <GitHubRepoLink className="text-zinc-400 hover:text-white mr-2" />
         <span className="text-xs text-zinc-500 font-mono">v{process.env.NEXT_PUBLIC_APP_VERSION}</span>
       </div>
     </header>

--- a/src/components/studio/StudioMobileHeader.tsx
+++ b/src/components/studio/StudioMobileHeader.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { GitHubRepoLink } from "@/components/github-repo-link";
 
 interface StudioMobileHeaderProps {
   connections: DatabaseConnection[];
@@ -170,6 +171,8 @@ export function StudioMobileHeader({
           >
             <Gauge strokeWidth={1.5} className="w-3.5 h-3.5" />
           </Button>
+          {/* Sized as the icon buttons beside it (h-8 w-8), not as the desktop's inline icon. */}
+          <GitHubRepoLink className="h-8 w-8 shrink-0 text-zinc-400 hover:text-white" />
           {connectionPulse && (
             <div
               className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-white/5"

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -12,6 +12,7 @@ import { shouldRefreshSchema } from "@/lib/query-generators";
 import { ApiErrorCode } from "@/lib/api/error-codes";
 import { logger } from "@/lib/logger";
 import { getExplainStrategy } from "@/lib/explain";
+import { maybeInviteToStar } from "@/lib/community/star-prompt-toast";
 import { buildConnectionPayload } from "./use-connection-payload";
 
 export interface QueryExecutionOptions {
@@ -419,6 +420,16 @@ export function useQueryExecution({
           if (shouldRefreshSchema(queryToExecute, metadata.capabilities.schemaRefreshPattern)) {
             fetchSchema(activeConnection);
           }
+        }
+
+        // A genuine success - not an error, not a cancellation, not a pagination
+        // fetch or a background EXPLAIN - may earn the one-shot star invitation
+        // (once per browser, ever). LAST in the try block on purpose: the result
+        // is already in the tab and the playground rollback has already run, so
+        // nothing downstream depends on this line. `maybeInviteToStar` cannot
+        // throw either, which keeps the catch below about queries only.
+        if (!isExplain && !isLoadMore && !resultData.hasError) {
+          maybeInviteToStar();
         }
       } catch (error) {
         // Playground mode: rollback on error too

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -45,6 +45,14 @@ export async function register(): Promise<void> {
   // server keeps running and the sample is silently absent.
   const { isSqliteSampleEnabled, resolveSqliteSamplePath, seedSqliteSampleFile, setSqliteSampleSeedState } =
     await import("@/lib/seed/sqlite-sample");
+
+  // Boot banner: version, URL, and the invitation to star the repo. Printed
+  // before the early return below so a deployment with the sqlite sample
+  // disabled still gets it, and after the preflight above so a server that
+  // refuses to boot never prints a welcome. Never throws.
+  const { printStartupBanner } = await import("@/lib/startup-banner");
+  printStartupBanner();
+
   if (!isSqliteSampleEnabled()) return;
 
   // "seeding" is set BEFORE the IIFE so no request can observe "idle" while a

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -1,0 +1,15 @@
+/**
+ * The version this build reports, or null when nothing injected one.
+ *
+ * `next.config.ts` injects NEXT_PUBLIC_APP_VERSION from package.json, so the
+ * standalone app always has it. The tsup library build declares no `define`, so
+ * inside the published `@libredb/studio` package the lookup survives into the
+ * chunk and is resolved against the HOST application's environment - where the
+ * variable is normally absent, and would render the literal "vundefined" in a
+ * paid product. Absence is therefore a first-class answer: callers render
+ * nothing rather than a broken token.
+ */
+export function getAppVersion(): string | null {
+  const version = (process.env.NEXT_PUBLIC_APP_VERSION ?? "").trim();
+  return version === "" ? null : version;
+}

--- a/src/lib/community/repo.ts
+++ b/src/lib/community/repo.ts
@@ -1,0 +1,9 @@
+/**
+ * The one place the public repository URL is written.
+ *
+ * It is referenced by the header/sidebar link, by the one-shot star toast and by
+ * the standalone boot banner. Those three live in different runtimes (client
+ * component, client module, server module), which is exactly how a rename ends up
+ * fixed in the visible copies and missed in the rest.
+ */
+export const REPO_URL = "https://github.com/libredb/libredb-studio";

--- a/src/lib/community/star-prompt-toast.ts
+++ b/src/lib/community/star-prompt-toast.ts
@@ -1,0 +1,46 @@
+import { toast } from "sonner";
+import { REPO_URL } from "./repo";
+import { dismissStarPrompt, recordQuerySuccess } from "./star-prompt";
+
+/**
+ * The one-shot star invitation. It waits for the user (duration Infinity) and
+ * both paths - starring and declining - mark the prompt handled, so it is asked
+ * once per browser and never again.
+ */
+export function showStarPromptToast(): void {
+  toast("LibreDB Studio is open source and free. A star on GitHub helps other teams find it.", {
+    duration: Number.POSITIVE_INFINITY,
+    action: {
+      label: "Star on GitHub",
+      onClick: () => {
+        dismissStarPrompt();
+        window.open(REPO_URL, "_blank", "noopener,noreferrer");
+      },
+    },
+    cancel: {
+      label: "Not now",
+      onClick: () => {
+        dismissStarPrompt();
+      },
+    },
+  });
+}
+
+/**
+ * Count one successful query and, on the single run that earns it, offer the
+ * invitation. This is the ONLY entry point query paths should use.
+ *
+ * It cannot throw. Both query paths call it from inside the try block that owns
+ * the query result, so an exception here would be caught by their error handler
+ * and reported to the user as a failed query - for a query that actually
+ * succeeded, and in playground mode with a second rollback POST behind it. A
+ * nudge is never worth a lost result.
+ */
+export function maybeInviteToStar(): void {
+  try {
+    if (recordQuerySuccess()) showStarPromptToast();
+  } catch {
+    // Deliberately silent: the user came here to run a query, not to be asked
+    // for a favour, and a broken favour must not become a broken query.
+  }
+}

--- a/src/lib/community/star-prompt.ts
+++ b/src/lib/community/star-prompt.ts
@@ -1,0 +1,61 @@
+/**
+ * One-shot invitation to star the repository, shown after the tenth successful
+ * query in a browser and never again.
+ *
+ * Persistence is localStorage ONLY - deliberately not the storage layer. This is
+ * a per-browser nudge rather than user data: it must never sync to a server and
+ * must never enter the embedded platform's server-side storage schema.
+ *
+ * Nothing here talks to the network, and every localStorage access is wrapped:
+ * a disabled or full store (Safari private mode, quota exceeded) degrades to
+ * "never prompt". A star prompt must not be able to break a query run.
+ */
+
+const COUNT_KEY = "libredb_star_prompt_query_count";
+const HANDLED_KEY = "libredb_star_prompt_handled";
+
+/** Successful queries before the prompt is offered, once. */
+export const STAR_PROMPT_QUERY_THRESHOLD = 10;
+
+function isClient(): boolean {
+  return typeof window !== "undefined";
+}
+
+function readItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeItem(key: string, value: string): boolean {
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Count one successful query. Returns true on the single run where the count
+ * reaches the threshold and the prompt has not already been handled.
+ */
+export function recordQuerySuccess(): boolean {
+  if (!isClient()) return false;
+  if (readItem(HANDLED_KEY) !== null) return false;
+
+  const parsed = Number.parseInt(readItem(COUNT_KEY) ?? "", 10);
+  const current = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  const next = current + 1;
+
+  if (!writeItem(COUNT_KEY, String(next))) return false;
+  return next === STAR_PROMPT_QUERY_THRESHOLD;
+}
+
+/** Mark the prompt handled - starred or declined, it is never shown again. */
+export function dismissStarPrompt(): void {
+  if (!isClient()) return;
+  writeItem(HANDLED_KEY, "1");
+}

--- a/src/lib/startup-banner.ts
+++ b/src/lib/startup-banner.ts
@@ -1,0 +1,48 @@
+/**
+ * Standalone boot banner: one short human-readable block naming the version,
+ * the local URL and the repository. Printed from instrumentation.register(),
+ * which only runs when this app boots its own Next.js server - so the banner
+ * is standalone-only by construction and needs no extra gate.
+ *
+ * console.log on purpose, not the app logger (which emits structured JSON):
+ * this block is for a human reading `docker logs`, same idiom as the first-run
+ * credentials banner in auth-bootstrap.ts. Nothing here touches the network -
+ * the star invitation is a static line, never a live count.
+ *
+ * Set LIBREDB_NO_BANNER=1 (or true) to silence it.
+ */
+
+import { getAppVersion } from "@/lib/app-version";
+import { REPO_URL } from "@/lib/community/repo";
+
+const DEFAULT_PORT = "3000";
+
+function isSuppressed(): boolean {
+  const value = (process.env.LIBREDB_NO_BANNER ?? "").trim().toLowerCase();
+  return value === "1" || value === "true";
+}
+
+/** The port the server actually listens on; never invent a hostname. */
+function resolveUrl(): string {
+  const port = (process.env.PORT ?? "").trim();
+  return `http://localhost:${port || DEFAULT_PORT}`;
+}
+
+/**
+ * Print the boot banner. Never throws: a failure here must not break boot.
+ */
+export function printStartupBanner(): void {
+  try {
+    if (isSuppressed()) return;
+
+    // Absent in unbuilt contexts; drop the token rather than print "undefined".
+    const version = getAppVersion();
+    const title = version ? `LibreDB Studio ${version}` : "LibreDB Studio";
+
+    console.log(
+      ["", `${title}  ->  ${resolveUrl()}`, "", "  Star the project if it helps you:", `  ${REPO_URL}`, ""].join("\n"),
+    );
+  } catch {
+    // A banner is never worth a failed boot - stay silent and carry on.
+  }
+}

--- a/src/workspace/hooks/use-query-adapter.ts
+++ b/src/workspace/hooks/use-query-adapter.ts
@@ -6,6 +6,7 @@ import type { WorkspaceQueryResult, WorkspaceFeatures } from "@/workspace/types"
 import type { BottomPanelMode } from "@/components/studio/BottomPanel";
 import { useToast } from "@/hooks/use-toast";
 import { isDangerousQuery } from "@/components/QuerySafetyDialog";
+import { maybeInviteToStar } from "@/lib/community/star-prompt-toast";
 
 /**
  * The channels a host result carries beyond rows and counts (#285).
@@ -157,6 +158,12 @@ export function useQueryAdapter({
         );
 
         setHistoryKey((prev) => prev + 1);
+
+        // The embedded workspace runs its queries here rather than through
+        // `useQueryExecution`, so the one-shot star invitation has to be offered
+        // from both paths or it would exist for standalone users only. Last in
+        // the block and unable to throw: the result is already in the tab.
+        maybeInviteToStar();
       } catch (error) {
         // Skip updates if cancelled
         if (cancelledRef.current) return;
@@ -240,6 +247,7 @@ export function useQueryAdapter({
           );
 
           setHistoryKey((prev) => prev + 1);
+          maybeInviteToStar();
         })
         .catch((error) => {
           if (cancelledRef.current) return;
@@ -397,6 +405,7 @@ export function useQueryAdapter({
         );
 
         setHistoryKey((prev) => prev + 1);
+        maybeInviteToStar();
       })
       .catch((error) => {
         if (cancelledRef.current) return;

--- a/tests/components/GitHubRepoLink.test.tsx
+++ b/tests/components/GitHubRepoLink.test.tsx
@@ -1,0 +1,80 @@
+import "../setup-dom";
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { GitHubRepoLink } from "@/components/github-repo-link";
+import { STAR_PROMPT_QUERY_THRESHOLD, recordQuerySuccess } from "@/lib/community/star-prompt";
+
+describe("GitHubRepoLink", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  test("links to the repository in a new tab, with an accessible name", () => {
+    const { container } = render(<GitHubRepoLink />);
+    const link = container.querySelector("a");
+
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe("https://github.com/libredb/libredb-studio");
+    expect(link!.getAttribute("target")).toBe("_blank");
+    expect(link!.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(link!.getAttribute("aria-label")).toBe("LibreDB Studio on GitHub");
+    // An icon-only link must never be announced as a button (jsx-a11y gate).
+    expect(link!.getAttribute("role")).toBeNull();
+  });
+
+  /**
+   * The caller owns spacing, sizing AND colour: this link sits in fixed dark
+   * chrome (the studio headers) and in theme-token chrome (the sidebar), and
+   * merging two competing text colours here would rely on tailwind-merge
+   * resolving a custom token, which it silently does not.
+   */
+  test("keeps the caller's own spacing and colour", () => {
+    const { container } = render(<GitHubRepoLink className="mx-2 text-zinc-400 hover:text-white" />);
+    const link = container.querySelector("a")!;
+
+    expect(link.className).toContain("mx-2");
+    expect(link.className).toContain("text-zinc-400");
+    expect(link.className).toContain("hover:text-white");
+    expect(link.className).toContain("transition-colors");
+  });
+
+  /**
+   * Someone who has already followed this link has answered the invitation; the
+   * one-shot toast must not ask again afterwards.
+   */
+  test("following the link marks the star prompt handled", () => {
+    const { container } = render(<GitHubRepoLink />);
+
+    fireEvent.click(container.querySelector("a")!);
+
+    for (let i = 0; i < STAR_PROMPT_QUERY_THRESHOLD + 1; i++) {
+      expect(recordQuerySuccess()).toBe(false);
+    }
+  });
+
+  /**
+   * A refusing store (Safari private mode, quota exceeded) must not turn a click
+   * on a link into an exception - the navigation matters, the bookkeeping does not.
+   */
+  test("a click cannot throw where the store refuses writes", () => {
+    const realSetItem = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+
+    try {
+      const { container } = render(<GitHubRepoLink />);
+      expect(() => fireEvent.click(container.querySelector("a")!)).not.toThrow();
+    } finally {
+      localStorage.setItem = realSetItem;
+    }
+  });
+});

--- a/tests/components/sidebar/Sidebar.test.tsx
+++ b/tests/components/sidebar/Sidebar.test.tsx
@@ -114,8 +114,18 @@ function createDefaultProps(overrides: Record<string, unknown> = {}) {
 }
 
 describe("Sidebar", () => {
+  // The version tests mutate a process-wide value. The file happens to run alone
+  // in its group today, but that isolation is incidental - restore it explicitly
+  // so a later regrouping cannot turn this into an order-dependent flake.
+  const originalAppVersion = process.env.NEXT_PUBLIC_APP_VERSION;
+
   afterEach(() => {
     cleanup();
+    if (originalAppVersion === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_VERSION;
+    } else {
+      process.env.NEXT_PUBLIC_APP_VERSION = originalAppVersion;
+    }
   });
 
   test("renders LibreDB Studio header", () => {
@@ -176,11 +186,51 @@ describe("Sidebar", () => {
     expect(connList.getAttribute("data-active-connection")).toBe(mockPostgresConnection.id);
   });
 
-  test("footer shows version info", () => {
+  /**
+   * The footer used to print a hardcoded "v1.2.5" while the package had long
+   * moved on, so the sidebar told users a version the build never was. It now
+   * reads the same injected value as the two studio headers and the login form.
+   */
+  test("footer shows the build's version, not a hardcoded one", () => {
+    process.env.NEXT_PUBLIC_APP_VERSION = "9.8.7";
     const props = createDefaultProps();
     const { queryByText } = render(<Sidebar {...props} />);
 
-    expect(queryByText("v1.2.5")).not.toBeNull();
+    expect(queryByText("v9.8.7")).not.toBeNull();
+    expect(queryByText("v1.2.5")).toBeNull();
+  });
+
+  /**
+   * The embedded case, and the reason this footer cannot simply interpolate the
+   * env var: the tsup library build declares no `define`, so inside the npm
+   * package the lookup resolves against the HOST's environment, where the
+   * variable is absent. Rendering "vundefined" in a paid product is worse than
+   * rendering nothing at all.
+   */
+  test("footer renders no version token when nothing injected one", () => {
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+    const props = createDefaultProps();
+    const { container, queryByText } = render(<Sidebar {...props} />);
+
+    expect(queryByText("vundefined")).toBeNull();
+    expect(container.textContent).not.toContain("undefined");
+    // The footer itself is still there - only the token is dropped.
+    expect(queryByText("Connected")).not.toBeNull();
+  });
+
+  /**
+   * The sidebar is the only chrome BOTH modes render: the embedded workspace
+   * supplies its own header, so a link mounted only in the studio headers would
+   * never reach a platform tenant.
+   */
+  test("footer links to the repository, in both standalone and embedded chrome", () => {
+    const props = createDefaultProps();
+    const { container } = render(<Sidebar {...props} />);
+    const link = container.querySelector('a[aria-label="LibreDB Studio on GitHub"]');
+
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe("https://github.com/libredb/libredb-studio");
+    expect(link!.getAttribute("rel")).toBe("noopener noreferrer");
   });
 
   test("footer shows connected status", () => {

--- a/tests/components/studio/StudioDesktopHeader.test.tsx
+++ b/tests/components/studio/StudioDesktopHeader.test.tsx
@@ -309,6 +309,35 @@ describe("StudioDesktopHeader", () => {
     });
   });
 
+  // ── GitHub Link ──
+
+  describe("github link", () => {
+    test("renders a repository link beside the version badge", () => {
+      const { container } = render(<StudioDesktopHeader {...defaultProps} />);
+      const link = container.querySelector('a[aria-label="LibreDB Studio on GitHub"]');
+
+      expect(link).not.toBeNull();
+      expect(link!.getAttribute("href")).toBe("https://github.com/libredb/libredb-studio");
+      expect(link!.getAttribute("target")).toBe("_blank");
+      expect(link!.getAttribute("rel")).toBe("noopener noreferrer");
+    });
+
+    // Someone who has already been to the repository must not be asked again by
+    // the tenth-query toast. Asserted through the observable effect: a
+    // `not.toThrow()` here could not fail, because the handler swallows every
+    // storage error internally.
+    test("following the link marks the star prompt handled", () => {
+      localStorage.removeItem("libredb_star_prompt_handled");
+      const { container } = render(<StudioDesktopHeader {...defaultProps} />);
+      const link = container.querySelector('a[aria-label="LibreDB Studio on GitHub"]')!;
+
+      fireEvent.click(link);
+
+      expect(localStorage.getItem("libredb_star_prompt_handled")).not.toBeNull();
+      localStorage.removeItem("libredb_star_prompt_handled");
+    });
+  });
+
   // ── Combinations / Edge Cases ──
 
   describe("edge cases", () => {

--- a/tests/components/studio/StudioMobileHeader.test.tsx
+++ b/tests/components/studio/StudioMobileHeader.test.tsx
@@ -308,6 +308,29 @@ describe("StudioMobileHeader", () => {
     expect((writeText.mock.calls as unknown[][])[0][0]).toBe("SELECT 2");
   });
 
+  test("renders a repository link in the header actions", () => {
+    const { container } = render(<StudioMobileHeader {...defaults} />);
+    const link = container.querySelector('a[aria-label="LibreDB Studio on GitHub"]');
+
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe("https://github.com/libredb/libredb-studio");
+    expect(link!.getAttribute("target")).toBe("_blank");
+    expect(link!.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  // Asserted through the observable effect rather than `not.toThrow()`: the
+  // handler swallows every storage error, so a throw assertion could not fail.
+  test("following the repository link marks the star prompt handled", () => {
+    localStorage.removeItem("libredb_star_prompt_handled");
+    const { container } = render(<StudioMobileHeader {...defaults} />);
+    const link = container.querySelector('a[aria-label="LibreDB Studio on GitHub"]')!;
+
+    fireEvent.click(link);
+
+    expect(localStorage.getItem("libredb_star_prompt_handled")).not.toBeNull();
+    localStorage.removeItem("libredb_star_prompt_handled");
+  });
+
   test("transactionActive=true shows TXN badge", () => {
     const { queryByText } = render(<StudioMobileHeader {...defaults} transactionActive />);
     expect(queryByText("TXN")).not.toBeNull();

--- a/tests/hooks/use-query-adapter.test.ts
+++ b/tests/hooks/use-query-adapter.test.ts
@@ -7,7 +7,7 @@ import { renderHook, act } from "@testing-library/react";
 import { useQueryAdapter } from "@/workspace/hooks/use-query-adapter";
 import type { DatabaseConnection, QueryTab } from "@/lib/types";
 import type { WorkspaceQueryResult, WorkspaceFeatures } from "@/workspace/types";
-import { mockToastSuccess, mockToastError } from "../helpers/mock-sonner";
+import { mockToastSuccess, mockToastError, mockToastDefault } from "../helpers/mock-sonner";
 
 // ── Test Data ───────────────────────────────────────────────────────────────
 
@@ -910,5 +910,117 @@ describe("useQueryAdapter", () => {
     expect(tabs[1].result).toBeNull();
     expect(mockToastError).toHaveBeenCalled();
     expect(result.current.pendingUnlimitedQuery).toBeNull();
+  });
+
+  // ── The one-shot star invitation exists in the embedded mode too ───────────
+  //
+  // The embedded workspace does NOT run `useQueryExecution`; it runs this
+  // adapter. Wiring the nudge only into the standalone hook would have made it
+  // structurally unreachable for every platform tenant - and because the prompt
+  // fires on the single run that reaches the threshold, a path that counts
+  // without being able to display would be worse than one that never counts.
+
+  describe("star prompt", () => {
+    const COUNT_KEY = "libredb_star_prompt_query_count";
+    const HANDLED_KEY = "libredb_star_prompt_handled";
+
+    beforeEach(() => {
+      mockToastDefault.mockClear();
+      localStorage.removeItem(COUNT_KEY);
+      localStorage.removeItem(HANDLED_KEY);
+    });
+
+    test("executeQuery invites a star on the tenth successful query", async () => {
+      localStorage.setItem(COUNT_KEY, "9");
+      const params = makeHookParams();
+      const { result } = renderHook(() => useQueryAdapter(params as never));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT 1");
+      });
+
+      expect(mockToastDefault).toHaveBeenCalled();
+    });
+
+    test("executeQuery counts quietly before the threshold", async () => {
+      const params = makeHookParams();
+      const { result } = renderHook(() => useQueryAdapter(params as never));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT 1");
+      });
+
+      expect(mockToastDefault).not.toHaveBeenCalled();
+      expect(localStorage.getItem(COUNT_KEY)).toBe("1");
+    });
+
+    test("a failed query is not a success", async () => {
+      localStorage.setItem(COUNT_KEY, "9");
+      const params = makeHookParams({ onQueryExecute: mock(() => Promise.reject(new Error("boom"))) });
+      const { result } = renderHook(() => useQueryAdapter(params as never));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT 1");
+      });
+
+      expect(mockToastDefault).not.toHaveBeenCalled();
+      expect(localStorage.getItem(COUNT_KEY)).toBe("9");
+    });
+
+    test("forceExecuteQuery counts the query the safety dialog confirmed", async () => {
+      const params = makeHookParams();
+      const { result } = renderHook(() => useQueryAdapter(params as never));
+
+      await act(async () => {
+        result.current.forceExecuteQuery("DELETE FROM users");
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      expect(localStorage.getItem(COUNT_KEY)).toBe("1");
+    });
+
+    test("handleUnlimitedQuery counts the confirmed unlimited run", async () => {
+      const targetTab = makeTab();
+      const { tabs, setTabs } = createMutableTabs([targetTab]);
+      const params = makeHookParams({ tabs, setTabs, currentTab: targetTab });
+      const { result } = renderHook(() => useQueryAdapter(params as never));
+
+      act(() => {
+        result.current.setPendingUnlimitedQuery({ query: "SELECT * FROM big", tabId: "tab-1" });
+      });
+
+      await act(async () => {
+        result.current.handleUnlimitedQuery();
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      expect(localStorage.getItem(COUNT_KEY)).toBe("1");
+    });
+
+    test("a load-more page is not a query the user ran", async () => {
+      localStorage.setItem(COUNT_KEY, "9");
+      const tabWithResults = makeTab({
+        result: {
+          rows: [{ id: 1, name: "Alice" }],
+          fields: ["id", "name"],
+          rowCount: 1,
+          executionTime: 1,
+          pagination: { limit: 500, offset: 0, hasMore: true, totalReturned: 1, wasLimited: true },
+        },
+        allRows: [{ id: 1, name: "Alice" }],
+        currentOffset: 1,
+      });
+      const { tabs, setTabs } = createMutableTabs([tabWithResults]);
+      const params = makeHookParams({ tabs, setTabs, currentTab: tabWithResults });
+      const { result } = renderHook(() => useQueryAdapter(params as never));
+
+      await act(async () => {
+        result.current.handleLoadMore();
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      expect(mockToastDefault).not.toHaveBeenCalled();
+      expect(localStorage.getItem(COUNT_KEY)).toBe("9");
+    });
   });
 });

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -1,5 +1,5 @@
 import "../setup-dom";
-import { mockToastSuccess, mockToastError } from "../helpers/mock-sonner";
+import { mockToastSuccess, mockToastError, mockToastDefault } from "../helpers/mock-sonner";
 import "../helpers/mock-navigation";
 
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
@@ -1824,5 +1824,106 @@ describe("useQueryExecution", () => {
     expect(mockToastSuccess).toHaveBeenCalled();
 
     globalThis.fetch = originalFetch;
+  });
+
+  // ── One-shot star prompt (#331 community nudge) ───────────────────────────
+
+  describe("star prompt", () => {
+    const COUNT_KEY = "libredb_star_prompt_query_count";
+    const HANDLED_KEY = "libredb_star_prompt_handled";
+
+    beforeEach(() => {
+      mockToastDefault.mockClear();
+      localStorage.removeItem(COUNT_KEY);
+      localStorage.removeItem(HANDLED_KEY);
+    });
+
+    test("invites a star on the tenth successful query", async () => {
+      localStorage.setItem(COUNT_KEY, "9");
+      mockGlobalFetch({ "/api/db/query": { ok: true, json: mockQueryResult } });
+      const params = createDefaultParams();
+
+      const { result } = renderHook(() => useQueryExecution(params));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT * FROM users");
+      });
+
+      expect(mockToastDefault).toHaveBeenCalled();
+    });
+
+    test("stays quiet on earlier successful queries", async () => {
+      mockGlobalFetch({ "/api/db/query": { ok: true, json: mockQueryResult } });
+      const params = createDefaultParams();
+
+      const { result } = renderHook(() => useQueryExecution(params));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT * FROM users");
+      });
+
+      expect(mockToastDefault).not.toHaveBeenCalled();
+      expect(localStorage.getItem(COUNT_KEY)).toBe("1");
+    });
+
+    test("does not count a failed statement in a multi-statement run", async () => {
+      localStorage.setItem(COUNT_KEY, "9");
+      mockGlobalFetch({
+        "/api/db/query": {
+          ok: true,
+          json: {
+            ...mockQueryResult,
+            hasError: true,
+            statements: [{ status: "error", index: 0, error: "boom" }],
+          },
+        },
+      });
+      const params = createDefaultParams();
+
+      const { result } = renderHook(() => useQueryExecution(params));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT * FROM users");
+      });
+
+      expect(mockToastDefault).not.toHaveBeenCalled();
+      expect(localStorage.getItem(COUNT_KEY)).toBe("9");
+    });
+
+    /**
+     * The once-per-browser invitation is spent the moment it fires, so it must
+     * fire on a query the user ran - not on a scroll. Both assertions matter:
+     * the count staying at "9" is what proves the guard short-circuits BEFORE
+     * `recordQuerySuccess`, rather than merely suppressing the toast.
+     */
+    test("a load-more page is not a query the user ran", async () => {
+      localStorage.setItem(COUNT_KEY, "9");
+      mockGlobalFetch({ "/api/db/query": { ok: true, json: mockQueryResult } });
+      const params = createDefaultParams();
+
+      const { result } = renderHook(() => useQueryExecution(params));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT * FROM users", "tab-1", false, { limit: 500, offset: 2 });
+      });
+
+      expect(mockToastDefault).not.toHaveBeenCalled();
+      expect(localStorage.getItem(COUNT_KEY)).toBe("9");
+    });
+
+    test("an explain run is not counted either", async () => {
+      localStorage.setItem(COUNT_KEY, "9");
+      mockGlobalFetch({ "/api/db/query": { ok: true, json: mockQueryResult } });
+      const params = createDefaultParams();
+
+      const { result } = renderHook(() => useQueryExecution(params));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT * FROM users", undefined, true);
+      });
+
+      expect(mockToastDefault).not.toHaveBeenCalled();
+      expect(localStorage.getItem(COUNT_KEY)).toBe("9");
+    });
   });
 });

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -222,6 +222,7 @@ run_group "Group 11/12: Smoke tests" \
   tests/components/LoginPage.test.tsx \
   tests/components/LoginPageOIDC.test.tsx \
   tests/components/CommunitySection.test.tsx \
+  tests/components/GitHubRepoLink.test.tsx \
   tests/components/MonitoringPage.test.tsx \
   tests/components/monitoring/MetricChart.test.tsx
 

--- a/tests/unit/instrumentation.test.ts
+++ b/tests/unit/instrumentation.test.ts
@@ -17,6 +17,7 @@ const ENV_KEYS = [
   "JWT_SECRET",
   "ADMIN_PASSWORD",
   "AUTH_BOOTSTRAP",
+  "LIBREDB_NO_BANNER",
 ] as const;
 
 /** The sqlite sample seeds fire-and-forget; poll for its observable effects. */
@@ -40,6 +41,9 @@ describe("instrumentation register()", () => {
     }
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "instrumentation-"));
     process.env.STORAGE_SQLITE_PATH = path.join(tmpDir, "libredb-storage.db");
+    // Keep the boot banner out of the test output; the banner tests below opt
+    // back in explicitly.
+    process.env.LIBREDB_NO_BANNER = "1";
     setSqliteSampleSeedState("idle");
   });
 
@@ -183,6 +187,52 @@ describe("instrumentation register()", () => {
       warn.mockRestore();
     }
     expect(fs.existsSync(path.join(tmpDir, "sample-employees.db"))).toBe(false);
+  });
+
+  test("prints the boot banner even when the sqlite sample is disabled", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.AUTH_BOOTSTRAP = "off";
+    process.env.LIBREDB_EMBEDDED_SAMPLE = "false";
+    process.env.SQLITE_EMBEDDED_SAMPLE = "false";
+    delete process.env.LIBREDB_NO_BANNER;
+
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    let output = "";
+    try {
+      await register();
+      // Read the recorded calls before mockRestore(): bun clears them on restore.
+      output = log.mock.calls.flat().join("\n");
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(output).toContain("LibreDB Studio");
+    expect(output).toContain("https://github.com/libredb/libredb-studio");
+  });
+
+  test("prints no banner when the server refuses to boot (#227)", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.JWT_SECRET = "x".repeat(24);
+    process.env.ADMIN_PASSWORD = "set-so-bootstrap-has-nothing-to-do";
+    process.env.LIBREDB_EMBEDDED_SAMPLE = "false";
+    process.env.SQLITE_EMBEDDED_SAMPLE = "false";
+    delete process.env.LIBREDB_NO_BANNER;
+
+    const originalExit = process.exit;
+    process.exit = (() => {}) as unknown as typeof process.exit;
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    let output = "";
+    try {
+      await register();
+      output = log.mock.calls.flat().join("\n");
+    } finally {
+      process.exit = originalExit;
+      log.mockRestore();
+      errorSpy.mockRestore();
+    }
+
+    expect(output).not.toContain("Star the project");
   });
 
   test("logs a warning and keeps boot alive when seeding fails", async () => {

--- a/tests/unit/lib/community/star-prompt-toast.test.ts
+++ b/tests/unit/lib/community/star-prompt-toast.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mockToastDefault } from "../../../helpers/mock-sonner";
+
+import { maybeInviteToStar, showStarPromptToast } from "@/lib/community/star-prompt-toast";
+import { REPO_URL } from "@/lib/community/repo";
+import { STAR_PROMPT_QUERY_THRESHOLD } from "@/lib/community/star-prompt";
+
+const COUNT_KEY = "libredb_star_prompt_query_count";
+const HANDLED_KEY = "libredb_star_prompt_handled";
+
+type ToastOptions = {
+  duration: number;
+  action: { label: string; onClick: () => void };
+  cancel: { label: string; onClick: () => void };
+};
+
+function lastToastCall() {
+  const call = mockToastDefault.mock.calls.at(-1) as unknown as [string, ToastOptions];
+  return { message: call[0], options: call[1] };
+}
+
+const originalOpen = window.open;
+
+beforeEach(() => {
+  mockToastDefault.mockClear();
+  localStorage.removeItem(HANDLED_KEY);
+  localStorage.removeItem(COUNT_KEY);
+});
+
+afterEach(() => {
+  window.open = originalOpen;
+});
+
+describe("showStarPromptToast", () => {
+  test("waits for the user instead of vanishing", () => {
+    showStarPromptToast();
+
+    expect(lastToastCall().options.duration).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  test("asks calmly, in one sentence, without emoji or exclamation", () => {
+    showStarPromptToast();
+
+    const { message } = lastToastCall();
+    expect(message).toContain("open source");
+    expect(message).not.toContain("!");
+    // Plain ASCII only - the repo bans emoji everywhere.
+    expect(/^[\x20-\x7E]+$/.test(message)).toBe(true);
+  });
+
+  test("opens the repository in a new tab with noopener noreferrer, and never asks again", () => {
+    const openMock = mock(() => null);
+    window.open = openMock as unknown as typeof window.open;
+
+    showStarPromptToast();
+    lastToastCall().options.action.onClick();
+
+    expect(openMock).toHaveBeenCalledWith(REPO_URL, "_blank", "noopener,noreferrer");
+    expect(REPO_URL).toBe("https://github.com/libredb/libredb-studio");
+    expect(localStorage.getItem(HANDLED_KEY)).not.toBeNull();
+  });
+
+  test("declining also means never asking again", () => {
+    const openMock = mock(() => null);
+    window.open = openMock as unknown as typeof window.open;
+
+    showStarPromptToast();
+    lastToastCall().options.cancel.onClick();
+
+    expect(openMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem(HANDLED_KEY)).not.toBeNull();
+  });
+
+  test("labels both paths", () => {
+    showStarPromptToast();
+
+    const { options } = lastToastCall();
+    expect(options.action.label.length).toBeGreaterThan(0);
+    expect(options.cancel.label.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The single entry point both query paths use. Its contract is as much about
+ * what it must NOT do - throw into the caller's try block, which owns a query
+ * result that has already been fetched - as about when it asks.
+ */
+describe("maybeInviteToStar", () => {
+  test("asks on the run that reaches the threshold", () => {
+    localStorage.setItem(COUNT_KEY, String(STAR_PROMPT_QUERY_THRESHOLD - 1));
+
+    maybeInviteToStar();
+
+    expect(mockToastDefault).toHaveBeenCalled();
+  });
+
+  test("counts quietly before the threshold", () => {
+    maybeInviteToStar();
+
+    expect(mockToastDefault).not.toHaveBeenCalled();
+    expect(localStorage.getItem(COUNT_KEY)).toBe("1");
+  });
+
+  test("swallows a failing toast rather than breaking the query that earned it", () => {
+    localStorage.setItem(COUNT_KEY, String(STAR_PROMPT_QUERY_THRESHOLD - 1));
+    mockToastDefault.mockImplementationOnce(() => {
+      throw new Error("sonner exploded");
+    });
+
+    expect(() => {
+      maybeInviteToStar();
+    }).not.toThrow();
+  });
+});

--- a/tests/unit/lib/community/star-prompt.test.ts
+++ b/tests/unit/lib/community/star-prompt.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, afterEach } from "bun:test";
+
+import { recordQuerySuccess, dismissStarPrompt, STAR_PROMPT_QUERY_THRESHOLD } from "@/lib/community/star-prompt";
+
+// The module writes straight to localStorage (a per-browser nudge, never user
+// data), so the tests drive a real key/value store rather than the storage layer.
+const COUNT_KEY = "libredb_star_prompt_query_count";
+const HANDLED_KEY = "libredb_star_prompt_handled";
+
+const originalLocalStorage = globalThis.localStorage;
+const originalWindow = globalThis.window;
+
+interface StorageBehaviour {
+  throwOnRead?: boolean;
+  throwOnWrite?: boolean;
+}
+
+function installStorage(entries: Record<string, string> = {}, behaviour: StorageBehaviour = {}) {
+  const store = new Map<string, string>(Object.entries(entries));
+  globalThis.localStorage = {
+    getItem: (key: string) => {
+      if (behaviour.throwOnRead) throw new Error("storage read denied");
+      return store.get(key) ?? null;
+    },
+    setItem: (key: string, value: string) => {
+      if (behaviour.throwOnWrite) throw new Error("storage write denied");
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    length: 0,
+    key: () => null,
+  } as unknown as Storage;
+  return store;
+}
+
+afterEach(() => {
+  globalThis.localStorage = originalLocalStorage;
+  globalThis.window = originalWindow;
+});
+
+describe("star-prompt", () => {
+  test("threshold is the tenth successful query", () => {
+    expect(STAR_PROMPT_QUERY_THRESHOLD).toBe(10);
+  });
+
+  test("stays silent below the threshold and counts every success", () => {
+    const store = installStorage();
+
+    for (let i = 1; i < STAR_PROMPT_QUERY_THRESHOLD; i++) {
+      expect(recordQuerySuccess()).toBe(false);
+    }
+
+    expect(store.get(COUNT_KEY)).toBe(String(STAR_PROMPT_QUERY_THRESHOLD - 1));
+  });
+
+  test("fires exactly once, on the run that reaches the threshold", () => {
+    const store = installStorage({ [COUNT_KEY]: String(STAR_PROMPT_QUERY_THRESHOLD - 1) });
+
+    expect(recordQuerySuccess()).toBe(true);
+    expect(store.get(COUNT_KEY)).toBe(String(STAR_PROMPT_QUERY_THRESHOLD));
+    expect(recordQuerySuccess()).toBe(false);
+  });
+
+  test("never fires again once the count is past the threshold", () => {
+    installStorage({ [COUNT_KEY]: String(STAR_PROMPT_QUERY_THRESHOLD + 5) });
+
+    expect(recordQuerySuccess()).toBe(false);
+  });
+
+  test("never fires once dismissed, and stops counting", () => {
+    const store = installStorage({ [COUNT_KEY]: String(STAR_PROMPT_QUERY_THRESHOLD - 1) });
+
+    dismissStarPrompt();
+    expect(store.get(HANDLED_KEY)).toBeDefined();
+
+    expect(recordQuerySuccess()).toBe(false);
+    expect(store.get(COUNT_KEY)).toBe(String(STAR_PROMPT_QUERY_THRESHOLD - 1));
+  });
+
+  test("treats a corrupt stored count as zero", () => {
+    const store = installStorage({ [COUNT_KEY]: "not-a-number" });
+
+    expect(recordQuerySuccess()).toBe(false);
+    expect(store.get(COUNT_KEY)).toBe("1");
+  });
+
+  test("treats a negative stored count as zero", () => {
+    const store = installStorage({ [COUNT_KEY]: "-4" });
+
+    expect(recordQuerySuccess()).toBe(false);
+    expect(store.get(COUNT_KEY)).toBe("1");
+  });
+
+  test("degrades to never prompting when reads throw", () => {
+    installStorage({ [COUNT_KEY]: String(STAR_PROMPT_QUERY_THRESHOLD - 1) }, { throwOnRead: true });
+
+    expect(recordQuerySuccess()).toBe(false);
+    expect(recordQuerySuccess()).toBe(false);
+  });
+
+  test("degrades to never prompting when writes throw", () => {
+    installStorage({ [COUNT_KEY]: String(STAR_PROMPT_QUERY_THRESHOLD - 1) }, { throwOnWrite: true });
+
+    expect(recordQuerySuccess()).toBe(false);
+    expect(() => {
+      dismissStarPrompt();
+    }).not.toThrow();
+  });
+
+  test("is a no-op on the server, where there is no window", () => {
+    // A WORKING store is installed on purpose: both guards must be pinned by the
+    // store staying untouched, not merely by nothing throwing.
+    const store = installStorage({ [COUNT_KEY]: String(STAR_PROMPT_QUERY_THRESHOLD - 1) });
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+
+    expect(recordQuerySuccess()).toBe(false);
+    expect(() => {
+      dismissStarPrompt();
+    }).not.toThrow();
+
+    expect(store.get(HANDLED_KEY)).toBeUndefined();
+    expect(store.get(COUNT_KEY)).toBe(String(STAR_PROMPT_QUERY_THRESHOLD - 1));
+  });
+});

--- a/tests/unit/startup-banner.test.ts
+++ b/tests/unit/startup-banner.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { printStartupBanner } from "@/lib/startup-banner";
+
+const ENV_KEYS = ["LIBREDB_NO_BANNER", "NEXT_PUBLIC_APP_VERSION", "PORT"] as const;
+
+/** Run the banner with console.log captured and return everything it printed. */
+function capture(): string {
+  const log = spyOn(console, "log").mockImplementation(() => {});
+  try {
+    printStartupBanner();
+    // Read the recorded calls before mockRestore(): bun clears them on restore.
+    return log.mock.calls.flat().join("\n");
+  } finally {
+    log.mockRestore();
+  }
+}
+
+describe("printStartupBanner", () => {
+  let orig: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    orig = {};
+    for (const key of ENV_KEYS) {
+      orig[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (orig[key] === undefined) delete process.env[key];
+      else process.env[key] = orig[key];
+    }
+  });
+
+  test("prints the version, the local URL and the repository invitation", () => {
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.2.3";
+
+    const output = capture();
+
+    expect(output).toContain("LibreDB Studio 1.2.3");
+    expect(output).toContain("http://localhost:3000");
+    expect(output).toContain("Star the project if it helps you");
+    expect(output).toContain("https://github.com/libredb/libredb-studio");
+  });
+
+  test("reflects a custom PORT", () => {
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.2.3";
+    process.env.PORT = "8080";
+
+    const output = capture();
+
+    expect(output).toContain("http://localhost:8080");
+    expect(output).not.toContain("localhost:3000");
+  });
+
+  test("falls back to the default port when PORT is blank", () => {
+    process.env.PORT = "   ";
+
+    expect(capture()).toContain("http://localhost:3000");
+  });
+
+  test("never prints 'undefined' when the version is missing", () => {
+    const output = capture();
+
+    expect(output).toContain("LibreDB Studio");
+    expect(output).not.toContain("undefined");
+    expect(output).toContain("https://github.com/libredb/libredb-studio");
+  });
+
+  test("prints nothing when LIBREDB_NO_BANNER=1", () => {
+    process.env.LIBREDB_NO_BANNER = "1";
+
+    expect(capture()).toBe("");
+  });
+
+  test("prints nothing when LIBREDB_NO_BANNER=true (any case)", () => {
+    process.env.LIBREDB_NO_BANNER = "TRUE";
+
+    expect(capture()).toBe("");
+  });
+
+  // `LIBREDB_NO_BANNER: " 1"` is what a compose file or an env file with a
+  // trailing space produces; an operator who explicitly opted out must be obeyed.
+  test("honours an opt-out that carries surrounding whitespace", () => {
+    for (const value of [" 1 ", " true ", "\ttrue\n"]) {
+      process.env.LIBREDB_NO_BANNER = value;
+      expect(capture()).toBe("");
+    }
+  });
+
+  test("still prints for values that are not an opt-out", () => {
+    for (const value of ["0", "false", "", "yes"]) {
+      process.env.LIBREDB_NO_BANNER = value;
+      expect(capture()).toContain("LibreDB Studio");
+    }
+  });
+
+  test("never throws when console.log fails", () => {
+    const log = spyOn(console, "log").mockImplementation(() => {
+      throw new Error("stdout is gone");
+    });
+    try {
+      expect(() => printStartupBanner()).not.toThrow();
+    } finally {
+      log.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## The measured problem

The repository gets roughly **590 Docker pulls a day** and roughly **15 unique visitors a day** on the GitHub repo page, against 152 stars.

That ratio is the whole story. Visitor-to-star conversion is already healthy — people who see the page do star it. The bottleneck is that the people actually running the product never arrive at the page: they pull an image, run a query, and there is nothing anywhere in the product that tells them where it came from.

So this PR is not about persuasion. It is about putting the repository in front of someone who is already using the thing, at moments where it has just done work for them.

## What was added

**1. A one-shot star invitation after the tenth successful query** (`src/lib/community/star-prompt.ts`, `star-prompt-toast.ts`)

Asked once per browser, ever. Both answers — "Star on GitHub" and "Not now" — retire it permanently, and so does following the icon link. Storage is localStorage only, never the storage layer: this is a per-browser nudge, not user data, and it must not sync anywhere or enter the embedded platform's server-side schema. Every storage access is wrapped, so a disabled or full store (Safari private mode, quota) degrades to "never prompt".

It is wired into **both** query paths: `useQueryExecution` (standalone) and `src/workspace/hooks/use-query-adapter.ts` (the embedded workspace, which does not use that hook). This matters more than it looks: the prompt fires on the single run that reaches the threshold, so a path that counted without being able to display would silently spend the one invitation on nothing. Pagination fetches and EXPLAIN runs are excluded on both paths — the invitation should follow a query the user ran, not a scroll.

The call cannot break a query. It sits last in the try block that owns the result, after the result is already in the tab and after the playground rollback, and `maybeInviteToStar()` swallows its own exceptions — otherwise a failing toast would surface to the user as a red "Query Error" for a query that actually succeeded.

**2. A boot banner for the standalone server** (`src/lib/startup-banner.ts`, printed from `instrumentation.register`)

One short block naming the version, the local URL, and the repository — the first thing an operator sees in `docker logs`. `console.log` on purpose rather than the structured logger, matching the existing first-run credentials banner. Suppressed with `LIBREDB_NO_BANNER=1`. It prints *after* the boot preflight, so a server that refuses to start never prints a welcome, and *before* the sqlite-sample early return, so a deployment with the sample disabled still gets it. It is standalone-only by construction — `register()` only runs when this app boots its own Next.js server — so it needs no feature gate.

**3. A permanent GitHub link in the chrome** (`src/components/github-repo-link.tsx`)

A static icon and a static href in the sidebar footer and both studio headers. The **sidebar** instance is the load-bearing one: it is the only chrome both modes render, since the embedded workspace supplies its own header. A link mounted only in the studio headers would have shipped to standalone users exclusively. Following it also marks the star prompt handled — someone who has already been to the repository should not be asked again.

## Bug fix: the sidebar version

The sidebar footer printed a hardcoded `v1.2.5`, a version this build stopped being a long time ago.

It now reads the injected version through `src/lib/app-version.ts`, which treats absence as a first-class answer and renders **nothing** rather than a token. That guard is the point: `next.config.ts` injects `NEXT_PUBLIC_APP_VERSION` for the standalone app, but the tsup library build declares no `define`, so inside the published package the lookup resolves against the *host* application's environment — where it is normally unset. Interpolating it directly would have put the literal string `vundefined` in the sidebar of a paid product, which is worse than the stale number it replaced.

## What was deliberately excluded, and why

**No telemetry.** Not anonymous counters, not a ping, not an install beacon. `docs/SECURITY.md` promises this product does not phone home, and that promise is worth more to the people evaluating it than any number this would produce. That file is untouched by this PR because nothing here changes what it says.

**No live star count.** A real count is the obvious "better" version of this and it is a trap on three counts: it needs an outbound request to the GitHub API, which means a CSP `connect-src` change that works standalone and **fails silently once embedded** in a host with its own policy; every air-gapped and firewalled install — a large share of who runs a self-hosted database client — would render a permanently broken counter; and it puts a third-party API on the render path of the sidebar.

**No outbound network call of any kind.** Everything added here is static strings, `localStorage`, and one `console.log`. The link is an `href`; the toast is text.

**No new feature flag.** The banner's `LIBREDB_NO_BANNER` is an opt-out for log noise, not a gate on the feature. The UI pieces are unconditional in both modes on purpose.

**No version, chart, or operator changes** — nothing here touches packaged chart files or `package.json` version, so neither the appVersion gate nor the chart-version gate applies.

## Verification

All local gates green: `format`, `lint`, `typecheck`, `knip`, `tests/run-core.sh` (280 files), `test:components` (28 groups), `build`, `build:lib`, and `test:coverage` + `coverage:check` at **100.00% (34046/34046 lines)**.

`build:lib` was run and the published `dist/workspace.{js,mjs}` was checked directly: it contains both the GitHub link and the star counter, which is the proof that the two embedded-reach fixes actually land in what platform consumes.
