### PR TITLE
docs(distribution): mark the TrueNAS SCALE channel live now that #5501 merged

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -532,7 +532,7 @@ channels:
   - id: truenas-scale
     name: TrueNAS SCALE community apps catalog
     short_name: TrueNAS SCALE apps
-    status: pending
+    status: live
     category: paas-catalogs
     platforms: [container]
     runtime: channel_supplied
@@ -544,16 +544,18 @@ channels:
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/278
       first_pr: https://github.com/truenas/apps/pull/5501
+      catalog: https://apps.truenas.com/catalog/libredb-studio_community/
       upstream_repo: https://github.com/truenas/apps
       docs: docs/DISTRIBUTION.md
     pin:
-      strategy: none
-      note: PR truenas/apps#5501 is open (fork yusuf-gundogdu/apps, branch add-libredb-studio), so nothing
-        is listed yet. On merge, flip to live and add a remote_file pin on
-        https://raw.githubusercontent.com/truenas/apps/master/ix-dev/community/libredb-studio/ix_values.yaml
-        with extract 'ghcr\.io/libredb/libredb-studio\s+tag:\s*(\d+\.\d+\.\d+)' - the container_utils_image
-        tag is a different repository and must not be matched. The user installs on their own TrueNAS box,
-        so the platform is container, not cloud.
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/truenas/apps/master/ix-dev/community/libredb-studio/ix_values.yaml
+      extract: 'ghcr\.io/libredb/libredb-studio\s+tag:\s*(\d+\.\d+\.\d+)'
+      note: Merged in truenas/apps#5501 (14 Aug 2026); live in the TrueNAS SCALE community catalog. The pin
+        reads the ghcr repo and tag in ix-dev/community/libredb-studio/ix_values.yaml (the maintainer-edited
+        source a bump PR touches) - the container_utils_image tag is a different repository and must not be
+        matched. The built catalog also renders under trains/community/libredb-studio/<version>/. The user
+        installs on their own TrueNAS box, so the platform is container, not cloud.
 
   - id: casaos
     name: CasaOS App Store

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -31,9 +31,9 @@ channel count.
 
 ## Coverage snapshot
 
-**32 channels · 22 live · 9 pending · 1 deprecated**
+**32 channels · 23 live · 8 pending · 1 deprecated**
 
-Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 3 · Kubernetes 1 · Cloud 10**
+Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 4 · Kubernetes 1 · Cloud 10**
 
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
@@ -42,7 +42,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 3 · K
 | Kubernetes & operators | 1 | 2 | 0 |
 | Package managers | 4 | 1 | 1 |
 | OS / desktop packages | 2 | 0 | 0 |
-| PaaS catalogs (listed) | 7 | 5 | 0 |
+| PaaS catalogs (listed) | 8 | 4 | 0 |
 | Deploy recipes | 3 | 0 | 0 |
 | Cloud marketplaces | 1 | 1 | 0 |
 
@@ -75,11 +75,11 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 3 · K
 | [Kubero template catalog](https://www.kubero.dev/templates) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/kubero/README.md](../deploy/kubero/README.md) |
 | [Railway one-click template](https://railway.com/deploy/libredb-studio) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/railway/PUBLISH.md](../deploy/railway/PUBLISH.md) |
 | [Sealos App Store template](https://sealos.io/products/app-store/libredb-studio) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [TrueNAS SCALE apps](https://apps.truenas.com/catalog/libredb-studio_community/) | PaaS catalogs (listed) | Container | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Unraid Community Apps](https://ca.unraid.net/apps/libredb-studio-0a5x41a1cy1kay) | PaaS catalogs (listed) | Container | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [CasaOS App Store](https://github.com/IceWhaleTech/CasaOS-AppStore) | PaaS catalogs (listed) | Container | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Easypanel template catalog](https://easypanel.io/templates) | PaaS catalogs (listed) | Cloud | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Portainer app templates](https://github.com/portainer/templates) | PaaS catalogs (listed) | Container | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [TrueNAS SCALE apps](https://github.com/truenas/apps) | PaaS catalogs (listed) | Container | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Umbrel App Store](https://github.com/getumbrel/umbrel-apps) | PaaS catalogs (listed) | Container | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Fly.io launch config](https://github.com/libredb/libredb-studio/blob/main/fly.toml) | Deploy recipes | Cloud | live | Manual, on demand | [FLY.md](FLY.md) |
 | [Koyeb deploy button](https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb) | Deploy recipes | Cloud | live | Manual, on demand | [deploy/koyeb/README.md](../deploy/koyeb/README.md) |

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1173,7 +1173,7 @@ pin or editing a channel entry is always a human commit.
 | 0 | Core registries, published directly by release CI | GitHub Releases, GHCR, Docker Hub, npm |
 | 1 | Packaged formats owned by this repo, CI-published | Helm, Homebrew tap, Snap, .deb/.rpm, desktop AppImage |
 | 2 | LibreDB-owned copies and listings, bumped by hand | Railway, Koyeb button, Fly.io config, Render Blueprint, Unraid CA template |
-| 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero, Sealos |
+| 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero, Sealos, TrueNAS SCALE |
 | 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DO, winget, Chocolatey, Flathub |
 
 **Categories** (`category` on every channel) are the business-facing buckets rendered in


### PR DESCRIPTION
## Description
truenas/apps#5501 merged on 2026-08-14 and LibreDB Studio is now live in the TrueNAS SCALE community catalog (https://apps.truenas.com/catalog/libredb-studio_community/). This flips the inventory entry from pending to live. Inventory and generated docs only, no source/workflow/packaging changes.

## Type of Change
- [x] Documentation update

## Related Issue
Refs #278 (TrueNAS tracking issue, closed on merge)

## Changes Made
- `distribution/channels.yaml`: `truenas-scale` goes `status: pending -> live`, gains a `catalog` link and a `remote_file` pin. The pin reads the ghcr repo+tag in the maintainer-edited `ix-dev/community/libredb-studio/ix_values.yaml`; the `container_utils_image` tag is a different repository and is not matched.
- `docs/DISTRIBUTION.md`: record TrueNAS SCALE in the tier-3 examples (upstream community catalogs bumped via PR).
- Regenerate `docs/CHANNELS.md` (live 22 -> 23, pending 9 -> 8).

## Testing
- [x] I have tested this locally
- [x] All existing tests pass

## Verification
`distribution:matrix --check` exit 0 · `distribution:check --strict` exit 0 · distribution-check unit tests 125/125 pass. The truenas-scale pin resolves to 0.11.0 (matches the current release), reported OK with no drift.
