### PR TITLE
feat(login): make the sign-in hero derive what it claims, and fit the viewport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@ jobs:
         env:
           CHART_SYNC_STRICT: "1"
 
+      - name: Login channel showcase drift guard (#425)
+        # Same reasoning as the chart guard above: inside the required check so
+        # it actually gates. src/lib/distribution/channels.generated.ts is the
+        # login hero's copy of distribution/channels.yaml, generated and
+        # committed so the unauthenticated page parses no yaml at runtime -
+        # nothing else notices when the inventory moves on without it.
+        run: bun run channels:showcase:check
+
       - name: Localized README drift guard (#317)
         # Same reasoning as the chart guard above: inside the required check so
         # it actually gates. README_zh.md and README_ja.md restate README.md's

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -30,7 +30,14 @@ Three properties frame everything below, and each of them is load-bearing rather
   anywhere.** They are the only providers implementing `queryReadOnly` (`postgres.ts:870`,
   `sqlite.ts:397`), so any other engine fails profiled acquisition with
   `PROFILE_UNSUPPORTED_BY_PROVIDER` and the run ends `engine-unsupported`
-  (`src/lib/agent/runtime.ts:199`). The restriction is a property of the **execution profile**, not
+  (`src/lib/agent/runtime.ts:199`). Surfaces that must *state* that reach — the login hero does,
+  since #425 — read `AGENT_EXECUTION_ENGINES` (`src/lib/agent/engine-support.ts`), which mirrors the
+  gate rather than replacing it: the factory keeps probing `typeof provider.queryReadOnly`, and
+  `tests/unit/lib/agent/engine-support.test.ts` measures the provider prototypes so the constant
+  cannot go stale against them in either direction. It is client-safe by construction (it imports
+  only `DatabaseType`), and it deliberately says nothing about plan mode, which executes nothing
+  anywhere, or about `operations`, which runs everywhere.
+  The restriction is a property of the **execution profile**, not
   of the factory: `agent-read-only` sends model-authored statements and is served only where the
   engine can bound one, `agent-handover` sends the statement a run already answered with and takes
   the same gate for the same reason, while `agent-operations` sends no statement at all — it calls

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -12,7 +12,10 @@ for the install or deploy steps.
 **Developers** — the Updates column says whether release CI publishes the channel
 or a human updates it by hand, and how quickly it is expected to follow a release.
 New channels are added in
-[`distribution/channels.yaml`](../distribution/channels.yaml).
+[`distribution/channels.yaml`](../distribution/channels.yaml), which also drives the
+product itself: the login page renders the live channels straight from that
+inventory (`bun run channels:showcase`, gated in CI), so flipping a channel to
+`live` publishes it in the UI with no code change.
 
 **Buyers, investors, supporters** — the snapshot below is the coverage claim.
 `pending` and `deprecated` rows are listed on purpose, not hidden.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1254,6 +1254,30 @@ historical PaaS drift. For the Helm chart the enforcement remains the required `
 gate (#138) — the matrix row is visibility, not a second gate. `--json` emits the rows for
 scripting.
 
+#### The inventory also drives the login page
+
+Since [#425](https://github.com/libredb/libredb-studio/issues/425) `channels.yaml` is read by the
+product itself, not only by the docs and the drift table. `bun run channels:showcase`
+([`scripts/generate-channel-showcase.mjs`](../scripts/generate-channel-showcase.mjs)) emits
+[`src/lib/distribution/channels.generated.ts`](../src/lib/distribution/channels.generated.ts) — the
+**live** channels, each mapped to one of the login hero's four rows (containers, Kubernetes, PaaS,
+packages) by its `category`, plus the platforms those channels cover — and the login page renders
+that module. `bun run channels:showcase:check` regenerates it in memory and fails on drift; it runs
+in the required `lint-and-build` job next to `chart:check`, so the committed module is always the
+inventory.
+
+The consequence worth stating: **flipping a channel's `status` to `live` publishes it on the login
+page, with no component edit** — the same one-line edit that already moves it in
+[`docs/CHANNELS.md`](CHANNELS.md) and in the drift table. Only `live` reaches the UI, so a `pending`
+submission or a `deprecated` listing renders nothing at all, and the count the page states is a
+`.length` over that array rather than a written number. The generator refuses to guess: a `category`
+with no row mapping throws instead of defaulting, so adding a business bucket to the inventory fails
+the gate loudly rather than quietly dropping a channel out of the product's front door.
+
+The channel's **label** on that page is its `short_name` when it has one and its `name` otherwise, so
+a channel whose full name is too long for the hero is shortened in `channels.yaml` — never in the
+component. The whole point of the generated module is that no channel name is typed into JSX.
+
 #### Turning a channel's automation off
 
 Some channels can be temporarily unable to publish for reasons outside this repository — a package

--- a/docs/ui/login-page.md
+++ b/docs/ui/login-page.md
@@ -24,36 +24,50 @@ src/app/login/
 
 ```
 ┌─────────────────────────────┬──────────────────────┐
+│  LibreDB Studio             │   Right Panel (45%)  │
 │                             │                      │
-│   Left Panel (55%)          │   Right Panel (45%)  │
-│                             │                      │
-│   ┌─ Logo ─────────────┐    │   ┌──────────────┐   │
-│   │ 🔲 LibreDB Studio  │    │   │ Welcome back │   │
-│   └────────────────────┘    │   │              │   │
-│                             │   │  [Form]      │   │
-│   Hero text                 │   │              │   │
-│   "The open-source SQL      │   │  OIDC: SSO   │   │
-│    IDE for cloud-native     │   │  button      │   │
-│    teams"                   │   │              │   │
-│                             │   │  Local:      │   │
-│   ┌─────────┐ ┌─────────┐   │   │  email/pass  │   │
-│   │Feature 1│ │Feature 2│   │   │              │   │
-│   └─────────┘ └─────────┘   │   │              │   │
-│   ┌─────────┐ ┌─────────┐   │   └──────────────┘   │
-│   │Feature 3│ │Feature 4│   │                      │
-│   └─────────┘ └─────────┘   │                      │
-│                             │                      │
-│   Supported Databases       │                      │
-│   [PG] [MySQL] [MongoDB]..  │                      │
-│                             │                      │
+│  The open-source SQL IDE    │   ┌──────────────┐   │
+│  that deploys next to       │   │ Welcome back │   │
+│  your data                  │   │              │   │
+│  <one-sentence subhead>     │   │  [Form]      │   │
+│                             │   │              │   │
+│  postgres://user@host/app   │ <- signature: one    │
+│                             │    line, cycling     │
+│  (pg) PostgreSQL (my) MySQL │ <- every engine,     │
+│  (lt) SQLite ... (lb)LibreDB│    icon + label      │
+│                             │   │  OIDC: SSO   │   │
+│  11        24        2      │ <- derived counts    │
+│  engines   channels  modes  │   │  or email/pw │   │
+│  <one qualifying line each> │   └──────────────┘   │
+│  Runs on Linux · macOS · …  │                      │
+│  ─────────────────────────  │                      │
+│  Open source · github.com…  │ <- one thin row      │
+│  (gh)(in)(X)(yt)(ig)(rd)(d) │    + social icons    │
 └─────────────────────────────┴──────────────────────┘
 ```
+
+The panel carries three tiers of weight - thesis, evidence, proof - rather than six blocks at
+one weight. That is the whole shape of the redesign, and it is load-bearing rather than
+cosmetic: the previous composition (four feature cards, an eleven-pill engine wall, all
+twenty-four channel names by group, and a six-card community block) made the panel 1294px
+tall in a 900px viewport, so the **page** scrolled and the sign-in card itself was pushed
+below the fold. Anything added here has to keep the panel inside the viewport at 1440x900.
+
+Two rules the components record in their own comments, repeated here because they are easy
+to undo from the outside:
+
+- **One `mt-auto` in the column, not two.** With an auto margin on both the middle and the
+  bottom group the column split its free space in two, and once the content outgrew the
+  viewport the groups closed up against each other and simply overflowed.
+- **The channel names are deliberately gone.** `LIVE_CHANNELS` still drives the count and
+  `DEPLOY_GROUP_LABELS` the four group names, so nothing can go stale, but the hero no
+  longer prints two dozen names. `docs/CHANNELS.md` remains the place that lists them.
 
 ### Mobile (below lg)
 
 ```
 ┌──────────────────────┐
-│   🔲 LibreDB Studio  │  ← Compact branding
+│    LibreDB Studio    │  <- Compact branding
 │  Open-source SQL IDE │
 │                      │
 │   ┌──────────────┐   │
@@ -63,7 +77,11 @@ src/app/login/
 │   │              │   │
 │   └──────────────┘   │
 │                      │
-│   [PG] [MySQL] ...   │  ← DB badges
+│   [PG] [MySQL] ...   │  <- every engine
+│   11 engines · 24 …  │  <- the same claims,
+│                      │     joined into a line
+│   Open source · gh…  │
+│   (gh)(in)(X)(yt)…   │
 └──────────────────────┘
 ```
 
@@ -141,7 +159,13 @@ The login page follows the app's premium dark aesthetic:
 |------|---------|
 | `src/app/login/page.tsx` | Server component, reads auth provider env var, forces dynamic rendering |
 | `src/app/login/login-form.tsx` | Client component, split-panel layout, OIDC/local form rendering |
-| `tests/components/LoginPage.test.tsx` | Component tests — rendering, form submission, OIDC mode |
+| `src/components/login/database-showcase.tsx` | Supported-engine list, both surfaces, from `DB_UI_CONFIG` |
+| `src/components/login/deploy-showcase.tsx` | Live install channels by group, both surfaces, from the generated inventory |
+| `src/lib/db-showcase.ts` | Showcase order and the derived engine list |
+| `src/lib/distribution/channels.generated.ts` | Generated live-channel list (`bun run channels:showcase`) |
+| `src/lib/agent/engine-support.ts` | The engines the agent card may claim execution on |
+| `tests/components/LoginPage.test.tsx` | Component tests — rendering, form submission, OIDC mode, and the pinned agent claim |
+| `e2e/login.spec.ts` | Browser assertions that both showcase blocks render every derived entry, desktop and mobile |
 
 ---
 
@@ -159,29 +183,40 @@ The login page follows the app's premium dark aesthetic:
 
 ### Changing branding text
 
-Edit the `features` array and hero text in `login-form.tsx`:
-
-```tsx
-const features = [
-  { icon: Globe, title: '7+ Database Engines', desc: 'PostgreSQL, MySQL, ...' },
-  { icon: Zap, title: 'AI-Assisted SQL', desc: 'Plan explanations, safety checks...' },
-  // ...
-];
-```
+Edit the `features` array and hero text in `login-form.tsx`. Every count and every
+product name in those cards is **derived**, not written: the engine count is
+`listShowcaseDatabases().length`, the channel count is `LIVE_CHANNELS.length`, and the
+agent card's sentence names the engines in `AGENT_EXECUTION_ENGINES`. Issue #425 exists
+because the previous copy typed those answers by hand and stopped tracking the product
+three providers and two dozen channels later, so re-introducing a literal here is the one
+edit this page asks you not to make. Change the wording around the values freely.
 
 Hero text is in the `<h1>` element. The gradient word uses `from-blue-400 to-cyan-400`.
 
-### Changing database badges
+### Changing the engine and channel lists
 
-Both desktop and mobile lists are separate arrays. Keep them in sync:
+You do not edit either list here. Both blocks render one component twice, once per
+surface (`variant="desktop"` in the hero, `variant="mobile"` under the sign-in card), and
+both read from a single source:
 
-```tsx
-// Desktop (left panel, line ~142)
-{['PostgreSQL', 'MySQL', 'MongoDB', 'Oracle', 'SQL Server'].map(...)}
+| Block | Component | Source of truth |
+|---|---|---|
+| Supported Databases | `src/components/login/database-showcase.tsx` | `DB_UI_CONFIG` via `listShowcaseDatabases()` (`src/lib/db-showcase.ts`) — label, brand icon and accent colour all come from the provider's own UI config |
+| Proof row (engine / channel / agent-mode counts) | `src/components/login/hero-proof.tsx` | `src/lib/distribution/channels.generated.ts`, generated from `distribution/channels.yaml` by `bun run channels:showcase` and gated in CI; group names from `src/lib/distribution/deploy-groups.ts`; agent-mode engines from `src/lib/agent/engine-support.ts` |
+| Connection signature | `src/components/login/connection-signature.tsx` | `ENGINE_URI_SCHEMES` in `src/lib/connection-string-parser.ts`, paired with each engine's own `defaultPort` — it can only show a URI the parser accepts, which is why SQLite, Druid and LibreDB never appear there |
 
-// Mobile (bottom pills, line ~297)
-{['PostgreSQL', 'MySQL', 'MongoDB', 'Oracle', 'SQL Server'].map(...)}
-```
+So **adding a provider publishes it on this page**, and **flipping a channel to `live` in
+`channels.yaml` publishes it too** — neither needs a component edit. Display order for the
+engines is `SHOWCASE_RANK` in `src/lib/db-showcase.ts`, a `Record<DatabaseType, number>`
+that fails `bun run typecheck` when a new engine has no rank; the deploy rows are ordered
+by `DEPLOY_GROUP_ORDER` and a channel reaches a group through its inventory `category`.
+
+Two constraints on any restyle of these blocks. The desktop copies live inside the
+pinned-dark hero and must use the `fill`/`hairline`/`fg` tokens, while the mobile copies
+follow the viewer's theme through `muted`/`muted-foreground` — swapping either family
+across produces text the colour of its own background in one theme. And the desktop text
+sits at `fg-tertiary` deliberately: the two ramp steps below it measure 2.6:1 and 3.9:1 on
+this ground, under the 4.5:1 WCAG AA floor for type this small.
 
 ### Changing colors
 

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,4 +1,7 @@
 import { test, expect } from "@playwright/test";
+import { listShowcaseDatabases } from "../src/lib/db-showcase";
+import { LIVE_CHANNELS, LIVE_PLATFORMS } from "../src/lib/distribution/channels.generated";
+import { DEPLOY_GROUP_LABELS, DEPLOY_GROUP_ORDER } from "../src/lib/distribution/deploy-groups";
 
 test.describe("Login Flow", () => {
   test.beforeEach(async ({ page }) => {
@@ -81,5 +84,92 @@ test.describe("Login Flow", () => {
     await page.goto("/admin");
     // Should redirect away from admin
     await expect(page).not.toHaveURL(/\/admin/);
+  });
+});
+
+/**
+ * The login hero's showcase blocks (issue #425).
+ *
+ * Every expectation below is derived from the same modules the page renders from -
+ * `listShowcaseDatabases()` over `DB_UI_CONFIG` and the generated live-channel list - never
+ * from a number or an engine name typed here. That is the whole point of the change these
+ * tests guard: the previous copy hard-coded five engine names and one deploy channel, and
+ * nothing failed when the product grew past them. A test that hard-coded the new answers
+ * would rot the same way, so it asserts the derivation instead.
+ *
+ * Both modules are pure data with no server or DOM dependency, which is why the spec can
+ * import them directly.
+ */
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
+test.describe("Login showcase", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+  });
+
+  test("hero lists every configured engine, by its accessible name", async ({ page }) => {
+    // Addressed the way a screen reader addresses it: the list's accessible name comes
+    // from the "Supported Databases" heading beside it, so this fails if the label is
+    // dropped or the association broken, not merely if the markup moves.
+    const engines = page.getByTestId("database-showcase-desktop");
+    await expect(page.getByRole("list", { name: "Supported Databases" })).toHaveCount(1);
+    await expect(engines).toBeVisible();
+
+    const expected = listShowcaseDatabases();
+    await expect(engines.getByRole("listitem")).toHaveCount(expected.length);
+    await expect(engines.getByRole("listitem")).toHaveText(expected.map((db) => db.label));
+  });
+
+  test("hero states the live channel count and names every group", async ({ page }) => {
+    // The hero claims the deploy story as a derived number plus the group names; it prints
+    // no channel names at all. So the assertion is the count and the four labels, which is
+    // what can go stale, rather than a row-per-channel walk of ink that is no longer there.
+    const proof = page.getByTestId("hero-proof");
+    await expect(proof).toBeVisible();
+    await expect(proof).toContainText(`${LIVE_CHANNELS.length}`);
+
+    const groups = new Set(LIVE_CHANNELS.map((channel) => channel.group));
+    expect(groups.size).toBeGreaterThan(0);
+    for (const group of DEPLOY_GROUP_ORDER) {
+      await expect(proof).toContainText(DEPLOY_GROUP_LABELS[group]);
+    }
+
+    // The platform line answers the question the count cannot - whether the machine in
+    // front of the reader can run it - and it too is filtered from the generated inventory.
+    const platformLine = page.getByTestId("platform-line");
+    await expect(platformLine).toBeVisible();
+    for (const platform of LIVE_PLATFORMS.filter((p) => ["linux", "macos", "windows"].includes(p))) {
+      await expect(platformLine).toContainText(new RegExp(platform, "i"));
+    }
+  });
+
+  test("hero cycles a connection string the parser would accept", async ({ page }) => {
+    // The signature is the evidence behind the engine count, so the scheme it opens on must
+    // be one the product honours. Rendered client-side in an effect, hence the visibility
+    // wait before reading it.
+    const signature = page.getByTestId("connection-signature");
+    await expect(signature).toBeVisible();
+    await expect(signature).toContainText("://");
+  });
+
+  test("condensed showcase replaces the hero at a small viewport", async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+
+    // The two surfaces are one component rendered twice, so the mobile block must carry the
+    // same engine set - a count that drifts between them means one variant stopped deriving.
+    const mobileEngines = page.getByTestId("database-showcase-mobile");
+    await expect(mobileEngines).toBeVisible();
+    await expect(mobileEngines.getByRole("listitem")).toHaveCount(listShowcaseDatabases().length);
+
+    // The condensed line restates the same claims on one row. Both surfaces mark their
+    // agent claim with the same test id, so it is selected by the text only the mobile one
+    // carries - the channel count, which is a `.length` and never a written number.
+    const mobileClaim = page.getByTestId("agent-claim").filter({ hasText: "install channels" });
+    await expect(mobileClaim).toBeVisible();
+    await expect(mobileClaim).toContainText(`${LIVE_CHANNELS.length} install channels`);
+
+    // The hero is display:none at this width, not merely off-screen.
+    await expect(page.getByTestId("database-showcase-desktop")).toBeHidden();
+    await expect(page.getByTestId("hero-proof")).toBeHidden();
   });
 });

--- a/package.json
+++ b/package.json
@@ -133,6 +133,8 @@
     "chart:bump": "node scripts/sync-chart-version.mjs --write",
     "distribution:check": "node scripts/distribution-check.mjs",
     "distribution:matrix": "node scripts/distribution-check.mjs --matrix",
+    "channels:showcase": "node scripts/generate-channel-showcase.mjs",
+    "channels:showcase:check": "node scripts/generate-channel-showcase.mjs --check",
     "readme:check": "node scripts/readme-check.mjs",
     "security:check": "node scripts/security-check.mjs"
   },

--- a/scripts/generate-channel-showcase.mjs
+++ b/scripts/generate-channel-showcase.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Login-page channel showcase generator (issue #425).
+ *
+ * Reads the human-maintained channel inventory (distribution/channels.yaml)
+ * and emits src/lib/distribution/channels.generated.ts: the live channels the
+ * login hero advertises, plus the platforms they cover. The generated module is
+ * committed, and `--check` (bun run channels:showcase:check) regenerates it in
+ * memory and fails on drift - wired into the required lint-and-build job next
+ * to the chart:check gate, so the product UI can never fall behind the
+ * inventory the release process already maintains.
+ *
+ * Generated rather than fetched on purpose: /login is unauthenticated, so it
+ * must not gain an API route or parse yaml at runtime for a list that only
+ * changes when someone edits this repository.
+ *
+ * This script only ever READS the inventory. Schema validation (statuses,
+ * kinds, runtimes, pins) belongs to scripts/distribution-check.mjs, which
+ * gates the same file; the two rules enforced here are the ones that decide
+ * what reaches the UI. Mirrors the style of scripts/distribution-check.mjs;
+ * the pure functions below are unit tested in
+ * tests/unit/generate-channel-showcase.test.ts.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const CHANNELS_YAML = "distribution/channels.yaml";
+const GENERATED_FILE = "src/lib/distribution/channels.generated.ts";
+const REGENERATE_COMMAND = "bun run channels:showcase";
+
+/**
+ * Inventory category -> the row the login hero renders it in. Deliberately
+ * exhaustive and deliberately many-to-one: the hero has four rows, the
+ * inventory has eight business buckets, and collapsing them is a UI decision
+ * that belongs here rather than in JSX. A category with no entry throws
+ * (groupForCategory), so adding a bucket to channels.yaml breaks this script
+ * loudly instead of quietly dropping a channel off the login page.
+ */
+export const CATEGORY_GROUPS = {
+  containers: "containers",
+  "kubernetes-operators": "kubernetes",
+  "paas-catalogs": "paas",
+  "deploy-recipes": "paas",
+  "cloud-marketplaces": "paas",
+  "package-managers": "packages",
+  "os-desktop": "packages",
+  "registries-releases": "packages",
+};
+
+/**
+ * The canonical platform order documented at the top of channels.yaml. Output
+ * follows it regardless of the order written in yaml, so a reordered inventory
+ * row never shows up as generated-file drift.
+ */
+export const SHOWCASE_PLATFORMS = ["linux", "macos", "windows", "container", "kubernetes", "cloud"];
+
+export function groupForCategory(category) {
+  if (!Object.hasOwn(CATEGORY_GROUPS, category)) {
+    throw new Error(
+      `${CHANNELS_YAML}: unknown category '${category}' - map it in CATEGORY_GROUPS (scripts/generate-channel-showcase.mjs)`,
+    );
+  }
+  return CATEGORY_GROUPS[category];
+}
+
+/**
+ * The live inventory as the UI needs it: `{ channels, platforms }`.
+ *
+ * Only `status: live` reaches the product. `pending` is not installable yet and
+ * `deprecated` must never render at all (docs/CHANNELS.md: "a deprecated
+ * channel renders no link at all"). The label is `short_name` when the
+ * inventory provides one - `name` carries qualifiers written for the docs
+ * matrix ("Docker image (GHCR, canonical)") that are too long for a hero row.
+ */
+export function buildShowcase(yamlText) {
+  const doc = parseYaml(yamlText);
+  if (!doc || !Array.isArray(doc.channels)) {
+    throw new Error(`${CHANNELS_YAML}: top-level 'channels' list is missing`);
+  }
+  const live = doc.channels.filter((channel) => channel.status === "live");
+  const channels = live.map((channel) => ({
+    id: channel.id,
+    label: channel.short_name ?? channel.name,
+    group: groupForCategory(channel.category),
+  }));
+  const covered = new Set();
+  for (const channel of live) {
+    for (const platform of channel.platforms) {
+      if (!SHOWCASE_PLATFORMS.includes(platform)) {
+        throw new Error(
+          `${CHANNELS_YAML}: ${channel.id}: platforms entries must be one of ${SHOWCASE_PLATFORMS.join("|")}`,
+        );
+      }
+      covered.add(platform);
+    }
+  }
+  return { channels, platforms: SHOWCASE_PLATFORMS.filter((platform) => covered.has(platform)) };
+}
+
+/**
+ * Renders the committed TypeScript module. The output is written the way Biome
+ * formats it (double quotes, trailing commas, 2-space indent, lineWidth 120),
+ * because `bun run format` checks src/** and a generated file that needed
+ * reformatting would fail the very gate that keeps it honest.
+ */
+export function renderModule({ channels, platforms }) {
+  const rows = channels
+    .map(
+      (channel) =>
+        `  { id: ${JSON.stringify(channel.id)}, label: ${JSON.stringify(channel.label)}, group: ${JSON.stringify(channel.group)} },`,
+    )
+    .join("\n");
+  // Biome keeps an array on one line while it fits in lineWidth 120 and breaks
+  // it one-per-line otherwise, so the generator has to make the same call - a
+  // file that `bun run format` would rewrite fails the gate that guards it.
+  const quoted = platforms.map((platform) => JSON.stringify(platform));
+  const oneLine = `export const LIVE_PLATFORMS: readonly ShowcasePlatform[] = [${quoted.join(", ")}];`;
+  const platformDeclaration =
+    oneLine.length <= 120
+      ? oneLine
+      : `export const LIVE_PLATFORMS: readonly ShowcasePlatform[] = [\n${quoted.map((platform) => `  ${platform},`).join("\n")}\n];`;
+  return `// GENERATED FILE - do not edit. Run: ${REGENERATE_COMMAND}
+//
+// Source: ${CHANNELS_YAML} (live channels only), via
+// scripts/generate-channel-showcase.mjs. CI fails on drift
+// (bun run channels:showcase:check), so this file is always the inventory.
+
+/** The row of the login hero's deploy block a channel belongs to. */
+export type ShowcaseGroup = "containers" | "kubernetes" | "paas" | "packages";
+
+/** Platforms a live channel serves, in the canonical order of ${CHANNELS_YAML}. */
+export type ShowcasePlatform = ${SHOWCASE_PLATFORMS.map((platform) => JSON.stringify(platform)).join(" | ")};
+
+export interface ShowcaseChannel {
+  id: string;
+  label: string;
+  group: ShowcaseGroup;
+}
+
+export const LIVE_CHANNELS: readonly ShowcaseChannel[] = [
+${rows}
+];
+
+${platformDeclaration}
+`;
+}
+
+function main(argv) {
+  const checkOnly = argv.includes("--check");
+  const rootIdx = argv.indexOf("--root");
+  const rootArg = rootIdx === -1 ? undefined : argv[rootIdx + 1];
+  if (rootIdx !== -1 && (rootArg === undefined || rootArg.startsWith("--"))) {
+    console.error("ERROR: --root requires a directory path");
+    process.exit(2);
+  }
+  const root = rootIdx === -1 ? process.cwd() : path.resolve(rootArg);
+
+  const generatedPath = path.join(root, GENERATED_FILE);
+  const next = renderModule(buildShowcase(fs.readFileSync(path.join(root, CHANNELS_YAML), "utf8")));
+  // Absent counts as stale: the file is committed, so "not there" and "out of
+  // date" are the same failure with the same fix.
+  const current = fs.existsSync(generatedPath) ? fs.readFileSync(generatedPath, "utf8") : null;
+
+  if (checkOnly) {
+    if (current !== next) {
+      console.error(`ERROR: ${GENERATED_FILE} is stale; run: ${REGENERATE_COMMAND}`);
+      process.exit(1);
+    }
+    console.log(`${GENERATED_FILE} is up to date`);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(generatedPath), { recursive: true });
+  fs.writeFileSync(generatedPath, next);
+  console.log(`Wrote ${GENERATED_FILE}`);
+}
+
+// CLI entry only when executed directly (the unit test imports this module).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2));
+}

--- a/scripts/generate-channel-showcase.mjs
+++ b/scripts/generate-channel-showcase.mjs
@@ -148,6 +148,24 @@ ${platformDeclaration}
 `;
 }
 
+/**
+ * The committed module's current text, or `null` when it is not there yet.
+ *
+ * Read-and-catch rather than `existsSync` then read. The stat bought nothing - the write
+ * below is unconditional and never consults the result - while leaving a check-then-use
+ * window CodeQL reports as `js/file-system-race`. Only `ENOENT` is swallowed: any other
+ * errno (a directory in the file's place, a permission failure) is a real problem and must
+ * surface, not read as "stale" and send someone off to run the generator again.
+ */
+function readGeneratedOrNull(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
 function main(argv) {
   const checkOnly = argv.includes("--check");
   const rootIdx = argv.indexOf("--root");
@@ -162,7 +180,7 @@ function main(argv) {
   const next = renderModule(buildShowcase(fs.readFileSync(path.join(root, CHANNELS_YAML), "utf8")));
   // Absent counts as stale: the file is committed, so "not there" and "out of
   // date" are the same failure with the same fix.
-  const current = fs.existsSync(generatedPath) ? fs.readFileSync(generatedPath, "utf8") : null;
+  const current = readGeneratedOrNull(generatedPath);
 
   if (checkOnly) {
     if (current !== next) {

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -6,10 +6,19 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { ExternalLink, Lock, Mail, ShieldCheck, Zap, Globe, Shield, Layers } from "lucide-react";
+import { ExternalLink, Lock, Mail, ShieldCheck, Shield } from "lucide-react";
 import { toast } from "sonner";
 import LibreDBLogo from "@/components/libredb-logo";
 import { CommunitySection } from "@/components/community-section";
+import { ConnectionSignature } from "@/components/login/connection-signature";
+import { DatabaseShowcase } from "@/components/login/database-showcase";
+import { HeroProof, HERO_CLAIMS } from "@/components/login/hero-proof";
+
+/**
+ * The agent half of the mobile summary. Pulled from `HERO_CLAIMS` rather than retyped, so
+ * the mobile line states exactly what the desktop figure states about the two modes.
+ */
+const agentClaimDetail = HERO_CLAIMS.find((claim) => claim.key === "agent")?.detail ?? "";
 
 function LoginFormInner({ authProvider }: { authProvider: string }) {
   const isOIDC = authProvider === "oidc";
@@ -57,17 +66,6 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
       setIsLoading(false);
     }
   };
-
-  const features = [
-    { icon: Globe, title: "7+ Database Engines", desc: "PostgreSQL, MySQL, MongoDB, Oracle, SQL Server" },
-    {
-      icon: Zap,
-      title: "AI-Assisted SQL",
-      desc: "Plan explanations, safety checks and schema docs, on your own model",
-    },
-    { icon: Shield, title: "Zero Install", desc: "Browser-based — deploy anywhere with Docker in seconds" },
-    { icon: Layers, title: "Real-Time Monitoring", desc: "Live metrics, schema explorer, and visual ERD diagrams" },
-  ];
 
   return (
     <div className="flex min-h-[100dvh] bg-background">
@@ -117,55 +115,46 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
             </span>
           </a>
 
-          {/* Middle: Hero text + Features */}
-          <div className="space-y-10 mt-auto">
-            <div className="space-y-4 max-w-lg">
-              <h1 className="text-4xl xl:text-5xl font-bold text-white tracking-tight leading-[1.1]">
-                The open-source SQL IDE for
+          {/*
+            Thesis, then evidence, then the proof numbers - three tiers of weight instead of
+            six blocks competing at one weight.
+
+            A single `mt-auto` here, and none below: with `mt-auto` on both the middle and
+            the bottom group the column split its free space in two, and once the content
+            grew past the viewport the two groups closed up against each other and the panel
+            simply overflowed the page (measured at 1294px tall in a 900px viewport, which
+            pushed the sign-in card itself below the fold). The content now ends with the
+            community row, so one auto margin above it is the whole layout.
+          */}
+          <div className="space-y-8 mt-auto">
+            <div className="space-y-4 max-w-xl">
+              <h1 className="text-4xl font-bold text-white tracking-tight leading-[1.1]">
+                The open-source SQL IDE that
                 <span className="bg-gradient-to-r from-blue-400 to-cyan-400 bg-clip-text text-transparent">
                   {" "}
-                  cloud-native teams
+                  deploys next to your data
                 </span>
               </h1>
-              <p className="text-lg text-fg-tertiary leading-relaxed">
-                Query, explore, and manage all your databases from a single AI-powered interface. Zero install — deploy
-                with Docker in seconds.
+              {/*
+                No longer "deploy with Docker in seconds": Docker is one of two dozen live
+                channels (distribution/channels.yaml), and half of the rest are installers,
+                so the old line was both an undercount and a contradiction of the deb, rpm,
+                Snap, winget, Homebrew and AppImage packages this project ships.
+              */}
+              <p className="text-base text-fg-tertiary leading-relaxed">
+                Point it at a database you already run. Query, explore and manage every one of them from a single
+                workspace.
               </p>
             </div>
 
-            <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
-              {features.map((feature) => (
-                <div
-                  key={feature.title}
-                  className="flex gap-3 p-3 rounded-xl bg-fill border border-hairline pointer-events-none select-none"
-                >
-                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 border border-blue-500/10">
-                    <feature.icon className="h-4 w-4 text-blue-400" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium text-fg">{feature.title}</p>
-                    <p className="text-xs text-fg-muted mt-0.5">{feature.desc}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
+            <ConnectionSignature />
+
+            <DatabaseShowcase variant="desktop" />
+
+            <HeroProof />
           </div>
 
-          {/* Bottom: DB badges + Community */}
-          <div className="space-y-6 mt-auto">
-            <div className="space-y-3">
-              <p className="text-xs text-fg-subtle uppercase tracking-widest font-medium">Supported Databases</p>
-              <div className="flex flex-wrap gap-2">
-                {["PostgreSQL", "MySQL", "MongoDB", "Oracle", "SQL Server"].map((db) => (
-                  <span
-                    key={db}
-                    className="text-xs px-3 py-1.5 rounded-full bg-fill text-fg-muted border border-hairline font-medium"
-                  >
-                    {db}
-                  </span>
-                ))}
-              </div>
-            </div>
+          <div className="mt-8">
             <CommunitySection variant="desktop" />
           </div>
         </div>
@@ -308,19 +297,25 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
             </CardFooter>
           </Card>
 
-          {/* Mobile community + DB pills */}
+          {/*
+            Mobile showcase: the same three derived sources as the hero, condensed. The
+            deploy block collapses to one line and the agent claim to its own paragraph -
+            these tokens follow the viewer's theme, unlike the pinned-dark hero above.
+          */}
           <div className="lg:hidden space-y-4">
+            <DatabaseShowcase variant="mobile" />
+            {/*
+              The same three claims the desktop hero makes, joined into one line rather than
+              re-worded for mobile: `HERO_CLAIMS` is the single source, so a change to the
+              agent copy cannot land on one surface and miss the other.
+            */}
+            <p
+              data-testid="agent-claim"
+              className="text-[10px] text-center text-muted-foreground leading-relaxed select-none"
+            >
+              {HERO_CLAIMS.map((claim) => `${claim.value} ${claim.unit}`).join(" · ")} — {agentClaimDetail}
+            </p>
             <CommunitySection variant="mobile" />
-            <div className="flex flex-wrap justify-center gap-2">
-              {["PostgreSQL", "MySQL", "MongoDB", "Oracle", "SQL Server"].map((db) => (
-                <span
-                  key={db}
-                  className="text-[10px] px-2.5 py-1 rounded-full bg-muted text-muted-foreground font-medium"
-                >
-                  {db}
-                </span>
-              ))}
-            </div>
           </div>
         </div>
       </div>

--- a/src/components/community-section.tsx
+++ b/src/components/community-section.tsx
@@ -1,25 +1,60 @@
-import { Star, Bug, MessageCircle, Code, Languages, Heart } from "lucide-react";
+import { SOCIAL_LINKS } from "@/lib/social-links";
 
-const communityUrls = {
-  repo: "https://github.com/libredb/libredb-studio",
-  issues: "https://github.com/libredb/libredb-studio/issues",
-  discussions: "https://github.com/libredb/libredb-studio/discussions",
-  contributing: "https://github.com/libredb/libredb-studio/blob/main/CONTRIBUTING.md",
-  translate: "https://github.com/libredb/libredb-studio/tree/main/src/lib",
-  sponsor: "https://github.com/sponsors/cevheri",
-} as const;
-
-const communityActions = [
-  { label: "Star & Fork", icon: Star, url: communityUrls.repo, color: "bg-blue-500/15 text-blue-400" },
-  { label: "Open an Issue", icon: Bug, url: communityUrls.issues, color: "bg-red-500/15 text-red-400" },
-  { label: "Discussions", icon: MessageCircle, url: communityUrls.discussions, color: "bg-cyan-500/15 text-cyan-400" },
-  { label: "Contribute", icon: Code, url: communityUrls.contributing, color: "bg-violet-500/15 text-violet-400" },
-  { label: "Translate", icon: Languages, url: communityUrls.translate, color: "bg-emerald-500/15 text-emerald-400" },
-  { label: "Sponsor", icon: Heart, url: communityUrls.sponsor, color: "bg-pink-500/15 text-pink-400" },
-] as const;
+/**
+ * The one destination this row names in words. Every other way into the project - issues,
+ * discussions, contributing, translating, sponsoring - is a path under this repository or a
+ * profile already in `SOCIAL_LINKS`, so six separate cards spent six lines of the login hero
+ * to say "GitHub" six times. The repository is the door; what is behind it is GitHub's job
+ * to show.
+ */
+const REPO_URL = "https://github.com/libredb/libredb-studio";
 
 interface CommunitySectionProps {
   variant: "desktop" | "mobile";
+}
+
+/**
+ * The social row's anchor styling, per surface.
+ *
+ * The two variants need two different token families, and this is the single easiest
+ * place in the login page to ship invisible text: the desktop row sits inside the hero's
+ * left column, which is pinned dark by a nested `dark` class and therefore re-declares
+ * fill/hairline/fg for that subtree only, while the mobile row lives in the right panel
+ * and follows the viewer's theme through muted/foreground. Swapping either set into the
+ * other surface renders the icons the same colour as their background.
+ *
+ * `h-8 w-8` is 32px, comfortably over the 24px minimum an icon-only target needs.
+ */
+const SOCIAL_ANCHOR_CLASSES = {
+  desktop:
+    "flex h-8 w-8 items-center justify-center rounded-lg bg-fill border border-hairline text-fg-tertiary hover:bg-fill-strong hover:border-hairline-strong hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 transition-all duration-200",
+  mobile:
+    "flex h-8 w-8 items-center justify-center rounded-full bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 transition-colors",
+} as const;
+
+/**
+ * Icon-only links to where the project lives. Both surfaces map `SOCIAL_LINKS`; neither
+ * carries a destination of its own, so the two rows cannot drift apart. Icon-only means
+ * `aria-label` is the anchor's entire accessible name - without it a screen reader
+ * announces eight identical unnamed links.
+ */
+function SocialRow({ variant }: CommunitySectionProps) {
+  return (
+    <div className={variant === "desktop" ? "flex flex-wrap gap-2" : "flex flex-wrap justify-center gap-2"}>
+      {SOCIAL_LINKS.map((link) => (
+        <a
+          key={link.id}
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={link.label}
+          className={SOCIAL_ANCHOR_CLASSES[variant]}
+        >
+          <link.icon className="h-4 w-4" />
+        </a>
+      ))}
+    </div>
+  );
 }
 
 export function CommunitySection({ variant }: CommunitySectionProps) {
@@ -34,33 +69,23 @@ function DesktopCommunity() {
     <div className="space-y-4">
       <div className="h-px bg-fill-strong" />
 
-      <div className="flex items-center justify-between">
-        <div className="space-y-1">
-          <h3 className="text-xs font-medium text-fg">Join the Community</h3>
-          <p className="text-xs text-fg-muted">This project is open source. Your contributions make it better!</p>
-        </div>
-        <span className="shrink-0 text-xs font-medium px-2.5 py-1 rounded-full bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
-          Open Source
-        </span>
-      </div>
-
-      <div className="flex flex-wrap gap-2.5">
-        {communityActions.map((action) => (
+      <div className="flex items-center justify-between gap-4">
+        <p className="text-xs text-fg-tertiary">
+          Open source
+          <span aria-hidden="true" className="mx-1.5 text-fg-muted">
+            ·
+          </span>
           <a
-            key={action.label}
-            href={action.url}
+            href={REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2.5 min-w-[140px] flex-1 px-3 py-2.5 rounded-xl bg-fill border border-hairline hover:bg-fill-strong hover:border-hairline-strong transition-all duration-200 group"
+            className="hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 rounded-sm transition-colors duration-200"
           >
-            <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${action.color}`}>
-              <action.icon className="h-4 w-4" />
-            </div>
-            <span className="text-xs font-medium text-fg-tertiary group-hover:text-fg transition-colors duration-200">
-              {action.label}
-            </span>
+            github.com/libredb/libredb-studio
           </a>
-        ))}
+        </p>
+
+        <SocialRow variant="desktop" />
       </div>
     </div>
   );
@@ -71,22 +96,22 @@ function MobileCommunity() {
     <div className="space-y-3">
       <div className="h-px bg-muted" />
 
-      <p className="text-xs font-medium text-center text-muted-foreground">Join the Community</p>
+      <p className="text-xs text-center text-muted-foreground">
+        Open source
+        <span aria-hidden="true" className="mx-1.5">
+          ·
+        </span>
+        <a
+          href={REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 rounded-sm transition-colors"
+        >
+          github.com/libredb/libredb-studio
+        </a>
+      </p>
 
-      <div className="flex flex-wrap justify-center gap-2">
-        {communityActions.map((action) => (
-          <a
-            key={action.label}
-            href={action.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-muted text-muted-foreground hover:bg-muted/80 transition-colors text-xs font-medium"
-          >
-            <action.icon className="h-3 w-3" />
-            <span>{action.label}</span>
-          </a>
-        ))}
-      </div>
+      <SocialRow variant="mobile" />
     </div>
   );
 }

--- a/src/components/icons/social-icons.tsx
+++ b/src/components/icons/social-icons.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+
+/**
+ * Monochrome social marks for the login page's community row.
+ *
+ * Deliberately hand-drawn rather than pulled from an icon package: adding a runtime
+ * dependency (or a remote image host) for eight glyphs would put the product's front
+ * door behind someone else's release cadence and CDN. They follow the same contract as
+ * `db-icons.tsx` - `viewBox="0 0 24 24"`, no width/height attributes so the caller's size
+ * classes win, and `currentColor` throughout so one component works both inside the
+ * hero's pinned-dark subtree and in the theme-following mobile block.
+ *
+ * None of them redraw a wordmark. Each doc comment records what was dropped and why the
+ * remainder still reads at 16px, which is the size the row actually renders at.
+ */
+interface IconProps extends React.SVGAttributes<SVGSVGElement> {
+  className?: string;
+}
+
+/**
+ * GitHub's Octocat, kept as a filled silhouette. The mark's interior detail (the face,
+ * the individual tentacles) closes up below about 20px, so the outline plus the single
+ * tail stroke is what carries recognition here; filled rather than stroked because a
+ * 1.5-weight outline of a shape this intricate turns into noise at 16px.
+ */
+export const GitHubIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" stroke="none" className={className} {...props}>
+    <path d="M12 2.5a9.5 9.5 0 00-3 18.5c.47.09.65-.2.65-.45v-1.6c-2.64.58-3.2-1.27-3.2-1.27-.43-1.1-1.06-1.4-1.06-1.4-.86-.59.07-.58.07-.58.95.07 1.45.98 1.45.98.85 1.45 2.23 1.03 2.77.79.09-.62.33-1.03.6-1.27-2.1-.24-4.31-1.05-4.31-4.68 0-1.03.37-1.88.98-2.54-.1-.24-.43-1.2.09-2.51 0 0 .8-.26 2.62 .97a9.1 9.1 0 014.77 0c1.82-1.23 2.62-.97 2.62-.97.52 1.31.19 2.27.1 2.51.61.66.98 1.51.98 2.54 0 3.64-2.22 4.44-4.33 4.67.34.3.64.87.64 1.76v2.6c0 .26.17.55.66.45A9.5 9.5 0 0012 2.5z" />
+  </svg>
+);
+
+/**
+ * LinkedIn: the rounded tile plus the lowercase "in". The letterforms are drawn as
+ * strokes rather than set as text so they scale with the icon's own weight; the dot over
+ * the "i" stays a filled circle because a 1.5-weight ring collapses to a blob at 16px.
+ */
+export const LinkedInIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    <rect x="3" y="3" width="18" height="18" rx="3" />
+    <circle cx="7.8" cy="8" r="0.9" fill="currentColor" stroke="none" />
+    <path d="M7.8 10.8v6" />
+    <path d="M11.6 16.8v-6" />
+    <path d="M11.6 13.6c0-1.55 1.15-2.8 2.6-2.8s2.6 1.25 2.6 2.8v3.2" />
+  </svg>
+);
+
+/**
+ * X: the two crossing strokes of the wordmark's glyph. The real mark tapers its strokes,
+ * which is invisible at this size, so a plain even-weight cross is the honest reduction -
+ * it is the whole logo, not a simplification of a larger drawing.
+ */
+export const XIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    <path d="M4.5 4.5l15 15" />
+    <path d="M19.5 4.5l-15 15" />
+  </svg>
+);
+
+/**
+ * YouTube: the rounded play tile. The triangle is filled because a hollow one reads as a
+ * generic "next" chevron at 16px, while the filled play-in-a-rectangle pairing is what
+ * makes this specific mark identifiable without any colour.
+ */
+export const YouTubeIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    <rect x="2.5" y="5.5" width="19" height="13" rx="4" />
+    <path d="M10.3 9.2l5 2.8-5 2.8z" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+/**
+ * Instagram: the rounded camera outline, the lens, and the flash dot. The brand's
+ * gradient carries most of its recognition, and this row is monochrome by design, so the
+ * three concentric shapes have to do that work alone - which they do, provided the flash
+ * dot stays filled and off-centre.
+ */
+export const InstagramIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    <rect x="3" y="3" width="18" height="18" rx="5" />
+    <circle cx="12" cy="12" r="4" />
+    <circle cx="17.2" cy="6.8" r="1" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+/**
+ * Reddit: Snoo reduced to head, two eyes, a smile and the antenna. The ears and the
+ * antenna's stalk are what separate this from a generic smiley, so they survive even
+ * though the head's own outline had to lose its ear cut-outs to stay clean at 16px.
+ */
+export const RedditIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    <circle cx="12" cy="14" r="7.5" />
+    <circle cx="9.3" cy="13.3" r="1" fill="currentColor" stroke="none" />
+    <circle cx="14.7" cy="13.3" r="1" fill="currentColor" stroke="none" />
+    <path d="M9.2 16.6c1.7 1.3 3.9 1.3 5.6 0" />
+    <path d="M13.6 6.6l1.3-2.9 2.6 1" />
+    <circle cx="18.2" cy="5.1" r="1.2" />
+  </svg>
+);
+
+/**
+ * Docker: the whale's hull with the stacked containers on its back and the spout. The
+ * brand mark draws each container as a separate box with its own gaps; those gaps fill in
+ * below 20px, so this keeps three boxes instead of twelve - enough for the silhouette to
+ * still read as "containers on a whale" rather than as a generic cargo icon.
+ */
+export const DockerIcon: React.FC<IconProps> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    {...props}
+  >
+    <path d="M3.5 12.5h13v2.5a3.5 3.5 0 01-3.5 3.5H7a3.5 3.5 0 01-3.5-3.5z" />
+    <path d="M6.5 12.5V10h3v2.5" />
+    <path d="M11 12.5V10h3v2.5" />
+    <path d="M9 10V7.5h3V10" />
+    <path d="M16.5 13.2c1.5.9 3.4.5 4.3-.8" />
+  </svg>
+);

--- a/src/components/login/connection-signature.tsx
+++ b/src/components/login/connection-signature.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ENGINE_URI_SCHEMES } from "@/lib/connection-string-parser";
+import { getDBConfig } from "@/lib/db-ui-config";
+import { listShowcaseDatabases } from "@/lib/db-showcase";
+import type { DatabaseType } from "@/lib/types";
+
+/** How long one scheme holds before the next replaces it. */
+const CYCLE_MS = 2600;
+
+/**
+ * The URIs the signature cycles through, built from the two sources that already know the
+ * answer: `ENGINE_URI_SCHEMES` says which engines have a scheme at all, and each engine's
+ * own `defaultPort` from `DB_UI_CONFIG` supplies the port. Nothing here is typed by hand,
+ * so an engine that gains a scheme joins the rotation and one whose default port moves
+ * follows it.
+ *
+ * Order follows `listShowcaseDatabases()` rather than the object literal, so the rotation
+ * opens on the engine the showcase leads with instead of on whatever key was declared first.
+ */
+export const SIGNATURE_URIS: readonly { type: DatabaseType; scheme: string; rest: string }[] = listShowcaseDatabases()
+  .filter((db) => ENGINE_URI_SCHEMES[db.type] !== undefined)
+  .map((db) => ({
+    type: db.type,
+    scheme: `${ENGINE_URI_SCHEMES[db.type]}://`,
+    rest: `user@db.internal:${getDBConfig(db.type).defaultPort}/app`,
+  }));
+
+/**
+ * The hero's one bold element: a line that reads as a real connection string and changes
+ * its scheme on a slow cycle.
+ *
+ * It is the thesis of the product stated in the product's own vernacular - you point this
+ * at a database you already run - and it replaces the wall of engine pills that made the
+ * panel unreadable. The engine COUNT is claimed once, in the proof row; this line is the
+ * evidence for it, and it can only show schemes `parseConnectionString` actually accepts.
+ *
+ * Accessibility: the animated line is `aria-hidden` because a string that rewrites itself
+ * every 2.6s is hostile to a screen reader. The same information is served statically to
+ * assistive technology by the visually hidden list below it, which names every scheme at
+ * once. Under `prefers-reduced-motion: reduce` the cycle never starts and the first URI
+ * stands, so the page has no motion at all rather than a faster or subtler motion.
+ */
+export function ConnectionSignature() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    // Read the preference in an effect, not during render: the server has no matchMedia,
+    // and branching on it during render would hydrate a different tree than it sent.
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const timer = setInterval(() => {
+      setIndex((current) => (current + 1) % SIGNATURE_URIS.length);
+    }, CYCLE_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  const current = SIGNATURE_URIS[index];
+
+  return (
+    <div className="space-y-2">
+      <div
+        data-testid="connection-signature"
+        aria-hidden="true"
+        className="font-mono text-xl xl:text-2xl tracking-tight text-fg-tertiary select-none"
+      >
+        <span key={current.type} className="text-blue-400 animate-in fade-in duration-500">
+          {current.scheme}
+        </span>
+        {current.rest}
+      </div>
+      <ul className="sr-only">
+        {SIGNATURE_URIS.map((uri) => (
+          <li key={uri.type}>{uri.scheme}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/login/database-showcase.tsx
+++ b/src/components/login/database-showcase.tsx
@@ -1,0 +1,73 @@
+import { listShowcaseDatabases } from "@/lib/db-showcase";
+
+interface DatabaseShowcaseProps {
+  variant: "desktop" | "mobile";
+}
+
+/**
+ * The login hero's engine list, on both surfaces.
+ *
+ * Every name, icon and accent colour comes from `DB_UI_CONFIG` through
+ * `listShowcaseDatabases()`. Nothing here types an engine name: the defect issue #425
+ * closes was two hand-written five-item arrays in `login-form.tsx` that stopped tracking
+ * `DatabaseType` three providers ago, so adding a provider must be enough to publish it.
+ *
+ * The two variants need two different token families and this is one of the two easiest
+ * places in the page to ship invisible text (`community-section.tsx` records the other):
+ * the desktop block sits inside the hero's left column, which is pinned dark by a nested
+ * `dark` class and therefore re-declares fill/hairline/fg for that subtree only, while the
+ * mobile block lives in the right panel and follows the viewer's theme through
+ * muted/foreground. Swapping either set into the other surface renders the pills the same
+ * colour as their background.
+ *
+ * `pointer-events-none select-none` matches the decorative feature cards above it: this is
+ * showcase content on an unauthenticated page, not navigation.
+ *
+ * The desktop text sits at `fg-tertiary` rather than further down the ramp because the ramp
+ * runs out of contrast before it runs out of steps on this ground: `fg-subtle` over
+ * `surface` measures 2.6:1 and `fg-muted` over a `fill` pill 3.9:1, both under the 4.5:1
+ * WCAG AA floor for 12px type. `fg-tertiary` is 7.7:1 and is already the hero's own body
+ * colour, so the block reads as one family rather than as an exception.
+ */
+export function DatabaseShowcase({ variant }: DatabaseShowcaseProps) {
+  if (variant === "desktop") {
+    return <DesktopDatabases />;
+  }
+  return <MobileDatabases />;
+}
+
+function DesktopDatabases() {
+  return (
+    <ul
+      aria-label="Supported databases"
+      data-testid="database-showcase-desktop"
+      className="flex flex-wrap gap-x-5 gap-y-2.5 pointer-events-none select-none"
+    >
+      {listShowcaseDatabases().map((db) => {
+        const Icon = db.icon;
+        return (
+          <li key={db.type} className="flex items-center gap-1.5 text-xs text-fg-tertiary">
+            <Icon className={`h-3.5 w-3.5 ${db.color}`} aria-hidden="true" />
+            {db.label}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function MobileDatabases() {
+  return (
+    <ul
+      aria-label="Supported databases"
+      data-testid="database-showcase-mobile"
+      className="flex flex-wrap justify-center gap-2 pointer-events-none select-none"
+    >
+      {listShowcaseDatabases().map((db) => (
+        <li key={db.type} className="text-[10px] px-2.5 py-1 rounded-full bg-muted text-muted-foreground font-medium">
+          {db.label}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/login/hero-proof.tsx
+++ b/src/components/login/hero-proof.tsx
@@ -1,0 +1,108 @@
+import { AGENT_EXECUTION_ENGINES } from "@/lib/agent/engine-support";
+import { getDBConfig } from "@/lib/db-ui-config";
+import { listShowcaseDatabases } from "@/lib/db-showcase";
+import { LIVE_CHANNELS, LIVE_PLATFORMS } from "@/lib/distribution/channels.generated";
+import { DEPLOY_GROUP_LABELS, DEPLOY_GROUP_ORDER } from "@/lib/distribution/deploy-groups";
+
+/**
+ * The two agent modes, in the order a user meets them.
+ *
+ * The descriptions are pinned to `docs/AGENT.md` and the split is load-bearing: plan mode
+ * executes nothing on any engine, agent mode executes read-only and only where the provider
+ * implements `queryReadOnly`. The engine names in the second line come from
+ * `AGENT_EXECUTION_ENGINES`, so an engine that gains that method updates this claim without
+ * a copy edit - and the count below is this array's length, never a typed "2".
+ *
+ * `tests/components/LoginPage.test.tsx` pins the claim rather than the wording: dropping a
+ * mode, or naming an engine agent mode cannot execute on, fails CI.
+ */
+const AGENT_MODES: readonly { key: string; label: string; detail: string }[] = [
+  { key: "plan", label: "plan mode", detail: "drafts one statement, runs nothing" },
+  {
+    key: "agent",
+    label: "agent mode",
+    detail: `runs read-only on ${AGENT_EXECUTION_ENGINES.map((type) => getDBConfig(type).label).join(" and ")}`,
+  },
+];
+
+/**
+ * Three claims, three derived numbers, nothing else.
+ *
+ * This replaces the four feature cards that used to sit here. The cards said the same
+ * things at four different lengths, which is what made the panel ragged: the agent card ran
+ * to four lines while the engine card ran to two, so the 2x2 grid never had a baseline.
+ * A number, a noun and one qualifying line give each claim the same shape, and the reader
+ * can compare them at a glance instead of reading four paragraphs.
+ *
+ * Every count is a `.length` on a derived array. That is the whole point of issue #425:
+ * "7+" was written when the answer was 7, and it stayed while the answer became 11.
+ */
+/**
+ * The three claims, shared by both login surfaces so they cannot drift: the desktop hero
+ * renders them as a three-column figure, the mobile block joins the same strings into one
+ * line. Every input is static, so this is computed once at module load rather than per
+ * render.
+ */
+export const HERO_CLAIMS: readonly { key: string; value: number; unit: string; detail: string }[] = [
+  {
+    key: "engines",
+    value: listShowcaseDatabases().length,
+    unit: "database engines",
+    detail: "one client, one workspace, every one of them",
+  },
+  {
+    key: "channels",
+    value: LIVE_CHANNELS.length,
+    unit: "install channels",
+    detail: DEPLOY_GROUP_ORDER.map((group) => DEPLOY_GROUP_LABELS[group]).join(", "),
+  },
+  {
+    key: "agent",
+    value: AGENT_MODES.length,
+    unit: "agent modes",
+    detail: AGENT_MODES.map((mode) => `${mode.label} ${mode.detail}`).join(" · "),
+  },
+];
+
+/**
+ * The workstation and server operating systems, taken from `LIVE_PLATFORMS`.
+ *
+ * Filtered rather than rendered whole, and the filter is the point: `container`,
+ * `kubernetes` and `cloud` are already the first three channel groups above, so printing
+ * them again here would say Containers and Kubernetes twice in adjacent lines. What is left
+ * is the question this line answers and the claim above cannot - whether the machine in
+ * front of you can run it.
+ */
+const OS_PLATFORM_LABELS: Record<string, string> = { linux: "Linux", macos: "macOS", windows: "Windows" };
+const OS_PLATFORMS = LIVE_PLATFORMS.filter((platform) => platform in OS_PLATFORM_LABELS);
+
+export function HeroProof() {
+  const claims = HERO_CLAIMS;
+
+  return (
+    <div className="space-y-3">
+      <dl data-testid="hero-proof" className="grid grid-cols-3 gap-x-6 gap-y-2 select-none">
+        {claims.map((claim) => (
+          <div key={claim.key} className="space-y-1">
+            <dt className="flex items-baseline gap-1.5">
+              <span className="text-2xl xl:text-3xl font-semibold text-white tabular-nums tracking-tight">
+                {claim.value}
+              </span>
+              <span className="text-xs text-fg-tertiary">{claim.unit}</span>
+            </dt>
+            <dd
+              className="text-xs text-fg-tertiary leading-relaxed"
+              data-testid={claim.key === "agent" ? "agent-claim" : undefined}
+            >
+              {claim.detail}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <p data-testid="platform-line" className="text-xs text-fg-tertiary select-none">
+        Runs on {OS_PLATFORMS.map((platform) => OS_PLATFORM_LABELS[platform]).join(" · ")}
+      </p>
+    </div>
+  );
+}

--- a/src/lib/agent/engine-support.ts
+++ b/src/lib/agent/engine-support.ts
@@ -1,0 +1,26 @@
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * The engines on which **agent mode** executes statements itself.
+ *
+ * This mirrors - it does not implement - the factory's gate. A profiled acquisition is
+ * refused unless the provider exposes a database-native read-only statement path
+ * (`acquisition.requiresReadOnlyStatements && typeof provider.queryReadOnly !== "function"`,
+ * `src/lib/db/factory.ts`), which throws `PROFILE_UNSUPPORTED_BY_PROVIDER` and ends the run
+ * `engine-unsupported`. `queryReadOnly` exists on exactly two providers today
+ * (`providers/sql/postgres.ts`, `providers/sql/sqlite.ts`), and that probe stays the real
+ * rule: replacing it with this list would let the list go stale against the drivers.
+ * `tests/unit/lib/agent/engine-support.test.ts` is what keeps the two equal - it measures the
+ * provider prototypes and fails if this array and reality diverge in either direction.
+ *
+ * Two things it deliberately does NOT say, because user-facing copy that compresses them
+ * overclaims (docs/AGENT.md, "How the agent is bounded"):
+ * - **Plan mode executes nothing, on any engine.** This list has no bearing on it; since #414
+ *   a plan run is grounded everywhere and still runs no statement anywhere.
+ * - **The `operations` workflow runs on every engine, in both modes**, because it composes no
+ *   SQL: its `agent-operations` acquisition sets `requiresReadOnlyStatements: false`.
+ *
+ * Imports nothing but the type union on purpose. It is read by the unauthenticated login
+ * hero, and a provider module here would drag `oracledb`/`mssql` toward that bundle.
+ */
+export const AGENT_EXECUTION_ENGINES: readonly DatabaseType[] = ["postgres", "sqlite"];

--- a/src/lib/connection-string-parser.ts
+++ b/src/lib/connection-string-parser.ts
@@ -22,6 +22,34 @@ export interface ParsedConnection {
 }
 
 /**
+ * The canonical URI scheme each engine is reachable by, for the engines that HAVE one.
+ *
+ * Deliberately partial, and the gaps are the point: SQLite is a file path, LibreDB is
+ * embedded in the process, and Druid is reached over plain HTTP through the form. Inventing
+ * `sqlite://` or `druid://` to make the map look complete would put a scheme on the login
+ * page that `parseConnectionString` below rejects - a claim the product does not honour,
+ * which is the class of defect issue #425 exists to remove.
+ *
+ * Aliases the parser also accepts (`postgresql://`, `mongodb+srv://`, `rediss://`,
+ * `sqlserver://`, `couchbases://`, and ClickHouse's `http(s)://`) are not listed: this map
+ * answers "what is the one scheme to show a reader for this engine", not "what will parse".
+ *
+ * `tests/unit/lib/connection-string-parser.test.ts` pins the entries against the parser
+ * itself - every scheme here must round-trip to its own `DatabaseType` - so the map cannot
+ * drift away from the `startsWith` checks below without failing CI.
+ */
+export const ENGINE_URI_SCHEMES: Partial<Record<DatabaseType, string>> = {
+  postgres: "postgres",
+  mysql: "mysql",
+  mongodb: "mongodb",
+  redis: "redis",
+  oracle: "oracle",
+  mssql: "mssql",
+  couchbase: "couchbase",
+  clickhouse: "clickhouse",
+};
+
+/**
  * Parse a database connection string URL into its components.
  * Supports: postgres://, postgresql://, mysql://, mongodb://, mongodb+srv://, redis://,
  * couchbase://, couchbases://, clickhouse://, http://, https://

--- a/src/lib/db-showcase.ts
+++ b/src/lib/db-showcase.ts
@@ -1,0 +1,63 @@
+import { DB_UI_CONFIG, type DBIcon } from "@/lib/db-ui-config";
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * Display rank for the marketing surfaces (the login hero's "Supported Databases"
+ * block, issue #425). Typed `Record<DatabaseType, number>`, so a twelfth member of the
+ * union fails `bun run typecheck` on the missing key instead of quietly never being
+ * shown - the same compile-time-exhaustive trick the connection picker's coverage map
+ * uses in tests/hooks/use-connection-form.test.ts.
+ *
+ * The order is recognisability-first: an evaluator scanning the login page should meet
+ * the names they already know before the ones they do not. It is deliberately NOT the
+ * connection picker's order (`selectableTypes`, src/hooks/use-connection-form.ts),
+ * which groups by connect-form affordance instead. The two lists answer different
+ * questions, so they are not unified; keep both when adding a provider.
+ */
+export const SHOWCASE_RANK: Record<DatabaseType, number> = {
+  postgres: 0,
+  mysql: 1,
+  sqlite: 2,
+  mongodb: 3,
+  redis: 4,
+  oracle: 5,
+  mssql: 6,
+  couchbase: 7,
+  clickhouse: 8,
+  druid: 9,
+  // Last on purpose: the embedded store is the least recognisable name here. It is
+  // still shown - it is a shipped provider with a doc (docs/providers/libredb.md), an
+  // icon and a slot in the connection picker, so omitting it would make the login page
+  // contradict the app (issue #425, step 2).
+  libredb: 10,
+};
+
+/**
+ * Every configured engine, in showcase order. Derived from `DB_UI_CONFIG`'s own keys
+ * rather than written out a second time, so an engine cannot be dropped from the page
+ * by being forgotten in a literal array - only by being removed from the config.
+ */
+export const SHOWCASE_DATABASE_ORDER: readonly DatabaseType[] = (Object.keys(DB_UI_CONFIG) as DatabaseType[]).sort(
+  (a, b) => SHOWCASE_RANK[a] - SHOWCASE_RANK[b],
+);
+
+export interface ShowcaseDatabase {
+  type: DatabaseType;
+  label: string;
+  icon: DBIcon;
+  color: string;
+}
+
+/**
+ * The engine list a marketing surface renders: brand icon, label and accent colour
+ * taken straight from `DB_UI_CONFIG`, so no engine name is ever typed into JSX.
+ * Returns a fresh array so a caller cannot mutate the shared order.
+ */
+export function listShowcaseDatabases(): ShowcaseDatabase[] {
+  return SHOWCASE_DATABASE_ORDER.map((type) => ({
+    type,
+    label: DB_UI_CONFIG[type].label,
+    icon: DB_UI_CONFIG[type].icon,
+    color: DB_UI_CONFIG[type].color,
+  }));
+}

--- a/src/lib/db-ui-config.ts
+++ b/src/lib/db-ui-config.ts
@@ -15,7 +15,7 @@ import {
 import type { DatabaseType } from "@/lib/types";
 
 // DB brand icons share the same interface as LucideIcon (className + SVG props)
-type DBIcon = LucideIcon | React.FC<React.SVGAttributes<SVGSVGElement> & { className?: string }>;
+export type DBIcon = LucideIcon | React.FC<React.SVGAttributes<SVGSVGElement> & { className?: string }>;
 
 export interface DatabaseUIConfig {
   icon: DBIcon;
@@ -35,7 +35,7 @@ export interface DatabaseUIConfig {
   )[];
 }
 
-const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
+export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   postgres: {
     icon: PostgreSQLIcon,
     color: "text-blue-400",

--- a/src/lib/distribution/channels.generated.ts
+++ b/src/lib/distribution/channels.generated.ts
@@ -1,0 +1,53 @@
+// GENERATED FILE - do not edit. Run: bun run channels:showcase
+//
+// Source: distribution/channels.yaml (live channels only), via
+// scripts/generate-channel-showcase.mjs. CI fails on drift
+// (bun run channels:showcase:check), so this file is always the inventory.
+
+/** The row of the login hero's deploy block a channel belongs to. */
+export type ShowcaseGroup = "containers" | "kubernetes" | "paas" | "packages";
+
+/** Platforms a live channel serves, in the canonical order of distribution/channels.yaml. */
+export type ShowcasePlatform = "linux" | "macos" | "windows" | "container" | "kubernetes" | "cloud";
+
+export interface ShowcaseChannel {
+  id: string;
+  label: string;
+  group: ShowcaseGroup;
+}
+
+export const LIVE_CHANNELS: readonly ShowcaseChannel[] = [
+  { id: "github-release", label: "GitHub Releases", group: "packages" },
+  { id: "docker-ghcr", label: "Docker image (GHCR)", group: "containers" },
+  { id: "docker-hub-mirror", label: "Docker Hub mirror", group: "containers" },
+  { id: "npm", label: "npm @libredb/studio", group: "packages" },
+  { id: "helm", label: "Helm chart", group: "kubernetes" },
+  { id: "homebrew", label: "Homebrew tap", group: "packages" },
+  { id: "snap", label: "Snap Store", group: "packages" },
+  { id: "linux-deb-rpm", label: "Linux .deb / .rpm", group: "packages" },
+  { id: "appimage", label: "Desktop app (AppImage, .deb)", group: "packages" },
+  { id: "railway-template", label: "Railway one-click template", group: "paas" },
+  { id: "koyeb-deploy-button", label: "Koyeb deploy button", group: "paas" },
+  { id: "fly-io", label: "Fly.io launch config", group: "paas" },
+  { id: "render", label: "Render Blueprint", group: "paas" },
+  { id: "unraid-ca", label: "Unraid Community Apps", group: "paas" },
+  { id: "caprover-official", label: "CapRover official", group: "paas" },
+  { id: "dokploy", label: "Dokploy template catalog", group: "paas" },
+  { id: "cosmos", label: "Cosmos servapp marketplace", group: "paas" },
+  { id: "kubero", label: "Kubero template catalog", group: "paas" },
+  { id: "sealos", label: "Sealos App Store template", group: "paas" },
+  { id: "truenas-scale", label: "TrueNAS SCALE apps", group: "paas" },
+  { id: "rancher-partner", label: "Rancher Partner Charts", group: "kubernetes" },
+  { id: "digitalocean", label: "DigitalOcean Marketplace", group: "paas" },
+  { id: "winget", label: "winget", group: "packages" },
+  { id: "flatpark", label: "FlatPark (Flatpak)", group: "packages" },
+];
+
+export const LIVE_PLATFORMS: readonly ShowcasePlatform[] = [
+  "linux",
+  "macos",
+  "windows",
+  "container",
+  "kubernetes",
+  "cloud",
+];

--- a/src/lib/distribution/deploy-groups.ts
+++ b/src/lib/distribution/deploy-groups.ts
@@ -1,0 +1,20 @@
+import type { ShowcaseGroup } from "@/lib/distribution/channels.generated";
+
+/**
+ * Reading order for the four channel groups, broadest first: a reader who already runs
+ * containers recognises the first name and can stop there.
+ *
+ * Typed `readonly ShowcaseGroup[]` and paired with the exhaustive label map below, so a new
+ * group in `scripts/generate-channel-showcase.mjs` fails `bun run typecheck` on the missing
+ * key rather than rendering an unlabelled one - the same compile-time rule the generator
+ * applies to an unknown `category`, which throws instead of defaulting.
+ */
+export const DEPLOY_GROUP_ORDER: readonly ShowcaseGroup[] = ["containers", "kubernetes", "paas", "packages"];
+
+/** Human labels for the four groups. */
+export const DEPLOY_GROUP_LABELS: Record<ShowcaseGroup, string> = {
+  containers: "Containers",
+  kubernetes: "Kubernetes",
+  paas: "PaaS",
+  packages: "Packages",
+};

--- a/src/lib/social-links.ts
+++ b/src/lib/social-links.ts
@@ -1,0 +1,54 @@
+import type React from "react";
+import { Heart } from "lucide-react";
+import {
+  DockerIcon,
+  GitHubIcon,
+  InstagramIcon,
+  LinkedInIcon,
+  RedditIcon,
+  XIcon,
+  YouTubeIcon,
+} from "@/components/icons/social-icons";
+
+/**
+ * One destination in the login page's community row.
+ *
+ * The icon travels with the entry rather than being looked up by id in the component,
+ * because a lookup needs a fallback for the miss that cannot happen - and an untaken
+ * fallback branch is a line the coverage gate can never cover honestly.
+ */
+export interface SocialLink {
+  /** Stable key for React and for tests; never rendered. */
+  id: string;
+  /** The link's accessible name. These links are icon-only, so this is their ONLY name. */
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+/**
+ * Where LibreDB actually is, in the order the row renders left to right.
+ *
+ * The handle is `libredb` on every platform; GitHub Sponsors is the one exception,
+ * because sponsorship is tied to the maintainer's account rather than to the
+ * organisation. All eight were opened and confirmed by the maintainer before shipping -
+ * a 404 in the product's front door is worse than an absent link, so a destination that
+ * cannot be confirmed does not get a row.
+ *
+ * Ordered by how much a first-time visitor is likely to want it: the repository first,
+ * the professional and short-form channels next, the community forums after, and the
+ * distribution and sponsorship links last. The component maps this array; it never
+ * writes a destination of its own.
+ */
+export const SOCIAL_LINKS: readonly SocialLink[] = [
+  { id: "github", label: "GitHub", href: "https://github.com/libredb", icon: GitHubIcon },
+  { id: "linkedin", label: "LinkedIn", href: "https://www.linkedin.com/company/libredb", icon: LinkedInIcon },
+  { id: "x", label: "X", href: "https://x.com/libredb", icon: XIcon },
+  { id: "youtube", label: "YouTube", href: "https://www.youtube.com/@libredb", icon: YouTubeIcon },
+  { id: "instagram", label: "Instagram", href: "https://www.instagram.com/libredb", icon: InstagramIcon },
+  { id: "reddit", label: "Reddit", href: "https://www.reddit.com/r/libredb", icon: RedditIcon },
+  { id: "dockerhub", label: "Docker Hub", href: "https://hub.docker.com/u/libredb", icon: DockerIcon },
+  // Reuses lucide's Heart: the sponsor card above the row already renders it, so drawing
+  // a second heart would put two different hearts on the same page.
+  { id: "sponsor", label: "Sponsor", href: "https://github.com/sponsors/cevheri", icon: Heart },
+];

--- a/tests/components/CommunitySection.test.tsx
+++ b/tests/components/CommunitySection.test.tsx
@@ -1,6 +1,7 @@
 import "../setup-dom";
 import React from "react";
 import { CommunitySection } from "@/components/community-section";
+import { SOCIAL_LINKS } from "@/lib/social-links";
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
@@ -10,84 +11,98 @@ describe("CommunitySection", () => {
     cleanup();
   });
 
-  const actionLabels = ["Star & Fork", "Open an Issue", "Discussions", "Contribute", "Translate", "Sponsor"];
+  const REPO_URL = "https://github.com/libredb/libredb-studio";
 
-  describe("Desktop variant", () => {
-    test("renders section title", () => {
-      const { getByText } = render(<CommunitySection variant="desktop" />);
-      expect(getByText("Join the Community")).not.toBeNull();
+  // The six action cards were removed with the login redesign: every one of them pointed at
+  // a path under the repository, so the hero spent six lines saying "GitHub" six times. What
+  // is left names the repository once and lets the social row carry the rest.
+  describe.each(["desktop", "mobile"] as const)("Repository line (%s variant)", (variant) => {
+    test("names the project as open source and links the repository once", () => {
+      const { container, getByText } = render(<CommunitySection variant={variant} />);
+      expect(getByText(/Open source/i)).not.toBeNull();
+
+      const repoAnchors = container.querySelectorAll(`a[href="${REPO_URL}"]`);
+      expect(repoAnchors.length).toBe(1);
+      expect(repoAnchors[0].getAttribute("target")).toBe("_blank");
+      expect(repoAnchors[0].getAttribute("rel")).toBe("noopener noreferrer");
     });
 
-    test("renders Open Source pill badge", () => {
-      const { getByText } = render(<CommunitySection variant="desktop" />);
-      expect(getByText("Open Source")).not.toBeNull();
+    test("renders the divider that separates it from the block above", () => {
+      const { container } = render(<CommunitySection variant={variant} />);
+      expect(container.querySelector(variant === "desktop" ? ".bg-fill-strong" : ".bg-muted")).not.toBeNull();
     });
 
-    test("renders subtitle text", () => {
-      const { getByText } = render(<CommunitySection variant="desktop" />);
-      expect(getByText("This project is open source. Your contributions make it better!")).not.toBeNull();
-    });
-
-    test("renders all 6 community action cards", () => {
-      const { getByText } = render(<CommunitySection variant="desktop" />);
-      for (const label of actionLabels) {
-        expect(getByText(label)).not.toBeNull();
-      }
-    });
-
-    test('each card is an anchor with target="_blank"', () => {
-      const { getByText } = render(<CommunitySection variant="desktop" />);
-      for (const label of actionLabels) {
-        const anchor = getByText(label).closest("a");
-        expect(anchor).not.toBeNull();
-        expect(anchor!.getAttribute("target")).toBe("_blank");
-        expect(anchor!.getAttribute("rel")).toBe("noopener noreferrer");
-      }
-    });
-
-    test("cards link to correct GitHub URLs", () => {
-      const { getByText } = render(<CommunitySection variant="desktop" />);
-      const expectedUrls: Record<string, string> = {
-        "Star & Fork": "https://github.com/libredb/libredb-studio",
-        "Open an Issue": "https://github.com/libredb/libredb-studio/issues",
-        Discussions: "https://github.com/libredb/libredb-studio/discussions",
-        Contribute: "https://github.com/libredb/libredb-studio/blob/main/CONTRIBUTING.md",
-        Translate: "https://github.com/libredb/libredb-studio/tree/main/src/lib",
-        Sponsor: "https://github.com/sponsors/cevheri",
-      };
-      for (const [label, url] of Object.entries(expectedUrls)) {
-        const anchor = getByText(label).closest("a");
-        expect(anchor!.getAttribute("href")).toBe(url);
+    test("carries no action cards any more", () => {
+      const { queryByText } = render(<CommunitySection variant={variant} />);
+      for (const gone of ["Join the Community", "Star & Fork", "Open an Issue", "Discussions", "Translate"]) {
+        expect(queryByText(gone)).toBeNull();
       }
     });
   });
 
-  describe("Mobile variant", () => {
-    test("renders section title", () => {
-      const { getByText } = render(<CommunitySection variant="mobile" />);
-      expect(getByText("Join the Community")).not.toBeNull();
-    });
-
-    test("renders all 6 community pills", () => {
-      const { getByText } = render(<CommunitySection variant="mobile" />);
-      for (const label of actionLabels) {
-        expect(getByText(label)).not.toBeNull();
+  // Every assertion below is driven from SOCIAL_LINKS rather than from a second literal
+  // list: the whole point of the module is that the row and the data cannot disagree, and
+  // a test carrying its own copy of the destinations would not notice if they did.
+  describe.each(["desktop", "mobile"] as const)("Social row (%s variant)", (variant) => {
+    test("renders exactly one anchor per social link", () => {
+      const { container } = render(<CommunitySection variant={variant} />);
+      for (const link of SOCIAL_LINKS) {
+        const anchors = container.querySelectorAll(`a[aria-label="${link.label}"]`);
+        expect(anchors.length).toBe(1);
       }
     });
 
-    test('each pill is an anchor with target="_blank"', () => {
-      const { getByText } = render(<CommunitySection variant="mobile" />);
-      for (const label of actionLabels) {
-        const anchor = getByText(label).closest("a");
+    test("each social anchor carries its href and opens safely in a new tab", () => {
+      const { container } = render(<CommunitySection variant={variant} />);
+      for (const link of SOCIAL_LINKS) {
+        const anchor = container.querySelector(`a[aria-label="${link.label}"]`);
         expect(anchor).not.toBeNull();
+        expect(anchor!.getAttribute("href")).toBe(link.href);
         expect(anchor!.getAttribute("target")).toBe("_blank");
+        // Both tokens matter: noopener denies the opened tab a handle on window.opener,
+        // noreferrer keeps the login URL out of the destination's referrer log.
+        const rel = anchor!.getAttribute("rel") ?? "";
+        expect(rel.split(/\s+/)).toContain("noopener");
+        expect(rel.split(/\s+/)).toContain("noreferrer");
       }
     });
 
-    test("renders divider", () => {
-      const { container } = render(<CommunitySection variant="mobile" />);
-      const divider = container.querySelector(".bg-muted");
-      expect(divider).not.toBeNull();
+    test("each social anchor is named by its label alone", () => {
+      // The links are icon-only, so aria-label is the only accessible name they have.
+      const { getByLabelText } = render(<CommunitySection variant={variant} />);
+      for (const link of SOCIAL_LINKS) {
+        const anchor = getByLabelText(link.label);
+        expect(anchor.tagName).toBe("A");
+        expect(anchor.textContent).toBe("");
+      }
+    });
+
+    test("each social anchor renders its icon as an svg", () => {
+      const { container } = render(<CommunitySection variant={variant} />);
+      for (const link of SOCIAL_LINKS) {
+        const anchor = container.querySelector(`a[aria-label="${link.label}"]`);
+        expect(anchor!.querySelector("svg")).not.toBeNull();
+      }
+    });
+
+    test("each social anchor keeps a tap target of at least 24px square", () => {
+      // h-8/w-8 is 32px. Anything smaller than 24px fails the WCAG 2.2 target-size
+      // minimum, and an icon-only row is exactly where that is easy to get wrong.
+      const { container } = render(<CommunitySection variant={variant} />);
+      for (const link of SOCIAL_LINKS) {
+        const anchor = container.querySelector(`a[aria-label="${link.label}"]`);
+        expect(anchor!.className).toContain("h-8");
+        expect(anchor!.className).toContain("w-8");
+      }
+    });
+
+    test("no social anchor claims the button role", () => {
+      // A link that navigates is a link; role="button" on an anchor is banned here.
+      const { container } = render(<CommunitySection variant={variant} />);
+      for (const link of SOCIAL_LINKS) {
+        const anchor = container.querySelector(`a[aria-label="${link.label}"]`);
+        expect(anchor!.getAttribute("role")).toBeNull();
+      }
     });
   });
 });

--- a/tests/components/ConnectionModal.mobile.test.tsx
+++ b/tests/components/ConnectionModal.mobile.test.tsx
@@ -202,6 +202,10 @@ mock.module("@/lib/db-ui-config", () => ({
   }),
   getDBIcon: () => () => null,
   getDBColor: () => "text-blue-400",
+  // See the same note in ConnectionModal.test.tsx: `DB_UI_CONFIG` became an exported
+  // binding in #425, so this mock's `{}` now reaches the real `isFileBased` unless the
+  // function is mocked here too.
+  isFileBased: (type: string) => type === "sqlite" || type === "libredb",
   DB_UI_CONFIG: {},
 }));
 

--- a/tests/components/ConnectionModal.test.tsx
+++ b/tests/components/ConnectionModal.test.tsx
@@ -233,6 +233,12 @@ mock.module("@/lib/db-ui-config", () => ({
   }),
   getDBIcon: () => () => null,
   getDBColor: () => "text-blue-400",
+  // `isFileBased` must be mocked now that `DB_UI_CONFIG` is an exported binding (#425 made
+  // it one so the login showcase can enumerate it). The real `isFileBased` reads that
+  // binding, and this mock replaces it with `{}`, so leaving the function to the real module
+  // makes it throw on `DB_UI_CONFIG[type].connectionFields` for every render. Mirrors the
+  // real rule: a file-based provider carries only a path.
+  isFileBased: (type: string) => type === "sqlite" || type === "libredb",
   DB_UI_CONFIG: {},
 }));
 

--- a/tests/components/ConnectionSignature.test.tsx
+++ b/tests/components/ConnectionSignature.test.tsx
@@ -1,0 +1,90 @@
+import "../setup-dom";
+import React from "react";
+import { ConnectionSignature, SIGNATURE_URIS } from "@/components/login/connection-signature";
+import { ENGINE_URI_SCHEMES, parseConnectionString } from "@/lib/connection-string-parser";
+
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+
+/** The real `matchMedia` happy-dom installed, kept so the stub below can be handed back. */
+const realMatchMedia = window.matchMedia;
+
+/**
+ * Stand in for `prefers-reduced-motion`. The component reads the preference inside an
+ * effect rather than during render, so the stub only has to answer the one query - but it
+ * must answer it before the effect runs, hence the assignment before `render`.
+ *
+ * The returned object is a whole `MediaQueryList` shape, not just `{ matches }`, and the
+ * real implementation goes back on in `afterAll`. Both halves matter: `window` is shared by
+ * every file in this component group (`tests/run-components.sh` Group 11), and `next-themes`
+ * - which `RootLayout.test.tsx` renders in the same process - subscribes with the legacy
+ * `addListener`. A stub missing that method, or left in place after this file finishes,
+ * fails those tests instead of these, which is exactly the process-wide contamination the
+ * grouping exists to prevent.
+ */
+function stubReducedMotion(reduce: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: reduce && query.includes("reduce"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+describe("ConnectionSignature", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, "matchMedia", { configurable: true, writable: true, value: realMatchMedia });
+  });
+
+  test("shows only schemes parseConnectionString accepts, one per engine that has one", () => {
+    // The line is the evidence behind the engine count on the login hero, so it may only
+    // show URIs the product honours. SQLite is a file, LibreDB is embedded and Druid is
+    // plain HTTP - a scheme invented for any of them would be a claim the parser rejects.
+    expect(SIGNATURE_URIS.length).toBe(Object.keys(ENGINE_URI_SCHEMES).length);
+    for (const uri of SIGNATURE_URIS) {
+      expect(parseConnectionString(`${uri.scheme}${uri.rest}`)?.type).toBe(uri.type);
+    }
+  });
+
+  test("names every scheme at once for assistive technology", () => {
+    // The visible line rewrites itself, so it is aria-hidden; the static list is what a
+    // screen reader gets, and it has to carry the whole set rather than the current frame.
+    stubReducedMotion(true);
+    const { container, getByTestId } = render(<ConnectionSignature />);
+
+    expect(getByTestId("connection-signature").getAttribute("aria-hidden")).toBe("true");
+    const announced = Array.from(container.querySelectorAll("ul.sr-only li")).map((li) => li.textContent);
+    expect(announced).toEqual(SIGNATURE_URIS.map((uri) => uri.scheme));
+  });
+
+  test("does not start the cycle when the viewer asked for reduced motion", async () => {
+    stubReducedMotion(true);
+    const { getByTestId } = render(<ConnectionSignature />);
+    const first = getByTestId("connection-signature").textContent;
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(getByTestId("connection-signature").textContent).toBe(first);
+  });
+
+  test("advances to the next URI on its own", async () => {
+    stubReducedMotion(false);
+    const { getByTestId } = render(<ConnectionSignature />);
+    const first = getByTestId("connection-signature").textContent;
+    expect(first).toContain(SIGNATURE_URIS[0].scheme);
+
+    await waitFor(() => expect(getByTestId("connection-signature").textContent).not.toBe(first), { timeout: 6000 });
+    expect(getByTestId("connection-signature").textContent).toContain(SIGNATURE_URIS[1].scheme);
+  });
+});

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -1,8 +1,17 @@
 import "../setup-dom";
 import React from "react";
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
 import { mockRouterPush, mockRouterRefresh } from "../helpers/mock-navigation";
 import { mockToastSuccess, mockToastError } from "../helpers/mock-sonner";
 import { mock } from "bun:test";
+import { listShowcaseDatabases } from "@/lib/db-showcase";
+import { getDBConfig } from "@/lib/db-ui-config";
+import { AGENT_EXECUTION_ENGINES } from "@/lib/agent/engine-support";
+import { LIVE_CHANNELS, LIVE_PLATFORMS } from "@/lib/distribution/channels.generated";
+import { DEPLOY_GROUP_LABELS, DEPLOY_GROUP_ORDER } from "@/lib/distribution/deploy-groups";
+import { ENGINE_URI_SCHEMES, parseConnectionString } from "@/lib/connection-string-parser";
+import { SIGNATURE_URIS } from "@/components/login/connection-signature";
 
 // sonner and next/navigation are mocked via preload
 // lucide-react resolves fine natively — no mock needed
@@ -224,5 +233,144 @@ describe("LoginPage route (app/login/page)", () => {
     const { queryByText, container } = render(<LoginPageRoute />);
     expect(queryByText("Login with SSO")).not.toBeNull();
     expect(container.querySelector("form")).toBeNull();
+  });
+});
+
+describe("LoginPage showcase (issue #425)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderShowcase() {
+    return render(<LoginForm authProvider="local" />);
+  }
+
+  test("renders every configured engine label on both surfaces", () => {
+    // Driven by DB_UI_CONFIG through listShowcaseDatabases, never by a literal list: the
+    // defect this issue closes was two hand-written five-item arrays that stopped tracking
+    // DatabaseType. Each label must appear twice - once in the desktop hero, once in the
+    // mobile block - so neither surface can quietly drop an engine.
+    const { getAllByText } = renderShowcase();
+    for (const db of listShowcaseDatabases()) {
+      expect(getAllByText(db.label).length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  test("names no engine outside DB_UI_CONFIG", () => {
+    const { getByTestId } = renderShowcase();
+    const known = new Set(listShowcaseDatabases().map((db) => db.label));
+    for (const item of getByTestId("database-showcase-desktop").querySelectorAll("li")) {
+      expect(known.has(item.textContent?.trim() ?? "")).toBe(true);
+    }
+  });
+
+  test("states the live channel count and every group name, without printing channel names", () => {
+    // The hero used to print all two dozen channel names, which is what made the panel
+    // unreadable. What survives is the claim - a derived count plus the four group names -
+    // so the count still cannot go stale while the ink is a single line.
+    const { getByTestId } = renderShowcase();
+    const proof = getByTestId("hero-proof");
+    expect(proof.textContent).toContain(`${LIVE_CHANNELS.length}`);
+    for (const group of DEPLOY_GROUP_ORDER) {
+      expect(proof.textContent).toContain(DEPLOY_GROUP_LABELS[group]);
+    }
+  });
+
+  test("names the operating systems a workstation reader is looking for", () => {
+    const { getByTestId } = renderShowcase();
+    const line = (getByTestId("platform-line").textContent ?? "").toLowerCase();
+    const expected = LIVE_PLATFORMS.filter((platform) => ["linux", "macos", "windows"].includes(platform));
+    expect(expected.length).toBeGreaterThan(0);
+    for (const platform of expected) {
+      expect(line).toContain(platform);
+    }
+  });
+
+  test("cycles only schemes parseConnectionString actually accepts", () => {
+    // The signature is the evidence behind the engine count, so it may only show URIs the
+    // product honours. SQLite is a file, LibreDB is embedded and Druid is plain HTTP -
+    // inventing a scheme for any of them would put a false claim on the front door.
+    const { getByTestId } = renderShowcase();
+    const scheme = (getByTestId("connection-signature").textContent ?? "").split("://")[0];
+    expect(Object.values(ENGINE_URI_SCHEMES)).toContain(scheme);
+    expect(SIGNATURE_URIS.length).toBe(Object.keys(ENGINE_URI_SCHEMES).length);
+    for (const uri of SIGNATURE_URIS) {
+      expect(parseConnectionString(`${uri.scheme}${uri.rest}`)?.type).toBe(uri.type);
+    }
+  });
+
+  test("shows no pending or deprecated channel anywhere on the page", () => {
+    // channels.yaml is the inventory; anything not `live` is a listing that does not exist
+    // yet (or no longer does), and docs/CHANNELS.md is explicit that a deprecated channel
+    // renders nothing at all. Parsed from the YAML rather than listed here, so a newly
+    // promoted or newly retired row is covered without touching this test.
+    const { container } = renderShowcase();
+    const inventory = parseYaml(readFileSync("distribution/channels.yaml", "utf8")) as {
+      channels: { status: string; name: string; short_name?: string }[];
+    };
+    const unlisted = inventory.channels.filter((channel) => channel.status !== "live");
+    expect(unlisted.length).toBeGreaterThan(0);
+    for (const channel of unlisted) {
+      expect(container.textContent).not.toContain(channel.short_name ?? channel.name);
+    }
+  });
+
+  test("derives the engine and channel counts instead of typing them", () => {
+    const { container } = renderShowcase();
+    expect(container.textContent).toContain(`${listShowcaseDatabases().length}`);
+    expect(container.textContent).toContain(`${LIVE_CHANNELS.length} install channels`);
+  });
+
+  test("no longer claims a stale engine count or a Docker-only install", () => {
+    const { container } = renderShowcase();
+    expect(container.textContent).not.toContain("7+");
+    expect(container.textContent).not.toContain("deploy with Docker in seconds");
+    expect(container.textContent).not.toContain("deploy anywhere with Docker in seconds");
+  });
+
+  test("pins the agent claim: two modes, and auto-execution only where agent mode runs", () => {
+    // This pins the CLAIM, not the wording, so a future copy edit is free to rewrite the
+    // sentence but not free to overclaim. docs/AGENT.md: plan mode executes nothing on any
+    // engine, and agent mode executes only where the provider implements `queryReadOnly`.
+    const { getAllByTestId } = renderShowcase();
+    const claims = getAllByTestId("agent-claim");
+    expect(claims.length).toBeGreaterThanOrEqual(2);
+
+    const allowed = new Set(AGENT_EXECUTION_ENGINES.map((type) => getDBConfig(type).label));
+    expect(allowed.size).toBeGreaterThan(0);
+
+    for (const claim of claims) {
+      const sentences = (claim.textContent ?? "").split(/(?<=\.)\s+/);
+
+      const planSentence = sentences.find((sentence) => /plan mode/i.test(sentence));
+      expect(planSentence).toBeDefined();
+      expect(/(executes|runs) nothing/i.test(planSentence!)).toBe(true);
+
+      const agentSentence = sentences.find((sentence) => /agent mode/i.test(sentence));
+      expect(agentSentence).toBeDefined();
+      for (const db of listShowcaseDatabases()) {
+        if (allowed.has(db.label)) continue;
+        expect(agentSentence).not.toContain(db.label);
+      }
+    }
+  });
+
+  test("gives the mobile surface the same claims and the full engine list", () => {
+    const { getAllByTestId, getByTestId } = renderShowcase();
+    const summary = getAllByTestId("agent-claim").map((node) => node.textContent ?? "");
+    expect(summary.some((text) => text.includes(`${LIVE_CHANNELS.length} install channels`))).toBe(true);
+
+    const engines = getByTestId("database-showcase-mobile");
+    expect(engines.querySelectorAll("li").length).toBe(listShowcaseDatabases().length);
+  });
+
+  test("keeps the showcase decorative - no channel or engine is a link", () => {
+    // The login page is unauthenticated; the maintainer's rule is that decorative showcase
+    // content adds no outbound navigation there. The community section's own anchors are
+    // the only links this half of the page is allowed to grow.
+    const { getByTestId } = renderShowcase();
+    for (const testId of ["database-showcase-desktop", "database-showcase-mobile", "hero-proof"]) {
+      expect(getByTestId(testId).querySelectorAll("a").length).toBe(0);
+    }
   });
 });

--- a/tests/components/LoginPageOIDC.test.tsx
+++ b/tests/components/LoginPageOIDC.test.tsx
@@ -2,6 +2,8 @@ import "../setup-dom";
 import React from "react";
 import { mock } from "bun:test";
 import { setMockSearchParams, resetMockSearchParams } from "../helpers/mock-navigation";
+import { listShowcaseDatabases } from "@/lib/db-showcase";
+import { LIVE_CHANNELS } from "@/lib/distribution/channels.generated";
 
 // next/navigation is mocked via the preloaded shared helper; search params
 // are driven through setMockSearchParams instead of a local mock.module call.
@@ -73,6 +75,28 @@ describe("LoginPage (OIDC mode)", () => {
     // Restore location
     if (savedDescriptor) {
       Object.defineProperty(window, "location", savedDescriptor);
+    }
+  });
+
+  test("renders the same derived showcase as the local login", () => {
+    // The hero is outside the auth branch, so the SSO deployment must advertise the same
+    // engines and the same channel count. Asserted here as well because the two forms have
+    // drifted before - the OIDC branch is the one nobody opens while editing copy.
+    const { container } = render(<LoginForm authProvider="oidc" />);
+    for (const db of listShowcaseDatabases()) {
+      expect(container.textContent).toContain(db.label);
+    }
+    expect(container.textContent).toContain(`${LIVE_CHANNELS.length} install channels`);
+    expect(container.textContent).not.toContain("7+");
+  });
+
+  test("states both agent modes on the SSO surface too", () => {
+    const { getAllByTestId } = render(<LoginForm authProvider="oidc" />);
+    const claims = getAllByTestId("agent-claim");
+    expect(claims.length).toBeGreaterThanOrEqual(2);
+    for (const claim of claims) {
+      expect(claim.textContent).toMatch(/plan mode/i);
+      expect(claim.textContent).toMatch(/agent mode/i);
     }
   });
 });

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -231,6 +231,7 @@ run_group "Group 11/12: Smoke tests" \
   tests/components/LoginPage.test.tsx \
   tests/components/LoginPageOIDC.test.tsx \
   tests/components/CommunitySection.test.tsx \
+  tests/components/ConnectionSignature.test.tsx \
   tests/components/GitHubRepoLink.test.tsx \
   tests/components/MonitoringPage.test.tsx \
   tests/components/monitoring/MetricChart.test.tsx

--- a/tests/unit/generate-channel-showcase.test.ts
+++ b/tests/unit/generate-channel-showcase.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for the login-page channel showcase generator
+ * (scripts/generate-channel-showcase.mjs, distribution/channels.yaml ->
+ * src/lib/distribution/channels.generated.ts).
+ *
+ * The building blocks (groupForCategory, buildShowcase, renderModule) are pure
+ * and tested against inline yaml fixtures; the CLI describe block runs the real
+ * script as a subprocess against throwaway temp-dir fixtures, exactly like
+ * tests/unit/distribution-check.test.ts does. The last block is the one that
+ * makes the committed artefact trustworthy in review: it regenerates from the
+ * real inventory and asserts the checked-in module is byte-identical.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LIVE_CHANNELS, LIVE_PLATFORMS } from "../../src/lib/distribution/channels.generated";
+import {
+  CATEGORY_GROUPS,
+  SHOWCASE_PLATFORMS,
+  buildShowcase,
+  groupForCategory,
+  renderModule,
+} from "../../scripts/generate-channel-showcase.mjs";
+
+const SCRIPT = join(import.meta.dir, "../../scripts/generate-channel-showcase.mjs");
+const REPO_ROOT = join(import.meta.dir, "../..");
+const GENERATED = "src/lib/distribution/channels.generated.ts";
+
+function channelsYaml(rows: string): string {
+  return `channels:\n${rows}`;
+}
+
+/** Minimal row: only the fields the generator reads (the full schema is validated by distribution-check.mjs). */
+function row({
+  id,
+  name,
+  status = "live",
+  category = "containers",
+  platforms = "[container]",
+  shortName,
+}: {
+  id: string;
+  name: string;
+  status?: string;
+  category?: string;
+  platforms?: string;
+  shortName?: string;
+}): string {
+  const short = shortName === undefined ? "" : `    short_name: ${shortName}\n`;
+  return `  - id: ${id}
+    name: ${name}
+${short}    status: ${status}
+    category: ${category}
+    platforms: ${platforms}
+`;
+}
+
+describe("groupForCategory", () => {
+  test("maps every category docs/CHANNELS.md defines onto a UI group", () => {
+    expect(groupForCategory("containers")).toBe("containers");
+    expect(groupForCategory("kubernetes-operators")).toBe("kubernetes");
+    expect(groupForCategory("paas-catalogs")).toBe("paas");
+    expect(groupForCategory("deploy-recipes")).toBe("paas");
+    expect(groupForCategory("cloud-marketplaces")).toBe("paas");
+    expect(groupForCategory("package-managers")).toBe("packages");
+    expect(groupForCategory("os-desktop")).toBe("packages");
+    expect(groupForCategory("registries-releases")).toBe("packages");
+  });
+
+  test("throws on an unknown category instead of defaulting it into a group", () => {
+    expect(() => groupForCategory("browser-extensions")).toThrow(/unknown category 'browser-extensions'/);
+  });
+
+  test("the map covers exactly the categories the inventory uses", () => {
+    const used = new Set(
+      readFileSync(join(REPO_ROOT, "distribution/channels.yaml"), "utf8")
+        .split("\n")
+        .filter((line) => line.trimStart().startsWith("category:"))
+        .map((line) => line.split(":")[1].trim()),
+    );
+    for (const category of used) {
+      expect(Object.keys(CATEGORY_GROUPS)).toContain(category);
+    }
+  });
+});
+
+describe("buildShowcase", () => {
+  test("keeps live channels and drops pending and deprecated ones", () => {
+    const showcase = buildShowcase(
+      channelsYaml(
+        row({ id: "docker-ghcr", name: "Docker image" }) +
+          row({ id: "chocolatey", name: "Chocolatey", status: "pending", category: "package-managers" }) +
+          row({ id: "flathub", name: "Flathub", status: "deprecated", category: "package-managers" }),
+      ),
+    );
+    expect(showcase.channels.map((channel: { id: string }) => channel.id)).toEqual(["docker-ghcr"]);
+  });
+
+  test("labels a channel with short_name, falling back to name", () => {
+    const showcase = buildShowcase(
+      channelsYaml(
+        row({ id: "docker-ghcr", name: "Docker image (GHCR, canonical)", shortName: "Docker image (GHCR)" }) +
+          row({ id: "railway", name: "Railway one-click template", category: "paas-catalogs", platforms: "[cloud]" }),
+      ),
+    );
+    expect(showcase.channels).toEqual([
+      { id: "docker-ghcr", label: "Docker image (GHCR)", group: "containers" },
+      { id: "railway", label: "Railway one-click template", group: "paas" },
+    ]);
+  });
+
+  test("deduplicates platforms and orders them canonically, ignoring yaml order", () => {
+    const showcase = buildShowcase(
+      channelsYaml(
+        row({ id: "helm", name: "Helm chart", category: "kubernetes-operators", platforms: "[kubernetes]" }) +
+          row({ id: "npm", name: "npm package", category: "registries-releases", platforms: "[windows, linux]" }) +
+          row({ id: "brew", name: "Homebrew tap", category: "package-managers", platforms: "[macos, linux]" }),
+      ),
+    );
+    expect(showcase.platforms).toEqual(["linux", "macos", "windows", "kubernetes"]);
+  });
+
+  test("counts platforms of live channels only", () => {
+    const showcase = buildShowcase(
+      channelsYaml(
+        row({ id: "docker-ghcr", name: "Docker image" }) +
+          row({
+            id: "azure",
+            name: "Azure Marketplace",
+            status: "pending",
+            category: "cloud-marketplaces",
+            platforms: "[cloud]",
+          }),
+      ),
+    );
+    expect(showcase.platforms).toEqual(["container"]);
+  });
+
+  test("throws when the top-level channels list is missing", () => {
+    expect(() => buildShowcase("channels: {}\n")).toThrow(/top-level 'channels' list is missing/);
+  });
+
+  test("throws on a platform outside the canonical list", () => {
+    expect(() =>
+      buildShowcase(channelsYaml(row({ id: "docker-ghcr", name: "Docker image", platforms: "[toaster]" }))),
+    ).toThrow(/platforms entries must be one of/);
+  });
+
+  test("SHOWCASE_PLATFORMS is the canonical order documented in channels.yaml", () => {
+    expect(SHOWCASE_PLATFORMS).toEqual(["linux", "macos", "windows", "container", "kubernetes", "cloud"]);
+  });
+});
+
+describe("renderModule", () => {
+  const rendered = renderModule(
+    buildShowcase(channelsYaml(row({ id: "docker-ghcr", name: "Docker image", shortName: "Docker image (GHCR)" }))),
+  );
+
+  test("carries the do-not-edit banner naming the regenerating command", () => {
+    expect(rendered.startsWith("// GENERATED FILE - do not edit. Run: bun run channels:showcase\n")).toBe(true);
+  });
+
+  test("emits the channel and platform constants", () => {
+    expect(rendered).toContain(`{ id: "docker-ghcr", label: "Docker image (GHCR)", group: "containers" },`);
+    expect(rendered).toContain(`export const LIVE_PLATFORMS: readonly ShowcasePlatform[] = ["container"];`);
+  });
+
+  test("ends with exactly one trailing newline", () => {
+    expect(rendered.endsWith("];\n")).toBe(true);
+    expect(rendered.endsWith("];\n\n")).toBe(false);
+  });
+});
+
+describe("CLI (subprocess against temp fixtures)", () => {
+  const fixtureRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeFixture(rows: string): string {
+    const root = mkdtempSync(join(tmpdir(), "channel-showcase-"));
+    fixtureRoots.push(root);
+    mkdirSync(join(root, "distribution"), { recursive: true });
+    mkdirSync(join(root, "src/lib/distribution"), { recursive: true });
+    writeFileSync(join(root, "distribution/channels.yaml"), channelsYaml(rows));
+    return root;
+  }
+
+  function run(root: string, args: string[] = []) {
+    return Bun.spawnSync(["node", SCRIPT, "--root", root, ...args], { stdout: "pipe", stderr: "pipe" });
+  }
+
+  test("writes the generated module and reports what it wrote", () => {
+    const root = makeFixture(row({ id: "docker-ghcr", name: "Docker image" }));
+    const result = run(root);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain(GENERATED);
+    expect(readFileSync(join(root, GENERATED), "utf8")).toContain(`id: "docker-ghcr"`);
+  });
+
+  test("--check passes when the committed file is current", () => {
+    const root = makeFixture(row({ id: "docker-ghcr", name: "Docker image" }));
+    expect(run(root).exitCode).toBe(0);
+    const result = run(root, ["--check"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toContain("up to date");
+  });
+
+  test("--check exits 1 on drift and names the command that fixes it", () => {
+    const root = makeFixture(row({ id: "docker-ghcr", name: "Docker image" }));
+    expect(run(root).exitCode).toBe(0);
+    writeFileSync(join(root, "distribution/channels.yaml"), channelsYaml(row({ id: "helm", name: "Helm chart" })));
+    const result = run(root, ["--check"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("bun run channels:showcase");
+  });
+
+  test("--check exits 1 when the generated file does not exist yet", () => {
+    const root = makeFixture(row({ id: "docker-ghcr", name: "Docker image" }));
+    const result = run(root, ["--check"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("bun run channels:showcase");
+  });
+
+  test("--root without a directory is a usage error", () => {
+    const result = Bun.spawnSync(["node", SCRIPT, "--root"], { stdout: "pipe", stderr: "pipe" });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toContain("--root requires a directory path");
+  });
+
+  test("an unknown category fails the run loudly", () => {
+    const root = makeFixture(row({ id: "extension", name: "Browser extension", category: "browser-extensions" }));
+    const result = run(root);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("unknown category 'browser-extensions'");
+  });
+});
+
+describe("committed artefact", () => {
+  test("src/lib/distribution/channels.generated.ts matches a fresh generation", () => {
+    const yamlText = readFileSync(join(REPO_ROOT, "distribution/channels.yaml"), "utf8");
+    expect(readFileSync(join(REPO_ROOT, GENERATED), "utf8")).toBe(renderModule(buildShowcase(yamlText)));
+  });
+
+  test("exports the live inventory the login hero renders", () => {
+    expect(LIVE_CHANNELS.length).toBeGreaterThan(0);
+    expect(LIVE_PLATFORMS.length).toBeGreaterThan(0);
+    // Every rendered group must be one the hero has a row for.
+    for (const channel of LIVE_CHANNELS) {
+      expect(["containers", "kubernetes", "paas", "packages"]).toContain(channel.group);
+    }
+    for (const platform of LIVE_PLATFORMS) {
+      expect(SHOWCASE_PLATFORMS).toContain(platform);
+    }
+  });
+});

--- a/tests/unit/generate-channel-showcase.test.ts
+++ b/tests/unit/generate-channel-showcase.test.ts
@@ -224,6 +224,18 @@ describe("CLI (subprocess against temp fixtures)", () => {
     expect(result.stderr.toString()).toContain("bun run channels:showcase");
   });
 
+  test("a read failure that is not ENOENT surfaces instead of reading as stale", () => {
+    // Only "the file is not there yet" may be swallowed. A directory sitting where the
+    // generated module belongs is a broken checkout, and reporting it as drift would send
+    // the reader off to run the generator - which would fail the same way, with no clue.
+    const root = makeFixture(row({ id: "docker-ghcr", name: "Docker image" }));
+    mkdirSync(join(root, GENERATED), { recursive: true });
+    const result = run(root, ["--check"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("EISDIR");
+    expect(result.stderr.toString()).not.toContain("bun run channels:showcase");
+  });
+
   test("--root without a directory is a usage error", () => {
     const result = Bun.spawnSync(["node", SCRIPT, "--root"], { stdout: "pipe", stderr: "pipe" });
     expect(result.exitCode).toBe(2);

--- a/tests/unit/lib/agent/engine-support.test.ts
+++ b/tests/unit/lib/agent/engine-support.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { AGENT_EXECUTION_ENGINES } from "@/lib/agent/engine-support";
+import { PostgresProvider } from "@/lib/db/providers/sql/postgres";
+import { SQLiteProvider } from "@/lib/db/providers/sql/sqlite";
+import { MySQLProvider } from "@/lib/db/providers/sql/mysql";
+import { ClickHouseProvider } from "@/lib/db/providers/sql/clickhouse";
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * The constant is a CLAIM about the providers, not a second source of truth. The factory's
+ * real gate is `typeof provider.queryReadOnly === "function"`
+ * (`src/lib/db/factory.ts`, PROFILE_UNSUPPORTED_BY_PROVIDER), so these tests measure the
+ * prototypes and fail the moment the list and the drivers disagree in either direction.
+ *
+ * The negative cases are the two SQL providers that pull no native driver in at module scope.
+ * Oracle and SQL Server are deliberately absent because they import `oracledb` / `mssql`
+ * there, and MongoDB because `bson` calls `node:v8 isBuildingSnapshot` at import time, which
+ * Bun does not implement. This test file is the only place a provider module is imported for
+ * this constant at all - the constant itself imports nothing but the type union, so it stays
+ * client-safe for the unauthenticated login page.
+ */
+describe("AGENT_EXECUTION_ENGINES", () => {
+  test("names exactly the engines whose provider implements queryReadOnly", () => {
+    expect([...AGENT_EXECUTION_ENGINES]).toEqual(["postgres", "sqlite"]);
+  });
+
+  test("every named engine's provider implements queryReadOnly", () => {
+    const prototypes: Record<string, object> = {
+      postgres: PostgresProvider.prototype,
+      sqlite: SQLiteProvider.prototype,
+    };
+    for (const type of AGENT_EXECUTION_ENGINES) {
+      const prototype = prototypes[type] as { queryReadOnly?: unknown };
+      expect(typeof prototype.queryReadOnly).toBe("function");
+    }
+  });
+
+  test("engines outside the list have no database-native read-only path", () => {
+    const excluded: [DatabaseType, object][] = [
+      ["mysql", MySQLProvider.prototype],
+      ["clickhouse", ClickHouseProvider.prototype],
+    ];
+    for (const [type, prototype] of excluded) {
+      expect(AGENT_EXECUTION_ENGINES).not.toContain(type);
+      expect(typeof (prototype as { queryReadOnly?: unknown }).queryReadOnly).not.toBe("function");
+    }
+  });
+});

--- a/tests/unit/lib/db-ui-config.test.ts
+++ b/tests/unit/lib/db-ui-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { getDBConfig, getDBIcon, getDBColor, isFileBased } from "@/lib/db-ui-config";
+import { SHOWCASE_DATABASE_ORDER, SHOWCASE_RANK, listShowcaseDatabases } from "@/lib/db-showcase";
 import type { DatabaseType } from "@/lib/types";
 
 const ALL_TYPES: DatabaseType[] = [
@@ -133,6 +134,65 @@ describe("db-ui-config", () => {
       expect(isFileBased("couchbase")).toBe(false);
       expect(isFileBased("clickhouse")).toBe(false);
       expect(isFileBased("druid")).toBe(false);
+    });
+  });
+});
+
+describe("db-showcase", () => {
+  describe("SHOWCASE_RANK", () => {
+    test("assigns every database type a distinct rank covering 0..N-1", () => {
+      // A stable sort silently preserves insertion order when two keys compare equal,
+      // so a duplicated rank would swap two engines without ever failing a type check.
+      // Asserting the ranks are a bijection onto 0..N-1 is what rules that out.
+      const ranks = ALL_TYPES.map((type) => SHOWCASE_RANK[type]);
+      expect([...ranks].sort((a, b) => a - b)).toEqual(ALL_TYPES.map((_, index) => index));
+    });
+  });
+
+  describe("SHOWCASE_DATABASE_ORDER", () => {
+    test("renders every configured engine exactly once", () => {
+      expect([...SHOWCASE_DATABASE_ORDER].sort()).toEqual([...ALL_TYPES].sort());
+    });
+
+    test("includes the embedded libredb provider", () => {
+      // Decided in issue #425 step 2: libredb is a shipped, user-selectable provider
+      // with its own doc and icon, so hiding it on the page that says "Supported
+      // Databases" would contradict the connection picker one click later.
+      expect(SHOWCASE_DATABASE_ORDER).toContain("libredb");
+    });
+
+    test("orders the engines by recognisability, best known first", () => {
+      expect([...SHOWCASE_DATABASE_ORDER]).toEqual([
+        "postgres",
+        "mysql",
+        "sqlite",
+        "mongodb",
+        "redis",
+        "oracle",
+        "mssql",
+        "couchbase",
+        "clickhouse",
+        "druid",
+        "libredb",
+      ]);
+    });
+  });
+
+  describe("listShowcaseDatabases", () => {
+    test("carries the label, icon and colour straight from DB_UI_CONFIG", () => {
+      const entries = listShowcaseDatabases();
+      expect(entries.map((entry) => entry.type)).toEqual([...SHOWCASE_DATABASE_ORDER]);
+      for (const entry of entries) {
+        const config = getDBConfig(entry.type);
+        expect(entry.label).toBe(config.label);
+        expect(entry.icon).toBe(config.icon);
+        expect(entry.color).toBe(config.color);
+      }
+    });
+
+    test("returns a fresh array each call, so a caller cannot mutate the shared order", () => {
+      expect(listShowcaseDatabases()).not.toBe(listShowcaseDatabases());
+      expect(listShowcaseDatabases()).toEqual(listShowcaseDatabases());
     });
   });
 });

--- a/tests/unit/lib/social-icons.test.tsx
+++ b/tests/unit/lib/social-icons.test.tsx
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  GitHubIcon,
+  LinkedInIcon,
+  XIcon,
+  YouTubeIcon,
+  InstagramIcon,
+  RedditIcon,
+  DockerIcon,
+} from "@/components/icons/social-icons";
+
+describe("social-icons", () => {
+  const icons = [
+    { name: "GitHubIcon", Component: GitHubIcon },
+    { name: "LinkedInIcon", Component: LinkedInIcon },
+    { name: "XIcon", Component: XIcon },
+    { name: "YouTubeIcon", Component: YouTubeIcon },
+    { name: "InstagramIcon", Component: InstagramIcon },
+    { name: "RedditIcon", Component: RedditIcon },
+    { name: "DockerIcon", Component: DockerIcon },
+  ];
+
+  for (const { name, Component } of icons) {
+    test(`${name} renders an SVG element`, () => {
+      const html = renderToStaticMarkup(React.createElement(Component, { className: "w-4 h-4" }));
+      expect(html).toContain("<svg");
+      expect(html).toContain("w-4 h-4");
+    });
+
+    test(`${name} passes extra props`, () => {
+      const html = renderToStaticMarkup(
+        React.createElement(Component, { "data-testid": `icon-${name}` } as React.SVGAttributes<SVGSVGElement>),
+      );
+      expect(html).toContain(`data-testid="icon-${name}"`);
+    });
+
+    test(`${name} inherits its colour and takes its size from the class alone`, () => {
+      // The same component is rendered twice on the login page: once inside the hero's
+      // pinned-dark subtree and once in the mobile block that follows the theme. A baked
+      // brand colour would be illegible in one of the two, so every mark is currentColor.
+      // Hard width/height attributes would likewise beat the caller's size classes.
+      const html = renderToStaticMarkup(React.createElement(Component, { className: "w-4 h-4" }));
+      expect(html).toContain("currentColor");
+      expect(html).toContain('viewBox="0 0 24 24"');
+      // Only the root tag is checked: inner rects legitimately carry width/height in the
+      // 24-unit user space, which the viewBox scales. It is a width on <svg> itself that
+      // would freeze the rendered size and beat the caller's classes.
+      const rootTag = html.slice(0, html.indexOf(">") + 1);
+      expect(rootTag).not.toMatch(/\swidth="/);
+      expect(rootTag).not.toMatch(/\sheight="/);
+    });
+  }
+});

--- a/tests/unit/lib/social-links.test.ts
+++ b/tests/unit/lib/social-links.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { SOCIAL_LINKS } from "@/lib/social-links";
+
+describe("social-links", () => {
+  test("lists the eight maintainer-confirmed destinations in row order", () => {
+    expect(SOCIAL_LINKS.map((link) => link.id)).toEqual([
+      "github",
+      "linkedin",
+      "x",
+      "youtube",
+      "instagram",
+      "reddit",
+      "dockerhub",
+      "sponsor",
+    ]);
+  });
+
+  test("every id is unique", () => {
+    const ids = SOCIAL_LINKS.map((link) => link.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("every href is unique", () => {
+    // A duplicated href means one row silently points somewhere it was not meant to;
+    // the icons differ, so nothing else in the UI would reveal it.
+    const hrefs = SOCIAL_LINKS.map((link) => link.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+
+  test("every href is an absolute https URL", () => {
+    for (const link of SOCIAL_LINKS) {
+      // A relative href resolves against whatever host the app is deployed on, and a
+      // plain-http one downgrades the front door. Both are silent in a unit render.
+      const url = new URL(link.href);
+      expect(url.protocol).toBe("https:");
+      expect(link.href.startsWith("https://")).toBe(true);
+    }
+  });
+
+  test("every label is a non-empty string", () => {
+    // The label is the only accessible name an icon-only link has.
+    for (const link of SOCIAL_LINKS) {
+      expect(link.label.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every entry carries a renderable icon", () => {
+    // Both component shapes count: the hand-drawn marks are plain functions, while
+    // lucide's Heart (reused for Sponsor) is a forwardRef object.
+    for (const link of SOCIAL_LINKS) {
+      expect(["function", "object"]).toContain(typeof link.icon);
+      expect(link.icon).toBeTruthy();
+    }
+  });
+
+  test("points at the libredb org on every platform except GitHub Sponsors", () => {
+    // The handle is "libredb" everywhere. GitHub Sponsors is the one exception: it is
+    // tied to the maintainer account, not to the organisation.
+    for (const link of SOCIAL_LINKS) {
+      if (link.id === "sponsor") {
+        expect(link.href).toBe("https://github.com/sponsors/cevheri");
+        continue;
+      }
+      expect(link.href.toLowerCase()).toContain("libredb");
+    }
+  });
+});


### PR DESCRIPTION
Closes #425.

## What was wrong

The login page is the first — often the only — screen an evaluator sees before they have credentials, and every claim on it had gone stale:

| Claim | Reality |
|---|---|
| "7+ Database Engines", five hand-typed names | `DatabaseType` has **11** members; six were invisible |
| "deploy anywhere with Docker in seconds" | `channels.yaml` lists **24 live** channels; Docker is one |
| No mention of the database agent | Two-mode agent shipped across #325 / #396 / #411 / #414 |
| No social presence | The project exists as `libredb` on seven platforms |

## What it does now

Everything the hero states is derived, so it cannot drift again:

- **`scripts/generate-channel-showcase.mjs`** turns `distribution/channels.yaml` into a committed `src/lib/distribution/channels.generated.ts`. Only `status: live` reaches the UI, an unknown `category` **throws** rather than defaulting, and a new `channels:showcase:check` gate fails CI on drift. Promoting a channel publishes it with no component edit — Rancher Partner Charts arrives that way today.
- **Engines** come from `DB_UI_CONFIG` via `listShowcaseDatabases()`, ordered by a `Record<DatabaseType, number>` that fails `typecheck` when a provider has no rank.
- **Agent copy** is derived from `AGENT_EXECUTION_ENGINES`. The test pins the *claim*, not the wording: plan mode executes nothing on any engine; agent mode auto-runs read-only and only where a provider implements `queryReadOnly`. A future copy edit is free to rewrite the sentence and not free to overclaim.
- **Social links** come from one `SOCIAL_LINKS` module with hand-drawn monochrome SVGs (no new dependency), rendered on both surfaces from the same array.

No engine name, channel name or count is a literal in any component. Counts are `.length` on derived arrays — "7+" was accurate the day it was written, which is the whole lesson.

## The redesign

The first cut was factually correct and unreadable. Measured at 1440x900:

| | before | after |
|---|---|---|
| Page height | **1294px** (394px past the viewport) | **900px**, no scroll |
| Sign-in card top | y=379, below the fold | y=182 |
| Text blocks in the hero | 19 | 14, in three weight tiers |

The panel now runs **thesis → evidence → proof**: a headline, one line that reads as a real connection string and slowly cycles the schemes `parseConnectionString` accepts, a quiet engine row, and three derived numbers. Four feature cards, the eleven-pill wall, the twenty-four printed channel names and the six-card community block are gone; `docs/CHANNELS.md` remains where the full inventory lives.

**SQLite, Druid and LibreDB never appear in the cycling line.** They have no URI scheme — SQLite is a file, LibreDB is embedded, Druid is plain HTTP — and inventing one would be precisely the class of false claim this PR exists to remove. A test round-trips every scheme through the parser to keep it that way.

## Verification

`format` · `lint` · `typecheck` · `knip` · `test:ci` · `build` all pass, merged lcov at **100.00% (37126/37126)**, and `e2e/login.spec.ts` is **13/13**.

> Note for anyone re-running the e2e suite locally: pass `E2E_PORT`. Playwright's `reuseExistingServer` will silently bind to whatever already holds port 3000 and test *that* app — it cost an hour of chasing nine phantom failures here.

## Deliberately not in this PR

`operatorhub-community` in `channels.yaml` holds one status for two catalogs. The OpenShift console catalog has been live since 2026-07-28 (`community-operators-prod#10497` + `#10581` merged) while OperatorHub.io `#8794` is still open, and the row's own rule is "pending until both are listed" — so OpenShift is installable today and invisible to this page. Splitting that row is a maintainer decision, not a drive-by fix, and the generated design means OpenShift appears with no component edit on the commit that flips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
