### PR TITLE
docs(distribution): correct two stale references in the channel docs

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -701,7 +701,7 @@ channels:
     pin:
       strategy: none
       note: Merged in rancher/partner-charts#1158 (17 Aug 2026); live in Rancher Partner Charts (the repo
-        index.yaml carries libredb-studio at appVersion 0.11.0) and listed in the SUSE Solutions Catalog.
+        index.yaml carries libredb-studio at appVersion 0.12.0) and listed in the SUSE Solutions Catalog.
         Partner catalog, not self-serve - the chart is regenerated on Rancher's cadence and index.yaml
         accumulates every chart version, so an image-tag extract there would be ambiguous; strategy stays
         none like the other tier-4 partner/curated catalogs.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1426,14 +1426,14 @@ deliverable (`pin.strategy: local_file` for the version-pinned `fly.toml`; `none
   workflows that exist on the chosen ref) and the GHCR package is public, which
   community catalog CI requires. From 0.9.60 on the tag ref carries the
   operator and the normal tag-pinned dispatch chain applies. What is still open
-  is upstream: the operatorhub.io bundle PR
-  ([k8s-operatorhub/community-operators#8794](https://github.com/k8s-operatorhub/community-operators/pull/8794))
-  and the OpenShift catalog PR
+  upstream is the operatorhub.io bundle PR
+  ([k8s-operatorhub/community-operators#8794](https://github.com/k8s-operatorhub/community-operators/pull/8794)).
+  The OpenShift catalog PR
   ([community-operators-prod#10581](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/10581),
-  the second half of the FBC release whose bundle merged as #10497) both wait
-  on maintainer review. Flip `operatorhub-community` in
-  `distribution/channels.yaml` from `pending` to `live` once the listings are
-  visible, and remember `release-config.yaml` for every later release (see
+  the second half of the FBC release whose bundle merged as #10497) has since
+  merged, so the OpenShift console listing is live. Flip `operatorhub-community` in
+  `distribution/channels.yaml` from `pending` to `live` once the operatorhub.io
+  listing is visible too, and remember `release-config.yaml` for every later release (see
   [An FBC release is two upstream PRs](#an-fbc-release-is-two-upstream-prs)).
 - **Snap Store listing screenshots**: the description and icon ship with the snap
   (`snap/snapcraft.yaml`, `public/logo.svg`), but screenshots are a manual upload in the


### PR DESCRIPTION
## Description
Two doc-only accuracy fixes. Inventory statuses and pins are unchanged; docs/CHANNELS.md is unaffected (no generated content changed).

## Type of Change
- [x] Documentation update

## Changes Made
- `distribution/channels.yaml`: the rancher-partner note said the index.yaml carries appVersion 0.11.0; the current release is 0.12.0.
- `docs/DISTRIBUTION.md`: the operator section listed community-operators-prod#10581 as still awaiting maintainer review, but it merged on 2026-07-28. Reworded so only the operatorhub.io PR (#8794) is listed as open and the OpenShift console listing is noted as live.

## Testing
- [x] I have tested this locally
- [x] All existing tests pass

## Verification
`distribution:matrix --check` exit 0 · `distribution:check --strict` exit 0 · distribution-check unit tests 125/125 pass. docs/CHANNELS.md not regenerated (no generated content changed).
