### PR TITLE
fix(agent): let an index answer, and let a stop that arrived late be said (#356)

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -369,9 +369,19 @@ something that is not an estimating plan of this run, while `PLAN_RESULT_RELEASE
 was honest and the rows have expired — telling a model the first when the second happened would send
 it looking for a mistake it did not make.
 
-Its goal verifier is `agent-query-optimization.1`: the investigation baseline, **and** a plan
-comparison on the ledger. The baseline dominates, so a run that never reported is told that rather
-than that it skipped a comparison.
+Its goal verifier is `agent-query-optimization.2`: the investigation baseline, **and** evidence that
+the change it proposes rests on what the engine actually does. The baseline dominates, so a run that
+never reported is told that rather than that it skipped a comparison.
+
+**That evidence has two shapes, because the two changes are not equally checkable (#356).** A
+rewrite is held to the plan comparison: both of its plans are readable without changing anything. An
+index's second plan is not readable at all — it would require the index to exist, and the run is
+read-only by contract. A live run on 2026-08-12 diagnosed the scan, recommended the right index,
+attempted `CREATE INDEX ...; SELECT ...`, was refused as it should be, and was then scored
+`unanswered` by a rule asking for the one artifact that answer cannot produce. So an index answers on
+the plan it **diagnosed**, cited by the recommendation itself: `no-plan-evidence` is an index
+recommendation that names no plan this run read. Not merely a plan somewhere on the ledger — the
+citation is what ties the index to the access path it changes.
 
 ### The database-assessment template
 
@@ -656,7 +666,7 @@ build until somebody decides what "answered" means for it.
 | --- | --- | --- |
 | `planning` | The run left non-empty closing prose. That mode is toolless and can never cite evidence, so judging it by the investigation rule would fail every planning run that did its job. | `no-plan` |
 | `agent` (investigation) | The run composed at least one claim, **and** the claims do not rest entirely on empty results. | `no-report`, `empty-evidence` |
-| `agent` (query-optimization) | The baseline above, **and** a plan comparison on the ledger. `agent-query-optimization.1`. | the above, plus `no-plan-comparison` |
+| `agent` (query-optimization) | The baseline above, **and** either a plan comparison on the ledger or an index recommendation citing a plan this run read. `agent-query-optimization.2`. | the above, plus `no-plan-comparison`, `no-plan-evidence` |
 | `agent` (database-assessment) | The baseline above, **and** a table profiled. `agent-database-assessment.1`. | the above, plus `no-table-profile` |
 
 A run stopped by its user reports `cancelled` instead of the missing output: a stop is not

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -132,8 +132,10 @@ Two things this workflow will not do, and it says so rather than implying otherw
   is an **Apply to editor** button, which puts the text in your editor and runs nothing
   (`HydrationControls`, `AgentRail.tsx:176-186`).
 
-**Answered when** the Investigate bar is met **and** a plan comparison is on the ledger
-(`verifyQueryOptimizationGoal`, `goal-verifier.ts:196`).
+**Answered when** the Investigate bar is met **and** the change it proposes rests on a plan it read:
+a before/after comparison for a rewrite, or — for an index, whose "after" plan would need the index
+to already exist — the recommendation citing the plan it diagnosed (`verifyQueryOptimizationGoal`,
+`goal-verifier.ts`).
 
 ### Assess
 
@@ -172,7 +174,7 @@ yet. A run's steps appear here as they are recorded."*
 | `Profiled <table>` | Assess only: counts and findings |
 | `Report composed` | How many claims, each citing evidence |
 | `Closing statement` | The model's closing prose. It cites nothing and claims nothing — a Plan run's whole output, an Agent run's aside |
-| `Stop requested` | You pressed Stop; *"the run ends at its next checkpoint"* |
+| `Stop requested` | You pressed Stop; *"the run takes no further database step; work already in hand, such as a report, still finishes"* |
 
 **Wording the application chose and text that came from elsewhere never share a line.** Headlines
 and details are the application's words; anything from the model, the engine or you is rendered as a
@@ -218,7 +220,8 @@ whole vocabulary (`SHORTFALL_SENTENCES`, `timeline.ts:335-343`):
 | `no-report` | "The run finished without composing a cited report, so nothing it found was written down." |
 | `empty-evidence` | "Every result the report cited came back empty, so the answer rests on nothing." |
 | `no-plan` | "The run produced no plan at all." |
-| `no-plan-comparison` | "No before-and-after plan comparison was recorded, which is what a query optimization rests on." |
+| `no-plan-comparison` | "No before-and-after plan comparison was recorded, and no index was recommended: a query optimization rests on one or the other." |
+| `no-plan-evidence` | "The index was recommended without citing a plan this run read, so nothing the engine said backs it." |
 | `no-table-profile` | "No table was profiled, so the state of the data was never established." |
 | `cancelled` | "The run was stopped before it could finish." |
 
@@ -390,7 +393,11 @@ Stated plainly, because a surface that hides its edges is the one that surprises
 - **It cannot be paused or resumed from the rail.** There is a Stop control and nothing standing in
   for a capability this build does not have (`docs/BACKLOG.md` B11).
 - **A stopped run stops at its next checkpoint**, not instantly: cancellation is enforced by the run
-  loop's own persisted state.
+  loop's own persisted state, and the checkpoint sits in the step that reaches a database. A run that
+  was already composing its report therefore finishes it and answers — twice on 2026-08-12 it did,
+  2.4 seconds after the Stop. That is the contract rather than a defect, so what changed in #356 is
+  that the ending now says it: *"A stop was requested before this ending: the run took no further
+  database step, and finished what it already had in hand."*
 - **A run's stored rows do not outlive it**, so a report can outlive the rows its citations point at
   (`docs/BACKLOG.md` B15). An artifact hydrates the grid and the explain view, not the chart or
   export surfaces (B14).

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -229,10 +229,12 @@ export default function Studio() {
     The workflow is INVESTIGATION, not query-optimization, and that is deliberate.
     The control being replaced was a general assistant, not an optimizer, so choosing
     the optimizer would commit the user to a goal they never asked for: that
-    workflow's verifier requires a plan COMPARISON (`src/lib/agent/goal-verifier.ts`,
-    the no-plan-comparison shortfall), and a run that perfectly explained what the
-    statement does would still be recorded as "did not answer". The workflow control
-    is one click away in the rail, and investigation is the general one.
+    workflow's verifier requires the run to PROPOSE a change and back it with a plan
+    it read — a comparison, or an index citing the plan it diagnosed
+    (`src/lib/agent/goal-verifier.ts`) — and a run that perfectly explained what the
+    statement does proposes nothing, so it would still be recorded as "did not
+    answer". The workflow control is one click away in the rail, and investigation is
+    the general one.
 
     The objective is the statement and nothing composed around it. Writing prose like
     "why is this slow?" on the user's behalf would put words in a box that is theirs

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -292,7 +292,7 @@ const STOP_SENTENCES: Readonly<Record<AgentRunMode, Record<AgentRunStopReason, s
  * The verdict's shortfall still wins over the stop reason in BOTH modes, so a
  * planning run that produced no plan is told that rather than told it stopped.
  */
-function describeEnding(
+function endingSentence(
   reason: AgentRunFailureReason | undefined,
   stopReason: AgentRunStopReason | undefined,
   verdict: AgentGoalVerdictRecord | undefined,
@@ -313,6 +313,43 @@ function describeEnding(
   // down mid-read.
   const sentence = STOP_SENTENCES[mode]?.[stopReason];
   return sentence === null || sentence === undefined ? {} : { detail: sentence };
+}
+
+/**
+ * What a run that was asked to stop and ended anyway owes the reader (#356).
+ *
+ * Twice on 2026-08-12 a Stop was pressed, the request was recorded, and 2.4 seconds
+ * later the run composed its report and ended `succeeded / answered`. That is
+ * correct by contract — cancellation is enforced at the run's own checkpoint, and
+ * the checkpoint is in the step that reaches a database, so a report already being
+ * composed is not abandoned — but the rail said "Run answered" and the ending said
+ * nothing about the stop. The user pressed a button that promises the run stops,
+ * and read a screen that never mentioned it again.
+ *
+ * So the ending accounts for it. Not by calling an answered run cancelled: it
+ * answered, and the verdict is about the run's output rather than about who asked
+ * for what. What was missing is the fact, and the fact is on the ledger.
+ */
+const STOP_ARRIVED_LATE =
+  "A stop was requested before this ending: the run took no further database step, and finished what it already had in hand.";
+
+/**
+ * The ending's sentence, plus the stop that did not change it.
+ *
+ * `stopUnhonoured` is false for a run that ended `cancelled`, where the stop IS the
+ * ending and `STOP_SENTENCES` already says so — repeating it there would tell a
+ * reader twice about one event.
+ */
+function describeEnding(
+  reason: AgentRunFailureReason | undefined,
+  stopReason: AgentRunStopReason | undefined,
+  verdict: AgentGoalVerdictRecord | undefined,
+  mode: AgentRunMode,
+  stopUnhonoured: boolean,
+): { detail?: string } {
+  const ending = endingSentence(reason, stopReason, verdict, mode);
+  if (!stopUnhonoured) return ending;
+  return { detail: ending.detail === undefined ? STOP_ARRIVED_LATE : `${ending.detail} ${STOP_ARRIVED_LATE}` };
 }
 
 /** The verdict as the ledger carries it. Optional everywhere, like the fields beside it. */
@@ -337,7 +374,9 @@ const SHORTFALL_SENTENCES: Readonly<Record<AgentGoalShortfall, string>> = {
   "empty-evidence": "Every result the report cited came back empty, so the answer rests on nothing.",
   "no-plan": "The run produced no plan at all.",
   "no-plan-comparison":
-    "No before-and-after plan comparison was recorded, which is what a query optimization rests on.",
+    "No before-and-after plan comparison was recorded, and no index was recommended: a query optimization rests on one or the other.",
+  "no-plan-evidence":
+    "The index was recommended without citing a plan this run read, so nothing the engine said backs it.",
   "no-table-profile": "No table was profiled, so the state of the data was never established.",
   cancelled: "The run was stopped before it could finish.",
 };
@@ -365,7 +404,16 @@ function describeRefusal(refusal: AgentToolRefusal): Omit<AgentTimelineItem, "id
   }
 }
 
-function describeEvent(event: AgentRunEvent, mode: AgentRunMode): Omit<AgentTimelineItem, "id" | "atMs"> {
+/**
+ * `stopRequested` is the fold's state at THIS entry, not the run's final state, and
+ * it can only be true for an entry that follows the request — which is the only
+ * ordering that makes the sentence it produces true.
+ */
+function describeEvent(
+  event: AgentRunEvent,
+  mode: AgentRunMode,
+  stopRequested: boolean,
+): Omit<AgentTimelineItem, "id" | "atMs"> {
   switch (event.kind) {
     case "run-started":
       return { tone: "neutral", headline: `Run started in ${event.mode} mode` };
@@ -463,12 +511,22 @@ function describeEvent(event: AgentRunEvent, mode: AgentRunMode): Omit<AgentTime
         // would be this component inventing a cause for every ending that had none.
         // `reason` wins when both are present: a drive that died outside the loop is
         // a more specific account of the ending than the loop's own exit.
-        ...describeEnding(event.reason, event.stopReason, event.goalVerdict, mode),
+        ...describeEnding(
+          event.reason,
+          event.stopReason,
+          event.goalVerdict,
+          mode,
+          stopRequested && event.status !== "cancelled",
+        ),
       };
   }
 }
 
-function describeEntry(entry: AgentLedgerEntry, mode: AgentRunMode): Omit<AgentTimelineItem, "id"> {
+function describeEntry(
+  entry: AgentLedgerEntry,
+  mode: AgentRunMode,
+  stopRequested: boolean,
+): Omit<AgentTimelineItem, "id"> {
   switch (entry.kind) {
     case "run-opened":
       return {
@@ -484,7 +542,7 @@ function describeEntry(entry: AgentLedgerEntry, mode: AgentRunMode): Omit<AgentT
         quoted: entry.objective,
       };
     case "event":
-      return { atMs: entry.event.atMs, ...describeEvent(entry.event, mode) };
+      return { atMs: entry.event.atMs, ...describeEvent(entry.event, mode, stopRequested) };
     default:
       return {
         atMs: entry.atMs,
@@ -492,7 +550,12 @@ function describeEntry(entry: AgentLedgerEntry, mode: AgentRunMode): Omit<AgentT
         headline: "Stop requested",
         // Deliberately not "cancelled": the run holds its budget and whatever it has
         // in flight until its own loop reaches a checkpoint (T7a).
-        detail: "the run ends at its next checkpoint",
+        //
+        // What the checkpoint IS, rather than that there is one (#356). "The run
+        // ends at its next checkpoint" was read as a promise the run ends, and twice
+        // it then composed a report and answered — because the checkpoint sits in
+        // the step that reaches a database, and composing a report reaches none.
+        detail: "the run takes no further database step; work already in hand, such as a report, still finishes",
       };
   }
 }
@@ -656,7 +719,7 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
     }
     // Indexed, because two entries can legitimately be identical in content and
     // timestamp (a resumed run replaying a step), and React needs distinct keys.
-    items.push({ id: `entry-${index}`, ...describeEntry(entry, mode) });
+    items.push({ id: `entry-${index}`, ...describeEntry(entry, mode, stopRequested) });
   });
 
   const budgets = AGENT_EXECUTION_POLICY.budgets;

--- a/src/lib/agent/goal-verifier.ts
+++ b/src/lib/agent/goal-verifier.ts
@@ -49,7 +49,15 @@ import type { AgentReportClaim, AgentRunEvent, AgentRunMode, AgentRunRecord, Age
 export type AgentGoalVerifierId =
   | "agent-planning.1"
   | "agent-investigation.1"
+  /**
+   * Retired by #356 and kept in the union anyway: verdicts recorded under it are on
+   * ledgers that outlive the rule, and this is the type a reader of one holds. What
+   * a versioned id must never do is mean something else later, so `.1` still means
+   * what it meant — a run judged to need a before/after comparison whatever it
+   * recommended.
+   */
   | "agent-query-optimization.1"
+  | "agent-query-optimization.2"
   | "agent-database-assessment.1";
 
 /**
@@ -66,13 +74,23 @@ export type AgentGoalShortfall =
   /** A planning run left no prose at all — the mute run of #341 F1. */
   | "no-plan"
   /**
-   * A query-optimization run never compared two plans.
+   * A query-optimization run never compared two plans, and recommended no index
+   * either.
    *
    * The template's own artifact. A run that recommends a rewrite without having
    * looked at what the engine does differently has recommended it on the strength
    * of its own opinion, and that is precisely what this workflow exists not to do.
    */
   | "no-plan-comparison"
+  /**
+   * A query-optimization run recommended an index and cited no plan it had read.
+   *
+   * The index arm of the same requirement (#356). What the comparison establishes
+   * for a rewrite — that the recommendation rests on what the engine actually does
+   * — the diagnosed plan establishes for an index, and this is a run that produced
+   * neither.
+   */
+  | "no-plan-evidence"
   /**
    * A database-assessment run never profiled a table.
    *
@@ -181,19 +199,58 @@ type GoalRule = (run: VerifiableAgentRun) => readonly AgentGoalShortfall[];
  * two halves of one decision, and the half that drifted would be the one a reader
  * could not interpret.
  */
+/** The operation an inspected plan is read under. */
+const PLAN_OPERATION = "sql.explain.estimate";
+
+/** Every plan THIS run read from the engine, by the id a citation would name. */
+function planArtifacts(events: readonly AgentRunEvent[]): ReadonlySet<string> {
+  const ids = new Set<string>();
+  for (const event of events) {
+    if (event.kind === "tool-completed" && event.artifact.operationId === PLAN_OPERATION) {
+      ids.add(event.artifact.correlationId);
+    }
+  }
+  return ids;
+}
+
 /**
- * The optimization bar: everything an investigation must meet, and then its own
- * artifact.
+ * The optimization bar: everything an investigation must meet, and then evidence
+ * that the change it proposes rests on what the engine actually does.
  *
  * Composed rather than replaced. A run that answered nothing has not become
  * acceptable by comparing two plans, so the baseline is checked first and its
- * shortfall dominates — reporting `no-plan-comparison` about a run that never
+ * shortfall dominates — reporting a missing comparison about a run that never
  * composed a report at all would name the smaller of two problems.
+ *
+ * **Two arms, because the two changes this workflow can propose are not equally
+ * checkable (#356).** A rewrite's "after" plan is readable without changing
+ * anything, so a rewrite is still held to the comparison. An index's is not: the
+ * second plan requires the index to EXIST, and the run is read-only by contract —
+ * a live run on 2026-08-12 diagnosed the scan, recommended the right index, tried
+ * `CREATE INDEX ...; SELECT ...`, was refused as it should be, and was then told by
+ * this rule that it had not answered. The requirement was never wrong; it was
+ * stated in terms of the one artifact only one of the two answers can produce.
+ *
+ * So an index answers on the plan it DIAGNOSED, cited by the recommendation itself.
+ * Not merely "a plan is somewhere on the ledger": the citation is what ties this
+ * recommendation to that plan, and without it the run is proposing an index beside
+ * a plan rather than because of one.
  */
 function verifyQueryOptimizationGoal(run: VerifiableAgentRun): readonly AgentGoalShortfall[] {
   const baseline = verifyInvestigationGoal(run);
   if (baseline.length > 0) return baseline;
-  return run.events.some((event) => event.kind === "plan-comparison") ? [] : ["no-plan-comparison"];
+  if (run.events.some((event) => event.kind === "plan-comparison")) return [];
+
+  const indexes = run.events.flatMap((event) =>
+    event.kind === "recommendation" && event.change === "index" ? [event] : [],
+  );
+  if (indexes.length === 0) return ["no-plan-comparison"];
+
+  const plans = planArtifacts(run.events);
+  const grounded = indexes.some((event) =>
+    event.evidence.some((reference) => reference.source === "artifact" && plans.has(reference.correlationId)),
+  );
+  return grounded ? [] : ["no-plan-evidence"];
 }
 
 /**
@@ -223,7 +280,7 @@ function verifyDatabaseAssessmentGoal(run: VerifiableAgentRun): readonly AgentGo
  */
 export const AGENT_WORKFLOW_GOALS: Readonly<Record<AgentRunWorkflowType, AgentWorkflowGoal>> = Object.freeze({
   investigation: { verifier: "agent-investigation.1", verify: verifyInvestigationGoal },
-  "query-optimization": { verifier: "agent-query-optimization.1", verify: verifyQueryOptimizationGoal },
+  "query-optimization": { verifier: "agent-query-optimization.2", verify: verifyQueryOptimizationGoal },
   "database-assessment": { verifier: "agent-database-assessment.1", verify: verifyDatabaseAssessmentGoal },
 } satisfies Record<AgentRunWorkflowType, AgentWorkflowGoal>);
 

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -197,6 +197,11 @@ const PLANNING_RULES = [
  * `PRAGMA index_list('a'); PRAGMA index_list('b')` — multi-statement text, refused
  * by the statement guard before the database — because the obvious route to an
  * index inventory is closed and nothing had said which one is open.
+ *
+ * It also says what to do about an index INSTEAD of comparing plans, and that
+ * sentence is the model's half of #356. The verifier now accepts a cited plan in
+ * place of a comparison for an index; a rule the model is not told about is a rule
+ * live runs fail, which is exactly how the evidence contract failed in #350.
  */
 /** What the run is FOR. Said in BOTH modes — a plan for an optimization is still about one. */
 const WORKFLOW_OBJECTIVES: Readonly<Record<AgentRunWorkflowType, string>> = Object.freeze({
@@ -216,6 +221,7 @@ const WORKFLOW_TOOL_RULES: Readonly<Record<AgentRunWorkflowType, string>> = Obje
   "query-optimization": [
     'Read the existing indexes with inspect_schema and kind="indexes" — a multi-statement PRAGMA or SHOW is refused before the database.',
     "Inspect the plan of the current statement, then of your rewrite, and call compare_plans with the two artifact ids. They must name two different plans.",
+    "An index cannot be compared that way: its second plan would need the index to already exist, and this run creates nothing. Recommend it instead, citing the inspect_plan artifact whose access path the index is meant to change.",
     "Every plan you can obtain is an ESTIMATE: nothing is executed, and there are no timings. Say so rather than implying a measurement.",
     "Propose changes with recommend_change. They are offered to the user and never applied by this run.",
   ].join(" "),

--- a/tests/evals/query-optimization.test.ts
+++ b/tests/evals/query-optimization.test.ts
@@ -118,7 +118,7 @@ describe("the optimization arc, on both reference engines", () => {
         "run-finished",
       ]);
       expect(drive.status).toBe("succeeded");
-      expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.1", unmet: [] });
+      expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
     });
 
     test(`${engine}: the comparison records what the engine's own plan said`, async () => {
@@ -166,9 +166,18 @@ describe("the optimization arc, on both reference engines", () => {
   });
 });
 
-describe("THE GATE: the verifier fails the run when the template's own artifact is absent", () => {
+/**
+ * The arc a live run actually takes when the answer is an index (#356).
+ *
+ * On 2026-08-12 a run against the SQLite sample diagnosed the scan, recommended
+ * `CREATE INDEX idx_salary_amount_emp`, composed an accurate report — and was
+ * scored `unanswered`, because the rule asked for a comparison whose second plan
+ * would need the index to exist. It tried that too, and was refused as it should
+ * be. This block is that run, both ways round.
+ */
+describe("an index answers on the plan it diagnosed", () => {
   for (const engine of ["postgres", "sqlite"] as const) {
-    test(`${engine}: a competent, fully cited report with no plan comparison does not answer`, async () => {
+    test(`${engine}: one plan, an index citing it, and a cited report is an answer`, async () => {
       const run = await open(engine);
 
       const drive = await run.drive([
@@ -179,9 +188,46 @@ describe("THE GATE: the verifier fails the run when the template's own artifact 
 
       expect(drive.status).toBe("succeeded");
       expect(drive.stopReason).toBe("report-composed");
+      expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+      // And it stays read-only: the DDL it proposed reached no database.
+      for (const statement of drive.modelStatements) expect(statement).not.toContain("CREATE INDEX");
+    });
+
+    test(`${engine}: an index citing a read rather than a plan does not answer`, async () => {
+      // The relaxation is about which artifact grounds the index, not about whether
+      // one has to. Nothing here asked the engine how it reaches its rows.
+      const run = await open(engine);
+
+      const drive = await run.drive([
+        callsTool("run_read_query", { sql: FAST }, "call_read"),
+        recommends(),
+        reportOn("The listing reads the whole table."),
+      ]);
+
       expect(drive.verdict).toEqual({
         outcome: "unanswered",
-        verifier: "agent-query-optimization.1",
+        verifier: "agent-query-optimization.2",
+        unmet: ["no-plan-evidence"],
+      });
+    });
+  }
+});
+
+describe("THE GATE: the verifier fails the run when the template's own artifact is absent", () => {
+  for (const engine of ["postgres", "sqlite"] as const) {
+    test(`${engine}: a competent, fully cited report that proposes nothing does not answer`, async () => {
+      const run = await open(engine);
+
+      const drive = await run.drive([
+        callsTool("inspect_plan", { sql: SLOW }, "call_plan_before"),
+        reportOn("The listing reads the whole table."),
+      ]);
+
+      expect(drive.status).toBe("succeeded");
+      expect(drive.stopReason).toBe("report-composed");
+      expect(drive.verdict).toEqual({
+        outcome: "unanswered",
+        verifier: "agent-query-optimization.2",
         unmet: ["no-plan-comparison"],
       });
     });
@@ -233,6 +279,6 @@ describe("a drive that dies after recording a comparison does not make it twice"
     expect(firstTurn).toContain("must not be made again");
     expect(firstTurn).toContain("was already recommended");
     // And the run still answers: the comparison it needs is on its own ledger.
-    expect(resumed.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.1", unmet: [] });
+    expect(resumed.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
   });
 });

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -438,7 +438,13 @@ describe("foldLedgerEntries", () => {
 
     expect(view.status).toBe("running");
     expect(view.items.at(-1)?.headline).toBe("Stop requested");
-    expect(view.items.at(-1)?.detail).toBe("the run ends at its next checkpoint");
+    // #356: what the checkpoint IS, rather than that there is one. "Ends at its next
+    // checkpoint" was read as a promise the run ends, and twice the run then composed
+    // a report and answered — composing one reaches no database, and the checkpoint
+    // is in the step that does.
+    expect(view.items.at(-1)?.detail).toBe(
+      "the run takes no further database step; work already in hand, such as a report, still finishes",
+    );
   });
 
   test("items are keyed uniquely even when two entries share a timestamp", () => {
@@ -1115,6 +1121,7 @@ describe("an ending says whether the run ANSWERED, not only how it stopped (B24)
       "empty-evidence",
       "no-plan",
       "no-plan-comparison",
+      "no-plan-evidence",
       "no-table-profile",
       "cancelled",
     ]) {
@@ -1150,6 +1157,69 @@ describe("an ending says whether the run ANSWERED, not only how it stopped (B24)
 
     expect(view.items[1]?.headline).toBe("Run succeeded");
     expect(view.items[1]?.detail).toContain("stopped without composing a cited report");
+  });
+
+  /**
+   * #356 finding 2, observed twice on 2026-08-12: Stop was pressed, the request was
+   * recorded, and the run composed its report 2.4s later and ended
+   * `succeeded / answered`. Correct by contract, and the rail said "Run answered"
+   * and never mentioned the stop again.
+   */
+  describe("a run that was asked to stop and finished anyway says so", () => {
+    const stop: AgentLedgerEntry = { kind: "cancellation-requested", atMs: 13, bySessionId: "ada" };
+
+    test("the ending accounts for the stop it outran", () => {
+      const view = foldLedgerEntries([
+        OPENED,
+        stop,
+        finished("succeeded", { outcome: "answered", verifier: "agent-investigation.1" }, "report-composed"),
+      ]);
+
+      // The verdict is unchanged: the run answered, and who asked for what is a
+      // different fact from what the run produced.
+      expect(view.items.at(-1)?.headline).toBe("Run answered");
+      expect(view.items.at(-1)?.detail).toBe(
+        "A stop was requested before this ending: the run took no further database step, and finished what it already had in hand.",
+      );
+    });
+
+    test("a shortfall still leads, and the stop is added after it", () => {
+      const view = foldLedgerEntries([
+        OPENED,
+        stop,
+        finished(
+          "failed",
+          { outcome: "unanswered", verifier: "agent-investigation.1", unmet: ["no-report"] },
+          "turn-limit",
+        ),
+      ]);
+
+      expect(view.items.at(-1)?.detail).toContain("without composing a cited report");
+      expect(view.items.at(-1)?.detail).toContain("A stop was requested before this ending");
+    });
+
+    test("a run that ended cancelled is not told about its own cancellation twice", () => {
+      const view = foldLedgerEntries([
+        OPENED,
+        stop,
+        finished(
+          "cancelled",
+          { outcome: "unanswered", verifier: "agent-investigation.1", unmet: ["cancelled"] },
+          "cancelled",
+        ),
+      ]);
+
+      expect(view.items.at(-1)?.detail).toBe("The run was stopped before it could finish.");
+    });
+
+    test("an ending nobody asked for says nothing about a stop", () => {
+      const view = foldLedgerEntries([
+        OPENED,
+        finished("succeeded", { outcome: "answered", verifier: "agent-investigation.1" }, "report-composed"),
+      ]);
+
+      expect(view.items.at(-1)?.detail).toBeUndefined();
+    });
   });
 });
 

--- a/tests/unit/lib/agent/goal-verifier.test.ts
+++ b/tests/unit/lib/agent/goal-verifier.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { AGENT_PLANNING_VERIFIER, AGENT_WORKFLOW_GOALS, verifyRunGoal } from "@/lib/agent/goal-verifier";
 import type {
   AgentArtifactReference,
+  AgentEvidenceReference,
   AgentRunEvent,
   AgentRunMode,
   AgentRunRecord,
@@ -25,6 +26,8 @@ const CORRELATION = {
   full: "4f2c9a10-0000-4000-8000-000000000001",
   empty: "4f2c9a10-0000-4000-8000-000000000002",
   alsoEmpty: "4f2c9a10-0000-4000-8000-000000000003",
+  /** A plan this run asked the engine for, under `sql.explain.estimate`. */
+  plan: "4f2c9a10-0000-4000-8000-000000000004",
 } as const;
 
 const SNAPSHOT_FINGERPRINT = "ctx_2f0a";
@@ -238,7 +241,7 @@ describe("a query-optimization run is judged by its own artifact as well as the 
       ),
     );
 
-    expect(verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.1", unmet: [] });
+    expect(verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
   });
 
   test("THE GATE: a perfect report with no plan comparison does not answer this workflow's question", () => {
@@ -250,7 +253,7 @@ describe("a query-optimization run is judged by its own artifact as well as the 
     expect(verifyRunGoal(run("agent", "succeeded", events, "investigation")).outcome).toBe("answered");
     expect(verifyRunGoal(run("agent", "succeeded", events, "query-optimization"))).toEqual({
       outcome: "unanswered",
-      verifier: "agent-query-optimization.1",
+      verifier: "agent-query-optimization.2",
       unmet: ["no-plan-comparison"],
     });
   });
@@ -288,6 +291,118 @@ describe("a query-optimization run is judged by its own artifact as well as the 
     );
 
     expect(verdict.outcome).toBe("answered");
+  });
+
+  /**
+   * #356 finding 1: the live run that did everything right and was told it had not
+   * answered. It diagnosed the scan, recommended the index that addresses it, and
+   * could not compare plans because the "after" plan needs the index to exist —
+   * which a read-only run cannot create. It tried, and was refused as it should be.
+   */
+  describe("an index answers on the plan it diagnosed, because its second plan cannot exist", () => {
+    const planRead: AgentRunEvent = {
+      kind: "tool-completed",
+      atMs: 20,
+      stepId: "step_plan",
+      artifact: {
+        correlationId: CORRELATION.plan,
+        runId: "arun_1",
+        operationId: "sql.explain.estimate",
+        summary: { rowCount: 3, columnNames: ["detail"], elapsedMs: 4 },
+      },
+    };
+
+    const recommends = (
+      change: "index" | "rewrite",
+      ...references: readonly { source: "artifact" | "context-snapshot"; id: string }[]
+    ): AgentRunEvent => ({
+      kind: "recommendation",
+      atMs: 28,
+      change,
+      statement: change === "index" ? "CREATE INDEX salary_amount ON salary (amount)" : "SELECT emp_no FROM salary",
+      rationale: "The engine scans salary whole to satisfy the filter.",
+      evidence: references.map((reference) =>
+        reference.source === "artifact"
+          ? ({ source: "artifact", correlationId: reference.id } as const)
+          : ({ source: "context-snapshot", fingerprint: reference.id } as const),
+      ) as [AgentEvidenceReference, ...AgentEvidenceReference[]],
+    });
+
+    const optimization = (events: readonly AgentRunEvent[]) =>
+      verifyRunGoal(run("agent", "succeeded", events, "query-optimization"));
+
+    test("a cited report and an index recommendation citing the plan is an answer", () => {
+      const verdict = optimization([
+        contextCaptured,
+        planRead,
+        completed(CORRELATION.full, 8),
+        recommends("index", ARTIFACT(CORRELATION.plan)),
+        reportCiting(ARTIFACT(CORRELATION.full)),
+      ]);
+
+      expect(verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+    });
+
+    test("an index citing a read rather than a plan is not grounded in what the engine does", () => {
+      // The plan is on the ledger; this recommendation does not rest on it. Naming
+      // the plan is what ties this index to that access path.
+      const verdict = optimization([
+        contextCaptured,
+        planRead,
+        completed(CORRELATION.full, 8),
+        recommends("index", ARTIFACT(CORRELATION.full)),
+        reportCiting(ARTIFACT(CORRELATION.full)),
+      ]);
+
+      expect(verdict.unmet).toEqual(["no-plan-evidence"]);
+    });
+
+    test("an index citing only the schema snapshot is an index proposed from the shape of the table", () => {
+      const verdict = optimization([
+        contextCaptured,
+        completed(CORRELATION.full, 8),
+        recommends("index", SNAPSHOT),
+        reportCiting(ARTIFACT(CORRELATION.full)),
+      ]);
+
+      expect(verdict.unmet).toEqual(["no-plan-evidence"]);
+    });
+
+    test("a rewrite is still held to the comparison, because both of ITS plans are readable", () => {
+      const verdict = optimization([
+        contextCaptured,
+        planRead,
+        completed(CORRELATION.full, 8),
+        recommends("rewrite", ARTIFACT(CORRELATION.plan)),
+        reportCiting(ARTIFACT(CORRELATION.full)),
+      ]);
+
+      expect(verdict.unmet).toEqual(["no-plan-comparison"]);
+    });
+
+    test("one grounded index among several answers, and the rest do not have to be", () => {
+      const verdict = optimization([
+        contextCaptured,
+        planRead,
+        completed(CORRELATION.full, 8),
+        recommends("index", SNAPSHOT),
+        recommends("index", ARTIFACT(CORRELATION.plan)),
+        reportCiting(ARTIFACT(CORRELATION.full)),
+      ]);
+
+      expect(verdict.outcome).toBe("answered");
+    });
+
+    test("a comparison still answers on its own, with no recommendation at all", () => {
+      const verdict = optimization([
+        contextCaptured,
+        completed(CORRELATION.full, 8),
+        planComparison,
+        reportCiting(ARTIFACT(CORRELATION.full)),
+      ]);
+
+      expect(verdict.outcome).toBe("answered");
+    });
   });
 
   test("each template is held to its OWN bar, and not to the other's", () => {


### PR DESCRIPTION
Closes #356 — the two findings that came out of driving the agent rather than reading it. Both are
cases where the product does the right thing and reports something else, so both fixes are about the
report rather than about the behaviour.

## An index recommendation was scored "did not answer"

The optimization goal required a `plan-comparison`, and `compare_plans` takes a **before and an
after**. An "after" plan for an index requires the index to exist, and the run is read-only by
contract — the live run in #356 tried, drafting `CREATE INDEX ...; SELECT ...`, and was refused as it
should be. So the most common optimization answer had no path to satisfying its own workflow's goal,
while a rewrite satisfied it easily. The requirement was never wrong; it was stated in terms of the
one artifact only one of the two answers can produce.

**Two arms now, one per shape of change.** A rewrite is still held to the comparison: both of its
plans are readable without changing anything. An index answers on the plan it **diagnosed**, cited by
the recommendation itself — not merely a plan somewhere on the ledger, because the citation is what
ties the index to the access path it changes. An index citing no plan is `no-plan-evidence`, its own
fact rather than a reworded `no-plan-comparison`.

The verifier id moves to `agent-query-optimization.2`. `.1` stays in the union: verdicts recorded
under it are on ledgers that outlive the rule, and the one thing a versioned id must never do is come
to mean something else.

**The model is told.** The optimization block now says an index cannot be compared and what to cite
instead. A rule the model is not told about is a rule live runs fail — which is exactly how the
evidence contract failed in #350.

## Stop recorded the request while the run finished anyway

Correct by contract, and it stays: the checkpoint sits in the step that reaches a database, and
composing a report reaches none, so a report already being written is not abandoned (T7a). What was
wrong is what the user was told — the timeline said *"the run ends at its next checkpoint"*, then
*"Run answered"*, and never mentioned the stop again.

So the entry now says what the checkpoint **is**, and the ending accounts for a stop it outran:
*"A stop was requested before this ending: the run took no further database step, and finished what
it already had in hand."* A run that ended `cancelled` is not told twice — there the stop **is** the
ending. The verdict is deliberately unchanged: the run answered, and who asked for what is a
different fact from what the run produced.

## Verified by driving it, since that is what found it

On this branch, against the bundled SQLite sample with a real `gemini-3.5-flash-lite` key:

- **The #356 objective, verbatim.** The run read the plan, recommended
  `CREATE INDEX idx_salary_amount ON salary(amount)` **citing that plan artifact**, composed a
  three-claim report, and the ledger recorded
  `{"outcome":"answered","verifier":"agent-query-optimization.2"}`. It did that without being nudged
  — the prompt sentence carried it.
- **Stop, twice.** Both runs were stopped at the checkpoint and ended `cancelled`, and both rendered
  the new "Stop requested" wording and the single cancellation sentence — the not-told-twice branch.
  The outrun branch is a race today's runs did not reproduce, and it is pinned at the fold instead.

One thing seen in passing and **not** touched here: a `database-assessment` run profiled nine tables
and hit the turn ceiling without composing (`failed / turn-limit / no-report`). That is the workflow
spending its budget on breadth, not a regression from this change.

## Gates

Six local gates green, plus `test:coverage` + `coverage:check` at 100% (33985/33985). The
optimization eval's gate block was rewritten rather than deleted: it now asserts the answer this
change allows on both reference engines, **and** keeps two runs unanswered — an index citing a read
instead of a plan (`no-plan-evidence`), and a report that proposes nothing at all
(`no-plan-comparison`).
