### PR TITLE
fix(auth): read JWT_SECRET per call instead of memoizing it

### DIFF
--- a/src/lib/auth-compare.ts
+++ b/src/lib/auth-compare.ts
@@ -12,7 +12,9 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
  *
  * HMAC with a per-process random key rather than a bare digest, so the digests are unpredictable
  * to an attacker who can submit inputs. The key is a lazy module-level singleton, matching the
- * _jwtSecret pattern in src/lib/auth.ts:11-17.
+ * _jwtSecret pattern in src/proxy.ts:14-20. Unlike that one, the memo here is load-bearing rather
+ * than an optimization: the key is generated, not read, so re-deriving it per call would make two
+ * digests of the same input differ.
  *
  * node:crypto is unconditionally available: no route declares an edge runtime and production runs
  * `node server.js`.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,29 +3,17 @@ import { cookies, headers } from "next/headers";
 import { logger } from "@/lib/logger";
 import { getJwtSecret } from "@/lib/config/auth-env";
 
-// getJwtSecret throws AuthConfigError lazily (at sign/verify time), so the login
-// route can turn it into a clear on-screen 503 instead of a misleading
-// "Invalid email or password".
-// Lazy-initialized to prevent module-level crash if JWT_SECRET is misconfigured.
-// A module-level throw would crash ALL modules that import auth.ts.
-let _jwtSecret: Uint8Array | null = null;
-function jwtSecret(): Uint8Array {
-  if (!_jwtSecret) {
-    _jwtSecret = getJwtSecret();
-  }
-  return _jwtSecret;
-}
-
-/**
- * Test seam. The memo above is module-level and only ever holds a SUCCESSFUL read, so a suite
- * that shares one process cannot observe the throwing cases once any earlier file has signed a
- * token: the cached key answers before `getJwtSecret` is ever called again. That is what made
- * `tests/unit/lib/auth-jwt-config.test.ts` pass alone and fail under `bun run test`, and its own
- * header note ("this file runs in its own process") was the workaround rather than the fix.
- */
-export function resetJwtSecretCache(): void {
-  _jwtSecret = null;
-}
+// getJwtSecret is called per sign/verify rather than at module load, so a
+// misconfigured JWT_SECRET surfaces as an AuthConfigError the login route can turn
+// into a clear on-screen 503 instead of a misleading "Invalid email or password" —
+// and never as a module-level throw, which would crash every importer of auth.ts.
+//
+// The result is deliberately NOT memoized. The reader is stateless (auth-env.ts), a
+// TextEncoder pass is nothing next to the HMAC that follows, and the other consumers
+// (oidc.ts, drive-token.ts, storage/encryption.ts) all call it fresh. A module-level
+// cache would hold only SUCCESSFUL reads, so any earlier signature in the process
+// would answer before the guard ran — silently unobservable in production and, in a
+// shared-process test run, the reason the config-guard cases could not fail.
 
 export type Role = "admin" | "user";
 
@@ -39,12 +27,12 @@ export async function signJWT(payload: UserPayload) {
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime("24h")
-    .sign(jwtSecret());
+    .sign(getJwtSecret());
 }
 
 export async function verifyJWT(token: string) {
   try {
-    const { payload } = await jwtVerify(token, jwtSecret());
+    const { payload } = await jwtVerify(token, getJwtSecret());
     return payload as unknown as UserPayload;
   } catch (error) {
     if (error instanceof Error) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,6 +16,17 @@ function jwtSecret(): Uint8Array {
   return _jwtSecret;
 }
 
+/**
+ * Test seam. The memo above is module-level and only ever holds a SUCCESSFUL read, so a suite
+ * that shares one process cannot observe the throwing cases once any earlier file has signed a
+ * token: the cached key answers before `getJwtSecret` is ever called again. That is what made
+ * `tests/unit/lib/auth-jwt-config.test.ts` pass alone and fail under `bun run test`, and its own
+ * header note ("this file runs in its own process") was the workaround rather than the fix.
+ */
+export function resetJwtSecretCache(): void {
+  _jwtSecret = null;
+}
+
 export type Role = "admin" | "user";
 
 export interface UserPayload {

--- a/tests/unit/lib/auth-jwt-config.test.ts
+++ b/tests/unit/lib/auth-jwt-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
+import { describe, test, expect, mock, afterEach } from "bun:test";
 import { AuthConfigError } from "@/lib/auth-errors";
 
 // auth.ts imports `cookies` from next/headers at module load; stub it so the
@@ -11,32 +11,34 @@ mock.module("next/headers", () => ({
   headers: async () => ({ get: () => null }),
 }));
 
-const { signJWT, resetJwtSecretCache } = await import("@/lib/auth");
+const { signJWT } = await import("@/lib/auth");
 
-// NOTE ON ORDERING: getJwtSecret() memoizes the first *successful* result in a module-level
-// cache. The throwing cases below never cache, so they are safe in any order — but the
-// dev-fallback success case must run LAST, otherwise its cached key would mask the throws.
-// The cache is cleared before each case rather than assumed empty: `tests/run-core.sh` gives
-// this file its own process, but `bun run test` does not, and under that command an earlier
-// file's successful sign left a key here that answered before the guard could throw.
+// ORDER-INDEPENDENT BY CONSTRUCTION: the dev-fallback success case runs FIRST, so a
+// successful secret read is always behind us by the time the guards are exercised.
+// signJWT re-reads JWT_SECRET on every call, so there is nothing to carry over. If a
+// module-level memo is ever reintroduced in auth.ts, the two throwing cases below fail
+// immediately - here, and under `bun run test`, where every file shares one process and
+// any earlier signature would otherwise answer before the guard could throw.
 describe("auth JWT_SECRET config guard", () => {
   const origSecret = process.env.JWT_SECRET;
   const origNodeEnv = process.env.NODE_ENV;
 
-  beforeEach(() => {
-    resetJwtSecretCache();
-  });
-
   afterEach(() => {
     setEnv("JWT_SECRET", origSecret);
     setEnv("NODE_ENV", origNodeEnv);
-    resetJwtSecretCache();
   });
 
   function setEnv(key: string, value: string | undefined): void {
     if (value === undefined) delete (process.env as Record<string, string>)[key];
     else (process.env as Record<string, string>)[key] = value;
   }
+
+  test("uses the dev fallback (no throw) when JWT_SECRET is missing outside production", async () => {
+    delete (process.env as Record<string, string>).JWT_SECRET;
+    (process.env as Record<string, string>).NODE_ENV = "development";
+
+    await expect(signJWT({ role: "admin", username: "admin" })).resolves.toBeString();
+  });
 
   test("throws AuthConfigError when JWT_SECRET is missing in production", async () => {
     delete (process.env as Record<string, string>).JWT_SECRET;
@@ -52,11 +54,14 @@ describe("auth JWT_SECRET config guard", () => {
     await expect(signJWT({ role: "admin", username: "admin" })).rejects.toThrow(AuthConfigError);
   });
 
-  // Must run last — this is the only case that populates the memoized cache.
-  test("uses the dev fallback (no throw) when JWT_SECRET is missing outside production", async () => {
-    delete (process.env as Record<string, string>).JWT_SECRET;
-    (process.env as Record<string, string>).NODE_ENV = "development";
+  test("signs with the current JWT_SECRET after a rotation, without a restart", async () => {
+    (process.env as Record<string, string>).JWT_SECRET = "a".repeat(32);
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    const before = await signJWT({ role: "admin", username: "admin" });
 
-    await expect(signJWT({ role: "admin", username: "admin" })).resolves.toBeString();
+    (process.env as Record<string, string>).JWT_SECRET = "b".repeat(32);
+    const after = await signJWT({ role: "admin", username: "admin" });
+
+    expect(after.split(".")[2]).not.toBe(before.split(".")[2]);
   });
 });

--- a/tests/unit/lib/auth-jwt-config.test.ts
+++ b/tests/unit/lib/auth-jwt-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
 import { AuthConfigError } from "@/lib/auth-errors";
 
 // auth.ts imports `cookies` from next/headers at module load; stub it so the
@@ -11,20 +11,26 @@ mock.module("next/headers", () => ({
   headers: async () => ({ get: () => null }),
 }));
 
-const { signJWT } = await import("@/lib/auth");
+const { signJWT, resetJwtSecretCache } = await import("@/lib/auth");
 
-// NOTE ON ORDERING: getJwtSecret() memoizes the first *successful* result in a
-// module-level cache. The throwing cases below never cache, so they are safe in
-// any order — but the dev-fallback success case must run LAST, otherwise its
-// cached key would mask the throws. This file runs in its own process (see
-// tests/run-core.sh), so the cache starts empty.
+// NOTE ON ORDERING: getJwtSecret() memoizes the first *successful* result in a module-level
+// cache. The throwing cases below never cache, so they are safe in any order — but the
+// dev-fallback success case must run LAST, otherwise its cached key would mask the throws.
+// The cache is cleared before each case rather than assumed empty: `tests/run-core.sh` gives
+// this file its own process, but `bun run test` does not, and under that command an earlier
+// file's successful sign left a key here that answered before the guard could throw.
 describe("auth JWT_SECRET config guard", () => {
   const origSecret = process.env.JWT_SECRET;
   const origNodeEnv = process.env.NODE_ENV;
 
+  beforeEach(() => {
+    resetJwtSecretCache();
+  });
+
   afterEach(() => {
     setEnv("JWT_SECRET", origSecret);
     setEnv("NODE_ENV", origNodeEnv);
+    resetJwtSecretCache();
   });
 
   function setEnv(key: string, value: string | undefined): void {


### PR DESCRIPTION
## What

`src/lib/auth.ts` no longer memoizes the JWT secret: `signJWT` and `verifyJWT` call
`getJwtSecret()` directly and the module-level `_jwtSecret` cache is gone, so there is no state left
to reset and no `resetJwtSecretCache` seam.

`tests/unit/lib/auth-jwt-config.test.ts` runs the successful dev-fallback case **first** and gains a
secret-rotation case. The file is now a regression test for the memo instead of a victim of it:
reintroduce a cache in `auth.ts` and these cases fail immediately, in any process layout.

## Why

The original diagnosis on this branch was right and the defect is real. `getJwtSecret()` reads the
environment on every call, but `auth.ts` wrapped it in a module-level memo that only ever holds a
**successful** read. Once anything in the process has signed a token, the cached key answers and the
guard is never reached — so "JWT_SECRET missing in production" and "JWT_SECRET shorter than 32
characters" cannot be observed.

Reproduced on an otherwise untouched tree, with only the file's own success case moved to the top:

```
(fail) auth JWT_SECRET config guard > throws AuthConfigError when JWT_SECRET is missing in production
(fail) auth JWT_SECRET config guard > throws AuthConfigError when JWT_SECRET is shorter than 32 characters
 1 pass, 2 fail
```

Those are exactly the two failures reported here. Whether they surface under `bun run test` depends
on file load order and on bun re-evaluating `auth.ts` when this file mocks `next/headers`, which is
why the same command is green on one machine and red on another. A guard whose observability rests
on that is broken either way — and a cache that can hide a misconfiguration is not only a test
problem.

## Why the memo goes rather than gaining a seam

The first revision exported `resetJwtSecretCache()`. That follows a real convention here
(`resetSecurityConfigWarnings`, `resetAgentCapabilityCache`, and `resetCookieSecurityWarning` in
this very file), but `@/lib/auth` is not comparable to those modules in one respect: **36 test files
replace it wholesale** with an object literal (`tests/api/auth/login.test.ts:10`), against 1 for the
cited precedents. None of them carries the new name, so a load order that puts one first turns this
file's `await import("@/lib/auth")` into a link-time `Export named 'resetJwtSecretCache' not found`
— the failure mode the file's own header comment already documents for `next/headers`. That trades
an order-dependent assertion failure for an order-dependent link failure with a wider trigger.

Removing the state avoids both:

- `auth-env.ts` already documents the reader as stateless — "reads the environment on every call".
- `oidc.ts`, `drive-token.ts` and `storage/encryption.ts` all call it fresh; the memo was the odd one
  out (`proxy.ts` keeps its own, in a separate runtime).
- The cost is one `TextEncoder` pass per sign, against the HMAC that immediately follows.
- Laziness is unchanged: a misconfigured secret still throws `AuthConfigError` at sign/verify time,
  never at module load, so the login route keeps turning it into a clear 503.
- A rotated `JWT_SECRET` now takes effect without a process restart — pinned by the new fourth case.

`src/lib/auth-compare.ts` referenced the removed memo by line number; its comment now points at
`proxy.ts` and records why the key there is load-bearing (it is generated, not read, so re-deriving
it per call would make two digests of the same input differ).

## Verification

All six gates locally: `format`, `lint` (0 errors), `typecheck`, `knip`, `test`, `build`.
`bun run test` — the command in the original report — is green end to end: 7070 core, then
`All 30 groups passed!`. Coverage holds the gate: `check-coverage: OK — 36004/36004 lines (100.00%)`.

## Out of scope

The four `scripts/lib/pack-standalone-zip.sh` failures in the original report are a missing local
`7z`, as noted there — unrelated to this change and untouched.
