### PR TITLE
fix(deps): upgrade monaco-editor to 0.56.0 so the shipped DOMPurify moves off 3.2.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
         "ioredis": "^5.11.1",
         "jose": "^6.2.8",
         "lucide-react": "^0.562.0",
-        "monaco-editor": "^0.55.1",
+        "monaco-editor": "^0.56.0",
         "mongodb": "^7.5.0",
         "mssql": "^12.7.0",
         "mysql2": "^3.23.3",
@@ -1408,7 +1408,7 @@
 
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
-    "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
+    "dompurify": ["dompurify@3.4.8", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ=="],
 
     "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
@@ -1954,7 +1954,7 @@
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
-    "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
+    "monaco-editor": ["monaco-editor@0.56.0", "", { "dependencies": { "dompurify": "3.4.8", "marked": "14.0.0" } }, "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg=="],
 
     "mongodb": ["mongodb@7.5.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.4.11", "bson": "^7.2.0", "mongodb-connection-string-url": "^7.0.1" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": "^7.2.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g=="],
 

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "ioredis": "^5.11.1",
     "jose": "^6.2.8",
     "lucide-react": "^0.562.0",
-    "monaco-editor": "^0.55.1",
+    "monaco-editor": "^0.56.0",
     "mongodb": "^7.5.0",
     "mssql": "^12.7.0",
     "mysql2": "^3.23.3",


### PR DESCRIPTION
fix(deps): upgrade monaco-editor to 0.56.0 so the shipped DOMPurify moves off 3.2.7

The editor is served as Monaco's prebuilt AMD bundle: scripts/copy-monaco.mjs
stages node_modules/monaco-editor/min/vs into public/monaco/vs, and DOMPurify is
inlined into that bundle rather than resolved at runtime. Nothing in src/ imports
dompurify, so the hoisted npm package was never executed by anything we ship.

That is why the obvious fix does not work. A package.json `overrides` entry for
dompurify would replace a package no shipped code runs, leave min/vs byte for
byte identical, and make the scanner finding disappear without changing what a
browser executes. Upgrading Monaco is what actually moves the inlined copy,
because Monaco pins dompurify exactly (0.55.1 pins 3.2.7, 0.56.0 pins 3.4.8) and
ships the bundle prebuilt.

Verified rather than assumed: the new bundle (editor-KLE6jdfb.js, a different
filename from 0.55.1's editor.api-CalNCsUg.js) carries the literal "3.4.8" as
DOMPurify's version constant, and so does the staged copy under public/monaco/vs.

Against the 17 dompurify advisories FOSSA reports, 3.4.8 clears 14. Three remain
and cannot be closed here - CVE-2026-66010 (<3.4.12), CVE-2026-65899 (<3.4.9) and
CVE-2026-65898 (<3.4.11) all need a dompurify newer than the one Monaco pins.
Reachability is low either way: Monaco runs DOMPurify over markdown in its hover
and suggest widgets, and src/lib/editor passes plain strings for `documentation`,
never a MarkdownString.

One behavioural change worth recording: 0.56.0 replaces the hidden
`textarea.inputarea` with the native EditContext API (`div.native-edit-context`,
role="textbox"). Keyboard input still works - verified live - and no code or test
in this repo targets that element, but anything that did would break silently.

Verified in a browser against the SQLite employees sample, all six gates green
first:

- editor loads from our own origin (localhost/monaco/vs/editor/editor.main.js),
  one instance, SQL syntax highlighting correct
- keyboard input reaches the model through the new EditContext path
- schema-aware autocomplete returns "employee | Table (1000 rows)" from the live
  connection
- a six-line join runs and returns the right 9 rows (Development 289, Production
  248, Sales 183, ... summing to the 1103 rows dept_emp holds)
- Format rewrites the query, EXPLAIN returns a real SQLite plan (SCAN de USING
  COVERING INDEX ...), the ER diagram lays out 6 tables and 6 relationships
  through ELK
- zero console errors or warnings across the whole session
