### PR TITLE
docs(agent): say which runtime the measured rows came from, and record what the nudges do not

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2207,14 +2207,17 @@ classifier's real-world agreement rate was measured — and they are the same ki
   open question is whether one sentence about operational cost belongs in the rules, against the
   owner's deferral of per-engine knowledge files and the argument that banning a command by name is
   engine trivia that goes stale. Recorded, not decided.
-- **B51** — the loop delivers three one-shot notices to a model (the reserve warning, the report
-  reminder of #416, the present-before-report notice of #417) and records none of them. `recordEvent`
-  is called for what the RUN did and never for what the server said to it, so a rescued run and a run
-  that never needed rescuing leave the same ledger — and a `compose_report` the loop withheld leaves
-  no trace that a call was made. That is a measurement problem first: [`docs/llms/`](./llms/) is built
-  by reading those ledgers, and its whole claim is that each figure comes from an observed run. The
-  guards are also the part that keeps being got wrong — both notices shipped with a condition that
-  named one thing and read another, and both were caught in review rather than by a gate.
+- **B51** — the loop delivers three notices to a model (the reserve warning, the report reminder of
+  #416, the present-before-report notice of #417) and records none of them. `recordEvent` is called
+  for what the RUN did and never for what the server said to it, so a rescued run and a run that never
+  needed rescuing leave the same ledger — and a `compose_report` the loop withheld leaves no trace
+  that a call was made. That is a measurement problem first: [`docs/llms/`](./llms/) is built by
+  reading those ledgers, and its whole claim is that each figure comes from an observed run. Each
+  notice is sent once per DRIVE and not once per run, and the missing entry is why: the three booleans
+  live inside `runInvestigation`, which is also what resumes a run a dead process left running, so a
+  resumed drive starts with all three false. The guards are the part that keeps being got wrong —
+  both new notices shipped with a condition that named one thing and read another, and both were
+  caught in review rather than by a gate.
 
 ## Related documentation
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2207,6 +2207,14 @@ classifier's real-world agreement rate was measured — and they are the same ki
   open question is whether one sentence about operational cost belongs in the rules, against the
   owner's deferral of per-engine knowledge files and the argument that banning a command by name is
   engine trivia that goes stale. Recorded, not decided.
+- **B51** — the loop delivers three one-shot notices to a model (the reserve warning, the report
+  reminder of #416, the present-before-report notice of #417) and records none of them. `recordEvent`
+  is called for what the RUN did and never for what the server said to it, so a rescued run and a run
+  that never needed rescuing leave the same ledger — and a `compose_report` the loop withheld leaves
+  no trace that a call was made. That is a measurement problem first: [`docs/llms/`](./llms/) is built
+  by reading those ledgers, and its whole claim is that each figure comes from an observed run. The
+  guards are also the part that keeps being got wrong — both notices shipped with a condition that
+  named one thing and read another, and both were caught in review rather than by a gate.
 
 ## Related documentation
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2313,3 +2313,41 @@ product that reads for them does not have to think for them.
 
 Not decided here. Done when the owner rules, and — whichever way — the reason is recorded next to the
 derived-groupings rule so the two read as one decision.
+
+### B51. The run loop nudges a model three times and records none of it, so a rescued run is indistinguishable from one that never needed rescuing
+
+`runInvestigation` now delivers three one-shot notices, each with its own boolean, its own guard set
+and its own delivery mechanism:
+
+| Notice | When | Delivered as |
+| --- | --- | --- |
+| `AGENT_REPORT_RESERVE_NOTICE` | within the turn or time reserve of a ceiling | a `user` message, riding the turn about to be taken |
+| `AGENT_REPORT_REMINDER_NOTICE` | a prose turn after a tool this run holds was called | a `user` message, and the turn is taken again |
+| `AGENT_PRESENT_BEFORE_REPORT_NOTICE` | a `compose_report` on an answering workflow with a presentable read and no presentation | a `tool` result, INSTEAD of running the call |
+
+None of the three writes to the ledger. `service.recordEvent` is called for the schema capture, the
+drafted statement, the closing prose, the recommendation, the answer and the report — and for nothing
+the server said to the model. So a run's timeline shows a model that read, narrated, and then
+reported, with no entry anywhere saying it was told to report; and a `compose_report` the loop
+withheld leaves no record that a call was made at all.
+
+That is a measurement problem before it is a design one. `docs/llms/` is built by reading run ledgers
+out of `.workflow-data`, and its whole claim is that each figure comes from an observed run. After
+#416 and #417 a ledger can no longer answer "did this model do that by itself?" — which is the exact
+question those pages exist to answer, and the question that decides whether a nudge is worth keeping.
+`methodology.md` already warns that one run per cell is the weakest part of the method; an
+unattributable rescue is weaker still, because re-running does not reveal it either.
+
+The second half is the shape. Each notice's GUARDS are the load-bearing part, and they are the part
+that keeps being got wrong: #416 arrived without the tool-set bound (a planning run, which holds no
+tools, was told to call `compose_report`) and without the turn bound (a run narrating at the ceiling
+was turned from `succeeded` / `model-stopped` into `failed` / `turn-limit`); #417 arrived with a
+condition that named "a result this run can present" and read an operation id that `inspect_schema`
+shares. Both were caught in review rather than by a gate, and a fourth notice will be written by
+someone reading the third.
+
+Done when a delivery is an entry on the ledger — one event kind, carrying which notice and what the
+run had done when it arrived — and the three share one declared shape, so a new one states its
+condition, its one-shot and its delivery in the same place rather than inventing them again. Whether
+the rail SHOWS the entry is a separate question and probably a no: the notices exist to be invisible
+to a user, and the timeline is not the same surface as the ledger.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2316,8 +2316,8 @@ derived-groupings rule so the two read as one decision.
 
 ### B51. The run loop nudges a model three times and records none of it, so a rescued run is indistinguishable from one that never needed rescuing
 
-`runInvestigation` now delivers three one-shot notices, each with its own boolean, its own guard set
-and its own delivery mechanism:
+`runInvestigation` now delivers three notices, each one-shot per DRIVE, each with its own boolean,
+its own guard set and its own delivery mechanism:
 
 | Notice | When | Delivered as |
 | --- | --- | --- |
@@ -2330,6 +2330,16 @@ drafted statement, the closing prose, the recommendation, the answer and the rep
 the server said to the model. So a run's timeline shows a model that read, narrated, and then
 reported, with no entry anywhere saying it was told to report; and a `compose_report` the loop
 withheld leaves no record that a call was made at all.
+
+**"Once" means once per drive, and the missing entry is why.** All three booleans are `let`s inside
+`runInvestigation` (`src/lib/agent/investigation.ts`, beside `let turns = 0`), and that function is
+what RESUMES an already-running run — `service.resume` at its head distinguishes a queued run from
+one a dead process left running. A resumed drive therefore starts with every flag false and can
+deliver a notice the previous drive already delivered. Two of the three have a partial durable guard
+by accident: the present-before-report notice reads `answer-composed` off the ledger, so a run that
+presented is not told to again — but a run whose `present_answer` was REFUSED writes no event, and is.
+Nothing bounds the report reminder or the reserve notice across a resume at all. Recording delivery is
+what would make "once" mean once, which is why this is one entry and not two.
 
 That is a measurement problem before it is a design one. `docs/llms/` is built by reading run ledgers
 out of `.workflow-data`, and its whole claim is that each figure comes from an observed run. After
@@ -2347,7 +2357,8 @@ shares. Both were caught in review rather than by a gate, and a fourth notice wi
 someone reading the third.
 
 Done when a delivery is an entry on the ledger — one event kind, carrying which notice and what the
-run had done when it arrived — and the three share one declared shape, so a new one states its
-condition, its one-shot and its delivery in the same place rather than inventing them again. Whether
+run had done when it arrived — read back at the head of a drive so a resumed run is not told twice,
+and the three share one declared shape, so a new one states its condition, its scope and its delivery
+in the same place rather than inventing them again. Whether
 the rail SHOWS the entry is a separate question and probably a no: the notices exist to be invisible
 to a user, and the timeline is not the same surface as the ledger.

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -8,7 +8,7 @@ how many times, and where the results stop being safe to generalise from.
 | | |
 | --- | --- |
 | Measured | 16–17 August 2026 |
-| Application | LibreDB Studio at `907e83c` for the baseline, `b64941e` for the rescued rows |
+| Application | LibreDB Studio at three revisions — see "Which revision a row is from" below |
 | Runtime | Ollama, OpenAI-compatible endpoint (`http://localhost:11434/v1`) |
 | Database | the embedded SQLite sample (`seed:sqlite-embedded-sample`) |
 | Evidence | every run's ledger, in `.workflow-data` |
@@ -16,15 +16,26 @@ how many times, and where the results stop being safe to generalise from.
 Model behaviour changes when a family publishes a new build under the same tag, so
 these results describe the tags as they were on those dates.
 
-Two commits are named because two runtime changes were made while measuring, and every
-page says which side of them a row sits on. A figure marked *(fixed)*, and every "after"
-column, was taken with the report reminder (#416) and the present-before-report notice
-(#417) in place; everything else is the baseline. Both notices were narrowed in review
-before they landed — the reminder to a tool the run holds and a turn the loop will grant,
-the notice to a read the answer tool would accept — and the runs recorded here sit inside
-the narrower triggers: each was an agent run that drafted its own read and had turns to
-spare. Anything measured against `907e83c` alone will not reproduce the rescued rows,
-because the runtime that produced them is not in that commit.
+### Which revision a row is from
+
+Three runtime fixes were made while measuring, so no single commit produces every figure
+on these pages. A row's numbers belong to whichever revision could have produced them:
+
+| Revision | What it is | Which figures |
+| --- | --- | --- |
+| `7256f93` | before the serialized-presentation fix (#406) | the BEFORE figures on [`qwen3.8`](qwen/qwen3.8.md) (`no-answer` in 84.9s) and [`muse-glimmer`](muse/muse-glimmer.md) (`no-answer` after 234.4s) |
+| `907e83c` | the baseline; #406 is already in it | everything not named in the other two rows, including both models' "after" figures |
+| `b64941e` | with the report reminder (#416) and the present-before-report notice (#417) | every row marked *(fixed)*, and the "after" column of those two fixes |
+
+The first row is the one worth stating rather than leaving to be worked out: #406 is an
+ancestor of the baseline, so those two before-figures cannot be reproduced from the
+baseline either — the runtime that produced them is older than both of the other
+revisions here.
+
+Both of the later notices were narrowed in review before they landed — the reminder to a
+tool the run holds and a turn the loop will grant, the notice to a read the answer tool
+would accept. The runs recorded here sit inside the narrower triggers: each was an agent
+run that drafted its own read and had turns to spare.
 
 ## The machine
 

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -8,13 +8,23 @@ how many times, and where the results stop being safe to generalise from.
 | | |
 | --- | --- |
 | Measured | 16–17 August 2026 |
-| Application | LibreDB Studio at commit `907e83c` |
+| Application | LibreDB Studio at `907e83c` for the baseline, `b64941e` for the rescued rows |
 | Runtime | Ollama, OpenAI-compatible endpoint (`http://localhost:11434/v1`) |
 | Database | the embedded SQLite sample (`seed:sqlite-embedded-sample`) |
 | Evidence | every run's ledger, in `.workflow-data` |
 
 Model behaviour changes when a family publishes a new build under the same tag, so
 these results describe the tags as they were on those dates.
+
+Two commits are named because two runtime changes were made while measuring, and every
+page says which side of them a row sits on. A figure marked *(fixed)*, and every "after"
+column, was taken with the report reminder (#416) and the present-before-report notice
+(#417) in place; everything else is the baseline. Both notices were narrowed in review
+before they landed — the reminder to a tool the run holds and a turn the loop will grant,
+the notice to a read the answer tool would accept — and the runs recorded here sit inside
+the narrower triggers: each was an agent run that drafted its own read and had turns to
+spare. Anything measured against `907e83c` alone will not reproduce the rescued rows,
+because the runtime that produced them is not in that commit.
 
 ## The machine
 

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -2014,13 +2014,22 @@ export async function runInvestigation(
 
   let turns = 0;
   let text = "";
-  /** The reserve notice is a one-shot: a run is told once that it is out of room. */
+  /*
+    The three notice flags below are one-shots per DRIVE, not per run, and the
+    distinction is worth stating where they are declared: this function is also what
+    RESUMES a run a dead process left running (`service.resume`, at its head), so a
+    resumed drive starts with all three false and can say again what the previous drive
+    already said. Nothing durable bounds them, because a delivery writes no ledger entry
+    — `docs/BACKLOG.md` B51 records both halves as one item, since recording delivery is
+    what would make "once" mean once.
+  */
+  /** The reserve notice is a one-shot: a drive tells the run once that it is out of room. */
   let reserveAnnounced = false;
   /** Whether a tool this run HOLDS has been called; see `remindToReport`. */
   let anyToolCalled = false;
-  /** The report reminder is a one-shot too; see `AGENT_REPORT_REMINDER_NOTICE`. */
+  /** The report reminder is a one-shot per drive too; see `AGENT_REPORT_REMINDER_NOTICE`. */
   let reportReminded = false;
-  /** The present-before-report notice is a one-shot; see `AGENT_PRESENT_BEFORE_REPORT_NOTICE`. */
+  /** The present-before-report notice, once per drive; see `AGENT_PRESENT_BEFORE_REPORT_NOTICE`. */
   let presentReminded = false;
   /**
    * Whether `present_answer` has been CALLED, which is not the same as answered: a


### PR DESCRIPTION
Follow-up to #416 and #417, which landed the two runtime notices `docs/llms/` already described.

> Not strictly docs-only after review: three comment lines in `src/lib/agent/investigation.ts` are scoped too. No behaviour, no executable line changed.

## `methodology.md` did not name every revision it reports

The header said *Application: LibreDB Studio at commit `907e83c`*. Three runtime fixes were made while measuring, so no single commit produces every figure on these pages:

| Revision | What it is | Which figures |
| --- | --- | --- |
| `7256f93` | before the serialized-presentation fix (#406) | the BEFORE figures on `qwen3.8` (`no-answer` in 84.9s) and `muse-glimmer` (`no-answer` after 234.4s) |
| `907e83c` | the baseline; #406 is already in it | everything not named in the other two rows, including both models' "after" figures |
| `b64941e` | with the report reminder (#416) and the present-before-report notice (#417) | every row marked *(fixed)*, and the "after" column of those two fixes |

The first row is the one review caught: `df15e56` (#406) is an **ancestor** of the baseline, so those two before-figures are reproducible from neither commit the page originally named — and they are the rows a reader is most likely to try first.

## B51 — the nudges leave no trace in the run's own record

`recordEvent` is called for what a run DID: the capture, the drafted statement, the closing prose, the recommendation, the answer, the report. It is called for nothing the server SAID to the model. So:

- a run's timeline shows a model that read, narrated and then reported, with no entry anywhere saying it was told to report
- a `compose_report` the loop withheld leaves no record that a call was made at all
- **"once" means once per DRIVE.** The three booleans are `let`s inside `runInvestigation`, which is also what resumes a run a dead process left running, so a resumed drive starts with all three false. The present-before-report notice is partly covered by accident — it reads `answer-composed` off the ledger — but a *refused* `present_answer` writes no event, and nothing bounds the report reminder or the reserve notice across a resume at all.

That last point is the same defect from the other side, which is why it is one entry: recording delivery is exactly what would make "once" mean once.

It is a measurement problem before it is a design one. `docs/llms/` is built by reading run ledgers out of `.workflow-data`, and its whole claim is that each figure comes from an observed run — so after #416 and #417 a ledger can no longer answer *"did this model do that by itself?"*, which is the exact question those pages exist to answer and the one that decides whether a nudge is worth keeping. Re-running does not reveal it either, which is why it is worse than the one-run-per-cell weakness `methodology.md` already admits.

The entry carries the shape half too. Three notices, each with its own boolean, its own guard set and its own delivery (two push a `user` message, one substitutes a `tool` result), and the guards are the load-bearing part — both new ones shipped with a condition that named one thing and read another, and both were caught in review rather than by a gate. Done when a delivery is a ledger entry read back at the head of a drive, and the three share one declared shape.

Cited from `docs/AGENT.md`, which the `agent-documentation` guard requires in both directions.

`format`, `lint`, `typecheck`, `knip`, `test:ci` (297 core + 30 groups), `build` and `coverage:check` (100.00%, 36721/36721) pass locally.
