### PR TITLE
feat(agent): let a plan run reason about the database it was opened on

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -148,7 +148,9 @@ The mode is HOW a run executes:
 - **`planning`** — the model reasons about the objective and produces a plan. Its tool set is
   **empty**, so a planning run performs zero database operations. This is decided on the server from
   the run's persisted mode; a client-supplied tool list has no way in, because there is no parameter
-  for one.
+  for one. A planning run may still be told what this database CONTAINS — see
+  [What a plan run knows](#what-a-plan-run-knows) — and that changes nothing about the sentence
+  above: the inventory it is shown was read by an earlier agent run, never by it.
 - **`agent`** — the model receives the read-class tools below and investigates.
 
 The mode is fixed when the run is opened. A later request cannot widen a planning run, and the
@@ -239,6 +241,46 @@ is the successful ending — planning is toolless, `compose_report` does not exi
 once the plan is written is the only way a good planning run can end. The rail therefore words that
 one ending per mode (#350); every other ending is a shortfall in either mode, because a planning run
 that ran out of time produced no plan either.
+
+### What a plan run knows
+
+A plan run reaches no database, so everything it knows about your schema, it was told. Until #384 it
+was told nothing, and the plans showed it: asked on 2026-08-15 how it would assess a real six-table
+SQLite database before a release, a live run answered that it could not reach the live environment
+and produced an inspection plan that would have read identically against any database in the world.
+
+The fix does not change what plan mode DOES. It changes what it is given:
+
+- **An agent run reads a connection's catalog once per run**, through `inspect_schema` and the
+  audited execution path, and records the inventory in its own ledger (`context-captured`).
+- **`context-snapshot.ts` also holds that inventory in the server process**, keyed by connection and
+  refused unless it fingerprints as itself — the same check `reusableSnapshot` applies to a ledger
+  entry. Nothing else writes to it, so there is no second path to an engine anywhere in it.
+- **A plan run on that connection is handed it.** It arrives exactly as it arrives in agent mode —
+  the packed inventory and the relations, both fenced as `UNTRUSTED_CONTENT` — with one preface
+  saying what only the server can say: *the inventory below was read from this database by an earlier
+  run on this connection. This run has read nothing and will read nothing.* The rules then tell the
+  model to write the plan against it, to name the real tables rather than tables in general, and that
+  an inventory of what EXISTS carries no row counts, no sizes and no timings, so nothing in it is a
+  measurement.
+- **A plan run that is handed none is told so**, in the same rules: it has not seen this database, it
+  must say so, and it must invent no table names. That is what a plan run gets on a connection no
+  agent run has read in this process — a brand-new connection, or any connection after a restart.
+
+Three consequences worth stating plainly, because each is easy to assume the other way round:
+
+1. **Plan mode still performs zero database operations.** It sends no statement, captures nothing,
+   writes no `context-captured` entry, and acquires no provider. Being handed an inventory costs
+   nothing, which is exactly why this is the only grounding the mode may have.
+2. **The hold is process memory, not durable state**, like the run-scoped artifact store and for the
+   same reason: nothing about a plan run is worth a second durable store keyed outside a run. So a
+   plan drive resumed in a process that has read nothing for its connection is ungrounded and says
+   so, rather than being given an inventory nobody in that process ever read. That a restart plans
+   blind until the next agent run is the honest cost, and it is recorded as `docs/BACKLOG.md` B42
+   rather than left for a reader to discover.
+3. **The schema is never egressed anywhere it was not already going.** The same table and column
+   names an agent run's prompt carries reach the same model, for a connection the same user can open
+   an agent run on.
 
 ## Durability and resume
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -251,11 +251,22 @@ and produced an inspection plan that would have read identically against any dat
 
 The fix does not change what plan mode DOES. It changes what it is given:
 
-- **An agent run reads a connection's catalog once per run**, through `inspect_schema` and the
-  audited execution path, and records the inventory in its own ledger (`context-captured`).
+- **Some agent runs read a connection's catalog once per run**, through `inspect_schema` and the
+  audited execution path, and record the inventory in their own ledger (`context-captured`). Which
+  ones is narrower than "an agent run", and the difference is what decides whether a plan run on that
+  connection can be grounded at all: the capture happens on **PostgreSQL and SQLite** — the only
+  engines `CATALOG_PLANS` can build an inventory for, and the only ones whose provider serves the
+  `agent-read-only` profile at all — and in **every workflow but `operations`**, which skips the
+  capture by design because it reads what the engine reports about itself rather than what its tables
+  contain. Anywhere else the capture answers `CATALOG_READ_REFUSED`, as does a catalog read the
+  database itself refuses. None of those runs leaves an inventory behind.
 - **`context-snapshot.ts` also holds that inventory in the server process**, keyed by connection and
   refused unless it fingerprints as itself — the same check `reusableSnapshot` applies to a ledger
-  entry. Nothing else writes to it, so there is no second path to an engine anywhere in it.
+  entry. Nothing else writes to it, so there is no second path to an engine anywhere in it. It keeps
+  the **newest** reading of a connection, decided by `capturedAtMs` rather than by arrival order, so a
+  run resumed hours later cannot walk the process back to the schema it started with; and it is
+  **bounded to the 16 most recently used connections**, so a connection can fall out of it without any
+  restart once enough others have been read.
 - **A plan run on that connection is handed it.** It arrives exactly as it arrives in agent mode —
   the packed inventory and the relations, both fenced as `UNTRUSTED_CONTENT` — with one preface
   saying what only the server can say: *the inventory below was read from this database by an earlier
@@ -264,8 +275,11 @@ The fix does not change what plan mode DOES. It changes what it is given:
   an inventory of what EXISTS carries no row counts, no sizes and no timings, so nothing in it is a
   measurement.
 - **A plan run that is handed none is told so**, in the same rules: it has not seen this database, it
-  must say so, and it must invent no table names. That is what a plan run gets on a connection no
-  agent run has read in this process — a brand-new connection, or any connection after a restart.
+  must say so, and it must invent no table names. That is what a plan run gets whenever this process
+  holds no inventory for its connection, which is more cases than "nobody has run one": a brand-new
+  connection, any connection after a restart, a connection whose only agent runs were `operations`
+  runs or ran on an engine this cannot inventory, and a connection pushed out of the bound by
+  sixteen others.
 
 Three consequences worth stating plainly, because each is easy to assume the other way round:
 
@@ -275,9 +289,9 @@ Three consequences worth stating plainly, because each is easy to assume the oth
 2. **The hold is process memory, not durable state**, like the run-scoped artifact store and for the
    same reason: nothing about a plan run is worth a second durable store keyed outside a run. So a
    plan drive resumed in a process that has read nothing for its connection is ungrounded and says
-   so, rather than being given an inventory nobody in that process ever read. That a restart plans
-   blind until the next agent run is the honest cost, and it is recorded as `docs/BACKLOG.md` B42
-   rather than left for a reader to discover.
+   so, rather than being given an inventory nobody in that process ever read. That a restart — or a
+   seventeenth connection — plans blind until the next agent run is the honest cost, and it is
+   recorded as `docs/BACKLOG.md` B42 rather than left for a reader to discover.
 3. **The schema is never egressed anywhere it was not already going.** The same table and column
    names an agent run's prompt carries reach the same model, for a connection the same user can open
    an agent run on.

--- a/docs/AGENT_ANALYST_DESIGN.md
+++ b/docs/AGENT_ANALYST_DESIGN.md
@@ -1323,9 +1323,17 @@ is stated rather than left as an omission.
   follows the seams it uses. Where the two meet — both will want a fourth `WORKFLOW_*` record and
   both touch B17/B27's unresolved question of what operation descriptor a non-SQL metadata read
   takes — that is a merge conversation, not a design one.
-- **Giving plan mode database context.** Planning is toolless by contract and performs zero database
-  operations (`investigation.ts:736-738`), and a planning run of an analysis is an ordinary thing to
-  ask for. Whether it should see the schema is a separate decision with its own egress consequences.
+- **~~Giving plan mode database context.~~ Decided and built in #384, and narrower than the heading
+  suggests.** Plan mode still performs zero database operations: it captures nothing, and the
+  question this bullet left open — whether it should READ the schema — was answered *no*, because the
+  reading is the promise. What it may be given instead is an inventory somebody else already read.
+  `context-snapshot.ts` holds each connection's most recent inventory in the process that captured
+  it, agent runs put it there through the audited catalog path, and a plan run on that connection is
+  handed it with no statement sent — fenced as untrusted content and prefaced with whose reading it
+  was. A plan run on a connection this process has read nothing for is told so in its rules and
+  writes a generic plan on purpose. The egress consequence this bullet anticipated is therefore the
+  one the inventory already had: the same table and column names an agent run's prompt carries, sent
+  to the same model, for a connection the same user could open a run on.
 - **Timeline autoscroll.** Real, and a UI decision that has nothing to do with any of the above.
 - **Run history.** A run is observable only from its own ledger; nothing enqueues a drive (B9) and
   nothing lists past runs. Out of scope.

--- a/docs/AGENT_ANALYST_DESIGN.md
+++ b/docs/AGENT_ANALYST_DESIGN.md
@@ -1327,11 +1327,14 @@ is stated rather than left as an omission.
   suggests.** Plan mode still performs zero database operations: it captures nothing, and the
   question this bullet left open — whether it should READ the schema — was answered *no*, because the
   reading is the promise. What it may be given instead is an inventory somebody else already read.
-  `context-snapshot.ts` holds each connection's most recent inventory in the process that captured
-  it, agent runs put it there through the audited catalog path, and a plan run on that connection is
-  handed it with no statement sent — fenced as untrusted content and prefaced with whose reading it
-  was. A plan run on a connection this process has read nothing for is told so in its rules and
-  writes a generic plan on purpose. The egress consequence this bullet anticipated is therefore the
+  `context-snapshot.ts` holds each connection's most recent inventory — newest by `capturedAtMs`, and
+  bounded to sixteen connections — in the process that captured it. What puts one there is narrower
+  than "an agent run": the capture serves PostgreSQL and SQLite only, and every workflow but
+  `operations`, so an Operate run and a run on any other engine leave nothing behind. A plan run on a
+  connection that IS held is handed it with no statement sent, fenced as untrusted content and
+  prefaced with whose reading it was; a plan run on one that is not — never read, read only by the
+  runs above, evicted, or lost to a restart — is told so in its rules and writes a generic plan on
+  purpose. The egress consequence this bullet anticipated is therefore the
   one the inventory already had: the same table and column names an agent run's prompt carries, sent
   to the same model, for a connection the same user could open a run on.
 - **Timeline autoscroll.** Real, and a UI decision that has nothing to do with any of the above.

--- a/docs/AGENT_DATA_FLOW.md
+++ b/docs/AGENT_DATA_FLOW.md
@@ -98,9 +98,14 @@ Gemini deployment behind a proxy is therefore not configurable (`docs/BACKLOG.md
 - **Opening the rail sends nothing.** A shortcut fills the objective box and starts nothing
   (`src/components/agent/use-agent-prefill.ts`); the first model call happens when you press
   **Start**.
-- **A `planning` run reaches no database.** Its tool set is empty, so nothing but your objective and
-  the server's own rules is sent (`selectAgentTools`, and `establishContext` returns early for a
-  non-agent mode at `src/lib/agent/investigation.ts:728-733`).
+- **A `planning` run reaches no database.** Its tool set is empty, so it sends no statement, captures
+  nothing and acquires no provider (`selectAgentTools`, and the planning branch of
+  `establishContext` in `src/lib/agent/investigation.ts`). What it MAY send to the model, besides
+  your objective and the server's own rules, is a schema inventory an **agent** run on the same
+  connection already read and this process still holds (#384): the same packed tables and relations
+  an agent run's prompt carries, fenced identically. Nothing about your DATA is in it — an inventory
+  is names, types, keys and relations, and no row is read to build one — and a plan run on a
+  connection this process has read nothing for sends nothing of the kind and is told it has none.
 
 There is one model call the agent makes before the run itself: the **capability probe**, one round
 trip asking the model to call a trivial tool. Its prompt is a fixed server-written string and

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -119,22 +119,34 @@ A Plan run never sends a statement to your database. That is the whole point of 
 not changed: you can start one against production and nothing reaches it.
 
 What changed is what the run is *told*. A Plan run is shown the schema inventory — tables, columns,
-keys and relations — **if an Agent run has already read it on this connection since the server
-started.** An Agent run reads the catalog once at the top of its run and the server keeps that
-reading; a Plan run is handed it, and is told plainly that it was somebody else's reading. So the
-plan you get names your real tables and the joins between them instead of describing an inspection
-of a database in general.
+keys and relations — **if an Agent run has already read it on this connection.** An Agent run reads
+the catalog once at the top of its run and the server keeps that reading; a Plan run is handed it,
+and is told plainly that it was somebody else's reading. So the plan you get names your real tables
+and the joins between them instead of describing an inspection of a database in general.
 
-A Plan run that has no inventory — a connection nothing has investigated yet, or any connection
-after the server restarts — says so in its answer and writes the plan as the inspection it would
-carry out to find out. It will not name tables it has not been shown. If you want a Plan run
-grounded in your schema, run an Agent run on that connection first; a short one is enough, because
-the catalog reading happens before the model's first turn.
+If you want a Plan run grounded in your schema, run an **Agent** run on that connection first; a
+short one is enough, because the catalog reading happens before the model's first turn. Three things
+decide whether that reading exists, and it is worth knowing them before concluding the feature is
+broken:
+
+- **The engine.** The catalog is read on PostgreSQL and SQLite — the two engines whose Agent runs
+  send statements at all. Nothing is captured on the others, so a Plan run there is never grounded.
+- **The workflow.** Investigate, Optimize, Assess and Analyze read the catalog. **Operate does not** —
+  it asks the engine about itself rather than about its tables — so an Operate run does not ground
+  anything.
+- **How recently.** The server keeps the reading in memory, for the **16 most recently used
+  connections**. A restart clears it, and a connection you have not touched in a while can drop out
+  once sixteen others have been read — with no restart involved. Running an Agent run on it again
+  brings it back.
+
+A Plan run that has no inventory says so in its answer and writes the plan as the inspection it
+would carry out to find out. It will not name tables it has not been shown.
 
 Two things the inventory is not. It is **structure, not measurement**: it says a table exists and
 what its columns are, never how many rows it holds or how large it is, so a plan cannot tell you
-which table is the big one. And it is **a reading from a moment**: it is whatever the last Agent run
-saw, and a schema that changed since is not noticed until the next Agent run reads it.
+which table is the big one. And it is **a reading from a moment**: it is the most recent reading any
+Agent run has taken — a run resumed from an older one does not push the newer reading out — and a
+schema that changed since is not noticed until the next Agent run reads it.
 
 ---
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -74,7 +74,7 @@ You choose three things before pressing Start, and two of them are controls in t
 
 | Button | What it means |
 | --- | --- |
-| **Plan** | The model reasons about your objective and writes an approach. It has **no tools**, so it performs zero database operations. This is what a run opens in. |
+| **Plan** | The model reasons about your objective and writes an approach. It has **no tools**, so it performs zero database operations. This is what a run opens in. It can still plan against your real tables — see [What a Plan run knows about your database](#what-a-plan-run-knows-about-your-database). |
 | **Agent** | The model is given the read-only tools and investigates: it drafts statements, reads results, and finishes by composing a report whose claims cite what it read. |
 
 **2. The workflow — what the run is for** (`AgentRail.tsx:433-448`, labels at `AgentRail.tsx:94-98`):
@@ -112,6 +112,29 @@ investigated. The rail says so rather than offering a Start that must fail:
 > *"… cannot be rebuilt on the server: its settings live in this browser. A run re-resolves its
 > connection there after a restart, so it can only investigate a connection the server holds too."*
 > (`AgentRail.tsx:492-498`)
+
+### What a Plan run knows about your database
+
+A Plan run never sends a statement to your database. That is the whole point of the mode, and it has
+not changed: you can start one against production and nothing reaches it.
+
+What changed is what the run is *told*. A Plan run is shown the schema inventory — tables, columns,
+keys and relations — **if an Agent run has already read it on this connection since the server
+started.** An Agent run reads the catalog once at the top of its run and the server keeps that
+reading; a Plan run is handed it, and is told plainly that it was somebody else's reading. So the
+plan you get names your real tables and the joins between them instead of describing an inspection
+of a database in general.
+
+A Plan run that has no inventory — a connection nothing has investigated yet, or any connection
+after the server restarts — says so in its answer and writes the plan as the inspection it would
+carry out to find out. It will not name tables it has not been shown. If you want a Plan run
+grounded in your schema, run an Agent run on that connection first; a short one is enough, because
+the catalog reading happens before the model's first turn.
+
+Two things the inventory is not. It is **structure, not measurement**: it says a table exists and
+what its columns are, never how many rows it holds or how large it is, so a plan cannot tell you
+which table is the big one. And it is **a reading from a moment**: it is whatever the last Agent run
+saw, and a schema that changed since is not noticed until the next Agent run reads it.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1896,8 +1896,9 @@ A planning run performs zero database operations, so the only schema it can know
 on the same connection already read. `context-snapshot.ts` holds that inventory in the server
 process (#384), which means a restarted server plans blind on every connection until someone drives
 an agent run again — and the same plan run resumed in a fresh process is grounded on one drive and
-not on the next. The run says which case it is in, so nothing it writes is false; what it is not is
-predictable.
+not on the next. The hold is also bounded at 16 connections, so a deployment working across more
+than that loses grounding on the least recently used one with no restart involved. The run says
+which case it is in, so nothing it writes is false; what it is not is predictable.
 
 The two candidate fixes were both rejected in #384 for reasons that still hold: capturing the
 catalog in plan mode would end the mode's promise, and writing the inventory into the plan run's own

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1889,3 +1889,21 @@ experiment.
 
 Done when the documented behaviour and the schema agree, whichever way is chosen, with a test
 covering a config that sets `roles` only in `defaults`.
+
+### B42. A plan run's grounding does not survive a restart, because the inventory is held in memory
+
+A planning run performs zero database operations, so the only schema it can know is one an agent run
+on the same connection already read. `context-snapshot.ts` holds that inventory in the server
+process (#384), which means a restarted server plans blind on every connection until someone drives
+an agent run again — and the same plan run resumed in a fresh process is grounded on one drive and
+not on the next. The run says which case it is in, so nothing it writes is false; what it is not is
+predictable.
+
+The two candidate fixes were both rejected in #384 for reasons that still hold: capturing the
+catalog in plan mode would end the mode's promise, and writing the inventory into the plan run's own
+ledger would need an event kind whose timeline copy says "Schema captured" about a run that captured
+nothing. A durable store keyed by connection is the third, and it needs an eviction answer — one
+entry per schema change, per connection, forever — before it is worth having.
+
+Done when a plan run's grounding is the same before and after a restart, or when the process-held
+hold is documented as the intended ceiling and this entry is deleted.

--- a/src/lib/agent/context-snapshot.ts
+++ b/src/lib/agent/context-snapshot.ts
@@ -377,15 +377,33 @@ const HELD_SNAPSHOT_LIMIT = 16;
 
 const heldSnapshots = new Map<string, AgentContextSnapshot>();
 
-/** Holds one connection's inventory for later reuse. Bounded, most recent kept. */
+/**
+ * Holds one connection's inventory for later reuse. Bounded, newest reading kept.
+ *
+ * Two things happen here and they are deliberately not the same thing, because the
+ * callers differ in age. A fresh CAPTURE is always the newest reading of a
+ * connection there is; a resumed run's LEDGER REUSE carries whatever that run read
+ * when it started, which may be hours older than what another run has since held.
+ *
+ *  - **Which reading is kept is decided by `capturedAtMs`**, so a resumed run cannot
+ *    walk the whole process back to its own older schema and ground every later plan
+ *    run on it. Nothing would observe that regression: both inventories are
+ *    internally valid, and neither is a lie about the database it came from.
+ *  - **Where the connection sits in the bound is decided by USE**, so re-holding it
+ *    moves it to the end of the insertion order whichever reading won. A connection a
+ *    resumed run is actively working on must not age out under sixteen connections
+ *    read once each.
+ *
+ * Found by review on #384, which had one `delete`/`set` doing both jobs at once.
+ */
 export function holdSnapshotForConnection(snapshot: AgentContextSnapshot): void {
   if (fingerprintTables(snapshot.tables) !== snapshot.fingerprint) return;
-  // Deleted before it is set, so re-holding a connection makes it the most recent
-  // rather than leaving it where it first entered: insertion order is the eviction
-  // order below, and a connection under active use must not age out under one that
-  // was read once.
+  const held = heldSnapshots.get(snapshot.connectionId);
+  const newest = held !== undefined && held.capturedAtMs > snapshot.capturedAtMs ? held : snapshot;
+  // Deleted before it is set, so the connection's place in the eviction order below
+  // is refreshed even on the path where the reading it arrived with was the older one.
   heldSnapshots.delete(snapshot.connectionId);
-  heldSnapshots.set(snapshot.connectionId, snapshot);
+  heldSnapshots.set(snapshot.connectionId, newest);
   for (const oldest of heldSnapshots.keys()) {
     if (heldSnapshots.size <= HELD_SNAPSHOT_LIMIT) break;
     heldSnapshots.delete(oldest);

--- a/src/lib/agent/context-snapshot.ts
+++ b/src/lib/agent/context-snapshot.ts
@@ -27,6 +27,12 @@
  * reading time, not of the connection — so two identical builds agree and a changed
  * schema does not.
  *
+ * A captured inventory is also HELD for its connection, in this process, and that is
+ * what a planning run may be handed (#384). Planning stays toolless and reads
+ * nothing; being given an inventory an agent run already read costs no statement, so
+ * the mode's bar is untouched, and a plan run with none is told so rather than left
+ * to write about a database it has not seen. See `holdSnapshotForConnection`.
+ *
  * That is what makes the REFRESH free. A capture is recorded in the run's ledger
  * with the inventory attached, so a later drive — including one that resumed after
  * the process died — calls `reusableSnapshot` and re-derives its whole schema
@@ -330,6 +336,74 @@ export async function captureContextSnapshot(context: AgentToolContext): Promise
       tables,
     },
   };
+}
+
+// ============================================================================
+// What this process has already read
+// ============================================================================
+
+/**
+ * The inventories this PROCESS has already read, one per connection (#384).
+ *
+ * It exists for planning mode, which is toolless and must perform zero database
+ * operations. A plan run may therefore never read a catalog — and a plan run told
+ * nothing about the schema writes the plan it would write about any database in the
+ * world, which is what live runs on 2026-08-15 produced. The only honest way out is
+ * to hand it an inventory somebody ELSE already paid for: this holds the ones an
+ * agent run on the same connection read through the audited catalog path, so a plan
+ * run can be given one without a single statement being sent.
+ *
+ * Three properties are what make that safe rather than merely cheap:
+ *
+ *  - **Nothing here ever reads a database.** Entries arrive only from
+ *    `captureContextSnapshot`, which is agent-mode-only and goes through the T6
+ *    catalog tool; this module adds no second path to an engine.
+ *  - **An entry is refused unless its identity is the one its own inventory
+ *    produces**, exactly as `reusableSnapshot` refuses a ledger entry. A snapshot
+ *    that fingerprints as something else is not held at all, so a reader never has
+ *    to decide whether to trust one.
+ *  - **It is keyed by connection**, which is the same boundary the run loop already
+ *    enforces (`RUN_CONNECTION_MISMATCH`). An inventory cannot travel between
+ *    databases, and everyone who can open a run on a connection can read its catalog
+ *    through that run anyway.
+ *
+ * What it deliberately is NOT: durable. This is process memory, like the run-scoped
+ * artifact store and for the same reason — a restart loses it, and a plan run in a
+ * process that has read nothing is told plainly that it has no inventory rather than
+ * being given a stale one from somewhere. A plan run's grounding is therefore a
+ * property of the deployment's recent history, and the run says which case it is.
+ */
+const HELD_SNAPSHOT_LIMIT = 16;
+
+const heldSnapshots = new Map<string, AgentContextSnapshot>();
+
+/** Holds one connection's inventory for later reuse. Bounded, most recent kept. */
+export function holdSnapshotForConnection(snapshot: AgentContextSnapshot): void {
+  if (fingerprintTables(snapshot.tables) !== snapshot.fingerprint) return;
+  // Deleted before it is set, so re-holding a connection makes it the most recent
+  // rather than leaving it where it first entered: insertion order is the eviction
+  // order below, and a connection under active use must not age out under one that
+  // was read once.
+  heldSnapshots.delete(snapshot.connectionId);
+  heldSnapshots.set(snapshot.connectionId, snapshot);
+  for (const oldest of heldSnapshots.keys()) {
+    if (heldSnapshots.size <= HELD_SNAPSHOT_LIMIT) break;
+    heldSnapshots.delete(oldest);
+  }
+}
+
+/** The inventory this process holds for a connection, or `null` when it holds none. */
+export function heldSnapshotForConnection(connectionId: string): AgentContextSnapshot | null {
+  return heldSnapshots.get(connectionId) ?? null;
+}
+
+/**
+ * Empties the hold. For tests, which must be able to express the cold process —
+ * the one a plan run finds after a restart, and the case a grounded run must not
+ * be mistaken for.
+ */
+export function forgetHeldSnapshots(): void {
+  heldSnapshots.clear();
 }
 
 // ============================================================================

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -45,7 +45,13 @@
 
 import { createHash } from "node:crypto";
 import { type ModelMessage, type ToolSet, streamText, tool } from "ai";
-import { captureContextSnapshot, packContextForTask, reusableSnapshot } from "./context-snapshot";
+import {
+  captureContextSnapshot,
+  heldSnapshotForConnection,
+  holdSnapshotForConnection,
+  packContextForTask,
+  reusableSnapshot,
+} from "./context-snapshot";
 import { erDetailForWorkflow, renderErDiagram } from "./er-diagram";
 import {
   AGENT_MODEL_TURN_TIMEOUT_MS,
@@ -236,6 +242,37 @@ const PLANNING_RULES = [
 ].join(" ");
 
 /**
+ * What a plan run is told when it HAS an inventory, and what it is told when it has
+ * none (#384).
+ *
+ * Both halves are the #350 rule applied twice over. A run handed a schema and not
+ * told to write the plan against it produces the same generic advice it produced
+ * without one — the inventory sits in the window unused — and a run handed nothing
+ * and not told so writes about tables it invented. Live runs on 2026-08-15 are the
+ * first of those: six real tables were on the connection, none of them appeared, and
+ * the plan would have read identically against any database in the world.
+ *
+ * The grounded half says three things and each is load-bearing. It names the
+ * inventory as something an EARLIER run read, because this run read nothing and a
+ * plan that implies otherwise is the false-self-description defect this repository
+ * keeps finding. It asks for the real names, which is the whole point. And it says
+ * what an inventory is not: a list of what EXISTS carries no row counts, no sizes
+ * and no timings, so a plan that concludes which table is the big one from it has
+ * measured nothing.
+ */
+const PLANNING_SCHEMA_RULES = [
+  "A schema inventory for this database is in this conversation, with its relations beside it.",
+  "It was read by an EARLIER run on this connection, never by you: this run sends nothing to any database, so it is a record of what exists — not of how many rows anything holds, how large it is, or how fast it runs.",
+  "Write the plan against it. Name the real tables, columns and relations each step would inspect instead of writing about tables in general, and say what each step would establish about them.",
+  "Name nothing that is not in it, and say plainly where it does not reach — an inventory shows structure, and most of what your objective asks about is established only by the reads you are proposing.",
+].join(" ");
+
+const PLANNING_NO_SCHEMA_RULES = [
+  "No schema inventory is available to this run, so you have not seen this database at all.",
+  "Say that plainly in your plan and invent no table or column names: write it as the inspection that would establish what this database holds, step by step, starting from its catalog.",
+].join(" ");
+
+/**
  * What each workflow is FOR, said to the model (#330 T3).
  *
  * A total record, so a workflow added to the contract stops this file compiling
@@ -354,8 +391,16 @@ const AUTO_EXECUTE_RULE = [
   "So call inspect_plan on the statement that IS the answer before you present it. Without one, the statement is placed in the editor unrun and the run says why.",
 ].join(" ");
 
-function systemPrompt(record: AgentRunRecord): string {
-  const rules = record.mode === "agent" ? `${AGENT_RULES} ${WORKFLOW_TOOL_RULES[record.workflowType]}` : PLANNING_RULES;
+/**
+ * The rules, given what this drive was able to give the run.
+ *
+ * `schemaKnown` bears on planning alone: agent mode already tells the model about a
+ * missing inventory in the capture's own words (`FALLBACK_ADVICE`), and its rules
+ * are about the tools either way.
+ */
+function systemPrompt(record: AgentRunRecord, schemaKnown: boolean): string {
+  const planningRules = `${PLANNING_RULES} ${schemaKnown ? PLANNING_SCHEMA_RULES : PLANNING_NO_SCHEMA_RULES}`;
+  const rules = record.mode === "agent" ? `${AGENT_RULES} ${WORKFLOW_TOOL_RULES[record.workflowType]}` : planningRules;
   // Said only where it can happen, on all THREE counts. A planning run has no tools;
   // a run opened without the setting hands nothing anywhere; and a workflow that is
   // not offered `present_answer` has no way to make the presentation this rule is
@@ -394,6 +439,22 @@ const snapshotHandoverText = (fingerprint: string): string =>
  */
 function packSnapshotMessage(snapshot: AgentContextSnapshot, objective: string): string {
   return packContextForTask(snapshot, objective, { preface: snapshotHandoverText(snapshot.fingerprint) });
+}
+
+/**
+ * The same inventory, prefaced for a run that did not read it.
+ *
+ * A plan run is given no citation form, because it has no `compose_report` to cite
+ * into; what it is given instead is the one sentence that keeps its plan honest —
+ * who read this, and that this run read nothing. The fenced header already carries
+ * when it was read and that it has not been re-read since, so the preface says the
+ * part the header cannot: that the reading was somebody else's.
+ */
+const PLANNING_SNAPSHOT_PREFACE =
+  "The inventory below was read from this database by an earlier run on this connection. This run has read nothing and will read nothing.";
+
+function packPlanningSnapshotMessage(snapshot: AgentContextSnapshot, objective: string): string {
+  return packContextForTask(snapshot, objective, { preface: PLANNING_SNAPSHOT_PREFACE });
 }
 
 /**
@@ -843,7 +904,6 @@ export async function runInvestigation(
     actor: record.actor,
   };
   const tools = declaredTools(record);
-  const instructions = systemPrompt(record);
   const messages: ModelMessage[] = [{ role: "user", content: record.objective }];
   const priorProgress = describePriorProgress(record);
   if (priorProgress !== null) messages.push({ role: "user", content: priorProgress });
@@ -857,6 +917,8 @@ export async function runInvestigation(
   const notAttempted = new Set<string>();
 
   let contextEstablished = false;
+  /** Whether this drive was able to put an inventory in front of the model. */
+  let schemaKnown = false;
 
   /**
    * Gives this drive the run's schema context, once, before the first turn.
@@ -873,12 +935,27 @@ export async function runInvestigation(
    * A run whose catalog cannot be read is told so and continues: the tools are
    * still there, and a narrowed `inspect_schema` is exactly what an overflowing
    * catalog needs.
+   *
+   * PLANNING takes neither path (#384). It stays toolless and still sends nothing:
+   * what it may be given is an inventory some agent run on this same connection
+   * already read, held in this process by `context-snapshot.ts`. Being handed one
+   * costs no statement, so the mode's bar is untouched — a plan run reaches no
+   * database whether or not one is there — and a plan run that is handed none is
+   * told so in its rules rather than left to write about a database it has not seen.
    */
   const establishContext = async (): Promise<void> => {
     contextEstablished = true;
     // Planning is toolless and must perform zero database operations. Not merely
     // skipped for cost: reaching the catalog here would break the mode's own bar.
-    if (record.mode !== "agent") return;
+    // So it is offered only what this process READ ALREADY, and never a read.
+    if (record.mode !== "agent") {
+      const inventory = heldSnapshotForConnection(record.connectionId);
+      if (inventory === null) return;
+      schemaKnown = true;
+      messages.push({ role: "user", content: packPlanningSnapshotMessage(inventory, record.objective) });
+      messages.push({ role: "user", content: packRelations(inventory, record.workflowType) });
+      return;
+    }
 
     // An operations run captures no schema inventory, and this is the one workflow
     // where that is a decision rather than a failure. The capture reads the catalog
@@ -895,6 +972,10 @@ export async function runInvestigation(
 
     const recorded = reusableSnapshot(record.events, record.connectionId);
     if (recorded !== null) {
+      // Held on the reuse path too, not only on the capture: a resumed drive in a
+      // fresh process is exactly where the hold is empty, and this is the reading
+      // that refills it from what the ledger already proved.
+      holdSnapshotForConnection(recorded);
       messages.push({ role: "user", content: packSnapshotMessage(recorded, record.objective) });
       messages.push({ role: "user", content: packRelations(recorded, record.workflowType) });
       return;
@@ -912,6 +993,10 @@ export async function runInvestigation(
       tableCount: snapshot.tables.length,
       snapshot,
     });
+    // After the ledger, never before it: what a plan run may later be handed is an
+    // inventory that is durably part of some run's own history, not one this process
+    // read and failed to write down.
+    holdSnapshotForConnection(snapshot);
     messages.push({ role: "user", content: packSnapshotMessage(snapshot, record.objective) });
     messages.push({ role: "user", content: packRelations(snapshot, record.workflowType) });
   };
@@ -968,7 +1053,10 @@ export async function runInvestigation(
     // Whichever bound is smaller applies, and which one it was decides what the user
     // is told: a call that never returned is not a run that used its time.
     const turnBudgetMs = Math.min(remainingMs, turnTimeoutMs);
-    const turn = await takeTurn(model, instructions, messages, tools, turnBudgetMs);
+    // Built after the context, because in planning mode the rules depend on whether
+    // there WAS one: a run told to plan against an inventory it was not given is the
+    // same defect as a run given one and never told to use it (#350).
+    const turn = await takeTurn(model, systemPrompt(record, schemaKnown), messages, tools, turnBudgetMs);
     text = turn.text;
     if (turn.aborted) return conclude("failed", turnBudgetMs < remainingMs ? "model-timeout" : "deadline-exceeded");
     if (turn.toolCalls.length === 0) return conclude("succeeded", "model-stopped");

--- a/tests/evals/investigation-arc.test.ts
+++ b/tests/evals/investigation-arc.test.ts
@@ -198,6 +198,22 @@ describe("the planning-grounded case can fail on the defect it was written for",
     const generic = await vague.drive([answersProse("I would review schema definitions and available artifacts.")]);
     expect(summarise(planningCase, generic).verdict).toBe("unanswered (plan-names-no-real-table)");
   });
+
+  /*
+    Prose is not an identifier. A model writing "the Engineering table", or quoting
+    the name as SQL uppercases it, has named the table this bar is about — and a
+    judge that missed it would report the defect against a run that did exactly what
+    it was supposed to, which is worse than having no bar.
+  */
+  test("the bar reads a table name the way a sentence writes it, not the way the catalog stores it", async () => {
+    const run = await openCase();
+
+    const drive = await run.drive([
+      answersProse("I would start with the Engineering table, then ENGINEERING's indexes."),
+    ]);
+
+    expect(summarise(planningCase, drive).verdict).toBe("answered");
+  });
 });
 
 describe("the verdict is on the ledger, where a user reads it (B24)", () => {

--- a/tests/evals/investigation-arc.test.ts
+++ b/tests/evals/investigation-arc.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { type EvalEngine, type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
+import { forgetHeldSnapshots } from "@/lib/agent/context-snapshot";
+import { DEPARTMENTS, type EvalEngine, type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
 import { answersProse, callsTool, reportOn } from "../isolated/fixtures/agent-scripted-model";
 import { chatToolCallStream } from "../isolated/fixtures/agent-transport";
+import { CASES, openCaseRun, summarise } from "./real-model";
 
 /**
  * The canonical investigation, on both Phase 1 engines (#330 T1).
@@ -23,6 +25,9 @@ let consoleSpy: ReturnType<typeof spyOn<Console, "log">>;
 beforeEach(() => {
   // The audited execution layer writes one JSON line per operation to stdout.
   consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+  // What a plan run may be handed outlives the run that read it (#384), so each
+  // scenario states its own starting point instead of inheriting the last one's.
+  forgetHeldSnapshots();
 });
 
 afterEach(() => {
@@ -113,6 +118,85 @@ describe("a planning run is judged by what planning mode can produce", () => {
 
     expect(drive.kinds).toEqual(["run-started", "run-finished"]);
     expect(drive.verdict.unmet).toEqual(["no-plan"]);
+  });
+
+  /*
+    The scenario #384 exists for, end to end: an agent run reads this connection's
+    catalog through the audited path, and the plan run that follows is given what it
+    read — every table by name, and not one statement of its own.
+
+    Both runs are opened before either is driven, which is what makes the ORDER the
+    thing under test: the plan run is grounded by the reading, not by having been
+    opened after it.
+  */
+  test("a plan run on a connection this deployment has already read plans against its real tables", async () => {
+    const reader = await open("postgres");
+    const planner = await open("postgres", { mode: "planning" });
+
+    const reading = await reader.drive([answersProse("Nothing to add.")]);
+    const drive = await planner.drive([answersProse("I would start with ", "the employees table.")]);
+
+    expect(reading.statements).toHaveLength(3);
+    // The plan run sent none of its own, and recorded no capture: what it was given,
+    // it was given for free.
+    expect(drive.statements).toEqual([]);
+    expect(drive.kinds).toEqual(["run-started", "closing-statement", "run-finished"]);
+    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-planning.1", unmet: [] });
+
+    const transcript = drive.transcripts[0] ?? "";
+    for (const table of DEPARTMENTS) expect(transcript).toContain(table);
+    expect(transcript).toContain("This run has read nothing and will read nothing.");
+  });
+
+  test("a plan run on a connection nothing has read says so instead of inventing tables", async () => {
+    const run = await open("postgres", { mode: "planning" });
+
+    const drive = await run.drive([answersProse("I would begin with the catalog.")]);
+
+    expect(drive.statements).toEqual([]);
+    expect(drive.transcripts[0] ?? "").toContain("No schema inventory is available to this run");
+    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-planning.1", unmet: [] });
+  });
+});
+
+/*
+  What the real-model eval's `planning-grounded` case can catch, pinned the way
+  `empty-result-detection.test.ts` pins its own case: with the case object the live
+  job uses, and a scripted model where the live one goes.
+
+  The case is the only measurement of whether a REAL model uses an inventory it was
+  handed, so what it can detect must not be established by reading it. Two things
+  are asserted — that opening the case grounds its run at all, and that its bar
+  separates a plan naming a real table from one naming none.
+*/
+describe("the planning-grounded case can fail on the defect it was written for", () => {
+  const planningCase = CASES.find((entry) => entry.name === "planning-grounded");
+  if (!planningCase) throw new Error("no eval case named planning-grounded");
+
+  const openCase = async (): Promise<EvalRun> => {
+    const run = await openCaseRun(planningCase);
+    runs.push(run);
+    return run;
+  };
+
+  test("opening the case grounds its run, without the case sending anything itself", async () => {
+    const run = await openCase();
+
+    const drive = await run.drive([answersProse("I would start with the engineering table.")]);
+
+    // The warm-up read the catalog; the case's own run read nothing.
+    expect(drive.statements).toEqual([]);
+    expect(drive.transcripts[0] ?? "").toContain("This run has read nothing and will read nothing.");
+  });
+
+  test("a plan naming no real table is scored unanswered, and one naming a real table is not", async () => {
+    const naming = await openCase();
+    const named = await naming.drive([answersProse("I would profile ", "the engineering table first.")]);
+    expect(summarise(planningCase, named).verdict).toBe("answered");
+
+    const vague = await openCase();
+    const generic = await vague.drive([answersProse("I would review schema definitions and available artifacts.")]);
+    expect(summarise(planningCase, generic).verdict).toBe("unanswered (plan-names-no-real-table)");
   });
 });
 

--- a/tests/evals/real-model.ts
+++ b/tests/evals/real-model.ts
@@ -290,7 +290,12 @@ const noneUnnamed = async (sql: string) => {
  * naming one real table is the floor, not the ceiling.
  */
 function plannedAgainstNoRealTable(drive: EvalDrive): string | undefined {
-  return DEPARTMENTS.some((table) => drive.text.includes(table)) ? undefined : "plan-names-no-real-table";
+  // Case-folded on both sides: the plan is PROSE, so "the Engineering table" and an
+  // identifier quoted the way SQL uppercases it both name the table this bar is
+  // about. A case-sensitive match would report the defect against a run that did
+  // exactly what it was asked to.
+  const plan = drive.text.toLowerCase();
+  return DEPARTMENTS.some((table) => plan.includes(table.toLowerCase())) ? undefined : "plan-names-no-real-table";
 }
 
 const populationShortfall = (drive: EvalDrive): string | undefined => {

--- a/tests/evals/real-model.ts
+++ b/tests/evals/real-model.ts
@@ -22,14 +22,26 @@
  */
 
 import { createAgentModel } from "@/lib/agent/model-adapter";
-import type { AgentRunWorkflowType } from "@/lib/agent/types";
+import type { AgentRunMode, AgentRunWorkflowType } from "@/lib/agent/types";
 import { LLMRateLimitError } from "@/lib/llm/types";
 import { DEPARTMENTS, type EvalEngine, type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
 import type { EvalDrive } from "../isolated/fixtures/agent-eval-harness";
+import { answersProse } from "../isolated/fixtures/agent-scripted-model";
 
 interface RealModelCase {
   readonly name: string;
   readonly engine: EvalEngine;
+  /** HOW the run executes. Absent means `agent`, as the store's default is. */
+  readonly mode?: AgentRunMode;
+  /**
+   * Whether this connection's inventory must already be read when the run opens.
+   *
+   * For plan cases (#384): planning reads no catalog of its own, so what it knows
+   * about the schema is what an agent run left behind. Setting this reads it once
+   * with a SCRIPTED model, which costs no credential and makes the case measure the
+   * live model instead of which other cases happened to run before it.
+   */
+  readonly grounded?: boolean;
   /** What the run is FOR. Absent means the store's default, an investigation. */
   readonly workflowType?: AgentRunWorkflowType;
   readonly objective: string;
@@ -268,6 +280,19 @@ const noneUnnamed = async (sql: string) => {
  *  - Whether the model UNDERSTOOD what it cited. The bar is about what the claims
  *    rest on, and a run can rest on the right result for the wrong reason.
  */
+/**
+ * The bar a grounded plan is held to: it names at least one table this database has.
+ *
+ * What it cannot see, said rather than implied: whether the plan's STEPS are any
+ * good, whether the tables it names are the ones the objective is about, and whether
+ * it claimed anything it could not know from an inventory — an inventory carries no
+ * row counts, so "the largest table" is a claim no plan run can support. A plan
+ * naming one real table is the floor, not the ceiling.
+ */
+function plannedAgainstNoRealTable(drive: EvalDrive): string | undefined {
+  return DEPARTMENTS.some((table) => drive.text.includes(table)) ? undefined : "plan-names-no-real-table";
+}
+
 const populationShortfall = (drive: EvalDrive): string | undefined => {
   const draftedFor = new Map<string, string>();
   for (const event of drive.events) {
@@ -427,8 +452,33 @@ export const CASES: readonly RealModelCase[] = [
   {
     name: "planning",
     engine: "postgres",
+    mode: "planning",
     objective: "How would you find out why the orders report is slow?",
     expectation: "produces a plan in prose; performs zero database operations",
+  },
+  {
+    /*
+      #384's live half, on the objective that produced the defect.
+
+      Driven in a browser against Gemini on 2026-08-15, a plan run answered "without
+      direct access to the live environment … I cannot execute live queries or run
+      diagnostics directly" and named none of the six tables the connection had. The
+      plan was true about itself and useless about the database.
+
+      A plan run is now handed the inventory an agent run already read, and this is
+      the only thing no scripted model can measure: whether a live one USES it. The
+      bar is deliberately the lowest honest one — at least one real table named —
+      because what the run was told is checkable and what a good plan reads like is
+      not. `grounded` warms the connection with a SCRIPTED drive, so the case
+      measures the model rather than which cases ran before it.
+    */
+    name: "planning-grounded",
+    engine: "postgres",
+    mode: "planning",
+    grounded: true,
+    objective: "How would you assess this database's health before a production release?",
+    expectation: "plans against the tables this database actually has, naming them",
+    judge: plannedAgainstNoRealTable,
   },
   {
     /*
@@ -503,13 +553,31 @@ export function summarise(testCase: RealModelCase, drive: EvalDrive): CaseOutcom
  * happens to look like it today.
  */
 export async function openCaseRun(testCase: RealModelCase): Promise<EvalRun> {
+  if (testCase.grounded === true) await readInventoryOnce(testCase.engine);
   return openEvalRun({
     engine: testCase.engine,
     objective: testCase.objective,
     ...(testCase.workflowType === undefined ? {} : { workflowType: testCase.workflowType }),
-    ...(testCase.name === "planning" ? { mode: "planning" as const } : {}),
+    ...(testCase.mode === undefined ? {} : { mode: testCase.mode }),
     ...(testCase.answer === undefined ? {} : { answer: testCase.answer }),
   });
+}
+
+/**
+ * Reads one engine's catalog through a scripted agent run, and throws it away.
+ *
+ * The reading is the point: `context-snapshot.ts` holds the inventory for the
+ * connection, which is the only way a plan run can know anything about a schema. The
+ * model here is scripted and says one word, so this costs no model credit — the run
+ * captures its context before the first turn either way.
+ */
+async function readInventoryOnce(engine: EvalEngine): Promise<void> {
+  const reader = await openEvalRun({ engine });
+  try {
+    await reader.drive([answersProse("Nothing to add.")]);
+  } finally {
+    reader.dispose();
+  }
 }
 
 async function runCase(testCase: RealModelCase): Promise<CaseOutcome> {

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createLocalWorld } from "@workflow/world-local";
+import { forgetHeldSnapshots } from "@/lib/agent/context-snapshot";
 import { AgentRunDeadline } from "@/lib/agent/deadline";
 import { AGENT_REPORT_RESERVE_TURNS, AGENT_WORKFLOW_BUDGETS } from "@/lib/agent/execution-policy";
 import {
@@ -241,6 +242,10 @@ let consoleSpy: ReturnType<typeof spyOn<Console, "log">>;
 
 beforeEach(() => {
   consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+  // The inventories a process holds outlive a run by design (#384), so every test
+  // here starts from the cold process. Without this a planning test would be
+  // grounded or not depending on which agent test ran before it.
+  forgetHeldSnapshots();
 });
 
 afterEach(() => {
@@ -745,6 +750,211 @@ describe("planning mode performs zero database operations", () => {
     expect(invocationsOf(await eventsOf(b.store, run.runId))).toEqual([]);
     expect(script.turns[1]?.transcript).toContain("run_read_query");
     expect(result.status).toBe("succeeded");
+  });
+
+  /*
+    #384. Plan mode's promise is that it never executes a query against the
+    database, and these do not touch it: what changes is what the run is TOLD.
+
+    The defect that produced this block was measured on 2026-08-15. Asked how it
+    would assess a real six-table database, a plan run answered "without direct
+    access to the live environment … I cannot execute live queries or run
+    diagnostics directly" and named not one table. Nothing was wrong with the
+    sentence — the run genuinely had nothing — and that is the point: a plan that
+    would read identically against any database in the world is not a plan about
+    this one.
+
+    So a plan run is handed the inventory an agent run on the same connection
+    already read (`context-snapshot.ts` holds it), and the two directions are both
+    asserted here: what a grounded plan run is shown and told, and what an
+    ungrounded one is told instead. Neither acquires a provider.
+  */
+  describe("a plan run reasons about THIS database when the process has already read it", () => {
+    /** The system prompt, which is where a planning run's rules are stated. */
+    const rulesOf = (turn: Turn): string => {
+      const messages = (turn.body.messages ?? []) as { role?: string; content?: unknown }[];
+      const system = messages.find((message) => message.role === "system");
+      return typeof system?.content === "string" ? system.content : "";
+    };
+
+    /** A catalog that answers with two related tables, so the inventory has real names. */
+    const catalog = async (sql: string): Promise<QueryResult> => {
+      if (sql.includes("information_schema.columns")) {
+        return queryResult({
+          rows: [
+            {
+              table_schema: "public",
+              table_name: "orders",
+              column_name: "id",
+              data_type: "integer",
+              is_nullable: "NO",
+            },
+            {
+              table_schema: "public",
+              table_name: "orders",
+              column_name: "customer_id",
+              data_type: "integer",
+              is_nullable: "NO",
+            },
+            {
+              table_schema: "public",
+              table_name: "customers",
+              column_name: "id",
+              data_type: "integer",
+              is_nullable: "NO",
+            },
+          ],
+          fields: ["table_schema", "table_name", "column_name", "data_type", "is_nullable"],
+          rowCount: 3,
+        });
+      }
+      if (sql.includes("table_constraints")) {
+        return queryResult({
+          rows: [
+            {
+              table_schema: "public",
+              table_name: "orders",
+              column_name: "customer_id",
+              referenced_schema: "public",
+              referenced_table: "customers",
+              referenced_column: "id",
+            },
+          ],
+          fields: ["table_schema", "table_name", "column_name", "referenced_table", "referenced_column"],
+          rowCount: 1,
+        });
+      }
+      return queryResult({ rows: [], fields: [], rowCount: 0 });
+    };
+
+    /** One agent run, which is what puts this connection's inventory in the process. */
+    const readTheCatalogOnce = async (b: Boot): Promise<void> => {
+      const run = await startRun(b, "agent");
+      const script = scriptedModel(answersProse("understood"));
+      await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+      });
+    };
+
+    test("it is shown the real tables and their relations, fenced, and still sends nothing", async () => {
+      const reader = boot(freshDataDir(), { answer: catalog });
+      await readTheCatalogOnce(reader);
+
+      const b = boot(freshDataDir(), { answer: catalog });
+      const run = await startRun(b, "planning");
+      const script = scriptedModel(answersProse("a plan"));
+
+      const result = await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+      });
+
+      const transcript = script.turns[0]?.transcript ?? "";
+      expect(transcript).toContain("orders");
+      expect(transcript).toContain("customers");
+      // The relations block, so a plan can name a join and not only a table.
+      expect(transcript).toContain("customer_id");
+      // Database-derived text reaches the model fenced here exactly as in agent
+      // mode: table names are writable by whoever can write to the database.
+      expect(transcript).toContain(UNTRUSTED_CONTENT_BEGIN);
+      // And the mode's own bar is untouched: no tool, no provider, no statement.
+      expect(script.turns[0]?.body.tools).toBeUndefined();
+      expect(b.acquireProvider).not.toHaveBeenCalled();
+      expect(b.queryReadOnly).not.toHaveBeenCalled();
+      expect(kindsOf(await eventsOf(b.store, run.runId))).not.toContain("context-captured");
+      expect(result.status).toBe("succeeded");
+    });
+
+    /*
+      The prompt half, which is not optional (#350): a rule the model is not told is
+      a rule live runs fail. An inventory handed over and never mentioned in the
+      rules is a window full of schema and a plan that ignores it.
+    */
+    test("it is told the inventory is somebody else's reading, and what it may not conclude from it", async () => {
+      const reader = boot(freshDataDir(), { answer: catalog });
+      await readTheCatalogOnce(reader);
+
+      const b = boot(freshDataDir(), { answer: catalog });
+      const run = await startRun(b, "planning");
+      const script = scriptedModel(answersProse("a plan"));
+
+      await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+      });
+
+      const rules = rulesOf(script.turns[0] as Turn);
+      expect(rules).toContain("A schema inventory for this database is in this conversation");
+      expect(rules).toContain("read by an EARLIER run on this connection, never by you");
+      expect(rules).toContain("Name the real tables");
+      // What an inventory is NOT: it says what exists, so nothing in it is a
+      // measurement, and a plan that ranks tables by size from it has measured
+      // nothing.
+      expect(rules).toContain("not of how many rows anything holds");
+      // The workflow framing still applies to a plan of one.
+      expect(rules).toContain("You have no tools in this mode");
+      // The preface the inventory arrives under says the same thing in the messages.
+      expect(script.turns[0]?.transcript).toContain("This run has read nothing and will read nothing.");
+    });
+
+    test("a run whose schema is unknown is told so rather than left to invent one", async () => {
+      const b = boot(freshDataDir(), { answer: catalog });
+      const run = await startRun(b, "planning");
+      const script = scriptedModel(answersProse("a plan"));
+
+      await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+      });
+
+      const rules = rulesOf(script.turns[0] as Turn);
+      expect(rules).toContain("No schema inventory is available to this run");
+      expect(rules).toContain("invent no table or column names");
+      expect(rules).not.toContain("A schema inventory for this database is in this conversation");
+      // Nothing was shown to it either — no packed inventory reaches a run that has
+      // none, so there is nothing for it to mistake for one. (The fence markers
+      // themselves are in every run's rules, which is why the header is what this
+      // looks for.)
+      expect(script.turns[0]?.transcript).not.toContain("table(s) read at epoch");
+      expect(b.acquireProvider).not.toHaveBeenCalled();
+    });
+
+    /*
+      An inventory is held for the connection it describes, and a plan run reads the
+      connection its own record names. This is the same boundary the loop already
+      enforces on the resources it is driven with, seen from the other side.
+    */
+    test("an inventory read for another connection does not ground this one", async () => {
+      const reader = boot(freshDataDir(), { answer: catalog });
+      await readTheCatalogOnce(reader);
+
+      const other = boot(freshDataDir(), { answer: catalog });
+      const run = await other.service.start({
+        mode: "planning",
+        actor: ACTOR,
+        connectionId: "conn_2",
+        objective: OBJECTIVE,
+      });
+      const script = scriptedModel(answersProse("a plan"));
+
+      await runInvestigation(run.runId, {
+        service: other.service,
+        model: await modelOver(script.fetch),
+        resources: {
+          ...other.resources,
+          connection: { ...CONNECTION, id: "conn_2" },
+          scope: createTargetScope("conn_2"),
+        },
+      });
+
+      expect(rulesOf(script.turns[0] as Turn)).toContain("No schema inventory is available to this run");
+      expect(script.turns[0]?.transcript).not.toContain("customers");
+    });
   });
 
   test("no workflow may present an answer yet, so an agent run calling it is told there is no such tool", async () => {
@@ -1774,9 +1984,12 @@ describe("the run reads its schema context through the catalog tool", () => {
 
     expect(b.acquireProvider).not.toHaveBeenCalled();
     expect(kindsOf(await eventsOf(b.store, run.runId))).not.toContain("context-captured");
-    // Not merely skipped for cost: a planning run is never even TOLD that a schema
-    // inventory was unavailable, because it was never going to read one.
+    // Not merely skipped for cost. Since #384 a planning run IS told whether an
+    // inventory was available to it — but never in the capture's own words, which
+    // send a model to `inspect_schema`: that is a tool this mode does not have, and
+    // naming it would be the #350 failure exactly.
     expect(script.turns[0]?.transcript).not.toContain("inspect_schema");
+    expect(script.turns[0]?.transcript).toContain("No schema inventory is available to this run");
   });
 
   test("a catalog the run cannot read leaves the run going, and says what to do instead", async () => {

--- a/tests/unit/lib/agent/context-snapshot.test.ts
+++ b/tests/unit/lib/agent/context-snapshot.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   AGENT_CONTEXT_PACK_MAX_CHARS,
   captureContextSnapshot,
+  forgetHeldSnapshots,
+  heldSnapshotForConnection,
+  holdSnapshotForConnection,
   packContextForTask,
   reusableSnapshot,
 } from "@/lib/agent/context-snapshot";
@@ -665,5 +668,81 @@ describe("reusableSnapshot — the refresh that reads nothing", () => {
     const second: AgentContextSnapshot = { ...first, fingerprint: first.fingerprint, capturedAtMs: 9_999 };
 
     expect(reusableSnapshot([captureEvent(first), captureEvent(second)], "conn-1")?.capturedAtMs).toBe(9_999);
+  });
+});
+
+/**
+ * What one PROCESS holds, which is what a plan run may be handed (#384).
+ *
+ * A planning run is toolless and reads nothing, so the only inventory it can be
+ * given is one somebody else already read. These assert the two properties that
+ * make handing it over safe: an inventory never travels between connections, and an
+ * entry whose identity is not the one its own inventory produces is never held at
+ * all — the same bar `reusableSnapshot` applies to a ledger entry.
+ */
+describe("the inventories a process holds", () => {
+  beforeEach(() => {
+    forgetHeldSnapshots();
+  });
+
+  test("what was held for a connection is what comes back", async () => {
+    const snapshot = await captured("postgres");
+    holdSnapshotForConnection(snapshot);
+
+    expect(heldSnapshotForConnection("conn-1")).toEqual(snapshot);
+  });
+
+  test("a process that has read nothing for a connection holds nothing", async () => {
+    const snapshot = await captured("postgres");
+    holdSnapshotForConnection(snapshot);
+
+    // Not "no inventory anywhere": one is held, for another database entirely, and
+    // that is exactly the answer a run on this connection must not be given.
+    expect(heldSnapshotForConnection("conn-other")).toBeNull();
+  });
+
+  test("an inventory that does not fingerprint as itself is not held", async () => {
+    const snapshot = await captured("postgres");
+    const tampered: AgentContextSnapshot = {
+      ...snapshot,
+      tables: snapshot.tables.map((table) => ({ ...table, columns: [] })),
+    };
+
+    holdSnapshotForConnection(tampered);
+
+    expect(heldSnapshotForConnection("conn-1")).toBeNull();
+  });
+
+  test("the newest reading of a connection replaces the one before it", async () => {
+    const snapshot = await captured("postgres");
+    holdSnapshotForConnection(snapshot);
+    holdSnapshotForConnection({ ...snapshot, capturedAtMs: 9_999 });
+
+    expect(heldSnapshotForConnection("conn-1")?.capturedAtMs).toBe(9_999);
+  });
+
+  /**
+   * Bounded, because these are whole inventories and a long-lived server touches
+   * many connections. The eviction is by least-recently-held, which is why holding a
+   * connection again moves it to the end rather than leaving it where it entered.
+   */
+  test("holding many connections evicts the least recently held, not the newest", async () => {
+    const snapshot = await captured("postgres");
+    for (let index = 0; index < 17; index += 1) {
+      holdSnapshotForConnection({ ...snapshot, connectionId: `conn-${index}` });
+      // Re-held on every pass, so it stays the most recent and outlives 16 others.
+      holdSnapshotForConnection({ ...snapshot, connectionId: "conn-kept" });
+    }
+
+    expect(heldSnapshotForConnection("conn-0")).toBeNull();
+    expect(heldSnapshotForConnection("conn-16")).not.toBeNull();
+    expect(heldSnapshotForConnection("conn-kept")).not.toBeNull();
+  });
+
+  test("forgetting empties the hold, which is what a restart does to it", async () => {
+    holdSnapshotForConnection(await captured("postgres"));
+    forgetHeldSnapshots();
+
+    expect(heldSnapshotForConnection("conn-1")).toBeNull();
   });
 });

--- a/tests/unit/lib/agent/context-snapshot.test.ts
+++ b/tests/unit/lib/agent/context-snapshot.test.ts
@@ -722,6 +722,42 @@ describe("the inventories a process holds", () => {
   });
 
   /**
+   * The hold is fed by two callers with different ages: a fresh CAPTURE, which is
+   * always the newest reading there is, and a resumed run's LEDGER REUSE, which
+   * carries whatever that run read when it started. A run resumed hours later would
+   * otherwise walk the whole process back to its own older schema, and every plan
+   * run on that connection would be grounded on it — a regression nothing observes,
+   * because both inventories are internally valid and neither is a lie.
+   */
+  test("an older reading never replaces a newer one", async () => {
+    const snapshot = await captured("postgres");
+    holdSnapshotForConnection({ ...snapshot, capturedAtMs: 9_999 });
+    holdSnapshotForConnection({ ...snapshot, capturedAtMs: 1 });
+
+    expect(heldSnapshotForConnection("conn-1")?.capturedAtMs).toBe(9_999);
+  });
+
+  /**
+   * Recency and AGE are two different things, and the fix for one must not undo the
+   * other: the reading kept is the newest, while the connection's place in the bound
+   * is refreshed by being USED. A resumed run holding its own older inventory is a
+   * connection in active use, so it must not age out under sixteen connections read
+   * once each.
+   */
+  test("re-holding an older reading still refreshes the connection's place in the bound", async () => {
+    const snapshot = await captured("postgres");
+    holdSnapshotForConnection({ ...snapshot, capturedAtMs: 9_999 });
+
+    for (let index = 0; index < 17; index += 1) {
+      holdSnapshotForConnection({ ...snapshot, connectionId: `conn-${index}` });
+      holdSnapshotForConnection({ ...snapshot, capturedAtMs: 1 });
+    }
+
+    expect(heldSnapshotForConnection("conn-1")?.capturedAtMs).toBe(9_999);
+    expect(heldSnapshotForConnection("conn-0")).toBeNull();
+  });
+
+  /**
    * Bounded, because these are whole inventories and a long-lived server touches
    * many connections. The eviction is by least-recently-held, which is why holding a
    * connection again moves it to the end rather than leaving it where it entered.


### PR DESCRIPTION
Driven in a browser against a live model on 2026-08-15, a plan run asked how it would
assess a real six-table SQLite database before a production release answered that it
could not reach the live environment and produced an inspection plan that named not one
of those tables. The sentence was true about the run and useless about the database: the
plan would have read identically against any database in the world. The cause was one
line — `establishContext` returned immediately for a non-agent mode — so a planning run
was handed its objective and nothing else.

## What a plan run knows now, and where that comes from

An agent run reads its connection's catalog once, before its first model turn, through
`inspect_schema` and the audited execution path, and records the inventory in its own
ledger. `context-snapshot.ts` now also **holds that inventory in the server process**,
keyed by connection and refused unless it fingerprints as itself — the same verification
`reusableSnapshot` applies to a ledger entry, and the same connection boundary the run
loop already enforces with `RUN_CONNECTION_MISMATCH`. A plan run opened on that
connection is handed it.

It arrives exactly the way it arrives in agent mode: the packed inventory and the
relations, both through `packContextForTask` / `fenceUntrustedContent` with their
`UNTRUSTED_CONTENT` markers, because table and column names are database-derived text
whether or not a tool read them in this run. There is no second path. The one difference
is the preface, which says what only the server can say — *the inventory below was read
from this database by an earlier run on this connection. This run has read nothing and
will read nothing.*

The prompt half is not left implicit. `PLANNING_RULES` gains a grounded clause telling
the model that the inventory is somebody else's reading, that it should name the real
tables, columns and relations its steps would inspect rather than write about tables in
general, and that an inventory is a record of what exists and therefore carries no row
counts, no sizes and no timings — so a plan cannot conclude which table is the big one
from it. `WORKFLOW_OBJECTIVES` is unchanged and still applies in both modes, so a plan of
a query optimization is still about access paths.

## Where the schema does not come from, and why

Three sources were evaluated in the code before choosing.

The run's **own ledger** is free and perfectly safe, and it is empty for every plan run
that has ever existed: nothing in plan mode writes a `context-captured` entry, so
consulting it there would be a branch no run can take.

The **schema explorer's** inventory turned out to be browser state and nothing else —
`use-connection-manager.ts` holds it in React `useState` and re-fetches `/api/db/schema/list`
and `/api/db/schema/relations` on every mount, and there is no server-side cache anywhere
between the route and the provider. The only server-persisted schema-shaped collection,
`schema_snapshots`, is written solely by the Schema Diff tool when a user presses "Take
Snapshot". Neither can reach a run that persists a connection id and no browser.

**Capturing the catalog in plan mode** was rejected, and this is the decision worth
disagreeing with if you want to. Two or three catalog statements are still statements,
and plan mode's promise — never executes a query against the database, comfortable to
point at production — is the reason the mode exists. Trading it for a better first plan
is a product call, not a refactor, so this change does not make it.

## Plan mode still performs zero database operations

Nothing about what a plan run may DO changed. `selectAgentTools` still returns the empty
set, the capability gate still admits planning unconditionally, and a plan run acquires no
provider, sends no statement, captures nothing and writes no `context-captured` entry —
all four asserted. So every existing statement of the promise in `README.md`,
`docs/FEATURES.md`, `docs/AGENT.md`, `docs/AGENT_GUIDE.md` and the rail's own copy is
still true and is left as it stands. The one sentence that stopped being true was in
`docs/AGENT_DATA_FLOW.md` — "nothing but your objective and the server's own rules is
sent" — and it now says what may also be sent, and that an inventory is names, types,
keys and relations with no row read to build it.

`docs/AGENT.md` gains **What a plan run knows**, `docs/AGENT_GUIDE.md` gains a user-facing
section saying that a Plan run is grounded when an Agent run has already read that
connection and that running a short Agent run first is how you get one, and
`docs/AGENT_ANALYST_DESIGN.md` §5's "deliberately not in this design" bullet now records
what was decided and built instead of recording the gap.

## What a run without a schema does

It is told, in its own rules, that no inventory is available and that it has not seen this
database at all; that it must say so plainly; and that it must invent no table or column
names but write the plan as the inspection that would establish what the database holds.
Nothing is shown to it that it could mistake for an inventory. That is what a plan run
gets on a connection no agent run has read in this process — a new connection, or any
connection after a restart, because the hold is process memory like the run-scoped
artifact store. A plan run's grounding is therefore a property of the deployment's recent
history, the run always says which case it is in, and the honest cost is recorded as
`docs/BACKLOG.md` B42 rather than left for a reader to find.

## Tests

Both directions of the new branch are covered in `tests/isolated/agent-investigation.test.ts`:
what a grounded plan run is shown and told, what an ungrounded one is told instead, that an
inventory read for another connection does not ground this one, and that neither acquires a
provider. `tests/unit/lib/agent/context-snapshot.test.ts` covers the hold itself — the
fingerprint refusal, the connection boundary, the bound and its eviction order. The harness
does support a planning drive, so `tests/evals/investigation-arc.test.ts` gains the scenario
end to end: an agent run reads the catalog, the plan run that follows names every table and
sends nothing. Every test that must observe the cold process clears the hold in `beforeEach`,
so a plan assertion cannot pass because of which test ran before it.

The live eval gains a `planning-grounded` case on the objective that produced the defect,
with the lowest honest bar — at least one real table named — and a scripted warm-up so it
measures the model rather than case ordering. What that case can catch is pinned with a
scripted model, the way `empty-result-detection.test.ts` pins its own.

## Out of scope

The auto-execute gate, the verdict rules, the budgets, the chart path, run history and the
timeline are untouched. The rail is untouched: its copy still describes the mode accurately.
Agent mode's own context path is unchanged — it still captures its own inventory and cites
it — and the hold is written by it, never read by it.

All gates pass locally: `format`, `lint`, `typecheck`, `knip`, `bash tests/run-core.sh`,
`test:components`, `build`, and `test:coverage` + `coverage:check`.
