### PR TITLE
docs(agent): a demo script of twenty-four cases that were actually driven

### DIFF
--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -8,6 +8,40 @@ Nothing in this file is aspirational.
 The refusals are not filler. Half of what makes an agent worth putting near a production database is
 what it declines to do, and a demo that only shows the happy path sells the wrong product.
 
+## What works on which engine
+
+Driven live on 2026-08-15, one engine at a time, against real servers. **Verified** means a run of
+that kind was started on that engine and its outcome read off the screen — nothing in this table is
+inferred from the code.
+
+| Engine | Plan mode | Operate | Investigate · Analyze · Optimize · Assess |
+| --- | --- | --- | --- |
+| **PostgreSQL** 18 | Verified, grounded | Verified | Verified |
+| **SQLite** | Verified, grounded | Verified | Verified |
+| **Redis** 7 | Verified | Verified | Refused |
+| **MongoDB** 8 | Verified | Verified | Refused, verified |
+| **SQL Server** 2022 | Verified | Verified | Refused |
+| **ClickHouse** 26 | Verified | Verified | Refused |
+| **LibreDB** (embedded) | Verified | Not established | Refused, verified |
+| MySQL · Oracle · Couchbase · Druid | Expected to work | Expected to work | Refused |
+
+**Read the table this way.** Plan mode has no engine limit — it sends no statements at all — but it
+is only *grounded* (case 18) on PostgreSQL and SQLite, because only those two capture a schema
+inventory. Operate reads what the engine reports about itself, so it needs no SQL and reaches
+everything. The other four workflows write SQL and need a database-native read-only statement path,
+which today only PostgreSQL and SQLite provide; everywhere else the run ends with *"The agent cannot
+run on this database engine: it offers no read-only execution profile."*
+
+The last row is honest rather than modest: those four implement the same provider interface the six
+above do, so the same rules should apply — but nobody has started a run on them, so they are not
+claimed. "Refused" for their four SQL workflows is not a guess: it follows from the same
+`queryReadOnly` requirement that refused MongoDB, and that one was watched.
+
+**LibreDB's own embedded sample** is the one gap. Its four SQL workflows refuse like the others
+(watched), but an Operate run against it could not be completed here: the sample file was held under
+an exclusive lock by another process, so the run failed on the connection rather than on anything the
+agent did. Worth knowing before you demo against it.
+
 ## Before you demo
 
 **Databases used here.** PostgreSQL 18 with the [Pagila / dvdrental sample](https://neon.com/postgresql/getting-started/sample-database)
@@ -280,10 +314,9 @@ in that result or it is refused. An answer must be a result of a query the run a
 or a profile cannot be presented as one. The verdict at the end of a run is computed from the run's
 ledger, not from the model's opinion of its own work.
 
-**"Which databases?"** Analyze, Optimize, Assess and Investigate need a database-native read-only
-path, which today means **PostgreSQL and SQLite**. Operate reads the engine's own statistics instead
-and works on every provider — driven live against Redis, which has no SQL at all (case 12b). Plan
-mode has no limit at all.
+**"Which databases?"** See the table at the top. The short version: Operate works everywhere and was
+driven live on six engines including Redis, which has no SQL at all; the four SQL workflows need
+PostgreSQL or SQLite today; plan mode has no engine limit and is grounded on those same two.
 
 **"What does it cost per question?"** Each workflow has a frozen ceiling on model turns, statements,
 wall clock and database time, and the rail shows the meter live. The figures are the starting point
@@ -291,14 +324,28 @@ for a measurement that has not been taken yet — treat them as bounds, not as a
 
 ---
 
-## Cases that are not ready to demo
+## Not yet — and what each one is waiting on
 
-Say these plainly if asked; do not build a demo around them.
+Say these plainly if asked. Everything here is recorded in `docs/BACKLOG.md` with the design that
+would close it, so "not yet" means deferred with a reason, not overlooked.
 
-- **Follow-up questions.** Each run starts fresh. Asking "and how many of those?" after another
-  question gets a confident answer to a different question, because nothing carries the referent.
-  (`docs/BACKLOG.md` B36.)
-- **A plan on a cold server.** Case 18 grounds a plan from an inventory an agent run left behind, so
-  a freshly restarted server plans generically until something has read that connection. The run says
-  so; do not build the demo on it. (`docs/BACKLOG.md` B42.)
-- **Causal questions** — "why are sales down?" — need business context the schema does not carry.
+| Not yet | What happens today | Waiting on |
+| --- | --- | --- |
+| **Follow-up questions** | Each run starts fresh, and neither the surface nor the model says so — ask "and how many of those?" and you get a confident answer to a different question | B36 — either carrying the previous run's objective and report into the next as fenced context, or run history |
+| **A plan on a cold server** | The inventory lives in the server process, so after a restart a plan run is ungrounded and says so | B42 — a durable inventory, which needs a timeline that does not claim a plan run captured a schema |
+| **Causal questions** — "why are sales down?" | Answered from the schema alone, which cannot know which decomposition of a metric is the business one | A per-connection business note, held server-side; sketched in `docs/AGENT_ANALYST_DESIGN.md` §5 |
+| **"This database cannot answer that"** | It does say so, but has to run a throwaway query to be scored as having answered — the run above spent 36 steps to report that an employees database holds no customer data | B39 — a second arm on the verdict, so a schema-only conclusion counts |
+| **Agent mode on MySQL, Oracle, MongoDB, Redis…** | Only Operate. The other four workflows refuse, correctly and clearly | A database-native read-only statement path per engine — the same `queryReadOnly` PostgreSQL and SQLite implement |
+| **A run you can watch from your own stack** | Everything is in the run's ledger and on the rail; nothing is exported | B33 — OpenTelemetry spans, designed in #332 and deliberately not built while the event model is still moving |
+| **Resuming a run after a restart** | A drive that dies leaves a durable ledger, but nothing picks it up | B9 — a queue and a re-attach path for the stream |
+| **A budget you can trust to the minute** | The ceilings are real and enforced; the *numbers* are a starting point nobody has measured | One instrumented long run per workflow |
+| **Connections you created in the UI** | Agent mode is offered only on seed connections, because a run has to be rebuildable server-side | A server-held credential for user connections — not designed |
+
+Two smaller ones worth knowing before they surprise you on stage:
+
+- **A refused PostgreSQL role reads as a refused engine.** Point the agent at a superuser and the
+  message says the engine offers no read-only profile. The engine does; the role is too broad, and
+  only the server log says so (case 22).
+- **A connection error can arrive as "the reason is in the server log".** An Operate run against a
+  locked LibreDB file failed with a perfectly actionable message — *"already open by another process
+  (exclusive lock)"* — that the rail did not show.

--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -206,16 +206,32 @@ This is the case to dwell on. A demo that only shows case 16 is showing a party 
 
 ## Act 6 — "it is safe to point at production" (4 minutes)
 
-### 18. Plan mode: it never touches the database
-Switch to **Plan** and ask anything: `How would you assess this database before a production release?`
+### 18. Plan mode: it knows your schema and still never touches the database
+Switch to **Plan** and ask: `How would you assess this database before a production release?`
 
-A structured plan comes back — phases, what to inspect, what each step would establish — rendered as
-headings and bullets. Zero statements were sent. This is the mode to hand someone who wants the
-reasoning without the risk.
+A structured plan comes back — phases, what to inspect, what each step would establish, and what it
+does *not* reach — rendered as headings and bullets. Point at the meter while it is on screen:
+**`Statements 0 / 30`, `Database time 0.0 s`.** Nothing was sent.
 
-*Known limitation, and say it rather than let someone find it:* a plan run reasons from the objective
-alone, so today it gives a sound general method rather than a plan naming your tables. The written
-plan is honest about what it did not inspect.
+Then look at what the plan names. Against dvdrental it works through `public.staff`, `public.rental`,
+`public.payment`, `public.inventory`, `public.film_actor`, the reporting views — and in one run it
+singled out `public.staff` for a credentials check, naming the `username`, `password` and `email`
+columns. It has never seen a row.
+
+**The trick, and it is worth explaining because it is the whole safety argument:** the run is handed
+a schema inventory an *earlier agent run* on the same connection already read. Reading it costs
+nothing and touches nothing, so plan mode keeps its promise exactly — still toolless, still zero
+statements — while reasoning about your database rather than about databases in general.
+
+**Demo it in this order or the point is lost.** On a freshly started server, ask the plan question
+first: the model says plainly that it has not seen this database and gives a general method. Then run
+any Agent-mode question against that connection. Then ask the plan question again. Same question,
+same model, and now it names your tables. That contrast is the case.
+
+*Bounds, worth stating before someone finds them:* the inventory is held in the server process, for
+the last sixteen connections used, and only PostgreSQL and SQLite runs outside the Operate workflow
+capture one. After a restart, or on a connection no agent run has touched, a plan run says so rather
+than inventing tables.
 
 ### 19. Both axes are independent
 **Plan · Optimize ·** `What would you check first if this database were slow in production?`
@@ -282,5 +298,7 @@ Say these plainly if asked; do not build a demo around them.
 - **Follow-up questions.** Each run starts fresh. Asking "and how many of those?" after another
   question gets a confident answer to a different question, because nothing carries the referent.
   (`docs/BACKLOG.md` B36.)
-- **A plan that names your tables.** See case 18.
+- **A plan on a cold server.** Case 18 grounds a plan from an inventory an agent run left behind, so
+  a freshly restarted server plans generically until something has read that connection. The run says
+  so; do not build the demo on it. (`docs/BACKLOG.md` B42.)
 - **Causal questions** — "why are sales down?" — need business context the schema does not carry.

--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -1,6 +1,6 @@
 # Agent demo script
 
-Twenty-three cases, ordered easy to hard, for showing LibreDB Studio's agent to someone who has
+Twenty-four cases, ordered easy to hard, for showing LibreDB Studio's agent to someone who has
 not seen it. Every case here was **driven live** against a real model and a real database before it
 was written down, and each one records what actually came back — including the ones that refuse.
 Nothing in this file is aspirational.
@@ -241,11 +241,16 @@ This is the case to dwell on. A demo that only shows case 16 is showing a party 
 ## Act 6 — "it is safe to point at production" (4 minutes)
 
 ### 18. Plan mode: it knows your schema and still never touches the database
-Switch to **Plan** and ask: `How would you assess this database before a production release?`
+Switch to **Plan**, select **Investigate**, and ask: `How would you assess this database before a production release?`
 
 A structured plan comes back — phases, what to inspect, what each step would establish, and what it
 does *not* reach — rendered as headings and bullets. Point at the meter while it is on screen:
 **`Statements 0 / 30`, `Database time 0.0 s`.** Nothing was sent.
+
+Select the workflow deliberately here rather than leaving whatever the last case selected: the
+statement ceiling is per workflow, so the same untouched meter reads `0 / 30` under Investigate,
+`0 / 42` under Analyze and `0 / 45` under Assess. The zero is the point; the denominator is whichever
+workflow is selected.
 
 Then look at what the plan names. Against dvdrental it works through `public.staff`, `public.rental`,
 `public.payment`, `public.inventory`, `public.film_actor`, the reporting views — and in one run it
@@ -294,19 +299,27 @@ role rather than trusting the transaction. *(The message a user sees today names
 than the role; the server log carries the exact reason. Recorded in `docs/BACKLOG.md`.)*
 
 ### 23. Every claim is checkable
-Open any report and look at a claim. Each one cites an artifact this run actually read, with its
-correlation id and row count, and the statement behind it. A claim citing evidence the run never
-produced is refused when the report is composed — the model cannot assert something and leave you to
-trust it.
+Open any report and look at a claim. Each one cites something **this run** produced, and the citation
+is shown rather than described: a result it read, with the correlation id, the row count and the
+statement behind it — or the schema inventory it captured, named by its `ctx_…` fingerprint, for a
+claim that rests on structure rather than on rows (case 1 is full of those).
+
+A claim citing evidence the run never produced is refused when the report is composed. The model
+cannot assert something and leave you to trust it.
 
 ---
 
 ## What to say when someone asks the hard question
 
-**"Can it damage my database?"** Writes and DDL are refused by the engine, not by parsing the SQL.
-The run's own path is a database-enforced read-only session with a statement timeout, a row cap and a
-byte cap, and it refuses rather than truncating. The editor replay in cases 15-17 uses the same
-read-only session; what it gives up is the timeout, and the checkbox says so.
+**"Can it damage my database?"** Writes and DDL are refused twice over, and the second refusal is the
+one that matters. Before a provider is even acquired, the statement is inspected and anything that is
+not a single read is rejected. Then the read runs inside a **database-enforced** read-only session
+with a statement timeout, a row cap and a byte cap, refusing rather than truncating.
+
+Lead with the second one when you answer. A parser can be fooled — a `SELECT` may call a function
+that writes, and no amount of reading the text reveals that — which is exactly why the boundary is
+the engine's own read-only transaction rather than the guard in front of it. The editor replay in
+cases 15-17 runs in that same session; what it gives up is the timeout, and the checkbox says so.
 
 **"What if the model hallucinates?"** It can, and the product is built on the assumption that it
 will. A claim must cite something the run read or it is refused. A chart must name columns that exist

--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -135,6 +135,19 @@ reading claimed `slowQueryCount: 2` while the log itself returned zero rows, and
 discrepancy** instead of picking whichever number made a better answer. If it happens during your
 demo, stop and read it out.
 
+### 12b. The same question, against Redis
+**Agent · Operate ·** on a Redis connection: `How is this Redis instance doing? Memory, clients, and what keys are stored.`
+
+Answers: memory used (2.30M, and what share of the limit that is), connected clients, whether anything
+is blocked, and which commands those clients are running. Verified against `redis-cli INFO` — the
+figures match.
+
+**This is the case to show a sceptic.** Redis has no SQL at all, and agent mode's other workflows
+cannot reach it: they need a database-native read-only statement path, which only PostgreSQL and
+SQLite provide. Operate does not write SQL — it reads what the engine already reports about itself —
+so it answers the same operational questions on every provider Studio supports. Run case 9 against
+PostgreSQL and this one against Redis back to back, and the point makes itself.
+
 ---
 
 ## Act 4 — "it makes queries faster, and shows its work" (4 minutes)
@@ -253,7 +266,8 @@ ledger, not from the model's opinion of its own work.
 
 **"Which databases?"** Analyze, Optimize, Assess and Investigate need a database-native read-only
 path, which today means **PostgreSQL and SQLite**. Operate reads the engine's own statistics instead
-and works on every provider. Plan mode has no limit at all.
+and works on every provider — driven live against Redis, which has no SQL at all (case 12b). Plan
+mode has no limit at all.
 
 **"What does it cost per question?"** Each workflow has a frozen ceiling on model turns, statements,
 wall clock and database time, and the rail shows the meter live. The figures are the starting point

--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -1,0 +1,272 @@
+# Agent demo script
+
+Twenty-three cases, ordered easy to hard, for showing LibreDB Studio's agent to someone who has
+not seen it. Every case here was **driven live** against a real model and a real database before it
+was written down, and each one records what actually came back — including the ones that refuse.
+Nothing in this file is aspirational.
+
+The refusals are not filler. Half of what makes an agent worth putting near a production database is
+what it declines to do, and a demo that only shows the happy path sells the wrong product.
+
+## Before you demo
+
+**Databases used here.** PostgreSQL 18 with the [Pagila / dvdrental sample](https://neon.com/postgresql/getting-started/sample-database)
+(22 tables, 16 044 rentals, 14 596 payments) and the SQLite employees sample this repository ships
+(1 000 employees, 9 488 salary rows). Both are public sample data — safe to project.
+
+**Agent mode needs a seed connection.** A connection created in the UI cannot be investigated: a run
+persists a connection id and no credential, so the server has to be able to rebuild it. Put the
+connection in `seed-connections.yaml` and point `SEED_CONFIG_PATH` at it. See
+[`docs/SEED_CONNECTIONS.md`](./SEED_CONNECTIONS.md).
+
+**PostgreSQL needs a least-privilege role.** The agent refuses a superuser outright — a read-only
+transaction does not stop `COPY TO PROGRAM` or server-side file access, so the profile checks the
+role itself. This is a good thing to show, not a snag to hide (case 22). A role that works:
+
+```sql
+CREATE ROLE libredb_agent LOGIN PASSWORD '...';
+GRANT CONNECT ON DATABASE dvdrental TO libredb_agent;
+GRANT USAGE ON SCHEMA public TO libredb_agent;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO libredb_agent;
+GRANT pg_read_all_stats TO libredb_agent;   -- for the Operate workflow
+```
+
+**Run it from a production build** (`bun run build` then `bun run start`). In development React needs
+`eval`, which the CSP does not allow, so the login page does not hydrate (`docs/BACKLOG.md` B40).
+
+**Two axes, chosen independently.** Plan or Agent decides whether the run may touch the database;
+Investigate / Optimize / Assess / Operate / Analyze decides what it is for. A planning run of a query
+optimization is an ordinary thing to ask for.
+
+---
+
+## Act 1 — "it knows my database" (2 minutes)
+
+Low risk, instant payoff. Use these to establish that the thing is real before asking anything hard.
+
+### 1. What is in here?
+**Agent · Investigate ·** `What tables are in this database and how do they relate to each other?`
+
+Comes back with the table inventory and the relationships between them, each claim citing the schema
+snapshot it read. On the employees database: six tables and two views, named correctly.
+
+### 2. The join path nobody remembers
+**Agent · Investigate ·** `How would I find which films a given customer has rented? Explain the join path.`
+
+Answers `customer → rental → inventory → film`, naming the key on each hop. This is the moment a
+developer in the room stops taking notes and starts watching: it is the three-hop join they would
+have had to reconstruct from an ER diagram.
+
+### 3. Write me the query
+**Agent · Investigate ·** `Write me a query for the ten highest-paid employees with their department name.`
+
+The statement appears in the timeline with an **Apply to editor** button. Click it — the SQL lands in
+the editor, formatted, ready to run. Nothing ran on its own.
+
+---
+
+## Act 2 — "it answers business questions" (5 minutes)
+
+This is the data-analyst face and the strongest part of the demo. Ask in plain language; never
+mention a table name.
+
+### 4. Plain question, exact answer
+**Agent · Analyze ·** `Who are our top 10 customers by total revenue, and how much did each spend?`
+
+Named customers with amounts to the cent: Eleanor Hunt $211.55, Karl Seal $208.58, Marion Snyder
+$194.61. Verified against the database by hand — every figure matched.
+
+### 5. Ask for a chart, get a chart
+**Agent · Analyze ·** `Draw a bar chart of rental volume per month.`
+
+The Charts tab opens by itself and the bars are drawn. The run reads the data on its own bounded,
+read-only path, names which result **is** the answer, and the chart is shown without anyone clicking
+anything. If the columns a chart names are not columns of that result, the chart is refused rather
+than drawn wrong.
+
+### 6. A question that spans the schema
+**Agent · Analyze ·** `Which part of the company costs us the most in salary?`
+
+Answers *Development*, with the total, and says which definition it used ("current salary") — which
+matters, because the ranking is the same under either definition but the number is not.
+
+### 7. Two periods, compared
+**Agent · Analyze ·** `Compare the average salary of employees hired before 1990 with those hired after, as a chart.`
+
+66 181.48 against 61 050.05. Both verified by hand, both exact.
+
+### 8. Is the trend up or down?
+**Agent · Analyze ·** `Is our headcount growing? Show hires per year as a chart.`
+
+Fifteen years as bars, and a written conclusion that hiring is **not** growing — a peak of 118 in
+1985 falling to 4 in 1999. Worth pausing on: it answered the question that was asked, not the
+question the data flatters.
+
+---
+
+## Act 3 — "it thinks like a DBA" (5 minutes)
+
+The Operate workflow answers from the engine's own statistics rather than by writing SQL. It works on
+every provider, including the ones agent mode otherwise cannot reach.
+
+### 9. What is happening right now?
+**Agent · Operate ·** `Which sessions are active on this server, is anything blocked, and which queries are slowest?`
+
+Real `pg_stat_activity`: session count, user, client address, state, and whether anything is blocked
+or waiting on a lock. Every reading carries the caveat *"A moment, not a history"* — it is a point in
+time and the product says so rather than letting the model imply a trend.
+
+### 10. Which indexes are dead weight?
+**Agent · Operate ·** `Which indexes are never used, and which tables are the largest?`
+
+Index scan counts and table sizes straight from the catalog. On dvdrental: `rental` at 2 408 448
+bytes, `payment` at 1 859 584 — byte-exact against a hand-written query.
+
+### 11. Where is the storage going?
+**Agent · Operate ·** `How is storage distributed across this database, and is anything unusually large?`
+
+Main file, WAL, shared memory, and table-level distribution.
+
+### 12. The honest empty answer
+**Agent · Operate ·** `Which queries are slowest on this database right now?`
+
+On an idle database the slow-query log is empty — and in one run the agent noticed that the health
+reading claimed `slowQueryCount: 2` while the log itself returned zero rows, and **reported the
+discrepancy** instead of picking whichever number made a better answer. If it happens during your
+demo, stop and read it out.
+
+---
+
+## Act 4 — "it makes queries faster, and shows its work" (4 minutes)
+
+### 13. Why is this slow?
+**Agent · Optimize ·** paste a real query, e.g.
+`This is slow: SELECT c.first_name, c.last_name, SUM(p.amount) FROM customer c JOIN payment p ON c.customer_id = p.customer_id WHERE p.amount > 5 GROUP BY c.customer_id, c.first_name, c.last_name. How would you make it faster?`
+
+Two things land. **Plans compared** — with real PostgreSQL costs, e.g. *"a full scan (599 rows, cost
+348.07) to a full scan (599 rows, cost 348.07)"* — and **Index recommended**, with the `CREATE INDEX`
+statement and an Apply to editor button.
+
+Read the caveat aloud: *"Estimates only: these plans were described, not executed. EXPLAIN ANALYZE is
+policy-denied because it would run the statement."* The agent will not run your slow query to find
+out how slow it is.
+
+### 14. It never applies anything
+Point at the recommendation and note that nothing created the index. Every statement the model writes
+is offered, never applied. The run has no way to change your database at all.
+
+---
+
+## Act 5 — "it can drive the editor, within limits" (4 minutes)
+
+This is the part that gets the room's attention, and the part to demo carefully, because what makes
+it defensible is the gate.
+
+### 15. The checkbox that names its bounds
+**Agent · Analyze ·** tick **"Also run the final answer in my editor"** and read the copy under it out
+loud. It states what is given up (the time limit) and what is kept (the row limit), and that writes
+and DDL are refused **by the engine rather than by reading the statement**. On SQLite it adds that a
+long read blocks other writers.
+
+### 16. Gate open: the answer runs
+**Agent · Analyze ·** `What did customer 5 pay in total, and how many payments did they make?`
+
+Three conditions all hold — the run executed that exact statement itself, the plan reads as cheap,
+and the measured time is under the threshold — so the statement runs in the editor and the rows
+appear: 134.65 across 35 payments. Verified by hand.
+
+The replay does not go through the ordinary editor route. It goes to a run-scoped endpoint that takes
+**no SQL at all**: the statement comes off that run's own ledger, and it executes inside the
+database's own read-only session.
+
+### 17. Gate closed: it says why
+**Agent · Analyze ·** `What is the total revenue per film category? Show it as a chart.`
+
+The plan reads as a full table read, so the gate declines. The statement is placed in the editor
+**unrun**, with the reason in plain words — and the chart is still drawn, because the run had already
+read the answer on its own bounded path. Nothing on screen claims an execution that did not happen.
+
+This is the case to dwell on. A demo that only shows case 16 is showing a party trick; showing 16 and
+17 together is showing a control.
+
+---
+
+## Act 6 — "it is safe to point at production" (4 minutes)
+
+### 18. Plan mode: it never touches the database
+Switch to **Plan** and ask anything: `How would you assess this database before a production release?`
+
+A structured plan comes back — phases, what to inspect, what each step would establish — rendered as
+headings and bullets. Zero statements were sent. This is the mode to hand someone who wants the
+reasoning without the risk.
+
+*Known limitation, and say it rather than let someone find it:* a plan run reasons from the objective
+alone, so today it gives a sound general method rather than a plan naming your tables. The written
+plan is honest about what it did not inspect.
+
+### 19. Both axes are independent
+**Plan · Optimize ·** `What would you check first if this database were slow in production?`
+
+Still a plan, still zero statements — but framed by the optimization workflow, so it is about access
+paths rather than generic health. Plan/Agent and the workflow are two separate choices.
+
+### 20. Stop means stop
+Start a long run — **Agent · Assess ·** `Profile every table at pattern depth and grade completeness, uniqueness, consistency and validity for each one` — and press **Stop** while it is working.
+
+The run takes no further database step and finishes the report from what it already had. The ending
+says so: *"A stop was requested before this ending: the run took no further database step, and
+finished what it already had in hand."* You get a partial answer with its evidence, not a discarded
+run.
+
+### 21. It will not invent an answer
+**Agent · Analyze ·** `What is our customer churn rate this quarter?` against the employees database.
+
+It does not produce a churn number. It reports that the schema holds employee records rather than
+customer records, and says the question is not answerable here.
+
+### 22. It refuses a superuser
+Point it at PostgreSQL as `postgres` and start a run. It refuses, because a read-only transaction
+does not stop `COPY TO PROGRAM` or server-side file reads — so the profile requires a least-privilege
+role rather than trusting the transaction. *(The message a user sees today names the engine rather
+than the role; the server log carries the exact reason. Recorded in `docs/BACKLOG.md`.)*
+
+### 23. Every claim is checkable
+Open any report and look at a claim. Each one cites an artifact this run actually read, with its
+correlation id and row count, and the statement behind it. A claim citing evidence the run never
+produced is refused when the report is composed — the model cannot assert something and leave you to
+trust it.
+
+---
+
+## What to say when someone asks the hard question
+
+**"Can it damage my database?"** Writes and DDL are refused by the engine, not by parsing the SQL.
+The run's own path is a database-enforced read-only session with a statement timeout, a row cap and a
+byte cap, and it refuses rather than truncating. The editor replay in cases 15-17 uses the same
+read-only session; what it gives up is the timeout, and the checkbox says so.
+
+**"What if the model hallucinates?"** It can, and the product is built on the assumption that it
+will. A claim must cite something the run read or it is refused. A chart must name columns that exist
+in that result or it is refused. An answer must be a result of a query the run actually ran — a plan
+or a profile cannot be presented as one. The verdict at the end of a run is computed from the run's
+ledger, not from the model's opinion of its own work.
+
+**"Which databases?"** Analyze, Optimize, Assess and Investigate need a database-native read-only
+path, which today means **PostgreSQL and SQLite**. Operate reads the engine's own statistics instead
+and works on every provider. Plan mode has no limit at all.
+
+**"What does it cost per question?"** Each workflow has a frozen ceiling on model turns, statements,
+wall clock and database time, and the rail shows the meter live. The figures are the starting point
+for a measurement that has not been taken yet — treat them as bounds, not as a price list.
+
+---
+
+## Cases that are not ready to demo
+
+Say these plainly if asked; do not build a demo around them.
+
+- **Follow-up questions.** Each run starts fresh. Asking "and how many of those?" after another
+  question gets a confident answer to a different question, because nothing carries the referent.
+  (`docs/BACKLOG.md` B36.)
+- **A plan that names your tables.** See case 18.
+- **Causal questions** — "why are sales down?" — need business context the schema does not carry.

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -487,6 +487,7 @@ export const AGENT_ANSWER_CONTRACT = [
   "Every column a chart names must be a column of THAT result, spelled as the result spells it, and every y column must hold numbers.",
   "A chart needs at least two rows; a pie takes exactly one y; a scatter needs a numeric x as well.",
   "Present a table when the result is a single number, has one row, or has no numeric column: that is a complete answer, not a lesser one.",
+  "When the objective asks for a chart and the result can carry one, chart it: the user named the shape of the answer they wanted.",
 ].join(" ");
 
 const recommendationSchema = z.strictObject({

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -2688,6 +2688,29 @@ describe("present_answer records which result IS the answer, and how to show it"
     expect(AGENT_TOOL_DEFINITIONS.present_answer.description).toContain(AGENT_ANSWER_CONTRACT);
   });
 
+  /*
+    Driven live on 2026-08-15, twice, on both engines: "Show me the average salary by
+    department as a chart" and "Draw a bar chart of rental volume per month" were both
+    answered with a TABLE. The data carried a category and a number in each case, so
+    nothing refused the chart — the model simply chose the other one.
+
+    Reading the contract explains why. It defends the table ("that is a complete
+    answer, not a lesser one"), which is deliberate and stays: a single number charted
+    is worse than a single number. But it never said when a chart IS right, and it
+    never mentioned the objective. A model reading the list found a permission and no
+    pull the other way.
+
+    So the asymmetry is the defect, and the fix is one sentence rather than a rule
+    engine: the model decides, and now it decides knowing what was asked. #350's
+    lesson — a behaviour nobody states is a behaviour live runs do not have.
+  */
+  test("the contract says when a chart is right, not only when a table is", () => {
+    expect(AGENT_ANSWER_CONTRACT).toContain("asks for a chart");
+    // The table's defence stays: it is what stops a single number being charted to
+    // look like more than it is.
+    expect(AGENT_ANSWER_CONTRACT).toContain("complete answer, not a lesser one");
+  });
+
   test("the description shows both presentations, and its own schema accepts them", () => {
     // The `AGENT_EVIDENCE_CONTRACT` pattern: the example and the parser come from one
     // piece of code, so a description offering a shape the schema refuses fails here


### PR DESCRIPTION
Split out of #385 on review: that PR is one contract sentence and its regression assertion, and this is a 350-line product document. They came from the same session — the document is what the driving produced — but they are independently reviewable, which was the point.

## What this is

A demo script for showing the agent to someone who has not seen it: twenty-four cases ordered easy to hard, across six acts, with the personas they suit. **Every case was driven live** against a real model and a real database before it was written down, and each records what actually came back.

Refusals carry the same weight as answers. Half of what makes an agent worth putting near a production database is what it declines to do, so the gate declining an expensive statement, the superuser being refused, the stop being honoured and the unanswerable question being reported as unanswerable are each cases in their own right — not caveats in a footnote.

## The engine matrix

Six engines were driven **one at a time** rather than reasoned about from the code: PostgreSQL 18, SQLite, Redis 7, MongoDB 8, SQL Server 2022 and ClickHouse 26. Operate answered on all six — including Redis, which has no SQL at all — and the four SQL workflows refused everywhere except PostgreSQL and SQLite, with that refusal watched on MongoDB rather than assumed.

Engines nobody started a run on are marked **expected** rather than verified. The difference between those two words is the reason the table is worth having.

## What is not yet, and what each one waits on

Nine rows, each carrying its backlog entry: follow-up questions (B36), a plan on a cold server (B42), causal questions, the fabricated read behind an unanswerable question (B39), agent mode on other engines, exported observability (B33), resume after restart (B9), unmeasured budgets, and UI-created connections.

A launch audience asks "what about X" about things a feature list does not mention. That answer is better delivered before the question than after it.

## Review corrections already applied

Four findings on the first draft, all of them the document saying something untrue about itself:

- it counted twenty-three cases and had twenty-four;
- case 18 quoted a meter reading of `0 / 30` without naming the workflow that produces that denominator, so following the previous case leaves `0 / 42` on screen;
- case 23 promised a correlation id and row count for **every** claim, while case 1 on the same page is full of claims citing the schema snapshot, which has neither;
- the security answer said writes are refused "not by parsing the SQL", when `inspectAgentStatement` rejects non-read, side-effect and multi-statement input before a provider is acquired.

The last one mattered most. The engine's read-only session **is** the boundary, and the reason is that a parser can be fooled — a `SELECT` may call a function that writes. But writing that as "no parsing happens" describes a product that does less than this one, in the answer a security-minded listener will remember.

Documentation only; no code changes. `bun run format` clean and the documentation guard passes.