### PR TITLE
docs(distribution): mark the Rancher Partner Charts channel live now that #1158 merged

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -684,7 +684,7 @@ channels:
 
   - id: rancher-partner
     name: Rancher Partner Charts
-    status: pending
+    status: live
     category: kubernetes-operators
     platforms: [kubernetes]
     runtime: channel_supplied
@@ -696,10 +696,15 @@ channels:
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/166
       first_pr: https://github.com/rancher/partner-charts/pull/1158
+      catalog: https://www.suse.com/pcsc/viewVersionPage?versionID=26969
       upstream_repo: https://github.com/rancher/partner-charts
     pin:
       strategy: none
-      note: Awaiting certification; pin strategy decided once the listing exists.
+      note: Merged in rancher/partner-charts#1158 (17 Aug 2026); live in Rancher Partner Charts (the repo
+        index.yaml carries libredb-studio at appVersion 0.11.0) and listed in the SUSE Solutions Catalog.
+        Partner catalog, not self-serve - the chart is regenerated on Rancher's cadence and index.yaml
+        accumulates every chart version, so an image-tag extract there would be ambiguous; strategy stays
+        none like the other tier-4 partner/curated catalogs.
 
   - id: koyeb-catalog
     name: Koyeb One-Click Apps catalog (curated by Koyeb)

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -31,15 +31,15 @@ channel count.
 
 ## Coverage snapshot
 
-**32 channels · 23 live · 8 pending · 1 deprecated**
+**32 channels · 24 live · 7 pending · 1 deprecated**
 
-Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 4 · Kubernetes 1 · Cloud 10**
+Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 4 · Kubernetes 2 · Cloud 10**
 
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
 | Registries & releases | 2 | 0 | 0 |
 | Containers | 2 | 0 | 0 |
-| Kubernetes & operators | 1 | 2 | 0 |
+| Kubernetes & operators | 2 | 1 | 0 |
 | Package managers | 4 | 1 | 1 |
 | OS / desktop packages | 2 | 0 | 0 |
 | PaaS catalogs (listed) | 8 | 4 | 0 |
@@ -59,8 +59,8 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 4 · K
 | [Docker image (GHCR)](https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio) | Containers | Container | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Docker Hub mirror](https://hub.docker.com/r/libredb/libredb-studio) | Containers | Container | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Helm chart](https://artifacthub.io/packages/helm/libredb-studio/libredb-studio) | Kubernetes & operators | Kubernetes | live | Automated, every release | [HELM_CHART.md](HELM_CHART.md) |
+| [Rancher Partner Charts](https://www.suse.com/pcsc/viewVersionPage?versionID=26969) | Kubernetes & operators | Kubernetes | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [OperatorHub / OpenShift](https://github.com/redhat-openshift-ecosystem/community-operators-prod) | Kubernetes & operators | Kubernetes | pending | Manual, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [Rancher Partner Charts](https://github.com/rancher/partner-charts) | Kubernetes & operators | Kubernetes | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [FlatPark (Flatpak)](https://flatpark.org/) | Package managers | Linux | live | Manual, every release | [packaging/flatpark/README.md](../packaging/flatpark/README.md) |
 | [Homebrew tap](https://github.com/libredb/homebrew-tap) | Package managers | Linux, macOS | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Snap Store](https://snapcraft.io/libredb-studio) | Package managers | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |


### PR DESCRIPTION
## Description
rancher/partner-charts#1158 merged on 2026-08-17. LibreDB Studio is now live in Rancher Partner Charts (the repo index.yaml carries the chart at appVersion 0.11.0) and is listed in the SUSE Solutions Catalog. This flips the inventory entry from pending to live. Inventory and generated docs only.

## Type of Change
- [x] Documentation update

## Related Issue
Refs #166 (Rancher tracking issue, closed on merge)

## Changes Made
- `distribution/channels.yaml`: `rancher-partner` goes `status: pending -> live`, gains a `catalog` link (SUSE Solutions Catalog) and an updated note. `pin.strategy` stays `none`, consistent with the other tier-4 partner/curated catalogs (digitalocean, koyeb-catalog) - the partner chart is regenerated on Rancher's cadence and index.yaml accumulates every chart version, so an image-tag extract there would be ambiguous.
- Regenerate `docs/CHANNELS.md` (live 23 -> 24, pending 8 -> 7; Kubernetes live platform 1 -> 2).
- `docs/DISTRIBUTION.md` unchanged: its tier-4 examples already list Rancher and it carries no pending/awaiting reference to de-hedge.

## Testing
- [x] I have tested this locally
- [x] All existing tests pass

## Verification
`distribution:matrix --check` exit 0 · `distribution:check --strict` exit 0 · distribution-check unit tests 125/125 pass. rancher-partner correctly reports SKIP in the drift table (live + strategy none).
