### PR TITLE
docs(backlog): U14 landed with #452, and D7 says why that does not close it

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -293,6 +293,12 @@ populated wrong one is not", and it is the reason Citus and TimescaleDB are reco
 despite answering every surface. The same argument applies to our own fallback, and it is worse here
 because the engine is not the author of the number - we are.
 
+**This is the provider half of a problem whose panel half is now closed.** PR #452 taught the five
+monitoring tabs to render an omitted metric as unavailable rather than as zero, which retired the
+former U14 entry. It cannot reach this one: a fabricated `99` is not an absence, so there is nothing
+for a panel to detect - the number arrives indistinguishable from a measurement and is rendered as
+one. The OceanBase reading above is exactly as true after #452 as before it.
+
 Done when a provider that cannot measure the cache hit ratio reports it as unavailable rather than as
 a figure, on all three sites, and this entry is deleted.
 
@@ -2807,17 +2813,6 @@ Done when a provider declares whether it has transactions, `Studio.tsx` omits th
 toggle where it does not, and every provider's doc states its answer. Deliberately not
 folded into #424: the capability has to be added to every provider at once, which is a wider change
 than the PR that found it.
-
-### U14. Monitoring reports relational zeros as measurements on engines that have no such counter
-
-The monitoring Overview renders *Buffer Pool 0%*, *Deadlocks 0* and *Checkpoint N/A* for a search
-cluster (measured 2026-08-19 on OpenSearch). `N/A` is the honest one: a cluster has no checkpoint. A
-`0` for a counter the engine does not keep reads as a measurement — the same class of claim the #414
-work removed from the schema tree, where an empty foreign-key list had to say "impossible here" rather
-than "none found".
-
-Done when a metric an engine cannot report renders as unavailable rather than as zero, on every
-provider whose health payload omits it.
 
 ### U15. The IPv6-only container default is unverified on a kernel without AF_INET6
 


### PR DESCRIPTION
`U14` asked that a metric an engine cannot report render as unavailable rather than as zero,
"on every provider whose health payload omits it". #452 (`408a1e9`) implemented exactly that
across the Overview, Performance, Tables, Pool and Queries tabs. This file's convention is
that a landed entry is deleted rather than annotated, and #452 did not touch `docs/BACKLOG.md`,
which is the only reason `U14` was still on `main`.

**Deleting it alone would read as the problem being solved, and it is not.** So `D7` gains a
paragraph naming which half closed:

- #452 fixed the **panel** half. A field the provider omits is now rendered as unavailable.
- `D7` is the **provider** half. `mysql.ts` and `mongodb.ts` return `cacheHitRatio: 99` from a
  `catch`; `libredb.ts` returns `100` unconditionally. A fabricated number is not an absence,
  so there is nothing for a panel to detect - it arrives indistinguishable from a measurement
  and is rendered as one.

The OceanBase reading already recorded in `D7` - 99 percent cache hit on every refresh,
forever, against a tenant with no `performance_schema` database at all - is exactly as true
after #452 as before it. `U12` is likewise untouched: `QueriesTab` still hardcodes
*"pg_stat_statements required"* as the empty state for every engine.

Both are named in the [#424 comment of 2026-08-21](https://github.com/libredb/libredb-studio/issues/424#issuecomment-5370995544)
alongside this deletion, so the record sits in one place.

### Verification

Docs-only, one file. No entry other than `U14` is removed and no `B`-numbered entry is
touched, so the M2 deferral assertions in `tests/unit/agent-documentation.test.ts` - which
match `### (B\d+)\.` only - are unaffected. Confirmed by running them rather than by reading:

- `bun run format` · `bun run lint` · `bun run typecheck` · `bun run knip` - clean
- `tests/run-core.sh` - **all 330 core test files passed**
- `bun run test:components` - **all 30 groups passed**
- `bun run build` - exit 0

`git grep U14` now returns one line, the deliberate back-reference inside `D7`.
