### PR TITLE
chore(ci): let Dependabot raise the bumps nobody was raising by hand

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,145 @@
+# Dependabot version updates (docs/BACKLOG.md C5).
+#
+# Grouping is the whole point of this file. Ungrouped, a repository with ~1170
+# installed packages raises one pull request per package, every one of which has
+# to pass the same six gates as a human's - and the 100 percent line-coverage
+# gate means a bot pull request is never a rubber stamp. So updates are batched
+# into a handful of pull requests a week, split only where the split changes how
+# a reviewer reads them: what ships versus what does not.
+#
+# Bun is supported through the `npm` ecosystem - Dependabot treats it as part of
+# `npm_and_yarn` and understands `bun.lock`. Only version updates work today;
+# Bun security updates are not implemented upstream, which is why the security
+# side still runs through Trivy and `bun audit`.
+#
+# CI installs with `bun install --frozen-lockfile` (scripts/ci-install.sh), so a
+# pull request whose `bun.lock` does not match its `package.json` fails loudly
+# rather than resolving around the difference. That is the safety net behind
+# every group below.
+
+version: 2
+
+updates:
+  # ---------------------------------------------------------------- npm / bun
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Istanbul"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+    groups:
+      # What ships. Kept separate from tooling because a reviewer weighs these
+      # against "does the editor still work in a browser", not "does lint pass".
+      production:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+
+      # What never leaves CI or a developer's machine. Safe to batch wide: the
+      # gates are themselves the test of a tooling bump.
+      development:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
+    ignore:
+      # Database driver majors are deliberate work, not a merge. Each one is
+      # bound by the provider tri-sync rule (code, docs and tests move in the
+      # same pull request) and, more importantly, our unit tests mock these
+      # drivers - so a major that changes wire behaviour passes CI green and
+      # breaks only against a real server. ioredis 6 is the live example: it
+      # defaults to RESP3, and src/lib/db/providers/keyvalue/redis.ts parses
+      # INFO, SLOWLOG GET and CLIENT LIST by hand. A bot pull request for that
+      # would look safe and would not be. Patch and minor updates still flow.
+      - dependency-name: "pg"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mysql2"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "better-sqlite3"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "oracledb"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mssql"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mongodb"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ioredis"
+        update-types: ["version-update:semver-major"]
+
+      # The agent runtime is pinned to exact versions the owner ratified, and
+      # tests/unit/agent-dependency-boundary.test.ts fails if any of them moves.
+      # A bot bump here is a guaranteed red build, so do not raise one.
+      - dependency-name: "ai"
+      - dependency-name: "workflow"
+      - dependency-name: "@workflow/world-local"
+      - dependency-name: "@workflow/world-postgres"
+      - dependency-name: "@ai-sdk/openai"
+      - dependency-name: "@ai-sdk/google"
+      - dependency-name: "@ai-sdk/anthropic"
+
+      # Exact-pinned on purpose: the html-to-image family mis-renders Tailwind 4
+      # computed styles, which is why the ER diagram export uses this engine and
+      # this version (see tsup.config.ts). Moving it is an export-quality
+      # decision to make in a browser, not a version bump.
+      - dependency-name: "@zumer/snapdom"
+
+  # ------------------------------------------------------------ GitHub Actions
+  # Actions are SHA-pinned with the human-readable tag in a trailing comment
+  # (`uses: actions/checkout@de0fac2... # v6`). Dependabot moves both together,
+  # which is the only practical way to keep SHA pinning current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Istanbul"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  # ------------------------------------------------------------------- Docker
+  # Two Dockerfiles: the application image and the OLM operator image. The
+  # generated .next/standalone/Dockerfile is build output and is not tracked.
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/operator"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Istanbul"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "build(deps)"
+    groups:
+      docker:
+        applies-to: version-updates
+        patterns: ["*"]
+    ignore:
+      # `oven/bun:<version>` in the Dockerfile and `bun-version:` in the
+      # workflows are the same number maintained in two places Dependabot cannot
+      # see as one. Bumping only the image would build the release with a
+      # different Bun than every CI job used - including a different lockfile
+      # writer - and would still go green, which is the worst shape a drift can
+      # take. Move both by hand, in one pull request.
+      - dependency-name: "oven/bun"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,14 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
 
+    # Both groups batch minor and patch only, which means a major that is not
+    # ignored below arrives as its own pull request. That is deliberate, not an
+    # oversight: batching majors with routine updates makes one pull request that
+    # cannot be merged as a unit - refusing recharts 3 would also hold back the
+    # `next` patch riding along with it - and majors are individually a decision
+    # rather than a bump. The fan-out is bounded: nine majors are outstanding as
+    # of 2026-08-15 across ~1170 installed packages, and open-pull-requests-limit
+    # caps how many wait at once.
     groups:
       # What ships. Kept separate from tooling because a reviewer weighs these
       # against "does the editor still work in a browser", not "does lint pass".

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -723,8 +723,9 @@ with its reason recorded in the config: database driver majors (mocked in tests,
 a wire-behaviour change goes green - ioredis 6's RESP3 default is the live case),
 the exact-pinned agent runtime (a bump fails
 `tests/unit/agent-dependency-boundary.test.ts` by design), `@zumer/snapdom` (pinned
-for ER-diagram export fidelity), and the `oven/bun` base image (its version is
-maintained in two places Dependabot sees as one).
+for ER-diagram export fidelity), and the `oven/bun` base image (its version lives
+in two places - the Dockerfile tag and the workflows' `bun-version` input - that
+Dependabot cannot see as one, so it must move by hand in both).
 
 Done when Bun security updates land upstream and the exclusion list can be
 re-read against whatever they cover.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -708,16 +708,26 @@ the operator image has a different lifecycle and a different consumer (OpenShift
 OperatorHub, which does its own scanning). Done when a certification requirement
 asks for one.
 
-### C5. Dependabot has alerts but no version-update configuration
+### C5. Dependabot raises version updates but cannot raise security ones
 
-The repository has Dependabot alerts and secret scanning enabled, but there is no
-`.github/dependabot.yml`, so nothing opens a pull request for a bump. The
-dependency gate therefore reports advisories that a human has to act on by hand.
-Adding version updates is cheap and the reason it was not done here is scope, not
-disagreement - it also interacts with the 100 percent coverage gate and the
-required checks in ways worth thinking about once (a bot pull request must pass
-the same six gates). Done when `dependabot.yml` lands with a grouping strategy
-that does not produce one pull request per transitive package.
+`.github/dependabot.yml` now groups weekly version updates across npm/bun, GitHub
+Actions and both Dockerfiles, which is what the original entry asked for. What it
+cannot do is the other half: Dependabot's Bun support covers **version updates
+only** - security updates are not implemented upstream for this ecosystem. So an
+advisory against a package Bun resolves still reaches nobody automatically; Trivy
+and `bun audit` remain the only things that see it, and acting on one is still a
+human step.
+
+That is also why several dependencies are deliberately excluded from the bot, each
+with its reason recorded in the config: database driver majors (mocked in tests, so
+a wire-behaviour change goes green - ioredis 6's RESP3 default is the live case),
+the exact-pinned agent runtime (a bump fails
+`tests/unit/agent-dependency-boundary.test.ts` by design), `@zumer/snapdom` (pinned
+for ER-diagram export fidelity), and the `oven/bun` base image (its version is
+maintained in two places Dependabot sees as one).
+
+Done when Bun security updates land upstream and the exclusion list can be
+re-read against whatever they cover.
 
 ### C6. `bun audit` cannot answer "is there a fix"
 


### PR DESCRIPTION
chore(ci): let Dependabot raise the bumps nobody was raising by hand

Closes the version-update half of docs/BACKLOG.md C5. Three ecosystems, weekly,
grouped so the repository's ~1170 installed packages cannot turn into ~1170 pull
requests: npm/bun split into what ships and what does not, GitHub Actions as one
group, and both Dockerfiles as one.

Bun is covered - Dependabot folds it into the npm ecosystem and reads bun.lock.
CI installs with `bun install --frozen-lockfile`, so a bot pull request whose
lockfile and manifest disagree fails loudly instead of resolving around the gap.

The exclusions are the part worth reviewing, because each one is a case where a
bot pull request would look green and be wrong:

- **Database driver majors.** Our unit tests mock the drivers, so a major that
  changes wire behaviour passes every gate and breaks only against a real server.
  ioredis 6 is the live example: it defaults to RESP3, while
  src/lib/db/providers/keyvalue/redis.ts parses INFO, SLOWLOG GET and CLIENT LIST
  by hand. These majors are also bound by the provider tri-sync rule. Patch and
  minor updates still flow.
- **The agent runtime** (`ai`, `workflow`, `@workflow/*`, `@ai-sdk/*`). Pinned to
  exact ratified versions, with tests/unit/agent-dependency-boundary.test.ts
  failing if any of them moves. A bot bump there is a guaranteed red build.
- **`@zumer/snapdom`.** Exact-pinned because the html-to-image family mis-renders
  Tailwind 4 computed styles; moving it is an export-quality decision to make in a
  browser.
- **`oven/bun`.** The image tag in the Dockerfile and `bun-version:` in the
  workflows are one number stored in two places Dependabot sees as unrelated.
  Bumping only the image would build the release with a different Bun than every
  CI job used, and would still go green.

C5 is rewritten rather than deleted, because setting this up surfaced a gap the
original entry did not know about: Dependabot's Bun support is version updates
only - security updates are not implemented upstream for this ecosystem, so an
advisory still reaches nobody automatically and Trivy plus `bun audit` remain the
only things that see one.
