### PR TITLE
chore(chart): 0.1.38 - say which engines the chart supports (#424)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -40,9 +40,21 @@ will not re-bump a version that is already in sync to repair it.
 ```bash
 # 1. package.json "version" -> the new version, by hand
 # 2. charts/libredb-studio/Chart.yaml artifacthub.io/changes -> rewrite by hand, see below
+# 3. charts/libredb-studio/Chart.yaml description -> check the engine list, see below
 bun run chart:bump            # Chart.yaml version+appVersion, image tag, chart README, operator chart copy
 make -C operator bundle       # CSV version + controller image tag (reads package.json)
 ```
+
+**Check `Chart.yaml`'s `description` against the engines that ship.** It is the string Rancher renders
+on its Apps catalog card and ArtifactHub shows beside the chart, `chart:bump` never touches it, and it
+has been left behind before: it still named seven engines after Couchbase, ClickHouse and Druid had
+shipped, and was corrected only in chart 0.1.38, whose entire content is that sentence. Correcting it
+on its own costs a whole chart version, because the #167 gate requires a `version:` bump for any
+packaged-file edit once the current version is released - so **here** is where it is free, since this
+step moves `version:` anyway. The chart `keywords` are the same check: ArtifactHub search matches on
+them, and an engine missing there is an engine nobody finds. Read the engine count from `SHIPPED` in `src/lib/db/compatibility.ts` (minus the embedded
+`libredb`) rather than from any prose, and check the same list in `README.md`, `DOCKERHUB.md` and
+`deploy/rancher/CATALOG_LISTING.md` while you are here.
 
 **Rewrite `artifacthub.io/changes` by hand, every release.** `chart:bump` *does* rewrite it, but only
 to the single generic line `Track app release <version> (appVersion bump; default image tag follows)`
@@ -222,6 +234,7 @@ true on a tag ref.
 | Trap | What happens |
 |---|---|
 | `artifacthub.io/changes` left to `chart:bump` | ArtifactHub shows one generic `Track app release` line as the whole changelog - and on a release flagged `containsSecurityUpdates`, that is the text an operator upgrades or does not upgrade on. Frozen once the chart publishes (#167) |
+| `Chart.yaml`'s `description` left as it was | It names the engines and `chart:bump` never touches it, so it goes stale silently - and it is what Rancher's Apps card and ArtifactHub display. Fixing it later needs a chart version of its own (#167); this release is the free moment. Read the count from `SHIPPED` in `src/lib/db/compatibility.ts`, minus `libredb` |
 | Chart hand-edited AFTER `chart:bump` | `operator/helm-charts/` keeps the pre-edit copy, `chart:check` fails on the mismatch, and `chart:bump` will not re-bump an already-in-sync version to fix it. Edit first, bump last |
 | Chart version already released | Republishing rewrites the released chart's gh-pages index digest and OCI content (#167). `chart:check` blocks it; `force_republish` is the only escape hatch, for an asset-uploaded-but-index-failed run |
 | Unquoted `{}:[],&*#?\|-<>=!%@` in a changes entry | ArtifactHub hard-skips that chart version, permanently |

--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: libredb-studio
-description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
+description: Web-based SQL IDE for cloud-native teams supporting twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch
 type: application
-version: 0.1.37
+version: 0.1.38
 appVersion: "0.12.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -20,6 +20,11 @@ keywords:
   - sqlite
   - oracle
   - mssql
+  - couchbase
+  - clickhouse
+  - druid
+  - elasticsearch
+  - opensearch
   - web-ide
 maintainers:
   - name: cevheri
@@ -28,7 +33,11 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
-  artifacthub.io/containsSecurityUpdates: "true"
+  # False for this chart version, and that is a statement rather than a default:
+  # 0.1.38 changes chart metadata only and installs the same 0.12.0 image 0.1.37
+  # installs, so it carries no security fix of its own. The app-level fixes are
+  # recorded on 0.1.37, which is the chart version that first shipped them.
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
       image: ghcr.io/libredb/libredb-studio:0.12.0
@@ -43,11 +52,9 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Agent runs now ground their plan on the connected database's own schema on every supported engine, so a drafted statement names objects that exist rather than ones the model assumed"
-    - "An agent run reads its workflow from the objective instead of asking for it, and an Operate run is given a schema inventory before its first turn"
-    - "A light theme ships alongside the dark one through a shared token layer, and four defects that let a query fail silently are fixed"
-    - "Security: monaco-editor moves to 0.56.0 so the bundled DOMPurify leaves 3.2.7, JWT_SECRET is read per call rather than memoized once, and every field an export writes is escaped"
-    - "Fixes a SQL Server connection addressed by an IP address, which this release would otherwise have broken: the image moves to Node 26, which refuses an IP as the TLS SNI server name, and the pinned tedious sent one on the encrypt path. Addressing a server by hostname was never affected"
+    - "Chart metadata only, and no application change: the appVersion stays 0.12.0 and the deployed image is the same one 0.1.37 installs"
+    - "The chart description named seven engines and twelve ship - Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch were missing from the text Rancher and ArtifactHub render beside this chart"
+    - "Those five engines are searchable now: they are keywords on the chart rather than only prose"
     - "Track app release 0.12.0 (appVersion bump; default image tag follows)"
 dependencies:
   - name: postgresql

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.37 \
+  --version 0.1.38 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: libredb-studio
-description: Web-based SQL IDE for cloud-native teams supporting PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and Redis
+description: Web-based SQL IDE for cloud-native teams supporting twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch
 type: application
-version: 0.1.37
+version: 0.1.38
 appVersion: "0.12.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -20,6 +20,11 @@ keywords:
   - sqlite
   - oracle
   - mssql
+  - couchbase
+  - clickhouse
+  - druid
+  - elasticsearch
+  - opensearch
   - web-ide
 maintainers:
   - name: cevheri
@@ -28,7 +33,11 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
-  artifacthub.io/containsSecurityUpdates: "true"
+  # False for this chart version, and that is a statement rather than a default:
+  # 0.1.38 changes chart metadata only and installs the same 0.12.0 image 0.1.37
+  # installs, so it carries no security fix of its own. The app-level fixes are
+  # recorded on 0.1.37, which is the chart version that first shipped them.
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
       image: ghcr.io/libredb/libredb-studio:0.12.0
@@ -43,11 +52,9 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Agent runs now ground their plan on the connected database's own schema on every supported engine, so a drafted statement names objects that exist rather than ones the model assumed"
-    - "An agent run reads its workflow from the objective instead of asking for it, and an Operate run is given a schema inventory before its first turn"
-    - "A light theme ships alongside the dark one through a shared token layer, and four defects that let a query fail silently are fixed"
-    - "Security: monaco-editor moves to 0.56.0 so the bundled DOMPurify leaves 3.2.7, JWT_SECRET is read per call rather than memoized once, and every field an export writes is escaped"
-    - "Fixes a SQL Server connection addressed by an IP address, which this release would otherwise have broken: the image moves to Node 26, which refuses an IP as the TLS SNI server name, and the pinned tedious sent one on the encrypt path. Addressing a server by hostname was never affected"
+    - "Chart metadata only, and no application change: the appVersion stays 0.12.0 and the deployed image is the same one 0.1.37 installs"
+    - "The chart description named seven engines and twelve ship - Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch were missing from the text Rancher and ArtifactHub render beside this chart"
+    - "Those five engines are searchable now: they are keywords on the chart rather than only prose"
     - "Track app release 0.12.0 (appVersion bump; default image tag follows)"
 dependencies:
   - name: postgresql

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.37 \
+  --version 0.1.38 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```


### PR DESCRIPTION
Chart-only release. `appVersion` stays **0.12.0** and the deployed image is the one 0.1.37 already installs — the chart version and the app version move independently, and this one moves alone.

### Why

`charts/libredb-studio/Chart.yaml`'s `description` named seven engines while twelve ship. It is not an internal string: Rancher renders it on the Apps catalog card and ArtifactHub shows it beside the chart, so it was the last listing still telling a prospective user this product stops at Redis. Couchbase, ClickHouse and Apache Druid have shipped since 0.11.0; Elasticsearch and OpenSearch landed in #429. Every other channel — Docker Hub, CapRover, Railway, Koyeb, Azure, WinGet, Chocolatey, Homebrew, nfpm, both Flatpak descriptor sets, the OLM CSV, the desktop bundle — was refreshed in #429; this one needed a chart version of its own, which is why it was held back.

### What is in it

- **`description`**: the twelve engines, named.
- **`keywords`**: `couchbase`, `clickhouse`, `druid`, `elasticsearch`, `opensearch` added. ArtifactHub search matches on keywords, so an engine that lives only in prose is an engine nobody finds.
- **`artifacthub.io/containsSecurityUpdates` → `false`**, as a statement rather than a default: this version carries no application change, so claiming a security update would be false. The app-level fixes stay recorded on 0.1.37, the chart version that first shipped them.
- **`artifacthub.io/changes`** rewritten so the entries a user reads on 0.1.38 describe 0.1.38, with the `Track app release` line kept **last** so the next `chart:bump` can still find and update it.
- **`/cut-release` runbook**: checking `description` and `keywords` against `SHIPPED` in `src/lib/db/compatibility.ts` is now step 3 of the Phase 1 bump, beside the `artifacthub.io/changes` rule that exists for the same reason — a field `chart:bump` never touches goes stale silently — plus a Traps row. At a version bump the fix is free, because that step moves `version:` anyway; alone it costs a whole chart version, which is exactly what this PR is.

### Verification

- `bun run chart:check` → `OK: chart 0.1.38 / appVersion 0.12.0 in sync with package.json 0.12.0`
- `helm lint charts/libredb-studio --strict` → 0 failed
- Edited in the order the runbook requires: chart by hand first, `chart:bump` last, so the vendored `operator/helm-charts/` copy is refreshed rather than left stale for `chart:check` to catch.
- `make -C operator bundle` produces no change beyond its volatile `createdAt`, which the CI gate ignores, so `operator/bundle` is deliberately untouched.
- `bun run format`, `bun run test` (7827 pass, 0 fail).

### On merge

`helm-release.yml` fires on `charts/**` pushed to `main` and publishes 0.1.38. Its image gate passes immediately because the `appVersion` image (0.12.0) is already on GHCR — the workflow's own term for this is a chart-only release. Nothing dispatches an app release.
