### PR TITLE
chore(ci): tell Dependabot this is a Bun project, not an npm one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,21 +7,28 @@
 # into a handful of pull requests a week, split only where the split changes how
 # a reviewer reads them: what ships versus what does not.
 #
-# Bun is supported through the `npm` ecosystem - Dependabot treats it as part of
-# `npm_and_yarn` and understands `bun.lock`. Only version updates work today;
-# Bun security updates are not implemented upstream, which is why the security
-# side still runs through Trivy and `bun audit`.
+# Bun is its own ecosystem (`package-ecosystem: "bun"`), NOT part of `npm`. The
+# `npm` ecosystem covers npm and pnpm; its updater looks for package-lock.json,
+# yarn.lock or pnpm-lock.yaml and cannot see `bun.lock` at all. Configuring bun
+# under `npm` is what shipped in #375, and the result was five pull requests that
+# bumped `package.json` alone - every CI job then died in its first step on
+# `error: lockfile had changes, but lockfile is frozen`. The compatibility badge
+# in those pull request bodies said `package-manager=npm_and_yarn`, which was the
+# tell. Only version updates work today; Bun security updates are not implemented
+# upstream, which is why the security side still runs through Trivy and
+# `bun audit`.
 #
 # CI installs with `bun install --frozen-lockfile` (scripts/ci-install.sh), so a
 # pull request whose `bun.lock` does not match its `package.json` fails loudly
 # rather than resolving around the difference. That is the safety net behind
-# every group below.
+# every group below - and it worked exactly as designed above; the bug was the
+# ecosystem name, never the gate.
 
 version: 2
 
 updates:
-  # ---------------------------------------------------------------- npm / bun
-  - package-ecosystem: "npm"
+  # ---------------------------------------------------------------------- bun
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -43,6 +50,15 @@ updates:
     # rather than a bump. The fan-out is bounded: nine majors are outstanding as
     # of 2026-08-15 across ~1170 installed packages, and open-pull-requests-limit
     # caps how many wait at once.
+    #
+    # UNVERIFIED under `bun`: the options reference lists `dependency-type`
+    # inside `groups` for bundler, composer, mix, maven, npm and pip - bun is not
+    # named. The published schema does not restrict it per ecosystem, so this
+    # config is valid either way and cannot break the Actions or Docker blocks
+    # below. If the first bun run ignores it, both groups match everything and
+    # the production/development split collapses into one pull request; the fix
+    # is then to separate them with `patterns` instead. Cosmetic either way -
+    # check the grouping on the first run before assuming it took.
     groups:
       # What ships. Kept separate from tooling because a reviewer weighs these
       # against "does the editor still work in a browser", not "does lint pass".

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,17 @@
 # a reviewer reads them: what ships versus what does not.
 #
 # Bun is its own ecosystem (`package-ecosystem: "bun"`), NOT part of `npm`. The
-# `npm` ecosystem covers npm and pnpm; its updater looks for package-lock.json,
-# yarn.lock or pnpm-lock.yaml and cannot see `bun.lock` at all. Configuring bun
-# under `npm` is what shipped in #375, and the result was five pull requests that
-# bumped `package.json` alone - every CI job then died in its first step on
-# `error: lockfile had changes, but lockfile is frozen`. The compatibility badge
-# in those pull request bodies said `package-manager=npm_and_yarn`, which was the
-# tell. Only version updates work today; Bun security updates are not implemented
-# upstream, which is why the security side still runs through Trivy and
-# `bun audit`.
+# `npm` ecosystem covers npm, pnpm and Yarn - internally Dependabot calls it
+# `npm_and_yarn` - so its updater looks for package-lock.json, pnpm-lock.yaml or
+# yarn.lock, and cannot see `bun.lock` at all. Configuring bun under `npm` is what
+# shipped in #375, and the result was five pull requests that bumped
+# `package.json` alone - every CI job then died in its first step on
+# `error: lockfile had changes, but lockfile is frozen`. That internal name was
+# the tell twice over: the compatibility badge in those pull request bodies said
+# `package-manager=npm_and_yarn`, and the branches were called
+# `dependabot/npm_and_yarn/...`. Only version updates work today; Bun security
+# updates are not implemented upstream, which is why the security side still runs
+# through Trivy and `bun audit`.
 #
 # CI installs with `bun install --frozen-lockfile` (scripts/ci-install.sh), so a
 # pull request whose `bun.lock` does not match its `package.json` fails loudly

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -710,9 +710,12 @@ asks for one.
 
 ### C5. Dependabot raises version updates but cannot raise security ones
 
-`.github/dependabot.yml` now groups weekly version updates across npm/bun, GitHub
-Actions and both Dockerfiles, which is what the original entry asked for. What it
-cannot do is the other half: Dependabot's Bun support covers **version updates
+`.github/dependabot.yml` now groups weekly version updates across Bun, GitHub
+Actions and both Dockerfiles, which is what the original entry asked for. Bun is
+its own `package-ecosystem`, not part of `npm` - the config shipped in #375 said
+`npm`, whose updater cannot see `bun.lock`, so five bot pull requests bumped
+`package.json` alone and died on `--frozen-lockfile`. What Dependabot still
+cannot do is the other half: its Bun support covers **version updates
 only** - security updates are not implemented upstream for this ecosystem. So an
 advisory against a package Bun resolves still reaches nobody automatically; Trivy
 and `bun audit` remain the only things that see it, and acting on one is still a


### PR DESCRIPTION
## What

One word in `.github/dependabot.yml`: `package-ecosystem: "npm"` becomes `"bun"`. Plus the two comments that asserted the wrong thing, and the matching line in `docs/BACKLOG.md` C5.

## Why

Bun is its own ecosystem. The `npm` ecosystem covers **npm and pnpm**, and its updater resolves `package-lock.json`, `yarn.lock` or `pnpm-lock.yaml` — it cannot see `bun.lock` at all.

So the config shipped in #375 routed every JavaScript update through an updater that was blind to this repository's lockfile. It bumped `package.json`, left `bun.lock` alone, and all five resulting bot pull requests (#376–#379, #381) died in their first CI step:

```
bun install v1.3.14
Resolving dependencies
error: lockfile had changes, but lockfile is frozen
```

Five jobs went red per pull request, which reads as five faults and is one — `scripts/ci-install.sh` is the first step of every one of them. Everything downstream showed `skipping`.

The tell was in the bot's own pull request bodies the whole time: the compatibility badge reads `package-manager=npm_and_yarn`.

**`--frozen-lockfile` did exactly what it was added to do.** It refused to resolve around a manifest/lockfile mismatch instead of silently installing a tree nobody reviewed. Nothing about the gate needed changing; the ecosystem name did.

## Evidence

| Source | Finding |
|---|---|
| [GitHub Docs — supported ecosystems](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories) | `bun` is a separate GA ecosystem (bun >= 1.1.39); `npm` = npm + pnpm |
| [`dsp-testing/dependabot-bun-public`](https://github.com/dsp-testing/dependabot-bun-public) | GitHub's own bun test repo ships `bun.lock` and uses `package-ecosystem: "bun"` |
| [dependabot-core#13623](https://github.com/dependabot/dependabot-core/issues/13623) (closed) | Reporter on the `bun` ecosystem complains Dependabot *strips a field from* `bun.lock` — it can only do that to a file it writes |

## Verification

- Validated against the schemastore `dependabot-2.0` schema: passes.
- Control run on the same validator: a typo'd ecosystem (`bunn`) and an unknown key are both rejected — so the pass means something.
- Reproduced the CI failure locally from `package.json` + `bun.lock` alone, then confirmed it disappears when the single manifest line is reverted.
- Six gates green.

## Known unknown

The options reference lists `dependency-type` inside `groups` for bundler, composer, mix, maven, npm and pip — bun is not named. The published schema does not restrict it per ecosystem, so this config is valid either way and **cannot** take the Actions or Docker blocks down with it. If the first bun run ignores it, the production/development split collapses into a single pull request and `patterns` replaces it. Cosmetic; flagged in a comment next to the groups. Worth a look on the first run rather than assuming it took.

## After merge

`dependabot.yml` only takes effect from the default branch, so this has to land first, then a manual "Check for updates" from the Dependabot page. The five open npm pull requests should be superseded by bun ones that carry `bun.lock`; any that linger get closed by hand.

Unrelated and still open: `SONAR_TOKEN` lives in Actions secrets, and Dependabot-triggered runs read the Dependabot secret store instead, so SonarCloud fails on bot pull requests. Not a required check, tracked separately.
