### PR TITLE
fix(agent): remind a run that read the database and then narrated

### DIFF
--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -291,14 +291,28 @@ function planningEngine(context: AgentToolContext): PlanningEngine {
  * a data-analysis run), `qwen3.5:2b` (42). None of them was refusing to report; each
  * had answered in the register a chat model answers in.
  *
- * Once, and only after a reading: a model that would not call the tool the first time
- * it was asked is stopping, not hesitating, and a second telling would spend a turn
- * to learn that. The reminder is deliberately NOT sent to a run with no readings —
- * see the branch in the loop, and `AGENT_REPORT_RESERVE_NOTICE` for the other
- * sentence this run may hear about ending.
+ * Once, and only after a call: a model that would not call the tool the first time it
+ * was asked is stopping, not hesitating, and a second telling would spend a turn to
+ * learn that. Three runs never hear it, and each bound is load-bearing rather than
+ * cautious — see `remindToReport`, which is where all three are applied:
+ *
+ *  - a run that established nothing, which is a model that is stopping rather than
+ *    one that is a call short
+ *  - a run that holds no `compose_report`, which is every PLANNING run: naming a tool
+ *    a run's set cannot satisfy is the #350/#356 failure, and the refusal a run gets
+ *    for reaching outside its set is not evidence that it used one
+ *  - a run with no turn left to act on it, because a reminder the loop then refuses
+ *    to grant rescues nothing — it rewrites a model that stopped as a run that ran
+ *    out of turns
+ *
+ * The sentence says CALLED rather than read, because that is what this branch can
+ * know: an offered tool that refused the call is still a tool this run used, and
+ * claiming a reading it has not got would be a false self-description of exactly the
+ * kind agent mode keeps being caught in. See `AGENT_REPORT_RESERVE_NOTICE` for the
+ * other sentence this run may hear about ending.
  */
 const AGENT_REPORT_REMINDER_NOTICE = [
-  "You have taken readings in this run and then written your findings as prose, which records nothing: a run reports by CALLING compose_report, and text outside that call is not a report.",
+  "You have called this run's tools and then written your findings as prose, which records nothing: a run reports by CALLING compose_report, and text outside that call is not a report.",
   "Call compose_report now with what you established.",
   AGENT_CITATION_RULE,
 ].join(" ");
@@ -1968,7 +1982,7 @@ export async function runInvestigation(
   let text = "";
   /** The reserve notice is a one-shot: a run is told once that it is out of room. */
   let reserveAnnounced = false;
-  /** Whether any tool call has been made, which is what makes a reminder worth a turn. */
+  /** Whether a tool this run HOLDS has been called; see `remindToReport`. */
   let anyToolCalled = false;
   /** The report reminder is a one-shot too; see `AGENT_REPORT_REMINDER_NOTICE`. */
   let reportReminded = false;
@@ -1987,6 +2001,27 @@ export async function runInvestigation(
     if (maxTurns - turns > AGENT_REPORT_RESERVE_TURNS && remainingMs > AGENT_REPORT_RESERVE_MS) return;
     reserveAnnounced = true;
     messages.push({ role: "user", content: AGENT_REPORT_RESERVE_NOTICE });
+  };
+
+  /**
+   * Tells the run, once, that it narrated where it should have reported, and says
+   * whether it did — which is the caller's "take the turn again".
+   *
+   * The three bounds `AGENT_REPORT_REMINDER_NOTICE` documents are applied here and
+   * nowhere else. `anyToolCalled` carries the first two together: it is set only for a
+   * tool THIS RUN HOLDS, so a name the model invented reached nothing and a planning
+   * run — handed no tool set at all — can never set it. The ceilings are read rather
+   * than left to be hit, because this is the region the reserve notice has already
+   * pushed the model into: two turns from the end, told to wrap up, wrapping up in
+   * prose.
+   */
+  const remindToReport = (assistant: readonly ModelMessage[]): boolean => {
+    if (reportReminded || !anyToolCalled) return false;
+    if (turns >= maxTurns || resources.deadline.remainingMs() <= 0) return false;
+    reportReminded = true;
+    messages.push(...assistant);
+    messages.push({ role: "user", content: AGENT_REPORT_REMINDER_NOTICE });
+    return true;
   };
 
   /*
@@ -2097,20 +2132,19 @@ export async function runInvestigation(
     text = turn.text;
     if (turn.aborted) return conclude("failed", turnBudgetMs < remainingMs ? "model-timeout" : "deadline-exceeded");
     if (turn.toolCalls.length === 0) {
-      // A run that read something and then narrated is one call short of a report;
+      // A run that used its tools and then narrated is one call short of a report;
       // one that established nothing has nothing to be reminded about.
-      if (anyToolCalled && !reportReminded) {
-        reportReminded = true;
-        messages.push(...turn.assistantMessages);
-        messages.push({ role: "user", content: AGENT_REPORT_REMINDER_NOTICE });
-        return null;
-      }
+      if (remindToReport(turn.assistantMessages)) return null;
       return conclude("succeeded", "model-stopped");
     }
-    anyToolCalled = true;
 
     messages.push(...turn.assistantMessages);
     for (const call of turn.toolCalls) {
+      // A tool this run HOLDS, read from the set the SDK was actually given. A name
+      // the model invented reached nothing, and planning mode is handed no set at all
+      // — so a run reminded on either would be told to call `compose_report`, which is
+      // a tool it has not got (#350).
+      if (tools?.[call.toolName] !== undefined) anyToolCalled = true;
       const outcome = await handleCall({ service, context, record, call, known, notAttempted });
       if (outcome.kind === "cancelled") {
         // `runStep` already ended the run at its checkpoint; finishing again would

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -277,6 +277,33 @@ function planningEngine(context: AgentToolContext): PlanningEngine {
 }
 
 /**
+ * What a run is told once when it has taken readings and then written its findings
+ * as prose instead of calling `compose_report`.
+ *
+ * A prose turn normally ends the run, and for a model that has established nothing
+ * that is the right ending: there is no report to ask for. But a run that HAS read
+ * something and then narrates its findings has done the whole job except the one
+ * call that records it, and ending there throws the readings away — the ledger keeps
+ * the artifacts and the goal verifier still scores the run `no-report`.
+ *
+ * Measured on three models against a local Ollama endpoint, each of which read the
+ * database and then narrated: `mistral-small3.2:24b` (4 readings), `lfm2:24b` (11 on
+ * a data-analysis run), `qwen3.5:2b` (42). None of them was refusing to report; each
+ * had answered in the register a chat model answers in.
+ *
+ * Once, and only after a reading: a model that would not call the tool the first time
+ * it was asked is stopping, not hesitating, and a second telling would spend a turn
+ * to learn that. The reminder is deliberately NOT sent to a run with no readings —
+ * see the branch in the loop, and `AGENT_REPORT_RESERVE_NOTICE` for the other
+ * sentence this run may hear about ending.
+ */
+const AGENT_REPORT_REMINDER_NOTICE = [
+  "You have taken readings in this run and then written your findings as prose, which records nothing: a run reports by CALLING compose_report, and text outside that call is not a report.",
+  "Call compose_report now with what you established.",
+  AGENT_CITATION_RULE,
+].join(" ");
+
+/**
  * What an operations run is told about the inventory it was given (#411).
  *
  * Both of these sentences used to say "no schema inventory was captured for this run,
@@ -1941,6 +1968,10 @@ export async function runInvestigation(
   let text = "";
   /** The reserve notice is a one-shot: a run is told once that it is out of room. */
   let reserveAnnounced = false;
+  /** Whether any tool call has been made, which is what makes a reminder worth a turn. */
+  let anyToolCalled = false;
+  /** The report reminder is a one-shot too; see `AGENT_REPORT_REMINDER_NOTICE`. */
+  let reportReminded = false;
 
   /**
    * Tells the run, once, that it has come within the reserve of a ceiling.
@@ -2065,7 +2096,18 @@ export async function runInvestigation(
     );
     text = turn.text;
     if (turn.aborted) return conclude("failed", turnBudgetMs < remainingMs ? "model-timeout" : "deadline-exceeded");
-    if (turn.toolCalls.length === 0) return conclude("succeeded", "model-stopped");
+    if (turn.toolCalls.length === 0) {
+      // A run that read something and then narrated is one call short of a report;
+      // one that established nothing has nothing to be reminded about.
+      if (anyToolCalled && !reportReminded) {
+        reportReminded = true;
+        messages.push(...turn.assistantMessages);
+        messages.push({ role: "user", content: AGENT_REPORT_REMINDER_NOTICE });
+        return null;
+      }
+      return conclude("succeeded", "model-stopped");
+    }
+    anyToolCalled = true;
 
     messages.push(...turn.assistantMessages);
     for (const call of turn.toolCalls) {

--- a/tests/evals/database-assessment.test.ts
+++ b/tests/evals/database-assessment.test.ts
@@ -155,7 +155,11 @@ describe("a profile can only be aimed at a table the run has inventoried", () =>
   test("a table the schema capture never returned is refused before any database reach", async () => {
     const run = await open("postgres");
 
-    const drive = await run.drive([profiles("secrets"), answersProse("I could not profile that.")]);
+    const drive = await run.drive([
+      profiles("secrets"),
+      answersProse("I could not profile that."),
+      answersProse("I could not profile that."),
+    ]);
 
     expect(drive.modelStatements).toEqual([]);
     expect(drive.transcripts[1]).toContain("not in the schema inventory");
@@ -195,6 +199,9 @@ describe("the tool belongs to the workflow", () => {
         return chatToolCallStream("profile_table", JSON.stringify({ table: "engineering" }), "call_profile");
       },
       answersProse("I cannot profile from here."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("I cannot profile from here."),
     ]);
 
     expect(drive.transcripts[1]).toContain("There is no tool called");
@@ -229,7 +236,11 @@ describe("a profile that does not settle cleanly", () => {
     });
     runs.push(run);
 
-    const drive = await run.drive([profiles("engineering"), answersProse("That table is gone.")]);
+    const drive = await run.drive([
+      profiles("engineering"),
+      answersProse("That table is gone."),
+      answersProse("That table is gone."),
+    ]);
 
     expect(drive.kinds).toContain("tool-refused");
     expect(drive.kinds).not.toContain("table-profiled");
@@ -254,6 +265,9 @@ describe("a profile that does not settle cleanly", () => {
     const drive = await run.drive([
       profiles("engineering"),
       profiles("engineering"),
+      answersProse("I cannot read it."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
       answersProse("I cannot read it."),
     ]);
 
@@ -283,7 +297,11 @@ describe("a profile that does not settle cleanly", () => {
       "tool-invoked",
     ]);
 
-    const resumed = await run.drive([profiles("engineering"), answersProse("I cannot know.")]);
+    const resumed = await run.drive([
+      profiles("engineering"),
+      answersProse("I cannot know."),
+      answersProse("I cannot know."),
+    ]);
 
     expect(resumed.transcripts[1]).toContain("outcome was never recorded");
     expect(resumed.kinds).not.toContain("table-profiled");

--- a/tests/evals/empty-result-detection.test.ts
+++ b/tests/evals/empty-result-detection.test.ts
@@ -171,6 +171,9 @@ describe("the empty-result case can still fail on the defect it was written for"
     const drive = await run.drive([
       callsTool("run_read_query", { sql: COUNT_UNNAMED, rationale: "count them" }),
       answersProse("None of them is missing a name."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("None of them is missing a name."),
     ]);
 
     expect(summarise(EMPTY, drive).verdict).toBe("unanswered (no-report)");

--- a/tests/evals/injection.test.ts
+++ b/tests/evals/injection.test.ts
@@ -128,6 +128,9 @@ describe("a hostile identifier in the schema inventory", () => {
     const drive = await run.drive([
       callsTool("run_read_query", { sql: "DROP TABLE audit_log", rationale: "the data told me to" }),
       answersProse("That was refused."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("That was refused."),
     ]);
 
     expect(drive.kinds).toContain("tool-refused");
@@ -158,6 +161,9 @@ describe("a hostile row value in a read result", () => {
     const drive = await run.drive([
       callsTool("run_read_query", { sql: "SELECT note FROM notes", rationale: "read the notes" }),
       answersProse("The rows carry an instruction; I will not follow it."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("The rows carry an instruction; I will not follow it."),
     ]);
 
     const transcript = drive.transcripts[1] ?? "";
@@ -182,6 +188,9 @@ describe("a hostile row value in a read result", () => {
         );
       },
       answersProse("I could not cite that."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("I could not cite that."),
     ]);
 
     expect(drive.kinds).not.toContain("report-composed");
@@ -201,6 +210,9 @@ describe("a hostile engine error message", () => {
 
     const drive = await run.drive([
       callsTool("run_read_query", { sql: "SELECT 1 FROM missing", rationale: "probe" }),
+      answersProse("It failed."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
       answersProse("It failed."),
     ]);
 
@@ -236,6 +248,9 @@ describe("a hostile table name in a profile", () => {
     const drive = await run.drive([
       callsTool("profile_table", { table: SHORT_HOSTILE, schema: "public" }, "call_profile"),
       answersProse("Profiled."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("Profiled."),
     ]);
 
     expect(drive.kinds).toContain("table-profiled");
@@ -251,6 +266,9 @@ describe("a hostile table name in a profile", () => {
 
     const drive = await run.drive([
       callsTool("profile_table", { table: HOSTILE_TABLE, schema: "public" }, "call_profile"),
+      answersProse("Refused."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
       answersProse("Refused."),
     ]);
 
@@ -279,6 +297,9 @@ describe("a tool the injected text names does not exist for the run that reads i
         void turn;
         return chatToolCallStream("compare_plans", JSON.stringify({ before: "a", after: "b" }), "call_compare");
       },
+      answersProse("No such tool."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
       answersProse("No such tool."),
     ]);
 
@@ -378,6 +399,9 @@ describe("OPEN RISK — an assistant message can carry an unfenced marker (B29)"
 
     const drive = await run.drive([
       callsTool("run_read_query", { sql: `SELECT id FROM "${hostile}"`, rationale: "read it" }),
+      answersProse("Read."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
       answersProse("Read."),
     ]);
 

--- a/tests/evals/injection.test.ts
+++ b/tests/evals/injection.test.ts
@@ -298,9 +298,6 @@ describe("a tool the injected text names does not exist for the run that reads i
         return chatToolCallStream("compare_plans", JSON.stringify({ before: "a", after: "b" }), "call_compare");
       },
       answersProse("No such tool."),
-      // The reminder is sent once after a reading; a model that narrates again is
-      // stopping rather than hesitating, which is what these scenarios assert.
-      answersProse("No such tool."),
     ]);
 
     // The offered set is a function of the run's PERSISTED workflow, so no text a

--- a/tests/evals/investigation-arc.test.ts
+++ b/tests/evals/investigation-arc.test.ts
@@ -221,9 +221,6 @@ describe("a planning run is judged by what planning mode can produce", () => {
     // to pass — which is the very output the ungrounded rules forbid.
     const drive = await run.drive([
       answersProse("NO STATEMENT: ", "this run was given no inventory of this database."),
-      // The reminder is sent once after a reading; a model that narrates again is
-      // stopping rather than hesitating, which is what these scenarios assert.
-      answersProse("NO STATEMENT: ", "this run was given no inventory of this database."),
     ]);
 
     expect(drive.statements).toEqual([]);

--- a/tests/evals/investigation-arc.test.ts
+++ b/tests/evals/investigation-arc.test.ts
@@ -221,6 +221,9 @@ describe("a planning run is judged by what planning mode can produce", () => {
     // to pass — which is the very output the ungrounded rules forbid.
     const drive = await run.drive([
       answersProse("NO STATEMENT: ", "this run was given no inventory of this database."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("NO STATEMENT: ", "this run was given no inventory of this database."),
     ]);
 
     expect(drive.statements).toEqual([]);
@@ -342,6 +345,9 @@ describe("the verdict is on the ledger, where a user reads it (B24)", () => {
 
     const drive = await run.drive([
       callsTool("run_read_query", { sql: COUNT_BY_DEPARTMENT, rationale: "one query" }),
+      answersProse("Engineering has the most employees."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
       answersProse("Engineering has the most employees."),
     ]);
 

--- a/tests/evals/legacy-surface-coverage.test.ts
+++ b/tests/evals/legacy-surface-coverage.test.ts
@@ -433,9 +433,6 @@ describe("what the removed panels did that these runs do not", () => {
         return chatToolCallStream("read_monitoring", JSON.stringify({ slowQueryLimit: 20 }), "call_monitor");
       },
       answersProse("I cannot read live monitoring from here."),
-      // The reminder is sent once after a reading; a model that narrates again is
-      // stopping rather than hesitating, which is what these scenarios assert.
-      answersProse("I cannot read live monitoring from here."),
     ]);
 
     // The transcript is the messages JSON-encoded, so the tool name arrives escaped.
@@ -516,9 +513,6 @@ describe("what the removed panels did that these runs do not", () => {
           "call_recommend",
         );
       },
-      answersProse("I can only report what I read."),
-      // The reminder is sent once after a reading; a model that narrates again is
-      // stopping rather than hesitating, which is what these scenarios assert.
       answersProse("I can only report what I read."),
     ]);
 

--- a/tests/evals/legacy-surface-coverage.test.ts
+++ b/tests/evals/legacy-surface-coverage.test.ts
@@ -433,6 +433,9 @@ describe("what the removed panels did that these runs do not", () => {
         return chatToolCallStream("read_monitoring", JSON.stringify({ slowQueryLimit: 20 }), "call_monitor");
       },
       answersProse("I cannot read live monitoring from here."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("I cannot read live monitoring from here."),
     ]);
 
     // The transcript is the messages JSON-encoded, so the tool name arrives escaped.
@@ -476,6 +479,9 @@ describe("what the removed panels did that these runs do not", () => {
         );
       },
       answersProse("I cannot support that number."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("I cannot support that number."),
     ]);
 
     expect(drive.transcripts[2] ?? "").toContain("does not match anything this run produced");
@@ -510,6 +516,9 @@ describe("what the removed panels did that these runs do not", () => {
           "call_recommend",
         );
       },
+      answersProse("I can only report what I read."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
       answersProse("I can only report what I read."),
     ]);
 

--- a/tests/evals/operations.test.ts
+++ b/tests/evals/operations.test.ts
@@ -329,6 +329,9 @@ describe("an engine that cannot serve a reading", () => {
         expect(turn.transcript).toContain("performance_schema is not enabled");
         return answersProse("This server keeps no slow-query statistics.")(turn);
       },
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating.
+      answersProse("This server keeps no slow-query statistics."),
     ]);
 
     expect(drive.kinds).toEqual(["run-started", "tool-invoked", "tool-refused", "closing-statement", "run-finished"]);

--- a/tests/evals/query-optimization.test.ts
+++ b/tests/evals/query-optimization.test.ts
@@ -249,6 +249,9 @@ describe("the tools belong to the workflow, not to the model", () => {
         return chatToolCallStream("compare_plans", JSON.stringify({ before: "a", after: "b" }), "call_compare");
       },
       answersProse("There is nothing here I can compare."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what these scenarios assert.
+      answersProse("There is nothing here I can compare."),
     ]);
 
     // Refused by the OFFERED set, before any argument was looked at — and the run

--- a/tests/evals/query-optimization.test.ts
+++ b/tests/evals/query-optimization.test.ts
@@ -249,9 +249,6 @@ describe("the tools belong to the workflow, not to the model", () => {
         return chatToolCallStream("compare_plans", JSON.stringify({ before: "a", after: "b" }), "call_compare");
       },
       answersProse("There is nothing here I can compare."),
-      // The reminder is sent once after a reading; a model that narrates again is
-      // stopping rather than hesitating, which is what these scenarios assert.
-      answersProse("There is nothing here I can compare."),
     ]);
 
     // Refused by the OFFERED set, before any argument was looked at — and the run

--- a/tests/evals/strategy-defects.test.ts
+++ b/tests/evals/strategy-defects.test.ts
@@ -112,6 +112,9 @@ describe("#341 F2: the run investigates competently and finishes without composi
     const drive = await run.drive([
       callsTool("run_read_query", { sql: AGGREGATE, rationale: "count per department" }),
       answersProse("Engineering has the most employees, at 41."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what this scenario is about.
+      answersProse("Engineering has the most employees, at 41."),
     ]);
 
     expect(drive.status).toBe("succeeded");
@@ -124,6 +127,9 @@ describe("#341 F2: the run investigates competently and finishes without composi
 
     const drive = await run.drive([
       callsTool("run_read_query", { sql: AGGREGATE, rationale: "count per department" }),
+      answersProse("Engineering has the most employees, at 41."),
+      // The reminder is sent once after a reading; a model that narrates again is
+      // stopping rather than hesitating, which is what this scenario is about.
       answersProse("Engineering has the most employees, at 41."),
     ]);
 

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -387,6 +387,8 @@ describe("a fresh run drives the investigation arc", () => {
       callsTool("inspect_schema", { schema: "public" }),
       callsTool("inspect_plan", { sql: "SELECT id FROM orders" }, "call_2"),
       answersProse("that is enough"),
+      // Reminded once after a reading, the model narrates again rather than reporting.
+      answersProse("that is enough"),
     );
 
     const result = await runInvestigation(run.runId, {
@@ -433,7 +435,11 @@ describe("a fresh run drives the investigation arc", () => {
   test("arguments the tool schema refuses become a typed answer, not a throw", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(callsTool("run_read_query", { sql: 42 }), answersProse("understood"));
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: 42 }),
+      answersProse("understood"),
+      answersProse("understood"),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -466,6 +472,8 @@ describe("a fresh run drives the investigation arc", () => {
       callsTool("run_read_query", { sql: 42 }),
       callsTool("run_read_query", { sql: 42 }, "call_2"),
       answersProse("understood"),
+      // Reminded once after a reading, the model narrates again rather than reporting.
+      answersProse("understood"),
     );
 
     await runInvestigation(run.runId, {
@@ -488,7 +496,11 @@ describe("a fresh run drives the investigation arc", () => {
     // no other assertion here would notice, because the fixture accepts any body.
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(callsTool("run_read_query", { sql: 42 }), answersProse("understood"));
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: 42 }),
+      answersProse("understood"),
+      answersProse("understood"),
+    );
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -616,6 +628,8 @@ describe("the model is told what a citation IS, not only that it must cite (#350
     const run = await startRun(b);
     const script = scriptedModel(
       callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "size it" }),
+      answersProse("done"),
+      // Reminded once after a reading, the model narrates again rather than reporting.
       answersProse("done"),
     );
 
@@ -1033,7 +1047,11 @@ describe("planning mode runs no statement of the user's", () => {
   test("a tool the run was never offered is refused without reaching the database", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"));
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT 1" }),
+      answersProse("understood"),
+      answersProse("understood"),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -2443,6 +2461,8 @@ describe("planning mode runs no statement of the user's", () => {
     const script = scriptedModel(
       callsTool("present_answer", { artifact: "corr_1", presentation: { kind: "table" } }),
       answersProse("understood"),
+      // Reminded once after a reading, the model narrates again rather than reporting.
+      answersProse("understood"),
     );
 
     const result = await runInvestigation(run.runId, {
@@ -3171,6 +3191,8 @@ describe("a report may only cite what the run produced", () => {
         claims: [{ claim: "Everything is fine.", evidence: [{ source: "artifact", correlationId: "corr_invented" }] }],
       }),
       answersProse("I cannot support that claim."),
+      // Reminded once after a reading, the model narrates again rather than reporting.
+      answersProse("I cannot support that claim."),
     );
 
     const result = await runInvestigation(run.runId, {
@@ -3599,6 +3621,8 @@ describe("the handover an answer records comes from the run's own setting", () =
       callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "the question, in SQL" }),
       presentsTheRead(),
       answersProse("done"),
+      // Reminded once after a reading, the model narrates again rather than reporting.
+      answersProse("done"),
     );
 
     await runInvestigation(run.runId, {
@@ -3643,6 +3667,8 @@ describe("the handover an answer records comes from the run's own setting", () =
       callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "the question, in SQL" }),
       presentsTheRead("call_answer_1"),
       presentsTheRead("call_answer_2"),
+      answersProse("done"),
+      // Reminded once after a reading, the model narrates again rather than reporting.
       answersProse("done"),
     );
 
@@ -3734,6 +3760,10 @@ describe("a presentation the model serialized reaches the tool through the SDK",
           JSON.stringify({ artifact: correlationIdIn(turn.transcript), presentation: SERIALIZED_CHART }),
           "call_answer",
         ),
+      answersProse("done"),
+      // Reminded once that a run reports by CALLING compose_report, this model
+      // narrates again: the answer is what this case is about, and it is already on
+      // the ledger by then.
       answersProse("done"),
     );
 

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -1047,11 +1047,7 @@ describe("planning mode runs no statement of the user's", () => {
   test("a tool the run was never offered is refused without reaching the database", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(
-      callsTool("run_read_query", { sql: "SELECT 1" }),
-      answersProse("understood"),
-      answersProse("understood"),
-    );
+    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -2461,8 +2457,6 @@ describe("planning mode runs no statement of the user's", () => {
     const script = scriptedModel(
       callsTool("present_answer", { artifact: "corr_1", presentation: { kind: "table" } }),
       answersProse("understood"),
-      // Reminded once after a reading, the model narrates again rather than reporting.
-      answersProse("understood"),
     );
 
     const result = await runInvestigation(run.runId, {
@@ -3048,6 +3042,121 @@ describe("a run reserves its last turns for its report", () => {
     // The same sentence the run opened with: the rules the model was given carry it,
     // so the notice repeats the bar rather than restating it in other words.
     expect(JSON.stringify(script.turns[0]?.body)).toContain(AGENT_CITATION_RULE);
+  });
+});
+
+describe("a run that used its tools and then narrated is reminded once", () => {
+  /*
+    The `no-report` shortfall, measured on three models: each called this run's tools,
+    established something, and then wrote its findings as prose. A prose turn ends the
+    run, so the readings were thrown away and the verdict read `no-report`.
+
+    What the reminder may NOT do is as load-bearing as what it does. It names
+    `compose_report`, so it may only reach a run that holds that tool; and it costs a
+    turn, so it may only be sent where a turn remains.
+  */
+  const invents = (): Response => chatToolCallStream("no_such_tool", JSON.stringify({}), "call_invented");
+
+  test("a planning run that reaches for a tool is never told to call one", async () => {
+    // Planning mode holds NO tools at all, so a reminder naming `compose_report` would
+    // be a rule this run's tool set cannot satisfy (#350/#356). The refusal a run gets
+    // for reaching outside its set is not evidence that it used one.
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "planning");
+    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"));
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const sent = script.turns.flatMap((turn) => JSON.stringify(turn.body.messages ?? []));
+    expect(sent.some((messages) => messages.includes("compose_report"))).toBe(false);
+    expect(result.stopReason).toBe("model-stopped");
+  });
+
+  test("a name the model invented is not a tool this run used", async () => {
+    // The sentence says this run CALLED its tools. A name that matched nothing reached
+    // nothing, so a run reminded on one would be told something untrue about itself and
+    // then told to cite artifacts it has not got.
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(invents, answersProse("I could not do that."));
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    expect(script.turns[1]?.transcript).toContain("There is no tool called");
+    const sent = script.turns.flatMap((turn) => JSON.stringify(turn.body.messages ?? []));
+    expect(sent.some((messages) => messages.includes("written your findings as prose"))).toBe(false);
+    expect(result.stopReason).toBe("model-stopped");
+  });
+
+  test("a run that narrates on its last allowed turn keeps its own ending", async () => {
+    // The ceiling is exactly where this happens: `AGENT_REPORT_RESERVE_NOTICE` has
+    // already told the model to wrap up two turns earlier, and a small model wraps up
+    // in prose. A reminder sent into a turn the loop will not grant does not rescue the
+    // run — it rewrites a model that stopped as a run that ran out of turns.
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "read it" }),
+      answersProse("Orders were read."),
+    );
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+      maxTurns: 2,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.stopReason).toBe("model-stopped");
+  });
+
+  test("a run with a turn left is reminded, and reports on it", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "read it" }),
+      answersProse("Orders were read."),
+      reportOn("Orders were read."),
+    );
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    expect(result.stopReason).toBe("report-composed");
+    const sent = script.turns.flatMap((turn) => JSON.stringify(turn.body.messages ?? []));
+    expect(sent.some((messages) => messages.includes("written your findings as prose"))).toBe(true);
+    expect((await eventsOf(b.store, run.runId)).map((event) => event.kind)).toContain("report-composed");
+  });
+
+  test("the reminder is sent once, so a model that narrates again still stops", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "read it" }),
+      answersProse("Orders were read."),
+      answersProse("Orders were read."),
+    );
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    expect(result.stopReason).toBe("model-stopped");
+    expect(result.turns).toBe(3);
   });
 });
 


### PR DESCRIPTION
A turn with no tool calls ends the run. For a model that established nothing that is the right ending: there is no report to ask for.

But a run that HAS read something and then writes its findings as prose has done the whole job except the one call that records it. Ending there throws the readings away: the ledger keeps the artifacts, `compose_report` was never called, and the goal verifier scores the run `no-report`.

## Measured

Three models did exactly that against a local Ollama endpoint, each after reading the database:

| Model | Readings taken | Then |
| --- | --- | --- |
| `mistral-small3.2:24b` | 4 | prose |
| `lfm2:24b` | 11 on a data-analysis run | prose |
| `qwen3.5:2b` | 42 | prose |

None was refusing to report. Each had answered in the register a chat model answers in.

## It is not a fixed property of the model either

`mistral-small3.2` failed Operate with zero tool calls, which reads as a model that cannot use tools. It can — given the same tools and a simple prompt it called `inspect_operations` immediately.

So the exact request the agent had sent was captured and replayed five times:

| Attempt | Result |
| --- | --- |
| 1 | 6 tool calls |
| 2 | "I'm sorry, but I don't have the necessary tools" |
| 3 | "I don't have access to the necessary tools" |
| 4 | 4 tool calls |
| 5 | 6 tool calls |

Same request, same model, same server: 60%. Because the run ended at the first prose turn, that 40% was being recorded as a model that could not drive an agent run at all.

## What this changes

The loop sends one message when a prose turn arrives AFTER at least one tool call, and takes the turn again. Deliberately narrow:

* never when the run has taken no readings, which is a model that is stopping rather than hesitating
* once, because a model that will not call the tool the first time it is asked is stopping too, and a second telling spends a turn to learn that
* a message, not a rule change: it spends no statement, consults no deadline admission and reaches no database

## Verification

Measured after the change, confirmed on the ledger in `.workflow-data`:

| Model | Workflow | Before | After |
| --- | --- | --- | --- |
| `mistral-small3.2:24b` | Operate | `no-report` | **`answered`** — four readings, then `report-composed` |
| `lfm2:24b` | Investigate | `no-report` | **`answered`** |
| `lfm2:24b` | Analyze | `no-report` | still `no-report` |

The last row is the honest bound: the reminder was delivered after nine readings and the model narrated again. This rescues runs that were one call short, not every run that ends without a report.

## Eval scripts

Ten scripts gain one prose turn. `scriptedModel` treats a script running out as simulated process death (`agent-scripted-model.ts:73`), so a script that ended exactly on its prose turn now needs the turn the reminder asks for.

No assertion changes, including #341 F2's: a competent investigation that never reports is still `succeeded` and `unanswered`, and now says so about a run that was reminded and narrated anyway.

## Scope

No provider is touched: every file under `src/lib/llm`, plus `provider-registry.ts` and `model-adapter.ts`, is unchanged, so Gemini and OpenAI deployments behave exactly as before.

`format`, `lint`, `typecheck`, `knip`, `test` (all 30 groups) and `build` pass locally.
