### PR TITLE
ci(helm): run Helm 4.1.3 in the test and release lanes, keep the ct install job on Helm 3

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -122,6 +122,11 @@ curl -sSL -o /dev/null -w '%{http_code}\n' https://charts.bitnami.com/bitnami/in
 gh run rerun <run-id> --failed
 ```
 
+Those seven sites do **not** all pin the same Helm CLI. Six run Helm 4.1.3; `helm-release.yml`'s
+`lint-test` job stays on Helm 3.16 on purpose, because its two `ct install` runs are the only place
+the chart is installed into a cluster and our users install with Helm 3. The split is enforced by
+`tests/unit/helm-pin-matrix.test.ts` in the required test lane - do not unify the odd one out.
+
 ## Phase 3 - Draft release with hand-written notes
 
 Create the draft BEFORE pushing the tag. `release-artifacts` reuses an existing draft for the tag and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,13 +131,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.16.0
+          version: v4.1.3
 
       - name: Add Bitnami repo
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami --timeout 5m
 
+      # --skip-refresh: the `helm repo add` above already fetched the index; Helm 4's `dependency build` re-fetches it by default and takes no --timeout.
       - name: Build chart dependencies
-        run: helm dependency build charts/libredb-studio
+        run: helm dependency build charts/libredb-studio --skip-refresh
 
       - name: Run merged test coverage (core + components)
         run: bun run test:coverage
@@ -334,13 +335,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.16.0
+          version: v4.1.3
 
       - name: Add Bitnami repo
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami --timeout 5m
 
+      # --skip-refresh: the `helm repo add` above already fetched the index; Helm 4's `dependency build` re-fetches it by default and takes no --timeout.
       - name: Build chart dependencies
-        run: helm dependency build charts/libredb-studio
+        run: helm dependency build charts/libredb-studio --skip-refresh
 
       - name: Lint Helm chart
         run: helm lint charts/libredb-studio --strict

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -191,6 +191,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # helm3-pinned: our users install with Helm 3, and these two `ct install`
+      # runs are the only place in this repo where a Helm 3 client installs the
+      # chart into a cluster at all. Scope, precisely: `ct install` installs the
+      # chart SOURCE directory, never the .tgz that release-github-pages packages
+      # with Helm 4 - so this proves "Helm 3 installs this chart", not "Helm 3
+      # installs the released artifact". That residual gap is tracked in
+      # docs/BACKLOG.md. Every other setup-helm site here is v4.1.3 - see
+      # tests/unit/helm-pin-matrix.test.ts. Do not "consistency fix" this.
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
@@ -254,13 +262,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.16.0
+          version: v4.1.3
 
       - name: Add Bitnami repo
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami --timeout 5m
 
+      # --skip-refresh: the `helm repo add` above already fetched the index; Helm 4's `dependency build` re-fetches it by default and takes no --timeout.
       - name: Build chart dependencies
-        run: helm dependency build charts/libredb-studio
+        run: helm dependency build charts/libredb-studio --skip-refresh
 
       - name: Package chart
         run: |
@@ -393,16 +402,17 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.16.0
+          version: v4.1.3
 
       - name: Add Bitnami repo
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami --timeout 5m
 
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      # --skip-refresh: the `helm repo add` above already fetched the index; Helm 4's `dependency build` re-fetches it by default and takes no --timeout.
       - name: Build dependencies
-        run: helm dependency build charts/libredb-studio
+        run: helm dependency build charts/libredb-studio --skip-refresh
 
       - name: Package chart
         run: helm package charts/libredb-studio -d .cr-release-packages

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,13 +44,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.16.0
+          version: v4.1.3
 
       - name: Add Bitnami repo
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami --timeout 5m
 
+      # --skip-refresh: the `helm repo add` above already fetched the index; Helm 4's `dependency build` re-fetches it by default and takes no --timeout.
       - name: Build chart dependencies
-        run: helm dependency build charts/libredb-studio
+        run: helm dependency build charts/libredb-studio --skip-refresh
 
       - name: Lint
         run: bun run lint

--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -101,16 +101,17 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.16.0
+          version: v4.1.3
 
       - name: Vendor embedded chart dependencies
         # charts/*.tgz is gitignored; without this the image ships the chart
         # with its declared postgresql dependency missing, and helm silently
         # installs without the subchart when postgresql.enabled=true.
+        # --skip-refresh: the `helm repo add` in the same block already fetched the index; Helm 4's `dependency build` re-fetches it by default and takes no --timeout.
         if: steps.version.outputs.skip != 'true'
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm dependency build operator/helm-charts/libredb-studio
+          helm repo add bitnami https://charts.bitnami.com/bitnami --timeout 5m
+          helm dependency build operator/helm-charts/libredb-studio --skip-refresh
 
       - name: Set up QEMU
         if: steps.version.outputs.skip != 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,13 @@ helm dependency build charts/libredb-studio
 helm lint charts/libredb-studio --strict
 ```
 
+CI's test and lint lanes run Helm 4.1.3, so that is the client to develop against.
+That is not the chart's floor: the chart README states Helm >= 3.12, and CI's only
+Helm 3 evidence is 3.16.0. The release workflow's `ct install` job stays on Helm 3.16
+deliberately, so a Helm 3 client keeps installing the chart source - see
+`tests/unit/helm-pin-matrix.test.ts`, and R1 in `docs/BACKLOG.md` for what that
+still does not cover.
+
 ## Coding Guidelines
 
 ### TypeScript

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -770,6 +770,32 @@ shipped product, and the entry is deleted then and not before.
 
 ---
 
+## Release pipeline
+
+### R1. No CI job installs the released chart artifact with a Helm 3 client
+
+The CI Helm matrix pins six of its seven `azure/setup-helm` sites to Helm 4.1.3 and keeps
+`helm-release.yml` -> `lint-test` on Helm 3.16 on purpose, because our users install with Helm 3.
+`tests/unit/helm-pin-matrix.test.ts` locks that split. What the Helm 3 job actually proves is
+narrower than the marker at the site used to claim: `ct install --charts charts/libredb-studio`
+installs the chart SOURCE directory, never the `.tgz` that `release-github-pages` packages with
+Helm 4 and never the OCI artifact `release-oci` pushes. So no job anywhere performs `helm install`
+with a Helm 3 client against a released byte.
+
+The gap is believed narrow — a Helm 4 package differs from a Helm 3 one only in preserved source
+mtimes; extracted trees, `tar` member lists, `helm3 lint --strict`, `helm3 show chart`,
+`helm3 template` and a `helm3 pull` of the pushed OCI artifact were all verified equivalent by hand
+before the pins were raised. But "verified once by hand" is not a gate, and nothing would catch a
+future Helm 4 packaging change that a Helm 3 client rejects at install time.
+
+Done when `helm-index-check.yml` (which today only curls the index and compares sha256, running no
+Helm client at all) also runs a pinned Helm 3.16 `helm repo add` + `helm pull` + `helm install` of
+the published chart version against a kind cluster — or when an equivalent post-publish smoke lands
+elsewhere and this entry is deleted.
+
+---
+
+
 ## Chart configuration surface
 
 These were found while reviewing #362, which added the Gateway API `HTTPRoute` template, and its

--- a/tests/unit/helm-chart-agent.test.ts
+++ b/tests/unit/helm-chart-agent.test.ts
@@ -319,9 +319,11 @@ describe("the guard's blind spots are real, and completely listed", () => {
 describe("an operator is told where run history lives", () => {
   test("the install notes carry it, guarded on persistence being off", () => {
     // Asserted against the template source rather than rendered output on purpose:
-    // `helm template` does not print NOTES.txt in Helm 3 (CI pins v3.16.0) and does
-    // in Helm 4, so an assertion on stdout would pass on one machine and fail on the
-    // other. What must not silently disappear is the note and its condition.
+    // `helm template` prints no NOTES.txt at all, and the dry-run path that would
+    // render it behaves differently across Helm majors - which contributors run
+    // freely, and helm-release's ct install job still pins to Helm 3.16. An
+    // assertion on stdout would pass on one machine and fail on the other. What
+    // must not silently disappear is the note and its condition.
     const notes = read("charts/libredb-studio/templates/NOTES.txt");
     const block = notes.split(/^{{- if and \(include "libredb-studio\.agentPossible"/m)[1] ?? "";
     expect(block).toContain("persistenceEnabled");

--- a/tests/unit/helm-chart-dualstack.test.ts
+++ b/tests/unit/helm-chart-dualstack.test.ts
@@ -314,13 +314,14 @@ describe("charts/libredb-studio dual-stack needs the pod to listen on :: (#432)"
 });
 
 describe("charts/libredb-studio install notes warn about an unbound IPv6 address (#432)", () => {
-  // `helm template` never emits NOTES.txt and `helm install --dry-run=client`
-  // cannot render it without a cluster: Helm 3.16 - the version CI pins - calls
-  // IsReachable() before it renders anything, so the dry run dies on
-  // "Kubernetes cluster unreachable" even for a chart created by `helm create`.
-  // (Helm 4 does not, which is exactly how this went green locally and red in
-  // CI.) So render the real NOTES.txt through the one path that needs no
-  // cluster on either version: a throwaway copy of the chart in which the
+  // `helm template` never emits NOTES.txt, and `helm install --dry-run=client`
+  // renders it only on Helm 4: Helm 3.16 calls IsReachable() before it renders
+  // anything, so the dry run dies on "Kubernetes cluster unreachable" even for
+  // a chart created by `helm create`. CI's test lane now runs Helm 4, but
+  // contributors run whatever helm they have, and helm-release's ct install job
+  // is still Helm 3.16 on purpose - so this stays written to hold on BOTH
+  // majors: render the real NOTES.txt through the one path that needs no
+  // cluster on either version, a throwaway copy of the chart in which the
   // file's own bytes are wrapped in a named template and emitted as a
   // ConfigMap. Helm does the rendering, the template text is the shipped one,
   // and nothing here reimplements the condition under test.

--- a/tests/unit/helm-pin-matrix.test.ts
+++ b/tests/unit/helm-pin-matrix.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Unit tests for the Helm CLI version matrix pinned across the five workflows
+ * that run `azure/setup-helm` (seven sites in total).
+ *
+ * This exists because of #434. Its NOTES.txt assertions used
+ * `helm install --dry-run=client`, which is green on Helm 4 (the maintainer's
+ * local binary) and red on Helm 3.16 (the CI pin), because Helm 3.16 calls
+ * IsReachable() before it renders anything and so demands a cluster even for a
+ * client-side dry run. The defect was structural, not textual: two jobs run the
+ * same helm-touching test suite (`ci.yml` -> test, `npm-publish.yml` ->
+ * validate) and nothing stopped their Helm versions from drifting apart, or
+ * from drifting away from what contributors run locally.
+ *
+ * The matrix is deliberately NOT uniform, and the asymmetry is the point:
+ *   - Six sites run Helm 4, so the test suite, the lint job and every
+ *     byte-producing release step use the client the project develops against.
+ *   - `helm-release.yml` -> lint-test stays on Helm 3.16, because its two
+ *     `ct install` runs are the only place in this repo where a Helm 3 client
+ *     installs the chart into a cluster at all, and our users install with Helm
+ *     3 (the packaged chart README promises a floor of Helm >= 3.12). Nothing
+ *     else runs a Helm 3 client against the chart: helm-index-check.yml only
+ *     curls the index and compares sha256. Raising that one pin would leave the
+ *     project publishing for Helm 3 users while only ever install-testing as
+ *     Helm 4.
+ *
+ * Be precise about what that job proves, because the marker comment at the site
+ * is the thing a future maintainer reads: `ct install` installs the chart SOURCE
+ * directory, never the .tgz that release-github-pages packages with Helm 4. So
+ * the evidence is "a Helm 3 client installs this chart into a cluster", NOT "a
+ * Helm 3 client installs the released artifact". Closing that residual gap (a
+ * pinned Helm 3 `repo add` + `pull` + `install` of the published .tgz in
+ * helm-index-check.yml) is tracked in docs/BACKLOG.md.
+ *
+ * So a future "consistency fix" that unifies the odd one out must fail HERE,
+ * with the reason attached, rather than silently retiring the only evidence
+ * that the published chart installs for the clients users actually run.
+ *
+ * The assertions are pure string checks over the workflow files themselves - no
+ * network, no helm binary (CI is the only place a helm binary exists).
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "../..");
+const WORKFLOWS = join(REPO_ROOT, ".github/workflows");
+/**
+ * EVERY workflow file, derived - never a literal. A new publishing workflow (a
+ * Rancher partner-charts push, an ArtifactHub mirror, a repaired-index job) is
+ * exactly the case this test exists for: it must arrive as an unclassified-key
+ * failure against EXPECTED_PINS below, not slip past a hard-coded four-file scan.
+ */
+const WORKFLOW_FILES = readdirSync(WORKFLOWS)
+  .filter((name) => /\.ya?ml$/.test(name))
+  .sort();
+
+const SETUP_HELM_SHA = "9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310";
+const HELM_4 = "v4.1.3";
+const HELM_3 = "v3.16.0";
+
+/**
+ * The whole matrix, hard-coded. A site that changes version, a site that
+ * disappears, and a site that is added without being classified all fail.
+ */
+const EXPECTED_PINS: Record<string, string> = {
+  // Required "Unit & Integration Tests" check: spawns `helm template` from the
+  // ten helm-chart-*.test.ts files. Produces no published byte.
+  "ci.yml:test": HELM_4,
+  // Advisory chart lint + a conditional kind `ct install`. Raised on purpose so
+  // chart-testing under Helm 4 is exercised somewhere non-blocking.
+  "ci.yml:helm-lint": HELM_4,
+  // Runs the same helm-touching suite as ci.yml:test - see the drift test below.
+  "npm-publish.yml:validate": HELM_4,
+  // THE DELIBERATE ODD ONE OUT. Do not "fix" this. See the header.
+  "helm-release.yml:lint-test": HELM_3,
+  // helm dependency build + helm package + helm repo index --merge.
+  "helm-release.yml:release-github-pages": HELM_4,
+  // helm registry login + helm package + helm push to oci://ghcr.io/libredb/charts.
+  "helm-release.yml:release-oci": HELM_4,
+  // helm dependency build, vendoring the mirror chart into the operator image.
+  "operator-release.yml:build-and-push": HELM_4,
+};
+
+/** The site whose Helm 3 pin is load-bearing evidence, not an oversight. */
+const HELM3_PINNED_SITE = "helm-release.yml:lint-test";
+
+/** The two jobs that run the helm-touching test suite; #434 was their drift. */
+const SUITE_SITES = ["ci.yml:test", "npm-publish.yml:validate"];
+
+interface HelmPin {
+  site: string;
+  file: string;
+  job: string;
+  line: number;
+  sha: string;
+  version: string;
+  /** Contiguous comment lines immediately above the step. */
+  comments: string[];
+}
+
+/** The enclosing job key for every line of a workflow file. */
+function jobAtLine(lines: string[]): string[] {
+  const owners: string[] = [];
+  let inJobs = false;
+  let job = "";
+  for (const line of lines) {
+    if (/^jobs:\s*$/.test(line)) inJobs = true;
+    else if (/^\S/.test(line)) inJobs = false;
+    const jobStart = inJobs ? /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line) : null;
+    if (jobStart) job = jobStart[1];
+    owners.push(job);
+  }
+  return owners;
+}
+
+/** Every `azure/setup-helm` step in one workflow file, with its resolved version. */
+function parseHelmPins(text: string, file: string): HelmPin[] {
+  const lines = text.split("\n");
+  const owners = jobAtLine(lines);
+  const pins: HelmPin[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const uses = /uses:\s*azure\/setup-helm@([0-9a-f]{40})/.exec(lines[i]);
+    if (!uses) continue;
+    let version = "";
+    for (let j = i + 1; j < Math.min(i + 6, lines.length); j++) {
+      const found = /^\s*version:\s*(\S+)\s*$/.exec(lines[j]);
+      if (found) {
+        version = found[1];
+        break;
+      }
+      if (/^\s*-\s/.test(lines[j])) break;
+    }
+    // Walk up to the step's `- name:` line, then collect the comment block above it.
+    let start = i;
+    while (start > 0 && !/^\s*-\s/.test(lines[start])) start--;
+    const comments: string[] = [];
+    for (let k = start - 1; k >= 0 && /^\s*#/.test(lines[k]); k--) comments.unshift(lines[k].trim());
+    pins.push({
+      site: `${file}:${owners[i]}`,
+      file,
+      job: owners[i],
+      line: i + 1,
+      sha: uses[1],
+      version,
+      comments,
+    });
+  }
+  return pins;
+}
+
+/**
+ * Command-carrying lines of one job: every line the job owns, minus comments.
+ * Comments are dropped so that documenting a flag (`# never add --timeout here`)
+ * cannot turn the required check red, nor satisfy a guard that wants the flag.
+ */
+function jobCommandLines(text: string, job: string): string[] {
+  const lines = text.split("\n");
+  const owners = jobAtLine(lines);
+  return lines.filter((line, i) => owners[i] === job && !/^\s*#/.test(line));
+}
+
+function readWorkflow(file: string): string {
+  return readFileSync(join(WORKFLOWS, file), "utf8");
+}
+
+const ALL_PINS: HelmPin[] = WORKFLOW_FILES.flatMap((file) => parseHelmPins(readWorkflow(file), file));
+const BY_SITE = new Map(ALL_PINS.map((pin) => [pin.site, pin]));
+
+function major(version: string): number {
+  return Number.parseInt(version.replace(/^v/, "").split(".")[0], 10);
+}
+
+describe("parseHelmPins", () => {
+  test("reads the job, sha and version of a setup-helm step", () => {
+    const text = [
+      "jobs:",
+      "  build:",
+      "    steps:",
+      "      # why this one is different",
+      "      - name: Set up Helm",
+      `        uses: azure/setup-helm@${SETUP_HELM_SHA} # v5.0.1`,
+      "        with:",
+      "          version: v4.1.3",
+      "",
+    ].join("\n");
+    expect(parseHelmPins(text, "x.yml")).toEqual([
+      {
+        site: "x.yml:build",
+        file: "x.yml",
+        job: "build",
+        line: 6,
+        sha: SETUP_HELM_SHA,
+        version: "v4.1.3",
+        comments: ["# why this one is different"],
+      },
+    ]);
+  });
+
+  test("finds no pin in a workflow that never sets up helm", () => {
+    expect(parseHelmPins("jobs:\n  build:\n    steps:\n      - run: echo hi\n", "x.yml")).toEqual([]);
+  });
+});
+
+describe("jobCommandLines", () => {
+  const text = [
+    "jobs:",
+    "  a:",
+    "    steps:",
+    "      # never add --timeout to `helm repo add bitnami` here",
+    "      - run: helm repo add bitnami https://charts.bitnami.com/bitnami",
+    "  b:",
+    "    steps:",
+    "      - run: helm repo add bitnami https://charts.bitnami.com/bitnami --timeout 5m",
+    "",
+  ].join("\n");
+
+  test("returns the job's command lines and drops its comments", () => {
+    expect(jobCommandLines(text, "a")).toEqual([
+      "  a:",
+      "    steps:",
+      "      - run: helm repo add bitnami https://charts.bitnami.com/bitnami",
+    ]);
+  });
+
+  test("a comment mentioning a flag neither satisfies nor violates a flag guard", () => {
+    // The flag guards below match on substrings. Without comment filtering,
+    // documenting `--timeout` in the Helm 3 job would redden the required check.
+    expect(jobCommandLines(text, "a").some((line) => line.includes("--timeout"))).toBe(false);
+    expect(jobCommandLines(text, "b").some((line) => line.includes("--timeout 5m"))).toBe(true);
+  });
+});
+
+describe("the seven setup-helm sites", () => {
+  test("there are exactly seven, and every one is classified", () => {
+    expect(ALL_PINS).toHaveLength(7);
+    expect([...BY_SITE.keys()].sort()).toEqual(Object.keys(EXPECTED_PINS).sort());
+  });
+
+  test("every site pins the exact version the matrix assigns it", () => {
+    const actual = Object.fromEntries([...BY_SITE].map(([site, pin]) => [site, pin.version]));
+    expect(actual).toEqual(EXPECTED_PINS);
+  });
+
+  test("the scan covers every workflow file, not a hand-kept subset", () => {
+    // The guard above is only worth anything if a NEW publishing workflow that
+    // packages or pushes the chart is scanned too. Assert the list is derived:
+    // it must contain workflows that have nothing to do with helm.
+    const onDisk = readdirSync(WORKFLOWS).filter((name) => /\.ya?ml$/.test(name));
+    expect(WORKFLOW_FILES).toEqual([...onDisk].sort());
+    expect(WORKFLOW_FILES).toContain("codeql.yml");
+    expect(WORKFLOW_FILES.length).toBeGreaterThan(Object.keys(EXPECTED_PINS).length);
+  });
+
+  test("every site uses the same pinned setup-helm action sha", () => {
+    // The action resolves `version:` into a get.helm.sh URL with no major-version
+    // branch, so Helm 4 needs no action bump - only the scalar moves.
+    expect([...new Set(ALL_PINS.map((pin) => pin.sha))]).toEqual([SETUP_HELM_SHA]);
+  });
+});
+
+describe("#434 regression: the two suite-running jobs cannot drift apart", () => {
+  test("ci.yml:test and npm-publish.yml:validate pin the identical Helm version", () => {
+    // Asserted against each other, not against a literal: the defect in #434 was
+    // one helm here and another there, whatever the versions happened to be.
+    const [ci, npm] = SUITE_SITES.map((site) => BY_SITE.get(site)?.version);
+    expect(ci).toBe(npm as string);
+  });
+
+  test("reintroducing `helm install --dry-run=client` requires a Helm 4 suite pin", () => {
+    // The workaround in helm-chart-dualstack.test.ts exists only because Helm
+    // 3.16 calls IsReachable() on a client-side dry run. The idiom becomes legal
+    // again the moment - and only the moment - the suite pins are Helm 4.
+    const usesDryRun = readdirSync(join(REPO_ROOT, "tests/unit"))
+      .filter((name) => /^helm-chart-.*\.test\.ts$/.test(name))
+      .some((name) =>
+        readFileSync(join(REPO_ROOT, "tests/unit", name), "utf8")
+          .split("\n")
+          .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+          .some((line) => line.includes("--dry-run=client")),
+      );
+    if (!usesDryRun) return;
+    for (const site of SUITE_SITES) expect(major(BY_SITE.get(site)?.version ?? "v0")).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("the Helm 3 site is pinned on purpose and says so", () => {
+  test("helm-release.yml lint-test stays on Helm 3.16", () => {
+    // Its two `ct install` runs are the only cluster install in the repo, and
+    // Helm 3 is what users run. Do not unify this with the other six.
+    expect(BY_SITE.get(HELM3_PINNED_SITE)?.version).toBe(HELM_3);
+  });
+
+  test("a marker comment above the step explains why, so deleting the reason is a red build", () => {
+    const comments = (BY_SITE.get(HELM3_PINNED_SITE)?.comments ?? []).join(" ");
+    expect(comments).toMatch(/#\s*helm3-pinned:/);
+    expect(comments).toContain("Helm 3");
+    expect(comments).toContain("install");
+  });
+});
+
+describe("Helm-4-only flags stay out of the Helm 3 job", () => {
+  test("the Helm 3 job's `helm repo add bitnami` carries no --timeout", () => {
+    // `--timeout` does not exist on `helm repo add` in 3.16; it would hard-fail.
+    const pin = BY_SITE.get(HELM3_PINNED_SITE);
+    const runs = jobCommandLines(readWorkflow(pin?.file ?? ""), pin?.job ?? "").filter((line) =>
+      line.includes("helm repo add bitnami"),
+    );
+    expect(runs.length).toBeGreaterThan(0);
+    for (const line of runs) expect(line).not.toContain("--timeout");
+  });
+
+  test("every Helm 4 job's `helm repo add bitnami` carries --timeout 5m", () => {
+    // Helm 4 imposes a 2m0s deadline on the index download; bitnami's index is
+    // big enough that this has already been reproduced as a hard failure.
+    for (const pin of ALL_PINS) {
+      if (pin.site === HELM3_PINNED_SITE) continue;
+      const runs = jobCommandLines(readWorkflow(pin.file), pin.job).filter((line) =>
+        line.includes("helm repo add bitnami"),
+      );
+      if (runs.length === 0) continue;
+      for (const line of runs) expect(`${pin.site}: ${line}`).toContain("--timeout 5m");
+    }
+  });
+});
+
+describe("the second index download is skipped, not merely timed out", () => {
+  test("every `helm dependency build` carries --skip-refresh", () => {
+    // `helm repo add --timeout 5m` covers only the FIRST index download. Helm 4's
+    // `dependency build` refreshes the repository cache again by default and
+    // exposes no --timeout of its own, so the 2m0s deadline is only off the
+    // release path once the refresh itself is skipped. --skip-refresh exists in
+    // 3.16 as well, so this is safe on every pin in the matrix.
+    const seen: string[] = [];
+    for (const file of WORKFLOW_FILES) {
+      for (const line of readWorkflow(file).split("\n")) {
+        if (/^\s*#/.test(line) || !line.includes("helm dependency build")) continue;
+        seen.push(`${file}: ${line.trim()}`);
+        expect(`${file}: ${line.trim()}`).toContain("--skip-refresh");
+      }
+    }
+    expect(seen).not.toEqual([]);
+  });
+});
+
+describe("`helm registry login` targets a bare domain", () => {
+  test("no login target carries a path component", () => {
+    // Helm 4 breaking change: the login must be the domain only. `ghcr.io` is
+    // fine, `ghcr.io/libredb` would break the OCI publish with no other signal.
+    for (const file of WORKFLOW_FILES) {
+      for (const line of readWorkflow(file).split("\n")) {
+        const login = /helm registry login\s+(\S+)/.exec(line);
+        if (login) expect(`${file}: ${login[1]}`).not.toContain("/");
+      }
+    }
+  });
+});
+
+describe("the release runbook records the split", () => {
+  test("cut-release SKILL.md points at this test as the matrix's enforcement", () => {
+    // SKILL.md is the single written inventory of the seven sites; without this
+    // pointer the next reader re-unifies them from the runbook.
+    const skill = readFileSync(join(REPO_ROOT, ".claude/skills/cut-release/SKILL.md"), "utf8");
+    const mentions = skill.split("\n").filter((line) => line.includes("helm-pin-matrix.test.ts"));
+    expect(mentions).not.toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up to #434, which surfaced the underlying problem.

## Why

#434 added a chart test that passed locally on Helm 4 and failed in CI on the pinned Helm 3.16.0: `helm install --dry-run=client` calls `IsReachable()` before rendering on 3.16, so a *client-side* dry run still demands a cluster. Reproduced against a chart from `helm create`, so it is the tool, not our chart. That test was reworked to avoid `helm install` entirely, but the class of failure — green on a contributor's machine, red on the runner — stays open until the pin moves.

## What this is not

A uniform version bump. **Five of the seven pinned sites sit in the release path**, and our users install with Helm 3. So the sites were classified, and the outcome is deliberately asymmetric:

| Site | Job | Pin | Why |
|---|---|---|---|
| `ci.yml:134` | test (required) | **v4.1.3** | helm exists only so the chart tests can spawn `helm template` |
| `ci.yml:338` | helm-lint (advisory) | **v4.1.3** | lint + advisory `ct install`; buys evidence on chart-testing under Helm 4 without gating |
| `npm-publish.yml:47` | validate | **v4.1.3** | runs the same suite as `ci.yml:test`; must move in lockstep or the drift is #434 again |
| `helm-release.yml:265` | release-github-pages | **v4.1.3** | packages + indexes — raised on measured evidence, below |
| `helm-release.yml:405` | release-oci | **v4.1.3** | packages + pushes OCI — raised on measured evidence, below |
| `operator-release.yml:104` | build-and-push | **v4.1.3** | only vendors the subchart into the image |
| `helm-release.yml:205` | **lint-test** | **v3.16.0 (kept)** | the only place a Helm 3 client installs the chart into a cluster |

## Evidence for the release sites

These moved on positive evidence that a Helm 3 consumer is unaffected, not on "CI stayed green".

- **`Chart.lock`** — byte-identical built by either major (same digest, same `generated:`), and the vendored `postgresql-16.7.27.tgz` is byte-identical too.
- **`helm package`** — the archives differ only in preserved source mtimes (Helm 4's reproducible-build change). Extracted trees, `tar` member lists and order, and gzip headers all match. Helm 3.16 fully consumes a Helm-4-built package: `show chart`, `lint --strict` (so `values.schema.json` survives), and `template` all succeed and render identically to templating the source directory — subchart path included.
- **`helm repo index --merge`** — run against the **real live 2122-line** `https://libredb.org/libredb-studio/index.yaml`. Both majors produced 2122 lines; the diff is two timestamp hunks, with all 36 historical entries and their download URLs verbatim. Then a virgin Helm 3.16 client consumed a Helm-4-generated index end to end over HTTP: `repo add` → `repo update` → `search --versions` → `pull` (pulled sha256 equals the pushed package) → `template`.
- **OCI** — the media-type constants are literally identical in v3.16.0 and v4.1.3 `pkg/registry/constants.go` despite Helm 4's move to oras-go v2. Same config digest, same annotation set, same manifest digest for the same archive. `helm3 pull oci://…` returns the pushed bytes exactly.

Spot-checked independently of the probes before merging this: `helm4 package` → `helm3 show chart` / `helm3 lint --strict` (0 failed) / `helm3 template` (exit 0).

## Two Helm 4 behaviour changes, handled where they bite

- **`helm repo add` gained a 2-minute download deadline.** The raised sites pass `--timeout 5m`. The kept Helm 3 site deliberately does **not** — 3.16 has no such flag and would hard-fail on it.
- **`helm dependency build` re-fetches the repo index by default and takes no timeout of its own.** The raised sites pass `--skip-refresh` and rely on the `repo add` that already ran. Verified locally on 4.1.3: resolves in ~6s and vendors the subchart correctly.

`azure/setup-helm` needs no change — it string-templates the `get.helm.sh` URL with no major-version branch, and the pinned v5.0.1 SHA installs v4.1.3 fine. No action pin moves, so this carries no supply-chain change.

## Keeping the asymmetry from being "fixed"

`tests/unit/helm-pin-matrix.test.ts` enumerates the **workflows directory** rather than a file list, so a `setup-helm` site added anywhere fails until it is classified, and it pins the kept site to Helm 3 with the reason at hand. Verified by dropping a probe workflow with an unclassified site: 2 tests go red. The reason is also stated **at the site itself** and in the release runbook — a comment in a test file is not where someone about to fix an inconsistent workflow will look.

## What this does not fix

`ct install` installs the chart **source directory**, never the `.tgz` that `release-github-pages` packages or the artifact `release-oci` pushes. So no job anywhere installs a *released byte* with a Helm 3 client, and `helm-index-check.yml` only curls and `yq`s the index without running a Helm client at all. The evidence above was gathered by hand, and "verified once by hand" is not a gate. Recorded as **R1 in `docs/BACKLOG.md`** with what would close it.

## Verification

Six gates green: `format`, `lint`, `typecheck`, `knip`, tests (core suite exit 0), `build`. The helm-touching test files were run under **both** majors — 98 pass / 0 fail on 4.1.3 and on 3.16.0 — because contributors run whatever Helm they have and the kept job is still Helm 3.
