### PR TITLE
docs(llms): what each local model actually does in Agent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ what comes back, and finishes by composing a report whose every claim cites the 
 Standalone application only: the embedded `@libredb/studio` package carries no agent surface.
 **Guide:** [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md) · **What leaves the machine:**
 [`docs/AGENT_DATA_FLOW.md`](docs/AGENT_DATA_FLOW.md) · **Behaviour and limits:**
-[`docs/AGENT.md`](docs/AGENT.md)
+[`docs/AGENT.md`](docs/AGENT.md) · **Which local model to run:**
+[`docs/llms/`](docs/llms/README.md)
 
 ### Model-backed helpers
 - **Universal LLM Support**: Defaults to Gemini 2.5 Flash, and serves OpenAI, Ollama and any OpenAI-compatible endpoint (LM Studio, LiteLLM, vLLM).
@@ -827,6 +828,7 @@ extraEnvFrom:
 | [API Docs](docs/API_DOCS.md) | Complete REST API reference |
 | [Agent Guide](docs/AGENT_GUIDE.md) | Using the agent: a run, the three workflows, what "answered" means, the budget meter, and the Ollama path |
 | [Agent Data Flow](docs/AGENT_DATA_FLOW.md) | What leaves the machine, when, and to which model provider — written from call sites |
+| [Local models](docs/llms/README.md) | Which local model can actually drive an agent run, measured across three workflows, one page per model |
 | [Agent Runtime](docs/AGENT.md) | Agent behaviour, bounds, deployment and known limitations |
 | [OIDC SSO](docs/OIDC.md) | SSO setup (Auth0, Keycloak, Okta, Azure AD, Zitadel, Google) + subsystem internals & security model |
 | [Theming Guide](docs/ui/theming.md) | CSS theming, dark mode, and styling customization |

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -1,0 +1,94 @@
+# Local models in Agent mode
+
+Which models can actually drive an agent run, measured rather than assumed.
+
+Agent mode asks a model to do something a chat model is never asked to do: call a
+tool, read what comes back, call another, and finish by calling `compose_report`
+with claims that cite what it read. A model that writes beautiful prose about a
+database and never calls a tool answers nothing here. So the only useful question
+is what a model DOES on a run, and every figure on these pages comes from a run
+whose ledger is in `.workflow-data`.
+
+One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b`
+is how the size is chosen and because the interesting fact is usually the difference
+between two sizes of the same model.
+
+## What was measured
+
+Three workflows, one question each, against the embedded SQLite sample:
+
+| Workflow | Question | What it takes to pass |
+| --- | --- | --- |
+| Investigate | "What tables are in this database and how do they relate?" | a report, cited |
+| Operate | "What is currently happening on this database?" | readings, then a report |
+| Analyze | "Which part of the company costs us the most in salary?" | a read, an answer PRESENTED, then a report |
+
+Analyze is the hard one and the one that separates models: it is not enough to read
+the data and describe it, the result has to be handed over with `present_answer`.
+
+**Hardware:** Apple M5 Max, 48 GB, macOS in high-power mode. Timings scale with the
+machine; the pass/fail column does not, except where a run is close to the 90-second
+per-turn ceiling. If your machine is slower, prefer a smaller model rather than a
+larger one you will wait on. Power mode alone was measured at 2.8x throughput on this
+machine, and it decided pass from fail for one model.
+
+## The short answer
+
+| If you have | Use | Disk |
+| --- | --- | --- |
+| a modest laptop | [`qwen3:4b`](qwen/qwen3.md) | 2.5 GB |
+| a little more room | [`ornith:9b`](ornith/ornith.md) | 5.6 GB |
+| a workstation | [`gemma4:26b`](gemma/gemma4.md) or [`granite4.1:30b`](granite/granite4.1.md) | 17 GB |
+| a DeepSeek preference | none of them work — [why](deepseek/deepseek-r1.md) | — |
+
+## Every model measured
+
+| Model | Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`gemma4`](gemma/gemma4.md) | 26b | 17 GB | ✅ 6.5s | ✅ 12.0s | ✅ 25.6s | **3/3** |
+| [`granite4.1`](granite/granite4.1.md) | 30b | 17 GB | ✅ 6.7s | ✅ 23.7s | ✅ 19.9s | **3/3** |
+| [`nemotron-3.5-lightning`](nemotron/nemotron-3.5-lightning.md) | 30b | 25 GB | ✅ 14s | ✅ 15s | ✅ 21s | **3/3** |
+| [`qwen3.8`](qwen/qwen3.8.md) | 27b | 17 GB | ✅ 49.3s | ✅ 90.0s | ✅ 62.0s | **3/3** |
+| [`qwen3.6`](qwen/qwen3.6.md) | 27b | 17 GB | ✅ 56s | ✅ 108s | ✅ 87s | **3/3** |
+| [`muse-glimmer`](muse/muse-glimmer.md) | — | 18 GB | ✅ 90.4s | ✅ 69.4s | ✅ | **3/3** |
+| [`gemma4`](gemma/gemma4.md) | 12b | 7.6 GB | ✅ 21s | ✅ 72s | ✅ 119s | **3/3** |
+| [`qwen3.5`](qwen/qwen3.5.md) | 9b | 6.6 GB | ✅ 25s | ✅ 16s | ✅ | **3/3** |
+| [`ornith`](ornith/ornith.md) | 9b | 5.6 GB | ✅ 14s | ✅ 26s | ✅ 21s | **3/3** |
+| [`qwen3`](qwen/qwen3.md) | 8b | 5.2 GB | ✅ | ✅ 17s | ✅ 31s | **3/3** |
+| [`qwen3.5`](qwen/qwen3.5.md) | 4b | 3.4 GB | ✅ 24s | ✅ 10s | ✅ | **3/3** |
+| [`qwen3`](qwen/qwen3.md) | 4b | 2.5 GB | ✅ 27s | ✅ 36s | ✅ 56s | **3/3** |
+| [`granite4.1`](granite/granite4.1.md) | 8b | 5.3 GB | ✅ 4.0s | ✅ 2.9s | ❌ | 2/3 |
+| [`granite4.1`](granite/granite4.1.md) | 3b | 2.1 GB | ✅ 2.8s | ✅ 1.3s | ❌ | 2/3 |
+| [`mistral-small3.2`](mistral/mistral-small3.2.md) | 24b | 15 GB | ✅ 7.2s | ✅ | ❌ | 2/3 |
+| [`lfm2`](lfm/lfm2.md) | 24b | 14 GB | ✅ | ❌ | ❌ | 1/3 |
+| [`qwen3.5`](qwen/qwen3.5.md) | 2b | 2.7 GB | ❌ | ❌ | ❌ | 0/3 |
+| [`qwen3`](qwen/qwen3.md) | 1.7b | 1.4 GB | ❌ | ❌ | ❌ | 0/3 |
+| [`qwen3`](qwen/qwen3.md) | 0.6b | 522 MB | — | ❌ | ❌ | 0/3 |
+| [`deepseek-r1`](deepseek/deepseek-r1.md) | 7b–32b | 4.7–19 GB | ❌ | ❌ | ❌ | **0/3** |
+
+## Size is the strongest predictor, and 4B is the floor
+
+| Size | What happens |
+| --- | --- |
+| under 2B | calls tools, then narrates its findings instead of reporting. Nothing is recorded. |
+| 2B | same, and more stubbornly: one run made 42 tool calls and still wrote prose. |
+| **4B and up** | **works.** `qwen3:4b` passes all three at 2.5 GB. |
+| 9B and up | works, with more headroom on the analysis question. |
+
+Newer is not automatically better within a family: `qwen3:4b` (older generation)
+scores 3/3 where `qwen3.5:2b` scores 0/3, and the difference is size, not generation.
+
+## What a failure looks like
+
+The verdict on a run names which of these happened, and each has a different cause:
+
+| Verdict | What the model did | Fixable? |
+| --- | --- | --- |
+| `no-report` | called tools, then wrote its findings as prose | yes, the run is reminded once |
+| `no-answer` | read the data, then reported without presenting the result | yes, the run is told to present first |
+| `empty-evidence` | reported claims nothing in the run establishes | no, that is the citation contract working |
+| `model-timeout` | one turn took longer than 90 seconds | usually the machine, not the model |
+| no tool call at all | answered the question as a chat model would | no |
+
+Two of those are handled in the runtime now, which is why several models on this page
+score 3/3 today and scored 2/3 when first measured. The pages say which.

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -13,6 +13,12 @@ One page per model version. Sizes are rows inside it, because `ollama pull qwen3
 is how the size is chosen and because the interesting fact is usually the difference
 between two sizes of the same model.
 
+| | |
+| --- | --- |
+| Setting a local model up | [`setup.md`](setup.md) |
+| How these numbers were produced, and where they stop being safe | [`methodology.md`](methodology.md) |
+| Measuring a model these pages do not cover | [`testing-your-own.md`](testing-your-own.md) |
+
 ## What was measured
 
 Three workflows, one question each, against the embedded SQLite sample:
@@ -26,11 +32,20 @@ Three workflows, one question each, against the embedded SQLite sample:
 Analyze is the hard one and the one that separates models: it is not enough to read
 the data and describe it, the result has to be handed over with `present_answer`.
 
-**Hardware:** Apple M5 Max, 48 GB, macOS in high-power mode. Timings scale with the
-machine; the pass/fail column does not, except where a run is close to the 90-second
-per-turn ceiling. If your machine is slower, prefer a smaller model rather than a
-larger one you will wait on. Power mode alone was measured at 2.8x throughput on this
-machine, and it decided pass from fail for one model.
+**Two caveats worth carrying into every table below.**
+
+**One run per cell.** These models are not deterministic: one captured request
+replayed five times against `mistral-small3.2:24b` produced three tool-calling runs
+and two refusals. A single result is one observation, not a verdict. Where a figure
+was reproduced, the page says so.
+
+**One machine, and a fast one.** Apple M5 Max, 48 GB, macOS in high-power mode. Every
+timing here is a best case, and nothing was measured on a 16 GB laptop. The pass/fail
+column is the transferable part; the seconds are a lower bound. Power mode alone was
+worth 2.8x throughput and decided pass from fail for one model, so check
+`pmset -g | grep powermode` before blaming a model for a timeout.
+
+Both are expanded in [`methodology.md`](methodology.md), with what else is not covered.
 
 ## The short answer
 

--- a/docs/llms/deepseek/deepseek-r1.md
+++ b/docs/llms/deepseek/deepseek-r1.md
@@ -1,0 +1,70 @@
+# deepseek-r1
+
+`ollama pull deepseek-r1:<size>` · sizes measured: 7b, 8b, 14b, 32b
+
+**None of them can drive an agent run, and no configuration changes that.** Four
+sizes, two endpoints, the same result each time: the model is given tools, thinks
+about the question, and answers in prose without calling one.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 7b | 4.7 GB | ❌ | ❌ | ❌ | 0/3 |
+| 8b | 5.2 GB | ❌ | ❌ | ❌ | 0/3 |
+| 14b | 9.0 GB | ❌ | ❌ | ❌ | 0/3 |
+| 32b | 19 GB | ❌ | ❌ | ❌ | 0/3 |
+
+## What it does instead
+
+Given `inspect_operations` and asked what is happening on the database, with the tool
+declared in the request:
+
+```
+--- deepseek-r1:8b ---
+  tool_calls : none
+  thinking   : "Okay, user is asking about the health of a database. That's a pretty
+                broad question..."
+  content    : "To check the health of a database, I need to know which specific
+                database you're referring to (e.g., MySQL, PostgreSQL)..."
+```
+
+It sees the tool, reasons about the request, and then asks a clarifying question. It
+is treating the exchange as a conversation rather than as work to be done.
+
+`deepseek-r1:32b` fails a step further out: rather than calling the tool it writes a
+shell block, ` ```bash libredb_capability_probe -ack``` `, inventing a command line
+for a tool it was handed a calling convention for.
+
+## What was ruled out
+
+This is not our client, not the endpoint, and not the prompt:
+
+| Checked | Result |
+| --- | --- |
+| OpenAI-compatible endpoint (`/v1/chat/completions`) | no `tool_calls` |
+| Native Ollama endpoint (`/api/chat`) | no `tool_calls` |
+| Same request replayed with a control model | `gemma4:26b` calls the tool immediately |
+| Short prompt, no system prompt | still no `tool_calls` |
+| Four sizes | identical behaviour |
+
+One hypothesis was tested and **disproved**: that Ollama's packaging was at fault,
+because the `deepseek-r1` chat template contains no `.Tools` block while the tag
+advertises `capabilities: ["tools"]`. Scanning all installed models killed it —
+`gemma4:26b`, `qwen3.8` and `muse-glimmer` have no `.Tools` in their templates either,
+and all three score 3/3. Recent Ollama renders tools outside the Go template, so the
+template says nothing about capability.
+
+The remaining explanation is the model itself. DeepSeek-R1 is a reasoning model
+trained to think and then answer; the distills inherit that and not tool use.
+
+## What to use instead
+
+`deepseek-r1:8b` is a Qwen3 distill, so the closest working substitute at the same
+size is the model it was distilled from:
+
+```bash
+ollama pull qwen3:8b     # 5.2 GB, 3/3
+```
+
+Or, smaller, [`qwen3:4b`](../qwen/qwen3.md) at 2.5 GB — also 3/3.

--- a/docs/llms/gemma/gemma4.md
+++ b/docs/llms/gemma/gemma4.md
@@ -1,0 +1,40 @@
+# gemma4
+
+`ollama pull gemma4:<size>` · sizes measured: 12b, 26b
+
+Both sizes pass all three workflows, and 26b is the fastest large model measured.
+Nothing here needed a runtime fix.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| **12b** | **7.6 GB** | ✅ 21s | ✅ 72s | ✅ 119s | **3/3** |
+| **26b** | **17 GB** | ✅ 6.5s | ✅ 12.0s | ✅ 25.6s | **3/3** |
+
+26b is not just larger, it is faster on this workload: 25.6s on the analysis question
+against 119s for 12b. The larger model spends fewer turns getting there.
+
+```bash
+ollama pull gemma4:26b
+LLM_PROVIDER=ollama LLM_MODEL=gemma4:26b LLM_API_URL=http://localhost:11434/v1
+```
+
+## Answer quality
+
+On the salary question, 26b reported 16,171,239 for Development. Reproduced by hand,
+that figure double-counts 103 employees who changed department: it joins through
+`dept_emp` rather than `current_dept_emp`, so anyone who moved is counted twice.
+
+The run passes — it read the data, presented a result and cited it, which is what the
+verifier checks. Whether the join was the right one is not something any automated
+check on this workload can see. [`qwen3.8`](../qwen/qwen3.8.md) got the more
+defensible figure and was, at the time, the one being scored as having failed.
+
+Treat a passing run as a run that did the work, not as a run that was right.
+
+## Note on the chat template
+
+`gemma4` ships without a `.Tools` block in its Ollama chat template and calls tools
+perfectly. If you are debugging a model that will not call tools, the template is not
+where the answer is — see [`deepseek-r1`](../deepseek/deepseek-r1.md).

--- a/docs/llms/granite/granite4.1.md
+++ b/docs/llms/granite/granite4.1.md
@@ -1,0 +1,37 @@
+# granite4.1
+
+`ollama pull granite4.1:<size>` · sizes measured: 3b, 8b, 30b
+
+The fastest family measured by a wide margin — and the one where speed does not carry
+over to the analysis question.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 3b | 2.1 GB | ✅ 2.8s | ✅ 1.3s | ❌ `no-report` | 2/3 |
+| 8b | 5.3 GB | ✅ 4.0s | ✅ 2.9s | ❌ `empty-evidence` | 2/3 |
+| **30b** | **17 GB** | ✅ 6.7s | ✅ 23.7s | ✅ 19.9s | **3/3** |
+
+`granite4.1:3b` finishing Operate in **1.3 seconds** is the fastest run recorded on
+any model here. For questions that are only about the engine's own state, at 2.1 GB,
+that is hard to beat.
+
+## The two smaller sizes fail differently
+
+**3b — `no-report`.** It reads, then writes its findings as prose instead of calling
+`compose_report`. The runtime reminds such a run once; this one narrates again.
+
+**8b — `empty-evidence`.** More interesting: it composes a report, but the claims
+cite nothing the run established. This is the citation contract doing its job rather
+than a defect. A report whose claims are not backed by a reading this run took is
+refused, and that refusal is the feature — it is what stops a confident summary of a
+database nobody looked at.
+
+Neither is fixable by a nudge. `empty-evidence` in particular should not be: loosening
+it would let exactly the failure the contract exists to prevent through.
+
+## Recommendation
+
+Use `granite4.1:30b` if you want the whole workflow set. Use `granite4.1:3b`
+deliberately, for operational questions only, where its speed is remarkable.

--- a/docs/llms/lfm/lfm2.md
+++ b/docs/llms/lfm/lfm2.md
@@ -1,0 +1,38 @@
+# lfm2
+
+`ollama pull lfm2:24b` · one size measured: 24b (14 GB)
+
+An unproven family worth trying and, so far, the least reliable model measured. It
+calls tools freely and finishes almost nothing.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 24b | 14 GB | ✅ *(fixed)* | ❌ `no-report` | ❌ `no-report` | 1/3 |
+
+## It reads and then does not record
+
+Every failure has the same shape: tools called, readings taken, findings written as
+prose. On the analysis question it made **eleven** tool calls and composed no report.
+
+| Workflow | Tool calls | Report |
+| --- | --- | --- |
+| Investigate | 4 | ❌ |
+| Operate | 3 | ❌ |
+| Analyze | 11 | ❌ |
+
+The runtime reminds such a run once, and that rescued Investigate. It did not rescue
+Analyze: the reminder was delivered after nine readings and the model narrated again.
+So the reminder helps models that were one call short of reporting, and `lfm2` is
+often further away than that.
+
+## It is also unstable between runs
+
+Investigate passed in one measurement round and failed in the next with no change to
+the code or the machine — the same variance seen in
+[`mistral-small3.2`](../mistral/mistral-small3.2.md), but wider. Treat any single
+`lfm2` result as one sample.
+
+Not recommended for agent mode today. Kept on these pages because the failure is
+specific and recorded, and because a future release of the family may close it.

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -1,0 +1,90 @@
+# How these numbers were produced
+
+Read this before trusting a row in the tables. It says what was measured, on what,
+how many times, and where the results stop being safe to generalise from.
+
+## When, and against what
+
+| | |
+| --- | --- |
+| Measured | 16–17 August 2026 |
+| Application | LibreDB Studio at commit `907e83c` |
+| Runtime | Ollama, OpenAI-compatible endpoint (`http://localhost:11434/v1`) |
+| Database | the embedded SQLite sample (`seed:sqlite-embedded-sample`) |
+| Evidence | every run's ledger, in `.workflow-data` |
+
+Model behaviour changes when a family publishes a new build under the same tag, so
+these results describe the tags as they were on those dates.
+
+## The machine
+
+| | |
+| --- | --- |
+| Hardware | Apple M5 Max, 48 GB unified memory |
+| Storage | 2 TB SSD |
+| Power | macOS high-power mode, on AC |
+
+**This is a fast machine, and that is a limitation of these pages, not a feature of
+them.** Every timing here is a best case. Nothing was measured on a laptop with
+16 GB, and a reader with one should treat the pass/fail column as the transferable
+part and the seconds column as a lower bound.
+
+Power mode alone was worth 2.8x throughput on this machine, and it decided pass from
+fail for one model — see [`qwen3.6`](qwen/qwen3.6.md). Before concluding anything
+from a `model-timeout`, check it:
+
+```bash
+pmset -g | grep powermode     # 2 is high power
+```
+
+## The three questions
+
+One question per workflow, the same wording for every model:
+
+| Workflow | Question |
+| --- | --- |
+| Investigate | "What tables are in this database and how do they relate to each other?" |
+| Operate | "What is currently happening on this database?" |
+| Analyze | "Which part of the company costs us the most in salary?" |
+
+A cell is a pass only when the run's goal verdict is `answered`. A run that ends
+`succeeded` having answered nothing is a failure here, and the tables say which
+shortfall it hit.
+
+## One run per cell
+
+**This is the weakest part of the method, and it matters.**
+
+Each figure comes from a single run. That would be fine if these models were
+deterministic, and they are not. The clearest evidence is in this very data set: one
+captured request, replayed five times against `mistral-small3.2:24b`, produced three
+runs that called tools and two that answered *"I don't have the necessary tools"* —
+**60%**, from an identical request.
+
+So:
+
+* a single ❌ on a model that otherwise looks capable may be a sample, not a verdict
+* a single ✅ on a model near the size floor may be luck
+* the models the tables call unstable — `mistral-small3.2`, `lfm2` — are the ones
+  where this matters most, and their pages say so
+
+Where a result was reproduced (before and after a runtime fix, or across power
+modes), the page says that explicitly. Treat everything else as one observation.
+
+## What is not covered
+
+* **Only Ollama.** Gemini and OpenAI deployments are not characterised here.
+* **Only SQLite.** Agent mode reaches PostgreSQL and SQLite; the sample used is
+  SQLite, and a large PostgreSQL schema changes what fits in the captured inventory.
+* **Only three questions.** They exercise the three workflows, not the space of
+  things a user will ask.
+* **Answer correctness is largely unchecked.** The verifier checks that a run read
+  something, presented it and cited it. Whether the SQL was the right SQL is a
+  separate question, and where it was checked by hand the pages say what was found —
+  including one model that passes with a figure that double-counts.
+
+## Reproducing this
+
+The procedure is in [`testing-your-own.md`](testing-your-own.md). If you run it on
+different hardware, the numbers will differ; if the pass/fail column differs, that is
+worth reporting, because it is the part these pages claim is portable.

--- a/docs/llms/mistral/mistral-small3.2.md
+++ b/docs/llms/mistral/mistral-small3.2.md
@@ -1,0 +1,54 @@
+# mistral-small3.2
+
+`ollama pull mistral-small3.2:24b` · one size measured: 24b (15 GB)
+
+Passes two of three. Its value on these pages is what it taught: that a run ending
+without a report is often not a model that cannot, but a model that did not on that
+particular try.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 24b | 15 GB | ✅ 7.2s | ✅ *(fixed)* | ❌ `no-answer` | 2/3 |
+
+## The variance that looked like incapability
+
+Operate failed with `no-report` and zero tool calls, which reads as a model that
+cannot use tools. It can. Given the same tools and a simple prompt it called
+`inspect_operations` immediately.
+
+So the exact request the agent had sent was captured and replayed five times:
+
+| Attempt | Result |
+| --- | --- |
+| 1 | ✅ 6 tool calls |
+| 2 | ❌ *"I'm sorry, but I don't have the necessary tools"* |
+| 3 | ❌ *"I don't have access to the necessary tools"* |
+| 4 | ✅ 4 tool calls |
+| 5 | ✅ 6 tool calls |
+
+Same request, same model, same server: **60% success**. Because a run ended at the
+first prose turn, that 40% was recorded as a model that could not drive an agent at
+all.
+
+The runtime now reminds a run once when it has taken readings and then narrated.
+Operate went from `no-report` to **`answered`**, confirmed on the ledger: four
+readings, then `report-composed`.
+
+## Why Analyze still fails
+
+A different shortfall, and the reminder correctly stays silent for it. The ledger:
+
+```
+context-captured -> tool-invoked (profile_table) -> table-profiled
+                 -> tool-completed -> report-composed -> run-finished
+```
+
+It profiled a table and went straight to the report. A profile counts a table; it
+does not answer "which department costs most". There was no reading to present, so
+the run had nothing to hand over and was scored `no-answer`.
+
+The fix that rescues [`qwen3.5`](../qwen/qwen3.5.md) here requires a completed read to
+exist. This run has none, so telling it to present would be telling it to do something
+impossible. Left as measured.

--- a/docs/llms/muse/muse-glimmer.md
+++ b/docs/llms/muse/muse-glimmer.md
@@ -1,0 +1,30 @@
+# muse-glimmer
+
+`ollama pull muse-glimmer` · one tag: `latest` (18 GB)
+
+Passes all three workflows. Reached that score through the same fix as
+[`qwen3.8`](../qwen/qwen3.8.md), which is what makes it interesting: two unrelated
+model families were losing runs to one encoding detail.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| latest | 18 GB | ✅ 90.4s | ✅ 69.4s | ✅ *(fixed)* | **3/3** |
+
+The slowest passing model measured — 90.4s on Investigate, where
+[`gemma4:26b`](../gemma/gemma4.md) takes 6.5s at a similar size. It finishes, but a
+run is a wait.
+
+## The fix it needed
+
+Like `qwen3.8`, it called `present_answer` with the nested `presentation` object
+serialized as a string rather than nested. Every call was refused as invalid input,
+no event was written for the refusal, and the run was scored `no-answer` — a report
+with an empty answer beside it.
+
+Two model families making the identical mistake is why this was treated as a
+compatibility gap rather than a quirk of one model: the tool now reads such a payload
+back once, through the same schema, and `muse-glimmer` answers.
+
+Before: `no-answer` after 234.4s. After: **answered**.

--- a/docs/llms/nemotron/nemotron-3.5-lightning.md
+++ b/docs/llms/nemotron/nemotron-3.5-lightning.md
@@ -1,0 +1,25 @@
+# nemotron-3.5-lightning
+
+`ollama pull nemotron-3.5-lightning:30b` · one size measured: 30b (25 GB)
+
+Passes all three workflows, and does it fast for a 30B model.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| **30b** | **25 GB** | ✅ 14s | ✅ 15s | ✅ 21s | **3/3** |
+
+Consistent across the set — 14 to 21 seconds — where several other large models vary
+by a factor of five between workflows. On the analysis question it read the data,
+presented the result and reported, with no runtime fix required.
+
+The largest download on these pages at 25 GB, so it earns its place only where the
+disk and memory are there. At that size [`gemma4:26b`](../gemma/gemma4.md) does the
+same job in 17 GB and is faster on Investigate.
+
+## Why it is here
+
+The second unproven family tried on purpose, after [`ornith`](../ornith/ornith.md).
+Both score 3/3, which is the argument for testing outside the well-known names rather
+than assuming the familiar ones are the capable ones.

--- a/docs/llms/nemotron/nemotron3.md
+++ b/docs/llms/nemotron/nemotron3.md
@@ -1,0 +1,16 @@
+# nemotron3
+
+`ollama pull nemotron3:33b` · 33b (~27 GB)
+
+**Not yet measured.** The download is in progress; this page exists so the family
+folder is complete and will be filled in with the same three workflows as everything
+else.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 33b | ~27 GB | — | — | — | pending |
+
+For a measured Nemotron today, see
+[`nemotron-3.5-lightning`](nemotron-3.5-lightning.md), which scores 3/3.

--- a/docs/llms/ornith/ornith.md
+++ b/docs/llms/ornith/ornith.md
@@ -1,0 +1,31 @@
+# ornith
+
+`ollama pull ornith:9b` · one size measured: 9b (5.6 GB)
+
+An unproven family that passes everything, quickly, at a size a laptop can hold. One
+of the two models worth reaching for first on modest hardware.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| **9b** | **5.6 GB** | ✅ 14s | ✅ 26s | ✅ 21s | **3/3** |
+
+Every workflow inside half a minute, including the analysis question, where it read
+the data, presented the result and reported with citations. No runtime fix was needed
+for any of it.
+
+```bash
+ollama pull ornith:9b
+LLM_PROVIDER=ollama LLM_MODEL=ornith:9b LLM_API_URL=http://localhost:11434/v1
+```
+
+## Why it is here
+
+It was pulled as a deliberate long shot — a family with no track record for this
+workload — on the reasoning that a user browsing the model library will try exactly
+such a model, so the docs should say what happens when they do. It scores 3/3.
+
+For an even smaller download at the same score, see
+[`qwen3:4b`](../qwen/qwen3.md) at 2.5 GB. `ornith:9b` has more headroom on the
+analysis question.

--- a/docs/llms/qwen/qwen3.5.md
+++ b/docs/llms/qwen/qwen3.5.md
@@ -1,0 +1,45 @@
+# qwen3.5
+
+`ollama pull qwen3.5:<size>` · sizes measured: 2b, 4b, 9b
+
+Two of the three sizes pass everything. The one that does not is the smallest, and it
+fails the same way every sub-4B model does.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 2b | 2.7 GB | ❌ `no-report` | ❌ `no-report` | ❌ `no-report` | 0/3 |
+| **4b** | **3.4 GB** | ✅ 24s | ✅ 10s | ✅ | **3/3** |
+| **9b** | **6.6 GB** | ✅ 25s | ✅ 16s | ✅ | **3/3** |
+
+## 4b and 9b needed a runtime fix to reach 3/3
+
+Both passed Investigate and Operate from the start and failed Analyze with
+`no-answer`: they read the data, got the right result, and then called
+`compose_report` without ever calling `present_answer`. The report landed with an
+empty answer pane beside it, and the goal verifier scored the run as having answered
+nothing.
+
+The answer was one call away in both cases. The runtime now intercepts that
+`compose_report` — the call is not executed, and the run is told to present the
+result it already has first. Both models then present and report normally.
+
+| | Before | After |
+| --- | --- | --- |
+| 4b Analyze | `no-answer` | ✅ `answered`, 5 tool calls |
+| 9b Analyze | `no-answer` | ✅ `answered` |
+
+## Why 2b fails
+
+It calls tools eagerly — on the salary question it made **42 tool calls** — and then
+writes its findings as prose instead of calling `compose_report`. Reminded once that
+a run reports by calling the tool, it narrates again.
+
+Compare [`qwen3:4b`](qwen3.md), an older generation at a smaller download, which
+scores 3/3. Within Qwen, size predicts agent capability and generation does not.
+
+```bash
+ollama pull qwen3.5:4b
+LLM_PROVIDER=ollama LLM_MODEL=qwen3.5:4b LLM_API_URL=http://localhost:11434/v1
+```

--- a/docs/llms/qwen/qwen3.6.md
+++ b/docs/llms/qwen/qwen3.6.md
@@ -1,0 +1,48 @@
+# qwen3.6
+
+`ollama pull qwen3.6:27b` · one size measured: 27b (17 GB)
+
+Passes all three workflows — and is the clearest evidence on these pages that the
+machine matters as much as the model.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 27b | 17 GB | ✅ 56s | ✅ 108s | ✅ 87s | **3/3** |
+
+No small tags are published, same as [`qwen3.8`](qwen3.8.md). For a smaller Qwen see
+[`qwen3`](qwen3.md) or [`qwen3.5`](qwen3.5.md).
+
+## It scored 0/3 on the same machine an hour earlier
+
+Every one of the three workflows failed with `model-timeout`. The ledger showed where
+the 90-second per-turn ceiling went:
+
+```
+    0.0s  run-started
+   42.0s  tool-invoked x4        <- turn 1 took 42s
+  132.0s  run-finished           <- turn 2 hit exactly 90s and was cut
+```
+
+Lifting the ceiling temporarily to measure it showed turn 2 needed **91.4 seconds**.
+The model was missing agent mode by 1.4 seconds.
+
+The laptop was in low-power mode. Switched to high power, the same run passed:
+
+| | Low power | High power |
+| --- | --- | --- |
+| one turn, small prompt | 20.6s | 4.6s |
+| throughput | 10.3 tok/s | 28.9 tok/s |
+| Investigate | ❌ `model-timeout` | ✅ 56s |
+| Operate | ❌ `model-timeout` | ✅ 108s |
+| Analyze | ❌ `model-timeout` | ✅ 87s |
+
+No code changed. A per-turn timeout override was drafted and then not written,
+because the number it was sized against turned out to be an artifact of the power
+setting.
+
+**If a 27B model times out for you, check the power mode before concluding anything
+about the model.** On macOS: `pmset -g | grep powermode` — `2` is high power. Turn 2
+of an agent run is the expensive one, because the tool results from turn 1 are in the
+prompt by then.

--- a/docs/llms/qwen/qwen3.8.md
+++ b/docs/llms/qwen/qwen3.8.md
@@ -1,0 +1,53 @@
+# qwen3.8
+
+`ollama pull qwen3.8` · one size published: 27b (17 GB)
+
+Passes all three workflows. Worth reading for what it took to get there: this model
+was scored as answering nothing for weeks, and the model was never the problem.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 27b (`latest`) | 17 GB | ✅ 49.3s | ✅ 90.0s | ✅ 62.0s | **3/3** |
+
+There is no small `qwen3.8`. `4b`, `8b` and `12b` tags do not exist; the registry
+serves `latest` and `27b`, which are the same 27.3B model. For a smaller Qwen see
+[`qwen3`](qwen3.md) or [`qwen3.5`](qwen3.5.md).
+
+## It was being refused, not failing
+
+On the salary question it read the data, wrote the right query, got the right figure,
+and was scored `no-answer`. The rail showed a report with nothing beside it.
+
+`present_answer` had been called three times, each with a correct artifact id and a
+correct chart spec — right type, right x, right y, columns spelled as the result
+spells them. Each call was refused, because the model had serialized the nested
+object instead of nesting it:
+
+```json
+{"artifact": "67fb154a-…",
+ "presentation": "{\"kind\": \"chart\", \"spec\": {\"type\": \"bar\", …}}"}
+```
+
+A string holding an object, where the schema wanted the object. None of it was
+visible: a refused ledger-only tool records no event, so the run's ledger could not
+tell "never tried" from "tried and was refused". The only surviving trace was the
+model saying so in its closing prose — *"the presentation call is being persistently
+rejected despite conforming to the declared shape"*. It was conforming; only the
+encoding was wrong.
+
+The tool now reads such a payload back once before validating, through the same
+schema, so nothing is admitted that would not have been admitted written properly.
+`qwen3.8` went from `no-answer` in 84.9s to **answered in 62.0s**.
+
+## Answer quality
+
+Asked which part of the company costs most in salary, it reported 14,121,582 for
+Development — the most defensible figure of the seven models compared by hand. It
+joined through `current_dept_emp`, the strictest reading of "current", and said in
+its claims which reading it had used. Two models that also passed report inflated
+totals because they double-count employees who changed department, or include people
+who have left.
+
+Passing and being right are different things, and only one of them is checked.

--- a/docs/llms/qwen/qwen3.md
+++ b/docs/llms/qwen/qwen3.md
@@ -1,0 +1,67 @@
+# qwen3
+
+`ollama pull qwen3:<size>` · sizes measured: 0.6b, 1.7b, 4b, 8b, 14b
+
+The family where the size threshold is visible in one table. The same generation,
+the same training, the same tool-calling format — and 4b answers every workflow
+while 1.7b answers none. Whatever agent work needs, it is not present at 1.7b and
+is present at 4b.
+
+## Results
+
+| Size | Disk | Investigate | Operate | Analyze | Score |
+| --- | --- | --- | --- | --- | --- |
+| 0.6b | 522 MB | — | ❌ `no-report` | ❌ `no-report` | 0/3 |
+| 1.7b | 1.4 GB | ❌ `no-report` | ❌ `no-report` | ❌ `no-answer` | 0/3 |
+| **4b** | **2.5 GB** | ✅ 27s | ✅ 36s | ✅ 56s | **3/3** |
+| **8b** | **5.2 GB** | ✅ | ✅ 17s | ✅ 31s | **3/3** |
+| 14b | 9.3 GB | not yet measured | | | |
+
+## 4b is the recommendation for a modest machine
+
+2.5 GB, and it does the whole job: it reads, it presents the result, it reports with
+citations. On the salary question it made 5 tool calls and left an `answer-composed`
+entry on the ledger — the thing a 0.6b run never produces.
+
+It is also the counterexample to reading version numbers as quality: `qwen3:4b` is an
+older generation than `qwen3.5:2b`, and it scores 3/3 where that one scores 0/3.
+
+```bash
+ollama pull qwen3:4b
+LLM_PROVIDER=ollama LLM_MODEL=qwen3:4b LLM_API_URL=http://localhost:11434/v1
+```
+
+## Why the small sizes fail
+
+They call tools. That is the surprise — `qwen3:0.6b` and `qwen3:1.7b` both invoke
+`inspect_operations` correctly, with the right argument. What they will not do is
+finish: having taken readings, they write their findings as prose instead of calling
+`compose_report`, and a run that ends that way recorded nothing.
+
+The runtime reminds such a run once, and these sizes narrate again rather than
+reporting. The reminder rescues models that were one call short; these are not one
+call short, they are answering in a different register entirely.
+
+`qwen3:0.6b` is worth calling out because it is the most-downloaded Qwen model on
+Hugging Face by a wide margin. It is an excellent small chat model. It is not an
+agent.
+
+## Ledger evidence
+
+`qwen3:4b`, the salary question:
+
+```
+run-started -> context-captured -> statement-drafted
+            -> tool-invoked (run_read_query) -> tool-completed
+            -> answer-composed
+            -> report-composed -> run-finished
+```
+
+`qwen3:1.7b`, the same question:
+
+```
+run-started -> context-captured -> tool-invoked x4 -> tool-completed x4
+            -> run-finished    (stopReason: model-stopped, unmet: no-report)
+```
+
+Four readings taken, nothing recorded.

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -1,0 +1,88 @@
+# Running Agent mode against a local model
+
+From nothing to a finished agent run, on your own machine, with no key and no traffic
+leaving it.
+
+## 1. Install Ollama and pull a model
+
+```bash
+# macOS
+brew install ollama
+ollama serve            # leave running
+
+ollama pull qwen3:4b    # 2.5 GB, passes all three workflows
+```
+
+`qwen3:4b` is the smallest model measured that does the whole job. For the
+alternatives and what each costs in disk, see the [index](README.md).
+
+## 2. Point LibreDB Studio at it
+
+In `.env.local`:
+
+```bash
+LLM_PROVIDER=ollama
+LLM_MODEL=qwen3:4b
+LLM_API_URL=http://localhost:11434/v1
+```
+
+`LLM_API_URL` must end in `/v1`: that is Ollama's OpenAI-compatible endpoint, which is
+what the agent runtime posts to. The native `/api/chat` endpoint is not used.
+
+No API key is needed. Nothing reaches a hosted provider on this path — what a run
+sends and where is documented in [`../AGENT_DATA_FLOW.md`](../AGENT_DATA_FLOW.md).
+
+Restart the server after editing the file; these are read server-side at startup.
+
+## 3. Check the model can drive a run at all
+
+Agent mode needs tool calling. A model that cannot call a tool will produce fluent
+prose and answer nothing, so it is worth ten seconds to find out first:
+
+```bash
+curl -s http://localhost:11434/api/chat -d '{
+  "model": "qwen3:4b",
+  "messages": [{"role": "user", "content": "Check this database health."}],
+  "tools": [{"type": "function", "function": {
+    "name": "inspect_operations",
+    "description": "Read live database operational state.",
+    "parameters": {"type": "object",
+      "properties": {"kind": {"type": "string", "enum": ["health"]}},
+      "required": ["kind"]}}}],
+  "stream": false
+}' | grep -o '"tool_calls".\{0,120\}'
+```
+
+A model that is usable answers with a `tool_calls` array naming
+`inspect_operations`. One that is not answers in prose — that is what every
+`deepseek-r1` size does, and [its page](deepseek/deepseek-r1.md) has the detail.
+
+The application runs its own capability probe before a run and refuses a model whose
+tool calling is established as absent, so this check only saves you the wait.
+
+## 4. Run one
+
+Open Agent mode, pick a connection, and ask a question that needs the database. The
+embedded SQLite sample is there by default.
+
+A finished run leaves a report with cited claims. If a workflow presents answers, it
+also leaves the result beside the report.
+
+## When it does not work
+
+| What you see | Where to look |
+| --- | --- |
+| Report with an empty answer pane | the model reported without presenting; see the verdict on the ledger |
+| A run that ends having recorded nothing | `no-report` — the model narrated its findings. Common below 4B |
+| `model-timeout` | one turn exceeded 90 seconds. Check the power mode first: `pmset -g \| grep powermode` |
+| The model refuses, saying it has no tools | it may be unstable rather than incapable; see [`mistral-small3.2`](mistral/mistral-small3.2.md) |
+
+Every run writes its ledger to `.workflow-data`, and that is the authority on what a
+run actually did — which tools it called, what came back, and why it was scored the
+way it was.
+
+## Using something other than Ollama
+
+`LLM_PROVIDER=custom` with `LLM_API_URL` pointing at any OpenAI-compatible endpoint
+works the same way; `openai` and `gemini` take a key. All variables are documented in
+[`.env.example`](../../.env.example).

--- a/docs/llms/testing-your-own.md
+++ b/docs/llms/testing-your-own.md
@@ -1,0 +1,75 @@
+# Measuring a model these pages do not cover
+
+The library has more models than anyone can test, and new ones land weekly. This is
+the procedure that produced every table here, so a result you get is comparable with
+a result on these pages.
+
+## Before spending the download
+
+Tool calling is the gate. Pull the model, then run the probe in
+[`setup.md`](setup.md#3-check-the-model-can-drive-a-run-at-all). A model that answers
+in prose rather than with a `tool_calls` array cannot drive a run, and no amount of
+prompting changes that — four `deepseek-r1` sizes were confirmed that way.
+
+Two things that look like evidence and are not:
+
+* **the `tools` tag on the Ollama model page.** `deepseek-r1` advertises it and cannot
+  do it.
+* **the chat template.** A missing `.Tools` block proves nothing: `gemma4:26b`,
+  `qwen3.8` and `muse-glimmer` all lack it and all score 3/3, because recent Ollama
+  renders tools outside the template.
+
+## The three runs
+
+Ask each question against the embedded SQLite sample, one run each:
+
+| Workflow | Question |
+| --- | --- |
+| Investigate | What tables are in this database and how do they relate to each other? |
+| Operate | What is currently happening on this database? |
+| Analyze | Which part of the company costs us the most in salary? |
+
+Analyze is the one that separates models. It is not enough to read the data and
+describe it: the result has to be handed over with `present_answer`, and most models
+that score 2/3 fail exactly there.
+
+## Reading the result
+
+A run is a pass only when its goal verdict is `answered`. `succeeded` is not the same
+thing — a run can end successfully having answered nothing.
+
+The ledger in `.workflow-data` is the authority. What to look for:
+
+| On the ledger | What happened |
+| --- | --- |
+| `tool-invoked` / `tool-completed` | the model called a tool and it settled |
+| `answer-composed` | a result was presented. Absent on every `no-answer` run |
+| `report-composed` | the run reported. Absent on every `no-report` run |
+| `run-finished` with `stopReason` | how the loop ended |
+
+One thing the ledger cannot tell you: a refused ledger-only tool writes no event, so
+"never called `present_answer`" and "called it and was refused" look identical. If a
+model insists it is presenting and the verdict says otherwise, that is the case to
+suspect — it is what [`qwen3.8`](qwen/qwen3.8.md) turned out to be.
+
+## Recording it
+
+Note these, because a number without them cannot be compared:
+
+* the exact tag (`qwen3:4b`, not "qwen")
+* disk size and parameter count, from `ollama list` and `/api/show`
+* the machine, and the power mode
+* seconds per workflow, and the verdict for each
+
+Then add a row to the model's page, or a new page under the family folder if the
+family is not covered. Sizes are rows inside a version page, not separate files.
+
+## Run it more than once
+
+Every table on these pages is one run per cell, and that is the method's weakest
+point — see [`methodology.md`](methodology.md). Some models are genuinely unstable:
+one captured request replayed five times against `mistral-small3.2:24b` produced three
+tool-calling runs and two refusals.
+
+If a result surprises you, run it again before writing it down. If a model passes
+sometimes and fails sometimes, that IS the finding, and it belongs on the page.


### PR DESCRIPTION
## What

`docs/llms/`, one page per model version, with a size row inside each.

```
docs/llms/README.md          the index: every model measured, in one table
docs/llms/qwen/qwen3.md      0.6b · 1.7b · 4b · 8b · 14b
docs/llms/qwen/qwen3.5.md    2b · 4b · 9b
docs/llms/qwen/qwen3.6.md    27b
docs/llms/qwen/qwen3.8.md    27b
docs/llms/gemma/gemma4.md    12b · 26b
docs/llms/granite/granite4.1.md
docs/llms/deepseek/deepseek-r1.md
docs/llms/mistral/mistral-small3.2.md
docs/llms/nemotron/nemotron-3.5-lightning.md · nemotron3.md
docs/llms/lfm/lfm2.md
docs/llms/ornith/ornith.md
docs/llms/muse/muse-glimmer.md
```

Sizes are rows rather than files because `ollama pull qwen3:4b` is how a size gets chosen, and because the interesting fact is usually the difference between two sizes of one model. Splitting them would also make `deepseek-r1` repeat one sentence four times.

## Why

Agent mode asks a model to do something a chat model is never asked to do: call a tool, read what comes back, and finish by calling `compose_report` with claims that cite what it read. A model that writes fluent prose about a database and never calls a tool answers nothing here.

Nothing in the settings surface distinguishes the two. A user picking a model from the Ollama library finds out after the download, the pull and a failed run.

## What was measured

Twenty models, three workflows each, against the embedded SQLite sample. Every figure comes from a run whose ledger is in `.workflow-data`.

| Workflow | Question | What it takes to pass |
| --- | --- | --- |
| Investigate | what tables exist and how they relate | a cited report |
| Operate | what is happening on this database | readings, then a report |
| Analyze | which department costs most in salary | a read, an answer PRESENTED, then a report |

## What the pages record beyond the table

**The size floor is 4B.** Below it a model calls tools and then narrates its findings instead of reporting; one 2B run made 42 tool calls and recorded nothing. `qwen3:4b` passes all three at 2.5 GB.

**Generation does not predict capability inside a family.** `qwen3:4b` scores 3/3 where the newer `qwen3.5:2b` scores 0/3. The difference is size.

**`deepseek-r1` cannot drive a run** at any of four sizes, on either endpoint. The page also records the hypothesis that looked like the cause and was disproved: its Ollama chat template carries no `.Tools` block, but neither do `gemma4:26b`, `qwen3.8` or `muse-glimmer`, and all three score 3/3.

**A 27B model scoring 0/3 was the laptop, not the model.** `qwen3.6:27b` failed all three with `model-timeout`; on high power the same three passed. The page carries the measurement — turn 2 needed 91.4s against a 90s ceiling — and the `pmset` check to run before blaming a model.

**Which failures are handled and which are the contract working.** `no-report` and `no-answer` are nudged by the runtime; `empty-evidence` is refused on purpose, because a report whose claims cite nothing the run established is exactly what the citation contract exists to stop.

## Two things stated plainly, because a table hides them

**Passing is not being right.** `gemma4:26b` passes the salary question with a figure that double-counts 103 employees who changed department. The model that produced the most defensible figure was, at the time, the one being scored as having failed. The index says so.

**The runtime fixes have limits.** The `mistral-small3.2` and `lfm2` pages say why the reminder does not rescue them, rather than leaving a reader to assume every failure is now handled.

## Scope

Documentation only. No source, no tests, no behaviour change.
