### PR TITLE
docs(contributing): write down the two rules a chart change has to obey

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,44 @@ pull requests. If you hit one, take the fix and commit `bun.lock`. Suppressing i
 in `.trivyignore.yaml` is the last resort and requires a justification and an
 expiry date.
 
+### Helm Chart Changes
+
+Touching anything packaged under `charts/libredb-studio/` pulls in two invariants
+that CI enforces and that nothing in the chart itself hints at. Both are checked
+by one command, and running it locally is faster than reading a CI log:
+
+```bash
+bun run chart:check
+```
+
+**The operator carries a verbatim copy.** `operator/helm-charts/libredb-studio/`
+is a byte-for-byte mirror of the source chart, because the OLM operator embeds
+the chart rather than fetching it. Never hand-edit the copy — change the source
+chart and regenerate:
+
+```bash
+bun run chart:bump
+```
+
+**An already-released chart version cannot be re-published.** Chart releases are
+immutable: re-publishing a version that already has a `libredb-studio-<version>`
+tag would mutate the released index entry and the OCI digest that existing users
+resolve (#167). So when the current `version:` in `Chart.yaml` is already tagged,
+raise it by hand — both `version:` in `Chart.yaml` and the `--version` example in
+`charts/libredb-studio/README.md`.
+
+`chart:bump` deliberately will *not* raise `version:` for you while `appVersion`
+is already in sync with `package.json`, so this step is easy to miss; `chart:check`
+is what catches it. `appVersion` tracks the app's `package.json` version and is
+the one field `chart:bump` does maintain.
+
+Finally, the chart should lint clean:
+
+```bash
+helm dependency build charts/libredb-studio
+helm lint charts/libredb-studio --strict
+```
+
 ## Coding Guidelines
 
 ### TypeScript


### PR DESCRIPTION
## Description

PR #362 - a first-time contribution adding Gateway API `HTTPRoute` support to the chart - went red on two CI jobs (`Lint, Typecheck and Build` and `Unit & Integration Tests`) for reasons the repository states nowhere a contributor would look. `CONTRIBUTING.md` had nothing about the chart at all.

## Type of Change

- [x] Documentation update

## Changes Made

Adds a `Helm Chart Changes` section to `CONTRIBUTING.md`, covering the two invariants CI enforces:

1. **The operator carries a verbatim copy.** `operator/helm-charts/libredb-studio/` mirrors the source chart byte-for-byte because the OLM operator embeds it; `bun run chart:bump` regenerates it.
2. **An already-released chart version cannot be re-published** (#167) - `version:` in `Chart.yaml` and the `--version` example in the chart README have to be raised by hand.

The second is specifically easy to fall into: `chart:bump` deliberately leaves `version:` alone while `appVersion` is already in sync with `package.json`, so the command named in the failure output does not by itself fix the failure. `bun run chart:check` is what catches it, and the section leads with running that locally.

Placed as a sibling of the existing `Security Scanning` section, which already takes the line that reproducing a gate locally beats waiting on CI.

## Testing

Every command quoted in the new section was run against this branch:

- `bun run chart:check` -> `OK: chart 0.1.34 / appVersion 0.11.0 in sync with package.json 0.11.0`
- `helm dependency build charts/libredb-studio` -> pulls postgresql 16.7.27
- `helm lint charts/libredb-studio --strict` -> `1 chart(s) linted, 0 chart(s) failed`
- `bun run format` -> clean

The `chart:bump` behaviour described is the code path at `scripts/sync-chart-version.mjs`: `const newVersion = appVersion === pkgVersion ? version : bumpPatch(version)`.

Docs-only; no executable lines added, so coverage is unaffected.
