### PR TITLE
docs(count): nine places still said thirteen engines, and the fixture table had no way to reach Cassandra

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino
 type: application
-version: 0.1.42
+version: 0.1.43
 appVersion: "0.12.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio

--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: libredb-studio
-description: Web-based SQL IDE for cloud-native teams supporting thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino
+description: Web-based SQL IDE for cloud-native teams supporting fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra
 type: application
 version: 0.1.43
 appVersion: "0.12.0"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -2,7 +2,7 @@
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/libredb-studio)](https://artifacthub.io/packages/search?repo=libredb-studio)
 
-Web-based SQL IDE for cloud-native teams supporting thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino.
+Web-based SQL IDE for cloud-native teams supporting fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra.
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.42 \
+  --version 0.1.43 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -33,15 +33,25 @@ partner contact.
 > `UPDATE` or `CREATE TABLE` — so "manage data across …" must not be extended to include
 > them.
 >
-> The chart's own `description` in `Chart.yaml` names thirteen and **has not been updated
-> for Cassandra**, deliberately: `charts/libredb-studio/` is a packaged path, so editing it
-> requires a `Chart.yaml` version bump in the same PR (#167's required check) plus the
-> README `--version` examples and the `operator/helm-charts` mirror. That is a
-> release-coupled change and it belongs to whoever cuts the next chart, not to the PR that
-> added the engine. The same applies to every marketplace and packaging description that
-> spells the count (`deploy/azure`, `deploy/railway`, `deploy/caprover`, `packaging/*`,
-> `desktop/src-tauri/tauri.conf.json`, the operator CSVs): all of them describe a released
-> artifact. Read the number from `SHIPPED` when you update them.
+> **The chart's own `description` is not release-coupled and does name Cassandra.** An
+> earlier revision of this note said it deliberately did not, on the reasoning that
+> `charts/libredb-studio/` is a packaged path and editing it drags in a `Chart.yaml` version
+> bump (#167's required check), the README `--version` examples and the `operator/helm-charts`
+> mirror. Those four edits are the cost, not a reason to defer: the chart has been carried
+> with the engine since [#438](https://github.com/libredb/libredb-studio/pull/438), which
+> moved the description to thirteen and 0.1.39 to 0.1.40 in the PR that added Trino. Cassandra
+> followed the same path at chart 0.1.43. So a PR that adds an engine updates all four files;
+> it does not hand them to whoever cuts the next chart. Note the mirror must stay
+> byte-identical — run `bun run chart:bump` rather than editing
+> `operator/helm-charts/libredb-studio/` by hand, or the sync guard fails the required check.
+>
+> What *is* release-coupled is every marketplace and packaging description that spells the
+> count: `deploy/azure`, `deploy/railway`, `deploy/caprover`, `packaging/winget`,
+> `packaging/chocolatey`, `packaging/homebrew` and `desktop/src-tauri/tauri.conf.json` all
+> still say thirteen, because each describes an artifact a user can already download and
+> 0.12.0 ships no Cassandra provider. Read the number from `SHIPPED` when a tag carries it.
+> (`packaging/linux/nfpm.yaml` and the operator CSVs are the exception: both are consumed at
+> release time from `main`, so they name fourteen now and the next tag publishes it.)
 
 ## Listing facts
 

--- a/deploy/rancher/E2E_VALIDATION_TASK.md
+++ b/deploy/rancher/E2E_VALIDATION_TASK.md
@@ -276,9 +276,9 @@ Common conventions for every scenario:
   install works zero-config there as it does from the live Helm repo. The scenario still
   only previews catalog presentation - installing from it is S1's job, not this one.
 - **Known and expected:** the card's description line comes from `Chart.yaml`, which now
-  names thirteen engines, while the app-readme still names ten. The ten-engine wording is
+  names fourteen engines, while the app-readme still names ten. The ten-engine wording is
   deliberate and version-scoped — the catalog prose describes a released version and stays
-  at ten until a tag ships Elasticsearch, OpenSearch and Apache Trino — so this mismatch is
+  at ten until a tag ships Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra — so this mismatch is
   expected, is tracked in `CATALOG_LISTING.md`, and must NOT be reported as a rendering
   failure. Record a screenshot/API dump of the card.
 

--- a/docs/DATABASE_PROVIDERS.md
+++ b/docs/DATABASE_PROVIDERS.md
@@ -146,7 +146,7 @@ QueryEditor                      /api/db/query
 
 ## Supported Databases
 
-Fourteen type-ids are supported by thirteen provider modules — `elasticsearch` and `opensearch` share
+Fifteen type-ids are supported by fourteen provider modules — `elasticsearch` and `opensearch` share
 one, `providers/sql/search/`. The count is derived from the exhaustive `SHIPPED` record in
 [`src/lib/db/compatibility.ts`](../src/lib/db/compatibility.ts) rather than written here twice. For
 the per-provider reference (driver, pooling, query format,

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -145,9 +145,11 @@ grid. Each row was verified against the running container on 2026-08-19, and the
 2026-08-20 — the credentials are the ones the fixture actually accepts, not the ones its environment
 block asks for (twice those differ; see the notes).
 
-Start the twelve always-on services with a plain `docker compose -f database-compose.yml up -d` -
-eleven engine containers plus the one-shot `couchbase-init` seed sidecar; the `Profile` column names
-the ones that need asking for.
+Start the thirteen always-on services with a plain `docker compose -f database-compose.yml up -d` -
+twelve engine containers plus the one-shot `couchbase-init` seed sidecar; the `Profile` column names
+the ones that need asking for. The count is derived, not written: a service in this file carries no
+`profiles:` key precisely when it backs a SHIPPED provider, so a plain `up -d` can reproduce that
+provider's integration pass.
 
 | Provider | Compose service | Host | Port | User | Password | Database / service | Profile |
 |---|---|---|---|---|---|---|---|
@@ -163,6 +165,7 @@ the ones that need asking for.
 | Elasticsearch | `elasticsearch` | localhost | 9200 | *none* | *none* | *none* | — |
 | OpenSearch | `opensearch` | localhost | **9201** | *none* | *none* | *none* | — |
 | Apache Trino | `trino` | localhost | 8080 | *none* | *none* | `tpch` (catalog) | — |
+| Apache Cassandra | `cassandra` | localhost | **19042** | *none* | *none* | `probe` (keyspace) | — |
 | SQLite | *no service* | — | — | — | — | a file path on the Studio host | — |
 | LibreDB | *no service* | — | — | — | — | a directory on the Studio host | — |
 
@@ -173,6 +176,14 @@ security extension in a default install, both search services run with their sec
 connection**: the coordinator answers `401 Password not allowed for insecure authentication` even
 with authentication off, so a password breaks a connection that works without one
 ([trino.md §4.3](./trino.md#43-tls-and-the-password-rule)).
+
+**Cassandra needs one field this table has no column for, and will not connect without it.** `Local
+Data Center` must be `datacenter1` - a stock single node names its own data centre that, and the
+driver refuses to open a session when the field is empty rather than defaulting to the only data
+centre it can see ([cassandra.md §3.4](./cassandra.md#34-localdatacenter-is-a-required-connection-field-and-nothing-else-here-has-one)).
+Its port is the second thing to watch: the compose service publishes the native protocol on **19042**
+rather than 9042, while the connection dialog prefills the default, so leaving the port untouched
+answers `ECONNREFUSED`. `docker port libredb-cassandra` prints the mapping.
 
 **The two embedded providers have no container, and that is the whole point of them.** SQLite takes a
 path resolved *in the Studio process* and LibreDB a directory; neither reaches a network. Both also

--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -22,10 +22,11 @@ metadata:
     capabilities: Basic Install
     categories: Database, Developer Tools
     containerImage: ghcr.io/libredb/libredb-studio-operator:0.12.0
-    createdAt: "2026-08-19T11:25:23Z"
-    description: Open-source web-based SQL IDE for thirteen engines - PostgreSQL,
+    createdAt: "2026-08-21T10:50:26Z"
+    description: Open-source web-based SQL IDE for fourteen engines - PostgreSQL,
       MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache
-      Druid, Elasticsearch, OpenSearch and Apache Trino - with AI-powered query assistance.
+      Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra - with AI-powered
+      query assistance.
     operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/libredb/libredb-studio

--- a/operator/config/manifests/bases/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/libredb-studio-operator.clusterserviceversion.yaml
@@ -6,9 +6,10 @@ metadata:
     capabilities: Basic Install
     categories: Database, Developer Tools
     containerImage: ghcr.io/libredb/libredb-studio-operator:0.0.0
-    description: Open-source web-based SQL IDE for thirteen engines - PostgreSQL,
+    description: Open-source web-based SQL IDE for fourteen engines - PostgreSQL,
       MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache
-      Druid, Elasticsearch, OpenSearch and Apache Trino - with AI-powered query assistance.
+      Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra - with AI-powered
+      query assistance.
     repository: https://github.com/libredb/libredb-studio
     support: LibreDB
   labels:

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: libredb-studio
-description: Web-based SQL IDE for cloud-native teams supporting thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino
+description: Web-based SQL IDE for cloud-native teams supporting fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra
 type: application
-version: 0.1.42
+version: 0.1.43
 appVersion: "0.12.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -2,7 +2,7 @@
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/libredb-studio)](https://artifacthub.io/packages/search?repo=libredb-studio)
 
-Web-based SQL IDE for cloud-native teams supporting thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino.
+Web-based SQL IDE for cloud-native teams supporting fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra.
 
 ## Prerequisites
 

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.42 \
+  --version 0.1.43 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -23,9 +23,9 @@ section: database
 priority: optional
 maintainer: cevheri <cevheribozoglan@gmail.com>
 description: |
-  Web-based SQL IDE for thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
-  MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and
-  Apache Trino - with AI query assistance.
+  Web-based SQL IDE for fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
+  MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch,
+  Apache Trino and Apache Cassandra - with AI query assistance.
   Ships the standalone Next.js server with a bundled private Node.js
   runtime (no external dependencies) and a systemd unit (libredb-studio)
   serving the app on port 3000; enable it with


### PR DESCRIPTION
docs(count): nine places still said thirteen engines, and the fixture table had no way to reach Cassandra

Apache Cassandra shipped in #448 and the README, the localized READMEs, DOCKERHUB.md and
`docs/BRAND_MESSAGING.md` were all updated with it. Nine other places were not, and
`grep -n thirteen` found every one of them. Each is public: an ArtifactHub page, an
OperatorHub listing, a Linux package description, a Marketplace listing draft.

- `charts/libredb-studio/README.md` said thirteen and omitted Cassandra. This is the page
  ArtifactHub renders, so the chart version had to move with it: 0.1.42 is published, and
  the required check refuses a packaged-file change without a bump (#167). Bumped to
  0.1.43 by hand, since `chart:bump` will not touch `version` while `appVersion` is already
  in sync, and the README's own `--version` example moved with it.
- `operator/helm-charts/libredb-studio/{Chart.yaml,README.md}` carry the same copy for the
  operator's vendored mirror of that chart, bumped the same way.
- The operator CSV description reaches OperatorHub. Edited in `operator/config/manifests/bases`,
  which is the source, and the bundle regenerated with `make -C operator bundle` rather
  than hand-edited: CI re-runs that generation and diffs the result, so a hand-wrapped
  string would have failed the check even when the words were right.
- `packaging/linux/nfpm.yaml` is the description apt and rpm show.
- `docs/DATABASE_PROVIDERS.md` was stale on BOTH of its numbers - "fourteen type-ids ...
  thirteen provider modules" is now fifteen and fourteen. The two are different counts and
  drifted together: `elasticsearch` and `opensearch` still share one module, which is the
  whole reason the second number is one lower.

The fixture table in `docs/providers/README.md` was the one with a cost attached rather
than an inconsistency. It had no Cassandra row at all, and this is the table a developer
reads to connect to the local stack, so its absence cost a full browser run today:

- The compose service publishes the native protocol on host port **19042**, not 9042, while
  the connection dialog prefills the default. Leaving the port untouched answers
  `ECONNREFUSED`, which reads as a broken driver. The table already records exactly this
  kind of deviation in bold for OpenSearch (9201), so the convention existed and only the
  row was missing.
- `Local Data Center` has no column, and the driver refuses to open a session without it,
  so the row alone would still leave a reader stuck. Stated in prose beside the Trino
  password rule, which is the same shape of field-level trap.
- The intro counted "twelve always-on services ... eleven engine containers". Measured
  against the compose file: thirteen and twelve. The count now states its own basis - a
  service carries no `profiles:` key precisely when it backs a shipped provider - so the
  next engine makes it wrong in a way that is visible rather than silent.

No code changed. `helm lint --strict` passes, and the chart and pin-matrix tests pass
against the bumped version.


---

**Follow-up commit — the mirror invariant needed both halves of the edit.** The first
revision gave `charts/libredb-studio/Chart.yaml` the version bump but not the
fourteen-engine description, and `operator/helm-charts/.../README.md` the description but
not the `--version` bump. The operator copy must be byte-identical, so either half alone is
a violation, reported twice: `chart:check` in the required lint job, and
`operatorCopyViolations` in `tests/unit/agent-documentation.test.ts:390`. Fixed the source
description and re-mirrored with `bun run chart:bump` rather than editing the copy by hand.

Two prose corrections came with it, both about this PR's own subject:

- `deploy/rancher/CATALOG_LISTING.md` said the chart description named thirteen and "has
  not been updated for Cassandra, deliberately", reasoning that a packaged path drags in a
  version bump, the README examples and the mirror. Those are the cost of the edit, not a
  reason to defer it - 5378636 (#438) moved the same four files to thirteen and 0.1.39 to
  0.1.40 in the PR that added Trino, so carrying the chart with the engine is the
  established path. Rewrote the paragraph, and kept the deferral for what it is still true
  of: the marketplace and packaging listings that describe an artifact a user can already
  download, none of which ships Cassandra at 0.12.0.
- `deploy/rancher/E2E_VALIDATION_TASK.md` told a validator to expect thirteen on the
  catalog card as a known-and-expected mismatch. One numeral, but a runbook naming the
  wrong expected value turns a correct render into a reported failure.
