### PR TITLE
feat(login): the front door named 15 engines while the product connects to 32

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3008,3 +3008,36 @@ Cassandra field, and Scylla's version string is not `release_version`-shaped. An
 
 Done when each of the four has either been taken further or judged settled, when ScyllaDB has been
 probed or ruled out, and this entry is deleted.
+
+### U18. The login hero has no vertical slack left, and the relatives line spends 56px it does not have
+
+Measured on the built app (`next start`, Chromium), the same page before and after the change that
+added the wire-compatible relatives line:
+
+| Viewport | Before | After | Sign-in card |
+| --- | --- | --- | --- |
+| 1440x900 | page 900px, no scroll | page 900px, no scroll | above the fold in both |
+| 1280x800 | page 800px, no scroll | **page 856px, scrolls 56px** | above the fold in both |
+| 1920x1080 | page 1080px, no scroll | page 1080px, no scroll | above the fold in both |
+| 390x844 | page 991px (already scrolls) | page 1062px | above the fold in both |
+
+The cause is not the line's height alone. At 1280x800 the hero column measured **exactly 800px before
+the change** - the content block was 489px and the chrome around it took the rest, so the column had
+**zero slack** and the `mt-auto` above it had nothing left to absorb. Any block added anywhere in that
+column scrolls the page at that height; one more row of engine pills would do it too.
+
+What was already spent to reduce it: folding the relatives line into the pills' own block instead of
+the hero's 32px rhythm (20px), `leading-snug` instead of `leading-relaxed` (12px), and a shorter lead
+sentence (one line, 16px) - 104px of overflow brought down to 56px. Reaching zero means taking height
+out of a block that is not the relatives line, which is a decision about what the hero says rather
+than about how this line is set: the candidates are the `platform-line` ("Runs on Linux · macOS ·
+Windows", 20px plus its gap), the h1's two-line setting at 1280px, and the `connection-signature`'s
+`text-xl` at that width.
+
+The harm today is bounded and worth stating plainly: the sign-in card is unaffected at every measured
+size, and what falls below the fold at 1280x800 is the bottom of the hero (the community row) plus the
+column's own top padding, which collapses first. It is not the failure `login-form.tsx`'s comment
+records - a hero that measured 1294px in a 900px viewport and pushed the sign-in card itself down.
+
+Done when the hero fits at 1280x800 with the relatives line intact, or when scrolling at that height
+is accepted deliberately and this entry is deleted.

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import { listShowcaseDatabases } from "../src/lib/db-showcase";
 import { LIVE_CHANNELS, LIVE_PLATFORMS } from "../src/lib/distribution/channels.generated";
 import { DEPLOY_GROUP_LABELS, DEPLOY_GROUP_ORDER } from "../src/lib/distribution/deploy-groups";
+import { WIRE_COMPATIBLE_ENGINES } from "../src/lib/db/compatibility";
 
 test.describe("Login Flow", () => {
   test.beforeEach(async ({ page }) => {
@@ -115,9 +116,31 @@ test.describe("Login showcase", () => {
     await expect(page.getByRole("list", { name: "Supported Databases" })).toHaveCount(1);
     await expect(engines).toBeVisible();
 
+    // Matched per item as a pattern rather than a string, because the embedded provider's
+    // item carries an "(embedded)" marker after its label: the hero claims the external
+    // engines only, and this is the marker that tells a reader which pill the claim leaves
+    // out. The `embedded` flag comes from the same module the page renders from, so the
+    // expectation still names no engine.
     const expected = listShowcaseDatabases();
     await expect(engines.getByRole("listitem")).toHaveCount(expected.length);
-    await expect(engines.getByRole("listitem")).toHaveText(expected.map((db) => db.label));
+    await expect(engines.getByRole("listitem")).toHaveText(
+      expected.map((db) => new RegExp(`^${db.label}\\s*${db.embedded ? "\\(embedded\\)" : ""}$`)),
+    );
+  });
+
+  test("hero names every wire-compatible relative, with the registry's own count", async ({ page }) => {
+    // The gap this closes: the hero named the shipped drivers and stopped, while the product
+    // connects to thirty-two named products. The eighteen relatives were published in
+    // README.md and the docs compatibility table but on no surface a visitor sees first.
+    const line = page.getByTestId("wire-compatible-desktop");
+    await expect(line).toBeVisible();
+    await expect(line).toContainText(`${WIRE_COMPATIBLE_ENGINES.length}`);
+    for (const engine of WIRE_COMPATIBLE_ENGINES) {
+      await expect(line).toContainText(engine.name);
+    }
+    // No tier word: the per-engine tier belongs to the connection dialog's hint, which has
+    // room to qualify it. A hero line that implied parity would be the overclaim #424 bans.
+    await expect(line).not.toContainText(/partial|query-only/i);
   });
 
   test("hero states the live channel count and names every group", async ({ page }) => {
@@ -160,6 +183,12 @@ test.describe("Login showcase", () => {
     const mobileEngines = page.getByTestId("database-showcase-mobile");
     await expect(mobileEngines).toBeVisible();
     await expect(mobileEngines.getByRole("listitem")).toHaveCount(listShowcaseDatabases().length);
+
+    // The relatives line is the second half of that engine set, so it must survive the
+    // collapse too - a mobile visitor is the one most likely to be evaluating on a phone.
+    const mobileRelatives = page.getByTestId("wire-compatible-mobile");
+    await expect(mobileRelatives).toBeVisible();
+    await expect(mobileRelatives).toContainText(`${WIRE_COMPATIBLE_ENGINES.length}`);
 
     // The condensed line restates the same claims on one row. Both surfaces mark their
     // agent claim with the same test id, so it is selected by the text only the mobile one

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -13,6 +13,7 @@ import { CommunitySection } from "@/components/community-section";
 import { ConnectionSignature } from "@/components/login/connection-signature";
 import { DatabaseShowcase } from "@/components/login/database-showcase";
 import { HeroProof, HERO_CLAIMS } from "@/components/login/hero-proof";
+import { WireCompatibleLine } from "@/components/login/wire-compatible-line";
 
 /**
  * The agent half of the mobile summary. Pulled from `HERO_CLAIMS` rather than retyped, so
@@ -149,7 +150,19 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
 
             <ConnectionSignature />
 
-            <DatabaseShowcase variant="desktop" />
+            {/*
+              The pills and the relatives line are ONE block with a 12px gap, not two
+              siblings in the 32px rhythm above. Two reasons, and the second is a measurement:
+              the line is the second half of the engine list rather than a fourth claim, so it
+              belongs to the pills; and this column had no room to give. At 1280x800 the hero
+              measured exactly 800px before this change - zero slack - so every pixel added
+              here scrolls the page. Folding the two into one block buys back 20px of the 32
+              the standalone gap would have cost.
+            */}
+            <div className="space-y-3">
+              <DatabaseShowcase variant="desktop" />
+              <WireCompatibleLine variant="desktop" />
+            </div>
 
             <HeroProof />
           </div>
@@ -304,6 +317,7 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
           */}
           <div className="lg:hidden space-y-4">
             <DatabaseShowcase variant="mobile" />
+            <WireCompatibleLine variant="mobile" />
             {/*
               The same three claims the desktop hero makes, joined into one line rather than
               re-worded for mobile: `HERO_CLAIMS` is the single source, so a change to the

--- a/src/components/login/database-showcase.tsx
+++ b/src/components/login/database-showcase.tsx
@@ -48,7 +48,22 @@ function DesktopDatabases() {
         return (
           <li key={db.type} className="flex items-center gap-1.5 text-xs text-fg-tertiary">
             <Icon className={`h-3.5 w-3.5 ${db.color}`} aria-hidden="true" />
-            {db.label}
+            {/*
+              Label and marker share ONE span rather than sitting as two flex children. As
+              flex children the gap between them was visual only - the item's text read
+              "LibreDB(embedded)" with no separator at all, which is what a screen reader and
+              a copy-paste get. Inside one span the space is a real text node.
+
+              No colour class on the marker: it inherits the item's own `fg-tertiary`.
+              Stepping it down the ramp is what the eye wants and what the ramp cannot give
+              on this ground - the measurements in this file's header put `fg-muted` at 3.9:1
+              and `fg-subtle` at 2.6:1, both under the 4.5:1 AA floor for type this small.
+              The parentheses carry the demotion instead.
+            */}
+            <span>
+              <span data-engine-label>{db.label}</span>
+              {db.embedded && <span> (embedded)</span>}
+            </span>
           </li>
         );
       })}
@@ -65,7 +80,8 @@ function MobileDatabases() {
     >
       {listShowcaseDatabases().map((db) => (
         <li key={db.type} className="text-[10px] px-2.5 py-1 rounded-full bg-muted text-muted-foreground font-medium">
-          {db.label}
+          <span data-engine-label>{db.label}</span>
+          {db.embedded && <span> (embedded)</span>}
         </li>
       ))}
     </ul>

--- a/src/components/login/hero-proof.tsx
+++ b/src/components/login/hero-proof.tsx
@@ -1,6 +1,6 @@
 import { AGENT_EXECUTION_ENGINES } from "@/lib/agent/engine-support";
 import { getDBConfig } from "@/lib/db-ui-config";
-import { listShowcaseDatabases } from "@/lib/db-showcase";
+import { EXTERNAL_DATABASE_TYPES } from "@/lib/db/compatibility";
 import { LIVE_CHANNELS, LIVE_PLATFORMS } from "@/lib/distribution/channels.generated";
 import { DEPLOY_GROUP_LABELS, DEPLOY_GROUP_ORDER } from "@/lib/distribution/deploy-groups";
 
@@ -46,7 +46,13 @@ const AGENT_MODES: readonly { key: string; label: string; detail: string }[] = [
 export const HERO_CLAIMS: readonly { key: string; value: number; unit: string; detail: string }[] = [
   {
     key: "engines",
-    value: listShowcaseDatabases().length,
+    // EXTERNAL_DATABASE_TYPES, not the showcase length. The two differ by one and the one is
+    // the embedded store: it is a provider this app carries, not a database anyone points us
+    // at, so counting it here claimed one external engine more than the product has and put
+    // this page one out of step with the number README.md publishes. The pill for it stays -
+    // it is a provider the connection picker offers - marked as embedded so the reader can
+    // see why fifteen pills sit under a claim of fourteen.
+    value: EXTERNAL_DATABASE_TYPES.length,
     unit: "database engines",
     detail: "one client, one workspace, every one of them",
   },

--- a/src/components/login/wire-compatible-line.tsx
+++ b/src/components/login/wire-compatible-line.tsx
@@ -1,0 +1,63 @@
+import { Fragment } from "react";
+import { WIRE_COMPATIBLE_ENGINES } from "@/lib/db/compatibility";
+
+interface WireCompatibleLineProps {
+  variant: "desktop" | "mobile";
+}
+
+/**
+ * The engines that connect through a driver of their own name's making.
+ *
+ * The login page named fifteen providers and stopped there, while the product connects to
+ * thirty-two named products: the other eighteen speak a wire protocol we already ship and
+ * were published in README.md and the docs compatibility table, but nowhere a visitor to
+ * the front door could see them. This line closes that gap and nothing else - the count and
+ * every name come from `WIRE_COMPATIBLE_ENGINES`, so a nineteenth probed engine joins the
+ * page by being added to the registry.
+ *
+ * What it deliberately does NOT carry is the per-engine tier. `WireCompatibilityHint` shows
+ * it in the connection dialog, where there is room to say that Materialize is query-editor
+ * only and that a Citus distributed table reports row counts you should not trust. A hero
+ * line has no room for eighteen qualifications, and the alternative to qualifying them is
+ * not to imply parity: the wording claims a measurement, which is the one thing every entry
+ * here really has (issue #424's claim discipline - "connects is not supported"), and the
+ * docs table is where a reader finds out how much of the product each one gives them.
+ *
+ * The two variants exist for the same reason `database-showcase.tsx` has two: the desktop
+ * block sits in the hero's left column, pinned dark by a nested `dark` class, so it needs
+ * that subtree's own `fg-*` tokens, while the mobile block follows the viewer's theme
+ * through `muted-foreground`. Swapping either set into the other surface renders the text
+ * the same colour as its background.
+ *
+ * `pointer-events-none select-none` and no anchor: this is decorative showcase content on
+ * an unauthenticated page, which is the rule the rest of the hero already follows.
+ *
+ * `leading-snug` rather than the hero's usual `leading-relaxed`, and the lead sentence is as
+ * short as it can be while still claiming a measurement rather than parity. Both are height
+ * budget: the hero column measured exactly 800px at a 1280x800 viewport before this line
+ * existed, so this is the one block on the page that has to earn its lines.
+ */
+export function WireCompatibleLine({ variant }: WireCompatibleLineProps) {
+  const isDesktop = variant === "desktop";
+  return (
+    <p
+      data-testid={`wire-compatible-${variant}`}
+      className={
+        isDesktop
+          ? "text-xs text-fg-tertiary leading-snug pointer-events-none select-none"
+          : "text-[10px] text-center text-muted-foreground leading-snug pointer-events-none select-none"
+      }
+    >
+      Plus {WIRE_COMPATIBLE_ENGINES.length} wire-compatible engines, each measured on a live instance:{" "}
+      {WIRE_COMPATIBLE_ENGINES.map((engine, index) => (
+        <Fragment key={engine.name}>
+          {index > 0 && ", "}
+          <span data-relative-name className={isDesktop ? "text-fg-secondary" : "text-foreground"}>
+            {engine.name}
+          </span>
+        </Fragment>
+      ))}
+      .
+    </p>
+  );
+}

--- a/src/lib/db-showcase.ts
+++ b/src/lib/db-showcase.ts
@@ -1,4 +1,5 @@
 import { DB_UI_CONFIG, type DBIcon } from "@/lib/db-ui-config";
+import { isExternalDatabaseType } from "@/lib/db/compatibility";
 import type { DatabaseType } from "@/lib/types";
 
 /**
@@ -61,6 +62,14 @@ export interface ShowcaseDatabase {
   label: string;
   icon: DBIcon;
   color: string;
+  /**
+   * True for the embedded store, false for a database the user already runs.
+   *
+   * The showcase shows all fifteen providers while the hero claims fourteen engines,
+   * and this flag is how the page carries that difference without any surface typing
+   * the word "libredb": the pill it marks is the one the count leaves out.
+   */
+  embedded: boolean;
 }
 
 /**
@@ -74,5 +83,6 @@ export function listShowcaseDatabases(): ShowcaseDatabase[] {
     label: DB_UI_CONFIG[type].label,
     icon: DB_UI_CONFIG[type].icon,
     color: DB_UI_CONFIG[type].color,
+    embedded: !isExternalDatabaseType(type),
   }));
 }

--- a/src/lib/db/compatibility.ts
+++ b/src/lib/db/compatibility.ts
@@ -44,8 +44,8 @@ const SHIPPED: Readonly<Record<DatabaseType, true>> = Object.freeze({
   // Two ids served by ONE provider module (`providers/sql/search/`), which is the
   // first time "shipped" here does not mean one provider file per id. They are still
   // two entries because the tri-sync invariant is per type-id - each has its own doc
-  // page and its own integration test - and because `verifiedEngineCount()` counts
-  // what a user can pick, not how the code is laid out.
+  // page and its own integration test - and because the published count counts what
+  // a user can pick, not how the code is laid out.
   elasticsearch: true,
   opensearch: true,
   mongodb: true,
@@ -57,12 +57,57 @@ const SHIPPED: Readonly<Record<DatabaseType, true>> = Object.freeze({
 /**
  * Derived from an exhaustive Record on purpose. As a hand-written array this was
  * the one mandatory registration surface in the codebase with no guard at all: a
- * new type-id omitted here made `verifiedEngineCount()` undercount, nothing failed,
+ * new type-id omitted here made the published count undercount, nothing failed,
  * and the unit test that checked the count read the same constant on both sides.
  * With the Record the compiler refuses the omission, which is the same technique
  * `src/lib/sql/fence-tags.ts` already uses over this union.
  */
 export const SHIPPED_DATABASE_TYPES: readonly DatabaseType[] = Object.freeze(Object.keys(SHIPPED) as DatabaseType[]);
+
+/**
+ * Which shipped ids are databases a user already runs, and which one is not.
+ *
+ * `libredb` is the embedded store this app carries with it; the other fourteen are
+ * external engines you point the product at. Everything published as a database
+ * count means the external fourteen - README.md's "fourteen drivers reach
+ * thirty-two named engines", the login hero's engine claim - so the split needs a
+ * definition somewhere, and it belongs beside `SHIPPED` rather than in the UI that
+ * prints it. That is the same reason `SHIPPED` itself lives here.
+ *
+ * An exhaustive Record again, so a new type-id cannot join without someone
+ * answering the question. The alternative - filtering `libredb` out by name at each
+ * call site - is how the two halves of a published count drift apart.
+ */
+const EXTERNAL: Readonly<Record<DatabaseType, boolean>> = Object.freeze({
+  postgres: true,
+  mysql: true,
+  sqlite: true,
+  oracle: true,
+  mssql: true,
+  clickhouse: true,
+  druid: true,
+  trino: true,
+  cassandra: true,
+  elasticsearch: true,
+  opensearch: true,
+  mongodb: true,
+  couchbase: true,
+  redis: true,
+  // The one false entry. SQLite is a file rather than a server and is still
+  // external: it is the user's file, opened from a path they give us. libredb is
+  // ours, created by this app, so it is the only id that answers no here.
+  libredb: false,
+});
+
+/** The shipped ids that are databases a user already runs, in registry order. */
+export const EXTERNAL_DATABASE_TYPES: readonly DatabaseType[] = Object.freeze(
+  SHIPPED_DATABASE_TYPES.filter((type) => EXTERNAL[type]),
+);
+
+/** True for every shipped id except the embedded store. */
+export function isExternalDatabaseType(type: DatabaseType): boolean {
+  return EXTERNAL[type] === true;
+}
 
 /**
  * How much of the product works against a wire-compatible engine.
@@ -339,14 +384,24 @@ export function compatibleEnginesFor(type: DatabaseType): readonly WireCompatibl
 }
 
 /**
- * The counting rule for #424's claim discipline: a published count is the shipped
- * drivers plus the relatives an actual probe verified, and nothing else.
+ * The counting rule for #424's claim discipline: a published count is the external
+ * engines plus the relatives an actual probe verified, and nothing else.
  *
- * No runtime consumer today - the README and the docs table are markdown and quote
- * the number as prose. This exists so the arithmetic has one definition instead of
- * being redone by hand in each place, and the unit test pins it. If a UI surface
- * ever prints the count, it reads it here rather than hardcoding it.
+ * Renamed from `verifiedEngineCount`, and the rename is the fix rather than a
+ * tidy-up. That function counted `SHIPPED_DATABASE_TYPES`, which includes the
+ * embedded store, so it answered 33 while README.md published 32 for the same
+ * claim. Both numbers were defensible and neither said which set it was counting,
+ * which is precisely the failure a single definition exists to prevent: a count is
+ * wrong when its denominator is unstated, not when its digit is stale.
+ *
+ * The name now says the set. A product is countable here when a user can point the
+ * app at it, so the embedded store is out of both halves of the sum.
+ *
+ * Still no runtime consumer: README.md and the docs table are markdown and quote the
+ * number as prose, and the login hero prints the two halves separately - fourteen in
+ * the proof row, eighteen in the relatives line - rather than their sum. This exists
+ * so the arithmetic has one definition, and the unit test pins it.
  */
-export function verifiedEngineCount(): number {
-  return SHIPPED_DATABASE_TYPES.length + WIRE_COMPATIBLE_ENGINES.length;
+export function connectableProductCount(): number {
+  return EXTERNAL_DATABASE_TYPES.length + WIRE_COMPATIBLE_ENGINES.length;
 }

--- a/tests/components/LoginPage.test.tsx
+++ b/tests/components/LoginPage.test.tsx
@@ -12,6 +12,7 @@ import { LIVE_CHANNELS, LIVE_PLATFORMS } from "@/lib/distribution/channels.gener
 import { DEPLOY_GROUP_LABELS, DEPLOY_GROUP_ORDER } from "@/lib/distribution/deploy-groups";
 import { ENGINE_URI_SCHEMES, parseConnectionString } from "@/lib/connection-string-parser";
 import { SIGNATURE_URIS } from "@/components/login/connection-signature";
+import { EXTERNAL_DATABASE_TYPES, SHIPPED_DATABASE_TYPES, WIRE_COMPATIBLE_ENGINES } from "@/lib/db/compatibility";
 
 // sonner and next/navigation are mocked via preload
 // lucide-react resolves fine natively — no mock needed
@@ -257,11 +258,71 @@ describe("LoginPage showcase (issue #425)", () => {
   });
 
   test("names no engine outside DB_UI_CONFIG", () => {
+    // Reads the label node rather than the whole item: the embedded provider's pill also
+    // carries an "embedded" marker, so comparing the item's full text would either fail
+    // here or force the marker out of the pill it belongs in.
     const { getByTestId } = renderShowcase();
     const known = new Set(listShowcaseDatabases().map((db) => db.label));
     for (const item of getByTestId("database-showcase-desktop").querySelectorAll("li")) {
-      expect(known.has(item.textContent?.trim() ?? "")).toBe(true);
+      const label = item.querySelector("[data-engine-label]")?.textContent?.trim() ?? "";
+      expect(known.has(label)).toBe(true);
     }
+  });
+
+  test("marks the embedded provider in the pill list instead of dropping it", () => {
+    // The hero claims 14 external engines while showing 15 pills, and this marker is what
+    // reconciles the two for a reader. Hiding the pill was the alternative and it is worse:
+    // libredb is a provider the connection picker offers, so a login page that never names
+    // it contradicts the app - the reasoning db-showcase.ts already records for issue #425.
+    const { getByTestId } = renderShowcase();
+    const embedded = listShowcaseDatabases().filter((db) => db.embedded);
+    expect(embedded.length).toBe(1);
+    for (const testId of ["database-showcase-desktop", "database-showcase-mobile"]) {
+      const marked = [...getByTestId(testId).querySelectorAll("li")].filter((item) =>
+        /embedded/i.test(item.textContent ?? ""),
+      );
+      expect(marked.length).toBe(embedded.length);
+      expect(marked[0]?.textContent).toContain(embedded[0].label);
+    }
+  });
+
+  test("names every verified relative on both surfaces, with the registry's own count", () => {
+    // The gap this closes: the page claimed its engine count while the product connects to
+    // thirty-two named products, and the other eighteen were published in README.md and the
+    // docs compatibility table but nowhere a visitor to the login page could see them.
+    const { getByTestId } = renderShowcase();
+    expect(WIRE_COMPATIBLE_ENGINES.length).toBeGreaterThan(0);
+    for (const testId of ["wire-compatible-desktop", "wire-compatible-mobile"]) {
+      const text = getByTestId(testId).textContent ?? "";
+      expect(text).toContain(`${WIRE_COMPATIBLE_ENGINES.length}`);
+      for (const engine of WIRE_COMPATIBLE_ENGINES) {
+        expect(text).toContain(engine.name);
+      }
+    }
+  });
+
+  test("names no relative the registry does not carry", () => {
+    // The same guard the engine pills have. A name typed into the JSX would be a claim no
+    // gate-4 probe stands behind, which is the overclaim issue #424 exists to forbid.
+    const { getByTestId } = renderShowcase();
+    const known = new Set(WIRE_COMPATIBLE_ENGINES.map((engine) => engine.name));
+    for (const testId of ["wire-compatible-desktop", "wire-compatible-mobile"]) {
+      const named = getByTestId(testId).querySelectorAll("[data-relative-name]");
+      expect(named.length).toBe(WIRE_COMPATIBLE_ENGINES.length);
+      for (const node of named) {
+        expect(known.has(node.textContent?.trim() ?? "")).toBe(true);
+      }
+    }
+  });
+
+  test("claims no parity for a relative: no tier word reaches the login page", () => {
+    // WireCompatibilityHint carries the per-engine tier because the connection dialog has
+    // room to qualify it. This line does not, so it may not imply the relatives behave like
+    // their driver's own engine: it says what was measured and nothing more.
+    const { getByTestId } = renderShowcase();
+    const text = getByTestId("wire-compatible-desktop").textContent ?? "";
+    expect(/partial|query-only|fully supported/i.test(text)).toBe(false);
+    expect(/measured/i.test(text)).toBe(true);
   });
 
   test("states the live channel count and every group name, without printing channel names", () => {
@@ -317,8 +378,28 @@ describe("LoginPage showcase (issue #425)", () => {
 
   test("derives the engine and channel counts instead of typing them", () => {
     const { container } = renderShowcase();
-    expect(container.textContent).toContain(`${listShowcaseDatabases().length}`);
+    expect(container.textContent).toContain(`${EXTERNAL_DATABASE_TYPES.length} database engines`);
     expect(container.textContent).toContain(`${LIVE_CHANNELS.length} install channels`);
+  });
+
+  test("counts external engines in the claim, never the embedded provider", () => {
+    // The number this page publishes is the one README.md publishes - fourteen drivers
+    // reaching thirty-two named engines - and the embedded store is in neither half of that
+    // arithmetic. Both counts are interpolated from the registry, so reverting the claim to
+    // the showcase length (which includes libredb) fails the second assertion.
+    // Matched with a tolerant regex rather than a substring: the desktop figure puts the
+    // number and the unit in adjacent spans with no whitespace between them, so a
+    // "14 database engines" substring check would pass only on the mobile line and silently
+    // stop covering the surface it was written for.
+    const { container, getByTestId } = renderShowcase();
+    const external = new RegExp(`${EXTERNAL_DATABASE_TYPES.length}\\s*database engines`);
+    const shipped = new RegExp(`${SHIPPED_DATABASE_TYPES.length}\\s*database engines`);
+    // The desktop figure specifically, then the page as a whole, so neither surface can
+    // carry the claim alone.
+    expect(external.test(getByTestId("hero-proof").textContent ?? "")).toBe(true);
+    expect(external.test(container.textContent ?? "")).toBe(true);
+    expect(shipped.test(container.textContent ?? "")).toBe(false);
+    expect(SHIPPED_DATABASE_TYPES.length).toBe(EXTERNAL_DATABASE_TYPES.length + 1);
   });
 
   test("no longer claims a stale engine count or a Docker-only install", () => {
@@ -369,7 +450,13 @@ describe("LoginPage showcase (issue #425)", () => {
     // content adds no outbound navigation there. The community section's own anchors are
     // the only links this half of the page is allowed to grow.
     const { getByTestId } = renderShowcase();
-    for (const testId of ["database-showcase-desktop", "database-showcase-mobile", "hero-proof"]) {
+    for (const testId of [
+      "database-showcase-desktop",
+      "database-showcase-mobile",
+      "wire-compatible-desktop",
+      "wire-compatible-mobile",
+      "hero-proof",
+    ]) {
       expect(getByTestId(testId).querySelectorAll("a").length).toBe(0);
     }
   });

--- a/tests/components/WireCompatibilityHint.test.tsx
+++ b/tests/components/WireCompatibilityHint.test.tsx
@@ -33,7 +33,9 @@ mock.module("@/lib/db/compatibility", () => ({
   SHIPPED_DATABASE_TYPES: ["postgres", "mysql"],
   WIRE_COMPATIBLE_ENGINES: MOCK,
   compatibleEnginesFor: (type: string) => MOCK.filter((e) => e.via === type),
-  verifiedEngineCount: () => 13,
+  EXTERNAL_DATABASE_TYPES: ["postgres", "mysql"],
+  isExternalDatabaseType: () => true,
+  connectableProductCount: () => 13,
 }));
 
 const { WireCompatibilityHint } = await import("@/components/WireCompatibilityHint");

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -28,7 +28,9 @@ FAIL=0
 # was added. Verify with `grep -c '^run_group ' tests/run-components.sh`, which is how
 # the third drift was caught (#331 T5): 26 was declared while 27 calls existed, so the
 # green summary line reported a group count no run had.
-TOTAL_GROUPS=30
+# Drifted again before this line was touched: it read 30 while 32 `run_group` calls
+# existed, so every green run reported a group count no run had. 33 is the grep below.
+TOTAL_GROUPS=33
 EXTRA_BUN_ARGS=("$@")
 GROUP_INDEX=0
 COVERAGE_MODE=0
@@ -305,6 +307,14 @@ run_group "Group 18: ThemeToggle" \
 
 run_group "Group 19: ThemeProvider" \
   tests/components/ThemeProvider.test.tsx
+
+# Group 20: WireCompatibilityHint. Its own group, and it had NO group at all until now:
+# the file shipped with #426 and was never added to this script, so its seven tests had
+# never run in CI once. It cannot join Group 11 or 15 either - it mocks
+# @/lib/db/compatibility, and mock.module is process-wide, so it would hand LoginPage's
+# engine-count assertions and ConnectionModal's own hint render a two-entry stub registry.
+run_group "Group 20: WireCompatibilityHint" \
+  tests/components/WireCompatibilityHint.test.tsx
 
 # Summary
 echo ""

--- a/tests/unit/db/compatibility.test.ts
+++ b/tests/unit/db/compatibility.test.ts
@@ -12,7 +12,8 @@ import { describe, test, expect } from "bun:test";
 import {
   WIRE_COMPATIBLE_ENGINES,
   compatibleEnginesFor,
-  verifiedEngineCount,
+  connectableProductCount,
+  EXTERNAL_DATABASE_TYPES,
   SHIPPED_DATABASE_TYPES,
 } from "@/lib/db/compatibility";
 import type { DatabaseType } from "@/lib/types";
@@ -116,8 +117,24 @@ describe("wire-compatibility registry", () => {
     expect(compatibleEnginesFor("not-a-database" as DatabaseType)).toEqual([]);
   });
 
-  test("verifiedEngineCount is the shipped drivers plus the verified relatives", () => {
-    expect(verifiedEngineCount()).toBe(SHIPPED_DATABASE_TYPES.length + WIRE_COMPATIBLE_ENGINES.length);
+  test("EXTERNAL_DATABASE_TYPES omits the embedded provider and nothing else", () => {
+    // The login hero publishes this length as "database engines", so the one thing this
+    // list may not contain is the embedded provider: libredb is a store this app carries,
+    // not a database a user already runs and points us at. Every other shipped id belongs.
+    expect(EXTERNAL_DATABASE_TYPES).not.toContain("libredb");
+    expect(EXTERNAL_DATABASE_TYPES.length).toBe(SHIPPED_DATABASE_TYPES.length - 1);
+    for (const type of EXTERNAL_DATABASE_TYPES) {
+      expect(SHIPPED_DATABASE_TYPES).toContain(type);
+    }
+  });
+
+  test("connectableProductCount is the external engines plus the verified relatives", () => {
+    // Not the shipped drivers plus the relatives, which is what this function counted
+    // before and what made it disagree with the number README.md publishes: the embedded
+    // provider is a driver we ship and not a product anyone connects to, so counting it
+    // here overstated the claim by one.
+    expect(connectableProductCount()).toBe(EXTERNAL_DATABASE_TYPES.length + WIRE_COMPATIBLE_ENGINES.length);
+    expect(connectableProductCount()).toBe(SHIPPED_DATABASE_TYPES.length + WIRE_COMPATIBLE_ENGINES.length - 1);
   });
 
   test("a query-only engine always carries a caveat saying so", () => {


### PR DESCRIPTION
The login hero derives its engine pills from `DB_UI_CONFIG`, so it was already current — Apache Cassandra and Trino were on the page. Two things were not.

## The claim counted the wrong set

`HERO_CLAIMS` read `listShowcaseDatabases().length`, which includes `libredb`: the embedded store this app carries, not a database anyone points it at. The page published one external engine more than the product has.

`EXTERNAL_DATABASE_TYPES` now defines the split beside `SHIPPED` in `src/lib/db/compatibility.ts`, as an exhaustive `Record<DatabaseType, boolean>` so a new type-id cannot join without someone answering the question. The claim reads **14**. The LibreDB pill stays and is marked `(embedded)` — it is a provider the connection picker offers, so hiding it would put the login page at odds with the app, which is the reasoning `db-showcase.ts` already records for #425.

## The eighteen relatives were nowhere

MariaDB, Citus, TimescaleDB, Valkey, Vitess, FerretDB and the rest were published in `README.md` and the docs compatibility table but on no surface a visitor meets first. `WireCompatibleLine` names all eighteen from `WIRE_COMPATIBLE_ENGINES`, count as a `.length`, on the desktop hero and the mobile block.

It carries **no tier word**. The per-engine tier belongs to the connection dialog's `WireCompatibilityHint`, which has room to say that Materialize is query-editor-only; a hero line has no room for eighteen qualifications, so it claims a measurement rather than parity. A test pins that.

## The counting rule disagreed with the README

`verifiedEngineCount()` becomes `connectableProductCount()`, and the rename is the fix rather than a tidy-up: it summed the shipped drivers, so it answered **33** while `README.md` publishes **32** for the same claim. A count is wrong when its denominator is unstated, not when its digit is stale.

## Two things found on the way

- **`tests/components/WireCompatibilityHint.test.tsx` was in no run group.** It shipped with #426 and `tests/run-components.sh` never listed it, so its seven tests have never run in CI. It gets its own group — it mocks `@/lib/db/compatibility`, and `mock.module` is process-wide, so it cannot share a process with `LoginPage.test.tsx` or `ConnectionModal.test.tsx`.
- **`TOTAL_GROUPS` read 30 against 32 `run_group` calls**, so every green summary reported a group count no run had. Now 33, verified with the `grep -c` the script's own comment prescribes.

## Verification

Six gates locally: `format` · `lint` (0 errors) · `typecheck` · `knip` · `test` (all 33 groups) · `build`. Plus `test:coverage` + `coverage:check` at **40700/40700 lines (100.00%)**, `build:lib` + the packaged surface, and `e2e/login.spec.ts` **14/14** including the two new assertions.

Layout measured in a real browser on the built app (`next start`, Chromium), the same page before and after:

| Viewport | Before | After | Sign-in card |
| --- | --- | --- | --- |
| 1440x900 | page 900px, no scroll | page 900px, no scroll | above the fold in both |
| 1280x800 | page 800px, no scroll | **page 856px, scrolls 56px** | above the fold in both |
| 1920x1080 | page 1080px, no scroll | page 1080px, no scroll | above the fold in both |
| 390x844 | page 991px (already scrolls) | page 1062px | above the fold in both |

The cause is not the line alone: at 1280x800 the hero column measured **exactly 800px before this change** — zero slack, nothing for its `mt-auto` to absorb — so one more row of engine pills would have done the same. 104px of overflow was reclaimed by folding the line into the pills' own block (20px), `leading-snug` (12px) and a shorter lead sentence (16px). What falls below the fold in the residual 56px is the bottom of the hero and the column's own top padding, not the sign-in card; this is not the failure `login-form.tsx`'s comment records, where the hero measured 1294px in a 900px viewport. The residual, with its numbers and the candidates for closing it, is **U18** in `docs/BACKLOG.md`.

Also fixed on measurement: the desktop pill's text read `LibreDB(embedded)` with no separator — the space was flex `gap` only, so a screen reader and a copy-paste both lost it. Label and marker now share one span.

Closes nothing on its own; it brings the login page in line with the counts `README.md` already publishes.
