### PR TITLE
fix(agent): tell a run to present its answer before it reports

### DIFF
--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -318,6 +318,31 @@ const AGENT_REPORT_REMINDER_NOTICE = [
 ].join(" ");
 
 /**
+ * What an answer-presenting run is told once when it would report without presenting.
+ *
+ * A workflow offered `present_answer` is one whose whole point is the answer: the goal
+ * verifier scores it `no-answer` when the report lands with nothing presented beside
+ * it, and the rail shows a report with an empty answer pane. Measured on three models
+ * (`qwen3.5:4b`, `qwen3.5:9b`, `mistral-small3.2:24b`), each read the data, got a
+ * result, and then went straight to `compose_report`: the reading was taken and the
+ * answer was one call away.
+ *
+ * Said at the moment it can still be acted on. `compose_report` ENDS the run, so a
+ * message delivered after it arrives too late; this one is delivered INSTEAD of that
+ * call, and the call is not executed. The run then has the turn it needs to present.
+ *
+ * Only where all three hold, which is what keeps it from ever being a lecture: the
+ * workflow presents answers, the run HAS a readable result to present, and the model
+ * has not already tried to present one. A model that tried and was refused is not
+ * hesitating about the answer — it is stuck on the payload, and telling it to present
+ * again would spend the turn on a call the tool has already rejected.
+ */
+const AGENT_PRESENT_BEFORE_REPORT_NOTICE = [
+  "This run answers by PRESENTING a result, and nothing has been presented yet: a report on its own is scored as having answered nothing.",
+  "Your compose_report call was not run. Call present_answer first, with the artifact id of the result that answers the objective, and then call compose_report.",
+].join(" ");
+
+/**
  * What an operations run is told about the inventory it was given (#411).
  *
  * Both of these sentences used to say "no schema inventory was captured for this run,
@@ -1986,6 +2011,14 @@ export async function runInvestigation(
   let anyToolCalled = false;
   /** The report reminder is a one-shot too; see `AGENT_REPORT_REMINDER_NOTICE`. */
   let reportReminded = false;
+  /** The present-before-report notice is a one-shot; see `AGENT_PRESENT_BEFORE_REPORT_NOTICE`. */
+  let presentReminded = false;
+  /**
+   * Whether `present_answer` has been CALLED, which is not the same as answered: a
+   * refused call writes no event, so the ledger cannot tell the two apart and this is
+   * the only place that can.
+   */
+  let answerAttempted = false;
 
   /**
    * Tells the run, once, that it has come within the reserve of a ceiling.
@@ -2145,6 +2178,27 @@ export async function runInvestigation(
       // — so a run reminded on either would be told to call `compose_report`, which is
       // a tool it has not got (#350).
       if (tools?.[call.toolName] !== undefined) anyToolCalled = true;
+      if (call.toolName === "present_answer") answerAttempted = true;
+      // A run whose workflow answers by presenting, which read something and is about
+      // to report without presenting it, is one call short of an answer. Checked here
+      // and not after the call, because `compose_report` ends the run.
+      if (
+        call.toolName === "compose_report" &&
+        !presentReminded &&
+        !answerAttempted &&
+        AGENT_WORKFLOW_PRESENTS_ANSWER[record.workflowType]
+      ) {
+        const { record: sofar } = await service.resume(context.runId);
+        const hasReading = sofar.events.some(
+          (event) => event.kind === "tool-completed" && event.artifact.operationId === "sql.query.read",
+        );
+        const presented = sofar.events.some((event) => event.kind === "answer-composed");
+        if (hasReading && !presented) {
+          presentReminded = true;
+          messages.push(toolResultMessage(call, AGENT_PRESENT_BEFORE_REPORT_NOTICE));
+          continue;
+        }
+      }
       const outcome = await handleCall({ service, context, record, call, known, notAttempted });
       if (outcome.kind === "cancelled") {
         // `runStep` already ended the run at its checkpoint; finishing again would

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -332,10 +332,19 @@ const AGENT_REPORT_REMINDER_NOTICE = [
  * call, and the call is not executed. The run then has the turn it needs to present.
  *
  * Only where all three hold, which is what keeps it from ever being a lecture: the
- * workflow presents answers, the run HAS a readable result to present, and the model
- * has not already tried to present one. A model that tried and was refused is not
- * hesitating about the answer — it is stuck on the payload, and telling it to present
- * again would spend the turn on a call the tool has already rejected.
+ * workflow presents answers, the run HAS a result this tool would accept, and the
+ * model has not already tried to present one. A model that tried and was refused is
+ * not hesitating about the answer — it is stuck on the payload, and telling it to
+ * present again would spend the turn on a call the tool has already rejected.
+ *
+ * The middle one is read from the ledger the way `present_answer` reads it, and the
+ * join is the whole of it: a completed `sql.query.read` whose STEP also drafted a
+ * statement. The operation id alone admits `inspect_schema`, which is a catalog read
+ * under that same id — real evidence, and nothing an answer can hand to an editor,
+ * because the statement behind it is the server's. A run whose only reading is a
+ * catalog inspection would be told to present something the tool refuses every time,
+ * and would then neither present nor report: measured, the run lost the report it was
+ * about to compose.
  */
 const AGENT_PRESENT_BEFORE_REPORT_NOTICE = [
   "This run answers by PRESENTING a result, and nothing has been presented yet: a report on its own is scored as having answered nothing.",
@@ -2189,8 +2198,20 @@ export async function runInvestigation(
         AGENT_WORKFLOW_PRESENTS_ANSWER[record.workflowType]
       ) {
         const { record: sofar } = await service.resume(context.runId);
+        // The reading `present_answer` will ACCEPT, joined the way that tool joins it.
+        // The operation id alone is not the question: `inspect_schema` is a catalog read
+        // under that very id, and its statement is the SERVER's — so `statementBehind`
+        // finds none and the tool refuses every artifact such a run holds. A run told to
+        // present one would be told to do the impossible, which is the condition this
+        // check exists to be.
+        const drafted = new Set(
+          sofar.events.flatMap((event) => (event.kind === "statement-drafted" ? [event.stepId] : [])),
+        );
         const hasReading = sofar.events.some(
-          (event) => event.kind === "tool-completed" && event.artifact.operationId === "sql.query.read",
+          (event) =>
+            event.kind === "tool-completed" &&
+            event.artifact.operationId === "sql.query.read" &&
+            drafted.has(event.stepId),
         );
         const presented = sofar.events.some((event) => event.kind === "answer-composed");
         if (hasReading && !presented) {

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -3806,6 +3806,41 @@ describe("a run that would report an answer it never presented", () => {
     const sent = script.turns.flatMap((turn) => JSON.stringify(turn.body.messages ?? []));
     expect(sent.some((messages) => messages.includes("This run answers by PRESENTING"))).toBe(false);
   });
+
+  test("a catalog read is not a result this run can present, so it is never told to", async () => {
+    /*
+      The same guard, on the reading that looks like one and is not. `inspect_schema`
+      reads the catalog under the SAME operation id a drafted read uses, so a run that
+      inspected the schema and nothing else has `sql.query.read` on its ledger — and
+      `present_answer` will refuse every artifact it holds, because the statement behind
+      a catalog read is the SERVER's and there is nothing of the model's to hand over.
+      Told to present one, such a run neither presents nor reports.
+    */
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "agent", "data-analysis", true);
+    const script = scriptedModel(
+      callsTool("inspect_schema", { schema: "public" }),
+      reportOn("The schema was inspected."),
+      answersProse("done"),
+    );
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const events = await eventsOf(b.store, run.runId);
+    // The reading is on the ledger under the answer's own operation id, which is what
+    // makes this case the trap rather than a run with an empty ledger.
+    expect(
+      events.some((event) => event.kind === "tool-completed" && event.artifact.operationId === "sql.query.read"),
+    ).toBe(true);
+    const sent = script.turns.flatMap((turn) => JSON.stringify(turn.body.messages ?? []));
+    expect(sent.some((messages) => messages.includes("This run answers by PRESENTING"))).toBe(false);
+    // And the report it did compose was composed, not intercepted.
+    expect(events.map((event) => event.kind)).toContain("report-composed");
+  });
 });
 
 describe("the handover an answer records comes from the run's own setting", () => {

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -3712,6 +3712,102 @@ describe("a run opened with auto-execute is told what the gate needs", () => {
   });
 });
 
+describe("a run that would report an answer it never presented", () => {
+  /*
+    The `no-answer` shortfall, measured on three models: each read the data, got a
+    result, and went straight to `compose_report`. The report lands with nothing
+    beside it and the verifier scores the run as having answered nothing.
+
+    The notice is delivered INSTEAD of that call — `compose_report` ends the run, so
+    a message after it arrives too late — and the run then has the turn it needs.
+  */
+  const presentsRead =
+    (callId = "call_answer") =>
+    (turn: Turn): Response =>
+      chatToolCallStream(
+        "present_answer",
+        JSON.stringify({ artifact: correlationIdIn(turn.transcript), presentation: { kind: "table" } }),
+        callId,
+      );
+
+  test("its compose_report is not run, and the answer it then presents is on the ledger", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "agent", "data-analysis", true);
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "the question, in SQL" }),
+      // Reports without presenting: this call is the one that gets intercepted.
+      reportOn("Orders were read."),
+      presentsRead(),
+      reportOn("Orders were read."),
+    );
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    expect(result.status).toBe("succeeded");
+    const kinds = (await eventsOf(b.store, run.runId)).map((event) => event.kind);
+    expect(kinds).toContain("answer-composed");
+    // One report on the ledger, not two: the intercepted call never reached the tool.
+    expect(kinds.filter((kind) => kind === "report-composed")).toHaveLength(1);
+    // And the answer was recorded BEFORE the report, which is the ordering the
+    // shortfall is about.
+    expect(kinds.indexOf("answer-composed")).toBeLessThan(kinds.indexOf("report-composed"));
+  });
+
+  test("the notice is sent once, so a model that ignores it still reports", async () => {
+    // The one-shot matters: without it a model that never presents would have every
+    // report intercepted and the run would spend its turns rather than ending.
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "agent", "data-analysis", true);
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "the question, in SQL" }),
+      reportOn("Orders were read."),
+      reportOn("Orders were read."),
+    );
+
+    const result = await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    expect(result.stopReason).toBe("report-composed");
+    const kinds = (await eventsOf(b.store, run.runId)).map((event) => event.kind);
+    expect(kinds).not.toContain("answer-composed");
+    expect(kinds.filter((kind) => kind === "report-composed")).toHaveLength(1);
+  });
+
+  test("a run with no reading to present is never told to present one", async () => {
+    // The guard the earlier attempt at this fix lacked: told to present when nothing
+    // has been read, a run can neither present nor report, and loops to `no-report`
+    // instead — which the repository's own data-analysis eval caught. So a run whose
+    // ledger holds no completed read must never see the notice at all.
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "agent", "data-analysis", true);
+    // Cites the schema snapshot rather than a result, which is what a run with no
+    // reading has: `reportOn` looks for an artifact reference and there is none.
+    const reportsWithoutReading = (): Response =>
+      chatToolCallStream(
+        "compose_report",
+        JSON.stringify({ claims: [{ claim: "Nothing was read.", evidence: [{ source: "schema" }] }] }),
+        "call_report",
+      );
+    const script = scriptedModel(reportsWithoutReading, answersProse("done"), answersProse("done"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const sent = script.turns.flatMap((turn) => JSON.stringify(turn.body.messages ?? []));
+    expect(sent.some((messages) => messages.includes("This run answers by PRESENTING"))).toBe(false);
+  });
+});
+
 describe("the handover an answer records comes from the run's own setting", () => {
   /** Presents whatever result this run has already read, as a table. */
   const presentsTheRead =


### PR DESCRIPTION
A workflow offered `present_answer` is one whose whole point is the answer. When the report lands with nothing presented beside it, the goal verifier scores the run `no-answer`, and what a user sees is a report with an empty answer pane next to it.

## Measured

Three models did exactly that on the same question, each having already read the data and got a result back:

| Model | What the ledger shows | Verdict |
| --- | --- | --- |
| `qwen3.5:4b` | read, then `compose_report` | `no-answer` |
| `qwen3.5:9b` | read, then `compose_report` | `no-answer` |
| `mistral-small3.2:24b` | one tool call, then `compose_report` | `no-answer` |

The answer was one call away in the first two.

## What this changes

The notice is delivered INSTEAD of the `compose_report` call, and that call is not run. `compose_report` ends the run, so a message delivered after it arrives too late to be acted on; delivered in its place, the run still has the turn it needs to present.

Three conditions, all required, which is what keeps this from ever being a lecture:

* **the workflow presents answers at all**, so the tool being named exists for this run. This is the #350/#356 rule: never state a rule a model's tool set cannot satisfy
* **the run HAS a reading to present**, checked on the ledger as a completed `sql.query.read`. Without it there is nothing to present and the run would be told to do something impossible — which is the trap an earlier attempt at this fell into, and which the repository's own data-analysis eval caught
* **the model has not already CALLED `present_answer`.** A model that tried and was refused is not hesitating about the answer, it is stuck on the payload, and telling it to present again spends the turn on a call already rejected

That last one is tracked in the loop rather than read from the ledger, because a refused ledger-only tool records no event: the ledger cannot tell "never tried" from "tried and was refused", and the loop is the only place that can.

## Verification

Same question, same connection, measured before and after:

| Model | Before | After |
| --- | --- | --- |
| `qwen3.5:4b` | `no-answer` | **`answered`** — 5 tool calls, `answer-composed` on the ledger |
| `qwen3.5:9b` | `no-answer` | **`answered`** |
| `mistral-small3.2:24b` | `no-answer` | still `no-answer` |

Both rescued models are now 3/3 across investigation, operations and data-analysis.

`mistral-small3.2` is unchanged and the ledger says why: it called one tool and never ran a read, so it has no reading to present and the notice correctly stays silent. This fixes runs that were one call short of an answer, not every run that ends without one.

## Eval scripts

None changed. The trigger is narrow enough that no existing scenario reaches it, and the full suite passes as it stands.

## Scope

No provider is touched: every file under `src/lib/llm`, plus `provider-registry.ts` and `model-adapter.ts`, is unchanged.

`format`, `lint`, `typecheck`, `knip`, `test` (all 30 groups) and `build` pass locally.

## Depends on

#416 (the report reminder). Both commits add to the same region of `investigation.ts`, so this one is built on top of it.
