### PR TITLE
fix(mongodb): the redacted seed made every capability null, and plan mode wrote mongosh

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra
 type: application
-version: 0.1.44
-appVersion: "0.13.0"
+version: 0.1.45
+appVersion: "0.13.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -50,7 +50,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.13.0
+      image: ghcr.io/libredb/libredb-studio:0.13.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -70,7 +70,7 @@ annotations:
     - "OIDC logout resolves generic end-session URLs from the provider's discovery document rather than building one by hand"
     - "The query agent enforces single-drive ownership and refuses appends once a run has closed, and its rail answers first instead of narrating its steps"
     - "Chart 0.1.44 changes no template: its content is the appVersion move to 0.13.0 and the cassandra keyword that ArtifactHub search needs. The IPv6 bind behaviour is 0.1.42's, unchanged"
-    - "Track app release 0.13.0 (appVersion bump; default image tag follows)"
+    - "Track app release 0.13.1 (appVersion bump; default image tag follows)"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.44 \
+  --version 0.1.45 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2418,6 +2418,23 @@ classifier's real-world agreement rate was measured — and they are the same ki
   not in the server log either. So the only trace is the model's own sentence, and this repo has
   already recorded why that is dangerous - a missing event reads as work that was not needed rather
   than knowledge that was lost.
+- **B55** — a grounded LibreDB plan run drafts `GET users:*`, and `get` is an exact-key lookup with no
+  glob: the key does not exist, so the command answers zero rows and no error. The inventory's rows are
+  NAMED `users:*`, which reads as a glob the grammar does not have, and LibreDB declares no
+  `statementLanguage`, so the five verbs (`get`, `put`, `delete`, `prefix`, `range`) are left to be
+  guessed. MongoDB and Redis were fixed the same way in 0.13.1 - each declares the sentence its
+  statement form needs - and LibreDB's turn was deferred by the owner on 2026-08-22 until the other
+  providers are done.
+- **B56** — a planning run's grounding is HELD for the process lifetime, so a schema that changes is
+  invisible to plan mode until a restart. `holdSnapshotForConnection` keeps one inventory per
+  connection identity with no expiry, and it is consulted before any capture. Measured twice on
+  2026-08-22: after MongoDB's inference began expanding subdocuments, `schema/list` returned
+  `shipping.city` at once and the schema tree showed it, while two plan runs still grouped by
+  `$shipping.region` and recorded no `context-captured` event at all; a restart fixed it on the first
+  run. Redis showed the same shape, refusing an objective about keys that had just been seeded. The
+  design intent - a run reasons over the inventory its claims cite - is not the problem; a NEW run
+  inheriting it indefinitely is, and B54's gap means the ledger cannot tell "held, hours old" from
+  "captured just now".
 
 ## Related documentation
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,7 +22,7 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S1–S8 · 8
-- [Drivers and connections](#drivers-and-connections) — D1–D8, U17 · 9
+- [Drivers and connections](#drivers-and-connections) — D1–D10, U17 · 11
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
 - [Studio UI and query execution](#studio-ui-and-query-execution) — X1–X7, U2–U18 · 20
@@ -37,7 +37,7 @@ None of it is a GitHub issue.
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C1–C10 · 10
 - [Security Phase 3 deferrals](#security-phase-3-deferrals) — K1–K4 · 4
 - [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A6 · 5
-- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B54 · 44
+- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B56 · 46
 
 ---
 
@@ -396,6 +396,31 @@ failure rather than an empty panel.
 stops being gated on health, which is the wider question and should be answered for StarRocks and
 SingleStore in the same pass — and the ScyllaDB row in `docs/providers/README.md` is re-probed
 against that build.
+
+### D10. MongoDB `distinct` takes its field from `options.projection`, and any other spelling silently returns `_id`
+
+`query()`'s `distinct` branch reads the field as
+`query.options?.projection ? Object.keys(query.options.projection)[0] : "_id"`
+(`src/lib/db/providers/document/mongodb.ts`). So the field is carried by the FIRST KEY of a
+projection, which is not what a projection means anywhere else in the envelope, and is documented
+nowhere: `docs/providers/mongodb.md` §3.1 lists `distinct` among the supported operations and shows
+no example of one.
+
+Measured 2026-08-22 against live `mongo:latest`, 120 seeded products in five categories:
+
+| Sent | Answered |
+| --- | --- |
+| `{"operation":"distinct","filter":{},"field":"category"}` | 120 rows of `_id` — the `field` key is ignored and the default stands |
+| `{"operation":"distinct","options":{"projection":{"category":1}}}` | 5 rows: books, clothing, electronics, home, sports |
+
+The first is the failure mode that matters: `field` is the obvious spelling (it is the driver's own
+parameter name), it is accepted without complaint, and the answer is a plausible-looking list of ids
+rather than an error. A user reads it as "this collection has 120 distinct categories".
+
+**Done when:** `distinct` takes its field from a named key, an unknown or missing one is a
+`QueryError` naming what it expected rather than a silent `_id`, and §3.1 shows a `distinct` example.
+The driver's spelling (`field`) is the one to accept; `options.projection` may stay as a compatible
+alias or go, since nothing in the product generates a `distinct` today.
 
 ---
 ### U17. Four things the Cassandra provider declined to do
@@ -2858,6 +2883,13 @@ rows ARE and names no command, pinned by a test ("it names no command and forbid
 - Third position: this is the user's call. The draft is theirs to run, on their own connection, and a
   product that reads for them does not have to think for them.
 
+**Update 2026-08-22.** The SHAPE half of this is fixed and is not what B50 is about: `redis.ts` now
+declares a `statementLanguage`, because a plan run drafted `1) KEYS session:*` / `2) GET session:1` and
+`executeRedisCommand` reads the whole body as one command, so the server answered `ERR unknown command
+'1)'`. That sentence deliberately names no command and forbids none — it names the packaging (one
+command, no numbering, no `redis-cli` prefix) and repeats what the rows ARE. The cost question below is
+untouched by it and still the owner's.
+
 **Done when:** the owner rules, and the reason is recorded next to the derived-groupings rule so the two
 read as one decision.
 
@@ -2999,3 +3031,60 @@ Related: B13, where the capture's own SPEND is missing from the ledger for the s
 **Done when:** a refused capture records an event carrying its `reasonCode` and, where the reason is the
 row budget, the two numbers — rows projected and rows allowed — and a plan run whose capture was refused
 can be explained from its ledger alone.
+
+### B55. A LibreDB plan run drafts `GET users:*`, a command that answers zero rows rather than failing
+
+Measured 2026-08-22 on the embedded LibreDB sample, plan mode, objective *"list every entry under the
+users prefix and read one user by key"*. The run was grounded — `context-captured`, three prefixes
+(`articles:*`, `config:*`, `users:*`) — and drafted:
+
+```libredb
+GET users:*
+```
+
+`dispatchCommand` gives `get` exactly one meaning: `kv.get(parts[1])`, an exact-key lookup with no glob
+of any kind. The key `users:*` does not exist, so the command returns **zero rows and no error** — the
+same silently-wrong class as the MongoDB `$shipping.region` case, and harder to notice because an empty
+result on a key-value store reads as "nothing stored there". The runnable form is `prefix users:`, which
+is what `generateTableQuery` already emits for the same row when a person clicks it.
+
+The cause is the one Redis has too: the inventory's rows are named `users:*`, which reads as a glob the
+grammar does not have. Redis's half was fixed by declaring `ProviderLabels.statementLanguage`
+(`redis.ts`); LibreDB declares none, so the plan contract tells the model only "this engine speaks no
+SQL" and leaves the five verbs — `get`, `put`, `delete`, `prefix`, `range` — to be guessed.
+
+Deferred by the owner on 2026-08-22, explicitly: LibreDB's agent and plan-mode behaviour waits until the
+other providers are done. Recorded here so the deferral is a decision rather than an omission.
+
+**Done when:** `LibreDbProvider.getLabels()` declares a `statementLanguage` that names the five verbs and
+says a key is exact (no glob, no wildcard), with a test pinning it the way `mongodb.ts` and `redis.ts` are
+pinned — and a live plan run on the embedded sample drafts `prefix users:` for this objective.
+
+### B56. Plan grounding is held for the process lifetime, so a schema change is invisible until a restart
+
+`holdSnapshotForConnection` keeps one inventory per connection identity in a bounded map with **no
+expiry**: newest reading wins, eviction is by use, and nothing re-reads. `heldSnapshotForConnection` is
+one of the three places a planning run's grounding comes from, and it is consulted before any capture.
+
+Measured 2026-08-22, twice in one session. MongoDB's schema inference was changed to expand subdocuments
+into dotted paths; `POST /api/db/schema/list` returned `shipping.city` immediately, and the schema tree
+showed it. Two plan runs afterwards still grouped by `$shipping.region`, and their ledgers carry **no**
+`context-captured` event at all — the hold answered, from an inventory read before the change. Restarting
+the process fixed it on the first run: `context-captured` appeared and the draft named `$shipping.city`.
+
+The same shape hit Redis: keys seeded into an empty database were invisible to a plan run until a restart,
+which is what "NO STATEMENT: the `session:*` key pattern is not present in the inventory" meant — a
+correct refusal against a stale inventory.
+
+Two properties make this hard to see rather than merely stale. The hold has no TTL, so on a long-lived
+server the window is unbounded; and B54's gap means a run that used the hold records nothing about where
+its inventory came from, so the ledger cannot distinguish "held, hours old" from "captured just now".
+
+The design intent is real and documented (`context-snapshot.ts`: a run reasons over the inventory its
+claims cite, and a mid-run re-read would leave those claims describing a schema the report no longer
+shows). What is not intended is that a NEW run inherits it indefinitely.
+
+**Done when:** a new run's grounding is either re-captured or explicitly recorded as reused with the age
+of the reading it reused, so a user who just added a collection is not silently planned against the
+database as it was.
+

--- a/docs/providers/mongodb.md
+++ b/docs/providers/mongodb.md
@@ -98,15 +98,28 @@ nested objects/arrays are walked recursively. **Only these types are special-cas
 types (`Long`, `Timestamp`, `UUID`, `RegExp`, `Code`, `DBRef`) fall through as generic objects and
 may render poorly ([Known limitations](#13-known-limitations--future-work)).
 
-### 3.3 Sampling-based, flat schema inference
+### 3.3 Sampling-based schema inference, nested to three levels
 
 MongoDB has no fixed schema, so `getSchema()` ([mongodb.ts:476](../../src/lib/db/providers/document/mongodb.ts))
 **infers** one: it lists collections (skipping `system.*`, capped at 200), and for each samples the
 first **100 documents** to derive field types ([mongodb.ts:510](../../src/lib/db/providers/document/mongodb.ts)).
 Caveats baked into this approach:
 - Fields absent from the sample (or appearing only in unsampled documents) won't show.
-- Inference is **flat** — nested object fields are reported as type `object`, not expanded into
-  dotted sub-fields (the recursion is intentionally disabled).
+- **Subdocuments are expanded into dotted paths**, to `MAX_NESTED_FIELD_DEPTH = 3` counting the top
+  level as 1 — so `shipping`, `shipping.city` and `shipping.geo.lat` are all listed, and
+  `shipping.geo.deep.tooFar` is not. The container at the boundary is still named, so a reader can
+  see that the nesting continues. `shipping.city` is a field name in MQL, and a schema that stopped
+  at `shipping: object` did not name it: a plan run on 2026-08-22 grouped by `$shipping.region`, a
+  path the database does not have, and MongoDB answers that with one null group rather than an
+  error — so the plan read as runnable and was silently wrong.
+- **Arrays are named and left closed.** `items.sku` addresses one value *per array entry*, so it
+  does not mean on an array what the same syntax means on a subdocument; listing it in a flat field
+  list would invite exactly that confusion. Date/ObjectId/Binary/Decimal128 are scalars here and
+  are never descended into.
+- **The field list is capped at `MAX_INFERRED_FIELDS = 200` per collection**, applied after the
+  sort, so what survives is a deterministic prefix and `_id` always survives. Nesting multiplies:
+  60 subdocuments of 10 fields each is 661 rows in the schema tree and 661 lines in an agent run's
+  context window, for one collection.
 - A field with multiple observed types is reported as `mixed(a|b)`. `_id` is marked primary.
 
 ### 3.4 `find` is capped at 100; `aggregate` is not
@@ -194,7 +207,7 @@ injection, no transactions, and no `cancelQuery`. `EXPLAIN` is not supported
 | Collections | `listCollections()` (skip `system.*`, cap 200) — **views included**, see below |
 | Row count | `estimatedDocumentCount()` — **not asked of a view**; absent there |
 | Size | `collStats` command (`size`) — **not asked of a view**; absent there |
-| Columns | inferred from a 100-document sample ([§3.3](#33-sampling-based-flat-schema-inference)), on a view exactly as on a collection |
+| Columns | inferred from a 100-document sample ([§3.3](#33-sampling-based-schema-inference-nested-to-three-levels)), on a view exactly as on a collection |
 | Indexes | `collection.indexes()` (`unique` flag, key fields) — **not asked of a view**; `[]` there |
 | Foreign keys | always `[]` — MongoDB has none to declare, which the provider states as `declaresForeignKeys: false` ([§9](#9-capabilities--labels)) rather than leaving a reader to guess whether the read simply found none |
 
@@ -277,6 +290,14 @@ after inserts/updates/deletes.
 Document vocabulary: entity → *Collection*, row → *document*, select → *Find Documents*, analyze →
 *Validate Collection*, vacuum → *Compact Collection*, search → *Search collections or fields…*.
 
+`statementLanguage` is the one label a person never sees: the agent's plan contract states it
+verbatim to the model. It carries the JSON envelope of [§3.1](#31-json--mql-query-format) and names
+**mongosh** as the form that is excluded. It exists for the reason the search products' does — told
+to write "one runnable statement in this MongoDB database's own query language", a plan run on
+2026-08-22 answered `db.orders.aggregate([{ $group: … }])`, which is correct MongoDB and unrunnable
+here, because `query()` parses the JSON command object and nothing else. Naming only what the
+language *is* did not survive contact with the model's prior; naming what it is not did.
+
 ---
 
 ## 10. Error handling
@@ -354,9 +375,9 @@ Over the API: `POST /api/db/query` (JSON MQL in the `sql` field) and `POST /api/
 
 ## 13. Known limitations & future work
 
-- **Schema is inferred from a 100-document sample, flat.** Fields outside the sample don't appear,
-  and nested object fields are shown as `object` rather than expanded into sub-fields
-  ([§3.3](#33-sampling-based-flat-schema-inference)).
+- **Schema is inferred from a 100-document sample.** Fields outside the sample don't appear;
+  subdocuments are expanded only to depth 3 and only up to 200 fields per collection, and array
+  elements' fields are never expanded ([§3.3](#33-sampling-based-schema-inference-nested-to-three-levels)).
 - **`aggregate` results are unbounded.** Only `find` gets a default 100-document cap; an `aggregate`
   pipeline without `$limit` can return a very large result set
   ([§3.4](#34-find-is-capped-at-100-aggregate-is-not)). *Future:* inject a safety `$limit` / cap

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -514,6 +514,21 @@ The labels rename actions that behave differently here, not generic ones wearing
 *"Scan Keys"* really emits `SCAN`, and *"Generate Command"* really emits Redis commands (§5.3).
 That was not true before #427, when both emitted MongoDB documents under these labels.
 
+`statementLanguage` is the one label no person sees: the agent's plan contract states it verbatim to
+the model. Unlike MongoDB's, it is not about the language — a plan run on 2026-08-22 wrote real Redis
+commands — but about the **shape** they were packaged in:
+
+```
+1) KEYS session:*
+2) GET session:1
+```
+
+`executeRedisCommand` reads the whole body as **one** command (§5), so the server answered
+`ERR unknown command '1)'`. The label therefore names the two things that made it unrunnable — the
+list numbering and the second command — alongside the two accepted forms (plain and the lossless
+`{"command": …, "args": […]}`), and repeats in words what `tablesAreDerivedGroupings` says in a flag:
+a `prefix:*` row is this server's grouping, not a key, so a prefix is reached with `SCAN … MATCH`.
+
 `analyzeGlobalLabel` / `analyzeGlobalTitle` / `analyzeGlobalDesc` (*"Run Info"*, *"Server Info"*,
 *"Get Redis server information and statistics."*) are rendered by the admin Operations tab. The
 `vacuumAction` / `vacuumGlobal*` fields (*"Memory Doctor"*, *"Memory Analysis"*) are still declared

--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -21,8 +21,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Database, Developer Tools
-    containerImage: ghcr.io/libredb/libredb-studio-operator:0.13.0
-    createdAt: "2026-08-21T14:54:06Z"
+    containerImage: ghcr.io/libredb/libredb-studio-operator:0.13.1
+    createdAt: "2026-08-21T23:18:00Z"
     description: Open-source web-based SQL IDE for fourteen engines - PostgreSQL,
       MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache
       Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra - with AI-powered
@@ -35,7 +35,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: libredb-studio-operator.v0.13.0
+  name: libredb-studio-operator.v0.13.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -258,7 +258,7 @@ spec:
                 - --leader-elect
                 - --leader-election-id=libredb-studio-operator
                 - --health-probe-bind-address=:8081
-                image: ghcr.io/libredb/libredb-studio-operator:0.13.0
+                image: ghcr.io/libredb/libredb-studio-operator:0.13.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -369,4 +369,4 @@ spec:
   provider:
     name: LibreDB
     url: https://libredb.org
-  version: 0.13.0
+  version: 0.13.1

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/libredb/libredb-studio-operator
-  newTag: 0.13.0
+  newTag: 0.13.1

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra
 type: application
-version: 0.1.44
-appVersion: "0.13.0"
+version: 0.1.45
+appVersion: "0.13.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -50,7 +50,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.13.0
+      image: ghcr.io/libredb/libredb-studio:0.13.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -70,7 +70,7 @@ annotations:
     - "OIDC logout resolves generic end-session URLs from the provider's discovery document rather than building one by hand"
     - "The query agent enforces single-drive ownership and refuses appends once a run has closed, and its rail answers first instead of narrating its steps"
     - "Chart 0.1.44 changes no template: its content is the appVersion move to 0.13.0 and the cassandra keyword that ArtifactHub search needs. The IPv6 bind behaviour is 0.1.42's, unchanged"
-    - "Track app release 0.13.0 (appVersion bump; default image tag follows)"
+    - "Track app release 0.13.1 (appVersion bump; default image tag follows)"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.44 \
+  --version 0.1.45 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/src/app/api/db/profile/route.ts
+++ b/src/app/api/db/profile/route.ts
@@ -42,7 +42,12 @@ export async function POST(req: NextRequest) {
         const totalCountResult = await provider.query(
           JSON.stringify({
             collection: tableName,
-            operation: "countDocuments",
+            // `count`, the operation MongoDBProvider dispatches (it calls the
+            // driver's countDocuments internally). `countDocuments` is not in its
+            // SUPPORTED_OPERATIONS, so every MongoDB profile answered 400
+            // "Unsupported operation: countDocuments" - the route's own test mock
+            // had accepted the name and hid it.
+            operation: "count",
             filter: {},
           }),
         );

--- a/src/components/DataProfiler.tsx
+++ b/src/components/DataProfiler.tsx
@@ -5,6 +5,7 @@ import { Loader2, BarChart3, X, Hash, AlertCircle, Sparkles, Lock } from "lucide
 import { cn } from "@/lib/utils";
 import { TableSchema, DatabaseConnection } from "@/lib/types";
 import { detectSensitiveColumns, maskValue } from "@/lib/data-masking";
+import { buildConnectionPayload } from "@/hooks/use-connection-payload";
 
 interface ColumnProfile {
   name: string;
@@ -91,7 +92,10 @@ export function DataProfiler({
         const response = await fetch("/api/db/profile", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ connection, tableName, columns }),
+          // The seed id for a managed connection: the browser's copy has had its
+          // password and connection string stripped, so the object cannot be
+          // resolved to a database from a cold provider cache.
+          body: JSON.stringify({ ...buildConnectionPayload(connection), tableName, columns }),
         });
 
         if (!response.ok) {

--- a/src/components/monitoring/tabs/PoolTab.tsx
+++ b/src/components/monitoring/tabs/PoolTab.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 import type { DatabaseConnection } from "@/lib/types";
+import { buildConnectionPayload } from "@/hooks/use-connection-payload";
 
 interface PoolStats {
   total: number;
@@ -32,7 +33,10 @@ export function PoolTab({ connection }: PoolTabProps) {
       const res = await fetch("/api/db/pool-stats", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ connection }),
+        // The seed id, not the object: a managed connection arrives here with its
+        // password and connection string stripped, so the object cannot be resolved
+        // to a database once the provider cache is cold.
+        body: JSON.stringify(buildConnectionPayload(connection)),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Failed to fetch pool stats");

--- a/src/hooks/use-provider-metadata.ts
+++ b/src/hooks/use-provider-metadata.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import type { DatabaseConnection } from "@/lib/types";
 import type { ProviderCapabilities, ProviderLabels } from "@/lib/db/types";
 import { logger } from "@/lib/logger";
+import { buildConnectionPayload } from "./use-connection-payload";
 
 export interface ProviderMetadata {
   capabilities: ProviderCapabilities;
@@ -55,7 +56,15 @@ export function useProviderMetadata(connection: DatabaseConnection | null): {
     fetch("/api/db/provider-meta", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(connection),
+      // `buildConnectionPayload`, not the connection object: a managed (seed)
+      // connection reaches the browser with its credentials stripped, and one
+      // defined by `connectionString` alone keeps nothing that identifies a
+      // database at all. Posting that object made the route answer 400 for the
+      // MongoDB seed, leaving capabilities null - which is what made the schema
+      // tree offer SQL labels and generate `SELECT * FROM <collection> LIMIT 50`
+      // against MongoDB. The server resolves `seed:<id>` to its own descriptor,
+      // exactly as the schema, query and monitoring routes are already called.
+      body: JSON.stringify(buildConnectionPayload(connection)),
       signal: controller.signal,
     })
       .then((res) => {

--- a/src/lib/db/providers/document/mongodb.ts
+++ b/src/lib/db/providers/document/mongodb.ts
@@ -77,6 +77,22 @@ const SUPPORTED_OPERATIONS: ReadonlySet<MongoQuery["operation"]> = new Set([
   "deleteMany",
 ]);
 
+/**
+ * How deep `inferSchemaFromDocuments` walks a subdocument, counting the top level as
+ * 1 — so `shipping.geo.lat` is named and `shipping.geo.deep.tooFar` is not. Three
+ * levels is where the dotted paths a query actually groups or filters on live; past
+ * that the tree stops describing the collection and starts transcribing one document.
+ * The container at the boundary is still listed, so the nesting continuing is visible.
+ */
+const MAX_NESTED_FIELD_DEPTH = 3;
+
+/**
+ * Upper bound on the fields one collection reports. Nesting multiplies, and both
+ * consumers of this list are bounded surfaces: the schema tree a person scrolls and
+ * the inventory an agent run is given.
+ */
+const MAX_INFERRED_FIELDS = 200;
+
 // Maintenance operations runMaintenance() accepts; validated the same way.
 const SUPPORTED_MAINTENANCE_TYPES: ReadonlySet<MaintenanceType> = new Set([
   "analyze",
@@ -143,6 +159,17 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       vacuumGlobalLabel: "Run Compact",
       vacuumGlobalTitle: "Compact Storage",
       vacuumGlobalDesc: "Defragments and compacts collection storage to reclaim disk space.",
+      // Stated verbatim in the agent's plan contract, and needed for the reason the
+      // search products needed theirs: told to write "one runnable statement in this
+      // MongoDB database's own query language", a live plan run on 2026-08-22 wrote
+      // mongosh - `db.orders.aggregate([{ $group: ... }])`. That is correct MongoDB
+      // and unrunnable here, because `query()` parses the JSON command object and
+      // nothing else, so what the user was handed was a plan they could not execute.
+      // The sentence therefore carries the envelope itself and names the shell form
+      // it excludes: naming only what the language IS did not survive contact with
+      // the model's prior on Elasticsearch, and does not here either.
+      statementLanguage:
+        'the JSON command object this editor executes - {"collection": "<name>", "operation": "find" | "findOne" | "aggregate" | "count" | "distinct", "filter": {...}, "pipeline": [...], "options": {"limit": 50}} - and NOT mongosh shell syntax: a statement that starts with `db.` cannot be run here',
     };
   }
 
@@ -561,10 +588,16 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       return a.name.localeCompare(b.name);
     });
 
-    return columns;
+    // Bounded AFTER sorting, so what survives is a deterministic prefix rather than
+    // whichever fields the sampled documents happened to mention first - and `_id`,
+    // the field every generated statement addresses, always survives. The bound
+    // exists because nesting multiplies: a document with 60 subdocuments of 10 fields
+    // each is 661 rows in the schema tree and 661 lines in a model's context window,
+    // for one collection. Same reason `getSchema` already stops at 200 collections.
+    return columns.slice(0, MAX_INFERRED_FIELDS);
   }
 
-  private extractFieldTypes(doc: Document, prefix: string, fieldTypes: Map<string, Set<string>>): void {
+  private extractFieldTypes(doc: Document, prefix: string, fieldTypes: Map<string, Set<string>>, depth = 1): void {
     for (const [key, value] of Object.entries(doc)) {
       const fieldName = prefix ? `${prefix}.${key}` : key;
 
@@ -575,11 +608,22 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       const type = this.getMongoType(value);
       fieldTypes.get(fieldName)!.add(type);
 
-      // Don't recurse into nested objects for now (keep it flat)
-      // Uncomment below to include nested fields
-      // if (type === 'object' && value !== null && !Array.isArray(value)) {
-      //   this.extractFieldTypes(value as Document, fieldName, fieldTypes);
-      // }
+      // Descend into subdocuments, because `shipping.city` is a field name in this
+      // engine's own query language and a schema that stops at `shipping: object`
+      // does not name it. That absence is not only cosmetic: the same inventory
+      // grounds an agent plan run, and a run on 2026-08-22 grouped by
+      // `$shipping.region` - a path the database does not have - which MongoDB
+      // answers with a single null group rather than an error, so the plan read as
+      // runnable and was silently wrong.
+      //
+      // `getMongoType` has already ruled out every object that is really a scalar
+      // (Date, ObjectId, Binary, Decimal128) and arrays, which are deliberately left
+      // closed: `items.sku` addresses one value PER ARRAY ENTRY, so it does not mean
+      // on an array what the same syntax means on a subdocument, and listing it
+      // beside the others would invite exactly that confusion.
+      if (type === "object" && depth < MAX_NESTED_FIELD_DEPTH) {
+        this.extractFieldTypes(value as Document, fieldName, fieldTypes, depth + 1);
+      }
     }
   }
 

--- a/src/lib/db/providers/keyvalue/redis.ts
+++ b/src/lib/db/providers/keyvalue/redis.ts
@@ -102,6 +102,21 @@ export class RedisProvider extends BaseDatabaseProvider {
       vacuumGlobalLabel: "Memory Doctor",
       vacuumGlobalTitle: "Memory Analysis",
       vacuumGlobalDesc: "Analyze memory usage and provide optimization suggestions.",
+      // Stated verbatim in the agent's plan contract. Unlike MongoDB's, this sentence
+      // is not about the LANGUAGE - a plan run on 2026-08-22 wrote real Redis
+      // commands - but about the SHAPE it packaged them in:
+      //
+      //   1) KEYS session:*
+      //   2) GET session:1
+      //
+      // `executeRedisCommand` reads the whole body as one command, so the server
+      // answered `ERR unknown command '1)'`. The list numbering and the second
+      // command are what made it unrunnable, so those are what this names. The
+      // prefix-group sentence is here for the same reason `tablesAreDerivedGroupings`
+      // exists: the inventory's rows are named `session:*`, which reads as something
+      // addressable and is not (#427).
+      statementLanguage:
+        'exactly one Redis command, in the plain form `SCAN 0 MATCH session:* COUNT 50` or the lossless form {"command": "GET", "args": ["session:1"]} - one command and no more, with no list numbering, no bullet, no `redis-cli` prefix and no trailing semicolon; and the inventory\'s `prefix:*` rows are groupings this server summarised, not keys, so reach a prefix with SCAN ... MATCH and a key by its real name',
     };
   }
 

--- a/tests/api/db/profile.test.ts
+++ b/tests/api/db/profile.test.ts
@@ -217,10 +217,14 @@ describe("POST /api/db/profile", () => {
           executionTime: 5,
         };
       }
-      if (parsed.operation === "countDocuments") {
+      if (parsed.operation === "count") {
         return { rows: [{ count: 50 }], fields: ["count"], rowCount: 1, executionTime: 3 };
       }
-      return { rows: [], fields: [], rowCount: 0, executionTime: 1 };
+      // The real provider answers an unknown operation with QueryError
+      // ("Unsupported operation: X"), so the mock must too: a mock that returns
+      // empty rows for anything at all accepted `countDocuments` - an operation
+      // MongoDBProvider has never supported - and the route shipped with it.
+      throw new Error(`Unsupported operation: ${parsed.operation}`);
     });
     mockGetOrCreateProvider.mockResolvedValueOnce(mongoProvider);
 

--- a/tests/components/DataProfiler.test.tsx
+++ b/tests/components/DataProfiler.test.tsx
@@ -679,4 +679,35 @@ describe("DataProfiler", () => {
     const nineNineNine = within(container).queryAllByText("999");
     expect(nineNineNine.length).toBeGreaterThan(0);
   });
+  // Same rule as every other connection-bearing request: a managed (seed)
+  // connection is sent as its seed id, because the copy the browser holds has had
+  // `password` and `connectionString` stripped. Sending the object made
+  // `/api/db/profile` answer 400 CONFIG_ERROR for a connection-string-only seed
+  // (the MongoDB one) whenever the server's provider cache was cold - it appeared
+  // to work only while an earlier request had left a provider cached.
+  test("sends connectionId for a managed seed connection", async () => {
+    const fetchMock = mockGlobalFetch({
+      "/api/db/profile": { ok: true, json: mockProfileResponse },
+      "/api/ai/describe-schema": { ok: false, status: 500, json: { error: "AI not configured" } },
+    });
+    const seedConnection = {
+      ...mockPostgresConnection,
+      id: "seed:mongo-local",
+      managed: true,
+      seedId: "mongo-local",
+    };
+
+    render(<DataProfiler {...createDefaultProps({ connection: seedConnection })} />);
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([url]) => String(url) === "/api/db/profile")).toBe(true);
+    });
+
+    const call = fetchMock.mock.calls.find(([url]) => String(url) === "/api/db/profile");
+    if (!call) throw new Error("no /api/db/profile call recorded");
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.connectionId).toBe("seed:mongo-local");
+    expect(body.connection).toBeUndefined();
+    expect(body.tableName).toBe("users");
+  });
 });

--- a/tests/components/monitoring/PoolTab.test.tsx
+++ b/tests/components/monitoring/PoolTab.test.tsx
@@ -118,4 +118,23 @@ describe("PoolTab", () => {
     expect(queryAllByText("0").length).toBe(5);
     expect(queryAllByText("N/A").length).toBe(0);
   });
+  // A managed (seed) connection reaches the browser with `password` and
+  // `connectionString` stripped, so the object alone no longer identifies a
+  // database - a seed defined by connection string has nothing left at all, and
+  // `/api/db/pool-stats` answers 400 CONFIG_ERROR for it whenever the provider
+  // cache is cold. Every other connection-bearing call sends the seed id and lets
+  // the server resolve it (`buildConnectionPayload`).
+  test("sends connectionId for a managed seed connection", async () => {
+    const seedConn = { ...conn, id: "seed:mongo-local", managed: true, seedId: "mongo-local" };
+    render(<PoolTab connection={seedConn} />);
+
+    await waitFor(() => {
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(0);
+    });
+
+    const [, init] = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.connectionId).toBe("seed:mongo-local");
+    expect(body.connection).toBeUndefined();
+  });
 });

--- a/tests/hooks/use-provider-metadata.test.ts
+++ b/tests/hooks/use-provider-metadata.test.ts
@@ -91,7 +91,7 @@ describe("useProviderMetadata", () => {
     expect(url).toBe("/api/db/provider-meta");
     expect(options?.method).toBe("POST");
     const body = JSON.parse(options?.body as string);
-    expect(body.id).toBe("conn-1");
+    expect(body.connection.id).toBe("conn-1");
   });
 
   test("sets isLoading true during fetch", async () => {
@@ -327,5 +327,57 @@ describe("useProviderMetadata", () => {
       expect(result.current.isLoading).toBe(false);
     });
     expect(result.current.metadata?.capabilities.supportsInlineRowEdit).toBe(false);
+  });
+  // A managed (seed) connection reaches the browser with every credential stripped:
+  // `GET /api/connections/managed` serves the descriptor, not the secrets. A seed
+  // defined by `connectionString` alone - the MongoDB seed is one - therefore has
+  // NOTHING left that identifies a database, so posting the object answers 400
+  // ("Host or connection string is required for MongoDB") and the hook holds null
+  // capabilities: the schema tree then offers SQL labels and "Select Top 50" writes
+  // `SELECT * FROM customers LIMIT 50;` against MongoDB. Every other consumer of a
+  // managed connection sends `{ connectionId: "seed:<id>" }` and lets the server
+  // resolve it (`buildConnectionPayload`); this one must too.
+  test("sends connectionId for a managed seed connection rather than the redacted object", async () => {
+    const connection = makeConnection({
+      id: "seed:mongo-local",
+      type: "mongodb",
+      host: undefined,
+      port: undefined,
+      database: undefined,
+      managed: true,
+      seedId: "mongo-local",
+    });
+    const fetchMock = mockGlobalFetch({
+      "/api/db/provider-meta": { ok: true, status: 200, json: mockMetadata },
+    });
+
+    const { result } = renderHook(() => useProviderMetadata(connection));
+
+    await waitFor(() => {
+      expect(result.current.metadata).not.toBeNull();
+    });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options?.body as string);
+    expect(body.connectionId).toBe("seed:mongo-local");
+    expect(body.connection).toBeUndefined();
+  });
+
+  test("sends the connection object for a user connection", async () => {
+    const connection = makeConnection();
+    const fetchMock = mockGlobalFetch({
+      "/api/db/provider-meta": { ok: true, status: 200, json: mockMetadata },
+    });
+
+    const { result } = renderHook(() => useProviderMetadata(connection));
+
+    await waitFor(() => {
+      expect(result.current.metadata).not.toBeNull();
+    });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options?.body as string);
+    expect(body.connection?.id).toBe("conn-1");
+    expect(body.connectionId).toBeUndefined();
   });
 });

--- a/tests/integration/db/mongodb-provider.test.ts
+++ b/tests/integration/db/mongodb-provider.test.ts
@@ -334,6 +334,28 @@ describe("MongoDBProvider", () => {
       expect(labels.rowName).toBe("document");
       expect(labels.selectAction).toBe("Find Documents");
     });
+
+    // `statementLanguage` is the sentence the agent's plan contract states verbatim
+    // (`ProviderLabels.statementLanguage`), and this engine needs one for the reason
+    // the search products did: asked for "one runnable statement in this MongoDB
+    // database's own query language", a live plan run on 2026-08-22 answered with
+    // mongosh shell syntax - `db.orders.aggregate([{ $group: ... }])` - which is
+    // correct MongoDB and unrunnable here, because `query()` takes the JSON command
+    // object and nothing else. So the sentence has to name the envelope AND rule out
+    // the shell by name; naming only what the language is did not survive contact
+    // with the model's prior on Elasticsearch and does not here either.
+    test("declares the JSON command envelope as the statement language and rules out mongosh", () => {
+      const { statementLanguage } = provider.getLabels();
+
+      expect(statementLanguage).toBeString();
+      // The keys a runnable command is built from - the ones `parseQuery` reads.
+      for (const key of ["collection", "operation", "filter", "pipeline"]) {
+        expect(statementLanguage).toContain(key);
+      }
+      // The two forms a model reaches for instead, named so they are excluded.
+      expect(statementLanguage).toContain("mongosh");
+      expect(statementLanguage).toContain("db.");
+    });
   });
 
   // --------------------------------------------------------------------------
@@ -474,6 +496,83 @@ describe("MongoDBProvider", () => {
       // The collections after it are still read, which is the half of the defect a
       // user actually noticed.
       expect(schemas.find((s) => s.name === "orders")!.rowCount).toBe(42);
+    });
+
+    // Why nested fields are listed at all: the inventory this schema feeds is what
+    // grounds an agent plan run, and a document field recorded only as
+    // `shipping: object` tells a model that something is nested there and nothing
+    // about what. A live plan run on 2026-08-22 grouped by `$shipping.region` - a
+    // path that does not exist in the database it was handed - and MongoDB answers
+    // that with one null group rather than an error, so the plan looked runnable and
+    // was silently wrong. `shipping.city` is a first-class field name in MQL, so the
+    // fix is to name it.
+    test("lists nested object fields as dotted paths, down to the depth limit", async () => {
+      mockCollectionData = [
+        {
+          _id: new MockObjectId("aaa"),
+          total: 10,
+          shipping: { city: "Istanbul", method: "express", geo: { lat: 41, deep: { tooFar: 1 } } },
+        },
+      ];
+
+      const schemas = await provider.getSchema();
+      const names = schemas.find((s) => s.name === "users")!.columns.map((c) => c.name);
+
+      // The container is still listed - a query may address the whole subdocument.
+      expect(names).toContain("shipping");
+      expect(names).toContain("shipping.city");
+      expect(names).toContain("shipping.method");
+      // Depth 3 is reached and named.
+      expect(names).toContain("shipping.geo.lat");
+      // Depth 4 is not: an unbounded walk turns one deeply nested document into
+      // hundreds of rows in the schema tree and hundreds of lines in a model's
+      // context window. The container at the boundary is still named, so the reader
+      // knows the nesting continues.
+      expect(names).toContain("shipping.geo.deep");
+      expect(names).not.toContain("shipping.geo.deep.tooFar");
+    });
+
+    test("does not descend into arrays, and keeps _id first after nesting", async () => {
+      mockCollectionData = [
+        {
+          _id: new MockObjectId("aaa"),
+          items: [{ sku: "A-1", qty: 2 }],
+          tags: ["seed"],
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+        },
+      ];
+
+      const schemas = await provider.getSchema();
+      const columns = schemas.find((s) => s.name === "users")!.columns;
+      const names = columns.map((c) => c.name);
+
+      expect(names[0]).toBe("_id");
+      expect(names).toContain("items");
+      expect(names).toContain("tags");
+      // An array element's fields are NOT dotted paths of the same kind: `items.sku`
+      // reads a value per array entry, so grouping or sorting on it does not mean
+      // what the same syntax means on a subdocument. Naming it in a flat field list
+      // would invite exactly that confusion, so the array is named and left closed.
+      expect(names).not.toContain("items.sku");
+      // A Date is an object to `typeof` and has no fields worth listing.
+      expect(names).not.toContain("createdAt.getTime");
+    });
+
+    test("caps the number of inferred fields so one wide document cannot flood the tree", async () => {
+      const wide: Record<string, unknown> = { _id: new MockObjectId("aaa") };
+      for (let i = 0; i < 60; i++) {
+        wide[`group${i}`] = Object.fromEntries(Array.from({ length: 10 }, (_, j) => [`f${j}`, j]));
+      }
+      mockCollectionData = [wide];
+
+      const schemas = await provider.getSchema();
+      const columns = schemas.find((s) => s.name === "users")!.columns;
+
+      // 60 containers + 600 leaves + _id would be 661 rows for one document.
+      expect(columns.length).toBeLessThanOrEqual(200);
+      // The cap keeps a deterministic prefix rather than an arbitrary slice, and _id
+      // survives it: it is the field every generated statement addresses.
+      expect(columns[0].name).toBe("_id");
     });
   });
 

--- a/tests/integration/db/redis-provider.test.ts
+++ b/tests/integration/db/redis-provider.test.ts
@@ -248,6 +248,30 @@ describe("RedisProvider", () => {
       expect(labels.rowName).toBe("key");
       expect(labels.selectAction).toBe("Scan Keys");
     });
+
+    // `statementLanguage` is stated verbatim in the agent's plan contract, and this
+    // engine needs one for a reason the MongoDB case does not cover: told to write
+    // "one runnable statement in this Redis database's own query language", a live
+    // plan run on 2026-08-22 answered with the right LANGUAGE in the wrong SHAPE —
+    //
+    //   1) KEYS session:*
+    //   2) GET session:1
+    //
+    // `executeRedisCommand` reads the whole body as ONE command, so the server
+    // answered `ERR unknown command '1)'`. The two failures the sentence has to rule
+    // out are therefore the list numbering and the second command, not the verbs.
+    test("declares the one-command statement shape as the statement language", () => {
+      const { statementLanguage } = provider.getLabels();
+
+      expect(statementLanguage).toBeString();
+      // Both accepted forms are named, because the lossless JSON form is what the
+      // generators fall back to for an argument the plain tokenizer cannot carry.
+      expect(statementLanguage).toContain("one");
+      expect(statementLanguage).toContain('"command"');
+      // And the shapes that are not runnable here, named so they are excluded.
+      expect(statementLanguage).toContain("numbering");
+      expect(statementLanguage).toContain("redis-cli");
+    });
   });
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
Fixed mongodb query generator and agent(plan mode)

## What was wrong

A collection's **Select Top 50** on the seeded MongoDB connection wrote `SELECT * FROM customers LIMIT 50;` SQL, on a document engine. The cause is one request:

`GET /api/connections/managed` strips `password` and `connectionString` from every managed connection before the browser sees it. MongoDB is the one seed defined by a connection string alone, so what reached the client had **nothing left that identifies a database**. `useProviderMetadata` posted that object, and `/api/db/provider-meta` answered `400 CONFIG_ERROR — Host or connection string is required for MongoDB`. Capabilities stayed null, and null capabilities fall back to SQL everywhere: the query generator, the provider labels, the tab type, the maintenance actions.

Every other connection-bearing call already sends `{ connectionId: "seed:<id>" }` and lets the server resolve it (`buildConnectionPayload`). This one did not.

### Blast radius, measured

All 23 seeded connections, old payload vs new:

| | |
|---|---|
| Broken before | **1** — `mongo-local` |
| Fixed | 1 |
| Unchanged (200 → 200) | 22 |

The 22 pass by luck of shape, not by design: `provider-meta` builds a provider without connecting, so a Postgres seed's surviving `host` satisfies validation. Probing each engine with a host-less connection returns 400 for **postgres, mysql, mongodb, clickhouse, redis and cassandra** alike — so the failing precondition is "a seed whose identity lives only in a stripped field", which any engine reaches through a connection string.

`provider-meta` failed **every** time because it calls `createDatabaseProvider`. Two other sites posting the same object were masked by the provider cache and fail only from cold — verified by clearing it with `/api/db/disconnect`:

- `DataProfiler` → `/api/db/profile`
- `PoolTab` → `/api/db/pool-stats`

Both now use `buildConnectionPayload`.

## Four more defects, each found by driving the app

Live `mongo:latest`, freshly created, seeded with 5 collections / 510 documents (customers, products, orders with nested `shipping` + `items[]`, reviews, audit_log).

**1. Profile Table was broken on every MongoDB collection.** `/api/db/profile` sent `operation: "countDocuments"`; `MongoDBProvider`'s supported set has `count`. Every profile answered `400 Unsupported operation: countDocuments`. The route's own test mock returned empty rows for any operation, so it accepted the name the provider never had — the mock now rejects unknown operations the way the provider does. Verified live: `customers` profiles 60 rows, 3 distinct tiers.

**2. Plan mode wrote mongosh.** Told to produce "one runnable statement in this MongoDB database's own query language", the model answered:

```
db.orders.aggregate([{ $group: { _id: "$shipping.region", … } }])
```

Correct MongoDB, unrunnable here — `query()` parses the JSON command object and nothing else. `getLabels()` now declares a `statementLanguage` carrying the envelope and naming the shell form it excludes, the same mechanism the search products use, for the same reason: naming only what the language *is* did not survive contact with the model's prior.

After: the same objective drafts

```json
{ "collection": "orders", "operation": "aggregate",
  "pipeline": [ { "$group": { "_id": "$shipping.city", "totalRevenue": { "$sum": "$total" }, "orderCount": { "$sum": 1 } } },
                { "$sort": { "totalRevenue": -1 } } ] }
```

which runs and returns revenue per city.

**3. The inventory named no nested field, so the model invented one.** `extractFieldTypes` had its recursion commented out (*"Don't recurse into nested objects for now"*), so the schema recorded `shipping: object` and stopped. `shipping.city` is a field name in MQL; `$shipping.region` is not, and MongoDB answers a missing group key with **one null group rather than an error** — the plan read as runnable and was silently wrong.

Subdocuments now expand to dotted paths, `depth ≤ 3`, capped at `200` fields per collection (applied after the sort, so `_id` always survives), arrays named and left closed — `items.sku` addresses one value *per entry*, so it does not mean on an array what it means on a subdocument. Measured cost on this dataset: 9 → 11–12 fields per collection.

Verified live with the original vague objective (*"siparişlerdeki bölgelere göre gelir dağılımını nasıl görebilirim"*): `context-captured` present, and the draft groups by the real `$shipping.city`.

**4. Redis had the same gap in a different shape.** Asked about session keys, a plan run drafted

```
1) KEYS session:*
2) GET session:1
```

The language is right; the packaging is not. `executeRedisCommand` reads the whole body as **one** command, so the server answered `ERR unknown command '1)'`. Its `statementLanguage` now names the two accepted forms and the three things that make a draft unrunnable — list numbering, a second command, a `redis-cli` prefix — and, per **B50**, names no command and forbids none. Verified live: the run now drafts `{"command": "GET", "args": ["session:1"]}`, which executes and returns `alice`.

## Not in this PR

- **B55** — LibreDB drafts `GET users:*`, and `get` is exact-key with no glob, so it answers zero rows and no error. Deferred by the owner: LibreDB's agent behaviour waits until the other providers are done.
- **B56** — a planning run's grounding is held for the process lifetime with no expiry, so a schema change is invisible to plan mode until a restart. Measured twice here; it is why the first verification run still said `$shipping.region`.
- **D10** — `distinct` takes its field from the first key of `options.projection`. Sending the driver's own spelling (`field`) is accepted and silently answers `_id`: 120 rows of ids where 5 categories were asked for.

## Verification

Six gates, plus the two the CI lint job adds and the coverage gate:

| Gate | Result |
|---|---|
| `format` · `lint` · `typecheck` · `knip` | pass (0 errors) |
| `test` | **8528 pass, 0 fail**, 284 files |
| `build` | pass |
| `build:lib` + `attw` | pass (`node16` 🟢, `bundler` 🟢) |
| `coverage:check` | **40724/40724 lines (100.00%)** |

Every claim above was measured against a live engine in a browser session, not inferred: the MongoDB container was recreated from scratch, the ledgers under `.workflow-data` are the record for each plan run, and each drafted statement was executed through `/api/db/query`.

Version bumped to **0.13.1**; `chart:bump` (chart `0.1.45`) and `make -C operator bundle` committed with it.
