### PR TITLE
ci: run SonarCloud only where SONAR_TOKEN can be read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,28 @@ jobs:
   sonarcloud:
     name: SonarCloud Analysis
     needs: [test]
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    # Runs only where SONAR_TOKEN can actually be read, because the scanner
+    # fails rather than degrades without it ("Not authorized or project not
+    # found", exit 3) and that red is pure noise on a pull request nobody can
+    # fix. Two populations cannot read it:
+    #
+    #   Forks - a fork pull request gets no secrets at all. Already guarded
+    #   below; this is the check that used to hard-block fork contributors.
+    #
+    #   Dependabot - its branches live in this repository, so the fork guard
+    #   says yes, but GitHub serves runs it triggers from the *Dependabot*
+    #   secret store rather than Actions secrets, and SONAR_TOKEN is not in it.
+    #   Every bot pull request therefore carried a red SonarCloud.
+    #
+    # Gated on the actor, not the branch name, and the distinction is load
+    # bearing: push a commit of your own onto a `dependabot/**` branch and the
+    # run is yours, Actions secrets come back, and the analysis is both
+    # possible and wanted. PR #394 is the worked example - red while Dependabot
+    # owned it, green on the very next human push to the same branch.
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event.pull_request.head.repo.full_name == github.repository
+        || github.event_name == 'push')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What

One condition on the `sonarcloud` job in `.github/workflows/ci.yml`: it now also skips runs triggered by `dependabot[bot]`.

```yaml
if: >-
  github.actor != 'dependabot[bot]'
  && (github.event.pull_request.head.repo.full_name == github.repository
    || github.event_name == 'push')
```

## Why

The scanner does not degrade without its token — it fails, loudly:

```
##[warning]Running this GitHub Action without SONAR_TOKEN is not recommended
Not authorized or project not found. Please check the 'SONAR_TOKEN' environment variable...
##[error]sonar-scanner failed with exit code 3
```

And on a Dependabot pull request the token is not missing by accident. The run log says it outright:

```
Secret source: Dependabot
```

GitHub serves runs Dependabot triggers from the **Dependabot secret store**, not Actions secrets, and `SONAR_TOKEN` lives in the latter. So every bot pull request has been carrying a red SonarCloud that nobody could act on.

The job already skipped fork pull requests, which have no secrets at all. Dependabot slipped through the existing guard because its branches live in this repository, so `head.repo.full_name == github.repository` is true — the fork guard asks the right question for forks and the wrong one for bots.

## Why the actor, not the branch name

This is the part worth reviewing. `startsWith(github.head_ref, 'dependabot/')` would look equivalent and would be wrong.

Push a commit of your own onto a `dependabot/**` branch and the run belongs to you: the actor is a human, Actions secrets come back, and the analysis is both possible and wanted. Branch-name gating would silently throw that analysis away.

PR #394 is the worked example, on one branch and one pull request:

| Head commit pushed by | SonarCloud Analysis |
|---|---|
| `dependabot[bot]` | fail — `Not authorized`, 25s |
| a human, next commit, same branch | **pass — 1m11s** |

Actor gating keeps the second row green and drops only the first.

## Scope

- Not a required check, so merge eligibility does not move.
- Fork behaviour is unchanged.
- `push` to `main`/`ci` is unchanged.
- Dependabot pull requests will now show SonarCloud as `skipping` instead of red.

## Verification

Workflow YAML parses and the folded condition resolves to the intended single expression. Truth table over the four populations:

| Event | Actor | Head repo | Result |
|---|---|---|---|
| `push` (main/ci) | human | — | runs |
| `pull_request`, same repo | human | this repo | runs |
| `pull_request`, same repo | `dependabot[bot]` | this repo | **skips (new)** |
| `pull_request`, fork | anyone | fork | skips (unchanged) |
