### PR TITLE
fix(agent): let the gate name the reading that refused, not the five it might have

### DIFF
--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -239,10 +239,17 @@ already read the answer on its own bounded path. Nothing on screen claims an exe
 happen.
 
 Read the sentence out. It names one reading, not a list of the readings that might have applied —
-and there are five it could have named: no plan held for that exact statement, a step the server
-could not interpret, a whole-table read, a plan with no cost in it, or a cost over the ceiling. That
-last one arrives with both numbers in it (*"the engine estimates 4320000, against a ceiling of
-50000"*), which is the version someone can argue with.
+and there are seven it could have named: no plan held for that exact statement, a plan in a dialect
+this server has no rule for, a step it could not interpret, an access path it could not determine, a
+whole-table read, a plan with no cost in it, or a cost over the ceiling.
+
+Two of those distinctions are finer than they look and worth keeping straight if someone asks: "the
+plan reads the whole table" and "this server could not tell how the statement reaches its rows" are
+different facts, and so are "no plan is held" and "a plan is held that this server cannot weigh". The
+gate refuses in all four, and says which.
+
+The cost case arrives with both numbers in it — *"the engine estimates 4320000, against a ceiling of
+50000"* — which is the version someone can argue with.
 
 This is the case to dwell on. A demo that only shows case 16 is showing a party trick; showing 16 and
 17 together is showing a control.

--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -229,9 +229,20 @@ database's own read-only session.
 ### 17. Gate closed: it says why
 **Agent · Analyze ·** `What is the total revenue per film category? Show it as a chart.`
 
-The plan reads as a full table read, so the gate declines. The statement is placed in the editor
-**unrun**, with the reason in plain words — and the chart is still drawn, because the run had already
-read the answer on its own bounded path. Nothing on screen claims an execution that did not happen.
+The gate declines and names the reading that declined it:
+
+> Not run for you: **the plan reads the whole table rather than reaching its rows through an index**,
+> so this one is yours to run.
+
+The statement is placed in the editor **unrun**, and the chart is still drawn, because the run had
+already read the answer on its own bounded path. Nothing on screen claims an execution that did not
+happen.
+
+Read the sentence out. It names one reading, not a list of the readings that might have applied —
+and there are five it could have named: no plan held for that exact statement, a step the server
+could not interpret, a whole-table read, a plan with no cost in it, or a cost over the ceiling. That
+last one arrives with both numbers in it (*"the engine estimates 4320000, against a ceiling of
+50000"*), which is the version someone can argue with.
 
 This is the case to dwell on. A demo that only shows case 16 is showing a party trick; showing 16 and
 17 together is showing a control.

--- a/src/lib/agent/auto-execute.ts
+++ b/src/lib/agent/auto-execute.ts
@@ -129,40 +129,73 @@ export type AgentAutoExecuteDecision =
  * writers and this application until it finishes. So a `mixed` plan passes on
  * PostgreSQL and does not pass here: any `SCAN` is a full read of a table whose size
  * nothing in the plan states.
+ *
+ * It answers WHICH reading refused rather than whether one did (#387 review). The five
+ * are distinguishable and this function has always known which applied; it used to
+ * collapse them into a boolean, and the sentence built from that then offered three of
+ * them as alternatives for the reader to pick from. Everywhere else this timeline says
+ * what happened, so a menu was the odd one out — and it hides the one a user most needs,
+ * because "the estimate is 4320000 against a ceiling of 50000" can be argued with and
+ * "possibly expensive" cannot.
  */
-function planIsSafe(plan: AgentAutoExecutePlan | undefined): boolean {
-  if (plan === undefined) return false;
-  if (plan.summary.uninterpretedStep === true) return false;
+type PlanRefusal = "no-plan" | "unreadable-step" | "reads-whole-table" | "no-estimate" | "over-ceiling";
+
+function planRefusal(plan: AgentAutoExecutePlan | undefined): PlanRefusal | null {
+  if (plan === undefined) return "no-plan";
+  if (plan.summary.uninterpretedStep === true) return "unreadable-step";
   if (plan.format === "postgres-json") {
-    if (plan.summary.access !== "index" && plan.summary.access !== "mixed") return false;
-    return plan.summary.estimatedCost !== undefined && plan.summary.estimatedCost <= AGENT_AUTO_EXECUTE_MAX_PLAN_COST;
+    if (plan.summary.access !== "index" && plan.summary.access !== "mixed") return "reads-whole-table";
+    if (plan.summary.estimatedCost === undefined) return "no-estimate";
+    return plan.summary.estimatedCost <= AGENT_AUTO_EXECUTE_MAX_PLAN_COST ? null : "over-ceiling";
   }
-  if (plan.format === "sqlite-queryplan") return plan.summary.access === "index";
-  return false;
+  // SQLite carries no cost at all, so `access` is the whole reading and anything that
+  // is not wholly indexed reads a table whose size nothing in the plan states.
+  if (plan.format === "sqlite-queryplan") return plan.summary.access === "index" ? null : "reads-whole-table";
+  return "no-plan";
+}
+
+/**
+ * The refusal in the reader's terms. A total record, so a refusal added later cannot
+ * ship without words — the rule `SHORTFALL_SENTENCES` follows in the timeline.
+ */
+const PLAN_REFUSAL_TEXT: Readonly<Record<PlanRefusal, string>> = Object.freeze({
+  "no-plan": "this run holds no plan for that exact statement, so there was nothing to weigh",
+  "unreadable-step":
+    "the plan carried a step this server could not read, and a reading it cannot interpret is not a reading that it is cheap",
+  "reads-whole-table": "the plan reads the whole table rather than reaching its rows through an index",
+  "no-estimate": "the engine returned a plan with no cost in it, so there was no number to weigh",
+  "over-ceiling": "the plan is too expensive",
+});
+
+/** The cost case earns its numbers: a ceiling nobody can see is a ceiling nobody can argue with. */
+function planRefusalText(refusal: PlanRefusal, plan: AgentAutoExecutePlan | undefined): string {
+  if (refusal !== "over-ceiling" || plan?.summary.estimatedCost === undefined) return PLAN_REFUSAL_TEXT[refusal];
+  return `${PLAN_REFUSAL_TEXT[refusal]} — the engine estimates ${plan.summary.estimatedCost}, against a ceiling of ${AGENT_AUTO_EXECUTE_MAX_PLAN_COST}`;
 }
 
 /**
  * The refusal sentences, in the register the timeline already speaks in: what was
  * not done, why, and whose the statement now is.
  */
-const CONDITION_WARNINGS: Readonly<Record<Exclude<AgentAutoExecuteCondition, "measured-slow">, string>> = Object.freeze(
-  {
-    "not-executed":
-      "Not run for you: this run never executed this exact statement itself, so this one is yours to run.",
-    "plan-risky":
-      "Not run for you: the plan for this statement reads as a full table read, or the engine gave this server no plan it could weigh, or the plan carried a step this server could not read, so this one is yours to run.",
-  },
-);
+const NOT_EXECUTED_WARNING =
+  "Not run for you: this run never executed this exact statement itself, so this one is yours to run.";
 
 /** Decides the `handover` an `answer-composed` event records. */
 export function evaluateAutoExecute(input: AgentAutoExecuteInput): AgentAutoExecuteDecision {
   // In condition order, so a refusal names the first thing that failed rather than
   // whichever check happened to be written last.
   if (!input.executedStatements.includes(input.sql)) {
-    return { handover: "applied", condition: "not-executed", warning: CONDITION_WARNINGS["not-executed"] };
+    return { handover: "applied", condition: "not-executed", warning: NOT_EXECUTED_WARNING };
   }
-  if (!planIsSafe(input.plan)) {
-    return { handover: "applied", condition: "plan-risky", warning: CONDITION_WARNINGS["plan-risky"] };
+  const refusal = planRefusal(input.plan);
+  if (refusal !== null) {
+    return {
+      handover: "applied",
+      condition: "plan-risky",
+      // `condition` stays as it was: it is recorded on the ledger and read back by
+      // runs older than this change. What got more specific is what a reader sees.
+      warning: `Not run for you: ${planRefusalText(refusal, input.plan)}, so this one is yours to run.`,
+    };
   }
   if (input.elapsedMs > AGENT_AUTO_EXECUTE_MAX_ELAPSED_MS) {
     return {

--- a/src/lib/agent/auto-execute.ts
+++ b/src/lib/agent/auto-execute.ts
@@ -138,20 +138,42 @@ export type AgentAutoExecuteDecision =
  * because "the estimate is 4320000 against a ceiling of 50000" can be argued with and
  * "possibly expensive" cannot.
  */
-type PlanRefusal = "no-plan" | "unreadable-step" | "reads-whole-table" | "no-estimate" | "over-ceiling";
+type PlanRefusal =
+  | "no-plan"
+  | "unverified-dialect"
+  | "unreadable-step"
+  | "unreadable-access"
+  | "reads-whole-table"
+  | "no-estimate"
+  | "over-ceiling";
 
+/**
+ * `unknown` and `full-scan` are separated here, and the first attempt at this grouped
+ * them (#388 review). They are not the same reading: `full-scan` means at least one
+ * relation is read end to end, and `unknown` means the reading could not tell
+ * (`plan-summary.ts`). Calling the second one a whole-table read is a specific claim
+ * about a plan nobody managed to interpret — which is worse than the menu this
+ * replaced, because a reader can act on "or" and cannot act on a confident wrong
+ * reason. The same applies to a dialect with no rule: a plan IS held, so "no plan" is
+ * false; what is missing is a way to weigh it.
+ */
 function planRefusal(plan: AgentAutoExecutePlan | undefined): PlanRefusal | null {
   if (plan === undefined) return "no-plan";
   if (plan.summary.uninterpretedStep === true) return "unreadable-step";
   if (plan.format === "postgres-json") {
+    if (plan.summary.access === "unknown") return "unreadable-access";
     if (plan.summary.access !== "index" && plan.summary.access !== "mixed") return "reads-whole-table";
     if (plan.summary.estimatedCost === undefined) return "no-estimate";
     return plan.summary.estimatedCost <= AGENT_AUTO_EXECUTE_MAX_PLAN_COST ? null : "over-ceiling";
   }
-  // SQLite carries no cost at all, so `access` is the whole reading and anything that
-  // is not wholly indexed reads a table whose size nothing in the plan states.
-  if (plan.format === "sqlite-queryplan") return plan.summary.access === "index" ? null : "reads-whole-table";
-  return "no-plan";
+  // SQLite carries no cost at all, so `access` is the whole reading: anything wholly
+  // indexed passes, an unreadable plan says so, and everything else reads a table whose
+  // size nothing in the plan states.
+  if (plan.format === "sqlite-queryplan") {
+    if (plan.summary.access === "index") return null;
+    return plan.summary.access === "unknown" ? "unreadable-access" : "reads-whole-table";
+  }
+  return "unverified-dialect";
 }
 
 /**
@@ -160,8 +182,12 @@ function planRefusal(plan: AgentAutoExecutePlan | undefined): PlanRefusal | null
  */
 const PLAN_REFUSAL_TEXT: Readonly<Record<PlanRefusal, string>> = Object.freeze({
   "no-plan": "this run holds no plan for that exact statement, so there was nothing to weigh",
+  "unverified-dialect":
+    "this server has no rule for weighing a plan from this database, and reading it by another engine's rule would be a claim about a plan nobody has looked at",
   "unreadable-step":
     "the plan carried a step this server could not read, and a reading it cannot interpret is not a reading that it is cheap",
+  "unreadable-access":
+    "this server could not tell from the plan how the statement reaches its rows, and said nothing must not read as said it was cheap",
   "reads-whole-table": "the plan reads the whole table rather than reaching its rows through an index",
   "no-estimate": "the engine returned a plan with no cost in it, so there was no number to weigh",
   "over-ceiling": "the plan is too expensive",

--- a/tests/unit/lib/agent/auto-execute.test.ts
+++ b/tests/unit/lib/agent/auto-execute.test.ts
@@ -310,6 +310,40 @@ describe("the eight combinations", () => {
     expect(warning).toContain("could not read");
   });
 
+  /*
+    The two readings the first attempt at this got WRONG (#388 review).
+
+    Replacing the menu with a specific sentence is only an improvement where the
+    sentence is true, and two cases were made worse rather than better: an access path
+    the reader could not determine was described as a whole-table read, and a plan in a
+    dialect this server has no rule for was described as no plan at all. Both went from
+    an honest list to a confident falsehood, which is the worse of the two failures —
+    a reader can act on "or", and cannot act on a wrong reason they believe.
+  */
+  test("an access path the reader could not determine is not called a whole-table read", () => {
+    const decision = evaluateAutoExecute({
+      ...passing(),
+      plan: { format: "postgres-json", summary: { access: "unknown", estimatedCost: 1 } },
+    });
+
+    const warning = decision.handover === "applied" ? decision.warning : "";
+    expect(decision).toMatchObject({ condition: "plan-risky" });
+    expect(warning).not.toContain("whole table");
+    expect(warning).toContain("could not tell");
+  });
+
+  test("a dialect with no rule is not called a missing plan", () => {
+    const decision = evaluateAutoExecute({
+      ...passing(),
+      plan: { format: "mysql-json", summary: { access: "index", estimatedCost: 1 } },
+    });
+
+    const warning = decision.handover === "applied" ? decision.warning : "";
+    expect(decision).toMatchObject({ condition: "plan-risky" });
+    expect(warning).not.toContain("no plan");
+    expect(warning).toContain("no rule for weighing");
+  });
+
   test("a plan reporting no cost is not the same refusal as one reporting a large one", () => {
     const noCost = evaluateAutoExecute({
       ...passing(),

--- a/tests/unit/lib/agent/auto-execute.test.ts
+++ b/tests/unit/lib/agent/auto-execute.test.ts
@@ -257,6 +257,77 @@ describe("the eight combinations", () => {
     expect(evaluateAutoExecute(inputFor(true, false, true))).toMatchObject({ condition: "plan-risky" });
   });
 
+  /*
+    A refusal names WHICH reading refused it (#387 review, found while re-driving the
+    demo script).
+
+    `plan-risky` covers five distinguishable readings — no plan held, a step the server
+    could not interpret, a full table read, a plan reporting no cost at all, and a cost
+    over the ceiling — and the sentence used to list three of them as alternatives and
+    leave the reader to guess. The gate already knows which one it was; discarding that
+    and offering a menu is the opposite of what this timeline does everywhere else.
+
+    The cost case carries both numbers, because "expensive" is an opinion and
+    "4320000 against a ceiling of 50000" is a reading someone can argue with.
+  */
+  test("a full table read is named as one", () => {
+    const decision = evaluateAutoExecute({
+      ...passing(),
+      plan: { format: "postgres-json", summary: { access: "full-scan", estimatedCost: 1 } },
+    });
+
+    expect(decision).toMatchObject({ condition: "plan-risky" });
+    expect(decision.handover === "applied" && decision.warning).toContain("reads the whole table");
+  });
+
+  test("a cost over the ceiling is named with both numbers", () => {
+    const over = AGENT_AUTO_EXECUTE_MAX_PLAN_COST + 1;
+    const decision = evaluateAutoExecute({
+      ...passing(),
+      plan: { format: "postgres-json", summary: { access: "index", estimatedCost: over } },
+    });
+
+    const warning = decision.handover === "applied" ? decision.warning : "";
+    expect(warning).toContain(String(over));
+    expect(warning).toContain(String(AGENT_AUTO_EXECUTE_MAX_PLAN_COST));
+  });
+
+  test("a plan the run never obtained is not described as an expensive one", () => {
+    const decision = evaluateAutoExecute({ ...passing(), plan: undefined });
+
+    const warning = decision.handover === "applied" ? decision.warning : "";
+    expect(warning).toContain("no plan");
+    expect(warning).not.toContain("whole table");
+  });
+
+  test("a plan carrying a step the server could not read says so", () => {
+    const decision = evaluateAutoExecute({
+      ...passing(),
+      plan: { format: "sqlite-queryplan", summary: { access: "index", uninterpretedStep: true } },
+    });
+
+    const warning = decision.handover === "applied" ? decision.warning : "";
+    expect(warning).toContain("could not read");
+  });
+
+  test("a plan reporting no cost is not the same refusal as one reporting a large one", () => {
+    const noCost = evaluateAutoExecute({
+      ...passing(),
+      plan: { format: "postgres-json", summary: { access: "index" } },
+    });
+    const overCost = evaluateAutoExecute({
+      ...passing(),
+      plan: {
+        format: "postgres-json",
+        summary: { access: "index", estimatedCost: AGENT_AUTO_EXECUTE_MAX_PLAN_COST + 1 },
+      },
+    });
+
+    const first = noCost.handover === "applied" ? noCost.warning : "";
+    const second = overCost.handover === "applied" ? overCost.warning : "";
+    expect(first).not.toBe(second);
+  });
+
   test("every refusal says why, in the register the app speaks in", () => {
     for (const executed of [true, false]) {
       for (const plan of [true, false]) {

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -2921,7 +2921,7 @@ describe("present_answer records which result IS the answer, and how to show it"
 
       if (outcome.kind !== "answered") throw new Error(`expected an answer, got ${outcome.kind}`);
       expect(outcome.answer.handover).toBe("applied");
-      expect(outcome.answer.handoverWarning).toContain("no plan it could weigh");
+      expect(outcome.answer.handoverWarning).toContain("holds no plan for that exact statement");
     });
 
     /**
@@ -2944,7 +2944,7 @@ describe("present_answer records which result IS the answer, and how to show it"
 
       if (outcome.kind !== "answered") throw new Error(`expected an answer, got ${outcome.kind}`);
       expect(outcome.answer.handover).toBe("applied");
-      expect(outcome.answer.handoverWarning).toContain("no plan it could weigh");
+      expect(outcome.answer.handoverWarning).toContain("holds no plan for that exact statement");
     });
 
     test("an answer that carries an optimizer hint is not licensed by the unhinted plan", () => {
@@ -2959,7 +2959,7 @@ describe("present_answer records which result IS the answer, and how to show it"
 
       if (outcome.kind !== "answered") throw new Error(`expected an answer, got ${outcome.kind}`);
       expect(outcome.answer.handover).toBe("applied");
-      expect(outcome.answer.handoverWarning).toContain("no plan it could weigh");
+      expect(outcome.answer.handoverWarning).toContain("holds no plan for that exact statement");
     });
 
     test("a hinted answer is not licensed by the plan of the identically hinted statement either", () => {
@@ -2977,7 +2977,7 @@ describe("present_answer records which result IS the answer, and how to show it"
 
       if (outcome.kind !== "answered") throw new Error(`expected an answer, got ${outcome.kind}`);
       expect(outcome.answer.handover).toBe("applied");
-      expect(outcome.answer.handoverWarning).toContain("no plan it could weigh");
+      expect(outcome.answer.handoverWarning).toContain("holds no plan for that exact statement");
     });
 
     test("an ordinary comment is still trivia, so the join still absorbs one", () => {
@@ -3371,7 +3371,9 @@ describe("present_answer records which result IS the answer, and how to show it"
 
     if (outcome.kind !== "answered") throw new Error("expected an answer");
     expect(outcome.answer.handover).toBe("applied");
-    expect(outcome.answer.handoverWarning).toContain("full table read");
+    // The reading that refused, not a list of the readings that might have (#387
+    // review): this plan scans, and that is what the sentence says.
+    expect(outcome.answer.handoverWarning).toContain("reads the whole table");
     // Never a silent skip: the model is told too, because it is what writes the
     // report the user reads next to the statement sitting there unrun.
     expect(outcome.modelText).toContain("Not run for you");


### PR DESCRIPTION
Found by re-driving the demo script against merged main, which is what that script is for.

## The sentence

When the auto-execute gate declined on the plan, it said:

> Not run for you: the plan for this statement reads as a full table read, **or** the engine gave this server no plan it could weigh, **or** the plan carried a step this server could not read, so this one is yours to run.

Three alternatives, and the reader picks. But the gate is not uncertain — `planIsSafe` distinguished **five** cases and collapsed them into a boolean on the way out:

- no plan held for that exact statement,
- a step the server could not interpret,
- a read of the whole table,
- a plan reporting no cost at all,
- a cost over the ceiling.

Everywhere else this timeline states what happened. The menu was the odd one out, and it hid the one reading a user most needs.

## What changed

`planRefusal` returns which reading refused, and a total record gives each one its words — so a refusal added later cannot ship without a sentence, the rule `SHORTFALL_SENTENCES` already follows in the timeline.

The cost case carries its numbers:

> the plan is too expensive — the engine estimates 4320000, against a ceiling of 50000

That is a reading someone can argue with. "Possibly expensive" is not, and a number a user cannot see is a ceiling they cannot check.

**The recorded `condition` is unchanged** at `plan-risky`. It is on the ledger and read back by runs older than this change; what got more specific is what a reader sees, not what the record says.

## Verified

Driven live on PostgreSQL after the change: a revenue-per-category aggregate declines with *"the plan reads the whole table rather than reaching its rows through an index"*, the statement sits in the editor unrun, and the chart is still drawn from the bounded read the run had already done.

Five new unit tests, each pinning one reading — including that a plan the run never obtained is **not** described as an expensive one, and that "no cost reported" and "cost over the ceiling" do not produce the same sentence. Three existing assertions moved to the more specific wording.

Case 17 of `docs/AGENT_DEMO.md` now quotes what the product actually says.

Gates: format, lint (0 errors), typecheck, knip, `tests/run-core.sh` (285 files), `test:components` (28 groups), build, `test:coverage` + `coverage:check` at 100% (35053/35053 lines).