### PR TITLE
ci: give the PostgreSQL functional smoke its own job, so it stops silently skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,13 @@ jobs:
         run: bunx playwright install chromium webkit
 
       - name: Run E2E tests
-        run: bunx playwright test
+        # --grep-invert: e2e/functional-smoke.spec.ts needs a Docker daemon,
+        # which a container job does not have. It has its own job below. Being
+        # explicit matters: the spec's own `test.skip(!dockerAvailable())` would
+        # let it vanish silently here (it did - PR #435 turned 0 skipped into 1
+        # skipped with CI still green), and a test that disappears without
+        # saying so is worse than one that is openly not run.
+        run: bunx playwright test --grep-invert "Functional smoke"
         env:
           JWT_SECRET: test-secret-for-ci-build-only-32ch
           ADMIN_EMAIL: admin@libredb.org
@@ -227,6 +233,54 @@ jobs:
         if: always()
         with:
           name: playwright-report
+          path: playwright-report/
+
+  # The product's reason to exist, end to end: boot the app, create a real
+  # PostgreSQL connection through the modal, run SQL, see rows. Split out of the
+  # e2e job because the spec starts its own throwaway postgres with
+  # `docker run -p 127.0.0.1:54329:5432` - that binds the HOST loopback, and a
+  # container job has its own network namespace and cannot reach it. Keeping
+  # this on the bare runner is what lets the spec stay free of any CI-only
+  # branch, which is the whole point of a test that claims to exercise the real
+  # path.
+  functional-smoke:
+    name: Functional Smoke (PostgreSQL)
+    needs: [lint-and-build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        uses: ./.github/actions/bun-install
+
+      - name: Install Playwright browsers
+        # chromium only and no --with-deps: ubuntu-latest ships Google Chrome,
+        # so chromium's shared libraries are already present, and this job runs
+        # no webkit - webkit is the browser that needs the extra packages whose
+        # apt download made these jobs take 86 minutes (PR #435).
+        run: bunx playwright install chromium
+
+      - name: Run functional smoke
+        run: bunx playwright test --project=chromium --grep "Functional smoke"
+        env:
+          JWT_SECRET: test-secret-for-ci-build-only-32ch
+          ADMIN_EMAIL: admin@libredb.org
+          ADMIN_PASSWORD: test-admin
+          USER_EMAIL: user@libredb.org
+          USER_PASSWORD: test-user
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: playwright-report-functional-smoke
           path: playwright-report/
 
   # The engines floor in package.json (>=24.0.0) is a tested claim: build the


### PR DESCRIPTION
## The regression this fixes

#435 moved the E2E jobs into Playwright's container image to take apt off the critical path. That
part worked - `Install Playwright browsers` went from 86 minutes to 0. But a container job has no
Docker daemon, and `e2e/functional-smoke.spec.ts` starts its own throwaway postgres. Its
`test.skip(!dockerAvailable())` guard then did what such guards do:

| Run | skipped | Result |
|---|---|---|
| Before #435 (bare runner) | **0** | green |
| After #435 (container) | **1** | green |

The skipped test is the one the spec's own header calls "the product's reason to exist": boot the
app, create a real PostgreSQL connection through the modal, run SQL, assert rows render. CI stayed
green throughout, which is the problem.

## Why it cannot just move into the container

The spec publishes postgres with `docker run -p 127.0.0.1:54329:5432` - that binds the **host**
loopback. A container job has its own network namespace and cannot reach it.

Mounting the daemon socket was the first plan and was measured, not assumed: a static docker CLI
from download.docker.com plus `-v /var/run/docker.sock:...` does give the container a working
`docker` (verified locally against the real image - `daemon reachable: 29.7.2`). But that fixes the
CLI, not the connection: the test would then *fail* instead of skip. Making it reachable means
teaching the spec a CI-only network mode (`--network container:$HOSTNAME`), in a test whose entire
value is that it exercises the real path with no special-casing.

## What this does

- New `Functional Smoke (PostgreSQL)` job on the bare runner. Docker works natively, `-p
  127.0.0.1` works as written, and **the spec changes not at all**.
- That job installs chromium with **no** `--with-deps` - `ubuntu-latest` ships Google Chrome so
  chromium's libraries are present, and it runs no webkit, which is the browser whose extra
  packages caused the original apt bill. Same pattern `Channel E2E (docker)` already proved in #435.
- The container job now excludes the spec with `--grep-invert "Functional smoke"` instead of
  relying on the skip guard. A test that is openly not run beats one that disappears quietly.

## Verification

`--list` confirms nothing is lost or double-counted:

- `--project=chromium --grep "Functional smoke"` -> **1 test**
- `--grep-invert "Functional smoke"` -> **51 tests**, `webkit-security` still included
- 1 + 51 = 52, the same total the container job reported

Done when this run shows `Functional Smoke (PostgreSQL)` passing and the `E2E Tests` job reporting
**0 skipped**.