### PR TITLE
feat(agent): let a plan's SQL be copied, and reach the editor

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1743,8 +1743,8 @@ way any of them could have been found: every one of them passes every gate.
 - **B41** — `defaults` in a seed config does not merge `roles`, though the documentation says the
   block is merged into every connection.
 - **B43** — every copy control outside the agent rail reaches `navigator.clipboard` unguarded, and it
-  is a secure-context API: on the plain-HTTP channels this product ships, four of them flip a label
-  to "Copied!" in the same statement that starts a write nobody observed.
+  is a secure-context API: nine call sites across seven components, four of which claim success — by
+  a label or a toast — in the same statement that starts a write nobody observed.
 - **B44** — a plan's SQL is read out of a markdown fence rather than recorded as a statement, because
   planning is toolless and writes no `statement-drafted` event. The alternative widens the mode's
   contract, so the fence is what the "Apply to editor" control there depends on.

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1742,6 +1742,12 @@ way any of them could have been found: every one of them passes every gate.
   development build needs it, so the login page never hydrates. Production is unaffected.
 - **B41** — `defaults` in a seed config does not merge `roles`, though the documentation says the
   block is merged into every connection.
+- **B43** — every copy control outside the agent rail reaches `navigator.clipboard` unguarded, and it
+  is a secure-context API: on the plain-HTTP channels this product ships, four of them flip a label
+  to "Copied!" in the same statement that starts a write nobody observed.
+- **B44** — a plan's SQL is read out of a markdown fence rather than recorded as a statement, because
+  planning is toolless and writes no `statement-drafted` event. The alternative widens the mode's
+  contract, so the fence is what the "Apply to editor" control there depends on.
 
 ## Related documentation
 

--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -1,6 +1,6 @@
 # Agent demo script
 
-Twenty-four cases, ordered easy to hard, for showing LibreDB Studio's agent to someone who has
+Twenty-five cases, ordered easy to hard, for showing LibreDB Studio's agent to someone who has
 not seen it. Every case here was **driven live** against a real model and a real database before it
 was written down, and each one records what actually came back — including the ones that refuse.
 Nothing in this file is aspirational.
@@ -295,6 +295,27 @@ than inventing tables.
 
 Still a plan, still zero statements — but framed by the optimization workflow, so it is about access
 paths rather than generic health. Plan/Agent and the workflow are two separate choices.
+
+### 19b. A plan you can actually take with you
+Ask the same Plan run for something concrete — **Plan · Optimize ·** `Which indexes would you check first, and what statement would show me their usage?` — and look at what comes back.
+
+The SQL arrives as a code block, not as a paragraph, and it carries two controls: **Apply to editor**
+puts the statement in the editor unrun, and **Copy** puts it on the clipboard. **Copy all** at the
+foot of the plan takes the whole thing as the markdown the model wrote — the version that pastes into
+a ticket with its headings intact.
+
+Driven live against dvdrental, the plan came back with two blocks — a `pg_stat_user_indexes` read
+ordered by `idx_scan`, and the `sys.dm_db_index_usage_stats` equivalent it offered for SQL Server —
+each with its own pair of controls. Click Apply on the first and it lands in the editor with its
+indentation intact, ready to run. Meter: **`Statements 0 / 30`.**
+
+Worth saying out loud if a DBA in the room asks how a toolless mode produced a statement: it did not
+run one and it did not record one. The statement is text inside the plan, and both controls hand it
+to a human. Nothing in plan mode reaches a database, including these.
+
+*Where the editor button is withheld:* a block the model tagged as something other than a query
+language — `bash`, `json` — is copyable and is not offered to the SQL editor, because the model said
+what it is.
 
 ### 20. Stop means stop
 Start a long run — **Agent · Assess ·** `Profile every table at pattern depth and grade completeness, uniqueness, consistency and validity for each one` — and press **Stop** while it is working.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1909,17 +1909,20 @@ entry per schema change, per connection, forever — before it is worth having.
 Done when a plan run's grounding is the same before and after a restart, or when the process-held
 hold is documented as the intended ceiling and this entry is deleted.
 
-### B43. Six copy buttons outside the agent rail fail silently on plain HTTP
+### B43. Nine copy call sites outside the agent rail fail silently on plain HTTP
 
 `navigator.clipboard` is a secure-context API: over plain HTTP on any host but loopback it is
 `undefined`, and this product ships that way on several distribution channels — the trap already
 recorded for `crypto.randomUUID` in `use-query-execution.ts`. `src/components/copy-button.tsx`
 (#389) handles it by falling back to `document.execCommand("copy")` and reporting a failure of both,
-but it is used only by the agent rail. Every other copy in the app reaches the API unguarded:
-`TableItem.tsx`, `RowDetailSheet.tsx`, `CodeGenerator.tsx`, `TestDataGenerator.tsx`,
-`DataImportModal.tsx`, `StudioMobileHeader.tsx` and `QueryEditor.tsx`. Four of them flip a label to
-"Copied!" in the same statement that starts the write, so on those channels the app reports a
-success nobody observed and the user finds out when they paste.
+but it is used only by the agent rail. Every other copy in the app reaches the API unguarded — nine
+call sites across seven components: `TableItem.tsx`, `RowDetailSheet.tsx` (three: one per field, two
+on the whole-row path), `CodeGenerator.tsx`, `TestDataGenerator.tsx`, `DataImportModal.tsx`,
+`StudioMobileHeader.tsx` and `QueryEditor.tsx`.
+
+Four of the seven claim a success nobody observed, in the same statement that starts the write:
+`CodeGenerator`, `TestDataGenerator` and `RowDetailSheet` flip a label, and `TableItem` raises a
+`toast.success`. On those channels the user is told the copy worked and finds out when they paste.
 
 Done when every copy in the app goes through `CopyButton` (or its `writeToClipboard`), with a test
 per site that the label does not claim success when the write was refused.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1908,3 +1908,34 @@ entry per schema change, per connection, forever — before it is worth having.
 
 Done when a plan run's grounding is the same before and after a restart, or when the process-held
 hold is documented as the intended ceiling and this entry is deleted.
+
+### B43. Six copy buttons outside the agent rail fail silently on plain HTTP
+
+`navigator.clipboard` is a secure-context API: over plain HTTP on any host but loopback it is
+`undefined`, and this product ships that way on several distribution channels — the trap already
+recorded for `crypto.randomUUID` in `use-query-execution.ts`. `src/components/copy-button.tsx`
+(#389) handles it by falling back to `document.execCommand("copy")` and reporting a failure of both,
+but it is used only by the agent rail. Every other copy in the app reaches the API unguarded:
+`TableItem.tsx`, `RowDetailSheet.tsx`, `CodeGenerator.tsx`, `TestDataGenerator.tsx`,
+`DataImportModal.tsx`, `StudioMobileHeader.tsx` and `QueryEditor.tsx`. Four of them flip a label to
+"Copied!" in the same statement that starts the write, so on those channels the app reports a
+success nobody observed and the user finds out when they paste.
+
+Done when every copy in the app goes through `CopyButton` (or its `writeToClipboard`), with a test
+per site that the label does not claim success when the write was refused.
+
+### B44. A plan's SQL is recognised from a markdown fence, not recorded as a statement
+
+Plan mode is toolless, so it writes no `statement-drafted` event: the only place a statement it
+drafted exists is inside the closing statement's markdown. #389 reads it from the fence, which is
+why the "Apply to editor" control there depends on the model having fenced its SQL at all — an
+unfenced statement in a paragraph is still just prose, and a fence tagged with something outside
+`QUERY_FENCE_TAGS` is deliberately not offered.
+
+The alternative is a planning-mode tool that records a drafted statement and reaches no database,
+which would make the statement a ledger fact rather than a parse. It was not built here because it
+widens the mode's contract — "planning has no tools" is a sentence three surfaces and the capability
+gate all rely on — and the fence covers what live models actually emit.
+
+Done when either the fence reading is judged sufficient and this entry is deleted, or planning
+records its statements durably and the rail reads them from the ledger like every other mode.

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { Bot, Loader2, PencilLine, Play, Square, TableProperties } from "lucide-react";
+import { CopyButton } from "@/components/copy-button";
 import { renderProse } from "@/components/rich-text";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
@@ -198,6 +199,50 @@ function refusalActionText(planModeOffered: boolean, streamingDisproved: boolean
     return "This endpoint answered without streaming, and plan mode reads the same stream, so it would produce nothing here either. A different model, or an endpoint that streams, is what gets an answer.";
   }
   return "A different model, one that passes the probe, is what gets a run that reads the database.";
+}
+
+/**
+ * Verbatim content, and the one thing every reader wants to do with it (#389).
+ *
+ * The block itself is unchanged and deliberately so: quoting is a security property
+ * here, not a style — a drafted statement, an engine's own message and the user's
+ * objective are shown exactly as they arrived, so a reader can see where the
+ * application stopped speaking. What was missing was any way to get the text OUT.
+ * Selecting it by hand is what a user was left with, inside a narrow panel that
+ * scrolls in both directions, and a statement wrapped across lines does not survive
+ * the drag.
+ *
+ * Used at every verbatim block in this rail rather than at a chosen few, because
+ * "which of these did the product decide I would want" is not a question a user
+ * should have to answer.
+ */
+function QuotedBlock({
+  text,
+  testId,
+  className,
+  /** A report's claim is the thing the report is FOR, and reads a shade brighter. */
+  tone = "quiet",
+}: {
+  readonly text: string;
+  readonly testId: string;
+  readonly className?: string;
+  readonly tone?: "quiet" | "loud";
+}) {
+  return (
+    <div className={className}>
+      <pre
+        className={cn(
+          "overflow-x-auto rounded bg-black/40 p-1.5 font-mono text-[0.625rem] whitespace-pre-wrap",
+          tone === "loud" ? "text-zinc-300" : "text-zinc-400",
+        )}
+      >
+        {text}
+      </pre>
+      <div className="mt-0.5 flex items-center gap-1">
+        <CopyButton text={text} testId={testId} />
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -1150,7 +1195,21 @@ export function AgentRail({
                   data-testid="agent-prose"
                   className="mt-1 ml-3.5 space-y-1 border-l border-white/10 pl-2 text-zinc-400"
                 >
-                  {renderProse(item.prose)}
+                  {/*
+                    The editor is offered to the statements INSIDE the prose (#389).
+                    Plan mode is toolless, so it writes no `statement-drafted` event and
+                    reaches no `applySql` — its SQL exists only as a fenced block in this
+                    text, which is why the hand-off is made here rather than beside the
+                    entry. A host with no editor passes nothing and is offered nothing,
+                    the rule every other affordance in this rail follows.
+                  */}
+                  {renderProse(item.prose, onApplyStatement === undefined ? {} : { onApplySql: onApplyStatement })}
+                  {/*
+                    And the plan as a whole, in the markdown the model wrote rather than
+                    in the rendering above: what a user pastes into a ticket is the text,
+                    and the text is what was recorded.
+                  */}
+                  <CopyButton text={item.prose} testId="agent-prose-copy" label="Copy all" />
                 </div>
               )}
               {/*
@@ -1182,9 +1241,7 @@ export function AgentRail({
               user should be able to see where the app stops speaking.
             */}
               {item.quoted !== undefined && (
-                <pre className="mt-1 ml-3.5 overflow-x-auto rounded bg-black/40 p-1.5 font-mono text-[0.625rem] text-zinc-400 whitespace-pre-wrap">
-                  {item.quoted}
-                </pre>
+                <QuotedBlock text={item.quoted} testId="agent-quoted-copy" className="mt-1 ml-3.5" />
               )}
               <div className="ml-3.5">
                 <HydrationControls
@@ -1233,9 +1290,7 @@ export function AgentRail({
             <h2 className="px-1 text-xs font-medium text-zinc-300">Report</h2>
             {run.timeline.report.claims.map((claim) => (
               <div key={claim.id} data-testid="agent-report-claim" className="rounded p-2 hover:bg-white/5">
-                <pre className="overflow-x-auto rounded bg-black/40 p-1.5 font-mono text-[0.625rem] text-zinc-300 whitespace-pre-wrap">
-                  {claim.quoted}
-                </pre>
+                <QuotedBlock text={claim.quoted} testId="agent-report-claim-copy" tone="loud" />
                 <ul className="mt-1 space-y-1">
                   {claim.citations.map((citation) => (
                     <li key={citation.id} data-testid="agent-report-citation" className="pl-1.5 text-xs">
@@ -1247,9 +1302,7 @@ export function AgentRail({
                         <span className="ml-1 font-mono text-[0.625rem] text-zinc-500">{citation.locator}</span>
                       )}
                       {citation.quoted !== undefined && (
-                        <pre className="mt-0.5 overflow-x-auto rounded bg-black/40 p-1.5 font-mono text-[0.625rem] text-zinc-400 whitespace-pre-wrap">
-                          {citation.quoted}
-                        </pre>
+                        <QuotedBlock text={citation.quoted} testId="agent-citation-quoted-copy" className="mt-0.5" />
                       )}
                       <HydrationControls
                         sql={citation.quoted}

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -98,6 +98,20 @@ const OUTCOME_LABELS: Readonly<Record<Exclude<CopyOutcome, "idle">, string>> = O
   failed: "Copy failed",
 });
 
+/**
+ * The accessible name per outcome. `idle` has none of its own: the resting name is the
+ * caller's `label`, which is also the visible text, so there is nothing to add.
+ *
+ * Each entry CONTAINS its visible label above, which is what WCAG 2.5.3 asks for — a
+ * name that dropped the visible words would leave voice-control users naming a button
+ * the page does not answer to.
+ */
+const ACCESSIBLE_NAMES: Readonly<Record<CopyOutcome, string | undefined>> = Object.freeze({
+  idle: undefined,
+  copied: "Copied",
+  failed: "Copy failed — select the text and copy it yourself",
+});
+
 export function CopyButton({ text, testId, label = "Copy", className }: CopyButtonProps) {
   const [outcome, setOutcome] = useState<CopyOutcome>("idle");
 
@@ -115,9 +129,18 @@ export function CopyButton({ text, testId, label = "Copy", className }: CopyButt
     <button
       type="button"
       data-testid={testId}
-      // The failure names what is left to do. A control that cannot perform its own
-      // action owes the user the one that still works.
-      aria-label={outcome === "failed" ? "Copy failed — select the text and copy it yourself" : label}
+      /*
+        The accessible name FOLLOWS the outcome, and the first version of this did not
+        (#389 review): it stayed the resting label while the visible text changed, so a
+        screen-reader user was told "Copy" over a button reading "Copied" and never
+        learned the copy had happened. It also broke WCAG 2.5.3 — the accessible name
+        must contain the visible label, and "Copied" is not inside "Copy".
+
+        The failure's name says what is left to do, because a control that cannot perform
+        its own action owes the user the one that still works. It still contains the
+        visible label, so 2.5.3 holds there too.
+      */
+      aria-label={ACCESSIBLE_NAMES[outcome] ?? label}
       onClick={() => {
         void writeToClipboard(text).then((copied) => setOutcome(copied ? "copied" : "failed"));
       }}

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, Copy, TriangleAlert } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * A small control that puts a block of text on the clipboard, and says whether it
+ * managed to (#389).
+ *
+ * It exists as a component rather than as a `navigator.clipboard.writeText` call at
+ * each site because of one fact about that API: **it is secure-context only.** Over
+ * plain HTTP on any host but loopback `navigator.clipboard` is undefined, and this
+ * product ships that way on several distribution channels — the same trap
+ * `crypto.randomUUID` set in `use-query-execution.ts`, where the fix was to stop
+ * reaching for the secure-context API at all. Here the API is the point, so the
+ * legacy command is the fallback instead.
+ *
+ * Two properties follow from that, and both are what make this honest rather than
+ * decorative:
+ *
+ *  - **The outcome is awaited.** The common pattern is to call `writeText` and flip to
+ *    "Copied!" in the same statement, which reports a success nobody observed: a
+ *    browser that refuses the write, a permissions policy that blocks it, and a page
+ *    that is not focused all reject the promise while the label says it worked.
+ *  - **A failure is said.** If both paths fail there is nothing more this control can
+ *    do, so it tells the user to select the text themselves rather than leaving them
+ *    to discover an empty clipboard when they paste.
+ */
+
+/** How long the outcome stays on the button before it offers itself again. */
+const OUTCOME_RESET_MS = 1_500;
+
+type CopyOutcome = "idle" | "copied" | "failed";
+
+/**
+ * The pre-`navigator.clipboard` route: a text area holding the text, selected, copied
+ * by the editing command, and removed.
+ *
+ * Deprecated and still the only thing that works in an insecure context. It is
+ * synchronous and must be called from the click handler's own task — a browser
+ * permits the command only while it is servicing a user gesture — which is why the
+ * caller awaits nothing before reaching it.
+ */
+function copyByEditingCommand(text: string): boolean {
+  const holder = document.createElement("textarea");
+  holder.value = text;
+  // Out of the layout and out of the tab order: the element exists for one command
+  // and must not move the page or take focus from what the user was doing.
+  holder.setAttribute("readonly", "");
+  holder.style.position = "fixed";
+  holder.style.top = "-9999px";
+  document.body.appendChild(holder);
+  holder.select();
+
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch {
+    // A browser that removed the command entirely. Nothing was copied, and the
+    // element below is still removed either way.
+    copied = false;
+  }
+
+  holder.remove();
+  return copied;
+}
+
+/** The async clipboard where there is one, the editing command where there is not. */
+async function writeToClipboard(text: string): Promise<boolean> {
+  // Typed as always present by the DOM lib, and absent in every insecure context, so
+  // the narrowing is the honest reading rather than defensive noise.
+  const clipboard = navigator.clipboard as Clipboard | undefined;
+  if (clipboard !== undefined) {
+    try {
+      await clipboard.writeText(text);
+      return true;
+    } catch {
+      // Refused rather than missing — a permissions policy, an unfocused document.
+      // The editing command is not subject to the same refusals, so it is still worth
+      // trying rather than reporting a failure here.
+    }
+  }
+  return copyByEditingCommand(text);
+}
+
+export interface CopyButtonProps {
+  /** Exactly what lands on the clipboard: no trimming, no re-formatting. */
+  readonly text: string;
+  readonly testId: string;
+  /** The resting label. "Copy" unless a site has more than one thing to copy. */
+  readonly label?: string;
+  readonly className?: string;
+}
+
+const OUTCOME_LABELS: Readonly<Record<Exclude<CopyOutcome, "idle">, string>> = Object.freeze({
+  copied: "Copied",
+  failed: "Copy failed",
+});
+
+export function CopyButton({ text, testId, label = "Copy", className }: CopyButtonProps) {
+  const [outcome, setOutcome] = useState<CopyOutcome>("idle");
+
+  // The outcome is a report on one click, not a state the button stays in: left
+  // standing it would say "Copied" over a button that has not been pressed since.
+  useEffect(() => {
+    if (outcome === "idle") return;
+    const timer = setTimeout(() => setOutcome("idle"), OUTCOME_RESET_MS);
+    return () => clearTimeout(timer);
+  }, [outcome]);
+
+  const Icon = outcome === "copied" ? Check : outcome === "failed" ? TriangleAlert : Copy;
+
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      // The failure names what is left to do. A control that cannot perform its own
+      // action owes the user the one that still works.
+      aria-label={outcome === "failed" ? "Copy failed — select the text and copy it yourself" : label}
+      onClick={() => {
+        void writeToClipboard(text).then((copied) => setOutcome(copied ? "copied" : "failed"));
+      }}
+      className={cn(
+        "flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] transition-colors",
+        outcome === "failed"
+          ? "text-amber-400/80 hover:bg-white/5"
+          : "text-zinc-400 hover:bg-white/5 hover:text-zinc-200",
+        className,
+      )}
+    >
+      <Icon strokeWidth={1.5} className="w-3 h-3" />
+      {outcome === "idle" ? label : OUTCOME_LABELS[outcome]}
+    </button>
+  );
+}

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { PencilLine } from "lucide-react";
+import { CopyButton } from "@/components/copy-button";
 
 /**
  * Renders the inline markup an LLM emits — `**bold**` and `` `code` `` — as React nodes.
@@ -56,6 +58,106 @@ const HEADING_LINE = /^(#{1,6})\s+(.*)$/;
 /** A bullet: a dash or asterisk followed by a space, which `**bold**` cannot be. */
 const BULLET_LINE = /^\s*[-*]\s+(.*)$/;
 
+/** A fence line: three backticks, and whatever the model called the block. */
+const FENCE_LINE = /^\s*```(.*)$/;
+
+/**
+ * The fence tags this surface will hand to a query editor.
+ *
+ * An ALLOWLIST, and fail-closed, which is the same posture the auto-execute gate takes
+ * about a dialect it has no rule for: the tag is the model saying what the block is,
+ * and offering to put a shell command into a SQL editor would be this surface claiming
+ * something the model contradicted. An untagged fence is offered — see `isQueryTag`.
+ *
+ * Every engine this product speaks is here, because the editor takes each of their
+ * query languages, plus the aliases models actually write for them. A tag missing from
+ * this set costs the user a button and never a wrong one; the copy control is offered
+ * on every block either way.
+ */
+const QUERY_FENCE_TAGS: ReadonlySet<string> = new Set([
+  "sql",
+  "postgres",
+  "postgresql",
+  "pgsql",
+  "psql",
+  "plpgsql",
+  "mysql",
+  "mariadb",
+  "sqlite",
+  "sqlite3",
+  "oracle",
+  "plsql",
+  "mssql",
+  "tsql",
+  "sqlserver",
+  "mongodb",
+  "mongo",
+  "redis",
+  "clickhouse",
+  "couchbase",
+  "n1ql",
+  "druid",
+]);
+
+/**
+ * Whether a fence holds something the editor should be offered.
+ *
+ * An untagged fence counts. Models write one for SQL constantly, and in a document
+ * whose entire subject is a database the bare fence is a query far more often than it
+ * is anything else — while the cost of being wrong is one click that puts text in an
+ * editor, which the user can see and undo.
+ */
+const isQueryTag = (tag: string | undefined): boolean => tag === undefined || QUERY_FENCE_TAGS.has(tag);
+
+export interface ProseOptions {
+  /**
+   * Puts a fenced statement into the host's editor. Absent where the host has no
+   * editor to put one in, and the control is then not rendered — the rule every
+   * affordance in the agent rail follows.
+   */
+  readonly onApplySql?: (sql: string) => void;
+}
+
+/**
+ * One fenced block: the model's text as typed, and what a reader may do with it.
+ *
+ * The controls sit UNDER the block rather than floating over its corner. A plan's SQL
+ * is often wider than the rail, so the block scrolls sideways; a control pinned inside
+ * it would sit on top of the text a user is reading, and one pinned outside the scroll
+ * would drift away from it.
+ */
+function CodeBlock({
+  code,
+  tag,
+  onApplySql,
+}: {
+  readonly code: string;
+  readonly tag: string | undefined;
+  readonly onApplySql: ((sql: string) => void) | undefined;
+}) {
+  return (
+    <div className="mt-1">
+      <pre className="overflow-x-auto rounded bg-black/40 p-1.5 font-mono text-[0.625rem] text-zinc-300 whitespace-pre">
+        {code}
+      </pre>
+      <div className="mt-0.5 flex items-center gap-1">
+        {onApplySql !== undefined && isQueryTag(tag) && (
+          <button
+            type="button"
+            data-testid="prose-code-apply"
+            onClick={() => onApplySql(code)}
+            className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] text-zinc-400 hover:bg-white/5 hover:text-zinc-200 transition-colors"
+          >
+            <PencilLine strokeWidth={1.5} className="w-3 h-3" />
+            Apply to editor
+          </button>
+        )}
+        <CopyButton text={code} testId="prose-code-copy" />
+      </div>
+    </div>
+  );
+}
+
 /**
  * Renders a block of model prose (#373 review).
  *
@@ -71,9 +173,16 @@ const BULLET_LINE = /^\s*[-*]\s+(.*)$/;
  *    as React nodes so that escaping is structural. There is no `dangerouslySetInnerHTML`
  *    on this path and no markdown library that could produce one.
  *  - **Only what the models actually emit**, which is headings, bullets, bold,
- *    paragraphs and inline code. Not a markdown engine: no links, no images, no tables,
- *    no fenced blocks, no ordered lists. Anything else stays the characters the model
+ *    paragraphs, inline code and fenced blocks. Not a markdown engine: no links, no
+ *    images, no tables, no ordered lists. Anything else stays the characters the model
  *    typed, which is the honest rendering of text this build does not interpret.
+ *  - **A fenced block is verbatim, and it is the reason this reads fences at all**
+ *    (#389). Plan mode is toolless, so its entire output is one of these blocks, and a
+ *    plan worth having contains SQL. Without fence handling that SQL arrived as
+ *    paragraphs of literal backticks with its whitespace collapsed — unreadable, and
+ *    with no way to get it into the editor. Nothing inside a fence is read as prose:
+ *    a `-` there is a minus sign and a `*` is a star, because that is what the model
+ *    typed and a code block is the one place markup must not be interpreted.
  *  - **Every heading renders at ONE level**, whatever the hash count. The heading
  *    outline of the page belongs to the application; a model's hash count is a claim
  *    about the structure of its own answer, not about this document, and letting it
@@ -83,10 +192,12 @@ const BULLET_LINE = /^\s*[-*]\s+(.*)$/;
  * boundary visible, because prose being READABLE must not make it look like the
  * application speaking.
  */
-export function renderProse(text: string): ReactNode[] {
+export function renderProse(text: string, options: ProseOptions = {}): ReactNode[] {
   const blocks: ReactNode[] = [];
   let bullets: string[] = [];
   let key = 0;
+  /** The fence being collected, or null outside one. */
+  let fence: { readonly tag: string | undefined; readonly lines: string[] } | null = null;
 
   const closeList = (): void => {
     if (bullets.length === 0) return;
@@ -107,7 +218,35 @@ export function renderProse(text: string): ReactNode[] {
     bullets = [];
   };
 
+  const closeFence = (): void => {
+    if (fence === null) return;
+    const code = fence.lines.join("\n");
+    // A fence with nothing in it is not a code block, for the same reason a heading
+    // with nothing after it is not a heading: it would render an empty box offering a
+    // copy of nothing.
+    if (code.trim().length > 0) {
+      blocks.push(<CodeBlock key={key} code={code} tag={fence.tag} onApplySql={options.onApplySql} />);
+      key += 1;
+    }
+    fence = null;
+  };
+
   for (const line of text.split("\n")) {
+    const marker = FENCE_LINE.exec(line);
+    if (fence !== null) {
+      // Inside a fence NOTHING is prose — including a line that looks like a bullet or
+      // a heading — so this branch comes before every other reading of the line.
+      if (marker === null) fence.lines.push(line);
+      else closeFence();
+      continue;
+    }
+    if (marker !== null) {
+      closeList();
+      const tag = marker[1].trim().toLowerCase();
+      fence = { tag: tag.length === 0 ? undefined : tag, lines: [] };
+      continue;
+    }
+
     const bullet = BULLET_LINE.exec(line);
     if (bullet !== null) {
       bullets.push(bullet[1]);
@@ -144,5 +283,9 @@ export function renderProse(text: string): ReactNode[] {
   }
 
   closeList();
+  // A fence the model never closed still renders what it holds: a run cut off at its
+  // turn limit or its deadline ends mid-block, and the statement it had written by then
+  // is the half the user came for.
+  closeFence();
   return blocks;
 }

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { PencilLine } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
+import type { DatabaseType } from "@/lib/types";
 
 /**
  * Renders the inline markup an LLM emits — `**bold**` and `` `code` `` — as React nodes.
@@ -71,52 +72,69 @@ const BULLET_LINE = /^\s*[-*]\s+(.*)$/;
 const FENCE_LINE = /^\s*```([^`]*)$/;
 
 /**
- * The fence tags this surface will hand to a query editor.
+ * Every engine this product speaks, as a fence tag.
  *
- * An ALLOWLIST, and fail-closed, which is the same posture the auto-execute gate takes
- * about a dialect it has no rule for: the tag is the model saying what the block is,
- * and offering to put a shell command into a SQL editor would be this surface claiming
- * something the model contradicted. An untagged fence is offered — see `isQueryTag`.
+ * A TOTAL RECORD over `DatabaseType` rather than a list, and that is the point: the
+ * first version of this was a hand-written set whose comment claimed every engine was
+ * in it, and `libredb` was not (#389 review). A comment cannot keep that promise and a
+ * record can — an engine added to the union stops this file compiling until someone
+ * decides what its blocks are called.
  *
- * Every engine this product speaks is here, because the editor takes each of their
- * query languages, plus the aliases models actually write for them. A tag missing from
- * this set costs the user a button and never a wrong one; the copy control is offered
- * on every block either way.
+ * The keys are the canonical type-ids because that is what the union holds; the aliases
+ * models actually write live below.
  */
-const QUERY_FENCE_TAGS: ReadonlySet<string> = new Set([
+const ENGINE_FENCE_TAGS: Readonly<Record<DatabaseType, true>> = Object.freeze({
+  postgres: true,
+  mysql: true,
+  sqlite: true,
+  mongodb: true,
+  redis: true,
+  oracle: true,
+  mssql: true,
+  libredb: true,
+  couchbase: true,
+  clickhouse: true,
+  druid: true,
+});
+
+/**
+ * The other names the same query languages go by, which is what a model actually types.
+ *
+ * Separate from the record above because these answer to nothing: no union widens when
+ * a model invents `pgsql`, so completeness here is a judgement rather than a guarantee.
+ * A tag missing from either costs the user a button and never a wrong one — the copy
+ * control is offered on every block regardless.
+ */
+const QUERY_FENCE_ALIASES: ReadonlySet<string> = new Set([
   "sql",
-  "postgres",
   "postgresql",
   "pgsql",
   "psql",
   "plpgsql",
-  "mysql",
   "mariadb",
-  "sqlite",
   "sqlite3",
-  "oracle",
   "plsql",
-  "mssql",
   "tsql",
   "sqlserver",
-  "mongodb",
   "mongo",
-  "redis",
-  "clickhouse",
-  "couchbase",
   "n1ql",
-  "druid",
 ]);
 
 /**
  * Whether a fence holds something the editor should be offered.
+ *
+ * Fail-closed on an unrecognised tag, the same posture the auto-execute gate takes about
+ * a dialect it has no rule for: the tag is the model saying what the block is, and
+ * offering to put a shell command into a SQL editor would be this surface claiming
+ * something the model contradicted.
  *
  * An untagged fence counts. Models write one for SQL constantly, and in a document
  * whose entire subject is a database the bare fence is a query far more often than it
  * is anything else — while the cost of being wrong is one click that puts text in an
  * editor, which the user can see and undo.
  */
-const isQueryTag = (tag: string | undefined): boolean => tag === undefined || QUERY_FENCE_TAGS.has(tag);
+const isQueryTag = (tag: string | undefined): boolean =>
+  tag === undefined || Object.hasOwn(ENGINE_FENCE_TAGS, tag) || QUERY_FENCE_ALIASES.has(tag);
 
 export interface ProseOptions {
   /**

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -58,8 +58,17 @@ const HEADING_LINE = /^(#{1,6})\s+(.*)$/;
 /** A bullet: a dash or asterisk followed by a space, which `**bold**` cannot be. */
 const BULLET_LINE = /^\s*[-*]\s+(.*)$/;
 
-/** A fence line: three backticks, and whatever the model called the block. */
-const FENCE_LINE = /^\s*```(.*)$/;
+/**
+ * A fence line: three backticks, and whatever the model called the block.
+ *
+ * The info string may hold no backtick, and that restriction is doing real work rather
+ * than following the spec for its own sake. CommonMark forbids it so that a whole fence
+ * written on ONE line — ```` ```sql SELECT 1``` ```` — is not read as an opener; without
+ * the rule, that single line opens a block nothing closes and the entire rest of the
+ * plan is swallowed into it. One malformed line would take the whole output with it, so
+ * such a line is left as the ordinary prose it renders as today.
+ */
+const FENCE_LINE = /^\s*```([^`]*)$/;
 
 /**
  * The fence tags this surface will hand to a query editor.

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -2207,6 +2207,117 @@ describe("AgentRail", () => {
   });
 
   /**
+   * Taking what a run produced away with you (#389).
+   *
+   * The gap: **plan mode reaches none of the events that carry `applySql`.** Every one
+   * of them — `statement-drafted`, `plan-comparison`, `recommendation`,
+   * `answer-composed` — is written by a tool call, and planning is toolless by
+   * contract. So the mode whose entire deliverable is a written plan was the one mode
+   * that could offer neither the editor nor the clipboard, and its SQL could only be
+   * dragged out of a scrolling panel by hand.
+   *
+   * Both halves are pinned here: the fenced statement inside a plan reaches the editor,
+   * and every verbatim block in the rail can be copied — the quoted content, the plan
+   * as a whole, a report's claims and the statements its citations rest on.
+   */
+  describe("taking a run's output away", () => {
+    const PLAN_WITH_SQL = [
+      "### Step 2: measure it",
+      "",
+      "Run this against `orders`:",
+      "",
+      "```sql",
+      "SELECT count(*) FROM orders WHERE created_at > now() - interval '7 days';",
+      "```",
+      "",
+      "It establishes the recent write rate.",
+    ].join("\n");
+
+    const closingLine = (text: string): string =>
+      `${JSON.stringify({ kind: "event", event: { kind: "closing-statement", atMs: 1_004, text } })}\n`;
+
+    async function planRun(props: Partial<React.ComponentProps<typeof AgentRail>> = {}) {
+      mockAgentFetch([OPENED_LINE, STARTED_LINE, closingLine(PLAN_WITH_SQL), FINISHED_LINE]);
+      const view = render(<AgentRail {...DEFAULT_PROPS} {...props} />);
+      fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "how would you check this" } });
+      await act(async () => {
+        fireEvent.click(view.getByTestId("agent-start"));
+      });
+      return view;
+    }
+
+    test("a plan's fenced statement reaches the editor, which no plan-mode entry could offer before", async () => {
+      const onApplyStatement = mock((_sql: string) => {});
+      const { findByTestId } = await planRun({ onApplyStatement });
+
+      fireEvent.click(await findByTestId("prose-code-apply"));
+      expect(onApplyStatement).toHaveBeenCalledWith(
+        "SELECT count(*) FROM orders WHERE created_at > now() - interval '7 days';",
+      );
+    });
+
+    test("the fence renders as a block, so the plan's SQL is readable at all", async () => {
+      const { findByTestId } = await planRun();
+
+      const prose = await findByTestId("agent-prose");
+      expect(prose.querySelector("pre")?.textContent).toBe(
+        "SELECT count(*) FROM orders WHERE created_at > now() - interval '7 days';",
+      );
+      expect(prose.textContent).not.toContain("```");
+    });
+
+    test("a host with no editor is offered no editor control, and still offers the clipboard", async () => {
+      const { queryByTestId, findByTestId } = await planRun();
+
+      expect(await findByTestId("prose-code-copy")).not.toBeNull();
+      expect(queryByTestId("prose-code-apply")).toBeNull();
+    });
+
+    test("the plan can be copied whole, in the markdown the model wrote", async () => {
+      const writeText = mock(() => Promise.resolve());
+      Object.defineProperty(globalThis.navigator, "clipboard", { value: { writeText }, configurable: true });
+      const { findByTestId } = await planRun();
+
+      fireEvent.click(await findByTestId("agent-prose-copy"));
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith(PLAN_WITH_SQL));
+    });
+
+    test("a quoted block is copyable, which is the whole of what a user could not do", async () => {
+      const writeText = mock(() => Promise.resolve());
+      Object.defineProperty(globalThis.navigator, "clipboard", { value: { writeText }, configurable: true });
+      mockAgentFetch([OPENED_LINE, STARTED_LINE, DRAFTED_LINE, FINISHED_LINE]);
+      const view = render(<AgentRail {...DEFAULT_PROPS} />);
+      fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why" } });
+      await act(async () => {
+        fireEvent.click(view.getByTestId("agent-start"));
+      });
+
+      const copies = await view.findAllByTestId("agent-quoted-copy");
+      // The objective and the drafted statement: every verbatim block, not a chosen one.
+      expect(copies.length).toBe(2);
+      fireEvent.click(copies[1]);
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith("SELECT count(*) FROM orders"));
+    });
+
+    test("a report's claim and the statement its citation rests on are both copyable", async () => {
+      const writeText = mock(() => Promise.resolve());
+      Object.defineProperty(globalThis.navigator, "clipboard", { value: { writeText }, configurable: true });
+      mockAgentFetch([OPENED_LINE, STARTED_LINE, DRAFTED_LINE, COMPLETED_LINE, REPORT_LINE, FINISHED_LINE]);
+      const view = render(<AgentRail {...DEFAULT_PROPS} />);
+      fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why" } });
+      await act(async () => {
+        fireEvent.click(view.getByTestId("agent-start"));
+      });
+
+      fireEvent.click(await view.findByTestId("agent-report-claim-copy"));
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith("checkout is slow because orders is scanned"));
+
+      fireEvent.click(await view.findByTestId("agent-citation-quoted-copy"));
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith("SELECT count(*) FROM orders"));
+    });
+  });
+
+  /**
    * The timeline follows the newest entry (#373 review).
    *
    * Measured on a completed run: the scroll container sat at `scrollTop: 0` with a

--- a/tests/components/copy-button.test.tsx
+++ b/tests/components/copy-button.test.tsx
@@ -117,6 +117,20 @@ describe("CopyButton", () => {
     expect(getByTestId("copy").getAttribute("aria-label")).toContain("select");
   });
 
+  test("tells a screen reader the copy happened, in a name that contains the visible label", async () => {
+    // The accessible name overrides the button's text, so one left at the resting label
+    // would report "Copy all" over a button reading "Copied" — no outcome for a screen
+    // reader, and a WCAG 2.5.3 failure for voice control, which names what it sees.
+    setClipboard({ writeText: () => Promise.resolve() });
+
+    const { getByTestId } = render(<CopyButton text="SELECT 9" testId="copy" label="Copy all" />);
+    expect(getByTestId("copy").getAttribute("aria-label")).toBe("Copy all");
+
+    fireEvent.click(getByTestId("copy"));
+    await waitFor(() => expect(getByTestId("copy").getAttribute("aria-label")).toBe("Copied"));
+    expect(getByTestId("copy").textContent).toContain("Copied");
+  });
+
   test("returns to its resting label, so a second copy reads as a second copy", async () => {
     setClipboard({ writeText: () => Promise.resolve() });
 

--- a/tests/components/copy-button.test.tsx
+++ b/tests/components/copy-button.test.tsx
@@ -1,0 +1,129 @@
+import "../setup-dom";
+
+import React from "react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { CopyButton } from "@/components/copy-button";
+
+/**
+ * The copy control (#389).
+ *
+ * What these tests pin is one property, and it is the reason this component exists
+ * rather than a `navigator.clipboard.writeText` call at each site:
+ *
+ *  - **The async clipboard is a secure-context API.** It is absent over plain HTTP on
+ *    any host but loopback, and this product ships that way on several distribution
+ *    channels — the same trap `crypto.randomUUID` set in `use-query-execution.ts`. A
+ *    button that reads "Copy" and does nothing on those channels is worse than no
+ *    button, so the legacy command is the fallback and a failure of BOTH is said out
+ *    loud rather than swallowed.
+ */
+
+const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, "clipboard");
+const originalExecCommand = Object.getOwnPropertyDescriptor(globalThis.document, "execCommand");
+
+/** Installs a clipboard object, or removes it entirely to model an insecure context. */
+function setClipboard(clipboard: { writeText: (text: string) => Promise<void> } | undefined): void {
+  Object.defineProperty(globalThis.navigator, "clipboard", { value: clipboard, configurable: true });
+}
+
+function setExecCommand(execCommand: ((command: string) => boolean) | undefined): void {
+  Object.defineProperty(globalThis.document, "execCommand", { value: execCommand, configurable: true });
+}
+
+afterEach(() => {
+  cleanup();
+  if (originalClipboard === undefined) setClipboard(undefined);
+  else Object.defineProperty(globalThis.navigator, "clipboard", originalClipboard);
+  if (originalExecCommand === undefined) setExecCommand(undefined);
+  else Object.defineProperty(globalThis.document, "execCommand", originalExecCommand);
+});
+
+describe("CopyButton", () => {
+  test("writes the text with the async clipboard when the browser has one", async () => {
+    const writeText = mock(() => Promise.resolve());
+    setClipboard({ writeText });
+
+    const { getByTestId } = render(<CopyButton text="SELECT 1" testId="copy" />);
+    fireEvent.click(getByTestId("copy"));
+
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copied"));
+    expect(writeText).toHaveBeenCalledWith("SELECT 1");
+  });
+
+  test("falls back to the legacy command when there is no clipboard object at all", async () => {
+    setClipboard(undefined);
+    const execCommand = mock(() => true);
+    setExecCommand(execCommand);
+
+    const { getByTestId } = render(<CopyButton text="SELECT 2" testId="copy" />);
+    fireEvent.click(getByTestId("copy"));
+
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copied"));
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  test("falls back to the legacy command when the clipboard object rejects", async () => {
+    setClipboard({ writeText: () => Promise.reject(new Error("denied")) });
+    const execCommand = mock(() => true);
+    setExecCommand(execCommand);
+
+    const { getByTestId } = render(<CopyButton text="SELECT 3" testId="copy" />);
+    fireEvent.click(getByTestId("copy"));
+
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copied"));
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  test("leaves nothing behind in the document after the fallback", async () => {
+    setClipboard(undefined);
+    setExecCommand(() => true);
+
+    const { getByTestId } = render(<CopyButton text="SELECT 4" testId="copy" />);
+    fireEvent.click(getByTestId("copy"));
+
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copied"));
+    expect(globalThis.document.querySelectorAll("textarea").length).toBe(0);
+  });
+
+  test("says the copy failed when the legacy command reports it did nothing", async () => {
+    setClipboard(undefined);
+    setExecCommand(() => false);
+
+    const { getByTestId } = render(<CopyButton text="SELECT 5" testId="copy" />);
+    fireEvent.click(getByTestId("copy"));
+
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copy failed"));
+  });
+
+  test("says the copy failed when the legacy command is absent too", async () => {
+    setClipboard(undefined);
+    setExecCommand(undefined);
+
+    const { getByTestId } = render(<CopyButton text="SELECT 6" testId="copy" />);
+    fireEvent.click(getByTestId("copy"));
+
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copy failed"));
+  });
+
+  test("tells a user whose copy failed what to do instead, in the accessible name", async () => {
+    setClipboard(undefined);
+    setExecCommand(() => false);
+
+    const { getByTestId } = render(<CopyButton text="SELECT 7" testId="copy" />);
+    fireEvent.click(getByTestId("copy"));
+
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copy failed"));
+    expect(getByTestId("copy").getAttribute("aria-label")).toContain("select");
+  });
+
+  test("returns to its resting label, so a second copy reads as a second copy", async () => {
+    setClipboard({ writeText: () => Promise.resolve() });
+
+    const { getByTestId } = render(<CopyButton text="SELECT 8" testId="copy" label="Copy plan" />);
+    fireEvent.click(getByTestId("copy"));
+
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copied"));
+    await waitFor(() => expect(getByTestId("copy").textContent).toContain("Copy plan"), { timeout: 4_000 });
+  });
+});

--- a/tests/components/rich-text.test.tsx
+++ b/tests/components/rich-text.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { renderProse } from "@/components/rich-text";
+import type { DatabaseType } from "@/lib/types";
 
 /**
  * Fenced code blocks in model prose (#389).
@@ -127,6 +128,46 @@ describe("renderProse code hand-off to the editor", () => {
 
     fireEvent.click(getByTestId("prose-code-apply"));
     expect(onApplySql).toHaveBeenCalledWith("SELECT 1;");
+  });
+
+  test("offers a fence tagged with the embedded engine, which the first allowlist omitted", () => {
+    // `libredb` is a `DatabaseType` and its provider declares `queryDialect: "libredb"`,
+    // so a plan for one is as applicable as a plan for PostgreSQL. The hand-written set
+    // this replaced claimed every engine was in it and left this one out (#389 review).
+    const onApplySql = mock((_sql: string) => {});
+    const { getByTestId } = render(<div>{renderProse(`${FENCE}libredb\nSELECT 1;\n${FENCE}`, { onApplySql })}</div>);
+
+    fireEvent.click(getByTestId("prose-code-apply"));
+    expect(onApplySql).toHaveBeenCalledWith("SELECT 1;");
+  });
+
+  test("offers a fence tagged with any engine the product speaks", () => {
+    // The record is total over `DatabaseType`, so this is the assertion that a NEW engine
+    // cannot ship without its tag: adding one to the union breaks the build, and adding
+    // it here without a tag breaks this.
+    const engines = [
+      "postgres",
+      "mysql",
+      "sqlite",
+      "mongodb",
+      "redis",
+      "oracle",
+      "mssql",
+      "libredb",
+      "couchbase",
+      "clickhouse",
+      "druid",
+    ] satisfies DatabaseType[];
+
+    for (const engine of engines) {
+      const onApplySql = mock((_sql: string) => {});
+      const { getByTestId, unmount } = render(
+        <div>{renderProse(`${FENCE}${engine}\nSELECT 1;\n${FENCE}`, { onApplySql })}</div>,
+      );
+      fireEvent.click(getByTestId("prose-code-apply"));
+      expect(onApplySql).toHaveBeenCalledWith("SELECT 1;");
+      unmount();
+    }
   });
 
   test("withholds the editor from a fence the model said is not a query", () => {

--- a/tests/components/rich-text.test.tsx
+++ b/tests/components/rich-text.test.tsx
@@ -1,0 +1,135 @@
+import "../setup-dom";
+
+import React from "react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { renderProse } from "@/components/rich-text";
+
+/**
+ * Fenced code blocks in model prose (#389).
+ *
+ * The gap these pin: plan mode is toolless, so its ENTIRE output is one block of model
+ * prose, and a plan for anything worth planning contains SQL. `renderProse` read
+ * headings, bullets, bold and inline code and deliberately not fences, so the SQL
+ * arrived as a paragraph of literal backticks with its whitespace collapsed — the one
+ * thing the mode produces, rendered as the one thing this renderer would not read.
+ *
+ * The security property of the block still holds and is pinned here too: a fence is
+ * rendered as text nodes inside a `pre`, so nothing in it reaches an HTML parser.
+ */
+
+afterEach(cleanup);
+
+const FENCE = "```";
+
+describe("renderProse fenced blocks", () => {
+  test("renders a fenced block verbatim, with the fence lines themselves gone", () => {
+    const { container } = render(
+      <div>{renderProse(`Look at this:\n${FENCE}sql\nSELECT 1;\n${FENCE}\nThat is all.`)}</div>,
+    );
+
+    const code = container.querySelector("pre");
+    expect(code?.textContent).toBe("SELECT 1;");
+    expect(container.textContent).not.toContain(FENCE);
+  });
+
+  test("keeps indentation and markdown characters inside a fence as the model typed them", () => {
+    const sql = "SELECT *\n  FROM orders o\n  JOIN customers c ON c.id = o.customer_id\n- not a bullet";
+    const { container } = render(<div>{renderProse(`${FENCE}sql\n${sql}\n${FENCE}`)}</div>);
+
+    expect(container.querySelector("pre")?.textContent).toBe(sql);
+    // Nothing inside the fence was read as prose: no list, no bold, no inline code.
+    expect(container.querySelector("ul")).toBeNull();
+    expect(container.querySelector("strong")).toBeNull();
+  });
+
+  test("renders the content of a fence the model never closed", () => {
+    // A run cut off at its turn limit or its deadline ends mid-block, and the SQL it
+    // had written is still the useful half.
+    const { container } = render(<div>{renderProse(`${FENCE}sql\nSELECT 1;`)}</div>);
+
+    expect(container.querySelector("pre")?.textContent).toBe("SELECT 1;");
+  });
+
+  test("renders nothing for a fence with nothing in it", () => {
+    const { container } = render(<div>{renderProse(`${FENCE}sql\n\n${FENCE}`)}</div>);
+
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  test("ends an open bullet list where a fence begins", () => {
+    const { container } = render(<div>{renderProse(`- first\n- second\n${FENCE}\nSELECT 1;\n${FENCE}`)}</div>);
+
+    expect(container.querySelectorAll("li").length).toBe(2);
+    expect(container.querySelector("pre")?.textContent).toBe("SELECT 1;");
+  });
+
+  test("renders two fences as two blocks", () => {
+    const { container } = render(
+      <div>{renderProse(`${FENCE}sql\nSELECT 1;\n${FENCE}\nthen\n${FENCE}sql\nSELECT 2;\n${FENCE}`)}</div>,
+    );
+
+    expect([...container.querySelectorAll("pre")].map((block) => block.textContent)).toEqual([
+      "SELECT 1;",
+      "SELECT 2;",
+    ]);
+  });
+
+  test("renders an HTML payload inside a fence as text, never as an element", () => {
+    const payload = '<img src=x onerror="steal()">';
+    const { container } = render(<div>{renderProse(`${FENCE}sql\n${payload}\n${FENCE}`)}</div>);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("pre")?.textContent).toBe(payload);
+  });
+
+  test("offers every fenced block to the clipboard", () => {
+    const { getAllByTestId } = render(<div>{renderProse(`${FENCE}sql\nSELECT 1;\n${FENCE}`)}</div>);
+
+    expect(getAllByTestId("prose-code-copy").length).toBe(1);
+  });
+});
+
+describe("renderProse code hand-off to the editor", () => {
+  test("offers a sql-tagged fence to the editor, with the statement the model wrote", () => {
+    const onApplySql = mock((_sql: string) => {});
+    const { getByTestId } = render(<div>{renderProse(`${FENCE}sql\nSELECT 1;\n${FENCE}`, { onApplySql })}</div>);
+
+    fireEvent.click(getByTestId("prose-code-apply"));
+    expect(onApplySql).toHaveBeenCalledWith("SELECT 1;");
+  });
+
+  test("offers an untagged fence, because a plan for a database writes one for its SQL", () => {
+    const onApplySql = mock((_sql: string) => {});
+    const { getByTestId } = render(<div>{renderProse(`${FENCE}\nSELECT 1;\n${FENCE}`, { onApplySql })}</div>);
+
+    fireEvent.click(getByTestId("prose-code-apply"));
+    expect(onApplySql).toHaveBeenCalledWith("SELECT 1;");
+  });
+
+  test("offers a fence tagged with an engine this product speaks", () => {
+    const onApplySql = mock((_sql: string) => {});
+    const { getByTestId } = render(<div>{renderProse(`${FENCE}PostgreSQL\nSELECT 1;\n${FENCE}`, { onApplySql })}</div>);
+
+    fireEvent.click(getByTestId("prose-code-apply"));
+    expect(onApplySql).toHaveBeenCalledWith("SELECT 1;");
+  });
+
+  test("withholds the editor from a fence the model said is not a query", () => {
+    const onApplySql = mock((_sql: string) => {});
+    const { queryByTestId, getByTestId } = render(
+      <div>{renderProse(`${FENCE}bash\npg_dump mydb\n${FENCE}`, { onApplySql })}</div>,
+    );
+
+    expect(queryByTestId("prose-code-apply")).toBeNull();
+    // Still copyable: withholding the editor is a claim about where the text belongs,
+    // not about whether the user may have it.
+    expect(getByTestId("prose-code-copy")).not.toBeNull();
+  });
+
+  test("offers no editor control at all where the host has no editor", () => {
+    const { queryByTestId } = render(<div>{renderProse(`${FENCE}sql\nSELECT 1;\n${FENCE}`)}</div>);
+
+    expect(queryByTestId("prose-code-apply")).toBeNull();
+  });
+});

--- a/tests/components/rich-text.test.tsx
+++ b/tests/components/rich-text.test.tsx
@@ -83,6 +83,20 @@ describe("renderProse fenced blocks", () => {
     expect(container.querySelector("pre")?.textContent).toBe(payload);
   });
 
+  test("does not let a one-line fence swallow the rest of the plan", () => {
+    // ```` ```sql SELECT 1``` ```` on one line. Read as an opener it would open a block
+    // nothing closes, and everything after it — the whole remainder of the plan — would
+    // render as code. CommonMark forbids a backtick in the info string for exactly this
+    // reason, so the line stays the prose it was.
+    const { container } = render(
+      <div>{renderProse(`${FENCE}sql SELECT 1${FENCE}\n\n### Step 2\n\nA real paragraph.`)}</div>,
+    );
+
+    expect(container.querySelector("pre")).toBeNull();
+    expect(container.querySelector("h4")?.textContent).toBe("Step 2");
+    expect(container.textContent).toContain("A real paragraph.");
+  });
+
   test("offers every fenced block to the clipboard", () => {
     const { getAllByTestId } = render(<div>{renderProse(`${FENCE}sql\nSELECT 1;\n${FENCE}`)}</div>);
 

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -245,6 +245,8 @@ run_group "Group 14/16: DataCharts" \
 
 # Group 15: All remaining files (safe together)
 run_group "Group 15/16: Remaining components" \
+  tests/components/copy-button.test.tsx \
+  tests/components/rich-text.test.tsx \
   tests/components/QueryEditor.test.tsx \
   tests/components/QuerySafetyDialog.test.tsx \
   tests/components/QueryHistory.test.tsx \


### PR DESCRIPTION
## The gap

Plan mode is toolless, so it writes no `statement-drafted` event and reaches none of the four events that carry `applySql` — every one of them is written by a tool call. Its entire output is one block of model prose, and `renderProse` read headings, bullets, bold and inline code, and **deliberately not fenced blocks**.

So the one mode whose whole deliverable is a written plan was the one mode that could offer neither the editor nor the clipboard. Its SQL arrived as paragraphs of literal backticks with the whitespace collapsed, and a user was left dragging it out of a narrow scrolling panel by hand.

Reproduced live before the fix, on the merged `main` build: `hasBacktickFence: true`, zero apply controls, zero copy controls.

## What changed

**`renderProse` reads fences.** The content is verbatim — nothing inside is read as prose, because a `-` in SQL is a minus sign and a `*` is a star — and an unclosed fence still renders, since a run cut off at its turn limit ends mid-block. It still builds React nodes and reaches no HTML parser, so the security property the function was written for is unchanged.

**A fenced block offers the editor when the model's own tag says it is a query**, or when there is no tag. An allowlist, fail-closed — the posture `planRefusal` takes about a dialect it has no rule for. Offering to put a `bash` block into a SQL editor would be this surface claiming something the model contradicted. Copy is offered on every block either way: withholding the editor is a claim about where text belongs, not about whether the user may have it.

**`CopyButton` on every verbatim block in the rail** — the quoted content, the plan as a whole (`Copy all`, in the markdown the model wrote), a report's claims, and the statements its citations rest on. Not a chosen few: *which of these did the product decide I would want* is not a question a user should have to answer.

## The clipboard is not as simple as it looks

`navigator.clipboard` is a **secure-context API**. Over plain HTTP on any host but loopback it is `undefined` — and this product ships that way on several distribution channels. It is the same trap `crypto.randomUUID` set in `use-query-execution.ts`, where the fix was to stop reaching for the secure-context API at all.

So `CopyButton` falls back to `document.execCommand("copy")`, and it **awaits its own outcome**. The common pattern is to call `writeText` and flip to "Copied!" in the same statement, which reports a success nobody observed: a refused write, a blocking permissions policy and an unfocused page all reject the promise while the label claims it worked. When both paths fail this one says so, and its accessible name tells the user to select the text instead.

`docs/BACKLOG.md` B43 records the six copy sites outside the rail that still reach the API unguarded — four of them flip the label in the same statement that starts the write.

## Driven live

Against dvdrental on `gemini-3.5-flash-lite`, **Plan · Optimize**:

- two SQL blocks came back, each with its own **Apply to editor** and **Copy**
- Apply put the `pg_stat_user_indexes` read into the editor with its indentation intact
- Copy wrote exactly that block's text, once
- **`Statements 0 / 30`** — plan mode sent nothing, which is the whole promise

`docs/AGENT_DEMO.md` gains case 19b recording it, and the count moves to twenty-five.

## Not done, and why

B44: a plan's SQL is read out of a markdown *fence* rather than recorded as a statement. The alternative is a planning-mode tool that records a drafted statement and reaches no database — which would widen the mode's contract, and "planning has no tools" is a sentence three surfaces and the capability gate all rely on. The fence covers what live models actually emit.

## Gates

`format` · `lint` · `typecheck` · `knip` · `test` · `build` all green locally. Coverage 35197/35197 lines (100.00%). 24 new tests.