### PR TITLE
docs(trino): say who owns the trailing semicolon, and stop the seam implying it strips one

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -215,6 +215,35 @@ work: this is a connection-form feature, not a grounding one. Done when the Mong
 carries an optional auth-database field that reaches the URI, with the tri-sync the provider rule
 requires (code, `docs/providers/mongodb.md`, `tests/integration/db/mongodb-provider.test.ts`).
 
+### D5. A trailing semicolon reaches Trino unchanged, and Trino is the one engine that refuses it
+
+Measured against Trino 476: `SELECT 1;` answers `SYNTAX_ERROR`, `line 1:9: mismatched input ';'`,
+while `SELECT 1` succeeds. `TrinoHttpTransport` sends the statement text verbatim and strips
+nothing, so `provider.query("SELECT 1;")` fails on Trino and succeeds on every other SQL engine
+we ship.
+
+**Not reachable through the product**, which is why it is here rather than in the provider PR:
+`splitStatements()` (`src/lib/sql/statement-splitter.ts:132`) consumes the semicolon as the
+delimiter, so nothing typed in the editor ever carries one to a provider. The exposure is the
+published library surface — `@libredb/studio` exports the providers, and a consumer calling
+`query()` directly gets an engine-specific failure with no hint that the semicolon caused it.
+
+Two things make it worth recording rather than dismissing. The comment at
+`src/lib/db/providers/sql/trino/http-transport.ts` describing the request body reads "no trailing
+semicolon", which states the requirement without anything enforcing it — corrected in the same
+change that filed this entry, so the comment no longer implies a strip that does not happen. And
+the provider already absorbs one Trino grammar quirk for the caller: `prepareQuery()` transposes
+`LIMIT n OFFSET m` into `OFFSET m LIMIT n` because only the second order parses. Absorbing one and
+not the other is the inconsistency, not the semicolon itself.
+
+Done when the transport drops a single trailing semicolon before the statement leaves it (a
+statement whose text is otherwise unchanged, so nothing that reads the statement back is
+surprised), with a test that proves `SELECT 1;` and `SELECT 1` reach the wire identically, and
+`docs/providers/trino.md` saying so. Deliberately NOT a general statement splitter: `SELECT 1;
+SELECT 2` must keep failing, because the endpoint takes exactly one statement.
+
+Found reviewing #438 against the live cluster; not raised by the external review of that PR.
+
 ---
 
 ## Value interpolation

--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -394,6 +394,12 @@ Measured: `SELECT 1;` answers `line 1:9: mismatched input ';'`. That is what
 `statementTerminator: "none"` declares, and it is mandatory rather than cosmetic — without it the
 shared query generators emit statements this engine refuses.
 
+The transport does **not** strip one for you: the statement reaches the coordinator verbatim. Every
+caller inside the product has already had it removed, because `splitStatements()` consumes the
+semicolon as its delimiter, so this is only reachable by a consumer of the published package calling
+`query()` directly. Recorded as `docs/BACKLOG.md` D5 rather than silently absorbed, because the
+endpoint takes exactly one statement and a strip is a smaller change than it first looks.
+
 `identifierQuoting: "double"` is declared explicitly for the neighbouring reason (#424 Phase 1's
 lesson): the generators otherwise derive the quote character from `defaultPort`, and `8080` is a
 generic HTTP port that says nothing about a dialect. Trino quotes with `"`, and a backtick is not a

--- a/src/lib/db/providers/sql/trino/http-transport.ts
+++ b/src/lib/db/providers/sql/trino/http-transport.ts
@@ -87,7 +87,17 @@ const STATEMENT_PATH = "/v1/statement";
  */
 const QUERY_PATH = "/v1/query";
 
-/** The statement travels as its own text: no JSON envelope, no trailing semicolon. */
+/**
+ * The statement travels as its own text, with no JSON envelope around it.
+ *
+ * It also travels VERBATIM: nothing here edits it, and the endpoint takes exactly
+ * one statement with no terminator. Measured on 476, `SELECT 1;` is a
+ * `SYNTAX_ERROR` (`mismatched input ';'`) where `SELECT 1` succeeds - so a
+ * trailing semicolon is the caller's to remove, and every caller inside this
+ * product has already had it removed by `splitStatements()`, which consumes it as
+ * the delimiter. See `docs/BACKLOG.md` D5 for why the seam does not strip one
+ * itself and what would have to be true to change that.
+ */
 const SQL_CONTENT_TYPE = "text/plain";
 const JSON_ACCEPT = "application/json";
 


### PR DESCRIPTION
Follow-up to #438, found reviewing it against the live cluster after it merged. Documentation and a
comment only - no behaviour change, no test change.

## What is wrong

`TrinoHttpTransport` sends the statement text verbatim. Trino is the one engine we ship that refuses
a trailing semicolon; measured on 476:

```
SELECT 1;   ->  FAILED   SYNTAX_ERROR   line 1:9: mismatched input ';'
SELECT 1    ->  FINISHED
```

The comment on the request content type read *"The statement travels as its own text: no JSON
envelope, no trailing semicolon."* That states the requirement as though the seam enforced it.
Nothing does, so the next reader of that line is told something untrue about the code beneath it.

## Why it is not a bug report against the product

`splitStatements()` (`src/lib/sql/statement-splitter.ts:132`) consumes the semicolon as its
delimiter, so nothing typed in the editor ever carries one to a provider. That is why the browser
run in #438 executed a plan-mode statement ending in `;` without complaint.

The exposure is the published package: `@libredb/studio` exports the providers, and a consumer
calling `query("SELECT 1;")` directly gets a failure on Trino and success on every other SQL engine.
Worth recording rather than dismissing, because the provider already absorbs one Trino grammar quirk
for the caller - `prepareQuery()` transposes `LIMIT n OFFSET m` into `OFFSET m LIMIT n`, the only
order that parses. Absorbing one and not the other is the inconsistency.

## What this changes

- The comment says what is true: the statement travels verbatim, the terminator is the caller's, and
  in-product callers have already had it removed.
- `docs/providers/trino.md` §3.13 says the same, so the doc and the code agree.
- `docs/BACKLOG.md` D5 records the decision to be made, with the boundary that matters: a strip must
  drop **one trailing** semicolon and must not become a statement splitter, because the endpoint
  takes exactly one statement and `SELECT 1; SELECT 2` has to keep failing.

## Verification

All six local gates green in an isolated worktree: format, lint (0 errors), typecheck, knip,
test (8210 tests, 0 fail, all 30 groups), build.

## Note on the external review of #438

An external agent reviewed #438 and raised four points. Three did not survive checking - one asked
whether `system.runtime.queries` has a third terminal state such as `CANCELED` that the provider's
`state <> 'FINISHED' AND state <> 'FAILED'` predicate would miscount, and the live cluster answers
`[["FAILED",7],["FINISHED",94],["RUNNING",1]]`, with both a client `DELETE` and
`CALL system.runtime.kill_query` landing in `FAILED`, exactly as the code comment claims. This
semicolon gap is the one real finding from that pass, and it came from re-probing rather than from
the review.
