### PR TITLE
fix(redis): give Redis its own command generator, so the schema explorer emits Redis (#427)

### DIFF
--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -184,6 +184,13 @@ export interface QueryTab {
 
 For most SQL databases, the existing `'sql'` type is sufficient. You only need a new tab type if your database uses a fundamentally different query language.
 
+A new tab type needs three things wired, all in `src/lib/editor/tab-language.ts` and its neighbours:
+declare `queryDialect` on the provider, add the arm to `resolveTabType()` **above** the
+`queryLanguage === 'json'` rung, and map the type to a Monaco language in
+`editorLanguageForTabType()` — registering that language module in `QueryEditor`'s
+`handleBeforeMount` alongside `registerLibreDBLanguage` / `registerRedisLanguage`. Skipping the
+dialect leaves the tab typed `mongodb` and the arm unreachable, which is exactly what #427 fixed.
+
 ## Step 2: Create the Provider Class
 
 Create the file under the right family folder, named by the canonical **type-id** —
@@ -543,38 +550,46 @@ Every field and what it controls:
 | Field | Type | Controls |
 |-------|------|----------|
 | `queryLanguage` | `'sql' \| 'json'` | Monaco editor language mode, AI prompt style, query template format |
-| `queryDialect` | `'libredb' \| undefined` | Optional. Opts a provider's tables into a custom client-side query generator (see `query-generators.ts`); left undefined by SQL/Mongo/Redis |
+| `queryDialect` | `'libredb' \| 'redis' \| undefined` | Optional. Opts a provider's tables into a custom client-side query generator (see `query-generators.ts`) and picks the editor tab type and Monaco language. Checked **before** `queryLanguage` everywhere — `queryLanguage: 'json'` alone means MongoDB, which is how Redis silently got MongoDB documents until #427. Left undefined by SQL and MongoDB |
 | `supportsExplain` | `boolean` | EXPLAIN button visibility in QueryEditor toolbar |
 | `explainFormat` | `ExplainFormat \| undefined` | **Required whenever `supportsExplain` is true.** Selects the strategy in `src/lib/explain/index.ts`. Setting the flag without the format leaves the control visible and dead — the UI resets out of explain mode when metadata lacks it |
 | `supportsExternalQueryLimiting` | `boolean` | Whether route applies LIMIT to queries (SQL) or provider handles it (MongoDB) |
 | `supportsCreateTable` | `boolean` | "Create Table" button in SchemaExplorer |
 | `supportsInlineRowEdit` | `boolean?` | Whether the results grid offers inline row editing. `false` hides the EDIT toggle and every editable cell — set it where the engine has no `UPDATE <table> SET <col> = <val> WHERE <pk> = <val>` statement, which is what `use-inline-editing.ts` builds. Optional only because the interface is published and a required addition breaks external implementers; every provider here declares it, and an absent flag reads as unsupported |
+| `declaresForeignKeys` | `boolean?` | Whether this engine has foreign keys in its model at all. `false` says an empty `TableSchema.foreignKeys` means "no such constraint exists here", not "this schema declares none" — set it on every engine without referential constraints. Optional for the published-interface reason above; consumers gate on `=== false`, so an absent flag reads as "may declare them" |
+| `tablesAreDerivedGroupings` | `boolean?` | Whether `getSchema()`'s rows are objects the engine holds, or groupings this server derived from a bounded scan. `true` on Redis and LibreDB only. Where it is true the schema explorer hides every menu item that *addresses* the row — `Profile Table`, `Generate Test Data`, and both per-row maintenance items, all of which name the row to a route that needs a real object — and keeps the ones that merely name it (`Select`, `Generate`, `Copy Name`, `Generate Code`). The agent layer states it to a plan run in one sentence. Consumers gate on `=== true`, so an absent flag reads as "ordinary objects" |
 | `supportsMaintenance` | `boolean` | Whether maintenance API accepts requests for this provider |
-| `maintenanceOperations` | `MaintenanceType[]` | Which operation cards show in MaintenanceModal (vacuum, analyze, reindex, etc.) |
+| `maintenanceOperations` | `MaintenanceType[]` | Which global cards and per-table buttons the admin Operations tab renders. `/api/db/maintenance` rejects anything not in this list, so a surface that ignored it could only offer a control answering HTTP 400. The schema explorer's row menu does **not** read it — its per-row maintenance items are gated on `isAdmin` and on `tablesAreDerivedGroupings`; see `docs/BACKLOG.md` U9 for the mismatches that leaves |
 | `supportsConnectionString` | `boolean` | Used for future connection validation logic |
 | `defaultPort` | `number \| null` | Informational; actual UI port comes from `db-ui-config.ts` |
 | `schemaRefreshPattern` | `string` | Regex to detect write/DDL queries that should trigger schema reload |
 
 ### ProviderLabels
 
-Every field and where it appears:
+Every field and where it appears. There is **no `MaintenanceModal` component** — earlier revisions of
+this table named one for ten of these rows; `git grep MaintenanceModal src/` finds only a ClickHouse
+comment. Two surfaces read labels today, plus the agent's prompt layer:
 
 | Field | Where it appears |
 |-------|-----------------|
-| `entityName` | "Create {Table}" button title, "{Table} name copied", "{Table} Optimizer" |
-| `entityNamePlural` | "{Tables} found" count in MaintenanceModal |
-| `rowName` / `rowNamePlural` | "{rows}" count in MaintenanceModal table list |
-| `selectAction` | SchemaExplorer dropdown: "Select Top 100" / "Find Documents" |
-| `generateAction` | SchemaExplorer dropdown: "Generate Query" / "Generate Find" |
-| `analyzeAction` | SchemaExplorer dropdown + MaintenanceModal button title |
-| `vacuumAction` | SchemaExplorer dropdown + MaintenanceModal button title |
-| `searchPlaceholder` | SchemaExplorer search input placeholder text |
-| `analyzeGlobalLabel` | MaintenanceModal "Run Analyze" button text |
-| `analyzeGlobalTitle` | MaintenanceModal card title ("Update Statistics") |
-| `analyzeGlobalDesc` | MaintenanceModal card description paragraph |
-| `vacuumGlobalLabel` | MaintenanceModal "Run Vacuum" button text |
-| `vacuumGlobalTitle` | MaintenanceModal card title ("Reclaim Space") |
-| `vacuumGlobalDesc` | MaintenanceModal card description paragraph |
+| `entityName` | `SchemaExplorer` "Create {Table}" button title; `TableItem` "{Table} name copied" toast; lowercased by `inventoryNoun()` into the agent's prompt noun |
+| `entityNamePlural` | Lowercased by `inventoryNoun()` (`src/lib/agent/inventory-noun.ts`) into the agent's prompt noun. No UI surface reads it |
+| `rowName` / `rowNamePlural` | **Nothing reads these.** Declared, defaulted in `base-provider.ts`, set by several providers, consumed nowhere in `src/` |
+| `selectAction` | `TableItem` row menu, first item ("Select Top 50" / "Find Documents" / "Scan Keys") |
+| `generateAction` | `TableItem` row menu, second item ("Generate Query" / "Generate Find") |
+| `analyzeAction` | `TableItem` row menu only, and only where the rows are not derived groupings. The Operations tab's per-table Analyze button title is still the hardcoded "Analyze" (`docs/BACKLOG.md` U6) |
+| `vacuumAction` | `TableItem` row menu only, under the same derived-groupings gate as `analyzeAction`. The Operations tab's per-table button is gated on the literal `vacuum` and titled "Vacuum", so the four providers that point this label at `optimize`/`reindex` show a row item whose wording the tab does not repeat (`docs/BACKLOG.md` U9) |
+| `searchPlaceholder` | `SchemaExplorer` search input placeholder text |
+| `analyzeGlobalLabel` | Admin Operations tab, analyze card's button text ("Run Analyze") |
+| `analyzeGlobalTitle` | Admin Operations tab, analyze card title ("Update Statistics") |
+| `analyzeGlobalDesc` | Admin Operations tab, analyze card description paragraph |
+| `vacuumGlobalLabel` | Admin Operations tab, vacuum card's button text ("Run Vacuum") |
+| `vacuumGlobalTitle` | Admin Operations tab, vacuum card title ("Reclaim Space") |
+| `vacuumGlobalDesc` | Admin Operations tab, vacuum card description paragraph |
+
+The `*Global*` triads reach only the card, never the per-table button, and only where the card
+renders: the analyze card is gated on `analyze`, the vacuum card on the **literal** `vacuum`. There
+is no `reindexGlobal*` triad; that card is still hardcoded (`docs/BACKLOG.md` U6).
 
 ### PreparedQuery
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -256,7 +256,8 @@ src/
     │   └── types.ts         # Database types
     ├── agent/               # Agent runtime: run ledger, workflow, tools, policy (docs/AGENT.md)
     ├── llm/                 # LLM provider module
-    ├── editor/              # Monaco completions (SQL + MongoDB)
+    ├── editor/              # Monaco completions (SQL + MongoDB), the tab-type/language ladder,
+    │                       # and the LibreDB + Redis command languages
     ├── schema-diff/         # Diff engine + migration SQL generator
     ├── export/              # The writers behind every "save this to disk": RFC 4180 CSV,
     │                        #   the SQL INSERT/DDL forms, and the one blob-download path

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -400,6 +400,119 @@ recorded here with the number that justified it.
 
 ---
 
+### U4. The profile modal's error state cannot be dismissed
+
+`DataProfiler` renders the message `/api/db/profile` returned and offers no way out: Escape does not
+close it, and the header's close control is under the error card. #427 measured this on Redis, where
+the route answered 400 for every key-prefix row, but the fault is not Redis's — any provider whose
+profile request fails traps the user in the same modal. #427 hid the menu item on providers whose
+rows are derived groupings, which removes the reachable path without fixing the modal.
+
+Done when a failed profile is dismissable by Escape and by the modal's own close control, for every
+provider that can fail it.
+
+### U5. The Operations tab shows `Tables (0)` for a key-value provider and preselects nothing
+
+Two separate gaps meet on the same screen. `OperationsTab` calls `useMonitoringData` with
+`includeTables: true` for every connection, so a provider that has no addressable tables renders an
+empty panel rather than none. And the Explorer's deep link — `onOpenMaintenance("tables", table.name)`
+— carries the row's name, but `openMaintenance` in `Studio.tsx` drops the second argument on the way
+to `/admin/operations`, so the tab opens with nothing selected however the user got there.
+
+Done when a provider whose rows are derived groupings renders no Tables panel, and a deep link from a
+row arrives with that row selected.
+
+### U6. The Reindex card has no per-provider wording, so it still speaks Postgres
+
+`ProviderLabels` carries an `analyzeGlobal*` and a `vacuumGlobal*` triad and no `reindexGlobal` one.
+#427 made the Operations tab render the first two, but the reindex card is left hardcoded to
+*"Run Reindex"* / *"Rebuild Indexes"* / *"Reconstructs all indexes in the database."* Three
+providers declare `reindex` — Postgres, SQLite and Couchbase — and for Couchbase, whose reindex is a
+GSI rebuild rather than a table reindex, that copy is wrong in the same way the analyze copy was
+wrong for Redis. Adding the triad was deliberately out of scope for #427: it means touching
+`ProviderLabels` and every provider that implements it, which is a wider change than the Redis fix.
+
+The same card gap has a smaller twin on the same screen: the per-table Analyze and Vacuum buttons are
+titled with the hardcoded `"Analyze"` and `"Vacuum"`, so MongoDB's *"Validate Collection"*,
+ClickHouse's *"Table Statistics"* and Oracle's *"Rebuild Indexes"* never reach them (#427). Wiring
+those two is entangled with U9 below and should be done with it, not before it.
+
+Done when `reindexGlobalLabel` / `reindexGlobalTitle` / `reindexGlobalDesc` exist, the three
+declaring providers set them, the card renders them with the current strings as the fallback, and the
+per-table buttons carry `analyzeAction` / `vacuumAction`.
+
+### U7. `StudioWorkspace` hands the toolbar a noop Save while the Save button renders unconditionally
+
+`QueryToolbar` renders its Save Query control whenever it is given an `onSaveQuery`, and
+`StudioWorkspace` passes `() => {}`. In the embedded surface the button is therefore always present
+and always dead — the same dead-control class #427 closed for the Redis row menu, but pre-existing
+and unrelated to that issue, which is why it was recorded rather than fixed there. The standalone
+`Studio` surface passes a real handler, so this is visible only in the npm-package render path.
+
+Done when the embedded surface either supplies a working save or does not render the control — and
+the decision is stated where the prop is passed, since "the host will wire it later" is a real option
+for a published library surface.
+
+### U8. The LibreDB Monaco language module's tokenizer is never exercised
+
+`registerLibreDBLanguage` (`src/lib/editor/libredb-language.ts`) hands Monaco a Monarch `tokenizer`
+whose rules are the whole point of the module, and `tests/unit/editor/libredb-language.test.ts`
+asserts only that a provider object with a non-empty `root` was passed. Nothing checks what the rules
+match, so a regex covering the wrong span, a shadowing rule order, or a word landing in both the
+keyword and modifier lists would pass every gate and be visible only in a browser. 100% line coverage
+does not help here: the rules are data, and loading the module covers them.
+
+The Redis half of this is **done** — `tests/unit/editor/redis-language.test.ts` now asserts the rule
+regexes directly (#427): what the `^\s*#` comment rule matches and does not, that a SCAN cursor
+tokenizes as a number, that `user:*` is ONE identifier token, that a quoted value keeps a `#` inside
+it, and that no two root rules can open on the same character — the property that makes the rule
+order safe. It needs no Monaco runtime, so the same shape applies to LibreDB.
+
+Done when the LibreDB module is checked the same way, or both are driven through Monaco's own Monarch
+runtime end to end.
+
+### U9. Four providers point `vacuumAction` at an operation that is not `vacuum`, and one shows a row item for an operation it does not have
+
+Two mismatches, measured while fixing #427 and deliberately left alone.
+
+(a) **MySQL shows the base default it never meant.** The schema explorer's per-row maintenance items
+are gated on `isAdmin` alone, so MySQL renders *"Vacuum Table"* — `BaseDatabaseProvider`'s default
+wording — although its `maintenanceOperations` is `['analyze', 'optimize', 'check', 'kill']` and
+contains no `vacuum`. The item names an operation MySQL does not have; following it reaches an
+Operations tab that renders no vacuum card either.
+
+(b) **ClickHouse, SQL Server, Oracle and Couchbase map the LABEL onto another operation.** Their
+`vacuumAction` reads *"Optimize Table"*, *"Rebuild Indexes"*, *"Rebuild Indexes"* and *"Compact"*,
+standing for the `optimize` / `optimize` / `optimize` / `reindex` each declares. So a label-driven
+gate is not enough on its own, and a *generic* label-to-operation mapping is actively wrong: #427
+built one, wired it into the Operations tab's per-table button, and thereby handed Oracle a per-table
+*"Rebuild Indexes"* control that sent `optimize` with a TABLE name — while `oracle.ts` builds
+`ALTER INDEX "<target>" REBUILD` from that target, so every click answered **ORA-01418: specified
+index does not exist**. A control that always fails is worse than the dead end it replaced, and the
+whole chain was reverted before merge.
+
+The conclusion the revert paid for: any future mapping must be **per provider**, declared by the
+provider next to the operation it names — because the target grammar differs even among providers
+that declare the same `MaintenanceType`. Oracle's `optimize` wants an index name; ClickHouse's wants
+a table; Couchbase's `reindex` wants a keyspace.
+
+Done when each provider declares which operation its `vacuumAction` (and `analyzeAction`) stands for
+*and* what kind of target that operation takes, both surfaces gate and title from that declaration,
+and a live run against Oracle proves the per-table control succeeds rather than returning ORA-01418.
+
+### U10. The Monarch rules for the Redis and LibreDB command languages carry no cross-line string state
+
+`redis-language.ts` and `libredb-language.ts` give Monaco a `root` state whose comment rule is
+`^\s*#`, with no separate string state carried between lines. The providers, however, treat a newline
+inside an open quoted argument as data (`SET note "line1` / `#tag"` stores a two-line value — see
+`docs/providers/redis.md` §3.4a). So the editor paints the continuation line as a comment while the
+provider stores it as part of the value: the highlighting and the execution disagree about the same
+buffer. Low severity — it misleads, it does not corrupt — and the tokenizer has no idea what the
+provider will do until the buffer runs.
+
+Done when an open quoted argument keeps its string state across the line break in both Monarch
+tokenizers, with a test asserting a `#`-leading continuation line is not tokenized as a comment.
+
 ## Authentication and security headers
 
 ### A1. Three copies of the 401 response, with two different shapes
@@ -2446,3 +2559,21 @@ and the three share one declared shape, so a new one states its condition, its s
 in the same place rather than inventing them again. Whether
 the rail SHOWS the entry is a separate question and probably a no: the notices exist to be invisible
 to a user, and the timeline is not the same surface as the ledger.
+
+### U11. The LibreDB "Scan Keys" generator interpolates a newline-bearing key name raw
+
+`generateSelectQuery`'s LibreDB branch refuses to emit a command line for a node whose name contains a
+newline (#427), because a line-oriented grammar cannot address it and a generated line would otherwise
+carry attacker-chosen text into the tab. `generateTableQuery` — the "Scan Keys" action, which
+`handleTableClick` AUTO-EXECUTES — was left as it was: for a key literally named
+`x\ndelete billing:2024` it returns `get x\ndelete billing:2024`. Only `get x` runs, because
+`firstCommandLine()` takes the first line, so nothing destructive executes and nothing is deleted; but
+line 2 sits in the editor as a plausible, runnable `delete billing:2024`, one Run Selected away.
+
+Redis's equivalent path is closed: an argument the plain tokenizer cannot round-trip switches that line
+to the lossless JSON command form, which has no line-oriented escape at all. LibreDB has no such form,
+so closing this needs either a quoting rule in its grammar or the same "emit a note, emit no command"
+answer `generateSelectQuery` already gives.
+
+Done when no generated LibreDB line can carry a second command, and `docs/providers/libredb.md` §5.3
+says so for Scan Keys as well as for the cheatsheet — today it claims the stronger property for both.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -68,7 +68,7 @@
 *   **Precision Row Counts:** Optimized PostgreSQL integration using `pg_class` statistics for fast, accurate (estimated) row counts even on large datasets.
 *   **Visual Table Designer:** Create new tables directly from the explorer with a modern, column-based UI. No SQL knowledge required for basic structures.
 *   **Contextual Actions:** Quick access menus for each table including "Select Top 50", "Generate Query", and "Copy Name". Action labels adapt per provider (e.g. "Scan Keys" for Redis, "Find Documents" for MongoDB).
-*   **DBA Quick Tools:** (Admin Only) Instant access to "Analyze Table" and "Vacuum Table" directly from the table context menu.
+*   **DBA Quick Tools:** (Admin Only) Instant access to "Analyze Table" and "Vacuum Table" directly from the table context menu, on the providers whose rows are real objects. A key-value provider such as Redis, whose rows are derived key-prefix groupings, offers neither -- there is no table for the maintenance page to act on.
 *   **Visual Clarity:** Modern glassmorphic design with Framer Motion animations for smooth transitions.
 *   **Database Stats:** Integrated table counts and connection health monitoring directly in the sidebar.
 

--- a/docs/editor/README.md
+++ b/docs/editor/README.md
@@ -28,6 +28,8 @@ package, which does not ship `public/` — set `NEXT_PUBLIC_MONACO_VS_PATH`.
 | Monaco loader config | `src/lib/editor/monaco-loader.ts` |
 | Asset staging | `scripts/copy-monaco.mjs` |
 | Completion provider | `src/lib/editor/sql-completions.ts` |
+| Tab type / language ladder | `src/lib/editor/tab-language.ts` |
+| Non-SQL command languages | `src/lib/editor/libredb-language.ts`, `src/lib/editor/redis-language.ts` |
 | Alias extraction | `src/lib/sql/alias-extractor.ts` |
 | Query limiting | `src/lib/db/utils/query-limiter.ts` |
 | Visual EXPLAIN | `src/components/VisualExplain.tsx` |

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -353,8 +353,9 @@ internal metadata.
 Right-clicking a node in the schema tree (or its `⋮` menu) offers commands generated for that
 node, so you do not have to type the grammar from memory. The generation is driven by the
 `queryDialect: 'libredb'` capability, which routes the shared client-side query generators
-(`src/lib/query-generators.ts`) to LibreDB output instead of the default MongoDB-JSON used by other
-`queryLanguage: 'json'` providers:
+(`src/lib/query-generators.ts`) to LibreDB output instead of the MongoDB-JSON that
+`queryLanguage: 'json'` otherwise implies. Redis took the same route in #427 with
+`queryDialect: 'redis'`; MongoDB is now the only provider that reaches the JSON branch:
 
 - **Scan Keys** runs `prefix <group>:` for a `:`-prefix group (e.g. `users:*` → `prefix users:`), or
   `get <name>` for a bare single-key node.
@@ -382,6 +383,32 @@ node, so you do not have to type the grammar from memory. The generation is driv
 
 Because the provider skips `#` comment and blank lines (see 5.1), selecting a single line runs just
 that command, and running the whole buffer runs the first real command (the prefix scan).
+
+The node name in the header comment is **JSON-quoted**, not interpolated raw: a key name is
+arbitrary text, and a name containing a newline used to end that comment and turn its own remainder
+into the buffer's first runnable line. For an ordinary name the rendering is unchanged. The Redis
+cheatsheet shares the helper and the defect (see `docs/providers/redis.md` §5.3) — that is where it
+was found (#427).
+
+The command lines themselves interpolate the node name **raw** — LibreDB's grammar has no quoting
+and no lossless JSON command form to fall back to the way Redis's does. Since every LibreDB command
+is line-oriented, a name containing CR or LF cannot be addressed by a generated line at all: a key
+named `x\ndelete billing:2024` would render `delete billing:2024` as a line of its own that
+**Run Selected** would execute. For such a name the cheatsheet emits the header plus a single `#`
+note saying the key must be addressed with a hand-written command, and **no command line** (#427).
+
+That answer covers the cheatsheet only. `Scan Keys` still emits `get <name>` for such a key, so its
+second line lands in the editor as a runnable command; nothing destructive auto-executes, because
+`firstCommandLine()` runs only `get x`. Recorded as U11 in [`docs/BACKLOG.md`](../BACKLOG.md).
+
+Two menu actions are **not offered** on this provider. `Profile Table` and `Generate Test Data`
+address an object and insert rows into it; a `users:*` row is a prefix grouping this server derived
+from one bounded scan (`tablesAreDerivedGroupings`, see 9), not an object any command can be given,
+so both are hidden rather than left to answer HTTP 400 (#427). The per-row `Analyze` and `Vacuum`
+items are hidden for the same reason — they call `onOpenMaintenance("tables", <row>)` and there is no
+such row to name; the row menu reads no maintenance capability of its own. `Generate Code`
+stays: it names the row, it does not address it, and it sanitises the name into an identifier that
+is legal in every target language (`users:*` -> `User`), keeping Unicode letters intact.
 
 ---
 
@@ -458,7 +485,8 @@ This is reflected in `getCapabilities().supportsMaintenance = false` and
 monitoring **Tables** tab renders no per-row control when a provider declares maintenance
 unsupported (issue #272), and the admin **Operations** tab hides its whole Global Operations group
 and its per-table buttons on the same reading (issue #282). Neither offers a control that could only
-answer HTTP 400.
+answer HTTP 400. The schema explorer's own per-row `Analyze`/`Vacuum` items are hidden here too, but
+for a different reason — the rows are derived groupings, see 5.3.
 
 ---
 

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -154,6 +154,52 @@ The query string is dispatched by its first character ([`redis.ts:165`](../../sr
 - Anything else → parsed as a **plain command** with a small quote-aware tokenizer that preserves
   single/double-quoted arguments (so `SET k "hello world"` is two args, not three).
 
+The dispatch happens *after* leading blank lines and `#` comment lines are dropped, so the character
+that decides the format is the first character of the first runnable line, not of the buffer.
+
+### 3.4a Comments and how one command is picked out of a buffer
+
+`commandBody()` reduces the buffer to the one command to run, in two steps:
+
+1. **Every `#` comment line is dropped**, wherever it sits — leading, interleaved or trailing. A
+   line is a comment only when it *starts* with `#` (after trimming) **and no quoted argument is
+   open across it**, so a `#` inside a key or a value is never mistaken for one — including the
+   continuation line of a multi-line quoted value (`SET note "line1` / `#tag"`). The same quote
+   state suspends the blank-line rule: a blank line inside an open quoted argument is data.
+
+   Quote state is tracked **only while the block is a plain command**. The block's kind is fixed by
+   its first content line with the same test §3.4 uses to pick a parser (`{` first), because the
+   tracker's rules are the plain tokenizer's — no escape handling — and a JSON body's `\"` inside a
+   string is not a quote to it. A key named `say"hi` therefore left a phantom quote open, no later
+   comment line was dropped, and the whole-buffer run reached `JSON.parse` with comments in it:
+   *"Invalid JSON command format"* instead of a `TYPE` result. A JSON body needs no tracking anyway
+   — a JSON string carries no literal newline, so no line inside one can begin with `#` (#427).
+2. **The first blank-line-delimited block of what remains is taken**, and its lines are joined back
+   with a **newline**, verbatim. Leading blank lines are padding and are skipped; the first blank
+   line *after* content ends the block.
+
+A block rather than a line, because *outside quotes* the tokenizer treats a newline as ordinary
+whitespace: a single command wrapped over several lines (`HSET k a 1` / `b 2`) has always run whole,
+and `JSON.stringify(cmd, null, 2)` is legitimately multi-line — taking only line 1 would silently
+half-execute both. Not the whole buffer, because the generated cheatsheet (§5.3) is a list of
+alternatives separated by blank lines, and running it must run only its first command.
+
+Joined with a newline and not a space, because the tokenizer's whitespace branch is guarded by
+`!inQuote`: *inside* a quoted argument a newline is data. `SET note "line1` / `line2"` stores a
+two-line value, and a space join silently rewrote it to `line1 line2`. Lines are also appended
+without trimming, so indentation inside a quoted value survives.
+
+The dispatch of §3.4 then looks at the first character of that block, not of the buffer. A JSON
+command is parsed whole, so a trailing **comment** after a JSON body is fine (it was dropped in
+step 1) but trailing **non-comment** text is not — it joins the block and fails `JSON.parse`.
+
+Input that is only comments or blank lines raises
+`QueryError("No command to run (only comments or blank lines)")`.
+
+This mirrors the embedded LibreDB provider, and exists so the commented cheatsheet the schema
+explorer inserts is directly runnable: selecting one command runs it, and running the whole buffer
+runs its first one (#427).
+
 ### 3.5 Reply normalisation into the shared grid
 
 Redis replies are heterogeneous (status strings, integers, nil, flat arrays, hash arrays, bulk
@@ -220,6 +266,10 @@ KEYS user:*
 # JSON command object
 { "command": "HGETALL", "args": ["user:1"] }
 { "command": "SET", "args": ["greeting", "hello world"] }
+
+# Comments: blank lines and lines starting with '#' are skipped (see 3.4a)
+# Read every field of the hash
+HGETALL user:1
 ```
 
 ### 5.2 Result shaping
@@ -239,6 +289,122 @@ KEYS user:*
 `INFO` is special-cased: `parseInfoResult()` splits the bulk reply into one row per metric, tagging
 each with its `# Section` header ([`redis.ts:288`](../../src/lib/db/providers/keyvalue/redis.ts)).
 
+### 5.3 Schema-explorer menu actions
+
+Right-clicking a node in the schema tree (or its `⋮` menu) offers commands generated for that node,
+so you do not have to type them from memory. The generation is driven by the `queryDialect: 'redis'`
+capability, which routes the shared client-side query generators
+([`src/lib/query-generators.ts`](../../src/lib/query-generators.ts)) to Redis command output.
+
+Before #427 Redis declared no dialect, so those generators fell through to their MongoDB branch on
+the strength of `queryLanguage: 'json'` alone and every action emitted a
+`{"collection": "user:*", "operation": "find", …}` document that this provider answered with
+`Command is required in JSON format`. The dialect is checked **before** `queryLanguage` everywhere
+for that reason.
+
+Both generators are **type-aware**: they read the sampled Redis type off the synthetic `type`
+column that `getSchema()` builds (§6). A prefix that sampled a single type resolves; one that
+sampled several (`string, hash`) or none does not, and falls into the unknown bucket.
+
+**Scan Keys** (`generateTableQuery`) inserts one runnable command and executes it immediately:
+
+| Node | Sampled type | Command |
+|------|--------------|---------|
+| prefix group `user:*` | any | `SCAN 0 MATCH user:* COUNT 50` |
+| bare key `counter` | `string` | `GET counter` |
+| bare key `session` | `hash` | `HGETALL session` |
+| bare key `queue` | `list` | `LRANGE queue 0 -1` |
+| bare key `tags` | `set` | `SMEMBERS tags` |
+| bare key `board` | `zset` | `ZRANGE board 0 -1 WITHSCORES` |
+| bare key | unknown or mixed | `TYPE <key>` |
+
+A prefix group always SCANs and is never used as a key argument: it is a derived grouping
+(`tablesAreDerivedGroupings`), so `GET user:*` would read a key literally named `user:*`. `TYPE` is
+the unknown-bucket answer rather than a guessed reader, because a wrong reader (`GET` on a hash)
+returns a `WRONGTYPE` error instead of an answer.
+
+**Generate Command** (`generateSelectQuery`) inserts a cheatsheet instead — a use-case comment above
+each command, where **every command line is runnable on its own** via "Run Selected". For a
+`user:*` group whose keys sampled as `hash`:
+
+```text
+# Redis commands for "user:*" — select a line and Run Selected.
+
+# List keys under this prefix — ONE scan iteration, not the whole set.
+# 0 is the start cursor; the reply's first row is the next cursor. Re-run
+# with that value in place of 0 until it comes back 0 (a page may be empty).
+SCAN 0 MATCH user:* COUNT 50
+
+# Check the key's type
+TYPE user:1
+
+# Read every field of the hash
+HGETALL user:1
+
+# Create or update one field — this overwrites an existing field
+HSET user:1 field example
+
+# Time to live in seconds (-1 no expiry, -2 no such key)
+TTL user:1
+
+# Delete the key (DEL takes a literal key name, never a pattern)
+DEL user:1
+```
+
+Shape rules:
+
+- The `SCAN` block appears only for a prefix group. A bare key starts at `TYPE`.
+- The example key for a prefix group is the prefix plus `1` (`user:` → `user:1`), so every line is
+  concrete rather than a `<placeholder>` — the same rule the LibreDB cheatsheet follows.
+- The read/write pair appears only when the type resolved. An unknown or mixed group gets the
+  `TYPE` / `TTL` / `DEL` frame alone. The pairs are `GET`/`SET`, `HGETALL`/`HSET`,
+  `LRANGE`/`RPUSH`, `SMEMBERS`/`SADD`, `ZRANGE`/`ZADD`.
+- `DEL` is given a literal key, never the group pattern: Redis key arguments are byte strings, so
+  `DEL user:*` deletes a key named `user:*` or nothing at all.
+- Glob metacharacters are escaped in the `MATCH` half of a `SCAN` only (a key `a[b:1` groups to
+  `a[b:*`, whose unescaped `[` would open a character class), never in a key argument, where
+  escaping would corrupt a literal key that genuinely contains `*`.
+- An argument containing whitespace is double-quoted for the tokenizer of §3.4. An argument that the
+  tokenizer cannot round-trip — one containing `"`, `'`, a backslash or a newline — makes **that line
+  alone** switch to the lossless JSON command form (`{"command":"DEL","args":["say\"hi\""]}`). The two
+  forms mix freely inside one cheatsheet: the provider decides per run, and every line is run on its
+  own. Plain `DEL "say"hi""` would reach the driver as the key `sayhi` — a different key.
+- The node name in the **header comment** is JSON-quoted, not interpolated raw. A key name is
+  arbitrary bytes: a name containing a newline used to end the comment and make its own remainder
+  the buffer's first runnable line, so a key called `a⏎DEL user:1 x` produced a cheatsheet whose
+  first command was `DEL user:1`. The per-argument defence above never engaged, because the
+  injection travelled through a comment rather than through a command. The LibreDB cheatsheet header
+  is quoted the same way. For an ordinary name the rendering is unchanged (#427).
+- **`SCAN 0 MATCH <prefix>* COUNT 50` is ONE cursor iteration, not a listing.** `0` is the start
+  cursor and the reply's first row is the next cursor; re-run with that value in place of `0` until
+  it comes back `0`. On a large keyspace an iteration can legitimately return a **non-zero cursor and
+  no keys**, so "Scan Keys" may show a cursor and nothing else while the schema tree reports the
+  prefix has keys — the tree's count comes from `getSchema()`, which loops the cursor over up to
+  1000 keys (§6) rather than stopping at one page. A one-line command cannot loop, so the cheatsheet
+  documents the continuation instead of hiding it.
+
+A Redis tab is typed `redis` and rendered by a dedicated Monaco language
+([`src/lib/editor/redis-language.ts`](../../src/lib/editor/redis-language.ts)) — command verbs as
+keywords, argument words such as `MATCH` / `COUNT` / `WITHSCORES` as functions, `#` line comments.
+Before #427 a Redis tab was typed `mongodb` and highlighted as JSON, which flagged every command as
+a syntax error.
+
+Four menu actions are **not offered** on Redis, all for the same reason: they address the row as an
+object, and a `user:*` row is this server's grouping of a key prefix, not an object any command can
+be given.
+
+- `Profile Table` and `Generate Test Data` profile an object and insert rows into it. Both are
+  hidden wherever `tablesAreDerivedGroupings` is true rather than left to answer HTTP 400 (#427).
+- **Redis offers no per-row maintenance action at all** — neither *"Key Info"* nor *"Memory
+  Doctor"*. Both items call `onOpenMaintenance("tables", <row>)`, which opens the admin Operations
+  tab against a named table; there is no such table here, so the item was a dead end even for the
+  `analyze` this provider does declare (#427). Global maintenance is unaffected and still runs from
+  the Operations page (§8).
+
+`Generate Code` stays — it names the row, it does not address it, and it sanitises the name into an
+identifier that is legal in every target language (`user:*` → `User`), keeping Unicode letters
+intact so a non-ASCII key prefix does not collide with another one.
+
 ---
 
 ## 6. Schema introspection
@@ -253,7 +419,9 @@ each with its `# Section` header ([`redis.ts:288`](../../src/lib/db/providers/ke
      for each key:
         prefix = substring before first ':' + ':*'   (or the whole key)
         increment prefix.count
-        if prefix has < 3 sampled types: TYPE key → add to prefix.types
+        if prefix has < 3 DISTINCT sampled types: TYPE key → add to prefix.types
+           (one blocking round-trip per key until the 3rd distinct type — a
+            uniform prefix pays it for every key the scan cap allows)
    until cursor == "0"  OR  totalScanned >= 1000
 3. emit TableSchema per prefix, sorted by rowCount desc
 ```
@@ -298,8 +466,16 @@ Redis exposes a single maintenance operation:
 | `analyze` | Runs `INFO` and reports the number of lines in the output as a snapshot. Non-destructive. |
 | anything else | Throws `QueryError` (`Unsupported maintenance type for Redis`) |
 
-This is reflected in `getCapabilities().maintenanceOperations = ['analyze']`. The UI relabels these
-actions for Redis via `getLabels()` (e.g. *"Memory Doctor"*, *"Run Info"*).
+This is reflected in `getCapabilities().maintenanceOperations = ['analyze']`. The admin Operations
+tab has gated each card on that list since #282, so it renders the analyze card only and never
+offered Redis a vacuum action; #427 changed the **wording** on that card, not the gate (§9). The
+schema explorer's **per-row** menu offers neither *"Key Info"* nor *"Memory Doctor"*, because a
+per-row action needs an addressable row and these rows are derived groupings (§5.3).
+
+The admin Operations tab also renders this provider's own wording for the analyze card — *"Run
+Info"* / *"Server Info"* / *"Get Redis server information and statistics."* — instead of Postgres's
+query-planner copy. Those `analyzeGlobal*` fields had been declared and set for a long time and read
+by no component (#427).
 
 ---
 
@@ -310,6 +486,7 @@ actions for Redis via `getLabels()` (e.g. *"Memory Doctor"*, *"Run Info"*).
 | Capability | Value |
 |------------|-------|
 | `queryLanguage` | `json` |
+| `queryDialect` | `redis` — routes the client-side query generators to Redis command output and types the editor tab `redis` (see 5.3). Checked before `queryLanguage`, which says only "not SQL" and by itself meant MongoDB (#427) |
 | `supportsExplain` | `false` |
 | `supportsExternalQueryLimiting` | `false` |
 | `supportsCreateTable` | `false` |
@@ -328,8 +505,22 @@ refresh — i.e. commands that add or remove keys.
 ### `getLabels()` ([`redis.ts:70`](../../src/lib/db/providers/keyvalue/redis.ts))
 
 The label map relabels the generic schema-explorer UI for key-value semantics: entity → *"Key
-Pattern"*, row → *"key"*, select → *"Scan Keys"*, analyze → *"Key Info"*, vacuum → *"Memory
-Doctor"*, search placeholder → *"Search keys…"*, etc.
+Pattern"*, row → *"key"*, select → *"Scan Keys"*, generate → *"Generate Command"*, analyze → *"Key
+Info"*, search placeholder → *"Search keys…"*, etc. `analyzeAction` (*"Key Info"*) is declared but
+no longer reaches the schema explorer's per-row menu, which offers no maintenance here at all
+(§5.3); it stays because it is the correct wording the moment a per-row target exists.
+
+The labels rename actions that behave differently here, not generic ones wearing Redis names:
+*"Scan Keys"* really emits `SCAN`, and *"Generate Command"* really emits Redis commands (§5.3).
+That was not true before #427, when both emitted MongoDB documents under these labels.
+
+`analyzeGlobalLabel` / `analyzeGlobalTitle` / `analyzeGlobalDesc` (*"Run Info"*, *"Server Info"*,
+*"Get Redis server information and statistics."*) are rendered by the admin Operations tab. The
+`vacuumAction` / `vacuumGlobal*` fields (*"Memory Doctor"*, *"Memory Analysis"*) are still declared
+but reach no screen: the admin Operations tab's vacuum card and per-table button are gated on
+`maintenanceOperations` containing `vacuum`, which this provider does not list (§8 — that gate is
+#282 and unchanged here), and the schema explorer's row item is hidden because the rows are derived
+groupings (§5.3). They stay so the map is complete if a vacuum-shaped operation is ever added.
 
 ---
 
@@ -442,6 +633,14 @@ request/response contract.
   Redis ACL / user role, not the provider.
 - **Binary values** are stringified via `String(...)`; non-UTF8 binary payloads may not render
   faithfully in the grid.
+- **The plain-command tokenizer has no escape syntax.** Quotes group an argument but cannot be
+  escaped inside one, so a key or value containing a literal `"` or `'` is not expressible in plain
+  form; use the JSON command object for those. The schema-explorer generators detect this and emit
+  the JSON form for the affected line automatically (§5.3), so only hand-typed plain commands are
+  exposed to it.
+- **Non-comment text cannot follow a JSON command.** Comment lines anywhere are dropped, including
+  after a JSON body, but the body itself is parsed whole (§3.4a) — so trailing text that is not a
+  `#` comment joins the block and fails `JSON.parse`.
 - **No column modification in a generated migration.** Since
   [#269](https://github.com/libredb/libredb-studio/issues/269) the schema-diff migration generator
   answers a modified column per dialect; keys are not tables and carry no column definitions, so it

--- a/src/components/CodeGenerator.tsx
+++ b/src/components/CodeGenerator.tsx
@@ -31,6 +31,36 @@ export function toPascalCase(str: string): string {
     .replace(/s$/, ""); // Remove trailing 's' (pluralized table name)
 }
 
+/**
+ * A legal type identifier for every target language. Table names are not always
+ * identifiers: Redis "tables" are key-prefix groupings like `user:*` (#427), so
+ * `export interface User:*` was being emitted for every language. Punctuation
+ * runs become word boundaries, the segments PascalCase, and anything that cannot
+ * start an identifier is replaced rather than prefixed with `_`, because Prisma
+ * model names must begin with a letter and would reject a leading underscore.
+ * One shared rule for all six languages: their union constraint is a letter
+ * followed by letters and digits, so per-language variants would buy nothing.
+ *
+ * The classes are Unicode (`\p{L}` / `\p{N}`), never `A-Za-z0-9`: TypeScript,
+ * Zod, Go, Python and Java all accept Unicode letters in an identifier, so an
+ * ASCII-only strip DESTROYS names that were already legal in five of the six
+ * targets — `musteri` with its Turkish diacritics collapsed to `MTeri`, and a
+ * wholly non-Latin name such as a CJK one lost every character and fell back to
+ * `Record`, which made two different tables generate two files declaring ONE
+ * type (#427).
+ *
+ * Prisma is the exception: a model name is `[A-Za-z][A-Za-z0-9_]*`, so a Unicode
+ * name still yields a model Prisma would reject. Stripping to ASCII would not
+ * rescue it — the surviving stem names the wrong thing, or nothing — and it
+ * would break the other five, so the Unicode classes stand and the Prisma output
+ * for such a name is left where it already was before this function existed.
+ */
+export function toIdentifier(str: string): string {
+  const result = toPascalCase(str.replace(/[^\p{L}\p{N}]+/gu, "_").replace(/^_+|_+$/g, ""));
+  if (!/^\p{L}/u.test(result)) return result ? `T${result}` : "Record";
+  return result;
+}
+
 export function toCamelCase(str: string): string {
   const pascal = toPascalCase(str);
   return pascal.charAt(0).toLowerCase() + pascal.slice(1);
@@ -141,7 +171,7 @@ export function mapSqlTypeToJava(sqlType: string): string {
 }
 
 export function generateCode(lang: Language, table: TableSchema): string {
-  const name = toPascalCase(table.name);
+  const name = toIdentifier(table.name);
   const columns = table.columns || [];
 
   switch (lang) {

--- a/src/components/CodeGenerator.tsx
+++ b/src/components/CodeGenerator.tsx
@@ -56,7 +56,11 @@ export function toPascalCase(str: string): string {
  * for such a name is left where it already was before this function existed.
  */
 export function toIdentifier(str: string): string {
-  const result = toPascalCase(str.replace(/[^\p{L}\p{N}]+/gu, "_").replace(/^_+|_+$/g, ""));
+  // The trim is `^_|_$`, not `^_+|_+$`: the collapse above has already reduced
+  // every run of separators to ONE underscore, so a repeated quantifier here can
+  // never match more — it only adds the backtracking that makes the pattern
+  // super-linear on a long run of separators (SonarCloud S5852).
+  const result = toPascalCase(str.replace(/[^\p{L}\p{N}]+/gu, "_").replace(/^_|_$/g, ""));
   if (!/^\p{L}/u.test(result)) return result ? `T${result}` : "Record";
   return result;
 }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -11,6 +11,7 @@ import { registerSQLCompletionProvider } from "@/lib/editor/sql-completions";
 import type { SchemaCompletionCache, SchemaColumnItem } from "@/lib/editor/sql-completions";
 import { registerMongoDBCompletionProvider } from "@/lib/editor/mongodb-completions";
 import { registerLibreDBLanguage } from "@/lib/editor/libredb-language";
+import { registerRedisLanguage } from "@/lib/editor/redis-language";
 import { configureMonacoLoader } from "@/lib/editor/monaco-loader";
 import { useEffectiveTheme } from "@/hooks/use-effective-theme";
 import { logger } from "@/lib/logger";
@@ -41,7 +42,7 @@ interface QueryEditorProps {
   /** Called when content changes in real-time. Use sparingly as it triggers on every keystroke. */
   onContentChange?: (val: string) => void;
   onExplain?: () => void;
-  language?: "sql" | "json" | "libredb";
+  language?: "sql" | "json" | "libredb" | "redis";
   schemaContext?: string;
   capabilities?: import("@/lib/db/types").ProviderCapabilities;
 }
@@ -393,9 +394,10 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
     }, []);
 
     const handleBeforeMount = (monacoInstance: typeof Monaco) => {
-      // Register the LibreDB command language (idempotent) so its tabs highlight
-      // correctly instead of being treated as JSON.
+      // Register the LibreDB and Redis command languages (both idempotent) so
+      // their tabs highlight correctly instead of being treated as JSON (#427).
       registerLibreDBLanguage(monacoInstance);
+      registerRedisLanguage(monacoInstance);
 
       // Suppress Monaco's "Canceled" errors in console (with cleanup tracking)
       if (!originalConsoleErrorRef.current) {

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -25,6 +25,7 @@ import { AgentRail } from "@/components/agent/AgentRail";
 import { DatabaseConnection, SavedQuery } from "@/lib/types";
 import { ChunkBoundary, ViewLoading } from "@/components/LazyView";
 import { lazyRetry } from "@/lib/lazy";
+import { editorLanguageForTabType, resolveTabType } from "@/lib/editor/tab-language";
 import { buildResultExport, type ResultExportFormat } from "@/lib/export/result-export";
 import { downloadText } from "@/lib/export/download";
 import { newLocalId } from "@/lib/ids";
@@ -147,14 +148,7 @@ export default function Studio() {
       editing.setEditingEnabled(false);
       editing.handleDiscardChanges();
       conn.fetchSchema(conn.activeConnection);
-      const tabType =
-        metadata?.capabilities.queryDialect === "libredb"
-          ? "libredb"
-          : metadata?.capabilities.queryLanguage === "json"
-            ? "mongodb"
-            : conn.activeConnection.type === "redis"
-              ? "redis"
-              : "sql";
+      const tabType = resolveTabType(metadata?.capabilities);
       tabMgr.setTabs((prev) =>
         prev.map((t) => {
           return {
@@ -580,13 +574,7 @@ export default function Studio() {
                                 ? () => queryExec.executeQuery(undefined, undefined, true)
                                 : undefined
                             }
-                            language={
-                              tabMgr.currentTab.type === "libredb"
-                                ? "libredb"
-                                : tabMgr.currentTab.type === "mongodb"
-                                  ? "json"
-                                  : "sql"
-                            }
+                            language={editorLanguageForTabType(tabMgr.currentTab.type)}
                             schemaContext={conn.schemaContext}
                             capabilities={metadata?.capabilities}
                           />

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -75,6 +75,18 @@ export function OperationsTab() {
   const canRun = (type: MaintenanceType) =>
     metadata?.capabilities.supportsMaintenance === true && metadata.capabilities.maintenanceOperations.includes(type);
   const anyMaintenance = canRun("analyze") || canRun("vacuum") || canRun("reindex");
+  // The six analyze/vacuum global ProviderLabels fields were declared, set by
+  // seven providers, and read by no component, so every engine rendered
+  // Postgres's query-planner copy (#427).
+  //
+  // Which card each provider's wording actually reaches follows from the gates
+  // below, not from the labels: the analyze card renders for every provider that
+  // declares `analyze`, so Redis now says "Server Info" and MongoDB "Validate
+  // Collections"; the GLOBAL vacuum card is gated on the literal `vacuum`, which
+  // among the providers that ship vacuum wording only MongoDB declares.
+  //
+  // The `??` fallbacks stay: `metadata` may carry capabilities without labels.
+  const labels = metadata?.labels;
 
   const { connections: allConns } = useAllConnections();
   useEffect(() => {
@@ -259,12 +271,12 @@ export function OperationsTab() {
                     disabled={!!actionLoading || !selectedConnection}
                   >
                     {actionLoading === "analyze-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
-                    Run Analyze
+                    {labels?.analyzeGlobalLabel ?? "Run Analyze"}
                   </Button>
                 </div>
-                <h4 className="text-sm font-bold text-fg mb-1">Update Statistics</h4>
+                <h4 className="text-sm font-bold text-fg mb-1">{labels?.analyzeGlobalTitle ?? "Update Statistics"}</h4>
                 <p className="text-xs text-fg-muted leading-relaxed">
-                  Updates query planner statistics for all tables.
+                  {labels?.analyzeGlobalDesc ?? "Updates query planner statistics for all tables."}
                 </p>
               </div>
             )}
@@ -284,15 +296,18 @@ export function OperationsTab() {
                     disabled={!!actionLoading || !selectedConnection}
                   >
                     {actionLoading === "vacuum-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
-                    Run Vacuum
+                    {labels?.vacuumGlobalLabel ?? "Run Vacuum"}
                   </Button>
                 </div>
-                <h4 className="text-sm font-bold text-fg mb-1">Reclaim Space</h4>
-                <p className="text-xs text-fg-muted leading-relaxed">Removes dead rows and returns space to the OS.</p>
+                <h4 className="text-sm font-bold text-fg mb-1">{labels?.vacuumGlobalTitle ?? "Reclaim Space"}</h4>
+                <p className="text-xs text-fg-muted leading-relaxed">
+                  {labels?.vacuumGlobalDesc ?? "Removes dead rows and returns space to the OS."}
+                </p>
               </div>
             )}
 
-            {/* Reindex */}
+            {/* Reindex — ProviderLabels declares no reindexGlobal triad, so this
+                card stays generic; adding one is out of scope for #427. */}
             {canRun("reindex") && (
               <div className="p-4 rounded-xl border border-hairline bg-fill-subtle hover:bg-fill transition-colors">
                 <div className="flex items-start justify-between mb-3">

--- a/src/components/schema-explorer/SchemaExplorer.tsx
+++ b/src/components/schema-explorer/SchemaExplorer.tsx
@@ -155,6 +155,7 @@ export function SchemaExplorer({
               isExpanded={expandedTables.has(table.name)}
               onToggle={() => toggleTable(table.name)}
               labels={labels}
+              capabilities={capabilities}
               isAdmin={isAdmin}
               onTableClick={onTableClick}
               onGenerateSelect={onGenerateSelect}

--- a/src/components/schema-explorer/TableItem.tsx
+++ b/src/components/schema-explorer/TableItem.tsx
@@ -39,6 +39,7 @@ interface TableItemProps {
   isExpanded: boolean;
   onToggle: () => void;
   labels?: ProviderMetadata["labels"];
+  capabilities?: ProviderMetadata["capabilities"];
   isAdmin: boolean;
   onTableClick?: (tableName: string) => void;
   onGenerateSelect?: (tableName: string) => void;
@@ -56,12 +57,20 @@ type TableItemCallbacks = Pick<
 function renderMenuItems(
   table: TableSchema,
   labels: TableItemProps["labels"],
+  capabilities: TableItemProps["capabilities"],
   isAdmin: boolean,
   callbacks: TableItemCallbacks,
   copyToClipboard: (text: string, label: string) => void,
   Item: React.ComponentType<{ onClick?: () => void; children: React.ReactNode }>,
   Separator: React.ComponentType,
 ): React.ReactNode {
+  // Rows that are derived groupings are not addressable objects: a Redis `user:*`
+  // row is this server's summary of a key prefix, so profiling it and inserting
+  // rows into it have no target and the provider answers 400 (#427). Gate on the
+  // declared capability, never on connection.type. Absent capabilities read as
+  // "ordinary objects", matching the flag's own docblock.
+  const rowsAreAddressable = capabilities?.tablesAreDerivedGroupings !== true;
+
   return (
     <>
       <Item onClick={() => callbacks.onTableClick?.(table.name)}>
@@ -76,20 +85,31 @@ function renderMenuItems(
         <Copy strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-muted-foreground" />
         {"Copy Name"}
       </Item>
+      {/* Generate Code stays visible everywhere — it names the row, it does not
+          address it — so this separator is unconditional (#427). */}
       <Separator />
-      <Item onClick={() => callbacks.onProfileTable?.(table.name)}>
-        <BarChart3 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-cyan-500" />
-        {"Profile Table"}
-      </Item>
+      {rowsAreAddressable && (
+        <Item onClick={() => callbacks.onProfileTable?.(table.name)}>
+          <BarChart3 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-cyan-500" />
+          {"Profile Table"}
+        </Item>
+      )}
       <Item onClick={() => callbacks.onGenerateCode?.(table.name)}>
         <Code strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-purple-500" />
         {"Generate Code"}
       </Item>
-      <Item onClick={() => callbacks.onGenerateTestData?.(table.name)}>
-        <Wand2 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-amber-500" />
-        {"Generate Test Data"}
-      </Item>
-      {isAdmin && (
+      {rowsAreAddressable && (
+        <Item onClick={() => callbacks.onGenerateTestData?.(table.name)}>
+          <Wand2 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-amber-500" />
+          {"Generate Test Data"}
+        </Item>
+      )}
+      {/* A PER-ROW maintenance action needs an addressable row: both items call
+          `onOpenMaintenance("tables", table.name)`, and for a derived grouping
+          there is no such object to name — which is exactly the dead end #427
+          reported for Redis "Key Info". Global maintenance is unaffected: it lives
+          on the admin Operations page and still runs there. */}
+      {isAdmin && rowsAreAddressable && (
         <>
           <Separator />
           <Item onClick={() => callbacks.onOpenMaintenance?.("tables", table.name)}>
@@ -111,6 +131,7 @@ export const TableItem = React.memo(function TableItem({
   isExpanded,
   onToggle,
   labels,
+  capabilities,
   isAdmin,
   onTableClick,
   onGenerateSelect,
@@ -192,6 +213,7 @@ export const TableItem = React.memo(function TableItem({
                   {renderMenuItems(
                     table,
                     labels,
+                    capabilities,
                     isAdmin,
                     callbacks,
                     copyToClipboard,
@@ -204,7 +226,16 @@ export const TableItem = React.memo(function TableItem({
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent className="w-48">
-          {renderMenuItems(table, labels, isAdmin, callbacks, copyToClipboard, ContextMenuItem, ContextMenuSeparator)}
+          {renderMenuItems(
+            table,
+            labels,
+            capabilities,
+            isAdmin,
+            callbacks,
+            copyToClipboard,
+            ContextMenuItem,
+            ContextMenuSeparator,
+          )}
         </ContextMenuContent>
       </ContextMenu>
 

--- a/src/components/schema-explorer/TableItem.tsx
+++ b/src/components/schema-explorer/TableItem.tsx
@@ -38,7 +38,9 @@ interface TableItemProps {
   table: TableSchema;
   isExpanded: boolean;
   onToggle: () => void;
-  labels?: ProviderMetadata["labels"];
+  // `labels` is itself optional on ProviderMetadata, so the indexed access already
+  // carries `undefined`; NonNullable keeps the `?` from restating it (#427).
+  labels?: NonNullable<ProviderMetadata["labels"]>;
   capabilities?: ProviderMetadata["capabilities"];
   isAdmin: boolean;
   onTableClick?: (tableName: string) => void;
@@ -54,16 +56,32 @@ type TableItemCallbacks = Pick<
   "onTableClick" | "onGenerateSelect" | "onProfileTable" | "onGenerateCode" | "onGenerateTestData" | "onOpenMaintenance"
 >;
 
-function renderMenuItems(
-  table: TableSchema,
-  labels: TableItemProps["labels"],
-  capabilities: TableItemProps["capabilities"],
-  isAdmin: boolean,
-  callbacks: TableItemCallbacks,
-  copyToClipboard: (text: string, label: string) => void,
-  Item: React.ComponentType<{ onClick?: () => void; children: React.ReactNode }>,
-  Separator: React.ComponentType,
-): React.ReactNode {
+/**
+ * What one rendering of the menu needs. The two call sites differ only in which
+ * primitives they pass (`DropdownMenu*` vs `ContextMenu*`), so everything else
+ * travels as one object rather than as a positional list.
+ */
+interface MenuItemsContext {
+  table: TableSchema;
+  labels: TableItemProps["labels"];
+  capabilities: TableItemProps["capabilities"];
+  isAdmin: boolean;
+  callbacks: TableItemCallbacks;
+  copyToClipboard: (text: string, label: string) => void;
+  Item: React.ComponentType<{ onClick?: () => void; children: React.ReactNode }>;
+  Separator: React.ComponentType;
+}
+
+function renderMenuItems({
+  table,
+  labels,
+  capabilities,
+  isAdmin,
+  callbacks,
+  copyToClipboard,
+  Item,
+  Separator,
+}: MenuItemsContext): React.ReactNode {
   // Rows that are derived groupings are not addressable objects: a Redis `user:*`
   // row is this server's summary of a key prefix, so profiling it and inserting
   // rows into it have no target and the provider answers 400 (#427). Gate on the
@@ -210,32 +228,32 @@ export const TableItem = React.memo(function TableItem({
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-48">
-                  {renderMenuItems(
+                  {renderMenuItems({
                     table,
                     labels,
                     capabilities,
                     isAdmin,
                     callbacks,
                     copyToClipboard,
-                    DropdownMenuItem,
-                    DropdownMenuSeparator,
-                  )}
+                    Item: DropdownMenuItem,
+                    Separator: DropdownMenuSeparator,
+                  })}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent className="w-48">
-          {renderMenuItems(
+          {renderMenuItems({
             table,
             labels,
             capabilities,
             isAdmin,
             callbacks,
             copyToClipboard,
-            ContextMenuItem,
-            ContextMenuSeparator,
-          )}
+            Item: ContextMenuItem,
+            Separator: ContextMenuSeparator,
+          })}
         </ContextMenuContent>
       </ContextMenu>
 

--- a/src/components/studio/QueryToolbar.tsx
+++ b/src/components/studio/QueryToolbar.tsx
@@ -17,13 +17,21 @@ interface QueryToolbarProps {
   onSaveQuery: () => void;
   onExecuteQuery: () => void;
   onCancelQuery: () => void;
-  onBeginTransaction: () => void;
-  onCommitTransaction: () => void;
-  onRollbackTransaction: () => void;
-  onTogglePlayground: () => void;
+  /**
+   * The transaction trio, supplied together or not at all. A caller that cannot
+   * run transactions omits all three and BEGIN/COMMIT/ROLLBACK do not render —
+   * the embedded shell passed `noop` for them and, once it started passing real
+   * provider metadata, showed three buttons that did nothing (#427).
+   */
+  onBeginTransaction?: () => void;
+  onCommitTransaction?: () => void;
+  onRollbackTransaction?: () => void;
+  /** Omitted where the caller cannot run sandboxed (auto-rolled-back) queries. */
+  onTogglePlayground?: () => void;
   /** Omitted where the provider declares no inline row editing (issue #269). */
   onToggleEditing?: () => void;
-  onImport: () => void;
+  /** Omitted where the caller offers no data import. */
+  onImport?: () => void;
 }
 
 export function QueryToolbar({
@@ -43,6 +51,16 @@ export function QueryToolbar({
   onToggleEditing,
   onImport,
 }: QueryToolbarProps) {
+  // Bundled so the three cannot be half-supplied: a caller offering BEGIN without
+  // COMMIT would strand the user inside a transaction it cannot close.
+  const transaction =
+    onBeginTransaction && onCommitTransaction && onRollbackTransaction
+      ? { begin: onBeginTransaction, commit: onCommitTransaction, rollback: onRollbackTransaction }
+      : null;
+  // The group's border and separator are chrome for its members; with no member to
+  // show, the whole group goes rather than leaving an empty rule (#427).
+  const hasGroupControls = transaction !== null || !!onTogglePlayground || !!onToggleEditing || !!onImport;
+
   return (
     <>
       {/* Playground Mode Banner */}
@@ -92,58 +110,61 @@ export function QueryToolbar({
         )}
 
         {/* Transaction Controls + Playground + Import + Edit */}
-        {activeConnection && metadata?.capabilities.queryLanguage === "sql" && (
+        {activeConnection && metadata?.capabilities.queryLanguage === "sql" && hasGroupControls && (
           <div className="flex items-center gap-1 ml-2 pl-2 border-l border-hairline-strong">
-            {transactionActive ? (
-              <>
-                <span className="text-[0.625rem] font-medium text-amber-400 px-1.5 py-0.5 bg-amber-500/10 rounded border border-amber-500/20 mr-1">
-                  TXN
-                </span>
+            {transaction !== null &&
+              (transactionActive ? (
+                <>
+                  <span className="text-[0.625rem] font-medium text-amber-400 px-1.5 py-0.5 bg-amber-500/10 rounded border border-amber-500/20 mr-1">
+                    TXN
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 text-xs font-medium text-emerald-400 hover:text-emerald-300 hover:bg-emerald-500/10 gap-1"
+                    onClick={transaction.commit}
+                  >
+                    COMMIT
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 text-xs font-medium text-red-400 hover:text-red-300 hover:bg-red-500/10 gap-1"
+                    onClick={transaction.rollback}
+                  >
+                    ROLLBACK
+                  </Button>
+                </>
+              ) : (
                 <Button
                   size="sm"
                   variant="ghost"
-                  className="h-7 text-xs font-medium text-emerald-400 hover:text-emerald-300 hover:bg-emerald-500/10 gap-1"
-                  onClick={onCommitTransaction}
+                  className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-1"
+                  onClick={transaction.begin}
+                  disabled={playgroundMode}
                 >
-                  COMMIT
+                  BEGIN
                 </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 text-xs font-medium text-red-400 hover:text-red-300 hover:bg-red-500/10 gap-1"
-                  onClick={onRollbackTransaction}
-                >
-                  ROLLBACK
-                </Button>
-              </>
-            ) : (
+              ))}
+
+            {onTogglePlayground && (
               <Button
                 size="sm"
                 variant="ghost"
-                className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-1"
-                onClick={onBeginTransaction}
-                disabled={playgroundMode}
+                className={cn(
+                  "h-7 text-xs font-medium gap-1",
+                  playgroundMode
+                    ? "text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20"
+                    : "text-fg-muted hover:text-fg-bright",
+                )}
+                onClick={onTogglePlayground}
+                disabled={transactionActive}
+                title="Playground mode: queries are auto-rolled back"
               >
-                BEGIN
+                <FlaskConical strokeWidth={1.5} className="w-3 h-3" />
+                SANDBOX
               </Button>
             )}
-
-            <Button
-              size="sm"
-              variant="ghost"
-              className={cn(
-                "h-7 text-xs font-medium gap-1",
-                playgroundMode
-                  ? "text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20"
-                  : "text-fg-muted hover:text-fg-bright",
-              )}
-              onClick={onTogglePlayground}
-              disabled={transactionActive}
-              title="Playground mode: queries are auto-rolled back"
-            >
-              <FlaskConical strokeWidth={1.5} className="w-3 h-3" />
-              SANDBOX
-            </Button>
 
             {onToggleEditing && (
               <Button
@@ -163,16 +184,18 @@ export function QueryToolbar({
               </Button>
             )}
 
-            <Button
-              size="sm"
-              variant="ghost"
-              className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-1"
-              onClick={onImport}
-              title="Import data from CSV/JSON"
-            >
-              <Upload strokeWidth={1.5} className="w-3 h-3" />
-              IMPORT
-            </Button>
+            {onImport && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-1"
+                onClick={onImport}
+                title="Import data from CSV/JSON"
+              >
+                <Upload strokeWidth={1.5} className="w-3 h-3" />
+                IMPORT
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -24,4 +24,4 @@ export type {
 } from "../lib/types";
 
 // Also export provider types
-export type { ProviderCapabilities } from "../lib/db/types";
+export type { ProviderCapabilities, ProviderLabels } from "../lib/db/types";

--- a/src/hooks/use-provider-metadata.ts
+++ b/src/hooks/use-provider-metadata.ts
@@ -7,7 +7,17 @@ import { logger } from "@/lib/logger";
 
 export interface ProviderMetadata {
   capabilities: ProviderCapabilities;
-  labels: ProviderLabels;
+  /**
+   * Optional because one producer genuinely cannot supply it. `/api/db/provider-meta`
+   * always answers with both, but the embedded shell has no such route: the host
+   * declares each connection's metadata, and `WorkspaceConnection.labels` is
+   * optional there so a host that only knows the capabilities need not restate
+   * fifteen strings (#427). Every consumer already reads labels through `?.` with
+   * its own fallback wording, so this states what was already true rather than
+   * changing any behaviour — and it removes an `as ProviderLabels` cast that was
+   * laundering `undefined` into a field declared required.
+   */
+  labels?: ProviderLabels;
 }
 
 export function useProviderMetadata(connection: DatabaseConnection | null): {

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -277,12 +277,23 @@ export function useQueryExecution({
         // splits the payload and binds nothing, so the values would be dropped and
         // the statement would run with unbound placeholders. Parameters may only
         // travel to an endpoint that binds them (PR #304 review).
+        //
+        // The splitter is a SQL splitter: it cuts on `;` outside quotes. A dialect
+        // that is not SQL has no such separator, so every cut it makes there is an
+        // invented fragment. Measured on Redis (#427): the generated cheatsheet
+        // carried a `;` inside a `#` comment, so the buffer was split, and the
+        // first "statement" was comments only - the run failed with "No command to
+        // run" and the panel reported a successful empty result. Unknown metadata
+        // keeps the pre-existing behaviour, since only a declared JSON dialect is
+        // known not to be SQL.
+        const dialectIsSql = (metadata?.capabilities.queryLanguage ?? "sql") === "sql";
         const useMultiQuery =
           !isExplain &&
           !isLoadMore &&
           !transactionActive &&
           !isPlaygroundRun &&
           !params &&
+          dialectIsSql &&
           isMultiStatement(queryToExecute);
 
         // Use transaction endpoint if a transaction is active or in playground mode

--- a/src/hooks/use-tab-manager.ts
+++ b/src/hooks/use-tab-manager.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect, useMemo } from "react";
 import type { DatabaseConnection, TableSchema, QueryTab } from "@/lib/types";
 import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
 import { generateTableQuery, generateSelectQuery } from "@/lib/query-generators";
+import { resolveTabType } from "@/lib/editor/tab-language";
 import { logger } from "@/lib/logger";
 import { newLocalId } from "@/lib/ids";
 
@@ -148,8 +149,6 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
 
   const addTab = useCallback(() => {
     const newId = newLocalId();
-    const queryLanguage = metadata?.capabilities.queryLanguage;
-    const queryDialect = metadata?.capabilities.queryDialect;
     setTabs((prev) => [
       ...prev,
       {
@@ -158,7 +157,7 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
         query: "",
         result: null,
         isExecuting: false,
-        type: queryDialect === "libredb" ? "libredb" : queryLanguage === "json" ? "mongodb" : "sql",
+        type: resolveTabType(metadata?.capabilities),
       },
     ]);
     setActiveTabId(newId);
@@ -183,8 +182,13 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
   const handleTableClick = useCallback(
     (tableName: string, executeQueryFn: (query: string, tabId: string) => void) => {
       const capabilities = metadata?.capabilities;
+      // Look the table up exactly as handleGenerateSelect does: the Redis
+      // generator is type-aware, and the sampled key type lives on the schema
+      // node's `type` column (#427).
+      const table = schema.find((t) => t.name === tableName);
+      const columns = table?.columns || [];
       const newQuery = capabilities
-        ? generateTableQuery(tableName, capabilities)
+        ? generateTableQuery(tableName, capabilities, columns)
         : `SELECT * FROM ${tableName} LIMIT 50;`;
 
       const newId = newLocalId();
@@ -194,18 +198,13 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
         query: newQuery,
         result: null,
         isExecuting: false,
-        type:
-          capabilities?.queryDialect === "libredb"
-            ? "libredb"
-            : capabilities?.queryLanguage === "json"
-              ? "mongodb"
-              : "sql",
+        type: resolveTabType(capabilities),
       };
       setTabs((prev) => [...prev, newTab]);
       setActiveTabId(newId);
       setTimeout(() => executeQueryFn(newQuery, newId), 100);
     },
-    [metadata],
+    [metadata, schema],
   );
 
   const handleGenerateSelect = useCallback(
@@ -218,12 +217,7 @@ export function useTabManager({ activeConnection, metadata, schema, persistWorks
         ? generateSelectQuery(tableName, columns, capabilities)
         : `SELECT\n${columns.map((c) => `  ${c.name}`).join(",\n") || "  *"}\nFROM ${tableName}\nWHERE 1=1\nLIMIT 100;`;
 
-      const tabType: "sql" | "mongodb" | "redis" | "libredb" =
-        capabilities?.queryDialect === "libredb"
-          ? "libredb"
-          : capabilities?.queryLanguage === "json"
-            ? "mongodb"
-            : "sql";
+      const tabType = resolveTabType(capabilities);
 
       const newId = newLocalId();
       setTabs((prev) => [

--- a/src/lib/db/providers/keyvalue/redis.ts
+++ b/src/lib/db/providers/keyvalue/redis.ts
@@ -217,19 +217,29 @@ export class RedisProvider extends BaseDatabaseProvider {
    * keeps both behaviours exactly, and lines are appended verbatim so
    * indentation inside a quoted value survives too.
    */
+  /**
+   * What a buffer line is to `commandBody`. Both chrome kinds require that no
+   * quoted argument is open across the line: inside one, a line-leading `#` and
+   * an empty line are data, not structure (#427).
+   */
+  private static lineKind(raw: string, quoteChar: string): "comment" | "blank" | "content" {
+    if (quoteChar !== "") return "content";
+    const line = raw.trim();
+    if (line.startsWith("#")) return "comment";
+    return line === "" ? "blank" : "content";
+  }
+
   private commandBody(input: string): string {
     const block: string[] = [];
     let quoteChar = "";
     let isJsonBlock = false;
     for (const raw of input.split("\n")) {
-      if (quoteChar === "") {
-        const line = raw.trim();
-        if (line.startsWith("#")) continue;
-        if (line === "") {
-          // A blank line ends the first block; blank lines before it are leading padding.
-          if (block.length > 0) break;
-          continue;
-        }
+      const kind = RedisProvider.lineKind(raw, quoteChar);
+      if (kind === "comment") continue;
+      if (kind === "blank") {
+        // A blank line ends the first block; blank lines before it are leading padding.
+        if (block.length > 0) break;
+        continue;
       }
       // The block's kind is fixed by its first content line, using the SAME test
       // `executeRedisCommand` uses to pick a parser. Quote tracking exists only to

--- a/src/lib/db/providers/keyvalue/redis.ts
+++ b/src/lib/db/providers/keyvalue/redis.ts
@@ -59,6 +59,10 @@ export class RedisProvider extends BaseDatabaseProvider {
   public override getCapabilities(): ProviderCapabilities {
     return {
       queryLanguage: "json",
+      // Redis says "json" only because it is not SQL. Without this the client-side
+      // generators fall through to their MongoDB branch and every schema-explorer
+      // action emits `{"collection":...}` that `executeRedisCommand` rejects (#427).
+      queryDialect: "redis",
       supportsExplain: false,
       supportsExternalQueryLimiting: false,
       supportsCreateTable: false,
@@ -172,13 +176,92 @@ export class RedisProvider extends BaseDatabaseProvider {
     });
   }
 
-  private async executeRedisCommand(input: string): Promise<Omit<QueryResult, "executionTime">> {
-    const trimmed = input.trim();
+  /**
+   * Advance the plain tokenizer's quote state across one line of text, using the
+   * SAME rule `executePlainCommand` uses: outside a quote any `"` or `'` opens
+   * one, inside a quote only the matching character closes it, and there is no
+   * escape handling. Returns the open quote character, or '' when none is open.
+   */
+  private static quoteStateAfter(text: string, quoteChar: string): string {
+    let open = quoteChar;
+    for (const ch of text) {
+      if (open === "") {
+        if (ch === '"' || ch === "'") open = ch;
+      } else if (ch === open) {
+        open = "";
+      }
+    }
+    return open;
+  }
 
-    // Try JSON format first
-    if (trimmed.startsWith("{")) {
+  /**
+   * Reduce a buffer to the ONE command it should run: drop every `#` comment
+   * line, then take the first blank-line-delimited block and join its lines back
+   * with a NEWLINE. A line is a comment only when it *starts* with `#` (after
+   * trimming) AND no quoted argument is open across it, so a `#` inside a key or
+   * value is never mistaken for one. Returns '' when nothing runnable remains
+   * (#427).
+   *
+   * Why a block rather than a line: outside quotes the tokenizer treats a
+   * newline as ordinary whitespace, so a single command wrapped across several
+   * lines (`HSET k a 1` / `b 2`) has always run whole, and a pretty-printed JSON
+   * command is legitimately multi-line — picking only line 1 would silently
+   * half-execute both. Why not the whole buffer: the schema-explorer "Generate
+   * Command" cheatsheet is a list of alternatives separated by blank lines, and
+   * running the buffer must run only its first command, not all of them.
+   *
+   * Why the join character is a newline and not a space: the tokenizer's
+   * whitespace branch is guarded by `!inQuote`, so a newline INSIDE a quoted
+   * argument is data. `SET note "line1\nline2"` stores a two-line value, and
+   * joining with a space silently rewrote it to `line1 line2`. A newline join
+   * keeps both behaviours exactly, and lines are appended verbatim so
+   * indentation inside a quoted value survives too.
+   */
+  private commandBody(input: string): string {
+    const block: string[] = [];
+    let quoteChar = "";
+    let isJsonBlock = false;
+    for (const raw of input.split("\n")) {
+      if (quoteChar === "") {
+        const line = raw.trim();
+        if (line.startsWith("#")) continue;
+        if (line === "") {
+          // A blank line ends the first block; blank lines before it are leading padding.
+          if (block.length > 0) break;
+          continue;
+        }
+      }
+      // The block's kind is fixed by its first content line, using the SAME test
+      // `executeRedisCommand` uses to pick a parser. Quote tracking exists only to
+      // protect a `#` inside a quoted argument of a PLAIN command, and its rules
+      // are the plain tokenizer's — no escape handling. Applying them to a JSON
+      // body counted `\"` inside a string as a real quote, so a key named `say"hi`
+      // left a phantom quote open, every later comment line stopped being dropped,
+      // and the buffer reached `JSON.parse` with comments in it (#427). A JSON
+      // body cannot hide a line-leading `#` inside a string — JSON strings carry
+      // no literal newline — so it needs no tracking at all.
+      if (block.length === 0) isJsonBlock = raw.trimStart().startsWith("{");
+      block.push(raw);
+      if (!isJsonBlock) quoteChar = RedisProvider.quoteStateAfter(raw, quoteChar);
+    }
+    return block.join("\n");
+  }
+
+  private async executeRedisCommand(input: string): Promise<Omit<QueryResult, "executionTime">> {
+    const body = this.commandBody(input);
+    if (body.trim() === "") {
+      throw new QueryError("No command to run (only comments or blank lines)", "redis");
+    }
+
+    // Try JSON format first — over the whole block, because `JSON.stringify(cmd,
+    // null, 2)` is what the MongoDB-shaped generator emits and what users paste.
+    // It is also the lossless form the Redis generators fall back to for any
+    // argument the plain tokenizer cannot round-trip. Trailing `#` comment lines
+    // are dropped with every other comment; trailing non-comment text is not —
+    // it joins the block and fails JSON.parse (#427).
+    if (body.trimStart().startsWith("{")) {
       try {
-        const parsed = JSON.parse(trimmed);
+        const parsed = JSON.parse(body);
         return this.executeJsonCommand(parsed);
       } catch {
         throw new QueryError("Invalid JSON command format", "redis");
@@ -186,7 +269,7 @@ export class RedisProvider extends BaseDatabaseProvider {
     }
 
     // Plain text command format: COMMAND arg1 arg2 ...
-    return this.executePlainCommand(trimmed);
+    return this.executePlainCommand(body);
   }
 
   private async executeJsonCommand(cmd: RedisJsonCommand): Promise<Omit<QueryResult, "executionTime">> {

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -103,10 +103,13 @@ export interface ProviderCapabilities {
    * Optional client-side query dialect. `queryLanguage` only says SQL vs JSON;
    * for non-SQL providers the query generators otherwise assume MongoDB syntax.
    * A provider sets `queryDialect` to opt its tables into a custom client-side
-   * generator (see `query-generators.ts`). Left undefined by SQL/Mongo/Redis,
-   * so their generation is unchanged.
+   * generator (see `query-generators.ts`), and it is checked BEFORE
+   * `queryLanguage` everywhere. Left undefined by SQL and MongoDB, so their
+   * generation is unchanged; Redis declares `"redis"` because it too says
+   * `queryLanguage: "json"` while speaking neither MongoDB JSON nor SQL, and
+   * silently got MongoDB commands its own driver rejected (#427).
    */
-  queryDialect?: "libredb";
+  queryDialect?: "libredb" | "redis";
   supportsExplain: boolean;
   /**
    * Present iff supportsExplain is true (enforced by provider tests).

--- a/src/lib/editor/redis-language.ts
+++ b/src/lib/editor/redis-language.ts
@@ -1,0 +1,155 @@
+import type * as Monaco from "monaco-editor";
+
+/**
+ * Monaco language for the Redis command grammar.
+ *
+ * Redis commands are neither SQL nor MongoDB JSON, so reusing the `json`
+ * language mis-highlights them and flags every command as invalid JSON — the
+ * visible half of #427, where a Redis tab was typed `mongodb`. This registers a
+ * minimal language whose tokens map onto the editor's shared `db-dark` theme:
+ * command verbs as keywords, argument keywords (`MATCH`, `COUNT`,
+ * `WITHSCORES`) as functions, `#` line comments (matching the cheatsheet the
+ * generators emit and the provider's line skipper), quoted strings and numbers.
+ * Everything else — keys and key patterns like `user:*` — reads as a plain
+ * identifier.
+ */
+const REDIS_LANGUAGE_ID = "redis";
+
+/**
+ * Command verbs. `KEYS` is highlighted but never generated: the provider's
+ * SCAN-never-KEYS rule stands, and a user who types it should still see it
+ * tokenized.
+ */
+const REDIS_KEYWORDS = [
+  "SCAN",
+  "TYPE",
+  "GET",
+  "SET",
+  "SETEX",
+  "DEL",
+  "EXISTS",
+  "TTL",
+  "EXPIRE",
+  "PERSIST",
+  "RENAME",
+  "INCR",
+  "DECR",
+  "MGET",
+  "MSET",
+  "HGETALL",
+  "HGET",
+  "HSET",
+  "HDEL",
+  "HKEYS",
+  "HVALS",
+  "HLEN",
+  "LRANGE",
+  "LLEN",
+  "LPUSH",
+  "RPUSH",
+  "LPOP",
+  "RPOP",
+  "SMEMBERS",
+  "SADD",
+  "SREM",
+  "SCARD",
+  "SISMEMBER",
+  "ZRANGE",
+  "ZREVRANGE",
+  "ZADD",
+  "ZREM",
+  "ZCARD",
+  "ZSCORE",
+  "ZRANGEBYSCORE",
+  "INFO",
+  "DBSIZE",
+  "PING",
+  "MEMORY",
+  "CLIENT",
+  "SLOWLOG",
+  "CONFIG",
+  "COMMAND",
+  "KEYS",
+  "RANDOMKEY",
+  "OBJECT",
+];
+
+/**
+ * Argument keywords, tokenized separately so `MATCH user:* COUNT 50` reads as
+ * verb + modifier + data. Words that are also verbs (`GET`, `SET`, `TYPE`) are
+ * deliberately absent: a cases map has one entry per word, so a collision would
+ * silently pick one class — keeping the lists disjoint is the simpler fix.
+ */
+const REDIS_MODIFIERS = [
+  "MATCH",
+  "COUNT",
+  "WITHSCORES",
+  "LIMIT",
+  "EX",
+  "PX",
+  "NX",
+  "XX",
+  "ASC",
+  "DESC",
+  "BYSCORE",
+  "REV",
+  "STORE",
+];
+
+/**
+ * Register the Redis language on a Monaco instance. Idempotent — safe to call
+ * on every editor mount; it no-ops once the language is already registered.
+ */
+export function registerRedisLanguage(monaco: typeof Monaco): void {
+  if (monaco.languages.getLanguages().some((lang) => lang.id === REDIS_LANGUAGE_ID)) {
+    return;
+  }
+
+  monaco.languages.register({ id: REDIS_LANGUAGE_ID });
+
+  monaco.languages.setMonarchTokensProvider(REDIS_LANGUAGE_ID, {
+    ignoreCase: true,
+    keywords: REDIS_KEYWORDS,
+    modifiers: REDIS_MODIFIERS,
+    tokenizer: {
+      // Monarch tries these in order and takes the first match at the current
+      // position. Every rule here starts on a disjoint character — `#`, `"`, `'`,
+      // digit-or-`-`, letter-or-`_`, `*`-or-`:` — so at most one can match and the
+      // order is documentation rather than precedence. Keep it that way: a rule
+      // whose opening character overlaps another's makes this list order-sensitive
+      // in a way nothing on the screen would announce. `tests/unit/editor/
+      // redis-language.test.ts` asserts the disjointness.
+      root: [
+        // A line is a comment only when it STARTS with `#` (after whitespace),
+        // matching the provider's line skipper — `#` inside a key or value
+        // stays data (#427).
+        [/^\s*#.*$/, "comment"],
+        [/"([^"\\]|\\.)*"/, "string"],
+        [/'([^'\\]|\\.)*'/, "string"],
+        // SCAN's cursor `0`, COUNT's `50` and the `0 -1` range of LRANGE/ZRANGE
+        // read as numbers rather than falling through to the editor's default
+        // token. Not "before the identifier rule": the identifier rule below
+        // cannot start on a digit or `-`, so these two never compete.
+        [/-?\b\d+(\.\d+)?\b/, "number"],
+        // A key or key pattern (`user:*`, `session:abc:data`) is ONE identifier
+        // token: letter/underscore start, then word chars and key punctuation.
+        [
+          /[a-zA-Z_][\w:.*/-]*/,
+          { cases: { "@keywords": "keyword", "@modifiers": "function", "@default": "identifier" } },
+        ],
+        // A pattern that starts with punctuation (`*`, `:*`) still reads as data.
+        [/[*:][\w:.*/-]*/, "identifier"],
+      ],
+    },
+  });
+
+  monaco.languages.setLanguageConfiguration(REDIS_LANGUAGE_ID, {
+    comments: { lineComment: "#" },
+    autoClosingPairs: [
+      { open: '"', close: '"' },
+      { open: "'", close: "'" },
+      { open: "{", close: "}" },
+      { open: "[", close: "]" },
+    ],
+  });
+}

--- a/src/lib/editor/tab-language.ts
+++ b/src/lib/editor/tab-language.ts
@@ -1,0 +1,29 @@
+import type { ProviderCapabilities } from "@/lib/db/types";
+import type { QueryTab } from "@/lib/types";
+
+/**
+ * The tab type a connection's tabs take.
+ *
+ * Order matters: `queryDialect` is checked BEFORE `queryLanguage`, because
+ * Redis and LibreDB both declare `queryLanguage: "json"` while speaking neither
+ * MongoDB JSON nor SQL. Getting that order wrong is exactly why the
+ * `connection.type === "redis"` arm in Studio.tsx was unreachable dead code
+ * before #427 — the json rung above it always matched first.
+ *
+ * Lives here rather than inline because the same ladder had been copied to four
+ * call sites and had already drifted between them.
+ */
+export function resolveTabType(capabilities?: ProviderCapabilities | null): QueryTab["type"] {
+  if (capabilities?.queryDialect === "libredb") return "libredb";
+  if (capabilities?.queryDialect === "redis") return "redis";
+  if (capabilities?.queryLanguage === "json") return "mongodb";
+  return "sql";
+}
+
+/** The Monaco language id a tab type renders in (#427). */
+export function editorLanguageForTabType(type: QueryTab["type"]): "sql" | "json" | "libredb" | "redis" {
+  if (type === "libredb") return "libredb";
+  if (type === "redis") return "redis";
+  if (type === "mongodb") return "json";
+  return "sql";
+}

--- a/src/lib/query-generators.ts
+++ b/src/lib/query-generators.ts
@@ -110,12 +110,34 @@ export function quoteQualifiedName(name: string, capabilities: ProviderCapabilit
 }
 
 /**
- * Resolve a LibreDB schema-tree node name to its command shape. A node is either
- * a `:`-prefix group (e.g. `users:*`, whose rows live under the `users:` prefix)
- * or a bare single key with no colon. The `*` is stripped so the base is the
- * literal prefix used in commands (`users:*` -> `users:`).
+ * Render a schema-tree node name for a `#` comment line. A node name is a real
+ * key/collection name taken from the server, and a Redis key is an arbitrary
+ * byte string — so a name containing a newline used to END the header comment
+ * and turn its own remainder into the first RUNNABLE line of the cheatsheet,
+ * which the provider then executed (`a\nDEL user:1 x` ran `DEL user:1`). The
+ * per-argument defence never engaged, because the injection travelled through
+ * the comment rather than through a command.
+ *
+ * JSON quoting is the fix: it escapes CR, LF and the quote character in one
+ * lossless step, and for an ordinary name it renders exactly the `"name"` the
+ * headers already wrote by hand. Any name entering a comment line must go
+ * through this (#427).
  */
-function libredbGroup(name: string): { isPrefixGroup: boolean; base: string } {
+function commentName(name: string): string {
+  return JSON.stringify(name);
+}
+
+/**
+ * Resolve a key-value schema-tree node name to its command shape. A node is
+ * either a `:`-prefix group (e.g. `users:*`, whose rows live under the `users:`
+ * prefix) or a bare single key with no colon. The `*` is stripped so the base is
+ * the literal prefix used in commands (`users:*` -> `users:`).
+ *
+ * Shared by the LibreDB and Redis branches: both build their tree from the same
+ * `getKeyPrefix` grouping, so a future change to what a prefix node looks like
+ * must not be able to make the two dialects disagree (#427).
+ */
+function prefixGroup(name: string): { isPrefixGroup: boolean; base: string } {
   if (name.endsWith(":*")) return { isPrefixGroup: true, base: name.slice(0, -1) };
   return { isPrefixGroup: false, base: name };
 }
@@ -154,12 +176,141 @@ function libredbExampleValue(columns: ColumnSchema[]): string {
   return `'${JSON.stringify(obj)}'`;
 }
 
-export function generateTableQuery(tableName: string, capabilities: ProviderCapabilities): string {
+/**
+ * Redis key types this generator can produce a read/write command for. `TYPE`
+ * also replies `stream` and `none`; both fall into the unknown bucket, which
+ * emits `TYPE <key>` rather than guessing a reader (#427).
+ */
+type RedisKeyType = "string" | "hash" | "list" | "set" | "zset";
+
+/**
+ * The read and write command each key type gets, with the use-case comment that
+ * introduces it in the generated cheatsheet. A lookup table rather than a
+ * `switch` so every arm is one attributable line.
+ */
+const REDIS_COMMANDS: Record<
+  RedisKeyType,
+  { readComment: string; read: (key: string) => string[]; writeComment: string; write: (key: string) => string[] }
+> = {
+  string: {
+    readComment: "# Read the value",
+    read: (key) => ["GET", key],
+    writeComment: "# Create or update it — this overwrites an existing value",
+    write: (key) => ["SET", key, "example"],
+  },
+  hash: {
+    readComment: "# Read every field of the hash",
+    read: (key) => ["HGETALL", key],
+    writeComment: "# Create or update one field — this overwrites an existing field",
+    write: (key) => ["HSET", key, "field", "example"],
+  },
+  list: {
+    readComment: "# Read the whole list",
+    read: (key) => ["LRANGE", key, "0", "-1"],
+    writeComment: "# Append an element to the list",
+    write: (key) => ["RPUSH", key, "example"],
+  },
+  set: {
+    readComment: "# Read every member",
+    read: (key) => ["SMEMBERS", key],
+    writeComment: "# Add a member to the set",
+    write: (key) => ["SADD", key, "example"],
+  },
+  zset: {
+    readComment: "# Read every member with its score",
+    read: (key) => ["ZRANGE", key, "0", "-1", "WITHSCORES"],
+    writeComment: "# Add a member with a score",
+    write: (key) => ["ZADD", key, "1", "example"],
+  },
+};
+
+/**
+ * Whether an argument survives a round-trip through the provider's plain-command
+ * tokenizer. That tokenizer splits on unquoted whitespace and has NO escape
+ * handling: it toggles quote mode on every `"` or `'` and drops the character.
+ * So `DEL "say"hi""` reaches the driver as the key `sayhi` — a DIFFERENT key —
+ * and a quote inside a MATCH pattern swallows the rest of the line. A backslash
+ * or a newline is treated the same way for safety (#427).
+ */
+function redisPlainSafe(value: string): boolean {
+  return !/["'\\\n]/.test(value);
+}
+
+/**
+ * Render one Redis command in the form the provider can actually run it in.
+ *
+ * Plain form (`SET key value`, quoting an argument that contains whitespace) is
+ * the readable default. When any argument cannot round-trip through the plain
+ * tokenizer, this line — and only this line — is emitted in the lossless JSON
+ * form the provider also accepts, `{"command":"DEL","args":["say\"hi\""]}`.
+ * The two forms mix freely inside one cheatsheet: the provider decides per run,
+ * and every line is run on its own via "Run Selected" (#427).
+ */
+function renderRedisCommand(parts: string[]): string {
+  if (parts.every(redisPlainSafe)) {
+    return parts.map((part) => (/\s/.test(part) ? `"${part}"` : part)).join(" ");
+  }
+  return JSON.stringify({ command: parts[0], args: parts.slice(1) });
+}
+
+/**
+ * Escape Redis glob metacharacters. Applied ONLY to the prefix half of a MATCH
+ * pattern, never to a key argument: a real key `a[b:1` groups to `a[b:*`, and an
+ * unescaped `[` opens a glob class that matches the wrong set. Escaping a key
+ * argument would instead corrupt a literal key that genuinely contains `*` (#427).
+ */
+function escapeGlob(value: string): string {
+  return value.replace(/[\\*?[\]^]/g, "\\$&");
+}
+
+/**
+ * The single Redis key type a schema node's sample resolves to, or `null` for the
+ * unknown bucket. The source is the `type` column's own `type` field, which
+ * `redis.ts` `getSchema()` builds as `types.join(", ")` over the DISTINCT `TYPE`
+ * replies it sampled — it issues `TYPE` for every key of a prefix until it has
+ * seen 3 distinct types (or the 1000-key scan cap ends the walk), so a uniform
+ * prefix costs one blocking round-trip per key and still yields one type — so `"string"` resolves, and `""` (every TYPE call threw) or
+ * `"string, hash"` (a mixed prefix) deliberately do not. The `value` column
+ * carries the same sample joined with `/` and exists for display only (#427).
+ */
+function redisKeyType(columns?: ColumnSchema[]): RedisKeyType | null {
+  const sample = columns?.find((c) => c.name === "type")?.type;
+  const parts = (sample || "")
+    .split(",")
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part !== "");
+  // Redis TYPE replies are lowercase already; normalising keeps a hand-authored
+  // schema from reading as a silent unknown.
+  if (parts.length !== 1) return null;
+  return parts[0] in REDIS_COMMANDS ? (parts[0] as RedisKeyType) : null;
+}
+
+/** The SCAN command listing a prefix group's keys — the only place a glob is interpreted. */
+function redisScan(base: string): string {
+  return renderRedisCommand(["SCAN", "0", "MATCH", `${escapeGlob(base)}*`, "COUNT", "50"]);
+}
+
+export function generateTableQuery(
+  tableName: string,
+  capabilities: ProviderCapabilities,
+  columns?: ColumnSchema[],
+): string {
   // LibreDB speaks its own command grammar (get/put/delete/prefix/range), not SQL
   // and not MongoDB JSON. "Scan" lists everything under the group's prefix.
   if (capabilities.queryDialect === "libredb") {
-    const { isPrefixGroup, base } = libredbGroup(tableName);
+    const { isPrefixGroup, base } = prefixGroup(tableName);
     return isPrefixGroup ? `prefix ${base}` : `get ${base}`;
+  }
+  // Redis speaks its own command grammar. It must be checked BEFORE the JSON
+  // branch below: it declares `queryLanguage: "json"` too, so it silently got
+  // MongoDB documents its driver answered with HTTP 400 (#427). A prefix group
+  // is not addressable (`tablesAreDerivedGroupings`), so it always SCANs; a bare
+  // key gets the reader its sampled type calls for, or `TYPE` when unknown.
+  if (capabilities.queryDialect === "redis") {
+    const { isPrefixGroup, base } = prefixGroup(tableName);
+    if (isPrefixGroup) return redisScan(base);
+    const keyType = redisKeyType(columns);
+    return renderRedisCommand(keyType ? REDIS_COMMANDS[keyType].read(base) : ["TYPE", base]);
   }
   if (capabilities.queryLanguage === "json") {
     return JSON.stringify({ collection: tableName, operation: "find", filter: {}, options: { limit: 50 } }, null, 2);
@@ -194,9 +345,23 @@ export function generateSelectQuery(
   // (so "Run Selected" on any line works as-is). The provider skips `#` comment
   // and blank lines, so running the whole buffer runs its first real command.
   if (capabilities.queryDialect === "libredb") {
-    const { isPrefixGroup, base } = libredbGroup(tableName);
+    const { isPrefixGroup, base } = prefixGroup(tableName);
     const value = libredbExampleValue(columns);
-    const header = `# LibreDB commands for "${tableName}" — select a line and Run Selected.`;
+    const header = `# LibreDB commands for ${commentName(tableName)} — select a line and Run Selected.`;
+    // A schema-tree node name is a real key name, and LibreDB keys are arbitrary
+    // byte strings. The header is JSON-quoted so a newline in one cannot end it,
+    // but `get`/`put`/`delete` interpolate the name raw, and every LibreDB command
+    // is line-oriented: a key named `x\ndelete billing:2024` would render its own
+    // second half as a runnable `delete billing:2024` line. LibreDB has no lossless
+    // JSON command form to fall back to the way Redis does, so emit no command
+    // line at all and say why (#427).
+    if (/[\r\n]/.test(base)) {
+      return [
+        header,
+        "",
+        "# This key's name contains a newline. LibreDB commands are line-oriented, so no generated line can address it — write the command by hand.",
+      ].join("\n");
+    }
     if (isPrefixGroup) {
       const key = `${base}1`; // a concrete example key (e.g. users:1)
       return [
@@ -227,6 +392,51 @@ export function generateSelectQuery(
       "# Delete it",
       `delete ${base}`,
     ].join("\n");
+  }
+  // Redis: the same cheatsheet shape as LibreDB above — a use-case comment over
+  // each command, every command line runnable on its own via "Run Selected". The
+  // provider skips `#` and blank lines, so running the whole buffer runs its
+  // first real command. A group name never appears as a key argument: Redis key
+  // arguments are literal byte strings, so `DEL user:*` would delete nothing (or
+  // the wrong thing) rather than the group (#427).
+  if (capabilities.queryDialect === "redis") {
+    const { isPrefixGroup, base } = prefixGroup(tableName);
+    const key = isPrefixGroup ? `${base}1` : base;
+    const keyType = redisKeyType(columns);
+    const lines = [`# Redis commands for ${commentName(tableName)} — select a line and Run Selected.`, ""];
+    if (isPrefixGroup) {
+      // SCAN is a cursor step, not a listing: one call returns one page and the
+      // next cursor, and on a large keyspace the first page can be EMPTY with a
+      // non-zero cursor. A one-line command cannot loop, so say how to continue
+      // rather than pretend the first reply is the whole answer (#427).
+      lines.push(
+        "# List keys under this prefix — ONE scan iteration, not the whole set.",
+        "# 0 is the start cursor; the reply's first row is the next cursor. Re-run",
+        "# with that value in place of 0 until it comes back 0 (a page may be empty).",
+        redisScan(base),
+        "",
+      );
+    }
+    lines.push("# Check the key's type", renderRedisCommand(["TYPE", key]), "");
+    if (keyType) {
+      const commands = REDIS_COMMANDS[keyType];
+      lines.push(
+        commands.readComment,
+        renderRedisCommand(commands.read(key)),
+        "",
+        commands.writeComment,
+        renderRedisCommand(commands.write(key)),
+        "",
+      );
+    }
+    lines.push(
+      "# Time to live in seconds (-1 no expiry, -2 no such key)",
+      renderRedisCommand(["TTL", key]),
+      "",
+      "# Delete the key (DEL takes a literal key name, never a pattern)",
+      renderRedisCommand(["DEL", key]),
+    );
+    return lines.join("\n");
   }
   if (capabilities.queryLanguage === "json") {
     const projection: Record<string, number> = {};

--- a/src/lib/query-generators.ts
+++ b/src/lib/query-generators.ts
@@ -260,7 +260,7 @@ function renderRedisCommand(parts: string[]): string {
  * argument would instead corrupt a literal key that genuinely contains `*` (#427).
  */
 function escapeGlob(value: string): string {
-  return value.replace(/[\\*?[\]^]/g, "\\$&");
+  return value.replace(/[\\*?[\]^]/g, String.raw`\$&`);
 }
 
 /**
@@ -335,6 +335,110 @@ export function generateTableQuery(
   return `SELECT * FROM ${table} LIMIT 50;`;
 }
 
+/**
+ * The LibreDB cheatsheet: a use-case comment over each command, where every
+ * command line is a concrete, directly-runnable example (so "Run Selected" on
+ * any line works as-is). The provider skips `#` comment and blank lines, so
+ * running the whole buffer runs its first real command.
+ */
+function libredbCheatsheet(tableName: string, columns: ColumnSchema[]): string {
+  const { isPrefixGroup, base } = prefixGroup(tableName);
+  const value = libredbExampleValue(columns);
+  const header = `# LibreDB commands for ${commentName(tableName)} — select a line and Run Selected.`;
+  // A schema-tree node name is a real key name, and LibreDB keys are arbitrary
+  // byte strings. The header is JSON-quoted so a newline in one cannot end it,
+  // but `get`/`put`/`delete` interpolate the name raw, and every LibreDB command
+  // is line-oriented: a key named `x\ndelete billing:2024` would render its own
+  // second half as a runnable `delete billing:2024` line. LibreDB has no lossless
+  // JSON command form to fall back to the way Redis does, so emit no command
+  // line at all and say why (#427).
+  if (/[\r\n]/.test(base)) {
+    return [
+      header,
+      "",
+      "# This key's name contains a newline. LibreDB commands are line-oriented, so no generated line can address it — write the command by hand.",
+    ].join("\n");
+  }
+  if (isPrefixGroup) {
+    const key = `${base}1`; // a concrete example key (e.g. users:1)
+    return [
+      header,
+      "",
+      "# List every key under this prefix",
+      `prefix ${base}`,
+      "",
+      "# Read one entry by key",
+      `get ${key}`,
+      "",
+      "# Create or update an entry",
+      `put ${key} ${value}`,
+      "",
+      "# Delete an entry",
+      `delete ${key}`,
+    ].join("\n");
+  }
+  return [
+    header,
+    "",
+    "# Read the value",
+    `get ${base}`,
+    "",
+    "# Create or update it",
+    `put ${base} ${value}`,
+    "",
+    "# Delete it",
+    `delete ${base}`,
+  ].join("\n");
+}
+
+/**
+ * Redis: the same cheatsheet shape as LibreDB above — a use-case comment over
+ * each command, every command line runnable on its own via "Run Selected". The
+ * provider skips `#` and blank lines, so running the whole buffer runs its
+ * first real command. A group name never appears as a key argument: Redis key
+ * arguments are literal byte strings, so `DEL user:*` would delete nothing (or
+ * the wrong thing) rather than the group (#427).
+ */
+function redisCheatsheet(tableName: string, columns: ColumnSchema[]): string {
+  const { isPrefixGroup, base } = prefixGroup(tableName);
+  const key = isPrefixGroup ? `${base}1` : base;
+  const keyType = redisKeyType(columns);
+  const lines = [`# Redis commands for ${commentName(tableName)} — select a line and Run Selected.`, ""];
+  if (isPrefixGroup) {
+    // SCAN is a cursor step, not a listing: one call returns one page and the
+    // next cursor, and on a large keyspace the first page can be EMPTY with a
+    // non-zero cursor. A one-line command cannot loop, so say how to continue
+    // rather than pretend the first reply is the whole answer (#427).
+    lines.push(
+      "# List keys under this prefix — ONE scan iteration, not the whole set.",
+      "# 0 is the start cursor; the reply's first row is the next cursor. Re-run",
+      "# with that value in place of 0 until it comes back 0 (a page may be empty).",
+      redisScan(base),
+      "",
+    );
+  }
+  lines.push("# Check the key's type", renderRedisCommand(["TYPE", key]), "");
+  if (keyType) {
+    const commands = REDIS_COMMANDS[keyType];
+    lines.push(
+      commands.readComment,
+      renderRedisCommand(commands.read(key)),
+      "",
+      commands.writeComment,
+      renderRedisCommand(commands.write(key)),
+      "",
+    );
+  }
+  lines.push(
+    "# Time to live in seconds (-1 no expiry, -2 no such key)",
+    renderRedisCommand(["TTL", key]),
+    "",
+    "# Delete the key (DEL takes a literal key name, never a pattern)",
+    renderRedisCommand(["DEL", key]),
+  );
+  return lines.join("\n");
+}
+
 export function generateSelectQuery(
   tableName: string,
   columns: ColumnSchema[],
@@ -345,98 +449,10 @@ export function generateSelectQuery(
   // (so "Run Selected" on any line works as-is). The provider skips `#` comment
   // and blank lines, so running the whole buffer runs its first real command.
   if (capabilities.queryDialect === "libredb") {
-    const { isPrefixGroup, base } = prefixGroup(tableName);
-    const value = libredbExampleValue(columns);
-    const header = `# LibreDB commands for ${commentName(tableName)} — select a line and Run Selected.`;
-    // A schema-tree node name is a real key name, and LibreDB keys are arbitrary
-    // byte strings. The header is JSON-quoted so a newline in one cannot end it,
-    // but `get`/`put`/`delete` interpolate the name raw, and every LibreDB command
-    // is line-oriented: a key named `x\ndelete billing:2024` would render its own
-    // second half as a runnable `delete billing:2024` line. LibreDB has no lossless
-    // JSON command form to fall back to the way Redis does, so emit no command
-    // line at all and say why (#427).
-    if (/[\r\n]/.test(base)) {
-      return [
-        header,
-        "",
-        "# This key's name contains a newline. LibreDB commands are line-oriented, so no generated line can address it — write the command by hand.",
-      ].join("\n");
-    }
-    if (isPrefixGroup) {
-      const key = `${base}1`; // a concrete example key (e.g. users:1)
-      return [
-        header,
-        "",
-        "# List every key under this prefix",
-        `prefix ${base}`,
-        "",
-        "# Read one entry by key",
-        `get ${key}`,
-        "",
-        "# Create or update an entry",
-        `put ${key} ${value}`,
-        "",
-        "# Delete an entry",
-        `delete ${key}`,
-      ].join("\n");
-    }
-    return [
-      header,
-      "",
-      "# Read the value",
-      `get ${base}`,
-      "",
-      "# Create or update it",
-      `put ${base} ${value}`,
-      "",
-      "# Delete it",
-      `delete ${base}`,
-    ].join("\n");
+    return libredbCheatsheet(tableName, columns);
   }
-  // Redis: the same cheatsheet shape as LibreDB above — a use-case comment over
-  // each command, every command line runnable on its own via "Run Selected". The
-  // provider skips `#` and blank lines, so running the whole buffer runs its
-  // first real command. A group name never appears as a key argument: Redis key
-  // arguments are literal byte strings, so `DEL user:*` would delete nothing (or
-  // the wrong thing) rather than the group (#427).
   if (capabilities.queryDialect === "redis") {
-    const { isPrefixGroup, base } = prefixGroup(tableName);
-    const key = isPrefixGroup ? `${base}1` : base;
-    const keyType = redisKeyType(columns);
-    const lines = [`# Redis commands for ${commentName(tableName)} — select a line and Run Selected.`, ""];
-    if (isPrefixGroup) {
-      // SCAN is a cursor step, not a listing: one call returns one page and the
-      // next cursor, and on a large keyspace the first page can be EMPTY with a
-      // non-zero cursor. A one-line command cannot loop, so say how to continue
-      // rather than pretend the first reply is the whole answer (#427).
-      lines.push(
-        "# List keys under this prefix — ONE scan iteration, not the whole set.",
-        "# 0 is the start cursor; the reply's first row is the next cursor. Re-run",
-        "# with that value in place of 0 until it comes back 0 (a page may be empty).",
-        redisScan(base),
-        "",
-      );
-    }
-    lines.push("# Check the key's type", renderRedisCommand(["TYPE", key]), "");
-    if (keyType) {
-      const commands = REDIS_COMMANDS[keyType];
-      lines.push(
-        commands.readComment,
-        renderRedisCommand(commands.read(key)),
-        "",
-        commands.writeComment,
-        renderRedisCommand(commands.write(key)),
-        "",
-      );
-    }
-    lines.push(
-      "# Time to live in seconds (-1 no expiry, -2 no such key)",
-      renderRedisCommand(["TTL", key]),
-      "",
-      "# Delete the key (DEL takes a literal key name, never a pattern)",
-      renderRedisCommand(["DEL", key]),
-    );
-    return lines.join("\n");
+    return redisCheatsheet(tableName, columns);
   }
   if (capabilities.queryLanguage === "json") {
     const projection: Record<string, number> = {};

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -20,6 +20,7 @@ import { type StudioWorkspaceProps, DEFAULT_WORKSPACE_FEATURES } from "@/workspa
 import { cn } from "@/lib/utils";
 import { ChunkBoundary, ViewLoading } from "@/components/LazyView";
 import { lazyRetry } from "@/lib/lazy";
+import { editorLanguageForTabType } from "@/lib/editor/tab-language";
 import { buildResultExport, type ResultExportFormat } from "@/lib/export/result-export";
 import { downloadText } from "@/lib/export/download";
 
@@ -183,7 +184,7 @@ export function StudioWorkspace({
   // 2. Tab Manager (pure UI state, reused as-is)
   const tabMgr = useTabManager({
     activeConnection: conn.activeConnection,
-    metadata: null,
+    metadata: conn.metadata,
     schema: conn.schema,
   });
 
@@ -307,7 +308,7 @@ export function StudioWorkspace({
             isAdmin={false}
             onOpenMaintenance={noop}
             databaseType={conn.activeConnection?.type}
-            metadata={null}
+            metadata={conn.metadata}
             onProfileTable={features.codeGenerator ? (name: string) => setProfilerTable(name) : undefined}
             onGenerateCode={features.codeGenerator ? (name: string) => setCodeGenTable(name) : undefined}
             onGenerateTestData={features.testDataGenerator ? (name: string) => setTestDataTable(name) : undefined}
@@ -359,7 +360,7 @@ export function StudioWorkspace({
                       <div className="h-full flex flex-col">
                         <QueryToolbar
                           activeConnection={conn.activeConnection}
-                          metadata={null}
+                          metadata={conn.metadata}
                           isExecuting={tabMgr.currentTab.isExecuting}
                           playgroundMode={false}
                           transactionActive={false}
@@ -367,12 +368,21 @@ export function StudioWorkspace({
                           onSaveQuery={onSaveQueryProp ? () => setIsSaveQueryModalOpen(true) : noop}
                           onExecuteQuery={() => queryExec.executeQuery()}
                           onCancelQuery={queryExec.cancelQuery}
-                          onBeginTransaction={noop}
-                          onCommitTransaction={noop}
-                          onRollbackTransaction={noop}
-                          onTogglePlayground={noop}
-                          onToggleEditing={noop}
-                          onImport={features.dataImport ? () => setIsImportModalOpen(true) : noop}
+                          // Withheld, not `noop`: this shell runs no transaction,
+                          // no sandbox and no inline editing — `transactionActive`
+                          // and `editingEnabled` are hardcoded false above and
+                          // nothing here can change them. While it passed
+                          // `metadata={null}` the group never rendered and `noop`
+                          // was invisible; passing the host's real metadata (#427)
+                          // would have put three dead buttons on any host that
+                          // declares `queryLanguage: "sql"`, with no disabled state
+                          // and no tooltip. A withheld callback hides its control.
+                          onBeginTransaction={undefined}
+                          onCommitTransaction={undefined}
+                          onRollbackTransaction={undefined}
+                          onTogglePlayground={undefined}
+                          onToggleEditing={undefined}
+                          onImport={features.dataImport ? () => setIsImportModalOpen(true) : undefined}
                         />
 
                         <div className="flex-1 relative min-h-0">
@@ -380,15 +390,9 @@ export function StudioWorkspace({
                             ref={queryEditorRef}
                             value={tabMgr.currentTab.query}
                             onContentChange={(val) => tabMgr.updateTabById(tabMgr.currentTab.id, { query: val })}
-                            language={
-                              tabMgr.currentTab.type === "libredb"
-                                ? "libredb"
-                                : tabMgr.currentTab.type === "mongodb"
-                                  ? "json"
-                                  : "sql"
-                            }
+                            language={editorLanguageForTabType(tabMgr.currentTab.type)}
                             schemaContext={conn.schemaContext}
-                            capabilities={undefined}
+                            capabilities={conn.metadata?.capabilities}
                           />
                         </div>
                       </div>
@@ -402,7 +406,7 @@ export function StudioWorkspace({
                         schema={conn.schema}
                         schemaContext={conn.schemaContext}
                         activeConnection={conn.activeConnection}
-                        metadata={null}
+                        metadata={conn.metadata}
                         historyKey={queryExec.historyKey}
                         savedKey={savedKey}
                         maskingEnabled={false}

--- a/src/workspace/hooks/use-connection-adapter.ts
+++ b/src/workspace/hooks/use-connection-adapter.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import type { DatabaseConnection, TableSchema } from "@/lib/types";
+import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
 import type { WorkspaceConnection } from "@/workspace/types";
 
 interface UseConnectionAdapterParams {
@@ -54,7 +55,24 @@ export function useConnectionAdapter({ connections: externalConnections, onSchem
 
   const schemaContext = useMemo(() => JSON.stringify(schema), [schema]);
 
+  // The embedded shell's stand-in for `useProviderMetadata`: it has no
+  // `/api/db/provider-meta` of its own and holds no credentials to describe, so
+  // the host declares each connection's capabilities and wording alongside it
+  // (#427). Absent stays `null` — the same value this hook returned before the
+  // fields existed, which every consumer already reads as "provider unknown".
+  const metadata = useMemo<ProviderMetadata | null>(() => {
+    const declared = externalConnections.find((c) => c.id === activeConnection?.id);
+    if (!declared?.capabilities) return null;
+    // `labels` is optional for the host on purpose: every consumer reads it
+    // through `?.` and falls back to its own base wording, so a host that only
+    // knows the capabilities does not have to restate fifteen strings. It is
+    // optional on `ProviderMetadata` too, so this passes it through as-is rather
+    // than casting `undefined` into a field declared required.
+    return { capabilities: declared.capabilities, labels: declared.labels };
+  }, [externalConnections, activeConnection]);
+
   return {
+    metadata,
     connections,
     setConnections: (() => {}) as React.Dispatch<React.SetStateAction<DatabaseConnection[]>>,
     activeConnection,

--- a/src/workspace/types.ts
+++ b/src/workspace/types.ts
@@ -1,5 +1,6 @@
 // src/workspace/types.ts
 import type { DatabaseType, TableSchema, SavedQuery, QueryWarning } from "@/lib/types";
+import type { ProviderCapabilities, ProviderLabels } from "@/lib/db/types";
 
 // === Connection (platform → studio) ===
 
@@ -7,6 +8,25 @@ export interface WorkspaceConnection {
   id: string;
   name: string;
   type: DatabaseType;
+  /**
+   * What this connection's provider can do, as `getCapabilities()` reports it.
+   *
+   * The standalone shell reads the same object from `POST /api/db/provider-meta`;
+   * the embedded shell cannot — it has no route of its own, and the connection it
+   * is handed carries no credentials to describe, so the host is the only party
+   * that can answer. Both fields are therefore supplied per connection here.
+   *
+   * Everything capability-driven is off until they are: the tab's query dialect,
+   * so a Redis connection gets Redis commands instead of `SELECT * FROM user:*`
+   * (#427); the schema explorer's per-row actions; the provider's own wording.
+   *
+   * Additive and optional, like every field on this published interface. Absent
+   * reads exactly as it did before the field existed — studio treats the provider
+   * as unknown and falls back to SQL and to the base labels.
+   */
+  capabilities?: ProviderCapabilities;
+  /** This provider's UI wording, as `getLabels()` reports it. See `capabilities`. */
+  labels?: ProviderLabels;
 }
 
 // === User (platform → studio) ===

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -1262,6 +1262,19 @@ describe("Studio", () => {
     expect(result[0].type).toBe("sql");
   });
 
+  test("connection-change effect retypes tabs to redis when the provider declares that dialect (#427)", () => {
+    // Redis declares queryLanguage "json"; before #427 the json rung matched
+    // first and the redis arm below it was unreachable dead code.
+    connMgrOverride = { activeConnection: pgConn };
+    capabilitiesOverride = { queryLanguage: "json", queryDialect: "redis" };
+    render(<Studio />);
+    const updater = (mockSetTabs.mock.calls[0] as unknown[])[0] as (prev: unknown[]) => Array<{ type: string }>;
+    const result = updater([
+      { id: "tab-1", name: "Query 1", query: "GET k", result: null, isExecuting: false, type: "sql" },
+    ]);
+    expect(result[0].type).toBe("redis");
+  });
+
   // --- exportResults sql-ddl type mapping ---
   test("exportResults sql-ddl maps boolean and date sample values", async () => {
     tabMgrOverride = {

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -19,6 +19,9 @@ let capturedSchemaDiagramProps: Record<string, unknown> = {};
 let capturedDataProfilerProps: Record<string, unknown> = {};
 let capturedCodeGeneratorProps: Record<string, unknown> = {};
 let capturedTestDataGeneratorProps: Record<string, unknown> = {};
+// The arguments StudioWorkspace hands the shared tab manager. `metadata` used to
+// be hardcoded `null` here, which made the whole of #427 inert in this surface.
+let capturedTabManagerArgs: Record<string, unknown> = {};
 
 // ---- Trackable mock functions (shared across mocks + assertions) ----
 
@@ -88,6 +91,7 @@ mock.module("@/workspace/hooks/use-connection-adapter", () => ({
     connectionPulse: null,
     fetchSchema: mockFetchSchema,
     schemaContext: JSON.stringify([usersTable]),
+    metadata: null,
     ...connAdapterOverride,
   })),
 }));
@@ -115,24 +119,27 @@ mock.module("@/workspace/hooks/use-query-adapter", () => ({
 // ---- Mock shared studio hooks ----
 
 mock.module("@/hooks/use-tab-manager", () => ({
-  useTabManager: mock(() => ({
-    tabs: [baseTab],
-    activeTabId: "tab-1",
-    currentTab: baseTab,
-    setTabs: mockSetTabs,
-    setActiveTabId: mock(() => {}),
-    editingTabId: null,
-    editingTabName: "",
-    setEditingTabId: mock(() => {}),
-    setEditingTabName: mock(() => {}),
-    addTab: mock(() => {}),
-    closeTab: mock(() => {}),
-    updateCurrentTab: mockUpdateCurrentTab,
-    updateTabById: mockUpdateTabById,
-    handleTableClick: mockHandleTableClick,
-    handleGenerateSelect: mockHandleGenerateSelect,
-    ...tabMgrOverride,
-  })),
+  useTabManager: mock((args: Record<string, unknown>) => {
+    capturedTabManagerArgs = args;
+    return {
+      tabs: [baseTab],
+      activeTabId: "tab-1",
+      currentTab: baseTab,
+      setTabs: mockSetTabs,
+      setActiveTabId: mock(() => {}),
+      editingTabId: null,
+      editingTabName: "",
+      setEditingTabId: mock(() => {}),
+      setEditingTabName: mock(() => {}),
+      addTab: mock(() => {}),
+      closeTab: mock(() => {}),
+      updateCurrentTab: mockUpdateCurrentTab,
+      updateTabById: mockUpdateTabById,
+      handleTableClick: mockHandleTableClick,
+      handleGenerateSelect: mockHandleGenerateSelect,
+      ...tabMgrOverride,
+    };
+  }),
 }));
 
 mock.module("@/hooks/use-toast", () => ({
@@ -278,6 +285,8 @@ import { describe, test, expect, afterEach, beforeEach } from "bun:test";
 import { render, cleanup, act } from "@testing-library/react";
 import React from "react";
 import type { SavedQueryInput, StudioWorkspaceProps } from "@/workspace/types";
+import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
+import { generateTableQuery } from "@/lib/query-generators";
 
 const { StudioWorkspace } = await import("@/workspace/StudioWorkspace");
 
@@ -344,6 +353,7 @@ describe("StudioWorkspace", () => {
     capturedDataProfilerProps = {};
     capturedCodeGeneratorProps = {};
     capturedTestDataGeneratorProps = {};
+    capturedTabManagerArgs = {};
 
     // Reset overrides
     connAdapterOverride = {};
@@ -723,8 +733,9 @@ describe("StudioWorkspace", () => {
     expect(capturedSidebarProps.onProfileTable).toBeUndefined();
     expect(capturedSidebarProps.onGenerateCode).toBeUndefined();
     expect(capturedSidebarProps.onGenerateTestData).toBeUndefined();
-    // Import and save become noops
-    act(() => (capturedQueryToolbarProps.onImport as () => void)());
+    // Import is withheld entirely, so the toolbar renders no IMPORT button (#427);
+    // save stays wired and becomes a noop when the host passes no onSaveQuery.
+    expect(capturedQueryToolbarProps.onImport).toBeUndefined();
     expect(queryByTestId("dataimportmodal")).toBeNull();
     act(() => (capturedQueryToolbarProps.onSaveQuery as () => void)());
     expect(queryByTestId("savequerymodal")).toBeNull();
@@ -792,12 +803,13 @@ describe("StudioWorkspace", () => {
     act(() => (capturedQueryToolbarProps.onExecuteQuery as () => void)());
     expect(mockExecuteQuery).toHaveBeenCalledTimes(1);
     expect(capturedQueryToolbarProps.onCancelQuery).toBe(mockCancelQuery);
-    // Transaction and playground callbacks are noops in embedded mode
-    act(() => (capturedQueryToolbarProps.onBeginTransaction as () => void)());
-    act(() => (capturedQueryToolbarProps.onCommitTransaction as () => void)());
-    act(() => (capturedQueryToolbarProps.onRollbackTransaction as () => void)());
-    act(() => (capturedQueryToolbarProps.onTogglePlayground as () => void)());
-    act(() => (capturedQueryToolbarProps.onToggleEditing as () => void)());
+    // Transaction, playground and editing are withheld, not noops, in embedded
+    // mode — see "withholds every control the embedded shell cannot serve" (#427).
+    expect(capturedQueryToolbarProps.onBeginTransaction).toBeUndefined();
+    expect(capturedQueryToolbarProps.onCommitTransaction).toBeUndefined();
+    expect(capturedQueryToolbarProps.onRollbackTransaction).toBeUndefined();
+    expect(capturedQueryToolbarProps.onTogglePlayground).toBeUndefined();
+    expect(capturedQueryToolbarProps.onToggleEditing).toBeUndefined();
   });
 
   test("toolbar onImport opens the import modal which delegates and closes", () => {
@@ -836,6 +848,90 @@ describe("StudioWorkspace", () => {
     tabMgrOverride = { currentTab: { ...baseTab, type: "mongodb" } };
     renderWorkspace();
     expect(capturedQueryEditorProps.language).toBe("json");
+  });
+
+  test("editor language is redis for redis tabs (#427)", () => {
+    tabMgrOverride = { currentTab: { ...baseTab, type: "redis" } };
+    renderWorkspace();
+    expect(capturedQueryEditorProps.language).toBe("redis");
+  });
+
+  // =========================================================================
+  // Provider metadata wiring (#427)
+  // =========================================================================
+  //
+  // This shell hardcoded `metadata: null` into the tab manager and `metadata={null}`
+  // into every child that reads it, so a Redis connection here still generated
+  // `SELECT * FROM user:* LIMIT 50;` and still offered per-row actions the provider
+  // answers 400 to — the whole of #427 was inert in the published surface.
+  describe("provider metadata wiring (#427)", () => {
+    const redisMetadata = {
+      capabilities: {
+        queryLanguage: "json",
+        queryDialect: "redis",
+        tablesAreDerivedGroupings: true,
+        supportsMaintenance: true,
+        maintenanceOperations: ["analyze"],
+      },
+      labels: { selectAction: "Scan Keys" },
+    } as unknown as ProviderMetadata;
+
+    test("hands the connection adapter's metadata to the tab manager and every child that reads it", () => {
+      connAdapterOverride = { activeConnection: { ...dbConn, type: "redis" as const }, metadata: redisMetadata };
+      renderWorkspace();
+
+      expect(capturedTabManagerArgs.metadata).toBe(redisMetadata);
+      expect(capturedSidebarProps.metadata).toBe(redisMetadata);
+      expect(capturedQueryToolbarProps.metadata).toBe(redisMetadata);
+      expect(capturedBottomPanelProps.metadata).toBe(redisMetadata);
+      expect(capturedQueryEditorProps.capabilities).toBe(redisMetadata.capabilities);
+    });
+
+    test("a redis connection here generates a redis command, not SQL", () => {
+      connAdapterOverride = { activeConnection: { ...dbConn, type: "redis" as const }, metadata: redisMetadata };
+      renderWorkspace();
+
+      // The generator the tab manager runs, fed the metadata this shell actually
+      // passed it: with `null` it fell through to `SELECT * FROM user:* LIMIT 50;`.
+      const capabilities = (capturedTabManagerArgs.metadata as ProviderMetadata).capabilities;
+      const query = generateTableQuery("user:*", capabilities, []);
+      expect(query.startsWith("SCAN ")).toBe(true);
+      expect(query).not.toContain("SELECT");
+    });
+
+    test("stays null when the host declares no capabilities", () => {
+      renderWorkspace();
+      expect(capturedTabManagerArgs.metadata).toBeNull();
+      expect(capturedSidebarProps.metadata).toBeNull();
+    });
+
+    // Passing real metadata un-hides QueryToolbar's `queryLanguage === "sql"`
+    // group, which this shell serves none of: `transactionActive` and
+    // `editingEnabled` are hardcoded false here and nothing can change them, so a
+    // `noop` callback is a button that silently does nothing. Withholding the
+    // callback is how the toolbar is told not to render the control (#269, #427).
+    test("withholds every control the embedded shell cannot serve", () => {
+      const sqlMetadata = {
+        capabilities: { queryLanguage: "sql", supportsMaintenance: false, maintenanceOperations: [] },
+      } as unknown as ProviderMetadata;
+      connAdapterOverride = { metadata: sqlMetadata };
+      renderWorkspace();
+
+      expect(capturedQueryToolbarProps.metadata).toBe(sqlMetadata);
+      expect(capturedQueryToolbarProps.onBeginTransaction).toBeUndefined();
+      expect(capturedQueryToolbarProps.onCommitTransaction).toBeUndefined();
+      expect(capturedQueryToolbarProps.onRollbackTransaction).toBeUndefined();
+      expect(capturedQueryToolbarProps.onTogglePlayground).toBeUndefined();
+      expect(capturedQueryToolbarProps.onToggleEditing).toBeUndefined();
+      // The controls it does serve stay wired.
+      expect(typeof capturedQueryToolbarProps.onExecuteQuery).toBe("function");
+      expect(typeof capturedQueryToolbarProps.onImport).toBe("function");
+    });
+
+    test("withholds onImport too when the host disables the data-import feature", () => {
+      renderWorkspace({ features: ALL_FEATURES_OFF });
+      expect(capturedQueryToolbarProps.onImport).toBeUndefined();
+    });
   });
 
   // =========================================================================

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -31,7 +31,7 @@ let mockActiveConnectionId: string | null = "c1";
 // The capabilities the selected connection's provider declares. `null` is the
 // state before `/api/db/provider-meta` answers, and the state it stays in when
 // that request fails (#282).
-let mockMetadata: { capabilities: Record<string, unknown> } | null = {
+let mockMetadata: { capabilities: Record<string, unknown>; labels?: Record<string, string> } | null = {
   capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze", "vacuum", "reindex"] },
 };
 
@@ -311,6 +311,61 @@ describe("OperationsTab", () => {
     const titles = Array.from(container.querySelectorAll("button")).map((b) => b.getAttribute("title"));
     expect(titles).toContain("Analyze");
     expect(titles).not.toContain("Vacuum");
+  });
+
+  // ── Global maintenance cards speak the provider's language (#427) ─────────
+  //
+  // The six analyze/vacuum global ProviderLabels fields were declared in the type,
+  // set by four providers, and read by no component: Redis rendered Postgres's
+  // "Update Statistics / Updates query planner statistics for all tables".
+
+  test("renders the provider's own global maintenance wording", async () => {
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze", "vacuum"] },
+      labels: {
+        analyzeGlobalLabel: "Run Info",
+        analyzeGlobalTitle: "Server Info",
+        analyzeGlobalDesc: "Get Redis server information and statistics.",
+        vacuumGlobalLabel: "Run Memory Doctor",
+        vacuumGlobalTitle: "Memory Doctor",
+        vacuumGlobalDesc: "Analyzes memory usage and reports issues.",
+      },
+    };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Run Info")).not.toBeNull();
+    expect(queryByText("Server Info")).not.toBeNull();
+    expect(queryByText("Get Redis server information and statistics.")).not.toBeNull();
+    expect(queryByText("Run Memory Doctor")).not.toBeNull();
+    expect(queryByText("Memory Doctor")).not.toBeNull();
+    expect(queryByText("Analyzes memory usage and reports issues.")).not.toBeNull();
+
+    // The Postgres wording must be gone, not merely joined.
+    expect(queryByText("Run Analyze")).toBeNull();
+    expect(queryByText("Update Statistics")).toBeNull();
+    expect(queryByText("Reclaim Space")).toBeNull();
+  });
+
+  test("falls back to the generic wording when the provider ships no labels", async () => {
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze", "vacuum"] },
+    };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Run Analyze")).not.toBeNull();
+    expect(queryByText("Update Statistics")).not.toBeNull();
+    expect(queryByText("Updates query planner statistics for all tables.")).not.toBeNull();
+    expect(queryByText("Run Vacuum")).not.toBeNull();
+    expect(queryByText("Reclaim Space")).not.toBeNull();
+    expect(queryByText("Removes dead rows and returns space to the OS.")).not.toBeNull();
   });
 
   test("warning card present", async () => {

--- a/tests/components/schema-explorer/TableItem.test.tsx
+++ b/tests/components/schema-explorer/TableItem.test.tsx
@@ -56,6 +56,41 @@ mock.module("@/components/schema-explorer/ColumnList", () => ({
 
 import { TableItem } from "@/components/schema-explorer/TableItem";
 import type { TableSchema } from "@/lib/types";
+import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
+
+// Capability fixtures are partial on purpose: TableItem reads three fields, and
+// spelling out every ProviderCapabilities key in each case would bury them (#427).
+type Caps = ProviderMetadata["capabilities"];
+const caps = (partial: Partial<Caps>): Caps => partial as Caps;
+
+/** Postgres-shaped: ordinary tables, both maintenance operations declared. */
+const sqlCaps = caps({ supportsMaintenance: true, maintenanceOperations: ["vacuum", "analyze"] });
+/** Redis-shaped: rows are derived key-prefix groupings, only ANALYZE declared. */
+const redisCaps = caps({
+  tablesAreDerivedGroupings: true,
+  supportsMaintenance: true,
+  maintenanceOperations: ["analyze"],
+});
+/**
+ * LibreDB-shaped: the OTHER provider that declares `tablesAreDerivedGroupings`,
+ * and the one the Redis fixture does not stand in for — it declares NO
+ * maintenance at all, so its rows lose the same four items by two independent
+ * gates rather than one (#427).
+ */
+const libredbCaps = caps({
+  tablesAreDerivedGroupings: true,
+  supportsMaintenance: false,
+  maintenanceOperations: [],
+});
+
+/**
+ * Labels are partial for the same reason capabilities are: TableItem reads four
+ * of the fifteen. The two defaults spelled out here are `BaseDatabaseProvider`'s
+ * own, so a case that overrides one is visibly overriding it (#427).
+ */
+type Labels = ProviderMetadata["labels"];
+const labelsFor = (partial: Partial<Labels>): Labels =>
+  ({ analyzeAction: "Analyze Table", vacuumAction: "Vacuum Table", ...partial }) as Labels;
 
 // ── Test data ───────────────────────────────────────────────────────────────
 
@@ -285,7 +320,7 @@ describe("TableItem", () => {
 
   test("shows Analyze and Vacuum actions for admin", () => {
     const { getByTestId } = render(
-      <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin />,
+      <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin capabilities={sqlCaps} />,
     );
     const dropdown = within(getByTestId("dropdown"));
     expect(dropdown.queryByText("Analyze Table")).not.toBeNull();
@@ -312,6 +347,7 @@ describe("TableItem", () => {
         isExpanded={false}
         onToggle={mock(() => {})}
         isAdmin
+        capabilities={sqlCaps}
         onOpenMaintenance={onOpenMaintenance}
       />,
     );
@@ -333,6 +369,7 @@ describe("TableItem", () => {
         isExpanded={false}
         onToggle={mock(() => {})}
         isAdmin
+        capabilities={sqlCaps}
         onOpenMaintenance={onOpenMaintenance}
       />,
     );
@@ -364,7 +401,14 @@ describe("TableItem", () => {
       vacuumGlobalDesc: "Compact all",
     };
     const { getByTestId } = render(
-      <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin labels={labels} />,
+      <TableItem
+        table={largeTable}
+        isExpanded={false}
+        onToggle={mock(() => {})}
+        isAdmin
+        capabilities={sqlCaps}
+        labels={labels}
+      />,
     );
     const dropdown = within(getByTestId("dropdown"));
     expect(dropdown.queryByText("Run db.find()")).not.toBeNull();
@@ -406,7 +450,7 @@ describe("TableItem", () => {
 
   test("does not crash when optional callbacks are not provided", () => {
     const { getByTestId } = render(
-      <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin />,
+      <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin capabilities={sqlCaps} />,
     );
     const dropdown = within(getByTestId("dropdown"));
     // Click all menu items without providing callbacks - should not throw
@@ -445,7 +489,7 @@ describe("TableItem", () => {
 
   test("renders context menu with same actions as dropdown", () => {
     const { queryAllByText } = render(
-      <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin />,
+      <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin capabilities={sqlCaps} />,
     );
     // Each action should appear twice: once in dropdown, once in context menu
     expect(queryAllByText("Select Top 50").length).toBe(2);
@@ -495,6 +539,111 @@ describe("TableItem", () => {
       const toggle = getByRole("button", { name: "users" });
       expect(toggle.className).toContain("py-1.5");
       expect(toggle.parentElement?.className).not.toContain("py-1.5");
+    });
+  });
+  // ── Derived-grouping rows and declared maintenance (#427) ─────────────────
+
+  describe("capability gating (#427)", () => {
+    test("hides Profile Table and Generate Test Data when rows are derived groupings", () => {
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin={false}
+          capabilities={redisCaps}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Profile Table")).toBeNull();
+      expect(dropdown.queryByText("Generate Test Data")).toBeNull();
+    });
+
+    test("keeps Generate Code visible when rows are derived groupings", () => {
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin={false}
+          capabilities={redisCaps}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Generate Code")).not.toBeNull();
+    });
+
+    test("shows Profile Table and Generate Test Data when rows are addressable objects", () => {
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin={false}
+          capabilities={sqlCaps}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Profile Table")).not.toBeNull();
+      expect(dropdown.queryByText("Generate Test Data")).not.toBeNull();
+    });
+
+    test("offers no per-row maintenance at all when rows are derived groupings (#427)", () => {
+      // The issue's own symptom: Redis declares `analyze`, so "Key Info" survived
+      // a declared-operation gate and still called onOpenMaintenance("tables",
+      // "user:*") — a row the maintenance page cannot name.
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin
+          capabilities={redisCaps}
+          labels={labelsFor({ analyzeAction: "Key Info", vacuumAction: "Memory Doctor" })}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Key Info")).toBeNull();
+      expect(dropdown.queryByText("Memory Doctor")).toBeNull();
+    });
+
+    // The embedded LibreDB provider declares the same flag as Redis, so the gate
+    // reaches it too and its doc had to say so (docs/providers/libredb.md 5.3).
+    // A Redis-shaped fixture alone would not have caught a regression here: its
+    // labels and its maintenance list are both different (#427).
+    test("hides the same four items for the embedded LibreDB provider (#427)", () => {
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin
+          capabilities={libredbCaps}
+          labels={labelsFor({ analyzeAction: "Key Info", vacuumAction: "Compact" })}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Profile Table")).toBeNull();
+      expect(dropdown.queryByText("Generate Test Data")).toBeNull();
+      expect(dropdown.queryByText("Key Info")).toBeNull();
+      expect(dropdown.queryByText("Compact")).toBeNull();
+      // Naming the row is still fine; addressing it is not.
+      expect(dropdown.queryByText("Generate Code")).not.toBeNull();
+    });
+
+    test("hides maintenance from a non-admin even when declared", () => {
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin={false}
+          capabilities={sqlCaps}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Analyze Table")).toBeNull();
+      expect(dropdown.queryByText("Vacuum Table")).toBeNull();
     });
   });
 });

--- a/tests/components/studio/QueryToolbar.test.tsx
+++ b/tests/components/studio/QueryToolbar.test.tsx
@@ -9,10 +9,32 @@ import React from "react";
 import { QueryToolbar } from "@/components/studio/QueryToolbar";
 import { mockPostgresConnection } from "../../fixtures/connections";
 import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
+import type { ProviderLabels } from "@/lib/db/types";
 
 // =============================================================================
 // QueryToolbar Tests
 // =============================================================================
+
+// Named separately so a variant can spread it: `ProviderMetadata.labels` is
+// optional (a host of the embedded shell may declare capabilities only), and
+// spreading an optional field yields optional members (#427).
+const sqlLabels: ProviderLabels = {
+  entityName: "table",
+  entityNamePlural: "tables",
+  rowName: "row",
+  rowNamePlural: "rows",
+  selectAction: "SELECT * FROM",
+  generateAction: "Generate",
+  analyzeAction: "Analyze",
+  vacuumAction: "Vacuum",
+  searchPlaceholder: "Search tables...",
+  analyzeGlobalLabel: "Analyze All",
+  analyzeGlobalTitle: "Analyze All Tables",
+  analyzeGlobalDesc: "Update statistics for all tables",
+  vacuumGlobalLabel: "Vacuum All",
+  vacuumGlobalTitle: "Vacuum All Tables",
+  vacuumGlobalDesc: "Reclaim storage for all tables",
+};
 
 const sqlMetadata: ProviderMetadata = {
   capabilities: {
@@ -27,23 +49,7 @@ const sqlMetadata: ProviderMetadata = {
     defaultPort: 5432,
     schemaRefreshPattern: "",
   },
-  labels: {
-    entityName: "table",
-    entityNamePlural: "tables",
-    rowName: "row",
-    rowNamePlural: "rows",
-    selectAction: "SELECT * FROM",
-    generateAction: "Generate",
-    analyzeAction: "Analyze",
-    vacuumAction: "Vacuum",
-    searchPlaceholder: "Search tables...",
-    analyzeGlobalLabel: "Analyze All",
-    analyzeGlobalTitle: "Analyze All Tables",
-    analyzeGlobalDesc: "Update statistics for all tables",
-    vacuumGlobalLabel: "Vacuum All",
-    vacuumGlobalTitle: "Vacuum All Tables",
-    vacuumGlobalDesc: "Reclaim storage for all tables",
-  },
+  labels: sqlLabels,
 };
 
 function createDefaultProps(overrides: Record<string, unknown> = {}) {
@@ -142,6 +148,86 @@ describe("QueryToolbar", () => {
     expect(queryByText("SANDBOX")).not.toBeNull();
     expect(queryByText("IMPORT")).not.toBeNull();
     expect(queryByText("BEGIN")).not.toBeNull();
+  });
+
+  // ── Every control in the SQL group is withheld the same way (#427) ─────────
+  //
+  // The embedded shell serves none of transactions, sandbox or inline editing, and
+  // used to hide the whole group by passing `metadata={null}`. Once it passes the
+  // host's real metadata, a host declaring `queryLanguage: "sql"` rendered three
+  // buttons wired to `noop` — no disabled state, no tooltip, nothing happens. A
+  // caller that cannot serve a control omits its callback, as #269 established for
+  // EDIT, and the control does not render.
+
+  test("No transaction controls when the transaction callbacks are not provided", () => {
+    const { queryByText } = render(
+      <QueryToolbar
+        {...createDefaultProps({
+          onBeginTransaction: undefined,
+          onCommitTransaction: undefined,
+          onRollbackTransaction: undefined,
+        })}
+      />,
+    );
+
+    expect(queryByText("BEGIN")).toBeNull();
+    expect(queryByText("SANDBOX")).not.toBeNull();
+    expect(queryByText("IMPORT")).not.toBeNull();
+  });
+
+  test("No COMMIT/ROLLBACK in an active transaction when the callbacks are not provided", () => {
+    const { queryByText } = render(
+      <QueryToolbar
+        {...createDefaultProps({
+          transactionActive: true,
+          onBeginTransaction: undefined,
+          onCommitTransaction: undefined,
+          onRollbackTransaction: undefined,
+        })}
+      />,
+    );
+
+    expect(queryByText("COMMIT")).toBeNull();
+    expect(queryByText("ROLLBACK")).toBeNull();
+    expect(queryByText("TXN")).toBeNull();
+  });
+
+  test("No SANDBOX button when onTogglePlayground is not provided", () => {
+    const { queryByText } = render(<QueryToolbar {...createDefaultProps({ onTogglePlayground: undefined })} />);
+
+    expect(queryByText("SANDBOX")).toBeNull();
+    expect(queryByText("BEGIN")).not.toBeNull();
+  });
+
+  test("No IMPORT button when onImport is not provided", () => {
+    const { queryByText } = render(<QueryToolbar {...createDefaultProps({ onImport: undefined })} />);
+
+    expect(queryByText("IMPORT")).toBeNull();
+    expect(queryByText("BEGIN")).not.toBeNull();
+  });
+
+  test("No group at all when the caller can serve none of it, even on SQL", () => {
+    // The embedded shell's exact shape: real SQL metadata, no servable control.
+    const { queryByText } = render(
+      <QueryToolbar
+        {...createDefaultProps({
+          onBeginTransaction: undefined,
+          onCommitTransaction: undefined,
+          onRollbackTransaction: undefined,
+          onTogglePlayground: undefined,
+          onToggleEditing: undefined,
+          onImport: undefined,
+        })}
+      />,
+    );
+
+    expect(queryByText("BEGIN")).toBeNull();
+    expect(queryByText("SANDBOX")).toBeNull();
+    expect(queryByText("EDIT")).toBeNull();
+    expect(queryByText("IMPORT")).toBeNull();
+    // The controls this shell does serve are outside the group and stay.
+    expect(queryByText("RUN")).not.toBeNull();
+    expect(queryByText("Save")).not.toBeNull();
   });
 
   test("Run button disabled when no activeConnection", () => {
@@ -299,7 +385,7 @@ describe("QueryToolbar", () => {
         queryLanguage: "json",
       },
       labels: {
-        ...sqlMetadata.labels,
+        ...sqlLabels,
         entityName: "collection",
         entityNamePlural: "collections",
       },

--- a/tests/hooks/use-connection-adapter.test.ts
+++ b/tests/hooks/use-connection-adapter.test.ts
@@ -291,4 +291,77 @@ describe("useConnectionAdapter", () => {
 
     expect(result.current.connectionPulse).toBeNull();
   });
+
+  // ── Provider metadata (#427) ───────────────────────────────────────────
+
+  describe("provider metadata", () => {
+    const redisCapabilities = {
+      queryLanguage: "json",
+      queryDialect: "redis",
+      tablesAreDerivedGroupings: true,
+      supportsMaintenance: true,
+      maintenanceOperations: ["analyze"],
+    } as unknown as NonNullable<WorkspaceConnection["capabilities"]>;
+
+    test("is null when the host declares no capabilities", () => {
+      const connections = [makeWorkspaceConnection({ id: "c1" })];
+      const onSchemaFetch = mock(() => Promise.resolve([]));
+
+      const { result } = renderHook(() => useConnectionAdapter({ connections, onSchemaFetch }));
+
+      expect(result.current.metadata).toBeNull();
+    });
+
+    test("reports the active connection's declared capabilities", () => {
+      const connections = [
+        makeWorkspaceConnection({ id: "c1", type: "redis", capabilities: redisCapabilities }),
+        makeWorkspaceConnection({ id: "c2" }),
+      ];
+      const onSchemaFetch = mock(() => Promise.resolve([]));
+
+      const { result } = renderHook(() => useConnectionAdapter({ connections, onSchemaFetch }));
+
+      expect(result.current.metadata?.capabilities.queryDialect).toBe("redis");
+    });
+
+    test("follows the active connection when it changes", () => {
+      const connections = [
+        makeWorkspaceConnection({ id: "c1", type: "redis", capabilities: redisCapabilities }),
+        makeWorkspaceConnection({ id: "c2" }),
+      ];
+      const onSchemaFetch = mock(() => Promise.resolve([]));
+
+      const { result } = renderHook(() => useConnectionAdapter({ connections, onSchemaFetch }));
+
+      act(() => {
+        result.current.setActiveConnection(result.current.connections[1]);
+      });
+
+      expect(result.current.metadata).toBeNull();
+    });
+
+    test("passes the host's labels through when it declares them", () => {
+      const labels = { vacuumAction: "Memory Doctor" } as unknown as NonNullable<WorkspaceConnection["labels"]>;
+      const connections = [
+        makeWorkspaceConnection({ id: "c1", type: "redis", capabilities: redisCapabilities, labels }),
+      ];
+      const onSchemaFetch = mock(() => Promise.resolve([]));
+
+      const { result } = renderHook(() => useConnectionAdapter({ connections, onSchemaFetch }));
+
+      expect(result.current.metadata?.labels?.vacuumAction).toBe("Memory Doctor");
+    });
+
+    // `ProviderMetadata.labels` is optional precisely so this case needs no cast:
+    // a host that knows only the capabilities leaves the wording to studio's own
+    // fallbacks, and every consumer reads labels through `?.` (#427).
+    test("leaves labels absent when the host declares only capabilities", () => {
+      const connections = [makeWorkspaceConnection({ id: "c1", type: "redis", capabilities: redisCapabilities })];
+      const onSchemaFetch = mock(() => Promise.resolve([]));
+
+      const { result } = renderHook(() => useConnectionAdapter({ connections, onSchemaFetch }));
+
+      expect(result.current.metadata?.labels).toBeUndefined();
+    });
+  });
 });

--- a/tests/hooks/use-provider-metadata.test.ts
+++ b/tests/hooks/use-provider-metadata.test.ts
@@ -156,7 +156,9 @@ describe("useProviderMetadata", () => {
 
     expect(result.current.metadata!.capabilities.queryLanguage).toBe("sql");
     expect(result.current.metadata!.capabilities.supportsExplain).toBe(true);
-    expect(result.current.metadata!.labels.entityName).toBe("Table");
+    // `/api/db/provider-meta` always answers with labels; the field is optional on
+    // `ProviderMetadata` only because the embedded shell's host may omit it (#427).
+    expect(result.current.metadata!.labels?.entityName).toBe("Table");
   });
 
   test("sets metadata to null on fetch error", async () => {

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -648,6 +648,40 @@ describe("useQueryExecution", () => {
     expect(multiCall).toBeDefined();
   });
 
+  // ── a non-SQL dialect never takes the statement splitter ──────────────────
+
+  test("executeQuery keeps a JSON-dialect buffer on /api/db/query, semicolons and all (#427)", async () => {
+    // Redis commands are not `;`-separated, so splitting one buffer into
+    // "statements" can only invent fragments. Measured in the browser before this
+    // gate existed: the generated Redis cheatsheet carried a `;` inside a `#`
+    // comment, `isMultiStatement` said 2, and /api/db/multi-query executed a
+    // comments-only fragment -> "No command to run (only comments or blank lines)"
+    // reported to the user as a successful empty result.
+    const fetchMock = mockGlobalFetch({
+      "/api/db/multi-query": { ok: true, json: mockQueryResult },
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
+
+    const params = createDefaultParams({
+      metadata: { ...mockMetadata, capabilities: { ...mockMetadata.capabilities, queryLanguage: "json" } },
+    });
+
+    const { result } = renderHook(() => useQueryExecution(params));
+
+    await act(async () => {
+      await result.current.executeQuery("# 0 is the cursor; re-run with it\nSCAN 0 MATCH user:* COUNT 50");
+    });
+
+    const multiCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/multi-query"),
+    );
+    expect(multiCall).toBeUndefined();
+    const singleCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
+    );
+    expect(singleCall).toBeDefined();
+  });
+
   // ── executeQuery uses /api/db/transaction when transactionActive ───────────
 
   test("executeQuery uses /api/db/transaction when transactionActive", async () => {

--- a/tests/hooks/use-tab-manager.test.ts
+++ b/tests/hooks/use-tab-manager.test.ts
@@ -757,3 +757,115 @@ describe("useTabManager", () => {
     expect(newTab.query).toContain('"operation": "find"');
   });
 });
+
+// ─── Redis: dialect-aware tab type and type-aware generation (#427) ───
+
+describe("useTabManager — Redis dialect", () => {
+  const redisMetadata: ProviderMetadata = {
+    capabilities: {
+      ...defaultMetadata.capabilities,
+      queryLanguage: "json" as const,
+      queryDialect: "redis" as const,
+      defaultPort: 6379,
+    },
+    labels: defaultMetadata.labels,
+  } as ProviderMetadata;
+
+  // The provider's schema nodes: a `:`-prefix grouping and a bare key, each
+  // carrying the sampled Redis type on the `type` column (redis.ts getSchema).
+  const redisSchema: TableSchema[] = [
+    {
+      name: "session:*",
+      columns: [
+        { name: "key", type: "string", nullable: false, isPrimary: true },
+        { name: "type", type: "hash", nullable: false, isPrimary: false },
+        { name: "value", type: "hash", nullable: true, isPrimary: false },
+      ],
+      indexes: [],
+    },
+    {
+      name: "counter",
+      columns: [
+        { name: "key", type: "string", nullable: false, isPrimary: true },
+        { name: "type", type: "hash", nullable: false, isPrimary: false },
+        { name: "value", type: "hash", nullable: true, isPrimary: false },
+      ],
+      indexes: [],
+    },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("addTab creates a redis tab type", () => {
+    const { result } = renderHook(() =>
+      useTabManager({
+        activeConnection: makeConnection({ type: "redis", port: 6379 }),
+        metadata: redisMetadata,
+        schema: redisSchema,
+      }),
+    );
+
+    act(() => {
+      result.current.addTab();
+    });
+
+    expect(result.current.tabs[1].type).toBe("redis");
+  });
+
+  test("handleTableClick creates a redis tab and passes the table's columns to the generator", () => {
+    const executeFn = mock(() => {});
+    const { result } = renderHook(() =>
+      useTabManager({
+        activeConnection: makeConnection({ type: "redis", port: 6379 }),
+        metadata: redisMetadata,
+        schema: redisSchema,
+      }),
+    );
+
+    act(() => {
+      result.current.handleTableClick("session:*", executeFn);
+    });
+
+    const newTab = result.current.tabs[1];
+    expect(newTab.type).toBe("redis");
+    expect(newTab.query).toBe("SCAN 0 MATCH session:* COUNT 50");
+  });
+
+  test("handleTableClick on a bare key uses the sampled type from its columns", () => {
+    const executeFn = mock(() => {});
+    const { result } = renderHook(() =>
+      useTabManager({
+        activeConnection: makeConnection({ type: "redis", port: 6379 }),
+        metadata: redisMetadata,
+        schema: redisSchema,
+      }),
+    );
+
+    act(() => {
+      result.current.handleTableClick("counter", executeFn);
+    });
+
+    expect(result.current.tabs[1].query).toBe("HGETALL counter");
+  });
+
+  test("handleGenerateSelect creates a redis tab", () => {
+    const { result } = renderHook(() =>
+      useTabManager({
+        activeConnection: makeConnection({ type: "redis", port: 6379 }),
+        metadata: redisMetadata,
+        schema: redisSchema,
+      }),
+    );
+
+    act(() => {
+      result.current.handleGenerateSelect("session:*");
+    });
+
+    const newTab = result.current.tabs[1];
+    expect(newTab.type).toBe("redis");
+    expect(newTab.query).toContain("SCAN 0 MATCH session:* COUNT 50");
+    expect(newTab.query).not.toContain('"collection"');
+  });
+});

--- a/tests/integration/db/redis-provider.test.ts
+++ b/tests/integration/db/redis-provider.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import type { DatabaseConnection } from "@/lib/types";
+import { generateTableQuery, generateSelectQuery } from "@/lib/query-generators";
 
 // ============================================================================
 // Mock Setup — MUST come before provider import
@@ -52,7 +53,28 @@ const mockCallResults: Record<string, unknown> = {
   PING: "PONG",
   DBSIZE: 42,
   SLOWLOG: MOCK_SLOWLOG_ENTRIES,
+  // Every verb the schema-explorer generators can emit, so the round-trip tests
+  // below can feed generated command lines straight into query() (#427). One
+  // entry per verb is enough; `capturedCalls` records the args separately.
+  SCAN: ["0", ["user:1", "user:2"]],
+  TYPE: "string",
+  TTL: -1,
+  HSET: 1,
+  LRANGE: [],
+  RPUSH: 1,
+  SMEMBERS: [],
+  SADD: 1,
+  ZRANGE: [],
+  ZADD: 1,
 };
+
+/**
+ * Every (command, args) tuple the provider actually handed the driver. The
+ * round-trip tests assert against THIS, not against the reply: a generated
+ * command that reaches the driver with mangled args still "succeeds" otherwise,
+ * which is exactly how the quote defect survived the first review (#427).
+ */
+const capturedCalls: Array<{ command: string; args: string[] }> = [];
 
 mock.module("ioredis", () => {
   class MockRedis {
@@ -91,8 +113,9 @@ mock.module("ioredis", () => {
       return "OK";
     }
 
-    async call(command: string) {
+    async call(command: string, ...args: string[]) {
       const cmd = command.toUpperCase();
+      capturedCalls.push({ command: cmd, args });
       // Simulate a Redis-side error (e.g. unknown command / wrong arity)
       if (cmd === "BOGUS") {
         throw new Error("ERR unknown command 'BOGUS'");
@@ -205,6 +228,13 @@ describe("RedisProvider", () => {
       expect(caps.explainFormat).toBeUndefined();
       expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);
     });
+
+    test("declares the redis query dialect (#427)", () => {
+      // Without this the client-side generators fall through to the MongoDB
+      // branch on `queryLanguage === "json"` and every schema-explorer action
+      // emits JSON this provider rejects.
+      expect(provider.getCapabilities().queryDialect).toBe("redis");
+    });
   });
 
   // --------------------------------------------------------------------------
@@ -302,6 +332,297 @@ describe("RedisProvider", () => {
 
     test("Redis-side command error is surfaced as QueryError", async () => {
       await expect(provider.query("BOGUS arg1")).rejects.toThrow(/Redis error: ERR unknown command/);
+    });
+
+    // --- Commented cheatsheets from the schema explorer (#427) ---
+
+    test("a leading # comment line is skipped; the command runs", async () => {
+      const result = await provider.query("# Read the value\nGET mykey");
+      expect(result.rows[0].result).toBe("hello-world");
+    });
+
+    test("blank lines are skipped", async () => {
+      const result = await provider.query("\n\n   \nGET mykey");
+      expect(result.rows[0].result).toBe("hello-world");
+    });
+
+    test('a "#" inside an argument is not a comment', async () => {
+      const result = await provider.query("SET k #tag");
+      expect(result.rows[0].result).toBe("OK");
+    });
+
+    test("input that is only comments and blank lines is rejected", async () => {
+      await expect(provider.query("# just a note\n\n# and another")).rejects.toThrow(/only comments|no command/i);
+    });
+
+    test("a line that tokenizes to nothing throws Empty command", async () => {
+      await expect(provider.query('""')).rejects.toThrow(/Empty command/);
+    });
+
+    test("a pretty-printed multi-line JSON command still parses", async () => {
+      const result = await provider.query(JSON.stringify({ command: "GET", args: ["mykey"] }, null, 2));
+      expect(result.rows[0].result).toBe("hello-world");
+    });
+
+    test("a JSON command preceded by comment lines still parses", async () => {
+      const result = await provider.query('# a note\n\n{"command":"GET","args":["mykey"]}');
+      expect(result.rows[0].result).toBe("hello-world");
+    });
+
+    test("a trailing # comment after a JSON body is dropped, not an error", async () => {
+      const result = await provider.query('{"command":"GET","args":["mykey"]}\n# trailing note');
+      expect(result.rows[0].result).toBe("hello-world");
+    });
+
+    test("trailing non-comment text after a JSON body is still an Invalid JSON command format", async () => {
+      await expect(provider.query('{"command":"GET","args":["mykey"]}\ntrailing note')).rejects.toThrow(
+        /Invalid JSON command format/,
+      );
+    });
+
+    test("the generated Scan Keys command runs against this provider (#427)", async () => {
+      const schema = await provider.getSchema();
+      const generated = generateTableQuery(schema[0].name, provider.getCapabilities(), schema[0].columns);
+      const result = await provider.query(generated);
+      expect(result.rows).toBeArray();
+    });
+
+    test("every command line the cheatsheet generates is accepted (#427)", async () => {
+      for (const sample of ["string", "hash", "list", "set", "zset"]) {
+        const columns = [
+          { name: "key", type: "string", nullable: false, isPrimary: true },
+          { name: "value", type: sample, nullable: true, isPrimary: false },
+          { name: "type", type: sample, nullable: false, isPrimary: false },
+        ];
+        const out = generateSelectQuery("user:*", columns, provider.getCapabilities());
+        const lines = out
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l !== "" && !l.startsWith("#"));
+        expect(lines.length).toBeGreaterThan(0);
+        for (const line of lines) {
+          await expect(provider.query(line)).resolves.toBeDefined();
+        }
+      }
+    });
+
+    // --- Round-trip: generator output THROUGH this provider's own parser (#427) ---
+
+    /**
+     * Run every runnable line of a generated buffer and return what the driver
+     * was actually called with. Comments and blank lines are dropped exactly as
+     * "Run Selected" would leave them out.
+     *
+     * NOTE: this helper strips comments and blank lines ITSELF and runs each line
+     * on its own, so it exercises the per-line paths and NOT `commandBody`'s block
+     * logic — which is how a comment-stripping defect survived two reviews (#427).
+     * The whole-buffer suite below is the one that covers `commandBody`.
+     */
+    async function runGeneratedLines(buffer: string): Promise<Array<{ command: string; args: string[] }>> {
+      capturedCalls.length = 0;
+      const lines = buffer
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l !== "" && !l.startsWith("#"));
+      for (const line of lines) await provider.query(line);
+      return [...capturedCalls];
+    }
+
+    const KEY_COLUMNS = (sample: string) => [
+      { name: "key", type: "string", nullable: false, isPrimary: true },
+      { name: "value", type: sample, nullable: true, isPrimary: false },
+      { name: "type", type: sample, nullable: false, isPrimary: false },
+    ];
+
+    test("a key containing a double quote reaches the driver unmangled (#427)", async () => {
+      // Plain-form `DEL "say"hi""` tokenizes to `sayhi` — a DIFFERENT key. The
+      // generator must fall back to the lossless JSON form for such a line.
+      const calls = await runGeneratedLines(
+        generateSelectQuery('say"hi"', KEY_COLUMNS("string"), provider.getCapabilities()),
+      );
+      for (const call of calls) {
+        expect(call.args[0]).toBe('say"hi"');
+      }
+      expect(calls.map((c) => c.command)).toContain("DEL");
+    });
+
+    test("a key containing a single quote reaches the driver unmangled (#427)", async () => {
+      const calls = await runGeneratedLines(
+        generateSelectQuery("it's", KEY_COLUMNS("hash"), provider.getCapabilities()),
+      );
+      for (const call of calls) {
+        expect(call.args[0]).toBe("it's");
+      }
+    });
+
+    test("a quoted prefix group SCANs the pattern it meant to (#427)", async () => {
+      const calls = await runGeneratedLines(
+        generateTableQuery('a"b:*', provider.getCapabilities(), KEY_COLUMNS("string")),
+      );
+      expect(calls).toEqual([{ command: "SCAN", args: ["0", "MATCH", 'a"b:*', "COUNT", "50"] }]);
+    });
+
+    test("a key containing whitespace still round-trips in plain form (#427)", async () => {
+      const calls = await runGeneratedLines(
+        generateTableQuery("my key", provider.getCapabilities(), KEY_COLUMNS("string")),
+      );
+      expect(calls).toEqual([{ command: "GET", args: ["my key"] }]);
+    });
+
+    test("an ordinary key still round-trips in plain form (#427)", async () => {
+      const calls = await runGeneratedLines(
+        generateTableQuery("user:1", provider.getCapabilities(), KEY_COLUMNS("zset")),
+      );
+      expect(calls).toEqual([{ command: "ZRANGE", args: ["user:1", "0", "-1", "WITHSCORES"] }]);
+    });
+
+    test("a glob-escaped prefix reaches the driver with its backslash intact (#427)", async () => {
+      const calls = await runGeneratedLines(
+        generateTableQuery("a[b:*", provider.getCapabilities(), KEY_COLUMNS("string")),
+      );
+      expect(calls).toEqual([{ command: "SCAN", args: ["0", "MATCH", "a\\[b:*", "COUNT", "50"] }]);
+    });
+
+    // --- Multi-line bodies (#427 F2 regression) ---
+
+    test("a plain command wrapped across lines still runs whole", async () => {
+      // On main the tokenizer treated a newline as ordinary whitespace, so this
+      // wrote BOTH fields. First-line-only picking silently dropped the second.
+      capturedCalls.length = 0;
+      await provider.query("HSET user:1 name alice\nemail a@b.c");
+      expect(capturedCalls).toEqual([{ command: "HSET", args: ["user:1", "name", "alice", "email", "a@b.c"] }]);
+    });
+
+    test("a blank line ends the command: the cheatsheet runs only its first block", async () => {
+      capturedCalls.length = 0;
+      await provider.query(generateSelectQuery("user:*", KEY_COLUMNS("string"), provider.getCapabilities()));
+      expect(capturedCalls).toEqual([{ command: "SCAN", args: ["0", "MATCH", "user:*", "COUNT", "50"] }]);
+    });
+
+    test("comment lines between the wrapped lines of one command are dropped", async () => {
+      capturedCalls.length = 0;
+      await provider.query("HSET user:1 name alice\n# a note\nemail a@b.c");
+      expect(capturedCalls).toEqual([{ command: "HSET", args: ["user:1", "name", "alice", "email", "a@b.c"] }]);
+    });
+
+    // --- A node name may not smuggle a command through the header comment (#427) ---
+
+    /**
+     * A schema-tree node name is a real key name, and Redis keys are arbitrary
+     * byte strings — a newline in one used to end the cheatsheet's header
+     * comment and turn its own remainder into the FIRST runnable line of the
+     * buffer, which this provider then executed. Asserted on what the driver was
+     * called with, because a mangled command still "succeeds" otherwise.
+     */
+    async function runWholeBuffer(buffer: string): Promise<Array<{ command: string; args: string[] }>> {
+      capturedCalls.length = 0;
+      await provider.query(buffer);
+      return [...capturedCalls];
+    }
+
+    test("a node name containing a newline cannot inject a command (#427)", async () => {
+      const name = "a\nDEL user:1 x";
+      const calls = await runWholeBuffer(generateSelectQuery(name, KEY_COLUMNS("string"), provider.getCapabilities()));
+      expect(calls).toEqual([{ command: "TYPE", args: [name] }]);
+    });
+
+    test("a node name containing CRLF cannot inject a command (#427)", async () => {
+      const name = "a\r\nDEL user:1 x";
+      const calls = await runWholeBuffer(generateSelectQuery(name, KEY_COLUMNS("string"), provider.getCapabilities()));
+      expect(calls).toEqual([{ command: "TYPE", args: [name] }]);
+    });
+
+    test("a node name containing a newline and a quote cannot inject a command (#427)", async () => {
+      const name = 'a\nDEL "user:1" x';
+      const calls = await runWholeBuffer(generateSelectQuery(name, KEY_COLUMNS("hash"), provider.getCapabilities()));
+      expect(calls).toEqual([{ command: "TYPE", args: [name] }]);
+    });
+
+    test("a newline-bearing prefix group still SCANs its own pattern (#427)", async () => {
+      const calls = await runWholeBuffer(
+        generateSelectQuery("a\nDEL user:1 x:*", KEY_COLUMNS("string"), provider.getCapabilities()),
+      );
+      expect(calls).toEqual([{ command: "SCAN", args: ["0", "MATCH", "a\nDEL user:1 x:*", "COUNT", "50"] }]);
+    });
+
+    // --- The WHOLE generated buffer through commandBody (#427 S4) ---
+    //
+    // `runGeneratedLines` above pre-strips comments and blank lines, so it never
+    // reaches `commandBody`. These hand the buffer over UNMODIFIED — what a user
+    // gets by pressing Run with nothing selected — and assert the args the driver
+    // received for the FIRST block, which is the only command that may run.
+    const wholeBufferCases: {
+      name: string;
+      node: string;
+      sample: string;
+      expected: { command: string; args: string[] };
+    }[] = [
+      {
+        name: "a plain prefix group",
+        node: "user:*",
+        sample: "string",
+        expected: { command: "SCAN", args: ["0", "MATCH", "user:*", "COUNT", "50"] },
+      },
+      {
+        name: "a bare key",
+        node: "user:1",
+        sample: "zset",
+        expected: { command: "TYPE", args: ["user:1"] },
+      },
+      {
+        // The quote forces every command line into the JSON form, and JSON's `\"`
+        // is not the plain tokenizer's quote: counting it left a phantom quote
+        // open, so no later comment line was dropped and the whole buffer reached
+        // JSON.parse with comments in it — "Invalid JSON command format" instead
+        // of a TYPE result (#427).
+        name: "a name containing a double quote",
+        node: 'say"hi',
+        sample: "string",
+        expected: { command: "TYPE", args: ['say"hi'] },
+      },
+      {
+        name: "a name containing a newline",
+        node: "a\nDEL user:1 x",
+        sample: "string",
+        expected: { command: "TYPE", args: ["a\nDEL user:1 x"] },
+      },
+    ];
+
+    for (const { name, node, sample, expected } of wholeBufferCases) {
+      test(`the whole cheatsheet buffer for ${name} runs exactly its first block (#427)`, async () => {
+        const buffer = generateSelectQuery(node, KEY_COLUMNS(sample), provider.getCapabilities());
+        const calls = await runWholeBuffer(buffer);
+        expect(calls).toEqual([expected]);
+      });
+    }
+
+    // --- A quoted argument spanning lines keeps its newline (#427 regression) ---
+
+    test("a quoted value spanning two lines keeps the newline", async () => {
+      // The tokenizer's whitespace branch is guarded by `!inQuote`, so inside a
+      // quoted argument a newline is DATA. Joining the block with a space
+      // rewrote the stored value silently.
+      capturedCalls.length = 0;
+      await provider.query('SET note "line1\nline2"');
+      expect(capturedCalls).toEqual([{ command: "SET", args: ["note", "line1\nline2"] }]);
+    });
+
+    test("a quoted value whose continuation starts with # is data, not a comment", async () => {
+      capturedCalls.length = 0;
+      await provider.query('SET note "line1\n#tag"');
+      expect(capturedCalls).toEqual([{ command: "SET", args: ["note", "line1\n#tag"] }]);
+    });
+
+    test("a blank line inside a quoted value does not end the command", async () => {
+      capturedCalls.length = 0;
+      await provider.query('SET note "line1\n\nline3"');
+      expect(capturedCalls).toEqual([{ command: "SET", args: ["note", "line1\n\nline3"] }]);
+    });
+
+    test("indentation inside a quoted value is preserved", async () => {
+      capturedCalls.length = 0;
+      await provider.query('SET note "line1\n  line2"');
+      expect(capturedCalls).toEqual([{ command: "SET", args: ["note", "line1\n  line2"] }]);
     });
 
     test("query on a disconnected provider throws", async () => {

--- a/tests/unit/code-generator-functions.test.ts
+++ b/tests/unit/code-generator-functions.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import {
   toPascalCase,
+  toIdentifier,
   toCamelCase,
   toSnakeCase,
   mapSqlTypeToTS,
@@ -266,4 +267,104 @@ describe("generateCode", () => {
     expect(code).toContain("export interface Empty");
     expect(code).toContain("{\n\n}");
   });
+});
+
+// ============================================================================
+// toIdentifier (#427)
+// ============================================================================
+
+describe("toIdentifier", () => {
+  test("redis key-prefix grouping becomes a legal identifier", () => expect(toIdentifier("user:*")).toBe("User"));
+  test("a second grouping keeps its singular-stripping behaviour", () =>
+    expect(toIdentifier("session:*")).toBe("Session"));
+  test("a bare key is unchanged", () => expect(toIdentifier("counter")).toBe("Counter"));
+  test("punctuation runs become word boundaries", () => expect(toIdentifier("a-b:*")).toBe("AB"));
+  test("a name with no alphanumerics falls back to Record", () => expect(toIdentifier(":*")).toBe("Record"));
+  test("an empty name falls back to Record", () => expect(toIdentifier("")).toBe("Record"));
+  test("an ordinary SQL table name is unaffected (regression)", () => expect(toIdentifier("users")).toBe("User"));
+  test("a leading digit is prefixed rather than left illegal", () => expect(toIdentifier("2fa:*")).toBe("T2fa"));
+
+  // Non-ASCII names were ALREADY legal identifiers in all six target languages,
+  // and an ASCII-only strip destroyed them: "musteri" lost its diacritics and
+  // two entirely non-Latin names collapsed onto the same fallback, so two tables
+  // generated two files declaring one type (#427).
+  test("a Turkish name keeps its letters", () => expect(toIdentifier("m\u00fc\u015fteri")).toBe("M\u00fc\u015fteri"));
+  test("an already-capitalised Turkish name is unchanged", () =>
+    expect(toIdentifier("\u00dcr\u00fcnler")).toBe("\u00dcr\u00fcnler"));
+  test("a CJK name is unchanged rather than replaced by the fallback", () =>
+    expect(toIdentifier("\u65e5\u672c\u8a9e")).toBe("\u65e5\u672c\u8a9e"));
+  test("two distinct non-ASCII names do not collide", () =>
+    expect(toIdentifier("\u65e5\u672c\u8a9e")).not.toBe(toIdentifier("\u00dcr\u00fcnler")));
+  test("a non-ASCII prefix group is still stripped of its glob", () =>
+    expect(toIdentifier("m\u00fc\u015fteri:*")).toBe("M\u00fc\u015fteri"));
+});
+
+describe("generateCode — non-identifier table names (#427)", () => {
+  const redisSchema: TableSchema = {
+    name: "user:*",
+    indexes: [],
+    columns: [
+      { name: "key", type: "string", nullable: false, isPrimary: true },
+      { name: "value", type: "string", nullable: true, isPrimary: false },
+    ],
+  };
+
+  test("TypeScript emits a legal interface name", () => {
+    const code = generateCode("typescript", redisSchema);
+    expect(code).toContain("export interface User {");
+    expect(code).not.toContain("User:*");
+  });
+
+  test("Zod emits a legal schema name", () => {
+    const code = generateCode("zod", redisSchema);
+    expect(code).toContain("export const UserSchema = z.object");
+    expect(code).not.toContain("User:*");
+  });
+
+  test("Prisma emits a legal model name but maps the raw key pattern", () => {
+    const code = generateCode("prisma", redisSchema);
+    expect(code).toContain("model User {");
+    expect(code).toContain('@@map("user:*")');
+  });
+
+  test("Go emits a legal struct name", () => {
+    const code = generateCode("go", redisSchema);
+    expect(code).toContain("type User struct");
+    expect(code).not.toContain("User:*");
+  });
+
+  test("Python emits a legal class name", () => {
+    const code = generateCode("python", redisSchema);
+    expect(code).toContain("class User:");
+    expect(code).not.toContain("User:*");
+  });
+
+  test("Java emits a legal class name", () => {
+    const code = generateCode("java", redisSchema);
+    expect(code).toContain("public class User {");
+    expect(code).not.toContain("User:*");
+  });
+
+  // Every target language accepts Unicode letters in an identifier, so a
+  // non-ASCII table name must survive intact in all six outputs (#427).
+  const unicodeSchema: TableSchema = {
+    name: "m\u00fc\u015fteri",
+    indexes: [],
+    columns: [{ name: "id", type: "INT", nullable: false, isPrimary: true }],
+  };
+
+  const unicodeExpectations: [Parameters<typeof generateCode>[0], string][] = [
+    ["typescript", "export interface M\u00fc\u015fteri {"],
+    ["zod", "export const M\u00fc\u015fteriSchema = z.object"],
+    ["prisma", "model M\u00fc\u015fteri {"],
+    ["go", "type M\u00fc\u015fteri struct"],
+    ["python", "class M\u00fc\u015fteri:"],
+    ["java", "public class M\u00fc\u015fteri {"],
+  ];
+
+  for (const [lang, expected] of unicodeExpectations) {
+    test(`${lang} keeps a non-ASCII table name intact`, () => {
+      expect(generateCode(lang, unicodeSchema)).toContain(expected);
+    });
+  }
 });

--- a/tests/unit/editor/redis-language.test.ts
+++ b/tests/unit/editor/redis-language.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from "bun:test";
+import type * as Monaco from "monaco-editor";
+import { registerRedisLanguage } from "@/lib/editor/redis-language";
+
+// ---------------------------------------------------------------------------
+// Mock Monaco — a local copy of the harness in libredb-language.test.ts. Kept
+// local on purpose: sharing a mock module across test files is the documented
+// `mock.module()` contamination trap in this repo.
+// ---------------------------------------------------------------------------
+
+interface MockMonacoState {
+  registered: Monaco.languages.ILanguageExtensionPoint[];
+  tokensProviders: Array<{ languageId: string; provider: Monaco.languages.IMonarchLanguage }>;
+  configurations: Array<{ languageId: string; configuration: Monaco.languages.LanguageConfiguration }>;
+}
+
+function createMockMonaco() {
+  const state: MockMonacoState = {
+    registered: [],
+    tokensProviders: [],
+    configurations: [],
+  };
+
+  const mockMonaco = {
+    languages: {
+      getLanguages: () => state.registered,
+      register: (language: Monaco.languages.ILanguageExtensionPoint) => {
+        state.registered.push(language);
+      },
+      setMonarchTokensProvider: (languageId: string, provider: Monaco.languages.IMonarchLanguage) => {
+        state.tokensProviders.push({ languageId, provider });
+        return { dispose: () => {} };
+      },
+      setLanguageConfiguration: (languageId: string, configuration: Monaco.languages.LanguageConfiguration) => {
+        state.configurations.push({ languageId, configuration });
+        return { dispose: () => {} };
+      },
+    },
+    _state: state,
+  };
+
+  return mockMonaco as unknown as typeof Monaco & { _state: MockMonacoState };
+}
+
+describe("registerRedisLanguage", () => {
+  test("registers the redis language with tokens provider and configuration", () => {
+    const monaco = createMockMonaco();
+
+    registerRedisLanguage(monaco);
+
+    expect(monaco._state.registered).toEqual([{ id: "redis" }]);
+    expect(monaco._state.tokensProviders).toHaveLength(1);
+    expect(monaco._state.tokensProviders[0]?.languageId).toBe("redis");
+    expect(monaco._state.configurations).toHaveLength(1);
+    expect(monaco._state.configurations[0]?.languageId).toBe("redis");
+  });
+
+  test("tokens provider declares case-insensitive verbs and argument modifiers", () => {
+    const monaco = createMockMonaco();
+
+    registerRedisLanguage(monaco);
+
+    const provider = monaco._state.tokensProviders[0]?.provider as Monaco.languages.IMonarchLanguage & {
+      keywords: string[];
+      modifiers: string[];
+    };
+    expect(provider.ignoreCase).toBe(true);
+    // Every verb the #427 generators can emit must tokenize as a keyword.
+    for (const verb of [
+      "SCAN",
+      "TYPE",
+      "GET",
+      "SET",
+      "TTL",
+      "DEL",
+      "HGETALL",
+      "HSET",
+      "LRANGE",
+      "RPUSH",
+      "SMEMBERS",
+      "SADD",
+      "ZRANGE",
+      "ZADD",
+    ]) {
+      expect(provider.keywords).toContain(verb);
+    }
+    expect(provider.modifiers).toContain("MATCH");
+    expect(provider.modifiers).toContain("COUNT");
+    expect(provider.modifiers).toContain("WITHSCORES");
+    // GET/SET/TYPE are verbs; keeping them out of the modifier list is what
+    // avoids a cases-map collision.
+    expect(provider.modifiers).not.toContain("GET");
+    expect(provider.modifiers).not.toContain("SET");
+    expect(provider.modifiers).not.toContain("TYPE");
+    expect(provider.tokenizer.root.length).toBeGreaterThan(0);
+  });
+
+  // ── The Monarch rules themselves (#427) ───────────────────────────────────
+  //
+  // The rules are DATA: loading this module covers every line of it, so the 100%
+  // gate says nothing about whether a regex matches the right span. A comment rule
+  // that is not anchored, a cursor that tokenizes as an identifier, or a new rule
+  // that shadows an older one would pass every gate and be visible only in a
+  // browser. These assert the regexes directly — no Monaco runtime involved.
+
+  describe("tokenizer rules", () => {
+    function rootRules() {
+      const monaco = createMockMonaco();
+      registerRedisLanguage(monaco);
+      const provider = monaco._state.tokensProviders[0]!.provider;
+      return provider.tokenizer.root as unknown as [RegExp, unknown][];
+    }
+
+    // Index by the token class each rule assigns so a reordering does not silently
+    // repoint these assertions at a different rule.
+    const COMMENT = 0;
+    const DOUBLE_QUOTED = 1;
+    const SINGLE_QUOTED = 2;
+    const NUMBER = 3;
+    const WORD = 4;
+    const PUNCTUATION_LED = 5;
+
+    test("the comment rule matches a `#` line and nothing after other data", () => {
+      const [comment] = rootRules()[COMMENT]!;
+
+      // The cheatsheet header the generators emit, and an indented one.
+      expect(comment.test("# Redis commands for key prefix")).toBe(true);
+      expect(comment.test("    # indented")).toBe(true);
+      expect(comment.test("#")).toBe(true);
+
+      // Anchored: a `#` that follows data is DATA, matching the provider's line
+      // skipper, which only skips a line whose first non-space character is `#`.
+      expect(comment.test('SET note "line1 #tag"')).toBe(false);
+      expect(comment.test("GET user:1 # trailing")).toBe(false);
+      expect(comment.test("SET tag #value")).toBe(false);
+    });
+
+    test("a SCAN cursor and a COUNT tokenize as numbers, never as identifiers", () => {
+      const rules = rootRules();
+      const [number] = rules[NUMBER]!;
+      const [word] = rules[WORD]!;
+
+      for (const literal of ["0", "50", "-1", "1.5"]) {
+        expect(number.test(literal)).toBe(true);
+        // The reason the order between these two does not matter: the word rule
+        // cannot open on a digit or a minus sign.
+        expect(new RegExp(`^(?:${word.source})`).test(literal)).toBe(false);
+      }
+    });
+
+    test("a key pattern is ONE identifier token, not a command split at the colon", () => {
+      const [word] = rootRules()[WORD]!;
+      const anchored = new RegExp(`^(?:${word.source})`);
+
+      for (const key of ["user:*", "session:abc:data", "cache.v2", "a/b", "my-key"]) {
+        expect(anchored.exec(key)?.[0]).toBe(key);
+      }
+    });
+
+    test("a pattern that opens on punctuation still reads as data", () => {
+      const [punctuationLed] = rootRules()[PUNCTUATION_LED]!;
+      const anchored = new RegExp(`^(?:${punctuationLed.source})`);
+
+      expect(anchored.exec("*")?.[0]).toBe("*");
+      expect(anchored.exec(":*")?.[0]).toBe(":*");
+    });
+
+    test("a quoted value is one string token, including a `#` inside it", () => {
+      const rules = rootRules();
+      const [double] = rules[DOUBLE_QUOTED]!;
+      const [single] = rules[SINGLE_QUOTED]!;
+
+      expect(double.exec('"line1 #tag"')?.[0]).toBe('"line1 #tag"');
+      expect(double.exec('"esc \\" still inside"')?.[0]).toBe('"esc \\" still inside"');
+      expect(single.exec("'a #b'")?.[0]).toBe("'a #b'");
+      // A double-quoted rule must not swallow a single quote and vice versa.
+      expect(double.test("'a'")).toBe(false);
+      expect(single.test('"a"')).toBe(false);
+    });
+
+    // The ordering property the tokenizer relies on: no two rules can match at the
+    // same position, so the list is order-independent today. A rule added with an
+    // overlapping opening character would make order load-bearing silently.
+    test("no two root rules can open on the same character", () => {
+      const rules = rootRules();
+      const openers = "#\"'0-9aZ_*:{}[]() \t.".split("");
+
+      for (const ch of openers) {
+        const matching = rules.filter(([regex]) => new RegExp(`^(?:${regex.source})`, regex.flags).test(ch));
+        expect(matching.length).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  test("language configuration uses # line comments and quote/bracket auto-closing pairs", () => {
+    const monaco = createMockMonaco();
+
+    registerRedisLanguage(monaco);
+
+    const configuration = monaco._state.configurations[0]?.configuration;
+    expect(configuration?.comments).toEqual({ lineComment: "#" });
+    expect(configuration?.autoClosingPairs).toEqual([
+      { open: '"', close: '"' },
+      { open: "'", close: "'" },
+      { open: "{", close: "}" },
+      { open: "[", close: "]" },
+    ]);
+  });
+
+  test("is idempotent: a second call no-ops once the language is registered", () => {
+    const monaco = createMockMonaco();
+
+    registerRedisLanguage(monaco);
+    registerRedisLanguage(monaco);
+
+    expect(monaco._state.registered).toHaveLength(1);
+    expect(monaco._state.tokensProviders).toHaveLength(1);
+    expect(monaco._state.configurations).toHaveLength(1);
+  });
+
+  test("skips registration when another language with the redis id already exists", () => {
+    const monaco = createMockMonaco();
+    monaco._state.registered.push({ id: "redis" });
+
+    registerRedisLanguage(monaco);
+
+    expect(monaco._state.registered).toHaveLength(1);
+    expect(monaco._state.tokensProviders).toHaveLength(0);
+    expect(monaco._state.configurations).toHaveLength(0);
+  });
+});

--- a/tests/unit/editor/tab-language.test.ts
+++ b/tests/unit/editor/tab-language.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { editorLanguageForTabType, resolveTabType } from "@/lib/editor/tab-language";
+import type { ProviderCapabilities } from "@/lib/db/types";
+
+function makeCaps(overrides: Partial<ProviderCapabilities> = {}): ProviderCapabilities {
+  return {
+    queryLanguage: "sql",
+    supportsExplain: true,
+    supportsExternalQueryLimiting: true,
+    supportsCreateTable: true,
+    supportsInlineRowEdit: true,
+    supportsMaintenance: true,
+    maintenanceOperations: [],
+    supportsConnectionString: true,
+    schemaRefreshPattern: "CREATE|ALTER|DROP",
+    defaultPort: 5432,
+    ...overrides,
+  } as ProviderCapabilities;
+}
+
+describe("resolveTabType", () => {
+  test("SQL providers get a sql tab", () => {
+    expect(resolveTabType(makeCaps())).toBe("sql");
+  });
+
+  test("MongoDB (queryLanguage json, no dialect) gets a mongodb tab", () => {
+    expect(resolveTabType(makeCaps({ queryLanguage: "json" }))).toBe("mongodb");
+  });
+
+  test("LibreDB gets a libredb tab", () => {
+    expect(resolveTabType(makeCaps({ queryLanguage: "json", queryDialect: "libredb" }))).toBe("libredb");
+  });
+
+  test("Redis gets a redis tab even though it declares queryLanguage json (#427)", () => {
+    expect(resolveTabType(makeCaps({ queryLanguage: "json", queryDialect: "redis" }))).toBe("redis");
+  });
+
+  test("missing capabilities fall back to sql", () => {
+    expect(resolveTabType(undefined)).toBe("sql");
+    expect(resolveTabType(null)).toBe("sql");
+  });
+});
+
+describe("editorLanguageForTabType", () => {
+  test("maps every tab type to its Monaco language id", () => {
+    expect(editorLanguageForTabType("sql")).toBe("sql");
+    expect(editorLanguageForTabType("mongodb")).toBe("json");
+    expect(editorLanguageForTabType("libredb")).toBe("libredb");
+    expect(editorLanguageForTabType("redis")).toBe("redis");
+  });
+});

--- a/tests/unit/lib/query-generators.test.ts
+++ b/tests/unit/lib/query-generators.test.ts
@@ -104,6 +104,37 @@ describe("generateSelectQuery — LibreDB dialect", () => {
     expect(out.split("\n").some((l) => l.trim().startsWith("#"))).toBe(true);
   });
 
+  test("a node name containing a newline emits a note and NO command line (#427)", () => {
+    // A key name is server data. `get`/`put`/`delete` interpolate it raw, so its
+    // second line rendered as a runnable command of its own — `delete billing:2024`
+    // below would have been executed by Run Selected. LibreDB has no lossless JSON
+    // command form to fall back to, so the cheatsheet declines to guess.
+    const out = generateSelectQuery("x\ndelete billing:2024", kvColumns, libreCaps);
+    expect(out.split("\n")[0]).toBe(
+      '# LibreDB commands for "x\\ndelete billing:2024" — select a line and Run Selected.',
+    );
+    expect(commandLines(out)).toEqual([]);
+    expect(out).toContain("# This key's name contains a newline.");
+    expect(out).not.toContain("delete billing:2024\n");
+  });
+
+  test("a node name containing a bare CR emits the same note (#427)", () => {
+    // A lone CR ends a line for an editor and for Run Selected just as LF does.
+    const out = generateSelectQuery("x\rdelete billing:2024", kvColumns, libreCaps);
+    expect(commandLines(out)).toEqual([]);
+  });
+
+  test("a PREFIX GROUP whose name contains a newline emits the same note (#427)", () => {
+    const out = generateSelectQuery("x\ndelete billing:2024:*", kvColumns, libreCaps);
+    expect(commandLines(out)).toEqual([]);
+  });
+
+  test("an ordinary node name still renders unescaped in the header (#427)", () => {
+    expect(generateSelectQuery("users:*", kvColumns, libreCaps).split("\n")[0]).toBe(
+      '# LibreDB commands for "users:*" — select a line and Run Selected.',
+    );
+  });
+
   test("relational group: put example is a concrete JSON object from the columns", () => {
     const out = generateSelectQuery("users:*", relationalColumns, libreCaps);
     expect(commandLines(out)).toEqual([
@@ -513,5 +544,330 @@ describe("shouldRefreshSchema", () => {
 
   test("INSERT does NOT trigger refresh", () => {
     expect(shouldRefreshSchema("INSERT INTO users VALUES (1)", pattern)).toBe(false);
+  });
+});
+
+// ============================================================================
+// Redis dialect (#427)
+// ============================================================================
+
+const redisCaps = makeCaps({ queryLanguage: "json", defaultPort: 6379, queryDialect: "redis" });
+
+/** The three columns `redis.ts` `getSchema()` builds for every key-prefix row. */
+function typeCols(sample: string): ColumnSchema[] {
+  return [
+    { name: "key", type: "string", nullable: false, isPrimary: true },
+    { name: "value", type: sample.split(", ").join("/"), nullable: true, isPrimary: false },
+    { name: "type", type: sample, nullable: false, isPrimary: false },
+  ];
+}
+
+describe("generateTableQuery — Redis dialect", () => {
+  test("prefix group scans with SCAN 0 MATCH ... COUNT 50", () => {
+    expect(generateTableQuery("user:*", redisCaps, typeCols("string"))).toBe("SCAN 0 MATCH user:* COUNT 50");
+  });
+
+  test("prefix group SCANs regardless of the sampled type", () => {
+    expect(generateTableQuery("session:*", redisCaps, typeCols("hash"))).toBe("SCAN 0 MATCH session:* COUNT 50");
+  });
+
+  test("bare key, string sample -> GET", () => {
+    expect(generateTableQuery("counter", redisCaps, typeCols("string"))).toBe("GET counter");
+  });
+
+  test("bare key, hash sample -> HGETALL", () => {
+    expect(generateTableQuery("counter", redisCaps, typeCols("hash"))).toBe("HGETALL counter");
+  });
+
+  test("bare key, list sample -> LRANGE k 0 -1", () => {
+    expect(generateTableQuery("counter", redisCaps, typeCols("list"))).toBe("LRANGE counter 0 -1");
+  });
+
+  test("bare key, set sample -> SMEMBERS", () => {
+    expect(generateTableQuery("counter", redisCaps, typeCols("set"))).toBe("SMEMBERS counter");
+  });
+
+  test("bare key, zset sample -> ZRANGE k 0 -1 WITHSCORES", () => {
+    expect(generateTableQuery("counter", redisCaps, typeCols("zset"))).toBe("ZRANGE counter 0 -1 WITHSCORES");
+  });
+
+  test('bare key, mixed sample ("string, hash") -> TYPE', () => {
+    expect(generateTableQuery("counter", redisCaps, typeCols("string, hash"))).toBe("TYPE counter");
+  });
+
+  test('bare key, unrecognised sample ("stream") -> TYPE', () => {
+    expect(generateTableQuery("counter", redisCaps, typeCols("stream"))).toBe("TYPE counter");
+  });
+
+  test('bare key, empty sample ("") -> TYPE', () => {
+    expect(generateTableQuery("counter", redisCaps, typeCols(""))).toBe("TYPE counter");
+  });
+
+  test("bare key with no columns argument -> TYPE", () => {
+    expect(generateTableQuery("counter", redisCaps)).toBe("TYPE counter");
+  });
+
+  test('bare key with columns that have no "type" column -> TYPE', () => {
+    expect(generateTableQuery("counter", redisCaps, sampleColumns)).toBe("TYPE counter");
+  });
+
+  test("glob metacharacters in the prefix are escaped in MATCH", () => {
+    // The escape introduces a backslash, which the plain tokenizer cannot be
+    // trusted to carry, so the line switches to the lossless JSON form (#427).
+    expect(generateTableQuery("a[b:*", redisCaps, typeCols("string"))).toBe(
+      '{"command":"SCAN","args":["0","MATCH","a\\\\[b:*","COUNT","50"]}',
+    );
+  });
+
+  test("a key containing a double quote falls back to the JSON form (#427)", () => {
+    // Plain `GET "say"hi""` tokenizes to the key `sayhi` — a different key.
+    expect(generateTableQuery('say"hi"', redisCaps, typeCols("string"))).toBe(
+      '{"command":"GET","args":["say\\"hi\\""]}',
+    );
+  });
+
+  test("a key containing a single quote falls back to the JSON form (#427)", () => {
+    expect(generateTableQuery("it's", redisCaps, typeCols("hash"))).toBe('{"command":"HGETALL","args":["it\'s"]}');
+  });
+
+  test("a quoted prefix group falls back to the JSON form (#427)", () => {
+    expect(generateTableQuery('a"b:*', redisCaps, typeCols("string"))).toBe(
+      '{"command":"SCAN","args":["0","MATCH","a\\"b:*","COUNT","50"]}',
+    );
+  });
+
+  test("an argument containing whitespace is quoted", () => {
+    expect(generateTableQuery("my key", redisCaps, typeCols(""))).toBe('TYPE "my key"');
+  });
+
+  test("returns exactly one line", () => {
+    expect(generateTableQuery("user:*", redisCaps, typeCols("string"))).not.toContain("\n");
+    expect(generateTableQuery("counter", redisCaps, typeCols("string"))).not.toContain("\n");
+  });
+
+  test("Redis no longer emits MongoDB JSON (#427 regression)", () => {
+    const result = generateTableQuery("user:*", redisCaps, typeCols("string"));
+    expect(() => JSON.parse(result)).toThrow();
+  });
+});
+
+describe("generateSelectQuery — Redis dialect", () => {
+  // The runnable command lines (drop the use-case comments and blank lines).
+  const commandLines = (out: string) =>
+    out
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l !== "" && !l.startsWith("#"));
+
+  test("output carries explanatory # comments", () => {
+    const out = generateSelectQuery("user:*", typeCols("string"), redisCaps);
+    expect(out.split("\n").some((l) => l.trim().startsWith("#"))).toBe(true);
+  });
+
+  test("prefix group (string) emits the exact cheatsheet", () => {
+    expect(generateSelectQuery("user:*", typeCols("string"), redisCaps)).toBe(
+      [
+        '# Redis commands for "user:*" — select a line and Run Selected.',
+        "",
+        "# List keys under this prefix — ONE scan iteration, not the whole set.",
+        "# 0 is the start cursor; the reply's first row is the next cursor. Re-run",
+        "# with that value in place of 0 until it comes back 0 (a page may be empty).",
+        "SCAN 0 MATCH user:* COUNT 50",
+        "",
+        "# Check the key's type",
+        "TYPE user:1",
+        "",
+        "# Read the value",
+        "GET user:1",
+        "",
+        "# Create or update it — this overwrites an existing value",
+        "SET user:1 example",
+        "",
+        "# Time to live in seconds (-1 no expiry, -2 no such key)",
+        "TTL user:1",
+        "",
+        "# Delete the key (DEL takes a literal key name, never a pattern)",
+        "DEL user:1",
+      ].join("\n"),
+    );
+  });
+
+  test("hash prefix group emits the exact cheatsheet", () => {
+    expect(generateSelectQuery("session:*", typeCols("hash"), redisCaps)).toBe(
+      [
+        '# Redis commands for "session:*" — select a line and Run Selected.',
+        "",
+        "# List keys under this prefix — ONE scan iteration, not the whole set.",
+        "# 0 is the start cursor; the reply's first row is the next cursor. Re-run",
+        "# with that value in place of 0 until it comes back 0 (a page may be empty).",
+        "SCAN 0 MATCH session:* COUNT 50",
+        "",
+        "# Check the key's type",
+        "TYPE session:1",
+        "",
+        "# Read every field of the hash",
+        "HGETALL session:1",
+        "",
+        "# Create or update one field — this overwrites an existing field",
+        "HSET session:1 field example",
+        "",
+        "# Time to live in seconds (-1 no expiry, -2 no such key)",
+        "TTL session:1",
+        "",
+        "# Delete the key (DEL takes a literal key name, never a pattern)",
+        "DEL session:1",
+      ].join("\n"),
+    );
+  });
+
+  test("bare key (string) emits the exact cheatsheet", () => {
+    expect(generateSelectQuery("counter", typeCols("string"), redisCaps)).toBe(
+      [
+        '# Redis commands for "counter" — select a line and Run Selected.',
+        "",
+        "# Check the key's type",
+        "TYPE counter",
+        "",
+        "# Read the value",
+        "GET counter",
+        "",
+        "# Create or update it — this overwrites an existing value",
+        "SET counter example",
+        "",
+        "# Time to live in seconds (-1 no expiry, -2 no such key)",
+        "TTL counter",
+        "",
+        "# Delete the key (DEL takes a literal key name, never a pattern)",
+        "DEL counter",
+      ].join("\n"),
+    );
+  });
+
+  test("list prefix group emits LRANGE/RPUSH", () => {
+    expect(commandLines(generateSelectQuery("queue:*", typeCols("list"), redisCaps))).toEqual([
+      "SCAN 0 MATCH queue:* COUNT 50",
+      "TYPE queue:1",
+      "LRANGE queue:1 0 -1",
+      "RPUSH queue:1 example",
+      "TTL queue:1",
+      "DEL queue:1",
+    ]);
+  });
+
+  test("set prefix group emits SMEMBERS/SADD", () => {
+    expect(commandLines(generateSelectQuery("tags:*", typeCols("set"), redisCaps))).toEqual([
+      "SCAN 0 MATCH tags:* COUNT 50",
+      "TYPE tags:1",
+      "SMEMBERS tags:1",
+      "SADD tags:1 example",
+      "TTL tags:1",
+      "DEL tags:1",
+    ]);
+  });
+
+  test("zset prefix group emits ZRANGE ... WITHSCORES / ZADD", () => {
+    expect(commandLines(generateSelectQuery("score:*", typeCols("zset"), redisCaps))).toEqual([
+      "SCAN 0 MATCH score:* COUNT 50",
+      "TYPE score:1",
+      "ZRANGE score:1 0 -1 WITHSCORES",
+      "ZADD score:1 1 example",
+      "TTL score:1",
+      "DEL score:1",
+    ]);
+  });
+
+  test("mixed-type prefix group omits the read and write blocks", () => {
+    expect(commandLines(generateSelectQuery("misc:*", typeCols("string, hash"), redisCaps))).toEqual([
+      "SCAN 0 MATCH misc:* COUNT 50",
+      "TYPE misc:1",
+      "TTL misc:1",
+      "DEL misc:1",
+    ]);
+  });
+
+  test("bare key emits no SCAN line", () => {
+    const out = generateSelectQuery("counter", typeCols("string"), redisCaps);
+    expect(out).not.toContain("SCAN");
+  });
+
+  test("bare key with an unknown type omits the read and write blocks", () => {
+    expect(commandLines(generateSelectQuery("counter", typeCols(""), redisCaps))).toEqual([
+      "TYPE counter",
+      "TTL counter",
+      "DEL counter",
+    ]);
+  });
+
+  test("every command line is a single runnable command", () => {
+    for (const sample of ["string", "hash", "list", "set", "zset"]) {
+      for (const name of ["user:*", "counter"]) {
+        for (const line of commandLines(generateSelectQuery(name, typeCols(sample), redisCaps))) {
+          expect(line).not.toContain("\n");
+          expect(line).not.toContain("<");
+          expect(line.split(" ")[0]).toBe(line.split(" ")[0].toUpperCase());
+        }
+      }
+    }
+  });
+
+  test("no command line but SCAN takes the group name as a key argument", () => {
+    const lines = commandLines(generateSelectQuery("user:*", typeCols("string"), redisCaps));
+    for (const line of lines) {
+      if (line.includes(":*")) expect(line.startsWith("SCAN ")).toBe(true);
+    }
+    expect(lines.filter((l) => l.includes("*"))).toEqual(["SCAN 0 MATCH user:* COUNT 50"]);
+  });
+
+  test("Redis no longer emits MongoDB JSON (#427 regression)", () => {
+    const out = generateSelectQuery("user:*", typeCols("string"), redisCaps);
+    expect(out).not.toContain('"collection"');
+  });
+
+  test("only the lines that need it fall back to the JSON form (#427)", () => {
+    // Mixed forms in one cheatsheet are fine: the provider decides per run, and
+    // every line is run on its own. Here the key needs JSON; nothing else does.
+    const lines = commandLines(generateSelectQuery('say"hi"', typeCols("string"), redisCaps));
+    expect(lines).toEqual([
+      '{"command":"TYPE","args":["say\\"hi\\""]}',
+      '{"command":"GET","args":["say\\"hi\\""]}',
+      '{"command":"SET","args":["say\\"hi\\"","example"]}',
+      '{"command":"TTL","args":["say\\"hi\\""]}',
+      '{"command":"DEL","args":["say\\"hi\\""]}',
+    ]);
+  });
+
+  test("a node name containing a newline stays inside the header comment (#427)", () => {
+    // Redis keys are arbitrary byte strings. Raw interpolation put `DEL user:1
+    // x" — select a line and Run Selected.` on line 2, which the provider then
+    // ran as the buffer's first command.
+    const out = generateSelectQuery("a\nDEL user:1 x", typeCols("string"), redisCaps);
+    expect(out.split("\n")[0]).toBe('# Redis commands for "a\\nDEL user:1 x" — select a line and Run Selected.');
+    for (const line of commandLines(out)) expect(line).not.toContain("Run Selected");
+  });
+
+  test("a node name containing CR LF and a quote stays inside the header comment (#427)", () => {
+    const out = generateSelectQuery('a\r\nDEL "user:1" x', typeCols("hash"), redisCaps);
+    expect(out.split("\n")[0]).toBe(
+      '# Redis commands for "a\\r\\nDEL \\"user:1\\" x" — select a line and Run Selected.',
+    );
+    expect(commandLines(out)).toEqual([
+      '{"command":"TYPE","args":["a\\r\\nDEL \\"user:1\\" x"]}',
+      '{"command":"HGETALL","args":["a\\r\\nDEL \\"user:1\\" x"]}',
+      '{"command":"HSET","args":["a\\r\\nDEL \\"user:1\\" x","field","example"]}',
+      '{"command":"TTL","args":["a\\r\\nDEL \\"user:1\\" x"]}',
+      '{"command":"DEL","args":["a\\r\\nDEL \\"user:1\\" x"]}',
+    ]);
+  });
+
+  test("an ordinary node name still renders unescaped in the header (#427)", () => {
+    expect(generateSelectQuery("user:*", typeCols("string"), redisCaps).split("\n")[0]).toBe(
+      '# Redis commands for "user:*" — select a line and Run Selected.',
+    );
+  });
+
+  test("the SCAN comment says one iteration is not the whole set (#427)", () => {
+    const out = generateSelectQuery("user:*", typeCols("string"), redisCaps);
+    expect(out).toContain("ONE scan iteration");
+    expect(out).toContain("the reply's first row is the next cursor");
   });
 });


### PR DESCRIPTION
Closes #427.

Every command-producing action in the Redis schema explorer emitted **MongoDB** syntax, so nothing the sidebar generated could be executed. `query-generators.ts` branched on `queryLanguage === "json"` alone, and Redis declares that capability with no `queryDialect` — the mechanism the embedded LibreDB provider, another key-value store, already uses to opt out of the MongoDB shape. The capability's own docblock said so: *"Left undefined by SQL/Mongo/Redis, so their generation is unchanged."*

## What the menu does now

Measured in Chrome against a live `redis:7-alpine` (7 keys across 5 types), on the production build:

| Menu item | Before | After |
|---|---|---|
| Scan Keys | `{"collection":"user:*","operation":"find",...}` → **400** | `SCAN 0 MATCH user:* COUNT 50` → 2 rows, 1 ms |
| Scan Keys (bare key) | same MongoDB shape → **400** | `GET counter` → `42` — type-aware from the schema's own sample |
| Generate Command | same + projection → **400** | a commented cheatsheet, type-aware (`HGETALL`/`LRANGE`/`SMEMBERS`/`ZRANGE … WITHSCORES`); whole-buffer run → SCAN; Run Selected on `HGETALL session:1` → 2 rows |
| Profile Table | **400**, modal stuck showing the raw error | hidden — a derived grouping has no target |
| Generate Code | `export interface User:* {` | `export interface User {` |
| Generate Test Data | Mongo `insertMany` + Execute → **400** | hidden |
| Key Info / Memory Doctor | `/admin/operations`, Postgres wording, `Tables (0)` | per-row items hidden; the page speaks Redis for the global card ("Server Info" / "Run Info") |
| Copy Name | worked | unchanged |

The provider was never at fault — `SCAN`, `HGETALL` and the JSON command form all worked when typed by hand. This is a generator-layer fix.

## How

- Redis declares `queryDialect: "redis"`; `generateTableQuery` takes the node's columns so the sampled key type picks the read command.
- `generateSelectQuery` emits the LibreDB-shaped cheatsheet. The provider gained the matching rule: it strips `#` comment lines and runs the first blank-line-delimited block — so a **wrapped multi-line command still runs whole**, and a quoted value spanning lines keeps its newline.
- A Monaco language for the grammar, plus one shared tab-language helper replacing a ladder written out three times (the `connection.type === "redis"` arm in `Studio.tsx` was unreachable — the bug's fingerprint).

### Two things adversarial review caught that the gates could not

1. **The plain tokenizer has no escape syntax.** A key named `say"hi"` generated `DEL "say"hi""`, which reaches the driver as the key `sayhi` — deleting a *different* key. Any argument containing a quote, backslash or newline now emits in the lossless JSON command form instead.
2. **A name can escape through a comment.** A key named `` a\nDEL user:1 x `` ended the cheatsheet header and left a runnable `DEL user:1` as the buffer's first block. Names are JSON-quoted into comments now, on both the Redis and LibreDB cheatsheets.

Both are asserted end-to-end — through the provider's own parser to the args the driver receives, not against a mock that discards them.

### Two things only the browser caught

3. **A JSON-dialect buffer took the SQL statement splitter.** The cheatsheet carries a `;` inside a comment, so the buffer was cut into "statements" and the first was comments-only: the run failed while the panel reported a successful empty result. MongoDB shared this path. Multi-statement SQL is unaffected — verified in the same session (`SELECT 1 AS a; SELECT 2 AS b;` still routes to `/api/db/multi-query`).
4. **The embedded surface was inert.** `StudioWorkspace` hardcoded `metadata: null`, so in the published `@libredb/studio` render path a Redis table click wrote `SELECT * FROM user:* LIMIT 50;` and both hidden items were still offered. A host can supply capabilities and labels now.

### One cross-provider regression, caught before it shipped

`toIdentifier` initially stripped everything outside `[A-Za-z0-9]`, which turned `müşteri` into `MTeri` and `日本語` into the literal fallback `Record` — two non-ASCII tables would have generated the same type name. It keeps Unicode letters now: `müşteri` → `Müşteri`.

## Deliberately not fixed

Recorded in `docs/BACKLOG.md` rather than widened into this PR:

- **U9** — ClickHouse, MSSQL, Oracle and Couchbase point `vacuumAction` at an operation that is not `vacuum`. An earlier revision gated the row menu on `maintenanceOperations` and then mapped the label generically; that gave Oracle a "Rebuild Indexes" button sending `optimize` with a *table* name, which is `ORA-01418` every time, because Oracle's `optimize` rebuilds a named index. The whole chain was reverted: a mapping must be per provider, declaring the operation **and** its target grammar. The row menu for those providers is byte-identical to `main`.
- **U5** — the Operations tab still shows `Tables (0)` for a key-value provider and preselects nothing.
- **U4** — the profile modal's error state cannot be dismissed.
- **U11** — LibreDB's Scan Keys still interpolates a raw name (nothing destructive auto-executes; the cheatsheet path is closed).

One consequence worth flagging: Redis's `vacuumGlobalLabel` — "Memory Doctor", one of the two labels the issue named — is now provably unreachable, since Redis declares only `analyze` and the per-row item is gone. It never rendered on `main` either.

## Verification

Six local gates plus coverage, after rebasing onto `main`: format, lint (0 errors), typecheck, knip, `tests/run-core.sh` (308 files), `test:components` (30 groups), `build`, `build:lib` + `attw`, and `coverage:check` — **100.00%, 37218/37218 lines**.

Then driven in Chrome via Playwright against the live server: every row of the table above, plus the SQL multi-statement regression check and the identifier sanitizer across `user:*`, `müşteri`, `Ürünler`, `日本語`, `a-b:*`, `:*` and `""`.
