### PR TITLE
Use OIDC discovery for generic logout URLs

### DIFF
--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -514,7 +514,7 @@ The OIDC subsystem follows three core principles:
     │                            │     └─ delete auth-token   │
     │                            │                           │
     │                            │  3. if OIDC mode:          │
-    │                            │     buildLogoutUrl(returnTo)│
+    │                            │     await buildLogoutUrl(…)│
     │                            │                           │
     │  4. { success, redirectUrl }│                           │
     │◄───────────────────────────│                           │
@@ -596,7 +596,7 @@ mapOIDCRole(claims, roleClaim, adminRoles)   ← pure function, no deps
 
 encryptState(data) / decryptState(token)     ← jose JWT sign/verify
 
-buildLogoutUrl(returnTo)                     ← reads getOIDCConfig()
+buildLogoutUrl(returnTo)                     ← reads config; generic branch calls discoverProvider()
 ```
 
 #### Discovery Cache
@@ -851,10 +851,11 @@ Result:   "user" (no claim configured, default)
 
 ## Provider Logout Strategy
 
-Different OIDC providers have different logout endpoint conventions. `buildLogoutUrl()` handles this:
+Different OIDC providers have different logout endpoint conventions. `buildLogoutUrl()` preserves the existing Auth0
+and Zitadel integrations, then uses the provider's discovered `end_session_endpoint` for generic OIDC:
 
 ```typescript
-function buildLogoutUrl(returnTo: string): string | null {
+async function buildLogoutUrl(returnTo: string): Promise<string | null> {
   const config = getOIDCConfig();
   const issuerUrl = new URL(config.issuer);
   const roleClaim = config.roleClaim;
@@ -875,11 +876,11 @@ function buildLogoutUrl(returnTo: string): string | null {
     return logoutUrl.toString();
   }
 
-  // Generic OIDC (Keycloak, Okta, Azure AD, etc.):
-  // /protocol/openid-connect/logout?client_id=xxx&post_logout_redirect_uri=xxx
-  const logoutUrl = new URL('/protocol/openid-connect/logout', config.issuer);
-  logoutUrl.searchParams.set('client_id', config.clientId);
-  logoutUrl.searchParams.set('post_logout_redirect_uri', returnTo);
+  // Generic OIDC RP-Initiated Logout
+  const discovered = await discoverProvider(config);
+  const logoutUrl = client.buildEndSessionUrl(discovered, {
+    post_logout_redirect_uri: returnTo,
+  });
   return logoutUrl.toString();
 }
 ```
@@ -888,28 +889,22 @@ function buildLogoutUrl(returnTo: string): string | null {
 
 ### Provider Logout Endpoints
 
-> **What `buildLogoutUrl()` actually implements:** only **Auth0** and **Zitadel** are special-cased. Every other issuer — including Keycloak, Okta, and Azure AD — falls back to `/protocol/openid-connect/logout`. The table lists each provider's *native* logout endpoint; the "Wired?" column shows whether the code routes there today. For Okta/Azure AD the native endpoint differs from the fallback, so RP-initiated logout against those providers may need an explicit `buildLogoutUrl()` branch (see Extension Point below).
+> **What `buildLogoutUrl()` actually implements:** **Auth0** and **Zitadel** retain their existing special cases. Every
+> other issuer uses the `end_session_endpoint` advertised by OIDC Discovery. Providers that do not advertise this
+> metadata complete the local logout without a provider redirect.
 
 | Provider | Native Endpoint | Return Param | Wired? |
 |----------|-----------------|--------------|--------|
 | **Auth0** | `{issuer}/v2/logout` | `returnTo` | ✅ special-cased |
 | **Zitadel** | `{issuer}/oidc/v1/end_session` (auto-detected via role claim) | `post_logout_redirect_uri` | ✅ special-cased |
-| **Keycloak** | `{issuer}/protocol/openid-connect/logout` | `post_logout_redirect_uri` | ✅ matches generic fallback |
-| **Okta** | RP-Initiated Logout (via discovery) | `post_logout_redirect_uri` | ⚠️ generic fallback only |
-| **Azure AD** | `{issuer}/oauth2/v2.0/logout` | `post_logout_redirect_uri` | ⚠️ generic fallback only |
+| **Keycloak** | Discovery `end_session_endpoint` (typically `{issuer}/protocol/openid-connect/logout`) | `post_logout_redirect_uri` | ✅ discovery metadata |
+| **Okta** | Discovery `end_session_endpoint` | `post_logout_redirect_uri` | ✅ discovery metadata |
+| **Azure AD** | Discovery `end_session_endpoint` | `post_logout_redirect_uri` | ✅ discovery metadata |
 
 ### Extension Point
 
-To add a new provider's logout format, extend `buildLogoutUrl()` with a new hostname check:
-
-```typescript
-if (issuerUrl.hostname.includes('okta.com')) {
-  const logoutUrl = new URL('/oauth2/v1/logout', config.issuer);
-  logoutUrl.searchParams.set('id_token_hint', idToken);
-  logoutUrl.searchParams.set('post_logout_redirect_uri', returnTo);
-  return logoutUrl.toString();
-}
-```
+Standards-compliant providers need no logout-specific code. If a provider does not advertise `end_session_endpoint`
+and requires a non-standard endpoint, add a provider-specific case before the generic Discovery branch.
 
 ---
 
@@ -1052,6 +1047,6 @@ The OIDC claims contain `name`, `email`, `picture` etc. To display these:
 | **PKCE state in JWT cookie** | Stateless — no server-side session store needed | Redis/DB session store adds infrastructure dependency |
 | **5-minute state cookie TTL** | Long enough for slow providers, short enough to limit replay window | Shorter: may fail on slow networks. Longer: increases attack window |
 | **`prompt=login` always** | Prevents confusing auto-login behavior; user expects to choose account | `prompt=consent`: too aggressive. No prompt: users get stuck with one account |
-| **Provider-specific logout detection via hostname / role claim** | Simple, works for 90% of cases (Auth0 by hostname, Zitadel by role-claim URN, everything else via the generic fallback) | OIDC Discovery `end_session_endpoint`: not all providers support it; would require async call |
+| **Discovery-based generic logout with Auth0/Zitadel compatibility branches** | Uses the provider-advertised `end_session_endpoint` without changing the existing special integrations | Deriving a logout path from the issuer fails when the issuer contains a path or the provider uses a different endpoint |
 | **Module-level discovery cache** | Fast (avoids HTTP on every login), simple, process-scoped | Redis cache: overkill for single-instance deployments. No cache: 200-500ms per login |
 | **Binary role model (admin/user)** | Matches existing RBAC, simple to map from any claim format | Fine-grained roles: would require schema changes in JWT, proxy, and all components |

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -341,9 +341,9 @@ The role mapping system:
 
 ### Logout doesn't clear provider session
 
-- Auth0: Ensure `http://localhost:3000/login` is in Allowed Logout URLs
-- Keycloak: Provider logout is handled via RP-Initiated Logout endpoint
-- Other providers: Check if your provider supports end_session_endpoint
+- The return URL must be registered with the provider, or it rejects the redirect: Auth0 "Allowed Logout URLs", Keycloak "Valid post logout redirect URIs", Azure AD "Front-channel logout URL"
+- Keycloak / Okta / Azure AD: the logout endpoint comes from the provider's own Discovery metadata, so no per-provider configuration is needed on Studio's side
+- If the provider advertises no `end_session_endpoint` (Google, for one), the provider session survives on purpose — Studio clears its own cookie and skips the redirect. Signing in again still prompts, because Studio always sends `prompt=login`
 
 ---
 
@@ -891,15 +891,22 @@ async function buildLogoutUrl(returnTo: string): Promise<string | null> {
 
 > **What `buildLogoutUrl()` actually implements:** **Auth0** and **Zitadel** retain their existing special cases. Every
 > other issuer uses the `end_session_endpoint` advertised by OIDC Discovery. Providers that do not advertise this
-> metadata complete the local logout without a provider redirect.
+> metadata complete the local logout without a provider redirect. **Google is a real example of that last
+> case** — its discovery document carries no `end_session_endpoint`, so signing out of Studio deliberately
+> leaves the Google session alone (the next sign-in still prompts, because Studio always sends `prompt=login`).
+>
+> The request carries `post_logout_redirect_uri` and the `client_id` that `openid-client` adds; it does **not**
+> carry `id_token_hint`, because Studio never persists the ID token. Providers that require `id_token_hint`
+> for RP-initiated logout will reject the redirect — that is the one case the ✅ column below does not cover.
 
 | Provider | Native Endpoint | Return Param | Wired? |
 |----------|-----------------|--------------|--------|
 | **Auth0** | `{issuer}/v2/logout` | `returnTo` | ✅ special-cased |
 | **Zitadel** | `{issuer}/oidc/v1/end_session` (auto-detected via role claim) | `post_logout_redirect_uri` | ✅ special-cased |
 | **Keycloak** | Discovery `end_session_endpoint` (typically `{issuer}/protocol/openid-connect/logout`) | `post_logout_redirect_uri` | ✅ discovery metadata |
-| **Okta** | Discovery `end_session_endpoint` | `post_logout_redirect_uri` | ✅ discovery metadata |
-| **Azure AD** | Discovery `end_session_endpoint` | `post_logout_redirect_uri` | ✅ discovery metadata |
+| **Azure AD** | Discovery `end_session_endpoint` (measured: `{login.microsoftonline.com}/common/oauth2/v2.0/logout`) | `post_logout_redirect_uri` | ✅ discovery metadata |
+| **Okta** | Discovery `end_session_endpoint` | `post_logout_redirect_uri` | ⚠️ endpoint is used, not probed against a live tenant — org authorization servers may require `id_token_hint` |
+| **Google** | none advertised | — | ⚠️ local logout only, by design |
 
 ### Extension Point
 

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
     if (authProvider === "oidc") {
       const origin = getPublicOrigin(request);
       const returnTo = `${origin}/login`;
-      const oidcLogoutUrl = buildLogoutUrl(returnTo);
+      const oidcLogoutUrl = await buildLogoutUrl(returnTo);
 
       if (oidcLogoutUrl) {
         return NextResponse.json({ success: true, redirectUrl: oidcLogoutUrl });

--- a/src/lib/oidc.ts
+++ b/src/lib/oidc.ts
@@ -234,9 +234,9 @@ export function getPublicOrigin(request: Request): string {
 /**
  * Build the OIDC provider's logout URL.
  * Auth0: /v2/logout?client_id=...&returnTo=...
- * Generic: /protocol/openid-connect/logout?post_logout_redirect_uri=...&client_id=...
+ * Generic: use the discovered end_session_endpoint.
  */
-export function buildLogoutUrl(returnTo: string): string | null {
+export async function buildLogoutUrl(returnTo: string): Promise<string | null> {
   try {
     const config = getOIDCConfig();
     const issuerUrl = new URL(config.issuer);
@@ -258,10 +258,11 @@ export function buildLogoutUrl(returnTo: string): string | null {
       return logoutUrl.toString();
     }
 
-    // Generic OIDC (Keycloak, Okta, Azure AD, etc.) — RP-Initiated Logout
-    const logoutUrl = new URL("/protocol/openid-connect/logout", config.issuer);
-    logoutUrl.searchParams.set("client_id", config.clientId);
-    logoutUrl.searchParams.set("post_logout_redirect_uri", returnTo);
+    // Generic OIDC — RP-Initiated Logout via the provider's discovered endpoint
+    const discovered = await discoverProvider(config);
+    const logoutUrl = client.buildEndSessionUrl(discovered, {
+      post_logout_redirect_uri: returnTo,
+    });
     return logoutUrl.toString();
   } catch (error) {
     logger.warn("Failed to build OIDC logout URL", {

--- a/tests/api/auth/logout.test.ts
+++ b/tests/api/auth/logout.test.ts
@@ -13,7 +13,7 @@ mock.module("@/lib/auth", () => ({
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockBuildLogoutUrl = mock((_returnTo: string) => null as string | null);
+const mockBuildLogoutUrl = mock(async (_returnTo: string) => null as string | null);
 
 const mockGetPublicOrigin = mock((req: Request) => new URL(req.url).origin);
 
@@ -114,7 +114,7 @@ describe("POST /api/auth/logout (oidc)", () => {
   });
 
   test("returns redirectUrl when OIDC logout URL is available", async () => {
-    mockBuildLogoutUrl.mockReturnValue(
+    mockBuildLogoutUrl.mockResolvedValue(
       "https://auth0.com/v2/logout?client_id=abc&returnTo=http://localhost:3000/login",
     );
 
@@ -127,7 +127,7 @@ describe("POST /api/auth/logout (oidc)", () => {
   });
 
   test("calls buildLogoutUrl with correct returnTo", async () => {
-    mockBuildLogoutUrl.mockReturnValue("https://auth0.com/v2/logout");
+    mockBuildLogoutUrl.mockResolvedValue("https://auth0.com/v2/logout");
 
     await POST(makeRequest("http://localhost:3000/api/auth/logout") as never);
 
@@ -135,7 +135,7 @@ describe("POST /api/auth/logout (oidc)", () => {
   });
 
   test("returns success without redirectUrl when buildLogoutUrl returns null", async () => {
-    mockBuildLogoutUrl.mockReturnValue(null);
+    mockBuildLogoutUrl.mockResolvedValue(null);
 
     const res = await POST(makeRequest() as never);
     const data = await parseResponseJSON<{ success: boolean; redirectUrl?: string }>(res);
@@ -146,7 +146,7 @@ describe("POST /api/auth/logout (oidc)", () => {
   });
 
   test("calls logout() even in OIDC mode", async () => {
-    mockBuildLogoutUrl.mockReturnValue("https://auth0.com/v2/logout");
+    mockBuildLogoutUrl.mockResolvedValue("https://auth0.com/v2/logout");
 
     await POST(makeRequest() as never);
 

--- a/tests/security/auth-audit.test.ts
+++ b/tests/security/auth-audit.test.ts
@@ -43,7 +43,7 @@ mock.module("@/lib/oidc", () => ({
   exchangeCode: mockExchangeCode,
   mapOIDCRole: mock(() => "user" as "admin" | "user"),
   resetDiscoveryCache: mock(() => {}),
-  buildLogoutUrl: mock(() => null as string | null),
+  buildLogoutUrl: mock(async () => null as string | null),
   getPublicOrigin: mock((req: Request) => new URL(req.url).origin),
 }));
 

--- a/tests/unit/lib/oidc.test.ts
+++ b/tests/unit/lib/oidc.test.ts
@@ -12,6 +12,10 @@ const mockBuildAuthorizationUrl = mock(
   (_config: unknown, _params: Record<string, string>) =>
     new URL("https://provider.com/authorize?state=mock-state-value"),
 );
+const mockBuildEndSessionUrl = mock(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (_config: unknown, _params: Record<string, string>) => new URL("https://provider.com/logout"),
+);
 const mockClaims = mock(() => ({ sub: "user-123", email: "user@test.com" }) as Record<string, unknown> | undefined);
 const mockAuthorizationCodeGrant = mock(async () => ({
   claims: mockClaims,
@@ -25,6 +29,7 @@ mock.module("openid-client", () => ({
   randomState: mockRandomState,
   randomNonce: mockRandomNonce,
   buildAuthorizationUrl: mockBuildAuthorizationUrl,
+  buildEndSessionUrl: mockBuildEndSessionUrl,
   authorizationCodeGrant: mockAuthorizationCodeGrant,
   ClientSecretPost: mockClientSecretPost,
 }));
@@ -225,42 +230,69 @@ describe("buildLogoutUrl", () => {
     process.env.OIDC_ISSUER = "https://libredb.eu.auth0.com";
     process.env.OIDC_CLIENT_ID = "test-client-id";
     process.env.OIDC_CLIENT_SECRET = "test-client-secret";
+    mockDiscoveryFn.mockClear();
+    mockBuildEndSessionUrl.mockClear();
+    resetDiscoveryCache();
   });
 
   afterEach(() => {
     Object.assign(process.env, originalEnv);
+    resetDiscoveryCache();
   });
 
-  test("builds Auth0 logout URL with /v2/logout", () => {
-    const url = buildLogoutUrl("http://localhost:3000/login");
+  test("builds Auth0 logout URL with /v2/logout", async () => {
+    const url = await buildLogoutUrl("http://localhost:3000/login");
     expect(url).not.toBeNull();
     expect(url).toContain("/v2/logout");
     expect(url).toContain("client_id=test-client-id");
     expect(url).toContain("returnTo=http%3A%2F%2Flocalhost%3A3000%2Flogin");
   });
 
-  test("builds generic OIDC logout URL for non-Auth0 issuers", () => {
+  test("uses the discovered end-session endpoint instead of deriving one from the issuer", async () => {
     process.env.OIDC_ISSUER = "https://keycloak.example.com/realms/myrealm";
-    const url = buildLogoutUrl("http://localhost:3000/login");
+    const returnTo = "http://localhost:3000/login";
+    mockBuildEndSessionUrl.mockReturnValue(
+      new URL(
+        "https://logout.example.net/custom/end-session?client_id=test-client-id&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Flogin",
+      ),
+    );
+
+    const url = await buildLogoutUrl(returnTo);
     expect(url).not.toBeNull();
-    expect(url).toContain("/protocol/openid-connect/logout");
-    expect(url).toContain("client_id=test-client-id");
-    expect(url).toContain("post_logout_redirect_uri=");
+    const parsed = new URL(url!);
+    expect(parsed.origin).toBe("https://logout.example.net");
+    expect(parsed.pathname).toBe("/custom/end-session");
+    expect(parsed.searchParams.get("client_id")).toBe("test-client-id");
+    expect(parsed.searchParams.get("post_logout_redirect_uri")).toBe(returnTo);
+    expect(mockBuildEndSessionUrl).toHaveBeenCalledWith("mock-oidc-config", {
+      post_logout_redirect_uri: returnTo,
+    });
   });
 
-  test("builds Zitadel logout URL", () => {
+  test("returns null when the provider does not advertise an end-session endpoint", async () => {
+    process.env.OIDC_ISSUER = "https://provider.example.com/tenant";
+    mockBuildEndSessionUrl.mockImplementationOnce(() => {
+      throw new Error("authorization server metadata does not contain an end_session_endpoint");
+    });
+
+    const url = await buildLogoutUrl("http://localhost:3000/login");
+
+    expect(url).toBeNull();
+  });
+
+  test("builds Zitadel logout URL", async () => {
     process.env.OIDC_ISSUER = "https://my-instance.zitadel.cloud";
     process.env.OIDC_ROLE_CLAIM = "urn:zitadel:iam:org:project:roles";
-    const url = buildLogoutUrl("http://localhost:3000/login");
+    const url = await buildLogoutUrl("http://localhost:3000/login");
     expect(url).not.toBeNull();
     expect(url).toContain("/oidc/v1/end_session");
     expect(url).toContain("client_id=test-client-id");
     expect(url).toContain("post_logout_redirect_uri=");
   });
 
-  test("returns null when OIDC config is missing", () => {
+  test("returns null when OIDC config is missing", async () => {
     delete process.env.OIDC_ISSUER;
-    const url = buildLogoutUrl("http://localhost:3000/login");
+    const url = await buildLogoutUrl("http://localhost:3000/login");
     expect(url).toBeNull();
   });
 });

--- a/tests/unit/lib/oidc.test.ts
+++ b/tests/unit/lib/oidc.test.ts
@@ -232,6 +232,10 @@ describe("buildLogoutUrl", () => {
     process.env.OIDC_CLIENT_SECRET = "test-client-secret";
     mockDiscoveryFn.mockClear();
     mockBuildEndSessionUrl.mockClear();
+    // mockClear() drops recorded calls but keeps whatever return value a previous test queued, so
+    // the default is re-established here: otherwise a mockReturnValue set in one test silently
+    // decides what a later test sees, and the suite's outcome depends on declaration order.
+    mockBuildEndSessionUrl.mockReturnValue(new URL("https://provider.com/logout"));
     resetDiscoveryCache();
   });
 
@@ -251,19 +255,20 @@ describe("buildLogoutUrl", () => {
   test("uses the discovered end-session endpoint instead of deriving one from the issuer", async () => {
     process.env.OIDC_ISSUER = "https://keycloak.example.com/realms/myrealm";
     const returnTo = "http://localhost:3000/login";
-    mockBuildEndSessionUrl.mockReturnValue(
-      new URL(
-        "https://logout.example.net/custom/end-session?client_id=test-client-id&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Flogin",
-      ),
-    );
+    // Deliberately a BARE endpoint, with no query string and an origin that is not the issuer's:
+    // the assertions below then describe what buildLogoutUrl() did, not what this fixture spelled out.
+    mockBuildEndSessionUrl.mockReturnValue(new URL("https://logout.example.net/custom/end-session"));
 
     const url = await buildLogoutUrl(returnTo);
     expect(url).not.toBeNull();
+    // The endpoint comes from Discovery, not from the issuer: neither the issuer's origin nor its
+    // /realms/myrealm path may appear in the result. That is the regression this test exists for.
     const parsed = new URL(url!);
     expect(parsed.origin).toBe("https://logout.example.net");
     expect(parsed.pathname).toBe("/custom/end-session");
-    expect(parsed.searchParams.get("client_id")).toBe("test-client-id");
-    expect(parsed.searchParams.get("post_logout_redirect_uri")).toBe(returnTo);
+    // The only logout parameter this module owns. `client_id` is NOT asserted on the URL: the real
+    // buildEndSessionUrl() injects it (openid-client build/index.js sets it when absent), and that
+    // function is mocked here — asserting it would only re-assert the mock's own output.
     expect(mockBuildEndSessionUrl).toHaveBeenCalledWith("mock-oidc-config", {
       post_logout_redirect_uri: returnTo,
     });


### PR DESCRIPTION
## Description

Generic OIDC logout currently derives a Keycloak-specific logout path from the issuer URL. Besides not being provider-neutral, the root-relative URL construction drops issuer path components such as `/realms/myrealm`.

This change uses the provider's discovered `end_session_endpoint` and `openid-client`'s `buildEndSessionUrl()` helper for generic RP-Initiated Logout.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Changes Made

- Use the existing cached OIDC Discovery configuration for generic logout.
- Build logout URLs from the discovered `end_session_endpoint` instead of deriving a path from the issuer.
- Await asynchronous logout URL construction in the logout API route.
- Preserve the existing Auth0 and Zitadel compatibility branches.
- Complete local logout without a provider redirect when Discovery or `end_session_endpoint` is unavailable.
- Add regression coverage proving that the logout endpoint can be independent of the issuer origin and path.
- Update the OIDC documentation to describe the Discovery-based behavior.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [ ] All existing tests pass