### PR TITLE
fix(monitoring): five panels answered an absent measurement with a confident zero (#424)

### DIFF
--- a/docs/providers/cassandra.md
+++ b/docs/providers/cassandra.md
@@ -163,7 +163,13 @@ absence and zero are different facts: a zero is a measurement, and the Storage t
 formatted a `0 B` total and divided a 0.0% breakdown out of it. With the field absent the tab's two
 size cards read `N/A`, carry no percentage, and the breakdown is replaced by *"No storage size
 information available."* A provider that publishes a real `0` (Trino, Druid) has measured one and is
-unaffected. The **table, index and storage panels report nothing**. Two other engines are
+unaffected. The **table, index and storage panels report nothing** — and for the table panel that
+became true only when the same rule was applied there. Measured 2026-08-21 in Chrome against this
+node, the monitoring **Tables** tab still summarised the empty `getTableStats()` as *Tables* `0` over
+*0 rows*, *Size* `0 B` over *Total*, and *Vacuum* `0` over *OK*, in the very frame where the Overview
+tab read *Tables 6 / 2 indexes* out of `system_schema`: the `0 B` was the sentinel this section had
+just deleted, surviving one component over, and the *OK* was a clean bill of health for an operation
+Cassandra does not have at all ([§7.4](#74-the-panels-that-report-nothing)). Two other engines are
 recorded in `compatibility.ts` as failures for doing the opposite (Citus and TimescaleDB report row
 counts and sizes that are wrong rather than missing), and this provider is not going to join them.
 
@@ -638,6 +644,15 @@ second — there is no queries-per-second figure to read. `cacheHitRatio` itself
 server reports null (an unused cache): `DEFAULT_THRESHOLDS` scores that metric `direction: "below"`
 with `critical: 80`, so a substituted zero would paint an idle cluster red.
 
+Two panels read those absences, and both used to fill them in. The Overview tab's Performance card
+drew `bufferPoolUsage` as *0%* with an empty bar and `deadlocks` as a `0` badge in the healthy
+variant; the Performance tab's Buffer card rated the same `0` **Poor** in red, and its Deadlocks card
+badged `0` **Healthy** over *None detected* — a verdict on a measurement nobody made, and in the
+deadlock case a verdict read off a counter this engine does not keep. Both now read `N/A` beside the
+words *Not measured*, and the Buffer Pool and Deadlock trend charts say the same instead of drawing a
+flat line along zero. `cacheHitRatio` is the one field here that was measured, so it keeps its gauge
+and its rating.
+
 ### 7.3 Active sessions are running statements with no owner
 
 ```sql
@@ -660,12 +675,17 @@ connection list rather than a session list.
 
 ### 7.4 The panels that report nothing
 
-| Panel | Why empty |
-|---|---|
-| Slow queries | There is no aggregate of finished statements anywhere CQL can read. `system_views.system_logs` is a tail of the node's log file (0 rows on this image), and the slow-query threshold that exists writes to that log. **No statement is sent** to discover this |
-| Table statistics | `TableStats` needs a row count and a byte size; see [§3.2](#32-there-is-no-honest-row-count-and-no-honest-size). **No statement is sent** |
-| Index statistics | `system_schema.indexes` gives a name, a table and a target column — all of which the tree already shows — and `IndexStats` also wants a size and a scan count. Nothing reachable from CQL reports either, and a zeroed scan count reads as "never used" |
-| Storage statistics | The only storage figures a statement can read are whole mebibytes per table, so `databaseSizeBytes` is omitted rather than zeroed and the tab says so in words ([§3.2](#32-there-is-no-honest-row-count-and-no-honest-size)) |
+Each of these returns an empty list, and the second column is why. The third is what the panel does
+with it: an empty list is the only way a required field can decline, so a panel that reduces one into
+a total publishes a figure the engine refused to give — which is what the Tables and Queries tabs did
+here until the rule of [§3.2](#32-there-is-no-honest-row-count-and-no-honest-size) reached them.
+
+| Panel | Why empty | What it renders |
+|---|---|---|
+| Slow queries | There is no aggregate of finished statements anywhere CQL can read. `system_views.system_logs` is a tail of the node's log file (0 rows on this image), and the slow-query threshold that exists writes to that log. **No statement is sent** to discover this | *Queries*, *Avg Time* and *Slow* all read `N/A`. They used to read `0`, `0.00ms` and `0`, and an average over no statements is not zero milliseconds |
+| Table statistics | `TableStats` needs a row count and a byte size; see [§3.2](#32-there-is-no-honest-row-count-and-no-honest-size). **No statement is sent** | *Tables* and *Size* read `N/A`, and the list below them says *No table statistics available.* rather than *No tables found.* The tab separates the two cases by the **required** `overview.tableCount`, which `system_schema` fills honestly (6 here): tables the engine knows about, with statistics for none of them, means the figures are not knowable rather than that the keyspace is empty |
+| Index statistics | `system_schema.indexes` gives a name, a table and a target column — all of which the tree already shows — and `IndexStats` also wants a size and a scan count. Nothing reachable from CQL reports either, and a zeroed scan count reads as "never used" | There is no index panel; `IndexStats` feeds the Storage tab's *Indexes* card, which reads `N/A` on the absent `databaseSizeBytes` rather than on this list ([§3.2](#32-there-is-no-honest-row-count-and-no-honest-size)) |
+| Storage statistics | The only storage figures a statement can read are whole mebibytes per table, so `databaseSizeBytes` is omitted rather than zeroed and the tab says so in words ([§3.2](#32-there-is-no-honest-row-count-and-no-honest-size)) | Both size cards read `N/A` with no percentage, and the breakdown is replaced by *No storage size information available.* |
 
 ---
 
@@ -685,6 +705,16 @@ one of the six `MaintenanceType` values, and a user who wants it can type it.
 
 The two label triads are rewritten anyway — the cards do not render, but the inherited copy would
 promise a user that this panel updates planner statistics and reclaims space.
+
+`supportsMaintenance: false` is read in one more place than the maintenance controls. The monitoring
+**Tables** tab carries a *Vacuum* summary card, and it counted rows over a bloat ratio to decide
+between *Need* and *OK* — with no rows it said `0` over **OK** in green, which is a clean bill of
+health for an operation that does not exist here. Whether an engine *has* vacuum is a capability
+question rather than a data question, so the card now reads the declared capability and says `N/A`
+over *Not supported*. (The same tab's per-row *Last Vacuum* column now shows a dash rather than
+*Never* on an engine that declares no `vacuum` — on PostgreSQL a null there is the measurement "never
+vacuumed", elsewhere it is a history for an operation there is none of. No row of it renders here,
+because there are no table statistics to list at all.)
 
 ---
 

--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -1174,6 +1174,17 @@ the declared operations where it is `true`, and none at all until the metadata h
 never Druid-specific: `libredb.ts` also sets `supportsMaintenance: false` and had exactly the same
 dead buttons, so the fix landed once in shared UI for every provider.
 
+**The same tab's *Vacuum* summary card reads `N/A` over *Not supported* here**, and that is a second,
+later reading of the same declaration. The card counted table rows whose bloat ratio exceeded 10 and
+labelled the count *Need* or *OK*; Druid publishes no bloat ratio, so the count was always `0` and the
+label always a green **OK** — a clean bill of health for an operation this provider refuses. Whether
+an engine has vacuum is a capability question, so the card is now gated on `supportsMaintenance`
+exactly as the controls are. Two per-row columns went the same way, because `getTableStats()` here
+sets neither field: *Bloat* shows a dash instead of a `0.0%` badge in the healthy variant, and *Last
+Vacuum* a dash instead of *Never*, which claimed a vacuum history for an engine with no vacuum. None
+of this touches the *Tables* and *Size* cards or the row and byte columns — those come from
+`sys.segments` and are measurements ([§7](#7-monitoring--health)).
+
 **The admin Operations tab closed the same gap (issue #282).** It rendered its global
 `Run Analyze` / `Run Vacuum` / `Run Reindex` controls and its per-table Analyze/Vacuum buttons
 without reading `getCapabilities()`, so all of them answered 400 here. `OperationsTab.tsx` now

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -829,9 +829,12 @@ The honest empties, each with its reason:
   scored `direction: "below"` with `critical: 80` by `DEFAULT_THRESHOLDS`, so a "neutral" 0 would
   paint a red critical cache fault on every healthy cluster; the monitoring tabs default an **absent**
   ratio to a healthy 100 instead. Every other metric would read as a measurement of zero, which is a
-  different and false claim. The numbers do exist on this product's stats endpoints, so this is a
-  recorded gap rather than an impossibility: widening the seam by one call is what a future phase
-  would do, and doing it here would have meant reaching around the seam.
+  different and false claim — and **the tabs did read them that way** until the rule #448 settled for
+  the Storage tab reached them: measured 2026-08-19 on OpenSearch, which is this same code path, the
+  Overview showed *Buffer Pool 0%* and *Deadlocks 0* for two fields this payload omits. Both cards now
+  read `N/A` beside *Not measured*, so the empty payload survives to the screen. The numbers do exist on this product's stats endpoints, so
+  this is a recorded gap rather than an impossibility: widening the seam by one call is what a future
+  phase would do, and doing it here would have meant reaching around the seam.
 - **`getSlowQueries()` and `getActiveSessions()` return `[]` rather than throwing.** Nothing is broken
   and nothing is misconfigured, so a monitoring tab should render as quiet, not as failed. Only
   `runMaintenance()` throws, because that one is a *request to act*.
@@ -875,7 +878,10 @@ bytes.
 **There is none.** `supportsMaintenance` is `false` and `maintenanceOperations` is `[]`, so no
 maintenance control renders for this connection: `TablesTab.tsx` reads the connected provider's
 capabilities (#272) and `OperationsTab.tsx` hides the whole Global Operations group where
-`supportsMaintenance` is false (#282).
+`supportsMaintenance` is false (#282). That first tab's *Vacuum* summary card reads the same
+declaration: it counted rows over a bloat ratio this provider never publishes, so it always said `0`
+over a green **OK** — a clean bill of health for an operation named below as impossible here — and it
+now says `N/A` over *Not supported*, with a dash in the per-row *Bloat* and *Last Vacuum* cells.
 
 Every `MaintenanceType` is either an index API rather than a statement, or impossible on this surface
 altogether:

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -470,6 +470,16 @@ There is no embedded stats API.
 `getOverview().tableCount` calls `getSchema()` internally — it is a full scan, so it honors the
 10 000-key cap and may undercount for very large files.
 
+The `[]` and the absent metrics above now reach the panels as absence rather than as zero. The
+**Tables** tab reads the empty `getTableStats()` against `tableCount` — prefix groups the store does
+know about, with statistics for none of them — so its *Tables* and *Size* cards read `N/A` and the
+list says *No table statistics available.* instead of summing `0` and `0 B`; the **Queries** tab's
+three cards read `N/A` for the same reason, an average over no statements not being `0.00ms`; and
+because `getPerformanceMetrics()` reports only `cacheHitRatio`, the *Buffer* and *Deadlocks* cards on
+the Overview and Performance tabs read `N/A` beside *Not measured* rather than `0%` and a `0` badged
+healthy. `cacheHitRatio: 100` is the one figure here that is stated rather than absent, and it keeps
+its gauge.
+
 ---
 
 ## 8. Maintenance
@@ -483,8 +493,10 @@ QueryError: Maintenance operation "<type>" is not supported for LibreDB
 This is reflected in `getCapabilities().supportsMaintenance = false` and
 `maintenanceOperations = []`. Both tabs that offer maintenance now hide it for this provider: the
 monitoring **Tables** tab renders no per-row control when a provider declares maintenance
-unsupported (issue #272), and the admin **Operations** tab hides its whole Global Operations group
-and its per-table buttons on the same reading (issue #282). Neither offers a control that could only
+unsupported (issue #272) — and, on the same reading, its *Vacuum* summary card now reads `N/A` over
+*Not supported* rather than the `0` over green **OK** that a bloat count over no rows produced, which
+was a clean bill of health for an operation this provider does not offer — and the admin
+**Operations** tab hides its whole Global Operations group and its per-table buttons (issue #282). Neither offers a control that could only
 answer HTTP 400. The schema explorer's own per-row `Analyze`/`Vacuum` items are hidden here too, but
 for a different reason — the rows are derived groupings, see 5.3.
 

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -836,8 +836,12 @@ The honest empties, each with its reason:
 - **`getPerformanceMetrics()` returns `{}`, not zeroes**, and this is load-bearing. `cacheHitRatio` is
   scored `direction: "below"` with `critical: 80` by `DEFAULT_THRESHOLDS`, so a "neutral" 0 would paint
   a red critical cache fault on every healthy cluster; the monitoring tabs default an **absent** ratio
-  to a healthy 100 instead. Every other metric would read as a measurement of zero. The numbers exist
-  on this product's stats endpoints, so this is a recorded gap rather than an impossibility.
+  to a healthy 100 instead. Every other metric would read as a measurement of zero — and **the tabs did
+  read them that way** until the rule #448 settled for the Storage tab reached them: measured
+  2026-08-19 on this product, the Overview showed *Buffer Pool 0%* and *Deadlocks 0* for two fields
+  this payload omits. Both cards now read `N/A` beside *Not measured*, so the empty payload survives to
+  the screen. The numbers exist on this product's stats endpoints, so this is a recorded gap rather
+  than an impossibility.
 - **`getSlowQueries()` and `getActiveSessions()` return `[]` rather than throwing.** Nothing is broken
   and nothing is misconfigured, so a monitoring tab should render as quiet, not as failed. Only
   `runMaintenance()` throws, because that one is a *request to act*.
@@ -878,7 +882,10 @@ rather than a row claiming the cluster stores zero bytes.
 **There is none.** `supportsMaintenance` is `false` and `maintenanceOperations` is `[]`, so no
 maintenance control renders for this connection: `TablesTab.tsx` reads the connected provider's
 capabilities (#272) and `OperationsTab.tsx` hides the whole Global Operations group where
-`supportsMaintenance` is false (#282).
+`supportsMaintenance` is false (#282). That first tab's *Vacuum* summary card reads the same
+declaration: it counted rows over a bloat ratio this provider never publishes, so it always said `0`
+over a green **OK** — a clean bill of health for an operation named below as impossible here — and it
+now says `N/A` over *Not supported*, with a dash in the per-row *Bloat* and *Last Vacuum* cells.
 
 Every `MaintenanceType` is either an index API rather than a statement, or impossible on this surface
 altogether:

--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -348,6 +348,14 @@ The rate is read from JMX rather than derived from the query log on purpose: the
 in-memory history the coordinator trims, so counting rows in it over a window would report a rate
 that **falls to zero on a busy cluster** the moment the history wraps.
 
+The panels keep the absences absent, which they did not always: the Overview and Performance tabs read
+`bufferPoolUsage` and `deadlocks` as `?? 0` and so drew a `0 %` bar rated **Poor** in red and a `0`
+deadlock count badged **Healthy** — a fault and a clean bill of health for two figures this provider
+declines to publish. Both now read `N/A` beside the words *Not measured*, and their trend charts say
+the same instead of tracing zero. The monitoring Tables tab's per-row *Bloat* column went the same
+way: `getTableStats()` sets no bloat ratio, and a `0.0%` badge in the healthy variant reported a
+measurement nobody made, so the cell is a dash.
+
 ### 3.11 Values are passed through exactly as the wire encodes them
 
 Measured on 476, one statement:

--- a/src/components/monitoring/tabs/OverviewTab.tsx
+++ b/src/components/monitoring/tabs/OverviewTab.tsx
@@ -30,6 +30,16 @@ export function OverviewTab({ data, loading, history = [] }: OverviewTabProps) {
   // nothing, and that must not be displayed as a measured 0%.
   const cacheHitRatio = performance?.cacheHitRatio;
 
+  // The same distinction, on the two rows of the Performance card. An engine that
+  // holds no buffer pool publishes no usage - Trino omits it because "it holds no
+  // pages", Cassandra and SQLite omit it too - and an engine that takes no locks
+  // keeps no deadlock counter. Rendering those absences as "0%" with an empty bar
+  // and as the badge 0 in the healthy `secondary` variant claimed measurements
+  // nobody made, and the deadlock one read as a clean bill of health. A real 0 from
+  // an engine that does measure keeps exactly its former rendering.
+  const bufferPoolUsage = performance?.bufferPoolUsage;
+  const deadlocks = performance?.deadlocks;
+
   // A limit of 0 means "no limit published", not "no capacity": mssql.ts says so in
   // as many words, and Druid genuinely has no connection pool and no SQL-readable
   // limit. Dividing by it produced NaN, which rendered as the literal "NaN% used"
@@ -180,17 +190,37 @@ export function OverviewTab({ data, loading, history = [] }: OverviewTabProps) {
             <div className="flex justify-between items-center gap-2">
               <span className="text-xs sm:text-xs text-muted-foreground">Buffer Pool</span>
               <div className="flex items-center gap-1 sm:gap-2">
-                <Progress value={performance?.bufferPoolUsage ?? 0} className="w-16 sm:w-24 h-1.5 sm:h-2" />
-                <span className="text-xs sm:text-xs font-medium w-8 sm:w-12 text-right">
-                  {performance?.bufferPoolUsage?.toFixed(0) ?? 0}%
-                </span>
+                {bufferPoolUsage === undefined ? (
+                  <>
+                    <span className="text-xs sm:text-xs text-muted-foreground">Not measured</span>
+                    <span className="text-xs sm:text-xs font-medium w-8 sm:w-12 text-right text-muted-foreground">
+                      N/A
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <Progress value={bufferPoolUsage} className="w-16 sm:w-24 h-1.5 sm:h-2" />
+                    <span className="text-xs sm:text-xs font-medium w-8 sm:w-12 text-right">
+                      {bufferPoolUsage.toFixed(0)}%
+                    </span>
+                  </>
+                )}
               </div>
             </div>
             <div className="flex justify-between items-center">
               <span className="text-xs sm:text-xs text-muted-foreground">Deadlocks</span>
-              <Badge variant={performance?.deadlocks ? "destructive" : "secondary"} className="text-xs">
-                {performance?.deadlocks ?? 0}
-              </Badge>
+              {deadlocks === undefined ? (
+                <div className="flex items-center gap-1 sm:gap-2">
+                  <span className="text-xs sm:text-xs text-muted-foreground">Not measured</span>
+                  <Badge variant="outline" className="text-xs text-muted-foreground">
+                    N/A
+                  </Badge>
+                </div>
+              ) : (
+                <Badge variant={deadlocks ? "destructive" : "secondary"} className="text-xs">
+                  {deadlocks}
+                </Badge>
+              )}
             </div>
             <div className="flex justify-between items-center">
               <span className="text-xs sm:text-xs text-muted-foreground">Checkpoint</span>

--- a/src/components/monitoring/tabs/OverviewTab.tsx
+++ b/src/components/monitoring/tabs/OverviewTab.tsx
@@ -222,11 +222,11 @@ function PerformanceSummaryCard({
   bufferPoolUsage,
   deadlocks,
   checkpointWriteTime,
-}: {
+}: Readonly<{
   bufferPoolUsage: number | undefined;
   deadlocks: number | undefined;
   checkpointWriteTime: string | undefined;
-}) {
+}>) {
   return (
     <Card className="p-0">
       <CardHeader className="p-3 sm:p-4 pb-2">
@@ -281,7 +281,7 @@ function PerformanceSummaryCard({
 }
 
 /** Slow-query and session counts, read straight off the payload. */
-function QuickStatsCard({ data }: { data: MonitoringData | null }) {
+function QuickStatsCard({ data }: Readonly<{ data: MonitoringData | null }>) {
   return (
     <Card className="p-0">
       <CardHeader className="p-3 sm:p-4 pb-2">

--- a/src/components/monitoring/tabs/OverviewTab.tsx
+++ b/src/components/monitoring/tabs/OverviewTab.tsx
@@ -178,88 +178,12 @@ export function OverviewTab({ data, loading, history = [] }: OverviewTabProps) {
 
       {/* Secondary Stats */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-4">
-        {/* Performance Metrics */}
-        <Card className="p-0">
-          <CardHeader className="p-3 sm:p-4 pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium flex items-center gap-2">
-              <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4" />
-              Performance
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-3 sm:p-4 pt-0 space-y-2 sm:space-y-3">
-            <div className="flex justify-between items-center gap-2">
-              <span className="text-xs sm:text-xs text-muted-foreground">Buffer Pool</span>
-              <div className="flex items-center gap-1 sm:gap-2">
-                {bufferPoolUsage === undefined ? (
-                  <>
-                    <span className="text-xs sm:text-xs text-muted-foreground">Not measured</span>
-                    <span className="text-xs sm:text-xs font-medium w-8 sm:w-12 text-right text-muted-foreground">
-                      N/A
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <Progress value={bufferPoolUsage} className="w-16 sm:w-24 h-1.5 sm:h-2" />
-                    <span className="text-xs sm:text-xs font-medium w-8 sm:w-12 text-right">
-                      {bufferPoolUsage.toFixed(0)}%
-                    </span>
-                  </>
-                )}
-              </div>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-xs sm:text-xs text-muted-foreground">Deadlocks</span>
-              {deadlocks === undefined ? (
-                <div className="flex items-center gap-1 sm:gap-2">
-                  <span className="text-xs sm:text-xs text-muted-foreground">Not measured</span>
-                  <Badge variant="outline" className="text-xs text-muted-foreground">
-                    N/A
-                  </Badge>
-                </div>
-              ) : (
-                <Badge variant={deadlocks ? "destructive" : "secondary"} className="text-xs">
-                  {deadlocks}
-                </Badge>
-              )}
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-xs sm:text-xs text-muted-foreground">Checkpoint</span>
-              <span className="text-xs sm:text-xs font-mono truncate max-w-[100px] sm:max-w-none">
-                {performance?.checkpointWriteTime || "N/A"}
-              </span>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Quick Stats */}
-        <Card className="p-0">
-          <CardHeader className="p-3 sm:p-4 pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium flex items-center gap-2">
-              <Hash strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4" />
-              Quick Stats
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-3 sm:p-4 pt-0 space-y-2 sm:space-y-3">
-            <div className="flex justify-between items-center">
-              <span className="text-xs sm:text-xs text-muted-foreground">Slow Queries</span>
-              <Badge variant={data?.slowQueries?.length ? "outline" : "secondary"} className="text-xs">
-                {data?.slowQueries?.length ?? 0}
-              </Badge>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-xs sm:text-xs text-muted-foreground">Active</span>
-              <Badge variant="secondary" className="text-xs">
-                {data?.activeSessions?.filter((s) => s.state === "active").length ?? 0}
-              </Badge>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-xs sm:text-xs text-muted-foreground">Idle</span>
-              <Badge variant="secondary" className="text-xs">
-                {data?.activeSessions?.filter((s) => s.state === "idle").length ?? 0}
-              </Badge>
-            </div>
-          </CardContent>
-        </Card>
+        <PerformanceSummaryCard
+          bufferPoolUsage={bufferPoolUsage}
+          deadlocks={deadlocks}
+          checkpointWriteTime={performance?.checkpointWriteTime}
+        />
+        <QuickStatsCard data={data} />
       </div>
     </div>
   );
@@ -286,5 +210,106 @@ function OverviewSkeleton() {
         ))}
       </div>
     </div>
+  );
+}
+
+/**
+ * Buffer pool, deadlocks and checkpoint, each rendered from whether the engine
+ * published the figure at all. `undefined` is the absence; a real 0 keeps the
+ * rendering a measured 0 always had.
+ */
+function PerformanceSummaryCard({
+  bufferPoolUsage,
+  deadlocks,
+  checkpointWriteTime,
+}: {
+  bufferPoolUsage: number | undefined;
+  deadlocks: number | undefined;
+  checkpointWriteTime: string | undefined;
+}) {
+  return (
+    <Card className="p-0">
+      <CardHeader className="p-3 sm:p-4 pb-2">
+        <CardTitle className="text-xs sm:text-xs font-medium flex items-center gap-2">
+          <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4" />
+          Performance
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 sm:p-4 pt-0 space-y-2 sm:space-y-3">
+        <div className="flex justify-between items-center gap-2">
+          <span className="text-xs sm:text-xs text-muted-foreground">Buffer Pool</span>
+          <div className="flex items-center gap-1 sm:gap-2">
+            {bufferPoolUsage === undefined ? (
+              <>
+                <span className="text-xs sm:text-xs text-muted-foreground">Not measured</span>
+                <span className="text-xs sm:text-xs font-medium w-8 sm:w-12 text-right text-muted-foreground">N/A</span>
+              </>
+            ) : (
+              <>
+                <Progress value={bufferPoolUsage} className="w-16 sm:w-24 h-1.5 sm:h-2" />
+                <span className="text-xs sm:text-xs font-medium w-8 sm:w-12 text-right">
+                  {bufferPoolUsage.toFixed(0)}%
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-xs sm:text-xs text-muted-foreground">Deadlocks</span>
+          {deadlocks === undefined ? (
+            <div className="flex items-center gap-1 sm:gap-2">
+              <span className="text-xs sm:text-xs text-muted-foreground">Not measured</span>
+              <Badge variant="outline" className="text-xs text-muted-foreground">
+                N/A
+              </Badge>
+            </div>
+          ) : (
+            <Badge variant={deadlocks ? "destructive" : "secondary"} className="text-xs">
+              {deadlocks}
+            </Badge>
+          )}
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-xs sm:text-xs text-muted-foreground">Checkpoint</span>
+          <span className="text-xs sm:text-xs font-mono truncate max-w-[100px] sm:max-w-none">
+            {checkpointWriteTime || "N/A"}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Slow-query and session counts, read straight off the payload. */
+function QuickStatsCard({ data }: { data: MonitoringData | null }) {
+  return (
+    <Card className="p-0">
+      <CardHeader className="p-3 sm:p-4 pb-2">
+        <CardTitle className="text-xs sm:text-xs font-medium flex items-center gap-2">
+          <Hash strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4" />
+          Quick Stats
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 sm:p-4 pt-0 space-y-2 sm:space-y-3">
+        <div className="flex justify-between items-center">
+          <span className="text-xs sm:text-xs text-muted-foreground">Slow Queries</span>
+          <Badge variant={data?.slowQueries?.length ? "outline" : "secondary"} className="text-xs">
+            {data?.slowQueries?.length ?? 0}
+          </Badge>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-xs sm:text-xs text-muted-foreground">Active</span>
+          <Badge variant="secondary" className="text-xs">
+            {data?.activeSessions?.filter((s) => s.state === "active").length ?? 0}
+          </Badge>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-xs sm:text-xs text-muted-foreground">Idle</span>
+          <Badge variant="secondary" className="text-xs">
+            {data?.activeSessions?.filter((s) => s.state === "idle").length ?? 0}
+          </Badge>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/monitoring/tabs/PerformanceTab.tsx
+++ b/src/components/monitoring/tabs/PerformanceTab.tsx
@@ -12,6 +12,14 @@ import { evaluateThreshold, getThresholdColor, DEFAULT_THRESHOLDS } from "@/lib/
 import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 import { MetricChart } from "./MetricChart";
 
+/**
+ * The spelling every card in this panel uses for a figure the engine never reported.
+ * Same word as {@link CACHE_HIT_RATIO_UNAVAILABLE} and as the providers that already
+ * say "N/A" for a ratio they cannot read; named for the panel because the buffer pool
+ * and deadlock counters are not cache hit ratios.
+ */
+const METRIC_UNAVAILABLE = "N/A";
+
 interface PerformanceTabProps {
   data: MonitoringData | null;
   loading: boolean;
@@ -38,21 +46,34 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
   const cacheHitRatio = performance?.cacheHitRatio;
   const cacheStatus =
     cacheHitRatio === undefined ? undefined : { ratio: cacheHitRatio, ...getHealthStatus(cacheHitRatio) };
-  const bufferStatus = getHealthStatus(performance?.bufferPoolUsage ?? 0);
 
-  // Threshold evaluations
+  // Optional for the same reason: Trino "holds no buffer pool" and "takes no locks, so
+  // there are no deadlocks to count" (providers/sql/trino/introspect.ts), Cassandra and
+  // Druid omit both fields, and sqlite.ts sets bufferPoolUsage undefined outright. A
+  // "0 %" bar rated "Poor", or a zero deadlock count badged "Healthy", is a verdict on a
+  // measurement nobody made - and the deadlock one is a clean bill of health for an
+  // operation the engine does not perform. A measured 0 (mongodb, mysql, sqlite) is a
+  // real fact and keeps its rendering.
+  const bufferPoolUsage = performance?.bufferPoolUsage;
+  const bufferStatus =
+    bufferPoolUsage === undefined ? undefined : { usage: bufferPoolUsage, ...getHealthStatus(bufferPoolUsage) };
+  const deadlocks = performance?.deadlocks;
+
+  // Threshold evaluations. An absent metric scores "healthy" so the card border stays
+  // neutral: colouring it would rate the absence, which is what the stand-in 100 below
+  // does for the cache ratio.
   const cacheThreshold = evaluateThreshold(
     cacheHitRatio ?? 100,
     DEFAULT_THRESHOLDS.find((t) => t.metric === "cacheHitRatio")!,
   );
-  const bufferThreshold = evaluateThreshold(
-    performance?.bufferPoolUsage ?? 0,
-    DEFAULT_THRESHOLDS.find((t) => t.metric === "bufferPoolUsage")!,
-  );
-  const deadlockThreshold = evaluateThreshold(
-    performance?.deadlocks ?? 0,
-    DEFAULT_THRESHOLDS.find((t) => t.metric === "deadlocks")!,
-  );
+  const bufferThreshold =
+    bufferPoolUsage === undefined
+      ? "healthy"
+      : evaluateThreshold(bufferPoolUsage, DEFAULT_THRESHOLDS.find((t) => t.metric === "bufferPoolUsage")!);
+  const deadlockThreshold =
+    deadlocks === undefined
+      ? "healthy"
+      : evaluateThreshold(deadlocks, DEFAULT_THRESHOLDS.find((t) => t.metric === "deadlocks")!);
 
   // Build trend data from history
   // Missing samples are DROPPED, not zeroed. An engine that cannot measure a cache hit
@@ -64,11 +85,16 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
       ? []
       : [{ timestamp: h.timestamp, value: h.data.performance.cacheHitRatio }],
   );
-  const bufferHistory = history.map((h) => ({
-    timestamp: h.timestamp,
-    value: h.data.performance?.bufferPoolUsage ?? 0,
-  }));
-  const deadlockHistory = history.map((h) => ({ timestamp: h.timestamp, value: h.data.performance?.deadlocks ?? 0 }));
+  const bufferHistory = history.flatMap((h) =>
+    h.data.performance?.bufferPoolUsage === undefined
+      ? []
+      : [{ timestamp: h.timestamp, value: h.data.performance.bufferPoolUsage }],
+  );
+  const deadlockHistory = history.flatMap((h) =>
+    h.data.performance?.deadlocks === undefined
+      ? []
+      : [{ timestamp: h.timestamp, value: h.data.performance.deadlocks }],
+  );
 
   return (
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">
@@ -115,20 +141,31 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
         <Card className={`p-0 border-2 transition-colors ${getThresholdColor(bufferThreshold)}`}>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Buffer</CardTitle>
-            <Gauge className={`h-3 w-3 sm:h-4 sm:w-4 ${bufferStatus.color}`} />
+            <Gauge className={`h-3 w-3 sm:h-4 sm:w-4 ${bufferStatus?.color ?? "text-muted-foreground"}`} />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="flex items-end gap-1">
-              <span className="text-lg sm:text-3xl font-medium">{performance?.bufferPoolUsage?.toFixed(0) ?? 0}</span>
-              <span className="text-xs sm:text-xl text-muted-foreground">%</span>
-            </div>
-            <Progress value={performance?.bufferPoolUsage ?? 0} className="h-1 sm:h-2 mt-1 sm:mt-3" />
-            <div className="flex items-center justify-between mt-1 sm:mt-2">
-              <Badge variant="outline" className={`${bufferStatus.color} text-xs sm:text-xs`}>
-                {bufferStatus.label}
-              </Badge>
-              <span className="text-xs sm:text-xs text-muted-foreground hidden sm:inline">Cache</span>
-            </div>
+            {bufferStatus === undefined ? (
+              <>
+                <div className="flex items-end gap-1">
+                  <span className="text-lg sm:text-3xl font-medium text-muted-foreground">{METRIC_UNAVAILABLE}</span>
+                </div>
+                <p className="text-xs sm:text-xs text-muted-foreground mt-1 sm:mt-3">Not measured</p>
+              </>
+            ) : (
+              <>
+                <div className="flex items-end gap-1">
+                  <span className="text-lg sm:text-3xl font-medium">{bufferStatus.usage.toFixed(0)}</span>
+                  <span className="text-xs sm:text-xl text-muted-foreground">%</span>
+                </div>
+                <Progress value={bufferStatus.usage} className="h-1 sm:h-2 mt-1 sm:mt-3" />
+                <div className="flex items-center justify-between mt-1 sm:mt-2">
+                  <Badge variant="outline" className={`${bufferStatus.color} text-xs sm:text-xs`}>
+                    {bufferStatus.label}
+                  </Badge>
+                  <span className="text-xs sm:text-xs text-muted-foreground hidden sm:inline">Cache</span>
+                </div>
+              </>
+            )}
           </CardContent>
         </Card>
 
@@ -137,22 +174,32 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Deadlocks</CardTitle>
             <AlertTriangle
-              className={`h-3 w-3 sm:h-4 sm:w-4 ${performance?.deadlocks ? "text-red-500" : "text-green-500"}`}
+              className={`h-3 w-3 sm:h-4 sm:w-4 ${
+                deadlocks === undefined ? "text-muted-foreground" : deadlocks ? "text-red-500" : "text-green-500"
+              }`}
             />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="flex items-end gap-1">
-              <span className="text-lg sm:text-3xl font-medium">{performance?.deadlocks ?? 0}</span>
-            </div>
-            <p className="text-xs sm:text-xs text-muted-foreground mt-1 sm:mt-3 hidden sm:block">
-              {performance?.deadlocks ? "Review queries" : "None detected"}
-            </p>
-            <Badge
-              variant={performance?.deadlocks ? "destructive" : "secondary"}
-              className="mt-1 sm:mt-2 text-xs sm:text-xs"
-            >
-              {performance?.deadlocks ? "Attention" : "Healthy"}
-            </Badge>
+            {deadlocks === undefined ? (
+              <>
+                <div className="flex items-end gap-1">
+                  <span className="text-lg sm:text-3xl font-medium text-muted-foreground">{METRIC_UNAVAILABLE}</span>
+                </div>
+                <p className="text-xs sm:text-xs text-muted-foreground mt-1 sm:mt-3">Not measured</p>
+              </>
+            ) : (
+              <>
+                <div className="flex items-end gap-1">
+                  <span className="text-lg sm:text-3xl font-medium">{deadlocks}</span>
+                </div>
+                <p className="text-xs sm:text-xs text-muted-foreground mt-1 sm:mt-3 hidden sm:block">
+                  {deadlocks ? "Review queries" : "None detected"}
+                </p>
+                <Badge variant={deadlocks ? "destructive" : "secondary"} className="mt-1 sm:mt-2 text-xs sm:text-xs">
+                  {deadlocks ? "Attention" : "Healthy"}
+                </Badge>
+              </>
+            )}
           </CardContent>
         </Card>
       </div>
@@ -177,7 +224,11 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
               <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Buffer Pool Trend</CardTitle>
             </CardHeader>
             <CardContent className="p-2 sm:p-3 pt-0">
-              <MetricChart data={bufferHistory} color="#3b82f6" title="Buffer Pool" unit="%" />
+              {bufferHistory.length === 0 ? (
+                <p className="text-xs sm:text-xs text-muted-foreground">Not measured</p>
+              ) : (
+                <MetricChart data={bufferHistory} color="#3b82f6" title="Buffer Pool" unit="%" />
+              )}
             </CardContent>
           </Card>
           <Card className="p-0">
@@ -185,7 +236,11 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
               <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Deadlock Trend</CardTitle>
             </CardHeader>
             <CardContent className="p-2 sm:p-3 pt-0">
-              <MetricChart data={deadlockHistory} color="#ef4444" title="Deadlocks" />
+              {deadlockHistory.length === 0 ? (
+                <p className="text-xs sm:text-xs text-muted-foreground">Not measured</p>
+              ) : (
+                <MetricChart data={deadlockHistory} color="#ef4444" title="Deadlocks" />
+              )}
             </CardContent>
           </Card>
         </div>

--- a/src/components/monitoring/tabs/PerformanceTab.tsx
+++ b/src/components/monitoring/tabs/PerformanceTab.tsx
@@ -62,13 +62,13 @@ function MetricTrendCard({
   data,
   color,
   unit,
-}: {
+}: Readonly<{
   heading: string;
   title: string;
   data: { timestamp: number; value: number }[];
   color: string;
   unit?: string;
-}) {
+}>) {
   return (
     <Card className="p-0">
       <CardHeader className="p-2 sm:p-3 pb-0">

--- a/src/components/monitoring/tabs/PerformanceTab.tsx
+++ b/src/components/monitoring/tabs/PerformanceTab.tsx
@@ -20,6 +20,71 @@ import { MetricChart } from "./MetricChart";
  */
 const METRIC_UNAVAILABLE = "N/A";
 
+/**
+ * One trend series, built from history. Missing samples are DROPPED, not zeroed: an
+ * engine that cannot measure a cache hit ratio (Druid) reports none, and mapping that to
+ * 0 would plot a measured 0% trend - exactly the fabricated metric the current-value
+ * cards withhold. Dropping leaves an empty series, which `MetricTrendCard` renders as
+ * "Not measured" rather than as a line along the floor.
+ */
+function metricSeries(
+  history: TimeSeriesPoint<MonitoringData>[],
+  read: (performance: MonitoringData["performance"] | undefined) => number | undefined,
+): { timestamp: number; value: number }[] {
+  return history.flatMap((h) => {
+    const value = read(h.data.performance);
+    return value === undefined ? [] : [{ timestamp: h.timestamp, value }];
+  });
+}
+
+/**
+ * Three states, not two, which is why this is a function and not the nested ternary it
+ * replaces: no deadlock counter at all (Trino takes no locks, Cassandra and Druid omit
+ * the field), a real count above zero, or a measured zero. The absence must not borrow
+ * the green of an engine that looked and found none.
+ */
+function deadlockIconClass(deadlocks: number | undefined): string {
+  if (deadlocks === undefined) return "text-muted-foreground";
+  if (deadlocks > 0) return "text-red-500";
+  return "text-green-500";
+}
+
+/**
+ * One trend card. The three below differ only in their copy, colour and unit, and an
+ * empty series is the dropped-sample case from `flatMap` above: the engine published no
+ * reading, so the card says so instead of drawing a line along the floor. `heading` is
+ * passed rather than derived from `title` because the deadlock card is labelled
+ * "Deadlock Trend" while its chart is titled "Deadlocks".
+ */
+function MetricTrendCard({
+  heading,
+  title,
+  data,
+  color,
+  unit,
+}: {
+  heading: string;
+  title: string;
+  data: { timestamp: number; value: number }[];
+  color: string;
+  unit?: string;
+}) {
+  return (
+    <Card className="p-0">
+      <CardHeader className="p-2 sm:p-3 pb-0">
+        <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">{heading}</CardTitle>
+      </CardHeader>
+      <CardContent className="p-2 sm:p-3 pt-0">
+        {data.length === 0 ? (
+          <p className="text-xs sm:text-xs text-muted-foreground">Not measured</p>
+        ) : (
+          <MetricChart data={data} color={color} title={title} unit={unit} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 interface PerformanceTabProps {
   data: MonitoringData | null;
   loading: boolean;
@@ -75,26 +140,11 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
       ? "healthy"
       : evaluateThreshold(deadlocks, DEFAULT_THRESHOLDS.find((t) => t.metric === "deadlocks")!);
 
-  // Build trend data from history
-  // Missing samples are DROPPED, not zeroed. An engine that cannot measure a cache hit
-  // ratio (Druid) reports none, and mapping that to 0 would plot a measured 0% trend -
-  // exactly the fabricated metric the current-value card above withholds. Dropping
-  // leaves an empty series, which the chart renders as no data rather than as a floor.
-  const cacheHistory = history.flatMap((h) =>
-    h.data.performance?.cacheHitRatio === undefined
-      ? []
-      : [{ timestamp: h.timestamp, value: h.data.performance.cacheHitRatio }],
-  );
-  const bufferHistory = history.flatMap((h) =>
-    h.data.performance?.bufferPoolUsage === undefined
-      ? []
-      : [{ timestamp: h.timestamp, value: h.data.performance.bufferPoolUsage }],
-  );
-  const deadlockHistory = history.flatMap((h) =>
-    h.data.performance?.deadlocks === undefined
-      ? []
-      : [{ timestamp: h.timestamp, value: h.data.performance.deadlocks }],
-  );
+  // Build trend data from history. See `metricSeries` for why a missing sample is
+  // dropped rather than read as a zero.
+  const cacheHistory = metricSeries(history, (p) => p?.cacheHitRatio);
+  const bufferHistory = metricSeries(history, (p) => p?.bufferPoolUsage);
+  const deadlockHistory = metricSeries(history, (p) => p?.deadlocks);
 
   return (
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">
@@ -173,11 +223,7 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
         <Card className={`p-0 border-2 transition-colors ${getThresholdColor(deadlockThreshold)}`}>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Deadlocks</CardTitle>
-            <AlertTriangle
-              className={`h-3 w-3 sm:h-4 sm:w-4 ${
-                deadlocks === undefined ? "text-muted-foreground" : deadlocks ? "text-red-500" : "text-green-500"
-              }`}
-            />
+            <AlertTriangle className={`h-3 w-3 sm:h-4 sm:w-4 ${deadlockIconClass(deadlocks)}`} />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
             {deadlocks === undefined ? (
@@ -207,42 +253,15 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
       {/* Trend Charts */}
       {history.length >= 2 && (
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4">
-          <Card className="p-0">
-            <CardHeader className="p-2 sm:p-3 pb-0">
-              <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Cache Hit Trend</CardTitle>
-            </CardHeader>
-            <CardContent className="p-2 sm:p-3 pt-0">
-              {cacheHistory.length === 0 ? (
-                <p className="text-xs sm:text-xs text-muted-foreground">Not measured</p>
-              ) : (
-                <MetricChart data={cacheHistory} color="#22c55e" title="Cache Hit" unit="%" />
-              )}
-            </CardContent>
-          </Card>
-          <Card className="p-0">
-            <CardHeader className="p-2 sm:p-3 pb-0">
-              <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Buffer Pool Trend</CardTitle>
-            </CardHeader>
-            <CardContent className="p-2 sm:p-3 pt-0">
-              {bufferHistory.length === 0 ? (
-                <p className="text-xs sm:text-xs text-muted-foreground">Not measured</p>
-              ) : (
-                <MetricChart data={bufferHistory} color="#3b82f6" title="Buffer Pool" unit="%" />
-              )}
-            </CardContent>
-          </Card>
-          <Card className="p-0">
-            <CardHeader className="p-2 sm:p-3 pb-0">
-              <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Deadlock Trend</CardTitle>
-            </CardHeader>
-            <CardContent className="p-2 sm:p-3 pt-0">
-              {deadlockHistory.length === 0 ? (
-                <p className="text-xs sm:text-xs text-muted-foreground">Not measured</p>
-              ) : (
-                <MetricChart data={deadlockHistory} color="#ef4444" title="Deadlocks" />
-              )}
-            </CardContent>
-          </Card>
+          <MetricTrendCard heading="Cache Hit Trend" title="Cache Hit" data={cacheHistory} color="#22c55e" unit="%" />
+          <MetricTrendCard
+            heading="Buffer Pool Trend"
+            title="Buffer Pool"
+            data={bufferHistory}
+            color="#3b82f6"
+            unit="%"
+          />
+          <MetricTrendCard heading="Deadlock Trend" title="Deadlocks" data={deadlockHistory} color="#ef4444" />
         </div>
       )}
 

--- a/src/components/monitoring/tabs/PoolTab.tsx
+++ b/src/components/monitoring/tabs/PoolTab.tsx
@@ -111,64 +111,75 @@ export function PoolTab({ connection }: PoolTabProps) {
       )}
 
       {/* Pool Stats Cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-4">
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Total</CardTitle>
-            <Server strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-blue-500" />
-          </CardHeader>
-          <CardContent className="p-3 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.total : "N/A"}</div>
-            {measured !== null && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Max pool size</p>}
-          </CardContent>
-        </Card>
+      <PoolStatsGrid measured={measured} usagePercent={usagePercent} />
+    </div>
+  );
+}
 
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Active</CardTitle>
-            <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
-          </CardHeader>
-          <CardContent className="p-3 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.active : "N/A"}</div>
-            {measured !== null && (
-              <>
-                <Progress value={usagePercent} className="h-1 mt-1 sm:mt-2" />
-                <p className="text-xs sm:text-xs text-muted-foreground mt-1">{usagePercent}% utilized</p>
-              </>
-            )}
-          </CardContent>
-        </Card>
+/**
+ * The four figures, once `PoolTab` has decided whether anything was measured.
+ * `measured === null` is the unmeasured case for every card at once, so each renders
+ * "N/A" and drops its sub-label rather than showing a zero nobody read.
+ */
+function PoolStatsGrid({ measured, usagePercent }: { measured: PoolStats | null; usagePercent: number }) {
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-4">
+      <Card className="p-0">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
+          <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Total</CardTitle>
+          <Server strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-blue-500" />
+        </CardHeader>
+        <CardContent className="p-3 sm:p-4 pt-0">
+          <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.total : "N/A"}</div>
+          {measured !== null && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Max pool size</p>}
+        </CardContent>
+      </Card>
 
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Idle</CardTitle>
-            <Clock strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-yellow-500" />
-          </CardHeader>
-          <CardContent className="p-3 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.idle : "N/A"}</div>
-            {measured !== null && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Available</p>}
-          </CardContent>
-        </Card>
+      <Card className="p-0">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
+          <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Active</CardTitle>
+          <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
+        </CardHeader>
+        <CardContent className="p-3 sm:p-4 pt-0">
+          <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.active : "N/A"}</div>
+          {measured !== null && (
+            <>
+              <Progress value={usagePercent} className="h-1 mt-1 sm:mt-2" />
+              <p className="text-xs sm:text-xs text-muted-foreground mt-1">{usagePercent}% utilized</p>
+            </>
+          )}
+        </CardContent>
+      </Card>
 
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Waiting</CardTitle>
-            {measured !== null && (
-              <Badge variant={measured.waiting ? "destructive" : "secondary"} className="text-xs">
-                {measured.waiting}
-              </Badge>
-            )}
-          </CardHeader>
-          <CardContent className="p-3 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.waiting : "N/A"}</div>
-            {measured !== null && (
-              <p className="text-xs sm:text-xs text-muted-foreground mt-1">
-                {measured.waiting ? "Queued requests" : "No queue"}
-              </p>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+      <Card className="p-0">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
+          <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Idle</CardTitle>
+          <Clock strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-yellow-500" />
+        </CardHeader>
+        <CardContent className="p-3 sm:p-4 pt-0">
+          <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.idle : "N/A"}</div>
+          {measured !== null && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Available</p>}
+        </CardContent>
+      </Card>
+
+      <Card className="p-0">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
+          <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Waiting</CardTitle>
+          {measured !== null && (
+            <Badge variant={measured.waiting ? "destructive" : "secondary"} className="text-xs">
+              {measured.waiting}
+            </Badge>
+          )}
+        </CardHeader>
+        <CardContent className="p-3 sm:p-4 pt-0">
+          <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.waiting : "N/A"}</div>
+          {measured !== null && (
+            <p className="text-xs sm:text-xs text-muted-foreground mt-1">
+              {measured.waiting ? "Queued requests" : "No queue"}
+            </p>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/components/monitoring/tabs/PoolTab.tsx
+++ b/src/components/monitoring/tabs/PoolTab.tsx
@@ -77,7 +77,19 @@ export function PoolTab({ connection }: PoolTabProps) {
     );
   }
 
-  const usagePercent = stats && stats.total > 0 ? Math.round((stats.active / stats.total) * 100) : 0;
+  // Absence and zero are different inputs. `/api/db/pool-stats` answers a literal
+  // `{total: 0, idle: 0, active: 0, waiting: 0, message: "Pool statistics not available
+  // for this provider"}` for every provider without `getPoolStats` - only postgres,
+  // oracle and mssql have one, so Cassandra, MySQL, SQLite, ClickHouse, Druid, Trino,
+  // Mongo, Redis and Couchbase all land there - and `stats === null` is the state of the
+  // very first paint, before any request has been made. In both cases nothing was
+  // inspected, so `message` (present in exactly the unmeasured case) is what separates
+  // them from a real reading: postgres before its pool opens returns an all-zero body
+  // with no message, and that IS a measurement - 0 connections, truthfully - which keeps
+  // the arithmetic and the labels below unchanged.
+  const measured = stats !== null && stats.message === undefined ? stats : null;
+  const usagePercent =
+    measured !== null && measured.total > 0 ? Math.round((measured.active / measured.total) * 100) : 0;
 
   return (
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">
@@ -92,8 +104,10 @@ export function PoolTab({ connection }: PoolTabProps) {
         </Button>
       </div>
 
-      {stats?.message && (
-        <div className="text-xs text-muted-foreground bg-muted/30 rounded-lg p-3">{stats.message}</div>
+      {measured === null && (
+        <div className="text-xs text-muted-foreground bg-muted/30 rounded-lg p-3">
+          {stats?.message ?? "No connection pool information available."}
+        </div>
       )}
 
       {/* Pool Stats Cards */}
@@ -104,8 +118,8 @@ export function PoolTab({ connection }: PoolTabProps) {
             <Server strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-blue-500" />
           </CardHeader>
           <CardContent className="p-3 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{stats?.total ?? 0}</div>
-            <p className="text-xs sm:text-xs text-muted-foreground mt-1">Max pool size</p>
+            <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.total : "N/A"}</div>
+            {measured !== null && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Max pool size</p>}
           </CardContent>
         </Card>
 
@@ -115,9 +129,13 @@ export function PoolTab({ connection }: PoolTabProps) {
             <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
           </CardHeader>
           <CardContent className="p-3 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{stats?.active ?? 0}</div>
-            <Progress value={usagePercent} className="h-1 mt-1 sm:mt-2" />
-            <p className="text-xs sm:text-xs text-muted-foreground mt-1">{usagePercent}% utilized</p>
+            <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.active : "N/A"}</div>
+            {measured !== null && (
+              <>
+                <Progress value={usagePercent} className="h-1 mt-1 sm:mt-2" />
+                <p className="text-xs sm:text-xs text-muted-foreground mt-1">{usagePercent}% utilized</p>
+              </>
+            )}
           </CardContent>
         </Card>
 
@@ -127,23 +145,27 @@ export function PoolTab({ connection }: PoolTabProps) {
             <Clock strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-yellow-500" />
           </CardHeader>
           <CardContent className="p-3 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{stats?.idle ?? 0}</div>
-            <p className="text-xs sm:text-xs text-muted-foreground mt-1">Available</p>
+            <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.idle : "N/A"}</div>
+            {measured !== null && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Available</p>}
           </CardContent>
         </Card>
 
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Waiting</CardTitle>
-            <Badge variant={stats?.waiting ? "destructive" : "secondary"} className="text-xs">
-              {stats?.waiting ?? 0}
-            </Badge>
+            {measured !== null && (
+              <Badge variant={measured.waiting ? "destructive" : "secondary"} className="text-xs">
+                {measured.waiting}
+              </Badge>
+            )}
           </CardHeader>
           <CardContent className="p-3 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{stats?.waiting ?? 0}</div>
-            <p className="text-xs sm:text-xs text-muted-foreground mt-1">
-              {stats?.waiting ? "Queued requests" : "No queue"}
-            </p>
+            <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.waiting : "N/A"}</div>
+            {measured !== null && (
+              <p className="text-xs sm:text-xs text-muted-foreground mt-1">
+                {measured.waiting ? "Queued requests" : "No queue"}
+              </p>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/src/components/monitoring/tabs/PoolTab.tsx
+++ b/src/components/monitoring/tabs/PoolTab.tsx
@@ -121,7 +121,7 @@ export function PoolTab({ connection }: PoolTabProps) {
  * `measured === null` is the unmeasured case for every card at once, so each renders
  * "N/A" and drops its sub-label rather than showing a zero nobody read.
  */
-function PoolStatsGrid({ measured, usagePercent }: { measured: PoolStats | null; usagePercent: number }) {
+function PoolStatsGrid({ measured, usagePercent }: Readonly<{ measured: PoolStats | null; usagePercent: number }>) {
   return (
     <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-4">
       <Card className="p-0">

--- a/src/components/monitoring/tabs/QueriesTab.tsx
+++ b/src/components/monitoring/tabs/QueriesTab.tsx
@@ -60,9 +60,17 @@ export function QueriesTab({ data, loading }: QueriesTabProps) {
     return n.toString();
   };
 
-  // Calculate stats
+  // Calculate stats. Absence and zero are different inputs: `MonitoringData.slowQueries`
+  // is required, so a provider that keeps no query log at all - Cassandra
+  // (cassandra/index.ts:573-575), Druid (index.ts:486-488), SQLite (sqlite.ts:734-737) -
+  // can only answer `[]`, and reducing that yielded "Queries 0 / Avg Time 0.00ms /
+  // Slow 0", measured 2026-08-21 in Chrome against Apache Cassandra 5.0.9. An average
+  // over an empty set is not 0.00ms and a call total of 0 is a claim about the database,
+  // so with no statistics the three cards read N/A and the sentence below them says why.
+  // Any non-empty list has been measured, zeros included, and keeps today's arithmetic.
+  const statsKnown = slowQueries.length > 0;
   const totalQueries = slowQueries.reduce((sum, q) => sum + q.calls, 0);
-  const avgTime = slowQueries.length > 0 ? slowQueries.reduce((sum, q) => sum + q.avgTime, 0) / slowQueries.length : 0;
+  const avgTime = statsKnown ? slowQueries.reduce((sum, q) => sum + q.avgTime, 0) / slowQueries.length : 0;
   const slowCount = slowQueries.filter((q) => q.avgTime > 1000).length;
 
   return (
@@ -75,7 +83,7 @@ export function QueriesTab({ data, loading }: QueriesTabProps) {
             <Search strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{formatNumber(totalQueries)}</div>
+            <div className="text-lg sm:text-2xl font-medium">{statsKnown ? formatNumber(totalQueries) : "N/A"}</div>
           </CardContent>
         </Card>
 
@@ -85,7 +93,7 @@ export function QueriesTab({ data, loading }: QueriesTabProps) {
             <Clock strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{formatTime(avgTime)}</div>
+            <div className="text-lg sm:text-2xl font-medium">{statsKnown ? formatTime(avgTime) : "N/A"}</div>
           </CardContent>
         </Card>
 
@@ -97,7 +105,7 @@ export function QueriesTab({ data, loading }: QueriesTabProps) {
             />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{slowCount}</div>
+            <div className="text-lg sm:text-2xl font-medium">{statsKnown ? slowCount : "N/A"}</div>
           </CardContent>
         </Card>
       </div>

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -69,11 +69,11 @@ function VacuumNote({
   stateKnown,
   needingVacuum,
   unsupported,
-}: {
+}: Readonly<{
   stateKnown: boolean;
   needingVacuum: number;
   unsupported: boolean;
-}) {
+}>) {
   if (stateKnown) {
     return <p className="text-xs sm:text-xs text-muted-foreground mt-1">{needingVacuum > 0 ? "Need" : "OK"}</p>;
   }

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -55,6 +55,31 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
   const totalSize = tables.reduce((sum, t) => sum + t.totalSizeBytes, 0);
   const tablesNeedingVacuum = tables.filter((t) => (t.bloatRatio ?? 0) > 10).length;
 
+  // ABSENCE and ZERO are different inputs — the rule #448 settled for StorageTab, which
+  // this panel was still breaking one component over. A provider that publishes no table
+  // statistics answers `[]` (Apache Cassandra's `getTableStats` returns an empty array as
+  // a documented refusal; Apache Druid and Apache Trino do the same), and `BaseProvider`
+  // assigns that array whenever `includeTables` is set, so `tables` alone cannot tell a
+  // refusal from an empty database. The required `overview.tableCount` can: Cassandra
+  // populates it from `system_schema`, and it read 6 in the very frame these cards read 0
+  // (measured 2026-08-21 in Chrome against Apache Cassandra 5.0.9). Tables the engine
+  // knows about but reports no statistics for means the figures are not knowable, so the
+  // cards say so rather than publishing a confident zero the engine never measured. A
+  // provider that reports a genuine 0 keeps today's arithmetic and today's rendering.
+  const statsAbsent = tables.length === 0 && (data?.overview.tableCount ?? 0) > 0;
+
+  // Whether the engine HAS vacuum is a capability question, not a data question, so it is
+  // read from what the provider declares instead of inferred from the rows. Cassandra
+  // declares `supportsMaintenance: false, maintenanceOperations: []` and every maintenance
+  // action on it is a `nodetool` call this studio never issues — a green "OK" there is a
+  // clean bill of health for an operation that does not exist. Undefined capabilities mean
+  // the provider metadata has not resolved yet, which is not a denial: that path keeps the
+  // existing rendering, exactly as the maintenance-control gate (#272) treats it.
+  const vacuumUnsupported = capabilities?.supportsMaintenance === false;
+  const vacuumSupported =
+    capabilities?.supportsMaintenance === true && capabilities.maintenanceOperations.includes("vacuum");
+  const vacuumStateKnown = !vacuumUnsupported && !statsAbsent;
+
   const formatBytes = (bytes: number) => {
     if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
     if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(2)} MB`;
@@ -68,8 +93,13 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
     return n.toString();
   };
 
+  // `lastVacuum` is optional, and its absence means two different things. On PostgreSQL a
+  // NULL `last_vacuum` really does mean the table has never been vacuumed, so "Never" is a
+  // measurement; on an engine with no vacuum at all the same word claims a history for an
+  // operation that does not exist. Only an engine that declares vacuum gets the word — the
+  // rest get the dash this table already uses for a cell it cannot fill (`indexSize`).
   const formatDate = (date?: Date) => {
-    if (!date) return "Never";
+    if (!date) return vacuumSupported ? "Never" : "-";
     return new Date(date).toLocaleDateString();
   };
 
@@ -95,8 +125,10 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
             <Table2 strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{tables.length}</div>
-            <p className="text-xs sm:text-xs text-muted-foreground mt-1">{formatNumber(totalRows)} rows</p>
+            <div className="text-lg sm:text-2xl font-medium">{statsAbsent ? "N/A" : tables.length}</div>
+            {!statsAbsent && (
+              <p className="text-xs sm:text-xs text-muted-foreground mt-1">{formatNumber(totalRows)} rows</p>
+            )}
           </CardContent>
         </Card>
 
@@ -106,8 +138,8 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
             <Search strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{formatBytes(totalSize)}</div>
-            <p className="text-xs sm:text-xs text-muted-foreground mt-1">Total</p>
+            <div className="text-lg sm:text-2xl font-medium">{statsAbsent ? "N/A" : formatBytes(totalSize)}</div>
+            {!statsAbsent && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Total</p>}
           </CardContent>
         </Card>
 
@@ -115,12 +147,22 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Vacuum</CardTitle>
             <AlertTriangle
-              className={`h-3 w-3 sm:h-4 sm:w-4 ${tablesNeedingVacuum > 0 ? "text-yellow-500" : "text-green-500"}`}
+              className={`h-3 w-3 sm:h-4 sm:w-4 ${
+                !vacuumStateKnown
+                  ? "text-muted-foreground"
+                  : tablesNeedingVacuum > 0
+                    ? "text-yellow-500"
+                    : "text-green-500"
+              }`}
             />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{tablesNeedingVacuum}</div>
-            <p className="text-xs sm:text-xs text-muted-foreground mt-1">{tablesNeedingVacuum > 0 ? "Need" : "OK"}</p>
+            <div className="text-lg sm:text-2xl font-medium">{vacuumStateKnown ? tablesNeedingVacuum : "N/A"}</div>
+            {vacuumStateKnown ? (
+              <p className="text-xs sm:text-xs text-muted-foreground mt-1">{tablesNeedingVacuum > 0 ? "Need" : "OK"}</p>
+            ) : vacuumUnsupported ? (
+              <p className="text-xs sm:text-xs text-muted-foreground mt-1">Not supported</p>
+            ) : null}
           </CardContent>
         </Card>
       </div>
@@ -145,7 +187,7 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
           {filteredTables.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               <Table2 strokeWidth={1.5} className="h-8 w-8 mx-auto mb-2 opacity-50" />
-              <p className="text-xs">No tables found.</p>
+              <p className="text-xs">{statsAbsent ? "No table statistics available." : "No tables found."}</p>
             </div>
           ) : (
             <div className="overflow-x-auto">
@@ -185,18 +227,20 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
                         {table.indexSize || "-"}
                       </TableCell>
                       <TableCell className="text-right hidden sm:table-cell py-2">
-                        <Badge
-                          variant={
-                            (table.bloatRatio ?? 0) > 20
-                              ? "destructive"
-                              : (table.bloatRatio ?? 0) > 10
-                                ? "outline"
-                                : "secondary"
-                          }
-                          className="text-xs sm:text-xs"
-                        >
-                          {(table.bloatRatio ?? 0).toFixed(1)}%
-                        </Badge>
+                        {table.bloatRatio === undefined ? (
+                          // No bloat figure published: a "0.0%" badge in the healthy
+                          // variant would report a measurement the engine never made.
+                          <span className="text-xs text-muted-foreground">-</span>
+                        ) : (
+                          <Badge
+                            variant={
+                              table.bloatRatio > 20 ? "destructive" : table.bloatRatio > 10 ? "outline" : "secondary"
+                            }
+                            className="text-xs sm:text-xs"
+                          >
+                            {table.bloatRatio.toFixed(1)}%
+                          </Badge>
+                        )}
                       </TableCell>
                       <TableCell className="text-xs text-muted-foreground hidden lg:table-cell py-2">
                         {formatDate(table.lastVacuum)}

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -22,6 +22,73 @@ const MAINTENANCE_ACTIONS: { type: MaintenanceType; label: string; Icon: LucideI
   { type: "reindex", label: "Reindex", Icon: Zap, className: "h-6 w-6 sm:h-8 sm:w-8 hidden sm:inline-flex" },
 ];
 
+/**
+ * Pure formatters, at module scope rather than re-created inside `TablesTab` on every
+ * render. They also keep the component's own cognitive complexity to the decisions it
+ * actually makes about absence, which is what this panel is about.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
+  if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(2)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+  return `${bytes} B`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return n.toString();
+}
+
+/**
+ * `lastVacuum` is optional, and its absence means two different things. On PostgreSQL a
+ * NULL `last_vacuum` really does mean the table has never been vacuumed, so "Never" is a
+ * measurement; on an engine with no vacuum at all the same word claims a history for an
+ * operation that does not exist. Only an engine that declares vacuum gets the word - the
+ * rest get the dash this table already uses for a cell it cannot fill (`indexSize`).
+ */
+function formatVacuumDate(date: Date | undefined, vacuumSupported: boolean): string {
+  if (!date) return vacuumSupported ? "Never" : "-";
+  return new Date(date).toLocaleDateString();
+}
+
+/**
+ * Three states, not two, which is why this is a function and not the nested ternary it
+ * replaces: the vacuum figure can be a real reading, a denial from an engine with no
+ * vacuum, or simply unknown because the engine published no table statistics at all. The
+ * unknown case must not borrow the green of a healthy reading.
+ */
+function vacuumIconClass(stateKnown: boolean, needingVacuum: number): string {
+  if (!stateKnown) return "text-muted-foreground";
+  if (needingVacuum > 0) return "text-yellow-500";
+  return "text-green-500";
+}
+
+/** The same three states, as the note under the figure. `null` is the unknown case. */
+function VacuumNote({
+  stateKnown,
+  needingVacuum,
+  unsupported,
+}: {
+  stateKnown: boolean;
+  needingVacuum: number;
+  unsupported: boolean;
+}) {
+  if (stateKnown) {
+    return <p className="text-xs sm:text-xs text-muted-foreground mt-1">{needingVacuum > 0 ? "Need" : "OK"}</p>;
+  }
+  if (unsupported) {
+    return <p className="text-xs sm:text-xs text-muted-foreground mt-1">Not supported</p>;
+  }
+  return null;
+}
+
+function bloatBadgeVariant(ratio: number): "destructive" | "outline" | "secondary" {
+  if (ratio > 20) return "destructive";
+  if (ratio > 10) return "outline";
+  return "secondary";
+}
+
 interface TablesTabProps {
   data: MonitoringData | null;
   loading: boolean;
@@ -80,29 +147,6 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
     capabilities?.supportsMaintenance === true && capabilities.maintenanceOperations.includes("vacuum");
   const vacuumStateKnown = !vacuumUnsupported && !statsAbsent;
 
-  const formatBytes = (bytes: number) => {
-    if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
-    if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(2)} MB`;
-    if (bytes >= 1024) return `${(bytes / 1024).toFixed(2)} KB`;
-    return `${bytes} B`;
-  };
-
-  const formatNumber = (n: number) => {
-    if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
-    if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
-    return n.toString();
-  };
-
-  // `lastVacuum` is optional, and its absence means two different things. On PostgreSQL a
-  // NULL `last_vacuum` really does mean the table has never been vacuumed, so "Never" is a
-  // measurement; on an engine with no vacuum at all the same word claims a history for an
-  // operation that does not exist. Only an engine that declares vacuum gets the word — the
-  // rest get the dash this table already uses for a cell it cannot fill (`indexSize`).
-  const formatDate = (date?: Date) => {
-    if (!date) return vacuumSupported ? "Never" : "-";
-    return new Date(date).toLocaleDateString();
-  };
-
   const handleMaintenance = async (type: MaintenanceType, tableName: string) => {
     setActionLoading(`${type}-${tableName}`);
     await onRunMaintenance(type, tableName);
@@ -147,22 +191,16 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Vacuum</CardTitle>
             <AlertTriangle
-              className={`h-3 w-3 sm:h-4 sm:w-4 ${
-                !vacuumStateKnown
-                  ? "text-muted-foreground"
-                  : tablesNeedingVacuum > 0
-                    ? "text-yellow-500"
-                    : "text-green-500"
-              }`}
+              className={`h-3 w-3 sm:h-4 sm:w-4 ${vacuumIconClass(vacuumStateKnown, tablesNeedingVacuum)}`}
             />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
             <div className="text-lg sm:text-2xl font-medium">{vacuumStateKnown ? tablesNeedingVacuum : "N/A"}</div>
-            {vacuumStateKnown ? (
-              <p className="text-xs sm:text-xs text-muted-foreground mt-1">{tablesNeedingVacuum > 0 ? "Need" : "OK"}</p>
-            ) : vacuumUnsupported ? (
-              <p className="text-xs sm:text-xs text-muted-foreground mt-1">Not supported</p>
-            ) : null}
+            <VacuumNote
+              stateKnown={vacuumStateKnown}
+              needingVacuum={tablesNeedingVacuum}
+              unsupported={vacuumUnsupported}
+            />
           </CardContent>
         </Card>
       </div>
@@ -232,18 +270,13 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
                           // variant would report a measurement the engine never made.
                           <span className="text-xs text-muted-foreground">-</span>
                         ) : (
-                          <Badge
-                            variant={
-                              table.bloatRatio > 20 ? "destructive" : table.bloatRatio > 10 ? "outline" : "secondary"
-                            }
-                            className="text-xs sm:text-xs"
-                          >
+                          <Badge variant={bloatBadgeVariant(table.bloatRatio)} className="text-xs sm:text-xs">
                             {table.bloatRatio.toFixed(1)}%
                           </Badge>
                         )}
                       </TableCell>
                       <TableCell className="text-xs text-muted-foreground hidden lg:table-cell py-2">
-                        {formatDate(table.lastVacuum)}
+                        {formatVacuumDate(table.lastVacuum, vacuumSupported)}
                       </TableCell>
                       <TableCell className="text-right py-2">
                         {isAdmin && availableActions.length > 0 ? (

--- a/tests/components/monitoring/OverviewTab.test.tsx
+++ b/tests/components/monitoring/OverviewTab.test.tsx
@@ -155,4 +155,61 @@ describe("OverviewTab", () => {
     expect(card.className).not.toContain("red");
     expect(card.className).not.toContain("yellow");
   });
+  // Trino publishes no `bufferPoolUsage` because it holds no buffer pool ("it holds no
+  // pages", trino/introspect.ts), Cassandra and SQLite omit it too. Rendering that
+  // absence as "0%" with an empty bar claimed a measurement none of them made.
+  test("reports an unmeasured buffer pool as unavailable instead of 0%", () => {
+    const base = makeData();
+    const data = {
+      ...base,
+      performance: { ...base.performance, bufferPoolUsage: undefined },
+    } as MonitoringData;
+    const { queryByText } = render(<OverviewTab data={data} loading={false} />);
+    const card = queryByText("Performance")!.closest('[data-slot="card"]')!;
+
+    expect(card.textContent).toContain("N/A");
+    expect(card.textContent).toContain("Not measured");
+    // No fabricated reading: no percentage and no bar for a pool that does not exist.
+    expect(card.textContent).not.toContain("0%");
+    expect(card.querySelectorAll('[data-slot="progress"]').length).toBe(0);
+  });
+
+  // The other half of the same distinction, pinned so the two inputs cannot be
+  // collapsed again: an engine that measured its pool at 0 keeps today's rendering.
+  test("keeps a measured zero buffer pool rendering as 0% with its bar", () => {
+    const base = makeData();
+    const data = { ...base, performance: { ...base.performance, bufferPoolUsage: 0 } } as MonitoringData;
+    const { queryByText } = render(<OverviewTab data={data} loading={false} />);
+    const card = queryByText("Performance")!.closest('[data-slot="card"]')!;
+
+    expect(card.textContent).toContain("0%");
+    expect(card.textContent).not.toContain("Not measured");
+    expect(card.querySelectorAll('[data-slot="progress"]').length).toBe(1);
+  });
+
+  // An engine that takes no locks has no deadlocks to count - Trino says so in as
+  // many words. The badge 0 in the healthy `secondary` variant read as a clean bill
+  // of health for a counter nobody kept.
+  test("reports unmeasured deadlocks as unavailable instead of a healthy zero", () => {
+    const base = makeData();
+    const data = { ...base, performance: { ...base.performance, deadlocks: undefined } } as MonitoringData;
+    const { queryByText } = render(<OverviewTab data={data} loading={false} />);
+    const row = queryByText("Deadlocks")!.parentElement!;
+
+    expect(row.textContent).toContain("N/A");
+    expect(row.textContent).not.toContain("0");
+    // Absence is not health: the badge must not wear the healthy fill.
+    expect(row.querySelector('[data-slot="badge"]')!.className).not.toContain("bg-secondary");
+  });
+
+  test("keeps a measured zero deadlock count rendering as a healthy 0", () => {
+    const base = makeData();
+    const data = { ...base, performance: { ...base.performance, deadlocks: 0 } } as MonitoringData;
+    const { queryByText } = render(<OverviewTab data={data} loading={false} />);
+    const row = queryByText("Deadlocks")!.parentElement!;
+
+    const badge = row.querySelector('[data-slot="badge"]')!;
+    expect(badge.textContent).toBe("0");
+    expect(badge.className).toContain("bg-secondary");
+  });
 });

--- a/tests/components/monitoring/PerformanceTab.test.tsx
+++ b/tests/components/monitoring/PerformanceTab.test.tsx
@@ -156,4 +156,111 @@ describe("PerformanceTab", () => {
 
     expect(queryAllByTestId("metric-chart").length).toBe(3);
   });
+
+  // Trino "holds no buffer pool" and "takes no locks, so there are no deadlocks to
+  // count" (providers/sql/trino/introspect.ts:622-639), Cassandra and Druid omit the
+  // same two fields, and sqlite.ts:729 sets bufferPoolUsage undefined outright. The
+  // panel used to answer those absences with "0 %"/"Poor" and "0"/"None
+  // detected"/"Healthy" - a rating and a clean bill of health for measurements nobody
+  // made. Same rule as the cache hit ratio card three lines above it.
+  test("reports an unmeasured buffer pool as unavailable instead of 0% and a rating", () => {
+    const { queryByText } = render(<PerformanceTab data={makeData({ bufferPoolUsage: undefined })} loading={false} />);
+
+    expect(queryByText("Buffer")).not.toBeNull();
+    const card = queryByText("Buffer")!.closest('[data-slot="card"]')!;
+    expect(card.textContent).toContain("N/A");
+    expect(card.textContent).toContain("Not measured");
+    // No fabricated measurement: no percentage, no bar, no rating.
+    expect(card.textContent).not.toContain("%");
+    expect(card.querySelectorAll('[data-slot="progress"]').length).toBe(0);
+    for (const rating of ["Excellent", "Good", "Fair", "Poor"]) {
+      expect(card.textContent).not.toContain(rating);
+    }
+    // Absence is not a fault: no red icon, no red or yellow border.
+    expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-muted-foreground");
+    expect(card.className).not.toContain("red");
+    expect(card.className).not.toContain("yellow");
+  });
+
+  test("reports unmeasured deadlocks as unavailable instead of a healthy zero", () => {
+    const { queryByText } = render(<PerformanceTab data={makeData({ deadlocks: undefined })} loading={false} />);
+
+    expect(queryByText("Deadlocks")).not.toBeNull();
+    const card = queryByText("Deadlocks")!.closest('[data-slot="card"]')!;
+    expect(card.textContent).toContain("N/A");
+    expect(card.textContent).toContain("Not measured");
+    // An engine that takes no locks has not detected zero deadlocks - it counted none.
+    expect(card.textContent).not.toContain("None detected");
+    expect(card.textContent).not.toContain("Healthy");
+    expect(card.textContent).not.toContain("Attention");
+    // A green icon is a verdict too.
+    expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-muted-foreground");
+    expect(card.className).not.toContain("red");
+    expect(card.className).not.toContain("yellow");
+  });
+
+  // The pin that keeps absence and zero from being collapsed back together: mongodb.ts:856,
+  // mysql.ts:855 and sqlite.ts:729 report a real measured 0, and that measurement must keep
+  // exactly the rendering it has today.
+  test("keeps a measured zero rendering as a measured zero", () => {
+    const { queryByText } = render(
+      <PerformanceTab data={makeData({ bufferPoolUsage: 0, deadlocks: 0 })} loading={false} />,
+    );
+
+    const buffer = queryByText("Buffer")!.closest('[data-slot="card"]')!;
+    expect(buffer.textContent).toContain("0");
+    expect(buffer.textContent).toContain("%");
+    expect(buffer.textContent).toContain("Poor");
+    expect(buffer.querySelectorAll('[data-slot="progress"]').length).toBe(1);
+    expect(buffer.textContent).not.toContain("Not measured");
+
+    const deadlocks = queryByText("Deadlocks")!.closest('[data-slot="card"]')!;
+    expect(deadlocks.textContent).toContain("0");
+    expect(deadlocks.textContent).toContain("None detected");
+    expect(deadlocks.textContent).toContain("Healthy");
+    expect(deadlocks.textContent).not.toContain("N/A");
+    expect(deadlocks.querySelector("svg")?.getAttribute("class")).toContain("text-green-500");
+  });
+
+  test("renders the buffer and deadlock trends as not measured when no sample carries them", () => {
+    const history = [
+      {
+        timestamp: new Date("2026-02-15T12:00:00Z"),
+        data: makeData({ bufferPoolUsage: undefined, deadlocks: undefined }),
+      },
+      {
+        timestamp: new Date("2026-02-15T12:01:00Z"),
+        data: makeData({ bufferPoolUsage: undefined, deadlocks: undefined }),
+      },
+    ] as unknown as TimeSeriesPoint<MonitoringData>[];
+
+    const { queryByText, queryAllByText, queryAllByTestId } = render(
+      <PerformanceTab
+        data={makeData({ bufferPoolUsage: undefined, deadlocks: undefined })}
+        loading={false}
+        history={history}
+      />,
+    );
+
+    expect(queryByText("Buffer Pool Trend")).not.toBeNull();
+    expect(queryByText("Deadlock Trend")).not.toBeNull();
+    // Only the cache trend, which every sample does carry, is still drawn.
+    expect(queryAllByTestId("metric-chart").length).toBe(1);
+    // Two cards and two trends decline to show a number.
+    expect(queryAllByText("Not measured")).toHaveLength(4);
+  });
+
+  test("still plots the buffer and deadlock trends from the samples that do carry them", () => {
+    const history = [
+      {
+        timestamp: new Date("2026-02-15T12:00:00Z"),
+        data: makeData({ bufferPoolUsage: undefined, deadlocks: undefined }),
+      },
+      { timestamp: new Date("2026-02-15T12:01:00Z"), data: makeData({ bufferPoolUsage: 72, deadlocks: 1 }) },
+    ] as unknown as TimeSeriesPoint<MonitoringData>[];
+
+    const { queryAllByTestId } = render(<PerformanceTab data={makeData()} loading={false} history={history} />);
+
+    expect(queryAllByTestId("metric-chart").length).toBe(3);
+  });
 });

--- a/tests/components/monitoring/PoolTab.test.tsx
+++ b/tests/components/monitoring/PoolTab.test.tsx
@@ -62,4 +62,60 @@ describe("PoolTab", () => {
       expect(queryByText("Pool not available")).not.toBeNull();
     });
   });
+
+  // Absence and zero are different inputs. `/api/db/pool-stats` answers a literal
+  // all-zero body plus `message` for every provider without `getPoolStats` (Cassandra,
+  // MySQL, SQLite, ClickHouse, Druid, Trino, Mongo, Redis, Couchbase), so those zeros
+  // are the route's, not the engine's, and must not be rendered as measurements.
+  test("renders absence as words when the provider reports no pool statistics", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            total: 0,
+            idle: 0,
+            active: 0,
+            waiting: 0,
+            message: "Pool statistics not available for this provider",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+    const { queryAllByText, queryByText } = render(<PoolTab connection={conn} />);
+    await waitFor(() => {
+      expect(queryByText("Pool statistics not available for this provider")).not.toBeNull();
+    });
+    // One "N/A" per card: Total, Active, Idle, Waiting.
+    expect(queryAllByText("N/A").length).toBe(4);
+    // The sub-labels each assert a fact about a pool nobody inspected.
+    expect(queryByText("Max pool size")).toBeNull();
+    expect(queryByText("Available")).toBeNull();
+    expect(queryByText("0% utilized")).toBeNull();
+    expect(queryByText("No queue")).toBeNull();
+  });
+
+  // The pin for the other input: postgres with no pool opened yet returns a real
+  // all-zero reading and no `message`. That is a measurement, and its rendering must
+  // stay byte-for-byte what it is today so the two inputs can never be collapsed.
+  test("keeps today's rendering for a measured zero", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ total: 0, idle: 0, active: 0, waiting: 0 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    const { queryAllByText, queryByText } = render(<PoolTab connection={conn} />);
+    await waitFor(() => {
+      expect(queryByText("Max pool size")).not.toBeNull();
+    });
+    expect(queryByText("Available")).not.toBeNull();
+    expect(queryByText("0% utilized")).not.toBeNull();
+    expect(queryByText("No queue")).not.toBeNull();
+    // Four card values plus the Waiting badge.
+    expect(queryAllByText("0").length).toBe(5);
+    expect(queryAllByText("N/A").length).toBe(0);
+  });
 });

--- a/tests/components/monitoring/QueriesTab.test.tsx
+++ b/tests/components/monitoring/QueriesTab.test.tsx
@@ -100,4 +100,40 @@ describe("QueriesTab", () => {
     const { queryAllByText } = render(<QueriesTab data={data} loading={false} />);
     expect(queryAllByText("2.5M").length).toBeGreaterThan(0);
   });
+
+  test("an engine that keeps no query log gets absence, not statistics it never gathered", () => {
+    // Measured 2026-08-21 in Chrome against Apache Cassandra 5.0.9: this tab read
+    // "Queries 0 / Avg Time 0.00ms / Slow 0" while the list below correctly said no
+    // statistics were available. Cassandra keeps no query log at all
+    // (cassandra/index.ts:573-575), and neither do Druid (index.ts:486-488) or SQLite
+    // (sqlite.ts:734-737) - they answer `[]` by design. An average over an empty set is
+    // not 0.00ms, and "Queries 0" claims a call total against the database rather than
+    // counting visible rows, so all three figures render as absence instead.
+    const { queryAllByText, queryByText } = render(
+      <QueriesTab data={{ ...makeData(), slowQueries: [] } as MonitoringData} loading={false} />,
+    );
+
+    expect(queryAllByText("0.00ms").length).toBe(0);
+    expect(queryAllByText("0").length).toBe(0);
+    expect(queryAllByText("N/A").length).toBe(3);
+    expect(queryByText("No query statistics available.")).not.toBeNull();
+  });
+
+  test("a measured zero still renders as a zero, because absence is the only new input", () => {
+    // The guard is on the presence of statistics, never on their value. A provider that
+    // reports a query which has run zero times, or whose recorded average is 0, HAS
+    // measured those figures, so the cards keep formatting them exactly as before -
+    // otherwise a future reader could collapse the two inputs back together.
+    const measuredZero = {
+      ...makeData(),
+      slowQueries: [{ queryId: "z1", query: "SELECT 1", calls: 0, totalTime: 0, avgTime: 0, rows: 0 }],
+    } as MonitoringData;
+
+    const { queryAllByText, queryByText } = render(<QueriesTab data={measuredZero} loading={false} />);
+
+    expect(queryAllByText("N/A").length).toBe(0);
+    expect(queryAllByText("0.00ms").length).toBe(3);
+    expect(queryAllByText("0").length).toBe(4);
+    expect(queryByText("No query statistics available.")).toBeNull();
+  });
 });

--- a/tests/components/monitoring/TablesTab.test.tsx
+++ b/tests/components/monitoring/TablesTab.test.tsx
@@ -105,9 +105,13 @@ describe("TablesTab", () => {
   });
 
   test("shows empty state when no tables match", () => {
+    // `tableCount: 0` keeps this the genuine-empty-database case: with a non-zero
+    // tableCount the same `tables: []` means the engine refused statistics, which the
+    // absence tests below cover instead.
+    const base = makeData();
     const { queryByText } = render(
       <TablesTab
-        data={{ ...makeData(), tables: [] } as MonitoringData}
+        data={{ ...base, overview: { ...base.overview, tableCount: 0 }, tables: [] } as MonitoringData}
         loading={false}
         onRunMaintenance={mock(async () => true)}
       />,
@@ -263,5 +267,124 @@ describe("TablesTab", () => {
     expect(container.querySelector('button[title="Vacuum"]')).toBeNull();
     expect(container.querySelector('button[title="Reindex"]')).toBeNull();
     expect(queryAllByText("-").length).toBeGreaterThan(0);
+  });
+  // #448 settled the rule this panel broke one component over: absence and zero are
+  // different inputs. Measured 2026-08-21 in Chrome against Apache Cassandra 5.0.9 —
+  // Monitoring -> Tables read "Tables 0 / 0 rows", "Size 0 B" and a green "Vacuum 0 / OK"
+  // while the Overview tab of the same session read 6 tables from `system_schema`.
+  test("renders absence rather than zeros when the engine publishes no table statistics", () => {
+    const base = makeData();
+    const { queryByText, queryAllByText } = render(
+      <TablesTab
+        data={{ ...base, overview: { ...base.overview, tableCount: 6 }, tables: [] } as MonitoringData}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities()}
+      />,
+    );
+
+    // All three card figures decline to answer instead of reporting a measured zero.
+    expect(queryAllByText("N/A").length).toBe(3);
+    expect(queryByText("0 rows")).toBeNull();
+    expect(queryByText("0 B")).toBeNull();
+    expect(queryByText("Total")).toBeNull();
+    expect(queryByText("OK")).toBeNull();
+    // The engine does have vacuum here, so the card says nothing about it either way.
+    expect(queryByText("Not supported")).toBeNull();
+    // "No tables found." is a false claim when the overview counts six of them.
+    expect(queryByText("No table statistics available.")).not.toBeNull();
+    expect(queryByText("No tables found.")).toBeNull();
+  });
+
+  test("keeps the measured zero rendering exactly as it is today", () => {
+    // A provider answering a real 0 has measured one. This test is the guard that stops
+    // the two inputs being collapsed back together by a later simplification.
+    const base = makeData();
+    const { queryByText, queryAllByText } = render(
+      <TablesTab
+        data={{ ...base, overview: { ...base.overview, tableCount: 0 }, tables: [] } as MonitoringData}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities()}
+      />,
+    );
+
+    expect(queryAllByText("0").length).toBe(2); // the Tables and the Vacuum card figures
+    expect(queryByText("0 rows")).not.toBeNull();
+    expect(queryByText("0 B")).not.toBeNull();
+    expect(queryByText("Total")).not.toBeNull();
+    expect(queryByText("OK")).not.toBeNull();
+    expect(queryAllByText("N/A").length).toBe(0);
+    expect(queryByText("No tables found.")).not.toBeNull();
+  });
+
+  test("reports no vacuum state at all for an engine whose provider declares no maintenance", () => {
+    // Apache Cassandra publishes `supportsMaintenance: false, maintenanceOperations: []`
+    // and every maintenance action on it is a `nodetool` call the studio never makes, so
+    // a green "OK" is a clean bill of health for an operation that does not exist.
+    const { queryByText } = render(
+      <TablesTab
+        data={makeData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities({ supportsMaintenance: false, maintenanceOperations: [] })}
+      />,
+    );
+
+    expect(queryByText("Not supported")).not.toBeNull();
+    expect(queryByText("OK")).toBeNull();
+    expect(queryByText("Need")).toBeNull();
+    // The statistics the engine did publish are untouched.
+    expect(queryByText("users")).not.toBeNull();
+    expect(queryByText("501.2K rows")).not.toBeNull(); // 1,200 + 500,000 across the two rows
+  });
+
+  test("renders no bloat badge and no vacuum history for per-row figures the engine never published", () => {
+    const base = makeData();
+    const data = {
+      ...base,
+      tables: [
+        {
+          schemaName: "ks",
+          tableName: "sensors",
+          rowCount: 12,
+          tableSize: "1 MiB",
+          tableSizeBytes: 1048576,
+          indexSize: "",
+          indexSizeBytes: 0,
+          totalSize: "1 MiB",
+          totalSizeBytes: 1048576,
+        },
+      ],
+    } as unknown as MonitoringData;
+
+    const { queryByText, container } = render(
+      <TablesTab
+        data={data}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities({ supportsMaintenance: false, maintenanceOperations: [] })}
+      />,
+    );
+
+    expect(container.querySelectorAll("tbody tr").length).toBe(1);
+    expect(queryByText("sensors")).not.toBeNull();
+    expect(queryByText("0.0%")).toBeNull();
+    expect(queryByText("Never")).toBeNull();
+  });
+
+  test("still calls a missing vacuum history Never on an engine that has vacuum", () => {
+    // PostgreSQL's NULL `last_vacuum` genuinely means never vacuumed, and the `events`
+    // row carries no `lastVacuum`, so this rendering must survive the fix above.
+    const { queryByText } = render(
+      <TablesTab
+        data={makeData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities()}
+      />,
+    );
+
+    expect(queryByText("Never")).not.toBeNull();
   });
 });


### PR DESCRIPTION
fix(monitoring): five panels answered an absent measurement with a confident zero (#424)

#448 settled a rule for one panel and a live browser drive of that same release found the
neighbours still breaking it. Connected to Apache Cassandra 5.0.9 in Chrome, Monitoring ->
Tables read `Tables 0 / "0 rows"`, `Size "0 B" / "Total"` and `Vacuum 0 / "OK"` while the
list underneath correctly said "No tables found" - and the Overview tab of the same
session, same connection, read `Tables 6 / 2 indexes`. The product answered one question
two ways, republished the sentinel #448 had just deleted, and issued a clean bill of health
for an operation Apache Cassandra does not have.

An audit of every tab found the same shape in five of six. The cause is never
engine-specific: a `reduce` over `data?.tables ?? []`, or a `?? 0` on a field its own type
marks optional, turns a refusal into a number.

The rule applied throughout, unchanged from #448: ABSENCE and ZERO are different inputs. A
provider reporting nothing is saying the figure is not knowable; a provider reporting 0 has
measured one. Only the first changes, and every panel now pins the second with a test of
its own so the two cannot be collapsed again.

- **TablesTab** - the panel the browser proved. Statistics are absent, rather than the
  database being empty, exactly when the engine knows of tables and reports none for them,
  which the required `overview.tableCount` can say and `tables` alone cannot. The Vacuum
  card is now a capability question rather than a data one: `supportsMaintenance: false`
  means the engine has no such operation, so the card states no verdict for it, and
  `lastVacuum` no longer renders the word "Never" - a measurement on PostgreSQL, a claimed
  history elsewhere - for an engine that cannot vacuum.
- **PerformanceTab** - `bufferPoolUsage` and `deadlocks` are optional and genuinely
  omitted: Trino's provider records in prose that it "holds no buffer pool" and "takes no
  locks, so there are no deadlocks to count", Cassandra and Druid omit both, and SQLite
  sets the first undefined outright. The panel was rating that absence "Poor" from a
  fabricated 0, and badging the second "Healthy". It already did the right thing three
  lines above for `cacheHitRatio`; the two now agree, trend charts included, which stops
  the charts plotting a zero floor nobody measured.
- **OverviewTab** - the same two fields on the compact rows.
- **PoolTab** - the zeros were not even the provider's: the route answers a literal
  `{total: 0, idle: 0, active: 0, waiting: 0}` with a "not available" message for engines
  that pool nothing, and the panel rendered "Max pool size 0" and "No queue" from it.
- **QueriesTab** - same shape, same fix.
- **SessionsTab** - examined and REFUTED, no change: its counts are of a list the user can
  see, which is honest, and its `?? 0` fallbacks read fields their types mark required.

Nineteen tests added across the five panels, each pinning both inputs. Provider docs synced
where they described a panel's rendering: cassandra, druid, trino, elasticsearch, opensearch
and libredb.

Found by driving the product rather than by a gate - all six gates were green over the
frame that showed `Vacuum 0 - OK`.


---

**Follow-up commit — the absence branching had put four of these files over Sonar's
cognitive complexity threshold.** The quality gate passed regardless (0 blocking issues,
100% coverage on new code), so this is legibility, not a defect; but the four nested
ternaries it flagged sit at exactly the places a reader is most likely to misread, because
each encodes THREE states in a shape that looks like two.

`vacuumIconClass` / `VacuumNote` (TablesTab) and `deadlockIconClass` (PerformanceTab) each
replace `absent ? grey : positive ? warn : green`. As early returns the third state is
visible: an engine that published no statistics at all is not an engine that looked and
found nothing, and must not borrow the green of one that did. `bloatBadgeVariant` does the
same for the >20 / >10 thresholds. `formatBytes`, `formatNumber` and `formatVacuumDate`
moved to module scope - pure, and previously re-created on every render. `MetricTrendCard`
and `metricSeries` replace three near-identical chart cards and three near-identical
`flatMap` builders. `PoolStatsGrid`, `PerformanceSummaryCard` and `QuickStatsCard` move
presentation to where it reads as presentation.

Nothing rendered changes, which is what the existing tests assert: 330 core files and all
30 component groups pass untouched, no test added or edited, and every extracted branch was
already exercised - the four files stay at 100% line coverage.

Two notes worth recording. `MetricTrendCard` takes `heading` as a separate prop rather than
deriving it from `title`, because the deadlock card is labelled "Deadlock Trend" while its
chart is titled "Deadlocks" - deriving one from the other would have silently changed that
copy. And moving the Performance card out of `OverviewTab` left `performance?.checkpointWriteTime`
resolving to the DOM `performance` global rather than the prop; it failed typecheck only
because `Performance` has no such property, and a colliding name would have compiled.
