### PR TITLE
docs(agent): say what the grounding denominator counts, not just a digit (#424) (B53)

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -48,7 +48,7 @@ Three properties frame everything below, and each of them is load-bearing rather
   on which of its two readings it takes**: `agent-read-only` on the dialects `CATALOG_PLANS` serves,
   because it composes catalog statements, and `agent-operations` everywhere else, because asking a
   provider to describe its own schema sends nothing an engine has to plan. That is what lets grounding
-  reach the nine engines the read-only profile refuses, and it still cannot narrow any workflow's
+  reach the twelve the read-only profile refuses, and it still cannot narrow any workflow's
   reach: the profile whose acquisition would be refused is never the profile that capture asks for. Everything else about
   the three acquisitions is identical: the same `readOnly: true` open, the same optional
   least-privilege `agentUser`, and the same profiled cache, so neither an operations run nor an
@@ -356,7 +356,7 @@ What a grounded plan run is given, and where each part comes from:
   which process happened to have read a catalog first. They are read from what the engine already
   holds — `pg_class.reltuples` and `pg_stats` on PostgreSQL, `sqlite_stat1` on SQLite — so no column
   is scanned and no value is read out of any row. `ESTIMATE_BUILDERS` serves those two dialects and
-  nothing else, and #414 added no engine to it: on the other nine `readSchemaStatistics` answers
+  nothing else, and #414 added no engine to it: on the other twelve `readSchemaStatistics` answers
   `DIALECT_HAS_NO_STATISTICS` — *"this engine does not hold statistics this run knows how to read"* —
   so **a known schema with no statistics is now the ORDINARY combination rather than a rare one**, and
   the two sentences the run is handed agree: the inventory is a record of what exists, and every
@@ -477,7 +477,7 @@ Three consequences worth stating plainly, because each is easy to assume the oth
 
 1. **A plan run costs statements now.** On PostgreSQL and SQLite grounding is catalog reads plus one
    statistics read (two on SQLite: the `sqlite_stat1` availability probe has to be its own statement,
-   because SQLite resolves table names at prepare time). On the other nine engines it is **one** — the
+   because SQLite resolves table names at prepare time). On the other twelve it is **one** — the
    single `db.schema.read` call, with no statistics read to add, since those dialects hold none this
    run knows how to read. They come out of the same per-run statement budget every other read does,
    and they are audited the same way. The ledger-reuse path saves the schema reading and deliberately
@@ -723,7 +723,7 @@ Two consequences worth stating:
   composed path has and the provider path cannot: reads audited statement by statement rather than as
   one opaque call; foreign keys, which no provider can report on an engine that declares none; and
   SQLite's inventory, which is parsed out of the DDL text the engine stored and which its provider
-  does not expose in the same shape. Collapsing the other nine onto the composed one is the thing
+  does not expose in the same shape. Collapsing the other twelve onto the composed one is the thing
   #414 exists because nobody can do: a catalog statement has to be written per dialect and verified
   against a live server, and until it is, refusing the dialect was the honest answer and reading the
   provider is a better one.
@@ -2235,12 +2235,6 @@ classifier's real-world agreement rate was measured — and they are the same ki
   and YugabyteDB both captured their schemas under the same least-privilege role, and granting that
   role the internal schemas changed nothing. The agent is therefore unusable on a stock TimescaleDB,
   and the same shape will appear on any PostgreSQL carrying a catalog-heavy extension.
-- **B53** — ten sites in these docs and in `src/lib/agent/` say the composed grounding path leaves
-  "the other **nine** engines" to their providers. Nine was 11 type-ids minus PostgreSQL and SQLite;
-  the factory now builds fourteen. The replacement is not obvious: the thirteen external engines give
-  eleven, while the original basis - every type-id, embedded `libredb` included - gives twelve, and
-  no site says which it counts. B49 complicates the choice, since a `libredb` connection cannot be
-  grounded at all. Recorded in `docs/BACKLOG.md` rather than patched to a digit nobody has decided.
 
 ## Related documentation
 

--- a/docs/AGENT_DATA_FLOW.md
+++ b/docs/AGENT_DATA_FLOW.md
@@ -44,7 +44,7 @@ if it only lists the good news.
 | Surface | What it sends | Fenced? |
 | --- | --- | --- |
 | `POST /api/agent/classify`, **before any run exists** | Your objective, and nothing else. One short completion that asks the model to name one of the five workflows. It fires when you press **Start** with the workflow left on **Automatic**, which is the default; naming a workflow yourself under **Advanced** skips it entirely. See [the classification, before any run](#the-classification-before-any-run) | No — it carries no database content to fence. Your objective is sent as the user message, and the server's instructions tell the model to treat that text as data to classify and never as instructions to it |
-| Any **run**, in either mode, on **any** engine | Your objective, and a schema inventory (table, column, index identifiers and column types) with its relations graph (identifiers only). **Since #414 that inventory leaves on every engine**, where before it left on PostgreSQL and SQLite alone: those two are read with catalog statements the server composes, and the other nine by asking the connection's own provider to describe its schema. On **MongoDB and Couchbase** the provider works out a collection's fields from a **sample of your own documents** — no value from them is in the message, but the **existence** of a field there is derived from your data rather than read from a catalog, which is a weaker claim than the other nine engines' and is why that reading has its own operation id (`db.schema.read`) an operator can deny alone. When the reading cannot be taken — a refusal, a provider that cannot describe its own schema, a description that overran the time the run granted it — nothing of the schema leaves and a server sentence saying which of those happened goes in its place. See [the schema inventory](#3-the-schema-inventory--identifiers-and-types-fenced) | Everything derived from the database is wrapped in an untrusted-content fence before it reaches a prompt |
+| Any **run**, in either mode, on **any** engine | Your objective, and a schema inventory (table, column, index identifiers and column types) with its relations graph (identifiers only). **Since #414 that inventory leaves on every engine**, where before it left on PostgreSQL and SQLite alone: those two are read with catalog statements the server composes, and the other twelve by asking the connection's own provider to describe its schema. On **MongoDB and Couchbase** the provider works out a collection's fields from a **sample of your own documents** — no value from them is in the message, but the **existence** of a field there is derived from your data rather than read from a catalog, which is a weaker claim than a catalog reading's and is why that reading has its own operation id (`db.schema.read`) an operator can deny alone. When the reading cannot be taken — a refusal, a provider that cannot describe its own schema, a description that overran the time the run granted it — nothing of the schema leaves and a server sentence saying which of those happened goes in its place. See [the schema inventory](#3-the-schema-inventory--identifiers-and-types-fenced) | Everything derived from the database is wrapped in an untrusted-content fence before it reaches a prompt |
 | An **agent run** | The above, plus the rows of each read the model performed, up to 200 per read; engine error text; server-written refusals; server-minted ids | Same fence |
 | An **agent run opened as Operate** | Your objective; a **schema inventory reduced to its own names and index names** (no column names, no column types, no relations graph), read whichever of the two ways that engine is read and named with whichever noun that engine's provider declares — tables, collections, datasources, key patterns; in Plan mode the engine's **row-count estimates** for those same tables where the engine holds any — PostgreSQL and SQLite — and nothing per column; and the rows of each curated reading — which, for the `sessions` and `slow-queries` kinds, include **other database users' in-flight statement text and their database usernames**. See [the operations workflow](#5a-the-operations-workflow-what-a-curated-reading-sends) | Same fence: the inventory and every reading's rows are database content and are fenced |
 | `POST /api/ai/explain` | Your statement, the EXPLAIN plan, the schema context the browser holds, the engine type | No |
@@ -225,9 +225,17 @@ cannot be taken at all — a provider that cannot describe itself, a description
 a refusal — nothing of the schema leaves and a server-written note says so in its place.
 
 **Two readings produce it, and which one runs is the dialect's decision** (#414). On PostgreSQL and
-SQLite the server composes a catalog statement per kind and executes it read-only. On the other nine
-engines it invokes `db.schema.read`, which calls the connection's own `provider.getSchema()` — the
-inspection the sidebar performs when it lists your tables — and composes no statement at all. What
+SQLite the server composes a catalog statement per kind and executes it read-only. On the other
+twelve it invokes `db.schema.read`, which calls the connection's own `provider.getSchema()` — the
+inspection the sidebar performs when it lists your tables — and composes no statement at all.
+**Twelve counts type-ids the factory can build, not engines a user would name**: `SHIPPED` holds
+fourteen, `CATALOG_PLANS` serves two of them, and the remainder is what this second reading covers.
+Every other "twelve" said about grounding in these docs counts the same thing. Two things it does
+NOT count. The wire-compatible engines of
+[`docs/providers/README.md`](./providers/README.md) are not extra members — TiDB is grounded because it
+arrives as `mysql`, and it is that type-id that is counted. And one of the twelve, the embedded
+`libredb`, is reached by this path but cannot complete it: the file takes an exclusive lock, so the
+grounding provider never connects and the run is honestly ungrounded (`docs/BACKLOG.md` B49). What
 leaves this process is the same KIND of thing either way, identifiers and types and nothing else, but
 two properties differ and are stated here rather than left to be discovered:
 
@@ -483,7 +491,7 @@ The frozen execution policies are the ceiling on one run's egress, one row per w
 | Bound | Value | What it caps |
 | --- | --- | --- |
 | `maxResultRows` / `maxResultBytes` | 200 rows / 256 KiB | The most one read can return — and therefore the most one tool result can send |
-| `maxStatementsPerRun` | 18-45, by workflow | Reads per drive, grounding reads and repairs included — the composed catalog reads and, since #414, the one `db.schema.read` call that replaces them on the other nine engines. The figures did not move for it: that path is the cheapest of the three, so nothing had to be bought (`docs/AGENT.md`, the budget arithmetic) |
+| `maxStatementsPerRun` | 18-45, by workflow | Reads per drive, grounding reads and repairs included — the composed catalog reads and, since #414, the one `db.schema.read` call that replaces them on the other twelve. The figures did not move for it: that path is the cheapest of the three, so nothing had to be bought (`docs/AGENT.md`, the budget arithmetic) |
 | `AGENT_CONTEXT_PACK_MAX_CHARS` | 6000 | The fenced schema inventory |
 | `MAX_ER_CHARS` | 2000 | The fenced relations block |
 | `AGENT_MAX_OBJECTIVE_LENGTH` | 4000 | Your objective |

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -799,7 +799,7 @@ Stated plainly, because a surface that hides its edges is the one that surprises
   (`src/lib/db/providers/embedded/libredb.ts`) — the bundled **SQLite sample** is the seeded
   connection to try a run against (`src/lib/seed/sqlite-sample.ts:131`). **Plan** mode still opens on
   every connection — the model is toolless there, so no profile has to be acquired for it — and since
-  #414 its **grounding** no longer takes this path at all on the other nine: it asks the provider to
+  #414 its **grounding** no longer takes this path at all on the other twelve: it asks the provider to
   describe its schema, which needs no read-only statement profile, so a Plan run on MongoDB or MySQL
   is ordinarily grounded while an Agent run on the same connection still cannot read anything. Where
   the reading does fail — a provider that cannot describe itself, a description that overran its

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2519,7 +2519,7 @@ ungrounded with the reason, exactly as the provider path now does, with a test p
 A plan run on the seeded `Demo (LibreDB)` connection (`data/demo.libredb`, type `libredb`) is
 ungrounded on every attempt: it writes no `context-captured` event at all and answers with the
 refusal it is instructed to give — "this run was given no inventory of this database". The provider
-path reaches this engine like the other eight, so the reading is attempted; it simply cannot open the
+path reaches this engine like the other eleven, so the reading is attempted; it simply cannot open the
 file.
 
 Measured on 2026-08-17, against `@libredb/libredb` 0.2.2 and a copy of the seeded file:
@@ -2775,29 +2775,3 @@ parses.
 Done when a plan run against a stock TimescaleDB reports a captured schema naming the user's tables,
 and this entry is deleted.
 
-### B53. The agent docs say "the other nine engines", and the right replacement is not the obvious one
-
-Since #414 the grounding capture has two paths: PostgreSQL and SQLite are read with catalog
-statements the server composes, and every other engine by asking its provider to describe itself.
-Ten sites state the second set's size as **nine**: `docs/AGENT.md` (4), `docs/AGENT_DATA_FLOW.md`
-(3), `src/lib/agent/investigation.ts` (2) and `src/lib/agent/schema-stats.ts` (1), with matching
-wording in `tests/unit/lib/agent/context-snapshot.test.ts` and
-`tests/isolated/agent-investigation.test.ts`.
-
-Nine was right when the factory built eleven type-ids: 11 - 2 = 9. It now builds fourteen, so the
-number is stale.
-
-**The trap is which number replaces it.** Counting the thirteen EXTERNAL engines gives 13 - 2 = 11.
-Counting every type-id the factory can build, which is what the original nine did, gives
-14 - 2 = 12. The two differ by the embedded `libredb`, and the sentences never say which basis they
-use - that is the whole defect, not just the digit. A reviewer already proposed eleven on the
-external reading; twelve is what preserves the original meaning.
-
-Deciding it needs one more judgement: B49 records that a `libredb` connection can never be grounded
-at all, because `lib.open()` holds an exclusive file lock. So "the other twelve engines" is
-arithmetically faithful but describes a path one of the twelve cannot actually complete, while
-"eleven" silently redefines the set. Whichever is chosen, each site should name its basis rather
-than leave a bare numeral - the same claim discipline #424 applies to published engine counts.
-
-Done when every site above states a number and what it counts, the two test files agree, and this
-entry is deleted.

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -432,7 +432,7 @@ const planningOperationsContextNote = (noun: AgentInventoryNoun): string =>
  * A NEWLINE joins the diagnosis to the advice, and it is load-bearing rather than
  * formatting. `fenceUntrustedContent` ends with its terminator marker and no trailing
  * newline, so a `detail` that is a fenced database error — an ordinary outcome on the
- * nine engines #414 grounds through their providers — would otherwise continue the
+ * twelve type-ids #414 grounds through their providers — would otherwise continue the
  * terminator line with this server's own prose. The whole point of the marker is to be
  * a line the model can see the untrusted content end at; a sentence sharing that line
  * is a sentence inside the boundary the fence exists to draw.
@@ -666,7 +666,7 @@ interface PlanningGrounding {
  *
  * FOUR sentences since #414, over the same two axes as `PLANNING_SNAPSHOT_PREFACE`,
  * and this record was left one-dimensional when that one was made 2x2 — which put the
- * two halves of one conversation in direct contradiction on nine engines. The rules
+ * two halves of one conversation in direct contradiction on twelve of the fourteen
  * said the inventory came "through the same read-only catalog path the agent mode
  * uses" and the message under them said it came from the engine's own inspection.
  * Both halves of the first were false there: no catalog statement is composed on a

--- a/src/lib/agent/schema-stats.ts
+++ b/src/lib/agent/schema-stats.ts
@@ -50,7 +50,7 @@ export type AgentStatisticsUnavailableCode =
   /**
    * No verified statistics composition for this engine. The run has no size estimates
    * here; it may still be grounded in a schema — since #414 that is the ORDINARY case
-   * on the nine engines whose inventory comes from their own provider, where
+   * on the twelve type-ids whose inventory comes from their own provider, where
    * `schemaKnown` is true and `statisticsShown` is false.
    */
   | "DIALECT_HAS_NO_STATISTICS"

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -1278,7 +1278,7 @@ describe("planning mode runs no statement of the user's", () => {
 
     /*
       #414. A dialect with no catalog plan is no longer refused on the dialect: it asks
-      its PROVIDER for the same inventory, and on nine engines it gets one. Everything
+      its PROVIDER for the same inventory, and on twelve type-ids it gets one. Everything
       the run is then TOLD has to change with it, because four separate sentences were
       written for the composed path and are false on this one — how the reading was
       taken, what language to answer in, what an empty relations block means, and what
@@ -4105,7 +4105,7 @@ describe("a presentation the model serialized reaches the tool through the SDK",
   #414's own bound, and the one invariant whose whole point is that this change did NOT
   widen agent mode.
 
-  Grounding reached the nine engines the read-only profile refuses, because the schema
+  Grounding reached the twelve type-ids the read-only profile refuses, because the schema
   capture asks for `agent-operations` — a profile whose acquisition does not require
   `queryReadOnly`. Agent mode's TOOLS are unchanged: `inspect_schema` and
   `run_read_query` compose SQL and acquire `agent-read-only`, which those engines cannot

--- a/tests/unit/lib/agent/context-snapshot.test.ts
+++ b/tests/unit/lib/agent/context-snapshot.test.ts
@@ -713,7 +713,7 @@ describe("captureContextSnapshot — the provider's own inventory", () => {
     grounding rather than the run.
 
     Plan mode's promise is that it opens and answers on every connection, and on these
-    nine engines it did — because it reached no database at all. Letting an unreachable
+    twelve type-ids it did — because it reached no database at all. Letting an unreachable
     host or a half-configured `agentUser` out of the capture would lose a plan run to an
     improvement, and on the profile error it would lose it under "the agent cannot run on
     this database engine", said about an engine plan mode demonstrably works on.


### PR DESCRIPTION
Closes B53 in `docs/BACKLOG.md`. Part of #424.

## What was wrong

Fifteen sites said the composed grounding path leaves **"the other nine engines"** to their providers. Nine was `11 type-ids - 2` when #414 shipped; `SHIPPED` now holds fourteen. Every one of them was stale.

## Why it was filed rather than patched

Two replacements were defensible and nothing in the prose chose between them:

| Basis | Count |
|---|---|
| the thirteen EXTERNAL engines, minus PostgreSQL and SQLite | eleven |
| every type-id the factory can build, minus the same two | twelve |

They differ by the embedded `libredb`. **No site said which one it was counting** — so a reader could not check the number, and it would go stale again on the next engine. That ambiguity was the defect; the digit was the smaller half of it.

Twelve is what the original nine counted, so it preserves the sentences' meaning. Eleven would have silently redefined the set while looking like a correction.

## What changed

`docs/AGENT_DATA_FLOW.md` states the basis once, where the two-path split is defined; every other site counts the same thing:

- twelve counts **type-ids the factory can build**, not engines a user would name;
- the wire-compatible engines are **not extra members** — TiDB is grounded because it arrives as `mysql`, and it is that type-id that is counted;
- one of the twelve, the embedded `libredb`, **is reached by this path and cannot complete it**: the file takes an exclusive lock, the grounding provider never connects, and the run is honestly ungrounded (B49).

That last point is exactly why the numeral alone was not good enough. Twelve is arithmetically faithful and describes a path one of its members cannot finish, so the sentence has to say so.

Also corrects **B49's own stale numeral** — it described a LibreDB connection as reached "like the other eight" — and deletes B53.

## Verification

Sites: `docs/AGENT.md` (4), `docs/AGENT_DATA_FLOW.md` (4), `docs/AGENT_GUIDE.md` (1), `src/lib/agent/investigation.ts` (2), `src/lib/agent/schema-stats.ts` (1), two test comments (3), `docs/BACKLOG.md` (1). A repo-wide grep for `other nine` / `nine engines` / `nine other` now returns nothing.

Twelve was measured, not assumed: `SHIPPED` holds fourteen keys and `CATALOG_PLANS` holds two (`postgres`, `sqlite`). `AGENT_EXECUTION_ENGINES` confirms the read-only profile is refused on exactly the other twelve — `queryReadOnly` exists on two providers.

**No executable line changes**: every site is prose or a comment, so coverage is untouched.

All six local gates pass: `format`, `lint` (0 errors), `typecheck`, `knip`, `test` (all 30 groups), `build`. `tests/unit/agent-documentation.test.ts` — the guard that every `B<n>` in the backlog is cited in `docs/AGENT.md` — passes with both the entry and its citation removed together.
