### PR TITLE
fix(chart): finish the Gateway API route surface (#366)

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.35
+version: 0.1.36
 appVersion: "0.11.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -43,11 +43,11 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Corrected what this chart says about the agent runtime. It is no longer off until a flag is set: the app derives whether an agent can run from a configured model plus a writable ledger, so an install that sets an LLM API key has an agent without asking for one"
-    - "Added an agent values block. Left unset, the chart writes no LIBREDB_AGENT_ENABLED at all and the runtime keeps deriving its own answer; agent.enabled false writes the off-switch, which is how a deployment that already has an LLM key declines the agent on upgrade"
-    - "The chart now REFUSES TO RENDER when an agent could run here and more than one replica is asked for, naming the three ways out. The single-instance ledger made that combination silently broken before"
-    - "Said plainly that run history lives in the ledger under /app/data, so with persistence disabled it is an emptyDir and goes with the pod. The install notes now say it too"
-    - "The chart now sets WORKFLOW_LOCAL_DATA_DIR=/app/data/workflow itself, so the agent's ledger is writable under readOnlyRootFilesystem with no extraEnv recipe to copy. The README's recipe is gone because the chart does it, not because it stopped being needed: the container image gains its own default for that variable in an app version later than the 0.11.0 this chart deploys. An extraEnv entry of the same name still overrides it"
+    - "BREAKING for anyone who enabled a route without attaching it: an enabled route.<name> that sets no parentRefs now REFUSES TO RENDER instead of emitting an HTTPRoute attached to no Gateway. That object was accepted by the API server and routed nothing, so the install succeeded with the app unreachable. parentRefs cannot be defaulted - the Gateway to attach to is specific to each cluster's Gateway API install - so the chart names the route at fault and what to set"
+    - "route.labels and route.annotations now reach every enabled route. values.schema.json has documented them as applying to all route resources since the route template landed, but nothing rendered them and they were silently dropped. A per-route labels/annotations entry still wins on a key collision, and chart labels win over both rather than being emitted as a duplicate YAML key"
+    - "labels and annotations are consequently reserved key names directly under route: they are shared settings, not route names, and the template no longer mistakes them for routes"
+    - "route.<name>.kind is constrained to HTTPRoute by the schema. It was overridable while only an HTTPRoute-shaped body was ever rendered, so kind: GRPCRoute produced a manifest the API server rejects - GRPCRoute matches on method, not path"
+    - "A route block set to null no longer aborts the render of the whole chart"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.35 \
+  --version 0.1.36 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```
@@ -442,18 +442,20 @@ helm uninstall libredb
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `80` |
 | `ingress.enabled` | Enable Ingress | `false` |
-| `route.main.enabled` | bool | `false` | Enables or disables the route |
-| `route.main.additionalRules` | list | `[]` |  |
-| `route.main.annotations` | object | `{}` |  |
-| `route.main.apiVersion` | string | `"gateway.networking.k8s.io/v1"` | Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2 |
-| `route.main.filters`| list | `[]` |  |
-| `route.main.hostnames` | list | `[]` |  |
-| `route.main.httpsRedirect` | bool | `false` |  |
-| `route.main.kind` | string | `"HTTPRoute"` | Set the route kind |
-| `route.main.labels` | object | `{}` |  |
-| `route.main.matches[0].path.type` | string | `"PathPrefix"` |  |
-| `route.main.matches[0].path.value` | string | `"/"` |  |
-| `route.main.parentRefs` | list | `[]` |  |
+| `route.labels` | Labels added to every enabled route (a per-route label with the same key wins); `labels` is therefore a reserved key name and cannot be a route name | `{}` |
+| `route.annotations` | Annotations added to every enabled route (a per-route annotation with the same key wins); reserved key name, as `route.labels` | `{}` |
+| `route.main.enabled` | Enables or disables the route | `false` |
+| `route.main.additionalRules` | Additional custom rules appended to `spec.rules` | `[]` |
+| `route.main.annotations` | Annotations for this route only | `{}` |
+| `route.main.apiVersion` | Route apiVersion, e.g. `gateway.networking.k8s.io/v1` or `gateway.networking.k8s.io/v1alpha2` | `gateway.networking.k8s.io/v1` |
+| `route.main.filters` | Filters applied to requests matching this rule | `[]` |
+| `route.main.hostnames` | Hostnames for the route | `[]` |
+| `route.main.httpsRedirect` | Redirect to HTTPS (HTTP 301) instead of routing to the Service | `false` |
+| `route.main.kind` | Route kind; only `HTTPRoute` is supported (schema-enforced) | `HTTPRoute` |
+| `route.main.labels` | Labels for this route only | `{}` |
+| `route.main.matches[0].path.type` | Path match type | `PathPrefix` |
+| `route.main.matches[0].path.value` | Path match value | `/` |
+| `route.main.parentRefs` | Gateways to attach to; required when the route is enabled (rendering fails without it, since it cannot be defaulted) | `[]` |
 | `autoscaling.enabled` | Enable HPA (ignored with SQLite storage: single-writer) | `false` |
 | `autoscaling.minReplicas` | Min replicas | `2` |
 | `autoscaling.maxReplicas` | Max replicas | `10` |

--- a/charts/libredb-studio/templates/route.yaml
+++ b/charts/libredb-studio/templates/route.yaml
@@ -1,19 +1,35 @@
 {{- $fullName := include "libredb-studio.fullname" . }}
 {{- $namespace := .Release.Namespace -}}
-{{- range $name, $route := .Values.route }}
+{{- /*
+  `labels` and `annotations` directly under `route` are shared across every
+  route rather than route names of their own, so the range below skips them.
+*/ -}}
+{{- $reserved := list "labels" "annotations" -}}
+{{- $routeValues := .Values.route | default dict -}}
+{{- $sharedLabels := deepCopy (get $routeValues "labels" | default dict) -}}
+{{- $sharedAnnotations := deepCopy (get $routeValues "annotations" | default dict) -}}
+{{- range $name, $route := $routeValues }}
+{{- if not (has $name $reserved) }}
 {{- if $route.enabled }}
+{{- if not $route.parentRefs }}
+{{- fail (printf "route.%s is enabled but sets no parentRefs: an HTTPRoute attached to no Gateway is accepted by the API server and routes nothing, so the install would succeed with the app unreachable. parentRefs cannot be defaulted because the Gateway to attach to is specific to this cluster's Gateway API install (its name, namespace and listener). Set route.%s.parentRefs, e.g. --set 'route.%s.parentRefs[0].name=traefik-gateway' --set 'route.%s.parentRefs[0].namespace=traefik' --set 'route.%s.parentRefs[0].sectionName=websecure', or set route.%s.enabled=false" $name $name $name $name $name $name) }}
+{{- end }}
+{{- $labels := merge (dict) (deepCopy ($route.labels | default dict)) (deepCopy $sharedLabels) }}
+{{- $annotations := merge (dict) (deepCopy ($route.annotations | default dict)) (deepCopy $sharedAnnotations) }}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}
 metadata:
   name: {{ $fullName }}{{ if ne $name "main" }}-{{ $name }}{{ end }}
   namespace: {{ $namespace }}
+  {{- /*
+    Merged rather than concatenated: a user-supplied label that collides with a
+    chart label would otherwise be emitted as a duplicate YAML mapping key, which
+    the API server rejects. The chart labels win.
+  */}}
   labels:
-    {{- include "libredb-studio.labels" $ | nindent 4 }}
-    {{- with $route.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- with $route.annotations }}
+    {{- toYaml (merge (include "libredb-studio.labels" $ | fromYaml) $labels) | nindent 4 }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -52,5 +68,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/libredb-studio/values.schema.json
+++ b/charts/libredb-studio/values.schema.json
@@ -330,7 +330,8 @@
           },
           "kind": {
             "type": "string",
-            "description": "Kubernetes resource kind for the route",
+            "description": "Kubernetes resource kind for the route. Only HTTPRoute is supported: the template renders an HTTPRoute-shaped body (path matches), which other route kinds reject",
+            "enum": ["HTTPRoute"],
             "default": "HTTPRoute"
           },
           "parentRefs": {

--- a/charts/libredb-studio/values.yaml
+++ b/charts/libredb-studio/values.yaml
@@ -284,13 +284,23 @@ ingress:
   #      - libredb.local
 
 route:
+  # -- Labels added to every enabled route (a per-route `labels` entry with the
+  # same key wins). Because `labels` and `annotations` are read as shared
+  # settings here, they are reserved key names and cannot be used as route names.
+  labels: {}
+  # -- Annotations added to every enabled route (a per-route `annotations` entry
+  # with the same key wins). Reserved key name, as `labels` above.
+  annotations: {}
+
   main:
     # -- Enables or disables the route
     enabled: false
 
     # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
     apiVersion: gateway.networking.k8s.io/v1
-    # -- Set the route kind
+    # -- Set the route kind. `HTTPRoute` is the only accepted value (enforced by
+    # values.schema.json): only an HTTPRoute-shaped body is rendered, so any other
+    # kind would produce a manifest the API server rejects.
     kind: HTTPRoute
 
     annotations: {}
@@ -298,8 +308,13 @@ route:
 
     hostnames: []
     # - libredb.local
+    # -- Required whenever this route is enabled: rendering fails without it. It
+    # cannot be defaulted because the Gateway to attach to is specific to each
+    # cluster's Gateway API install (name, namespace and listener).
     parentRefs: []
-    # - name: gateway
+    # - name: traefik-gateway
+    #   namespace: traefik
+    #   sectionName: websecure
 
     matches:
       - path:

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -464,8 +464,10 @@ shipped product, and the entry is deleted then and not before.
 
 ## Chart configuration surface
 
-Both entries were found on 2026-08-14 while reviewing #362, which added the Gateway API
-`HTTPRoute` template. Neither is caused by that change; both are gaps it made visible.
+These were found while reviewing #362, which added the Gateway API `HTTPRoute` template, and its
+follow-up #366. None is caused by those changes; all are gaps they made visible. They share one
+failure shape: configuration the chart accepts that produces an install which succeeds while the
+app stays unreachable.
 
 ### N1. The chart cannot expose the app on OpenShift, where `Route` is the native way in
 
@@ -512,7 +514,40 @@ documented in the chart README's values table, and leaves the app's own default 
 the variable's semantics are three-state (`true` / `false` / unset lets the app decide), so a plain
 boolean value with a `false` default would silently change behaviour for existing installs.
 
+### N3. Subpath deployment is build-time only, which is why #369 is deferred rather than scheduled
+
+[#369](https://github.com/libredb/libredb-studio/issues/369) asks to serve Studio under a path
+prefix on a shared domain — `https://example.com/libredb` next to `https://example.com/grafana`.
+`next.config.ts` sets no `basePath` and no `assetPrefix`, so there is zero support today.
+
+The constraint, recorded so nobody rediscovers it: **Next.js `basePath` is baked at build, not read
+at runtime.** Asset URLs (`/_next/static/...`) are emitted into the HTML and JS at build time and
+there is no supported runtime override, so a `BASE_PATH` env var on the prebuilt
+`ghcr.io/libredb/libredb-studio` image cannot work — the feature has to be a build arg and a
+rebuilt image. A reverse-proxy `StripPrefix` is not a workaround either: the browser asks for
+`/libredb/`, the proxy strips it, the app answers with HTML referencing `/_next/static/...` at the
+root, and that follow-up request no longer matches the `/libredb` router rule. Grafana can do this
+at runtime because it is a Go server templating its own HTML; a statically built Next.js app is
+structurally different.
+
+The surface a build-time implementation touches: roughly 40 `fetch('/api/...')` call sites, roughly
+15 `router.push('/...')`, the cookie `path: "/"` in `src/lib/auth.ts` and
+`src/app/api/auth/oidc/login/route.ts`, OIDC redirect URIs, `src/proxy.ts` matcher, the Docker
+healthcheck `GET /api/db/health`, the chart's ingress and route paths, the npm library surface, the
+E2E suite and the docs of roughly 27 distribution channels. `next/link` and the app-router `router`
+prefix automatically; `fetch`, middleware redirects and cookie paths do not.
+
+Deferred rather than scheduled because the acquisition-relevant PaaS one-click listings hand out
+subdomains, not subpaths, so no shipped channel needs it. Related sharp edge, same silent-no-op
+class as #366: `charts/libredb-studio/values.yaml` already lets a user set
+`ingress.hosts[].paths[].path` to `/libredb`, the install succeeds, and the app is unreachable.
+
+Done when a `BASE_PATH` build arg produces an image reachable under a path prefix — assets, API
+calls, auth cookie and OIDC redirect included — verified against a real path-routing proxy, or when
+the chart refuses a non-root ingress path outright and this entry records that as the answer.
+
 ---
+
 
 ## Security Phase 1 deferrals
 
@@ -1973,4 +2008,3 @@ Four of the seven claim a success nobody observed, in the same statement that st
 
 Done when every copy in the app goes through `CopyButton` (or its `writeToClipboard`), with a test
 per site that the label does not claim success when the write was refused.
-

--- a/docs/HELM_CHART.md
+++ b/docs/HELM_CHART.md
@@ -26,6 +26,7 @@ charts/libredb-studio/
     ├── deployment.yaml        # App Deployment (checksum restart, emptyDir, probes)
     ├── service.yaml           # ClusterIP / NodePort / LoadBalancer
     ├── ingress.yaml           # Optional Ingress (nginx/traefik)
+    ├── route.yaml             # Optional Gateway API HTTPRoute (default off)
     ├── configmap.yaml         # Non-sensitive env vars (PORT, storage, LLM, OIDC)
     ├── seed-configmap.yaml    # Optional seed-connections config (rendered when enabled)
     ├── secret.yaml            # Sensitive env vars (JWT, passwords, API keys)
@@ -366,6 +367,33 @@ helm install libredb libredb/libredb-studio \
   --set autoscaling.enabled=true \
   --set podDisruptionBudget.enabled=true
 ```
+
+### Gateway API instead of an Ingress
+```bash
+helm install libredb libredb/libredb-studio \
+  --set secrets.jwtSecret=$(openssl rand -base64 32) \
+  --set secrets.adminPassword="$ADMIN_PASSWORD" \
+  --set route.main.enabled=true \
+  --set "route.main.parentRefs[0].name=traefik-gateway" \
+  --set "route.main.parentRefs[0].namespace=traefik" \
+  --set "route.main.parentRefs[0].sectionName=websecure" \
+  --set "route.main.hostnames[0]=libredb.example.com"
+```
+
+`route` is a map of route names, so several routes can attach the same Service to different
+Gateways or listeners; `main` renders as `<fullname>`, any other name as `<fullname>-<name>`.
+Two constraints are enforced rather than documented:
+
+- An enabled route **must** set `parentRefs` or the render fails, naming the route at fault. The
+  chart cannot default it - the Gateway to attach to is specific to each cluster's Gateway API
+  install - and an HTTPRoute attached to no Gateway is accepted by the API server while routing
+  nothing, so the failure replaces an install that succeeds with the app unreachable.
+- `kind` accepts only `HTTPRoute` (schema-enforced): only an HTTPRoute-shaped body is rendered,
+  so any other kind would emit a manifest the API server rejects.
+
+`route.labels` and `route.annotations` are shared across every enabled route, which makes
+`labels` and `annotations` reserved key names directly under `route` rather than route names. A
+per-route entry wins on a key collision; the chart's own labels win over both.
 
 ### External Secrets (Vault / ESO)
 ```bash

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
 type: application
-version: 0.1.35
+version: 0.1.36
 appVersion: "0.11.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -43,11 +43,11 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Corrected what this chart says about the agent runtime. It is no longer off until a flag is set: the app derives whether an agent can run from a configured model plus a writable ledger, so an install that sets an LLM API key has an agent without asking for one"
-    - "Added an agent values block. Left unset, the chart writes no LIBREDB_AGENT_ENABLED at all and the runtime keeps deriving its own answer; agent.enabled false writes the off-switch, which is how a deployment that already has an LLM key declines the agent on upgrade"
-    - "The chart now REFUSES TO RENDER when an agent could run here and more than one replica is asked for, naming the three ways out. The single-instance ledger made that combination silently broken before"
-    - "Said plainly that run history lives in the ledger under /app/data, so with persistence disabled it is an emptyDir and goes with the pod. The install notes now say it too"
-    - "The chart now sets WORKFLOW_LOCAL_DATA_DIR=/app/data/workflow itself, so the agent's ledger is writable under readOnlyRootFilesystem with no extraEnv recipe to copy. The README's recipe is gone because the chart does it, not because it stopped being needed: the container image gains its own default for that variable in an app version later than the 0.11.0 this chart deploys. An extraEnv entry of the same name still overrides it"
+    - "BREAKING for anyone who enabled a route without attaching it: an enabled route.<name> that sets no parentRefs now REFUSES TO RENDER instead of emitting an HTTPRoute attached to no Gateway. That object was accepted by the API server and routed nothing, so the install succeeded with the app unreachable. parentRefs cannot be defaulted - the Gateway to attach to is specific to each cluster's Gateway API install - so the chart names the route at fault and what to set"
+    - "route.labels and route.annotations now reach every enabled route. values.schema.json has documented them as applying to all route resources since the route template landed, but nothing rendered them and they were silently dropped. A per-route labels/annotations entry still wins on a key collision, and chart labels win over both rather than being emitted as a duplicate YAML key"
+    - "labels and annotations are consequently reserved key names directly under route: they are shared settings, not route names, and the template no longer mistakes them for routes"
+    - "route.<name>.kind is constrained to HTTPRoute by the schema. It was overridable while only an HTTPRoute-shaped body was ever rendered, so kind: GRPCRoute produced a manifest the API server rejects - GRPCRoute matches on method, not path"
+    - "A route block set to null no longer aborts the render of the whole chart"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.35 \
+  --version 0.1.36 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```
@@ -442,18 +442,20 @@ helm uninstall libredb
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `80` |
 | `ingress.enabled` | Enable Ingress | `false` |
-| `route.main.enabled` | bool | `false` | Enables or disables the route |
-| `route.main.additionalRules` | list | `[]` |  |
-| `route.main.annotations` | object | `{}` |  |
-| `route.main.apiVersion` | string | `"gateway.networking.k8s.io/v1"` | Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2 |
-| `route.main.filters`| list | `[]` |  |
-| `route.main.hostnames` | list | `[]` |  |
-| `route.main.httpsRedirect` | bool | `false` |  |
-| `route.main.kind` | string | `"HTTPRoute"` | Set the route kind |
-| `route.main.labels` | object | `{}` |  |
-| `route.main.matches[0].path.type` | string | `"PathPrefix"` |  |
-| `route.main.matches[0].path.value` | string | `"/"` |  |
-| `route.main.parentRefs` | list | `[]` |  |
+| `route.labels` | Labels added to every enabled route (a per-route label with the same key wins); `labels` is therefore a reserved key name and cannot be a route name | `{}` |
+| `route.annotations` | Annotations added to every enabled route (a per-route annotation with the same key wins); reserved key name, as `route.labels` | `{}` |
+| `route.main.enabled` | Enables or disables the route | `false` |
+| `route.main.additionalRules` | Additional custom rules appended to `spec.rules` | `[]` |
+| `route.main.annotations` | Annotations for this route only | `{}` |
+| `route.main.apiVersion` | Route apiVersion, e.g. `gateway.networking.k8s.io/v1` or `gateway.networking.k8s.io/v1alpha2` | `gateway.networking.k8s.io/v1` |
+| `route.main.filters` | Filters applied to requests matching this rule | `[]` |
+| `route.main.hostnames` | Hostnames for the route | `[]` |
+| `route.main.httpsRedirect` | Redirect to HTTPS (HTTP 301) instead of routing to the Service | `false` |
+| `route.main.kind` | Route kind; only `HTTPRoute` is supported (schema-enforced) | `HTTPRoute` |
+| `route.main.labels` | Labels for this route only | `{}` |
+| `route.main.matches[0].path.type` | Path match type | `PathPrefix` |
+| `route.main.matches[0].path.value` | Path match value | `/` |
+| `route.main.parentRefs` | Gateways to attach to; required when the route is enabled (rendering fails without it, since it cannot be defaulted) | `[]` |
 | `autoscaling.enabled` | Enable HPA (ignored with SQLite storage: single-writer) | `false` |
 | `autoscaling.minReplicas` | Min replicas | `2` |
 | `autoscaling.maxReplicas` | Max replicas | `10` |

--- a/operator/helm-charts/libredb-studio/templates/route.yaml
+++ b/operator/helm-charts/libredb-studio/templates/route.yaml
@@ -1,19 +1,35 @@
 {{- $fullName := include "libredb-studio.fullname" . }}
 {{- $namespace := .Release.Namespace -}}
-{{- range $name, $route := .Values.route }}
+{{- /*
+  `labels` and `annotations` directly under `route` are shared across every
+  route rather than route names of their own, so the range below skips them.
+*/ -}}
+{{- $reserved := list "labels" "annotations" -}}
+{{- $routeValues := .Values.route | default dict -}}
+{{- $sharedLabels := deepCopy (get $routeValues "labels" | default dict) -}}
+{{- $sharedAnnotations := deepCopy (get $routeValues "annotations" | default dict) -}}
+{{- range $name, $route := $routeValues }}
+{{- if not (has $name $reserved) }}
 {{- if $route.enabled }}
+{{- if not $route.parentRefs }}
+{{- fail (printf "route.%s is enabled but sets no parentRefs: an HTTPRoute attached to no Gateway is accepted by the API server and routes nothing, so the install would succeed with the app unreachable. parentRefs cannot be defaulted because the Gateway to attach to is specific to this cluster's Gateway API install (its name, namespace and listener). Set route.%s.parentRefs, e.g. --set 'route.%s.parentRefs[0].name=traefik-gateway' --set 'route.%s.parentRefs[0].namespace=traefik' --set 'route.%s.parentRefs[0].sectionName=websecure', or set route.%s.enabled=false" $name $name $name $name $name $name) }}
+{{- end }}
+{{- $labels := merge (dict) (deepCopy ($route.labels | default dict)) (deepCopy $sharedLabels) }}
+{{- $annotations := merge (dict) (deepCopy ($route.annotations | default dict)) (deepCopy $sharedAnnotations) }}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}
 metadata:
   name: {{ $fullName }}{{ if ne $name "main" }}-{{ $name }}{{ end }}
   namespace: {{ $namespace }}
+  {{- /*
+    Merged rather than concatenated: a user-supplied label that collides with a
+    chart label would otherwise be emitted as a duplicate YAML mapping key, which
+    the API server rejects. The chart labels win.
+  */}}
   labels:
-    {{- include "libredb-studio.labels" $ | nindent 4 }}
-    {{- with $route.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- with $route.annotations }}
+    {{- toYaml (merge (include "libredb-studio.labels" $ | fromYaml) $labels) | nindent 4 }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -52,5 +68,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/operator/helm-charts/libredb-studio/values.schema.json
+++ b/operator/helm-charts/libredb-studio/values.schema.json
@@ -330,7 +330,8 @@
           },
           "kind": {
             "type": "string",
-            "description": "Kubernetes resource kind for the route",
+            "description": "Kubernetes resource kind for the route. Only HTTPRoute is supported: the template renders an HTTPRoute-shaped body (path matches), which other route kinds reject",
+            "enum": ["HTTPRoute"],
             "default": "HTTPRoute"
           },
           "parentRefs": {

--- a/operator/helm-charts/libredb-studio/values.yaml
+++ b/operator/helm-charts/libredb-studio/values.yaml
@@ -284,13 +284,23 @@ ingress:
   #      - libredb.local
 
 route:
+  # -- Labels added to every enabled route (a per-route `labels` entry with the
+  # same key wins). Because `labels` and `annotations` are read as shared
+  # settings here, they are reserved key names and cannot be used as route names.
+  labels: {}
+  # -- Annotations added to every enabled route (a per-route `annotations` entry
+  # with the same key wins). Reserved key name, as `labels` above.
+  annotations: {}
+
   main:
     # -- Enables or disables the route
     enabled: false
 
     # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
     apiVersion: gateway.networking.k8s.io/v1
-    # -- Set the route kind
+    # -- Set the route kind. `HTTPRoute` is the only accepted value (enforced by
+    # values.schema.json): only an HTTPRoute-shaped body is rendered, so any other
+    # kind would produce a manifest the API server rejects.
     kind: HTTPRoute
 
     annotations: {}
@@ -298,8 +308,13 @@ route:
 
     hostnames: []
     # - libredb.local
+    # -- Required whenever this route is enabled: rendering fails without it. It
+    # cannot be defaulted because the Gateway to attach to is specific to each
+    # cluster's Gateway API install (name, namespace and listener).
     parentRefs: []
-    # - name: gateway
+    # - name: traefik-gateway
+    #   namespace: traefik
+    #   sectionName: websecure
 
     matches:
       - path:

--- a/tests/unit/helm-chart-route.test.ts
+++ b/tests/unit/helm-chart-route.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Regression tests for the Gateway API route surface of the chart
+ * (templates/route.yaml), added by #362 and corrected by #366:
+ *
+ *   1. The top-level `route.labels` / `route.annotations` keys are documented
+ *      in values.schema.json as applying to *all* route resources, but the
+ *      template only ever read the per-route keys, so they were silently
+ *      dropped. They must be merged into every enabled route, with the
+ *      per-route value winning on a key collision - and the literal keys
+ *      `labels` and `annotations` must never be mistaken for route names by
+ *      the template's `range` over `.Values.route`.
+ *   2. An enabled route with no `parentRefs` used to render a valid but inert
+ *      HTTPRoute: attached to no Gateway, it does nothing, so the install
+ *      succeeds and the app stays unreachable. That must fail the render
+ *      loudly instead. `parentRefs` cannot be defaulted (it is specific to
+ *      the cluster's Gateway install), but the *disabled* default route must
+ *      of course still render nothing and must not fail.
+ *   3. `kind` was overridable while only an HTTPRoute-shaped body was ever
+ *      rendered, so `kind: GRPCRoute` emitted a manifest the API server
+ *      rejects (GRPCRoute matches on `method`, not `path`). `kind` is
+ *      constrained to HTTPRoute in the schema; `apiVersion` stays free
+ *      because v1 and v1alpha2 are both legitimate for HTTPRoute.
+ *
+ * Exercises the real `helm template` output against the actual chart - no
+ * reimplementation of the templating logic (same approach as
+ * helm-chart-openshift.test.ts). This file is also the baseline coverage for
+ * the feature #362 shipped, which had no tests at all.
+ */
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { parseAllDocuments } from "yaml";
+
+const CHART_DIR = join(import.meta.dir, "../../charts/libredb-studio");
+
+const MAIN_ENABLED = ["--set", "route.main.enabled=true", "--set", "route.main.parentRefs[0].name=gw"];
+
+interface RouteRule {
+  backendRefs?: Array<{ name: string; port: number; kind: string; group?: string; weight?: number }>;
+  matches?: Array<{ path?: { type?: string; value?: string } }>;
+  filters?: Array<{ type?: string; requestRedirect?: Record<string, unknown> }>;
+}
+
+interface RenderedManifest {
+  apiVersion: string;
+  kind: string;
+  metadata: { name: string; labels?: Record<string, string>; annotations?: Record<string, string> };
+  spec?: {
+    parentRefs?: Array<{ name: string }>;
+    hostnames?: string[];
+    rules?: RouteRule[];
+  };
+}
+
+function helmTemplate(args: string[]): { exitCode: number; stdout: string; stderr: string } {
+  const run = Bun.spawnSync(["helm", "template", "release-under-test", CHART_DIR, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { exitCode: run.exitCode, stdout: run.stdout.toString(), stderr: run.stderr.toString() };
+}
+
+function renderDocs(args: string[]): RenderedManifest[] {
+  const run = helmTemplate(args);
+  if (run.exitCode !== 0) {
+    throw new Error(`helm template failed (exit ${run.exitCode}): ${run.stderr}`);
+  }
+  return parseAllDocuments(run.stdout)
+    .map((doc) => doc.toJSON() as RenderedManifest)
+    .filter((doc) => doc != null);
+}
+
+function routes(args: string[]): RenderedManifest[] {
+  return renderDocs(args).filter((doc) => doc.kind === "HTTPRoute" || doc.kind === "GRPCRoute");
+}
+
+function onlyRoute(args: string[]): RenderedManifest {
+  const rendered = routes(args);
+  expect(rendered).toHaveLength(1);
+  return rendered[0];
+}
+
+describe("charts/libredb-studio route baseline (#362)", () => {
+  test("default values render no route at all", () => {
+    expect(routes([])).toHaveLength(0);
+  });
+
+  test("an enabled route with parentRefs renders a well-formed HTTPRoute", () => {
+    const route = onlyRoute(MAIN_ENABLED);
+    expect(route.apiVersion).toBe("gateway.networking.k8s.io/v1");
+    expect(route.kind).toBe("HTTPRoute");
+    expect(route.metadata.name).toBe("release-under-test-libredb-studio");
+    expect(route.metadata.labels).toMatchObject({
+      "app.kubernetes.io/name": "libredb-studio",
+      "app.kubernetes.io/instance": "release-under-test",
+      "app.kubernetes.io/managed-by": "Helm",
+    });
+    expect(route.spec?.parentRefs).toEqual([{ name: "gw" }]);
+    const rule = route.spec?.rules?.[0];
+    expect(rule?.backendRefs?.[0]).toMatchObject({
+      name: "release-under-test-libredb-studio",
+      port: 80,
+      kind: "Service",
+    });
+    expect(rule?.matches).toEqual([{ path: { type: "PathPrefix", value: "/" } }]);
+  });
+});
+
+describe("charts/libredb-studio route shared labels and annotations (#366 item 1)", () => {
+  test("top-level route.labels and route.annotations land on an enabled route", () => {
+    const route = onlyRoute([
+      ...MAIN_ENABLED,
+      "--set",
+      "route.labels.team=platform",
+      "--set",
+      "route.annotations.owner=infra",
+    ]);
+    expect(route.metadata.labels?.team).toBe("platform");
+    expect(route.metadata.annotations?.owner).toBe("infra");
+  });
+
+  test("top-level route.labels and route.annotations land on every enabled route", () => {
+    const rendered = routes([
+      ...MAIN_ENABLED,
+      "--set",
+      "route.extra.enabled=true",
+      "--set",
+      "route.extra.parentRefs[0].name=gw",
+      "--set",
+      "route.labels.team=platform",
+      "--set",
+      "route.annotations.owner=infra",
+    ]);
+    expect(rendered).toHaveLength(2);
+    for (const route of rendered) {
+      expect(route.metadata.labels?.team).toBe("platform");
+      expect(route.metadata.annotations?.owner).toBe("infra");
+    }
+  });
+
+  test("a per-route label wins over the top-level label with the same key", () => {
+    const route = onlyRoute([
+      ...MAIN_ENABLED,
+      "--set",
+      "route.labels.team=platform",
+      "--set",
+      "route.main.labels.team=main-only",
+    ]);
+    expect(route.metadata.labels?.team).toBe("main-only");
+  });
+
+  test("a per-route annotation wins over the top-level annotation with the same key", () => {
+    const route = onlyRoute([
+      ...MAIN_ENABLED,
+      "--set",
+      "route.annotations.owner=infra",
+      "--set",
+      "route.main.annotations.owner=main-only",
+    ]);
+    expect(route.metadata.annotations?.owner).toBe("main-only");
+  });
+
+  // A `labels`/`annotations` map without an `enabled` key is skipped by the
+  // `if $route.enabled` guard whether or not the template reserves the name, so
+  // asserting on that shape proves nothing. `--set-string` gets a truthy string
+  // `enabled` past both the schema (these maps are string-valued) and the guard,
+  // which is the only shape that actually exercises the reserved-key list.
+  test("a truthy `enabled` under route.labels still renders no -labels route", () => {
+    const run = helmTemplate([...MAIN_ENABLED, "--set-string", "route.labels.enabled=true"]);
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).not.toContain("release-under-test-libredb-studio-labels");
+  });
+
+  test("a truthy `enabled` under route.annotations still renders no -annotations route", () => {
+    const run = helmTemplate([...MAIN_ENABLED, "--set-string", "route.annotations.enabled=true"]);
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).not.toContain("release-under-test-libredb-studio-annotations");
+  });
+
+  // Helm's `merge` mutates its destination, so a shared map taken straight from
+  // `.Values` and merged into per iteration leaks the first route's labels onto
+  // every later route. Only a two-route render catches it.
+  test("a per-route label does not leak onto another route", () => {
+    const rendered = routes([
+      ...MAIN_ENABLED,
+      "--set",
+      "route.main.labels.only-main=yes",
+      "--set",
+      "route.extra.enabled=true",
+      "--set",
+      "route.extra.parentRefs[0].name=gw",
+    ]);
+    expect(rendered).toHaveLength(2);
+    const extra = rendered.find((route) => route.metadata.name.endsWith("-extra"));
+    expect(extra?.metadata.labels).not.toHaveProperty("only-main");
+    const main = rendered.find((route) => !route.metadata.name.endsWith("-extra"));
+    expect(main?.metadata.labels?.["only-main"]).toBe("yes");
+  });
+
+  // Emitting a colliding user key alongside the chart's own would produce a
+  // duplicate YAML mapping key, which the API server rejects outright.
+  test("a chart label cannot be overwritten or duplicated by route.labels", () => {
+    const args = [...MAIN_ENABLED, "--set", "route.labels.app\\.kubernetes\\.io/name=hijacked"];
+    expect(onlyRoute(args).metadata.labels?.["app.kubernetes.io/name"]).toBe("libredb-studio");
+    // Rendered in isolation so the count cannot pick up the Deployment/Service
+    // selector labels: the key must appear once, not once per source.
+    const routeOnly = helmTemplate([...args, "-s", "templates/route.yaml"]).stdout;
+    expect(routeOnly.split("app.kubernetes.io/name:").length - 1).toBe(1);
+    expect(routeOnly).not.toContain("hijacked");
+  });
+});
+
+describe("charts/libredb-studio route parentRefs guard (#366 item 2)", () => {
+  test("an enabled route with no parentRefs fails the render, naming what to set", () => {
+    const run = helmTemplate(["--set", "route.main.enabled=true"]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("route.main.parentRefs");
+  });
+
+  test("a disabled route with no parentRefs renders nothing and does not fail", () => {
+    const run = helmTemplate([]);
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).not.toContain("kind: HTTPRoute");
+  });
+
+  // A message that says "a route" leaves the user grepping their values file.
+  test("the failure names which route is at fault, not just that one is", () => {
+    const run = helmTemplate([...MAIN_ENABLED, "--set", "route.admin.enabled=true"]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("route.admin");
+    expect(run.stderr).not.toContain("route.main is enabled but sets no parentRefs");
+  });
+
+  // An httpsRedirect route attaches to a Gateway like any other: without
+  // parentRefs it redirects nothing, so the guard must not skip that branch.
+  test("an httpsRedirect route still needs parentRefs", () => {
+    const run = helmTemplate(["--set", "route.main.enabled=true", "--set", "route.main.httpsRedirect=true"]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("parentRefs");
+  });
+});
+
+describe("charts/libredb-studio route block edge cases", () => {
+  // The shared labels/annotations are read before the range, so an unguarded
+  // dereference of a null `route` aborts the whole chart, not just this template.
+  test("a null route block renders the rest of the chart and emits no route", () => {
+    const run = helmTemplate(["--set", "route=null"]);
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).not.toContain("kind: HTTPRoute");
+    expect(run.stdout).toContain("kind: Deployment");
+  });
+});
+
+describe("charts/libredb-studio route kind constraint (#366 item 3)", () => {
+  test("kind=GRPCRoute fails schema validation", () => {
+    const run = helmTemplate([...MAIN_ENABLED, "--set", "route.main.kind=GRPCRoute"]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("kind");
+  });
+
+  test("kind=HTTPRoute is accepted", () => {
+    const route = onlyRoute([...MAIN_ENABLED, "--set", "route.main.kind=HTTPRoute"]);
+    expect(route.kind).toBe("HTTPRoute");
+  });
+
+  test("apiVersion stays free: v1alpha2 still renders", () => {
+    const route = onlyRoute([...MAIN_ENABLED, "--set", "route.main.apiVersion=gateway.networking.k8s.io/v1alpha2"]);
+    expect(route.apiVersion).toBe("gateway.networking.k8s.io/v1alpha2");
+  });
+});
+
+describe("charts/libredb-studio multiple routes and httpsRedirect (#362)", () => {
+  test("a second named route renders with the -extra name suffix", () => {
+    const rendered = routes([
+      ...MAIN_ENABLED,
+      "--set",
+      "route.extra.enabled=true",
+      "--set",
+      "route.extra.parentRefs[0].name=gw-extra",
+    ]);
+    expect(rendered.map((route) => route.metadata.name).sort()).toEqual([
+      "release-under-test-libredb-studio",
+      "release-under-test-libredb-studio-extra",
+    ]);
+    const extra = rendered.find((route) => route.metadata.name.endsWith("-extra"));
+    expect(extra?.spec?.parentRefs).toEqual([{ name: "gw-extra" }]);
+  });
+
+  test("httpsRedirect renders the RequestRedirect filter instead of backendRefs", () => {
+    const route = onlyRoute([...MAIN_ENABLED, "--set", "route.main.httpsRedirect=true"]);
+    const rule = route.spec?.rules?.[0];
+    expect(rule?.backendRefs).toBeUndefined();
+    expect(rule?.filters?.[0]).toMatchObject({
+      type: "RequestRedirect",
+      requestRedirect: { scheme: "https", statusCode: 301 },
+    });
+  });
+});


### PR DESCRIPTION
Closes #366.

Follow-up to #362 (@ducminhle), which added the Gateway API `HTTPRoute` template. #366 recorded
three rough edges; fixing them surfaced two more.

## The three from #366

**1. `route.labels` / `route.annotations` were schema-only.** `values.schema.json` has documented
them as applying to all route resources since the template landed, but `templates/route.yaml` only
ever read the per-route keys, so they were silently dropped. They now reach every enabled route,
with a per-route entry winning on a key collision. The `range` over `.Values.route` skips those two
literal keys, so they are reserved key names rather than route names - previously
`--set-string route.labels.enabled=true` rendered a phantom `<fullname>-labels` HTTPRoute.

**2. An enabled route with no `parentRefs` rendered an inert object.** Attached to no Gateway it
routes nothing, so `helm install` succeeded and the app stayed unreachable - the exact symptom the
feature exists to remove. It now fails the render:

```
Error: execution error at (libredb-studio/templates/route.yaml:15:4): route.main is enabled but
sets no parentRefs: an HTTPRoute attached to no Gateway is accepted by the API server and routes
nothing, so the install would succeed with the app unreachable. parentRefs cannot be defaulted
because the Gateway to attach to is specific to this cluster's Gateway API install (its name,
namespace and listener). Set route.main.parentRefs, e.g. --set
'route.main.parentRefs[0].name=traefik-gateway' --set 'route.main.parentRefs[0].namespace=traefik'
--set 'route.main.parentRefs[0].sectionName=websecure', or set route.main.enabled=false
```

That `parentRefs` cannot be defaulted is exactly why the chart has to refuse rather than guess. The
message names the route at fault, and the example is @ducminhle's own Traefik shape from #366.

**3. `kind` was overridable while only an HTTPRoute body was rendered**, so `kind: GRPCRoute` emitted
a manifest the API server rejects (GRPCRoute matches on `method`, not `path`). The schema now
constrains it to `HTTPRoute`. `apiVersion` stays free - v1 and v1alpha2 are both legitimate.

## Two more, found reviewing the above

**4. A colliding label produced a duplicate YAML mapping key.** A user setting
`route.labels.app\.kubernetes\.io/name` got it emitted alongside the chart's own, which
`kubectl apply` rejects with "mapping key already defined". Chart labels are now merged and win.

**5. `route: null` aborted the render of the whole chart.** Reading the shared maps before the range
dereferenced `.Values.route` unguarded, so blanking the block broke every template, not just this
one. Regression against 0.1.35, caught before shipping.

## Coverage, docs, release

`templates/route.yaml` had **no test coverage at all**. `tests/unit/helm-chart-route.test.ts` is now
both its baseline and the regression suite for the above - 20 tests against real `helm template`
output, including the two-route render that is the only way to catch Helm's in-place `merge`
mutation leaking one route's labels onto the next.

`docs/HELM_CHART.md` gains the template and a Gateway API section; the README values table rows for
`route.*` were four-column against a three-column table and are now aligned, with `route.labels` /
`route.annotations` documented.

Chart `0.1.35` is already tagged, so this is **0.1.36** (#167), with the operator mirror regenerated
and `artifacthub.io/changes` rewritten - it still carried the previous release's agent-runtime
entries. The `parentRefs` refusal is **breaking** for anyone who enabled a route without attaching
it, and is announced as such.

#369 (subpath deployment) is recorded as backlog `N3` with the build-time constraint that defers it,
rather than scheduled.

## Verification

All six gates pass locally: `format`, `lint` (0 errors), `typecheck`, `knip`, `test` (28 groups),
`build`. Plus `helm lint charts/libredb-studio --strict` and `bun run chart:check`.
