### PR TITLE
fix(agent): tell the model that a request for a chart is an instruction

### DIFF
--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -487,6 +487,7 @@ export const AGENT_ANSWER_CONTRACT = [
   "Every column a chart names must be a column of THAT result, spelled as the result spells it, and every y column must hold numbers.",
   "A chart needs at least two rows; a pie takes exactly one y; a scatter needs a numeric x as well.",
   "Present a table when the result is a single number, has one row, or has no numeric column: that is a complete answer, not a lesser one.",
+  "When the objective asks for a chart and the result can carry one, chart it: the user named the shape of the answer they wanted.",
 ].join(" ");
 
 const recommendationSchema = z.strictObject({

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -2688,6 +2688,29 @@ describe("present_answer records which result IS the answer, and how to show it"
     expect(AGENT_TOOL_DEFINITIONS.present_answer.description).toContain(AGENT_ANSWER_CONTRACT);
   });
 
+  /*
+    Driven live on 2026-08-15, twice, on both engines: "Show me the average salary by
+    department as a chart" and "Draw a bar chart of rental volume per month" were both
+    answered with a TABLE. The data carried a category and a number in each case, so
+    nothing refused the chart — the model simply chose the other one.
+
+    Reading the contract explains why. It defends the table ("that is a complete
+    answer, not a lesser one"), which is deliberate and stays: a single number charted
+    is worse than a single number. But it never said when a chart IS right, and it
+    never mentioned the objective. A model reading the list found a permission and no
+    pull the other way.
+
+    So the asymmetry is the defect, and the fix is one sentence rather than a rule
+    engine: the model decides, and now it decides knowing what was asked. #350's
+    lesson — a behaviour nobody states is a behaviour live runs do not have.
+  */
+  test("the contract says when a chart is right, not only when a table is", () => {
+    expect(AGENT_ANSWER_CONTRACT).toContain("asks for a chart");
+    // The table's defence stays: it is what stops a single number being charted to
+    // look like more than it is.
+    expect(AGENT_ANSWER_CONTRACT).toContain("complete answer, not a lesser one");
+  });
+
   test("the description shows both presentations, and its own schema accepts them", () => {
     // The `AGENT_EVIDENCE_CONTRACT` pattern: the example and the parser come from one
     // piece of code, so a description offering a shape the schema refuses fails here


### PR DESCRIPTION
Found by driving the merged agent against **PostgreSQL** (the dvdrental sample, 16k rentals) and re-checking it on SQLite. Two runs, two engines, same miss: `Show me the average salary by department as a chart` and `Draw a bar chart of rental volume per month` were both answered with a **table**.

Nothing refused the chart. Both results carried a category column and a numeric one, so the validation never fired — the model simply chose the other shape.

The contract explains why, and the shape of the defect is worth stating: it is **asymmetric**. It defends the table, deliberately and correctly —

> Present a table when the result is a single number, has one row, or has no numeric column: that is a complete answer, not a lesser one.

— which is what stops a single number being charted to look like more than it is, and it stays. But it never said when a chart *is* right, and it never mentioned the objective at all. A model reading the list finds a permission to present a table and nothing pulling the other way.

So the fix is one sentence, not a rule about shapes. The model still decides; it now decides knowing what was asked.

Re-driven after the change, against the same database with the same question: `Shown as a bar chart, from 5 row(s)`, five bars rendered. The only thing that changed was the sentence.

This is #350's lesson in a new place — a behaviour nobody states is a behaviour live runs do not have — which is why the test asserts the contract carries both halves rather than asserting the new clause alone: an asymmetry restored is the thing that would regress.

Gates: format, lint (0 errors), typecheck, knip, `tests/run-core.sh` (285 files), `bun run build`, `test:coverage` + `coverage:check` at 100% (35004/35004 lines).