### PR TITLE
docs(search): close Phase 1 of #424 - say which licence was probed, and make every engine count agree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code in this repo — conventions, rules, and gotchas only. 
 
 ## Project Overview
 
-Web-based SQL IDE for cloud-native teams: PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch (plus the embedded LibreDB) + AI query assistance. Runs **two ways** — a standalone Next.js app AND a published npm package (CLI plus an embeddable library surface); `build:lib` (tsup) produces the package dist. The two modes render different chrome, so a UI change verified in one is not verified in the other.
+Web-based SQL IDE for cloud-native teams: PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino (plus the embedded LibreDB) + AI query assistance. Runs **two ways** — a standalone Next.js app AND a published npm package (CLI plus an embeddable library surface); `build:lib` (tsup) produces the package dist. The two modes render different chrome, so a UI change verified in one is not verified in the other.
 
 ## Branching & PRs
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -20,7 +20,7 @@
 
 > 📖 **Full documentation, source, and issues:** <https://github.com/libredb/libredb-studio>
 
-Query **PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch** from your browser — with AI-powered query assistance, interactive ER diagrams, schema diff, a virtualized data grid, RBAC, OIDC SSO, and a live monitoring dashboard. A lightweight, secure bridge between heavy desktop tools (DataGrip/DBeaver) and minimal CLIs.
+Query **PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino** from your browser — with AI-powered query assistance, interactive ER diagrams, schema diff, a virtualized data grid, RBAC, OIDC SSO, and a live monitoring dashboard. A lightweight, secure bridge between heavy desktop tools (DataGrip/DBeaver) and minimal CLIs.
 
 ---
 
@@ -107,7 +107,7 @@ The network route is the one to prefer for a real deployment: put Studio and its
 
 ## Supported databases
 
-Twelve engines share one interface, and three of them are read-only because their own SQL is.
+Thirteen engines share one interface, and three of them are read-only because their own SQL is.
 
 | Database | Driver | Highlights |
 | :--- | :--- | :--- |
@@ -123,6 +123,7 @@ Twelve engines share one interface, and three of them are read-only because thei
 | **Apache Druid** | none — HTTP | Read-only SQL IDE over the SQL endpoint, datasource and segment browser |
 | **Elasticsearch** | none — HTTP | Read-only SQL IDE over `_sql`, mapping-driven index/field explorer, cluster health with per-index document counts and store sizes |
 | **OpenSearch** | none — HTTP | The same read-only IDE over `_plugins/_sql`, from the same provider module; `LIMIT … OFFSET` paging works here |
+| **Apache Trino** | none — HTTP | Full SQL IDE over the client protocol, every configured catalog in one tree, `EXPLAIN (FORMAT JSON)` plans, `system.runtime` monitoring and query cancellation |
 | **LibreDB** | `@libredb/libredb` | The embedded key-value store, for a database with nothing to install |
 
 **Read-only where the engine is.** Druid, Elasticsearch and OpenSearch have no `UPDATE` and no `CREATE TABLE` anywhere in their grammar, so inline editing and DDL are reported as unsupported instead of failing when used. Everything else — the query editor, the object browser, ER diagrams, schema diff and monitoring — works wherever the engine has something to answer with.

--- a/deploy/azure/listing/description.html
+++ b/deploy/azure/listing/description.html
@@ -4,9 +4,9 @@ machine, behind an automatically provisioned HTTPS endpoint, in about five minut
 
 <h3>What you get</h3>
 <ul>
-  <li><strong>One workspace for twelve engines</strong> - PostgreSQL, MySQL/MariaDB, Microsoft SQL Server
+  <li><strong>One workspace for thirteen engines</strong> - PostgreSQL, MySQL/MariaDB, Microsoft SQL Server
       (including Azure SQL), Oracle, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid,
-      Elasticsearch and OpenSearch.</li>
+      Elasticsearch, OpenSearch and Apache Trino.</li>
   <li><strong>A real editor</strong> - Monaco-based SQL editing with schema-aware autocomplete,
       formatting, query history and virtualized result grids that stay fast on large result sets.</li>
   <li><strong>AI query assistance</strong> - turn natural language into SQL, explain and optimize

--- a/deploy/azure/listing/listing-fields.md
+++ b/deploy/azure/listing/listing-fields.md
@@ -31,12 +31,12 @@ LibreDB Studio
 **Search results summary** (limit 100):
 
 <!-- limit:100 -->
-Open-source SQL IDE with AI for 12 engines: PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis+
+Open-source SQL IDE with AI for 13 engines: PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis+
 
 **Short description** (limit 256):
 
 <!-- limit:256 -->
-Open-source, self-hosted SQL IDE for cloud-native teams. Connect to twelve engines - PostgreSQL, MySQL, SQL Server, Oracle, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch - explore schemas and write queries with AI help.
+Open-source, self-hosted SQL IDE for cloud-native teams. Connect to thirteen engines - PostgreSQL, MySQL, SQL Server, Oracle, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch, Trino - explore schemas and query with AI help.
 
 **Description** (limit 5000, HTML): see [description.html](description.html) —
 the limit is asserted by the unit test.
@@ -75,7 +75,7 @@ Planned captions:
 1. `hero-editor` — "Write and run SQL with schema-aware autocomplete and a virtualized result grid."
 2. `nl2sql` — "Turn a plain-English question into SQL with AI assistance."
 3. `erd-diagram` — "Explore relationships with an automatically generated ERD."
-4. `connection-modal` — "Connect to twelve engines, from PostgreSQL and SQL Server to Elasticsearch."
+4. `connection-modal` — "Connect to thirteen engines, from PostgreSQL and SQL Server to Apache Trino."
 5. `data-profiler` — "Profile table data: distributions, null ratios and outliers at a glance."
 
 ## Plan (§7.6)

--- a/deploy/caprover/libredb-studio.yml
+++ b/deploy/caprover/libredb-studio.yml
@@ -69,10 +69,10 @@ caproverOneClickApp:
     instructions:
         start: |-
             LibreDB Studio is a modern, open-source, web-based SQL IDE for the cloud era.
-            Query twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
-            MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and
-            OpenSearch - from your browser, with AI-powered query assistance, an ERD
-            viewer, schema diff and more.
+            Query thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
+            MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch,
+            OpenSearch and Apache Trino - from your browser, with AI-powered query
+            assistance, an ERD viewer, schema diff and more.
 
             What you can set below (defaults are sensible - you can usually just click Deploy):
               - Version: the image tag to deploy (a tested fixed version by default).
@@ -111,5 +111,5 @@ caproverOneClickApp:
             "App Configs" tab. See https://github.com/libredb/libredb-studio
     displayName: LibreDB Studio
     isOfficial: false
-    description: Open-source web-based SQL IDE. Query twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch & OpenSearch - from your browser, with AI-powered query assistance.
+    description: Open-source web-based SQL IDE. Query thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch & Apache Trino - from your browser, with AI-powered query assistance.
     documentation: Image and docs - https://github.com/libredb/libredb-studio . Uses ghcr.io/libredb/libredb-studio. Deploys with SQLite persistence; supports OIDC SSO and multiple AI providers via extra env vars.

--- a/deploy/koyeb/CATALOG_SUBMISSION.md
+++ b/deploy/koyeb/CATALOG_SUBMISSION.md
@@ -52,8 +52,8 @@ a backup.
 >
 > We maintain **LibreDB Studio**, an open-source, web-based SQL IDE for
 > cloud-native teams (PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis,
-> Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch,
-> Redis, with AI-assisted querying). It's free and Apache/MIT-style open source:
+> Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino,
+> with AI-assisted querying). It's free and Apache/MIT-style open source:
 > https://github.com/libredb/libredb-studio
 >
 > We already ship a working **Deploy to Koyeb** button (prebuilt GHCR image

--- a/deploy/railway/TEMPLATE_OVERVIEW.md
+++ b/deploy/railway/TEMPLATE_OVERVIEW.md
@@ -1,6 +1,6 @@
 # Deploy and Host libredb-studio on Railway
 
-LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. Query PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch from your browser — with AI-powered query assistance (natural-language-to-SQL, explain, and fix), an ERD viewer, schema diff, and a data profiler. No desktop client required.
+LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. Query PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino from your browser — with AI-powered query assistance (natural-language-to-SQL, explain, and fix), an ERD viewer, schema diff, and a data profiler. No desktop client required.
 
 ## About Hosting libredb-studio
 
@@ -14,7 +14,7 @@ Hosting LibreDB Studio means running a single stateless Next.js container that s
 
 ## Dependencies for libredb-studio Hosting
 
-- A database to connect to — any of the twelve engines above (bring your own, or add a Railway database to the project).
+- A database to connect to — any of the thirteen engines above (bring your own, or add a Railway database to the project).
 - A persistent volume mounted at `/app/data` for the SQLite-backed store of saved connections and settings (included in this template).
 
 ### Deployment Dependencies

--- a/deploy/railway/template.json
+++ b/deploy/railway/template.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Reviewable serialization of the LibreDB Studio Railway template. Railway does not ingest this file directly — the marketplace template is built in Railway's template editor (Workspace -> Templates -> New Template, at https://railway.com/workspace/templates). This file is the single source of truth for what to enter there (see PUBLISH.md) and what a future API automation would consume. Mirrors deploy/caprover/libredb-studio.yml.",
   "name": "LibreDB Studio",
-  "description": "Open-source web-based SQL IDE. Query twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch & OpenSearch - from your browser, with AI-powered query assistance.",
+  "description": "Open-source web-based SQL IDE. Query thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch & Apache Trino - from your browser, with AI-powered query assistance.",
   "tags": ["database", "sql", "ide", "postgres", "mysql", "mongodb", "redis"],
   "services": [
     {

--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -20,20 +20,21 @@ partner contact.
 > ten-engine wording against a version older than 0.11.0 — send the eight-engine
 > variant instead.
 >
-> **The count is now twelve on `main`, and that wording waits for a release.**
-> Elasticsearch and OpenSearch shipped on `main` with
-> [#424](https://github.com/libredb/libredb-studio/issues/424) Phase 1 and are in the
-> `SHIPPED` record in `src/lib/db/compatibility.ts`, but the catalog page describes a
-> released version. So the prose below stays at ten until a tag carries the two, and
-> then both the short and long descriptions gain "Elasticsearch and OpenSearch" and the
-> feature bullet becomes twelve. Read the number from `SHIPPED` (minus the embedded
-> `libredb`) rather than from this file, and state the scope with it: on those two
-> engines LibreDB Studio queries and browses — their SQL has no `INSERT`, `UPDATE` or
-> `CREATE TABLE` — so "manage data across …" must not be extended to include them.
+> **The count is now thirteen on `main`, and that wording waits for a release.**
+> Elasticsearch, OpenSearch and Apache Trino shipped on `main` with
+> [#424](https://github.com/libredb/libredb-studio/issues/424) Phases 1 and 2 and are in
+> the `SHIPPED` record in `src/lib/db/compatibility.ts`, but the catalog page describes a
+> released version. So the prose below stays at ten until a tag carries the three, and
+> then both the short and long descriptions gain "Elasticsearch, OpenSearch and Apache
+> Trino" and the feature bullet becomes thirteen. Read the number from `SHIPPED` (minus
+> the embedded `libredb`) rather than from this file, and state the scope with it: on the
+> two search engines LibreDB Studio queries and browses — their SQL has no `INSERT`,
+> `UPDATE` or `CREATE TABLE` — so "manage data across …" must not be extended to include
+> them.
 >
-> The chart's own `description` in `Chart.yaml` still names seven engines, and that is
-> the string Rancher renders on the Apps catalog card. Correcting it means a chart
-> version bump and a fresh release, so it is tracked separately from this file.
+> The chart's own `description` in `Chart.yaml` already names all thirteen, and that is
+> the string Rancher renders on the Apps catalog card, so it reaches users on the next
+> chart release rather than through this file.
 
 ## Listing facts
 

--- a/desktop/src-tauri/desktop-entry.hbs
+++ b/desktop/src-tauri/desktop-entry.hbs
@@ -7,6 +7,6 @@ Exec={{exec}}
 Icon={{icon}}
 Terminal=false
 Categories={{categories}}
-Keywords=SQL;Database;PostgreSQL;MySQL;SQLite;MongoDB;Redis;Oracle;SQLServer;ClickHouse;Couchbase;Druid;Elasticsearch;OpenSearch;IDE;Query;
+Keywords=SQL;Database;PostgreSQL;MySQL;SQLite;MongoDB;Redis;Oracle;SQLServer;ClickHouse;Couchbase;Druid;Elasticsearch;OpenSearch;Trino;IDE;Query;
 StartupNotify=true
 StartupWMClass=libredb-studio-desktop

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
     "targets": ["appimage", "deb"],
     "category": "DeveloperTool",
     "shortDescription": "The open-source SQL IDE for cloud-native teams",
-    "longDescription": "LibreDB Studio is an open-source SQL IDE for twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch - with AI query assistance. The desktop build runs the same server LibreDB Studio ships everywhere else as a local sidecar and keeps all data on this machine.",
+    "longDescription": "LibreDB Studio is an open-source SQL IDE for thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino - with AI query assistance. The desktop build runs the same server LibreDB Studio ships everywhere else as a local sidecar and keeps all data on this machine.",
     "homepage": "https://libredb.org",
     "publisher": "LibreDB",
     "license": "MIT",

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -535,7 +535,7 @@ not in the inventory. Since #414 the WORDING varies with the engine's `queryLang
 not: on a `json` engine the run is asked for one statement or command in that engine's own language —
 a MongoDB aggregation rather than a SELECT — and told that this engine speaks no SQL, while the tag
 stays the canonical type-id in both arms. That is deliberate rather than an oversight: `isQueryFenceTag`
-is a total record over `DatabaseType`, so all eleven ids pass it, whereas a draft the model fenced as
+is a total record over `DatabaseType`, so all fourteen ids pass it, whereas a draft the model fenced as
 ```` ```javascript ```` passes nothing and records no `plan-statement-drafted` event at all — the run
 would score as having drafted nothing while the user is looking at a statement. A run that cannot answer from the
 inventory takes the other legitimate ending: a line beginning `NO STATEMENT:` saying exactly what is
@@ -2052,7 +2052,7 @@ src/lib/agent/
 ├── runtime.ts            # composition root: the only place that assembles a tool context
 ├── tools.ts              # the four tools + server-side selection; the only database reach,
                           #   the model's tools and the server's own grounding reads alike
-├── composed-sql.ts       # the SQL the SERVER writes, per dialect — two of the eleven
+├── composed-sql.ts       # the SQL the SERVER writes, per dialect — two of the fourteen
 ├── sqlite-ddl.ts         # reading SQLite's stored DDL back into an inventory
 ├── execution-policy.ts   # the frozen policy and the run-level ceilings
 ├── deadline.ts           # the wall-clock deadline and the timeout clamp

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -98,12 +98,13 @@ Upstash, PlanetScale, Azure Cosmos DB and Amazon DocumentDB. Their status is tra
 What to type into the connection dialog for **every shipped provider**, against
 [`database-compose.yml`](../../database-compose.yml). One row per type-id, so the table covers the
 same set as the table at the top of this file and a new provider is a new row rather than a re-drawn
-grid. Each row was verified against the running container on 2026-08-19 — the credentials are the
-ones the fixture actually accepts, not the ones its environment block asks for (twice those differ;
-see the notes).
+grid. Each row was verified against the running container on 2026-08-19, and the Trino row on
+2026-08-20 — the credentials are the ones the fixture actually accepts, not the ones its environment
+block asks for (twice those differ; see the notes).
 
-Start the eleven always-on services with a plain `docker compose -f database-compose.yml up -d`; the
-`Profile` column names the ones that need asking for.
+Start the twelve always-on services with a plain `docker compose -f database-compose.yml up -d` -
+eleven engine containers plus the one-shot `couchbase-init` seed sidecar; the `Profile` column names
+the ones that need asking for.
 
 | Provider | Compose service | Host | Port | User | Password | Database / service | Profile |
 |---|---|---|---|---|---|---|---|

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -22,7 +22,7 @@
 | **Transactions** | Not exposed (Elasticsearch has none) |
 | **Maintenance** | None — nothing in `MaintenanceType` has a SQL-reachable analogue ([§8](#8-maintenance)) |
 | **Query cancellation** | No `cancelQuery`. An abort closes **this client's** socket; the cluster keeps working ([§3.8](#38-the-deadline-is-the-clients-and-only-the-clients)) |
-| **Verified against** | **Elasticsearch 9.1.4** (basic licence, security disabled), indices `probe_orders` (1 doc), `probe_shapes` (2 docs, an object and a multi-field), `probe_buckets` (1500 docs), measured 2026-08-19 |
+| **Verified against** | **Elasticsearch 9.1.4**, image `docker.elastic.co/elasticsearch/elasticsearch:9.1.4` - the **default** build flavour, not `oss` (`GET /` reports `build_flavor` `default`), software licence **Elastic License 2.0** (the image's own `/usr/share/elasticsearch/LICENSE.txt`), subscription tier **basic** and self-generated (`GET /_license` reports type `basic`, status `active`, issuer `elasticsearch`), security disabled; indices `probe_orders` (1 doc), `probe_shapes` (2 docs, an object and a multi-field), `probe_buckets` (1500 docs), measured 2026-08-19 |
 | **Source** | [`src/lib/db/providers/sql/search/`](../../src/lib/db/providers/sql/search/) |
 | **Tests** | [`tests/integration/db/elasticsearch-provider.test.ts`](../../tests/integration/db/elasticsearch-provider.test.ts) + [`tests/unit/db/search/`](../../tests/unit/db/search/) |
 | **Tracking issue** | [#424 — Search providers, Phase 1](https://github.com/libredb/libredb-studio/issues/424) |
@@ -32,7 +32,7 @@
 ## 1. Overview
 
 Elasticsearch is a distributed search and analytics engine. Its **SQL surface is a first-party HTTP
-endpoint** — `POST /_sql?format=json` — available on a basic licence with no plugin to install, and
+endpoint** — `POST /_sql?format=json` — available on the basic tier with no plugin to install, and
 that endpoint is the whole query surface this provider speaks. Schema and monitoring come from the
 REST APIs instead (`_cat/indices`, `<index>/_mapping`, `_cluster/health`, `_cluster/stats`), because
 the mapping is the index's own declaration while a `SELECT` only ever describes a statement
@@ -111,7 +111,7 @@ ElasticsearchProvider (search/index.ts:953)      OpenSearchProvider (search/inde
 ```
 
 `SearchProvider` extends `SQLBaseProvider` because the query language really is SQL — measured, the
-endpoint answers a `POST`ed statement with declared columns and positional rows on a basic licence —
+endpoint answers a `POST`ed statement with declared columns and positional rows on the basic tier —
 and because the shared limiter's `LIMIT n` is correct here. The abstract base is **not exported**: the
 factory constructs a type-id, and a type-id is one of the two concrete classes, which is what keeps
 both exports honestly thin (each one names its product and nothing else).
@@ -229,10 +229,10 @@ rule that no method branches on `this.dialect` at all — it reads `this.spec`.
 
 ### 3.3 SQL, and not ES|QL
 
-ES|QL exists on this product (`POST /_query`, and it works on a basic licence — measured) and is
+ES|QL exists on this product (`POST /_query`, and it works on the basic tier — measured) and is
 deliberately unused. **OpenSearch has no ES|QL at all**, and a surface only one of the two products
-has cannot be the shared query language, while the SQL endpoint is available on both without a
-licence. Declaring `queryLanguage: "sql"` also buys Monaco SQL highlighting, the shared limiter, the
+has cannot be the shared query language, while the SQL endpoint is available on both with no paid
+tier. Declaring `queryLanguage: "sql"` also buys Monaco SQL highlighting, the shared limiter, the
 `"sql"` tab type and saved queries with no additional code.
 
 ### 3.4 The success envelope: positional rows, and a duplicate name that must not vanish
@@ -914,7 +914,7 @@ difference — `OFFSET` — has no field in `ProviderCapabilities` to declare it
 
 | Capability | Value | Why |
 |---|---|---|
-| `queryLanguage` | `sql` | Elasticsearch SQL over the HTTP endpoint, no licence gate ([§3.3](#33-sql-and-not-esql)) |
+| `queryLanguage` | `sql` | Elasticsearch SQL over the HTTP endpoint, no tier gate ([§3.3](#33-sql-and-not-esql)) |
 | `supportsExplain` | **`false`** | No `explainFormat` is declared either, which hides both button and tab ([§3.10](#310-no-explain-even-though-elasticsearch-answers-one)) |
 | `supportsExternalQueryLimiting` | `true` | `LIMIT n` is correct here; the one form that is not is refused by `prepareQuery()` ([§5.5](#55-the-preparequery-override-there-is-no-second-page)) |
 | `supportsCreateTable` | **`false`** | Not in the grammar ([§5.6](#56-this-grammar-does-not-write)) |
@@ -1091,6 +1091,18 @@ header is ignored there, so no 401/403 body could ever be captured
 The health check waits for **yellow**, not green: a single node with a replica requested is yellow
 forever, so waiting for green would hang.
 
+**Which distribution, and under which licence.** The pinned image is the **default** build flavour -
+`GET /` reports `build_flavor` `default`, not `oss` - and the licence it ships is **Elastic License
+2.0**, the first line of `/usr/share/elasticsearch/LICENSE.txt` inside the image
+(<https://www.elastic.co/licensing/elastic-license>). The limitation that bears on this question is
+the one on providing the software to third parties as a hosted or managed service (the licence
+states two others, on the licence-key functionality and on removing notices), and it binds a
+would-be host of Elasticsearch rather than an HTTP client of one: this provider speaks HTTP to a
+server the user runs, and links, bundles and redistributes nothing. The **basic** that
+`GET /_license` reports (type `basic`, status `active`, issuer `elasticsearch`, issued to
+`docker-cluster`) is a different thing again - a self-generated **subscription tier**, not the
+software licence - and it is the tier the `_sql` endpoint is available on.
+
 Seed the three probe indices with the document API — there is no `CREATE TABLE` here:
 
 ```bash
@@ -1222,4 +1234,5 @@ because the provider exposes no `cancelQuery` ([§3.8](#38-the-deadline-is-the-c
 - SQL REST API: <https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest.html>
 - Mapping: <https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html>
 - `_cat/indices`: <https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html>
+- Elastic License 2.0: <https://www.elastic.co/licensing/elastic-license>
 - Sibling provider docs: [PostgreSQL](./postgres.md) · [MySQL](./mysql.md) · [Oracle](./oracle.md) · [SQL Server](./mssql.md) · [SQLite](./sqlite.md) · [MongoDB](./mongodb.md) · [Couchbase](./couchbase.md) · [ClickHouse](./clickhouse.md) · [Apache Druid](./druid.md) · [Apache Trino](./trino.md) · [OpenSearch](./opensearch.md) · [Redis](./redis.md) · [LibreDB](./libredb.md)

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -23,7 +23,7 @@
 | **Transactions** | Not exposed (the engine has none) |
 | **Maintenance** | None — nothing in `MaintenanceType` has a SQL-reachable analogue ([§8](#8-maintenance)) |
 | **Query cancellation** | No `cancelQuery`. An abort closes **this client's** socket; the cluster keeps working ([§3.8](#38-the-deadline-is-the-clients-and-only-the-clients)) |
-| **Verified against** | **OpenSearch 3.8.0** (security disabled, stock single node — `GET /` reported distribution `opensearch`, number `3.8.0`, build_date `2026-08-01`), indices `probe_orders` (1 doc) and `probe_shapes` (2 docs, an object, a `nested` and a multi-field), measured 2026-08-19 |
+| **Verified against** | **OpenSearch 3.8.0**, image `opensearchproject/opensearch:3.8.0` (security disabled, stock single node — `GET /` reported distribution `opensearch`, number `3.8.0`, build_date `2026-08-01`), software licence **Apache-2.0** (the image ships the Apache License, Version 2.0 as `/usr/share/opensearch/LICENSE.txt`) with no subscription tier to confuse it with, indices `probe_orders` (1 doc) and `probe_shapes` (2 docs, an object, a `nested` and a multi-field), measured 2026-08-19 |
 | **Source** | [`src/lib/db/providers/sql/search/`](../../src/lib/db/providers/sql/search/) |
 | **Tests** | [`tests/integration/db/opensearch-provider.test.ts`](../../tests/integration/db/opensearch-provider.test.ts) + [`tests/unit/db/search/`](../../tests/unit/db/search/) |
 | **Tracking issue** | [#424 — Search providers, Phase 1](https://github.com/libredb/libredb-studio/issues/424) |
@@ -33,7 +33,7 @@
 ## 1. Overview
 
 OpenSearch is the Apache-2.0 fork of Elasticsearch 7.10. Its **SQL surface is a bundled plugin** —
-`POST /_plugins/_sql`, present on a stock node with nothing to install and no licence to hold — and
+`POST /_plugins/_sql`, present on a stock node with nothing to install and no tier gate — and
 that endpoint is the whole query surface this provider speaks. Schema and monitoring come from the
 REST APIs instead (`_cat/indices`, `<index>/_mapping`, `_cluster/health`, `_cluster/stats`), because
 the mapping is the index's own declaration while a `SELECT` only ever describes a statement
@@ -231,7 +231,7 @@ Adopting `@opensearch-project/opensearch` later is one new file implementing the
 
 The upstream product has ES|QL (`POST /_query`); **this one has none at all** — the path answers 405.
 A surface only one of the two products has cannot be the shared query language, while the SQL endpoint
-is present on both with no licence, so `queryLanguage` is `sql` on both type-ids. That also buys Monaco
+is present on both with no tier gate, so `queryLanguage` is `sql` on both type-ids. That also buys Monaco
 SQL highlighting, the shared limiter, the `"sql"` tab type and saved queries with no additional code.
 
 ### 3.4 The success envelope: `schema`/`datarows`, a separate alias, and a count
@@ -1084,6 +1084,13 @@ Both services run together on purpose: every claim this document records is a cl
 two answered differently, and that can only be re-measured side by side. This service publishes
 **9201** on the host because both products ship on 9200 in the container.
 
+**Under which licence.** The licence the pinned image ships is **Apache-2.0**:
+`/usr/share/opensearch/LICENSE.txt` inside the image is the Apache License, Version 2.0. There is no
+subscription tier here to confuse with the software licence, which is the distinction the upstream
+product forces
+([elasticsearch.md §11.4](./elasticsearch.md#114-optional-reproducing-the-live-pass)), and nothing
+in it constrains this provider either way.
+
 Two configuration details are load-bearing:
 
 - `DISABLE_SECURITY_PLUGIN: "true"` — the fork's own switch, **not** the upstream
@@ -1239,4 +1246,5 @@ because the provider exposes no `cancelQuery`
 - Mappings: <https://docs.opensearch.org/latest/field-types/>
 - `_cat/indices`: <https://docs.opensearch.org/latest/api-reference/cat/cat-indices/>
 - Query insights (`top_queries`): <https://docs.opensearch.org/latest/observing-your-data/query-insights/index/>
+- Apache License, Version 2.0: <https://www.apache.org/licenses/LICENSE-2.0>
 - Sibling provider docs: [PostgreSQL](./postgres.md) · [MySQL](./mysql.md) · [Oracle](./oracle.md) · [SQL Server](./mssql.md) · [SQLite](./sqlite.md) · [MongoDB](./mongodb.md) · [Couchbase](./couchbase.md) · [ClickHouse](./clickhouse.md) · [Apache Druid](./druid.md) · [Apache Trino](./trino.md) · [Elasticsearch](./elasticsearch.md) · [Redis](./redis.md) · [LibreDB](./libredb.md)

--- a/docs/ui/login-page.md
+++ b/docs/ui/login-page.md
@@ -36,7 +36,7 @@ src/app/login/
 │  (pg) PostgreSQL (my) MySQL │ <- every engine,     │
 │  (lt) SQLite ... (lb)LibreDB│    icon + label      │
 │                             │   │  OIDC: SSO   │   │
-│  11        24        2      │ <- derived counts    │
+│  14        24        2      │ <- derived counts    │
 │  engines   channels  modes  │   │  or email/pw │   │
 │  <one qualifying line each> │   └──────────────┘   │
 │  Runs on Linux · macOS · …  │                      │
@@ -78,7 +78,7 @@ to undo from the outside:
 │   └──────────────┘   │
 │                      │
 │   [PG] [MySQL] ...   │  <- every engine
-│   11 engines · 24 …  │  <- the same claims,
+│   14 engines · 24 …  │  <- the same claims,
 │                      │     joined into a line
 │   Open source · gh…  │
 │   (gh)(in)(X)(yt)…   │

--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -23,9 +23,9 @@ metadata:
     categories: Database, Developer Tools
     containerImage: ghcr.io/libredb/libredb-studio-operator:0.12.0
     createdAt: "2026-08-19T11:25:23Z"
-    description: Open-source web-based SQL IDE for twelve engines - PostgreSQL, MySQL,
-      Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid,
-      Elasticsearch and OpenSearch - with AI-powered query assistance.
+    description: Open-source web-based SQL IDE for thirteen engines - PostgreSQL,
+      MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache
+      Druid, Elasticsearch, OpenSearch and Apache Trino - with AI-powered query assistance.
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/libredb/libredb-studio
@@ -49,7 +49,7 @@ spec:
   description: |
     LibreDB Studio is an open-source, web-based SQL IDE. Query PostgreSQL,
     MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse,
-    Apache Druid, Elasticsearch and OpenSearch from the browser —
+    Apache Druid, Elasticsearch, OpenSearch and Apache Trino from the browser —
     with AI-powered query assistance (natural-language-to-SQL, explain, fix),
     an ERD viewer, schema diff and a data profiler. No desktop client required.
 

--- a/operator/config/manifests/bases/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/libredb-studio-operator.clusterserviceversion.yaml
@@ -6,9 +6,9 @@ metadata:
     capabilities: Basic Install
     categories: Database, Developer Tools
     containerImage: ghcr.io/libredb/libredb-studio-operator:0.0.0
-    description: Open-source web-based SQL IDE for twelve engines - PostgreSQL, MySQL,
-      Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid,
-      Elasticsearch and OpenSearch - with AI-powered query assistance.
+    description: Open-source web-based SQL IDE for thirteen engines - PostgreSQL,
+      MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache
+      Druid, Elasticsearch, OpenSearch and Apache Trino - with AI-powered query assistance.
     repository: https://github.com/libredb/libredb-studio
     support: LibreDB
   labels:
@@ -30,7 +30,7 @@ spec:
   description: |
     LibreDB Studio is an open-source, web-based SQL IDE. Query PostgreSQL,
     MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse,
-    Apache Druid, Elasticsearch and OpenSearch from the browser —
+    Apache Druid, Elasticsearch, OpenSearch and Apache Trino from the browser —
     with AI-powered query assistance (natural-language-to-SQL, explain, fix),
     an ERD viewer, schema diff and a data profiler. No desktop client required.
 

--- a/packaging/chocolatey/libredb-studio.nuspec.tmpl
+++ b/packaging/chocolatey/libredb-studio.nuspec.tmpl
@@ -28,9 +28,9 @@
     <docsUrl>https://github.com/libredb/libredb-studio/blob/main/docs/DISTRIBUTION.md</docsUrl>
     <bugTrackerUrl>https://github.com/libredb/libredb-studio/issues</bugTrackerUrl>
     <tags>libredb-studio database sql ide editor postgres postgresql mysql sqlite oracle mssql mongodb redis</tags>
-    <summary>Web-based SQL IDE for twelve engines, including PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis, ClickHouse and Elasticsearch.</summary>
+    <summary>Web-based SQL IDE for thirteen engines, including PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis, ClickHouse and Elasticsearch.</summary>
     <description><![CDATA[
-LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch, and ships a Monaco-powered editor with AI query assistance, schema browsing, ER diagrams, charts, and import/export tooling.
+LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino, and ships a Monaco-powered editor with AI query assistance, schema browsing, ER diagrams, charts, and import/export tooling.
 
 This package installs the standalone server together with a bundled, private Node.js runtime - nothing else to install.
 

--- a/packaging/flatpak/org.libredb.Studio.desktop
+++ b/packaging/flatpak/org.libredb.Studio.desktop
@@ -7,6 +7,6 @@ Exec=libredb-studio
 Icon=org.libredb.Studio
 Terminal=false
 Categories=Development;Database;
-Keywords=SQL;Database;PostgreSQL;MySQL;SQLite;MongoDB;Redis;Oracle;SQLServer;ClickHouse;Couchbase;Druid;Elasticsearch;OpenSearch;IDE;Query;
+Keywords=SQL;Database;PostgreSQL;MySQL;SQLite;MongoDB;Redis;Oracle;SQLServer;ClickHouse;Couchbase;Druid;Elasticsearch;OpenSearch;Trino;IDE;Query;
 StartupNotify=true
 StartupWMClass=libredb-studio-desktop

--- a/packaging/flatpak/org.libredb.Studio.metainfo.xml
+++ b/packaging/flatpak/org.libredb.Studio.metainfo.xml
@@ -41,6 +41,7 @@
       <li>Apache Druid (read-only)</li>
       <li>Elasticsearch (read-only)</li>
       <li>OpenSearch (read-only)</li>
+      <li>Apache Trino</li>
     </ul>
     <p>What you get:</p>
     <ul>

--- a/packaging/flatpark/org.libredb.Studio.desktop
+++ b/packaging/flatpark/org.libredb.Studio.desktop
@@ -7,6 +7,6 @@ Exec=libredb-studio
 Icon=org.libredb.Studio
 Terminal=false
 Categories=Development;Database;
-Keywords=SQL;Database;PostgreSQL;MySQL;SQLite;MongoDB;Redis;Oracle;SQLServer;ClickHouse;Couchbase;Druid;Elasticsearch;OpenSearch;IDE;Query;
+Keywords=SQL;Database;PostgreSQL;MySQL;SQLite;MongoDB;Redis;Oracle;SQLServer;ClickHouse;Couchbase;Druid;Elasticsearch;OpenSearch;Trino;IDE;Query;
 StartupNotify=true
 StartupWMClass=libredb-studio-desktop

--- a/packaging/flatpark/org.libredb.Studio.metainfo.xml
+++ b/packaging/flatpark/org.libredb.Studio.metainfo.xml
@@ -50,6 +50,7 @@
       <li>Apache Druid (read-only)</li>
       <li>Elasticsearch (read-only)</li>
       <li>OpenSearch (read-only)</li>
+      <li>Apache Trino</li>
     </ul>
     <p>What you get:</p>
     <ul>

--- a/packaging/flatpark/org.libredb.Studio.yml
+++ b/packaging/flatpark/org.libredb.Studio.yml
@@ -16,8 +16,8 @@ finish-args:
   - --device=dri
   # network is the core function: LibreDB Studio connects to PostgreSQL, MySQL,
   # SQL Server, Oracle, MongoDB and Redis over their own TCP protocols, to
-  # Couchbase, ClickHouse, Apache Druid, Elasticsearch and OpenSearch over HTTP,
-  # and to an AI provider when
+  # Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache
+  # Trino over HTTP, and to an AI provider when
   # the user configures one with their own API key. It also covers 127.0.0.1,
   # so a database running on the host is reachable without any filesystem
   # permission.

--- a/packaging/homebrew/libredb-studio.rb.tmpl
+++ b/packaging/homebrew/libredb-studio.rb.tmpl
@@ -9,7 +9,7 @@
 # the tap by hand - change this template and re-release.
 # ==============================================================================
 class LibredbStudio < Formula
-  desc "Web-based SQL IDE for twelve engines, from Postgres to Elasticsearch"
+  desc "Web-based SQL IDE for thirteen engines, from Postgres to Elasticsearch"
   homepage "https://github.com/libredb/libredb-studio"
   version "{{VERSION}}"
   license "MIT"

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -23,8 +23,9 @@ section: database
 priority: optional
 maintainer: cevheri <cevheribozoglan@gmail.com>
 description: |
-  Web-based SQL IDE for twelve engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
-  MongoDB, and Redis with AI query assistance.
+  Web-based SQL IDE for thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
+  MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and
+  Apache Trino - with AI query assistance.
   Ships the standalone Next.js server with a bundled private Node.js
   runtime (no external dependencies) and a systemd unit (libredb-studio)
   serving the app on port 3000; enable it with

--- a/packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl
+++ b/packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl
@@ -13,7 +13,7 @@ PackageUrl: https://github.com/libredb/libredb-studio
 License: MIT
 LicenseUrl: https://github.com/libredb/libredb-studio/blob/main/LICENSE
 Copyright: Copyright (c) 2025 LibreDB
-ShortDescription: Web-based SQL IDE for twelve engines, including PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis, ClickHouse and Elasticsearch, with AI query assistance.
+ShortDescription: Web-based SQL IDE for thirteen engines, including PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis, ClickHouse and Elasticsearch, with AI query assistance.
 Description: |-
   LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams.
   It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, and

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,8 @@ adopt-info: payload
 summary: The modern, AI-powered open-source SQL IDE for cloud-native teams
 description: |
   Web-based SQL IDE for PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
-  MongoDB, and Redis with AI query assistance.
+  MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch,
+  OpenSearch and Apache Trino with AI query assistance.
 
   Installing the snap starts a background service that serves the app on
   port 3000 (http://localhost:3000). State (SQLite storage, generated

--- a/src/components/WireCompatibilityHint.tsx
+++ b/src/components/WireCompatibilityHint.tsx
@@ -11,7 +11,7 @@ interface WireCompatibilityHintProps {
 
 /**
  * Tells the user that the driver they just selected also serves other engines
- * (issue #424, Phase 0). It exists because the connection dialog offers eleven
+ * (issue #424, Phase 0). It exists because the connection dialog offers fourteen
  * driver buttons and none of them says "MariaDB", so a MariaDB user has no way to
  * know that MySQL is the right button.
  *

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -566,7 +566,7 @@ const PLAN_DELIVERABLES: Readonly<Record<AgentRunWorkflowType, PlanDeliverable>>
  * `language` arrived with #414 and every sentence that assumed SQL is now written
  * twice. The tag does NOT vary with it and that is the point of taking the language
  * separately: the tag is the canonical type-id in both arms, because it is what
- * `isQueryFenceTag` accepts (a total record over `DatabaseType`, so all eleven pass)
+ * `isQueryFenceTag` accepts (a total record over `DatabaseType`, so all fourteen pass)
  * and what `rich-text.tsx` and `readPlanStatement` key the editor hand-off on. A draft
  * a model fenced as ```` ```javascript ```` produces no `plan-statement-drafted` event
  * at all — the run would be scored as having drafted nothing while the user is looking

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1556,7 +1556,7 @@ export type AgentProviderSchemaRead =
  *
  * The sibling of `readCatalogForGrounding`, for the engines that one cannot serve.
  * A catalog read is a statement the server composes per dialect, and it is composed
- * for two of the eleven; everywhere else a run had no inventory at all and was told
+ * for two of the fourteen; everywhere else a run had no inventory at all and was told
  * so. This is the other reading the product already knows how to take, brought inside
  * the same pipeline rather than called beside it: `runAuditedAgentCall` applies the
  * mode check, the repair ledger, the deadline admission, the budget clamp, the

--- a/tests/components/WireCompatibilityHint.test.tsx
+++ b/tests/components/WireCompatibilityHint.test.tsx
@@ -5,7 +5,7 @@ import { render, cleanup, screen } from "@testing-library/react";
 import type { WireCompatibleEngine } from "@/lib/db/compatibility";
 
 /**
- * The hint answers one user question - "I have MariaDB, which of these eleven
+ * The hint answers one user question - "I have MariaDB, which of these fourteen
  * buttons do I press?" - so the tests assert what a user can read, not markup.
  *
  * The registry is mocked rather than read, because the real one is data that


### PR DESCRIPTION
Closes the Phase 1 wrap-up of #424. Elasticsearch and OpenSearch shipped in #429; their bookkeeping
did not. Documentation, packaging copy and four comments - no behaviour change, no test change.

## 1. The licence box's own premise was wrong

It read *"Elasticsearch is SSPL / Elastic License, OpenSearch is Apache-2.0"*. Read out of the
running containers rather than recalled:

```
docker exec libredb-elasticsearch head -1 /usr/share/elasticsearch/LICENSE.txt  ->  Elastic License 2.0
docker exec libredb-opensearch    head -5 /usr/share/opensearch/LICENSE.txt     ->  Apache License, Version 2.0
```

No SSPL. Both docs now name the image and the licence it actually ships.

**And the blur worth removing was a different one.** Both docs said the probe ran on a "basic
licence". On Elasticsearch **basic** is the *subscription tier* - `GET /_license` reports
`{"type":"basic","status":"active","issuer":"elasticsearch"}`, self-generated - and not the software
licence. Separating the two is what made seven older sites ambiguous, so they are reworded too
("no licence gate" -> "no tier gate"). Nothing in this PR asserts a licence obligation on this
repo: the provider speaks HTTP to a server the user runs.

## 2. Gate 7 was asserted, not run

#429 recorded gate 7 as *"asserted rather than assumed"* on the grounds that both type-ids ground
through #414's `provider-inventory` path, so plan mode works at no per-provider cost. That argument
is correct and it is still an argument; the epic's own wording for this gate is **"Expected is not
verified"**. So both were run, 2026-08-20, against the live containers behind gate 4.

Plan mode captured **3 indices** on each - its own word, not "tables" - and drafted:

```sql
SELECT shipping.country, COUNT(*) AS order_count FROM orders
GROUP BY shipping.country ORDER BY order_count DESC LIMIT 1
```

That is grounded twice over: the real `orders` index, and `shipping.country`, a nested field it
could only know from the mapping capture. Applied to the editor unmodified it answered `TR | 40` on
both, columns typed `keyword` and `long`, 66 ms on OpenSearch and 131 ms on Elasticsearch.

Gate 2 was re-walked in the browser on the way, since Elasticsearch had no connection on this
machine: the dialog offers it, defaults to port 9200, and reported `Connected successfully (51ms)`.

## 3. Three engine counts, none saying what it counted

| Surface | Said | Counts |
|---|---|---|
| issue #424 Shipped list | 12 | stale - missing `elasticsearch` and `opensearch` |
| README, chart, listings | 13 | external engines, `libredb` excluded |
| the login page | 14 | every type-id, `libredb` included |

All three were locally true, which is exactly the ambiguity the epic's claim-discipline section
exists to prevent. The external number is **thirteen** and the internal one is **fourteen**; each
surface now agrees with its own list, and the issue states which denominator it is using.

Auditing for that found twenty-six files still enumerating engines without Trino - `DOCKERHUB.md`,
the Azure/Railway/CapRover/Koyeb/Rancher listings, five packaging manifests, the Tauri config, the
OLM bundle and `CLAUDE.md`. They are fixed here rather than left, because the same section requires
those numbers to move together.

Two judgement calls inside that sweep:

- **`snap/snapcraft.yaml` gains the missing engine names but deliberately no count.** It carried no
  number before. Store copy can only be corrected by a re-release, so introducing a count there
  creates a drift surface nothing can fix in between.
- **`deploy/rancher/CATALOG_LISTING.md`** has a version-scoped gate note protecting text SUSE
  re-publishes only on request. The frozen prose is left frozen; only the note's description of
  `main` is corrected - and one sentence in it was simply false, claiming the chart "still names
  seven engines" when `Chart.yaml` names thirteen.

The operator CSV was regenerated with `make -C operator bundle`, not hand-mirrored; the generator
reproduced the wrapping exactly. `createdAt` is left at its committed value - CI ignores it
(`git diff -I '^ *createdAt:'`) and churning it is noise.

## Review

The diff was read by an adversarial reviewer before this PR existed, which returned FIX-FIRST with
nine defects; all were addressed. The one worth naming: introducing the licence-vs-tier distinction
turned seven pre-existing "no licence" phrasings **in the same two files** into self-contradictions.
Those had been examined and deliberately kept as "the correct tier reading" - true before the edit,
false after it. The reviewer also caught a *new* cross-product blur being introduced inside the
change whose purpose was removing blur: `default` bolded for Elasticsearch's build flavour, while
the sibling document already bolds `default` for OpenSearch's security distribution.

One reviewer claim did not survive checking and was skipped: it reported that both "Verified
against" rows had pre-existing em dashes downgraded to hyphens. `git show HEAD:docs/providers/elasticsearch.md`
shows that row never contained one. Only the OpenSearch row had a genuine downgrade; that one is
restored.

## Verification

All six local gates green in an isolated worktree: format, lint (0 errors), typecheck, knip,
test (all 30 groups), build. No control bytes and no emoji on any added line.
