### PR TITLE
fix(agent): follow the timeline's bottom when the viewport moves under it

### DIFF
--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -705,6 +705,19 @@ export function AgentRail({
     `scrollHeight - clientHeight` rather than `scrollHeight`: a browser clamps the
     latter to the same value, and writing what is meant is what lets the position be
     asserted rather than inferred.
+
+    An entry arriving is not the only thing that moves the bottom, and driving the
+    merged branch is what proved it. A finished analysis run sat at `scrollTop: 245` of
+    a 1090-pixel column — 637 pixels short — with every entry already delivered. The
+    container had not grown; it had SHRUNK. Showing the run's answer opens the host's
+    result panel, the rail's own viewport goes from 360 pixels to 208, and the bottom
+    moves out from under a position that was correct when it was set. No entry arrives
+    to say so, so an effect keyed on the entries alone has nothing to re-run on.
+
+    Hence the observer: it is the resize, not the append, that this has to survive, and
+    a `ResizeObserver` sees both — the container's own box and the content growing
+    inside it. The entry effect stays because it is the cheaper path for the common
+    case and it is what the eight tests below pin.
   */
   const timelineScroller = useRef<HTMLDivElement | null>(null);
   const followingTimeline = useRef(true);
@@ -714,11 +727,21 @@ export function AgentRail({
     followingTimeline.current =
       scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <= TIMELINE_BOTTOM_SLACK_PX;
   };
-  useEffect(() => {
+  const pinToNewest = () => {
     const scroller = timelineScroller.current;
     if (scroller === null || !followingTimeline.current) return;
     scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
-  }, [run.timeline.items]);
+  };
+  useEffect(pinToNewest, [run.timeline.items]);
+  useEffect(() => {
+    const scroller = timelineScroller.current;
+    // `ResizeObserver` is absent in some test environments and in no browser this app
+    // supports, so its absence costs the observer and never the rail.
+    if (scroller === null || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(pinToNewest);
+    observer.observe(scroller);
+    return () => observer.disconnect();
+  }, []);
 
   const content = (
     <div className="flex flex-col h-full min-h-0 bg-[#0a0a0a] text-zinc-100">

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -2249,6 +2249,34 @@ describe("AgentRail", () => {
       };
     }
 
+    /*
+      A `ResizeObserver` this environment does not ship, kept only so a test can BE the
+      resize. It records what each instance observes, which is what lets `resizeObserved`
+      fire the callback for one element and nothing else — the rail reads the geometry
+      off the node rather than off the entry, so the entry may be empty.
+    */
+    const observed: { element: Element; notify: () => void }[] = [];
+    class TestResizeObserver {
+      constructor(private readonly callback: () => void) {}
+      observe(element: Element) {
+        observed.push({ element, notify: this.callback });
+      }
+      disconnect() {
+        for (let i = observed.length - 1; i >= 0; i -= 1) {
+          if (observed[i].notify === this.callback) observed.splice(i, 1);
+        }
+      }
+      unobserve() {}
+    }
+    const resizeObserved = (element: Element): void => {
+      for (const entry of observed) if (entry.element === element) entry.notify();
+    };
+
+    beforeEach(() => {
+      observed.length = 0;
+      (globalThis as { ResizeObserver?: unknown }).ResizeObserver = TestResizeObserver;
+    });
+
     /** The container, with a layout happy-dom would otherwise report as zero. */
     function measured(element: HTMLElement): HTMLElement {
       Object.defineProperty(element, "scrollHeight", { value: SCROLL_HEIGHT, configurable: true });
@@ -2321,6 +2349,57 @@ describe("AgentRail", () => {
       await waitFor(() => {
         expect(scroller.scrollTop).toBe(BOTTOM);
       });
+    });
+
+    /*
+      The bottom also moves when nothing arrives (#373 review, found by driving the
+      merged branch).
+
+      A finished analysis run sat at `scrollTop: 245` of a 1090-pixel column, 637 short,
+      with every entry already delivered. The column had not grown — the VIEWPORT had
+      shrunk: showing the run's answer opens the host's result panel and the rail's own
+      height fell from 360 to 208. No entry arrives to say so, so following keyed on the
+      entries alone has nothing to re-run on.
+
+      Driven here the way it happens: the last entry lands, the rail is followed to the
+      bottom, and then the container is re-measured shorter and the observer told, with
+      no further ledger line at all.
+    */
+    test("a viewport that shrinks under the timeline is followed too", async () => {
+      const { stream, scroller } = await startRun();
+      await act(async () => {
+        stream.push(OPENED_LINE);
+      });
+      await waitFor(() => {
+        expect(scroller.scrollTop).toBe(BOTTOM);
+      });
+
+      const SHRUNK = 208;
+      Object.defineProperty(scroller, "clientHeight", { value: SHRUNK, configurable: true });
+      await act(async () => {
+        resizeObserved(scroller);
+      });
+
+      expect(scroller.scrollTop).toBe(SCROLL_HEIGHT - SHRUNK);
+    });
+
+    test("a reader who scrolled away is not pulled back by a resize either", async () => {
+      const { stream, scroller } = await startRun();
+      await act(async () => {
+        stream.push(OPENED_LINE);
+      });
+      await waitFor(() => {
+        expect(scroller.scrollTop).toBe(BOTTOM);
+      });
+
+      scroller.scrollTop = 0;
+      fireEvent.scroll(scroller);
+      Object.defineProperty(scroller, "clientHeight", { value: 208, configurable: true });
+      await act(async () => {
+        resizeObserved(scroller);
+      });
+
+      expect(scroller.scrollTop).toBe(0);
     });
   });
 


### PR DESCRIPTION
Found by driving the merged `data-analysis` workflow in a browser against a live model.

A finished analysis run sat at `scrollTop: 245` of a 1090-pixel column — 637 pixels short of its own report — with every entry already delivered. The column had not grown. The **viewport had shrunk**: showing the run's answer opens the host's result panel, the rail's height falls from 360 pixels to 208, and the bottom moves out from under a position that was correct at the moment it was set.

No ledger entry arrives to announce that, so the effect that follows the newest entry had nothing to re-run on, and none of the four tests that already covered the following could see it — every one of them moves the bottom by appending.

A `ResizeObserver` on the container watches for it instead. The entry effect stays: it is the cheaper path for the common case and it is what those four tests pin. Where `ResizeObserver` is absent, the absence costs the observer and never the rail.

Two tests, driven the way it happens — the last entry lands, the rail is followed to the bottom, and then the container is re-measured shorter with no further ledger line at all. The second one pins the rule that matters more than the fix: a reader who scrolled up to read an earlier step is not pulled back by a resize either.

Worth recording that the case which failed is exactly the one the following was built for. The original measurement was taken on a plan run, which composes no report and shows no answer — so it never resizes, and it never revealed this.

Gates: format, lint (0 errors), typecheck, knip, `tests/run-core.sh` (285 files), `test:components` (28 groups), `test:coverage` + `coverage:check` at 100% (35003/35003 lines).