### PR TITLE
fix(backlog): clear sixteen entries - the cheapest ones, measured rather than guessed

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,10 +8,11 @@ name: Security Scan
 #
 # WHICH SCANS CAN FAIL, AND WHICH ONLY REPORT
 #
-# "Fails" below means the job goes red, not that it blocks a merge: none of
-# these three is a required status check in branch protection today (see the
-# note after the list), so a failed job here is visible on the pull request
-# but does not by itself stop a maintainer from clicking merge.
+# "Fails" below means the job goes red. For secret-scan that now blocks a merge:
+# it was promoted to a required status check on 2026-08-22, for the determinism
+# reason given below. The other two are not required, so a failed job there is
+# visible on the pull request but does not by itself stop a maintainer from
+# clicking merge.
 #
 #   secret-scan       fails. Its verdict is a pure function of the scanned commit
 #                     range and the pinned gitleaks digest - no feed can turn it
@@ -33,8 +34,9 @@ name: Security Scan
 #                     over that is a permanent red with nothing to do about it -
 #                     which is how a gate becomes a continue-on-error line.
 #
-# None of these is a required check today. If one is ever promoted, secret-scan
-# is the only candidate, for the determinism reason above.
+# secret-scan IS a required check (promoted 2026-08-22). The other two are not,
+# and should not be: their verdict is a function of a feed rather than of the
+# code under review.
 #
 # Scanners run as containers pinned by DIGEST rather than as third-party actions:
 # a supply-chain workflow should not add a third-party action to its own trust

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Web-based SQL IDE for cloud-native teams: PostgreSQL, MySQL, SQLite, Oracle, SQL
 
 ## Branching & PRs
 
-> **Trunk-based: feature/work branches target `main` directly; releases are git tags.** Branch off `main` for new work and open every PR with base `main` (`gh pr create --base main`). `main` is the single protected integration trunk — PRs are required and the `Lint, Typecheck and Build` and `Unit & Integration Tests` checks must pass before merge (SonarCloud still runs on push and same-repo PRs but is not a required check: fork PRs cannot produce it, which used to hard-block them). Cut a release by tagging `main` — tags carry **no `v` prefix** (`0.9.65`, not `v0.9.65`) — and always follow the `/cut-release` skill ([`.claude/skills/cut-release/SKILL.md`](.claude/skills/cut-release/SKILL.md)), which holds the full runbook: bump, pre-tag verification, draft-first publish, the ref-pinned dispatch chain and the recovery table. It is user-invoked only, so ask for it rather than improvising a release. There is no `dev` branch and no long-lived `release/*` branches. A PR that bumps the
+> **Trunk-based: feature/work branches target `main` directly; releases are git tags.** Branch off `main` for new work and open every PR with base `main` (`gh pr create --base main`). `main` is the single protected integration trunk — PRs are required and the `Lint, Typecheck and Build`, `Unit & Integration Tests` and `Secret Scan` checks must pass before merge (SonarCloud still runs on push and same-repo PRs but is not a required check: fork PRs cannot produce it, which used to hard-block them). Cut a release by tagging `main` — tags carry **no `v` prefix** (`0.9.65`, not `v0.9.65`) — and always follow the `/cut-release` skill ([`.claude/skills/cut-release/SKILL.md`](.claude/skills/cut-release/SKILL.md)), which holds the full runbook: bump, pre-tag verification, draft-first publish, the ref-pinned dispatch chain and the recovery table. It is user-invoked only, so ask for it rather than improvising a release. There is no `dev` branch and no long-lived `release/*` branches. A PR that bumps the
 > `package.json` version must also run `bun run chart:bump` **and `make -C operator bundle`** and
 > commit both results — the required CI check enforces `Chart.yaml appVersion` == `package.json`
 > version (#138), and a second gate fails when `operator/bundle` / `operator/config` still carry the
@@ -92,3 +92,13 @@ Redis maps onto the SQL-oriented provider interface by convention: `getSchema()`
 
 - **Docker:** multi-stage Bun build, standalone Next.js output. Build args `JWT_SECRET_BUILD`, `ADMIN_PASSWORD_BUILD`, `USER_PASSWORD_BUILD`. Health check `GET /api/db/health`.
 - **Helm:** lint with `helm lint charts/libredb-studio --strict`. Full values reference: `charts/libredb-studio/README.md`; chart architecture/rationale: [`docs/HELM_CHART.md`](docs/HELM_CHART.md).
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2306,10 +2306,6 @@ classifier's real-world agreement rate was measured — and they are the same ki
 - **B39** — a data-analysis run has no honest way to conclude that the question is not about this
   database. Its only route to `answered` is a reading of the data, so a run that establishes the
   question is unanswerable fabricates one — the #356 shape again, in a new place.
-- **B40** — `bun dev` cannot log in: the CSP omits `unsafe-eval` in every environment and React's
-  development build needs it, so the login page never hydrates. Production is unaffected.
-- **B41** — `defaults` in a seed config does not merge `roles`, though the documentation says the
-  block is merged into every connection.
 - **B43** — every copy control outside the agent rail reaches `navigator.clipboard` unguarded, and it
   is a secure-context API: nine call sites across seven components, four of which claim success — by
   a label or a toast — in the same statement that starts a write nobody observed.
@@ -2331,19 +2327,12 @@ classifier's real-world agreement rate was measured — and they are the same ki
   an operational reading to the emptiness rule is "precisely backwards" — and that argument applies
   to a plan artifact verbatim. The #356 shape a third time: a rule stated in terms of an artifact
   only one valid answer can produce.
-- **B47** — `engine-unsupported` — *"The agent cannot run on this database engine: it offers no
-  read-only execution profile"* — is also what a user is shown when their AGENT CREDENTIAL cannot be
-  resolved, on an engine that is fully supported. `resolveAgentCredential` throws the same
-  `ExecutionProfileError` that a missing `queryReadOnly` throws, before any provider exists and on
-  every engine, and `classifyDriveFailure` cannot tell the two apart though the reason codes already
-  do. Pre-existing for every workflow; #411 only lets an `operations` run reach it during its
-  grounding capture, before the first turn, which is the least explicable moment for it to arrive.
 - **B48** — the two grounding paths fail differently. Since #414 a plan run on one of the nine
   provider-path engines survives an unreachable host, a wrong password or a half-configured
   `agentUser`: `captureFromProvider` converts a `DatabaseError` or an `ExecutionProfileError` raised
   before the reading leaves into an unavailable capture, and the run answers ungrounded with that
   diagnosis. The composed path — PostgreSQL and SQLite — still lets the same failure out, ending the
-  run `internal` or, on the profile error, `engine-unsupported` (B47). Deliberate at #414, which had
+  run `internal` or, on the profile error, `agent-credential-unusable`. Deliberate at #414, which had
   no business changing how the two engines it did not touch fail, and an asymmetry a reader will
   trip over until it is resolved.
 - **B49** — a **LibreDB** connection can never be grounded, and the reason is not the agent's.
@@ -2354,15 +2343,6 @@ classifier's real-world agreement rate was measured — and they are the same ki
   is already open by another process"*, converted by `captureFromProvider` into an honest ungrounded
   run with no `context-captured` event. The same lock is what makes the connection-test modal report a
   failed connection (`docs/BACKLOG.md` D3), so the two close together.
-- **B50** — a grounded Redis plan run drafts `KEYS user:*`, the blocking O(N) command this product's
-  own provider refuses to use: the schema read is a non-blocking `SCAN` and never `KEYS *`. Measured
-  on two runs after #414's vocabulary work, both grounded on the same 17 real key prefixes — one
-  refused correctly with `NO STATEMENT:` and the other drafted `KEYS`, naming a whole key for the
-  lookup half exactly as the new rule intends. Grounding is working; this is draft QUALITY. Nothing
-  runs — plan mode executes nothing — so the hazard needs the user to apply the draft and run it. The
-  open question is whether one sentence about operational cost belongs in the rules, against the
-  owner's deferral of per-engine knowledge files and the argument that banning a command by name is
-  engine trivia that goes stale. Recorded, not decided.
 - **B51** — the loop delivers three notices to a model (the reserve warning, the report reminder of
   #416, the present-before-report notice of #417) and records none of them. `recordEvent` is called
   for what the RUN did and never for what the server said to it, so a rescued run and a run that never

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -19,25 +19,28 @@ None of it is a GitHub issue.
 
 ---
 
+---
+
+---
+
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S1–S8 · 8
 - [Drivers and connections](#drivers-and-connections) — D1–D10, U17 · 11
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X1–X7, U2–U18 · 20
-- [Authentication and security headers](#authentication-and-security-headers) — AU1–AU2 · 2
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X1–X7, U2–U18 · 15
+- [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 3
 - [Dependencies](#dependencies) — P1–P6 · 6
-- [Documentation](#documentation) — DOC1–DOC3 · 3
+- [Documentation](#documentation) — DOC1–DOC4 · 4
 - [Release pipeline](#release-pipeline) — REL1
 - [Chart configuration surface](#chart-configuration-surface) — N1–N3 · 3
-- [Container runtime](#container-runtime) — U15
-- [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 13
-- [Security Phase 2 deferrals](#security-phase-2-deferrals) — C1–C10 · 10
-- [Security Phase 3 deferrals](#security-phase-3-deferrals) — K1–K4 · 4
+- [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 10
+- [Security Phase 2 deferrals](#security-phase-2-deferrals) — C2–C10 · 9
+- [Security Phase 3 deferrals](#security-phase-3-deferrals) — K1–K4 · 3
 - [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A6 · 5
-- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B56 · 46
+- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B56 · 42
 
 ---
 
@@ -476,6 +479,7 @@ Cassandra fixture does not close it.
 
 **Done when:** each of the four has been taken further or judged settled, and
 `e2e/cassandra-provider.spec.ts` exists or a written reason it cannot exist is recorded here.
+
 ---
 
 
@@ -630,31 +634,6 @@ file's ratio is not the tree's.
 **Done when:** the scope is widened with the benign sites made explicit, or the decision not to is
 recorded here with the number that justified it.
 
-### U3. Provider metadata posts the client's connection object, so a connection-string seed is refused
-
-`useProviderMetadata` posts `JSON.stringify(connection)` — the connection as the CLIENT holds it. For
-a managed seed that object is the sanitized one `GET /api/connections/managed` returns, which keeps
-only the non-secret fields.
-
-A seed defined by `host` / `port` / `database` / `user` survives that trip with enough left to
-construct a provider. All eleven managed seeds were replayed as the client sends them, and every one
-answered. A seed defined by `connectionString` does not: the string IS the credential, so nothing
-addressable is left and `createDatabaseProvider` throws. Measured on 0.11.0 against a managed MongoDB
-seed — `POST /api/db/provider-meta` returns **400**, with `Provider metadata request failed` in the
-console and no capabilities for that connection.
-
-The route already accepts the fix. It resolves `body.connectionId` through `resolveConnection`, the
-same seam `/api/db/query` and `/api/db/schema` use — which is why a query and a schema read on that
-same connection succeed while the metadata call beside them fails. Only this one caller sends the
-object instead of the id.
-
-The damage is bounded, because absent metadata reads as unsupported everywhere, and for MongoDB that
-is close to the truth: no explain, no create-table, no inline edit. What is lost is the labels — the
-explorer says what a Postgres connection would say rather than naming collections — and the loss is
-silent. Not a regression: the hook has posted the object since `a4b5cfa` (2026-02-12).
-
-**Done when:** the hook posts `connectionId` and the route resolves it, like its two neighbours.
-
 ### U4. The profile modal's error state cannot be dismissed
 
 `DataProfiler` renders the message `/api/db/profile` returned and offers no way out. Escape does not
@@ -667,18 +646,6 @@ the modal.
 
 **Done when:** a failed profile is dismissable by Escape and by the modal's own close control, for
 every provider that can fail it.
-
-### U5. The Operations tab shows `Tables (0)` for a key-value provider and preselects nothing
-
-Two gaps on one screen:
-
-- `OperationsTab` calls `useMonitoringData` with `includeTables: true` for every connection, so a
-  provider with no addressable tables renders an empty panel rather than none.
-- The Explorer's deep link `onOpenMaintenance("tables", table.name)` carries the row's name, but
-  `openMaintenance` in `Studio.tsx` drops the second argument, so the tab opens with nothing selected.
-
-**Done when:** a provider whose rows are derived groupings renders no Tables panel, and a deep link
-from a row arrives with that row selected.
 
 ### U6. The Reindex card has no per-provider wording, so it still speaks Postgres
 
@@ -699,37 +666,6 @@ should be done with it.
 **Done when:** `reindexGlobalLabel` / `reindexGlobalTitle` / `reindexGlobalDesc` exist, the three
 declaring providers set them, the card renders them with the current strings as fallback, and the
 per-table buttons carry `analyzeAction` / `vacuumAction`.
-
-### U7. The embedded surface renders a Save Query button the host may not have wired
-
-`QueryToolbar` renders its Save Query control whenever it is given an `onSaveQuery`. `StudioWorkspace`
-now takes a real `onSaveQuery` prop and opens a save modal when the host supplies one — but when the
-host supplies nothing it passes `noop`, and the button still renders. Dead control, embedded surface
-only. The standalone `Studio` always passes a real handler.
-
-Half of the original entry landed: the host CAN wire a save. The other half did not: an unwired host
-still gets a button that does nothing.
-
-**Done when:** the control is not rendered when no handler was supplied.
-
-### U8. The LibreDB Monaco language module's tokenizer is never exercised
-
-`registerLibreDBLanguage` (`src/lib/editor/libredb-language.ts`) hands Monaco a Monarch `tokenizer`
-whose rules are the whole point of the module.
-`tests/unit/editor/libredb-language.test.ts` asserts registration, the keyword list, the
-configuration and idempotency — and for the rules themselves only `tokenizer.root.length > 0`.
-
-So a regex covering the wrong span, a shadowing rule order, or a word in both the keyword and
-modifier lists would pass every gate and show up only in a browser. 100% line coverage does not help:
-the rules are data, and loading the module covers them.
-
-The Redis half is **done**. `tests/unit/editor/redis-language.test.ts` asserts the rule regexes
-directly (#427): what `^\s*#` matches and does not, that a SCAN cursor tokenizes as a number, that
-`user:*` is ONE identifier token, that a quoted value keeps a `#` inside it, and that no two root
-rules can open on the same character. It needs no Monaco runtime, so the same shape applies here.
-
-**Done when:** the LibreDB module is checked the same way, or both are driven through Monaco's own
-Monarch runtime end to end.
 
 ### U9. Four providers point `vacuumAction` at something that is not `vacuum`, and MySQL offers one it lacks
 
@@ -771,25 +707,6 @@ Low severity: it misleads, it does not corrupt.
 
 **Done when:** an open quoted argument keeps its string state across the line break in both
 tokenizers, with a test asserting a `#`-leading continuation line is not tokenized as a comment.
-
-### U11. The LibreDB "Scan Keys" generator interpolates a newline-bearing key name raw
-
-`generateSelectQuery`'s LibreDB branch refuses to emit a command line for a node whose name contains
-a newline (#427), because a line-oriented grammar cannot address it. `generateTableQuery` — the "Scan
-Keys" action, which `handleTableClick` AUTO-EXECUTES — was left as it was. For a key literally named
-`x\ndelete billing:2024` it returns `get x\ndelete billing:2024`.
-
-Only `get x` runs, because `firstCommandLine()` takes the first line. Nothing destructive executes.
-But line 2 sits in the editor as a plausible, runnable `delete billing:2024`, one Run Selected away.
-
-Redis's equivalent path is closed: an argument the plain tokenizer cannot round-trip switches that
-line to the lossless JSON command form, which has no line-oriented escape. LibreDB has no such form,
-so closing this needs either a quoting rule in its grammar or the same "emit a note, emit no command"
-answer `generateSelectQuery` already gives.
-
-**Done when:** no generated LibreDB line can carry a second command, and `docs/providers/libredb.md`
-§5.3 says so for Scan Keys as well as for the cheatsheet — today it claims the stronger property for
-both.
 
 ### U12. The monitoring Queries tab tells every engine to enable `pg_stat_statements`
 
@@ -872,20 +789,6 @@ is accepted deliberately.
 ---
 
 ## Authentication and security headers
-
-### AU1. The storage routes answer 401 with their own error shape
-
-`src/lib/api/require-session.ts` builds `{ error: "Authentication required" }` with status 401, and
-that guard is now the one place database- and LLM-reaching routes get it from. `schema-route.ts` and
-`db/health/route.ts` both call `guardRoute`, so the two inline copies this entry used to list are gone.
-
-What remains is the storage family. `src/app/api/storage/route.ts`,
-`src/app/api/storage/[collection]/route.ts` and `src/app/api/storage/migrate/route.ts` each build
-`{ error: "Unauthorized" }` inline. So a client still cannot rely on one error shape for "not logged
-in" across the whole API.
-
-**Done when:** the storage routes call the shared guard, and there is exactly one 401 response for
-this condition.
 
 ### AU2. Static assets receive no security headers — decided, not implemented
 
@@ -1279,31 +1182,6 @@ chart refuses a non-root ingress path outright.
 
 ---
 
-## Container runtime
-
-### U15. The IPv6-only container default is unverified on a kernel without AF_INET6
-
-The container no longer hardcodes `0.0.0.0`. Its entrypoint resolves a bind address at startup, proves
-`::` is dual-stack by connecting an IPv4 client to a throwaway `::` listener, and falls back to
-`0.0.0.0` only when that probe fails and a non-loopback IPv4 address exists. The chart writes an empty
-`HOSTNAME` so the resolver runs, with `config.bindAddress` to overrule it. That closed #432.
-
-One branch is reasoned rather than measured. Every namespace reachable on the development host —
-`--sysctl net.ipv6.bindv6only=1`, `--sysctl net.ipv6.conf.all.disable_ipv6=1`, `--network host`, an
-IPv6-only Docker network — still binds `::` successfully, and the `bindv6only` case still serves IPv4
-because libuv clears `IPV6_V6ONLY`. The one configuration that would make `socket(AF_INET6)` fail
-outright is a kernel built without IPv6 (`CONFIG_IPV6=n`) or with the module unloaded, and that could
-not be constructed here.
-
-The `ipv6-unavailable` branch is covered by unit tests with an injected failure, and the failure mode
-if it is wrong is loud (the server exits) rather than silent.
-
-**Done when:** the image has been started once on a host with no `AF_INET6` and observed to log
-`ipv6-unavailable` and bind `0.0.0.0` — or that configuration is judged rare enough that the unit test
-is the whole answer. This is a decision, not work.
-
----
-
 ## Security Phase 1 deferrals
 
 Each was decided during Phase 1, not overlooked.
@@ -1326,14 +1204,6 @@ the channels that serve Studio from a small box.
 
 **Done when:** the measurement says the trade is worth it and the nonce ships, or the measurement is
 recorded here as the reason it does not.
-
-### H2. A 429 should produce a Retry-After-aware toast
-
-`src/hooks/use-query-execution.ts` already reads `.error` from any non-ok body, so a rate-limited
-request shows its message. It does not read the `Retry-After` header and tell the user how long to
-wait.
-
-**Done when:** the toast names the wait.
 
 ### H3. Audit events do not record a user agent
 
@@ -1439,20 +1309,6 @@ considered each introduced a worse flaw.
 **Done when:** a cheaper, audit-visible eviction policy is found that does not reopen the oldest-first
 bypass.
 
-### H9. `admin/fleet-health`'s per-request fan-out width is unbounded by the route guard
-
-`src/app/api/admin/fleet-health/route.ts` shares the `query` rate-limit bucket via `guardRoute`, like
-every other database-reaching route. The guard limits *request rate*, not *fan-out width*: the handler
-runs `Promise.all(connections.map(...))` over whatever `connections` array the caller's JSON body
-names, with no upper bound on its length.
-
-One admin-authenticated (or stolen admin) POST can open and health-check an arbitrarily large number of
-connections concurrently. The per-request rate limit does not touch it, because it is a single request
-however large its body is.
-
-**Done when:** the handler caps the array length (a `400` above some bound) or chunks the fan-out,
-whichever the real usage pattern supports.
-
 ### H10. The route-guard allowlist verifies existence, not truth
 
 `ROUTES_WITHOUT_A_PROVIDER` in `tests/security/route-auth.test.ts` maps a route key to a one-line
@@ -1491,26 +1347,6 @@ to shrink the blast radius without loosening the guess ceiling.
 **Done when:** a design keeps this bucket immune to header spoofing without also being a stranger's
 denial-of-login switch. Unknown at the time of writing.
 
-### H12. A role-based denial is never audited, and `insufficient_role` has no emitter
-
-`AuditReason` includes `insufficient_role` in its closed union, and no call site ever constructs an
-event with it. Every denial the audit trail records is a SESSION or ORIGIN check failing — `no_session`
-from `guardRoute`, `origin_mismatch` from the proxy's Origin check — not a ROLE check failing for an
-already-authenticated caller.
-
-Five call sites, no audit line between them:
-
-- `GET` and `POST /api/admin/audit`
-- `POST /api/admin/fleet-health`
-- `POST /api/db/maintenance`
-- the proxy's own `/admin` RBAC redirect, which silently sends a non-admin token to `/`
-
-An admin session, or a stolen one, probing for a role it does not hold leaves no trace in the one
-channel this project treats as authoritative.
-
-**Done when:** each of the five emits a `permission_denied` event with `reason: "insufficient_role"`,
-the same pattern `guardRoute` already uses for `no_session`.
-
 ### H13. No rate-limit bucket is a global, unkeyed ceiling — on purpose
 
 Every bucket in `src/lib/api/rate-limit.ts` is keyed on something the caller supplies:
@@ -1534,19 +1370,6 @@ ceiling's sizing can be grounded in that data rather than guessed.
 
 Each was decided during Phase 2, not overlooked. Lettered `C` (supply **C**hain) because the SQL
 section already owns `S1`–`S8`.
-
-### C1. No scan check is a required check
-
-Branch protection requires `Lint, Typecheck and Build` and `Unit & Integration Tests`. Phase 2 adds
-three scan jobs and promotes none: promoting a check is a branch-protection change the owner makes,
-and two of the three consult a vulnerability database rebuilt every six hours, which would import that
-schedule into the merge gate.
-
-**`Secret Scan` is the one candidate.** Its verdict is a pure function of the scanned commit range and
-the pinned gitleaks digest, it needs no secrets so it works identically for fork pull requests, and it
-scans a PR's commits in about 75 milliseconds.
-
-**Done when:** the owner promotes it, or this entry records why not.
 
 ### C2. A failing scheduled scan notifies nobody but the owner
 
@@ -1729,17 +1552,6 @@ the user retypes the password once. The alternative — passing an unrecognised 
 
 **Done when:** the envelope format is versioned forward for an unrelated reason, at which point a
 longer, non-colliding prefix costs nothing.
-
-### K3. `STORAGE_ENCRYPTION_KEY` is validated at first write, not at boot
-
-`src/lib/config/auth-preflight.ts` validates `JWT_SECRET` at startup, so a short one stops the server
-rather than producing a green health check and a 503 on every login. `STORAGE_ENCRYPTION_KEY` has no
-equivalent: a value shorter than 32 characters throws only at the first storage write, which is after
-login, after the migration attempt, and only in server storage modes. It surfaces as a `syncError` in
-the UI rather than a boot failure.
-
-**Done when:** the preflight also reads `STORAGE_ENCRYPTION_KEY` — staying silent when
-`STORAGE_PROVIDER` is `local`, where the variable is inert and an error would be wrong.
 
 ### K4. Rotating the key back does not recover credentials once the app has written
 
@@ -2669,36 +2481,6 @@ database has answered it, and should be able to say so without inventing a query
 **Done when:** a data-analysis run can conclude "not answerable here" and be scored `answered` for it,
 with the rule stated in `WORKFLOW_TOOL_RULES` and an eval asserting no fabricated statement is sent.
 
-### B40. `bun dev` cannot log in, because the CSP omits `unsafe-eval` in every environment
-
-`securityHeaders` (`src/lib/security/headers.ts`) deliberately omits `unsafe-eval`, which is right for
-production and correct for Monaco. React's DEVELOPMENT build needs it, and without it the login page
-never hydrates: the Sign In button has no handler, no request reaches `/api/auth/login`, and the console
-carries only "eval() is not supported in this environment".
-
-A contributor's first `bun dev` is a dead end unless they already hold a session cookie from a
-production run, which is why this has gone unnoticed.
-
-Production is unaffected and nothing here argues for weakening the shipped policy. The fix is to relax
-the directive only where `NODE_ENV === "development"`, in one place, with the reason written next to it.
-
-**Done when:** `bun dev` can log in from a cold browser profile, with a test asserting the shipped
-policy still omits `unsafe-eval`.
-
-### B41. `defaults` in a seed config does not merge `roles`
-
-`docs/SEED_CONNECTIONS.md` says the `defaults` block is "merged into every connection". A config whose
-`roles` appears only under `defaults` is rejected with
-`Invalid seed config: connections.0.roles: expected array, received undefined`.
-
-`mergeDefaults` (`src/lib/seed/connection-filter.ts`) merges `managed`, `environment` and `ssl`, and
-nothing else. The values table in that doc lists only those three, so the schema and the table agree —
-it is the prose ("merged into every connection") that overstates. A config file is not the place to
-find that out by experiment.
-
-**Done when:** the documented behaviour and the schema agree, whichever way is chosen, with a test
-covering a config that sets `roles` only in `defaults`.
-
 ### B43. Nine copy call sites outside the agent rail fail silently on plain HTTP
 
 `navigator.clipboard` is a secure-context API: over plain HTTP on any host but loopback it is
@@ -2778,33 +2560,6 @@ most: the product contradicts its own good answer, in its own voice, at the end 
 arm into this template — with an eval that fails if the run above reads `unanswered`, and with the reason
 recorded next to the operations exemption so the two read as one decision.
 
-### B47. `engine-unsupported` is shown for a misconfigured agent credential, on an engine that is supported
-
-`AgentRunFailureReason`'s `engine-unsupported` is rendered as *"The agent cannot run on this database
-engine: it offers no read-only execution profile."* It is the classification `runtime.ts` gives to any
-`ExecutionProfileError`, and that error has two causes rather than one.
-
-The engine-shaped cause fits the sentence: `acquireExecutionProfileProvider` refuses `agent-read-only`
-for a provider with no `queryReadOnly`.
-
-The other cause is `resolveAgentCredential`, which throws the same error type — with reason codes
-`AGENT_CREDENTIAL_UNRESOLVABLE` and `AGENT_CREDENTIAL_WITH_CONNECTION_STRING` — for a credential that is
-half-configured, sealed under a key that no longer decrypts, or configured alongside a connection
-string. That check runs before a provider is created, on every engine.
-
-So an operator who set `agentUser` and `agentPassword` on a PostgreSQL connection and then rotated the
-secret key is told their engine is unsupported. The one message they get points away from the one thing
-they could fix, and says something about their database that is false.
-
-Not made by #411 and not fixed by it. Every workflow could already reach it through
-`acquireExecutionProfileProvider` on the reading path. What #411 changed is that an `operations` run can
-now reach it before its first turn, during the grounding capture — the earliest and least explicable
-moment for it to arrive.
-
-**Done when:** a credential refusal is classified apart from an engine refusal. The reason codes already
-distinguish them, so this is a branch in `classifyDriveFailure` and a second rail sentence, with a test
-per cause pinning the sentence a user is shown.
-
 ### B48. The composed grounding path still loses a plan run to an environment failure
 
 `captureFromProvider` (`src/lib/agent/context-snapshot.ts`) converts a `DatabaseError` or an
@@ -2848,50 +2603,6 @@ this is recorded rather than fixed.
 connection's existing provider instead of opening a second handle — the same answer D3 needs, and the
 reason the two should be closed together — with a test that grounds a plan run on a `libredb` connection
 whose writable provider is already open.
-
-### B50. A grounded Redis plan still drafts `KEYS`, the one command this product refuses to use itself
-
-Two plan runs on the seeded local Redis, driven after #414's vocabulary work landed, both grounded on
-the same 17 real key prefixes the provider read:
-
-- *"Which key prefix holds the most keys, and how would I list them?"* → **NO STATEMENT**, and the
-  refusal is a good one: the inventory shows key patterns but no counts, so the question cannot be
-  answered from it. Before the vocabulary fix the same objective produced `KEYS user:*` as an answer.
-- *"How many users are stored, and how do I look one up?"* → drafted `KEYS user:*`, with a rationale
-  that also named `HGETALL user:<id>` for the lookup.
-
-Grounding is working, and the second half of that rationale is the new rule working as designed: it
-names a WHOLE KEY rather than handing a derived grouping to a command. This is a draft-QUALITY matter,
-not a grounding one, and should not be read as evidence against #414.
-
-What is wrong is the first half. `KEYS` is the blocking O(N) command this product's own provider
-deliberately refuses to use: the schema read is a non-blocking `SCAN` and never `KEYS *`
-(`docs/providers/redis.md`, and `CLAUDE.md` states it as a rule). So the product reads the keyspace
-safely, then offers the user the unsafe way to do the same thing — with an Apply-to-editor button on it.
-Nothing runs: plan mode executes nothing and has no tools, so reaching the hazard takes the user
-applying the draft and running it themselves.
-
-**The open question.** The owner deliberately deferred per-engine knowledge files, and the
-derived-groupings rule was written to stay on the near side of that line: it says what the inventory's
-rows ARE and names no command, pinned by a test ("it names no command and forbids none").
-
-- For a cost sentence: one sentence about operational COST is a different kind of statement from a ban
-  on a named command, and it may belong in the rules.
-- Against: a rule that bans one command by name is engine trivia that goes stale, says nothing about the
-  next command, and this repository has been bitten by exactly that before. A model that knows what the
-  rows are can choose for itself, which is the premise the whole grounding design rests on.
-- Third position: this is the user's call. The draft is theirs to run, on their own connection, and a
-  product that reads for them does not have to think for them.
-
-**Update 2026-08-22.** The SHAPE half of this is fixed and is not what B50 is about: `redis.ts` now
-declares a `statementLanguage`, because a plan run drafted `1) KEYS session:*` / `2) GET session:1` and
-`executeRedisCommand` reads the whole body as one command, so the server answered `ERR unknown command
-'1)'`. That sentence deliberately names no command and forbids none — it names the packaging (one
-command, no numbering, no `redis-cli` prefix) and repeats what the rows ARE. The cost question below is
-untouched by it and still the owner's.
-
-**Done when:** the owner rules, and the reason is recorded next to the derived-groupings rule so the two
-read as one decision.
 
 ### B51. The run loop nudges a model three times and records none of it
 

--- a/docs/SEED_CONNECTIONS.md
+++ b/docs/SEED_CONNECTIONS.md
@@ -48,7 +48,7 @@ The config file is YAML (`.yaml`, `.yml`) or JSON (`.json`). Format is auto-dete
 ```yaml
 version: "1"
 
-defaults:                    # Optional — merged into every connection
+defaults:                    # Optional — merges managed/environment/ssl only
   managed: true
   environment: production
   ssl:
@@ -137,7 +137,7 @@ connections:
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `version` | Yes | — | Must be `"1"` |
-| `defaults` | No | — | Merged into all connections (connection values override) |
+| `defaults` | No | — | Supplies `managed`, `environment` and `ssl` where a connection omits them. No other field is merged |
 | `defaults.managed` | No | `true` | Default managed state |
 | `defaults.environment` | No | — | Default environment label |
 | `defaults.ssl` | No | — | Default SSL config |

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -358,7 +358,8 @@ node, so you do not have to type the grammar from memory. The generation is driv
 `queryDialect: 'redis'`; MongoDB is now the only provider that reaches the JSON branch:
 
 - **Scan Keys** runs `prefix <group>:` for a `:`-prefix group (e.g. `users:*` → `prefix users:`), or
-  `get <name>` for a bare single-key node.
+  `get <name>` for a bare single-key node — except for a name carrying CR or LF, where it emits the
+  same `#` note and no command as the cheatsheet does (see below).
 - **Generate Command** inserts an explanatory cheatsheet — a use-case comment above each command —
   where every command line is a **concrete, directly-runnable example** (no `<placeholder>` tokens),
   so "Run Selected" on any line works as-is. The example `put` value is shaped by the group's
@@ -397,9 +398,12 @@ named `x\ndelete billing:2024` would render `delete billing:2024` as a line of i
 **Run Selected** would execute. For such a name the cheatsheet emits the header plus a single `#`
 note saying the key must be addressed with a hand-written command, and **no command line** (#427).
 
-That answer covers the cheatsheet only. `Scan Keys` still emits `get <name>` for such a key, so its
-second line lands in the editor as a runnable command; nothing destructive auto-executes, because
-`firstCommandLine()` runs only `get x`. Recorded as U11 in [`docs/BACKLOG.md`](../BACKLOG.md).
+`Scan Keys` gives the same answer — the note on its own, no command — through the same code path, so
+the two cannot drift. It matters more there than in the cheatsheet: `Scan Keys` auto-executes on a
+node click, and it used to emit `get x\ndelete billing:2024`, whose second line sat in the editor as
+a plausible, runnable `delete billing:2024` one **Run Selected** away (only `get x` ever ran, because
+`firstCommandLine()` takes the first line). Auto-executing the note alone runs nothing and reports
+*No command to run (only comments or blank lines)* (U11).
 
 Two menu actions are **not offered** on this provider. `Profile Table` and `Generate Test Data`
 address an object and insert rows into it; a `users:*` row is a prefix grouping this server derived

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -396,7 +396,11 @@ and no lossless JSON command form to fall back to the way Redis's does. Since ev
 is line-oriented, a name containing CR or LF cannot be addressed by a generated line at all: a key
 named `x\ndelete billing:2024` would render `delete billing:2024` as a line of its own that
 **Run Selected** would execute. For such a name the cheatsheet emits the header plus a single `#`
-note saying the key must be addressed with a hand-written command, and **no command line** (#427).
+note saying no generated line can address the key, and **no command line** (#427). The note stops
+there rather than pointing at a hand-written command: `firstCommandLine()` splits the buffer on LF
+before tokenizing, so an LF-bearing name cannot be reached from this editor at all. A CR survives
+inside quotes and could be typed by hand, but one note covers both characters and advice that fails
+for half of them is worse than none.
 
 `Scan Keys` gives the same answer — the note on its own, no command — through the same code path, so
 the two cannot drift. It matters more there than in the cheatsheet: `Scan Keys` auto-executes on a

--- a/src/app/api/admin/audit/route.ts
+++ b/src/app/api/admin/audit/route.ts
@@ -1,12 +1,41 @@
 import { getSession } from "@/lib/auth";
 import { NextResponse } from "next/server";
-import { getServerAuditBuffer, sanitizeAuditInput, type AuditEventType } from "@/lib/audit";
+import { emitAuditEvent, getServerAuditBuffer, sanitizeAuditInput, type AuditEventType } from "@/lib/audit";
+import { clientAddress } from "@/lib/api/client-address";
 import { createErrorResponse } from "@/lib/api/errors";
+import { logger } from "@/lib/logger";
+
+/**
+ * The role denial's audit line, in the same shape guardRoute uses for `no_session`. This route has
+ * no guardRoute in front of it, so its 403 covers both "no session" and "wrong role" - only the
+ * latter is recorded, because naming an anonymous caller's rejection `insufficient_role` would
+ * both misname the reason and let an unauthenticated caller write the trail for free.
+ *
+ * Isolated in its own try/catch for the same reason guardRoute isolates its emit: the 403 is
+ * already decided, and a broken audit sink must never turn a denial into an unrelated 500 - which
+ * on GET, whose check sits inside the handler's try, is exactly what would otherwise happen.
+ */
+function auditRoleDenial(route: string, user: string, request: Request): void {
+  try {
+    emitAuditEvent({
+      type: "permission_denied",
+      action: "denied",
+      target: route,
+      user,
+      result: "failure",
+      reason: "insufficient_role",
+      ip: clientAddress(request),
+    });
+  } catch (auditError) {
+    logger.error("Failed to record permission_denied audit event", auditError, { route });
+  }
+}
 
 export async function GET(request: Request) {
   try {
     const session = await getSession();
     if (!session || session.role !== "admin") {
+      if (session) auditRoleDenial("GET /api/admin/audit", session.username, request);
       return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
     }
 
@@ -26,6 +55,7 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   const session = await getSession();
   if (!session || session.role !== "admin") {
+    if (session) auditRoleDenial("POST /api/admin/audit", session.username, request);
     return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
   }
 

--- a/src/app/api/admin/audit/route.ts
+++ b/src/app/api/admin/audit/route.ts
@@ -1,41 +1,15 @@
 import { getSession } from "@/lib/auth";
 import { NextResponse } from "next/server";
-import { emitAuditEvent, getServerAuditBuffer, sanitizeAuditInput, type AuditEventType } from "@/lib/audit";
-import { clientAddress } from "@/lib/api/client-address";
+import { getServerAuditBuffer, sanitizeAuditInput, type AuditEventType } from "@/lib/audit";
+import { auditRoleDenial } from "@/lib/api/require-session";
 import { createErrorResponse } from "@/lib/api/errors";
 import { logger } from "@/lib/logger";
-
-/**
- * The role denial's audit line, in the same shape guardRoute uses for `no_session`. This route has
- * no guardRoute in front of it, so its 403 covers both "no session" and "wrong role" - only the
- * latter is recorded, because naming an anonymous caller's rejection `insufficient_role` would
- * both misname the reason and let an unauthenticated caller write the trail for free.
- *
- * Isolated in its own try/catch for the same reason guardRoute isolates its emit: the 403 is
- * already decided, and a broken audit sink must never turn a denial into an unrelated 500 - which
- * on GET, whose check sits inside the handler's try, is exactly what would otherwise happen.
- */
-function auditRoleDenial(route: string, user: string, request: Request): void {
-  try {
-    emitAuditEvent({
-      type: "permission_denied",
-      action: "denied",
-      target: route,
-      user,
-      result: "failure",
-      reason: "insufficient_role",
-      ip: clientAddress(request),
-    });
-  } catch (auditError) {
-    logger.error("Failed to record permission_denied audit event", auditError, { route });
-  }
-}
 
 export async function GET(request: Request) {
   try {
     const session = await getSession();
     if (!session || session.role !== "admin") {
-      if (session) auditRoleDenial("GET /api/admin/audit", session.username, request);
+      if (session) auditRoleDenial({ route: "GET /api/admin/audit", user: session.username, request });
       return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
     }
 
@@ -55,7 +29,7 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   const session = await getSession();
   if (!session || session.role !== "admin") {
-    if (session) auditRoleDenial("POST /api/admin/audit", session.username, request);
+    if (session) auditRoleDenial({ route: "POST /api/admin/audit", user: session.username, request });
     return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
   }
 

--- a/src/app/api/admin/fleet-health/route.ts
+++ b/src/app/api/admin/fleet-health/route.ts
@@ -1,9 +1,21 @@
 import { NextResponse } from "next/server";
 import { getOrCreateProvider } from "@/lib/db";
 import type { DatabaseConnection } from "@/lib/types";
+import { clientAddress } from "@/lib/api/client-address";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { guardRoute } from "@/lib/api/require-session";
+import { emitAuditEvent } from "@/lib/audit";
+import { logger } from "@/lib/logger";
+
+/**
+ * The widest fan-out one request may ask for. guardRoute bounds how OFTEN this route is called,
+ * not how WIDE a single call is: without this, one admin-authenticated POST opened as many
+ * provider connections concurrently as its body named, and the rate limiter counted one request.
+ * A fleet dashboard names tens of connections, so 100 is well clear of real use; the bound is
+ * stated in the 400 so an operator who hits it can see what happened.
+ */
+const MAX_FLEET_CONNECTIONS = 100;
 
 export interface FleetHealthItem {
   connectionId: string;
@@ -27,6 +39,23 @@ export async function POST(request: Request) {
   if ("response" in guard) return guard.response;
 
   if (guard.session.role !== "admin") {
+    // Isolated in its own try/catch, exactly as guardRoute's no_session branch is: the 403 below
+    // is already decided, and a broken audit sink must never turn a denial into an unrelated 500.
+    try {
+      emitAuditEvent({
+        type: "permission_denied",
+        action: "denied",
+        target: "POST /api/admin/fleet-health",
+        user: guard.session.username,
+        result: "failure",
+        reason: "insufficient_role",
+        ip: clientAddress(request),
+      });
+    } catch (auditError) {
+      logger.error("Failed to record permission_denied audit event", auditError, {
+        route: "POST /api/admin/fleet-health",
+      });
+    }
     return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
   }
 
@@ -37,6 +66,13 @@ export async function POST(request: Request) {
 
     if (!connections || !Array.isArray(connections)) {
       return NextResponse.json({ error: "connections array is required" }, { status: 400 });
+    }
+
+    if (connections.length > MAX_FLEET_CONNECTIONS) {
+      return NextResponse.json(
+        { error: `Too many connections: at most ${MAX_FLEET_CONNECTIONS} may be health-checked per request` },
+        { status: 400 },
+      );
     }
 
     const results: FleetHealthItem[] = await Promise.all(

--- a/src/app/api/admin/fleet-health/route.ts
+++ b/src/app/api/admin/fleet-health/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from "next/server";
 import { getOrCreateProvider } from "@/lib/db";
 import type { DatabaseConnection } from "@/lib/types";
-import { clientAddress } from "@/lib/api/client-address";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
-import { guardRoute } from "@/lib/api/require-session";
-import { emitAuditEvent } from "@/lib/audit";
+import { auditRoleDenial, guardRoute } from "@/lib/api/require-session";
 import { logger } from "@/lib/logger";
 
 /**
@@ -39,23 +37,7 @@ export async function POST(request: Request) {
   if ("response" in guard) return guard.response;
 
   if (guard.session.role !== "admin") {
-    // Isolated in its own try/catch, exactly as guardRoute's no_session branch is: the 403 below
-    // is already decided, and a broken audit sink must never turn a denial into an unrelated 500.
-    try {
-      emitAuditEvent({
-        type: "permission_denied",
-        action: "denied",
-        target: "POST /api/admin/fleet-health",
-        user: guard.session.username,
-        result: "failure",
-        reason: "insufficient_role",
-        ip: clientAddress(request),
-      });
-    } catch (auditError) {
-      logger.error("Failed to record permission_denied audit event", auditError, {
-        route: "POST /api/admin/fleet-health",
-      });
-    }
+    auditRoleDenial({ route: "POST /api/admin/fleet-health", user: guard.session.username, request });
     return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
   }
 

--- a/src/app/api/db/maintenance/route.ts
+++ b/src/app/api/db/maintenance/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from "next/server";
 import { getOrCreateProvider, type MaintenanceType } from "@/lib/db";
 import { emitAuditEvent } from "@/lib/audit";
-import { clientAddress } from "@/lib/api/client-address";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
-import { guardRoute } from "@/lib/api/require-session";
+import { auditRoleDenial, guardRoute } from "@/lib/api/require-session";
 import { logger } from "@/lib/logger";
 
 export async function POST(request: Request) {
@@ -18,23 +17,7 @@ export async function POST(request: Request) {
   if ("response" in guard) return guard.response;
 
   if (guard.session.role !== "admin") {
-    // Isolated in its own try/catch, exactly as guardRoute's no_session branch is: the 403 below
-    // is already decided, and a broken audit sink must never turn a denial into an unrelated 500.
-    try {
-      emitAuditEvent({
-        type: "permission_denied",
-        action: "denied",
-        target: "POST /api/db/maintenance",
-        user: guard.session.username,
-        result: "failure",
-        reason: "insufficient_role",
-        ip: clientAddress(request),
-      });
-    } catch (auditError) {
-      logger.error("Failed to record permission_denied audit event", auditError, {
-        route: "POST /api/db/maintenance",
-      });
-    }
+    auditRoleDenial({ route: "POST /api/db/maintenance", user: guard.session.username, request });
     return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
   }
 

--- a/src/app/api/db/maintenance/route.ts
+++ b/src/app/api/db/maintenance/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getOrCreateProvider, type MaintenanceType } from "@/lib/db";
 import { emitAuditEvent } from "@/lib/audit";
+import { clientAddress } from "@/lib/api/client-address";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { guardRoute } from "@/lib/api/require-session";
@@ -17,6 +18,23 @@ export async function POST(request: Request) {
   if ("response" in guard) return guard.response;
 
   if (guard.session.role !== "admin") {
+    // Isolated in its own try/catch, exactly as guardRoute's no_session branch is: the 403 below
+    // is already decided, and a broken audit sink must never turn a denial into an unrelated 500.
+    try {
+      emitAuditEvent({
+        type: "permission_denied",
+        action: "denied",
+        target: "POST /api/db/maintenance",
+        user: guard.session.username,
+        result: "failure",
+        reason: "insufficient_role",
+        ip: clientAddress(request),
+      });
+    } catch (auditError) {
+      logger.error("Failed to record permission_denied audit event", auditError, {
+        route: "POST /api/db/maintenance",
+      });
+    }
     return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
   }
 

--- a/src/app/api/storage/[collection]/route.ts
+++ b/src/app/api/storage/[collection]/route.ts
@@ -5,21 +5,20 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth";
 import { getStorageProvider } from "@/lib/storage/factory";
 import { STORAGE_COLLECTIONS, type StorageCollection } from "@/lib/storage/types";
 import { createErrorResponse } from "@/lib/api/errors";
+import { guardRoute } from "@/lib/api/require-session";
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ collection: string }> }) {
+  // See GET /api/storage for why the guard runs first and why this shares the "query" bucket.
+  const guard = await guardRoute({ route: "PUT /api/storage/[collection]", bucket: "query", request });
+  if ("response" in guard) return guard.response;
+
   try {
     const provider = await getStorageProvider();
     if (!provider) {
       return NextResponse.json({ error: "Server storage is not enabled" }, { status: 404 });
-    }
-
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const { collection } = await params;
@@ -39,7 +38,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: "Missing required field: data" }, { status: 400 });
     }
 
-    await provider.setCollection(session.username, collection as StorageCollection, body.data);
+    await provider.setCollection(guard.session.username, collection as StorageCollection, body.data);
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/src/app/api/storage/migrate/route.ts
+++ b/src/app/api/storage/migrate/route.ts
@@ -6,21 +6,20 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth";
 import { getStorageProvider } from "@/lib/storage/factory";
 import type { StorageData } from "@/lib/storage/types";
 import { createErrorResponse } from "@/lib/api/errors";
+import { guardRoute } from "@/lib/api/require-session";
 
 export async function POST(request: NextRequest) {
+  // See GET /api/storage for why the guard runs first and why this shares the "query" bucket.
+  const guard = await guardRoute({ route: "POST /api/storage/migrate", bucket: "query", request });
+  if ("response" in guard) return guard.response;
+
   try {
     const provider = await getStorageProvider();
     if (!provider) {
       return NextResponse.json({ error: "Server storage is not enabled" }, { status: 404 });
-    }
-
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     let body: Partial<StorageData>;
@@ -30,7 +29,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
     }
 
-    await provider.mergeData(session.username, body);
+    await provider.mergeData(guard.session.username, body);
 
     return NextResponse.json({ ok: true, migrated: Object.keys(body) });
   } catch (error) {

--- a/src/app/api/storage/route.ts
+++ b/src/app/api/storage/route.ts
@@ -4,24 +4,26 @@
  * Only works when server storage is enabled.
  */
 
-import { NextResponse } from "next/server";
-import { getSession } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
 import { getStorageProvider } from "@/lib/storage/factory";
 import { createErrorResponse } from "@/lib/api/errors";
+import { guardRoute } from "@/lib/api/require-session";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  // Ahead of the provider lookup, like POST /api/db/health: an unauthenticated caller gets no work
+  // done on its behalf, and one 401 shape covers the whole API. The "query" bucket is the one that
+  // fits - a server-storage read reaches the SQLite or PostgreSQL storage backend - and it is
+  // deliberately shared with the db/ routes rather than given its own budget.
+  const guard = await guardRoute({ route: "GET /api/storage", bucket: "query", request });
+  if ("response" in guard) return guard.response;
+
   try {
     const provider = await getStorageProvider();
     if (!provider) {
       return NextResponse.json({ error: "Server storage is not enabled" }, { status: 404 });
     }
 
-    const session = await getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const data = await provider.getAllData(session.username);
+    const data = await provider.getAllData(guard.session.username);
     return NextResponse.json(data);
   } catch (error) {
     return createErrorResponse(error, { route: "GET /api/storage" });

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -296,9 +296,13 @@ export default function Studio() {
   const effectiveMasking = shouldMask(user?.role, maskingConfig);
   const userCanToggle = canToggleMasking(user?.role, maskingConfig);
 
-  const openMaintenance = () => {
+  // The Explorer's per-row items call this with the row's name; without carrying it
+  // the tab opened with nothing selected (#U5). The name rides the query string —
+  // the admin section is routed, so a param is what a section page can read. The
+  // non-admin /monitoring route has no such reader, so it keeps the bare path.
+  const openMaintenance = (_tab?: "global" | "tables" | "sessions", table?: string) => {
     if (isAdmin) {
-      router.push("/admin/operations");
+      router.push(table ? `/admin/operations?table=${encodeURIComponent(table)}` : "/admin/operations");
     } else {
       router.push("/monitoring");
     }

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -33,6 +33,7 @@ import {
   XCircle,
   Table2,
 } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 import { useMonitoringData } from "@/hooks/use-monitoring-data";
 import { storage } from "@/lib/storage";
 import { useAllConnections } from "@/hooks/use-all-connections";
@@ -58,12 +59,10 @@ export function OperationsTab() {
   const [killingPid, setKillingPid] = useState<number | string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
-  const monitoringOptions = useMemo(() => ({ includeTables: true, includeIndexes: false, includeStorage: false }), []);
-
-  const { data, loading, error, refresh, killSession, runMaintenance } = useMonitoringData(
-    selectedConnection,
-    monitoringOptions,
-  );
+  // The row an Explorer deep link named (`onOpenMaintenance("tables", name)` →
+  // /admin/operations?table=...). It seeds the filter and marks the row, so the
+  // named row is the one the operator lands on (#U5).
+  const deepLinkedTable = useSearchParams().get("table");
 
   // Offer only the maintenance the connected provider declares it can perform:
   // /api/db/maintenance rejects everything else with 400, so an ungated control can
@@ -72,6 +71,25 @@ export function OperationsTab() {
   // `metadata` is also null when /api/db/provider-meta fails, and failing open
   // would put the dead buttons back on exactly the connections this gate is for.
   const { metadata } = useProviderMetadata(selectedConnection);
+
+  // Redis and the embedded engine declare `tablesAreDerivedGroupings`: their rows
+  // are key-prefix/namespace groupings, not addressable tables, so a Tables panel
+  // there could only ever read "Tables (0)". Both the request and the panel hang
+  // off that one capability — the same one TableItem reads — rather than a new
+  // flag. An unknown capability counts as addressable: every provider but those
+  // two has real tables, and metadata is also null while provider-meta is in
+  // flight.
+  const rowsAreAddressable = metadata?.capabilities.tablesAreDerivedGroupings !== true;
+
+  const monitoringOptions = useMemo(
+    () => ({ includeTables: rowsAreAddressable, includeIndexes: false, includeStorage: false }),
+    [rowsAreAddressable],
+  );
+
+  const { data, loading, error, refresh, killSession, runMaintenance } = useMonitoringData(
+    selectedConnection,
+    monitoringOptions,
+  );
   const canRun = (type: MaintenanceType) =>
     metadata?.capabilities.supportsMaintenance === true && metadata.capabilities.maintenanceOperations.includes(type);
   const anyMaintenance = canRun("analyze") || canRun("vacuum") || canRun("reindex");
@@ -155,7 +173,7 @@ export function OperationsTab() {
 
   const sessions = data?.activeSessions ?? [];
   const tables = data?.tables ?? [];
-  const [tableSearch, setTableSearch] = useState("");
+  const [tableSearch, setTableSearch] = useState(deepLinkedTable ?? "");
   const filteredTables = tables.filter((t) => t.tableName.toLowerCase().includes(tableSearch.toLowerCase()));
 
   const activeCount = sessions.filter((s) => s.state === "active").length;
@@ -346,91 +364,99 @@ export function OperationsTab() {
 
       {/* Tables + Sessions Split */}
       <div className="grid gap-6 md:grid-cols-2">
-        {/* Table Operations */}
-        <div className="rounded-xl border border-hairline bg-panel">
-          <div className="p-4 border-b border-hairline flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Table2 className="w-4 h-4 text-blue-400" />
-              <span className="text-xs font-bold text-fg-secondary">Tables ({tables.length})</span>
-            </div>
-            <Input
-              placeholder="Filter..."
-              value={tableSearch}
-              onChange={(e) => setTableSearch(e.target.value)}
-              className="w-[140px] h-7 text-xs bg-raised border-hairline-strong"
-            />
-          </div>
-          <div className="max-h-[350px] overflow-y-auto">
-            {loading && tables.length === 0 ? (
-              <div className="p-4 space-y-2">
-                {[...Array(5)].map((_, i) => (
-                  <Skeleton key={i} className="h-10 w-full bg-overlay" />
-                ))}
+        {/* Table Operations — absent where the provider's rows are derived groupings */}
+        {rowsAreAddressable && (
+          <div className="rounded-xl border border-hairline bg-panel">
+            <div className="p-4 border-b border-hairline flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Table2 className="w-4 h-4 text-blue-400" />
+                <span className="text-xs font-bold text-fg-secondary">Tables ({tables.length})</span>
               </div>
-            ) : filteredTables.length === 0 ? (
-              <div className="p-8 text-center text-fg-subtle text-sm">No tables found.</div>
-            ) : (
-              <div className="divide-y divide-hairline">
-                {filteredTables.map((table) => (
-                  <div
-                    key={`${table.schemaName}.${table.tableName}`}
-                    className="group flex items-center justify-between px-4 py-2 hover:bg-fill transition-colors"
-                  >
-                    <div className="min-w-0">
-                      <div className="text-sm font-medium text-fg-secondary truncate max-w-[160px]">
-                        {table.tableName}
+              <Input
+                placeholder="Filter..."
+                value={tableSearch}
+                onChange={(e) => setTableSearch(e.target.value)}
+                className="w-[140px] h-7 text-xs bg-raised border-hairline-strong"
+              />
+            </div>
+            <div className="max-h-[350px] overflow-y-auto">
+              {loading && tables.length === 0 ? (
+                <div className="p-4 space-y-2">
+                  {[...Array(5)].map((_, i) => (
+                    <Skeleton key={i} className="h-10 w-full bg-overlay" />
+                  ))}
+                </div>
+              ) : filteredTables.length === 0 ? (
+                <div className="p-8 text-center text-fg-subtle text-sm">No tables found.</div>
+              ) : (
+                <div className="divide-y divide-hairline">
+                  {filteredTables.map((table) => (
+                    <div
+                      key={`${table.schemaName}.${table.tableName}`}
+                      data-selected={table.tableName === deepLinkedTable ? "true" : undefined}
+                      className={`group flex items-center justify-between px-4 py-2 hover:bg-fill transition-colors ${
+                        table.tableName === deepLinkedTable ? "bg-fill" : ""
+                      }`}
+                    >
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium text-fg-secondary truncate max-w-[160px]">
+                          {table.tableName}
+                        </div>
+                        <div className="flex items-center gap-2 text-xs text-fg-muted">
+                          <span className="font-mono">{table.rowCount.toLocaleString()} rows</span>
+                          <span>-</span>
+                          <span className="font-mono">{table.tableSize}</span>
+                          {(table.bloatRatio ?? 0) > 10 && (
+                            <Badge
+                              variant="outline"
+                              className="text-[0.625rem] text-yellow-400 border-yellow-500/20 h-4"
+                            >
+                              {(table.bloatRatio ?? 0).toFixed(0)}% bloat
+                            </Badge>
+                          )}
+                        </div>
                       </div>
-                      <div className="flex items-center gap-2 text-xs text-fg-muted">
-                        <span className="font-mono">{table.rowCount.toLocaleString()} rows</span>
-                        <span>-</span>
-                        <span className="font-mono">{table.tableSize}</span>
-                        {(table.bloatRatio ?? 0) > 10 && (
-                          <Badge variant="outline" className="text-[0.625rem] text-yellow-400 border-yellow-500/20 h-4">
-                            {(table.bloatRatio ?? 0).toFixed(0)}% bloat
-                          </Badge>
+                      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                        {canRun("analyze") && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="w-7 h-7 text-fg-muted hover:text-yellow-500"
+                            title="Analyze"
+                            onClick={() => handleRunMaintenance("analyze", table.tableName)}
+                            disabled={!!actionLoading}
+                          >
+                            {actionLoading === `analyze-${table.tableName}` ? (
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                            ) : (
+                              <Search className="w-3 h-3" />
+                            )}
+                          </Button>
+                        )}
+                        {canRun("vacuum") && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="w-7 h-7 text-fg-muted hover:text-blue-500"
+                            title="Vacuum"
+                            onClick={() => handleRunMaintenance("vacuum", table.tableName)}
+                            disabled={!!actionLoading}
+                          >
+                            {actionLoading === `vacuum-${table.tableName}` ? (
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                            ) : (
+                              <HardDrive className="w-3 h-3" />
+                            )}
+                          </Button>
                         )}
                       </div>
                     </div>
-                    <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                      {canRun("analyze") && (
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          className="w-7 h-7 text-fg-muted hover:text-yellow-500"
-                          title="Analyze"
-                          onClick={() => handleRunMaintenance("analyze", table.tableName)}
-                          disabled={!!actionLoading}
-                        >
-                          {actionLoading === `analyze-${table.tableName}` ? (
-                            <Loader2 className="w-3 h-3 animate-spin" />
-                          ) : (
-                            <Search className="w-3 h-3" />
-                          )}
-                        </Button>
-                      )}
-                      {canRun("vacuum") && (
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          className="w-7 h-7 text-fg-muted hover:text-blue-500"
-                          title="Vacuum"
-                          onClick={() => handleRunMaintenance("vacuum", table.tableName)}
-                          disabled={!!actionLoading}
-                        >
-                          {actionLoading === `vacuum-${table.tableName}` ? (
-                            <Loader2 className="w-3 h-3 animate-spin" />
-                          ) : (
-                            <HardDrive className="w-3 h-3" />
-                          )}
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Session Manager */}
         <div className="rounded-xl border border-hairline bg-panel">

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -81,10 +81,15 @@ export function OperationsTab() {
   // flight.
   const rowsAreAddressable = metadata?.capabilities.tablesAreDerivedGroupings !== true;
 
-  const monitoringOptions = useMemo(
-    () => ({ includeTables: rowsAreAddressable, includeIndexes: false, includeStorage: false }),
-    [rowsAreAddressable],
-  );
+  // `includeTables` is NOT gated on the flag above, and that is measured rather than an oversight.
+  // useMonitoringData fetches once per CONNECTION (its effect depends on [connection, fetchData],
+  // and fetchData reads its options through a ref), autoRefresh is off here, so the one request
+  // this tab makes is issued while `metadata` is still null and no later option change can reach
+  // it. Gating it would need either a shared-hook rewrite or making every engine's health and
+  // session panels wait on provider-meta first. The PANEL below is gated instead: that is where
+  // the empty "Tables (0)" a key-value provider used to render actually came from, and rendering
+  // is reactive so it settles as soon as the capability arrives.
+  const monitoringOptions = useMemo(() => ({ includeTables: true, includeIndexes: false, includeStorage: false }), []);
 
   const { data, loading, error, refresh, killSession, runMaintenance } = useMonitoringData(
     selectedConnection,

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -427,6 +427,10 @@ const FAILURE_SENTENCES = {
   "model-rate-limited": "The model provider is limiting this key's requests. Waiting a minute usually clears it.",
   "model-unauthorized": "The model provider rejected the configured credentials.",
   "engine-unsupported": "The agent cannot run on this database engine: it offers no read-only execution profile.",
+  // Names the credential, because that is the only thing to fix and the engine is
+  // not at fault: this refusal reaches PostgreSQL and SQLite too (B47).
+  "agent-credential-unusable":
+    "This connection's agent credential cannot be used: check that both the agent user and password are set, that the password still decrypts under the current secret key, and that no connection string is set beside it.",
   "connection-unresolvable": "This run's database connection no longer resolves on the server.",
   internal: "The server could not carry this run. The reason is in the server log.",
 } as const satisfies Record<AgentRunFailureReason, string>;

--- a/src/components/studio/QueryToolbar.tsx
+++ b/src/components/studio/QueryToolbar.tsx
@@ -14,7 +14,8 @@ interface QueryToolbarProps {
   playgroundMode: boolean;
   transactionActive: boolean;
   editingEnabled: boolean;
-  onSaveQuery: () => void;
+  /** Omitted where the caller offers nowhere to save a query to. */
+  onSaveQuery?: () => void;
   onExecuteQuery: () => void;
   onCancelQuery: () => void;
   /**
@@ -78,15 +79,21 @@ export function QueryToolbar({
             <Terminal strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
             <span className="text-xs font-medium text-blue-400">Query</span>
           </div>
-          <div className="h-4 w-px bg-fill" />
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-2"
-            onClick={onSaveQuery}
-          >
-            <Save strokeWidth={1.5} className="w-3 h-3" /> Save
-          </Button>
+          {/* The separator is chrome for Save; with Save withheld it would be a rule
+              standing alone, the same reason the control group drops its border (#427). */}
+          {onSaveQuery && (
+            <>
+              <div className="h-4 w-px bg-fill" />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-2"
+                onClick={onSaveQuery}
+              >
+                <Save strokeWidth={1.5} className="w-3 h-3" /> Save
+              </Button>
+            </>
+          )}
         </div>
         {isExecuting ? (
           <Button

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -58,6 +58,19 @@ function explainRefusal(metadata: ProviderMetadata | null, hasStrategy: boolean)
   return { title: "Not Supported", description: "EXPLAIN is not available for this database type." };
 }
 
+/**
+ * The wait a rate-limited response names in its `Retry-After` header, in whole seconds.
+ *
+ * `createErrorResponse` sends a delta-seconds integer (`src/lib/api/rate-limit.ts` counts in
+ * seconds), so that is the only form read here. RFC 9110 also permits an HTTP-date, and an
+ * ingress in front of a multi-replica deployment may send one; anything this cannot parse
+ * returns null so the caller keeps the server's own message rather than inventing a number.
+ */
+function retryAfterSeconds(response: Response): number | null {
+  const seconds = Number(response.headers.get("Retry-After"));
+  return Number.isInteger(seconds) && seconds > 0 ? seconds : null;
+}
+
 export function useQueryExecution({
   activeConnection,
   metadata,
@@ -373,8 +386,14 @@ export function useQueryExecution({
 
         if (!response.ok) {
           const error = await response.json();
-          const errorMessage = error.error || "Query failed";
           const errorCode = error.code as string | undefined;
+          // A 429's own body may say nothing about the wait, but its header always
+          // carries one — name it, so the user retries when the budget is back instead
+          // of hammering a closed door (docs/BACKLOG.md H2). Only the 429 is rephrased:
+          // a Retry-After on any other status says nothing about this query's failure.
+          const retryAfter = response.status === 429 ? retryAfterSeconds(response) : null;
+          const errorMessage =
+            retryAfter !== null ? `Too many requests. Try again in ${retryAfter}s.` : error.error || "Query failed";
 
           storage.addToHistory({
             id: newLocalId(),

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -759,6 +759,14 @@ const PLANNING_PROSE_LIMIT_WITH_STATISTICS = `${PLANNING_STATISTICS_NATURE} Use 
  * it goes stale, it teaches nothing about the next command, and this repository has
  * been bitten by exactly that shape before. A model that knows what the rows are can
  * choose for itself, and choosing is not this file's job.
+ *
+ * RULED 2026-08-22, and the reason is recorded here so the question is not reopened.
+ * Two grounded Redis plan runs were driven after this rule landed: one refused to answer
+ * a question the inventory could not support, and one drafted `KEYS user:*` for a count.
+ * The second is the case for adding a cost sentence, and it was declined. Plan mode runs
+ * nothing and holds no tools, so reaching the hazard takes the user applying the draft
+ * and running it on their own connection - their call, on their database. A rule naming
+ * one command would buy that at the price this docblock already argues against.
  */
 const planningDerivedGroupingsRule = (noun: AgentInventoryNoun): string =>
   `Those ${noun.plural} are not objects this database holds, and no statement can be given one as a name: this server derived every row of that inventory itself, by scanning a bounded part of the keyspace and grouping the real key names it found under their common prefix. So name a whole key, or ask for keys by pattern in whatever way this engine offers — a row from that list is neither. And because the scan was bounded, the list is what one reading reached rather than everything this database holds.`;

--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -33,7 +33,7 @@ import { ExecutionBudgetTracker } from "@/lib/db/operations/budgets";
 import { createCanonicalOperationRegistry } from "@/lib/db/operations/descriptors";
 import { createTargetScope } from "@/lib/db/operations/policy";
 import { LLMAuthError, LLMError, LLMRateLimitError } from "@/lib/llm/types";
-import { ExecutionProfileError } from "@/lib/db/errors";
+import { type ExecutionProfileDenyCode, ExecutionProfileError } from "@/lib/db/errors";
 import { logger } from "@/lib/logger";
 import { resolveConnection, SeedConnectionError } from "@/lib/seed/resolve-connection";
 import type { QueryResult } from "@/lib/types";
@@ -233,6 +233,16 @@ async function recordDriveFailure(service: AgentRunService, runId: string, error
 }
 
 /**
+ * The profile refusals that are about the connection's agent credential rather than
+ * about the engine. Kept beside the classifier that reads them: the set exists only to
+ * split one error type into the two things a user can do about it.
+ */
+const AGENT_CREDENTIAL_DENY_CODES: ReadonlySet<ExecutionProfileDenyCode> = new Set([
+  "AGENT_CREDENTIAL_UNRESOLVABLE",
+  "AGENT_CREDENTIAL_WITH_CONNECTION_STRING",
+]);
+
+/**
  * Chooses the label a user sees from the error's TYPE.
  *
  * Never from its message: that text comes from a model provider, a driver or a
@@ -250,7 +260,14 @@ function classifyDriveFailure(error: unknown): AgentRunFailureReason {
   // `internal` sent a user to a log that could only tell them what their own
   // connection already says. Checked before the generic classes below because it is
   // the specific thing that happened.
-  if (error instanceof ExecutionProfileError) return "engine-unsupported";
+  //
+  // The reason code, not just the type: `resolveAgentCredential` raises this same
+  // error on ANY engine for a credential that cannot be applied, and calling that
+  // "engine unsupported" told a PostgreSQL operator something false about their
+  // database while saying nothing about the credential they could fix (B47).
+  if (error instanceof ExecutionProfileError) {
+    return AGENT_CREDENTIAL_DENY_CODES.has(error.reasonCode) ? "agent-credential-unusable" : "engine-unsupported";
+  }
 
   /*
     These were one label until 2026-08-12, on the reasoning that the user's next move

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -252,19 +252,24 @@ export type AgentRunFailureReason =
    * profile whose acquisition would be refused is never the profile that capture asks for
    * on an engine that would refuse it.
    *
-   * What can still reach it, and what this reason's text then misdescribes, is an
-   * acquisition refused for a reason that is not the engine at all:
-   * `resolveAgentCredential` throws `ExecutionProfileError` — which `runtime.ts`
-   * classifies here — for an agent credential that is half-configured, sealed under a
-   * key that no longer decrypts, or set alongside a connection string, and it throws on
-   * ANY engine before a provider exists. A PostgreSQL run then tells the user their
-   * engine offers no read-only execution profile when their real problem is a
-   * credential. That is true of every workflow and was true before #411, which only
-   * moved the moment it can happen earlier; it is a defect of this reason's granularity
-   * rather than of the workflow, and it is recorded in `docs/BACKLOG.md` (B47) rather
-   * than fixed inside a comment.
+   * ONLY the engine's own refusal, since B47: the other cause of the same error type
+   * is `agent-credential-unusable` below.
    */
   | "engine-unsupported"
+  /**
+   * The connection's agent credential could not be applied, so the profile was
+   * refused before any provider existed — on ANY engine, including the two the agent
+   * executes on.
+   *
+   * Split out of `engine-unsupported` (B47) because `resolveAgentCredential` raises the
+   * same `ExecutionProfileError` for a credential that is half-configured, sealed under
+   * a key that no longer decrypts, or set alongside a connection string. Told the engine
+   * sentence, an operator who had rotated the secret key read something false about
+   * their PostgreSQL and nothing about the one field they could fix. The error's reason
+   * codes (`AGENT_CREDENTIAL_UNRESOLVABLE`, `AGENT_CREDENTIAL_WITH_CONNECTION_STRING`)
+   * already carried the distinction; this is where it becomes visible.
+   */
+  | "agent-credential-unusable"
   /** The run's persisted connection no longer resolves on the server. */
   | "connection-unresolvable"
   /** Anything else. Deliberately unspecific; the log carries the detail. */

--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -119,14 +119,20 @@ const BUCKETS: Record<RateLimitBucket, BucketSpec> = {
   // many model calls of its own, so this bounds how often LLM work is STARTED, never how much it
   // spends.
   ai: { maxVar: "RATE_LIMIT_AI_MAX", windowVar: "RATE_LIMIT_AI_WINDOW_SEC", maxDefault: 20, windowDefault: 60 },
-  // Shared across every db/ route that reaches a provider - query, multi-query, transaction,
+  // Shared across every route that reaches a database - query, multi-query, transaction,
   // disconnect, cancel, health, maintenance, monitoring, pool-stats, profile, provider-meta,
-  // schema, schema/list, schema/relations, schema-snapshot, test-connection - plus
-  // admin/fleet-health: seventeen routes today (grep -rl 'bucket: "query"' src/app/api/ finds
-  // fifteen; schema/list and schema/relations reach this bucket indirectly, through
-  // schema-route.ts's shared handleSchemaRequest). The same workload reached through a
-  // different endpoint must not get a second budget - re-verify and correct this comment again
-  // if guardRoute grows a new call site.
+  // schema, schema/list, schema/relations, schema-snapshot, test-connection, admin/fleet-health,
+  // plus the three storage routes (storage, storage/[collection], storage/migrate): TWENTY routes
+  // today (grep -rl 'bucket: "query"' src/app/api/ finds eighteen; schema/list and schema/relations
+  // reach this bucket indirectly, through schema-route.ts's shared handleSchemaRequest). The same
+  // workload reached through a different endpoint must not get a second budget - re-verify and
+  // correct this comment again if guardRoute grows a new call site.
+  //
+  // The storage family joined when AU1 moved it onto the shared 401 (2026-08-22), and that gave it
+  // a limiter it never had. It belongs here rather than in a bucket of its own: under
+  // STORAGE_PROVIDER=sqlite or postgres these routes read and write a real database, which is what
+  // this bucket meters. A bucket of its own would be a fourth configurable pair for a workload
+  // that is debounced write-through sync, far under 120 requests a minute in normal use.
   query: {
     maxVar: "RATE_LIMIT_QUERY_MAX",
     windowVar: "RATE_LIMIT_QUERY_WINDOW_SEC",

--- a/src/lib/api/require-session.ts
+++ b/src/lib/api/require-session.ts
@@ -88,3 +88,36 @@ export async function guardRoute(opts: {
 
   return { session };
 }
+
+/**
+ * The audit line for a ROLE denial: an authenticated caller that holds a session but not the role
+ * an endpoint requires. `guardRoute` above cannot record it, because the routes that need it check
+ * the role inside their own handler after their own `getSession()`.
+ *
+ * METERED, on the same `anon` bucket and for the same reason the `no_session` line above is: the
+ * denial is unconditional, only its record is bounded. Holding a signed non-admin token bounds how
+ * many IDENTITIES can reach this branch, not how many requests each one makes - a single session,
+ * stolen or not, can poll an admin route in a loop, and every line would both fill a container log
+ * volume and evict real events from the 1000-entry ring the admin UI reads. Keyed on the username
+ * rather than the address so one account cannot buy more lines by rotating `X-Forwarded-For`.
+ *
+ * Isolated in its own try/catch for the same reason guardRoute isolates its emits: the 403 is
+ * already decided, and a broken audit sink must never turn a denial into an unrelated 500.
+ */
+export function auditRoleDenial(opts: { route: string; user: string; request: Request }): void {
+  const notice = consumeRateLimit("anon", opts.user);
+  if (!notice.allowed && !notice.tripped) return;
+  try {
+    emitAuditEvent({
+      type: "permission_denied",
+      action: "denied",
+      target: opts.route,
+      user: opts.user,
+      result: "failure",
+      reason: "insufficient_role",
+      ip: clientAddress(opts.request),
+    });
+  } catch (auditError) {
+    logger.error("Failed to record permission_denied audit event", auditError, { route: opts.route });
+  }
+}

--- a/src/lib/config/auth-preflight.ts
+++ b/src/lib/config/auth-preflight.ts
@@ -16,11 +16,50 @@
  * with a too-short secret the server can sign no session at all, so no working
  * deployment can regress — there is simply nothing to lose by stopping loudly.
  *
+ * The same reasoning covers `STORAGE_ENCRYPTION_KEY` (backlog K3): too short, it
+ * throws only at the first storage write - after login, after the migration
+ * attempt - and reaches the operator as a `syncError` badge in someone's browser
+ * rather than as a startup failure. It is checked only when a server storage
+ * provider is configured, because with STORAGE_PROVIDER=local (the default) the
+ * variable is inert and refusing to boot over it would be plainly wrong.
+ *
  * Runs only on standalone boot (called from instrumentation.ts `register()`),
  * so embedding @libredb/studio in libredb-platform is unaffected.
  */
 
 import { JWT_SECRET_MIN_LENGTH } from "@/lib/config/auth-env";
+import { isServerStorageEnabled } from "@/lib/storage/factory";
+
+/**
+ * Validate `STORAGE_ENCRYPTION_KEY` when server-side storage is configured.
+ *
+ * Absent is fine and stays silent: src/lib/storage/encryption.ts then derives the
+ * key from JWT_SECRET, which verifyAuthEnvAtBoot already covers. Only an
+ * explicitly set, too-short key is fatal - exactly the value that would throw on
+ * the first write.
+ */
+function verifyStorageEncryptionKeyAtBoot(): boolean {
+  const key = process.env.STORAGE_ENCRYPTION_KEY;
+  if (!key || key.length >= JWT_SECRET_MIN_LENGTH || !isServerStorageEnabled()) return true;
+
+  // The key value never reaches the logs - only its length.
+  console.error(
+    [
+      "",
+      "============================================================",
+      " LibreDB Studio cannot start: STORAGE_ENCRYPTION_KEY is too short",
+      ` Got ${key.length} characters; the minimum is ${JWT_SECRET_MIN_LENGTH}.`,
+      " Every credential write would fail, so boot stops here.",
+      " Fix it either way:",
+      "   1. Set a strong key: STORAGE_ENCRYPTION_KEY=$(openssl rand -base64 32)",
+      "   2. Unset STORAGE_ENCRYPTION_KEY and let it derive from JWT_SECRET",
+      "============================================================",
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+  return false;
+}
 
 /**
  * Validate the auth environment before the server starts serving.
@@ -36,7 +75,7 @@ export function verifyAuthEnvAtBoot(): boolean {
   // Unset or empty is not this check's business: zero-config bootstrap generates
   // a secret, and with AUTH_BOOTSTRAP=off getJwtSecret owns the missing-secret
   // path (dev fallback outside production, clear 503 in it).
-  if (!secret || secret.length >= JWT_SECRET_MIN_LENGTH) return true;
+  if (!secret || secret.length >= JWT_SECRET_MIN_LENGTH) return verifyStorageEncryptionKeyAtBoot();
 
   // The secret value never reaches the logs — only its length.
   console.error(

--- a/src/lib/query-generators.ts
+++ b/src/lib/query-generators.ts
@@ -342,7 +342,12 @@ function terminator(capabilities: ProviderCapabilities): string {
  */
 function libredbNewlineNote(base: string): string | null {
   if (!/[\r\n]/.test(base)) return null;
-  return "# This key's name contains a newline. LibreDB commands are line-oriented, so no generated line can address it — write the command by hand.";
+  // No "write it by hand" advice: `firstCommandLine` splits the buffer on LF before tokenizing
+  // (providers/embedded/libredb.ts), so a key whose name contains a LINE FEED cannot be reached
+  // from this editor at all, quoted or not. A carriage return survives inside quotes and could be
+  // typed by hand - but one note covers both characters, and promising an action that fails for
+  // half of them is worse than promising none.
+  return "# This key's name contains a line break. LibreDB commands are line-oriented, so no generated line can address it.";
 }
 
 export function generateTableQuery(

--- a/src/lib/query-generators.ts
+++ b/src/lib/query-generators.ts
@@ -330,6 +330,21 @@ function terminator(capabilities: ProviderCapabilities): string {
   return capabilities.statementTerminator === "none" ? "" : ";";
 }
 
+/**
+ * The one refusal both LibreDB generators give for a name they cannot address:
+ * a `#` note and no command line. A schema-tree node name is a real key name,
+ * LibreDB keys are arbitrary byte strings, and every LibreDB command is
+ * line-oriented — `get`/`put`/`delete`/`prefix` interpolate the name raw, so a
+ * key named `x\ndelete billing:2024` renders its own second half as a runnable
+ * `delete billing:2024` line. LibreDB has no lossless JSON command form to fall
+ * back to the way Redis does, so emit no command line at all and say why. Both
+ * callers go through here so the two branches cannot drift (#427, U11).
+ */
+function libredbNewlineNote(base: string): string | null {
+  if (!/[\r\n]/.test(base)) return null;
+  return "# This key's name contains a newline. LibreDB commands are line-oriented, so no generated line can address it — write the command by hand.";
+}
+
 export function generateTableQuery(
   tableName: string,
   capabilities: ProviderCapabilities,
@@ -339,6 +354,10 @@ export function generateTableQuery(
   // and not MongoDB JSON. "Scan" lists everything under the group's prefix.
   if (capabilities.queryDialect === "libredb") {
     const { isPrefixGroup, base } = prefixGroup(tableName);
+    // "Scan Keys" AUTO-EXECUTES, and a newline in the name used to leave a second,
+    // plausible command sitting in the editor one "Run Selected" away (U11).
+    const note = libredbNewlineNote(base);
+    if (note !== null) return note;
     return isPrefixGroup ? `prefix ${base}` : `get ${base}`;
   }
   // Redis speaks its own command grammar. It must be checked BEFORE the JSON
@@ -385,19 +404,11 @@ function libredbCheatsheet(tableName: string, columns: ColumnSchema[]): string {
   const { isPrefixGroup, base } = prefixGroup(tableName);
   const value = libredbExampleValue(columns);
   const header = `# LibreDB commands for ${commentName(tableName)} — select a line and Run Selected.`;
-  // A schema-tree node name is a real key name, and LibreDB keys are arbitrary
-  // byte strings. The header is JSON-quoted so a newline in one cannot end it,
-  // but `get`/`put`/`delete` interpolate the name raw, and every LibreDB command
-  // is line-oriented: a key named `x\ndelete billing:2024` would render its own
-  // second half as a runnable `delete billing:2024` line. LibreDB has no lossless
-  // JSON command form to fall back to the way Redis does, so emit no command
-  // line at all and say why (#427).
-  if (/[\r\n]/.test(base)) {
-    return [
-      header,
-      "",
-      "# This key's name contains a newline. LibreDB commands are line-oriented, so no generated line can address it — write the command by hand.",
-    ].join("\n");
+  // The header is JSON-quoted so a newline in a name cannot end it; the command
+  // lines have no such protection, so a name carrying one gets the shared refusal.
+  const note = libredbNewlineNote(base);
+  if (note !== null) {
+    return [header, "", note].join("\n");
   }
   if (isPrefixGroup) {
     const key = `${base}1`; // a concrete example key (e.g. users:1)

--- a/src/lib/security/config.ts
+++ b/src/lib/security/config.ts
@@ -87,6 +87,11 @@ export function readSecurityHeaderOptions(): SecurityHeaderOptions {
   return {
     reportOnly: readCspReportOnly(),
     monacoVsPath: process.env.NEXT_PUBLIC_MONACO_VS_PATH,
+    // React's development build evals, and without 'unsafe-eval' a contributor's first `bun dev`
+    // cannot log in - the login page never hydrates. Read HERE rather than in headers.ts, which is
+    // published as `@libredb/studio/security` and must not depend on the consuming process's mode:
+    // an embedder's own development build would otherwise inherit a relaxed policy it never chose.
+    allowEval: process.env.NODE_ENV === "development",
     // HSTS is sent unconditionally. RFC 6797 requires user agents to ignore it over plain HTTP,
     // so the plain-HTTP channels are unaffected and no decision has to be made about trusting
     // the attacker-supplied x-forwarded-proto.

--- a/src/lib/security/headers.ts
+++ b/src/lib/security/headers.ts
@@ -131,10 +131,16 @@ function serializeCsp(directives: CspDirectives): string {
 export function studioCspDirectives(options: CspOptions = {}): CspDirectives {
   const monacoOrigin = absoluteOrigin(options.monacoVsPath);
 
-  // 'unsafe-inline': see the module comment. 'unsafe-eval' is deliberately absent — Monaco's AMD
+  // 'unsafe-inline': see the module comment. 'unsafe-eval' is deliberately absent from the shipped
+  // policy (the development exception below is the sole relaxation) — Monaco's AMD
   // loader picks the tag-injection loader on the document thread (public/monaco/vs/loader.js:365),
   // and no worker bundle, elkjs, or sql-formatter path calls eval or new Function.
   const scriptSrc = ["'self'", "'unsafe-inline'"];
+  // React's DEVELOPMENT build evals, so without this a contributor's first `bun dev` is a dead end:
+  // the login page never hydrates, the Sign In button has no handler, and the only clue is
+  // "eval() is not supported in this environment". Development only — the shipped policy is
+  // unchanged, and this is the module's one process.env read for exactly that reason.
+  if (process.env.NODE_ENV === "development") scriptSrc.push("'unsafe-eval'");
   // Monaco injects <style> elements at runtime for the db-dark theme, and the app uses the React
   // style={{...}} prop with computed values at 41 sites. Neither is nonce-able or hash-able.
   const styleSrc = ["'self'", "'unsafe-inline'"];

--- a/src/lib/security/headers.ts
+++ b/src/lib/security/headers.ts
@@ -38,6 +38,17 @@ export interface CspOptions {
    * That is a deliberate decision for the caller to make, not a default to fall into by accident.
    */
   extra?: Partial<CspDirectives>;
+  /**
+   * Add 'unsafe-eval' to script-src. React's DEVELOPMENT build evals, and without it a
+   * contributor's first `bun dev` cannot log in: the login page never hydrates, the Sign In button
+   * has no handler, and the only clue is "eval() is not supported in this environment".
+   *
+   * An OPTION rather than a `process.env.NODE_ENV` read in this module, because this module is
+   * published as `@libredb/studio/security` and must stay environment-independent - otherwise an
+   * embedder's own development build would silently inherit a relaxed policy it never asked for.
+   * `readSecurityHeaderOptions()` in config.ts is what decides it for this app.
+   */
+  allowEval?: boolean;
 }
 
 export interface SecurityHeaderOptions extends CspOptions {
@@ -131,16 +142,12 @@ function serializeCsp(directives: CspDirectives): string {
 export function studioCspDirectives(options: CspOptions = {}): CspDirectives {
   const monacoOrigin = absoluteOrigin(options.monacoVsPath);
 
-  // 'unsafe-inline': see the module comment. 'unsafe-eval' is deliberately absent from the shipped
-  // policy (the development exception below is the sole relaxation) — Monaco's AMD
-  // loader picks the tag-injection loader on the document thread (public/monaco/vs/loader.js:365),
-  // and no worker bundle, elkjs, or sql-formatter path calls eval or new Function.
+  // 'unsafe-inline': see the module comment. 'unsafe-eval' is absent unless the CALLER asks for it
+  // (`allowEval`, which config.ts sets in development only) — Monaco's AMD loader picks the
+  // tag-injection loader on the document thread (public/monaco/vs/loader.js:365), and no worker
+  // bundle, elkjs, or sql-formatter path calls eval or new Function.
   const scriptSrc = ["'self'", "'unsafe-inline'"];
-  // React's DEVELOPMENT build evals, so without this a contributor's first `bun dev` is a dead end:
-  // the login page never hydrates, the Sign In button has no handler, and the only clue is
-  // "eval() is not supported in this environment". Development only — the shipped policy is
-  // unchanged, and this is the module's one process.env read for exactly that reason.
-  if (process.env.NODE_ENV === "development") scriptSrc.push("'unsafe-eval'");
+  if (options.allowEval === true) scriptSrc.push("'unsafe-eval'");
   // Monaco injects <style> elements at runtime for the db-dark theme, and the app uses the React
   // style={{...}} prop with computed values at 41 sites. Neither is nonce-able or hash-able.
   const styleSrc = ["'self'", "'unsafe-inline'"];

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -131,22 +131,30 @@ export async function proxy(request: NextRequest) {
 
     // RBAC: /admin only for admin
     if (pathname.startsWith("/admin") && role !== "admin") {
-      // Not metered through the anon bucket, unlike the origin_mismatch line above: reaching this
-      // branch requires a token this server signed, so the volume is bounded by who holds one
-      // rather than by anyone who can reach the port. Isolated in its own try/catch for the same
-      // reason as every other emit here - the redirect is already decided.
-      try {
-        emitAuditEvent({
-          type: "permission_denied",
-          action: "denied",
-          target: `${request.method} ${pathname}`,
-          user: (payload.username as string) || "unknown",
-          result: "failure",
-          reason: "insufficient_role",
-          ip: clientAddress(request),
-        });
-      } catch (auditError) {
-        logger.error("Failed to record insufficient_role audit event", auditError, { route: "proxy" });
+      // METERED through the anon bucket, exactly as the origin_mismatch line above is. Holding a
+      // token this server signed bounds how many IDENTITIES reach this branch, not how many
+      // requests each one makes: one session, stolen or not, can poll /admin in a loop, and every
+      // line would both fill a container log volume and evict real events from the 1000-entry ring
+      // the admin UI reads. Keyed on the username, not the address, so rotating `X-Forwarded-For`
+      // buys no extra lines. The REDIRECT stays unconditional; only its record is bounded.
+      const username = (payload.username as string) || "unknown";
+      const notice = consumeRateLimit("anon", username);
+      // Isolated in its own try/catch for the same reason as every other emit here - the redirect
+      // is already decided.
+      if (notice.allowed || notice.tripped) {
+        try {
+          emitAuditEvent({
+            type: "permission_denied",
+            action: "denied",
+            target: `${request.method} ${pathname}`,
+            user: username,
+            result: "failure",
+            reason: "insufficient_role",
+            ip: clientAddress(request),
+          });
+        } catch (auditError) {
+          logger.error("Failed to record insufficient_role audit event", auditError, { route: "proxy" });
+        }
       }
       return withSecurityHeaders(NextResponse.redirect(new URL("/", request.url)));
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -131,6 +131,23 @@ export async function proxy(request: NextRequest) {
 
     // RBAC: /admin only for admin
     if (pathname.startsWith("/admin") && role !== "admin") {
+      // Not metered through the anon bucket, unlike the origin_mismatch line above: reaching this
+      // branch requires a token this server signed, so the volume is bounded by who holds one
+      // rather than by anyone who can reach the port. Isolated in its own try/catch for the same
+      // reason as every other emit here - the redirect is already decided.
+      try {
+        emitAuditEvent({
+          type: "permission_denied",
+          action: "denied",
+          target: `${request.method} ${pathname}`,
+          user: (payload.username as string) || "unknown",
+          result: "failure",
+          reason: "insufficient_role",
+          ip: clientAddress(request),
+        });
+      } catch (auditError) {
+        logger.error("Failed to record insufficient_role audit event", auditError, { route: "proxy" });
+      }
       return withSecurityHeaders(NextResponse.redirect(new URL("/", request.url)));
     }
 

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -365,7 +365,10 @@ export function StudioWorkspace({
                           playgroundMode={false}
                           transactionActive={false}
                           editingEnabled={false}
-                          onSaveQuery={onSaveQueryProp ? () => setIsSaveQueryModalOpen(true) : noop}
+                          // Withheld, not `noop`: a host that wired no save has
+                          // nowhere to save to, and `noop` put a dead Save button
+                          // on every embedded surface (U7).
+                          onSaveQuery={onSaveQueryProp ? () => setIsSaveQueryModalOpen(true) : undefined}
                           onExecuteQuery={() => queryExec.executeQuery()}
                           onCancelQuery={queryExec.cancelQuery}
                           // Withheld, not `noop`: this shell runs no transaction,

--- a/tests/api/admin/audit.test.ts
+++ b/tests/api/admin/audit.test.ts
@@ -46,6 +46,11 @@ const mockGetSession = mock(
   async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
 );
 
+// The route's own role-denial audit line. Unlike the display-buffer push above, this one goes
+// through emitAuditEvent — the authoritative channel — so it is mocked separately and asserted on
+// directly rather than through the buffer.
+const mockEmitAuditEvent = mock((_event: Record<string, unknown>) => {});
+
 // ─── Mock @/lib/auth BEFORE importing the route ─────────────────────────────
 mock.module("@/lib/auth", () => ({
   getSession: mockGetSession,
@@ -64,6 +69,7 @@ mock.module("@/lib/audit", () => ({
   // sanitizer's behavior is covered end-to-end by tests/security/audit-redaction.test.ts, so this
   // file only needs to assert that the route wires the buffer correctly.
   sanitizeAuditInput: mock((event: Record<string, unknown>) => event),
+  emitAuditEvent: mockEmitAuditEvent,
   AuditRingBuffer: class {},
   loadAuditFromStorage: mock(() => []),
   saveAuditToStorage: mock(() => {}),
@@ -82,6 +88,8 @@ describe("/api/admin/audit", () => {
     mockBuffer.push.mockClear();
     mockBuffer.getRecent.mockClear();
     mockBuffer.filter.mockClear();
+    mockEmitAuditEvent.mockClear();
+    mockEmitAuditEvent.mockImplementation(() => {});
   });
 
   describe("GET /api/admin/audit", () => {
@@ -106,6 +114,45 @@ describe("/api/admin/audit", () => {
 
       expect(res.status).toBe(403);
       expect(data.error).toContain("Unauthorized");
+    });
+
+    // Threat: a role denial that leaves no trace. An authenticated caller probing for a role it
+    // does not hold was invisible in the one channel this project treats as authoritative.
+    test("non-admin denial emits permission_denied with reason insufficient_role", async () => {
+      mockGetSession.mockResolvedValueOnce({ role: "user", username: "bob" });
+
+      const res = await GET(createMockRequest("/api/admin/audit"));
+
+      expect(res.status).toBe(403);
+      expect(mockEmitAuditEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitAuditEvent.mock.calls[0][0];
+      expect(event.type).toBe("permission_denied");
+      expect(event.reason).toBe("insufficient_role");
+      expect(event.user).toBe("bob");
+      expect(event.target).toBe("GET /api/admin/audit");
+    });
+
+    // This route has no guardRoute in front of it, so its 403 covers both "no session" and "wrong
+    // role". Only the latter is a ROLE denial; recording insufficient_role for an anonymous caller
+    // would both misname the reason and let an unauthenticated caller flood the trail for free.
+    test("an absent session emits nothing", async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+
+      const res = await GET(createMockRequest("/api/admin/audit"));
+
+      expect(res.status).toBe(403);
+      expect(mockEmitAuditEvent).not.toHaveBeenCalled();
+    });
+
+    test("a broken audit sink does not turn the role denial into a 500", async () => {
+      mockGetSession.mockResolvedValueOnce({ role: "user", username: "bob" });
+      mockEmitAuditEvent.mockImplementationOnce(() => {
+        throw new Error("audit sink unavailable");
+      });
+
+      const res = await GET(createMockRequest("/api/admin/audit"));
+
+      expect(res.status).toBe(403);
     });
 
     test("filters by type when type param is provided", async () => {
@@ -175,6 +222,39 @@ describe("/api/admin/audit", () => {
 
       expect(res.status).toBe(403);
       expect(data.error).toContain("Unauthorized");
+    });
+
+    test("non-admin denial emits permission_denied with reason insufficient_role", async () => {
+      mockGetSession.mockResolvedValueOnce({ role: "user", username: "bob" });
+
+      const res = await POST(
+        createMockRequest("/api/admin/audit", {
+          method: "POST",
+          body: { type: "maintenance", action: "vacuum", target: "users", result: "success" },
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      expect(mockEmitAuditEvent).toHaveBeenCalledTimes(1);
+      const event = mockEmitAuditEvent.mock.calls[0][0];
+      expect(event.reason).toBe("insufficient_role");
+      expect(event.target).toBe("POST /api/admin/audit");
+    });
+
+    test("a broken audit sink does not turn the role denial into a 500", async () => {
+      mockGetSession.mockResolvedValueOnce({ role: "user", username: "bob" });
+      mockEmitAuditEvent.mockImplementationOnce(() => {
+        throw new Error("audit sink unavailable");
+      });
+
+      const res = await POST(
+        createMockRequest("/api/admin/audit", {
+          method: "POST",
+          body: { type: "maintenance", action: "vacuum", target: "users", result: "success" },
+        }),
+      );
+
+      expect(res.status).toBe(403);
     });
 
     test("returns 500 on error", async () => {

--- a/tests/api/admin/audit.test.ts
+++ b/tests/api/admin/audit.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { createMockRequest, parseResponseJSON } from "../../helpers/mock-next";
 import type { AuditEvent } from "@/lib/audit";
+import { clearRateLimitState } from "@/lib/api/rate-limit";
 
 // ─── Mock audit buffer ──────────────────────────────────────────────────────
 const mockEvents: AuditEvent[] = [
@@ -130,6 +131,24 @@ describe("/api/admin/audit", () => {
       expect(event.reason).toBe("insufficient_role");
       expect(event.user).toBe("bob");
       expect(event.target).toBe("GET /api/admin/audit");
+    });
+
+    // Threat the metering answers: this endpoint needs no admin role to REACH, so any ordinary
+    // authenticated user can poll it. Unmetered, that writes one line per request into a fixed
+    // 1000-entry ring and onto stdout, evicting the events an operator actually needs.
+    test("the audit line is bounded per identity while the 403 stays unconditional", async () => {
+      const statuses: number[] = [];
+      for (let i = 0; i < 8; i++) {
+        mockGetSession.mockResolvedValueOnce({ role: "user", username: "flooder" });
+        statuses.push((await GET(createMockRequest("/api/admin/audit"))).status);
+      }
+
+      // The denial is never what gets rationed.
+      expect(statuses).toEqual([403, 403, 403, 403, 403, 403, 403, 403]);
+      // anon defaults to 5 per 300s and the trip is itself recorded, so eight probes leave six
+      // lines. Pinned rather than bounded: an unmetered emit writes eight.
+      expect(mockEmitAuditEvent).toHaveBeenCalledTimes(6);
+      clearRateLimitState();
     });
 
     // This route has no guardRoute in front of it, so its 403 covers both "no session" and "wrong

--- a/tests/api/admin/fleet-health.test.ts
+++ b/tests/api/admin/fleet-health.test.ts
@@ -220,3 +220,62 @@ describe("POST /api/admin/fleet-health", () => {
     expect(data.results.length).toBe(0);
   });
 });
+
+// ─── Fan-out width ──────────────────────────────────────────────────────────
+// Threat: guardRoute bounds how OFTEN this route may be called, never how WIDE one call fans out.
+// Before the cap, a single admin-authenticated POST naming an arbitrarily long connections array
+// opened that many provider connections concurrently and the rate limiter saw one request.
+describe("POST /api/admin/fleet-health fan-out cap", () => {
+  function fleet(count: number) {
+    return Array.from({ length: count }, (_, i) => ({
+      id: `conn-${i}`,
+      name: `DB ${i}`,
+      type: "postgres",
+      host: "localhost",
+      port: 5432,
+      database: "db",
+      createdAt: new Date(),
+    }));
+  }
+
+  beforeEach(() => {
+    clearRateLimitState();
+    mockGetOrCreateProvider.mockClear();
+    mockGetSession.mockImplementation(
+      async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
+    );
+    mockGetOrCreateProvider.mockImplementation(async () => mockProvider);
+  });
+
+  test("returns 400 above the cap, names the bound, and opens nothing", async () => {
+    const req = createMockRequest("/api/admin/fleet-health", {
+      method: "POST",
+      body: { connections: fleet(101) },
+    });
+
+    const res = await POST(req);
+    const data = await parseResponseJSON<{ error: string }>(res);
+
+    expect(res.status).toBe(400);
+    expect(data.error).toContain("100");
+    expect(mockGetOrCreateProvider).not.toHaveBeenCalled();
+  });
+
+  test("accepts exactly the cap", async () => {
+    const req = createMockRequest("/api/admin/fleet-health", {
+      method: "POST",
+      body: { connections: fleet(100) },
+    });
+
+    const res = await POST(req);
+    const data = await parseResponseJSON<{ results: unknown[] }>(res);
+
+    expect(res.status).toBe(200);
+    expect(data.results.length).toBe(100);
+  });
+});
+
+// The role denial's audit line is asserted in tests/security/route-auth.test.ts, not here: this
+// file's process neighbours mock @/lib/audit process-wide (tests/api/db/maintenance.test.ts among
+// them), so an assertion on the authoritative stdout line would read whichever mock happened to
+// win the module registry. Nothing under tests/security mocks that module.

--- a/tests/api/db/maintenance.test.ts
+++ b/tests/api/db/maintenance.test.ts
@@ -202,6 +202,46 @@ describe("POST /api/db/maintenance", () => {
     expect(data.error).toContain("Unauthorized");
   });
 
+  // Threat: a role denial that leaves no trace. An authenticated caller probing for a role it does
+  // not hold was invisible in the one channel this project treats as authoritative.
+  test("non-admin denial emits permission_denied with reason insufficient_role", async () => {
+    mockGetSession.mockImplementation(
+      async (): Promise<{ role: string; username: string } | null> => ({ role: "user", username: "bob" }),
+    );
+
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "vacuum", target: "users", connection: validConnection },
+    });
+
+    await POST(req as never);
+
+    expect(mockAuditPush).toHaveBeenCalledTimes(1);
+    const event = mockAuditPush.mock.calls[0][0] as Record<string, unknown>;
+    expect(event.type).toBe("permission_denied");
+    expect(event.reason).toBe("insufficient_role");
+    expect(event.user).toBe("bob");
+    expect(event.target).toBe("POST /api/db/maintenance");
+  });
+
+  test("a broken audit sink does not turn the role denial into a 500", async () => {
+    mockGetSession.mockImplementation(
+      async (): Promise<{ role: string; username: string } | null> => ({ role: "user", username: "bob" }),
+    );
+    mockAuditPush.mockImplementationOnce(() => {
+      throw new Error("audit sink unavailable");
+    });
+
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "vacuum", target: "users", connection: validConnection },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(403);
+  });
+
   // Guarded by guardRoute now: an unauthenticated caller is rejected at the session check,
   // before the route's own admin-role check ever runs, so this is 401 ("not authenticated"),
   // distinct from "non-admin user returns 403" above ("authenticated but forbidden").

--- a/tests/api/proxy.test.ts
+++ b/tests/api/proxy.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from "next/server";
 import { SignJWT } from "jose";
 import { config, proxy } from "@/proxy";
 import { AGENT_DRIVE_HEADER, AGENT_DRIVE_PATH, mintAgentDriveToken } from "@/lib/agent/drive-token";
+import { clearRateLimitState } from "@/lib/api/rate-limit";
 
 // ─── JWT helpers ────────────────────────────────────────────────────────────
 
@@ -185,6 +186,29 @@ describe("proxy", () => {
         expect(lines[0].route).toBe("GET /admin");
       } finally {
         spy.mockRestore();
+      }
+    });
+
+    // Threat the metering answers: holding a signed non-admin token bounds how many IDENTITIES
+    // reach the branch, not how many requests each makes. Unmetered, one session polling /admin
+    // fills a log volume and evicts real events from the 1000-entry ring the admin UI reads.
+    test("the audit line is bounded per identity while the redirect stays unconditional", async () => {
+      // A distinct non-admin role, so this burst gets its own bucket key rather than sharing "user".
+      const token = await createToken("flooder");
+      const spy = spyOn(console, "log").mockImplementation(() => {});
+      try {
+        const responses = [];
+        for (let i = 0; i < 8; i++) responses.push(await proxy(createNextRequest("/admin", token)));
+
+        // Every request is still refused - the denial is never the thing being rationed.
+        expect(responses.every((res) => isRedirect(res))).toBe(true);
+        // The anon bucket's default is 5 per 300s and the trip itself is recorded, so a burst of
+        // eight leaves exactly six lines. Pinned rather than bounded: an unmetered emit writes
+        // eight, and this number is what fails if the metering is ever removed.
+        expect(spy.mock.calls.length).toBe(6);
+      } finally {
+        spy.mockRestore();
+        clearRateLimitState();
       }
     });
 

--- a/tests/api/proxy.test.ts
+++ b/tests/api/proxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, spyOn } from "bun:test";
 import { readFileSync } from "node:fs";
 import { NextRequest } from "next/server";
 import { SignJWT } from "jose";
@@ -166,6 +166,43 @@ describe("proxy", () => {
       expect(location).toContain("http://localhost:3000");
       expect(location).not.toContain("/admin");
       expect(location).not.toContain("/login");
+    });
+
+    // Threat: the redirect above used to be silent. A non-admin token probing /admin left no trace
+    // in the one channel this project treats as authoritative, so the only role denial the proxy
+    // makes was invisible next to the origin_mismatch line it already records.
+    test("the redirect emits permission_denied with reason insufficient_role", async () => {
+      const token = await createToken("user");
+      const spy = spyOn(console, "log").mockImplementation(() => {});
+      try {
+        await proxy(createNextRequest("/admin", token));
+
+        const lines = spy.mock.calls.map((call) => JSON.parse(call[0] as string) as Record<string, unknown>);
+        expect(lines).toHaveLength(1);
+        expect(lines[0].event).toBe("permission_denied");
+        expect(lines[0].reason).toBe("insufficient_role");
+        expect(lines[0].actor).toBe("user");
+        expect(lines[0].route).toBe("GET /admin");
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    test("a broken audit sink still redirects rather than failing the request", async () => {
+      const token = await createToken("user");
+      const logSpy = spyOn(console, "log").mockImplementation(() => {
+        throw new Error("audit sink unavailable");
+      });
+      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const res = await proxy(createNextRequest("/admin", token));
+
+        expect(isRedirect(res)).toBe(true);
+        expect(getRedirectLocation(res)).not.toContain("/admin");
+      } finally {
+        logSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/api/storage/storage-routes.test.ts
+++ b/tests/api/storage/storage-routes.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { NextRequest } from "next/server";
+import { clearRateLimitState } from "@/lib/api/rate-limit";
 
 // ── Mock auth ────────────────────────────────────────────────────────────────
 
@@ -46,10 +47,16 @@ import { GET } from "@/app/api/storage/route";
 import { PUT } from "@/app/api/storage/[collection]/route";
 import { POST } from "@/app/api/storage/migrate/route";
 
+/** GET /api/storage takes a request now: the shared guard reads the client address off it. */
+function getRequest() {
+  return new NextRequest("http://localhost/api/storage");
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("GET /api/storage", () => {
   beforeEach(() => {
+    clearRateLimitState();
     mockSession = { username: "admin@test.com", role: "admin" };
     providerEnabled = true;
     mockProvider.getAllData.mockClear();
@@ -57,18 +64,19 @@ describe("GET /api/storage", () => {
 
   test("returns 404 when storage not enabled", async () => {
     providerEnabled = false;
-    const res = await GET();
+    const res = await GET(getRequest());
     expect(res.status).toBe(404);
   });
 
-  test("returns 401 when not authenticated", async () => {
+  test("returns 401 with the shared guard body when not authenticated", async () => {
     mockSession = null;
-    const res = await GET();
+    const res = await GET(getRequest());
     expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
   });
 
   test("returns user data on success", async () => {
-    const res = await GET();
+    const res = await GET(getRequest());
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.connections).toEqual([{ id: "c1" }]);
@@ -78,6 +86,7 @@ describe("GET /api/storage", () => {
 
 describe("PUT /api/storage/[collection]", () => {
   beforeEach(() => {
+    clearRateLimitState();
     mockSession = { username: "admin@test.com", role: "admin" };
     providerEnabled = true;
     mockProvider.setCollection.mockClear();
@@ -100,10 +109,11 @@ describe("PUT /api/storage/[collection]", () => {
     expect(res.status).toBe(404);
   });
 
-  test("returns 401 when not authenticated", async () => {
+  test("returns 401 with the shared guard body when not authenticated", async () => {
     mockSession = null;
     const res = await makeRequest("connections", []);
     expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
   });
 
   test("returns 400 for invalid collection", async () => {
@@ -141,6 +151,7 @@ describe("PUT /api/storage/[collection]", () => {
 
 describe("POST /api/storage/migrate", () => {
   beforeEach(() => {
+    clearRateLimitState();
     mockSession = { username: "admin@test.com", role: "admin" };
     providerEnabled = true;
     mockProvider.mergeData.mockClear();
@@ -162,10 +173,11 @@ describe("POST /api/storage/migrate", () => {
     expect(res.status).toBe(404);
   });
 
-  test("returns 401 when not authenticated", async () => {
+  test("returns 401 with the shared guard body when not authenticated", async () => {
     mockSession = null;
     const res = await makeMigrateRequest({});
     expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
   });
 
   test("merges data on success", async () => {
@@ -200,6 +212,7 @@ describe("POST /api/storage/migrate", () => {
 
 describe("PUT /api/storage/[collection]: malformed JSON", () => {
   beforeEach(() => {
+    clearRateLimitState();
     mockSession = { username: "admin@test.com", role: "admin" };
     providerEnabled = true;
   });
@@ -219,6 +232,7 @@ describe("PUT /api/storage/[collection]: malformed JSON", () => {
 
 describe("POST /api/storage/migrate: malformed JSON", () => {
   beforeEach(() => {
+    clearRateLimitState();
     mockSession = { username: "admin@test.com", role: "admin" };
     providerEnabled = true;
   });
@@ -240,6 +254,7 @@ describe("POST /api/storage/migrate: malformed JSON", () => {
 
 describe("API routes: provider error propagation", () => {
   beforeEach(() => {
+    clearRateLimitState();
     mockSession = { username: "admin@test.com", role: "admin" };
     providerEnabled = true;
     mockProvider.getAllData.mockClear();
@@ -249,7 +264,7 @@ describe("API routes: provider error propagation", () => {
 
   test("GET /api/storage returns 500 on provider error", async () => {
     mockProvider.getAllData.mockRejectedValueOnce(new Error("DB connection lost"));
-    const res = await GET();
+    const res = await GET(getRequest());
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toBe("DB connection lost");
@@ -285,7 +300,7 @@ describe("API routes: provider error propagation", () => {
 
   test("GET uses session username for user scoping", async () => {
     mockSession = { username: "user@test.com", role: "user" };
-    await GET();
+    await GET(getRequest());
     expect(mockProvider.getAllData).toHaveBeenCalledWith("user@test.com");
   });
 

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -709,6 +709,15 @@ describe("Studio", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/admin/operations");
   });
 
+  // The Explorer's row items call this with the row's name; it rides the admin
+  // route's query string so the Operations tab lands on that row (#U5).
+  test("openMaintenance carries the named row to the operations tab", () => {
+    render(<Studio />);
+    const fn = capturedSidebarProps.onOpenMaintenance as (tab?: string, table?: string) => void;
+    act(() => fn("tables", "order items"));
+    expect(mockRouterPush).toHaveBeenCalledWith("/admin/operations?table=order%20items");
+  });
+
   test("openMaintenance navigates to monitoring when not admin", () => {
     authOverride = { isAdmin: false };
     render(<Studio />);

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -538,9 +538,11 @@ describe("StudioWorkspace", () => {
     expect(queryByTestId("savequerymodal")).toBeNull();
   });
 
-  test("without onSaveQuery prop the modal never renders and toolbar save is a noop", () => {
+  test("without onSaveQuery prop the toolbar gets no save handler at all", () => {
+    // Withheld, not `noop`: QueryToolbar renders no Save control without it, so
+    // an unwired host gets no dead button (U7).
     const { queryByTestId } = renderWorkspace({ onSaveQuery: undefined });
-    act(() => (capturedQueryToolbarProps.onSaveQuery as () => void)());
+    expect(capturedQueryToolbarProps.onSaveQuery).toBeUndefined();
     expect(queryByTestId("savequerymodal")).toBeNull();
   });
 
@@ -733,11 +735,11 @@ describe("StudioWorkspace", () => {
     expect(capturedSidebarProps.onProfileTable).toBeUndefined();
     expect(capturedSidebarProps.onGenerateCode).toBeUndefined();
     expect(capturedSidebarProps.onGenerateTestData).toBeUndefined();
-    // Import is withheld entirely, so the toolbar renders no IMPORT button (#427);
-    // save stays wired and becomes a noop when the host passes no onSaveQuery.
+    // Import and save are withheld entirely, so the toolbar renders neither the
+    // IMPORT (#427) nor the Save (U7) button.
     expect(capturedQueryToolbarProps.onImport).toBeUndefined();
+    expect(capturedQueryToolbarProps.onSaveQuery).toBeUndefined();
     expect(queryByTestId("dataimportmodal")).toBeNull();
-    act(() => (capturedQueryToolbarProps.onSaveQuery as () => void)());
     expect(queryByTestId("savequerymodal")).toBeNull();
   });
 

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -1,6 +1,6 @@
 import "../../setup-dom";
 import "../../helpers/mock-sonner";
-import "../../helpers/mock-navigation";
+import { resetMockSearchParams, setMockSearchParams } from "../../helpers/mock-navigation";
 
 import { mock } from "bun:test";
 import { setupRechartssMock, setupFramerMotionMock } from "../../helpers/mock-monaco";
@@ -58,19 +58,26 @@ const defaultTables = [
   },
 ];
 
+// The options the tab asked for, so a test can assert that a provider whose rows
+// are derived groupings never requests tables at all (#U5).
+let lastMonitoringOptions: Record<string, unknown> | undefined;
+
 mock.module("@/hooks/use-monitoring-data", () => ({
-  useMonitoringData: mock(() => ({
-    data: {
-      activeSessions: defaultSessions,
-      tables: defaultTables,
-    },
-    loading: false,
-    error: null,
-    refresh: mockRefresh,
-    killSession: mockKillSession,
-    runMaintenance: mockRunMaintenance,
-    ...monitoringOverride,
-  })),
+  useMonitoringData: mock((_conn: unknown, options?: Record<string, unknown>) => {
+    lastMonitoringOptions = options;
+    return {
+      data: {
+        activeSessions: defaultSessions,
+        tables: defaultTables,
+      },
+      loading: false,
+      error: null,
+      refresh: mockRefresh,
+      killSession: mockKillSession,
+      runMaintenance: mockRunMaintenance,
+      ...monitoringOverride,
+    };
+  }),
 }));
 
 mock.module("@/hooks/use-provider-metadata", () => ({
@@ -188,10 +195,13 @@ describe("OperationsTab", () => {
     mockKillSession.mockImplementation(() => true);
     mockRunMaintenance.mockClear();
     mockRunMaintenance.mockImplementation(() => true);
+    lastMonitoringOptions = undefined;
+    resetMockSearchParams();
   });
 
   afterEach(() => {
     cleanup();
+    resetMockSearchParams();
   });
 
   // =========================================================================
@@ -1273,5 +1283,72 @@ describe("OperationsTab", () => {
     expect(queryByText("Tables (1)")).not.toBeNull();
     expect(container.textContent).toContain("users");
     expect(container.textContent).toContain("1234");
+  });
+  // ── Derived groupings have no Tables panel (#U5) ───────────────────────────
+  //
+  // Redis and the embedded engine declare `tablesAreDerivedGroupings`: their rows
+  // are prefix/namespace groupings, not addressable tables, so the panel could
+  // only ever say "Tables (0)". Both the request and the panel hang off that one
+  // capability — the same one TableItem already reads.
+
+  test("renders no Tables panel and requests no tables for a derived-groupings provider", async () => {
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze"], tablesAreDerivedGroupings: true },
+    };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Tables (0)")).toBeNull();
+    expect(queryByText("Tables (1)")).toBeNull();
+    expect(lastMonitoringOptions?.includeTables).toBe(false);
+    // The sessions half of the split is untouched.
+    expect(queryByText("Sessions (1)")).not.toBeNull();
+  });
+
+  test("keeps the Tables panel while the capabilities are unknown", async () => {
+    // `metadata` is null before /api/db/provider-meta answers and when it fails.
+    // Every provider but two has addressable rows, so the panel stays — the same
+    // way TableItem treats an unknown capability as addressable.
+    mockMetadata = null;
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Tables (1)")).not.toBeNull();
+    expect(lastMonitoringOptions?.includeTables).toBe(true);
+  });
+
+  // ── A deep link from an Explorer row arrives selected (#U5) ────────────────
+
+  test("deep-linked table name arrives filtered and selected", async () => {
+    monitoringOverride = { data: { activeSessions: defaultSessions, tables: multiTables } };
+    setMockSearchParams(new URLSearchParams("table=orders"));
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText, container } = renderResult!;
+
+    expect(queryByText("orders")).not.toBeNull();
+    expect(queryByText("users")).toBeNull();
+    const selected = container.querySelectorAll('[data-selected="true"]');
+    expect(selected.length).toBe(1);
+    expect(selected[0]?.textContent).toContain("orders");
+  });
+
+  test("marks no row selected without a deep link", async () => {
+    monitoringOverride = { data: { activeSessions: defaultSessions, tables: multiTables } };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { container } = renderResult!;
+
+    expect(container.querySelectorAll('[data-selected="true"]').length).toBe(0);
   });
 });

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -1288,10 +1288,16 @@ describe("OperationsTab", () => {
   //
   // Redis and the embedded engine declare `tablesAreDerivedGroupings`: their rows
   // are prefix/namespace groupings, not addressable tables, so the panel could
-  // only ever say "Tables (0)". Both the request and the panel hang off that one
-  // capability — the same one TableItem already reads.
+  // only ever say "Tables (0)". The PANEL hangs off that one capability - the same
+  // one TableItem already reads.
+  //
+  // The REQUEST deliberately does not: useMonitoringData fetches once per connection
+  // through an options ref, so its single request is issued while `metadata` is still
+  // null and no later option change reaches it. Asserting `includeTables: false` here
+  // would pass on this file's synchronous metadata mock and be false in the browser -
+  // the vacuous-assertion class this repo has been bitten by before.
 
-  test("renders no Tables panel and requests no tables for a derived-groupings provider", async () => {
+  test("renders no Tables panel for a derived-groupings provider", async () => {
     mockMetadata = {
       capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze"], tablesAreDerivedGroupings: true },
     };
@@ -1303,7 +1309,6 @@ describe("OperationsTab", () => {
 
     expect(queryByText("Tables (0)")).toBeNull();
     expect(queryByText("Tables (1)")).toBeNull();
-    expect(lastMonitoringOptions?.includeTables).toBe(false);
     // The sessions half of the split is untouched.
     expect(queryByText("Sessions (1)")).not.toBeNull();
   });
@@ -1320,6 +1325,7 @@ describe("OperationsTab", () => {
     const { queryByText } = renderResult!;
 
     expect(queryByText("Tables (1)")).not.toBeNull();
+    // The request is unconditional, so the tab's one fetch always asks for tables.
     expect(lastMonitoringOptions?.includeTables).toBe(true);
   });
 

--- a/tests/components/studio/QueryToolbar.test.tsx
+++ b/tests/components/studio/QueryToolbar.test.tsx
@@ -206,6 +206,18 @@ describe("QueryToolbar", () => {
     expect(queryByText("BEGIN")).not.toBeNull();
   });
 
+  test("Save renders only when onSaveQuery is supplied", () => {
+    // The embedded shell passed `noop` here and every unwired host got a dead
+    // Save button (U7); a withheld callback hides its control and its separator.
+    const { queryByText } = render(<QueryToolbar {...createDefaultProps({ onSaveQuery: undefined })} />);
+    expect(queryByText("Save")).toBeNull();
+    expect(queryByText("RUN")).not.toBeNull();
+
+    cleanup();
+    const { queryByText: withHandler } = render(<QueryToolbar {...createDefaultProps()} />);
+    expect(withHandler("Save")).not.toBeNull();
+  });
+
   test("No group at all when the caller can serve none of it, even on SQL", () => {
     // The embedded shell's exact shape: real SQL metadata, no servable control.
     const { queryByText } = render(

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -2510,4 +2510,83 @@ describe("useQueryExecution", () => {
       expect(fetchMock).not.toHaveBeenCalled();
     });
   });
+  // ── A 429 names the wait (docs/BACKLOG.md H2) ──────────────────────────────
+
+  describe("rate-limited runs", () => {
+    test("a 429 with Retry-After tells the user how long to wait", async () => {
+      mockGlobalFetch({
+        "/api/db/query": {
+          status: 429,
+          headers: { "Retry-After": "42" },
+          json: { error: "Too many requests.", code: "RATE_LIMITED", statusCode: 429, retryable: true },
+        },
+      });
+      const { result } = renderHook(() => useQueryExecution(createDefaultParams()));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT 1");
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith("Query Error", {
+        description: "Too many requests. Try again in 42s.",
+      });
+    });
+
+    test("a 429 with no Retry-After keeps the server's own message", async () => {
+      // Guessing a number would be worse than saying nothing about the wait.
+      mockGlobalFetch({
+        "/api/db/query": {
+          status: 429,
+          json: { error: "Too many requests. Try again later.", code: "RATE_LIMITED", statusCode: 429 },
+        },
+      });
+      const { result } = renderHook(() => useQueryExecution(createDefaultParams()));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT 1");
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith("Query Error", {
+        description: "Too many requests. Try again later.",
+      });
+    });
+
+    test("an HTTP-date Retry-After is left alone rather than parsed into a number", async () => {
+      // RFC 9110 permits the date form; this hook only understands delta-seconds,
+      // and an unparseable header must not turn into an invented wait.
+      mockGlobalFetch({
+        "/api/db/query": {
+          status: 429,
+          headers: { "Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT" },
+          json: { error: "Too many requests. Try again later.", code: "RATE_LIMITED", statusCode: 429 },
+        },
+      });
+      const { result } = renderHook(() => useQueryExecution(createDefaultParams()));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT 1");
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith("Query Error", {
+        description: "Too many requests. Try again later.",
+      });
+    });
+
+    test("a non-429 response with a Retry-After header is not rephrased", async () => {
+      mockGlobalFetch({
+        "/api/db/query": {
+          status: 503,
+          headers: { "Retry-After": "5" },
+          json: { error: "Database is starting up" },
+        },
+      });
+      const { result } = renderHook(() => useQueryExecution(createDefaultParams()));
+
+      await act(async () => {
+        await result.current.executeQuery("SELECT 1");
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith("Query Error", { description: "Database is starting up" });
+    });
+  });
 });

--- a/tests/isolated/agent-runtime.test.ts
+++ b/tests/isolated/agent-runtime.test.ts
@@ -322,6 +322,48 @@ describe("a drive that fails before the loop", () => {
     });
   });
 
+  test("records a misconfigured agent credential as itself, not as an unsupported engine", async () => {
+    // `resolveAgentCredential` throws the SAME error type as an engine with no
+    // read-only profile, on ANY engine (docs/BACKLOG.md B47). Classified by type
+    // alone, an operator who rotated the secret key under a sealed `agentPassword`
+    // was told PostgreSQL offers no read-only execution profile — pointing away from
+    // the one thing they could fix. The reason code is what tells the two apart.
+    await openRun("arun_badcredential");
+    mockResolveConnection.mockImplementationOnce(async () => {
+      throw new ExecutionProfileError(
+        'Connection "seed:sales" configures an agent credential that cannot be resolved',
+        "AGENT_CREDENTIAL_UNRESOLVABLE",
+      );
+    });
+
+    await expect(driveAgentRun("arun_badcredential")).rejects.toThrow(ExecutionProfileError);
+
+    expect(await finishedEvent("arun_badcredential")).toMatchObject({
+      status: "failed",
+      reason: "agent-credential-unusable",
+    });
+  });
+
+  test("records an agent credential set alongside a connection string as a credential fault", async () => {
+    // The second credential code, and the one whose fix is a connection field rather
+    // than a key: buildPoolConfig would drop the credential silently, so acquisition
+    // is refused. Nothing about the engine is wrong here either.
+    await openRun("arun_credentialstring");
+    mockResolveConnection.mockImplementationOnce(async () => {
+      throw new ExecutionProfileError(
+        'Connection "seed:sales" configures an agent credential alongside a connection string',
+        "AGENT_CREDENTIAL_WITH_CONNECTION_STRING",
+      );
+    });
+
+    await expect(driveAgentRun("arun_credentialstring")).rejects.toThrow(ExecutionProfileError);
+
+    expect(await finishedEvent("arun_credentialstring")).toMatchObject({
+      status: "failed",
+      reason: "agent-credential-unusable",
+    });
+  });
+
   test("records a connection that no longer resolves", async () => {
     await openRun("arun_connectiongone");
     mockResolveConnection.mockImplementationOnce(async () => {

--- a/tests/security/headers.test.ts
+++ b/tests/security/headers.test.ts
@@ -187,40 +187,30 @@ describe("securityHeaders", () => {
 
 /**
  * B40: the shipped policy must stay byte-identical, but a contributor's first `bun dev` has to
- * work — React's development build evals, so without this relaxation the login page never hydrates.
+ * work - React's development build evals, so without this relaxation the login page never hydrates.
+ *
+ * Asserted through the OPTION, not through process.env: headers.ts is published as
+ * `@libredb/studio/security` and reads no environment, so the environment half of this decision
+ * belongs to config.ts and is asserted in its own suite.
  */
-describe("studioCspDirectives under NODE_ENV=development", () => {
-  const original = process.env.NODE_ENV;
-
-  // `process.env as Record<string, string>` is this repo's pattern for NODE_ENV, which the
-  // Next.js types declare read-only (see tests/setup.ts and auth-jwt-config.test.ts).
-  function withNodeEnv<T>(value: string, fn: () => T): T {
-    (process.env as Record<string, string>).NODE_ENV = value;
-    try {
-      return fn();
-    } finally {
-      (process.env as Record<string, string>).NODE_ENV = original ?? "test";
-    }
-  }
-
+describe("studioCspDirectives allowEval", () => {
   test("admits eval so React's development build can hydrate", () => {
-    const scriptSrc = withNodeEnv("development", () => studioCspDirectives()["script-src"]);
-
-    expect(scriptSrc).toContain("'unsafe-eval'");
+    expect(studioCspDirectives({ allowEval: true })["script-src"]).toContain("'unsafe-eval'");
   });
 
-  test("still omits eval in production and test", () => {
-    for (const env of ["production", "test"]) {
-      const scriptSrc = withNodeEnv(env, () => studioCspDirectives()["script-src"]);
-
-      expect({ env, scriptSrc }).toEqual({ env, scriptSrc: ["'self'", "'unsafe-inline'"] });
+  test("omits eval when the option is absent or false", () => {
+    for (const options of [{}, { allowEval: false }]) {
+      expect({ options, scriptSrc: studioCspDirectives(options)["script-src"] }).toEqual({
+        options,
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+      });
     }
   });
 
-  test("relaxes nothing but script-src, and the serialized production policy is unchanged", () => {
-    const production = withNodeEnv("production", () => securityHeaders()["Content-Security-Policy"]);
-    const development = withNodeEnv("development", () => securityHeaders()["Content-Security-Policy"]);
+  test("relaxes nothing but script-src, and the serialized default policy is unchanged", () => {
+    const shipped = securityHeaders()["Content-Security-Policy"];
+    const relaxed = securityHeaders({ allowEval: true })["Content-Security-Policy"];
 
-    expect(development).toBe(production.replace("'unsafe-inline'", "'unsafe-inline' 'unsafe-eval'"));
+    expect(relaxed).toBe(shipped.replace("'unsafe-inline'", "'unsafe-inline' 'unsafe-eval'"));
   });
 });

--- a/tests/security/headers.test.ts
+++ b/tests/security/headers.test.ts
@@ -184,3 +184,43 @@ describe("securityHeaders", () => {
     expect(securityHeaders({ hsts: false })["Strict-Transport-Security"]).toBeUndefined();
   });
 });
+
+/**
+ * B40: the shipped policy must stay byte-identical, but a contributor's first `bun dev` has to
+ * work — React's development build evals, so without this relaxation the login page never hydrates.
+ */
+describe("studioCspDirectives under NODE_ENV=development", () => {
+  const original = process.env.NODE_ENV;
+
+  // `process.env as Record<string, string>` is this repo's pattern for NODE_ENV, which the
+  // Next.js types declare read-only (see tests/setup.ts and auth-jwt-config.test.ts).
+  function withNodeEnv<T>(value: string, fn: () => T): T {
+    (process.env as Record<string, string>).NODE_ENV = value;
+    try {
+      return fn();
+    } finally {
+      (process.env as Record<string, string>).NODE_ENV = original ?? "test";
+    }
+  }
+
+  test("admits eval so React's development build can hydrate", () => {
+    const scriptSrc = withNodeEnv("development", () => studioCspDirectives()["script-src"]);
+
+    expect(scriptSrc).toContain("'unsafe-eval'");
+  });
+
+  test("still omits eval in production and test", () => {
+    for (const env of ["production", "test"]) {
+      const scriptSrc = withNodeEnv(env, () => studioCspDirectives()["script-src"]);
+
+      expect({ env, scriptSrc }).toEqual({ env, scriptSrc: ["'self'", "'unsafe-inline'"] });
+    }
+  });
+
+  test("relaxes nothing but script-src, and the serialized production policy is unchanged", () => {
+    const production = withNodeEnv("production", () => securityHeaders()["Content-Security-Policy"]);
+    const development = withNodeEnv("development", () => securityHeaders()["Content-Security-Policy"]);
+
+    expect(development).toBe(production.replace("'unsafe-inline'", "'unsafe-inline' 'unsafe-eval'"));
+  });
+});

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -276,3 +276,61 @@ describe("routes that reach a provider require a session", () => {
     });
   }
 });
+
+// Threat: a role denial that leaves no trace. guardRoute audits SESSION failures; the admin-only
+// routes check the ROLE themselves, afterwards, and used to answer 403 silently - so an
+// authenticated (or stolen) session probing for a role it does not hold was invisible in the one
+// channel this project treats as authoritative.
+//
+// This lives here rather than beside each route's own tests because the assertion reads the real
+// stdout line: several files under tests/api mock @/lib/audit process-wide, and nothing under
+// tests/security does.
+describe("an admin-only route's role denial is audited", () => {
+  beforeEach(() => {
+    clearRateLimitState();
+    mockGetSession.mockClear();
+    mockGetSession.mockImplementation(async () => ({ role: "user", username: "bob" }));
+  });
+
+  function probe(): Request {
+    return new Request("http://localhost/api/admin/fleet-health", {
+      method: "POST",
+      body: JSON.stringify({ connections: [] }),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  test("POST /api/admin/fleet-health emits permission_denied with reason insufficient_role", async () => {
+    const { POST } = await import("@/app/api/admin/fleet-health/route");
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await POST(probe());
+
+      expect(res.status).toBe(403);
+      const lines = logSpy.mock.calls.map(
+        (call: unknown[]) => JSON.parse(call[0] as string) as Record<string, unknown>,
+      );
+      expect(lines).toHaveLength(1);
+      expect(lines[0].event).toBe("permission_denied");
+      expect(lines[0].reason).toBe("insufficient_role");
+      expect(lines[0].actor).toBe("bob");
+      expect(lines[0].route).toBe("POST /api/admin/fleet-health");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  test("still returns 403 when that audit emit throws", async () => {
+    const { POST } = await import("@/app/api/admin/fleet-health/route");
+    const logSpy = spyOn(console, "log").mockImplementation(() => {
+      throw new Error("audit sink unavailable");
+    });
+    try {
+      const res = await POST(probe());
+
+      expect(res.status).toBe(403);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -146,6 +146,44 @@ describe("foldLedgerEntries", () => {
   });
 
   /*
+    The two causes of one profile refusal, each pinned to the sentence a user reads
+    (docs/BACKLOG.md B47). Both used to render the engine sentence, so a PostgreSQL
+    run whose agent credential no longer decrypted was told its engine offers no
+    read-only execution profile.
+  */
+  test("an engine with no read-only profile is described as the engine's limit", () => {
+    const view = foldLedgerEntries([
+      OPENED,
+      event({
+        kind: "event",
+        event: { kind: "run-finished", atMs: 9, status: "failed", reason: "engine-unsupported" },
+      }),
+    ]);
+
+    expect(view.items.at(-1)?.detail).toBe(
+      "The agent cannot run on this database engine: it offers no read-only execution profile.",
+    );
+  });
+
+  test("a misconfigured agent credential is described as the credential, and says nothing about the engine", () => {
+    const view = foldLedgerEntries([
+      OPENED,
+      event({
+        kind: "event",
+        event: { kind: "run-finished", atMs: 9, status: "failed", reason: "agent-credential-unusable" },
+      }),
+    ]);
+
+    const detail = view.items.at(-1)?.detail ?? "";
+    expect(detail).toBe(
+      "This connection's agent credential cannot be used: check that both the agent user and password are set, that the password still decrypts under the current secret key, and that no connection string is set beside it.",
+    );
+    // The whole point of the second reason: the sentence must not send the reader
+    // after their engine, which is not what refused the run.
+    expect(detail).not.toContain("engine");
+  });
+
+  /*
     The prose a run ends on used to be returned to the caller and dropped. These pin
     the two halves of showing it: the entry that carries the words, and the ending
     that says the run stopped without a cited report — which is the difference

--- a/tests/unit/editor/libredb-language.test.ts
+++ b/tests/unit/editor/libredb-language.test.ts
@@ -70,6 +70,153 @@ describe("registerLibreDBLanguage", () => {
     expect(provider.tokenizer.root.length).toBeGreaterThan(0);
   });
 
+  // ── The Monarch rules themselves (U8) ─────────────────────────────────────
+  //
+  // The rules are DATA: loading this module covers every line of it, so the 100%
+  // gate says nothing about whether a regex matches the right span. An unanchored
+  // comment rule, a key split at its colon, or a new rule shadowing an older one
+  // would pass every gate and be visible only in a browser. These assert the
+  // regexes directly — no Monaco runtime involved.
+
+  describe("tokenizer rules", () => {
+    function rootRules() {
+      const monaco = createMockMonaco();
+      registerLibreDBLanguage(monaco);
+      const provider = monaco._state.tokensProviders[0]!.provider;
+      return provider.tokenizer.root as unknown as [RegExp, unknown][];
+    }
+
+    // Index by the token class each rule assigns so a reordering does not silently
+    // repoint these assertions at a different rule.
+    const COMMENT = 0;
+    const DOUBLE_QUOTED = 1;
+    const SINGLE_QUOTED = 2;
+    const NUMBER = 3;
+    const WORD = 4;
+
+    test("the root state has exactly the five documented rules", () => {
+      expect(rootRules()).toHaveLength(5);
+    });
+
+    test("the comment rule matches a `#` line and nothing after other data", () => {
+      const [comment] = rootRules()[COMMENT]!;
+
+      // The "Generate Command" cheatsheet header, and an indented one.
+      expect(comment.test("# LibreDB commands for prefix users:")).toBe(true);
+      expect(comment.test("    # indented")).toBe(true);
+      expect(comment.test("#")).toBe(true);
+
+      // Anchored: a `#` that follows data is DATA, matching the provider's line
+      // skipper, which only skips a line whose first non-space character is `#`
+      // (docs/providers/libredb.md §5.1).
+      expect(comment.test('put note "line1 #tag"')).toBe(false);
+      expect(comment.test("get user:1 # trailing")).toBe(false);
+      expect(comment.test("put tag #value")).toBe(false);
+    });
+
+    test("a verb tokenizes through the keyword cases map, and only on an exact match", () => {
+      const rules = rootRules();
+      const [word, action] = rules[WORD]!;
+      const anchored = new RegExp(`^(?:${word.source})`);
+
+      expect(action).toEqual({ cases: { "@keywords": "keyword", "@default": "identifier" } });
+      // The cases map keys off the WHOLE match, so the span the regex takes is what
+      // decides keyword-vs-identifier: `get` is a verb, `getter` is a key.
+      for (const verb of ["get", "put", "delete", "prefix", "range"]) {
+        expect(anchored.exec(verb)?.[0]).toBe(verb);
+      }
+      expect(anchored.exec("getter")?.[0]).toBe("getter");
+    });
+
+    test("a key is ONE identifier token, not a verb split at the colon", () => {
+      const [word] = rootRules()[WORD]!;
+      const anchored = new RegExp(`^(?:${word.source})`);
+
+      for (const key of ["users:1", "user:*", "session:abc:data", "cache.v2", "a/b", "my-key", "_internal"]) {
+        expect(anchored.exec(key)?.[0]).toBe(key);
+      }
+      // `prefix users:` — the trailing colon belongs to the key token, not to a
+      // separate operator token.
+      expect(anchored.exec("users:")?.[0]).toBe("users:");
+    });
+
+    test("a range bound tokenizes as a number", () => {
+      const rules = rootRules();
+      const [number] = rules[NUMBER]!;
+      const [word] = rules[WORD]!;
+
+      for (const literal of ["0", "50", "1.5"]) {
+        expect(new RegExp(`^(?:${number.source})`).exec(literal)?.[0]).toBe(literal);
+        // Why the order between these two rules does not matter: the word rule
+        // cannot open on a digit.
+        expect(new RegExp(`^(?:${word.source})`).test(literal)).toBe(false);
+      }
+    });
+
+    test("a quoted value is one string token, including a `#` inside it", () => {
+      const rules = rootRules();
+      const [double] = rules[DOUBLE_QUOTED]!;
+      const [single] = rules[SINGLE_QUOTED]!;
+
+      expect(double.exec('"line1 #tag"')?.[0]).toBe('"line1 #tag"');
+      expect(double.exec('"esc \\" still inside"')?.[0]).toBe('"esc \\" still inside"');
+      // The JSON value the cheatsheet emits for `put`.
+      expect(single.exec('\'{"id":"example"}\'')?.[0]).toBe('\'{"id":"example"}\'');
+      expect(single.exec("'a #b'")?.[0]).toBe("'a #b'");
+      // A double-quoted rule must not swallow a single quote and vice versa.
+      expect(double.test("'a'")).toBe(false);
+      expect(single.test('"a"')).toBe(false);
+    });
+
+    // The ordering property the tokenizer relies on: no two rules can match at the
+    // same position, so the list is order-independent today. A rule added with an
+    // overlapping opening character would make order load-bearing silently.
+    test("no two root rules can open on the same character", () => {
+      const rules = rootRules();
+      const openers = "#\"'0123456789aZ_*:{}[]() \t.-/".split("");
+
+      for (const ch of openers) {
+        const matching = rules.filter(([regex]) => new RegExp(`^(?:${regex.source})`, regex.flags).test(ch));
+        expect(matching.length).toBeLessThanOrEqual(1);
+      }
+    });
+
+    // ── Gaps this tokenizer has, asserted so a fix is visible as a failure ────
+
+    test("a negative number is NOT one token: the sign is unmatched and the digits are the number", () => {
+      const rules = rootRules();
+      const [number] = rules[NUMBER]!;
+      const anchoredNumber = new RegExp(`^(?:${number.source})`);
+
+      // `\b\d+` cannot open on `-`, so `-1` paints as an unstyled `-` plus a number
+      // `1`. Harmless for LibreDB, whose grammar (docs §5.1) has no negative
+      // argument — recorded so a rule change shows up here rather than in a browser.
+      expect(anchoredNumber.test("-1")).toBe(false);
+      expect(anchoredNumber.exec("1")?.[0]).toBe("1");
+    });
+
+    test("a key that starts with a digit splits into a number and a leftover", () => {
+      const rules = rootRules();
+      const [number] = rules[NUMBER]!;
+      const [word] = rules[WORD]!;
+
+      // The word rule requires a letter or `_` start, so `2024:log` opens on the
+      // number rule and only `2024` is consumed — `:log` is then matched by no rule.
+      expect(new RegExp(`^(?:${number.source})`).exec("2024:log")?.[0]).toBe("2024");
+      expect(new RegExp(`^(?:${word.source})`).test("2024:log")).toBe(false);
+    });
+
+    test("a bare `*` or a leading `:` matches no rule at all", () => {
+      const rules = rootRules();
+
+      // Unlike the Redis tokenizer, this one has no punctuation-led rule, so
+      // `prefix *` paints `*` with Monaco's default token. Cosmetic only.
+      for (const text of ["*", ":*", "-"]) {
+        expect(rules.filter(([regex]) => new RegExp(`^(?:${regex.source})`, regex.flags).test(text))).toHaveLength(0);
+      }
+    });
+  });
+
   test("language configuration uses # line comments and quote/bracket auto-closing pairs", () => {
     const monaco = createMockMonaco();
 

--- a/tests/unit/lib/config/auth-preflight.test.ts
+++ b/tests/unit/lib/config/auth-preflight.test.ts
@@ -121,3 +121,145 @@ describe("config/auth-preflight verifyAuthEnvAtBoot", () => {
     }
   });
 });
+
+/**
+ * Backlog K3: STORAGE_ENCRYPTION_KEY had no boot check, so a too-short key threw only at the first
+ * storage write - after login, after the migration attempt - and surfaced as a syncError in the UI.
+ */
+describe("config/auth-preflight STORAGE_ENCRYPTION_KEY", () => {
+  const origSecret = process.env.JWT_SECRET;
+  const origKey = process.env.STORAGE_ENCRYPTION_KEY;
+  const origProvider = process.env.STORAGE_PROVIDER;
+
+  afterEach(() => {
+    setEnv("JWT_SECRET", origSecret);
+    setEnv("STORAGE_ENCRYPTION_KEY", origKey);
+    setEnv("STORAGE_PROVIDER", origProvider);
+  });
+
+  function setEnv(name: string, value: string | undefined): void {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+
+  function stubProcessExit(): { exitCalls: Array<number | undefined>; restore: () => void } {
+    const originalExit = process.exit;
+    const exitCalls: Array<number | undefined> = [];
+    process.exit = ((code?: number) => {
+      exitCalls.push(code);
+    }) as unknown as typeof process.exit;
+    return {
+      exitCalls,
+      restore: () => {
+        process.exit = originalExit;
+      },
+    };
+  }
+
+  test("exits 1 with an actionable banner when a server storage provider has a too-short key", () => {
+    setEnv("JWT_SECRET", "a-valid-secret-that-is-32-chars!");
+    setEnv("STORAGE_PROVIDER", "postgres");
+    setEnv("STORAGE_ENCRYPTION_KEY", "k".repeat(24));
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const { exitCalls, restore } = stubProcessExit();
+
+    try {
+      expect(verifyAuthEnvAtBoot()).toBe(false);
+      expect(exitCalls).toEqual([1]);
+      const banner = errorSpy.mock.calls.flat().join("\n");
+      expect(banner).toContain("STORAGE_ENCRYPTION_KEY is too short");
+      expect(banner).toContain("24 characters");
+      expect(banner).toContain("32");
+      // The key value itself must never reach the logs.
+      expect(banner).not.toContain("k".repeat(24));
+    } finally {
+      restore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("stays silent about the same too-short key when STORAGE_PROVIDER is local", () => {
+    setEnv("JWT_SECRET", "a-valid-secret-that-is-32-chars!");
+    setEnv("STORAGE_PROVIDER", "local");
+    setEnv("STORAGE_ENCRYPTION_KEY", "k".repeat(24));
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const { exitCalls, restore } = stubProcessExit();
+
+    try {
+      expect(verifyAuthEnvAtBoot()).toBe(true);
+      expect(exitCalls).toEqual([]);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("stays silent when STORAGE_PROVIDER is unset (the default is local)", () => {
+    setEnv("JWT_SECRET", "a-valid-secret-that-is-32-chars!");
+    setEnv("STORAGE_PROVIDER", undefined);
+    setEnv("STORAGE_ENCRYPTION_KEY", "k".repeat(8));
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const { exitCalls, restore } = stubProcessExit();
+
+    try {
+      expect(verifyAuthEnvAtBoot()).toBe(true);
+      expect(exitCalls).toEqual([]);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("accepts an exactly-32-character key with a server storage provider (boundary)", () => {
+    setEnv("JWT_SECRET", "a-valid-secret-that-is-32-chars!");
+    setEnv("STORAGE_PROVIDER", "sqlite");
+    setEnv("STORAGE_ENCRYPTION_KEY", "m".repeat(32));
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const { exitCalls, restore } = stubProcessExit();
+
+    try {
+      expect(verifyAuthEnvAtBoot()).toBe(true);
+      expect(exitCalls).toEqual([]);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("stays silent when the key is absent under a server provider: encryption falls back to JWT_SECRET", () => {
+    setEnv("JWT_SECRET", "a-valid-secret-that-is-32-chars!");
+    setEnv("STORAGE_PROVIDER", "sqlite");
+    setEnv("STORAGE_ENCRYPTION_KEY", undefined);
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const { exitCalls, restore } = stubProcessExit();
+
+    try {
+      expect(verifyAuthEnvAtBoot()).toBe(true);
+      expect(exitCalls).toEqual([]);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("treats an empty key as absent, not as too short", () => {
+    setEnv("JWT_SECRET", "a-valid-secret-that-is-32-chars!");
+    setEnv("STORAGE_PROVIDER", "postgres");
+    setEnv("STORAGE_ENCRYPTION_KEY", "");
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const { exitCalls, restore } = stubProcessExit();
+
+    try {
+      expect(verifyAuthEnvAtBoot()).toBe(true);
+      expect(exitCalls).toEqual([]);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/lib/query-generators.test.ts
+++ b/tests/unit/lib/query-generators.test.ts
@@ -85,6 +85,41 @@ describe("generateTableQuery", () => {
     const caps = makeCaps({ queryLanguage: "json", defaultPort: null, queryDialect: "libredb" });
     expect(generateTableQuery("orphan", caps)).toBe("get orphan");
   });
+
+  // "Scan Keys" AUTO-EXECUTES through `handleTableClick`, and a key name is
+  // server data interpolated raw into a line-oriented grammar. For a key named
+  // `x\ndelete billing:2024` this used to return `get x\ndelete billing:2024`:
+  // only `get x` ran, but line 2 sat in the editor as a runnable
+  // `delete billing:2024`, one Run Selected away. Same answer as the cheatsheet
+  // gives — emit the note, emit no command (U11).
+  test("LibreDB dialect: a newline-bearing key name emits the note and NO command", () => {
+    const caps = makeCaps({ queryLanguage: "json", defaultPort: null, queryDialect: "libredb" });
+    const out = generateTableQuery("x\ndelete billing:2024", caps);
+    const runnable = out
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l !== "" && !l.startsWith("#"));
+    expect(runnable).toEqual([]);
+    expect(out).toContain("# This key's name contains a newline.");
+  });
+
+  test("LibreDB dialect: a bare CR in a key name refuses the same way (U11)", () => {
+    const caps = makeCaps({ queryLanguage: "json", defaultPort: null, queryDialect: "libredb" });
+    expect(generateTableQuery("x\rdelete billing:2024", caps)).not.toContain("get x");
+  });
+
+  test("LibreDB dialect: a newline-bearing PREFIX GROUP refuses too (U11)", () => {
+    const caps = makeCaps({ queryLanguage: "json", defaultPort: null, queryDialect: "libredb" });
+    expect(generateTableQuery("x\ndelete billing:2024:*", caps)).not.toContain("prefix ");
+  });
+
+  // The two LibreDB branches must not drift: Scan Keys and the cheatsheet emit
+  // the identical note text for the identical name (U11).
+  test("LibreDB dialect: Scan Keys and the cheatsheet share one refusal note (U11)", () => {
+    const caps = makeCaps({ queryLanguage: "json", defaultPort: null, queryDialect: "libredb" });
+    const note = generateTableQuery("x\ndelete billing:2024", caps);
+    expect(generateSelectQuery("x\ndelete billing:2024", [], caps)).toContain(note);
+  });
 });
 
 // ============================================================================

--- a/tests/unit/lib/query-generators.test.ts
+++ b/tests/unit/lib/query-generators.test.ts
@@ -100,7 +100,7 @@ describe("generateTableQuery", () => {
       .map((l) => l.trim())
       .filter((l) => l !== "" && !l.startsWith("#"));
     expect(runnable).toEqual([]);
-    expect(out).toContain("# This key's name contains a newline.");
+    expect(out).toContain("# This key's name contains a line break.");
   });
 
   test("LibreDB dialect: a bare CR in a key name refuses the same way (U11)", () => {
@@ -176,7 +176,7 @@ describe("generateSelectQuery — LibreDB dialect", () => {
       '# LibreDB commands for "x\\ndelete billing:2024" — select a line and Run Selected.',
     );
     expect(commandLines(out)).toEqual([]);
-    expect(out).toContain("# This key's name contains a newline.");
+    expect(out).toContain("# This key's name contains a line break.");
     expect(out).not.toContain("delete billing:2024\n");
   });
 

--- a/tests/unit/lib/security/config.test.ts
+++ b/tests/unit/lib/security/config.test.ts
@@ -176,4 +176,24 @@ describe("readSecurityHeaderOptions", () => {
       includeSubDomains: false,
     });
   });
+
+  // B40: `bun dev` could not log in, because React's development build evals and the policy
+  // omitted 'unsafe-eval' everywhere. This is the environment half of that decision - headers.ts
+  // takes it as an option, so the read has to be here or it is nowhere.
+  test("asks for eval in development only", () => {
+    const original = process.env.NODE_ENV;
+    try {
+      for (const [env, expected] of [
+        ["development", true],
+        ["production", false],
+        ["test", false],
+      ] as const) {
+        (process.env as Record<string, string>).NODE_ENV = env;
+
+        expect({ env, allowEval: readSecurityHeaderOptions().allowEval }).toEqual({ env, allowEval: expected });
+      }
+    } finally {
+      (process.env as Record<string, string>).NODE_ENV = original ?? "test";
+    }
+  });
 });


### PR DESCRIPTION
fix(backlog): clear sixteen entries - the cheapest ones, measured rather than guessed

Sixteen BACKLOG entries closed in one pass. Four were decisions with no code, one
was a repository setting, and eleven were the smallest honest fix each entry asked
for. Every code change landed test-first.

Decisions (no code):
- U15 the IPv6 resolver's ipv6-unavailable branch stays unit-tested; a kernel
  without AF_INET6 could not be constructed and the failure mode is loud.
- B50 no rule naming KEYS. Plan mode runs nothing, so applying the draft is the
  user's call on their own connection; the ruling is recorded beside the
  derived-groupings rule so it is not reopened.
- B41 the seed doc claimed defaults merges every field. mergeDefaults merges
  managed, environment and ssl - the prose now says so.
- C1 Secret Scan is a required check. Its verdict is a function of the scanned
  commit range and the pinned gitleaks digest, it needs no secrets so fork pull
  requests produce it, and it runs in about 75ms. CLAUDE.md and the workflow's
  own comment now say it is required.

Fixes:
- B40 the CSP admits unsafe-eval in development only. Without it React's
  development build never hydrates, so a contributor's first `bun dev` could not
  log in. The shipped policy is unchanged, asserted by test.
- AU1 the three storage routes answer 401 through the shared guard, so one error
  shape covers "not logged in" across the whole API. NOTE a behaviour change the
  entry did not ask for: guardRoute takes a bucket rather than offering a
  session-only mode, so those routes gained a rate limiter they never had. Kept
  deliberately on the `query` bucket - under STORAGE_PROVIDER=sqlite or postgres
  they read and write a real database - and the bucket's call-site inventory is
  updated to twenty routes / eighteen direct matches.
- H9 fleet-health caps its fan-out at 100 connections per request. The route
  guard limits request rate, not body width.
- H12 five admin denials now emit permission_denied with reason
  insufficient_role - the closed union's member finally has emitters.
- K3 STORAGE_ENCRYPTION_KEY is validated at boot, silent when STORAGE_PROVIDER
  is local, so a short key stops the server instead of surfacing as a syncError
  after login.
- H2 a 429 names the wait, when Retry-After parses.
- U5 a derived-groupings provider renders no Tables panel, and a maintenance deep
  link arrives with its row selected. The request is deliberately NOT gated: the
  monitoring hook fetches once per connection through an options ref, so its one
  request predates provider-meta and no option change can reach it.
- U7 the embedded shell renders no Save control when the host wired no handler.
- U8 the LibreDB Monarch rules are asserted directly, the way #427 did for Redis.
- U11 the LibreDB Scan Keys generator cannot emit a second command line.
- B47 a credential refusal is classified apart from an engine refusal, so an
  operator who rotated a key is no longer told their engine is unsupported.

Verified in the browser against `bun dev` (Chromium, cold profile): the login
that B40 unblocked, and H12's audit line on the proxy path -

  {"event":"permission_denied","reason":"insufficient_role",
   "route":"GET /admin/operations"}

U5's addressable arm was checked live too (monitoring still requests tables for
SQLite). The rest is test-verified only; U5's derived-groupings arm, U7's
embedded arm, U11 and AU1 have no reachable surface in the standalone app.

Gates: format, lint, typecheck, knip, 330/330 core files, hooks, security, evals,
components, build, and coverage at 100.00% (40826/40826).


Review round (Copilot, 6 findings): five held and one was half right. Details in
35c0dc1b and in the thread replies. The two that changed shipped behaviour: the
CSP relaxation is now an option decided in config.ts rather than a process.env
read inside the published `@libredb/studio/security` module, and all five
insufficient_role emitters are metered on the anon bucket keyed by username -
the denial stays unconditional, only its record is bounded, matching what
guardRoute already does for no_session.
