### PR TITLE
feat(agent): answer first, one hand-off, and a standing claim about what the mode executes

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1784,7 +1784,7 @@ model passed the capability probe**; for anybody else the answer is that there i
 | --- | --- | --- |
 | **Any AI at all, for an EMBEDDED user** — one working panel and one exported component, which is less than "both tabs worked". The embedded shell rendered both TABS regardless of `features.ai`, and only Autopilot was behind them: `AIAutopilotPanel` had no feature gate, so a libredb-platform user had a fully working Autopilot panel posting to `/api/db/monitoring` and `/api/ai/autopilot` on the HOST's origin. The NL2SQL tab rendered an EMPTY PANE under the default `features.ai: false` — the shell passed `isOpen={features.ai ? isNL2SQLOpen : false}` and the panel returns `null` when it is not open — so what an embedded host lost there is `NL2SQLPanel` itself, exported from `@libredb/studio/components` for a host to mount on its own, plus the tab for a host that had switched `features.ai` on. | Nothing. The rail lives in the standalone shell only; the package carries no agent surface, `WorkspaceFeatures` deliberately gained no agent field, and no package entry point transitively imports `src/lib/agent`. For an embedded user every "what a run does instead" cell below is false, because there is no run. | The removal itself (`5bbea51`, which deletes the export, both render arms and the flag), read against the code it deleted: `git show 5bbea51^:src/workspace/StudioWorkspace.tsx` (the two `features.ai ?` props), `git show 5bbea51^:src/components/NL2SQLPanel.tsx` (`if (!isOpen) return null`), `git show 5bbea51^:src/workspace/types.ts` (`DEFAULT_WORKSPACE_FEATURES.ai: false`); `tests/unit/agent-package-boundary.test.ts`; [The surface in the app](#the-surface-in-the-app). |
 | **A TOOLLESS model drove both panels.** Each posted a prompt and rendered what came back, so any configured model produced an answer — including one that cannot call a tool, which is what a small local `ollama` model usually is. | An agent run is refused before it opens: the start path probes the model, and an established incapability is a `422` naming what could not be established. What such a model can still drive is planning mode, which is toolless by contract: the model there is handed no tool, runs no statement of the user's, writes nothing, and drafts a statement for the user to run themselves. | `src/lib/agent/capability-gate.ts`; `tests/isolated/agent-capability-gate.test.ts`; [What a refused model looks like in the app](#what-a-refused-model-looks-like-in-the-app). |
-| **One click that RAN the model's SQL.** NL2SQL's Run and Autopilot's Execute pushed model-authored SQL — including DDL — straight into the studio's execution path. | The rail hands a statement to the **editor** and never runs it: an explicit "Apply to editor" on a drafted statement, a recommendation, or a plan run's drafted statement. Nothing in the runtime executes a proposed statement. A plan run's statement is offered through its own card rather than the shared control, because that card is also what marks a statement the guard did not classify as read-only and names the tables the inventory does not hold — the marking and the offer have to arrive together. | `src/components/agent/timeline.ts` — the `statement-drafted` and `recommendation` entries carry `applySql`, and `plan-statement-drafted` deliberately does not; `src/components/agent/AgentRail.tsx` — the plan statement card; `tests/evals/query-optimization.test.ts` — the recommendation is recorded and no `CREATE INDEX` reaches the database. |
+| **One click that RAN the model's SQL.** NL2SQL's Run and Autopilot's Execute pushed model-authored SQL — including DDL — straight into the studio's execution path. | The rail hands a statement to the **editor** and never runs it: an explicit "Apply to editor" on a drafted statement, a recommendation, or a plan run's drafted statement. Nothing in the runtime executes a proposed statement. A plan run's statement is offered through the answer card rather than the shared control, because that card is also what marks a statement the guard did not classify as read-only and names what the inventory does not hold, in the engine's own noun — the marking and the offer have to arrive together, and since the 2026-08-21 redesign that offer exists in exactly one place. | `src/components/agent/timeline.ts` — the `statement-drafted` and `recommendation` entries carry `applySql`, and `plan-statement-drafted` deliberately does not; `src/components/agent/AnswerCard.tsx` — the marked hand-off, and `AgentRail.tsx` withholding every other one; `tests/evals/query-optimization.test.ts` — the recommendation is recorded and no `CREATE INDEX` reaches the database. |
 | **Proposed a statement the run never sent.** NL2SQL's product was a statement, whatever the model wrote. | Only `recommend_change` proposes an unexecuted statement; it accepts `index` or `rewrite`, the statement must match the card it is filed under, and it belongs to the `query-optimization` workflow. An investigation — what a plain-English question opens — cannot propose anything. | `src/lib/agent/tools.ts` (`recommendationSchema`, `matchesCard`, `QUERY_OPTIMIZATION_TOOLS`); `tests/evals/legacy-surface-coverage.test.ts`. |
 | **Read live monitoring.** Autopilot's whole input came from `/api/db/monitoring`: slow queries, index usage, table statistics, cache and connection metrics. | **Restored, and bounded.** `inspect_operations` reads the same provider methods under the `db.operations.read` descriptor, and it reaches ONE workflow: a run opened to Operate. An investigation or an assessment is still offered nothing that reads monitoring, so "the agent can read monitoring" is only true of that workflow. The two deferrals that tracked this — the monitoring half of the M2 tooling entry, and the assessment's missing monitor snapshot — are closed and removed from the backlog. | `src/lib/agent/tools.ts`; `tests/evals/legacy-surface-coverage.test.ts` — the members and the operations they may name are asserted as a set, so a monitoring member under ANY name has to land there; `tests/evals/operations.test.ts` — the arc, on an engine that answers no statement. |
 | **A free-form markdown report**, opening with a performance score out of 100 and closing with configuration advice. | A report is claims, each citing an artifact this run read or the snapshot it captured, verified against the run's own ledger before it is recorded. A number cited to nothing cannot be reported — the citation is what is checked, never the claim's text, so a fabricated score citing a real artifact would be accepted. | `src/lib/agent/tools.ts` (`composeReportTool`); `tests/evals/legacy-surface-coverage.test.ts` — an invented correlation id is refused and the run ends `unanswered (no-report)`. |
@@ -1855,14 +1855,161 @@ mobile layout. Visibility is discovered at runtime from `GET /api/agent/config`:
 unavailable nothing renders and no further agent request is made. The hook reads `body.enabled ===
 true` and nothing else — a refusal, an unreachable server, a body of another shape and the richer
 `{enabled: false, reason, detail}` body all resolve to absent. The rail is imported statically, like
-every other component in this repository, so the six client modules under `src/components/agent/` and
+every other component in this repository, so every client module under `src/components/agent/` and
 `src/hooks/use-agent-capability.ts` — plus `execution-policy.ts`, whose ceilings the meter reads as
 values — are in the standalone bundle either way; what availability governs is what renders and what
 runs, not what was bundled.
 
-The rail shows the run's semantic timeline, a stop control, evidence citations, and a budget meter.
-What each of those says to a user, in the words it actually renders, is
-[`docs/AGENT_GUIDE.md`](./AGENT_GUIDE.md). Two rules govern it:
+The rail shows, from the top down: a **safety strip** stating what the open run executes — or, before
+one, what the selected mode would — the
+objective, the start controls, a folded **Run details** holding the budget meter, and a scroll area
+whose first block is the run's **answer** — the drafted statement or the report with its evidence
+citations — and whose remainder is the semantic timeline. There is no second report section under the
+transcript: the card is the answer. What each of those says to a user, in the words it actually
+renders, is [`docs/AGENT_GUIDE.md`](./AGENT_GUIDE.md).
+
+**The safety strip is one module's reading, in four levels** (`src/lib/agent/posture.ts`, rendered by
+`src/components/agent/SafetyStrip.tsx`). Each level is a pill and a qualifier on one line, and both
+halves are the posture's: the strip owns the palette and the popover and writes no sentence of its
+own.
+
+| Level | The pill says | The qualifier beside it | When |
+| --- | --- | --- | --- |
+| `safe` | *Executes nothing it drafts* | *one schema read grounds it, nothing else reaches the database* | Plan mode, on every engine, with or without the hand-over |
+| `reads` | *Reads only* | the policy row's own per-statement row cap and timeout, *enforced by the engine* | Agent mode on an engine in `AGENT_EXECUTION_ENGINES`, hand-over not ticked |
+| `widened` | *Reads only, and one statement in your editor* | `AGENT_HANDOVER_BUDGET`'s row cap, *no time limit, same read-only session* | The same, with the hand-over consented for the run being opened |
+| `blocked` | *Cannot execute on `<engine>`* | *plan mode drafts here, and the operations workflow still runs* | Agent mode on any other engine |
+| `blocked` | *Cannot execute yet* | *no connection is resolved, so no engine has been established* | Agent mode with no connection resolved |
+
+Four levels and five readings: `blocked` covers both arms that execute nothing and have no bound to
+state, and they stay separate arms because "has no read-only statement path" is a claim about an
+engine, which a panel that has resolved no connection has not seen. Not one engine name and not one
+figure is typed in the module — the names come from `AGENT_EXECUTION_ENGINES` through
+`getDBConfig().label` and the figures from the policy rows, which is the rule `hero-proof.tsx`
+follows and #425 is the record of what typing them costs. `blocked` also takes no hue of its own
+(`fg-muted`): nothing executes and there is nothing to widen, so it is a dead end rather than a
+hazard, and the amber pre-start card below — which renders for an unsupported engine and not for an
+unresolved connection (`engineUnsupported`, `AgentRail.tsx`) — is where that reading is alerted.
+
+**The qualifier is visible, and that is a claim rather than a layout choice.** A bare "executes
+nothing" overclaims: on the dialects `CATALOG_PLANS` serves (`src/lib/agent/context-snapshot.ts`)
+plan mode's grounding capture IS a catalog read, and `engine-support.ts` says in its own header that
+copy compressing these facts overclaims. So both halves sit on the same line, the row wraps rather
+than truncating — a qualifier cut off mid-clause is the same overclaim with an ellipsis on it — and
+the ⓘ carries the whole claim rather than the missing half. That claim node is rendered whether or
+not the popover is open (`sr-only` while shut, and the strip's `aria-describedby` target either way),
+so the ⓘ is never the only route to it.
+
+Both `blocked` readings are presentation of a refusal the provider factory already decides, and they
+gate nothing — **Start** stays live, because the `operations` workflow sends no statement and runs on
+every engine. What the strip does not do is make the offered-then-withdrawn run impossible: an agent
+run started there still spends a model turn before it ends `engine-unsupported`, which is what is
+left of B38.
+
+**One module, two questions, because with a run open they stop having the same answer.** The strip
+says what the OPEN run does, and both of its axes come off that run (`describedMode` and
+`handoverConsented`, `AgentRail.tsx`): the mode from `AgentRunTimeline.mode`, which
+`foldLedgerEntries` reads off the run's header or off `run-started`, and the hand-over from what the
+open request carried (`openedWithHandover`). Neither may come from the control beside it, and each
+fails differently if it does. The mode toggle is frozen only while a start is HELD — deliberately,
+because it decides the next run — so it is live again the moment this one opens, and reading it there
+let one click on **Plan** restate a running agent run as *Executes nothing it drafts*.
+`openedWithHandover` is a record and is never cleared, so it is gated on the run still being open, or
+the strip goes on promising *one statement in your editor* after the widened run has ended while the
+next consent step defaults the tick to OFF. The same reading writes the workflow-and-mode line under
+the objective, so the panel's two descriptions of one run cannot disagree.
+
+The amber engine notice asks the other question — what pressing Start would do — and takes the
+SELECTION (`selectionPosture`): the toggle's mode, and the hand-over tick only where a consent step is
+actually standing. The notice renders *on* the selected mode and offers the way out of that selection,
+so the run's reading there would put plan mode's body inside a card whose whole subject is the engine
+agent mode cannot execute on. The two readings coincide whenever no run is open, which is most of the
+panel's life; they differ in the one state where a box and a run both exist, an objective being edited
+beside a run that is still going.
+
+A muted line under **Start** used to ask that question in words, and it is gone: it printed the
+strip's own headline and qualifier joined, about 200 pixels below the strip (L7, measured 2026-08-21),
+so one 384-pixel panel carried the same sentence twice. The strip is permanent and states it for the
+selected mode already. The login hero's claim — *plan mode drafts one statement, runs nothing* /
+*agent mode runs read-only on \<engines\>* — was the considered alternative and was not taken: it
+describes both modes at once, for a visitor who has selected neither.
+
+The strip exists because the rail answered this question in six places at once — a mode description, a
+consent paragraph, a budget note, a guard line, a refusal and a claim under the answer — and a user
+comparing two of them could not tell which one bounded the run.
+
+Three rules govern the layout, beyond the two below. The **answer card is a second rendering of
+entries the ledger already holds** — no field on it is one a run did not record. It has one state per
+ending the ledger can reach and no state that is not one of them: a plan run's drafted statement with
+what the guard made of it (`agent-answer-plan`), an agent run's quoted claim with its citations
+(`agent-answer-report`), the step a live run is on with its spend (`agent-answer-running`), a plan run
+that drafted nothing (`agent-answer-refused`) and a run that failed having produced nothing
+(`agent-answer-failed`). Which of them it is, is decided by the run's **product and not by its
+status**, in the one exported reading `answerCardState` — a run can end `failed` holding a drafted
+statement or a composed report, because `conclude()` records both before `service.finish()` and is
+called with `failed` for a model timeout, an exhausted deadline and the turn ceiling. The ending is
+then stated beside the product, so `agent-answer-failed` is the whole card only on a run that
+produced nothing. The transcript withholds its copies from that same reading rather than from the
+ledger: the rail asks the card what it is rendering, so a suppression cannot outlive what it
+de-duplicates. The
+**`Apply to editor` control for a run's own statement exists exactly once**, in that card, carrying the
+accessible name `applyStatementName` builds; the transcript entry it duplicates keeps its headline,
+its timestamp and a one-line guard summary and reprints neither the statement nor the guard's
+paragraph, because an unmarked control against the statement is the silent hand-off the marking exists to
+prevent.
+
+**What that suppression covers was settled by driving the built rail, not by reading it** (the four
+runs of 2026-08-21, against live PostgreSQL, live MongoDB and live Gemini). Four things it did not
+cover, each measured:
+
+- the whole report was rendered **twice** — the card and a surviving `agent-report` section at the
+  foot of the scroll area — so the model's claim printed twice and the report path offered *three*
+  `Apply to editor` controls for one statement, none of them named. That section is gone: its claims
+  are the card's, and its citations are the card's `Evidence` fold, label, the ledger's own detail and
+  the statement each rests on. Its `Show result` was itself a second offer of the artifact the
+  `Result stored` entry offers under the same live-run rule;
+- an agent run records **every statement it executes** (`statement-drafted`) and the answer's `sql` is
+  the statement of the step whose artifact it presents — so the same text reached the ledger twice.
+  The transcript therefore withholds a hand-off for the statement the card is handing over **by text**
+  and not by entry id, which is what keeps it a de-duplication: a read the run took along the way
+  whose statement is not the answer's keeps its own control;
+- the closing prose **holds** the fenced statement, so every surface rendering that prose reprinted
+  it — in the card's own `Why this statement` and again in the transcript entry. `renderProse`'s
+  `cardedStatement` suppresses that one block where the statement is displayed beside it, the same
+  shape as the per-block control's own suppression. Nothing is edited: every other fence renders, and
+  `Copy all` takes the string the model wrote rather than this rendering of it;
+- and the guard's reading was stated **three times** inside ~400px, twice at length. The entry whose
+  statement the card holds now drops its `detail` paragraph and keeps the one-line summary; the full
+  text is where it already was, in the card's ⓘ under its own test ids.
+
+**Two more the same drive measured, neither of them a duplication.** The card's grounding chips —
+`${n} ${noun.plural} read` and the schema fingerprint — are read off the run's **capture** and not off
+the guard's reading, so they are stated on every engine. They had been a second prop beside the
+timeline, and a claim a caller can forget to pass is a claim that disappears: on MongoDB the answer
+carried the amber `not checked` chip **alone**, while the chrome fold two lines below it said *Schema
+captured — 5 collections* (L4). That is backwards where it costs most — where nothing examined the
+draft, the inventory it was drafted against is the only grounding claim left. And a citation chip
+names its evidence at **chip length**: a correlation id is a UUID, so `Artifact
+722b2a10-e3f2-4b9c-8177-367359a21500` filled a 384-pixel chip and left no room for what the ledger
+knows about that read (L8). `AgentEvidenceCitation` therefore carries `shortLabel` beside `label` —
+the identifier cut to the eight characters the schema-snapshot label was already written at, both
+spelled by one author in `citationOf` — and the chip prints that plus the ledger's own `detail`, while
+the whole identifier stays in the `Evidence` fold. `detail` is what states, in text and not in amber
+alone (WCAG 1.4.1), whether the rail resolved the citation at all; the two readings keep separate test
+ids, because a shared one would pass on either sentence.
+
+**The answer is followed, not the newest entry.** The scroller follows the newest entry while the run
+is live and brings the answer into view — once — when the run reaches a terminal status, because the
+newest entry at that moment is `run-finished` while the thing the user waited for is at the top: both
+paths were measured landing at their own scroll maximum with the card entirely above the fold. A
+reader who scrolled away is left where they are in both regimes. The card stays inside the scroller
+deliberately — lifted out, a long report would take a fixed share of a 384-pixel panel away from the
+transcript. And the **budget meter is folded**: the gauges (`agent-budget`) and all three of its claims —
+`agent-budget-limits`, `agent-budget-reserve`, `agent-budget-caveats` — live inside
+`agent-run-details`, open by default only while the run is live, with each claim behind an ⓘ on the
+figure it qualifies and still in the accessibility tree whether or not that popover is open.
+
+Two further rules govern it:
 
 - **A control the service cannot honour is not rendered at all.** There is no disabled-looking button
   standing in for a capability, which is why the rail stops a run but does not offer pause/resume
@@ -2073,8 +2220,10 @@ src/lib/agent/
 └── untrusted-content.ts  # the prompt-side fence for database content
 
 src/app/api/agent/        # the six route paths above
-src/components/agent/     # AgentRail.tsx, timeline.ts (event fold), hydration.ts,
-                          #   use-agent-run.ts, use-agent-artifact.ts
+src/components/agent/     # AgentRail.tsx, SafetyStrip.tsx, AnswerCard.tsx,
+                          #   ConsentCard.tsx, rail-parts.tsx (what the rail and the
+                          #   answer card both render), timeline.ts (event fold),
+                          #   hydration.ts, use-agent-run.ts, use-agent-artifact.ts
 src/hooks/                # use-agent-capability.ts (the flag probe; the rail's own hooks
                           #   sit beside it above)
 ```

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -401,14 +401,86 @@ report as unanswered.
 
 ## What you see while a run goes
 
+**Under the header, one line always says what reaches your database.** While a run is open that is
+the *run's* reading, taken from its own record; before one, and once one has ended, it is what
+pressing **Start** would do. It is five readings and not a mood, and the qualifier beside the pill is
+part of the claim rather than a footnote:
+
+| The pill says | Beside it | When |
+| --- | --- | --- |
+| *Executes nothing it drafts* | *one schema read grounds it, nothing else reaches the database* | **Plan** mode, on every engine — production included. The one reach is the schema capture that grounds the draft: metadata only, no data rows |
+| *Reads only* | *200 rows and 10 s per statement, enforced by the engine* | **Agent** mode on an engine whose provider implements a database-native read-only statement path |
+| *Reads only, and one statement in your editor* | *500 rows, no time limit, same read-only session* | The same, with **auto-execute** ticked for the run being opened — and it stays that reading while that run is going |
+| *Cannot execute on `<engine>`* | *plan mode drafts here, and the operations workflow still runs* | **Agent** mode on any other engine. The run would end `engine-unsupported` before its first statement |
+| *Cannot execute yet* | *no connection is resolved, so no engine has been established* | **Agent** mode with no connection resolved. Nothing has been read, so the panel does not claim to know which engine you are on |
+
+Those two figures are the ones the server is enforcing, and they are the same on every workflow — the
+strip is shown before a run has one, so it states the pair every workflow row shares rather than
+guessing at a row. The **500** is the editor's own limit, which is what auto-execute widens to.
+
+**While a run is open, both halves describe that run.** A run's mode is fixed when it opens and its
+own header says which one, so switching the toggle beside a run that is going decides what the *next*
+run will be and leaves this line where it is — it does not restate a running agent run as *Executes
+nothing it drafts*. Auto-execute is frozen the same way, to the run that was opened with it. Once the
+run has ended there is no run to describe, so the line answers what pressing **Start** would do again
+— and it stops saying *one statement in your editor*, because the next run's tick starts unticked.
+
+The ⓘ at the end of the row opens the whole claim behind whichever of those is showing, and that text
+is readable to a screen reader whether or not the popover is open. On *Cannot execute on `<engine>`*
+an amber card appears above **Start** with the same facts and a **Switch to Plan** button — **and
+Start is not disabled**, because the refusal belongs to the provider factory and the **Operate**
+workflow sends no statement at all, so it runs on those engines exactly as it does anywhere else. Any
+other workflow started there anyway still ends `engine-unsupported` — after a model turn, and before
+its first statement. The strip tells you first; it does not stand in the way.
+
+**While a run is open the objective is a line rather than a box.** The question is settled — it is on
+the run's own header, and every entry below was framed with it — so it reads as one line with the
+run's own workflow and mode under it and an **Edit** control beside it. A screen reader announces that
+line as *the objective this run was opened with*, which is the label the box carried. Edit puts that
+same question back in the
+box, which is where refining it starts; pressing **Start** then opens a *new* run with whatever you
+made of it. When the run ends, the box comes back on its own.
+
+**The run's outcome is the first thing in the scroll area, above the transcript.** It is a second
+rendering of entries the timeline already holds, so there is nothing on it a run did not record: in
+Plan mode the drafted statement with what the guard made of it, in Agent mode the model's own quoted
+claim with the citations it rests on, while the run goes the step it is on and what it has spent, and
+on the two endings that are not answers — a refusal, a failure — the run's own words for it. What the
+run PRODUCED is what the block shows, not how the run ended: a run can reach its time or step limit
+just after drafting a statement, and the statement, the guard's reading and the one **Apply to
+editor** are all still there, with `Run failed` and the reason stated under them. It
+scrolls away with everything else rather than being pinned, because a fixed block would take a third
+of the panel from the transcript underneath it.
+
+**What the answer rests on is stated on every engine.** Under a drafted statement, two of the chips
+are the run's grounding rather than a verdict on the draft: how many rows the inventory held, in the
+engine's own noun — *5 collections read* — and the first 8 characters of that snapshot's fingerprint,
+the same pair the `Schema captured` entry carries. They come from the capture and so they are there
+whatever the guard could make of the statement. That matters most where the guard could make nothing
+of it: on an engine whose statements are not SQL the only other chip is the amber *not checked*, and
+the inventory the statement was drafted against is then the only grounding claim left on the card.
+
+**What a run cost is folded away; its answer is not.** `Run details` is the one fold between the Start
+row and everything that scrolls, and it is shut unless a run is live — its summary still carries the
+figures that move, so how far in a run is takes nothing to read. See
+[The budget meter's numbers](#the-budget-meters-numbers) for what is inside it. The answer is the part
+that is open, because it is what you asked for; the spend is what it took to get there.
+
 The rail's timeline is a fold over the run's ledger, one line per recorded event
 (`foldLedgerEntries`, `timeline.ts:1018-1189`). Before anything has happened it says *"No activity
 yet. A run's steps appear here as they are recorded."*
 
+**The three entries that only say a run began are folded** — `Run opened`, `Run started` and
+`Schema captured` collapse into one dim *Run setup* line that expands to all three, rendered in full,
+your quoted objective included. On a Plan run that is three of five lines, and the two that matter
+were starting below the fold. That summary line counts entries, and a counter is not progress, so it
+is excluded from what a screen reader is told as the run goes: the entries below it are announced as
+they arrive, exactly as before.
+
 | Headline | When |
 | --- | --- |
-| `Run opened in <mode> mode for <workflow>` | The run's own header. Your objective is shown quoted underneath. |
-| `Schema captured` | The run read the catalog once: table count and the first 8 characters of the snapshot fingerprint |
+| `Run opened in <mode> mode for <workflow>` | The run's own header. Your objective is shown quoted underneath. Folded under *Run setup* |
+| `Schema captured` | The run read the catalog once: how many rows the inventory held, in the engine's own noun — tables, collections, key patterns, datasources — and the first 8 characters of the snapshot fingerprint. Folded under *Run setup* |
 | `Statement drafted` | The model wrote SQL. The statement is shown quoted, with the model's stated reason |
 | `Tool invoked` / `Result stored` | The call, then its outcome: rows, columns, elapsed ms, and the artifact id |
 | `Refused by policy` | The operation layer denied it. Shown by deny code — there is no engine text, because a denial produced none |
@@ -419,8 +491,8 @@ yet. A run's steps appear here as they are recorded."*
 | `Result stored` … *"A moment, not a history"* | Operate only: an operational reading, with the caveat that it describes an instant already past |
 | `Answer composed` | The run named one stored result as its answer and said how to show it — as a table, or as a chart of a named type. A chart's caption is the model's own prose and is shown quoted; the columns never appear in the application's own sentence, because they are engine text |
 | `Report composed` | How many claims, each citing evidence |
-| `Closing statement` | The model's closing prose. It cites nothing and claims nothing — a Plan run's whole output, an Agent run's aside |
-| `Statement drafted` / `Statement drafted — not classified as a read` / `Statement drafted — not examined by the statement guard` | Plan mode: the one statement the run wrote, on its own card — the statement verbatim, any table it names that your schema does not have, and **Apply to editor**. The second headline is a statement the guard did not classify as read-only, and its reason is shown beside it: that can mean the statement writes, and it can equally mean the guard could not settle the text. The third is a draft on an engine whose statements are not SQL, where the guard is not a reader of that language and examined nothing — no reason is shown, because there was no objection to show. Nothing runs under any of the three |
+| `Closing statement` | The model's closing prose. It cites nothing and claims nothing — a Plan run's whole output, an Agent run's aside. On a Plan run that drafted a statement, this prose is the text that statement was read out of, so the block holding it is not printed here a second time: the statement is in the answer above, once. Every other word of the prose is there, and **Copy all** carries the whole thing, fence included |
+| `Statement drafted` / `Statement drafted — not classified as a read` / `Statement drafted — not examined by the statement guard` | Plan mode: the one statement the run wrote. **The statement itself, any name it uses that your schema does not have, and Apply to editor are in the answer at the top of the rail** — this entry keeps the headline, the timestamp and one line summarising what the guard made of it, and reprints neither the statement nor the guard's paragraph, so there is exactly one place the statement is offered to your editor and it is the one carrying the guard's marks. The second headline is a statement the guard did not classify as read-only, and its reason travels with it: that can mean the statement writes, and it can equally mean the guard could not settle the text. The third is a draft on an engine whose statements are not SQL, where the guard is not a reader of that language and examined nothing — no reason is shown, because there was no objection to show. Nothing runs under any of the three |
 | `No statement drafted` | A Plan run that could not answer from your schema, with what was missing. A legitimate ending, not a failure |
 | `Stop requested` | You pressed Stop; *"the run takes no further database step; work already in hand, such as a report, still finishes"* |
 
@@ -435,9 +507,15 @@ application stops speaking. Only those five forms are interpreted; links, tables
 stay the characters the model typed. Nothing on that path touches an HTML parser: it is built as
 React nodes, so a model that writes `<img src=x onerror=…>` has written text and nothing else.
 
-**The timeline stays at its newest entry** while you are at the bottom of it, so a run's report does
-not arrive below the fold. Scroll up to read an earlier step and it stops following — the next entry
-leaves you where you are — until you scroll back down.
+**The timeline stays at its newest entry while the run is going**, so a step does not arrive below the
+fold. Scroll up to read an earlier one and it stops following — the next entry leaves you where you
+are — until you scroll back down.
+
+**When the run ends, the answer is what you are left looking at.** The newest entry at that point is
+the run finishing, and the thing you waited for is at the top of the scroll area — so the rail brings
+it into view instead of holding the bottom of the transcript. It happens once, when the run reaches
+its ending, and not to a reader who had scrolled away: from there you are left where you are, in this
+regime as in the other.
 
 Two controls appear under an entry only when there is something to act on **and** the shell can act:
 
@@ -462,11 +540,17 @@ before, and while the run is live the entry's own **Show result** still brings t
 dismiss the panel. This is not the rail acting on your behalf in the sense the rule above forbids:
 nothing is executed, and the rows are ones the run already read on its own bounded read-only path.
 
-At the bottom, once a report exists, a **Report** section lists each claim as the model's own quoted
-prose with its citations under it — `Artifact <id>` with the row count and the statement that
-produced it, or `Schema snapshot <fingerprint>` with the table count. A citation the rail cannot
-resolve in what it has read says so in amber rather than looking checked
-(`UNRESOLVED_DETAIL`, `timeline.ts:967`).
+**A report is read in the answer at the top, and nowhere else.** Each claim is the model's own quoted
+prose; the chips under it name what it cites — the read's identifier at the length a chip can hold it,
+the model's own pointer into that evidence, and what the run's own record says that read returned, so
+a chip states its evidence rather than only naming it; and `Evidence` folds out each citation in full
+— `Artifact <id>`, with the whole identifier this time, the row count and the statement that produced
+it, or `Schema snapshot <fingerprint>` with the count in the engine's own noun. There is no second **Report**
+section at the foot of the rail: it rendered the same claims and the same citations again, which is
+how one statement came to be offered to your editor three times over. A citation the rail cannot
+resolve in what it has read says so rather than looking checked — in words and not only in amber, on
+the chip in the answer as well as in the evidence beneath it, because a gap in what a run established
+is not a thing to say in a colour (`UNRESOLVED_DETAIL`, `timeline.ts:967`).
 
 ---
 
@@ -620,9 +704,11 @@ failure whose reason is in the server log.
 
 ## The budget meter's numbers
 
-The meter above the timeline shows **three gauges, and it shows only what the server actually
-enforces and the ledger actually records** (`AgentRail.tsx:1967-2023`, gauges built in
-`timeline.ts:1182-1186`):
+**The meter is folded away under `Run details`**, above the timeline, and it opens itself while a run
+is live. Shut, its summary still carries the figures that move — how many steps the run has recorded,
+and its statement and database-time spend — so nothing has to be opened to see how far in a run is.
+Open, it shows **three gauges, and it shows only what the server actually enforces and the ledger
+actually records** (gauges built in `timeline.ts`):
 
 | Gauge | Reads | The limit, and where it comes from |
 | --- | --- | --- |
@@ -630,9 +716,11 @@ enforces and the ledger actually records** (`AgentRail.tsx:1967-2023`, gauges bu
 | **Database time** | `used / 90.0 s` on an investigation | `maxTotalRunMs`. **Database time only** — the elapsed time completed reads reported, not the wall clock |
 | **Repair attempts** | `used / 3` | `AGENT_MAX_REPAIR_ATTEMPTS`. Only statements that failed **at the database** consume one; a policy denial does not |
 
-Under them, one line states the three ceilings that nothing durable counts against, so they are
-given as ceilings rather than as gauges: *"Each statement gets 10.0 s, each drive 7.5 min and at
-most 36 model turns."*
+Under them, three ⓘ controls carry the claims that qualify those figures — **What is counted**,
+**Ceilings** and **Report reserve** — each on the figure it is about, each opening the same sentence
+it has always been, and each readable to a screen reader whether or not it is open. *Ceilings* is the
+three the server enforces and nothing durable counts against, so they are given as ceilings rather
+than as gauges: *"Each statement gets 10.0 s, each drive 7.5 min and at most 36 model turns."*
 
 **Every number on the meter is the one the server is enforcing on THIS run**, because the ceilings
 differ per workflow and both halves of the meter read the workflow off the run's own header. So the
@@ -665,7 +753,7 @@ for nginx, ingress-nginx and the common PaaS routers.
 
 Before any run is open there is no header to read, and what the meter says then depends on whether
 the workflow is decided yet. Name one under **Advanced** and it states that workflow's own ceilings.
-Leave it on **Automatic** and it states none of them — *"Every ceiling below is per workflow, and
+Leave it on **Automatic** and it states none of them — *"Every ceiling here is per workflow, and
 Automatic decides the workflow from your objective when the run opens — so the figures are stated
 once the run has one, and by the run's own record."* An Analyze run is bounded twice as long as an
 Investigate one, so a figure shown before the workflow is known would be a number nothing is
@@ -682,7 +770,8 @@ partial answer rather than a missing one. The bar does not move when it happens:
 cite something the run read, so a forced report is a cited report or it is no report at all. Nothing
 is asked of a **Plan** run, which has no report tool to call. The meter says this under the ceilings.
 
-Then the caveat, which is the part worth reading twice (`AgentRail.tsx:2018-2023`):
+Then the caveat, which is the part worth reading twice — behind the **What is counted** ⓘ, beside the
+gauges it is about:
 
 - **Every ceiling is per drive.** A run resumed after a restart starts each of them again, so these
   totals can read past a single drive's ceiling.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2429,9 +2429,22 @@ rather than disabled, and `canHandOver` withholds the auto-execute checkbox from
 runner. Agent mode on an unsupported engine is the one place a capability is offered and then
 withdrawn after it was taken up.
 
-Done when the rail states the engine's unsuitability before a run is started — the same way it
-already states an unresolvable connection — with a test that pins the message and one that pins
-Start being unavailable for it.
+The telling half landed with the rail redesign (2026-08-21) and the defect did not. The safety strip
+now reads *Cannot execute on `<engine>`* before anything is started, an amber pre-start card
+(`agent-engine-unsupported-notice`) carries the same facts with a **Switch to Plan** button, and both
+are pinned by tests. What did NOT land is the second clause of the original "done when", and it was
+refused rather than deferred: **Start must stay live**, because the `operations` workflow sends no
+statement at all and runs on every engine (#411), so a disabled Start would withhold a workflow over
+a claim that is not true of it. So a user who starts an analytical run there is now warned first, and
+still spends a model turn and a run id to reach `engine-unsupported`.
+
+Done when an agent run whose workflow needs a read-only statement path is refused on such an engine
+at the point the run is opened — from the connection's own type, with the sentence the rail already
+shows, and without a run id or a drive turn being spent — while a workflow that sends no statement
+still opens there. The workflow has to be known first, so under **Automatic** the refusal lands after
+the classify call and before the open; that call is ceilinged separately and is not the turn this
+entry is about. Tests: the refusal itself, an operations run still opening on the same connection,
+and no drive reaching the model.
 
 ### B39. An analysis run cannot say "this database cannot answer that" without fabricating a read
 

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -1597,7 +1597,21 @@ export function AgentRail({
     The two coincide whenever no run is open, which is most of the panel's life.
   */
   const engineLabel = connectionType === null ? "this connection" : getDBConfig(connectionType).label;
-  const handoverConsented = pendingStart !== null ? autoExecute : runOpen && openedWithHandover;
+  /*
+    Both axes of the open run's posture ask `runOpen` FIRST, and read the run before they
+    read any control. That order is the rule, and it is why these two lines look alike.
+
+    The asymmetry they replaced is what made a defect: the hand-over used to ask
+    `pendingStart` first, so a consent step standing for the NEXT run outranked the run
+    that was open — and the two coexist by design ("change" raises the step over a live
+    run, and stops nothing until it is accepted; a stream that ended without a terminal
+    entry clears `isBusy` with the status still `running`, which puts Start back within
+    reach). The strip then relabelled an executing run from a checkbox belonging to a run
+    nobody had opened: un-widened while the widened one was still handing statements over,
+    and widened while the open one may hand nothing over. Keep the order aligned, in both
+    lines, or that class of defect comes back on the next edit.
+  */
+  const handoverConsented = runOpen ? openedWithHandover : pendingStart !== null && autoExecute;
   const describedMode = runOpen ? run.timeline.mode : mode;
   const selectionPosture = agentPosture({
     mode,

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -1,35 +1,37 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import {
-  Bot,
-  ChevronDown,
-  ChevronRight,
-  Loader2,
-  PencilLine,
-  Play,
-  Square,
-  TableProperties,
-  TriangleAlert,
-} from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, Loader2, PencilLine, Play, Square, TriangleAlert } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
 import { renderProse } from "@/components/rich-text";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
 import { describeAgentCapability } from "@/lib/agent/capability-labels";
+/*
+  The list the SERVER gates a profiled acquisition on, read here for one presentation:
+  an engine outside it cannot execute an agent run's statement, and saying so before
+  Start is pressed is cheaper for the user than a run that ends `engine-unsupported`.
+  It gates nothing — the refusal is the factory's, and this is a notice about it.
+*/
+import { AGENT_EXECUTION_ENGINES } from "@/lib/agent/engine-support";
 import {
-  AGENT_HANDOVER_BUDGET,
   AGENT_MAX_OBJECTIVE_LENGTH,
   AGENT_REPORT_RESERVE_MS,
   AGENT_REPORT_RESERVE_TURNS,
   AGENT_WORKFLOW_BUDGETS,
 } from "@/lib/agent/execution-policy";
+/*
+  The rail's single reading of what the selected mode executes. It is the safety strip's
+  whole content, and the engine notice below is the same four levels read once more — so
+  neither can state a bound the other contradicts. The consent sentence lives there too,
+  beside the posture that quotes it.
+*/
+import { agentPosture } from "@/lib/agent/posture";
 import {
   AGENT_WORKFLOW_PRESENTS_ANSWER,
   DEFAULT_AGENT_WORKFLOW_TYPE,
   type AgentChartSpec,
   type AgentRunMode,
-  type AgentRunStatus,
   type AgentRunWorkflowReading,
   type AgentRunWorkflowSource,
   type AgentRunWorkflowType,
@@ -40,11 +42,23 @@ import {
   bundle. The same rule `use-agent-run.ts` follows for the capability probe.
 */
 import type { AgentWorkflowClassification } from "@/lib/agent/workflow-classifier";
+import { getDBConfig } from "@/lib/db-ui-config";
 import type { DatabaseType } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { AnswerCard, answerCardState } from "./AnswerCard";
+import { ConsentCard } from "./ConsentCard";
+/*
+  The pieces the answer card renders too, in the module they moved to when it was split
+  out of this file: this file imports that card, so anything it shares with it cannot
+  live here. Same components, same comments, same accessible names — see
+  `rail-parts.tsx` for why a second copy was not the answer.
+*/
+import { guardReading, guardSummaryLine, HydrationControls, InfoNote, LIVE_STATUSES, QuotedBlock } from "./rail-parts";
+import { SafetyStrip } from "./SafetyStrip";
 import {
   type AgentBudgetGauge,
   type AgentPlanStatementView,
+  type AgentTimelineItem,
   type AgentTimelineTone,
   describeFailureReason,
 } from "./timeline";
@@ -267,26 +281,6 @@ const isWorkflowType = (value: unknown): value is AgentRunWorkflowType =>
   typeof value === "string" && Object.hasOwn(WORKFLOW_LABELS, value);
 
 /**
- * The terms of the auto-execute consent, as ONE sentence-run rather than as JSX prose:
- * the figures are interpolated and a formatter is free to reflow JSX text around them,
- * which is how "500-row limit" becomes "500 -row limit" without anyone touching the
- * copy. This is the sentence a user consents to, so it is written and rendered as
- * written.
- *
- * It takes the workflow rather than reading a selection, because there is no longer a
- * selection to read at the moment it is shown: the consent step is reached with a
- * workflow already decided — by the classifier or by the user under Advanced — and the
- * bounds it names are that workflow's own.
- */
-function autoExecuteTerms(workflowType: AgentRunWorkflowType): string {
-  const budget = AGENT_WORKFLOW_BUDGETS[workflowType];
-  return `The run always produces its answer on its own read-only path, bounded to ${budget.policy.budgets.maxResultRows} rows and ${budget.policy.budgets.statementTimeoutMs / 1000} seconds. Tick this and it will also put that statement in your editor and run it there — on the connection the run was opened on, at the editor's ${AGENT_HANDOVER_BUDGET.maxResultRows}-row limit and with no time limit. It is the same database-enforced read-only session either way, so writes and DDL are refused by the engine rather than by reading the statement. Statements whose plan reads as expensive, or which the run measured as slow, are put in the editor without being run.`;
-}
-
-/** A run that is over cannot be asked for anything, so nothing is offered for it. */
-const LIVE_STATUSES: ReadonlySet<AgentRunStatus> = new Set<AgentRunStatus>(["queued", "running"]);
-
-/**
  * How near the bottom still counts as the bottom, for the timeline that follows its
  * newest entry.
  *
@@ -345,108 +339,6 @@ function refusalActionText(planModeOffered: boolean, streamingDisproved: boolean
 }
 
 /**
- * Verbatim content, and the one thing every reader wants to do with it (#389).
- *
- * The block itself is unchanged and deliberately so: quoting is a security property
- * here, not a style — a drafted statement, an engine's own message and the user's
- * objective are shown exactly as they arrived, so a reader can see where the
- * application stopped speaking. What was missing was any way to get the text OUT.
- * Selecting it by hand is what a user was left with, inside a narrow panel that
- * scrolls in both directions, and a statement wrapped across lines does not survive
- * the drag.
- *
- * Used at every verbatim block in this rail rather than at a chosen few, because
- * "which of these did the product decide I would want" is not a question a user
- * should have to answer.
- */
-function QuotedBlock({
-  text,
-  testId,
-  className,
-  /** A report's claim is the thing the report is FOR, and reads a shade brighter. */
-  tone = "quiet",
-}: {
-  readonly text: string;
-  readonly testId: string;
-  readonly className?: string;
-  readonly tone?: "quiet" | "loud";
-}) {
-  return (
-    <div className={className}>
-      <pre
-        className={cn(
-          "overflow-x-auto rounded bg-sunken p-1.5 font-mono text-[0.625rem] whitespace-pre-wrap",
-          tone === "loud" ? "text-fg-secondary" : "text-fg-tertiary",
-        )}
-      >
-        {text}
-      </pre>
-      <div className="mt-0.5 flex items-center gap-1">
-        <CopyButton text={text} testId={testId} />
-      </div>
-    </div>
-  );
-}
-
-/**
- * What one entry lets a user do with what the run produced (#329 T11).
- *
- * Rendered only where the ledger recorded something to act on AND the host can act
- * on it — the same rule the stop control follows in T10b, so nothing here is a
- * disabled button standing in for a capability this build does not have. Both are
- * explicit user actions: the rail never applies a statement or opens a result on its
- * own, because a statement the model drafted is untrusted content and putting it into
- * the editor is the user's decision.
- */
-function HydrationControls({
-  sql,
-  artifactId,
-  chartSpec,
-  testIdPrefix,
-  onApply,
-  onShow,
-}: {
-  readonly sql: string | undefined;
-  readonly artifactId: string | undefined;
-  /** Set only on an answer the run composed as a chart; undefined everywhere else. */
-  readonly chartSpec: AgentChartSpec | undefined;
-  readonly testIdPrefix: string;
-  readonly onApply: ((sql: string) => void) | undefined;
-  readonly onShow: ((correlationId: string, chartSpec: AgentChartSpec | undefined) => void) | undefined;
-}) {
-  const canApply = sql !== undefined && onApply !== undefined;
-  const canShow = artifactId !== undefined && onShow !== undefined;
-  if (!canApply && !canShow) return null;
-
-  return (
-    <div className="mt-1 flex items-center gap-1">
-      {sql !== undefined && onApply !== undefined && (
-        <button
-          type="button"
-          data-testid={`${testIdPrefix}apply-statement`}
-          onClick={() => onApply(sql)}
-          className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] text-fg-tertiary hover:bg-fill hover:text-fg transition-colors"
-        >
-          <PencilLine strokeWidth={1.5} className="w-3 h-3" />
-          Apply to editor
-        </button>
-      )}
-      {artifactId !== undefined && onShow !== undefined && (
-        <button
-          type="button"
-          data-testid={`${testIdPrefix}show-result`}
-          onClick={() => onShow(artifactId, chartSpec)}
-          className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] text-fg-tertiary hover:bg-fill hover:text-fg transition-colors"
-        >
-          <TableProperties strokeWidth={1.5} className="w-3 h-3" />
-          Show result
-        </button>
-      )}
-    </div>
-  );
-}
-
-/**
  * Prose the model wrote, in the structure it wrote it in (#389, #373 review).
  *
  * A component rather than inline JSX because it is now rendered in two places: bare
@@ -458,31 +350,42 @@ function HydrationControls({
 function ProseBlock({
   text,
   onApplySql,
-  statementCarded,
+  cardedStatement,
   className,
 }: {
   readonly text: string;
   readonly onApplySql: ((sql: string) => void) | undefined;
   /**
-   * Whether this run's drafted statement is already offered, MARKED, from the card
-   * beside this prose — in which case the per-block control inside it is withheld.
+   * This run's drafted statement, when the card beside this prose is already offering
+   * it MARKED — in which case the per-block control inside this block is withheld and
+   * the block holding that statement is not printed at all.
    *
    * A plan run's closing prose is the text its statement was read out of, so the same
-   * SQL is in both places, and #389's per-block "Apply to editor" says nothing about
-   * what it is applying: `renderProse` is handed text and knows nothing of the guard's
-   * verdict. Leaving it there puts an unmarked control immediately above the marked
-   * one, against the SQL, which is the silent hand-off the marking exists to prevent.
+   * SQL is in both places. Two consequences, and they are the same fact seen twice:
+   *
+   *  - #389's per-block "Apply to editor" says nothing about what it is applying —
+   *    `renderProse` is handed text and knows nothing of the guard's verdict — so
+   *    leaving it puts an unmarked control immediately above the marked one, against
+   *    the SQL, which is the silent hand-off the marking exists to prevent;
+   *  - and the BLOCK itself is the statement, printed a second time at full weight a
+   *    few hundred pixels under the card that shows it (L2, measured 2026-08-21). The
+   *    statement is carried rather than a flag so `renderProse` can suppress exactly
+   *    that block and no other: any other fence in the plan is another statement, and
+   *    the words around them are untouched.
+   *
+   * `Copy all` below is unaffected either way. It takes the string the model wrote, not
+   * this rendering of it, so the whole prose — fence included — is still one click away.
    */
-  readonly statementCarded: boolean;
+  readonly cardedStatement: string | undefined;
   readonly className: string;
 }) {
-  const apply = statementCarded ? undefined : onApplySql;
+  const apply = cardedStatement === undefined ? onApplySql : undefined;
   return (
     <div
       data-testid="agent-prose"
       className={cn("space-y-1 border-l border-hairline-strong pl-2 text-fg-tertiary", className)}
     >
-      {renderProse(text, apply === undefined ? {} : { onApplySql: apply })}
+      {renderProse(text, { onApplySql: apply, cardedStatement })}
       {/*
         And the plan as a whole, in the markdown the model wrote rather than in the
         rendering above: what a user pastes into a ticket is the text, and the text is
@@ -494,117 +397,40 @@ function ProseBlock({
 }
 
 /**
- * The name a screen reader, a voice user and a tooltip all get for the one control
- * that puts a plan run's statement into the editor (item 7 of the plan-mode design).
+ * What a PLAN run produced, as it is recorded in the CHRONOLOGY — a headline, a
+ * timestamp and one line saying what the guard made of it.
  *
- * The visible label comes FIRST and unaltered, which is WCAG 2.5.3: a voice user says
- * what they can see, so "Apply to editor" has to be inside whatever this returns.
- * Everything after it is the part a colour cannot carry.
+ * It used to be the whole card: the statement verbatim, the guard's paragraph, the
+ * identifier findings, the caveat and the editor hand-off. All of that moved UP, into
+ * `AnswerCard`, when the redesign put the run's outcome at the top of the rail — and
+ * moved rather than being copied, which is the point of this file being shorter. The
+ * reasoning that card carries is the reasoning that used to be here, and it is worth
+ * restating why the hand-off may not be in both places:
  *
- * Both warnings are stated in the terms the server established and no stronger, and the
- * first of them was once stated a good deal stronger. It read "This statement is not a
- * read: applying it puts SQL in your editor that can change or delete data", which is a
- * claim about the statement's EFFECT that `readOnly` cannot support: it is
- * `inspectAgentStatement(sql) === null`, and four of that guard's six objections say
- * only that it could not read the text — an unclosed span, a run two dialects disagree
- * about, a second statement, no statement at all — while its own header records that it
- * over-refuses legitimate reads on purpose. A jsonb read using `#>>` would have been
- * announced to a screen-reader user as SQL that can delete their data. So the name says
- * what the guard did, and the reason travels with it.
- *
- * The identifier finding is about names the captured inventory does not hold, which is
- * a reason the statement may not run rather than proof that it will not.
- */
-function applyStatementName(draft: AgentPlanStatementView): string {
-  const marks: string[] = [];
-  // The guard's reach comes FIRST, and it replaces the objection rather than joining
-  // it (#414). On an engine whose statements are not SQL the guard read nothing, so
-  // `readOnly` is `false` for a reason that is not about this draft — and the sentence
-  // below it, spoken to a screen-reader user who cannot see the card, would otherwise
-  // assert that nothing establishes this correct MongoDB aggregation only reads, as
-  // though something had looked and been unconvinced.
-  if (!draft.guardApplicable)
-    marks.push(
-      "The statement guard reads SQL and this engine's statements are not SQL, so nothing examined this draft.",
-    );
-  else if (!draft.readOnly)
-    marks.push(
-      `The statement guard did not read this as a bounded read (${draft.guardViolation ?? "no reason recorded"}), so nothing here establishes that running it would only read.`,
-    );
-  if (draft.identifiers.kind === "not-applicable")
-    marks.push("The name check reads SQL too, so the names it uses were not looked for in anything.");
-  else if (draft.identifiers.kind === "no-inventory") marks.push("Nothing checked the names it uses.");
-  else if (draft.identifiers.unknownTables.length > 0) {
-    // Named in the engine's own word (#414). This sentence is spoken to a user who
-    // cannot see the card, so it is the last place a Druid run should be told about
-    // "table(s)" while every visible surface beside it says datasources.
-    marks.push(
-      `It names ${draft.identifiers.unknownTables.length} ${draft.noun.singular}(s) the inventory this run read does not hold, so it may not run as written.`,
-    );
-  }
-  return ["Apply to editor.", ...marks].join(" ");
-}
-
-/**
- * What a PLAN run produced, as the one thing on this surface a user is meant to take
- * away with them (item 7 of the plan-mode SQL-generator design of 2026-08-15).
- *
- * Until this card, plan mode's statement could only be read out of a markdown fence in
- * the browser (#389) — which offered nothing when the model did not fence it, and, more
- * to the point, offered an unremarkable "Apply to editor" whatever the statement was.
  * The owner's ruling is that plan mode MAY draft a write and must never hand one over
- * quietly, so the marking is the reason this card exists and not decoration on it:
+ * quietly. So the marking is a correctness property, not decoration: the mark is in the
+ * applying control's accessible NAME (`applyStatementName`, in `rail-parts.tsx`), because
+ * a colour and a border say nothing to a screen reader, and it states what the GUARD did
+ * rather than what the SQL does — `readOnly` is `inspectAgentStatement(sql) === null`, and
+ * four of that guard's six objections say only that it could not settle the text.
  *
- *  - the mark is on the card, on a line of its own, and in the applying control's
- *    accessible NAME, because a colour and a border say nothing to a screen reader.
- *    It states what the GUARD did — "did not read this as a bounded read", with the
- *    reason — and never what the SQL does, because `readOnly` is
- *    `inspectAgentStatement(sql) === null` and four of that guard's six objections say
- *    only that it could not settle the text. It is also the only editor hand-off a
- *    plan run's statement gets: the closing prose the statement was read out of has
- *    its per-block control withheld (`planStatementRecorded`), because that one cannot
- *    say what it is applying;
- *  - `data-read-only` carries the guard's own verdict as data rather than as a class
- *    name, so the distinction can be asserted in a test instead of inferred from
- *    styling — and it is named after the field it holds, because "write" is a claim
- *    that verdict does not make. Three values since #414: `"unexamined"` is a verdict
- *    the guard did not reach, and it is not `"false"`, because `"false"` reads as an
- *    objection and there was none;
- *  - what the identifier check found sits beside the statement rather than in a
- *    sentence further up. An unvalidated statement that looks like a sound one is the
- *    failure this half exists to prevent, and a count alone leaves a reader with
- *    nothing to look for in the SQL above.
+ * **And there is exactly ONE such control.** The closing prose the statement was read out
+ * of has its per-block "Apply to editor" withheld (`planStatementRecorded`) because
+ * `renderProse` is handed text and cannot say what it is applying; this entry now reprints
+ * no statement at all, so it offers nothing to apply either. An unmarked control against
+ * the statement, one line above the marked one, is the control a user reaches for first — it is
+ * the silent hand-off the marking exists to prevent, and the answer card being a SECOND
+ * rendering of this entry is precisely the arrangement that could have reintroduced it.
  *
- * The names themselves are model and engine text and stay out of the app's sentences,
- * the rule every other block in this rail follows: the sentence is ours, the names are
- * listed beside it as the quoted content they are.
- *
- * Nothing here blocks anything, and nothing claims the statement will run. The
- * inventory records what EXISTS, not what the user's role may select from — said in the
- * card, where the claim is made — and the run itself executed nothing: applying is the
- * user's own action, on their own connection, as it has been in every mode.
+ * `data-read-only` stays, carrying the guard's own verdict as data rather than as a class
+ * name, so the distinction can be asserted in a test instead of inferred from styling —
+ * three values since #414, because `"unexamined"` is a verdict the guard did not reach and
+ * reads as neither `"true"` nor an objection.
  */
-function PlanStatementCard({
-  draft,
-  onApply,
-}: {
-  readonly draft: AgentPlanStatementView;
-  readonly onApply: ((sql: string) => void) | undefined;
-}) {
-  const unknown = draft.identifiers.kind === "checked" ? draft.identifiers.unknownTables : [];
-
+function PlanStatementCard({ draft }: { readonly draft: AgentPlanStatementView }) {
   return (
     <section
       data-testid="agent-plan-statement"
-      /*
-        THREE values, not two (#414). Every human-readable surface on this card reads
-        `guardApplicable` first and says the guard did not look; this machine-readable
-        one said `"false"` in the same breath, which a consumer can only read as "the
-        guard objected". A third value rather than a second attribute, deliberately: a
-        reader who tests for `"false"` must not be able to reach the accusation at all,
-        and a separate `data-guard-applicable` would leave `"false"` sitting there for
-        them to find.
-      */
       data-read-only={!draft.guardApplicable ? "unexamined" : draft.readOnly ? "true" : "false"}
       className={cn(
         "mt-1 ml-3.5 rounded border p-1.5",
@@ -612,103 +438,231 @@ function PlanStatementCard({
       )}
     >
       {/*
-        Read first, and a different claim rather than a softer one (#414). The banner
-        below it says the guard looked and was not satisfied; on an engine whose
-        statements are not SQL the guard did not look, and saying the first thing about
-        a correct MongoDB aggregation is the accusation this branch exists to stop. It
-        keeps the amber, because "nobody established anything about this" is what the
-        colour means on this card and it is exactly the state; what changes is the
-        words, and there is no reason code to show because there was no objection.
+        The one-line reading, from the module both surfaces read it out of: the answer
+        card states the same thing and then the whole claim behind it, and two authors
+        for a sentence about what examined a statement is how the two come to disagree.
       */}
-      {!draft.guardApplicable ? (
-        <p
-          data-testid="agent-plan-statement-guard-unread"
-          className="mb-1 flex items-start gap-1 text-[0.625rem] text-amber-300"
-        >
-          <TriangleAlert strokeWidth={1.5} className="mt-px w-3 h-3 shrink-0" aria-hidden="true" />
-          <span>
-            The statement guard reads SQL, and this engine&apos;s statements are not SQL — so nothing examined this
-            draft. It is drafted, not run — nothing has happened to your data — but nothing here has established
-            anything about it, for or against.
-          </span>
-        </p>
-      ) : (
-        !draft.readOnly && (
-          <p
-            data-testid="agent-plan-statement-guard"
-            className="mb-1 flex items-start gap-1 text-[0.625rem] text-amber-300"
-          >
-            <TriangleAlert strokeWidth={1.5} className="mt-px w-3 h-3 shrink-0" aria-hidden="true" />
-            <span>
-              The statement guard did not read this as a bounded read (
-              <span className="font-mono">{draft.guardViolation ?? "no reason recorded"}</span>). It is drafted, not run
-              — nothing has happened to your data — but nothing here establishes that running it would only read.
-            </span>
-          </p>
-        )
-      )}
-      {/* Verbatim, with the clipboard control every other verbatim block in this rail
-          carries: the statement is what the user came for, and selecting it by hand
-          inside a narrow scrolling panel is what they were left with before #389. */}
-      <QuotedBlock text={draft.sql} testId="agent-plan-statement-copy" tone="loud" />
-      {unknown.length > 0 && (
-        <div data-testid="agent-plan-statement-unknown" className="mt-1 text-[0.625rem] text-amber-400/80">
-          <p>These names are not in the inventory this run read, so the statement may not run as written:</p>
-          {/* Model and engine text, listed rather than spliced into the sentence above. */}
-          <ul className="mt-0.5 flex flex-wrap gap-1">
-            {unknown.map((name) => (
-              <li key={name} className="rounded bg-sunken px-1 py-0.5 font-mono text-amber-200">
-                {name}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      {draft.identifiers.kind === "no-inventory" && (
-        <p data-testid="agent-plan-statement-unchecked" className="mt-1 text-[0.625rem] text-amber-400/80">
-          No schema inventory was read for this run, so the names in this statement were not checked against anything.
-        </p>
-      )}
-      {/*
-        Its own line and its own words, not a reuse of the one above (#414). That one
-        reports a run with no inventory; this run usually HAS one, and what it lacks is
-        a reader that can find a collection name inside an aggregation pipeline. A user
-        told "no inventory was read" would go looking for a grounding failure that did
-        not happen.
-      */}
-      {draft.identifiers.kind === "not-applicable" && (
-        <p data-testid="agent-plan-statement-unread" className="mt-1 text-[0.625rem] text-amber-400/80">
-          The names in this statement were not checked: the check that would do it reads SQL, and this engine&apos;s
-          statements are not SQL.
-        </p>
-      )}
-      {onApply !== undefined && (
-        <div className="mt-1 flex items-center gap-1">
-          <button
-            type="button"
-            data-testid="agent-plan-apply-statement"
-            aria-label={applyStatementName(draft)}
-            onClick={() => onApply(draft.sql)}
-            className={cn(
-              "flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] transition-colors hover:bg-fill",
-              draft.readOnly ? "text-fg-tertiary hover:text-fg" : "text-amber-300",
-            )}
-          >
-            <PencilLine strokeWidth={1.5} className="w-3 h-3" />
-            Apply to editor
-          </button>
-        </div>
-      )}
-      {/*
-        Where the claim is made, so no reader takes a checked statement for a runnable
-        one (item 6 of the design). An inventory records what exists; whether this
-        session may read it is the engine's answer, given when the statement runs.
-      */}
-      <p data-testid="agent-plan-statement-caveat" className="mt-1 text-[0.625rem] text-fg-subtle">
-        The run executed nothing. What was checked is what this run read of the schema, which records what exists rather
-        than what your role is permitted to read.
+      <p
+        data-testid="agent-plan-statement-summary"
+        className={cn("text-[0.625rem]", guardReading(draft) === "checked" ? "text-fg-muted" : "text-amber-300")}
+      >
+        {guardSummaryLine(draft)} The statement, what the name check found and what applying it would and would not
+        establish are in the answer at the top of this rail.
       </p>
     </section>
+  );
+}
+
+/**
+ * One timeline entry's content, so the chronology and the folded scaffolding inside it
+ * render the same entry the same way (item 7 of the redesign).
+ *
+ * A component rather than a second copy of the JSX: the chrome entries are collapsed
+ * behind one summary line and are still rendered IN FULL when it is opened — the
+ * objective quoted under the run's header included — and two renderings of an entry
+ * would be two places for the boundary between the app's words and everyone else's to
+ * move.
+ */
+function TimelineEntryBody({
+  item,
+  onApplyStatement,
+  showArtifact,
+  declinedHandovers,
+  cardedAnswerId,
+  cardedStatement,
+  planCarded,
+}: {
+  readonly item: AgentTimelineItem;
+  readonly onApplyStatement: ((sql: string) => void) | undefined;
+  readonly showArtifact: ((correlationId: string, chartSpec: AgentChartSpec | undefined) => void) | undefined;
+  readonly declinedHandovers: readonly { readonly id: string; readonly openedOn: string | null }[];
+  /** The entry whose hand-off the answer card is already offering, or undefined. */
+  readonly cardedAnswerId: string | undefined;
+  /**
+   * The STATEMENT the answer card is handing over, in either of the two states that
+   * hand one over, or undefined.
+   *
+   * By text rather than by entry id, which is what makes this a de-duplication of one
+   * statement rather than the removal of an affordance (L6, measured 2026-08-21). An
+   * agent run drafts each statement it executes, and the answer's `sql` IS the
+   * statement of the step whose artifact it presents — so a one-read run had the same
+   * text offered by the card, by that `Statement drafted` entry and by the report
+   * section's citation, three times, none of them named. A read the run took along the
+   * way whose statement is NOT the answer's is another statement, and it keeps its own
+   * control.
+   */
+  readonly cardedStatement: string | undefined;
+  /**
+   * Whether the answer card is RENDERING the drafted statement — which is what makes
+   * withholding this entry's copy of the hand-off a de-duplication rather than a
+   * removal. Off the card's own state reading, never off the ledger: an entry can
+   * carry `planStatementRecorded` while the card is showing something else.
+   */
+  readonly planCarded: boolean;
+}) {
+  /*
+    The guard's reading, said once (L3). Measured on the MongoDB plan run: the card's
+    guard line, then THIS paragraph — four lines of it — then the amber summary box
+    below, all inside ~400px. One fact, three renderings, two of them long.
+
+    So the entry the card is rendering gives up the paragraph and keeps the one-line
+    summary (`PlanStatementCard`), and the full text is where it already was: in the
+    card's ⓘ, which carries both of these sentences verbatim under their own test ids.
+    Every other entry's detail is untouched — it is the only place its own fact is said.
+  */
+  const detail = planCarded && item.planStatement !== undefined ? undefined : item.detail;
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", TONE_CLASSES[item.tone])} />
+        <span className="text-xs text-fg-secondary">{item.headline}</span>
+      </div>
+      {detail !== undefined && <p className="mt-0.5 pl-3.5 text-xs text-fg-muted">{detail}</p>}
+      {/*
+        Prose the MODEL wrote, rendered with the structure it wrote it in
+        (#373 review). Measured in plan mode against a live model: the closing
+        statement arrived as markdown and reached the user as hash marks and
+        asterisks, and plan mode's whole output is this one block.
+
+        Inside its own bordered block, which is the half that has to survive
+        being readable: `renderProse` builds React nodes and reaches no HTML
+        parser, so nothing here can execute — but a heading a model wrote must
+        still not read as a heading the application wrote, and the rule that
+        the app's words and everyone else's never share a line is what the
+        border keeps true.
+      */}
+      {/*
+        The editor is offered to the statements INSIDE the prose (#389), EXCEPT on
+        the entry a plan run's statement was read out of.
+
+        That exception is the whole marking requirement, not a detail of it. The
+        closing prose of a plan run HOLDS the fenced statement, so without it the
+        same `DELETE` renders twice: once in the card below, amber, with the guard's
+        verdict and an accessible name that carries it — and once here, immediately
+        above it, as a plain grey "Apply to editor" with no mark and no name, which
+        is the control a user reaches for first because it sits against the SQL.
+        `renderProse` cannot label it: it is handed text and knows nothing of the
+        ledger. So the marked hand-off is the only hand-off, and the block keeps its
+        clipboard. Everywhere else — an agent run, a plan run that drafted nothing —
+        #389's control is untouched, because there is no card there to defer to.
+
+        A host with no editor passes nothing and is offered nothing, the rule every
+        other affordance in this rail follows.
+
+        A refusal is the same prose in a different frame. The run reached its other
+        legitimate ending — it says the schema does not answer the question — and
+        that is what the card states; the marker the ledger read it by was stripped
+        on the way here, because it is a protocol token the model was told to emit
+        and not a sentence it wrote for anyone to read.
+      */}
+      {item.prose !== undefined &&
+        (item.planRefusal === true ? (
+          <section
+            data-testid="agent-plan-refusal"
+            className="mt-1 ml-3.5 rounded border border-amber-400/40 bg-amber-500/5 p-1.5"
+          >
+            {/*
+              Says only that the run could not draft, never WHY — the two reasons
+              are different and this card cannot tell them apart. A grounded run
+              refuses because the inventory it was given does not reach the
+              question; an ungrounded one (a reading that was refused, that
+              overran its time, or a provider that cannot describe its own
+              schema — the engine alone stopped deciding it in #414) refuses
+              because there was no inventory at all. The earlier wording named "the schema it read",
+              which on the second path is a reading that never happened.
+            */}
+            <p className="text-[0.625rem] text-amber-300">
+              This run drafted no statement. What it says is missing, and what it needs from you, are in its own words
+              below.
+            </p>
+            <ProseBlock
+              text={item.prose}
+              onApplySql={onApplyStatement}
+              cardedStatement={planCarded && item.planStatementRecorded === true ? cardedStatement : undefined}
+              className="mt-1"
+            />
+          </section>
+        ) : (
+          <ProseBlock
+            text={item.prose}
+            onApplySql={onApplyStatement}
+            cardedStatement={planCarded && item.planStatementRecorded === true ? cardedStatement : undefined}
+            className="mt-1 ml-3.5"
+          />
+        ))}
+      {/*
+        The run's own deliverable, with what the server established about it. Its
+        own card rather than a line beside the entry, because a statement a user
+        may be about to run is the one thing on this surface that can do damage
+        if it is presented as something it is not.
+      */}
+      {item.planStatement !== undefined && <PlanStatementCard draft={item.planStatement} />}
+      {/*
+        The one place this surface contradicts the ledger, and it does so beside
+        the sentence it contradicts. The entry above is folded from what the RUN
+        recorded — that it handed the statement over to be run — and this rail
+        declined to perform it, so a reader who saw only the entry would believe
+        an execution that never happened. Said here rather than in a banner:
+        the fact is about this answer, and a notice elsewhere would be a
+        sentence the reader has to match to a line themselves.
+      */}
+      {declinedHandovers
+        .filter((declined) => declined.id === item.id)
+        .map((declined) => (
+          <p
+            key={declined.id}
+            data-testid="agent-handover-declined"
+            className="mt-0.5 pl-3.5 text-xs text-amber-400/80"
+          >
+            It was not run: this run was opened on {declined.openedOn ?? "another connection"} and your editor has moved
+            to a different one since. The answer would have arrived in a tab that is connected somewhere else, so
+            nothing was executed. The statement is below — take it yourself if you want it on the connection you are on
+            now.
+          </p>
+        ))}
+      {/*
+      Verbatim content from the model, the engine or the user, kept in its own
+      block rather than folded into a sentence: it is untrusted input, and the
+      user should be able to see where the app stops speaking.
+    */}
+      {item.quoted !== undefined && (
+        <QuotedBlock text={item.quoted} testId="agent-quoted-copy" className="mt-1 ml-3.5" />
+      )}
+      {/*
+        Withheld on the ONE entry the answer card is already offering these for (item 8
+        of the redesign), and rendered here for every other entry exactly as before.
+
+        The card renders this entry a second time — that is what it is — so leaving both
+        would put two "Apply to editor" controls in the rail for one statement, with
+        nothing on either saying they are the same act. A read the run took along the way
+        keeps its own controls, because it is another statement and the card renders none
+        of them — unless it IS the card's statement, which is what the `sql` below is
+        about: the run records every statement it executes, so the answer's own text is
+        on the ledger twice.
+      */}
+      {item.id !== cardedAnswerId && (
+        <div className="ml-3.5">
+          <HydrationControls
+            /*
+              And withheld for the STATEMENT the card is handing over, wherever it
+              appears (L6). The entry above is the answer's own; this covers the
+              `Statement drafted` entry that recorded the same text one step earlier,
+              which is how the report path came to offer the same statement twice under
+              two different names. Anything else the run drafted is another statement
+              and keeps its control — a result to SHOW is untouched either way, since the
+              card offers only the answer's.
+            */
+            sql={item.applySql === cardedStatement ? undefined : item.applySql}
+            artifactId={item.artifactId}
+            chartSpec={item.chartSpec}
+            testIdPrefix="agent-"
+            onApply={onApplyStatement}
+            onShow={showArtifact}
+          />
+        </div>
+      )}
+    </>
   );
 }
 
@@ -748,6 +702,23 @@ export function AgentRail({
   const [pendingStart, setPendingStart] = useState<AgentDecidedStart | null>(null);
   /** The consent step's own tick, reset every time that step is entered. */
   const [autoExecute, setAutoExecute] = useState(false);
+  /**
+   * What the OPEN run was opened with, which is a different question from what the tick
+   * says now: the tick belongs to a consent step that no longer exists, and the safety
+   * strip beside a running run has to read that run's own boundary. Set from the same
+   * resolution the open request carried, so the strip cannot say "one statement in your
+   * editor" about a run the server was never asked to widen.
+   */
+  const [openedWithHandover, setOpenedWithHandover] = useState(false);
+  /**
+   * The user asked to write in the objective box while a run is open.
+   *
+   * The box is a one-line summary during a run — the question is settled, and three rows
+   * of textarea for text nobody can change is the space the answer needed — so this is
+   * the way back to it. It is reset when a run opens, beside the clearing of the box
+   * itself: an edit begun against one run is not a state to carry into the next.
+   */
+  const [editingObjective, setEditingObjective] = useState(false);
   /**
    * A "change" whose cancellation the server did not accept, so no replacement was
    * opened and the run the user asked to end is still going.
@@ -999,8 +970,14 @@ export function AgentRail({
    * "change" has to re-ask the same question against another workflow. Reading the
    * textarea then would re-ask an empty one, or worse, whatever the user has begun
    * typing since.
+   *
+   * State rather than the ref it was until the redesign: the objective is RENDERED now —
+   * the box becomes a one-line summary of it while the run is open — and a ref read during
+   * render is a value React is free to have changed without a re-render, which is what the
+   * compiler's own rule says. The handlers that read it are called from the render that
+   * holds the current value, so nothing about "change" changes.
    */
-  const openedObjective = useRef("");
+  const [openedObjective, setOpenedObjective] = useState("");
 
   /*
     Opening the run, once every decision it carries has been made.
@@ -1048,7 +1025,7 @@ export function AgentRail({
     }
     setReplaceFailed(false);
     openedOn.current = { id: decided.connection.id, name: decided.connection.name };
-    openedObjective.current = decided.objective;
+    setOpenedObjective(decided.objective);
     /*
       What has already been delivered is about the run that is ending here, and the
       two effects below key that on the run id changing. They may not SEE it change:
@@ -1064,6 +1041,10 @@ export function AgentRail({
     handedOverRunId.current = null;
     handedOver.current.clear();
     setChangeOpen(false);
+    // The same resolution the request carries, kept for the strip beside the run: what
+    // this run may do is what was SENT, not what a control says afterwards.
+    const handover = canHandOver(decided.workflowType) && decided.autoExecute;
+    setOpenedWithHandover(handover);
     void run.start({
       mode,
       workflowType: decided.workflowType,
@@ -1072,7 +1053,7 @@ export function AgentRail({
       // sentence this rail owes is read back from, and a start that says nothing about
       // its reading is one a reloaded rail cannot describe.
       workflowReading: decided.reading,
-      autoExecute: canHandOver(decided.workflowType) && decided.autoExecute,
+      autoExecute: handover,
       objective: decided.objective,
       connectionId: decided.connection.id,
     });
@@ -1205,7 +1186,7 @@ export function AgentRail({
       workflowType: next,
       source: "chosen",
       reading: "unrecorded",
-      objective: openedObjective.current,
+      objective: openedObjective,
       // Snapshotted at this click for the reason `handleStart`'s is: this one can raise
       // the consent step too, and the shell can move while it stands.
       connection: { id: connectionId, name: connectionName, type: connectionType },
@@ -1235,7 +1216,11 @@ export function AgentRail({
     reused an id still moves the value.
   */
   useEffect(() => {
-    if (run.runId !== null) setObjective("");
+    if (run.runId === null) return;
+    setObjective("");
+    // An edit begun against the run that is ending here is not a state the next run
+    // inherits: the box is a summary again, of the question this new run was opened on.
+    setEditingObjective(false);
   }, [run.runId]);
 
   /**
@@ -1244,6 +1229,29 @@ export function AgentRail({
    * are asking about a run the server still has open.
    */
   const runOpen = run.runId !== null && LIVE_STATUSES.has(run.timeline.status);
+
+  /** Whether the objective is a box to type in or a line saying what was asked. */
+  const objectiveEditable = !runOpen || editingObjective;
+
+  /*
+    The focus the objective box was holding when it stopped existing.
+
+    `leaveConsent("objective")` lands focus in that box on purpose — Start disables the
+    instant the run is busy, so focus there is focus lost a beat later — and one commit
+    afterwards the run opens and the box becomes the summary. A browser drops focus to
+    the body when the focused node is removed, which is the same "left nowhere" the
+    consent step's own announcement exists to prevent, one step further along.
+
+    So the control that took the box's place takes the focus the box lost, and only when
+    it was actually lost: focus that is on a real control — Start, in a browser where the
+    click that opened the run left it there — is not moved out from under the user.
+  */
+  const objectiveEdit = useRef<HTMLButtonElement | null>(null);
+  useEffect(() => {
+    if (objectiveEditable) return;
+    const active = document.activeElement;
+    if (active === null || active === document.body) objectiveEdit.current?.focus();
+  }, [objectiveEditable]);
 
   /*
     Carrying out what the RUN decided (§2.1, §2.3).
@@ -1488,6 +1496,17 @@ export function AgentRail({
   */
   const timelineScroller = useRef<HTMLDivElement | null>(null);
   const followingTimeline = useRef(true);
+  /**
+   * Whether the run is still WRITING entries, for the observer's own closure.
+   *
+   * A ref rather than the value in scope because the `ResizeObserver` below is created
+   * once and holds the first render's `pinToNewest`: a status read out of that closure
+   * would be `queued` for the life of the panel. It is written in the effect that
+   * follows, never during render.
+   */
+  const timelineLive = useRef(true);
+  /** The run whose answer has already been brought into view, so it happens once. */
+  const revealedAnswerFor = useRef<string | null>(null);
   const readFollowing = () => {
     const scroller = timelineScroller.current;
     if (scroller === null) return; // Unreachable while the container is mounted; the event comes from it.
@@ -1496,10 +1515,51 @@ export function AgentRail({
   };
   const pinToNewest = () => {
     const scroller = timelineScroller.current;
-    if (scroller === null || !followingTimeline.current) return;
+    if (scroller === null || !followingTimeline.current || !timelineLive.current) return;
     scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
   };
-  useEffect(pinToNewest, [run.timeline.items]);
+
+  /*
+    Following the newest entry is right while there IS a newest entry to follow, and
+    wrong the moment there is not (L1, measured in Chrome on 2026-08-21).
+
+    Immediately after each run reached a terminal status, with nobody having scrolled,
+    the container sat at its own maximum — 224 of 224 on the plan run, 248 of 248 on the
+    agent run — and the answer card, which is the first child of this container, was that
+    far above the fold. The newest entry at that point is `run-finished`; the thing the
+    user has been waiting for is at the top. Every run therefore ended by landing the
+    reader at the bottom of the transcript, which defeats the one thing this redesign is
+    for.
+
+    So the run's own status bounds the following, and the end of the run brings the
+    answer into view instead — once per run, because it is an event and not a position to
+    hold: a reader who then scrolls down into the transcript must not be pulled back up
+    by the next resize. And it is still subject to the standing rule that a reader who
+    scrolled away is left where they are; the reveal is for the reader who was watching
+    the run, not for the one reading step four.
+
+    The card stays INSIDE the scroller. Lifting it out would give the answer a fixed
+    share of a 384-pixel panel — a long report would then starve the transcript, or need
+    a scroller of its own inside the one it sits above — and it would sit over the
+    reader's eyes while they read the chronology. Bounding the following costs nothing
+    the other arrangement would have bought.
+  */
+  useEffect(() => {
+    const live = run.runId === null || LIVE_STATUSES.has(run.timeline.status);
+    timelineLive.current = live;
+    if (live) {
+      pinToNewest();
+      return;
+    }
+    if (run.runId === null || revealedAnswerFor.current === run.runId) return;
+    revealedAnswerFor.current = run.runId;
+    // The reader who scrolled up to read an earlier step is not moved, exactly as they
+    // are not while the run is going.
+    if (!followingTimeline.current) return;
+    const scroller = timelineScroller.current;
+    if (scroller !== null) scroller.scrollTop = 0;
+  }, [run.timeline.items, run.timeline.status, run.runId]);
+
   useEffect(() => {
     const scroller = timelineScroller.current;
     // `ResizeObserver` is absent in some test environments and in no browser this app
@@ -1509,6 +1569,141 @@ export function AgentRail({
     observer.observe(scroller);
     return () => observer.disconnect();
   }, []);
+
+  /*
+    What reaches the database, from `posture.ts` and from nowhere else — the whole reason
+    that module exists is that the rail used to answer this question in six places and a
+    user comparing two of them could not tell which one bounded the run.
+
+    ONE module, asked TWO questions, because with a run open they stop having the same
+    answer:
+
+     - **what the open run does**, which the strip under the header says. Both of its axes
+       come off the run. The mode is the run's own ledger (`AgentRunTimeline.mode`), not
+       the toggle: the toggle is frozen only while a start is HELD, deliberately, since it
+       decides the NEXT run, so reading it here let one click on Plan relabel a run that
+       was executing reads as "Executes nothing it drafts". The hand-over is what the open
+       REQUEST carried, and `openedWithHandover` is never cleared — it is a record, not a
+       live reading — so it is gated on the run still being open, or the strip goes on
+       promising one statement in the editor after the widened run has ended, while the
+       next consent step defaults the tick to OFF.
+     - **what pressing Start would do**, which the amber engine notice is entirely about.
+       That one is the SELECTION's: the notice renders on the selected mode and offers the
+       way out of that selection, so reading the open run's posture there would put plan
+       mode's body inside a card whose whole subject is the engine agent mode cannot
+       execute on. A muted line under Start used to ask the same question in words, and it
+       said the strip's sentence over again 200px below it (L7), so it is gone.
+
+    The two coincide whenever no run is open, which is most of the panel's life.
+  */
+  const engineLabel = connectionType === null ? "this connection" : getDBConfig(connectionType).label;
+  const handoverConsented = pendingStart !== null ? autoExecute : runOpen && openedWithHandover;
+  const describedMode = runOpen ? run.timeline.mode : mode;
+  const selectionPosture = agentPosture({
+    mode,
+    engine: connectionType,
+    engineLabel,
+    // The standing step's tick, and OFF otherwise: nothing has been consented to for a
+    // run that is not being opened, and the next step's tick starts unticked.
+    handover: pendingStart !== null && autoExecute,
+  });
+
+  /*
+    An engine agent mode cannot execute a statement on, named before Start rather than
+    after a run that ends `engine-unsupported`.
+
+    It is PRESENTATION of the factory's own refusal and gates nothing: `canStart` does
+    not read it, the button stays live, and the run this rail opens is refused by the
+    server exactly as it was. A notice that also disabled Start would be this surface
+    deciding a question the server decides — and it would be wrong for the operations
+    workflow, which runs on every engine because it sends no statement at all.
+
+    `null` is not one of these engines: nothing has been resolved, so which engine this
+    is has not been established, and an amber card about an engine nobody named would be
+    a claim this panel cannot support. The strip says "Cannot execute yet" for that
+    state, which is what is true.
+  */
+  const engineUnsupported =
+    mode === "agent" && connectionType !== null && !AGENT_EXECUTION_ENGINES.includes(connectionType);
+
+  /*
+    The run's scaffolding, folded away (item 7 of the redesign).
+
+    Three entries of every run say only that it began: the header, the drive starting and
+    the schema capture that grounded it. On a plan run that is three of five lines, and
+    the two that matter — the statement and what the model said about it — start below
+    the fold. They are collapsed into one dim summary that expands, and they are still
+    rendered in full inside it: nothing is dropped, and the objective quoted under the
+    header is still there to read.
+
+    `item.chrome` comes off the FOLD and not off a headline: see `AgentTimelineItem`.
+  */
+  const chromeItems = run.timeline.items.filter((item) => item.chrome === true);
+  const substantiveItems = run.timeline.items.filter((item) => item.chrome !== true);
+
+  /*
+    What the answer card is already offering, so the transcript withholds exactly that
+    and nothing else (item 8).
+
+    Read from `answerCardState` — the card's OWN reading, asked rather than reproduced.
+    That is the correctness property here, not a tidiness one: this rail used to derive
+    the suppression from the ledger (`report !== null`, and `planStatementRecorded` on
+    the entry), which is a second, independent answer to "what is the card showing". The
+    two disagreed on a run that ended `failed` holding a product — the card rendered a
+    failure banner while this withheld the transcript's copies anyway, so the only
+    "Apply to editor" a drafted statement had disappeared from every surface, and the
+    entry went on saying the statement was "in the answer at the top of this rail".
+    One reading, asked in one place, cannot disagree with itself.
+
+     - `agent`: the card renders that answer's `applySql` through `HydrationControls` in
+       its report state, so the same control on the same entry below would be a second
+       "Apply to editor" for one statement — and a user who clicks the lower one has no
+       way to know they were the same act. A live run whose answer has arrived but whose
+       report has not is NOT that state, and the transcript's control is then the only
+       one there is.
+     - `plan`: the statement's own entry renders no statement and no control, and the
+       prose it was read out of gives up its per-block control — but only while the card
+       is showing the statement. Both halves of that conjunction are load-bearing: the
+       entry can carry `planStatementRecorded` for a card that is showing something else.
+  */
+  const answerState = answerCardState(run.timeline);
+  const answerItem = run.timeline.items.find((item) => item.isAnswer === true);
+  const cardedAnswerId = answerState === "report" ? answerItem?.id : undefined;
+  /*
+    The statement the card is handing over, whichever of its two states is offering one
+    — the plan draft it renders, or the answer entry's `applySql` in its report state.
+    Undefined everywhere else, including a report whose run composed no answer: the card
+    then offers no hand-off, so there is nothing below it to de-duplicate.
+
+    It is the TEXT and not an entry id because the same statement is recorded more than
+    once. An agent run drafts every statement it executes, and the answer's is the
+    statement of the step whose artifact it presents, so a one-read run wrote that SQL
+    to the ledger twice and the report cited it a third time (L6).
+  */
+  const cardedStatement =
+    answerState === "plan"
+      ? run.timeline.items.find((item) => item.planStatement !== undefined)?.planStatement?.sql
+      : answerState === "report"
+        ? answerItem?.applySql
+        : undefined;
+
+  /*
+    The live figures the folded run details carries on its summary, so a collapsed meter
+    still says what the run has spent. The gauges' own labels are lowercased into the
+    line rather than restated, and every figure is the gauge's own.
+  */
+  const detailsFigures = [
+    `${run.timeline.items.length} steps`,
+    ...run.timeline.budget
+      // The two the ledger MEASURES, in the order the meter shows them. Repair attempts
+      // are a count of a count and say nothing at a glance, so they stay in the gauges.
+      .filter((gauge) => gauge.id === "statements" || gauge.id === "database-time")
+      .map((gauge) =>
+        gauge.id === "statements"
+          ? `${gauge.used}/${gauge.limit} stmt`
+          : `${seconds(gauge.used)}/${seconds(gauge.limit)} s`,
+      ),
+  ].join(" · ");
 
   const content = (
     <div className="flex flex-col h-full min-h-0 bg-surface text-fg">
@@ -1546,21 +1741,100 @@ export function AgentRail({
         </div>
       </div>
 
+      {/*
+        The standing reading of what the open run executes — or of what pressing Start
+        would, when there is none — under the header and above everything else, because it
+        is true of the whole panel rather than of any one control in it. Its own component
+        and its own module: this file states no bound the strip does not, and the strip
+        states no bound `posture.ts` does not.
+      */}
+      <SafetyStrip
+        mode={describedMode}
+        engine={connectionType}
+        engineLabel={engineLabel}
+        handover={handoverConsented}
+      />
+
       <div className="p-3 border-b border-hairline shrink-0">
-        <label htmlFor="agent-objective" className="text-xs text-fg-muted">
-          What should the run investigate?
-        </label>
-        <textarea
-          id="agent-objective"
-          ref={objectiveBox}
-          data-testid="agent-objective"
-          value={objective}
-          onChange={(e) => setObjective(e.target.value)}
-          maxLength={AGENT_MAX_OBJECTIVE_LENGTH}
-          rows={3}
-          className="mt-1 w-full resize-none rounded bg-sunken border border-hairline-strong px-2 py-1.5 text-xs text-fg placeholder:text-fg-subtle focus:outline-none focus:border-blue-500/40"
-          placeholder="Why is checkout slow?"
-        />
+        {/*
+          The question, as a box while it is still a question and as a line once it is
+          settled (item 4 of the redesign).
+
+          A run's objective cannot be edited — it is on the run's own header, and every
+          entry below was framed with it — so three rows of textarea holding text nobody
+          can change is the space the run's answer needed. Edit is the way back: it puts
+          the run's own question in the box, which is what a user refining it starts
+          from, and Start then opens a NEW run with whatever they made of it.
+        */}
+        {objectiveEditable ? (
+          <>
+            <label htmlFor="agent-objective" className="text-xs text-fg-muted">
+              What should the run investigate?
+            </label>
+            <textarea
+              id="agent-objective"
+              ref={objectiveBox}
+              data-testid="agent-objective"
+              value={objective}
+              onChange={(e) => setObjective(e.target.value)}
+              maxLength={AGENT_MAX_OBJECTIVE_LENGTH}
+              rows={3}
+              className="mt-1 w-full resize-none rounded bg-sunken border border-hairline-strong px-2 py-1.5 text-xs text-fg placeholder:text-fg-subtle focus:outline-none focus:border-blue-500/40"
+              placeholder="Why is checkout slow?"
+            />
+          </>
+        ) : (
+          <div className="flex items-start gap-2">
+            <div className="min-w-0 flex-1">
+              {/*
+                The user's own text, on a line of its own: the app's words are the
+                workflow and the mode below it, and this rail's rule is that the two
+                never share one VISIBLE line.
+
+                The name in front of it is the exception that rule needs. The `<label>`
+                that said what this text is belongs to the box, and the box is not on
+                this branch — so a reader arriving at an open run reached an unattributed
+                sentence of their own text, on the first content under the safety strip.
+                It is `sr-only` rather than muted chrome because a sighted user has the
+                box's absence, the Edit control and the frame line below to read it from;
+                and it is a prefix inside this node rather than a named wrapper because
+                `<p>` prohibits an accessible name of its own and the jsx-a11y gate
+                prefers a semantic element over `role="group"` (see the mode toggle).
+              */}
+              <p data-testid="agent-objective-summary" className="text-xs text-fg-secondary break-words">
+                <span data-testid="agent-objective-summary-label" className="sr-only">
+                  The objective this run was opened with:{" "}
+                </span>
+                {openedObjective}
+              </p>
+              {/*
+                Both halves off the RUN's own record. The mode used to come from the header
+                toggle, which is live again the moment the run opens, so one click on Plan
+                relabelled a run that was executing reads — and the two halves of one
+                sentence came from two sources.
+              */}
+              <p data-testid="agent-objective-frame" className="mt-0.5 text-[0.625rem] text-fg-subtle">
+                {WORKFLOW_LABELS[run.timeline.workflowType]} · {MODE_LABELS[describedMode]} mode
+              </p>
+            </div>
+            <button
+              type="button"
+              ref={objectiveEdit}
+              data-testid="agent-objective-edit"
+              aria-label="Edit the objective and ask again"
+              onClick={() => {
+                // The run's question, not the emptied box: refining what was asked is
+                // what this control is for, and retyping it is what it exists to avoid.
+                setObjective(openedObjective);
+                setEditingObjective(true);
+              }}
+              className="flex shrink-0 items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] text-fg-tertiary hover:bg-fill hover:text-fg transition-colors"
+            >
+              <PencilLine strokeWidth={1.5} className="w-3 h-3" aria-hidden="true" />
+              Edit
+            </button>
+          </div>
+        )}
 
         {/*
           ONE line, and an OFFER rather than a change (#331 T1). The objective in the
@@ -1695,111 +1969,31 @@ export function AgentRail({
         )}
 
         {/*
-          The consent step (§2.6, and §"Why the consent step is placed there").
+          The consent step (§2.6, and §"Why the consent step is placed there"), in its own
+          component since the redesign — same decision, same default, same open-time
+          freezing, and the paragraph a user consents to now behind an ⓘ on the checkbox
+          it describes rather than above it. `ConsentCard` carries the reasoning; what
+          stays here is the half only this component knows.
 
-          It replaces the pre-start checkbox entirely. That checkbox rendered wherever
-          the workflow happened to be `data-analysis`, which is a state the user could
-          leave without the tick leaving with them — and, before #373, a state four
-          workflows could reach at all. Consent asked HERE cannot drift from the run it
-          is about: the workflow is already decided, and the very next thing that
-          happens is the request that opens the run with it.
-
-          It is still consent given at OPEN time, which is what `src/lib/agent/types.ts`
-          requires of every widening decision: no run exists yet.
-
-          The copy is the control. "Auto-mode" transfers no responsibility because it
-          names no bound, so this names all three — the bound the run keeps for its own
-          read, the bound the editor keeps, and the bound being given up — and says what
-          the run does INSTEAD when its gate declines, because a user who finds the
-          statement sitting unrun has to be able to read that as the feature working.
-          Every figure comes from the constants the enforcement reads.
+          The region's ref is one of those halves. The card focuses itself when it is
+          raised — that is the announcement — and the caller decides where focus goes when
+          it LEAVES, because the two exits need different answers (`leaveConsent`).
         */}
         {pendingStart !== null && (
-          <section
-            ref={consentRegion}
-            tabIndex={-1}
-            aria-labelledby="agent-consent-workflow"
-            aria-describedby="agent-consent-terms"
-            data-testid="agent-consent"
-            className="mt-2 rounded border border-blue-400/30 bg-blue-500/5 p-2 space-y-1 focus:outline-none focus:ring-1 focus:ring-blue-400/50"
-          >
-            {/*
-              The region's own name, and it names the CONNECTION as well as the workflow.
-              The terms below promise the statement will run "on the connection the run
-              was opened on", and that connection is the one this start was asked on
-              rather than whatever the shell is showing when Open is finally pressed — so
-              the sentence says which, and the run opens on exactly that one.
-            */}
-            <p id="agent-consent-workflow" data-testid="agent-consent-workflow" className="text-xs text-fg-secondary">
-              This run will open as {WORKFLOW_LABELS[pendingStart.workflowType]} on{" "}
-              {pendingStart.connection.name ?? "the connection you started it on"}, which answers with a result.
-            </p>
-            <label htmlFor="agent-auto-execute" className="flex items-start gap-2 cursor-pointer">
-              <input
-                id="agent-auto-execute"
-                data-testid="agent-auto-execute"
-                type="checkbox"
-                checked={autoExecute}
-                onChange={(e) => setAutoExecute(e.target.checked)}
-                className="mt-0.5 rounded border-edge bg-panel"
-              />
-              <span data-testid="agent-auto-execute-label" className="text-xs text-fg-secondary">
-                Also run the final answer in my editor
-              </span>
-            </label>
-            <p
-              id="agent-consent-terms"
-              data-testid="agent-auto-execute-terms"
-              className="text-[0.625rem] text-fg-muted"
-            >
-              {autoExecuteTerms(pendingStart.workflowType)}
-            </p>
-            {/*
-              One more sentence where the engine changes what a long read costs, in the
-              words the budget meter already uses for the same fact: SQLite does not
-              preempt a statement over its timeout, so the editor's missing time limit is
-              a different promise there than it is on PostgreSQL.
-
-              Read off the SNAPSHOT, like everything else in this panel: a user who
-              switches to PostgreSQL while the step stands still opens the run on SQLite,
-              and a warning that left with the switch would have been withdrawn from the
-              one run it is true of.
-            */}
-            {pendingStart.connection.type === "sqlite" && (
-              <p data-testid="agent-auto-execute-sqlite" className="text-[0.625rem] text-amber-400/70">
-                On SQLite a read is not interrupted when it runs long: it blocks other writers and this application
-                until it finishes.
-              </p>
-            )}
-            <p data-testid="agent-consent-frozen" className="text-[0.625rem] text-fg-subtle">
-              This is decided by the request that opens the run and stays what it was: a later request cannot widen a
-              run the server already holds.
-            </p>
-            <div className="flex items-center gap-1 pt-0.5">
-              <button
-                type="button"
-                data-testid="agent-consent-open"
-                onClick={() => {
-                  leaveConsent("objective");
-                  void beginRun({ ...pendingStart, autoExecute });
-                }}
-                className="px-2 py-1 rounded text-xs bg-blue-500/15 text-blue-300 hover:bg-blue-500/25 transition-colors"
-              >
-                Open
-              </button>
-              {/* Cancel opens nothing: the objective stays in the box, and Start is live
-                  again — and takes focus back, since the control that is live again is
-                  the one that raised this. */}
-              <button
-                type="button"
-                data-testid="agent-consent-cancel"
-                onClick={() => leaveConsent("start")}
-                className="px-2 py-1 rounded text-xs text-fg-tertiary hover:bg-fill transition-colors"
-              >
-                Cancel
-              </button>
-            </div>
-          </section>
+          <ConsentCard
+            workflowType={pendingStart.workflowType}
+            workflowLabel={WORKFLOW_LABELS[pendingStart.workflowType]}
+            connectionName={pendingStart.connection.name}
+            engine={pendingStart.connection.type}
+            autoExecute={autoExecute}
+            onAutoExecuteChange={setAutoExecute}
+            onOpen={() => {
+              leaveConsent("objective");
+              void beginRun({ ...pendingStart, autoExecute });
+            }}
+            onCancel={() => leaveConsent("start")}
+            regionRef={consentRegion}
+          />
         )}
 
         {/*
@@ -1891,6 +2085,43 @@ export function AgentRail({
           </div>
         )}
 
+        {/*
+          Agent mode on an engine that has no read-only statement path (item 5).
+
+          The facts are the posture's, so this card invents nothing: the engines that DO
+          have one are named from `AGENT_EXECUTION_ENGINES` rather than typed, the two
+          ways forward are the two that are actually open — plan mode drafts here, and the
+          operations workflow sends no statement at all — and the run would end
+          `engine-unsupported` before its first statement.
+
+          It does not gate Start, and `canStart` above is where that is visible: the
+          refusal belongs to the provider factory, this is a notice about it, and one
+          workflow runs here regardless. A disabled Start would take the operations
+          workflow away over a claim that is not true of it.
+        */}
+        {engineUnsupported && (
+          <div
+            data-testid="agent-engine-unsupported-notice"
+            className="mt-2 rounded border border-amber-400/40 bg-amber-500/5 p-2 space-y-1"
+          >
+            <p className="flex items-start gap-1 text-xs text-amber-300">
+              <TriangleAlert strokeWidth={1.5} className="mt-px w-3 h-3 shrink-0" aria-hidden="true" />
+              {selectionPosture.title}
+            </p>
+            <p data-testid="agent-engine-unsupported-reason" className="text-[0.625rem] text-amber-300/90">
+              {selectionPosture.body}
+            </p>
+            <button
+              type="button"
+              data-testid="agent-engine-unsupported-plan"
+              onClick={() => setMode("planning")}
+              className="px-1.5 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+            >
+              Switch to Plan
+            </button>
+          </div>
+        )}
+
         <div className="mt-2 flex items-center justify-between gap-2">
           <span data-testid="agent-run-id" className="font-mono text-[0.625rem] text-fg-subtle truncate">
             {run.runId ?? ""}
@@ -1930,6 +2161,25 @@ export function AgentRail({
             </button>
           </div>
         </div>
+
+        {/*
+          There is no second posture line under Start (L7, measured 2026-08-21).
+
+          It printed `${headline} — ${qualifier}.`, which is the strip's own sentence,
+          about 200px below the strip: two identical sentences in one 384px panel, and the
+          lower one was the easier to mistake for a claim about something else. The strip
+          is permanent and always visible, so what the line said is not lost — and the
+          panel's other reading of the SELECTION, the amber engine notice below, is the
+          one that says something the strip does not, because it is about a mode the user
+          has selected and the engine cannot execute.
+
+          The alternative considered was to give this line the login hero's claim
+          (`hero-proof.tsx`), which IS different information. It was not taken: that claim
+          describes both modes at once, for a visitor who has selected neither, and here
+          one is selected — and reusing it would mean exporting the hero's private
+          `AGENT_MODES` out of a module that also pulls in the distribution and showcase
+          catalogs, for a sentence about the mode the user did not pick.
+        */}
 
         {/*
           The refused model (#331 T4). A start refused because the model was ESTABLISHED
@@ -2018,78 +2268,131 @@ export function AgentRail({
       </div>
 
       {/*
-        The meter reports what the server ENFORCES, and reads every consumption off
-        the run's own ledger. Three bounds can be measured that way; the rest are
-        stated as the ceilings they are, because nothing durable records their
-        consumption — the wall-clock deadline and the model-turn count live in the
-        process driving the run, and this build enforces no token budget at all, so
-        no token figure is shown rather than one that means nothing.
+        The meter, FOLDED (item 6 of the redesign).
 
-        Every measured figure is a FLOOR on the spend, not the spend: the ledger is
-        narrower than the tracker in three known ways (`docs/BACKLOG.md` B12, B13),
-        and the caveat below names all three rather than leaving a user to read the
-        gauges as exact.
+        It reports what the server ENFORCES and reads every consumption off the run's own
+        ledger. Three bounds can be measured that way; the rest are stated as the ceilings
+        they are, because nothing durable records their consumption — the wall-clock
+        deadline and the model-turn count live in the process driving the run, and this
+        build enforces no token budget at all, so no token figure is shown rather than one
+        that means nothing.
+
+        What changed is where the reading SITS, and nothing about what it says. Four
+        stacked paragraphs of caveat above the transcript pushed the run's own output below
+        the fold on every viewport this rail ships in, so the block is a `<details>`: the
+        summary keeps the live figures, and the three claims move behind an ⓘ each — each
+        one on the figure it qualifies, each one still rendered in full, and each one still
+        in the accessibility tree whether or not its popover is open (`InfoNote`). Their
+        test ids travel with them, because they are the claims and not the layout.
+
+        Open while the run is live, shut otherwise: a run in flight is the only time these
+        figures are moving, and `open` is a prop React writes only when its value CHANGES,
+        so a user who folds it away mid-run is not fought on the next ledger line.
       */}
-      <div data-testid="agent-budget" className="px-3 py-2 border-b border-hairline shrink-0 space-y-1.5">
+      <details data-testid="agent-run-details" open={runOpen} className="border-b border-hairline shrink-0">
+        <summary className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-[0.625rem] text-fg-muted hover:text-fg-secondary">
+          Run details
+          {/*
+            The spend at a glance, so a folded meter still answers "how far in is it" —
+            and only once a run exists, which is the gauges' own rule inside. Before one,
+            these would read a run's worth of zeroes against the DEFAULT workflow's
+            ceilings, and under Automatic that is a workflow nobody has chosen and the
+            classifier may not pick: a bound stated before anything could enforce it.
+          */}
+          {run.runId !== null && (
+            <span data-testid="agent-run-details-figures" className="font-mono text-fg-subtle">
+              {detailsFigures}
+            </span>
+          )}
+        </summary>
         {/*
-          The gauges measure a run, so they wait for one. Before any run exists they
-          would read a full set of zeroes against the DEFAULT workflow's ceilings, which
-          under Automatic is a workflow nobody has chosen and the classifier may not
-          pick.
+          The meter's own wrapper keeps its id through the move behind the `<details>`:
+          it is the handle the gauges are read through as a BLOCK, and the disclosure
+          around it is a different node with a different id (`agent-run-details`).
         */}
-        {run.runId !== null &&
-          run.timeline.budget.map((gauge) => (
-            <div key={gauge.id} data-testid={`agent-budget-${gauge.id}`}>
-              <div className="flex items-center justify-between gap-2">
-                <span className="text-xs text-fg-muted">{gauge.label}</span>
-                <span className="font-mono text-[0.625rem] text-fg-tertiary">{readGauge(gauge)}</span>
+        <div data-testid="agent-budget" className="px-3 pb-2 space-y-1.5">
+          {/*
+            The gauges measure a run, so they wait for one. Before any run exists they
+            would read a full set of zeroes against the DEFAULT workflow's ceilings, which
+            under Automatic is a workflow nobody has chosen and the classifier may not
+            pick.
+          */}
+          {run.runId !== null &&
+            run.timeline.budget.map((gauge) => (
+              <div key={gauge.id} data-testid={`agent-budget-${gauge.id}`}>
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs text-fg-muted">{gauge.label}</span>
+                  <span className="font-mono text-[0.625rem] text-fg-tertiary">{readGauge(gauge)}</span>
+                </div>
+                <div className="mt-1 h-0.5 rounded-full bg-fill">
+                  <div
+                    data-testid={`agent-budget-${gauge.id}-bar`}
+                    className="h-full rounded-full bg-blue-400/60"
+                    style={{ width: `${gaugeFraction(gauge)}%` }}
+                  />
+                </div>
               </div>
-              <div className="mt-1 h-0.5 rounded-full bg-fill">
-                <div
-                  data-testid={`agent-budget-${gauge.id}-bar`}
-                  className="h-full rounded-full bg-blue-400/60"
-                  style={{ width: `${gaugeFraction(gauge)}%` }}
-                />
-              </div>
-            </div>
-          ))}
-        {/*
-          Withheld while the workflow is the classifier's to decide: these are per
-          workflow, and `data-analysis` and `investigation` are not close. A figure shown
-          before the workflow is known would be a claim this rail cannot keep, and the
-          user would read it as the bound their run will get.
-        */}
-        {showBudgetLimits ? (
-          <p data-testid="agent-budget-limits" className="pt-0.5 text-[0.625rem] text-fg-subtle">
-            Each statement gets {seconds(meterBudget.policy.budgets.statementTimeoutMs)} s, each drive{" "}
-            {(meterBudget.runDeadlineMs / 60_000).toFixed(1)} min and at most {meterBudget.maxModelTurns} model turns.
-          </p>
-        ) : (
-          <p data-testid="agent-budget-unknown" className="pt-0.5 text-[0.625rem] text-fg-subtle">
-            Every ceiling below is per workflow, and Automatic decides the workflow from your objective when the run
-            opens — so the figures are stated once the run has one, and by the run&apos;s own record.
-          </p>
-        )}
-        {/*
-          The reserve, stated where the ceilings are. Without it a run that ends short
-          of every figure above reads as one that gave up; it was asked to stop, and
-          the report it composed is the point of asking.
-        */}
-        <p data-testid="agent-budget-reserve" className="text-[0.625rem] text-fg-subtle">
-          The last {AGENT_REPORT_RESERVE_TURNS} model turns and the last {seconds(AGENT_REPORT_RESERVE_MS)} s are kept
-          back for the report: whichever it reaches first, the run is asked once to stop and report what it has
-          established. So a run that ends short of these figures was asked to stop rather than having given up, and its
-          claims still cite what it read. A plan run is never asked, having no report to compose.
-        </p>
-        <p data-testid="agent-budget-caveats" className="text-[0.625rem] text-fg-subtle">
-          Every ceiling is per drive, so a run resumed after a restart starts each of them again and these totals can
-          read past a single drive's ceiling. What is counted comes from the run's ledger, which records less than the
-          server charges: the schema capture's catalog reads are not itemized, a statement that failed at the database
-          records no duration, and a completed read reports the engine's own elapsed time rather than the span the
-          budget was charged. So a spend shown here is a floor, never a ceiling. On SQLite a statement over its timeout
-          is refused once it returns, not interrupted while it runs.
-        </p>
-      </div>
+            ))}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-0.5 text-[0.625rem] text-fg-subtle">
+            {/*
+              What the measured figures above are: a floor, per drive. The claim qualifies
+              the gauges, so it sits with them.
+            */}
+            <span className="inline-flex items-center gap-0.5">
+              What is counted
+              <InfoNote title="What these figures count" testId="agent-budget-spend">
+                <span data-testid="agent-budget-caveats" className="block">
+                  Every ceiling is per drive, so a run resumed after a restart starts each of them again and these
+                  totals can read past a single drive&apos;s ceiling. What is counted comes from the run&apos;s ledger,
+                  which records less than the server charges: the schema capture&apos;s catalog reads are not itemized,
+                  a statement that failed at the database records no duration, and a completed read reports the
+                  engine&apos;s own elapsed time rather than the span the budget was charged. So a spend shown here is a
+                  floor, never a ceiling. On SQLite a statement over its timeout is refused once it returns, not
+                  interrupted while it runs.
+                </span>
+              </InfoNote>
+            </span>
+            {/*
+              The ceilings nothing counts from, withheld while the workflow is the
+              classifier's to decide: these are per workflow, and `data-analysis` and
+              `investigation` are not close. A figure shown before the workflow is known
+              would be a claim this rail cannot keep, and the user would read it as the
+              bound their run will get. Where they ARE known the ⓘ carries them, and the
+              reserve — which is the reason a run can end short of every one of them — sits
+              beside the figures it is about.
+            */}
+            {showBudgetLimits ? (
+              <span className="inline-flex items-center gap-0.5">
+                Ceilings
+                <InfoNote title="The ceilings nothing measures" testId="agent-budget-ceilings">
+                  <span data-testid="agent-budget-limits" className="block">
+                    Each statement gets {seconds(meterBudget.policy.budgets.statementTimeoutMs)} s, each drive{" "}
+                    {(meterBudget.runDeadlineMs / 60_000).toFixed(1)} min and at most {meterBudget.maxModelTurns} model
+                    turns.
+                  </span>
+                </InfoNote>
+              </span>
+            ) : (
+              <p data-testid="agent-budget-unknown">
+                Every ceiling here is per workflow, and Automatic decides the workflow from your objective when the run
+                opens — so the figures are stated once the run has one, and by the run&apos;s own record.
+              </p>
+            )}
+            <span className="inline-flex items-center gap-0.5">
+              Report reserve
+              <InfoNote title="What is kept back for the report" testId="agent-budget-report-reserve">
+                <span data-testid="agent-budget-reserve" className="block">
+                  The last {AGENT_REPORT_RESERVE_TURNS} model turns and the last {seconds(AGENT_REPORT_RESERVE_MS)} s
+                  are kept back for the report: whichever it reaches first, the run is asked once to stop and report
+                  what it has established. So a run that ends short of these figures was asked to stop rather than
+                  having given up, and its claims still cite what it read. A plan run is never asked, having no report
+                  to compose.
+                </span>
+              </InfoNote>
+            </span>
+          </div>
+        </div>
+      </details>
 
       <div
         ref={timelineScroller}
@@ -2097,141 +2400,96 @@ export function AgentRail({
         data-testid="agent-timeline-scroll"
         className="flex-1 min-h-0 overflow-auto"
       >
+        {/*
+          What came of the run, above the chronology of it (item 2 of the redesign).
+
+          It is a SECOND rendering of entries the timeline below already holds, and it is
+          first in this container rather than pinned outside it deliberately: the answer
+          scrolls away like everything else, so a user reading the transcript is not
+          reading it under a fixed block that has taken a third of the panel.
+
+          No `capabilities`: this rail is given a connection id and a type, not a provider
+          descriptor, and there is no fetch here to get one — every test in this suite
+          counts the requests this component makes. The card's fallback is the honest one
+          for that state: it tints from what the LEDGER says the guard could read, and
+          answers "unknown" rather than SQL where nothing said.
+
+          The run's grounding is not passed either, and deliberately: the card reads the
+          capture off this same timeline. It used to be a second prop beside it, and a
+          claim a caller can forget to pass is a claim that disappears — on MongoDB the
+          answer showed the amber `not checked` chip alone while the fold two lines below
+          said `Schema captured — 5 collections` (L4, measured 2026-08-21).
+
+          `onStop` is deliberately not passed. The run's stop is one control and it is the
+          one in the row above, three lines up: a second Stop inside the card would be two
+          buttons for one ask, and the header's is the one this rail has always offered —
+          including in the window between an accepted start and its first ledger line,
+          where there is no card yet at all.
+        */}
+        <AnswerCard timeline={run.timeline} onApplyStatement={onApplyStatement} onShowArtifact={showArtifact} />
         <ol data-testid="agent-timeline" aria-live="polite" className="p-2 space-y-1">
           {run.timeline.items.length === 0 && (
             <li data-testid="agent-timeline-empty" className="p-2 text-xs text-fg-subtle">
               No activity yet. A run's steps appear here as they are recorded.
             </li>
           )}
-          {run.timeline.items.map((item) => (
+          {/*
+            The run's scaffolding, folded (item 7). One dim line where three entries were,
+            expanding to those three entries rendered exactly as any other — so nothing is
+            hidden, and the two lines a plan run is actually about start at the top.
+
+            `agent-timeline-item` stays the id of a SUBSTANTIVE entry, which is what makes
+            it worth asserting: a test that counts entries is counting what the run found.
+          */}
+          {chromeItems.length > 0 && (
+            /*
+              Silenced, and only this subtree: the nearest live ancestor governs, so
+              `aria-live="off"` here leaves every substantive entry below announced.
+
+              The summary interpolates a running count and the content of a closed
+              `<details>` is not exposed at all, so inside the polite region a reader heard
+              "Run setup · 1 entry", "· 2 entries", "· 3 entries" in place of the three
+              lines those entries actually say. The collapse is deliberate; three
+              announcements of a counter were not.
+            */
+            <li aria-live="off">
+              <details data-testid="agent-timeline-chrome" className="rounded">
+                <summary className="cursor-pointer p-2 text-[0.625rem] text-fg-subtle hover:text-fg-muted">
+                  Run setup · {chromeItems.length} {chromeItems.length === 1 ? "entry" : "entries"}
+                </summary>
+                <ol className="space-y-1">
+                  {chromeItems.map((item) => (
+                    <li
+                      key={item.id}
+                      data-testid="agent-timeline-chrome-item"
+                      className="rounded p-2 opacity-80 hover:bg-fill"
+                    >
+                      <TimelineEntryBody
+                        item={item}
+                        onApplyStatement={onApplyStatement}
+                        showArtifact={showArtifact}
+                        declinedHandovers={declinedHandovers}
+                        cardedAnswerId={cardedAnswerId}
+                        cardedStatement={cardedStatement}
+                        planCarded={answerState === "plan"}
+                      />
+                    </li>
+                  ))}
+                </ol>
+              </details>
+            </li>
+          )}
+          {substantiveItems.map((item) => (
             <li key={item.id} data-testid="agent-timeline-item" className="rounded p-2 hover:bg-fill">
-              <div className="flex items-center gap-2">
-                <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", TONE_CLASSES[item.tone])} />
-                <span className="text-xs text-fg-secondary">{item.headline}</span>
-              </div>
-              {item.detail !== undefined && <p className="mt-0.5 pl-3.5 text-xs text-fg-muted">{item.detail}</p>}
-              {/*
-                Prose the MODEL wrote, rendered with the structure it wrote it in
-                (#373 review). Measured in plan mode against a live model: the closing
-                statement arrived as markdown and reached the user as hash marks and
-                asterisks, and plan mode's whole output is this one block.
-
-                Inside its own bordered block, which is the half that has to survive
-                being readable: `renderProse` builds React nodes and reaches no HTML
-                parser, so nothing here can execute — but a heading a model wrote must
-                still not read as a heading the application wrote, and the rule that
-                the app's words and everyone else's never share a line is what the
-                border keeps true.
-              */}
-              {/*
-                The editor is offered to the statements INSIDE the prose (#389), EXCEPT on
-                the entry a plan run's statement was read out of.
-
-                That exception is the whole marking requirement, not a detail of it. The
-                closing prose of a plan run HOLDS the fenced statement, so without it the
-                same `DELETE` renders twice: once in the card below, amber, with the guard's
-                verdict and an accessible name that carries it — and once here, immediately
-                above it, as a plain grey "Apply to editor" with no mark and no name, which
-                is the control a user reaches for first because it sits against the SQL.
-                `renderProse` cannot label it: it is handed text and knows nothing of the
-                ledger. So the marked hand-off is the only hand-off, and the block keeps its
-                clipboard. Everywhere else — an agent run, a plan run that drafted nothing —
-                #389's control is untouched, because there is no card there to defer to.
-
-                A host with no editor passes nothing and is offered nothing, the rule every
-                other affordance in this rail follows.
-
-                A refusal is the same prose in a different frame. The run reached its other
-                legitimate ending — it says the schema does not answer the question — and
-                that is what the card states; the marker the ledger read it by was stripped
-                on the way here, because it is a protocol token the model was told to emit
-                and not a sentence it wrote for anyone to read.
-              */}
-              {item.prose !== undefined &&
-                (item.planRefusal === true ? (
-                  <section
-                    data-testid="agent-plan-refusal"
-                    className="mt-1 ml-3.5 rounded border border-amber-400/40 bg-amber-500/5 p-1.5"
-                  >
-                    {/*
-                      Says only that the run could not draft, never WHY — the two reasons
-                      are different and this card cannot tell them apart. A grounded run
-                      refuses because the inventory it was given does not reach the
-                      question; an ungrounded one (a reading that was refused, that
-                      overran its time, or a provider that cannot describe its own
-                      schema — the engine alone stopped deciding it in #414) refuses
-                      because there was no inventory at all. The earlier wording named "the schema it read",
-                      which on the second path is a reading that never happened.
-                    */}
-                    <p className="text-[0.625rem] text-amber-300">
-                      This run drafted no statement. What it says is missing, and what it needs from you, are in its own
-                      words below.
-                    </p>
-                    <ProseBlock
-                      text={item.prose}
-                      onApplySql={onApplyStatement}
-                      statementCarded={item.planStatementRecorded === true}
-                      className="mt-1"
-                    />
-                  </section>
-                ) : (
-                  <ProseBlock
-                    text={item.prose}
-                    onApplySql={onApplyStatement}
-                    statementCarded={item.planStatementRecorded === true}
-                    className="mt-1 ml-3.5"
-                  />
-                ))}
-              {/*
-                The run's own deliverable, with what the server established about it. Its
-                own card rather than a line beside the entry, because a statement a user
-                may be about to run is the one thing on this surface that can do damage
-                if it is presented as something it is not.
-              */}
-              {item.planStatement !== undefined && (
-                <PlanStatementCard draft={item.planStatement} onApply={onApplyStatement} />
-              )}
-              {/*
-                The one place this surface contradicts the ledger, and it does so beside
-                the sentence it contradicts. The entry above is folded from what the RUN
-                recorded — that it handed the statement over to be run — and this rail
-                declined to perform it, so a reader who saw only the entry would believe
-                an execution that never happened. Said here rather than in a banner:
-                the fact is about this answer, and a notice elsewhere would be a
-                sentence the reader has to match to a line themselves.
-              */}
-              {declinedHandovers
-                .filter((declined) => declined.id === item.id)
-                .map((declined) => (
-                  <p
-                    key={declined.id}
-                    data-testid="agent-handover-declined"
-                    className="mt-0.5 pl-3.5 text-xs text-amber-400/80"
-                  >
-                    It was not run: this run was opened on {declined.openedOn ?? "another connection"} and your editor
-                    has moved to a different one since. The answer would have arrived in a tab that is connected
-                    somewhere else, so nothing was executed. The statement is below — take it yourself if you want it on
-                    the connection you are on now.
-                  </p>
-                ))}
-              {/*
-              Verbatim content from the model, the engine or the user, kept in its own
-              block rather than folded into a sentence: it is untrusted input, and the
-              user should be able to see where the app stops speaking.
-            */}
-              {item.quoted !== undefined && (
-                <QuotedBlock text={item.quoted} testId="agent-quoted-copy" className="mt-1 ml-3.5" />
-              )}
-              <div className="ml-3.5">
-                <HydrationControls
-                  sql={item.applySql}
-                  artifactId={item.artifactId}
-                  chartSpec={item.chartSpec}
-                  testIdPrefix="agent-"
-                  onApply={onApplyStatement}
-                  onShow={showArtifact}
-                />
-              </div>
+              <TimelineEntryBody
+                item={item}
+                onApplyStatement={onApplyStatement}
+                showArtifact={showArtifact}
+                declinedHandovers={declinedHandovers}
+                cardedAnswerId={cardedAnswerId}
+                cardedStatement={cardedStatement}
+                planCarded={answerState === "plan"}
+              />
             </li>
           ))}
         </ol>
@@ -2257,50 +2515,25 @@ export function AgentRail({
         )}
 
         {/*
-          The run's conclusion, and the one place a user can check it: every claim
-          is the model's own prose — quoted, never narrated as the app speaking —
-          and every citation names something this run's ledger holds. The server
-          already refused a claim it could not verify (`composeReportTool`), so a
-          citation that does not resolve here is a gap in what this rail has read,
-          and says so rather than looking checked.
+          The run's conclusion is the CARD, at the top of this container, and there is no
+          second Report section down here any more (L6, measured 2026-08-21).
+
+          It was not a duplicate by accident: the card renders the same claims, quoted the
+          same way, with the same citations — so the rail printed the model's claim twice
+          and offered "Apply to editor" three times for one statement, the card's, this
+          section's citation and the `Statement drafted` entry that recorded it. Not one of
+          the three carried an accessible name.
+
+          Nothing this section said is gone. The claims are `agent-answer-claim`, quoted
+          exactly as they were and still never narrated as the app speaking; each
+          citation's label, the ledger's own detail for it and the statement it rests on
+          are in the card's `agent-answer-evidence` fold, with the locator on the chip
+          beside the claim; and a citation this timeline holds no entry for still says so
+          in its own words rather than looking checked. Its `Show result` is the one thing
+          not reproduced there, and it was already a second offer of the artifact the
+          `Result stored` entry offers under the same live-run rule — while the note above
+          is what explains the absence once a run has ended.
         */}
-        {run.timeline.report !== null && (
-          <section data-testid="agent-report" className="border-t border-hairline p-2 space-y-2">
-            <h2 className="px-1 text-xs font-medium text-fg-secondary">Report</h2>
-            {run.timeline.report.claims.map((claim) => (
-              <div key={claim.id} data-testid="agent-report-claim" className="rounded p-2 hover:bg-fill">
-                <QuotedBlock text={claim.quoted} testId="agent-report-claim-copy" tone="loud" />
-                <ul className="mt-1 space-y-1">
-                  {claim.citations.map((citation) => (
-                    <li key={citation.id} data-testid="agent-report-citation" className="pl-1.5 text-xs">
-                      <span className={citation.resolved ? "text-fg-tertiary" : "text-amber-400/80"}>
-                        {citation.label}
-                      </span>
-                      <span className="ml-1 text-fg-subtle">{citation.detail}</span>
-                      {citation.locator !== undefined && (
-                        <span className="ml-1 font-mono text-[0.625rem] text-fg-muted">{citation.locator}</span>
-                      )}
-                      {citation.quoted !== undefined && (
-                        <QuotedBlock text={citation.quoted} testId="agent-citation-quoted-copy" className="mt-0.5" />
-                      )}
-                      <HydrationControls
-                        sql={citation.quoted}
-                        artifactId={citation.artifactId}
-                        /* A citation is evidence, not a presentation: the decision to
-                           draw a chart belongs to the answer entry, and repeating it
-                           here would offer the same artifact under two accounts. */
-                        chartSpec={undefined}
-                        testIdPrefix="agent-citation-"
-                        onApply={onApplyStatement}
-                        onShow={showArtifact}
-                      />
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </section>
-        )}
       </div>
     </div>
   );

--- a/src/components/agent/AnswerCard.tsx
+++ b/src/components/agent/AnswerCard.tsx
@@ -1,0 +1,852 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Loader2, PencilLine, RotateCcw, Square, TriangleAlert } from "lucide-react";
+import { CopyButton } from "@/components/copy-button";
+import { renderProse } from "@/components/rich-text";
+import type { AgentChartSpec, AgentRunStatus } from "@/lib/agent/types";
+import type { ProviderCapabilities } from "@/lib/db/types";
+import { editorLanguageForTabType, resolveTabType } from "@/lib/editor/tab-language";
+import { cn } from "@/lib/utils";
+import {
+  applyStatementName,
+  guardObjectionLine,
+  guardReading,
+  type GuardReading,
+  guardSummaryLine,
+  HydrationControls,
+  InfoNote,
+  LIVE_STATUSES,
+  QuotedBlock,
+} from "./rail-parts";
+import {
+  type AgentBudgetGauge,
+  type AgentCaptureView,
+  type AgentPlanStatementView,
+  type AgentRunTimeline,
+  type AgentTimelineItem,
+  describeFailureReason,
+} from "./timeline";
+
+/**
+ * The run's outcome, at the top of the rail (the agent rail UX redesign of 2026-08-21).
+ *
+ * It is a SECOND rendering of entries the timeline already holds, and that is the whole
+ * shape of it: everything on this card is folded out of the run's ledger, so there is no
+ * field here a run did not record and no sentence about a run that is not already the
+ * app's own words somewhere else. The transcript below still holds the chronology; this
+ * says what came of it, without a scroll.
+ *
+ * Three properties are correctness rather than layout, and each is pinned by a test:
+ *
+ *  - **`Apply to editor` keeps the accessible name `applyStatementName` builds.** That
+ *    name is WCAG 2.5.3 and it carries the guard's marks — the one thing a control which
+ *    can put a `DELETE` in the user's editor may not lose by being moved.
+ *  - **On an engine whose statements are not SQL there is no read-only chip.** Nothing
+ *    examined the draft, so a chip saying it was read would be a claim no code in this
+ *    product made. It gets the amber `not checked` chip and the two existing sentences
+ *    instead.
+ *  - **A statement is tinted by the engine's language**, the ladder `tab-language.ts`
+ *    walks. Where no capabilities are to hand it falls back to what the LEDGER says the
+ *    guard could read, never to SQL: a Mongo aggregation painted as SQL is the same
+ *    overstatement #414 removed from the sentences beside it.
+ *
+ * What it deliberately does NOT do is offer a control for something this build cannot
+ * perform. A refusal names no "capture more schema" button and a failure's retry appears
+ * only where the host passed one, the rule the rest of this rail follows: nothing here is
+ * a disabled button standing in for a capability that does not exist.
+ */
+
+export interface AnswerCardProps {
+  /** The run, folded from its ledger. Every claim on this card comes from here. */
+  readonly timeline: AgentRunTimeline;
+  /**
+   * The engine's capabilities, for the statement block's language. `null` or absent is
+   * the honest state while nothing has answered for the connection — and it is read as
+   * "unknown", never as SQL.
+   */
+  readonly capabilities?: ProviderCapabilities | null;
+  /** Puts a statement into the host's editor. Absent hosts are offered no control. */
+  readonly onApplyStatement?: (sql: string) => void;
+  /** Asks the host to show a result the run stored. Same signature the rail passes on. */
+  readonly onShowArtifact?: (correlationId: string, chartSpec: AgentChartSpec | undefined) => void;
+  readonly onStop?: () => void;
+  readonly onRetry?: () => void;
+}
+
+/** Which of the run's five outcomes this card is rendering. */
+type AnswerState = "failed" | "plan" | "report" | "refused" | "running";
+
+/**
+ * The word above the card. "Answer" only where the run produced one: a refusal and a
+ * failure are outcomes and not answers, and calling them answers is the kind of small
+ * overstatement this rail spends its comments avoiding.
+ */
+const EYEBROWS: Readonly<Record<AnswerState, string>> = Object.freeze({
+  plan: "Answer",
+  report: "Answer",
+  running: "Working",
+  refused: "Outcome",
+  failed: "Outcome",
+});
+
+/**
+ * The pill's tone per status, as a TOTAL map: a status added to `AgentRunStatus` and not
+ * given a tone here fails to compile, which is the only thing that keeps this in step
+ * with a union that lives on the server.
+ */
+const STATUS_TONES: Readonly<Record<AgentRunStatus, string>> = Object.freeze({
+  queued: "bg-blue-500/10 text-blue-300",
+  running: "bg-blue-500/10 text-blue-300",
+  succeeded: "bg-emerald-500/10 text-emerald-300",
+  failed: "bg-rose-500/10 text-rose-300",
+  cancelled: "bg-amber-500/10 text-amber-300",
+});
+
+/**
+ * The language a statement block is tinted in, and the one value that is not a language:
+ * `"unknown"` is this surface having nothing to go on, which is a different state from
+ * every engine in the ladder and must not collapse into the first of them.
+ */
+type StatementLanguage = "sql" | "json" | "libredb" | "redis" | "unknown";
+
+/**
+ * Identity, never status. The rail spends amber on "nobody established this", rose on a
+ * failure and emerald on a clean verdict, so none of those three is in this map: a tint
+ * that a reader could mistake for a verdict is worse than no tint at all. `"unknown"`
+ * takes the hairline, which says nothing, because nothing is what is known.
+ */
+const LANGUAGE_ACCENTS: Readonly<Record<StatementLanguage, string>> = Object.freeze({
+  sql: "border-blue-400/40",
+  json: "border-cyan-400/40",
+  redis: "border-fuchsia-400/40",
+  libredb: "border-violet-400/40",
+  unknown: "border-hairline-strong",
+});
+
+/**
+ * The block's language, from the capabilities where there are any and from the LEDGER
+ * where there are none.
+ *
+ * `resolveTabType` answers `"sql"` for absent capabilities, which is right for a tab
+ * (something has to be typed into) and wrong here: it would paint a Mongo aggregation as
+ * SQL on every render before `/api/db/provider-meta` answers, and on every render after
+ * one that failed. What the ledger recorded instead is whether the SQL guard could read
+ * this draft at all — a fact about the run rather than about the connection as it stands
+ * now, which is the same reason the inventory noun is read off the capture entry.
+ */
+function statementLanguage(
+  capabilities: ProviderCapabilities | null | undefined,
+  guardApplicable: boolean,
+): StatementLanguage {
+  if (capabilities !== null && capabilities !== undefined)
+    return editorLanguageForTabType(resolveTabType(capabilities));
+  return guardApplicable ? "sql" : "unknown";
+}
+
+/**
+ * The chip per reading.
+ *
+ * There is no `Read-only` chip outside `checked`, and that is the point of the map rather
+ * than a detail of it: `objected` is the guard having looked and not been satisfied, and
+ * `unexamined` is nothing having looked, so neither may be labelled with the verdict the
+ * third one earned.
+ */
+const GUARD_CHIPS: Readonly<Record<GuardReading, { readonly label: string; readonly className: string }>> =
+  Object.freeze({
+    checked: { label: "Read-only", className: "text-emerald-300" },
+    // The timeline's own headline for this state, in its own words.
+    objected: { label: "not classified as a read", className: "text-amber-300" },
+    unexamined: { label: "not checked", className: "text-amber-300" },
+  });
+
+/*
+  The sentences below are the ones the transcript's plan card already carries, moved here
+  as strings rather than as JSX prose: these are claims a user reads at the moment they
+  decide whether to run something, a formatter is free to reflow JSX text around an
+  interpolated value, and a claim assembled from reflowed fragments is the kind that ends
+  up saying what no branch intended. They are reproduced word for word, and each keeps
+  the test id it carried as a paragraph on that card — `agent-plan-statement-guard-unread`,
+  `agent-plan-statement-unread`, `agent-plan-statement-unchecked`,
+  `agent-plan-statement-unknown` and `agent-plan-statement-caveat`.
+
+  The id travels WITH the claim rather than being replaced by one id on the popover,
+  which is the pattern `InfoNote`'s own docblock states and `agent-budget-limits` and its
+  two siblings follow. It is not bookkeeping: these ids are how a test pins that the
+  right sentence for THIS reading is present, and an assertion against one shared blob
+  cannot tell that apart from any sentence that happens to contain the phrase — the
+  `no-inventory` and `not-applicable` readings differ by exactly which of two sentences
+  they may make.
+*/
+
+/** One preserved claim, and the id a test finds it by. */
+interface GuardNote {
+  readonly testId: string;
+  readonly text: string;
+}
+
+/** Said where the guard reads SQL and the engine's statements are not. */
+const GUARD_UNREAD_NOTE: GuardNote = Object.freeze({
+  testId: "agent-plan-statement-guard-unread",
+  text: "The statement guard reads SQL, and this engine's statements are not SQL — so nothing examined this draft. It is drafted, not run — nothing has happened to your data — but nothing here has established anything about it, for or against.",
+});
+
+/** The same fact about the NAME check, which is a second SQL reader. */
+const NAMES_UNREAD_NOTE: GuardNote = Object.freeze({
+  testId: "agent-plan-statement-unread",
+  text: "The names in this statement were not checked: the check that would do it reads SQL, and this engine's statements are not SQL.",
+});
+
+/** A run that captured nothing to check against, which is not the same state. */
+const NO_INVENTORY_NOTE: GuardNote = Object.freeze({
+  testId: "agent-plan-statement-unchecked",
+  text: "No schema inventory was read for this run, so the names in this statement were not checked against anything.",
+});
+
+/** Names the inventory does not hold. The names themselves are chips, not part of this sentence. */
+const UNKNOWN_NAMES_NOTE: GuardNote = Object.freeze({
+  testId: "agent-plan-statement-unknown",
+  text: "These names are not in the inventory this run read, so the statement may not run as written:",
+});
+
+/** What a checked statement is still not: permission to run. */
+const EXECUTION_CAVEAT: GuardNote = Object.freeze({
+  testId: "agent-plan-statement-caveat",
+  text: "The run executed nothing. What was checked is what this run read of the schema, which records what exists rather than what your role is permitted to read.",
+});
+
+/**
+ * The guard's own objection, with the reason it recorded — the shared first sentence,
+ * continued with what the objection does and does not establish.
+ */
+const guardObjectionNote = (violation: string | undefined): string =>
+  `${guardObjectionLine(violation)} It is drafted, not run — nothing has happened to your data — but nothing here establishes that running it would only read.`;
+
+/** The rail's sentence for the ending a plan run reaches when it drafts nothing. */
+const REFUSAL_NOTE =
+  "This run drafted no statement. What it says is missing, and what it needs from you, are in its own words below.";
+
+/**
+ * The floor claim, in the words the meter's caveat paragraph already makes it in
+ * (`agent-budget-caveats`). The paragraph itself stays where the ceilings are; what a
+ * live figure needs beside it is the half that says the figure is not the spend.
+ */
+const SPEND_FLOOR_NOTE =
+  "What is counted comes from the run's ledger, which records less than the server charges, so a spend shown here is a floor, never a ceiling.";
+
+/** A failure the server carried without classifying. There is a cause; this is not it. */
+const UNCLASSIFIED_FAILURE_NOTE =
+  "This run ended as failed and its own record names no reason for it. The server log is where the cause is.";
+
+/** What the names the check could not find, or could not read, add to the popover. */
+function identifierNote(draft: AgentPlanStatementView): GuardNote | null {
+  if (draft.identifiers.kind === "not-applicable") return NAMES_UNREAD_NOTE;
+  if (draft.identifiers.kind === "no-inventory") return NO_INVENTORY_NOTE;
+  return draft.identifiers.unknownTables.length > 0 ? UNKNOWN_NAMES_NOTE : null;
+}
+
+const seconds = (ms: number): string => (ms / 1000).toFixed(1);
+
+/**
+ * One gauge, read in the unit it is bounded in and named by its own label.
+ *
+ * The formatter is the rail's, spelled again rather than imported: `AgentRail` imports
+ * this file, so nothing here can import that one, and a two-line number formatter is a
+ * cheaper duplicate than moving the meter out of the rail that owns it.
+ */
+const readGauge = (gauge: AgentBudgetGauge): string =>
+  gauge.unit === "ms"
+    ? `${seconds(gauge.used)} / ${seconds(gauge.limit)} s ${gauge.label.toLowerCase()}`
+    : `${gauge.used} / ${gauge.limit} ${gauge.label.toLowerCase()}`;
+
+/**
+ * How far through its budget the run is, as the FULLEST of its bounds.
+ *
+ * Not progress toward an answer: nothing the ledger holds measures that, and a bar
+ * claiming to would be this surface inventing a number. What it honestly shows is how
+ * much of the allowance is gone, and a run ends when any one bound is reached — so the
+ * fullest gauge is the one that says how near the end it is. Clamped, because a bound can
+ * be overrun by up to one statement and a bar past its own track reads as a larger
+ * allowance than exists.
+ */
+const budgetFraction = (gauges: readonly AgentBudgetGauge[]): number =>
+  Math.min(100, Math.max(0, ...gauges.map((gauge) => (gauge.used / gauge.limit) * 100)));
+
+/** A chip: one fact off the ledger, small enough to scan. */
+function Chip({
+  testId,
+  className,
+  resolved,
+  children,
+}: {
+  readonly testId: string;
+  readonly className?: string;
+  /**
+   * Whether what this chip names was found in the run's own ledger, for the chips where
+   * that is a question. Carried as data rather than only as a colour, the rule
+   * `data-read-only` follows on the transcript's card: a verdict a test can assert beats
+   * one a test has to infer from styling. Absent where the chip makes no such claim.
+   */
+  readonly resolved?: boolean;
+  readonly children: ReactNode;
+}) {
+  return (
+    <span
+      data-testid={testId}
+      data-resolved={resolved === undefined ? undefined : String(resolved)}
+      className={cn("rounded bg-fill px-1 py-0.5 text-[0.625rem] text-fg-tertiary whitespace-nowrap", className)}
+    >
+      {children}
+    </span>
+  );
+}
+
+/**
+ * The statement, quoted as it arrived and tinted by the language it is in.
+ *
+ * `data-language` carries the reading as DATA and not only as a class, for the reason
+ * `data-read-only` does on the transcript's card: a claim a test can assert beats one a
+ * test has to infer from styling.
+ */
+function StatementBlock({ sql, language }: { readonly sql: string; readonly language: StatementLanguage }) {
+  return (
+    <div
+      data-testid="agent-answer-statement"
+      data-language={language}
+      className={cn("border-l-2 pl-1.5", LANGUAGE_ACCENTS[language])}
+    >
+      <QuotedBlock text={sql} testId="agent-answer-statement-copy" tone="loud" />
+    </div>
+  );
+}
+
+/** What the guard did, said in one line with the full claim behind the ⓘ. */
+function GuardLine({ draft }: { readonly draft: AgentPlanStatementView }) {
+  const reading = guardReading(draft);
+  const identifier = identifierNote(draft);
+  const notes: GuardNote[] = [];
+  // The unexamined reading's visible line is the short form of this one, so the full
+  // sentence goes in the popover. The objection's visible line IS its full sentence,
+  // and repeating it below itself would say the same thing twice.
+  if (reading === "unexamined") notes.push(GUARD_UNREAD_NOTE);
+  if (identifier !== null) notes.push(identifier);
+  notes.push(EXECUTION_CAVEAT);
+
+  return (
+    <p
+      className={cn(
+        "mt-1 flex items-start gap-1 text-[0.625rem]",
+        reading === "checked" ? "text-fg-muted" : "text-amber-300",
+      )}
+    >
+      {reading !== "checked" && (
+        <TriangleAlert strokeWidth={1.5} className="mt-px w-3 h-3 shrink-0" aria-hidden="true" />
+      )}
+      {/* The testid is on the SENTENCE and not on the paragraph: the popover's own text
+          is a node inside it, and a reader asserting this line must not be handed the
+          line plus everything folded behind it. */}
+      <span data-testid="agent-answer-guard">
+        {reading === "objected" ? guardObjectionNote(draft.guardViolation) : guardSummaryLine(draft)}
+      </span>
+      <InfoNote
+        title={reading === "unexamined" ? "Why nothing examined this draft" : "What the statement guard checked"}
+        testId="agent-answer-guard-note"
+      >
+        {notes.map((note) => (
+          <span key={note.testId} data-testid={note.testId} className="block">
+            {note.text}
+          </span>
+        ))}
+      </InfoNote>
+    </p>
+  );
+}
+
+/**
+ * The provenance of a plan answer, as chips: every one off the ledger, none invented.
+ *
+ * The guard's reading and the run's grounding are TWO facts, and keeping them so is the
+ * whole point of the shape here (L4, measured against live MongoDB on 2026-08-21). The
+ * inventory and the fingerprint come from the run's capture — from `AgentRunTimeline`,
+ * which every caller of this card already holds — so they are stated on every engine,
+ * including the ones where the SQL guard could examine nothing. That is the case they
+ * matter most in: where nothing read the draft, the inventory it was drafted against is
+ * the only grounding claim left, and it was exactly the one that disappeared.
+ */
+function PlanChips({
+  draft,
+  capture,
+}: {
+  readonly draft: AgentPlanStatementView;
+  readonly capture: AgentCaptureView | null;
+}) {
+  const reading = guardReading(draft);
+  const unknown = draft.identifiers.kind === "checked" ? draft.identifiers.unknownTables : [];
+
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-1">
+      <Chip testId="agent-answer-chip-guard" className={GUARD_CHIPS[reading].className}>
+        {GUARD_CHIPS[reading].label}
+      </Chip>
+      {unknown.length > 0 && (
+        /* Model and engine text, listed as the content it is rather than spliced into a
+           sentence of ours. The list is named for a reader who cannot see the ⓘ beside
+           the guard line, because a bare name says nothing on its own. */
+        <ul
+          data-testid="agent-answer-chip-names"
+          aria-label={UNKNOWN_NAMES_NOTE.text}
+          className="flex flex-wrap items-center gap-1"
+        >
+          {unknown.map((name) => (
+            <li key={name}>
+              <Chip testId="agent-answer-chip-name" className="font-mono text-amber-200">
+                {name}
+              </Chip>
+            </li>
+          ))}
+        </ul>
+      )}
+      {capture !== null && (
+        <>
+          <Chip testId="agent-answer-chip-inventory">
+            {capture.tableCount} {capture.tableCount === 1 ? capture.noun.singular : capture.noun.plural} read
+          </Chip>
+          {/* Eight characters, the length every other surface prints a fingerprint at. */}
+          <Chip testId="agent-answer-chip-fingerprint" className="font-mono">
+            {capture.fingerprint.slice(0, 8)}
+          </Chip>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Which outcome this card renders, in the order the readings EXCLUDE each other — and
+ * the ONE place that reading is made.
+ *
+ * Exported because `AgentRail` needs the same answer: the transcript withholds its copy
+ * of a hand-off precisely BECAUSE this card offers it, so a suppression derived from the
+ * ledger instead of from this function is a second, independent reading of the same
+ * question — and two readings of one question is how the rail came to withhold the only
+ * `Apply to editor` a run had while the card was showing something else entirely.
+ *
+ * The run's PRODUCT decides, and the status does not:
+ *
+ *  - whatever the ledger holds as the deliverable comes first, before the status,
+ *    deliberately. A stream chunk can carry `answer-composed` and `run-finished`
+ *    together, and it can also carry an answer while the run is still finishing; an
+ *    answer gated on a terminal status would not be rendered in the first case at all,
+ *    which is the trap the rail's own artifact delivery already records.
+ *  - and `failed` is a status, not the absence of a product. `conclude` in
+ *    `src/lib/agent/investigation.ts` records the closing prose and then the drafted
+ *    statement BEFORE `service.finish`, and it is called with `"failed"` for a model
+ *    timeout, an exhausted deadline and the turn ceiling — so a plan run that fenced a
+ *    statement and then ran out of turns ends `failed` HOLDING its deliverable, and
+ *    `run-finished`'s own documentation names the combination. Reading the status first
+ *    replaced the statement, the marked hand-off, the guard's claims and the chips with
+ *    a banner, on the one surface the marking rules exist for. The failure is stated
+ *    beside the product instead (`FailureNote`), which loses nothing: the pill already
+ *    prints `failed`.
+ *
+ * `"running"` is what is left when the ledger holds no product yet, and `null` is a run
+ * with nothing recorded, or one that ended having produced nothing. Neither gets a card:
+ * the transcript says what happened, and a card would have to invent a headline for it.
+ */
+export function answerCardState(timeline: AgentRunTimeline): AnswerState | null {
+  if (timeline.items.length === 0) return null;
+  if (timeline.items.some((item) => item.planStatement !== undefined)) return "plan";
+  if (timeline.report !== null) return "report";
+  if (timeline.items.some((item) => item.planRefusal === true)) return "refused";
+  if (timeline.status === "failed") return "failed";
+  return LIVE_STATUSES.has(timeline.status) ? "running" : null;
+}
+
+export function AnswerCard({
+  timeline,
+  capabilities,
+  onApplyStatement,
+  onShowArtifact,
+  onStop,
+  onRetry,
+}: AnswerCardProps) {
+  const drafted = timeline.items.find((item) => item.planStatement !== undefined)?.planStatement;
+  const refusalProse = timeline.items.find((item) => item.planRefusal === true)?.prose;
+  const state = answerCardState(timeline);
+
+  if (state === null) return null;
+
+  return (
+    <section data-testid="agent-answer" className="border-b border-hairline p-2.5">
+      <div className="flex items-center gap-2">
+        <span className="text-[0.625rem] font-medium tracking-wide text-fg-subtle uppercase">{EYEBROWS[state]}</span>
+        <span
+          data-testid="agent-answer-status"
+          className={cn("rounded px-1.5 py-0.5 text-[0.625rem]", STATUS_TONES[timeline.status])}
+        >
+          {timeline.status}
+        </span>
+      </div>
+
+      {state === "plan" && drafted !== undefined && (
+        <PlanAnswer
+          draft={drafted}
+          rationale={timeline.items.find((item) => item.planStatementRecorded === true)?.prose}
+          language={statementLanguage(capabilities, drafted.guardApplicable)}
+          capture={timeline.capture}
+          onApplyStatement={onApplyStatement}
+        />
+      )}
+      {state === "report" && timeline.report !== null && (
+        <ReportAnswer
+          report={timeline.report}
+          answer={timeline.items.find((item) => item.isAnswer === true)}
+          onApplyStatement={onApplyStatement}
+          onShowArtifact={onShowArtifact}
+        />
+      )}
+      {state === "refused" && refusalProse !== undefined && <RefusedAnswer prose={refusalProse} />}
+      {/*
+        Keyed on the STATUS and not on the state, which is the whole point of splitting it
+        out: a run can end `failed` holding a statement or a report, and the reader needs
+        both facts. So the product above says what the run produced and this says how it
+        ended, on the same card — where the state IS `failed` it is the only thing there
+        is, which is exactly what it used to be.
+      */}
+      {timeline.status === "failed" && <FailureNote timeline={timeline} onRetry={onRetry} />}
+      {state === "running" && <RunningAnswer timeline={timeline} onStop={onStop} />}
+    </section>
+  );
+}
+
+/** How the run ended, for the endings the server calls failures. */
+function FailureNote({
+  timeline,
+  onRetry,
+}: {
+  readonly timeline: AgentRunTimeline;
+  readonly onRetry: (() => void) | undefined;
+}) {
+  return (
+    <div data-testid="agent-answer-failed" className="mt-1.5 rounded border border-rose-500/40 bg-rose-500/5 p-2">
+      <p className="flex items-center gap-1 text-xs text-rose-300">
+        <TriangleAlert strokeWidth={1.5} className="w-3 h-3 shrink-0" aria-hidden="true" />
+        Run failed
+      </p>
+      {/* The same map the timeline entry reads, so the two cannot disagree. */}
+      <p data-testid="agent-answer-failure" className="mt-1 text-[0.625rem] text-fg-tertiary">
+        {timeline.failureReason === null ? UNCLASSIFIED_FAILURE_NOTE : describeFailureReason(timeline.failureReason)}
+      </p>
+      {onRetry !== undefined && (
+        <button
+          type="button"
+          data-testid="agent-answer-retry"
+          onClick={onRetry}
+          className="mt-1 flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+        >
+          <RotateCcw strokeWidth={1.5} className="w-3 h-3" />
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** What a plan run produced, with what the server established about it. */
+function PlanAnswer({
+  draft,
+  rationale,
+  language,
+  capture,
+  onApplyStatement,
+}: {
+  readonly draft: AgentPlanStatementView;
+  readonly rationale: string | undefined;
+  readonly language: StatementLanguage;
+  readonly capture: AgentCaptureView | null;
+  readonly onApplyStatement: ((sql: string) => void) | undefined;
+}) {
+  return (
+    <div
+      data-testid="agent-answer-plan"
+      /*
+        THREE values, not two, the reading #414 settled on the transcript's card: a
+        consumer that tests for `"false"` must not be able to reach an objection the
+        guard never made, so an unexamined draft is neither `"true"` nor `"false"`.
+      */
+      data-read-only={!draft.guardApplicable ? "unexamined" : draft.readOnly ? "true" : "false"}
+      className="mt-1.5"
+    >
+      <StatementBlock sql={draft.sql} language={language} />
+      {onApplyStatement !== undefined && (
+        <div className="mt-1 flex items-center gap-1">
+          <button
+            type="button"
+            data-testid="agent-answer-plan-apply"
+            /*
+              The name the rail already builds, never a label written again here: it
+              carries the guard's marks, and the whole risk of moving this control up to
+              the card is that the marks stay behind. `applyStatementName` lives in
+              `rail-parts.tsx` precisely so both surfaces name the act the same way.
+            */
+            aria-label={applyStatementName(draft)}
+            onClick={() => onApplyStatement(draft.sql)}
+            className={cn(
+              "flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] transition-colors hover:bg-fill",
+              draft.readOnly ? "bg-blue-500/15 text-blue-300" : "bg-amber-500/15 text-amber-300",
+            )}
+          >
+            <PencilLine strokeWidth={1.5} className="w-3 h-3" />
+            Apply to editor
+          </button>
+        </div>
+      )}
+      <PlanChips draft={draft} capture={capture} />
+      {rationale !== undefined && (
+        <details data-testid="agent-answer-why" className="mt-1.5 group">
+          <summary className="cursor-pointer text-[0.625rem] text-fg-muted hover:text-fg-secondary">
+            Why this statement
+          </summary>
+          {/*
+            The model's prose, in the structure it wrote it in, with the per-block
+            editor control withheld AND the statement's own block not printed a second
+            time: this is the text the statement was read out of, so the same statement
+            is in both places, `renderProse`'s own control cannot say what it is
+            applying, and the block itself is a duplicate of what is displayed two lines
+            above (L5, measured 2026-08-21 — the card showed the statement, then the same
+            statement again in here, each with its own `Copy`).
+
+            `cardedStatement` is the same shape as that withheld control rather than a
+            second mechanism: the caller says what the surface beside the prose is
+            already showing. Nothing is edited — every other block still renders, the
+            words are untouched, and `Copy all` below carries the whole prose, fence
+            included, because it takes the string the model wrote and not this rendering
+            of it.
+          */}
+          <div
+            data-testid="agent-answer-why-prose"
+            className="mt-1 space-y-1 border-l border-hairline-strong pl-2 text-[0.625rem] text-fg-tertiary"
+          >
+            {renderProse(rationale, { cardedStatement: draft.sql })}
+            <CopyButton text={rationale} testId="agent-answer-why-copy" label="Copy all" />
+          </div>
+        </details>
+      )}
+      <GuardLine draft={draft} />
+    </div>
+  );
+}
+
+/** What an agent run concluded, and the evidence it rests on. */
+function ReportAnswer({
+  report,
+  answer,
+  onApplyStatement,
+  onShowArtifact,
+}: {
+  readonly report: NonNullable<AgentRunTimeline["report"]>;
+  readonly answer: AgentTimelineItem | undefined;
+  readonly onApplyStatement: ((sql: string) => void) | undefined;
+  readonly onShowArtifact: ((correlationId: string, chartSpec: AgentChartSpec | undefined) => void) | undefined;
+}) {
+  const citations = report.claims.flatMap((claim) => claim.citations);
+
+  return (
+    <div data-testid="agent-answer-report" className="mt-1.5">
+      {report.claims.map((claim) => (
+        <div key={claim.id} data-testid="agent-answer-claim" className="mb-1.5">
+          {/* The model's own words, quoted — never narrated as the app speaking. */}
+          <QuotedBlock text={claim.quoted} testId="agent-answer-claim-copy" tone="loud" />
+          <ul
+            data-testid="agent-answer-citation-chips"
+            aria-label="What this claim cites"
+            className="mt-1 flex flex-wrap items-center gap-1"
+          >
+            {claim.citations.map((citation) => (
+              <li key={citation.id}>
+                {/*
+                  A citation this timeline holds no entry for is marked as unresolved
+                  rather than dropped: the server refused a claim it could not verify, so
+                  a gap here is a gap in what the rail has READ, and saying so is honest
+                  where rendering it as checked would not be.
+                */}
+                <Chip
+                  testId="agent-answer-citation-chip"
+                  resolved={citation.resolved}
+                  /*
+                    Wrapping on BOTH readings now, not only on the long one: every chip
+                    here carries a sentence, and a chip that cannot wrap in a 384px panel
+                    takes the panel sideways instead — which is the failure the statement
+                    blocks in this same card were changed to avoid.
+                  */
+                  className={cn("font-mono whitespace-normal", citation.resolved ? undefined : "text-amber-300")}
+                >
+                  {/*
+                    The identifier at chip length, never the whole one: a correlation id
+                    is a UUID in a real run, and `Artifact
+                    722b2a10-e3f2-4b9c-8177-367359a21500` was measured filling this chip
+                    in a 384px panel on 2026-08-21 (L8), leaving no room for what the
+                    ledger knows about that read. The whole identifier is `label`, and it
+                    is printed in the `Evidence` fold below — which is the surface a
+                    reader chasing a correlation id through a server log opens anyway.
+                  */}
+                  {citation.shortLabel}
+                  {citation.locator === undefined ? "" : ` · ${citation.locator}`}
+                  {/*
+                    The ledger's own detail, on both readings, IN TEXT — and not only in
+                    amber (WCAG 1.4.1). Hue alone used to carry the whole distinction
+                    between a checked citation and one this timeline holds no entry for:
+                    a screen-reader user, and anyone who cannot separate amber from a
+                    neutral chip, read the two as the same fact. `detail` says which it
+                    is in the app's own words either way — the rows a read returned, or
+                    the sentence saying the rail has not read the entry — which is how
+                    the surface this replaced said it, visibly, beside the label.
+
+                    Two test ids for one node, by reading, because the id travels with
+                    the CLAIM here as it does with the guard's sentences above: one
+                    shared id would pass a test on either sentence, and these two states
+                    differ by exactly which sentence is right.
+                  */}
+                  <span
+                    data-testid={
+                      citation.resolved ? "agent-answer-citation-chip-detail" : "agent-answer-citation-chip-unresolved"
+                    }
+                    className="font-sans"
+                  >
+                    {` · ${citation.detail}`}
+                  </span>
+                </Chip>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      {/* Whatever the LEDGER offers on the answer entry, and nothing more. */}
+      <HydrationControls
+        sql={answer?.applySql}
+        artifactId={answer?.artifactId}
+        chartSpec={answer?.chartSpec}
+        testIdPrefix="agent-answer-"
+        /*
+          Named by the rail's own name-builder, which is what all three of the hand-offs
+          this path used to offer were missing (L6). `null` because there is no draft
+          view to read: the run wrote this statement, ran it on the read-only session the
+          engine enforced and answered from the rows, so no guard reading about it exists
+          to carry — and one invented here would be a claim no code in this product made.
+        */
+        applyName={applyStatementName(null)}
+        onApply={onApplyStatement}
+        onShow={onShowArtifact}
+      />
+      <details data-testid="agent-answer-evidence" className="mt-1.5">
+        <summary className="cursor-pointer text-[0.625rem] text-fg-muted hover:text-fg-secondary">
+          Evidence · {citations.length} {citations.length === 1 ? "citation" : "citations"}
+        </summary>
+        <div className="mt-1 space-y-1.5">
+          {citations.map((citation) => (
+            <div key={citation.id} data-testid="agent-answer-evidence-citation" className="text-[0.625rem]">
+              <span className={citation.resolved ? "text-fg-tertiary" : "text-amber-300"}>{citation.label}</span>
+              <span className="ml-1 text-fg-subtle">{citation.detail}</span>
+              {citation.quoted !== undefined && (
+                <QuotedBlock text={citation.quoted} testId="agent-answer-citation-quoted-copy" className="mt-0.5" />
+              )}
+            </div>
+          ))}
+        </div>
+      </details>
+    </div>
+  );
+}
+
+/**
+ * The other legitimate ending of a plan run: it says the schema does not answer the
+ * question.
+ *
+ * The card states that it drafted nothing and hands the reader the run's own words. It
+ * offers no next step of its own — the mockup's "capture more schema" is not a thing this
+ * build can do from here, and a button that does nothing is worse than the sentence that
+ * points at what the run actually said.
+ */
+function RefusedAnswer({ prose }: { readonly prose: string }) {
+  return (
+    <div data-testid="agent-answer-refused" className="mt-1.5 rounded border border-amber-400/40 bg-amber-500/5 p-2">
+      <p className="flex items-center gap-1 text-xs text-amber-300">
+        <TriangleAlert strokeWidth={1.5} className="w-3 h-3 shrink-0" aria-hidden="true" />
+        No statement drafted
+      </p>
+      <p data-testid="agent-answer-refusal-note" className="mt-1 text-[0.625rem] text-amber-300/90">
+        {REFUSAL_NOTE}
+      </p>
+      {/* The marker it was read by is already stripped: it is a protocol token the model
+          was told to emit, not something it wrote for a reader. */}
+      <div
+        data-testid="agent-answer-refusal-prose"
+        className="mt-1 space-y-1 border-l border-hairline-strong pl-2 text-[0.625rem] text-fg-tertiary"
+      >
+        {renderProse(prose)}
+        <CopyButton text={prose} testId="agent-answer-refusal-copy" label="Copy all" />
+      </div>
+    </div>
+  );
+}
+
+/** Where the run has got to, and what it has spent getting there. */
+function RunningAnswer({
+  timeline,
+  onStop,
+}: {
+  readonly timeline: AgentRunTimeline;
+  readonly onStop: (() => void) | undefined;
+}) {
+  const items = timeline.items;
+  const current = items[items.length - 1];
+  /*
+    The span the LEDGER covers, not a clock. A ticking elapsed time would run past what
+    the run recorded, and a rail that reloads would start it again from zero — so what is
+    shown is the distance between the first entry this rail has read and the newest one,
+    which is a fact about the run rather than about this page's uptime.
+  */
+  const span = (current?.atMs ?? 0) - (items[0]?.atMs ?? 0);
+
+  return (
+    <div data-testid="agent-answer-running" className="mt-1.5">
+      <p data-testid="agent-answer-step" className="flex items-center gap-1.5 text-xs text-fg-secondary">
+        <Loader2 strokeWidth={1.5} className="w-3 h-3 shrink-0 animate-spin" aria-hidden="true" />
+        {current?.headline}
+      </p>
+      {current?.detail !== undefined && <p className="mt-0.5 pl-4.5 text-[0.625rem] text-fg-muted">{current.detail}</p>}
+      <p data-testid="agent-answer-elapsed" className="mt-1 text-[0.625rem] text-fg-subtle">
+        {seconds(span)} s since this run&apos;s first recorded entry
+      </p>
+      <div className="mt-1 h-0.5 rounded-full bg-fill">
+        <div
+          data-testid="agent-answer-progress"
+          className="h-full rounded-full bg-blue-400/60"
+          style={{ width: `${budgetFraction(timeline.budget)}%` }}
+        />
+      </div>
+      <div className="mt-1 flex items-center justify-between gap-2">
+        <span
+          data-testid="agent-answer-spend"
+          className="flex items-start gap-1 font-mono text-[0.625rem] text-fg-tertiary"
+        >
+          {timeline.budget.map(readGauge).join(" · ")}
+          <InfoNote title="Figures are a floor, not the spend" testId="agent-answer-spend-note">
+            {SPEND_FLOOR_NOTE}
+          </InfoNote>
+        </span>
+        {onStop !== undefined && (
+          <button
+            type="button"
+            data-testid="agent-answer-stop"
+            onClick={onStop}
+            className="flex items-center gap-1 rounded bg-amber-500/15 px-1.5 py-0.5 text-[0.625rem] text-amber-300 hover:bg-amber-500/25 transition-colors"
+          >
+            <Square strokeWidth={1.5} className="w-3 h-3" />
+            Stop
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/agent/ConsentCard.tsx
+++ b/src/components/agent/ConsentCard.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import React, { useEffect, useState, type RefObject } from "react";
+import { Info, Play } from "lucide-react";
+import { AGENT_HANDOVER_BUDGET } from "@/lib/agent/execution-policy";
+import { autoExecuteTerms } from "@/lib/agent/posture";
+import type { AgentRunWorkflowType } from "@/lib/agent/types";
+import type { DatabaseType } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * The consent step (§2.6 of `docs/AGENT_ANALYST_DESIGN.md`, and §"Why the consent step is
+ * placed there"), lifted out of `AgentRail.tsx` unchanged in what it decides.
+ *
+ * It replaced the pre-start checkbox entirely. That checkbox rendered wherever the workflow
+ * happened to be `data-analysis`, which is a state the user could leave without the tick
+ * leaving with them — and, before #373, a state four workflows could reach at all. Consent
+ * asked HERE cannot drift from the run it is about: the workflow is already decided, and the
+ * very next thing that happens is the request that opens the run with it.
+ *
+ * It is still consent given at OPEN time, which is what `src/lib/agent/types.ts` requires of
+ * every widening decision: no run exists yet.
+ *
+ * **The copy is the control.** "Auto-mode" transfers no responsibility because it names no
+ * bound, so this names all three — the bound the run keeps for its own read, the bound the
+ * editor keeps, and the bound being given up — and says what the run does INSTEAD when its
+ * gate declines, because a user who finds the statement sitting unrun has to be able to read
+ * that as the feature working. Every figure comes from the constants the enforcement reads.
+ *
+ * What the redesign changed is the ORDER those facts are read in, and nothing else. The old
+ * card opened with a ninety-word paragraph, so the two things a user needs first — the tick
+ * is off, and the run is read-only either way — arrived last if they arrived at all. Here the
+ * heading states the default, the label carries the decision, and the paragraph moves into a
+ * popover on that label. It moves WITHOUT leaving the accessibility tree: it is still the
+ * checkbox's `aria-describedby` target, always rendered, hidden from sight alone. A
+ * description that exists only while a popover is open is a description a screen-reader user
+ * is never given, which would trade one audience's clarity for another's.
+ */
+export interface ConsentCardProps {
+  /** The workflow this start is already decided for; the terms' figures are its own. */
+  readonly workflowType: AgentRunWorkflowType;
+  /** How the product names that workflow — the rail's own label map, passed in. */
+  readonly workflowLabel: string;
+  /**
+   * The connection the start was asked ON, from the snapshot rather than from the shell.
+   *
+   * The terms promise the statement will run "on the connection the run was opened on", and
+   * that connection is the one this start was asked on rather than whatever the shell is
+   * showing when Start run is finally pressed — so the sentence says which.
+   */
+  readonly connectionName: string | null;
+  /**
+   * That connection's engine, also from the snapshot. Only SQLite changes what a long read
+   * costs, and the sentence that says so has to stay with the run it is true of.
+   */
+  readonly engine: DatabaseType | null;
+  /** The hand-over decision. OFF is the default, and the caller owns the state. */
+  readonly autoExecute: boolean;
+  readonly onAutoExecuteChange: (next: boolean) => void;
+  /** Open the run with the decision as it stands. */
+  readonly onOpen: () => void;
+  /** Abandon the start. The objective stays in the box. */
+  readonly onCancel: () => void;
+  /**
+   * The region node, handed back to the caller.
+   *
+   * Focus MOVES into this region on mount — that is the announcement for a keyboard user,
+   * who otherwise has focus on a control that just went disabled and no way to know two
+   * buttons appeared (#407 review, and this repo's own a11y history in #100). The EXIT half
+   * is the caller's: leaving the step has to put focus somewhere real rather than on a node
+   * about to be removed, and the two exits need different answers, which only the caller
+   * knows (see `leaveConsent` in `AgentRail.tsx`). So the caller holds the ref.
+   */
+  readonly regionRef: RefObject<HTMLElement | null>;
+}
+
+/**
+ * What the editor hand-over costs, in chips, and every figure read from the budget the
+ * server enforces rather than typed here. #425's lesson is that a typed figure outlives the
+ * value it described; these are the same numbers `AGENT_HANDOVER_BUDGET` hands the replay.
+ *
+ * "no time limit" is the word for the ceiling, not for an absent field: the plumbing cannot
+ * express an absent timeout, so `AGENT_HANDOVER_BUDGET` carries PostgreSQL's own 32-bit
+ * maximum — a little over 24 days — and `execution-policy.ts` states in its own header that
+ * "no" is the part of the promise that does not hold literally. The terms popover carries
+ * that full claim; the chip is its label, and sits beside it.
+ */
+const handoverChips = (): readonly { readonly text: string; readonly tone: "neutral" | "warn" }[] => [
+  { text: "same read-only session", tone: "neutral" },
+  { text: `${AGENT_HANDOVER_BUDGET.maxResultRows} rows`, tone: "neutral" },
+  { text: "no time limit", tone: "warn" },
+];
+
+/**
+ * The one sentence that is true of SQLite and of nothing else, in the words the budget meter
+ * already uses for the same fact: SQLite does not preempt a statement over its timeout, so
+ * the editor's missing time limit is a different promise there than it is on PostgreSQL.
+ */
+const SQLITE_COST =
+  "On SQLite a read is not interrupted when it runs long: it blocks other writers and this application until it finishes.";
+
+export function ConsentCard({
+  workflowType,
+  workflowLabel,
+  connectionName,
+  engine,
+  autoExecute,
+  onAutoExecuteChange,
+  onOpen,
+  onCancel,
+  regionRef,
+}: ConsentCardProps): React.JSX.Element {
+  const [termsOpen, setTermsOpen] = useState(false);
+  const isSqlite = engine === "sqlite";
+
+  /*
+    Raised, therefore announced. Mount is the moment the step appears, and focusing the
+    region here rather than in the caller keeps the announcement with the thing being
+    announced: a card rendered anywhere behaves the same way.
+  */
+  useEffect(() => {
+    regionRef.current?.focus();
+  }, [regionRef]);
+
+  return (
+    <section
+      ref={regionRef}
+      tabIndex={-1}
+      aria-labelledby="agent-consent-workflow"
+      aria-describedby="agent-consent-terms"
+      data-testid="agent-consent"
+      className="mt-2 rounded border border-blue-400/30 bg-blue-500/5 p-2 space-y-1 focus:outline-none focus:ring-1 focus:ring-blue-400/50"
+    >
+      {/*
+        The default, first. The pill says what the run is with the box untouched, which is
+        the fact the old card's paragraph buried: read-only is not what the tick buys, it is
+        what the run is either way.
+      */}
+      <div
+        data-testid="agent-consent-heading"
+        className="flex items-center gap-1.5 text-[0.625rem] uppercase tracking-wide text-fg-tertiary"
+      >
+        Start this run
+        <span
+          data-testid="agent-consent-pill"
+          className="rounded px-1 py-px text-[0.625rem] normal-case tracking-normal bg-emerald-500/10 text-emerald-400/90"
+        >
+          read-only
+        </span>
+      </div>
+      {/*
+        The region's own name, and it names the CONNECTION as well as the workflow — see
+        `connectionName` above for why the sentence has to say which one.
+      */}
+      <p id="agent-consent-workflow" data-testid="agent-consent-workflow" className="text-xs text-fg-secondary">
+        This run will open as {workflowLabel} on {connectionName ?? "the connection you started it on"}, which answers
+        with a result.
+      </p>
+      <p data-testid="agent-consent-editor-note" className="text-[0.625rem] text-fg-muted">
+        Nothing runs in your editor unless you ask for it below.
+      </p>
+      <div className="mt-1.5 pt-1.5 border-t border-hairline space-y-1">
+        <div className="flex items-start gap-1">
+          {/*
+            The info button is a SIBLING of the label, never a child of it: a button inside a
+            `<label>` toggles the checkbox when it is clicked, so reading the terms would
+            silently give the consent the terms describe.
+          */}
+          <label htmlFor="agent-auto-execute" className="flex items-start gap-2 cursor-pointer">
+            <input
+              id="agent-auto-execute"
+              data-testid="agent-auto-execute"
+              type="checkbox"
+              checked={autoExecute}
+              aria-describedby="agent-consent-terms"
+              onChange={(e) => onAutoExecuteChange(e.target.checked)}
+              className="mt-0.5 rounded border-edge bg-panel"
+            />
+            <span data-testid="agent-auto-execute-label" className="text-xs text-fg-secondary">
+              Also run the final answer in my editor
+            </span>
+          </label>
+          <button
+            type="button"
+            data-testid="agent-consent-terms-info"
+            aria-label="What the editor run adds"
+            aria-expanded={termsOpen}
+            aria-controls="agent-consent-terms"
+            onClick={() => setTermsOpen((open) => !open)}
+            className="mt-0.5 shrink-0 rounded p-0.5 text-fg-muted hover:bg-fill hover:text-fg-secondary transition-colors"
+          >
+            <Info strokeWidth={1.5} className="w-3 h-3" aria-hidden="true" />
+          </button>
+        </div>
+        {/*
+          One node in two presentations, and it is one node on purpose: this is the
+          checkbox's `aria-describedby` target, so it is always rendered and the popover only
+          unhides it. `sr-only` and not `hidden`/`aria-hidden` — a hidden node is not a
+          description any assistive technology will read.
+        */}
+        <p
+          id="agent-consent-terms"
+          data-testid="agent-auto-execute-terms"
+          className={cn(
+            termsOpen
+              ? "ml-5 rounded border border-hairline bg-raised p-2 text-[0.625rem] leading-relaxed text-fg-muted"
+              : "sr-only",
+          )}
+        >
+          {autoExecuteTerms(workflowType)}
+        </p>
+        {/*
+          The bounds of what was ticked, and only once it is ticked: with the box off there
+          is no widening to bound, and chips describing one would read as terms already
+          accepted.
+        */}
+        {autoExecute && (
+          <div data-testid="agent-consent-bounds" className="ml-5 flex flex-wrap items-center gap-1">
+            {[
+              ...handoverChips(),
+              /*
+                The SQLite chip is the label of the sentence below it, not a second opinion:
+                the two are adjacent, so nothing can show the compressed form alone.
+              */
+              ...(isSqlite ? ([{ text: "SQLite: not interruptible", tone: "warn" }] as const) : []),
+            ].map((chip) => (
+              <span
+                key={chip.text}
+                className={cn(
+                  "rounded px-1 py-px text-[0.625rem] bg-fill",
+                  chip.tone === "warn" ? "text-amber-400/90" : "text-fg-tertiary",
+                )}
+              >
+                {chip.text}
+              </span>
+            ))}
+          </div>
+        )}
+        {/*
+          Read off the SNAPSHOT, like everything else in this panel: a user who switches to
+          PostgreSQL while the step stands still opens the run on SQLite, and a warning that
+          left with the switch would have been withdrawn from the one run it is true of.
+
+          Ungated by the tick, because it is true of the run either way — the tick only
+          decides whether a second, unbounded read joins the run's own.
+        */}
+        {isSqlite && (
+          <p data-testid="agent-auto-execute-sqlite" className="ml-5 text-[0.625rem] text-amber-400/70">
+            {SQLITE_COST}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-1 pt-0.5">
+        <button
+          type="button"
+          data-testid="agent-consent-open"
+          onClick={onOpen}
+          className="flex items-center gap-1 px-2 py-1 rounded text-xs bg-blue-500/15 text-blue-300 hover:bg-blue-500/25 transition-colors"
+        >
+          <Play strokeWidth={1.5} className="w-3 h-3" aria-hidden="true" />
+          Start run
+        </button>
+        {/* Cancel opens nothing: the objective stays in the box, and Start is live again —
+            and takes focus back, since the control that is live again is the one that
+            raised this. The caller performs that return; see `regionRef` above. */}
+        <button
+          type="button"
+          data-testid="agent-consent-cancel"
+          onClick={onCancel}
+          className="px-2 py-1 rounded text-xs text-fg-tertiary hover:bg-fill transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+      {/*
+        Where the decision is made, which is what makes this consent rather than a
+        preference. Under the buttons: it is a note on what pressing one of them settles,
+        not a term to read before deciding.
+      */}
+      <p data-testid="agent-consent-frozen" className="text-[0.625rem] text-fg-subtle">
+        This is decided by the request that opens the run and stays what it was: a later request cannot widen a run the
+        server already holds.
+      </p>
+    </section>
+  );
+}

--- a/src/components/agent/SafetyStrip.tsx
+++ b/src/components/agent/SafetyStrip.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React, { useId, useRef, useState } from "react";
+import { Info } from "lucide-react";
+import { type AgentPostureTone, agentPosture } from "@/lib/agent/posture";
+import type { AgentRunMode } from "@/lib/agent/types";
+import type { DatabaseType } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * The standing safety strip: one always-visible row under the rail header saying what the
+ * SELECTED MODE does to the database.
+ *
+ * It renders `src/lib/agent/posture.ts` and decides nothing. That split is the point — the
+ * posture module owns every claim and every derived figure, this component owns the palette
+ * and the popover — so a restyle here cannot change what the rail asserts, and a change to
+ * `AGENT_EXECUTION_ENGINES` or to a policy row reaches this surface without a class being
+ * touched. Nothing below writes a sentence of its own; grep this file for a full stop
+ * outside a comment and you will not find one.
+ *
+ * Three properties are load-bearing, and each is one edit away from being lost:
+ *
+ *  - **The qualifier sits BESIDE the pill, never behind the ⓘ.** A bare "Executes nothing
+ *    it drafts" overclaims: on the dialects `CATALOG_PLANS` serves, plan mode's grounding
+ *    capture IS a catalog read, and `engine-support.ts` says in its own header that copy
+ *    compressing these facts overclaims. Both halves are on one line, and the row
+ *    flex-WRAPS rather than truncating, because a qualifier cut off mid-clause is the same
+ *    overclaim with an ellipsis on the end.
+ *  - **The full claim reaches assistive technology whether or not the popover is open.**
+ *    The claim node is rendered always — `sr-only` while shut, a card while open — and it
+ *    is the strip's `aria-describedby` target either way. One node and not two, so the
+ *    text a screen-reader user gets and the text a sighted user opens cannot become two
+ *    versions of the same claim.
+ *  - **The ⓘ is a real `<button>`, tied to no preference.** It is the only route to the
+ *    body, so it is not decoration and it is not optional: the platform gives it Enter,
+ *    Space, focus and a tab stop, which a `<span>` with an `onClick` gives none of.
+ *    Escape shuts it and returns focus, because a popover a keyboard user can open and not
+ *    close is one that traps their reading position.
+ *
+ * The connection name is NOT here. It is in the rail header, where it already is, and one
+ * name in two places is one name that can disagree with itself.
+ */
+
+export interface SafetyStripProps {
+  /** The mode the rail currently shows, which is the axis this strip reads. */
+  readonly mode: AgentRunMode;
+  /** The engine the run's connection speaks, or null when none is resolved. */
+  readonly engine: DatabaseType | null;
+  /** `getDBConfig(engine).label` — the product's own name for that engine. */
+  readonly engineLabel: string;
+  /** Whether the editor hand-over is consented for the run this strip describes. */
+  readonly handover: boolean;
+}
+
+/**
+ * A palette per level, and the levels are `posture.tone`'s — chosen here so the posture
+ * module never names a colour and this file never names a claim.
+ *
+ * The three ladder rungs take the three ladder hues, in the order the ladder widens:
+ * emerald executes nothing, blue executes reads on the run's own path, amber executes reads
+ * AND puts one statement in the user's editor. `blocked` is not a rung — nothing executes
+ * and there is nothing to widen — so it takes `fg-muted` rather than a fourth hue: it is a
+ * dead end rather than a hazard, the pre-start card is where that state is alerted, and
+ * `fg-muted` is the one value `theme.css` documents as reading correctly on both grounds,
+ * which is what the level with no hue of its own should have.
+ *
+ * Palette classes and tokens only. No literal colour appears in this file, and a test
+ * scans every rendered `class` attribute to keep it that way.
+ */
+const TONE_PILL: Readonly<Record<AgentPostureTone, string>> = Object.freeze({
+  safe: "text-emerald-400/90 bg-emerald-500/10",
+  reads: "text-blue-300 bg-blue-500/10",
+  widened: "text-amber-400 bg-amber-500/10",
+  blocked: "text-fg-muted bg-fill",
+} satisfies Record<AgentPostureTone, string>);
+
+export function SafetyStrip({ mode, engine, engineLabel, handover }: SafetyStripProps) {
+  const posture = agentPosture({ mode, engine, engineLabel, handover });
+  const [open, setOpen] = useState(false);
+  /*
+    The description's id, and the ⓘ's `aria-controls` target. From `useId` rather than a
+    constant because the rail renders in two presentations at once below `md` — the panel
+    and the sheet host the same content — and two nodes sharing one id leave
+    `aria-describedby` resolving to whichever the document happens to hold first.
+  */
+  const claimId = useId();
+  const infoButton = useRef<HTMLButtonElement | null>(null);
+
+  /*
+    Escape, on the ⓘ itself.
+
+    On the button and not on the row around it, for two reasons that agree. The card holds
+    no focusable content — it is two paragraphs — so the button is the only place focus can
+    be while the card is open, which makes this the whole keyboard path rather than half of
+    it. And a `keydown` handler on the row would put an interaction on a static element,
+    which the jsx-a11y gate refuses without a role: the fix there is a role invented to
+    satisfy a lint rule, or a landmark for a one-line strip, and neither is worth having
+    when the interactive element is already the right host.
+
+    Focus is returned deliberately even though it never left: `setOpen(false)` restyles the
+    node the browser is pointing at, and a control that survives its own popover should
+    still be the thing focused after it.
+  */
+  const handleInfoKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (event.key !== "Escape" || !open) return;
+    setOpen(false);
+    infoButton.current?.focus();
+  };
+
+  return (
+    <div
+      data-testid="agent-safety-strip"
+      /*
+        The level as data, so a test asserts the claim rather than inferring it from a
+        class name — the rule `PlanStatementCard`'s `data-read-only` already follows.
+      */
+      data-tone={posture.tone}
+      aria-describedby={claimId}
+      className="relative flex flex-wrap items-baseline gap-x-2 gap-y-0.5 px-3 py-1.5 border-b border-hairline bg-fill-subtle shrink-0"
+    >
+      <span
+        data-testid="agent-safety-headline"
+        className={cn("shrink-0 rounded px-1.5 py-px text-[0.625rem] font-medium", TONE_PILL[posture.tone])}
+      >
+        {posture.headline}
+      </span>
+      {/*
+        `min-w-0` and no truncation: the row wraps this onto a second line rather than
+        clipping it, which is the whole reason the qualifier is out here.
+      */}
+      <span data-testid="agent-safety-qualifier" className="min-w-0 text-[0.625rem] text-fg-muted">
+        {posture.qualifier}
+      </span>
+      <button
+        ref={infoButton}
+        type="button"
+        data-testid="agent-safety-info"
+        /*
+          The pill's own words, after the axis they are an answer to. A user who cannot see
+          the pill gets the level from the button's name alone, which is what makes this an
+          affordance rather than an unlabelled glyph.
+        */
+        aria-label={`What this mode executes: ${posture.headline}`}
+        aria-expanded={open}
+        aria-controls={claimId}
+        onClick={() => setOpen((was) => !was)}
+        onKeyDown={handleInfoKeyDown}
+        className="ml-auto shrink-0 self-center rounded p-0.5 text-fg-subtle transition-colors hover:bg-fill hover:text-fg-secondary"
+      >
+        <Info strokeWidth={1.5} className="w-3 h-3" aria-hidden="true" />
+      </button>
+      {/*
+        One node, always rendered. Shut it is `sr-only` — out of the layout, in the
+        accessibility tree, and still the `aria-describedby` target — so the claim is never
+        reachable only by clicking. Open it is the popover. Deliberately NOT `hidden` and
+        never `aria-hidden`: either one would make the ⓘ the sole route to the body, which
+        is the failure this arrangement exists to prevent.
+      */}
+      <div
+        id={claimId}
+        data-testid="agent-safety-claim"
+        data-open={open ? "true" : "false"}
+        className={cn(
+          open
+            ? "absolute left-3 right-3 top-full z-20 mt-1 rounded border border-hairline-strong bg-overlay p-2 shadow-lg"
+            : "sr-only",
+        )}
+      >
+        <p className="text-[0.6875rem] font-medium text-fg-secondary">{posture.title}</p>
+        <p className="mt-1 text-[0.625rem] leading-relaxed text-fg-tertiary">{posture.body}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/agent/rail-parts.tsx
+++ b/src/components/agent/rail-parts.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import { useId, useState, type ReactNode } from "react";
+import { Info, PencilLine, TableProperties } from "lucide-react";
+import { CopyButton } from "@/components/copy-button";
+import type { AgentChartSpec, AgentRunStatus } from "@/lib/agent/types";
+import { cn } from "@/lib/utils";
+import type { AgentPlanStatementView } from "./timeline";
+
+/**
+ * The pieces the rail and the answer card BOTH render.
+ *
+ * Their own module for a mechanical reason rather than a tidiness one: `AgentRail`
+ * imports `AnswerCard`, so anything the card needs cannot live in the rail without
+ * making the two files import each other. They were defined in `AgentRail.tsx` until
+ * the answer card was split out of it, and they moved here unchanged — the same
+ * components, the same accessible-name machinery, the same comments, which are the
+ * record of what each one may and may not claim.
+ *
+ * Nothing was rewritten on the way. A second copy in the card was the alternative, and
+ * it is the worse one twice over: `applyStatementName` is a WCAG 2.5.3 name carrying
+ * the guard's marks, and `QuotedBlock`'s quoting is a security property — either one
+ * duplicated is a place where a surface can come to say something the run never
+ * established while its twin still says the right thing.
+ */
+
+/** A run that is over cannot be asked for anything, so nothing is offered for it. */
+export const LIVE_STATUSES: ReadonlySet<AgentRunStatus> = new Set<AgentRunStatus>(["queued", "running"]);
+
+/**
+ * An ⓘ whose text is in the accessibility tree whether or not it is open.
+ *
+ * A popover that renders its body only while open hides the claim from everyone who
+ * cannot see the panel, and every body behind one of these IS a claim — the guard's
+ * reading, the spend's floor, the ceilings nothing measures. So the node is always
+ * there: visually hidden when closed, a panel when open, and named by the button
+ * either way.
+ *
+ * The body carries `testId` and the button carries `${testId}-info`, which is what
+ * lets a claim keep the test id it had as a paragraph after it moves behind an ⓘ. The
+ * title is rendered INSIDE the body so a reader who opens it is told what they are
+ * reading; a caller whose claim must keep its own exact text puts that text in a node
+ * of its own among the children (`agent-budget-limits` and its two siblings do).
+ */
+export function InfoNote({
+  title,
+  testId,
+  children,
+}: {
+  readonly title: string;
+  readonly testId: string;
+  readonly children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const bodyId = useId();
+
+  return (
+    <span className="relative inline-flex items-start">
+      <button
+        type="button"
+        data-testid={`${testId}-info`}
+        aria-label={title}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={() => setOpen(!open)}
+        className="rounded p-0.5 text-fg-subtle hover:bg-fill hover:text-fg-muted transition-colors"
+      >
+        <Info strokeWidth={1.5} className="w-3 h-3" aria-hidden="true" />
+      </button>
+      <span
+        id={bodyId}
+        data-testid={testId}
+        className={cn(
+          open
+            ? "absolute top-5 left-0 z-10 w-64 space-y-1 rounded border border-hairline-strong bg-overlay p-2 text-[0.625rem] text-fg-tertiary shadow-lg"
+            : "sr-only",
+        )}
+      >
+        <span className="block font-medium text-fg-secondary">{title}</span>
+        {children}
+      </span>
+    </span>
+  );
+}
+
+/** What the guard did to this draft. Three answers, and `"objected"` is not `"unexamined"`. */
+export type GuardReading = "checked" | "objected" | "unexamined";
+
+export const guardReading = (draft: AgentPlanStatementView): GuardReading =>
+  !draft.guardApplicable ? "unexamined" : draft.readOnly ? "checked" : "objected";
+
+/**
+ * The one-line reading, for the states where the full claim can be folded away.
+ *
+ * Here rather than in either surface because BOTH render it now: the answer card
+ * states it under the statement, and the transcript entry the card de-duplicated
+ * states it as the summary of what it no longer reprints. Two copies of a sentence
+ * about what examined a statement is exactly the drift this module exists to prevent.
+ *
+ * `checked` and `checkedNoInventory` are the SAME guard verdict said about two
+ * different runs, and the clause that separates them is a claim rather than a phrase.
+ * The guard is `inspectAgentStatement`, which reads the text and nothing else, so it
+ * says the same thing whether or not a schema was ever captured — and on a run whose
+ * grounding capture was refused or failed, `validatePlanStatement` records
+ * `identifiers.kind === "no-inventory"` while `readOnly` stays true. The single line
+ * then asserted a check "against the captured inventory" that no inventory existed
+ * for, directly above the popover sentence saying so: an overclaim contradicted by its
+ * own qualifier, and a NEW one — the card this replaced made no positive claim here at
+ * all. So the inventory clause appears only where an inventory was actually read.
+ */
+const GUARD_LINES: Readonly<Record<"checked" | "checkedNoInventory" | "unexamined", string>> = Object.freeze({
+  checked: "Checked as a bounded read against the captured inventory. Nothing was executed.",
+  checkedNoInventory: "Checked as a bounded read. Nothing was executed.",
+  unexamined: "Not examined: the statement guard reads SQL, and this engine's statements are not SQL.",
+});
+
+/**
+ * The guard's objection, as the one sentence that reports it.
+ *
+ * The answer card continues it with what the objection does and does not establish;
+ * the transcript's summary stops here. Same first sentence, one author, so the reason
+ * code and the wording around it cannot come to differ between the two.
+ */
+export const guardObjectionLine = (violation: string | undefined): string =>
+  `The statement guard did not read this as a bounded read (${violation ?? "no reason recorded"}).`;
+
+/**
+ * All three readings in one line, which is what a de-duplicated entry keeps — and what
+ * the answer card states above the claim behind it, so neither surface can say more
+ * about the inventory than the run read of one.
+ */
+export const guardSummaryLine = (draft: AgentPlanStatementView): string => {
+  const reading = guardReading(draft);
+  if (reading === "objected") return guardObjectionLine(draft.guardViolation);
+  if (reading === "unexamined") return GUARD_LINES.unexamined;
+  // `"checked"` is the guard's verdict about the STATEMENT; whether the names in it were
+  // looked for in anything is the identifier reading's answer, and only that one can
+  // support the inventory clause.
+  return draft.identifiers.kind === "checked" ? GUARD_LINES.checked : GUARD_LINES.checkedNoInventory;
+};
+
+/**
+ * Verbatim content, and the one thing every reader wants to do with it (#389).
+ *
+ * The block itself is unchanged and deliberately so: quoting is a security property
+ * here, not a style — a drafted statement, an engine's own message and the user's
+ * objective are shown exactly as they arrived, so a reader can see where the
+ * application stopped speaking. What was missing was any way to get the text OUT.
+ * Selecting it by hand is what a user was left with, inside a narrow panel that
+ * scrolls in both directions, and a statement wrapped across lines does not survive
+ * the drag.
+ *
+ * Used at every verbatim block in this rail rather than at a chosen few, because
+ * "which of these did the product decide I would want" is not a question a user
+ * should have to answer.
+ */
+export function QuotedBlock({
+  text,
+  testId,
+  className,
+  /** A report's claim is the thing the report is FOR, and reads a shade brighter. */
+  tone = "quiet",
+}: {
+  readonly text: string;
+  readonly testId: string;
+  readonly className?: string;
+  readonly tone?: "quiet" | "loud";
+}) {
+  return (
+    <div className={className}>
+      {/*
+        WRAPS, and does not scroll sideways (item 9 of the redesign). `whitespace-pre-wrap`
+        already broke at the newlines a statement carries; what was left was an
+        `overflow-x-auto` under it, so a single long line — a `SELECT` with a dozen
+        columns, a Mongo pipeline written flat — put a second horizontal scrollbar inside
+        a panel that already scrolls vertically, and the text ran off the edge of the one
+        thing a user came here to read. `break-words` breaks the long token instead, which
+        for a statement is the right trade: a wrapped identifier is still readable and
+        still copies verbatim, because the copy takes the STRING and not the layout.
+      */}
+      <pre
+        className={cn(
+          "rounded bg-sunken p-1.5 font-mono text-[0.625rem] whitespace-pre-wrap break-words",
+          tone === "loud" ? "text-fg-secondary" : "text-fg-tertiary",
+        )}
+      >
+        {text}
+      </pre>
+      <div className="mt-0.5 flex items-center gap-1">
+        <CopyButton text={text} testId={testId} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * What one entry lets a user do with what the run produced (#329 T11).
+ *
+ * Rendered only where the ledger recorded something to act on AND the host can act
+ * on it — the same rule the stop control follows in T10b, so nothing here is a
+ * disabled button standing in for a capability this build does not have. Both are
+ * explicit user actions: the rail never applies a statement or opens a result on its
+ * own, because a statement the model drafted is untrusted content and putting it into
+ * the editor is the user's decision.
+ */
+export function HydrationControls({
+  sql,
+  artifactId,
+  chartSpec,
+  testIdPrefix,
+  applyName,
+  onApply,
+  onShow,
+}: {
+  readonly sql: string | undefined;
+  readonly artifactId: string | undefined;
+  /** Set only on an answer the run composed as a chart; undefined everywhere else. */
+  readonly chartSpec: AgentChartSpec | undefined;
+  readonly testIdPrefix: string;
+  /**
+   * The accessible name for the hand-off, from `applyStatementName` and from nowhere
+   * else — passed by the surface that is offering the run's ANSWER, and absent on the
+   * entries of the chronology, which offer a statement the run took along the way and
+   * are named by their visible label as they always were.
+   *
+   * It is here because of L6: on the report path the rail offered three of these at
+   * once and none of them was named, on the one surface the marking rules exist for.
+   * Keeping one author for the name is what makes "every hand-off the card offers is
+   * named by `applyStatementName`" a property a test can assert instead of a spelling
+   * each site repeats.
+   */
+  readonly applyName?: string;
+  readonly onApply: ((sql: string) => void) | undefined;
+  readonly onShow: ((correlationId: string, chartSpec: AgentChartSpec | undefined) => void) | undefined;
+}) {
+  const canApply = sql !== undefined && onApply !== undefined;
+  const canShow = artifactId !== undefined && onShow !== undefined;
+  if (!canApply && !canShow) return null;
+
+  return (
+    <div className="mt-1 flex items-center gap-1">
+      {sql !== undefined && onApply !== undefined && (
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}apply-statement`}
+          aria-label={applyName}
+          onClick={() => onApply(sql)}
+          className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] text-fg-tertiary hover:bg-fill hover:text-fg transition-colors"
+        >
+          <PencilLine strokeWidth={1.5} className="w-3 h-3" />
+          Apply to editor
+        </button>
+      )}
+      {artifactId !== undefined && onShow !== undefined && (
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}show-result`}
+          onClick={() => onShow(artifactId, chartSpec)}
+          className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] text-fg-tertiary hover:bg-fill hover:text-fg transition-colors"
+        >
+          <TableProperties strokeWidth={1.5} className="w-3 h-3" />
+          Show result
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The name a screen reader, a voice user and a tooltip all get for the one control
+ * that puts a plan run's statement into the editor (item 7 of the plan-mode design).
+ *
+ * The visible label comes FIRST and unaltered, which is WCAG 2.5.3: a voice user says
+ * what they can see, so "Apply to editor" has to be inside whatever this returns.
+ * Everything after it is the part a colour cannot carry.
+ *
+ * Both warnings are stated in the terms the server established and no stronger, and the
+ * first of them was once stated a good deal stronger. It read "This statement is not a
+ * read: applying it puts SQL in your editor that can change or delete data", which is a
+ * claim about the statement's EFFECT that `readOnly` cannot support: it is
+ * `inspectAgentStatement(sql) === null`, and four of that guard's six objections say
+ * only that it could not read the text — an unclosed span, a run two dialects disagree
+ * about, a second statement, no statement at all — while its own header records that it
+ * over-refuses legitimate reads on purpose. A jsonb read using `#>>` would have been
+ * announced to a screen-reader user as SQL that can delete their data. So the name says
+ * what the guard did, and the reason travels with it.
+ *
+ * The identifier finding is about names the captured inventory does not hold, which is
+ * a reason the statement may not run rather than proof that it will not.
+ *
+ * `null` is the AGENT path, where there is no draft view to read: the run wrote that
+ * statement, executed it on the read-only session the engine enforced and answered from
+ * the rows, so the ledger holds no guard reading about it and this returns the visible
+ * label alone. A mark there would have to be invented, which is the one thing the
+ * paragraphs above refuse — and the name is still built HERE, because "every hand-off
+ * the answer card offers is named by this function" is the property that keeps a control
+ * from shipping unnamed the way all three of them had (L6).
+ */
+export function applyStatementName(draft: AgentPlanStatementView | null): string {
+  if (draft === null) return "Apply to editor.";
+  const marks: string[] = [];
+  // The guard's reach comes FIRST, and it replaces the objection rather than joining
+  // it (#414). On an engine whose statements are not SQL the guard read nothing, so
+  // `readOnly` is `false` for a reason that is not about this draft — and the sentence
+  // below it, spoken to a screen-reader user who cannot see the card, would otherwise
+  // assert that nothing establishes this correct MongoDB aggregation only reads, as
+  // though something had looked and been unconvinced.
+  if (!draft.guardApplicable)
+    marks.push(
+      "The statement guard reads SQL and this engine's statements are not SQL, so nothing examined this draft.",
+    );
+  else if (!draft.readOnly)
+    marks.push(
+      `The statement guard did not read this as a bounded read (${draft.guardViolation ?? "no reason recorded"}), so nothing here establishes that running it would only read.`,
+    );
+  if (draft.identifiers.kind === "not-applicable")
+    marks.push("The name check reads SQL too, so the names it uses were not looked for in anything.");
+  else if (draft.identifiers.kind === "no-inventory") marks.push("Nothing checked the names it uses.");
+  else if (draft.identifiers.unknownTables.length > 0) {
+    // Named in the engine's own word (#414). This sentence is spoken to a user who
+    // cannot see the card, so it is the last place a Druid run should be told about
+    // "table(s)" while every visible surface beside it says datasources.
+    marks.push(
+      `It names ${draft.identifiers.unknownTables.length} ${draft.noun.singular}(s) the inventory this run read does not hold, so it may not run as written.`,
+    );
+  }
+  return ["Apply to editor.", ...marks].join(" ");
+}

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -211,6 +211,23 @@ export interface AgentTimelineItem {
    * Only the editor control goes. The block still renders and still copies.
    */
   readonly planStatementRecorded?: true;
+  /**
+   * Set on the entries that are the run's own scaffolding rather than anything it
+   * found: the header it opened with, the drive starting, and the schema capture that
+   * grounded it.
+   *
+   * The FOLD names them, for the reason it names `isAnswer` rather than leaving the
+   * browser to infer it: a surface that collapsed them by matching their headlines
+   * would be reading the app's own copy as a protocol, and the first reworded
+   * headline would silently promote a chrome entry to a substantive one. What is
+   * chrome is a property of the EVENT KIND, which is a fact this function holds and a
+   * rendered string is not.
+   *
+   * It is a presentation hint and not a claim: every one of these entries is still
+   * folded in full, still carries its detail and its quoted objective, and a surface
+   * is free to render them exactly as it renders the rest.
+   */
+  readonly chrome?: true;
 }
 
 /**
@@ -234,6 +251,18 @@ export interface AgentEvidenceCitation {
   readonly id: string;
   /** The app's own words: which artifact or which capture. */
   readonly label: string;
+  /**
+   * The same words, at the length a chip can carry them.
+   *
+   * A correlation id is a UUID in a real run — `Artifact
+   * 722b2a10-e3f2-4b9c-8177-367359a21500` was measured filling a chip in a 384px
+   * panel on 2026-08-21, leaving no room for `detail`, which is the half that says
+   * what the read actually returned. So the identifier is cut to the eight characters
+   * this rail prints an identifier at everywhere else, `label` keeps the whole one for
+   * the surface that has the width for it, and both are written by one author so they
+   * cannot come to name different things.
+   */
+  readonly shortLabel: string;
   /** The app's own words about what the ledger holds for it. */
   readonly detail: string;
   /** False when this timeline holds no entry the reference names. */
@@ -262,6 +291,24 @@ export interface AgentRunReport {
   readonly claims: readonly AgentReportClaimView[];
 }
 
+/**
+ * What the run's LAST schema capture covered, for the surfaces that state the
+ * provenance of an answer rather than the chronology of the run.
+ *
+ * The last one and not the first: a run can capture more than once, and what grounded
+ * the answer is the reading that was in hand when it was composed. The fields are the
+ * capture event's own — `tableCount` included, which is the name of a SHAPE rather than
+ * a claim about the world, so the WORD a reader sees comes from `noun` (#414).
+ *
+ * Null for a run that captured nothing, which is a different state from a run that
+ * captured an empty schema and must not be rendered as one.
+ */
+export interface AgentCaptureView {
+  readonly fingerprint: string;
+  readonly tableCount: number;
+  readonly noun: AgentInventoryNoun;
+}
+
 export interface AgentRunTimeline {
   readonly items: readonly AgentTimelineItem[];
   /** Folded from the ledger, never from what a request once returned. */
@@ -272,6 +319,19 @@ export interface AgentRunTimeline {
    * T10a left it out precisely because nothing read it then.
    */
   readonly stopRequested: boolean;
+  /**
+   * The mode the run was OPENED in, folded from whichever of the two entries carries it
+   * — the header, or the `run-started` event for a stream joined after the header has
+   * gone past. `agent` for a ledger holding neither, which is the wording such a fold
+   * has always been described with.
+   *
+   * It is on the run record because the rail's own `mode` state is a SELECTION: the
+   * header toggle is frozen only while a start is held, so it is live again the moment
+   * the run opens and decides the NEXT run. A surface describing THIS run — the safety
+   * strip's posture, and the workflow-and-mode line under the objective — reads it here,
+   * or one click on Plan relabels a run that is executing reads.
+   */
+  readonly mode: AgentRunMode;
   /**
    * Why the run failed, when the server classified a cause; null otherwise.
    *
@@ -310,6 +370,8 @@ export interface AgentRunTimeline {
   readonly workflowReading: AgentRunWorkflowReading;
   /** The run's composed report, or null while it has composed none. */
   readonly report: AgentRunReport | null;
+  /** What the run's schema capture covered, or null for a run that captured nothing. */
+  readonly capture: AgentCaptureView | null;
 }
 
 const LEDGER_KINDS: ReadonlySet<string> = new Set<AgentLedgerEntry["kind"]>([
@@ -763,10 +825,11 @@ function describeEvent(
 ): Omit<AgentTimelineItem, "id" | "atMs"> {
   switch (event.kind) {
     case "run-started":
-      return { tone: "neutral", headline: `Run started in ${event.mode} mode` };
+      return { tone: "neutral", chrome: true, headline: `Run started in ${event.mode} mode` };
     case "context-captured":
       return {
         tone: "progress",
+        chrome: true,
         headline: "Schema captured",
         // Counted in the engine's own word (#414). The rail said "17 tables" over a
         // Redis keyspace while the sidebar beside it said Key Patterns and the model
@@ -975,6 +1038,7 @@ function describeEntry(
       return {
         atMs: entry.atMs,
         tone: "neutral",
+        chrome: true,
         // The workflow is named only when the header carries one. A ledger written
         // before the field says exactly what it always said, rather than being
         // narrated as an investigation it never declared itself to be.
@@ -1033,17 +1097,36 @@ interface LedgerIndex {
   readonly captures: ReadonlyMap<string, CitedCapture>;
 }
 
+/**
+ * How much of an identifier a surface too narrow for the whole one shows.
+ *
+ * Not a new convention: the schema-snapshot label below has been written at this
+ * length since it was added, and the answer card prints a capture's fingerprint at it.
+ * Named once so the artifact label cut to the same length is visibly the same rule
+ * rather than a second guess at what fits.
+ */
+const SHORT_IDENTIFIER_CHARS = 8;
+
 function citationOf(reference: AgentEvidenceReference, id: string, index: LedgerIndex): AgentEvidenceCitation {
   const locator = reference.locator === undefined ? {} : { locator: reference.locator };
 
   if (reference.source === "artifact") {
     const artifact = index.artifacts.get(reference.correlationId);
-    const label = `Artifact ${reference.correlationId}`;
-    if (artifact === undefined) return { id, label, detail: UNRESOLVED_DETAIL, resolved: false, ...locator };
+    /*
+      One author for the word, so the whole identifier and the chip-length one cannot
+      drift into naming different things — the reason `shortLabel` is derived here at
+      all rather than by whoever renders the chip.
+    */
+    const name = (identifier: string): string => `Artifact ${identifier}`;
+    const label = name(reference.correlationId);
+    const shortLabel = name(reference.correlationId.slice(0, SHORT_IDENTIFIER_CHARS));
+    if (artifact === undefined)
+      return { id, label, shortLabel, detail: UNRESOLVED_DETAIL, resolved: false, ...locator };
     const sql = index.statements.get(artifact.stepId);
     return {
       id,
       label,
+      shortLabel,
       detail: `${artifact.rowCount} ${artifact.rowCount === 1 ? "row" : "rows"} via ${artifact.operationId}`,
       resolved: true,
       artifactId: reference.correlationId,
@@ -1053,11 +1136,15 @@ function citationOf(reference: AgentEvidenceReference, id: string, index: Ledger
   }
 
   const capture = index.captures.get(reference.fingerprint);
-  const label = `Schema snapshot ${reference.fingerprint.slice(0, 8)}`;
-  if (capture === undefined) return { id, label, detail: UNRESOLVED_DETAIL, resolved: false, ...locator };
+  // Already written at chip length, so the two labels are the same string: a
+  // fingerprint is this product's own value and nothing reads more of it than this.
+  const label = `Schema snapshot ${reference.fingerprint.slice(0, SHORT_IDENTIFIER_CHARS)}`;
+  if (capture === undefined)
+    return { id, label, shortLabel: label, detail: UNRESOLVED_DETAIL, resolved: false, ...locator };
   return {
     id,
     label,
+    shortLabel: label,
     detail: `${capture.tableCount} ${capture.tableCount === 1 ? capture.noun.singular : capture.noun.plural}`,
     resolved: true,
     ...locator,
@@ -1135,6 +1222,8 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
   const artifacts = new Map<string, CitedArtifact>();
   const statementsByStep = new Map<string, string>();
   const captures = new Map<string, CitedCapture>();
+  /** The run's grounding, for the surfaces that state where an answer came from. */
+  let capture: AgentCaptureView | null = null;
 
   /*
     What this run's engine calls the rows of its inventory (#414), carried through the
@@ -1180,6 +1269,10 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
     never saw either has always shown the agent wording, and this must not change
     what such a ledger reads as. The default is only reachable for a ledger whose
     beginning the rail does not hold.
+
+    It is also what the rail describes an OPEN run with, on the strip and on the line
+    under the objective — see `AgentRunTimeline.mode` for why a selection cannot answer
+    that question.
   */
   let mode: AgentRunMode = "agent";
 
@@ -1237,6 +1330,9 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
         // itself recorded rather than in the one the entry before it was written with.
         noun = event.noun ?? TABLE_INVENTORY_NOUN;
         captures.set(event.fingerprint, { tableCount: event.tableCount, noun });
+        // Overwritten rather than kept, so a run that captured twice reports the
+        // reading that was in hand when it finished. See `AgentCaptureView`.
+        capture = { fingerprint: event.fingerprint, tableCount: event.tableCount, noun };
       } else if (event.kind === "statement-drafted") statementsByStep.set(event.stepId, event.sql);
       else if (event.kind === "report-composed") claims = event.claims;
       else if (event.kind === "tool-completed") {
@@ -1309,6 +1405,7 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
     items,
     status,
     stopRequested,
+    mode,
     failureReason,
     workflowType,
     workflowSource,
@@ -1319,5 +1416,6 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
       { id: "repairs", label: "Repair attempts", used: repairs, limit: AGENT_MAX_REPAIR_ATTEMPTS, unit: "count" },
     ],
     report: claims === null ? null : reportOf(claims, { artifacts, statements: statementsByStep, captures }),
+    capture,
   };
 }

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -78,6 +78,28 @@ export interface ProseOptions {
    * affordance in the agent rail follows.
    */
   readonly onApplySql?: (sql: string) => void;
+  /**
+   * A statement the surface AROUND this prose is already displaying verbatim, whose
+   * fenced block is therefore not printed here a second time.
+   *
+   * Measured in Chrome on 2026-08-21. A plan run's closing prose is the text its
+   * statement was read OUT of, so the statement is inside it — and every surface that
+   * rendered that prose reprinted the statement at full weight: the answer card showed
+   * the statement, then the same statement again inside its own "Why this statement"
+   * fold, and the transcript entry a few hundred pixels below printed it a third time.
+   * One draft, three copies, each with its own clipboard.
+   *
+   * Keyed on the TEXT and not on a flag, deliberately: the recorded deliverable is read
+   * out of this prose by `readPlanStatement`, which joins and trims a fence's lines
+   * exactly as `closeFence` below does, so the block that matches is the block the
+   * ledger took — and every OTHER block still renders, because a second block is not a
+   * second copy of anything.
+   *
+   * It suppresses one BLOCK and never a word of prose. The text around it is rendered
+   * unchanged, and a caller's "Copy all" takes the string the model wrote rather than
+   * this rendering of it, so nothing here narrows what a user can carry away.
+   */
+  readonly cardedStatement?: string;
 }
 
 /**
@@ -185,13 +207,17 @@ export function renderProse(text: string, options: ProseOptions = {}): ReactNode
     bullets = [];
   };
 
+  const carded = options.cardedStatement?.trim();
+
   const closeFence = (): void => {
     if (fence === null) return;
     const code = fence.lines.join("\n");
+    const statement = code.trim();
     // A fence with nothing in it is not a code block, for the same reason a heading
     // with nothing after it is not a heading: it would render an empty box offering a
-    // copy of nothing.
-    if (code.trim().length > 0) {
+    // copy of nothing. And the one block the caller is already showing verbatim is not
+    // printed either — see `cardedStatement`.
+    if (statement.length > 0 && statement !== carded) {
       blocks.push(<CodeBlock key={key} code={code} tag={fence.tag} onApplySql={options.onApplySql} />);
       key += 1;
     }

--- a/src/lib/agent/posture.ts
+++ b/src/lib/agent/posture.ts
@@ -1,0 +1,203 @@
+/**
+ * What the SELECTED MODE does to the database, on one axis: what does it execute?
+ *
+ * The rail used to answer that question in six places at once - a mode description, a
+ * consent paragraph, a budget note, a guard line, a refusal and a claim under the answer -
+ * and a user comparing two of them could not tell which one bounded the run. This module is
+ * the single reading, in four levels, and it is the ONLY thing the safety strip renders.
+ *
+ * It states nothing new. Every claim here is a claim some other module enforces:
+ * `AGENT_EXECUTION_ENGINES` mirrors the factory's profile gate, the figures come from the
+ * workflow policy rows and from `AGENT_HANDOVER_BUDGET`, and the hand-over paragraph IS the
+ * sentence the consent step shows - `autoExecuteTerms` below is that one source, exported so
+ * the strip and the consent card cannot drift into two versions of a sentence a user agrees
+ * to.
+ *
+ * Three properties are load-bearing and easy to lose:
+ *
+ *  - **Client-safe imports only** - types, `AGENT_EXECUTION_ENGINES`, `getDBConfig` and the
+ *    policy constants. A provider module here would drag `oracledb`/`mssql` toward a bundle
+ *    that must not have them, which is the rule `engine-support.ts` records in its header.
+ *  - **Every engine name and every number is DERIVED.** Not one is typed as a literal, and
+ *    not one is a count. The point of #425 is that "7+" was written when the answer was 7
+ *    and stayed while the answer became 11; the same trap is one edit away here, because
+ *    each of these sentences names a set the server decides.
+ *  - **The qualifier is visible, never folded into the popover.** A bare "executes nothing"
+ *    overclaims: on the dialects `CATALOG_PLANS` serves, plan mode's grounding capture IS a
+ *    catalog read, and `engine-support.ts` says in its own header that copy compressing these
+ *    facts overclaims. The strip therefore shows both halves on one line, and the popover
+ *    carries the full claim rather than the missing half.
+ */
+
+import { AGENT_EXECUTION_ENGINES } from "@/lib/agent/engine-support";
+import { AGENT_HANDOVER_BUDGET, AGENT_WORKFLOW_BUDGETS } from "@/lib/agent/execution-policy";
+import type { AgentRunMode, AgentRunWorkflowType } from "@/lib/agent/types";
+import { getDBConfig } from "@/lib/db-ui-config";
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * The four levels, named by what they say about execution rather than by a colour: a tone
+ * is chosen by this module and a palette is chosen by the strip, so a restyle cannot change
+ * a claim.
+ */
+export type AgentPostureTone = "safe" | "reads" | "widened" | "blocked";
+
+export interface AgentPosture {
+  readonly tone: AgentPostureTone;
+  /** The pill. Short enough to read at a glance, and true on its own. */
+  readonly headline: string;
+  /** Beside the pill, always visible: the half a compressed headline would drop. */
+  readonly qualifier: string;
+  /** The popover's heading. */
+  readonly title: string;
+  /** The popover's text, and the whole claim. */
+  readonly body: string;
+}
+
+/**
+ * The dialects whose grounding capture is a COMPOSED CATALOG READ rather than a request that
+ * the provider describe its own schema - `CATALOG_PLANS` in `src/lib/agent/context-snapshot.ts`.
+ *
+ * Mirrored rather than imported, and for the reason this module exists at all: that module
+ * reaches `node:crypto` and the tool layer, so importing it would put the agent's server tree
+ * behind a browser bundle. `tests/unit/lib/agent/posture.test.ts` reads the real
+ * `CATALOG_PLANS` out of its source and fails if this mirror falls behind it, which is what
+ * keeps a mirror from becoming a second opinion.
+ */
+const CATALOG_CAPTURE_ENGINES: readonly DatabaseType[] = ["postgres", "sqlite"];
+
+/**
+ * The per-statement bounds agent mode runs under, taken from one policy row.
+ *
+ * One row and not a fold, because the posture is read with no workflow in hand: the strip is
+ * shown before a run is opened and beside a run whose workflow the user did not choose.
+ * `workflowBudget()` writes `statementTimeoutMs` and `maxResultRows` once for every row and
+ * varies only the per-run ceilings, so one row's figures are every row's figures - and the
+ * test asserts exactly that, so a row that ever varied them fails CI rather than quietly
+ * making this sentence wrong for one workflow. The fix then is to give the posture a
+ * workflow, never to edit a digit.
+ */
+const STATEMENT_BOUNDS = AGENT_WORKFLOW_BUDGETS.investigation.policy.budgets;
+
+/** The engines agent mode can execute on, named as the product names them. */
+const engineNames = (types: readonly DatabaseType[]): string =>
+  types.map((type) => getDBConfig(type).label).join(" and ");
+
+/**
+ * The terms of the auto-execute consent, as ONE sentence-run rather than as JSX prose: the
+ * figures are interpolated and a formatter is free to reflow JSX text around them, which is
+ * how "500-row limit" becomes "500 -row limit" without anyone touching the copy. This is the
+ * sentence a user consents to, so it is written and rendered as written.
+ *
+ * It takes the workflow rather than reading a selection, because there is no longer a
+ * selection to read at the moment it is shown: the consent step is reached with a workflow
+ * already decided — by the classifier or by the user under Advanced — and the bounds it names
+ * are that workflow's own.
+ *
+ * It lives here, beside the posture that quotes it, so the strip's widened body and the
+ * checkbox's accessible description are one string with one author.
+ */
+export function autoExecuteTerms(workflowType: AgentRunWorkflowType): string {
+  return handoverTerms(AGENT_WORKFLOW_BUDGETS[workflowType].policy.budgets);
+}
+
+/** The consent sentence itself, over whichever row named it. */
+function handoverTerms(budgets: { readonly maxResultRows: number; readonly statementTimeoutMs: number }): string {
+  return `The run always produces its answer on its own read-only path, bounded to ${budgets.maxResultRows} rows and ${budgets.statementTimeoutMs / 1000} seconds. Tick this and it will also put that statement in your editor and run it there — on the connection the run was opened on, at the editor's ${AGENT_HANDOVER_BUDGET.maxResultRows}-row limit and with no time limit. It is the same database-enforced read-only session either way, so writes and DDL are refused by the engine rather than by reading the statement. Statements whose plan reads as expensive, or which the run measured as slow, are put in the editor without being run.`;
+}
+
+/** Plan mode, on every engine, with or without the hand-over ticked. */
+function planPosture(): AgentPosture {
+  return {
+    tone: "safe",
+    headline: "Executes nothing it drafts",
+    qualifier: "one schema read grounds it, nothing else reaches the database",
+    title: "Plan mode drafts, and never runs what it drafted",
+    body: `Plan mode never executes the statement it wrote, on any engine — production included. Its one reach is the schema capture that grounds it: metadata only, no data rows, and it is where the inventory in Run details came from. On ${engineNames(CATALOG_CAPTURE_ENGINES)} that capture is itself a catalog read; on every other engine it asks the provider to describe its own schema.`,
+  };
+}
+
+/**
+ * Agent mode on an engine whose provider implements no read-only statement path.
+ *
+ * Two facts travel with the refusal because leaving either out reads as a dead end: plan
+ * mode drafts here, and the `operations` workflow runs here too - it composes no statement
+ * at all, so its acquisition never asks the engine for a read-only one.
+ */
+function unsupportedPosture(engineLabel: string): AgentPosture {
+  return {
+    tone: "blocked",
+    headline: `Cannot execute on ${engineLabel}`,
+    qualifier: "plan mode drafts here, and the operations workflow still runs",
+    title: `Agent mode has no read-only statement path on ${engineLabel}`,
+    body: `Agent mode executes only where the provider implements a database-native read-only statement path — ${engineNames(AGENT_EXECUTION_ENGINES)}. On ${engineLabel} a profiled acquisition is refused and the run ends engine-unsupported before its first statement. The operations workflow still runs here, because it sends no statement at all: it calls the curated reporting methods every provider implements. Plan mode drafts on every engine.`,
+  };
+}
+
+/**
+ * Agent mode with no resolved connection.
+ *
+ * Blocked, because agent mode cannot execute anything from here - but blocked WITHOUT the
+ * engine claim, which is the whole reason this is its own arm rather than
+ * `unsupportedPosture("this connection")`. Nothing has been read, so "has no read-only
+ * statement path" would be a statement about an engine this panel has not seen; what is true
+ * is that it does not know which engine you are on. The caller's `engineLabel` is ignored on
+ * purpose: with `engine` null it is a label for nothing.
+ */
+function unresolvedPosture(): AgentPosture {
+  return {
+    tone: "blocked",
+    headline: "Cannot execute yet",
+    qualifier: "no connection is resolved, so no engine has been established",
+    title: "Agent mode has no connection to execute on",
+    body: `Agent mode executes only where the provider implements a database-native read-only statement path — ${engineNames(AGENT_EXECUTION_ENGINES)}. No connection is resolved here, so this panel cannot say which engine you are on, or whether it is one of those: until one is resolved, agent mode executes nothing. The operations workflow sends no statement at all, so it runs wherever a connection does, and plan mode drafts on every engine.`,
+  };
+}
+
+/** Agent mode with the editor hand-over consented: still read-only, and one statement wider. */
+function widenedPosture(): AgentPosture {
+  return {
+    tone: "widened",
+    headline: "Reads only, and one statement in your editor",
+    qualifier: `${AGENT_HANDOVER_BUDGET.maxResultRows} rows, no time limit, same read-only session`,
+    title: "Reads only, and one statement lands in your editor",
+    body: handoverTerms(STATEMENT_BOUNDS),
+  };
+}
+
+/** Agent mode, executing on its own path and nowhere else. */
+function readsPosture(): AgentPosture {
+  const rows = STATEMENT_BOUNDS.maxResultRows;
+  const seconds = STATEMENT_BOUNDS.statementTimeoutMs / 1000;
+  return {
+    tone: "reads",
+    headline: "Reads only",
+    qualifier: `${rows} rows and ${seconds} s per statement, enforced by the engine`,
+    title: "Agent mode reads, under a boundary the engine enforces",
+    body: `Agent mode runs statements it wrote itself, in a read-only session the database enforces, bounded to ${rows} rows and ${seconds} seconds each. Writes and DDL are refused by the engine rather than by reading the statement. Nothing reaches your editor unless you tick the hand-over when the run opens.`,
+  };
+}
+
+/**
+ * The rail's reading of the selected mode, in the order the arms EXCLUDE each other.
+ *
+ * Plan mode first, because it is engine-independent and the hand-over cannot widen it -
+ * there is no statement of the run's to hand over. Then the two arms that know no bounds to
+ * state: no connection, and an engine agent mode cannot execute a statement on. Only then
+ * does the hand-over matter, which is why a ticked hand-over on an unsupported engine still
+ * reads as blocked rather than as widened.
+ *
+ * `AGENT_EXECUTION_ENGINES` is read on every call, not folded into a constant at module
+ * load, so the copy follows the list in the process that is running.
+ */
+export function agentPosture(input: {
+  readonly mode: AgentRunMode;
+  readonly engine: DatabaseType | null;
+  readonly engineLabel: string;
+  readonly handover: boolean;
+}): AgentPosture {
+  if (input.mode === "planning") return planPosture();
+  if (input.engine === null) return unresolvedPosture();
+  if (!AGENT_EXECUTION_ENGINES.includes(input.engine)) return unsupportedPosture(input.engineLabel);
+  return input.handover ? widenedPosture() : readsPosture();
+}

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -4932,6 +4932,75 @@ describe("AgentRail", () => {
       });
 
       /*
+        A consent step standing for the NEXT run may not relabel the run that is open.
+
+        Both of these are reachable through "change": the control renders only while the
+        run is open, choosing `data-analysis` in agent mode raises the consent step, and
+        the replacement is not opened — nor the open run stopped — until that step is
+        accepted. So a pending start and a live run coexist by design, and while they do
+        the strip has two candidate answers about the hand-over: the open run's record and
+        the standing step's tick. It owes the open run's, in both directions — the same
+        rule the mode axis already follows — because the claim is about the run that is
+        executing, and the run that is executing was bounded when it was opened.
+      */
+      test("a consent step raised beside a widened run does not un-widen the strip", async () => {
+        mockClassifiedFetch({ workflowType: "data-analysis", outcome: "classified" }, [AGENT_STARTED_LINE]);
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" onRunStatement={() => {}} />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "sales by region" } });
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-start"));
+        });
+        fireEvent.click(view.getByTestId("agent-auto-execute"));
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-consent-open"));
+        });
+        await view.findByTestId("agent-run-status");
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("widened");
+
+        // A second run is being decided beside the widened one, and its tick starts OFF.
+        fireEvent.click(view.getByTestId("agent-opened-as-change"));
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-change-workflow-data-analysis"));
+        });
+        expect(view.getByTestId("agent-consent")).toBeTruthy();
+
+        // The run that is open is still the widened one, and still says so.
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("widened");
+        expect(view.getByTestId("agent-safety-headline").textContent).toBe(
+          "Reads only, and one statement in your editor",
+        );
+      });
+
+      test("ticking a consent step raised beside an open run does not widen the strip either", async () => {
+        mockClassifiedFetch({ workflowType: "data-analysis", outcome: "classified" }, [AGENT_STARTED_LINE]);
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" onRunStatement={() => {}} />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "sales by region" } });
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-start"));
+        });
+        // Opened WITHOUT the hand-over: the tick is left off, so this run may not hand
+        // anything over and the strip may not say it will.
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-consent-open"));
+        });
+        await view.findByTestId("agent-run-status");
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("reads");
+
+        fireEvent.click(view.getByTestId("agent-opened-as-change"));
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-change-workflow-data-analysis"));
+        });
+        fireEvent.click(view.getByTestId("agent-auto-execute"));
+
+        // The tick belongs to the run that has not opened yet. The one that IS open was
+        // opened on reads, and it is what the strip is describing.
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("reads");
+        expect(view.getByTestId("agent-safety-headline").textContent).toBe("Reads only");
+      });
+
+      /*
         The strip describes the OPEN run, and the mode axis is read off that run's own
         record rather than off the toggle.
 

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -4,8 +4,9 @@ import "../../helpers/mock-navigation";
 
 import React from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, fireEvent, waitFor, act } from "@testing-library/react";
+import { cleanup, render, fireEvent, waitFor, act, type RenderResult } from "@testing-library/react";
 import { AgentRail } from "@/components/agent/AgentRail";
+import { applyStatementName } from "@/components/agent/rail-parts";
 import { AGENT_WORKFLOW_BUDGETS } from "@/lib/agent/execution-policy";
 import type { AgentRunWorkflowType } from "@/lib/agent/types";
 
@@ -69,6 +70,19 @@ const openedFor = (workflowType: AgentRunWorkflowType): string =>
   })}\n`;
 
 const STARTED_LINE = `${JSON.stringify({ kind: "event", event: { kind: "run-started", atMs: 1_001, mode: "planning" } })}\n`;
+
+/**
+ * The same event for a run the server opened in AGENT mode.
+ *
+ * It exists because the rail now describes an open run from the run's own record, so a
+ * ledger whose `run-started` says `planning` under a header that says `agent` is not a
+ * ledger any server writes — and a test built on one would be asserting against a run
+ * that cannot exist.
+ */
+const AGENT_STARTED_LINE = `${JSON.stringify({
+  kind: "event",
+  event: { kind: "run-started", atMs: 1_001, mode: "agent" },
+})}\n`;
 
 const COMPLETED_LINE = `${JSON.stringify({
   kind: "event",
@@ -268,6 +282,26 @@ function mockDivergentServer(classification: unknown, header: Record<string, unk
   return fetchMock;
 }
 
+/**
+ * Every entry the rail rendered, the run's scaffolding included.
+ *
+ * The rail folds that scaffolding — the header, the drive starting, the schema capture —
+ * behind one summary line that expands, and those entries carry
+ * `agent-timeline-chrome-item` rather than `agent-timeline-item` (item 7 of the rail
+ * redesign): `agent-timeline-item` is now the id of a SUBSTANTIVE entry, which is what
+ * makes counting them worth doing. A test about the LEDGER PARSER counts what was folded
+ * out of the stream and so asks for both, in document order — the chrome group is rendered
+ * first, and it is the prefix of every ledger a run actually writes.
+ */
+async function findAllEntries(view: RenderResult): Promise<HTMLElement[]> {
+  await waitFor(() => {
+    expect(
+      view.queryAllByTestId("agent-timeline-chrome-item").length + view.queryAllByTestId("agent-timeline-item").length,
+    ).toBeGreaterThan(0);
+  });
+  return [...view.queryAllByTestId("agent-timeline-chrome-item"), ...view.queryAllByTestId("agent-timeline-item")];
+}
+
 /** The five workflows live behind the disclosure now, so a test that names one opens it. */
 const openAdvanced = (view: { getByTestId: (id: string) => HTMLElement }): void => {
   fireEvent.click(view.getByTestId("agent-advanced-toggle"));
@@ -356,7 +390,8 @@ describe("AgentRail", () => {
 
   test("starting a run asks for the selected mode against the resolvable connection, then follows its ledger", async () => {
     const fetchMock = mockAgentFetch([OPENED_LINE, STARTED_LINE]);
-    const { getByTestId, findAllByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+    const { getByTestId } = view;
 
     fireEvent.click(getByTestId("agent-mode-agent"));
     fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
@@ -364,10 +399,13 @@ describe("AgentRail", () => {
       fireEvent.click(getByTestId("agent-start"));
     });
 
-    const items = await findAllByTestId("agent-timeline-item");
+    // Both entries are the run's own scaffolding, so they are folded behind one summary
+    // line — and rendered in full inside it, which is what this reads.
+    const items = await findAllEntries(view);
     expect(items).toHaveLength(2);
     expect(items[0].textContent).toContain("Run opened in planning mode");
     expect(items[1].textContent).toContain("Run started in planning mode");
+    expect(getByTestId("agent-timeline-chrome").textContent).toContain("Run setup · 2 entries");
 
     // The classification comes first now, and the open request carries what it said —
     // here the answer every failure reaches, since this mock is not a classifier.
@@ -547,19 +585,22 @@ describe("AgentRail", () => {
   describe("the objective", () => {
     test("is cleared once the run has opened, and is still readable in the timeline", async () => {
       mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE]);
-      const { getByTestId, findAllByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+      const view = render(<AgentRail {...DEFAULT_PROPS} />);
+      const { getByTestId } = view;
 
       fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
       await act(async () => {
         fireEvent.click(getByTestId("agent-start"));
       });
 
+      // The run has ENDED here, so the box is a box again — while a run is open it is the
+      // one-line summary, which the objective suite below pins.
       await waitFor(() => {
         expect((getByTestId("agent-objective") as HTMLTextAreaElement).value).toBe("");
       });
       // Not lost, only moved: the question is on the run's own header, quoted under
       // the first entry, beside the run that is answering it.
-      const items = await findAllByTestId("agent-timeline-item");
+      const items = await findAllEntries(view);
       expect(items[0].textContent).toContain("why is checkout slow");
     });
 
@@ -986,27 +1027,29 @@ describe("AgentRail", () => {
   test("an entry split across two chunks still renders once", async () => {
     const half = Math.floor(OPENED_LINE.length / 2);
     mockAgentFetch([OPENED_LINE.slice(0, half), OPENED_LINE.slice(half), STARTED_LINE.trimEnd()]);
-    const { getByTestId, findAllByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+    const { getByTestId } = view;
 
     fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
     await act(async () => {
       fireEvent.click(getByTestId("agent-start"));
     });
 
-    const items = await findAllByTestId("agent-timeline-item");
+    const items = await findAllEntries(view);
     expect(items).toHaveLength(2);
   });
 
   test("a line this build cannot read is skipped, and the rest of the timeline survives", async () => {
     mockAgentFetch(['{"kind":"something-newer"}\n', OPENED_LINE, "\n"]);
-    const { getByTestId, findAllByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+    const { getByTestId } = view;
 
     fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
     await act(async () => {
       fireEvent.click(getByTestId("agent-start"));
     });
 
-    const items = await findAllByTestId("agent-timeline-item");
+    const items = await findAllEntries(view);
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toContain("Run opened");
   });
@@ -1071,7 +1114,8 @@ describe("AgentRail", () => {
       return jsonResponse({ runId: "arun_1", status: "queued", mode: "planning" }, 202);
     });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
-    const { getByTestId, findByTestId, findAllByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+    const { getByTestId, findByTestId } = view;
 
     fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
     await act(async () => {
@@ -1079,7 +1123,7 @@ describe("AgentRail", () => {
     });
 
     expect((await findByTestId("agent-error")).textContent).toContain("connection reset");
-    expect(await findAllByTestId("agent-timeline-item")).toHaveLength(1);
+    expect(await findAllEntries(view)).toHaveLength(1);
   });
 
   test("the rail stops following when it goes away", async () => {
@@ -1689,9 +1733,10 @@ describe("AgentRail", () => {
      * unavailable right now.
      */
     test("no pause or resume control is offered, because the service can honour neither", async () => {
-      const { queryByTestId, findAllByTestId } = await startRun([OPENED_LINE, STARTED_LINE]);
+      const view = await startRun([OPENED_LINE, STARTED_LINE]);
+      const { queryByTestId } = view;
 
-      await findAllByTestId("agent-timeline-item");
+      await findAllEntries(view);
       expect(queryByTestId("agent-pause")).toBeNull();
       expect(queryByTestId("agent-resume")).toBeNull();
     });
@@ -1714,7 +1759,19 @@ describe("AgentRail", () => {
       const budgets = AGENT_WORKFLOW_BUDGETS.investigation.policy.budgets;
 
       expect(queryByTestId("agent-budget-statements")).toBeNull();
-      expect(getByTestId("agent-budget-unknown").textContent).toContain("Automatic decides the workflow");
+      /*
+        The whole sentence, pinned.
+
+        It is the one claim in the budget block whose wording the rail redesign changed:
+        "Every ceiling BELOW is per workflow" became "Every ceiling HERE", because "below"
+        was a deictic that stopped being true once the ceilings moved into a sibling ⓘ.
+        Nothing pinned it before — both existing assertions checked a fragment — so a
+        worse rewrite would have gone through unnoticed. A reflow has to come here now.
+      */
+      expect(getByTestId("agent-budget-unknown").textContent).toBe(
+        "Every ceiling here is per workflow, and Automatic decides the workflow from your objective when the run " +
+          "opens — so the figures are stated once the run has one, and by the run's own record.",
+      );
 
       fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
       await act(async () => {
@@ -1890,6 +1947,14 @@ describe("AgentRail", () => {
    * Evidence citations (#329 T10b). The server refuses a claim whose evidence does
    * not match something the run produced; the rail's job is to show the user what
    * each claim rests on, and to keep the model's own words visibly the model's.
+   *
+   * They are read on the ANSWER CARD since the 2026-08-21 redesign, and since L6 that
+   * is the only place they are: the old `agent-report` section at the foot of the rail
+   * rendered the same claims and the same citations a second time, which is what put
+   * three "Apply to editor" controls for one statement on the report path. What each
+   * test asserts is unchanged — the claim quoted, the label, the ledger's own detail,
+   * the model's locator, the statement the artifact came from, and an unresolved
+   * reference saying so rather than looking checked. Only the ids moved.
    */
   describe("evidence citations", () => {
     test("a composed report renders its claims quoted, with what backs each of them", async () => {
@@ -1900,23 +1965,29 @@ describe("AgentRail", () => {
         fireEvent.click(getByTestId("agent-start"));
       });
 
-      const claims = await findAllByTestId("agent-report-claim");
+      const claims = await findAllByTestId("agent-answer-claim");
       expect(claims).toHaveLength(1);
       expect(claims[0].textContent).toContain("checkout is slow because orders is scanned");
+      // The model's own pointer into that evidence, carried through as its words, on the
+      // chip beside the claim.
+      expect(getByTestId("agent-answer-citation-chip").textContent).toContain("Artifact corr_9");
+      expect(getByTestId("agent-answer-citation-chip").textContent).toContain("row 2, total");
 
-      const citations = getByTestId("agent-report").querySelectorAll('[data-testid="agent-report-citation"]');
+      const citations = getByTestId("agent-answer-evidence").querySelectorAll(
+        '[data-testid="agent-answer-evidence-citation"]',
+      );
       expect(citations).toHaveLength(1);
       expect(citations[0].textContent).toContain("Artifact corr_9");
       expect(citations[0].textContent).toContain("3 rows via sql.query.read");
-      // The model's own pointer into that evidence, carried through as its words.
-      expect(citations[0].textContent).toContain("row 2, total");
       // And the statement the artifact came from, quoted rather than narrated.
       expect(citations[0].querySelector("pre")?.textContent).toBe("SELECT count(*) FROM orders");
     });
 
-    test("a run with no report renders no report section", () => {
+    test("a run with no report renders no report at all", () => {
       const { queryByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);
 
+      expect(queryByTestId("agent-answer-report")).toBeNull();
+      // And the section that used to repeat it below the transcript is gone for good.
       expect(queryByTestId("agent-report")).toBeNull();
     });
 
@@ -1931,9 +2002,10 @@ describe("AgentRail", () => {
         fireEvent.click(getByTestId("agent-start"));
       });
 
-      const [citation] = await findAllByTestId("agent-report-citation");
+      const [citation] = await findAllByTestId("agent-answer-evidence-citation");
       expect(citation.textContent).toContain("not in the part of this run's timeline the rail has read");
       expect(citation.querySelector("pre")).toBeNull();
+      expect(getByTestId("agent-answer-citation-chip").getAttribute("data-resolved")).toBe("false");
     });
   });
 
@@ -2020,20 +2092,33 @@ describe("AgentRail", () => {
       expect(queryAllByTestId("agent-apply-statement")).toHaveLength(0);
     });
 
-    test("a resolved citation carries both affordances; an unresolved one carries neither", async () => {
+    /*
+      A citation carries the statement it rests on and no hand-off of its own (L6).
+
+      It had both until the answer card became the answer: the card renders the same
+      claims and the same citations, so the section this pinned was a second rendering of
+      them — and its citation's "Apply to editor" was a THIRD offer of the answer's own
+      statement, since an answer's `sql` is the statement of the step whose artifact it
+      presents and the citation quotes that same step. Neither affordance is lost: the
+      statement is on the clipboard here, the card offers the marked hand-off, and the
+      artifact is offered by the `Result stored` entry that stored it.
+    */
+    test("a citation offers the statement it rests on, and no hand-off of its own", async () => {
       mockAgentFetch([OPENED_LINE, STARTED_LINE, DRAFTED_LINE, COMPLETED_LINE, REPORT_LINE]);
       const onShowArtifact = mock(() => {});
       const onApplyStatement = mock(() => {});
-      const { findAllByTestId, getByTestId } = await runWith({ onShowArtifact, onApplyStatement });
+      const { findAllByTestId, getByTestId, queryByTestId } = await runWith({ onShowArtifact, onApplyStatement });
 
-      const citations = await findAllByTestId("agent-report-citation");
+      const citations = await findAllByTestId("agent-answer-evidence-citation");
       expect(citations).toHaveLength(1);
+      expect(citations[0].querySelector("pre")?.textContent).toBe("SELECT count(*) FROM orders");
+      expect(getByTestId("agent-answer-citation-quoted-copy")).toBeTruthy();
+      expect(queryByTestId("agent-citation-apply-statement")).toBeNull();
+      expect(queryByTestId("agent-citation-show-result")).toBeNull();
 
-      fireEvent.click(getByTestId("agent-citation-show-result"));
+      // The artifact it cites, from the entry that recorded storing it.
+      fireEvent.click(getByTestId("agent-show-result"));
       expect(onShowArtifact).toHaveBeenCalledWith({ runId: "arun_1", correlationId: "corr_9" });
-
-      fireEvent.click(getByTestId("agent-citation-apply-statement"));
-      expect(onApplyStatement).toHaveBeenCalledWith("SELECT count(*) FROM orders");
     });
 
     /*
@@ -2063,9 +2148,8 @@ describe("AgentRail", () => {
       const onApplyStatement = mock(() => {});
       const { findAllByTestId, queryAllByTestId } = await runWith({ onShowArtifact, onApplyStatement });
 
-      await findAllByTestId("agent-report-citation");
+      await findAllByTestId("agent-answer-evidence-citation");
       expect(queryAllByTestId("agent-show-result")).toHaveLength(0);
-      expect(queryAllByTestId("agent-citation-show-result")).toHaveLength(0);
       expect(queryAllByTestId("agent-apply-statement")).toHaveLength(1);
     });
 
@@ -2073,9 +2157,8 @@ describe("AgentRail", () => {
       mockAgentFetch([OPENED_LINE, STARTED_LINE, DRAFTED_LINE, COMPLETED_LINE, REPORT_LINE]);
       const { findAllByTestId, queryAllByTestId } = await runWith({ onShowArtifact: mock(() => {}) });
 
-      await findAllByTestId("agent-report-citation");
-      expect(queryAllByTestId("agent-citation-show-result")).toHaveLength(1);
-      expect(queryAllByTestId("agent-citation-apply-statement")).toHaveLength(0);
+      await findAllByTestId("agent-answer-evidence-citation");
+      expect(queryAllByTestId("agent-show-result")).toHaveLength(1);
       expect(queryAllByTestId("agent-apply-statement")).toHaveLength(0);
     });
 
@@ -2096,7 +2179,7 @@ describe("AgentRail", () => {
       const note = await findByTestId("agent-report-retention");
       expect(note.textContent).toContain("released when the run ends");
       // No report was composed, which is exactly the case that had no explanation.
-      expect(queryByTestId("agent-report")).toBeNull();
+      expect(queryByTestId("agent-answer-report")).toBeNull();
     });
 
     test("a run that stored nothing says nothing about retention", async () => {
@@ -2112,7 +2195,7 @@ describe("AgentRail", () => {
       mockAgentFetch([OPENED_LINE, STARTED_LINE, COMPLETED_LINE, REPORT_LINE, FINISHED_LINE]);
       const { findByTestId, queryByTestId } = await runWith({});
 
-      await findByTestId("agent-report");
+      await findByTestId("agent-answer-report");
       expect(queryByTestId("agent-report-retention")).toBeNull();
     });
 
@@ -2121,8 +2204,10 @@ describe("AgentRail", () => {
       const onShowArtifact = mock(() => {});
       const { findAllByTestId, queryByTestId } = await runWith({ onShowArtifact });
 
-      await findAllByTestId("agent-report-citation");
-      expect(queryByTestId("agent-citation-show-result")).toBeNull();
+      const [citation] = await findAllByTestId("agent-answer-evidence-citation");
+      expect(citation.textContent).toContain("not in the part of this run's timeline the rail has read");
+      // Nothing stored it, so there is nothing anywhere in the rail to ask for.
+      expect(queryByTestId("agent-show-result")).toBeNull();
     });
   });
 
@@ -2207,7 +2292,7 @@ describe("AgentRail", () => {
       mockAgentFetch([OPENED_LINE, STARTED_LINE, COMPLETED_LINE, DRAFTED_LINE, REPORT_LINE, FINISHED_LINE]);
       const { findByTestId } = await runWith({ onShowArtifact });
 
-      await findByTestId("agent-report");
+      await findByTestId("agent-answer-report");
       expect(onShowArtifact).not.toHaveBeenCalled();
     });
 
@@ -2223,7 +2308,7 @@ describe("AgentRail", () => {
       ]);
       const { findByTestId } = await runWith({ onShowArtifact });
 
-      await findByTestId("agent-report");
+      await findByTestId("agent-answer-report");
       expect(onShowArtifact).toHaveBeenCalledTimes(1);
     });
 
@@ -2375,9 +2460,11 @@ describe("AgentRail", () => {
         connectionId: "seed:sales",
         objective,
       })}\n`;
-      const { findAllByTestId } = await runWith([opened, STARTED_LINE]);
+      const view = await runWith([opened, STARTED_LINE]);
 
-      const items = await findAllByTestId("agent-timeline-item");
+      // The header is chrome, so it is inside the folded group — and still quoting the
+      // objective exactly as it arrived, which is the property this is about.
+      const items = await findAllEntries(view);
       expect(items[0].querySelector("pre")?.textContent).toBe(objective);
       expect(items[0].querySelector("strong")).toBeNull();
     });
@@ -2486,10 +2573,12 @@ describe("AgentRail", () => {
         fireEvent.click(view.getByTestId("agent-start"));
       });
 
-      fireEvent.click(await view.findByTestId("agent-report-claim-copy"));
+      // On the answer card, which is where a report is read since the redesign — and the
+      // only place it is read since L6 took the duplicate section away.
+      fireEvent.click(await view.findByTestId("agent-answer-claim-copy"));
       await waitFor(() => expect(writeText).toHaveBeenCalledWith("checkout is slow because orders is scanned"));
 
-      fireEvent.click(await view.findByTestId("agent-citation-quoted-copy"));
+      fireEvent.click(await view.findByTestId("agent-answer-citation-quoted-copy"));
       await waitFor(() => expect(writeText).toHaveBeenCalledWith("SELECT count(*) FROM orders"));
     });
   });
@@ -2688,6 +2777,100 @@ describe("AgentRail", () => {
       });
 
       expect(scroller.scrollTop).toBe(0);
+    });
+
+    /**
+     * L1, measured in Chrome on 2026-08-21 — the blocker the redesign is FOR.
+     *
+     * Immediately after each run reached a terminal status, with no user scrolling at
+     * all, the scroller sat at its maximum (224 of 224 on plan/PostgreSQL, 248 of 248 on
+     * agent/PostgreSQL) and the answer card — the first child of this container — was
+     * that far above the fold. Following the newest entry is right while the run is
+     * PRODUCING entries; the moment it ends, the newest entry is `run-finished` and the
+     * thing the user waited for is at the top.
+     *
+     * So the following is bounded by the run being live, and the end of the run brings
+     * the answer into view once. The card stays inside the scroller deliberately: lifted
+     * out, a long report would take a fixed third of the panel away from the transcript,
+     * and the answer would sit under the reader's eyes while they are reading something
+     * else.
+     */
+    describe("and the answer, once the run has ended", () => {
+      /** A plan run's deliverable, so there is an answer card to bring into view. */
+      const DRAFT_LINE = `${JSON.stringify({
+        kind: "event",
+        event: {
+          kind: "plan-statement-drafted",
+          atMs: 1_004,
+          dialect: "postgres",
+          sql: "SELECT title FROM film",
+          readOnly: true,
+          identifiers: { kind: "checked", unknownTables: [] },
+        },
+      })}\n`;
+
+      test("a run that reaches a terminal status brings the answer into view, not the last entry", async () => {
+        const view = await startRun();
+        await act(async () => {
+          view.stream.push(OPENED_LINE);
+        });
+        await waitFor(() => {
+          expect(view.scroller.scrollTop).toBe(BOTTOM);
+        });
+
+        await act(async () => {
+          view.stream.push(DRAFT_LINE);
+          view.stream.push(FINISHED_LINE);
+        });
+
+        await waitFor(() => {
+          expect(view.scroller.scrollTop).toBe(0);
+        });
+        // Which is where the answer is: the card is the first thing in this container.
+        expect(view.scroller.firstElementChild?.getAttribute("data-testid")).toBe("agent-answer");
+      });
+
+      test("a reader who scrolled away is not yanked to the answer either", async () => {
+        const { stream, scroller } = await startRun();
+        await act(async () => {
+          stream.push(OPENED_LINE);
+        });
+        await waitFor(() => {
+          expect(scroller.scrollTop).toBe(BOTTOM);
+        });
+
+        scroller.scrollTop = 120;
+        fireEvent.scroll(scroller);
+        await act(async () => {
+          stream.push(DRAFT_LINE);
+          stream.push(FINISHED_LINE);
+        });
+
+        expect(scroller.scrollTop).toBe(120);
+      });
+
+      test("a viewport that shrinks after the run ended does not drag the transcript down", async () => {
+        // The bottom still moves when the host's result panel opens, and following it
+        // there would undo the reveal a beat after it happened. Nothing scrolled, so the
+        // reader is still counted as being at the end — the run being over is what stops
+        // the following, and that is what this pins.
+        const { stream, scroller } = await startRun();
+        await act(async () => {
+          stream.push(OPENED_LINE);
+          stream.push(DRAFT_LINE);
+          stream.push(FINISHED_LINE);
+        });
+        await waitFor(() => {
+          expect(scroller.scrollTop).toBe(0);
+        });
+
+        Object.defineProperty(scroller, "clientHeight", { value: 208, configurable: true });
+        await act(async () => {
+          resizeObserved(scroller);
+        });
+
+        expect(scroller.scrollTop).toBe(0);
+      });
     });
   });
 
@@ -3305,11 +3488,20 @@ describe("AgentRail", () => {
     test("the drafted statement gets a card of its own, showing the SQL verbatim", async () => {
       const { findByTestId } = await planRun([OPENED_LINE, STARTED_LINE, draftedLine(READ), FINISHED_LINE]);
 
+      // The statement moved UP, to the answer card at the top of the rail (item 2 of the
+      // rail redesign). Verbatim, in a block of its own: this is model text, and the
+      // rail's standing rule is that the user can see where the application stopped
+      // speaking.
+      expect((await findByTestId("agent-answer-statement")).querySelector("pre")?.textContent).toBe(READ.sql);
+      // The transcript entry keeps the guard's verdict — as data, and as the one line
+      // summarising what it no longer reprints — and reprints the statement nowhere: one
+      // statement, one place, which is what keeps the marked hand-off the only hand-off.
       const card = await findByTestId("agent-plan-statement");
-      // Verbatim, in a block of its own: this is model text, and the rail's standing
-      // rule is that the user can see where the application stopped speaking.
-      expect(card.querySelector("pre")?.textContent).toBe(READ.sql);
       expect(card.getAttribute("data-read-only")).toBe("true");
+      expect(card.querySelector("pre")).toBeNull();
+      expect((await findByTestId("agent-plan-statement-summary")).textContent).toContain(
+        "Checked as a bounded read against the captured inventory. Nothing was executed.",
+      );
     });
 
     test("applying hands the host the exact statement the ledger recorded", async () => {
@@ -3318,7 +3510,7 @@ describe("AgentRail", () => {
         onApplyStatement,
       });
 
-      fireEvent.click(await findByTestId("agent-plan-apply-statement"));
+      fireEvent.click(await findByTestId("agent-answer-plan-apply"));
       expect(onApplyStatement).toHaveBeenCalledWith(READ.sql);
     });
 
@@ -3332,8 +3524,8 @@ describe("AgentRail", () => {
         FINISHED_LINE,
       ]);
 
-      expect(queryByTestId("agent-plan-apply-statement")).toBeNull();
-      expect(await findByTestId("agent-plan-statement-copy")).not.toBeNull();
+      expect(queryByTestId("agent-answer-plan-apply")).toBeNull();
+      expect(await findByTestId("agent-answer-statement-copy")).not.toBeNull();
     });
 
     test("the statement can be copied through the control that works over plain HTTP", async () => {
@@ -3343,7 +3535,7 @@ describe("AgentRail", () => {
       Object.defineProperty(globalThis.navigator, "clipboard", { value: { writeText }, configurable: true });
       const { findByTestId } = await planRun([OPENED_LINE, STARTED_LINE, draftedLine(READ), FINISHED_LINE]);
 
-      fireEvent.click(await findByTestId("agent-plan-statement-copy"));
+      fireEvent.click(await findByTestId("agent-answer-statement-copy"));
       await waitFor(() => expect(writeText).toHaveBeenCalledWith(READ.sql));
     });
 
@@ -3364,7 +3556,7 @@ describe("AgentRail", () => {
         { onApplyStatement },
       );
 
-      const apply = await findByTestId("agent-plan-apply-statement");
+      const apply = await findByTestId("agent-answer-plan-apply");
       const name = apply.getAttribute("aria-label") ?? "";
       expect(name).toContain("Apply");
       // WCAG 2.5.3: the accessible name contains the visible label, so a voice user
@@ -3374,12 +3566,17 @@ describe("AgentRail", () => {
       // name, so it can be asserted rather than inferred from styling.
       const card = await findByTestId("agent-plan-statement");
       expect(card.getAttribute("data-read-only")).toBe("false");
-      const mark = await findByTestId("agent-plan-statement-guard");
+      const mark = await findByTestId("agent-answer-guard");
       expect(mark.textContent).toContain("did not read this as a bounded read");
       // The guard's own reason, beside the mark: it is this repository's closed
       // vocabulary rather than model text, and it is what tells a reader whether the
       // objection was about an effect or about text the guard could not settle.
       expect(mark.textContent).toContain("NON_READ_STATEMENT");
+      // And the transcript entry summarises the same objection, in the same words and
+      // with the same reason code, from the one module that writes the sentence.
+      expect((await findByTestId("agent-plan-statement-summary")).textContent).toContain(
+        "The statement guard did not read this as a bounded read (NON_READ_STATEMENT).",
+      );
     });
 
     /*
@@ -3414,30 +3611,39 @@ describe("AgentRail", () => {
       // Still marked, still amber, still not offered as an ordinary read: the run
       // could not establish that this only reads, and that is worth a user's attention.
       expect(card.getAttribute("data-read-only")).toBe("false");
-      expect((await findByTestId("agent-plan-statement-guard")).textContent).toContain("DIALECT_AMBIGUOUS_TEXT");
-      // And nowhere on it, or in the name the control carries, is the claim the server
-      // never made.
-      const name = (await findByTestId("agent-plan-apply-statement")).getAttribute("aria-label") ?? "";
-      expect(`${card.textContent} ${name}`).not.toContain("change or delete");
-      expect(`${card.textContent} ${name}`).not.toContain("This is not a read");
+      expect((await findByTestId("agent-answer-guard")).textContent).toContain("DIALECT_AMBIGUOUS_TEXT");
+      // And nowhere on the answer that carries the statement, nowhere on the entry that
+      // summarises it, and nowhere in the name the control carries, is the claim the
+      // server never made.
+      const name = (await findByTestId("agent-answer-plan-apply")).getAttribute("aria-label") ?? "";
+      const read = `${(await findByTestId("agent-answer")).textContent} ${card.textContent} ${name}`;
+      expect(read).not.toContain("change or delete");
+      expect(read).not.toContain("This is not a read");
     });
 
     /*
       The ledger shape a real run produces, which none of the cases above has: the
       closing prose HOLDS the fenced statement, and the drafted event is written from
-      it immediately after. So the same `DELETE` is on screen twice — inside the prose,
+      it immediately after. So the same `DELETE` was on screen twice — inside the prose,
       where #389's per-block control offers "Apply to editor" with no mark, no
       accessible name and no colour, and in the card, which marks it.
 
       The unmarked control sits directly above the marked one and is the one a user
       reaches for first. It is the silent hand-off item 4 of the design exists to
-      prevent, so it is withheld from the entry the statement was read out of; the
-      card is the hand-off, and the block keeps its clipboard.
+      prevent, so it is withheld from the entry the statement was read out of; the card
+      is the hand-off.
+
+      And since L2 the BLOCK is withheld with it, in both places that prose is rendered.
+      Measured in Chrome on 2026-08-21: the statement was printed three times over — on
+      the card, again inside the card's own `Why this statement`, and again in this entry,
+      each copy with its own `Copy`. The clipboard is not lost by that: the statement has
+      its own on the card, and `Copy all` still carries the whole prose with the fence in
+      it, because it takes the string the model wrote rather than this rendering of it.
     */
     test("the prose the statement was read out of offers no second, unmarked editor control", async () => {
       const onApplyStatement = mock((_sql: string) => {});
       const sql = "DELETE FROM film WHERE rental_count = 0";
-      const { findByTestId, queryByTestId, queryAllByTestId } = await planRun(
+      const { findByTestId, getByTestId, queryByTestId, queryAllByTestId } = await planRun(
         [
           OPENED_LINE,
           STARTED_LINE,
@@ -3453,12 +3659,22 @@ describe("AgentRail", () => {
         { onApplyStatement },
       );
 
-      // The marked control, and only it.
-      expect(await findByTestId("agent-plan-apply-statement")).not.toBeNull();
+      // The marked control, and only it — in the answer card, which is now the one place
+      // a plan run's statement is offered to the editor at all.
+      expect(await findByTestId("agent-answer-plan-apply")).not.toBeNull();
+      expect(queryAllByTestId("agent-answer-plan-apply")).toHaveLength(1);
       expect(queryByTestId("prose-code-apply")).toBeNull();
-      // Nothing else is taken away: the block still renders and still copies.
-      expect((await findByTestId("agent-prose")).textContent).toContain(sql);
-      expect(queryAllByTestId("prose-code-copy").length).toBe(1);
+      expect(queryAllByTestId("agent-apply-statement")).toHaveLength(0);
+      // And the statement itself is printed once, on the card. Neither rendering of the
+      // prose reprints it: not this entry, and not the card's own "Why this statement",
+      // which is the same text folded away.
+      expect((await findByTestId("agent-prose")).textContent).not.toContain(sql);
+      expect(queryAllByTestId("agent-answer-why-prose")).toHaveLength(1);
+      expect(getByTestId("agent-answer-why-prose").textContent).not.toContain(sql);
+      expect(queryAllByTestId("prose-code-copy")).toHaveLength(0);
+      // The prose keeps its own words, and the card keeps the statement.
+      expect((await findByTestId("agent-prose")).textContent).toContain("It removes the unrented titles.");
+      expect(getByTestId("agent-answer-statement").querySelector("pre")?.textContent).toBe(sql);
     });
 
     test("a plan run that drafted no statement keeps the fence reading #389 gave it", async () => {
@@ -3492,17 +3708,25 @@ describe("AgentRail", () => {
       // The finding reaches a screen reader too, on the control that acts on it: a
       // user who never sees the amber list is otherwise told only "Apply to editor"
       // about a statement whose names were not all found.
-      const name = (await findByTestId("agent-plan-apply-statement")).getAttribute("aria-label") ?? "";
+      const name = (await findByTestId("agent-answer-plan-apply")).getAttribute("aria-label") ?? "";
       expect(name).toContain("2 table(s)");
       expect(name).toContain("does not hold");
 
-      const findings = await findByTestId("agent-plan-statement-unknown");
+      const findings = await findByTestId("agent-answer-chip-names");
       // The names are engine and model text, so they are shown as quoted content
       // rather than spliced into the app's sentence — and they ARE shown: a count
       // alone leaves the user with nothing to look for in the statement above.
       expect(findings.textContent).toContain("payments");
       expect(findings.textContent).toContain("refunds");
-      expect(findings.textContent).toContain("not in the inventory");
+      // The sentence they are a list FOR, which names the list for a reader who cannot
+      // see it and is also what the guard's own note carries.
+      expect(findings.getAttribute("aria-label")).toContain("not in the inventory");
+      // The claim keeps the test id it has carried since before the card moved: a shared
+      // note blob cannot distinguish the right sentence for this reading from any
+      // sentence that happens to contain the phrase.
+      expect((await findByTestId("agent-plan-statement-unknown")).textContent).toBe(
+        "These names are not in the inventory this run read, so the statement may not run as written:",
+      );
     });
 
     test("the same finding names the objects in the engine's own word (#414)", async () => {
@@ -3534,7 +3758,7 @@ describe("AgentRail", () => {
         { onApplyStatement: mock((_sql: string) => {}) },
       );
 
-      const name = (await findByTestId("agent-plan-apply-statement")).getAttribute("aria-label") ?? "";
+      const name = (await findByTestId("agent-answer-plan-apply")).getAttribute("aria-label") ?? "";
       expect(name).toContain("1 datasource(s)");
       expect(name).not.toContain("table");
     });
@@ -3550,13 +3774,24 @@ describe("AgentRail", () => {
         { onApplyStatement: mock((_sql: string) => {}) },
       );
 
-      expect((await findByTestId("agent-plan-statement-unchecked")).textContent).toContain(
-        "No schema inventory was read",
+      // The sentence moved into the guard's own note, which is where everything the run
+      // established about this draft now reads — the claim is the same claim, in the node
+      // that has always carried it.
+      expect((await findByTestId("agent-plan-statement-unchecked")).textContent).toBe(
+        "No schema inventory was read for this run, so the names in this statement were not checked against anything.",
       );
-      expect(queryByTestId("agent-plan-statement-unknown")).toBeNull();
+      // And the line above it does not contradict it: no inventory was read, so the
+      // visible reading claims a bounded read and nothing about an inventory.
+      expect((await findByTestId("agent-answer-guard")).textContent).toBe(
+        "Checked as a bounded read. Nothing was executed.",
+      );
+      expect((await findByTestId("agent-plan-statement-summary")).textContent).toContain(
+        "Checked as a bounded read. Nothing was executed.",
+      );
+      expect(queryByTestId("agent-answer-chip-names")).toBeNull();
       // An empty list of unknown names would be a CLAIM — that every name resolves —
       // and this run made none, so the control says nothing checked them.
-      expect((await findByTestId("agent-plan-apply-statement")).getAttribute("aria-label")).toContain(
+      expect((await findByTestId("agent-answer-plan-apply")).getAttribute("aria-label")).toContain(
         "Nothing checked the names it uses",
       );
     });
@@ -3570,11 +3805,16 @@ describe("AgentRail", () => {
       ]);
 
       await findByTestId("agent-plan-statement");
-      expect(queryByTestId("agent-plan-statement-unknown")).toBeNull();
-      expect(queryByTestId("agent-plan-statement-unchecked")).toBeNull();
-      expect(queryByTestId("agent-plan-statement-guard")).toBeNull();
-      expect(queryByTestId("agent-plan-statement-guard-unread")).toBeNull();
-      expect(queryByTestId("agent-plan-statement-unread")).toBeNull();
+      expect(queryByTestId("agent-answer-chip-names")).toBeNull();
+      // The guard read it and was satisfied, so what is said is that and nothing else:
+      // no objection, no "nothing examined this", no report of a missing inventory.
+      expect((await findByTestId("agent-answer-guard")).textContent).toBe(
+        "Checked as a bounded read against the captured inventory. Nothing was executed.",
+      );
+      expect((await findByTestId("agent-answer-chip-guard")).textContent).toBe("Read-only");
+      const note = (await findByTestId("agent-answer-guard-note")).textContent ?? "";
+      expect(note).not.toContain("No schema inventory was read");
+      expect(note).not.toContain("not SQL");
     });
 
     /*
@@ -3607,11 +3847,21 @@ describe("AgentRail", () => {
         { onApplyStatement: mock((_sql: string) => {}) },
       );
 
+      // The visible line says the guard did not look, and the note behind it carries the
+      // whole claim — both in the words the transcript's card used to carry.
       const unread = await findByTestId("agent-plan-statement-guard-unread");
       expect(unread.textContent).toContain("The statement guard reads SQL");
       expect(unread.textContent).toContain("nothing examined this draft");
-      // The banner that blames the draft is not also on the card: one card, one claim.
-      expect(queryByTestId("agent-plan-statement-guard")).toBeNull();
+      expect((await findByTestId("agent-plan-statement-unread")).textContent).toBe(
+        "The names in this statement were not checked: the check that would do it reads SQL, and this engine's statements are not SQL.",
+      );
+      expect((await findByTestId("agent-answer-guard")).textContent).toBe(
+        "Not examined: the statement guard reads SQL, and this engine's statements are not SQL.",
+      );
+      // The banner that blames the draft is nowhere: one card, one claim. The chip says
+      // the same thing, and is not the verdict a checked statement earns.
+      expect((await findByTestId("agent-answer-chip-guard")).textContent).toBe("not checked");
+      expect((await findByTestId("agent-answer")).textContent).not.toContain("did not read this as a bounded read");
       // And the MACHINE-readable half says the same thing as the prose. `"false"` is
       // the objection the guard makes, and it made none here; a consumer keying on the
       // attribute must not be able to read one out of a draft nothing looked at.
@@ -3620,7 +3870,7 @@ describe("AgentRail", () => {
       // WCAG 2.5.3 still holds — the visible label is in the accessible name — and the
       // mark a screen-reader user hears is the one about the guard's reach, not the one
       // asserting that nothing established this only reads.
-      const name = (await findByTestId("agent-plan-apply-statement")).getAttribute("aria-label") ?? "";
+      const name = (await findByTestId("agent-answer-plan-apply")).getAttribute("aria-label") ?? "";
       expect(name).toContain("Apply");
       expect(name).toContain("this engine's statements are not SQL");
       expect(name).not.toContain("did not read this as a bounded read");
@@ -3653,10 +3903,13 @@ describe("AgentRail", () => {
 
       const unread = await findByTestId("agent-plan-statement-unread");
       expect(unread.textContent).toContain("the check that would do it reads SQL");
+      // Its own sentence and not the other one: this run may well HAVE an inventory, and
+      // a user told none was read would go looking for a grounding failure that did not
+      // happen. Two ids rather than one blob is what makes that assertable.
       expect(queryByTestId("agent-plan-statement-unchecked")).toBeNull();
-      expect(queryByTestId("agent-plan-statement-unknown")).toBeNull();
+      expect(queryByTestId("agent-answer-chip-names")).toBeNull();
 
-      const name = (await findByTestId("agent-plan-apply-statement")).getAttribute("aria-label") ?? "";
+      const name = (await findByTestId("agent-answer-plan-apply")).getAttribute("aria-label") ?? "";
       expect(name).toContain("The name check reads SQL too");
       expect(name).not.toContain("Nothing checked the names it uses.");
     });
@@ -3682,8 +3935,11 @@ describe("AgentRail", () => {
         { onApplyStatement: mock((_sql: string) => {}) },
       );
 
-      expect((await findByTestId("agent-plan-statement-guard")).textContent).toContain("NON_READ_STATEMENT");
-      expect(queryByTestId("agent-plan-statement-guard-unread")).toBeNull();
+      expect((await findByTestId("agent-answer-guard")).textContent).toContain("NON_READ_STATEMENT");
+      // Absent reads as "the guard applied", so what is said is the objection it made and
+      // never the sentence about an engine whose statements are not SQL.
+      expect((await findByTestId("agent-answer")).textContent).not.toContain("Not examined");
+      expect(queryByTestId("agent-plan-statement")).toBeTruthy();
     });
 
     test("a refusal renders as its own card, and the marker never reaches the user", async () => {
@@ -3699,8 +3955,13 @@ describe("AgentRail", () => {
       expect(card.textContent).toContain("Which table holds them?");
       expect(card.textContent).not.toContain("NO STATEMENT");
       // A refusal is not a statement: there is nothing to apply and nothing is offered.
+      //
+      // The apply control is asserted by the id it has NOW. It used to be
+      // `agent-plan-apply-statement`, built from a `testIdPrefix="agent-plan-"` this
+      // redesign removed with the transcript's copy of the statement — and a
+      // `toBeNull()` against an id no component can produce is a test that cannot fail.
       expect(queryByTestId("agent-plan-statement")).toBeNull();
-      expect(queryByTestId("agent-plan-apply-statement")).toBeNull();
+      expect(queryByTestId("agent-answer-plan-apply")).toBeNull();
     });
 
     test("an ordinary closing statement is not dressed as a refusal", async () => {
@@ -4106,8 +4367,13 @@ describe("AgentRail", () => {
         });
 
         // NOT Start: it is disabled from the moment the run is busy, and the browser
-        // drops focus to the body when the focused element disables under it.
-        expect(document.activeElement?.getAttribute("data-testid")).toBe("agent-objective");
+        // drops focus to the body when the focused element disables under it. So focus
+        // goes to the objective box — and one commit later the run opens, the box becomes
+        // the one-line summary of the question it was opened with (item 4 of the rail
+        // redesign), and the control that replaced it takes the focus the box lost. Left
+        // undone, that is the same "left nowhere" this whole suite is about, one step
+        // further along.
+        expect(document.activeElement?.getAttribute("data-testid")).toBe("agent-objective-edit");
         expect((view.getByTestId("agent-start") as HTMLButtonElement).disabled).toBe(true);
       });
     });
@@ -4522,6 +4788,899 @@ describe("AgentRail", () => {
         });
         expect(view.getByTestId("agent-opened-as").textContent).toContain("Opened as Optimize");
         expect(view.queryByTestId("agent-opened-as-change")).toBeNull();
+      });
+    });
+  });
+
+  /**
+   * The rail's 2026-08-21 redesign: what MOVED, and the three claims that may not move
+   * with it.
+   *
+   * Nothing here changes what a run does, what the ledger records or what any claim says.
+   * What changed is where a reader meets each of them, which is why these tests are about
+   * placement and derivation rather than about copy:
+   *
+   *  - **the safety strip states what the selected MODE executes**, on one axis, from one
+   *    module (`src/lib/agent/posture.ts`). The rail used to answer that question in six
+   *    places at once;
+   *  - **the engine notice gates nothing.** It presents a refusal the provider factory
+   *    makes, and one workflow — operations — runs on those engines regardless, so a
+   *    disabled Start would take a working thing away over a claim untrue of it;
+   *  - **the budget's three claims moved behind an ⓘ each and are still exactly
+   *    themselves.** A claim that is harder to reach is a decision; a claim that is
+   *    reworded on the way is a different claim.
+   */
+  describe("the redesigned rail", () => {
+    async function liveRun(props: Partial<React.ComponentProps<typeof AgentRail>> = {}, lines?: readonly string[]) {
+      mockAgentFetch(lines ?? [OPENED_LINE, STARTED_LINE]);
+      const view = render(<AgentRail {...DEFAULT_PROPS} {...props} />);
+      fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+      await act(async () => {
+        fireEvent.click(view.getByTestId("agent-start"));
+      });
+      return view;
+    }
+
+    describe("the safety strip", () => {
+      test("plan mode says it executes nothing, and says what its one reach is", () => {
+        const { getByTestId } = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" />);
+
+        expect(getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("safe");
+        expect(getByTestId("agent-safety-headline").textContent).toBe("Executes nothing it drafts");
+        // The qualifier is beside the pill and not behind the ⓘ, because "executes
+        // nothing" alone overclaims: plan mode's grounding capture IS a catalog read on
+        // PostgreSQL.
+        expect(getByTestId("agent-safety-qualifier").textContent).toContain("one schema read grounds it");
+      });
+
+      test("agent mode on an executable engine says what the engine enforces", () => {
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("reads");
+        expect(view.getByTestId("agent-safety-headline").textContent).toBe("Reads only");
+      });
+
+      test("agent mode on an engine it cannot execute on says so, and plan mode is offered", () => {
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="mongodb" />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("blocked");
+        expect(view.getByTestId("agent-safety-headline").textContent).toContain("MongoDB");
+        expect(view.getByTestId("agent-safety-qualifier").textContent).toContain("plan mode drafts here");
+      });
+
+      test("the tick in the consent step widens the strip, and only while it is ticked", async () => {
+        // The strip reads the hand-over from the step that is standing, because that is
+        // the decision being made: a widened reading before it is ticked would describe a
+        // run nobody has asked for.
+        // The started line says `agent` because the header this server writes does: the
+        // strip beside an open run reads that run's own mode, so a ledger disagreeing with
+        // itself is not a run any server could produce.
+        mockClassifiedFetch({ workflowType: "data-analysis", outcome: "classified" }, [AGENT_STARTED_LINE]);
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" onRunStatement={() => {}} />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "sales by region" } });
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-start"));
+        });
+
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("reads");
+        fireEvent.click(view.getByTestId("agent-auto-execute"));
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("widened");
+        expect(view.getByTestId("agent-safety-headline").textContent).toBe(
+          "Reads only, and one statement in your editor",
+        );
+
+        // And the run that opens carries it, so the strip beside a live run is describing
+        // that run rather than a control that no longer exists.
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-consent-open"));
+        });
+        await view.findByTestId("agent-run-status");
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("widened");
+      });
+
+      test("a cancelled consent leaves the strip where it was", async () => {
+        mockClassifiedFetch({ workflowType: "data-analysis", outcome: "classified" });
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" onRunStatement={() => {}} />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "sales by region" } });
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-start"));
+        });
+        fireEvent.click(view.getByTestId("agent-auto-execute"));
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-consent-cancel"));
+        });
+
+        // Nothing was widened, because nothing was opened.
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("reads");
+      });
+
+      /*
+        The hand-over is frozen for as long as the RUN is, and not one beat longer.
+
+        `openedWithHandover` is set when the run opens and never cleared, so with no
+        liveness guard the strip kept saying "Reads only, and one statement in your
+        editor" after the widened run had ended — over a panel whose next consent step
+        defaults the tick to OFF. This is the panel's single standing claim about what
+        pressing Start does, and after any widened run it stated a widening nobody had
+        agreed to for the run that was about to open.
+      */
+      test("a widened run that has ENDED stops the strip claiming the widening", async () => {
+        mockClassifiedFetch({ workflowType: "data-analysis", outcome: "classified" }, [
+          AGENT_STARTED_LINE,
+          FINISHED_LINE,
+        ]);
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" onRunStatement={() => {}} />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "sales by region" } });
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-start"));
+        });
+        fireEvent.click(view.getByTestId("agent-auto-execute"));
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-consent-open"));
+        });
+
+        await waitFor(() => {
+          expect(view.getByTestId("agent-run-status").textContent).toBe("succeeded");
+        });
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("reads");
+        expect(view.getByTestId("agent-safety-headline").textContent).toBe("Reads only");
+      });
+
+      /*
+        The strip describes the OPEN run, and the mode axis is read off that run's own
+        record rather than off the toggle.
+
+        The toggle is frozen only while a start is HELD, which is deliberate — it decides
+        the NEXT run — so it is live again the moment this one opens. One click on Plan
+        beside a running agent run moved the strip to `safe` and the pill to "Executes
+        nothing it drafts" while the run kept executing reads and kept spending its
+        budget: the one direction that matters, since it overclaims safety.
+      */
+      test("clicking Plan beside a live agent run does not relabel that run", async () => {
+        mockClassifiedFetch({ workflowType: "investigation", outcome: "classified" }, [AGENT_STARTED_LINE]);
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-start"));
+        });
+        await view.findByTestId("agent-run-status");
+
+        fireEvent.click(view.getByTestId("agent-mode-planning"));
+
+        expect(view.getByTestId("agent-mode-planning").getAttribute("aria-pressed")).toBe("true");
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("reads");
+        expect(view.getByTestId("agent-safety-headline").textContent).toBe("Reads only");
+        // And the same reading on the line under the objective, which used to take its
+        // workflow from the run's fold and its mode from the toggle — two halves of one
+        // sentence from two sources.
+        expect(view.getByTestId("agent-objective-frame").textContent).toBe("Investigate · Agent mode");
+      });
+
+      test("once the run has ended the strip follows the selection again", async () => {
+        mockClassifiedFetch({ workflowType: "investigation", outcome: "classified" }, [
+          AGENT_STARTED_LINE,
+          FINISHED_LINE,
+        ]);
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-start"));
+        });
+        await waitFor(() => {
+          expect(view.getByTestId("agent-run-status").textContent).toBe("succeeded");
+        });
+
+        // There is no open run to describe, so the strip is back to answering what
+        // pressing Start would do.
+        fireEvent.click(view.getByTestId("agent-mode-planning"));
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("safe");
+        expect(view.getByTestId("agent-safety-headline").textContent).toBe("Executes nothing it drafts");
+      });
+    });
+
+    /*
+      L7, measured in Chrome on 2026-08-21: a muted line under Start read
+      `Executes nothing it drafts — one schema read grounds it, nothing else reaches the
+      database.` — the strip's headline and qualifier joined, about 200px below the strip
+      itself. Two identical sentences in one 384px panel.
+
+      The line is gone rather than reworded. The strip is permanent and states this for
+      the selected mode already, and the panel's other reading of the selection — the
+      amber engine notice — says something the strip does not.
+    */
+    describe("what pressing Start means, said once", () => {
+      const occurrences = (haystack: string, needle: string): number => haystack.split(needle).length - 1;
+      /*
+        Asserted as a boolean rather than with `toBeNull()`, and that is not style: this
+        node lives deep inside the rail, and bun's inspector walks an element's parents
+        and listeners, so a restored line printed 23MB of one paragraph's ancestry and
+        the run stopped resembling a test run at all (measured while pinning this RED).
+        A regression here should read as one line.
+      */
+      const absent = (view: ReturnType<typeof render>, testId: string): boolean => view.queryByTestId(testId) === null;
+
+      test("the strip's sentence has no second copy under the button", () => {
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="postgres" />);
+
+        expect(absent(view, "agent-posture-line")).toBe(true);
+
+        // Both halves of it, each exactly once in the whole panel. Counted rather than
+        // queried by id, because the defect was not a testid: it was the same words
+        // rendered twice, and a reworded second copy would be the same defect.
+        const panel = view.container.textContent ?? "";
+        expect(view.getByTestId("agent-safety-headline").textContent).toBe("Executes nothing it drafts");
+        expect(occurrences(panel, "Executes nothing it drafts")).toBe(1);
+        expect(occurrences(panel, "one schema read grounds it, nothing else reaches the database")).toBe(1);
+      });
+
+      test("nor beside a run, where the strip is describing the run and not the selection", async () => {
+        const view = await liveRun({ connectionType: "postgres" });
+
+        await view.findByTestId("agent-run-status");
+        fireEvent.click(view.getByTestId("agent-objective-edit"));
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+
+        expect(absent(view, "agent-posture-line")).toBe(true);
+        // The strip goes on describing the run that is still open, which is the reading
+        // this state exists to keep apart from the toggle's.
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("safe");
+      });
+    });
+
+    describe("the engine notice", () => {
+      test("agent mode on an engine with no read-only statement path is told, before Start", () => {
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="mongodb" />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+
+        const notice = view.getByTestId("agent-engine-unsupported-notice").textContent ?? "";
+        expect(notice).toContain("MongoDB");
+        expect(notice).toContain("no read-only statement path");
+        // The two things that ARE open here, because a dead end is not what this is:
+        // the operations workflow sends no statement at all, and plan mode drafts.
+        expect(notice).toContain("The operations workflow still runs here");
+        expect(notice).toContain("Plan mode drafts on every engine");
+      });
+
+      test("it does not gate Start, because the refusal is the server's and one workflow is unaffected", () => {
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="mongodb" />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "what is blocked right now" } });
+
+        expect(view.getByTestId("agent-engine-unsupported-notice")).toBeTruthy();
+        expect((view.getByTestId("agent-start") as HTMLButtonElement).disabled).toBe(false);
+      });
+
+      test("its way out selects plan mode and starts nothing", () => {
+        const fetchMock = mock(async () => jsonResponse({}, 202));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="mongodb" />);
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+
+        fireEvent.click(view.getByTestId("agent-engine-unsupported-plan"));
+
+        expect(view.getByTestId("agent-mode-planning").getAttribute("aria-pressed")).toBe("true");
+        expect(view.queryByTestId("agent-engine-unsupported-notice")).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      test("an engine agent mode CAN execute on is not warned about, and neither is an unresolved one", () => {
+        const executable = render(<AgentRail {...DEFAULT_PROPS} connectionType="sqlite" />);
+        fireEvent.click(executable.getByTestId("agent-mode-agent"));
+        expect(executable.queryByTestId("agent-engine-unsupported-notice")).toBeNull();
+        cleanup();
+
+        // Nothing has been resolved, so which engine this is has not been established:
+        // an amber card about an engine nobody named would be a claim the panel cannot
+        // support, and the strip says "Cannot execute yet" instead.
+        const unresolved = render(<AgentRail {...DEFAULT_PROPS} connectionType={null} />);
+        fireEvent.click(unresolved.getByTestId("agent-mode-agent"));
+        expect(unresolved.queryByTestId("agent-engine-unsupported-notice")).toBeNull();
+        expect(unresolved.getByTestId("agent-safety-headline").textContent).toBe("Cannot execute yet");
+      });
+
+      /*
+        The notice is about the SELECTION, and the strip beside it is about the run: those
+        are two questions, and while a run is open they have different answers.
+
+        Selecting Agent on an engine with no read-only statement path, beside a plan run
+        that is going, has to say what starting an agent run there would do — the strip
+        goes on describing the plan run, because that is the run that is executing.
+      */
+      test("its facts are the selection's, even while another run is describing the strip", async () => {
+        mockAgentFetch([OPENED_LINE, STARTED_LINE]);
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="mongodb" />);
+        fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "what is slow" } });
+        await act(async () => {
+          fireEvent.click(view.getByTestId("agent-start"));
+        });
+        await view.findByTestId("agent-run-status");
+
+        fireEvent.click(view.getByTestId("agent-mode-agent"));
+
+        const notice = view.getByTestId("agent-engine-unsupported-notice").textContent ?? "";
+        expect(notice).toContain("no read-only statement path");
+        expect(view.getByTestId("agent-engine-unsupported-reason").textContent).toContain("On MongoDB");
+        // The open plan run is still what the strip describes.
+        expect(view.getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe("safe");
+      });
+
+      test("plan mode is warned about nothing, on any engine", () => {
+        const view = render(<AgentRail {...DEFAULT_PROPS} connectionType="mongodb" />);
+
+        expect(view.queryByTestId("agent-engine-unsupported-notice")).toBeNull();
+      });
+    });
+
+    describe("the objective while a run is open", () => {
+      test("it is the question that was asked, with the way back to the box", async () => {
+        const view = await liveRun();
+
+        // The user's question, behind the `sr-only` name that replaced the box's `<label>`
+        // on this branch — see the test below for why that name is there at all.
+        expect((await view.findByTestId("agent-objective-summary")).textContent).toBe(
+          "The objective this run was opened with: why is checkout slow",
+        );
+        // No textarea: the question is settled, and three rows of it holding text nobody
+        // can change is the space the answer needed.
+        expect(view.queryByTestId("agent-objective")).toBeNull();
+
+        fireEvent.click(view.getByTestId("agent-objective-edit"));
+
+        // Edit puts the RUN's question back in the box, because refining what was asked
+        // is what it is for — retyping it is what it exists to avoid.
+        expect((view.getByTestId("agent-objective") as HTMLTextAreaElement).value).toBe("why is checkout slow");
+        expect(view.queryByTestId("agent-objective-summary")).toBeNull();
+      });
+
+      /*
+        The label the box carried is content the redesign dropped on exactly the branch
+        where the user can no longer see a form control to infer it from: a reader
+        arriving at an open run reached an unattributed sentence of their own text.
+
+        `sr-only` and not muted chrome, because a sighted user has the box's absence, the
+        Edit control and the frame line below to read it from — and the one line is the
+        space the answer needed.
+      */
+      test("the summary is named for a reader who cannot see the box it replaced", async () => {
+        const view = await liveRun();
+
+        const summary = await view.findByTestId("agent-objective-summary");
+        expect(summary.textContent).toBe("The objective this run was opened with: why is checkout slow");
+        // Nothing visible was added: the name is in the accessibility tree only.
+        expect(view.getByTestId("agent-objective-summary-label").className).toContain("sr-only");
+      });
+
+      test("a run that has ENDED gives the box back on its own", async () => {
+        const view = await liveRun({}, [OPENED_LINE, STARTED_LINE, FINISHED_LINE]);
+
+        await waitFor(() => {
+          expect(view.getByTestId("agent-run-status").textContent).toBe("succeeded");
+        });
+        expect(view.queryByTestId("agent-objective-summary")).toBeNull();
+        expect((view.getByTestId("agent-objective") as HTMLTextAreaElement).value).toBe("");
+      });
+    });
+
+    describe("the folded run details", () => {
+      test("the summary carries the live figures, and is open while the run is", async () => {
+        const view = await liveRun({}, [OPENED_LINE, STARTED_LINE, COMPLETED_LINE]);
+        const budgets = AGENT_WORKFLOW_BUDGETS.investigation.policy.budgets;
+
+        await view.findByTestId("agent-budget-statements");
+        const figures = view.getByTestId("agent-run-details-figures").textContent ?? "";
+        expect(figures).toContain("3 steps");
+        expect(figures).toContain(`1/${budgets.maxStatementsPerRun} stmt`);
+        expect(figures).toContain("1.5/90.0 s");
+        expect((view.getByTestId("agent-run-details") as HTMLDetailsElement).open).toBe(true);
+      });
+
+      test("before a run there is nothing in flight, so it is shut and states no figure", () => {
+        const view = render(<AgentRail {...DEFAULT_PROPS} />);
+
+        expect((view.getByTestId("agent-run-details") as HTMLDetailsElement).open).toBe(false);
+        // Not "0 steps · 0/30 stmt": that would state the DEFAULT workflow's ceilings on a
+        // summary line, and under Automatic that is a workflow nobody has chosen and the
+        // classifier may not pick. The gauges inside wait for a run for the same reason.
+        expect(view.queryByTestId("agent-run-details-figures")).toBeNull();
+      });
+
+      /*
+        The meter's own wrapper, which is the handle every test of the gauges as a BLOCK
+        reads them through. It survived the move behind the `<details>` as an untagged
+        layout div, and a testid nothing currently names is still the documented handle
+        for the next test.
+      */
+      test("the gauges keep the wrapper the meter has always been read through", async () => {
+        const view = await liveRun({}, [OPENED_LINE, STARTED_LINE, COMPLETED_LINE]);
+
+        const budget = await view.findByTestId("agent-budget");
+        expect(budget.contains(view.getByTestId("agent-budget-statements"))).toBe(true);
+        expect(view.getByTestId("agent-run-details").contains(budget)).toBe(true);
+      });
+
+      test("each of the three claims is reachable, and is the claim it always was", () => {
+        const view = render(<AgentRail {...DEFAULT_PROPS} />);
+        openAdvanced(view);
+        fireEvent.click(view.getByTestId("agent-workflow-investigation"));
+
+        // Behind an ⓘ each, and in the accessibility tree whether or not it is open: the
+        // body is `sr-only` while shut rather than absent, so the claim is never reachable
+        // only by clicking.
+        expect(view.getByTestId("agent-budget-limits").textContent).toContain("10.0 s");
+        expect(view.getByTestId("agent-budget-reserve").textContent).toContain("asked to stop");
+        expect(view.getByTestId("agent-budget-caveats").textContent).toContain("a floor, never a ceiling");
+
+        const info = view.getByTestId("agent-budget-ceilings-info");
+        expect(info.getAttribute("aria-expanded")).toBe("false");
+        fireEvent.click(info);
+        expect(info.getAttribute("aria-expanded")).toBe("true");
+        expect(view.getByTestId("agent-budget-ceilings").className).not.toContain("sr-only");
+      });
+    });
+
+    describe("the folded run setup", () => {
+      /*
+        The visual collapse is deliberate; putting a counter into the live region was not.
+
+        The disclosure sits inside `<ol aria-live="polite">` and its summary interpolates a
+        running count, and the content of a closed `<details>` is not exposed at all — so a
+        reader following a run heard "Run setup · 1 entry", "· 2 entries", "· 3 entries"
+        where "Run opened", "Run started in plan mode" and "Schema captured" used to be.
+        The live region is the only channel a screen-reader user has for run progress.
+      */
+      test("its own counter is not announced, and the substantive entries still are", async () => {
+        const view = await liveRun();
+
+        const chrome = await view.findByTestId("agent-timeline-chrome");
+        // The nearest live ancestor governs, so silencing this subtree leaves the entries
+        // below it announced exactly as before.
+        expect(chrome.closest("li")?.getAttribute("aria-live")).toBe("off");
+        expect(view.getByTestId("agent-timeline").getAttribute("aria-live")).toBe("polite");
+      });
+    });
+
+    describe("the answer, above the transcript", () => {
+      const draftedLine = (event: Record<string, unknown>): string =>
+        `${JSON.stringify({
+          kind: "event",
+          event: { kind: "plan-statement-drafted", atMs: 1_005, dialect: "postgres", ...event },
+        })}\n`;
+
+      const READ = {
+        sql: "SELECT title FROM film ORDER BY rental_count DESC",
+        readOnly: true,
+        identifiers: { kind: "checked", unknownTables: [] },
+      };
+
+      test("the card is the first thing in the scroll area, above the timeline", async () => {
+        const view = await liveRun({}, [OPENED_LINE, STARTED_LINE, draftedLine(READ), FINISHED_LINE]);
+
+        await view.findByTestId("agent-answer");
+        const scroller = view.getByTestId("agent-timeline-scroll");
+        expect(scroller.firstElementChild?.getAttribute("data-testid")).toBe("agent-answer");
+        expect(view.getByTestId("agent-answer-plan")).toBeTruthy();
+      });
+
+      test("the statement is offered to the editor exactly once in the whole rail", async () => {
+        const onApplyStatement = mock((_sql: string) => {});
+        const view = await liveRun({ onApplyStatement }, [OPENED_LINE, STARTED_LINE, draftedLine(READ), FINISHED_LINE]);
+
+        await view.findByTestId("agent-answer-plan-apply");
+        // One marked control, and no unmarked twin: not in the transcript entry the card
+        // renders a second time, and not inside the prose the statement was read out of.
+        expect(view.queryAllByTestId("agent-answer-plan-apply")).toHaveLength(1);
+        expect(view.queryAllByTestId("agent-apply-statement")).toHaveLength(0);
+        expect(view.queryAllByTestId("prose-code-apply")).toHaveLength(0);
+
+        fireEvent.click(view.getByTestId("agent-answer-plan-apply"));
+        expect(onApplyStatement).toHaveBeenCalledWith(READ.sql);
+      });
+
+      test("an agent answer the card renders is not offered twice either", async () => {
+        // The card renders this entry's hand-off in its report state, so the transcript
+        // entry withholds its own: two "Apply to editor" controls for one statement, with
+        // nothing on either saying they are the same act, is what item 8 is about.
+        const onApplyStatement = mock((_sql: string) => {});
+        const answer = `${JSON.stringify({
+          kind: "event",
+          event: {
+            kind: "answer-composed",
+            atMs: 1_003,
+            sql: "SELECT count(*) FROM orders",
+            artifact: {
+              correlationId: "corr_9",
+              runId: "arun_1",
+              operationId: "sql.query.read",
+              summary: { rowCount: 1, columnNames: ["count"], elapsedMs: 4 },
+            },
+            presentation: { kind: "table" },
+            handover: "none",
+          },
+        })}\n`;
+        const view = await liveRun({ onApplyStatement }, [OPENED_LINE, STARTED_LINE, answer, REPORT_LINE]);
+
+        await view.findByTestId("agent-answer-report");
+        expect(view.queryAllByTestId("agent-answer-apply-statement")).toHaveLength(1);
+        expect(view.queryAllByTestId("agent-apply-statement")).toHaveLength(0);
+
+        fireEvent.click(view.getByTestId("agent-answer-apply-statement"));
+        expect(onApplyStatement).toHaveBeenCalledWith("SELECT count(*) FROM orders");
+      });
+
+      /*
+        A run CAN end `failed` holding what it produced, and the two surfaces have to
+        agree about it. `conclude` in `src/lib/agent/investigation.ts` writes the closing
+        prose and the drafted statement BEFORE `service.finish`, and is called with
+        `"failed"` for a model timeout, an exhausted deadline and the turn ceiling.
+
+        The card read the status first, so it rendered a failure banner — and the rail
+        withheld the transcript's copies anyway, because its suppression was keyed on the
+        LEDGER rather than on what the card renders. Net: no "Apply to editor" anywhere in
+        the rail for a drafted statement, no guard claims reachable, and an entry still
+        saying they were "in the answer at the top of this rail". One reading now answers
+        both surfaces (`answerCardState`).
+      */
+      const failedLine = (stopReason: string): string =>
+        `${JSON.stringify({
+          kind: "event",
+          event: { kind: "run-finished", atMs: 1_006, status: "failed", stopReason },
+        })}\n`;
+
+      test("a run that ran out of turns after drafting still shows the statement, and offers it once", async () => {
+        const onApplyStatement = mock((_sql: string) => {});
+        const view = await liveRun({ onApplyStatement }, [
+          OPENED_LINE,
+          STARTED_LINE,
+          draftedLine(READ),
+          failedLine("turn-limit"),
+        ]);
+
+        expect((await view.findByTestId("agent-answer-plan")).getAttribute("data-read-only")).toBe("true");
+        expect(view.getByTestId("agent-answer-statement").querySelector("pre")?.textContent).toBe(READ.sql);
+        // The one marked hand-off, still the only one: the card offers it and the entry
+        // the statement was read out of withholds its own, as on any other ending.
+        expect(view.queryAllByTestId("agent-answer-plan-apply")).toHaveLength(1);
+        expect(view.queryAllByTestId("agent-apply-statement")).toHaveLength(0);
+        // What the transcript entry promises is in the answer is in the answer.
+        expect(view.getByTestId("agent-answer-guard-note")).toBeTruthy();
+        expect(view.getByTestId("agent-plan-statement-caveat")).toBeTruthy();
+        expect(view.getByTestId("agent-plan-statement-summary").textContent).toContain("in the answer at the top");
+        // And the ending is still stated, on the card and in the transcript both.
+        expect(view.getByTestId("agent-answer-status").textContent).toBe("failed");
+        expect(view.getByTestId("agent-answer-failed")).toBeTruthy();
+      });
+
+      test("a report the run composed before it failed keeps the card's single hand-off", async () => {
+        const onApplyStatement = mock((_sql: string) => {});
+        const answer = `${JSON.stringify({
+          kind: "event",
+          event: {
+            kind: "answer-composed",
+            atMs: 1_003,
+            sql: "SELECT count(*) FROM orders",
+            artifact: {
+              correlationId: "corr_9",
+              runId: "arun_1",
+              operationId: "sql.query.read",
+              summary: { rowCount: 1, columnNames: ["count"], elapsedMs: 4 },
+            },
+            presentation: { kind: "table" },
+            handover: "none",
+          },
+        })}\n`;
+        const view = await liveRun({ onApplyStatement }, [
+          OPENED_LINE,
+          STARTED_LINE,
+          answer,
+          REPORT_LINE,
+          failedLine("deadline-exceeded"),
+        ]);
+
+        await view.findByTestId("agent-answer-report");
+        // Exactly one, and it is the card's — the suppression follows the card.
+        expect(view.queryAllByTestId("agent-answer-apply-statement")).toHaveLength(1);
+        expect(view.queryAllByTestId("agent-apply-statement")).toHaveLength(0);
+        expect(view.getByTestId("agent-answer-failed")).toBeTruthy();
+
+        fireEvent.click(view.getByTestId("agent-answer-apply-statement"));
+        expect(onApplyStatement).toHaveBeenCalledWith("SELECT count(*) FROM orders");
+      });
+
+      /*
+        The suppression follows what the card RENDERS, and this is the ledger that tells
+        the two derivations apart: a report AND a drafted statement, where the card's
+        reading is `plan`. Keyed on the ledger's report alone — as it was — the rail
+        withheld the answer entry's control for a card that is not offering it, which is
+        a control removed rather than de-duplicated. Every entry here is one the server
+        writes; what this pins is that the rail asks the card instead of guessing.
+      */
+      test("an answer the card is NOT rendering keeps its own control", async () => {
+        const onApplyStatement = mock((_sql: string) => {});
+        const answer = `${JSON.stringify({
+          kind: "event",
+          event: {
+            kind: "answer-composed",
+            atMs: 1_003,
+            sql: "SELECT count(*) FROM orders",
+            artifact: {
+              correlationId: "corr_9",
+              runId: "arun_1",
+              operationId: "sql.query.read",
+              summary: { rowCount: 1, columnNames: ["count"], elapsedMs: 4 },
+            },
+            presentation: { kind: "table" },
+            handover: "none",
+          },
+        })}\n`;
+        const view = await liveRun({ onApplyStatement }, [
+          OPENED_LINE,
+          STARTED_LINE,
+          answer,
+          REPORT_LINE,
+          draftedLine(READ),
+          FINISHED_LINE,
+        ]);
+
+        // The card is showing the statement, so it is offering no report hand-off.
+        await view.findByTestId("agent-answer-plan");
+        expect(view.queryAllByTestId("agent-answer-apply-statement")).toHaveLength(0);
+        // Which leaves the transcript's the only one there is, and it is still there.
+        expect(view.queryAllByTestId("agent-apply-statement")).toHaveLength(1);
+      });
+
+      test("a read the run took along the way keeps its own controls, because the card renders none of them", async () => {
+        const onApplyStatement = mock((_sql: string) => {});
+        const view = await liveRun({ onApplyStatement }, [OPENED_LINE, STARTED_LINE, DRAFTED_LINE, REPORT_LINE]);
+
+        // A `statement-drafted` entry is a different statement from the answer, and the
+        // card is not rendering it: withholding its control would take an affordance away
+        // rather than de-duplicate one.
+        expect(await view.findAllByTestId("agent-apply-statement")).toHaveLength(1);
+      });
+
+      /**
+       * L6, measured in Chrome on 2026-08-21 against live PostgreSQL and Gemini.
+       *
+       * The report path offered THREE "Apply to editor" controls at once —
+       * `agent-answer-apply-statement` on the card, `agent-apply-statement` on the
+       * `Statement drafted` entry and `agent-citation-apply-statement` in a surviving
+       * `agent-report` section — and printed the model's claim twice, because the old
+       * section stayed beside the new card. All three were the SAME statement: an
+       * answer's `sql` is the statement of the step whose artifact it presents, and the
+       * citation quotes that same step. None of the three carried an accessible name, on
+       * the one path where three unmarked hand-offs is worse than the one `main` had.
+       *
+       * The card IS the answer, which is what the design decided, so:
+       *
+       *  - the `agent-report` section is gone. Its claims are the card's, its citations
+       *    are the card's `agent-answer-evidence` fold — label, the ledger's own detail
+       *    and the statement each rests on — and its `Show result` was a second offer of
+       *    an artifact the `Result stored` entry already offers under the same rule;
+       *  - the transcript withholds a hand-off for the statement the card is handing
+       *    over, which is the report path's version of what the plan path already did to
+       *    the prose the statement was read out of. By the TEXT, not by the entry id: it
+       *    is a de-duplication of one statement, so a read the run took along the way
+       *    keeps its own control (the test above) unless it IS that statement.
+       */
+      describe("one answer, one hand-off", () => {
+        const ANSWERED = "SELECT country, count(*) FROM customer GROUP BY country";
+
+        const answerLine = (sql: string): string =>
+          `${JSON.stringify({
+            kind: "event",
+            event: {
+              kind: "answer-composed",
+              atMs: 1_004,
+              sql,
+              artifact: {
+                correlationId: "corr_9",
+                runId: "arun_1",
+                operationId: "sql.query.read",
+                summary: { rowCount: 5, columnNames: ["country", "count"], elapsedMs: 7 },
+              },
+              presentation: { kind: "table" },
+              handover: "none",
+            },
+          })}\n`;
+
+        const draftedStep = (sql: string): string =>
+          `${JSON.stringify({
+            kind: "event",
+            event: { kind: "statement-drafted", atMs: 1_002, stepId: "s1", sql, rationale: "count by country" },
+          })}\n`;
+
+        /** The ledger an agent run that reads once, answers and reports actually writes. */
+        const reportRun = (drafted: string, answered: string): readonly string[] => [
+          OPENED_LINE,
+          AGENT_STARTED_LINE,
+          draftedStep(drafted),
+          COMPLETED_LINE,
+          answerLine(answered),
+          REPORT_LINE,
+          FINISHED_LINE,
+        ];
+
+        test("the claim is printed once, and no second Report section repeats it", async () => {
+          const view = await liveRun({}, reportRun(ANSWERED, ANSWERED));
+
+          await view.findByTestId("agent-answer-report");
+          expect(view.queryByTestId("agent-report")).toBeNull();
+          expect(view.queryAllByTestId("agent-report-claim")).toHaveLength(0);
+          expect(view.queryAllByTestId("agent-answer-claim")).toHaveLength(1);
+          // What that section carried is in the fold: the citation, the ledger's own
+          // detail for it, and the statement it rests on.
+          const cited = view.getAllByTestId("agent-answer-evidence-citation");
+          expect(cited).toHaveLength(1);
+          expect(cited[0].textContent).toContain("Artifact corr_9");
+          expect(cited[0].textContent).toContain("3 rows via sql.query.read");
+          expect(cited[0].querySelector("pre")?.textContent).toBe(ANSWERED);
+        });
+
+        test("the whole rail offers one apply control, and it carries the name applyStatementName builds", async () => {
+          const onApplyStatement = mock((_sql: string) => {});
+          const view = await liveRun({ onApplyStatement }, reportRun(ANSWERED, ANSWERED));
+
+          const control = await view.findByTestId("agent-answer-apply-statement");
+          expect(view.queryAllByTestId("agent-answer-apply-statement")).toHaveLength(1);
+          // The two that used to stand beside it, each for the same statement.
+          expect(view.queryAllByTestId("agent-apply-statement")).toHaveLength(0);
+          expect(view.queryAllByTestId("agent-citation-apply-statement")).toHaveLength(0);
+          expect(view.queryAllByTestId("prose-code-apply")).toHaveLength(0);
+          // Named, which is why the control was allowed to move up here at all.
+          expect(control.getAttribute("aria-label")).toBe(applyStatementName(null));
+
+          fireEvent.click(control);
+          expect(onApplyStatement).toHaveBeenCalledWith(ANSWERED);
+        });
+
+        /*
+          The boundary of that suppression. A run reads more than once, and the answer
+          rests on one of those reads: the OTHER statements are other statements, and the
+          card renders none of them, so withholding their controls would remove an
+          affordance rather than de-duplicate one.
+        */
+        test("a read whose statement is not the answer's keeps the control it always had", async () => {
+          const other = "SELECT count(*) FROM rental";
+          const onApplyStatement = mock((_sql: string) => {});
+          const view = await liveRun({ onApplyStatement }, reportRun(other, ANSWERED));
+
+          await view.findByTestId("agent-answer-report");
+          expect(view.queryAllByTestId("agent-answer-apply-statement")).toHaveLength(1);
+          const kept = view.getAllByTestId("agent-apply-statement");
+          expect(kept).toHaveLength(1);
+
+          fireEvent.click(kept[0]);
+          expect(onApplyStatement).toHaveBeenCalledWith(other);
+        });
+
+        /*
+          The artifact is still reachable, which is what makes removing the citation's
+          own control a de-duplication too: `Result stored` carries the same correlation
+          id, under the same live-run rule.
+        */
+        test("the citation's result is still offered, from the entry that stored it", async () => {
+          const onShowArtifact = mock(() => {});
+          const view = await liveRun({ onShowArtifact }, [
+            OPENED_LINE,
+            AGENT_STARTED_LINE,
+            draftedStep(ANSWERED),
+            COMPLETED_LINE,
+            REPORT_LINE,
+          ]);
+
+          await view.findByTestId("agent-answer-report");
+          fireEvent.click((await view.findAllByTestId("agent-show-result"))[0]);
+          expect(onShowArtifact).toHaveBeenCalledWith({ runId: "arun_1", correlationId: "corr_9" });
+        });
+      });
+
+      /**
+       * L2 and L3, measured in Chrome on 2026-08-21.
+       *
+       * L2: the `Closing statement` entry rendered the model's closing prose in full, and
+       * that prose HOLDS the fenced statement — so the statement, its rationale and a
+       * second `Copy` all rendered again at full weight a few hundred pixels under the
+       * card. Item 8 of the design said this entry keeps its headline, timestamp and
+       * guard summary and reprints the statement no more; the per-block hand-off was
+       * withheld, the block itself was not.
+       *
+       * L3: the guard's reading was then stated three times inside ~400px — the card's
+       * line, this entry's four-line `detail`, and the amber summary box. One fact, three
+       * renderings, two of them long. The entry keeps the one-line summary and the full
+       * text stays in the card's ⓘ, where it already is.
+       */
+      describe("the transcript, once the card holds the answer", () => {
+        const closingLine = (text: string): string =>
+          `${JSON.stringify({ kind: "event", event: { kind: "closing-statement", atMs: 1_004, text } })}\n`;
+
+        const PROSE = `It counts the rentals per title.\n\`\`\`sql\n${READ.sql}\n\`\`\`\nRun it against the replica.`;
+
+        const planRun = (props: Partial<React.ComponentProps<typeof AgentRail>> = {}) =>
+          liveRun(props, [OPENED_LINE, STARTED_LINE, closingLine(PROSE), draftedLine(READ), FINISHED_LINE]);
+
+        test("the closing prose keeps its words and prints the statement no second time", async () => {
+          const view = await planRun({ onApplyStatement: mock((_sql: string) => {}) });
+
+          const prose = await view.findByTestId("agent-prose");
+          expect(prose.textContent).not.toContain(READ.sql);
+          expect(prose.querySelector("pre")).toBeNull();
+          // Every word around it is untouched — this is a suppressed duplicate, not an
+          // edited plan.
+          expect(prose.textContent).toContain("It counts the rentals per title.");
+          expect(prose.textContent).toContain("Run it against the replica.");
+          // And the statement is on the card, once, where the marked hand-off is.
+          expect(view.getByTestId("agent-answer-statement").querySelector("pre")?.textContent).toBe(READ.sql);
+        });
+
+        test("Copy all still carries the whole prose, fence and all", async () => {
+          const writeText = mock(() => Promise.resolve());
+          Object.defineProperty(globalThis.navigator, "clipboard", { value: { writeText }, configurable: true });
+          const view = await planRun();
+
+          fireEvent.click(await view.findByTestId("agent-prose-copy"));
+          await waitFor(() => expect(writeText).toHaveBeenCalledWith(PROSE));
+        });
+
+        test("the entry keeps the one-line reading and drops the paragraph the card carries", async () => {
+          const view = await liveRun({}, [
+            OPENED_LINE,
+            STARTED_LINE,
+            draftedLine({
+              sql: 'db.orders.aggregate([{ $group: { _id: "$customerId" } }])',
+              readOnly: false,
+              guardApplicable: false,
+              identifiers: { kind: "not-applicable" },
+            }),
+            FINISHED_LINE,
+          ]);
+
+          // The summary stays: it is the entry's account of what the card holds.
+          const summary = await view.findByTestId("agent-plan-statement-summary");
+          expect(summary.textContent).toContain("Not examined");
+          expect(summary.textContent).toContain("in the answer at the top of this rail");
+          // The long detail does not, in either of its two sentences.
+          const entry = summary.closest('[data-testid="agent-timeline-item"]');
+          expect(entry?.textContent).not.toContain("examined this draft at all");
+          expect(entry?.textContent).not.toContain("were not looked for in anything");
+          // Both are still reachable, in the ⓘ the card already carries them in.
+          expect(view.getByTestId("agent-plan-statement-guard-unread").textContent).toContain("nothing examined");
+          expect(view.getByTestId("agent-plan-statement-unread").textContent).toContain("were not checked");
+        });
+
+        test("an entry the card is not rendering keeps its own detail", async () => {
+          // The suppression follows what the CARD holds. A `Result stored` entry says what
+          // was stored and nothing else says it, so nothing is withheld there.
+          const view = await liveRun({}, [OPENED_LINE, AGENT_STARTED_LINE, COMPLETED_LINE, FINISHED_LINE]);
+
+          const items = await view.findAllByTestId("agent-timeline-item");
+          expect(items.map((item) => item.textContent).join(" ")).toContain("3 rows, 2 columns");
+        });
+      });
+
+      test("the run's grounding reaches the card, in the word the engine used for it", async () => {
+        const captured = `${JSON.stringify({
+          kind: "event",
+          event: {
+            kind: "context-captured",
+            atMs: 1_002,
+            fingerprint: "ctx_druid00",
+            tableCount: 3,
+            noun: { singular: "datasource", plural: "datasources" },
+          },
+        })}\n`;
+        const view = await liveRun({}, [OPENED_LINE, STARTED_LINE, captured, draftedLine(READ), FINISHED_LINE]);
+
+        // Off the run's own capture entry — the fold reads it there and nowhere else, so
+        // a connection retyped since the run cannot rewrite what it was read in.
+        expect((await view.findByTestId("agent-answer-chip-inventory")).textContent).toBe("3 datasources read");
+        expect(view.getByTestId("agent-answer-chip-fingerprint").textContent).toBe("ctx_drui");
       });
     });
   });

--- a/tests/components/agent/AnswerCard.test.tsx
+++ b/tests/components/agent/AnswerCard.test.tsx
@@ -1,0 +1,909 @@
+import "../../setup-dom";
+
+import React from "react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { AnswerCard, answerCardState } from "@/components/agent/AnswerCard";
+import { applyStatementName } from "@/components/agent/rail-parts";
+import { foldLedgerEntries } from "@/components/agent/timeline";
+import { AGENT_WORKFLOW_BUDGETS } from "@/lib/agent/execution-policy";
+import type { AgentInventoryNoun } from "@/lib/agent/inventory-noun";
+import type { AgentLedgerEntry } from "@/lib/agent/run-store";
+import type { AgentRunEvent } from "@/lib/agent/types";
+import type { ProviderCapabilities } from "@/lib/db/types";
+
+/**
+ * The run's outcome, rendered once at the top of the rail.
+ *
+ * What these tests pin is the property that makes the card safe to add at all: it is a
+ * SECOND rendering of entries the ledger already holds, so every claim on it has to be
+ * traceable to one. They are therefore written over `foldLedgerEntries` rather than over
+ * hand-built timeline objects — a hand-built one can say something no ledger produces,
+ * which is exactly the failure mode the card is meant not to have.
+ *
+ * Three of them are correctness rather than presentation:
+ *
+ *  - **`Apply to editor` keeps the accessible name `applyStatementName` builds.** That
+ *    name carries the guard's marks (WCAG 2.5.3), and the whole point of moving the
+ *    control up here is that it must not lose them on the way.
+ *  - **On an engine whose statements are not SQL there is no read-only chip.** Nothing
+ *    read the statement, so a green chip would be a claim no code in this product made.
+ *  - **A statement is never painted as SQL unless something says it is.** The tint
+ *    follows `tab-language.ts`, and where no capabilities are to hand it follows the
+ *    guard's own reach rather than defaulting to SQL.
+ */
+
+afterEach(cleanup);
+
+const FENCE = "```";
+
+const ACTOR = { sessionId: "ada", role: "user" } as const;
+
+const opened = (mode: "planning" | "agent"): AgentLedgerEntry => ({
+  kind: "run-opened",
+  atMs: 1_000,
+  runId: "arun_1",
+  mode,
+  actor: ACTOR,
+  connectionId: "seed:sales",
+  objective: "why is checkout slow",
+});
+
+const event = (value: AgentRunEvent): AgentLedgerEntry => ({ kind: "event", event: value });
+
+const started = (mode: "planning" | "agent") => event({ kind: "run-started", atMs: 1_001, mode });
+
+/**
+ * A capture entry, in the word the ENGINE itself used for its rows.
+ *
+ * Parameterised because the card's two grounding chips are read off THIS entry: the
+ * count, the noun and the fingerprint a run recorded are the only place those claims
+ * come from, so a test that wants a different one writes a different capture rather
+ * than handing the card a figure no ledger produced.
+ */
+const capturedAs = (options: {
+  readonly fingerprint: string;
+  readonly tableCount: number;
+  readonly noun?: AgentInventoryNoun;
+}): AgentLedgerEntry =>
+  event({
+    kind: "context-captured",
+    atMs: 1_002,
+    fingerprint: options.fingerprint,
+    tableCount: options.tableCount,
+    ...(options.noun === undefined ? {} : { noun: options.noun }),
+  });
+
+const captured = capturedAs({ fingerprint: "ctx_7dfa9911", tableCount: 2 });
+
+const closing = (text: string) => event({ kind: "closing-statement", atMs: 1_010, text });
+
+const finished = (status: "succeeded" | "failed" | "cancelled", reason?: "model-unavailable") =>
+  event({ kind: "run-finished", atMs: 1_020, status, ...(reason === undefined ? {} : { reason }) });
+
+const STATEMENT = "SELECT count(*) FROM orders";
+
+const capabilitiesFor = (queryLanguage: "sql" | "json", queryDialect?: "libredb" | "redis"): ProviderCapabilities => ({
+  queryLanguage,
+  supportsExplain: false,
+  supportsExternalQueryLimiting: false,
+  supportsCreateTable: false,
+  supportsMaintenance: false,
+  maintenanceOperations: [],
+  supportsConnectionString: false,
+  defaultPort: null,
+  schemaRefreshPattern: "",
+  ...(queryDialect === undefined ? {} : { queryDialect }),
+});
+
+/** A plan run that drafted a statement, with the guard's verdict the caller names. */
+function planTimeline(options: {
+  readonly sql?: string;
+  readonly readOnly: boolean;
+  readonly guardApplicable?: boolean;
+  readonly guardViolation?: "NON_READ_STATEMENT" | "MULTIPLE_STATEMENTS";
+  readonly identifiers: Parameters<typeof draftEvent>[0]["identifiers"];
+  readonly prose?: string;
+  /** The run's grounding: another capture entry, or `null` for a run that captured nothing. */
+  readonly capture?: AgentLedgerEntry | null;
+}) {
+  return foldLedgerEntries([
+    opened("planning"),
+    started("planning"),
+    ...(options.capture === null ? [] : [options.capture ?? captured]),
+    closing(options.prose ?? `Here is the read:\n${FENCE}sql\n${options.sql ?? STATEMENT}\n${FENCE}`),
+    draftEvent(options),
+    finished("succeeded"),
+  ]);
+}
+
+function draftEvent(options: {
+  readonly sql?: string;
+  readonly readOnly: boolean;
+  readonly guardApplicable?: boolean;
+  readonly guardViolation?: "NON_READ_STATEMENT" | "MULTIPLE_STATEMENTS";
+  readonly identifiers:
+    | { readonly kind: "checked"; readonly unknownTables: readonly string[] }
+    | { readonly kind: "no-inventory" }
+    | { readonly kind: "not-applicable" };
+}): AgentLedgerEntry {
+  return event({
+    kind: "plan-statement-drafted",
+    atMs: 1_011,
+    sql: options.sql ?? STATEMENT,
+    dialect: "postgres",
+    readOnly: options.readOnly,
+    ...(options.guardApplicable === undefined ? {} : { guardApplicable: options.guardApplicable }),
+    ...(options.guardViolation === undefined ? {} : { guardViolation: options.guardViolation }),
+    identifiers: options.identifiers,
+  });
+}
+
+/** What a correlation id looks like in a real run, read off the browser on 2026-08-21. */
+const LONG_ID = "722b2a10-e3f2-4b9c-8177-367359a21500";
+
+const ARTIFACT = {
+  correlationId: "corr_9",
+  runId: "arun_1",
+  operationId: "sql.select.rows",
+  summary: { rowCount: 1, columnNames: ["total"], elapsedMs: 12, truncated: false },
+} as const;
+
+/** An agent run that read once, answered from that read and reported one claim. */
+function reportTimeline(
+  options: {
+    readonly cites?: string;
+    readonly withAnswer?: boolean;
+    readonly failed?: boolean;
+    /** The correlation id the run's read was stored under. A real one is a UUID. */
+    readonly correlationId?: string;
+  } = {},
+) {
+  const artifact = { ...ARTIFACT, correlationId: options.correlationId ?? ARTIFACT.correlationId };
+  const cites = options.cites ?? artifact.correlationId;
+  return foldLedgerEntries([
+    opened("agent"),
+    started("agent"),
+    captured,
+    event({ kind: "statement-drafted", atMs: 1_003, stepId: "s1", sql: STATEMENT, rationale: "count the orders" }),
+    event({ kind: "tool-completed", atMs: 1_004, stepId: "s1", artifact }),
+    ...(options.withAnswer === false
+      ? []
+      : [
+          event({
+            kind: "answer-composed",
+            atMs: 1_005,
+            sql: STATEMENT,
+            artifact,
+            presentation: { kind: "table" },
+            handover: "none",
+          }),
+        ]),
+    event({
+      kind: "report-composed",
+      atMs: 1_006,
+      claims: [
+        {
+          claim: "Checkout writes 1 order per session.",
+          evidence: [{ source: "artifact", correlationId: cites, locator: "row 1" }],
+        },
+      ],
+    }),
+    options.failed === true ? finished("failed", "model-unavailable") : finished("succeeded"),
+  ]);
+}
+
+describe("AnswerCard — nothing to show", () => {
+  test("renders nothing before a run has recorded anything", () => {
+    const { queryByTestId } = render(<AnswerCard timeline={foldLedgerEntries([])} />);
+    expect(queryByTestId("agent-answer")).toBeNull();
+  });
+
+  test("renders nothing for a finished run whose ledger holds no answer, refusal or report", () => {
+    const timeline = foldLedgerEntries([opened("agent"), started("agent"), captured, finished("cancelled")]);
+    const { queryByTestId } = render(<AnswerCard timeline={timeline} />);
+    expect(queryByTestId("agent-answer")).toBeNull();
+  });
+});
+
+describe("AnswerCard — a plan run's statement", () => {
+  const checkedTimeline = () => planTimeline({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] } });
+
+  test("renders the drafted statement, its status and the guard's own reading", () => {
+    const { getByTestId } = render(<AnswerCard timeline={checkedTimeline()} capabilities={capabilitiesFor("sql")} />);
+
+    expect(getByTestId("agent-answer-plan")).toBeTruthy();
+    expect(getByTestId("agent-answer-status").textContent).toBe("succeeded");
+    expect(getByTestId("agent-answer-statement").textContent).toContain(STATEMENT);
+    expect(getByTestId("agent-answer-guard").textContent).toBe(
+      "Checked as a bounded read against the captured inventory. Nothing was executed.",
+    );
+    // The clipboard control every verbatim block in this rail carries.
+    expect(getByTestId("agent-answer-statement-copy")).toBeTruthy();
+  });
+
+  test("tints the block by the engine's language, and never paints a Mongo body as SQL", () => {
+    const sqlCard = render(<AnswerCard timeline={checkedTimeline()} capabilities={capabilitiesFor("sql")} />);
+    expect(sqlCard.getByTestId("agent-answer-statement").getAttribute("data-language")).toBe("sql");
+    cleanup();
+
+    const mongo = render(<AnswerCard timeline={checkedTimeline()} capabilities={capabilitiesFor("json")} />);
+    expect(mongo.getByTestId("agent-answer-statement").getAttribute("data-language")).toBe("json");
+    cleanup();
+
+    const redis = render(<AnswerCard timeline={checkedTimeline()} capabilities={capabilitiesFor("json", "redis")} />);
+    expect(redis.getByTestId("agent-answer-statement").getAttribute("data-language")).toBe("redis");
+    cleanup();
+
+    const libredb = render(
+      <AnswerCard timeline={checkedTimeline()} capabilities={capabilitiesFor("json", "libredb")} />,
+    );
+    expect(libredb.getByTestId("agent-answer-statement").getAttribute("data-language")).toBe("libredb");
+  });
+
+  test("with no capabilities to hand, the guard's reach decides the language rather than a default of SQL", () => {
+    const read = render(<AnswerCard timeline={checkedTimeline()} />);
+    expect(read.getByTestId("agent-answer-statement").getAttribute("data-language")).toBe("sql");
+    cleanup();
+
+    const unexamined = render(
+      <AnswerCard
+        timeline={planTimeline({ readOnly: false, guardApplicable: false, identifiers: { kind: "not-applicable" } })}
+        capabilities={null}
+      />,
+    );
+    expect(unexamined.getByTestId("agent-answer-statement").getAttribute("data-language")).toBe("unknown");
+  });
+
+  test("keeps the accessible name the guard's marks travel in", () => {
+    const timeline = planTimeline({
+      readOnly: false,
+      guardViolation: "MULTIPLE_STATEMENTS",
+      identifiers: { kind: "checked", unknownTables: ["shipments"] },
+    });
+    const draft = timeline.items.find((item) => item.planStatement !== undefined)?.planStatement;
+    expect(draft).toBeTruthy();
+
+    const { getByTestId } = render(<AnswerCard timeline={timeline} onApplyStatement={() => {}} />);
+    const apply = getByTestId("agent-answer-plan-apply");
+    // The name the rail already builds, not a label written again here.
+    expect(apply.getAttribute("aria-label")).toBe(applyStatementName(draft!));
+    expect(apply.getAttribute("aria-label")).toContain("Apply to editor.");
+    expect(apply.getAttribute("aria-label")).toContain("MULTIPLE_STATEMENTS");
+  });
+
+  test("applies the statement the ledger recorded, and only when the host can take it", () => {
+    const applied: string[] = [];
+    const { getByTestId } = render(
+      <AnswerCard timeline={checkedTimeline()} onApplyStatement={(sql) => applied.push(sql)} />,
+    );
+    fireEvent.click(getByTestId("agent-answer-plan-apply"));
+    expect(applied).toEqual([STATEMENT]);
+    cleanup();
+
+    const hostless = render(<AnswerCard timeline={checkedTimeline()} />);
+    expect(hostless.queryByTestId("agent-answer-plan-apply")).toBeNull();
+    // The statement is still readable and still copyable without an editor to take it.
+    expect(hostless.getByTestId("agent-answer-statement-copy")).toBeTruthy();
+  });
+
+  test("chips read the guard, the names, the inventory and the fingerprint off the ledger", () => {
+    const timeline = planTimeline({
+      readOnly: true,
+      identifiers: { kind: "checked", unknownTables: ["shipments"] },
+    });
+    const { getByTestId, getAllByTestId } = render(<AnswerCard timeline={timeline} />);
+
+    expect(getByTestId("agent-answer-chip-guard").textContent).toBe("Read-only");
+    expect(getAllByTestId("agent-answer-chip-name").map((chip) => chip.textContent)).toEqual(["shipments"]);
+    expect(getByTestId("agent-answer-chip-inventory").textContent).toBe("2 tables read");
+    expect(getByTestId("agent-answer-chip-fingerprint").textContent).toBe("ctx_7dfa");
+  });
+
+  test("counts the inventory in the engine's own word, and in the singular when there is one", () => {
+    const { getByTestId } = render(
+      <AnswerCard
+        timeline={planTimeline({
+          readOnly: true,
+          identifiers: { kind: "checked", unknownTables: [] },
+          capture: capturedAs({
+            fingerprint: "ctx_druid001",
+            tableCount: 1,
+            noun: { singular: "datasource", plural: "datasources" },
+          }),
+        })}
+      />,
+    );
+    expect(getByTestId("agent-answer-chip-inventory").textContent).toBe("1 datasource read");
+  });
+
+  test("says nothing about an inventory for a run whose ledger holds no capture", () => {
+    const { queryByTestId } = render(
+      <AnswerCard
+        timeline={planTimeline({
+          readOnly: true,
+          identifiers: { kind: "checked", unknownTables: [] },
+          capture: null,
+        })}
+      />,
+    );
+    expect(queryByTestId("agent-answer-chip-inventory")).toBeNull();
+    expect(queryByTestId("agent-answer-chip-fingerprint")).toBeNull();
+    expect(queryByTestId("agent-answer-chip-name")).toBeNull();
+  });
+
+  /*
+    L4, measured in Chrome on 2026-08-21 against live MongoDB: the plan answer carried
+    the amber `not checked` chip and NOTHING else, although that run had captured 5
+    collections under fingerprint `ctx_ae00` and the chrome fold said so on the same
+    screen. Backwards, and exactly where it costs most — where the guard examined
+    nothing, the inventory is the only grounding claim the card has left.
+
+    So both chips are read off the run's CAPTURE, which is a fact about what the run
+    grounded itself on and has nothing to do with what the SQL guard could make of the
+    draft. The capture is taken off the timeline the card is already handed rather than
+    from a second prop beside it: a claim a caller can forget to pass is a claim that
+    disappears, which is what happened here.
+  */
+  test("the inventory and the fingerprint are the capture's, on an engine the guard could not read", () => {
+    const timeline = planTimeline({
+      sql: "db.orders.find().sort({ placedAt: -1 }).limit(5)",
+      readOnly: false,
+      guardApplicable: false,
+      identifiers: { kind: "not-applicable" },
+      capture: capturedAs({
+        fingerprint: "ctx_ae001f22",
+        tableCount: 5,
+        noun: { singular: "collection", plural: "collections" },
+      }),
+    });
+    const { getByTestId } = render(<AnswerCard timeline={timeline} capabilities={capabilitiesFor("json")} />);
+
+    // The guard's reading is unchanged: nothing examined this draft, and no chip says
+    // it did.
+    expect(getByTestId("agent-answer-chip-guard").textContent).toBe("not checked");
+    // And the grounding is still stated, in the engine's own noun.
+    expect(getByTestId("agent-answer-chip-inventory").textContent).toBe("5 collections read");
+    expect(getByTestId("agent-answer-chip-fingerprint").textContent).toBe("ctx_ae00");
+  });
+
+  test("folds the model's own rationale away, and offers it whole", () => {
+    const { getByTestId } = render(
+      <AnswerCard timeline={planTimeline({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] } })} />,
+    );
+    const why = getByTestId("agent-answer-why");
+    expect(why.tagName).toBe("DETAILS");
+    expect((why as HTMLDetailsElement).open).toBe(false);
+    expect(getByTestId("agent-answer-why-prose").textContent).toContain("Here is the read:");
+    expect(getByTestId("agent-answer-why-copy")).toBeTruthy();
+  });
+
+  /*
+    L5, measured in Chrome on 2026-08-21 against live MongoDB: the card showed
+    `db.orders.find()…`, its own `Copy`, `Apply to editor`, the `not checked` chip — and
+    then, inside `Why this statement`, the SAME statement again with a second `Copy`.
+
+    The rationale IS the prose the statement was read out of, so the statement is in it;
+    the card displays that statement verbatim two lines above the fold. The words are
+    unchanged and only the second copy of that ONE block is not printed. `Copy all`
+    still carries the whole prose, which is the string the model wrote rather than this
+    rendering of it.
+  */
+  test("does not print the statement again inside the fold that explains it", () => {
+    const { getByTestId, queryByTestId } = render(
+      <AnswerCard timeline={planTimeline({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] } })} />,
+    );
+
+    const why = getByTestId("agent-answer-why-prose");
+    expect(why.textContent).not.toContain(STATEMENT);
+    expect(why.querySelector("pre")).toBeNull();
+    // The block's own clipboard goes with the block. Nothing is lost: the statement is
+    // displayed above with `agent-answer-statement-copy`, and `Copy all` holds the prose
+    // exactly as the model wrote it, fence and all.
+    expect(queryByTestId("prose-code-copy")).toBeNull();
+    expect(getByTestId("agent-answer-statement-copy")).toBeTruthy();
+    expect(why.textContent).toContain("Here is the read:");
+  });
+
+  test("copies the whole rationale, including the block it did not print", async () => {
+    const writeText = mock(() => Promise.resolve());
+    Object.defineProperty(globalThis.navigator, "clipboard", { value: { writeText }, configurable: true });
+    const prose = `Here is the read:\n${FENCE}sql\n${STATEMENT}\n${FENCE}`;
+    const { getByTestId } = render(
+      <AnswerCard
+        timeline={planTimeline({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] }, prose })}
+      />,
+    );
+
+    fireEvent.click(getByTestId("agent-answer-why-copy"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(prose));
+  });
+
+  test("offers no rationale for a run whose ledger holds no closing prose", () => {
+    const timeline = foldLedgerEntries([
+      opened("planning"),
+      started("planning"),
+      draftEvent({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] } }),
+      finished("succeeded"),
+    ]);
+    const { queryByTestId } = render(<AnswerCard timeline={timeline} />);
+    expect(queryByTestId("agent-answer-plan")).toBeTruthy();
+    expect(queryByTestId("agent-answer-why")).toBeNull();
+  });
+});
+
+describe("AnswerCard — what the guard did, and did not, examine", () => {
+  test("an engine whose statements are not SQL gets the amber reading and NO read-only chip", () => {
+    const timeline = planTimeline({
+      readOnly: false,
+      guardApplicable: false,
+      identifiers: { kind: "not-applicable" },
+    });
+    const { getByTestId, queryAllByText } = render(
+      <AnswerCard timeline={timeline} capabilities={capabilitiesFor("json")} onApplyStatement={() => {}} />,
+    );
+
+    expect(getByTestId("agent-answer-guard").textContent).toBe(
+      "Not examined: the statement guard reads SQL, and this engine's statements are not SQL.",
+    );
+    expect(getByTestId("agent-answer-chip-guard").textContent).toBe("not checked");
+    // The claim nothing in this product made: no code read this draft, so no chip says
+    // it was read.
+    expect(queryAllByText("Read-only")).toEqual([]);
+
+    // Both existing sentences, verbatim, plus the caveat about what an inventory is —
+    // each in the node whose test id it has carried since before the redesign, because
+    // a shared blob cannot distinguish the right sentence for this state from any
+    // sentence that happens to contain the phrase.
+    expect(getByTestId("agent-plan-statement-guard-unread").textContent).toBe(
+      "The statement guard reads SQL, and this engine's statements are not SQL — so nothing examined this draft. It is drafted, not run — nothing has happened to your data — but nothing here has established anything about it, for or against.",
+    );
+    expect(getByTestId("agent-plan-statement-unread").textContent).toBe(
+      "The names in this statement were not checked: the check that would do it reads SQL, and this engine's statements are not SQL.",
+    );
+    expect(getByTestId("agent-plan-statement-caveat").textContent).toBe(
+      "The run executed nothing. What was checked is what this run read of the schema, which records what exists rather than what your role is permitted to read.",
+    );
+    // And the claims are inside the popover that names them, not loose on the card.
+    expect(getByTestId("agent-answer-guard-note").textContent).toContain("nothing examined this draft");
+  });
+
+  test("an objection is stated in full where it can be read, not folded into the popover", () => {
+    const timeline = planTimeline({
+      readOnly: false,
+      guardViolation: "NON_READ_STATEMENT",
+      identifiers: { kind: "checked", unknownTables: [] },
+    });
+    const { getByTestId } = render(<AnswerCard timeline={timeline} />);
+
+    const guard = getByTestId("agent-answer-guard").textContent ?? "";
+    expect(guard).toContain("The statement guard did not read this as a bounded read (NON_READ_STATEMENT).");
+    expect(guard).toContain("nothing here establishes that running it would only read");
+    expect(getByTestId("agent-answer-chip-guard").textContent).toBe("not classified as a read");
+  });
+
+  test("a guard that objected with no recorded reason still says so", () => {
+    const timeline = planTimeline({ readOnly: false, identifiers: { kind: "checked", unknownTables: [] } });
+    const { getByTestId } = render(<AnswerCard timeline={timeline} />);
+    expect(getByTestId("agent-answer-guard").textContent).toContain("(no reason recorded)");
+  });
+
+  test("a run with no inventory says that, rather than that the names were unreadable", () => {
+    const timeline = planTimeline({ readOnly: true, identifiers: { kind: "no-inventory" } });
+    const { getByTestId, queryByTestId } = render(<AnswerCard timeline={timeline} />);
+    expect(getByTestId("agent-plan-statement-unchecked").textContent).toBe(
+      "No schema inventory was read for this run, so the names in this statement were not checked against anything.",
+    );
+    expect(queryByTestId("agent-plan-statement-unread")).toBeNull();
+  });
+
+  /*
+    The guard read this draft and was satisfied by it, and no inventory was captured. The
+    visible line must therefore not claim the inventory clause: the popover directly
+    behind it says no inventory was read, and a line asserting a check "against the
+    captured inventory" contradicts its own qualifier. The pre-redesign card made no
+    positive claim here at all, so the clause is a new assertion and it goes where an
+    inventory was actually read.
+  */
+  test("a checked statement with no inventory to check against drops the inventory clause", () => {
+    const { getByTestId } = render(
+      <AnswerCard timeline={planTimeline({ readOnly: true, identifiers: { kind: "no-inventory" } })} />,
+    );
+    expect(getByTestId("agent-answer-guard").textContent).toBe("Checked as a bounded read. Nothing was executed.");
+    expect(getByTestId("agent-answer-guard").textContent).not.toContain("inventory");
+  });
+
+  test("a checked statement whose names were checked keeps the inventory clause", () => {
+    const { getByTestId } = render(
+      <AnswerCard timeline={planTimeline({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] } })} />,
+    );
+    expect(getByTestId("agent-answer-guard").textContent).toBe(
+      "Checked as a bounded read against the captured inventory. Nothing was executed.",
+    );
+  });
+
+  test("names the inventory does not hold are said to be exactly that", () => {
+    const timeline = planTimeline({
+      readOnly: true,
+      identifiers: { kind: "checked", unknownTables: ["shipments"] },
+    });
+    const { getByTestId } = render(<AnswerCard timeline={timeline} />);
+    expect(getByTestId("agent-plan-statement-unknown").textContent).toBe(
+      "These names are not in the inventory this run read, so the statement may not run as written:",
+    );
+  });
+
+  test("the popover is a keyboard-reachable button, and its text is readable either way", () => {
+    const timeline = planTimeline({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] } });
+    const { getByTestId } = render(<AnswerCard timeline={timeline} />);
+    const info = getByTestId("agent-answer-guard-note-info");
+    const body = getByTestId("agent-answer-guard-note");
+
+    expect(info.tagName).toBe("BUTTON");
+    expect(info.getAttribute("type")).toBe("button");
+    expect(info.getAttribute("aria-label")).toBe("What the statement guard checked");
+    expect(info.getAttribute("aria-expanded")).toBe("false");
+    expect(info.getAttribute("aria-controls")).toBe(body.getAttribute("id"));
+    // Closed is visually hidden and NOT absent: the claim stays in the accessibility
+    // tree whether or not anyone opened the popover.
+    expect(body.className).toContain("sr-only");
+
+    fireEvent.click(info);
+    expect(info.getAttribute("aria-expanded")).toBe("true");
+    expect(getByTestId("agent-answer-guard-note").className).not.toContain("sr-only");
+
+    fireEvent.click(info);
+    expect(info.getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+describe("AnswerCard — an agent run's report", () => {
+  test("quotes the model's claim and names what it cites", () => {
+    const { getByTestId, getAllByTestId } = render(<AnswerCard timeline={reportTimeline()} />);
+
+    expect(getByTestId("agent-answer-report")).toBeTruthy();
+    expect(getByTestId("agent-answer-claim").textContent).toContain("Checkout writes 1 order per session.");
+    expect(getByTestId("agent-answer-claim-copy")).toBeTruthy();
+    const chips = getAllByTestId("agent-answer-citation-chip").map((chip) => chip.textContent ?? "");
+    expect(chips[0]).toContain("Artifact corr_9");
+    expect(chips[0]).toContain("row 1");
+  });
+
+  /*
+    L8, measured in Chrome on 2026-08-21: the chip read
+    `Artifact 722b2a10-e3f2-4b9c-8177-367359a21500` — a 36-character identifier filling
+    a 384px panel, with no room left for the one thing the ledger actually knows about
+    that read. A correlation id IS a UUID in a real run; `corr_9` is a fixture.
+
+    So the chip carries the identifier at the length this rail prints an identifier at
+    everywhere else — eight characters, which is the length the schema-snapshot label
+    was already written at in the same function — followed by the ledger's own detail.
+    The full identifier is in the `Evidence` fold, which is where a reader chasing a
+    correlation id through a server log goes.
+  */
+  test("a citation chip names the read at chip length, with the ledger's own detail", () => {
+    const { getByTestId } = render(<AnswerCard timeline={reportTimeline({ correlationId: LONG_ID })} />);
+
+    const chip = getByTestId("agent-answer-citation-chip");
+    expect(chip.textContent).toContain("Artifact 722b2a10");
+    expect(chip.textContent).not.toContain(LONG_ID);
+    // The ledger's own words about what that read returned, and the model's locator.
+    expect(getByTestId("agent-answer-citation-chip-detail").textContent).toContain("1 row via sql.select.rows");
+    expect(chip.textContent).toContain("row 1");
+    // Nothing is lost: the identifier that identifies the read is in the fold, whole.
+    expect(getByTestId("agent-answer-evidence-citation").textContent).toContain(LONG_ID);
+  });
+
+  test("offers the answer's own statement and result exactly as the ledger holds them", () => {
+    const applied: string[] = [];
+    const shown: string[] = [];
+    const { getByTestId } = render(
+      <AnswerCard
+        timeline={reportTimeline()}
+        onApplyStatement={(sql) => applied.push(sql)}
+        onShowArtifact={(correlationId) => shown.push(correlationId)}
+      />,
+    );
+
+    fireEvent.click(getByTestId("agent-answer-apply-statement"));
+    fireEvent.click(getByTestId("agent-answer-show-result"));
+    expect(applied).toEqual([STATEMENT]);
+    expect(shown).toEqual(["corr_9"]);
+  });
+
+  /*
+    L6, measured in Chrome on 2026-08-21: on the report path the rail offered three
+    "Apply to editor" controls at once and NOT ONE of them carried an accessible name.
+    The whole reason the redesign was allowed to move this control up here is that the
+    card names the act it performs, so the name is built by the same function that names
+    the plan card's — one author for every hand-off name in this rail, which is what
+    lets a test assert the property rather than each site's spelling.
+
+    It carries no mark, and that is the honest answer rather than an omission: a mark
+    states what the statement GUARD made of a draft, and nothing drafted this one as a
+    plan — the run wrote it, executed it on the engine's own read-only session and
+    answered from the rows. There is no guard reading on the ledger for it, so there is
+    nothing to say about one, and inventing a reassurance here is exactly the overclaim
+    `applyStatementName`'s own docblock spends its length refusing.
+  */
+  test("names the hand-off with the rail's own name-builder, and claims no guard reading", () => {
+    const { getByTestId } = render(<AnswerCard timeline={reportTimeline()} onApplyStatement={() => {}} />);
+
+    const control = getByTestId("agent-answer-apply-statement");
+    expect(control.getAttribute("aria-label")).toBe(applyStatementName(null));
+    // WCAG 2.5.3: the visible label comes first and unaltered, so a voice user can say
+    // what they can see.
+    expect(control.getAttribute("aria-label")).toBe("Apply to editor.");
+    expect(control.textContent).toContain("Apply to editor");
+  });
+
+  test("offers nothing to act on for a report whose run composed no answer", () => {
+    const { queryByTestId } = render(
+      <AnswerCard
+        timeline={reportTimeline({ withAnswer: false })}
+        onApplyStatement={() => {}}
+        onShowArtifact={() => {}}
+      />,
+    );
+    expect(queryByTestId("agent-answer-report")).toBeTruthy();
+    expect(queryByTestId("agent-answer-apply-statement")).toBeNull();
+    expect(queryByTestId("agent-answer-show-result")).toBeNull();
+  });
+
+  test("folds the evidence away with the statement each citation rests on", () => {
+    const { getByTestId, getAllByTestId } = render(<AnswerCard timeline={reportTimeline()} />);
+    const evidence = getByTestId("agent-answer-evidence");
+    expect(evidence.tagName).toBe("DETAILS");
+    expect((evidence as HTMLDetailsElement).open).toBe(false);
+
+    const cited = getAllByTestId("agent-answer-evidence-citation");
+    expect(cited).toHaveLength(1);
+    expect(cited[0]?.textContent).toContain("1 row via sql.select.rows");
+    expect(getByTestId("agent-answer-citation-quoted-copy")).toBeTruthy();
+    expect(cited[0]?.textContent).toContain(STATEMENT);
+  });
+
+  test("a citation this timeline holds no entry for says so instead of looking checked", () => {
+    const { getByTestId } = render(<AnswerCard timeline={reportTimeline({ cites: "corr_missing" })} />);
+    expect(getByTestId("agent-answer-evidence-citation").textContent).toContain(
+      "not in the part of this run's timeline the rail has read",
+    );
+    expect(getByTestId("agent-answer-citation-chip").getAttribute("data-resolved")).toBe("false");
+  });
+
+  /*
+    WCAG 1.4.1. An unresolved citation is a gap in what the run established, and amber
+    against a neutral chip says that to nobody who cannot see the hue — a screen-reader
+    user, and anyone who cannot separate the two, read a checked citation and an
+    unverified one as the same fact. The surface this replaced did not have the problem:
+    it followed the label with the ledger's own `detail`, which for an unresolved
+    citation IS the sentence saying so.
+  */
+  test("an unresolved chip says so in its own text, in the words the ledger recorded", () => {
+    const { getByTestId } = render(<AnswerCard timeline={reportTimeline({ cites: "corr_missing" })} />);
+    const chip = getByTestId("agent-answer-citation-chip");
+    expect(chip.textContent).toContain("not in the part of this run's timeline the rail has read");
+    expect(getByTestId("agent-answer-citation-chip-unresolved").textContent).toContain(
+      "not in the part of this run's timeline the rail has read",
+    );
+  });
+
+  /*
+    Both readings say what they are IN TEXT, and the id says which reading it is — the
+    rule this file follows for the guard's claims too. A single shared id for "the
+    sentence at the end of the chip" cannot tell a test that the right sentence for
+    this state is there: it would pass on either, and the two readings differ by
+    exactly that.
+  */
+  test("a resolved chip reports the read rather than a gap, and says which it is", () => {
+    const { getByTestId, queryByTestId } = render(<AnswerCard timeline={reportTimeline()} />);
+    expect(getByTestId("agent-answer-citation-chip").getAttribute("data-resolved")).toBe("true");
+    expect(getByTestId("agent-answer-citation-chip-detail").textContent).toContain("1 row via sql.select.rows");
+    expect(queryByTestId("agent-answer-citation-chip-unresolved")).toBeNull();
+  });
+
+  test("an unresolved chip carries no detail node, because what it has to say is the gap", () => {
+    const { queryByTestId } = render(<AnswerCard timeline={reportTimeline({ cites: "corr_missing" })} />);
+    expect(queryByTestId("agent-answer-citation-chip-detail")).toBeNull();
+  });
+});
+
+describe("AnswerCard — a plan run that drafted nothing", () => {
+  const refusedTimeline = () =>
+    foldLedgerEntries([
+      opened("planning"),
+      started("planning"),
+      captured,
+      closing("NO STATEMENT: the inventory has no country column"),
+      finished("succeeded"),
+    ]);
+
+  test("renders the run's own words as the ending they are", () => {
+    const { getByTestId } = render(<AnswerCard timeline={refusedTimeline()} />);
+
+    expect(getByTestId("agent-answer-refused")).toBeTruthy();
+    expect(getByTestId("agent-answer-refused").textContent).toContain("No statement drafted");
+    expect(getByTestId("agent-answer-refusal-note").textContent).toBe(
+      "This run drafted no statement. What it says is missing, and what it needs from you, are in its own words below.",
+    );
+    expect(getByTestId("agent-answer-refusal-prose").textContent).toContain("the inventory has no country column");
+    // The protocol token the model was told to emit never reaches the reader.
+    expect(getByTestId("agent-answer-refused").textContent).not.toContain("NO STATEMENT:");
+    expect(getByTestId("agent-answer-refusal-copy")).toBeTruthy();
+  });
+
+  test("offers no statement controls, because there is no statement", () => {
+    const { queryByTestId } = render(<AnswerCard timeline={refusedTimeline()} onApplyStatement={() => {}} />);
+    expect(queryByTestId("agent-answer-plan-apply")).toBeNull();
+    expect(queryByTestId("agent-answer-statement")).toBeNull();
+  });
+});
+
+describe("AnswerCard — a run that failed", () => {
+  test("says why, in the words the timeline already uses, and offers a retry", () => {
+    const retries: number[] = [];
+    const timeline = foldLedgerEntries([opened("agent"), started("agent"), finished("failed", "model-unavailable")]);
+    const { getByTestId } = render(<AnswerCard timeline={timeline} onRetry={() => retries.push(1)} />);
+
+    expect(getByTestId("agent-answer-failed")).toBeTruthy();
+    expect(getByTestId("agent-answer-status").textContent).toBe("failed");
+    expect(getByTestId("agent-answer-failure").textContent).toBe(
+      "The model provider is not configured or could not be reached.",
+    );
+    fireEvent.click(getByTestId("agent-answer-retry"));
+    expect(retries).toEqual([1]);
+  });
+
+  test("a failure the server classified no reason for says that, and offers no retry without a host", () => {
+    const timeline = foldLedgerEntries([opened("agent"), started("agent"), finished("failed")]);
+    const { getByTestId, queryByTestId } = render(<AnswerCard timeline={timeline} />);
+    expect(getByTestId("agent-answer-failure").textContent).toContain("names no reason");
+    expect(queryByTestId("agent-answer-retry")).toBeNull();
+  });
+});
+
+/*
+  A run CAN end `failed` holding what it produced, and the shape is not a corner case:
+  `conclude` in `src/lib/agent/investigation.ts` writes the closing prose and then the
+  drafted statement BEFORE `service.finish`, and it is called with `"failed"` for a
+  model timeout, an exhausted deadline and the turn ceiling. `run-finished`'s own
+  documentation names the combination — "`failed` having answered nothing (the turn
+  ceiling)" is one axis, and the product on the ledger is the other.
+
+  So the status is not what decides which card this is. The ledger's product decides,
+  and the failure is stated beside it: a card that read the status first replaced a
+  drafted statement, its marked hand-off, the guard's claims and the chips with a
+  banner — while the transcript entry below went on saying they were "in the answer at
+  the top of this rail".
+*/
+describe("AnswerCard — a run that failed holding what it produced", () => {
+  test("a plan run that drafted and then failed still shows the statement, the hand-off and the guard", () => {
+    const timeline = foldLedgerEntries([
+      opened("planning"),
+      started("planning"),
+      captured,
+      closing(`Here is the read:\n${FENCE}sql\n${STATEMENT}\n${FENCE}`),
+      draftEvent({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] } }),
+      finished("failed", "model-unavailable"),
+    ]);
+    const { getByTestId } = render(<AnswerCard timeline={timeline} onApplyStatement={() => {}} onRetry={() => {}} />);
+
+    expect(getByTestId("agent-answer-plan")).toBeTruthy();
+    expect(getByTestId("agent-answer-statement").textContent).toContain(STATEMENT);
+    expect(getByTestId("agent-answer-plan-apply")).toBeTruthy();
+    expect(getByTestId("agent-answer-guard")).toBeTruthy();
+    expect(getByTestId("agent-answer-chip-inventory")).toBeTruthy();
+    // Nothing is hidden by showing the answer: the status pill still reads `failed` and
+    // the reason is still stated, on the same card, with the retry beside it.
+    expect(getByTestId("agent-answer-status").textContent).toBe("failed");
+    expect(getByTestId("agent-answer-failed")).toBeTruthy();
+    expect(getByTestId("agent-answer-failure").textContent).toBe(
+      "The model provider is not configured or could not be reached.",
+    );
+    expect(getByTestId("agent-answer-retry")).toBeTruthy();
+  });
+
+  test("a report that arrived before the run failed is still the answer, with the failure beside it", () => {
+    const { getByTestId } = render(
+      <AnswerCard timeline={reportTimeline({ failed: true })} onApplyStatement={() => {}} onShowArtifact={() => {}} />,
+    );
+
+    expect(getByTestId("agent-answer-report")).toBeTruthy();
+    expect(getByTestId("agent-answer-claim").textContent).toContain("Checkout writes 1 order per session.");
+    // The hand-off the transcript entry withholds BECAUSE this card offers it.
+    expect(getByTestId("agent-answer-apply-statement")).toBeTruthy();
+    expect(getByTestId("agent-answer-failure").textContent).toBe(
+      "The model provider is not configured or could not be reached.",
+    );
+  });
+
+  test("a refusal a failing run recorded is still its own words, with the failure beside them", () => {
+    const timeline = foldLedgerEntries([
+      opened("planning"),
+      started("planning"),
+      captured,
+      closing("NO STATEMENT: the inventory has no country column"),
+      finished("failed"),
+    ]);
+    const { getByTestId } = render(<AnswerCard timeline={timeline} />);
+
+    expect(getByTestId("agent-answer-refused")).toBeTruthy();
+    expect(getByTestId("agent-answer-refusal-prose").textContent).toContain("the inventory has no country column");
+    expect(getByTestId("agent-answer-failure").textContent).toContain("names no reason");
+  });
+
+  test("the answer state a run resolves to is one reading, exported for the rail to share", () => {
+    // The rail withholds the transcript's copies of what the card renders, and it must
+    // read that from the same place the card does. Two derivations was the defect: the
+    // rail keyed its suppression on the ledger's report alone, so a failed run withheld
+    // the transcript's hand-off for a card that was showing a failure banner instead.
+    expect(answerCardState(reportTimeline({ failed: true }))).toBe("report");
+    expect(answerCardState(planTimeline({ readOnly: true, identifiers: { kind: "checked", unknownTables: [] } }))).toBe(
+      "plan",
+    );
+    expect(answerCardState(foldLedgerEntries([opened("agent"), started("agent"), finished("failed")]))).toBe("failed");
+    expect(answerCardState(foldLedgerEntries([]))).toBeNull();
+  });
+});
+
+describe("AnswerCard — a run still going", () => {
+  const liveTimeline = () =>
+    foldLedgerEntries([
+      opened("agent"),
+      started("agent"),
+      captured,
+      event({ kind: "statement-drafted", atMs: 1_003, stepId: "s1", sql: STATEMENT, rationale: "count the orders" }),
+      event({ kind: "tool-completed", atMs: 5_004, stepId: "s1", artifact: ARTIFACT }),
+    ]);
+
+  test("shows the step it is on, what it has spent, and how long the ledger covers", () => {
+    const timeline = liveTimeline();
+    const { getByTestId } = render(<AnswerCard timeline={timeline} />);
+
+    expect(getByTestId("agent-answer-running")).toBeTruthy();
+    expect(getByTestId("agent-answer-step").textContent).toContain("Result stored");
+    // The span the ledger records, not a clock: 1_000 to 5_004.
+    expect(getByTestId("agent-answer-elapsed").textContent).toContain("4.0 s");
+
+    const limit = AGENT_WORKFLOW_BUDGETS.investigation.policy.budgets.maxStatementsPerRun;
+    expect(getByTestId("agent-answer-spend").textContent).toContain(`1 / ${limit} statements`);
+    expect(getByTestId("agent-answer-spend-note").textContent).toContain("a floor, never a ceiling");
+    expect(getByTestId("agent-answer-progress").getAttribute("style")).toContain("width");
+  });
+
+  test("stops the run through the host, and offers no stop where the host cannot", () => {
+    const stops: number[] = [];
+    const { getByTestId } = render(<AnswerCard timeline={liveTimeline()} onStop={() => stops.push(1)} />);
+    fireEvent.click(getByTestId("agent-answer-stop"));
+    expect(stops).toEqual([1]);
+    cleanup();
+
+    const hostless = render(<AnswerCard timeline={liveTimeline()} />);
+    expect(hostless.queryByTestId("agent-answer-stop")).toBeNull();
+  });
+
+  test("an answer that arrives before the run ends is shown as the answer, not as progress", () => {
+    // Measured on the real stream: `answer-composed` and `run-finished` can reach the
+    // browser in one chunk, and an answer gated on the status would never be rendered
+    // in exactly that case. So the ledger's answer wins over the ledger's status.
+    const timeline = foldLedgerEntries([
+      opened("agent"),
+      started("agent"),
+      event({ kind: "statement-drafted", atMs: 1_003, stepId: "s1", sql: STATEMENT, rationale: "count" }),
+      event({ kind: "tool-completed", atMs: 1_004, stepId: "s1", artifact: ARTIFACT }),
+      event({
+        kind: "report-composed",
+        atMs: 1_006,
+        claims: [
+          {
+            claim: "Checkout writes 1 order per session.",
+            evidence: [{ source: "artifact", correlationId: "corr_9" }],
+          },
+        ],
+      }),
+    ]);
+    const { getByTestId, queryByTestId } = render(<AnswerCard timeline={timeline} />);
+    expect(getByTestId("agent-answer-report")).toBeTruthy();
+    expect(queryByTestId("agent-answer-running")).toBeNull();
+  });
+});

--- a/tests/components/agent/ConsentCard.test.tsx
+++ b/tests/components/agent/ConsentCard.test.tsx
@@ -1,0 +1,278 @@
+import "../../setup-dom";
+
+import React, { type RefObject } from "react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { ConsentCard } from "@/components/agent/ConsentCard";
+import { AGENT_HANDOVER_BUDGET } from "@/lib/agent/execution-policy";
+import { autoExecuteTerms } from "@/lib/agent/posture";
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * The hand-over consent step, as its own component (spec Deliverable 4).
+ *
+ * It decides exactly what the inline section in `AgentRail.tsx` decided: whether the
+ * run's final statement also lands in the user's editor and runs there. So the things
+ * these tests pin are the things that made that section correct, and none of them are
+ * presentational:
+ *
+ *  - **the tick is OFF unless the caller says otherwise**, because a widening that is
+ *    on by default is not consented to;
+ *  - **`autoExecuteTerms` is the accessible description of the checkbox**, and stays
+ *    one after it moved into a popover. A description that is only rendered when a
+ *    popover is open is a description a screen-reader user is never given, so the node
+ *    is always in the DOM and the popover only unhides it;
+ *  - **the figures are DERIVED** — the chips read `AGENT_HANDOVER_BUDGET`, so a change
+ *    to the budget cannot leave the copy behind (#425's lesson);
+ *  - **the SQLite sentence is read off the engine the start was decided on**, keeps its
+ *    exact words, and does not wait for the tick: it is true of the run either way;
+ *  - **focus moves into the region when it is raised**, which is the announcement a
+ *    keyboard user gets that two buttons appeared under a Start that just went
+ *    disabled.
+ */
+
+const WORKFLOW_LABEL = "Analyze";
+
+function refObject(): RefObject<HTMLElement | null> {
+  return { current: null };
+}
+
+interface Overrides {
+  readonly connectionName?: string | null;
+  readonly engine?: DatabaseType | null;
+  readonly autoExecute?: boolean;
+  readonly onAutoExecuteChange?: (next: boolean) => void;
+  readonly onOpen?: () => void;
+  readonly onCancel?: () => void;
+  readonly regionRef?: RefObject<HTMLElement | null>;
+}
+
+function renderCard(overrides: Overrides = {}) {
+  return render(
+    <ConsentCard
+      workflowType="data-analysis"
+      workflowLabel={WORKFLOW_LABEL}
+      connectionName={overrides.connectionName === undefined ? "Sales" : overrides.connectionName}
+      engine={overrides.engine === undefined ? "postgres" : overrides.engine}
+      autoExecute={overrides.autoExecute ?? false}
+      onAutoExecuteChange={overrides.onAutoExecuteChange ?? (() => {})}
+      onOpen={overrides.onOpen ?? (() => {})}
+      onCancel={overrides.onCancel ?? (() => {})}
+      regionRef={overrides.regionRef ?? refObject()}
+    />,
+  );
+}
+
+describe("ConsentCard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("the region a screen reader lands in", () => {
+    test("it is a named, described region that takes focus when it is raised", () => {
+      const regionRef = refObject();
+      const { getByTestId } = renderCard({ regionRef });
+
+      const region = getByTestId("agent-consent");
+      expect(region.tagName).toBe("SECTION");
+      // The name is the sentence naming the workflow and the connection; the
+      // description is the terms. Entering the region reads out what is being
+      // consented to rather than "group".
+      expect(region.getAttribute("aria-labelledby")).toBe("agent-consent-workflow");
+      expect(region.getAttribute("aria-describedby")).toBe("agent-consent-terms");
+      // Focusable programmatically, out of the tab order: the pattern for a region
+      // focus is moved TO rather than through.
+      expect(region.getAttribute("tabindex")).toBe("-1");
+      expect(document.activeElement).toBe(region);
+      // The caller keeps a handle on the node, because the exit half of the focus
+      // contract (Cancel returns focus to Start) is the caller's to decide.
+      expect(regionRef.current).toBe(region);
+    });
+  });
+
+  describe("what the card says before the checkbox", () => {
+    test("the heading states the default, and the run is read-only either way", () => {
+      const { getByTestId } = renderCard();
+
+      expect(getByTestId("agent-consent-heading").textContent).toContain("Start this run");
+      expect(getByTestId("agent-consent-pill").textContent).toBe("read-only");
+      expect(getByTestId("agent-consent-editor-note").textContent).toBe(
+        "Nothing runs in your editor unless you ask for it below.",
+      );
+    });
+
+    test("the region's own name carries the workflow AND the connection the start was decided on", () => {
+      const { getByTestId } = renderCard({ connectionName: "Sales" });
+
+      const named = getByTestId("agent-consent-workflow");
+      expect(named.id).toBe("agent-consent-workflow");
+      expect(named.textContent).toBe("This run will open as Analyze on Sales, which answers with a result.");
+    });
+
+    test("an unnamed connection is said as the one the start was made on, never as a blank", () => {
+      const { getByTestId } = renderCard({ connectionName: null });
+
+      expect(getByTestId("agent-consent-workflow").textContent).toBe(
+        "This run will open as Analyze on the connection you started it on, which answers with a result.",
+      );
+    });
+
+    test("the decision is stated as frozen at open time", () => {
+      const { getByTestId } = renderCard();
+
+      expect(getByTestId("agent-consent-frozen").textContent).toBe(
+        "This is decided by the request that opens the run and stays what it was: a later request cannot widen a run the server already holds.",
+      );
+    });
+  });
+
+  describe("the checkbox, which carries the whole decision", () => {
+    test("it is off by default and reports a tick to the caller", () => {
+      const ticks: boolean[] = [];
+      const { getByTestId } = renderCard({ onAutoExecuteChange: (next) => ticks.push(next) });
+
+      const box = getByTestId("agent-auto-execute") as HTMLInputElement;
+      expect(box.type).toBe("checkbox");
+      expect(box.checked).toBe(false);
+      expect(getByTestId("agent-auto-execute-label").textContent).toBe("Also run the final answer in my editor");
+
+      fireEvent.click(box);
+      expect(ticks).toEqual([true]);
+    });
+
+    test("a ticked box is rendered ticked, and unticking is reported as off", () => {
+      const ticks: boolean[] = [];
+      const { getByTestId } = renderCard({ autoExecute: true, onAutoExecuteChange: (next) => ticks.push(next) });
+
+      const box = getByTestId("agent-auto-execute") as HTMLInputElement;
+      expect(box.checked).toBe(true);
+
+      fireEvent.click(box);
+      expect(ticks).toEqual([false]);
+    });
+
+    test("the terms are the checkbox's accessible description, whether or not the popover is open", () => {
+      const { getByTestId } = renderCard();
+
+      const terms = getByTestId("agent-auto-execute-terms");
+      expect(terms.id).toBe("agent-consent-terms");
+      // Verbatim, and from the one author: the sentence the safety strip's widened
+      // reading quotes is the sentence this checkbox is described by.
+      expect(terms.textContent).toBe(autoExecuteTerms("data-analysis"));
+      expect(getByTestId("agent-auto-execute").getAttribute("aria-describedby")).toBe("agent-consent-terms");
+      // Present in the accessibility tree while the popover is closed — hidden from
+      // sight only. `aria-hidden` or a conditional render here would remove the
+      // description the checkbox claims to have.
+      expect(terms.className).toContain("sr-only");
+      expect(terms.getAttribute("aria-hidden")).toBeNull();
+    });
+
+    test("the info control is a keyboard-reachable button that unhides the terms", () => {
+      const { getByTestId } = renderCard();
+
+      const info = getByTestId("agent-consent-terms-info");
+      expect(info.tagName).toBe("BUTTON");
+      expect(info.getAttribute("type")).toBe("button");
+      // Named, because a lone glyph names nothing.
+      expect(info.getAttribute("aria-label")).toBe("What the editor run adds");
+      expect(info.getAttribute("aria-controls")).toBe("agent-consent-terms");
+      expect(info.getAttribute("aria-expanded")).toBe("false");
+
+      fireEvent.click(info);
+      expect(info.getAttribute("aria-expanded")).toBe("true");
+      expect(getByTestId("agent-auto-execute-terms").className).not.toContain("sr-only");
+
+      fireEvent.click(info);
+      expect(info.getAttribute("aria-expanded")).toBe("false");
+      expect(getByTestId("agent-auto-execute-terms").className).toContain("sr-only");
+    });
+
+    test("the info control is outside the label, so reading the terms cannot tick the box", () => {
+      const ticks: boolean[] = [];
+      const { getByTestId } = renderCard({ onAutoExecuteChange: (next) => ticks.push(next) });
+
+      fireEvent.click(getByTestId("agent-consent-terms-info"));
+      expect(ticks).toEqual([]);
+      expect(getByTestId("agent-auto-execute-label").contains(getByTestId("agent-consent-terms-info"))).toBe(false);
+    });
+  });
+
+  describe("the bounds of what was ticked", () => {
+    test("no chips while the box is off: there is no widening to bound", () => {
+      const { queryByTestId } = renderCard({ autoExecute: false });
+
+      expect(queryByTestId("agent-consent-bounds")).toBeNull();
+    });
+
+    test("the chips are read off AGENT_HANDOVER_BUDGET, not typed", () => {
+      const { getByTestId } = renderCard({ autoExecute: true });
+
+      const chips = getByTestId("agent-consent-bounds").textContent ?? "";
+      expect(chips).toContain("same read-only session");
+      // Derived: a budget change that leaves the copy behind fails here.
+      expect(chips).toContain(`${AGENT_HANDOVER_BUDGET.maxResultRows} rows`);
+      expect(chips).toContain("no time limit");
+    });
+
+    test("the SQLite chip is shown on SQLite and on nothing else", () => {
+      const { getByTestId } = renderCard({ autoExecute: true, engine: "sqlite" });
+      expect(getByTestId("agent-consent-bounds").textContent).toContain("SQLite: not interruptible");
+      cleanup();
+
+      const other = renderCard({ autoExecute: true, engine: "postgres" });
+      expect(other.getByTestId("agent-consent-bounds").textContent).not.toContain("SQLite");
+    });
+  });
+
+  describe("the sentence that is true of one engine", () => {
+    test("SQLite is told what a long read costs there, in the words the budget meter uses", () => {
+      const { getByTestId } = renderCard({ engine: "sqlite" });
+
+      expect(getByTestId("agent-auto-execute-sqlite").textContent).toBe(
+        "On SQLite a read is not interrupted when it runs long: it blocks other writers and this application until it finishes.",
+      );
+    });
+
+    test("it does not wait for the tick: it is true of the run either way", () => {
+      const { getByTestId } = renderCard({ engine: "sqlite", autoExecute: false });
+
+      expect(getByTestId("agent-auto-execute-sqlite")).toBeTruthy();
+    });
+
+    test("another engine is not told a SQLite fact, and neither is an unresolved one", () => {
+      const { queryByTestId } = renderCard({ engine: "postgres" });
+      expect(queryByTestId("agent-auto-execute-sqlite")).toBeNull();
+      cleanup();
+
+      const unresolved = renderCard({ engine: null });
+      expect(unresolved.queryByTestId("agent-auto-execute-sqlite")).toBeNull();
+    });
+  });
+
+  describe("the two exits", () => {
+    test("Start run opens the run, and keeps the testid the rail's tests reach for", () => {
+      const onOpen = mock(() => {});
+      const { getByTestId } = renderCard({ onOpen });
+
+      const open = getByTestId("agent-consent-open");
+      expect(open.textContent).toBe("Start run");
+      expect(open.getAttribute("type")).toBe("button");
+
+      fireEvent.click(open);
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
+
+    test("Cancel opens nothing and hands the focus decision back to the caller", () => {
+      const onCancel = mock(() => {});
+      const onOpen = mock(() => {});
+      const { getByTestId } = renderCard({ onCancel, onOpen });
+
+      const cancel = getByTestId("agent-consent-cancel");
+      expect(cancel.textContent).toBe("Cancel");
+
+      fireEvent.click(cancel);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onOpen).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/components/agent/SafetyStrip.test.tsx
+++ b/tests/components/agent/SafetyStrip.test.tsx
@@ -1,0 +1,272 @@
+import "../../setup-dom";
+
+import React from "react";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { SafetyStrip } from "@/components/agent/SafetyStrip";
+import { AGENT_EXECUTION_ENGINES } from "@/lib/agent/engine-support";
+import { type AgentPosture, type AgentPostureTone, agentPosture } from "@/lib/agent/posture";
+import { getDBConfig } from "@/lib/db-ui-config";
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * The standing safety strip: one always-visible row saying what the SELECTED MODE does
+ * to the database.
+ *
+ * The claims themselves are `src/lib/agent/posture.ts`'s, and
+ * `tests/unit/lib/agent/posture.test.ts` is where their exact reviewed wording is pinned.
+ * These tests therefore assert against `agentPosture` rather than against copied strings:
+ * a paraphrase here would be a second opinion about a sentence with one author, and a
+ * literal would pass while the strip rendered the wrong half of the posture. What is
+ * pinned HERE is that the strip renders that posture whole —
+ *
+ *  - the headline in the pill and the qualifier BESIDE it, never folded away. The
+ *    qualifier is the half a compressed headline drops, and dropping it overclaims;
+ *  - the full claim reaching assistive technology whether or not the popover is open,
+ *    which is the one property an ⓘ can quietly lose;
+ *  - a real `<button>` for the ⓘ, so the keyboard path is the platform's rather than a
+ *    click handler on a `<span>`;
+ *  - a tone for each of the four levels, expressed in palette classes and never in a
+ *    literal colour.
+ */
+
+afterEach(cleanup);
+
+/** An engine agent mode has no read-only statement path on, taken from the real gate. */
+const UNSUPPORTED_ENGINE: DatabaseType = (["mongodb", "redis", "oracle", "mssql", "mysql"] as DatabaseType[]).filter(
+  (type) => !AGENT_EXECUTION_ENGINES.includes(type),
+)[0] as DatabaseType;
+
+/** An engine it does, so this file cannot pin a tone the gate no longer produces. */
+const SUPPORTED_ENGINE: DatabaseType = AGENT_EXECUTION_ENGINES[0] as DatabaseType;
+
+interface StripCase {
+  readonly mode: "planning" | "agent";
+  readonly engine: DatabaseType | null;
+  readonly handover: boolean;
+}
+
+const PLAN: StripCase = { mode: "planning", engine: SUPPORTED_ENGINE, handover: false };
+const READS: StripCase = { mode: "agent", engine: SUPPORTED_ENGINE, handover: false };
+const WIDENED: StripCase = { mode: "agent", engine: SUPPORTED_ENGINE, handover: true };
+const BLOCKED: StripCase = { mode: "agent", engine: UNSUPPORTED_ENGINE, handover: false };
+const UNRESOLVED: StripCase = { mode: "agent", engine: null, handover: false };
+
+const labelFor = (engine: DatabaseType | null): string => (engine === null ? "" : getDBConfig(engine).label);
+
+const postureFor = (input: StripCase): AgentPosture =>
+  agentPosture({
+    mode: input.mode,
+    engine: input.engine,
+    engineLabel: labelFor(input.engine),
+    handover: input.handover,
+  });
+
+function renderStrip(input: StripCase) {
+  return render(
+    <SafetyStrip
+      mode={input.mode}
+      engine={input.engine}
+      engineLabel={labelFor(input.engine)}
+      handover={input.handover}
+    />,
+  );
+}
+
+describe("SafetyStrip renders the posture whole", () => {
+  test("the pill carries the headline and the qualifier sits beside it, visible", () => {
+    const { getByTestId } = renderStrip(PLAN);
+    const expected = postureFor(PLAN);
+
+    expect(getByTestId("agent-safety-headline").textContent).toBe(expected.headline);
+    expect(getByTestId("agent-safety-qualifier").textContent).toBe(expected.qualifier);
+    // Not merely present: not hidden either. A qualifier folded behind the ⓘ is the
+    // compression the posture module's header says overclaims.
+    expect(getByTestId("agent-safety-qualifier").className).not.toContain("sr-only");
+    expect(getByTestId("agent-safety-qualifier").getAttribute("aria-hidden")).toBeNull();
+  });
+
+  test("plan mode's headline is the reviewed one, so a strip rendering the wrong field fails", () => {
+    const { getByTestId } = renderStrip(PLAN);
+    expect(getByTestId("agent-safety-headline").textContent).toBe("Executes nothing it drafts");
+  });
+
+  test("the qualifier wraps to a second line rather than being truncated", () => {
+    const { getByTestId } = renderStrip(BLOCKED);
+    expect(getByTestId("agent-safety-strip").className).toContain("flex-wrap");
+    expect(getByTestId("agent-safety-qualifier").className).not.toContain("truncate");
+    expect(getByTestId("agent-safety-qualifier").className).not.toContain("text-ellipsis");
+  });
+
+  test("the strip renders the posture and invents nothing — no connection name of its own", () => {
+    const { getByTestId } = renderStrip(READS);
+    const expected = postureFor(READS);
+    // Everything the strip says, in the order it says it. The connection name is the
+    // rail header's and stays there, so anything here that is not one of the posture's
+    // four fields is copy this component wrote by itself.
+    expect(getByTestId("agent-safety-strip").textContent).toBe(
+      `${expected.headline}${expected.qualifier}${expected.title}${expected.body}`,
+    );
+  });
+});
+
+describe("SafetyStrip tones", () => {
+  const CASES: ReadonlyArray<readonly [string, StripCase, AgentPostureTone]> = [
+    ["plan mode is safe", PLAN, "safe"],
+    ["agent mode on an executable engine reads", READS, "reads"],
+    ["a consented hand-over is widened", WIDENED, "widened"],
+    ["an engine with no read-only statement path is blocked", BLOCKED, "blocked"],
+    ["no resolved connection is blocked too", UNRESOLVED, "blocked"],
+  ];
+
+  for (const [name, input, tone] of CASES) {
+    test(`${name}, and the tone is the posture's own`, () => {
+      const { getByTestId } = renderStrip(input);
+      expect(postureFor(input).tone).toBe(tone);
+      // Carried as data rather than inferred from a class name, so a restyle cannot
+      // change which level this strip claims.
+      expect(getByTestId("agent-safety-strip").getAttribute("data-tone")).toBe(tone);
+      expect(getByTestId("agent-safety-headline").textContent).toBe(postureFor(input).headline);
+    });
+  }
+
+  test("each of the four tones paints a different pill", () => {
+    const painted = new Set<string>();
+    for (const input of [PLAN, READS, WIDENED, BLOCKED]) {
+      const { getByTestId, unmount } = renderStrip(input);
+      painted.add(getByTestId("agent-safety-headline").className);
+      unmount();
+    }
+    expect(painted.size).toBe(4);
+  });
+
+  test("no tone is written as a literal colour", () => {
+    for (const input of [PLAN, READS, WIDENED, BLOCKED, UNRESOLVED]) {
+      const { container, unmount } = renderStrip(input);
+      for (const node of container.querySelectorAll<HTMLElement>("[class]")) {
+        expect(node.className).not.toMatch(/#[0-9a-f]{3}/i);
+        expect(node.className).not.toMatch(/\b(rgb|hsl|oklch)\(/i);
+      }
+      unmount();
+    }
+  });
+});
+
+describe("SafetyStrip's info affordance", () => {
+  test("is a real button, not a span with a handler", () => {
+    const { getByTestId } = renderStrip(READS);
+    const info = getByTestId("agent-safety-info");
+
+    expect(info.tagName).toBe("BUTTON");
+    expect(info.getAttribute("type")).toBe("button");
+    // Named for a user who cannot see the pill: the label says which axis this is and
+    // which level the strip is on.
+    expect(info.getAttribute("aria-label")).toContain(postureFor(READS).headline);
+  });
+
+  test("is keyboard reachable and reports its own state", () => {
+    const { getByTestId } = renderStrip(READS);
+    const info = getByTestId("agent-safety-info") as HTMLButtonElement;
+
+    expect(info.getAttribute("aria-expanded")).toBe("false");
+    expect(info.hasAttribute("disabled")).toBe(false);
+    expect(info.getAttribute("tabindex")).toBeNull();
+
+    info.focus();
+    expect(document.activeElement).toBe(info);
+  });
+
+  test("toggles the claim open and shut", () => {
+    const { getByTestId } = renderStrip(WIDENED);
+    const info = getByTestId("agent-safety-info");
+    const claim = getByTestId("agent-safety-claim");
+
+    expect(claim.getAttribute("data-open")).toBe("false");
+
+    fireEvent.click(info);
+    expect(claim.getAttribute("data-open")).toBe("true");
+    expect(info.getAttribute("aria-expanded")).toBe("true");
+    expect(claim.className).not.toContain("sr-only");
+
+    fireEvent.click(info);
+    expect(claim.getAttribute("data-open")).toBe("false");
+    expect(info.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  /*
+    The keyboard path in full, on the ⓘ itself: it is the only focusable node in the strip,
+    so it is where a keyboard user is when the card is open and the only place Escape can
+    be pressed from.
+  */
+  test("Escape shuts an open claim and leaves focus on the button", () => {
+    const { getByTestId } = renderStrip(BLOCKED);
+    const info = getByTestId("agent-safety-info") as HTMLButtonElement;
+
+    info.focus();
+    fireEvent.click(info);
+    expect(getByTestId("agent-safety-claim").getAttribute("data-open")).toBe("true");
+
+    fireEvent.keyDown(info, { key: "Escape" });
+    expect(getByTestId("agent-safety-claim").getAttribute("data-open")).toBe("false");
+    expect(document.activeElement).toBe(info);
+  });
+
+  test("a key that is not Escape leaves the claim alone", () => {
+    const { getByTestId } = renderStrip(BLOCKED);
+    const info = getByTestId("agent-safety-info");
+    fireEvent.click(info);
+    fireEvent.keyDown(info, { key: "a" });
+    expect(getByTestId("agent-safety-claim").getAttribute("data-open")).toBe("true");
+  });
+
+  test("Escape on a shut claim is not an error", () => {
+    const { getByTestId } = renderStrip(BLOCKED);
+    fireEvent.keyDown(getByTestId("agent-safety-info"), { key: "Escape" });
+    expect(getByTestId("agent-safety-claim").getAttribute("data-open")).toBe("false");
+  });
+});
+
+describe("SafetyStrip's accessible description", () => {
+  test("the strip is described by the claim node, and the claim holds title and body", () => {
+    const { getByTestId } = renderStrip(BLOCKED);
+    const strip = getByTestId("agent-safety-strip");
+    const claim = getByTestId("agent-safety-claim");
+    const expected = postureFor(BLOCKED);
+
+    expect(claim.id.length).toBeGreaterThan(0);
+    expect(strip.getAttribute("aria-describedby")).toBe(claim.id);
+
+    // BOTH halves, and the body is the whole claim rather than a summary of it.
+    expect(claim.textContent).toContain(expected.title);
+    expect(claim.textContent).toContain(expected.body);
+    // The engine the mode cannot execute on is named, not implied.
+    expect(claim.textContent).toContain(getDBConfig(UNSUPPORTED_ENGINE).label);
+  });
+
+  test("the claim reaches assistive tech while the popover is visually shut", () => {
+    const { getByTestId } = renderStrip(PLAN);
+    const claim = getByTestId("agent-safety-claim");
+
+    // Shut, so it is out of the layout — and still rendered, still named by
+    // `aria-describedby`, and NOT `aria-hidden`, which would take it back out of the
+    // accessibility tree and leave the ⓘ as the only way to the claim.
+    expect(claim.getAttribute("data-open")).toBe("false");
+    expect(claim.className).toContain("sr-only");
+    expect(claim.getAttribute("aria-hidden")).toBeNull();
+    expect(claim.getAttribute("hidden")).toBeNull();
+    expect(claim.textContent).toContain(postureFor(PLAN).body);
+  });
+
+  test("the button points at the claim it toggles", () => {
+    const { getByTestId } = renderStrip(READS);
+    expect(getByTestId("agent-safety-info").getAttribute("aria-controls")).toBe(getByTestId("agent-safety-claim").id);
+  });
+
+  test("every posture's body reaches the description, on all four levels", () => {
+    for (const input of [PLAN, READS, WIDENED, BLOCKED, UNRESOLVED]) {
+      const { getByTestId, unmount } = renderStrip(input);
+      expect(getByTestId("agent-safety-claim").textContent).toContain(postureFor(input).body);
+      unmount();
+    }
+  });
+});

--- a/tests/components/rich-text.test.tsx
+++ b/tests/components/rich-text.test.tsx
@@ -189,3 +189,73 @@ describe("renderProse code hand-off to the editor", () => {
     expect(queryByTestId("prose-code-apply")).toBeNull();
   });
 });
+
+/**
+ * A block a surface beside this prose is already showing verbatim (L2, L5).
+ *
+ * Measured in Chrome on 2026-08-21: a plan run's closing prose HOLDS the fenced
+ * statement, so every surface that rendered that prose reprinted the statement — the
+ * answer card showed the statement, then the same statement again inside its own
+ * `Why this statement` fold, and the transcript entry below printed it a third time,
+ * each copy with its own clipboard.
+ *
+ * So the caller may name the ONE block it is already showing, and that block is not
+ * printed a second time. It is the same shape the per-block editor control's
+ * suppression already has — the caller says what the surface beside it is offering —
+ * and it is deliberately keyed on the TEXT rather than on a flag: the recorded
+ * deliverable is read out of the prose by `readPlanStatement`, which joins and trims
+ * the fence's lines exactly as this does, so the block that matches is the block the
+ * ledger took.
+ *
+ * What is NOT suppressed is the prose. Every other fence still renders, and `Copy all`
+ * — which takes the string the model wrote, not this rendering of it — still carries
+ * the whole text including the block that was not printed.
+ */
+describe("renderProse and a statement already shown beside it", () => {
+  test("does not print the one block a caller says is displayed beside it", () => {
+    const { container, queryByTestId } = render(
+      <div>
+        {renderProse(`Here is the read:\n${FENCE}sql\nSELECT 1;\n${FENCE}\nIt counts the rows.`, {
+          cardedStatement: "SELECT 1;",
+        })}
+      </div>,
+    );
+
+    expect(container.querySelector("pre")).toBeNull();
+    expect(queryByTestId("prose-code-copy")).toBeNull();
+    // The words around it are untouched: one block is not printed, nothing is edited.
+    expect(container.textContent).toContain("Here is the read:");
+    expect(container.textContent).toContain("It counts the rows.");
+  });
+
+  test("prints every other block, because only the displayed one is a second copy", () => {
+    const { container, getAllByTestId } = render(
+      <div>
+        {renderProse(`${FENCE}sql\nSELECT 1;\n${FENCE}\n${FENCE}sql\nSELECT 2;\n${FENCE}`, {
+          cardedStatement: "SELECT 1;",
+        })}
+      </div>,
+    );
+
+    expect(getAllByTestId("prose-code-copy")).toHaveLength(1);
+    const printed = [...container.querySelectorAll("pre")].map((block) => block.textContent);
+    expect(printed).toEqual(["SELECT 2;"]);
+  });
+
+  test("matches the block the ledger took, which is trimmed as this one is", () => {
+    // `readPlanStatement` records `lines.join("\n").trim()`, so a fence whose content is
+    // padded is the SAME statement as the one recorded from it. Comparing the raw text
+    // would leave the padded copy printed beside the card showing it.
+    const { container } = render(
+      <div>{renderProse(`${FENCE}sql\n  SELECT 1;  \n${FENCE}`, { cardedStatement: "SELECT 1;" })}</div>,
+    );
+
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  test("a caller that names nothing gets every block, which is what every other caller is", () => {
+    const { getAllByTestId } = render(<div>{renderProse(`${FENCE}sql\nSELECT 1;\n${FENCE}`, {})}</div>);
+
+    expect(getAllByTestId("prose-code-copy")).toHaveLength(1);
+  });
+});

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -212,6 +212,9 @@ run_group "Group 10/12: PoolTab" \
 # Group 11: Smoke tests (isolated - mock globalThis.fetch + MonitoringEmbed)
 run_group "Group 11/12: Smoke tests" \
   tests/components/agent/AgentRail.test.tsx \
+  tests/components/agent/AnswerCard.test.tsx \
+  tests/components/agent/ConsentCard.test.tsx \
+  tests/components/agent/SafetyStrip.test.tsx \
   tests/components/agent/use-agent-run.test.tsx \
   tests/components/admin/MonitoringEmbed.test.tsx \
   tests/components/VisualExplain.test.tsx \

--- a/tests/unit/agent-documentation.test.ts
+++ b/tests/unit/agent-documentation.test.ts
@@ -146,6 +146,65 @@ describe("the two companion pages exist and are reachable", () => {
 });
 
 /**
+ * The rail runs on MongoDB, Redis, Couchbase, Elasticsearch, OpenSearch, Druid,
+ * ClickHouse and Trino as well as on the two dialects the agent composes SQL for, and
+ * #414 took the SQL-and-tables vocabulary out of the surfaces themselves: the answer
+ * card lists identifiers it could not find as bare chips under a sentence about the
+ * inventory, `applyStatementName` builds its accessible name from `draft.noun.singular`,
+ * and the schema-capture entry renders the count in `noun.singular`/`noun.plural` — "17
+ * key patterns" on Redis, "3 datasources" on Druid.
+ *
+ * These pages are what the next change reads to learn what the panel is allowed to say,
+ * so prose describing those surfaces in tables and SQL is how the noun comes back. Each
+ * claim below is pinned against the code that decides the word, so the assertion fails
+ * whichever side drifts.
+ */
+describe("the panel's documentation describes the rail in the words it renders", () => {
+  const AGENT_GUIDE = read("docs/AGENT_GUIDE.md");
+  const ANSWER_CARD = read("src/components/agent/AnswerCard.tsx");
+  const RAIL_PARTS = read("src/components/agent/rail-parts.tsx");
+  const TIMELINE = read("src/components/agent/timeline.ts");
+
+  test("the answer card's identifier marking is documented in the noun the card uses", () => {
+    // What the card actually says about names the inventory does not hold, and where
+    // the control beside them takes its own noun from.
+    expect(ANSWER_CARD).toContain("These names are not in the inventory this run read");
+    expect(RAIL_PARTS).toContain("draft.noun.singular");
+
+    const row = AGENT_DOC.split("\n").find((line) => line.includes("One click that RAN the model's SQL"));
+    expect(row).toBeDefined();
+    // The first cell is about NL2SQL, which wrote SQL, so it says SQL. The cell that
+    // describes today's card is the second one, and the card names no engine's rows.
+    const instead = row?.split("|")[2] ?? "";
+    expect(instead).toContain("the inventory does not hold");
+    expect(instead).not.toMatch(/\btables?\b/i);
+  });
+
+  test("the one-hand-off rule is stated over the statement, not over SQL", () => {
+    // A plan run on MongoDB drafts an aggregation, so the general statement of the rule
+    // cannot be made about a language only some engines speak.
+    expect(AGENT_DOC).toContain("an unmarked control against the statement is the silent hand-off");
+    expect(AGENT_DOC).not.toContain("against the SQL");
+  });
+
+  test("the guide's Schema captured row states the engine's own noun, not a table count", () => {
+    // The renderer takes the word from the provider's labels, never from the shape the
+    // capture happens to be recorded in.
+    // A regex rather than the line, so a reflow of that ternary is not a doc failure.
+    expect(TIMELINE).toMatch(/tableCount === 1\s*\?\s*noun\.singular\s*:\s*noun\.plural/);
+
+    // The row, not the paragraph above it that also names the entry: the fingerprint is
+    // what only the row states.
+    const row = AGENT_GUIDE.split("\n").find(
+      (line) => line.includes("`Schema captured`") && line.includes("fingerprint"),
+    );
+    expect(row).toBeDefined();
+    expect(row).not.toContain("table count");
+    expect(row).toContain("the engine's own noun");
+  });
+});
+
+/**
  * The egress table states ranges over the frozen decision table, and a range is the
  * kind of figure that goes stale silently (#373 review): `maxModelTurns` still said
  * "20-48" after `data-analysis` landed at 60, so the page that answers "how much can

--- a/tests/unit/components/agent-hydration.test.ts
+++ b/tests/unit/components/agent-hydration.test.ts
@@ -148,7 +148,15 @@ describe("the agent rail's module boundary", () => {
   const AGENT_DIR = path.join(process.cwd(), "src/components/agent");
   const RAIL_MODULES = [
     "AgentRail.tsx",
+    // The three the 2026-08-21 redesign split out of `AgentRail.tsx`, plus the module
+    // holding what it and the answer card both render. They are listed for the same
+    // reason the rail is: what may not reach a rail module may not reach a module the
+    // rail renders, and a card that pulled in the grid would be a grid in the rail.
+    "AnswerCard.tsx",
+    "ConsentCard.tsx",
+    "SafetyStrip.tsx",
     "hydration.ts",
+    "rail-parts.tsx",
     "timeline.ts",
     "use-agent-artifact.ts",
     "use-agent-prefill.ts",

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -755,6 +755,89 @@ describe("foldLedgerEntries", () => {
     expect(view.items[0].headline).toBe("Run started in planning mode");
   });
 
+  /**
+   * What is SCAFFOLDING and what a run found, named by the fold (the rail redesign of
+   * 2026-08-21).
+   *
+   * The rail collapses the run's chrome behind one summary line, and the flag is why it
+   * can: matching headlines would make the app's own copy a protocol, and the first
+   * reworded headline would silently promote a chrome entry to a substantive one. What is
+   * chrome is a property of the event KIND, which is a fact this function holds.
+   */
+  describe("which entries are the run's own scaffolding", () => {
+    test("the header, the drive starting and the schema capture are all chrome", () => {
+      const view = foldLedgerEntries([
+        OPENED,
+        event({ kind: "event", event: { kind: "run-started", atMs: 2, mode: "agent" } }),
+        event({
+          kind: "event",
+          event: { kind: "context-captured", atMs: 3, fingerprint: "abcdef1234567890", tableCount: 12 },
+        }),
+      ]);
+
+      expect(view.items.map((item) => item.chrome)).toEqual([true, true, true]);
+      // And they are still folded in FULL: the flag is a presentation hint, not a filter,
+      // so the objective quoted under the header is still there to read.
+      expect(view.items[0].quoted).toBe("why is checkout slow");
+      expect(view.items[2].detail).toBe("12 tables, fingerprint abcdef12");
+    });
+
+    test("anything the run FOUND is not chrome", () => {
+      const view = foldLedgerEntries([
+        event({
+          kind: "event",
+          event: {
+            kind: "statement-drafted",
+            atMs: 4,
+            stepId: "s1",
+            sql: "SELECT 1",
+            rationale: "count the orders",
+          },
+        }),
+        event({ kind: "event", event: { kind: "run-finished", atMs: 9, status: "succeeded" } }),
+      ]);
+
+      expect(view.items.every((item) => item.chrome === undefined)).toBe(true);
+    });
+  });
+
+  /**
+   * The run's grounding, folded once for the surfaces that state where an answer came
+   * from rather than the order it arrived in.
+   */
+  describe("the capture a run was grounded on", () => {
+    const captured = (fingerprint: string, tableCount: number, noun?: unknown): AgentLedgerEntry =>
+      event({
+        kind: "event",
+        event: { kind: "context-captured", atMs: 3, fingerprint, tableCount, ...(noun === undefined ? {} : { noun }) },
+      } as AgentLedgerEntry & { kind: "event" });
+
+    test("it carries what the capture covered, in the word the capture recorded", () => {
+      const view = foldLedgerEntries([captured("ctx_druid00", 3, { singular: "datasource", plural: "datasources" })]);
+
+      expect(view.capture).toEqual({
+        fingerprint: "ctx_druid00",
+        tableCount: 3,
+        noun: { singular: "datasource", plural: "datasources" },
+      });
+    });
+
+    test("a run that captured nothing has no capture, which is not an empty one", () => {
+      expect(foldLedgerEntries([OPENED]).capture).toBeNull();
+    });
+
+    test("a run that captured twice reports the reading it finished with", () => {
+      // A citation is resolved by fingerprint and keeps every capture; this field is the
+      // provenance of the ANSWER, and the answer was composed on the last reading.
+      const view = foldLedgerEntries([captured("ctx_first0", 2), captured("ctx_second", 9)]);
+
+      expect(view.capture?.fingerprint).toBe("ctx_second");
+      expect(view.capture?.tableCount).toBe(9);
+      // The default word, for a ledger written before the field: unchanged.
+      expect(view.capture?.noun).toEqual({ singular: "table", plural: "tables" });
+    });
+  });
+
   test("a captured schema reports what it covers, not the inventory", () => {
     const view = foldLedgerEntries([
       event({
@@ -1262,6 +1345,27 @@ describe("foldLedgerEntries — the budget meter", () => {
     }
   });
 
+  /**
+   * The run's OWN mode, which the fold already read for its wording and now states.
+   *
+   * The rail describes an open run from this rather than from the header toggle, which is
+   * live again the moment the run opens: a click on Plan beside a run that is executing
+   * reads used to relabel that run as plan mode on the safety strip and on the objective
+   * line beside it.
+   */
+  test("the run's own mode is folded from whichever entry carries it", () => {
+    expect(foldLedgerEntries([OPENED]).mode).toBe("agent");
+    expect(foldLedgerEntries([{ ...OPENED, mode: "planning" }]).mode).toBe("planning");
+    // A stream joined after the header has gone past reads it off `run-started`, which is
+    // the same pair of entries the wording is folded from.
+    const started = event({ kind: "event", event: { kind: "run-started", atMs: 2, mode: "planning" } });
+    expect(foldLedgerEntries([started]).mode).toBe("planning");
+    // And a ledger with neither reads as agent, because that is what such a fold has
+    // always been described with. The default is only reachable for a ledger whose
+    // beginning the rail does not hold.
+    expect(foldLedgerEntries([]).mode).toBe("agent");
+  });
+
   test("a run that has done nothing has consumed nothing", () => {
     const view = foldLedgerEntries([OPENED]);
 
@@ -1430,6 +1534,69 @@ describe("foldLedgerEntries — the report and its citations", () => {
     expect(citation.label).toBe("Artifact corr_9");
     expect(citation.detail).toBe("3 rows via sql.query.read");
     expect(citation.quoted).toBe("SELECT 1");
+  });
+
+  /*
+    A correlation id is a UUID in a real run, and a chip in a 384px panel cannot hold one:
+    `Artifact 722b2a10-e3f2-4b9c-8177-367359a21500` was measured filling one on 2026-08-21
+    with no room left for `detail`, which is the half that says what the read returned. So
+    the fold carries both readings of the same words — whole for the surface with the width
+    for it, and cut to the length the schema-snapshot label has always been written at for
+    the one without.
+  */
+  test("a citation names its evidence at two lengths, and the short one keeps the label's words", () => {
+    const view = foldLedgerEntries([
+      event({
+        kind: "event",
+        event: {
+          kind: "tool-completed",
+          atMs: 5,
+          stepId: "step_1",
+          artifact: {
+            correlationId: "722b2a10-e3f2-4b9c-8177-367359a21500",
+            runId: "arun_1",
+            operationId: "sql.query.read",
+            summary: { rowCount: 3, columnNames: ["a"], elapsedMs: 4 },
+          },
+        },
+      }),
+      reportOf([
+        {
+          claim: "checkout is slow",
+          evidence: [{ source: "artifact", correlationId: "722b2a10-e3f2-4b9c-8177-367359a21500" }],
+        },
+      ]),
+    ]);
+
+    const [citation] = view.report?.claims[0].citations ?? [];
+    expect(citation.label).toBe("Artifact 722b2a10-e3f2-4b9c-8177-367359a21500");
+    expect(citation.shortLabel).toBe("Artifact 722b2a10");
+  });
+
+  test("an unresolved artifact citation is named at both lengths too, because it is still a reference", () => {
+    const view = foldLedgerEntries([
+      reportOf([
+        {
+          claim: "checkout is slow",
+          evidence: [{ source: "artifact", correlationId: "722b2a10-e3f2-4b9c-8177-367359a21500" }],
+        },
+      ]),
+    ]);
+
+    const [citation] = view.report?.claims[0].citations ?? [];
+    expect(citation.resolved).toBe(false);
+    expect(citation.shortLabel).toBe("Artifact 722b2a10");
+  });
+
+  test("a schema citation's two labels are one string: a fingerprint is already read at that length", () => {
+    const view = foldLedgerEntries([
+      CAPTURED,
+      reportOf([{ claim: "orders is wide", evidence: [{ source: "context-snapshot", fingerprint: "fingerprint_9" }] }]),
+    ]);
+
+    const [citation] = view.report?.claims[0].citations ?? [];
+    expect(citation.shortLabel).toBe("Schema snapshot fingerpr");
+    expect(citation.shortLabel).toBe(citation.label);
   });
 
   test("an artifact read without a drafted statement cites the read alone", () => {

--- a/tests/unit/lib/agent/posture.test.ts
+++ b/tests/unit/lib/agent/posture.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, mock, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { AGENT_EXECUTION_ENGINES } from "@/lib/agent/engine-support";
+import { AGENT_HANDOVER_BUDGET, AGENT_WORKFLOW_BUDGETS } from "@/lib/agent/execution-policy";
+import { agentPosture, autoExecuteTerms } from "@/lib/agent/posture";
+import type { AgentRunWorkflowType } from "@/lib/agent/types";
+import { getDBConfig } from "@/lib/db-ui-config";
+
+/**
+ * The rail's one-axis reading of what the selected mode does to the database.
+ *
+ * Every claim in this module is a claim the server already enforces somewhere else, so the
+ * tests below check two different things and it matters which is which:
+ *
+ *  - the exact reviewed wording, because the strings were approved as written; and
+ *  - that every engine name and every number in that wording is DERIVED - from
+ *    `AGENT_EXECUTION_ENGINES`, from `CATALOG_PLANS` and from the policy rows - so a change
+ *    on the enforcing side cannot leave a stale claim behind. The last describe block is
+ *    that guard: it substitutes a third engine and fails if the copy does not follow.
+ */
+
+const labelsOf = (types: readonly string[]): string =>
+  types.map((type) => getDBConfig(type as Parameters<typeof getDBConfig>[0]).label).join(" and ");
+
+const EXECUTION_ENGINE_NAMES = labelsOf(AGENT_EXECUTION_ENGINES);
+const WORKFLOW_TYPES = Object.keys(AGENT_WORKFLOW_BUDGETS) as AgentRunWorkflowType[];
+const STATEMENT_BUDGETS = AGENT_WORKFLOW_BUDGETS.investigation.policy.budgets;
+
+/**
+ * The dialects whose grounding capture is a COMPOSED CATALOG READ, read out of
+ * `context-snapshot.ts` as source text rather than imported.
+ *
+ * `CATALOG_PLANS` is module-private, and its module imports `node:crypto` and the tool
+ * layer, so a posture module that imported it would stop being client-safe - which is the
+ * rule `engine-support.ts` records in its own header. So the production module mirrors the
+ * set, and this reads the real one to keep the mirror honest: a dialect added to
+ * `CATALOG_PLANS` fails this file until the posture copy names it.
+ */
+function catalogPlanDialects(): string[] {
+  const source = fs.readFileSync(path.join(process.cwd(), "src/lib/agent/context-snapshot.ts"), "utf8");
+  const block = /const CATALOG_PLANS: Partial<Record<DatabaseType, CatalogPlan>> = \{\n([\s\S]*?)\n\};/.exec(source);
+  expect(block).not.toBeNull();
+  const body = block?.[1] ?? "";
+  return [...body.matchAll(/^ {2}([a-z]+): \{/gm)].map((entry) => entry[1] as string);
+}
+
+describe("agentPosture in plan mode", () => {
+  test("reads the same on every engine, and says what its one reach is", () => {
+    const posture = agentPosture({
+      mode: "planning",
+      engine: "postgres",
+      engineLabel: getDBConfig("postgres").label,
+      handover: false,
+    });
+
+    expect(posture.tone).toBe("safe");
+    expect(posture.headline).toBe("Executes nothing it drafts");
+    expect(posture.qualifier).toBe("one schema read grounds it, nothing else reaches the database");
+    expect(posture.title).toBe("Plan mode drafts, and never runs what it drafted");
+    expect(posture.body).toBe(
+      `Plan mode never executes the statement it wrote, on any engine — production included. Its one reach is the schema capture that grounds it: metadata only, no data rows, and it is where the inventory in Run details came from. On ${labelsOf(catalogPlanDialects())} that capture is itself a catalog read; on every other engine it asks the provider to describe its own schema.`,
+    );
+  });
+
+  test("an engine agent mode cannot execute on gets the identical plan posture", () => {
+    const onMongo = agentPosture({
+      mode: "planning",
+      engine: "mongodb",
+      engineLabel: getDBConfig("mongodb").label,
+      handover: false,
+    });
+    const onPostgres = agentPosture({
+      mode: "planning",
+      engine: "postgres",
+      engineLabel: getDBConfig("postgres").label,
+      handover: false,
+    });
+
+    expect(onMongo).toEqual(onPostgres);
+  });
+
+  test("the hand-over tick cannot widen plan mode", () => {
+    const ticked = agentPosture({
+      mode: "planning",
+      engine: "postgres",
+      engineLabel: getDBConfig("postgres").label,
+      handover: true,
+    });
+
+    expect(ticked.tone).toBe("safe");
+    expect(ticked.headline).toBe("Executes nothing it drafts");
+  });
+
+  test("no resolved connection still reads as plan mode, which is engine-independent", () => {
+    const unresolved = agentPosture({ mode: "planning", engine: null, engineLabel: "", handover: false });
+
+    expect(unresolved.tone).toBe("safe");
+    expect(unresolved).toEqual(
+      agentPosture({
+        mode: "planning",
+        engine: "sqlite",
+        engineLabel: getDBConfig("sqlite").label,
+        handover: false,
+      }),
+    );
+  });
+});
+
+describe("agentPosture in agent mode, on an engine it can execute on", () => {
+  test("without the hand-over it names the bounds the engine enforces", () => {
+    const posture = agentPosture({
+      mode: "agent",
+      engine: "postgres",
+      engineLabel: getDBConfig("postgres").label,
+      handover: false,
+    });
+    const rows = STATEMENT_BUDGETS.maxResultRows;
+    const seconds = STATEMENT_BUDGETS.statementTimeoutMs / 1000;
+
+    expect(posture.tone).toBe("reads");
+    expect(posture.headline).toBe("Reads only");
+    expect(posture.qualifier).toBe(`${rows} rows and ${seconds} s per statement, enforced by the engine`);
+    expect(posture.title).toBe("Agent mode reads, under a boundary the engine enforces");
+    expect(posture.body).toBe(
+      `Agent mode runs statements it wrote itself, in a read-only session the database enforces, bounded to ${rows} rows and ${seconds} seconds each. Writes and DDL are refused by the engine rather than by reading the statement. Nothing reaches your editor unless you tick the hand-over when the run opens.`,
+    );
+  });
+
+  test("every executable engine reads the same, on the same tone", () => {
+    for (const engine of AGENT_EXECUTION_ENGINES) {
+      const posture = agentPosture({
+        mode: "agent",
+        engine,
+        engineLabel: getDBConfig(engine).label,
+        handover: false,
+      });
+      expect(posture.tone).toBe("reads");
+      expect(posture.headline).toBe("Reads only");
+    }
+  });
+
+  test("with the hand-over it is widened, and its body is the consent's own terms", () => {
+    const posture = agentPosture({
+      mode: "agent",
+      engine: "sqlite",
+      engineLabel: getDBConfig("sqlite").label,
+      handover: true,
+    });
+
+    expect(posture.tone).toBe("widened");
+    expect(posture.headline).toBe("Reads only, and one statement in your editor");
+    expect(posture.qualifier).toBe(
+      `${AGENT_HANDOVER_BUDGET.maxResultRows} rows, no time limit, same read-only session`,
+    );
+    expect(posture.title).toBe("Reads only, and one statement lands in your editor");
+    expect(posture.body).toBe(autoExecuteTerms("investigation"));
+  });
+});
+
+describe("agentPosture in agent mode, where it cannot execute", () => {
+  test("an unsupported engine is blocked, and the copy names what still runs", () => {
+    const posture = agentPosture({
+      mode: "agent",
+      engine: "mongodb",
+      engineLabel: getDBConfig("mongodb").label,
+      handover: false,
+    });
+
+    expect(posture.tone).toBe("blocked");
+    expect(posture.headline).toBe("Cannot execute on MongoDB");
+    expect(posture.qualifier).toBe("plan mode drafts here, and the operations workflow still runs");
+    expect(posture.title).toBe("Agent mode has no read-only statement path on MongoDB");
+    expect(posture.body).toBe(
+      `Agent mode executes only where the provider implements a database-native read-only statement path — ${EXECUTION_ENGINE_NAMES}. On MongoDB a profiled acquisition is refused and the run ends engine-unsupported before its first statement. The operations workflow still runs here, because it sends no statement at all: it calls the curated reporting methods every provider implements. Plan mode drafts on every engine.`,
+    );
+  });
+
+  test("the hand-over tick cannot unblock an unsupported engine", () => {
+    const posture = agentPosture({
+      mode: "agent",
+      engine: "oracle",
+      engineLabel: getDBConfig("oracle").label,
+      handover: true,
+    });
+
+    expect(posture.tone).toBe("blocked");
+    expect(posture.headline).toBe("Cannot execute on Oracle");
+    expect(posture.body).toContain("On Oracle a profiled acquisition is refused");
+  });
+
+  test("no resolved connection claims nothing about an engine it has not seen", () => {
+    const posture = agentPosture({ mode: "agent", engine: null, engineLabel: "", handover: false });
+
+    expect(posture.tone).toBe("blocked");
+    expect(posture.headline).toBe("Cannot execute yet");
+    expect(posture.qualifier).toBe("no connection is resolved, so no engine has been established");
+    expect(posture.title).toBe("Agent mode has no connection to execute on");
+    expect(posture.body).toBe(
+      `Agent mode executes only where the provider implements a database-native read-only statement path — ${EXECUTION_ENGINE_NAMES}. No connection is resolved here, so this panel cannot say which engine you are on, or whether it is one of those: until one is resolved, agent mode executes nothing. The operations workflow sends no statement at all, so it runs wherever a connection does, and plan mode drafts on every engine.`,
+    );
+  });
+
+  test("the unresolved reading never states an engine label, not even an empty one", () => {
+    const posture = agentPosture({ mode: "agent", engine: null, engineLabel: "Postgres-shaped guess", handover: true });
+
+    expect(posture.headline).toBe("Cannot execute yet");
+    expect(posture.body).not.toContain("Postgres-shaped guess");
+  });
+});
+
+describe("autoExecuteTerms", () => {
+  test("names the run's own bounds and the editor's, for every workflow", () => {
+    for (const workflowType of WORKFLOW_TYPES) {
+      const budgets = AGENT_WORKFLOW_BUDGETS[workflowType].policy.budgets;
+      const terms = autoExecuteTerms(workflowType);
+
+      expect(terms).toContain(
+        `bounded to ${budgets.maxResultRows} rows and ${budgets.statementTimeoutMs / 1000} seconds`,
+      );
+      expect(terms).toContain(
+        `at the editor's ${AGENT_HANDOVER_BUDGET.maxResultRows}-row limit and with no time limit`,
+      );
+      expect(terms).toContain(
+        "It is the same database-enforced read-only session either way, so writes and DDL are refused by the engine rather than by reading the statement.",
+      );
+    }
+  });
+
+  /**
+   * The widened posture carries no workflow, so it can only state one pair of figures.
+   * That is honest exactly while every row states the same pair - `workflowBudget()` writes
+   * `statementTimeoutMs` and `maxResultRows` once and varies only the per-run ceilings. If a
+   * row ever varies them this fails, and the fix is to give the posture a workflow rather
+   * than to edit a digit.
+   */
+  test("every workflow row agrees on the per-statement bounds the posture states", () => {
+    for (const workflowType of WORKFLOW_TYPES) {
+      const budgets = AGENT_WORKFLOW_BUDGETS[workflowType].policy.budgets;
+      expect(budgets.maxResultRows).toBe(STATEMENT_BUDGETS.maxResultRows);
+      expect(budgets.statementTimeoutMs).toBe(STATEMENT_BUDGETS.statementTimeoutMs);
+      expect(autoExecuteTerms(workflowType)).toBe(
+        agentPosture({
+          mode: "agent",
+          engine: "postgres",
+          engineLabel: getDBConfig("postgres").label,
+          handover: true,
+        }).body,
+      );
+    }
+  });
+});
+
+/**
+ * Kept last in the file on purpose: `mock.module` is process-wide, so this substitution
+ * would otherwise be read by every test after it. It is restored at the end regardless.
+ */
+describe("the engine names follow the enforcing list", () => {
+  test("an engine added to AGENT_EXECUTION_ENGINES changes the copy with no copy edit", async () => {
+    const real = [...AGENT_EXECUTION_ENGINES];
+    try {
+      mock.module("@/lib/agent/engine-support", () => ({
+        AGENT_EXECUTION_ENGINES: ["postgres", "sqlite", "mysql"],
+      }));
+      const { agentPosture: withThree } = await import("@/lib/agent/posture");
+      const blocked = withThree({
+        mode: "agent",
+        engine: "mongodb",
+        engineLabel: getDBConfig("mongodb").label,
+        handover: false,
+      });
+
+      expect(blocked.body).toContain("path — PostgreSQL and SQLite and MySQL.");
+      expect(withThree({ mode: "agent", engine: "mysql", engineLabel: "MySQL", handover: false }).tone).toBe("reads");
+    } finally {
+      mock.module("@/lib/agent/engine-support", () => ({ AGENT_EXECUTION_ENGINES: real }));
+    }
+  });
+
+  test("the list is read per call, so nothing in the copy is frozen at module load", () => {
+    expect(agentPosture({ mode: "agent", engine: "mongodb", engineLabel: "MongoDB", handover: false }).body).toContain(
+      `path — ${EXECUTION_ENGINE_NAMES}.`,
+    );
+  });
+});


### PR DESCRIPTION
## Why

The rail put the run's answer at the bottom of a wall of prose. Before a reader reached the statement
it drafted, the panel had spent about 150 words on budget semantics, printed the same statement twice,
and stated the guard's verdict three times — all at one weight, in one grey. A data analyst asking
"which country has the most orders" could not find the query the run wrote for them.

**This is a presentation change.** No request, no ledger record and no claim's wording changes. Every
sentence that moved kept its exact text, and the ones that moved out of sight moved into an info
popover that is the accessible description of the figure it qualifies.

## What the panel now does

- **The answer is first.** A fixed answer region at the top of the scroll area renders the outcome per
  state: the drafted statement in plan mode, the model's quoted claim in agent mode, the live step
  while running, an amber card when nothing was drafted, and a failure note that no longer hides a
  product the run did record (a run that drafted a statement and then ran out of turns used to render
  only the failure banner).
- **One hand-off.** `Apply to editor` is the primary control, sits against the statement, and exists
  exactly once in the rail on every path — carrying the accessible name `applyStatementName` builds,
  which is the reason a plan run is allowed to draft a write at all.
- **A standing safety strip**, answering one question — what does this mode EXECUTE? — in four levels,
  with the qualifier visible rather than compressed into the pill:

  | mode / engine | pill | qualifier |
  |---|---|---|
  | plan, any engine | `Executes nothing it drafts` | one schema read grounds it, nothing else reaches the database |
  | agent, PostgreSQL / SQLite | `Reads only` | 200 rows and 10 s per statement, enforced by the engine |
  | agent, hand-over consented | `Reads only, and one statement in your editor` | 500 rows, no time limit, same read-only session |
  | agent, any other engine | `Cannot execute on <engine>` | plan mode drafts here, and the operations workflow still runs |

  A bare "executes nothing" would overclaim: on the dialects `CATALOG_PLANS` serves, plan mode's
  grounding capture IS a catalog read. Both halves therefore stay on one line, and the popover carries
  the whole claim. Every engine name and figure is derived (`AGENT_EXECUTION_ENGINES`, the workflow
  policy, `AGENT_HANDOVER_BUDGET`) — not one literal — and the wording is the login hero's, so the two
  surfaces cannot drift.
- **Agent mode on an engine it cannot execute on says so before the run**, with `Switch to Plan`.
  Start is deliberately NOT gated: the `operations` workflow sends no statement and runs everywhere, so
  disabling Start would withhold a workflow over a claim that is not true of it. `docs/BACKLOG.md`'s
  B38 was rewritten to say what actually landed and what was refused.
- **The consent step states its default.** "Nothing runs in your editor unless you ask for it below",
  the tick stays off, `Open` becomes `Start run`, and `autoExecuteTerms`' paragraph moves verbatim
  behind an info control while remaining the checkbox's `aria-describedby`.
- **The budget moved below the answer.** Gauges and their three claims live in a collapsed
  `Run details` whose summary carries the live figures. `agent-budget-limits`, `-reserve` and
  `-caveats` still resolve to their exact text.
- **Nothing generic says "SQL".** The product's noun for the drafted artifact is "statement"; row nouns
  come from `inventoryNoun`, so a MongoDB run reads `5 collections read` and a Redis run `key patterns`;
  a Mongo aggregation is not painted as SQL; and where the guard could not read the statement the card
  says so instead of showing a `Read-only` chip no code earned.

## New modules

`src/lib/agent/posture.ts` (the single reading, client-safe, every figure derived), `SafetyStrip.tsx`,
`AnswerCard.tsx`, `ConsentCard.tsx`, `rail-parts.tsx`. `AgentRail.tsx` kept its size while about 1500
lines of presentation moved into units that can be tested on their own.

## Verification

Six local gates green, plus `bash tests/run-core.sh` 327/327 files, all 30 component groups, and
`coverage:check` at **100.00% (39993/39993 lines)**.

**Driven in Chrome against a real build, live PostgreSQL, live MongoDB and live Gemini** — `bun dev`
cannot log in (its CSP omits `unsafe-eval`), so this was `bun run build` + `bun run start`. Four real
runs. That drive found eight defects the gates structurally cannot see, every one measured out of the
DOM rather than inferred:

| | measured before | after the fix |
|---|---|---|
| answer card position when the run ends | `scrollTop` 224/224 (plan), 248/248 (agent); card 248px above the fold | `scrollTop` 0, card is the scroller's first child |
| apply controls visible at once (agent run) | 3, none carrying an accessible name | 1, named by `applyStatementName` |
| the claim on an agent run | printed twice (card + a surviving report section) | once; the old section is gone, its citations are the card's evidence fold |
| the statement | reprinted inside the card's fold and again in the transcript | one node |
| guard reading | stated three times | once, plus the marked one-line reference |
| provenance chips on MongoDB | only `not checked` — inventory and fingerprint absent | `not checked` · `5 collections read` · `ctx_ae00` |
| pre-start posture line | repeated the strip verbatim | removed |
| citation chip | `Artifact 722b2a10-e3f2-4b9c-8177-367359a21500` | `Artifact c2d65888 · 5 rows via sql.query.read` |

Three earlier review lenses (claims/testids, engine-neutral vocabulary, accessibility) found 14
further defects, all closed and independently verified; the one blocker among them was a failed run
shadowing a statement it had recorded, which was a regression against `main`.

The run ledger under `.workflow-data` agrees with what the strip claimed for the agent run:
`autoExecute: false`, one `run_read_query` via `sql.query.read`, one claim, two citations,
`goalVerdict: answered`.

## Two deliberate deviations, declared

- `Run details` sits as a collapsed one-line handle **above** the scroll area rather than at the very
  bottom of it. Keeping the answer as the scroller's first child is what makes the follow-the-run fix
  work; the disclosure stays reachable without scrolling past a long transcript.
- Three testids were renamed with the block they belong to: `agent-plan-apply-statement` →
  `agent-answer-plan-apply`, `agent-plan-statement-copy` → `agent-answer-statement-copy`,
  `agent-plan-statement-guard` → `agent-answer-guard`. The five ids that carry frozen CLAIMS
  (`agent-plan-statement-guard-unread`, `-unread`, `-unchecked`, `-unknown`, `-caveat`) kept their
  names, because those are the contract on the claims rather than on a region. One negative assertion
  that had silently become vacuous against a renamed id was repaired rather than left green.

One copy change is deliberate and pinned: `agent-budget-unknown` reads "Every ceiling **here** is per
workflow" where it read "below" — "below" stopped being true once the ceilings moved into a sibling
popover. The full sentence is now asserted with `toBe` so the next reflow cannot move it silently.
