### PR TITLE
ci: take apt off the E2E critical path, and bound every job in time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   lint-and-build:
     name: Lint, Typecheck and Build
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
       - name: Checkout code
@@ -115,6 +116,7 @@ jobs:
   test:
     name: Unit & Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
       - name: Checkout code
@@ -166,15 +168,32 @@ jobs:
     name: E2E Tests
     needs: [lint-and-build]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Runs INSIDE Playwright's own image so `playwright install` never touches
+    # apt. `--with-deps` used to pull ~111 MB of system libraries from
+    # azure.archive.ubuntu.com on every run; when that mirror degrades - as it
+    # did on 2026-08-18/19, down to 21.8 kB/s - the step took 86 minutes and
+    # twice ran into the 6-hour job default, against 12 seconds of actual
+    # browser download and 3 minutes of actual tests. The image ships those
+    # libraries prebuilt, so the apt path is removed rather than retried.
+    # The tag MUST track @playwright/test in package.json: a mismatch only
+    # costs a re-download into PLAYWRIGHT_BROWSERS_PATH (the install step below
+    # is the fail-safe), never a broken job.
+    container:
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
+      # oven-sh/setup-bun is not usable inside the Playwright image: it
+      # extracts bun from a .zip via @actions/tool-cache, which shells out to
+      # `unzip` - a binary this image does not ship, and installing it would
+      # put apt back on the critical path, which is the whole point of moving
+      # here. npm resolves bun through platform tarballs instead, so it needs
+      # no unzip. Keep the version in step with the setup-bun pins elsewhere.
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: "1.3.14"
+        run: npm install -g bun@1.3.14
 
       - name: Install dependencies
         uses: ./.github/actions/bun-install
@@ -189,7 +208,10 @@ jobs:
         # --config=playwright.channel.config.ts - a chromium-only project
         # list that never resolves the webkit-security project - so they stay
         # chromium-only on purpose.
-        run: bunx playwright install --with-deps chromium webkit
+        # No --with-deps: the container image already carries the system
+        # libraries. This step is now only a fail-safe for a tag/package
+        # version drift, and is a no-op when they agree.
+        run: bunx playwright install chromium webkit
 
       - name: Run E2E tests
         run: bunx playwright test
@@ -214,6 +236,7 @@ jobs:
   engine-payload:
     name: Engine Smoke - Build Payload
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -252,6 +275,7 @@ jobs:
     name: Engine Smoke (Node ${{ matrix.node-version }})
     needs: [engine-payload]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -292,25 +316,31 @@ jobs:
     name: Channel E2E (tarball + npx)
     needs: [engine-payload]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Same Playwright image as the e2e job above, for the same reason (no apt
+    # on the critical path). Safe here because the tarball and npx channels
+    # only need node + bun; the docker/deb/rpm/snap channels elsewhere need a
+    # daemon or a package manager and therefore stay on the bare runner.
+    container:
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
+      # No actions/setup-node: the Playwright image already ships Node 24
+      # (24.18.1 at v1.62.1-noble), and setup-node would unpack a Node tarball
+      # with `xz`, which this image does not ship either.
 
+      # npm rather than oven-sh/setup-bun - see the e2e job's note on unzip.
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: "1.3.14"
+        run: npm install -g bun@1.3.14
 
       - name: Install dependencies
         uses: ./.github/actions/bun-install
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        # Fail-safe only - see the e2e job's note on the container image.
+        run: bunx playwright install chromium
 
       - name: Download payload artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -327,6 +357,7 @@ jobs:
   helm-lint:
     name: Helm Chart Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -449,6 +480,7 @@ jobs:
       && (github.event.pull_request.head.repo.full_name == github.repository
         || github.event_name == 'push')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -41,6 +41,7 @@ jobs:
     if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'libredb-studio-')
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -273,6 +274,13 @@ jobs:
     name: Channel E2E (docker)
     needs: build-and-push
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Deliberately NOT run inside Playwright's container image (unlike the two
+    # jobs in ci.yml): this channel drives `docker pull` / `docker run`, and a
+    # container job has no daemon. scripts/channel-embedded-sample-e2e.sh would
+    # not fail loudly either - channel_docker() skips when docker is absent,
+    # and a directly requested channel that silently disappears is worse than a
+    # slow one. So the apt cost is removed here by dropping --with-deps instead.
     permissions:
       contents: read
       packages: read
@@ -289,7 +297,14 @@ jobs:
         uses: ./.github/actions/bun-install
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        # chromium only, and no --with-deps: the ubuntu-latest image already
+        # ships Google Chrome and therefore chromium's shared libraries. The
+        # apt half of --with-deps was the whole cost here (111 MB from
+        # azure.archive.ubuntu.com, 86 minutes when that mirror degraded on
+        # 2026-08-19) against 12 seconds of browser download. Webkit is the
+        # one that genuinely needs extra packages, and this channel never
+        # runs it: playwright.channel.config.ts is a chromium-only project list.
+        run: bunx playwright install chromium
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -326,6 +341,7 @@ jobs:
     needs: [build-and-push, channel-e2e]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_latest == true)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: write
     steps:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -811,7 +811,11 @@ jobs:
 
       - name: Install Playwright browsers (channel E2E)
         if: matrix.arch == 'amd64'
-        run: bunx playwright install --with-deps chromium
+        # chromium only, no --with-deps - see docker-build-push.yml's channel
+        # E2E for the reasoning. These channels install a .deb/.rpm/.snap and
+        # need dpkg/rpm/snapd plus sudo on the host, so Playwright's container
+        # image is not an option here; dropping the apt half is.
+        run: bunx playwright install chromium
 
       - name: Channel E2E - deb (native arch only)
         if: matrix.arch == 'amd64'
@@ -1041,7 +1045,11 @@ jobs:
 
       - name: Install Playwright browsers (channel E2E)
         if: steps.snapstore.outputs.enabled == 'true' && matrix.arch == 'amd64'
-        run: bunx playwright install --with-deps chromium
+        # chromium only, no --with-deps - see docker-build-push.yml's channel
+        # E2E for the reasoning. These channels install a .deb/.rpm/.snap and
+        # need dpkg/rpm/snapd plus sudo on the host, so Playwright's container
+        # image is not an option here; dropping the apt half is.
+        run: bunx playwright install chromium
 
       - name: Channel E2E - snap (gates the store publish)
         if: steps.snapstore.outputs.enabled == 'true' && matrix.arch == 'amd64'

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2647,3 +2647,20 @@ Done when either the image can pick its family without that failure mode — an 
 a path that currently has none — or the decision is closed as permanent and this entry is deleted.
 The alternative that needs no code is to leave the default and keep the opt-in documented, which is
 what ships today.
+
+### U16. release-artifacts.yml's Playwright installs lost `--with-deps` without a live run to prove it
+
+The deb/rpm/snap channel E2Es in `release-artifacts.yml` now run `bunx playwright install chromium`
+instead of `--with-deps chromium`, the same edit made in `docker-build-push.yml`. The reasoning is
+identical and the evidence is real - `ubuntu-latest` ships Google Chrome, so chromium's shared
+libraries are already present, and `playwright.channel.config.ts` is a chromium-only project list
+that never resolves the webkit project which is what actually needs extra packages.
+
+What is missing is a live run. `release-artifacts.yml` triggers only on a tag, so neither a PR nor a
+branch push exercises it; the ci.yml and docker-build-push.yml edits were both verified by real runs
+on the branch, and this one was not. If chromium fails to launch there, the failure surfaces as a red
+channel E2E during a release rather than before it - `run_playwright` calls `playwright test`
+directly, so it fails loudly rather than skipping, but it fails at the worst moment.
+
+Done when the next release's channel E2Es pass on deb, rpm and snap, and this entry is deleted - or
+they fail and `--with-deps` comes back for those three jobs only.


### PR DESCRIPTION
## What happened

The two workflows did not get slower because the tests grew. `bunx playwright install --with-deps`
fetches ~111 MB of system libraries from `azure.archive.ubuntu.com` on every run, and that mirror
degraded on 2026-08-18/19.

Measured on run 32240765059 (`E2E Tests`, unchanged code):

| Phase | Duration |
|---|---|
| `--with-deps` -> apt (111 MB @ **21.8 kB/s**) | **85m 54s** |
| Browser download from cdn.playwright.dev | 12s |
| The actual E2E tests | 3m 12s |

The same step across consecutive `main` runs: 47s, 49s, 11m, **86m**, 49s, **31m**, and twice the
full **6-hour** job default on 2026-08-18. Same commit, same command - this is the mirror, not us.

## What changed

- **`ci.yml` `e2e` + `channel-e2e` run inside `mcr.microsoft.com/playwright:v1.62.1-noble`.** The
  image ships the system libraries prebuilt, so apt is off the path entirely. The remaining
  `playwright install` (no `--with-deps`) is a fail-safe for image/package drift and is a no-op
  while they agree - verified the image carries `chromium-1234` and `webkit-2336`, exactly the
  builds 1.62.1 resolves.
- **`setup-bun` and `setup-node` are replaced inside the container.** The image ships no `unzip`
  (tool-cache needs it to extract bun's `.zip`) and no `xz` (setup-node's tarball). Both are
  replaced by `npm install -g bun@1.3.14` - npm resolves bun through platform tarballs - and by
  the image's own Node 24.18.1. Installing either tool would put apt back on the path.
- **The docker, deb, rpm and snap channels stay on the bare runner and drop `--with-deps`.** They
  need a daemon or a package manager, so a container is not an option; and `channel_docker()` skips
  rather than fails when no daemon is present, which would have hidden the test. Safe because
  `ubuntu-latest` ships Google Chrome (so chromium's shared libraries are present) and those
  channels pin `playwright.channel.config.ts`, a chromium-only project list. Webkit is what
  genuinely needs extra packages, and only `ci.yml`'s `e2e` job runs it.
- **Every job in both workflows now has `timeout-minutes`.** Two runs on 2026-08-18 burned the
  6-hour default before failing.

## Verification

Probed against the real image rather than assumed:

- `mcr.microsoft.com/playwright:v1.62.1-noble` exists on MCR; ships Node 24.18.1, git, curl, tar,
  python3; **no** unzip, xz, sudo, gcc, g++, make.
- `npm install -g bun@1.3.14` succeeds in the image with no unzip.
- No compiler is needed: `trustedDependencies` is `esbuild`, `oracledb`, `ssh2` (all prebuilt), and
  better-sqlite3 resolves through `prebuilds/linux-x64.node` with no `build/Release` step.
- Branch named `fix/**` on purpose so `docker-build-push.yml` (push-triggered, not PR-triggered)
  exercises its edit before merge.

`release-artifacts.yml` is tag-triggered only and cannot be exercised here - tracked as U16 in
`docs/BACKLOG.md`.