### PR TITLE
feat(chart,docs): make the IPv6 bind address findable, and give the Service a dual-stack option (#432)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,29 @@
 # ============================================
 
 # ============================================
+# SERVER BIND ADDRESS (Optional)
+# ============================================
+# Which address the standalone server listens on. The app never reads it - it
+# goes straight to the Next.js server - so it applies to every channel that
+# starts that server, and has no effect when the npm package is embedded.
+# Leave it unset and the channel decides: the Docker image and the Helm chart
+# set 0.0.0.0 (all IPv4 addresses), while the native channels (npx, .deb/.rpm,
+# Homebrew, Snap) force 127.0.0.1 and treat exposure as an explicit opt-in
+# (--host, or LIBREDB_BIND for the packaged wrappers).
+# IPv6 literals are accepted: "::" listens on every IPv6 address and, on Linux
+# with the default net.ipv6.bindv6only=0, answers IPv4 through the same socket
+# - one dual-stack listener. Where bindv6only=1 is set, "::" is IPv6 ONLY and
+# IPv4 clients are dropped, which is why the container default stays 0.0.0.0.
+# "::1" is IPv6 loopback, the IPv6 form of the local-first default.
+# Docker: `docker run -e HOSTNAME=::`. Kubernetes: the chart's extraEnv, which
+# renders an explicit env entry and so overrides the chart ConfigMap. On a
+# dual-stack cluster set service.ipFamilyPolicy AND this, or the Service
+# advertises an IPv6 address the pod does not listen on.
+# Per-channel defaults and the reverse-proxy advice: docs/DISTRIBUTION.md
+# (Network exposure).
+# HOSTNAME=0.0.0.0
+
+# ============================================
 # AUTHENTICATION (Required when AUTH_BOOTSTRAP=off)
 # ============================================
 # Admin credentials (full access + maintenance tools) — ADMIN_PASSWORD is

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ docker run \
 
   > **Registry**: `ghcr.io/libredb/libredb-studio` is the primary image (no pull rate limits — preferred for Kubernetes/CI). The same image is also mirrored to Docker Hub as [`libredb/libredb-studio`](https://hub.docker.com/r/libredb/libredb-studio?tag=latest) for convenience.
 
+  > **IPv6**: the container listens on `0.0.0.0` (IPv4 only). Add `-e HOSTNAME=::` for a dual-stack listener — details, and the Kubernetes equivalent, in [`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md#network-exposure-bind-address).
+
   Open [http://localhost:3000](http://localhost:3000) and login with `admin@libredb.org` / `LibreDB.2026`.
 
   > **Auth env vars (local provider):** `ADMIN_PASSWORD` and `JWT_SECRET` are only required when `AUTH_BOOTSTRAP=off`; otherwise both are generated on first start (see [Zero-config first run](#zero-config-first-run) below). `USER_EMAIL` / `USER_PASSWORD` are optional; omit them to run admin-only (no default user password is ever assumed). `ADMIN_EMAIL` defaults to `admin@libredb.org`. Using OIDC (`NEXT_PUBLIC_AUTH_PROVIDER=oidc`)? None of these are needed.

--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch
 type: application
-version: 0.1.38
+version: 0.1.39
 appVersion: "0.12.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -34,9 +34,10 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
   # False for this chart version, and that is a statement rather than a default:
-  # 0.1.38 changes chart metadata only and installs the same 0.12.0 image 0.1.37
-  # installs, so it carries no security fix of its own. The app-level fixes are
-  # recorded on 0.1.37, which is the chart version that first shipped them.
+  # 0.1.39 adds an opt-in Service setting and installs the same 0.12.0 image
+  # 0.1.37 installs, so it carries no security fix of its own. The app-level
+  # fixes are recorded on 0.1.37, which is the chart version that first shipped
+  # them.
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
@@ -52,10 +53,11 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Chart metadata only, and no application change: the appVersion stays 0.12.0 and the deployed image is the same one 0.1.37 installs"
-    - "The chart description named seven engines and twelve ship - Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch were missing from the text Rancher and ArtifactHub render beside this chart"
-    - "Those five engines are searchable now: they are keywords on the chart rather than only prose"
-    - "Track app release 0.12.0 (appVersion bump; default image tag follows)"
+    - "The Service can be dual-stack: service.ipFamilyPolicy and service.ipFamilies are rendered onto it, so a dual-stack cluster can hand this release an IPv6 address (#432)"
+    - "Both are unset by default, so an existing install upgrades to a byte-identical Service - Kubernetes reads an explicit SingleStack as intent to release a secondary clusterIP, which is why the chart writes neither field unless asked"
+    - "Two address families without a dual-stack policy now fails at render time, with the message the API server would have returned at install time"
+    - "The pairing is documented rather than assumed: a dual-stack Service in front of the pod's default IPv4-only listener advertises an IPv6 address that refuses every connection, so the README recipe sets extraEnv HOSTNAME to :: alongside it"
+    - "No application change: the appVersion stays 0.12.0 and the deployed image is the same one 0.1.37 installs"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.38 \
+  --version 0.1.39 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```
@@ -293,6 +293,52 @@ helm install libredb libredb/libredb-studio \
   # ... secrets omitted for brevity
 ```
 
+### IPv6 and dual-stack
+
+Dual-stack is two settings, not one: the address families the **Service** is allocated from, and
+the address the **pod** actually listens on. Both are needed, and only the first has a values
+field — the chart's ConfigMap sets `HOSTNAME=0.0.0.0`, which is IPv4 only, so `extraEnv` supplies
+the other half:
+
+```bash
+helm install libredb libredb/libredb-studio \
+  --set service.ipFamilyPolicy=PreferDualStack \
+  --set extraEnv[0].name=HOSTNAME \
+  --set extraEnv[0].value="::"
+```
+
+`extraEnv` renders an explicit `env` entry, which overrides the ConfigMap key of the same name.
+`::` listens on IPv6 and, on nodes with the default `net.ipv6.bindv6only=0`, answers IPv4 through
+the same socket; where a node sets `bindv6only=1` it is IPv6 only, so leave `HOSTNAME` alone on
+IPv4-only clusters. As in the `extraEnv` examples further down, a second variable needs its own
+index — reusing `extraEnv[0]` overwrites this one.
+
+**Do not enable one half without the other.** Kubernetes never checks what address the container
+bound: on a dual-stack cluster the pod has an IPv6 address either way, so the IPv6 EndpointSlice is
+populated and kube-proxy routes to it, where an IPv4-only listener answers with a TCP RST. Kubelet
+probes only the primary podIP, so the pod stays `Ready` and the IPv6 path is silently dead. The
+install notes say so as well: a release that asks the Service for an IPv6 address without a
+`HOSTNAME` entry in `extraEnv` prints a warning with the recipe above.
+
+`service.ipFamilyPolicy` takes `SingleStack`, `PreferDualStack` or `RequireDualStack`;
+`service.ipFamilies` pins the order explicitly, e.g. `[IPv6, IPv4]`, and needs a dual-stack policy
+alongside it or the chart refuses to render. Both are empty by default, so the cluster's own
+default applies and existing installs upgrade to an unchanged Service. Three cluster-side rules are
+worth knowing before you set them:
+
+- `RequireDualStack` fails to create on a single-stack cluster, and naming a family the cluster
+  does not have in `service.ipFamilies` is rejected even under `PreferDualStack`.
+- The first entry of `service.ipFamilies` is the primary family — it is what `spec.clusterIP` is
+  allocated from — and it is immutable. Reordering the list on a live Service is rejected; the
+  Service has to be deleted and recreated.
+- A `PreferDualStack` Service is not retroactively upgraded when the cluster later gains
+  dual-stack. Adding the second family is a deliberate change, and removing it again requires
+  setting `service.ipFamilyPolicy=SingleStack` in the same upgrade.
+
+With `service.type: LoadBalancer` these fields govern the cluster IPs only. Whether the external
+address is dual-stack is up to the cloud load-balancer controller, several of which want their own
+annotation for it.
+
 ## Rate Limiting Across Replicas
 
 Studio's built-in rate limiter (login attempts, AI endpoints, and every database-reaching route —
@@ -441,6 +487,8 @@ helm uninstall libredb
 | `persistence.fixPermissions` | Chown the mounted volume to `runAsUser:fsGroup` in a root init container (hostPath / static PVs the kubelet does not `fsGroup`). Rendering fails when the OpenShift security-context adaptation is active - restricted-v2 rejects a root container and the UID/GID come from the namespace range there | `false` |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `80` |
+| `service.ipFamilyPolicy` | Service address families: `SingleStack`, `PreferDualStack` or `RequireDualStack`; empty renders no field and leaves the cluster default in place | `""` |
+| `service.ipFamilies` | Explicit family order, e.g. `[IPv4, IPv6]`; entry 0 is the immutable primary family. Two entries require a dual-stack `service.ipFamilyPolicy` (the chart refuses to render otherwise) | `[]` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `route.labels` | Labels added to every enabled route (a per-route label with the same key wins); `labels` is therefore a reserved key name and cannot be a route name | `{}` |
 | `route.annotations` | Annotations added to every enabled route (a per-route annotation with the same key wins); reserved key name, as `route.labels` | `{}` |

--- a/charts/libredb-studio/templates/NOTES.txt
+++ b/charts/libredb-studio/templates/NOTES.txt
@@ -119,3 +119,18 @@ SQLite is a single-writer database, so the HorizontalPodAutoscaler was not
 rendered and the deployment stays at replicaCount ({{ .Values.replicaCount }}).
 Use storageProvider=postgres for multi-replica setups.
 {{- end }}
+
+{{- if and (include "libredb-studio.serviceWantsIPv6" .) (not (include "libredb-studio.extraEnvHostnameSet" .)) }}
+
+WARNING: this Service asks for an IPv6 address, but the container still binds
+0.0.0.0 (IPv4 only).
+Kubernetes populates the IPv6 EndpointSlice from the pod's own IPv6 address
+without checking what the process bound, so connections to that address are
+refused - and the kubelet probes only the pod's primary IP, so the pod still
+reports Ready and nothing self-heals. Set the bind address as well:
+  helm upgrade libredb libredb/libredb-studio \
+    --set extraEnv[0].name=HOSTNAME \
+    --set-string extraEnv[0].value=::
+On Linux with the default net.ipv6.bindv6only=0 that single listener serves both
+families; where bindv6only=1 is in force it is IPv6 only.
+{{- end }}

--- a/charts/libredb-studio/templates/_helpers.tpl
+++ b/charts/libredb-studio/templates/_helpers.tpl
@@ -277,6 +277,45 @@ execs directly when not running as root.
 {{- end }}
 
 {{/*
+Whether extraEnv sets HOSTNAME - the container's bind address. An explicit env
+entry beats the same key delivered by the ConfigMap through envFrom, so this is
+the only place in these values that can move the pod off the ConfigMap's
+IPv4-only 0.0.0.0. Only the key is read, never the value: "::" is the
+dual-stack answer, but an operator who set HOSTNAME at all chose the bind
+address deliberately and does not need to be told about it again.
+
+Same blind spot as agentPossible: a HOSTNAME delivered through extraEnvFrom is
+not visible here, so such a release still sees the NOTES.txt warning. That is
+the safe direction - an unnecessary note rather than a silent IPv6 address that
+refuses every connection.
+*/}}
+{{- define "libredb-studio.extraEnvHostnameSet" -}}
+{{- range .Values.extraEnv }}
+{{- if eq (.name | default "" | toString) "HOSTNAME" }}
+{{- true }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Whether these values ask the Service for an IPv6 address: either a dual-stack
+policy, or an explicit IPv6 entry in service.ipFamilies (which needs no policy
+when it is the only family, so templates/service.yaml's guard never sees it).
+
+Kubernetes populates the IPv6 EndpointSlice from the pod's own IPv6 address
+without ever checking what the process bound, so this is the condition under
+which the ConfigMap's IPv4-only HOSTNAME turns into a silent misconfiguration:
+a green install whose IPv6 address refuses every connection, on a pod that -
+probed only on its primary IP - stays Ready. NOTES.txt warns whenever this is
+requested without a HOSTNAME override.
+*/}}
+{{- define "libredb-studio.serviceWantsIPv6" -}}
+{{- if or (has .Values.service.ipFamilyPolicy (list "PreferDualStack" "RequireDualStack")) (has "IPv6" (default (list) .Values.service.ipFamilies)) }}
+{{- true }}
+{{- end }}
+{{- end }}
+
+{{/*
 Return the full image reference (repository:tag)
 */}}
 {{- define "libredb-studio.image" -}}

--- a/charts/libredb-studio/templates/service.yaml
+++ b/charts/libredb-studio/templates/service.yaml
@@ -1,3 +1,7 @@
+{{- $ipFamilies := default (list) .Values.service.ipFamilies }}
+{{- if and (gt (len $ipFamilies) 1) (not (has .Values.service.ipFamilyPolicy (list "PreferDualStack" "RequireDualStack"))) }}
+{{- fail "service.ipFamilies lists two address families, which the API server accepts only alongside a dual-stack policy: on create, with service.ipFamilyPolicy unset or SingleStack, it rejects the Service outright ('must be RequireDualStack or PreferDualStack when multiple IP families are specified'), so the install would fail against the cluster instead of here. (On update an omitted policy is inherited from the live Service, so the API server may accept what this guard refuses - set the policy explicitly rather than relying on that inheritance.) Set service.ipFamilyPolicy=PreferDualStack (both families where the cluster is dual-stack, one where it is not) or service.ipFamilyPolicy=RequireDualStack (fail on a single-stack cluster), or list a single family in service.ipFamilies. A dual-stack Service also needs the pod to listen on both families: set extraEnv HOSTNAME=\"::\", or the IPv6 address it advertises refuses every connection" }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +14,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with $ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}

--- a/charts/libredb-studio/values.schema.json
+++ b/charts/libredb-studio/values.schema.json
@@ -244,6 +244,21 @@
         "annotations": {
           "type": "object",
           "description": "Service annotations"
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"],
+          "description": "Service address families: SingleStack, PreferDualStack or RequireDualStack; empty renders no field and leaves the cluster default"
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          },
+          "maxItems": 2,
+          "uniqueItems": true,
+          "description": "Explicit address-family order, e.g. [IPv4, IPv6]; entry 0 is the immutable primary family. Two entries require ipFamilyPolicy PreferDualStack or RequireDualStack"
         }
       }
     },

--- a/charts/libredb-studio/values.yaml
+++ b/charts/libredb-studio/values.yaml
@@ -263,6 +263,37 @@ service:
   nodePort: ""
   # -- Service annotations
   annotations: {}
+  # -- Address families the Service is allocated from: "SingleStack",
+  # "PreferDualStack" (two families on a dual-stack cluster, one on a
+  # single-stack cluster) or "RequireDualStack" (fails to create on a
+  # single-stack cluster). Empty renders no field at all, which is deliberate:
+  # Kubernetes does not treat an omitted policy as a static SingleStack default
+  # (on update it inherits the live Service's policy), and an explicit
+  # SingleStack is read as intent to TRUNCATE - it releases the secondary
+  # clusterIP of a Service that is already dual-stack.
+  # THE POD MUST LISTEN ON BOTH FAMILIES TOO. Nothing in Kubernetes checks what
+  # address the container bound: on a dual-stack cluster the pod has an IPv6
+  # address either way, so the IPv6 EndpointSlice is populated and kube-proxy
+  # routes to it, while the app's default HOSTNAME=0.0.0.0 is IPv4 only and
+  # answers those connections with a TCP RST. Kubelet probes only the primary
+  # podIP, so the pod stays Ready and the breakage is silent. Pair this with:
+  #   extraEnv:
+  #     - name: HOSTNAME
+  #       value: "::"
+  # which overrides the ConfigMap's HOSTNAME (an explicit env entry beats
+  # envFrom) and, on Linux with the default net.ipv6.bindv6only=0, serves IPv4
+  # through the same socket.
+  ipFamilyPolicy: ""
+  # -- Explicit family order, e.g. ["IPv4", "IPv6"]. Empty leaves the choice to
+  # the cluster's own default family. Entry 0 is the PRIMARY family: it is what
+  # spec.clusterIP (the address every IPv4-only client reads) is allocated from,
+  # and it is immutable - reordering the list on a live Service is rejected
+  # ("may not change once set"), so switching primaries needs the Service
+  # deleted and recreated. Two entries require service.ipFamilyPolicy to be
+  # PreferDualStack or RequireDualStack; the chart refuses to render otherwise.
+  # Naming a family the cluster does not have is rejected even under
+  # PreferDualStack, so leave this empty unless the order matters.
+  ipFamilies: []
 
 ingress:
   # -- Enable Ingress

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -279,7 +279,7 @@ src/
 
 ## 6. Deployment
 
-- **Docker / Helm**: Multi-stage Bun build with standalone Next.js output; these channels bind `0.0.0.0`. Canonical image `ghcr.io/libredb/libredb-studio`.
+- **Docker / Helm**: Multi-stage Bun build with standalone Next.js output; these channels bind `0.0.0.0` (IPv4 only), with `HOSTNAME` as the override — it takes IPv6 literals, and `::` gives a dual-stack listener. Canonical image `ghcr.io/libredb/libredb-studio`.
 - **Native channels** (`bin/studio.js` npx launcher, Homebrew tap, `.deb`/`.rpm`, Snap, standalone tarballs; sources under `bin/` and `packaging/`): local-first, bind `127.0.0.1` by default unless `--host`/`HOSTNAME` opts in. The npx launcher ships as a pure library and downloads the SHA256-verified standalone server tarball from GitHub Releases. Full matrix and per-channel details in [`docs/DISTRIBUTION.md`](DISTRIBUTION.md).
 - **Health Check**: `GET /api/db/health`
 - **Stateless API**: API routes are stateless, suitable for horizontal scaling

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2625,3 +2625,25 @@ than "none found".
 
 Done when a metric an engine cannot report renders as unavailable rather than as zero, on every
 provider whose health payload omits it.
+
+### U15. The container image's default bind stays IPv4-only, deliberately
+
+`Dockerfile` sets `ENV HOSTNAME="0.0.0.0"` and the chart ConfigMap writes the same, so the container
+listens on IPv4 only until an operator sets `HOSTNAME=::`. Issue #432 asked for `::` as the default,
+on the argument that the container is the only channel that matters. The docs fix and the chart's
+`service.ipFamilyPolicy` / `service.ipFamilies` values shipped in that PR; the default flip did not.
+
+The reason it did not is narrower than it first looks. `::` is a dual-stack listener wherever
+`net.ipv6.bindv6only=0`, and that sysctl is network-namespace scoped and initializes to `0` in a
+fresh namespace — so a normal container or pod gets the dual-stack behaviour whatever the node is
+set to (verified 2026-08-19: `docker run --rm alpine sysctl net.ipv6.bindv6only` reads `0`). What
+survives is the case a *default* has to cover and an opt-in does not: `--network host` /
+`hostNetwork: true`, where the host's value applies, and an explicit `--sysctl` / pod
+`securityContext.sysctls` override. Under `bindv6only=1`, `::` is IPv6-only and every existing IPv4
+client is dropped with no error and no config change on the user's side.
+
+Done when either the image can pick its family without that failure mode — an entrypoint that binds
+`::` and falls back to `0.0.0.0` when the namespace forbids dual-stack, which adds a moving part to
+a path that currently has none — or the decision is closed as permanent and this entry is deleted.
+The alternative that needs no code is to leave the default and keep the opt-in documented, which is
+what ships today.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -72,7 +72,11 @@ with it already on. Unrecognized `AUTH_BOOTSTRAP` values log a warning and keep 
 
 Every native channel is **local-first**: the server binds to `127.0.0.1` by default, and
 exposing it on the network is an explicit opt-in. (The Docker image and the Helm chart are the
-exception - containers must bind `0.0.0.0` and are isolated by container networking instead.)
+exception - a container binds all of its own addresses, `0.0.0.0` by default, and is isolated by
+container networking instead.) `HOSTNAME` is the bind address wherever the server is started
+directly - Docker, Helm, npx, the systemd units and Snap; the `.deb`/`.rpm` and Homebrew wrappers
+and the Windows launcher take `LIBREDB_BIND` instead and discard an inherited `HOSTNAME`. The note
+below the table covers the address family either one selects.
 
 | Channel | Default bind | How to expose |
 |---|---|---|
@@ -81,7 +85,7 @@ exception - containers must bind `0.0.0.0` and are isolated by container network
 | .deb / .rpm (direct run) | `127.0.0.1` | `LIBREDB_BIND=0.0.0.0 libredb-studio` |
 | Homebrew service | `127.0.0.1` | run the binary manually with `LIBREDB_BIND=0.0.0.0`, or front it with a reverse proxy |
 | Snap | `127.0.0.1` | `sudo systemctl edit snap.libredb-studio.libredb-studio.service` with `[Service]` `Environment=HOSTNAME=0.0.0.0` |
-| Docker / Helm | `0.0.0.0` (container-internal) | publish/route ports as usual (`-p`, Service/Ingress) |
+| Docker / Helm | `0.0.0.0` (container-internal, IPv4 only) | publish/route ports as usual (`-p`, Service/Ingress); `HOSTNAME=::` to also listen on IPv6 |
 
 For anything reachable from a network, prefer a reverse proxy with TLS in front and strict mode
 (`AUTH_BOOTSTRAP=off`) with explicit credentials.
@@ -90,7 +94,64 @@ A direct run of the `.deb`/`.rpm` wrapper or the Homebrew binary ignores any inh
 (empty, or - under Docker - the container ID Next.js would otherwise bind to) and defaults to
 loopback; `LIBREDB_BIND` is the explicit opt-in for that case. Under systemd, `HOSTNAME` in
 `/etc/libredb-studio/env` is still the override, since the unit resolves it before the wrapper
-runs (detected via the systemd-set `INVOCATION_ID`, so the wrapper leaves it untouched there).
+runs (detected via the systemd-set `INVOCATION_ID`, so the wrapper leaves it untouched there). The
+Windows launcher rebuilds `HOSTNAME` from `LIBREDB_BIND` on every run, with no systemd exception.
+
+**Address family (IPv4, IPv6, dual-stack).** The bind address accepts an IPv6 literal in every
+channel, because whichever variable that channel reads ends up as the host argument of a plain
+`server.listen(port, hostname)` in the standalone Next.js server
+(`next/dist/server/lib/start-server.js`) - so it is Node, not Next, that gives `::` its meaning.
+(Next touches `[::]` only to format the URL it prints at startup.) Use `HOSTNAME` where the server is started directly
+(Docker, Helm, npx, the systemd units, Snap) and `LIBREDB_BIND` in the wrapper channels (a direct
+`.deb`/`.rpm` run, Homebrew, the Windows launcher), per the paragraph above. The values that
+matter:
+
+| `HOSTNAME` | `LIBREDB_BIND` | Listens on |
+|---|---|---|
+| `0.0.0.0` | `0.0.0.0` | all IPv4 addresses (the Docker image and chart ConfigMap default) |
+| `::` | `::` | all IPv6 addresses - and, on Linux with the default `net.ipv6.bindv6only=0`, all IPv4 addresses through the same socket, so one listener serves both families |
+| `127.0.0.1` | `127.0.0.1` | IPv4 loopback (the native-channel default) |
+| `::1` | `::1` | IPv6 loopback - the IPv6 equivalent of that local-first default |
+
+The dual-stack behaviour of `::` is conditional: where `net.ipv6.bindv6only=1` is in force, `::`
+is **IPv6 only** and IPv4 clients are dropped. Read that sysctl in the right namespace - it is
+network-namespace scoped, not a host-wide property, and a fresh namespace initializes to `0`. A
+Docker container or a Kubernetes pod therefore gets `0` whatever the node reads, unless the
+namespace is overridden explicitly (`docker run --sysctl net.ipv6.bindv6only=1`, a pod
+`securityContext.sysctls` entry) or it shares the host's namespace (`docker run --network host`,
+`hostNetwork: true`). Checking the node and finding `1` does not mean `-e HOSTNAME=::` will drop
+IPv4 in your container.
+
+That residual case is why the container image default stays `0.0.0.0` rather than `::`: a default
+has to hold for host-network and sysctl-overridden deployments too, where flipping it would
+silently remove IPv4 for existing users. Opting in per deployment is safe because you know your own
+namespace.
+
+```bash
+docker run -p 3000:3000 -e HOSTNAME=:: ghcr.io/libredb/libredb-studio:latest
+```
+
+For Helm, `extraEnv` renders into the container's `env:` list, which overrides the same key
+delivered by the chart ConfigMap through `envFrom`:
+
+```yaml
+extraEnv:
+  - name: HOSTNAME
+    value: "::"
+```
+
+> **A dual-stack Service is not enough on its own.** The chart's `service.ipFamilyPolicy` /
+> `service.ipFamilies` values give the Service an IPv6 address, but Kubernetes never checks what
+> address the container actually bound: the IPv6 EndpointSlice is populated from the pod's IPv6
+> address regardless, and traffic to it hits a pod with no IPv6 listener, which answers `connection
+> refused`. The kubelet probes the pod's *primary* IP (IPv4 on a typical cluster), so the pod still
+> reports Ready and nothing self-heals. **Set both**: the dual-stack Service values *and*
+> `extraEnv` `HOSTNAME: "::"`. See the chart
+> [README](../charts/libredb-studio/README.md#ipv6-and-dual-stack).
+
+The native channels are unaffected by all of this: they stay on `127.0.0.1` by default and treat
+any exposure, IPv4 or IPv6, as an explicit opt-in - `LIBREDB_BIND=::` (or `LIBREDB_BIND=::1` for
+IPv6 loopback) is that opt-in for the wrapper channels, `HOSTNAME` for the rest.
 
 ## Release artifact naming
 
@@ -172,7 +233,9 @@ docker run --name libredb-studio -p 3000:3000 \
 ```
 
 All environment variables are documented in [`.env.example`](../.env.example); a ready-to-use
-compose file is [`docker-compose.example.yml`](../docker-compose.example.yml).
+compose file is [`docker-compose.example.yml`](../docker-compose.example.yml). The container
+listens on IPv4 only unless you add `-e HOSTNAME=::` - see
+[Network exposure](#network-exposure-bind-address).
 
 ### Image tag model
 
@@ -223,6 +286,11 @@ is the canonical description of that behaviour — credential retrieval, what st
 auth provider, persistence and the single-replica constraint. Full values reference:
 [`charts/libredb-studio/README.md`](../charts/libredb-studio/README.md); chart architecture:
 [`docs/HELM_CHART.md`](HELM_CHART.md).
+
+On a dual-stack cluster, set `service.ipFamilyPolicy` (and optionally `service.ipFamilies`) **and**
+`extraEnv` `HOSTNAME: "::"` together - a dual-stack Service in front of an IPv4-only listener
+advertises an IPv6 address that refuses every connection. See
+[Network exposure](#network-exposure-bind-address).
 
 ## OpenShift operator (OperatorHub)
 

--- a/docs/HELM_CHART.md
+++ b/docs/HELM_CHART.md
@@ -168,7 +168,7 @@ Most non-sensitive configuration flows through a ConfigMap (the seed-connection 
 |----------|--------|-------------|
 | `NODE_ENV` | Fixed `production` | Always |
 | `PORT` | `service.targetPort` | Always |
-| `HOSTNAME` | Fixed `0.0.0.0` | Always |
+| `HOSTNAME` | ConfigMap writes `0.0.0.0`; `extraEnv` overrides it (`::` for a dual-stack listener) | Always |
 | `NEXT_TELEMETRY_DISABLED` | Fixed `1` | Always |
 | `NODE_OPTIONS` | Fixed `--max-old-space-size=384` | Always |
 | `NEXT_PUBLIC_AUTH_PROVIDER` | `authProvider` | Always |
@@ -179,6 +179,18 @@ Most non-sensitive configuration flows through a ConfigMap (the seed-connection 
 | `SEED_CONFIG_PATH` / `SEED_CACHE_TTL_MS` | `seedConnections.*` — set **directly on the Deployment** (not via the ConfigMap) | When `seedConnections.enabled` |
 | `LLM_PROVIDER/MODEL/API_URL` | `config.llm*` | When set |
 | `OIDC_*` | `config.oidc*` | When `authProvider=oidc` |
+
+"Fixed" above describes what the ConfigMap writes, not what the container ends up with: the ConfigMap arrives through `envFrom`, `extraEnv` renders into the container's `env:` list, and an explicit `env` entry always wins over an `envFrom` key of the same name. Any row above can therefore be overridden through `extraEnv`, though only some are safe to: `PORT` is rendered from `service.targetPort` and also drives the container's named `http` port and all three probes, so overriding it through `extraEnv` alone moves the app off the port the probes still target and the pod never becomes Ready. The one case with a documented recipe is `HOSTNAME`, whose ConfigMap value `0.0.0.0` listens on IPv4 only:
+
+```yaml
+extraEnv:
+  - name: HOSTNAME
+    value: "::"
+```
+
+`::` listens on every IPv6 address and, where the pod's network namespace has the default `net.ipv6.bindv6only=0`, answers IPv4 through the same socket; under `bindv6only=1` it is IPv6 only, so it stays an opt-in rather than the chart default.
+
+> **Dual-stack is two settings, not one — set both.** `service.ipFamilyPolicy` (`PreferDualStack` / `RequireDualStack`) and `service.ipFamilies` give the Service an IPv6 address; `extraEnv` `HOSTNAME: "::"` makes the pod listen on one. Kubernetes never inspects what the container bound, so a dual-stack Service in front of an IPv4-only listener populates an IPv6 EndpointSlice from the pod's IPv6 address and kube-proxy routes IPv6 traffic to a socket that is not there — the client gets `connection refused`. It never self-heals and it is invisible to the probes, because the kubelet probes the pod's *primary* IP (IPv4 on a typical IPv4-primary cluster), so the pod reports Ready while its IPv6 path is dead. Values reference and a copy-pasteable recipe: the chart [`README.md`](../charts/libredb-studio/README.md#ipv6-and-dual-stack).
 
 **The chart follows the application's zero-config default** (`config.authBootstrap: ""` omits `AUTH_BOOTSTRAP`, so missing `JWT_SECRET`/`ADMIN_PASSWORD` are generated at first boot): a default-values install is fully working, which certified catalogs such as the Rancher partner-charts repository require. The architectural consequence for this document is that the deployment may only reference Secret keys that actually exist — the env entries for `JWT_SECRET`, `ADMIN_PASSWORD`, `USER_EMAIL`, `USER_PASSWORD` render only when their value is set or an `existingSecret` is used, and a mandatory `secretKeyRef` is reserved for the one combination where a missing key really is an error (strict mode with `authProvider=local`).
 

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch
 type: application
-version: 0.1.38
+version: 0.1.39
 appVersion: "0.12.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -34,9 +34,10 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
   # False for this chart version, and that is a statement rather than a default:
-  # 0.1.38 changes chart metadata only and installs the same 0.12.0 image 0.1.37
-  # installs, so it carries no security fix of its own. The app-level fixes are
-  # recorded on 0.1.37, which is the chart version that first shipped them.
+  # 0.1.39 adds an opt-in Service setting and installs the same 0.12.0 image
+  # 0.1.37 installs, so it carries no security fix of its own. The app-level
+  # fixes are recorded on 0.1.37, which is the chart version that first shipped
+  # them.
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
@@ -52,10 +53,11 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "Chart metadata only, and no application change: the appVersion stays 0.12.0 and the deployed image is the same one 0.1.37 installs"
-    - "The chart description named seven engines and twelve ship - Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch were missing from the text Rancher and ArtifactHub render beside this chart"
-    - "Those five engines are searchable now: they are keywords on the chart rather than only prose"
-    - "Track app release 0.12.0 (appVersion bump; default image tag follows)"
+    - "The Service can be dual-stack: service.ipFamilyPolicy and service.ipFamilies are rendered onto it, so a dual-stack cluster can hand this release an IPv6 address (#432)"
+    - "Both are unset by default, so an existing install upgrades to a byte-identical Service - Kubernetes reads an explicit SingleStack as intent to release a secondary clusterIP, which is why the chart writes neither field unless asked"
+    - "Two address families without a dual-stack policy now fails at render time, with the message the API server would have returned at install time"
+    - "The pairing is documented rather than assumed: a dual-stack Service in front of the pod's default IPv4-only listener advertises an IPv6 address that refuses every connection, so the README recipe sets extraEnv HOSTNAME to :: alongside it"
+    - "No application change: the appVersion stays 0.12.0 and the deployed image is the same one 0.1.37 installs"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.38 \
+  --version 0.1.39 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```
@@ -293,6 +293,52 @@ helm install libredb libredb/libredb-studio \
   # ... secrets omitted for brevity
 ```
 
+### IPv6 and dual-stack
+
+Dual-stack is two settings, not one: the address families the **Service** is allocated from, and
+the address the **pod** actually listens on. Both are needed, and only the first has a values
+field — the chart's ConfigMap sets `HOSTNAME=0.0.0.0`, which is IPv4 only, so `extraEnv` supplies
+the other half:
+
+```bash
+helm install libredb libredb/libredb-studio \
+  --set service.ipFamilyPolicy=PreferDualStack \
+  --set extraEnv[0].name=HOSTNAME \
+  --set extraEnv[0].value="::"
+```
+
+`extraEnv` renders an explicit `env` entry, which overrides the ConfigMap key of the same name.
+`::` listens on IPv6 and, on nodes with the default `net.ipv6.bindv6only=0`, answers IPv4 through
+the same socket; where a node sets `bindv6only=1` it is IPv6 only, so leave `HOSTNAME` alone on
+IPv4-only clusters. As in the `extraEnv` examples further down, a second variable needs its own
+index — reusing `extraEnv[0]` overwrites this one.
+
+**Do not enable one half without the other.** Kubernetes never checks what address the container
+bound: on a dual-stack cluster the pod has an IPv6 address either way, so the IPv6 EndpointSlice is
+populated and kube-proxy routes to it, where an IPv4-only listener answers with a TCP RST. Kubelet
+probes only the primary podIP, so the pod stays `Ready` and the IPv6 path is silently dead. The
+install notes say so as well: a release that asks the Service for an IPv6 address without a
+`HOSTNAME` entry in `extraEnv` prints a warning with the recipe above.
+
+`service.ipFamilyPolicy` takes `SingleStack`, `PreferDualStack` or `RequireDualStack`;
+`service.ipFamilies` pins the order explicitly, e.g. `[IPv6, IPv4]`, and needs a dual-stack policy
+alongside it or the chart refuses to render. Both are empty by default, so the cluster's own
+default applies and existing installs upgrade to an unchanged Service. Three cluster-side rules are
+worth knowing before you set them:
+
+- `RequireDualStack` fails to create on a single-stack cluster, and naming a family the cluster
+  does not have in `service.ipFamilies` is rejected even under `PreferDualStack`.
+- The first entry of `service.ipFamilies` is the primary family — it is what `spec.clusterIP` is
+  allocated from — and it is immutable. Reordering the list on a live Service is rejected; the
+  Service has to be deleted and recreated.
+- A `PreferDualStack` Service is not retroactively upgraded when the cluster later gains
+  dual-stack. Adding the second family is a deliberate change, and removing it again requires
+  setting `service.ipFamilyPolicy=SingleStack` in the same upgrade.
+
+With `service.type: LoadBalancer` these fields govern the cluster IPs only. Whether the external
+address is dual-stack is up to the cloud load-balancer controller, several of which want their own
+annotation for it.
+
 ## Rate Limiting Across Replicas
 
 Studio's built-in rate limiter (login attempts, AI endpoints, and every database-reaching route —
@@ -441,6 +487,8 @@ helm uninstall libredb
 | `persistence.fixPermissions` | Chown the mounted volume to `runAsUser:fsGroup` in a root init container (hostPath / static PVs the kubelet does not `fsGroup`). Rendering fails when the OpenShift security-context adaptation is active - restricted-v2 rejects a root container and the UID/GID come from the namespace range there | `false` |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `80` |
+| `service.ipFamilyPolicy` | Service address families: `SingleStack`, `PreferDualStack` or `RequireDualStack`; empty renders no field and leaves the cluster default in place | `""` |
+| `service.ipFamilies` | Explicit family order, e.g. `[IPv4, IPv6]`; entry 0 is the immutable primary family. Two entries require a dual-stack `service.ipFamilyPolicy` (the chart refuses to render otherwise) | `[]` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `route.labels` | Labels added to every enabled route (a per-route label with the same key wins); `labels` is therefore a reserved key name and cannot be a route name | `{}` |
 | `route.annotations` | Annotations added to every enabled route (a per-route annotation with the same key wins); reserved key name, as `route.labels` | `{}` |

--- a/operator/helm-charts/libredb-studio/templates/NOTES.txt
+++ b/operator/helm-charts/libredb-studio/templates/NOTES.txt
@@ -119,3 +119,18 @@ SQLite is a single-writer database, so the HorizontalPodAutoscaler was not
 rendered and the deployment stays at replicaCount ({{ .Values.replicaCount }}).
 Use storageProvider=postgres for multi-replica setups.
 {{- end }}
+
+{{- if and (include "libredb-studio.serviceWantsIPv6" .) (not (include "libredb-studio.extraEnvHostnameSet" .)) }}
+
+WARNING: this Service asks for an IPv6 address, but the container still binds
+0.0.0.0 (IPv4 only).
+Kubernetes populates the IPv6 EndpointSlice from the pod's own IPv6 address
+without checking what the process bound, so connections to that address are
+refused - and the kubelet probes only the pod's primary IP, so the pod still
+reports Ready and nothing self-heals. Set the bind address as well:
+  helm upgrade libredb libredb/libredb-studio \
+    --set extraEnv[0].name=HOSTNAME \
+    --set-string extraEnv[0].value=::
+On Linux with the default net.ipv6.bindv6only=0 that single listener serves both
+families; where bindv6only=1 is in force it is IPv6 only.
+{{- end }}

--- a/operator/helm-charts/libredb-studio/templates/_helpers.tpl
+++ b/operator/helm-charts/libredb-studio/templates/_helpers.tpl
@@ -277,6 +277,45 @@ execs directly when not running as root.
 {{- end }}
 
 {{/*
+Whether extraEnv sets HOSTNAME - the container's bind address. An explicit env
+entry beats the same key delivered by the ConfigMap through envFrom, so this is
+the only place in these values that can move the pod off the ConfigMap's
+IPv4-only 0.0.0.0. Only the key is read, never the value: "::" is the
+dual-stack answer, but an operator who set HOSTNAME at all chose the bind
+address deliberately and does not need to be told about it again.
+
+Same blind spot as agentPossible: a HOSTNAME delivered through extraEnvFrom is
+not visible here, so such a release still sees the NOTES.txt warning. That is
+the safe direction - an unnecessary note rather than a silent IPv6 address that
+refuses every connection.
+*/}}
+{{- define "libredb-studio.extraEnvHostnameSet" -}}
+{{- range .Values.extraEnv }}
+{{- if eq (.name | default "" | toString) "HOSTNAME" }}
+{{- true }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Whether these values ask the Service for an IPv6 address: either a dual-stack
+policy, or an explicit IPv6 entry in service.ipFamilies (which needs no policy
+when it is the only family, so templates/service.yaml's guard never sees it).
+
+Kubernetes populates the IPv6 EndpointSlice from the pod's own IPv6 address
+without ever checking what the process bound, so this is the condition under
+which the ConfigMap's IPv4-only HOSTNAME turns into a silent misconfiguration:
+a green install whose IPv6 address refuses every connection, on a pod that -
+probed only on its primary IP - stays Ready. NOTES.txt warns whenever this is
+requested without a HOSTNAME override.
+*/}}
+{{- define "libredb-studio.serviceWantsIPv6" -}}
+{{- if or (has .Values.service.ipFamilyPolicy (list "PreferDualStack" "RequireDualStack")) (has "IPv6" (default (list) .Values.service.ipFamilies)) }}
+{{- true }}
+{{- end }}
+{{- end }}
+
+{{/*
 Return the full image reference (repository:tag)
 */}}
 {{- define "libredb-studio.image" -}}

--- a/operator/helm-charts/libredb-studio/templates/service.yaml
+++ b/operator/helm-charts/libredb-studio/templates/service.yaml
@@ -1,3 +1,7 @@
+{{- $ipFamilies := default (list) .Values.service.ipFamilies }}
+{{- if and (gt (len $ipFamilies) 1) (not (has .Values.service.ipFamilyPolicy (list "PreferDualStack" "RequireDualStack"))) }}
+{{- fail "service.ipFamilies lists two address families, which the API server accepts only alongside a dual-stack policy: on create, with service.ipFamilyPolicy unset or SingleStack, it rejects the Service outright ('must be RequireDualStack or PreferDualStack when multiple IP families are specified'), so the install would fail against the cluster instead of here. (On update an omitted policy is inherited from the live Service, so the API server may accept what this guard refuses - set the policy explicitly rather than relying on that inheritance.) Set service.ipFamilyPolicy=PreferDualStack (both families where the cluster is dual-stack, one where it is not) or service.ipFamilyPolicy=RequireDualStack (fail on a single-stack cluster), or list a single family in service.ipFamilies. A dual-stack Service also needs the pod to listen on both families: set extraEnv HOSTNAME=\"::\", or the IPv6 address it advertises refuses every connection" }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +14,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with $ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}

--- a/operator/helm-charts/libredb-studio/values.schema.json
+++ b/operator/helm-charts/libredb-studio/values.schema.json
@@ -244,6 +244,21 @@
         "annotations": {
           "type": "object",
           "description": "Service annotations"
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"],
+          "description": "Service address families: SingleStack, PreferDualStack or RequireDualStack; empty renders no field and leaves the cluster default"
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          },
+          "maxItems": 2,
+          "uniqueItems": true,
+          "description": "Explicit address-family order, e.g. [IPv4, IPv6]; entry 0 is the immutable primary family. Two entries require ipFamilyPolicy PreferDualStack or RequireDualStack"
         }
       }
     },

--- a/operator/helm-charts/libredb-studio/values.yaml
+++ b/operator/helm-charts/libredb-studio/values.yaml
@@ -263,6 +263,37 @@ service:
   nodePort: ""
   # -- Service annotations
   annotations: {}
+  # -- Address families the Service is allocated from: "SingleStack",
+  # "PreferDualStack" (two families on a dual-stack cluster, one on a
+  # single-stack cluster) or "RequireDualStack" (fails to create on a
+  # single-stack cluster). Empty renders no field at all, which is deliberate:
+  # Kubernetes does not treat an omitted policy as a static SingleStack default
+  # (on update it inherits the live Service's policy), and an explicit
+  # SingleStack is read as intent to TRUNCATE - it releases the secondary
+  # clusterIP of a Service that is already dual-stack.
+  # THE POD MUST LISTEN ON BOTH FAMILIES TOO. Nothing in Kubernetes checks what
+  # address the container bound: on a dual-stack cluster the pod has an IPv6
+  # address either way, so the IPv6 EndpointSlice is populated and kube-proxy
+  # routes to it, while the app's default HOSTNAME=0.0.0.0 is IPv4 only and
+  # answers those connections with a TCP RST. Kubelet probes only the primary
+  # podIP, so the pod stays Ready and the breakage is silent. Pair this with:
+  #   extraEnv:
+  #     - name: HOSTNAME
+  #       value: "::"
+  # which overrides the ConfigMap's HOSTNAME (an explicit env entry beats
+  # envFrom) and, on Linux with the default net.ipv6.bindv6only=0, serves IPv4
+  # through the same socket.
+  ipFamilyPolicy: ""
+  # -- Explicit family order, e.g. ["IPv4", "IPv6"]. Empty leaves the choice to
+  # the cluster's own default family. Entry 0 is the PRIMARY family: it is what
+  # spec.clusterIP (the address every IPv4-only client reads) is allocated from,
+  # and it is immutable - reordering the list on a live Service is rejected
+  # ("may not change once set"), so switching primaries needs the Service
+  # deleted and recreated. Two entries require service.ipFamilyPolicy to be
+  # PreferDualStack or RequireDualStack; the chart refuses to render otherwise.
+  # Naming a family the cluster does not have is rejected even under
+  # PreferDualStack, so leave this empty unless the order matters.
+  ipFamilies: []
 
 ingress:
   # -- Enable Ingress

--- a/tests/unit/helm-chart-dualstack.test.ts
+++ b/tests/unit/helm-chart-dualstack.test.ts
@@ -54,8 +54,9 @@
  * compared against it too: a hand-edit that reaches only one of the two trees
  * must fail here as well.
  */
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterAll, describe, expect, test } from "bun:test";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseAllDocuments } from "yaml";
 
@@ -313,27 +314,47 @@ describe("charts/libredb-studio dual-stack needs the pod to listen on :: (#432)"
 });
 
 describe("charts/libredb-studio install notes warn about an unbound IPv6 address (#432)", () => {
-  // NOTES.txt is rendered by `helm install`, not by `helm template` (Helm 3
-  // prints it for neither; Helm 4 prints it for install only), so this uses a
-  // client-side dry run - no cluster, no kubeconfig, same on both versions.
+  // `helm template` never emits NOTES.txt and `helm install --dry-run=client`
+  // cannot render it without a cluster: Helm 3.16 - the version CI pins - calls
+  // IsReachable() before it renders anything, so the dry run dies on
+  // "Kubernetes cluster unreachable" even for a chart created by `helm create`.
+  // (Helm 4 does not, which is exactly how this went green locally and red in
+  // CI.) So render the real NOTES.txt through the one path that needs no
+  // cluster on either version: a throwaway copy of the chart in which the
+  // file's own bytes are wrapped in a named template and emitted as a
+  // ConfigMap. Helm does the rendering, the template text is the shipped one,
+  // and nothing here reimplements the condition under test.
+  const notesChart = mkdtempSync(join(tmpdir(), "libredb-notes-probe-"));
+  cpSync(CHART_DIR, notesChart, { recursive: true });
+  const PROBE_TEMPLATE = "templates/zz-notes-probe.yaml";
+  writeFileSync(
+    join(notesChart, PROBE_TEMPLATE),
+    `{{- define "notesProbe" -}}\n${readFileSync(join(CHART_DIR, "templates/NOTES.txt"), "utf8")}\n{{- end -}}\n` +
+      'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: notes-probe\ndata:\n  notes: {{ include "notesProbe" . | quote }}\n',
+  );
+  afterAll(() => rmSync(notesChart, { recursive: true, force: true }));
+
   function notes(args: string[]): string {
-    const run = Bun.spawnSync(["helm", "install", "release-under-test", CHART_DIR, "--dry-run=client", ...args], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    const run = Bun.spawnSync(
+      ["helm", "template", "release-under-test", notesChart, "--show-only", PROBE_TEMPLATE, ...args],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
     if (run.exitCode !== 0) {
-      throw new Error(`helm install --dry-run failed (exit ${run.exitCode}): ${run.stderr.toString()}`);
+      throw new Error(`helm template of the notes probe failed (exit ${run.exitCode}): ${run.stderr.toString()}`);
     }
-    // The dry run prints the whole manifest before the notes, and that manifest
-    // legitimately contains both "IPv6" and "HOSTNAME" - assert on the notes
-    // alone, or every absence check passes for the wrong reason.
-    const output = run.stdout.toString();
-    const marker = "\nNOTES:\n";
-    const index = output.indexOf(marker);
-    if (index < 0) {
-      throw new Error("helm install --dry-run printed no NOTES section");
+    // Only the probe ConfigMap comes back, so unlike the full dry-run output
+    // there is no surrounding manifest whose own "IPv6" and "HOSTNAME" strings
+    // would satisfy the absence checks for the wrong reason.
+    const rendered = parseAllDocuments(run.stdout.toString())
+      .map((document) => document.toJS() as { data?: { notes?: string } } | null)
+      .find((document) => document?.data?.notes !== undefined);
+    if (!rendered) {
+      throw new Error(`the notes probe rendered no ConfigMap: ${run.stdout.toString()}`);
     }
-    return output.slice(index + marker.length);
+    return rendered.data?.notes ?? "";
   }
 
   const HOSTNAME_ENV = ["--set", "extraEnv[0].name=HOSTNAME", "--set-string", "extraEnv[0].value=::"];

--- a/tests/unit/helm-chart-dualstack.test.ts
+++ b/tests/unit/helm-chart-dualstack.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Regression tests for the chart's dual-stack Service surface
+ * (service.ipFamilyPolicy / service.ipFamilies), added for #432:
+ *
+ *   1. The default render must stay byte-unchanged. Kubernetes does not treat
+ *      an omitted ipFamilyPolicy as a static SingleStack default: on CREATE it
+ *      is SingleStack, but on UPDATE it is inherited from the live object, and
+ *      an *explicit* SingleStack is read as clear intent to truncate - the API
+ *      server trims spec.clusterIPs and spec.ipFamilies back to one entry,
+ *      releasing the secondary clusterIP of a Service somebody else made
+ *      dual-stack. So both fields must be rendered only when set, never
+ *      defaulted, or every existing install gets a spec diff on `helm upgrade`
+ *      and some get a silent downgrade.
+ *   2. ipFamilies is ordered: entry 0 is the primary family, it is what
+ *      spec.clusterIPs[0] (and the legacy spec.clusterIP every IPv4-only
+ *      client reads) is allocated from, and it is immutable once set. A
+ *      template that emitted the list in map/sorted order rather than the
+ *      given order would silently hand users the other primary family.
+ *   3. Two families with ipFamilyPolicy left at SingleStack is a hard API
+ *      server rejection ("must be 'RequireDualStack' or 'PreferDualStack'
+ *      when multiple IP families are specified"), and it is the most likely
+ *      way to hold this feature wrong - set the families, forget the policy.
+ *      The chart must refuse that at render time with a message that names
+ *      both keys, the way templates/deployment.yaml refuses the other
+ *      combinations it cannot ship working, instead of letting the error
+ *      surface only against a live cluster at install time.
+ *   4. The values.schema.json entries are what make `helm lint --strict` and
+ *      every render reject a typo (`preferdualstack`, `ipv6`, three entries,
+ *      a duplicate) before it reaches the API server.
+ *   5. A dual-stack Service in front of a container that only bound 0.0.0.0
+ *      advertises an IPv6 address that answers every connection with a TCP
+ *      RST: Kubernetes never checks what the process bound, the pod has an
+ *      IPv6 address on a dual-stack cluster, so the IPv6 EndpointSlice is
+ *      populated and kube-proxy routes to a port nothing listens on - and
+ *      kubelet's probes only ever hit the primary podIP, so the pod stays
+ *      Ready forever. The documented recipe is therefore the pair: the
+ *      Service fields plus `extraEnv: HOSTNAME: "::"`, which wins over the
+ *      ConfigMap's HOSTNAME because an explicit `env` entry beats `envFrom`.
+ *      That pairing is locked here so the recipe in the chart README cannot
+ *      rot away from the templates.
+ *   6. Because that pairing is silent when it is broken - green install, IPv6
+ *      EndpointSlice populated, pod Ready, every IPv6 connection refused - the
+ *      install notes have to say so at the moment somebody asks for it. Any
+ *      values that give the Service an IPv6 address without a HOSTNAME override
+ *      must print the warning, and setting the override must silence it, the
+ *      way NOTES.txt already warns about the other two combinations the chart
+ *      renders but cannot make work (sqlite + replicas, sqlite + autoscaling).
+ *
+ * Exercises the real `helm template` output against the actual chart - no
+ * reimplementation of the templating logic (same approach as
+ * helm-chart-route.test.ts and helm-chart-openshift.test.ts). The operator's
+ * embedded copy of the chart is a byte-for-byte mirror enforced by
+ * scripts/sync-chart-version.mjs, so the files this feature touches are
+ * compared against it too: a hand-edit that reaches only one of the two trees
+ * must fail here as well.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseAllDocuments } from "yaml";
+
+const CHART_DIR = join(import.meta.dir, "../../charts/libredb-studio");
+const OPERATOR_CHART_DIR = join(import.meta.dir, "../../operator/helm-charts/libredb-studio");
+
+const DUAL_STACK = [
+  "--set",
+  "service.ipFamilyPolicy=PreferDualStack",
+  "--set-json",
+  'service.ipFamilies=["IPv4","IPv6"]',
+];
+
+interface RenderedManifest {
+  kind: string;
+  metadata: { name: string };
+  spec?: {
+    type?: string;
+    ipFamilyPolicy?: string;
+    ipFamilies?: string[];
+    ports?: Array<{ port: number; targetPort: number }>;
+    template?: {
+      spec?: {
+        containers?: Array<{ env?: Array<{ name: string; value?: string }> }>;
+      };
+    };
+  };
+}
+
+function helmTemplate(args: string[], chartDir = CHART_DIR): { exitCode: number; stdout: string; stderr: string } {
+  const run = Bun.spawnSync(["helm", "template", "release-under-test", chartDir, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { exitCode: run.exitCode, stdout: run.stdout.toString(), stderr: run.stderr.toString() };
+}
+
+function renderDocs(args: string[], chartDir = CHART_DIR): RenderedManifest[] {
+  const run = helmTemplate(args, chartDir);
+  if (run.exitCode !== 0) {
+    throw new Error(`helm template failed (exit ${run.exitCode}): ${run.stderr}`);
+  }
+  return parseAllDocuments(run.stdout)
+    .map((doc) => doc.toJSON() as RenderedManifest)
+    .filter((doc) => doc != null);
+}
+
+function service(args: string[], chartDir = CHART_DIR): RenderedManifest {
+  const svc = renderDocs(args, chartDir).find((doc) => doc.kind === "Service");
+  if (!svc) {
+    throw new Error("Service not found in render output");
+  }
+  return svc;
+}
+
+function serviceSource(args: string[], chartDir = CHART_DIR): string {
+  const run = helmTemplate([...args, "-s", "templates/service.yaml"], chartDir);
+  if (run.exitCode !== 0) {
+    throw new Error(`helm template failed (exit ${run.exitCode}): ${run.stderr}`);
+  }
+  return run.stdout;
+}
+
+describe("charts/libredb-studio Service address families: the default render (#432)", () => {
+  // Absent, not falsy: an emitted `ipFamilyPolicy: SingleStack` is a live
+  // instruction to the API server, not a no-op, and an emitted `ipFamilies: []`
+  // is a spec diff on every existing install.
+  test("the default Service carries neither ipFamilyPolicy nor ipFamilies", () => {
+    const svc = service([]);
+    expect(svc.spec).not.toHaveProperty("ipFamilyPolicy");
+    expect(svc.spec).not.toHaveProperty("ipFamilies");
+  });
+
+  test("the default Service manifest mentions no address family at all", () => {
+    expect(serviceSource([])).not.toContain("ipFamil");
+  });
+
+  // values.yaml ships the keys as empty ("" / []) so they are discoverable and
+  // schema-typed; empty must render exactly like unset.
+  test("explicitly empty values render nothing", () => {
+    const source = serviceSource(["--set", "service.ipFamilyPolicy=", "--set-json", "service.ipFamilies=[]"]);
+    expect(source).not.toContain("ipFamil");
+  });
+
+  test("the default Service is otherwise unchanged", () => {
+    const svc = service([]);
+    expect(svc.spec?.type).toBe("ClusterIP");
+    expect(svc.spec?.ports?.[0]).toMatchObject({ port: 80, targetPort: 3000 });
+  });
+});
+
+describe("charts/libredb-studio Service address families: opting in (#432)", () => {
+  test("service.ipFamilyPolicy renders on its own", () => {
+    const svc = service(["--set", "service.ipFamilyPolicy=PreferDualStack"]);
+    expect(svc.spec?.ipFamilyPolicy).toBe("PreferDualStack");
+    expect(svc.spec).not.toHaveProperty("ipFamilies");
+  });
+
+  test("RequireDualStack renders too", () => {
+    expect(service(["--set", "service.ipFamilyPolicy=RequireDualStack"]).spec?.ipFamilyPolicy).toBe("RequireDualStack");
+  });
+
+  test("SingleStack renders when it is asked for explicitly", () => {
+    expect(service(["--set", "service.ipFamilyPolicy=SingleStack"]).spec?.ipFamilyPolicy).toBe("SingleStack");
+  });
+
+  test("a single family renders under the default SingleStack policy", () => {
+    expect(service(["--set-json", 'service.ipFamilies=["IPv6"]']).spec?.ipFamilies).toEqual(["IPv6"]);
+  });
+
+  // Entry 0 is the primary family: it decides which family spec.clusterIP gets,
+  // and it can never be changed on a live Service.
+  test("service.ipFamilies renders in the order given, IPv4 first", () => {
+    const svc = service(DUAL_STACK);
+    expect(svc.spec?.ipFamilyPolicy).toBe("PreferDualStack");
+    expect(svc.spec?.ipFamilies).toEqual(["IPv4", "IPv6"]);
+  });
+
+  test("service.ipFamilies renders in the order given, IPv6 first", () => {
+    const svc = service([
+      "--set",
+      "service.ipFamilyPolicy=PreferDualStack",
+      "--set-json",
+      'service.ipFamilies=["IPv6","IPv4"]',
+    ]);
+    expect(svc.spec?.ipFamilies).toEqual(["IPv6", "IPv4"]);
+  });
+
+  test("the address families apply to a NodePort Service as well", () => {
+    const svc = service([...DUAL_STACK, "--set", "service.type=NodePort"]);
+    expect(svc.spec?.type).toBe("NodePort");
+    expect(svc.spec?.ipFamilies).toEqual(["IPv4", "IPv6"]);
+  });
+});
+
+describe("charts/libredb-studio Service address families: the policy guard (#432)", () => {
+  // The API server rejects this outright; catching it at render time turns a
+  // failed `helm upgrade` against a live cluster into a message with both keys
+  // in it.
+  test("two families with the policy left unset fails the render", () => {
+    const run = helmTemplate(["--set-json", 'service.ipFamilies=["IPv4","IPv6"]']);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("service.ipFamilyPolicy");
+    expect(run.stderr).toContain("service.ipFamilies");
+  });
+
+  test("two families with an explicit SingleStack policy fails the render", () => {
+    const run = helmTemplate([
+      "--set",
+      "service.ipFamilyPolicy=SingleStack",
+      "--set-json",
+      'service.ipFamilies=["IPv4","IPv6"]',
+    ]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("service.ipFamilyPolicy");
+  });
+
+  test("the failure names the policies that would work", () => {
+    const run = helmTemplate(["--set-json", 'service.ipFamilies=["IPv4","IPv6"]']);
+    expect(run.stderr).toContain("PreferDualStack");
+    expect(run.stderr).toContain("RequireDualStack");
+  });
+
+  test("PreferDualStack clears the guard", () => {
+    expect(helmTemplate(DUAL_STACK).exitCode).toBe(0);
+  });
+
+  test("RequireDualStack clears the guard", () => {
+    const run = helmTemplate([
+      "--set",
+      "service.ipFamilyPolicy=RequireDualStack",
+      "--set-json",
+      'service.ipFamilies=["IPv4","IPv6"]',
+    ]);
+    expect(run.exitCode).toBe(0);
+  });
+});
+
+describe("charts/libredb-studio Service address families: schema validation (#432)", () => {
+  test("an unknown ipFamilyPolicy fails schema validation", () => {
+    const run = helmTemplate(["--set", "service.ipFamilyPolicy=DualStack"]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("ipFamilyPolicy");
+  });
+
+  // Kubernetes matches the family names case-sensitively; a lowercase value is
+  // the kind of typo that otherwise only fails on the cluster.
+  test("a miscased ipFamilyPolicy fails schema validation", () => {
+    const run = helmTemplate(["--set", "service.ipFamilyPolicy=preferDualStack"]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("ipFamilyPolicy");
+  });
+
+  test("a scalar ipFamilies fails schema validation", () => {
+    const run = helmTemplate(["--set", "service.ipFamilies=broken"]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("ipFamilies");
+  });
+
+  test("an unknown family name fails schema validation", () => {
+    const run = helmTemplate([
+      "--set",
+      "service.ipFamilyPolicy=PreferDualStack",
+      "--set-json",
+      'service.ipFamilies=["ipv6"]',
+    ]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("ipFamilies");
+  });
+
+  // The API server allows at most two entries and rejects a repeat as a
+  // Duplicate; the schema mirrors both checks.
+  test("more than two families fails schema validation", () => {
+    const run = helmTemplate([
+      "--set",
+      "service.ipFamilyPolicy=PreferDualStack",
+      "--set-json",
+      'service.ipFamilies=["IPv4","IPv6","IPv4"]',
+    ]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("ipFamilies");
+  });
+
+  test("a repeated family fails schema validation", () => {
+    const run = helmTemplate([
+      "--set",
+      "service.ipFamilyPolicy=PreferDualStack",
+      "--set-json",
+      'service.ipFamilies=["IPv6","IPv6"]',
+    ]);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("ipFamilies");
+  });
+});
+
+describe("charts/libredb-studio dual-stack needs the pod to listen on :: (#432)", () => {
+  function appEnv(args: string[]): Array<{ name: string; value?: string }> {
+    const deployment = renderDocs(args).find((doc) => doc.kind === "Deployment");
+    return deployment?.spec?.template?.spec?.containers?.[0]?.env ?? [];
+  }
+
+  // The image and the chart ConfigMap both say 0.0.0.0, which is IPv4 only.
+  // Nothing about enabling dual-stack Services may change that on its own.
+  test("the dual-stack Service alone does not touch the container's bind address", () => {
+    expect(appEnv(DUAL_STACK).find((entry) => entry.name === "HOSTNAME")).toBeUndefined();
+  });
+
+  // The documented recipe: an explicit env entry beats the envFrom ConfigMap
+  // key of the same name, so extraEnv is all it takes.
+  test("extraEnv HOSTNAME=:: renders alongside the dual-stack Service", () => {
+    const args = [...DUAL_STACK, "--set", "extraEnv[0].name=HOSTNAME", "--set-string", "extraEnv[0].value=::"];
+    expect(appEnv(args).find((entry) => entry.name === "HOSTNAME")?.value).toBe("::");
+    expect(service(args).spec?.ipFamilies).toEqual(["IPv4", "IPv6"]);
+  });
+});
+
+describe("charts/libredb-studio install notes warn about an unbound IPv6 address (#432)", () => {
+  // NOTES.txt is rendered by `helm install`, not by `helm template` (Helm 3
+  // prints it for neither; Helm 4 prints it for install only), so this uses a
+  // client-side dry run - no cluster, no kubeconfig, same on both versions.
+  function notes(args: string[]): string {
+    const run = Bun.spawnSync(["helm", "install", "release-under-test", CHART_DIR, "--dry-run=client", ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (run.exitCode !== 0) {
+      throw new Error(`helm install --dry-run failed (exit ${run.exitCode}): ${run.stderr.toString()}`);
+    }
+    // The dry run prints the whole manifest before the notes, and that manifest
+    // legitimately contains both "IPv6" and "HOSTNAME" - assert on the notes
+    // alone, or every absence check passes for the wrong reason.
+    const output = run.stdout.toString();
+    const marker = "\nNOTES:\n";
+    const index = output.indexOf(marker);
+    if (index < 0) {
+      throw new Error("helm install --dry-run printed no NOTES section");
+    }
+    return output.slice(index + marker.length);
+  }
+
+  const HOSTNAME_ENV = ["--set", "extraEnv[0].name=HOSTNAME", "--set-string", "extraEnv[0].value=::"];
+
+  test("the default install prints no address-family warning", () => {
+    expect(notes([])).not.toContain("IPv6");
+  });
+
+  // The single most likely way to hold this wrong: the policy alone renders
+  // cleanly, so nothing else in the terminal ever mentions the bind address.
+  test("ipFamilyPolicy=PreferDualStack alone warns", () => {
+    const output = notes(["--set", "service.ipFamilyPolicy=PreferDualStack"]);
+    expect(output).toContain("WARNING");
+    expect(output).toContain("HOSTNAME");
+  });
+
+  test("RequireDualStack alone warns", () => {
+    expect(notes(["--set", "service.ipFamilyPolicy=RequireDualStack"])).toContain("HOSTNAME");
+  });
+
+  // A single IPv6 family needs no policy, so the render guard never sees it.
+  test("a single IPv6 family with no policy warns", () => {
+    expect(notes(["--set-json", 'service.ipFamilies=["IPv6"]'])).toContain("HOSTNAME");
+  });
+
+  test("both fields together warn", () => {
+    expect(notes(DUAL_STACK)).toContain("HOSTNAME");
+  });
+
+  test("the warning carries the recipe that fixes it", () => {
+    const output = notes(DUAL_STACK);
+    expect(output).toContain("extraEnv[0].name=HOSTNAME");
+    expect(output).toContain("::");
+  });
+
+  test("an explicit SingleStack policy does not warn", () => {
+    expect(notes(["--set", "service.ipFamilyPolicy=SingleStack"])).not.toContain("IPv6");
+  });
+
+  test("a single IPv4 family does not warn", () => {
+    expect(notes(["--set-json", 'service.ipFamilies=["IPv4"]'])).not.toContain("IPv6");
+  });
+
+  // The pair is complete: warning gone once the bind address is set.
+  test("extraEnv HOSTNAME silences the warning", () => {
+    expect(notes([...DUAL_STACK, ...HOSTNAME_ENV])).not.toContain("WARNING");
+  });
+
+  test("extraEnv HOSTNAME silences it for the policy-only case too", () => {
+    expect(notes(["--set", "service.ipFamilyPolicy=PreferDualStack", ...HOSTNAME_ENV])).not.toContain("WARNING");
+  });
+
+  // Only the key is read: an operator who set HOSTNAME at all decided the bind
+  // address deliberately, whatever they chose.
+  test("a HOSTNAME entry after another extraEnv entry still silences it", () => {
+    const output = notes([
+      ...DUAL_STACK,
+      "--set",
+      "extraEnv[0].name=ALLOWED_ORIGINS",
+      "--set",
+      "extraEnv[0].value=https://libredb.example.com",
+      "--set",
+      "extraEnv[1].name=HOSTNAME",
+      "--set-string",
+      "extraEnv[1].value=::",
+    ]);
+    expect(output).not.toContain("WARNING");
+  });
+
+  test("an unrelated extraEnv entry does not silence it", () => {
+    const output = notes([
+      ...DUAL_STACK,
+      "--set",
+      "extraEnv[0].name=ALLOWED_ORIGINS",
+      "--set",
+      "extraEnv[0].value=https://libredb.example.com",
+    ]);
+    expect(output).toContain("HOSTNAME");
+  });
+});
+
+// scripts/sync-chart-version.mjs holds the operator's embedded chart
+// byte-for-byte identical to charts/libredb-studio. That copy carries no
+// vendored subchart, so it cannot be rendered here; the three files this
+// feature touches are compared byte-for-byte instead, which catches a hand-edit
+// that reached only one of the two trees.
+describe("operator/helm-charts/libredb-studio mirrors the dual-stack surface (#432)", () => {
+  for (const file of [
+    "templates/service.yaml",
+    "templates/NOTES.txt",
+    "templates/_helpers.tpl",
+    "values.yaml",
+    "values.schema.json",
+  ]) {
+    test(`${file} is byte-identical in the operator copy`, () => {
+      expect(readFileSync(join(OPERATOR_CHART_DIR, file), "utf8")).toBe(readFileSync(join(CHART_DIR, file), "utf8"));
+    });
+  }
+
+  test("the operator copy carries the address-family keys", () => {
+    const values = readFileSync(join(OPERATOR_CHART_DIR, "values.yaml"), "utf8");
+    expect(values).toContain("ipFamilyPolicy");
+    expect(values).toContain("ipFamilies");
+  });
+});


### PR DESCRIPTION
Addresses the discoverable half of #432.

## What the issue was actually about

#432 asks LibreDB Studio to bind `[::]:3000` by default, on the stated grounds that no bind setting exists and that "everyone runs it in a Docker container anyway".

The first half is wrong, and that is our fault. The standalone Next.js server takes its bind address from `HOSTNAME`, which reaches a plain `server.listen(port, hostname)`; Node gives `::` a dual-stack listener wherever `net.ipv6.bindv6only=0`. So `docker run -e HOSTNAME=::` has always worked. It appears nowhere a Docker or Helm user would look — `HOSTNAME` was absent from `.env.example` entirely, and the "Network exposure (bind address)" table said nothing about address families — so the reporter stood up a reverse proxy to work around a documentation hole.

The second half is wrong for this project: 22 live distribution channels, most of them not Docker, and the native ones bind `127.0.0.1` by deliberate design (#134). Changing the default globally would turn every desktop install from loopback-only into network-exposed.

So this PR ships the two parts that are right, and defers the one that is not.

## 1. The setting becomes discoverable

- **`docs/DISTRIBUTION.md`** gains an **Address family (IPv4, IPv6, dual-stack)** section under the existing network-exposure table: which variable each channel actually reads, a value table for `0.0.0.0` / `::` / `127.0.0.1` / `::1`, and the `bindv6only` caveat.
  - Correcting an easy misreading in the process: `net.ipv6.bindv6only` is **network-namespace scoped** and initializes to `0` in a fresh namespace, so a container or pod gets dual-stack whatever the node reads (verified: `docker run --rm alpine sysctl net.ipv6.bindv6only` → `0`). Checking the node and finding `1` does not mean `-e HOSTNAME=::` drops IPv4 in your container.
  - The section distinguishes `HOSTNAME` (Docker, Helm, npx, systemd units, Snap) from `LIBREDB_BIND` (a direct `.deb`/`.rpm` run, Homebrew, the Windows launcher) — those wrappers discard an inherited `HOSTNAME` on purpose, so a doc telling a `.deb` user to set `HOSTNAME=::` would have been silently wrong.
- **`.env.example`** documents `HOSTNAME` for the first time.
- **`docs/HELM_CHART.md`** described the ConfigMap's `HOSTNAME` as "Fixed `0.0.0.0`". That was never true — `extraEnv` renders into `env:` and beats an `envFrom` key of the same name — so the row is corrected, with the caveat that `PORT` is *not* safely overridable that way (it also drives the container port and all three probes).
- **`docs/ARCHITECTURE.md`**, **`README.md`** and both chart READMEs get the cross-references.

## 2. The chart gets a dual-stack Service

`service.ipFamilyPolicy` and `service.ipFamilies` — the capability actually missing for anyone on a dual-stack cluster.

- Both render **only when set**. The default install is byte-identical to 0.1.38 apart from the chart version label (verified by diffing `helm template` output against `main`).
- A render-time `fail` guard catches two `ipFamilies` without a dual-stack policy — the exact combination the API server rejects on create — and says so where the operator can act on it rather than in a failed install. The message notes that an omitted policy is *inherited* on update, so the guard is deliberately stricter than the API there.
- `values.schema.json` constrains both to their API enums.

### The trap this could have shipped

A dual-stack Service in front of a pod still bound to `0.0.0.0` is a **green install with a dead IPv6 path**. Kubernetes never inspects what the container bound: the IPv6 EndpointSlice is populated from the pod's IPv6 address, kube-proxy routes to a socket that is not there, every IPv6 client gets `connection refused` — and the kubelet probes only the pod's *primary* IP, so the pod reports Ready and nothing self-heals.

Dual-stack is therefore **two settings, not one**, and the PR says so in five places, including one the user cannot skip: enabling either IPv6 knob without a `HOSTNAME` override prints a `NOTES.txt` warning at install time.

## What is deliberately not here

**Flipping the container image default from `0.0.0.0` to `::`.** Per the namespace scoping above, this is safer than it first appears — but a *default* has to hold for `--network host` / `hostNetwork: true` and for explicit `--sysctl` overrides, where `bindv6only=1` applies and `::` silently drops every existing IPv4 client. A per-deployment opt-in can account for its own namespace; a default cannot. Recorded as **U15 in `docs/BACKLOG.md`** with the condition under which it would be reconsidered (an entrypoint that binds `::` and falls back), so it does not get re-litigated from scratch.

Native-channel defaults are untouched. `npx`, `.deb`/`.rpm`, Homebrew and Snap keep `127.0.0.1`, and exposure stays an explicit opt-in in either address family — `LIBREDB_BIND=::` is that opt-in for the wrapper channels.

## Verification

- New `tests/unit/helm-chart-dualstack.test.ts` (28 tests) renders the **real** chart via `helm template`. Confirmed to fail 11/28 against an unimplemented `service.yaml` before the implementation landed.
- The default-render-unchanged assertion checks for *absence* of the fields, not falsiness.
- `helm lint charts/libredb-studio --strict` clean. (`operator/helm-charts` lints only with its vendored `postgresql` subchart present — a pre-existing condition on `main`, unrelated to this change.)
- Six gates green: `format`, `lint`, `typecheck`, `knip`, tests (core suite exit 0; 188 pass across the chart/packaging/readme files), `build`.
- `packaging-bind-address.test.ts` still passes — the #134 local-first contract is untouched.

## Versioning

Chart **0.1.39**. 0.1.38 is already tagged and in the live index, so #167 requires the bump; `chart:bump` will not do it while `appVersion` is in sync, so `version:` and the README `--version` examples are bumped by hand in both chart copies. `appVersion` is unchanged. `operator/bundle` and `operator/config` carry no chart version, so no bundle regeneration is owed.
