### PR TITLE
docs(agent): record the observability deferral where the other ones live (#332)

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1065,6 +1065,9 @@ declared-target allowlist, the statement guard and the role's own grants are the
   against drift, but that guard derives only the agent paths: every other family is still hand-kept,
   and even here only a path's presence is asserted, never that a documented shape still matches its
   handler.
+- **B33** — a run is observable only from its own ledger. There is no OpenTelemetry export and no
+  metrics: the record described above is complete, and getting it into a stack the operator already
+  runs is designed (#332) and deliberately unbuilt.
 
 ## Related documentation
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1582,3 +1582,23 @@ Done when the guard derives every family from `src/app/api/**` under one stated 
 as documented, and the reference is reshaped where that rule does not currently hold. It is also
 worth noting what the guard does NOT check even for the agent: that a documented request or response
 shape still matches the handler. Only presence is asserted.
+
+### B33. An agent run is observable only from its own ledger — nothing exports it
+
+A run's whole record is the append-only ledger: lifecycle, tool invocations, refusals with their deny
+class, budget counters and the goal verdict. The rail and the eval harness both read runs out of it,
+and an operator debugging a run today reads it directly. What does not exist is a way to get that
+record into the observability stack a self-hosting team already runs — no OpenTelemetry spans, no
+OTLP export, no metrics.
+
+Designed in full and deliberately not built (#332, closed 2026-08-14): endpoint-gated activation on
+`OTEL_EXPORTER_OTLP_ENDPOINT`, a dynamic import so no exporter module loads while it is unset,
+metadata-only span attributes by default with a documented verbose delta, and no second global SDK
+registration in the embedded build. The reason it is deferred is dependency surface and timing rather
+than doubt about the design: it adds `@ai-sdk/otel` plus an exporter to a package libredb-platform
+also consumes, and the agent's event model is still gaining kinds — instrumenting it now means
+maintaining a span catalogue against a moving target. Nothing in Phase 1 depends on it and no user is
+waiting on it.
+
+Done when the event model has settled and somebody is running Studio beside a stack that wants agent
+runs in it. The decisions above are the starting point; #332 holds the full scope.


### PR DESCRIPTION
#332 is closed as deferred rather than built. The reason is dependency surface and timing, not doubt
about the design: it adds `@ai-sdk/otel` plus an OTLP exporter to a package libredb-platform also
consumes, and the agent's event model is still gaining event kinds — a span catalogue and an
attribute policy written now would be maintained against a moving target. Nothing in Phase 1 depends
on it and no user is waiting on it.

**B33 records what that leaves true**: a run is observable only from its own ledger. The ledger is
complete — lifecycle, tool invocations, refusals with their deny class, budget counters, the goal
verdict — and the rail and the eval harness both read runs out of it. What does not exist is a way to
get that record into a stack the operator already runs.

Recorded in `docs/BACKLOG.md` beside the other deliberate gaps rather than only inside a closed
issue, which is where a deferral goes to be forgotten. `docs/AGENT.md` names it too, because the
deferral guard requires every M2 entry to be cited by the behaviour document — it caught the missing
citation on the first run, which is the guard doing its job.

Docs only; no runtime change.