### PR TITLE
docs(rancher): refresh the catalog listing against 0.11.0

### DIFF
--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -4,8 +4,8 @@ Canonical listing content for LibreDB Studio in the SUSE Partner Certification &
 Solutions Catalog (PCSC), requested by SUSE as part of the SUSE Ready for Rancher
 certification (see rancher/partner-charts#1158 and tracking issue #166). This file is
 the single source for the catalog text; the partner-charts `app-readme.md` overlay is
-refreshed from it during the Phase-2 resubmission (see `E2E_VALIDATION_TASK.md` for the
-validation side).
+refreshed from it, most recently on 2026-08-18 (see the delivery note at the end).
+`E2E_VALIDATION_TASK.md` covers the validation side.
 
 The listing is live at https://www.suse.com/pcsc/viewVersionPage?versionID=26969 (SUSE
 published it on 2026-08-05 from an earlier revision of this file). Edits here do not
@@ -13,11 +13,16 @@ propagate automatically — SUSE owns the page, so any change has to be mailed t
 partner contact.
 
 > **Accuracy gate — engine count.** The wording below says ten engines. That is true
-> from the first release containing ClickHouse and Apache Druid onwards; both are merged
-> on `main` but unreleased as of **0.9.66**, which ships eight (PostgreSQL, MySQL,
-> Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase). The catalog entry is
-> version-scoped, so do not publish the ten-engine wording against a version older than
-> that — send the eight-engine variant instead, or cut the release first.
+> from **0.11.0** onwards, the first release shipping ClickHouse and Apache Druid
+> alongside the other eight (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB,
+> Redis, Couchbase); the provider registry in `src/lib/db/factory.ts` at that tag
+> resolves all ten. The catalog entry is version-scoped, so do not publish the
+> ten-engine wording against a version older than 0.11.0 — send the eight-engine
+> variant instead.
+>
+> The chart's own `description` in `Chart.yaml` still names seven engines, and that is
+> the string Rancher renders on the Apps catalog card. Correcting it means a chart
+> version bump and a fresh release, so it is tracked separately from this file.
 
 ## Listing facts
 
@@ -77,14 +82,15 @@ versions are documented and validated for every release.
 
 ## Outstanding corrections to the published page
 
-Checked against the live page on 2026-08-07. These are deltas between what SUSE
-published and what is true today; batch them into one mail to the partner contact rather
-than sending them one at a time.
+Re-checked against the live page on 2026-08-18. Nothing has been applied since the page
+went live on 2026-08-05, so all of these are still open; batch them into one mail to the
+partner contact rather than sending them one at a time.
 
 | Field on the page | Published value | Should be |
 |---|---|---|
-| Version | LibreDB Studio 0.9.44 | the current release (0.9.66 or later), with the release link updated to match |
-| Key features | "Seven database engines" | see the accuracy gate above — eight today, ten once ClickHouse and Druid ship |
+| Version | LibreDB Studio 0.9.44 | 0.11.0, with the release link pointing at <https://github.com/libredb/libredb-studio/releases/tag/0.11.0> |
+| Key features | "Seven database engines" | ten — the accuracy gate above is satisfied as of 0.11.0 |
+| Short and long description | the pre-0.11.0 revision, which names seven engines | the text in this file |
 | Hardware Architecture | x86-64 | x86-64 and Arm64 (`ghcr.io/libredb/libredb-studio` is linux/amd64 + linux/arm64) |
 
 Two open questions for the same mail: whether the version field can track the latest
@@ -99,6 +105,13 @@ The content above was delivered to Troy Topnik (SUSE) and published on 2026-08-0
 fitted as much of the long description as the page template allows. This file stays the
 canonical wording: any future edit happens here first, then goes to SUSE by mail and to
 the partner-charts `app-readme.md` overlay.
+
+**2026-08-18.** rancher/partner-charts#1158 was rebased onto the current `main-source`
+and regenerated against chart 0.1.36 / appVersion 0.11.0. The original 0.1.3 submission
+was dropped rather than carried alongside: it pinned appVersion 0.9.44 and the
+pre-Couchbase app-readme, so merging it would have offered a months-old version in the
+Rancher catalog. The overlay in that PR now carries the ten-engine wording from this
+file. The corrections above have **not** been mailed to SUSE yet.
 
 Vendor naming, as settled: the page heads the partner as **Sekoya** (the legal entity,
 Sekoya Grup Bilisim ve Teknoloji Ltd. Sti.) with the product named **LibreDB Studio**.

--- a/deploy/rancher/E2E_VALIDATION_TASK.md
+++ b/deploy/rancher/E2E_VALIDATION_TASK.md
@@ -272,9 +272,13 @@ Common conventions for every scenario:
 - Add a second ClusterRepo of type Git pointing at the partner-charts fork
   (`https://github.com/yusuf-gundogdu/partner-charts`, branch `add-libredb-studio`).
 - Expect: the catalog card renders (name, icon, description from the PR content).
-- **Known and expected:** that branch still carries chart 0.1.3, whose default install
-  fails on required secrets - do NOT count that as a chart failure; this scenario only
-  previews catalog presentation. Record a screenshot/API dump of the card.
+- Since 2026-08-18 that branch carries chart 0.1.36 (appVersion 0.11.0), so the default
+  install works zero-config there as it does from the live Helm repo. The scenario still
+  only previews catalog presentation - installing from it is S1's job, not this one.
+- **Known and expected:** the card's description line comes from `Chart.yaml`, which
+  still names seven engines while the app-readme names ten. That mismatch is tracked in
+  `CATALOG_LISTING.md`; do NOT report it as a rendering failure. Record a
+  screenshot/API dump of the card.
 
 ## Phase 4 - UI evidence (best effort, do not block the matrix)
 


### PR DESCRIPTION
Refreshes the Rancher and SUSE listing documents against the current release,
before the outstanding corrections go to SUSE by mail.

The engine-count accuracy gate in `CATALOG_LISTING.md` was written while ClickHouse
and Apache Druid were merged but unreleased, and it told a reader not to publish the
ten-engine wording against any released version. 0.11.0 ships both, so that wording
is valid for a published version now; the gate says so and names the version it
became true at, verified against the provider registry in `src/lib/db/factory.ts` at
that tag rather than against the docs directory.

The live PCSC page was re-checked today. None of the corrections have been applied
since it went live on 2026-08-05, so the outstanding-corrections table is restated
against 0.11.0 rather than 0.9.66 and gains a row it was missing: the published short
and long description are still the pre-0.11.0 revision that names seven engines, which
is a separate correction from the key-features count.

The delivery note records that rancher/partner-charts#1158 now carries chart 0.1.36 /
appVersion 0.11.0. The original 0.1.3 submission was dropped rather than carried
alongside it — it pinned appVersion 0.9.44 and the pre-Couchbase app-readme, so merging
it would have offered a months-old version in the Rancher catalog.

`E2E_VALIDATION_TASK.md` S9 told an agent to expect a failing zero-config install from
the fork branch and not to count it as a chart failure. That was true of chart 0.1.3
and is false of 0.1.36. It is replaced by the mismatch that is real: the catalog card's
description line comes from `Chart.yaml`, which still names seven engines while the
app-readme names ten.

Docs only — no executable lines, no chart files, no version bump.

Two things deliberately left out:

- `Chart.yaml`'s `description` still names seven engines, and that string is what
  Rancher renders on the Apps catalog card. Correcting it needs a chart version bump,
  a release, and a regenerate of #1158, which does not belong in a docs PR.
- `docs/RANCHER.md`'s validated-combinations table still ends at chart 0.1.9 /
  appVersion 0.9.49. No row was invented for 0.11.0; that needs a real E2E run.
