### PR TITLE
fix(providers): Trino handed back every bigint past 2^53 rounded (#424)

### DIFF
--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -367,15 +367,33 @@ Measured on 476, one statement:
 | Trino type | On the wire | Note |
 |---|---|---|
 | `decimal` | a **string** — `"1.23"` | Never a JS number: `JSON.parse` would round it |
+| `bigint` | an **unquoted number** | The one value this seam rewrites, because the server does not quote it and `JSON.parse` rounds it (below) |
 | `varbinary` | **base64** — `"AQI="` | |
 | `array(T)` | a JSON array | |
 | `map(K,V)` | a JSON object | |
 | `row(…)` | a JSON **array**, positionally | The field names live in the rendered type, not in the value |
 | `timestamp` | `"2020-01-01 10:00:00.000"` | Rendered in **UTC**, pinned by `X-Trino-Time-Zone` |
 
-Nothing is re-interpreted. The timezone pin is deliberate: the protocol's default is "the timezone of
-the Trino cluster, and not the timezone of the client", so leaving it unset makes the same statement
-produce different text depending on where the coordinator happens to run.
+Nothing is re-interpreted, with one declared exception: an integer too wide for a double. The
+timezone pin is deliberate: the protocol's default is "the timezone of the Trino cluster, and not the
+timezone of the client", so leaving it unset makes the same statement produce different text
+depending on where the coordinator happens to run.
+
+**A wide `bigint` is rewritten before the page is parsed.** Measured on 2026-08-22,
+`SELECT CAST(9223372036854775807 AS BIGINT)` puts the exact digits on the wire unquoted, and
+`JSON.parse` answers `9223372036854776000` with no error to catch. Written into `memory` and read
+back through this provider, a value the database held correctly reached the grid wrong. Trino has no
+counterpart to ClickHouse's `output_format_json_quote_64bit_integers` (#264), so the raw text is the
+only place left: `parseJson` runs `quoteUnsafeIntegers` (#265, shared with the Druid transport, which
+is in the same position) over the page first, and both endpoints of the range arrive as strings,
+`"9223372036854775807"` and `"-9223372036854775808"`. Anything a double holds exactly, `42`, is left
+a number, and a `decimal` was never at risk because the server already quotes it.
+
+The pass covers the whole envelope rather than `data` alone, because at that point the body is one
+JSON text and splitting it would mean parsing it twice. The cost is bounded and stated: a `stats`
+counter above 2^53 would arrive as a string and `numberField` would read it as absent, which needs
+`processedBytes` past 9 PB in a single statement. An absent statistic is recoverable, a rounded
+`bigint` in a result row is not, because nothing downstream can tell that it happened.
 
 Column labels are taken from the page's declaration and **de-duplicated** — a second column called
 `x` becomes `x (2)` — because the seam promises `fieldNames` is exactly the key set of every row.

--- a/src/lib/db/providers/sql/trino/http-transport.ts
+++ b/src/lib/db/providers/sql/trino/http-transport.ts
@@ -43,6 +43,11 @@
  */
 
 import type { DatabaseConnection } from "@/lib/db/types";
+// A `bigint` column arrives as an UNQUOTED JSON number and this protocol has no
+// setting that would quote it, so the raw body is rewritten before it is parsed.
+// Shared with the Druid transport, which is in the same position; ClickHouse escapes
+// it server-side instead (`output_format_json_quote_64bit_integers`, #264).
+import { quoteUnsafeIntegers } from "@/lib/db/utils/json-integers";
 import {
   type TrinoDialect,
   type TrinoErrorCategory,
@@ -327,9 +332,20 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+/**
+ * The page document, with every integer too wide for a double quoted first.
+ *
+ * The rewrite runs over the WHOLE envelope rather than over `data` alone, because
+ * the rows are not separable from it at this point: the body is one JSON text and
+ * splitting it to protect the six `stats` numbers would mean parsing it twice. The
+ * cost of that is bounded and stated: a `stats` counter above 2^53 would arrive as a
+ * string and `numberField` would read it as absent, which needs `processedBytes`
+ * past 9 PB in a single statement. An absent statistic is recoverable; a rounded
+ * `bigint` in a result row is not, because nothing downstream can tell it happened.
+ */
 function parseJson(text: string): unknown {
   try {
-    return JSON.parse(text) as unknown;
+    return JSON.parse(quoteUnsafeIntegers(text)) as unknown;
   } catch {
     return null;
   }

--- a/tests/integration/db/trino-provider.test.ts
+++ b/tests/integration/db/trino-provider.test.ts
@@ -696,6 +696,39 @@ describe("TrinoProvider query", () => {
     expect(result.rows).toEqual([{ c: 1, "c (2)": 2 }]);
   });
 
+  /**
+   * The one value the transport rewrites, proved through the PROVIDER rather than
+   * through the seam alone, because this is the layer a caller actually reads.
+   *
+   * The page is verbatim TEXT and not a `page()` call, and that is the whole point:
+   * `JSON.stringify` would round both endpoints while building the fixture, so a
+   * test written the ordinary way here would pass while proving nothing at all.
+   *
+   * Captured 2026-08-22 from `memory.fix.t`, written through this provider and read
+   * back. Before the rewrite the max returned 9223372036854776000, so a row the
+   * database held correctly reached the caller wrong, with nothing to catch.
+   */
+  test("hands a 64-bit id back exactly as the database holds it", async () => {
+    const provider = await connectProvider();
+    overrideSurface("memory.fix.t", (id) => ({
+      body:
+        `{"id":"${id}","infoUri":"${ORIGIN}/ui/query.html?${id}",` +
+        '"columns":[{"name":"id","type":"bigint"},{"name":"note","type":"varchar"}],' +
+        '"data":[[9223372036854775807,"max"],[-9223372036854775808,"min"],[42,"safe"]],' +
+        `"stats":${JSON.stringify(STATS)},"warnings":[]}`,
+    }));
+    const result = await provider.query("SELECT id, note FROM memory.fix.t ORDER BY note");
+
+    expect(result.rows).toEqual([
+      { id: "9223372036854775807", note: "max" },
+      { id: "-9223372036854775808", note: "min" },
+      // A double holds 42 exactly, so nothing touches it: the rewrite is keyed on
+      // the digits, not on the column's declared type.
+      { id: 42, note: "safe" },
+    ]);
+    expect(result.columnTypes).toEqual({ id: "bigint", note: "varchar" });
+  });
+
   test("counts the rows a statement changed when it returned none", async () => {
     const provider = await connectProvider();
     overrideSurface("INSERT", (id) => ({

--- a/tests/unit/db/trino/http-transport.test.ts
+++ b/tests/unit/db/trino/http-transport.test.ts
@@ -215,6 +215,21 @@ const TYPED_PAGE =
   '"data":[[1,"1.5","x","2020-01-01","2020-01-01 10:00:00.000",null,[1,2],{"k":"v"},[1,"a"],"1.23",true,"AQI="]],' +
   `"stats":${FINISHED_STATS},"warnings":[]}`;
 
+/**
+ * `SELECT CAST(9223372036854775807 AS BIGINT) hi, CAST(-9223372036854775807 AS BIGINT) - 1 lo,
+ * 42 safe, CAST(1.5 AS DOUBLE) d`, captured 2026-08-22.
+ *
+ * The two wide values are the BIGINT range's own endpoints, which is where the
+ * rounding shows; `safe` and `d` are here to prove the pass leaves everything it
+ * does not have to touch alone. The declaration is verbatim too, because it is the
+ * proof that the server called these `bigint` and still sent them UNQUOTED.
+ */
+const WIDE_INTEGER_PAGE =
+  `{"id":"${QUERY_ID}","columns":[{"name":"hi","type":"bigint"},{"name":"lo","type":"bigint"},` +
+  '{"name":"safe","type":"integer"},{"name":"d","type":"double"}],' +
+  '"data":[[9223372036854775807,-9223372036854775808,42,1.5]],' +
+  `"stats":${FINISHED_STATS},"warnings":[]}`;
+
 /** `SELEKT 1`. HTTP 200, `state: FAILED`, the fault inside the document. */
 const SYNTAX_FAILURE_PAGE =
   `{"id":"${QUERY_ID}","infoUri":"${INFO_URI}","stats":${FAILED_STATS},"error":{"message":` +
@@ -620,6 +635,34 @@ describe("TrinoHttpTransport result", () => {
     });
     expect(result.columnTypes?.dec).toBe("decimal(3, 2)");
     expect(result.columnTypes?.r).toBe("row(x integer, y varchar)");
+  });
+
+  /**
+   * A DECIMAL is safe because the server quotes it. A BIGINT is not: it arrives as
+   * an UNQUOTED JSON number, and `JSON.parse` has no exact form for an integer
+   * wider than 2^53 - it rounds one silently, with no error to catch. Measured on
+   * 2026-08-22: `9223372036854775807` written into `memory` and read back through
+   * this transport returned 9223372036854776000, so a value the database held
+   * correctly reached the grid wrong.
+   *
+   * ClickHouse escapes this with a server-side setting
+   * (`output_format_json_quote_64bit_integers`, #264) and Trino has no counterpart,
+   * which leaves the raw text as the only place to fix it - the same position Druid
+   * is in, and the reason `quoteUnsafeIntegers` (#265) lives in `db/utils` rather
+   * than inside one provider. Both endpoints come back as STRINGS for that reason;
+   * anything a double can hold exactly is left as a number.
+   */
+  test("keeps a 64-bit integer exact instead of letting JSON.parse round it", async () => {
+    sequence(WIDE_INTEGER_PAGE);
+
+    const result = await makeTransport().query("SELECT ...");
+
+    expect(result.rows[0]).toEqual({
+      hi: "9223372036854775807",
+      lo: "-9223372036854775808",
+      safe: 42,
+      d: 1.5,
+    });
   });
 
   test("reports the coordinator's own execution numbers", async () => {


### PR DESCRIPTION
## What was wrong

A `bigint` arrives from the Trino client protocol as an **unquoted JSON number**. `JSON.parse` has no exact form for an integer wider than 2^53: it rounds one silently, with no error to catch.

Measured on 2026-08-22 against a live `trinodb/trino:476`, writing into `memory` and reading back through the provider:

| written | returned before this change |
| --- | --- |
| `9223372036854775807` | `9223372036854776000` |

A row the database held correctly reached the caller wrong, and nothing downstream could tell it had happened. Any 64-bit id is affected: snowflake ids, hashes, nanosecond stamps, large counters.

## Why it was only Trino

The repo already knows this failure mode in two places:

* ClickHouse escapes it server-side with `output_format_json_quote_64bit_integers` (#264).
* Druid has no such setting, so it rewrites the raw body with `quoteUnsafeIntegers` (#265), which lives in `db/utils` precisely because it is not Druid-specific.

Trino has no such setting either and was using neither mechanism.

## The change

`parseJson` in the Trino transport now runs `quoteUnsafeIntegers` over the page before parsing it. Both endpoints of the BIGINT range come back as strings, and anything a double holds exactly is left a number:

```
before: [[9223372036854776000,-9223372036854776000,42,1.5]]
after:  [["9223372036854775807","-9223372036854775808",42,1.5]]
```

The pass covers the whole envelope rather than `data` alone, because at that point the body is one JSON text and splitting it would mean parsing it twice. The bounded cost is stated in the provider doc: a `stats` counter above 2^53 would arrive as a string and read as absent, which needs `processedBytes` past 9 PB in a single statement. An absent statistic is recoverable, a rounded `bigint` in a result row is not.

## Tests

Two, and both fail without the change (verified by reverting the one line):

* `tests/unit/db/trino/http-transport.test.ts` at the seam.
* `tests/integration/db/trino-provider.test.ts` through the provider.

The integration fixture is **verbatim text** rather than a `page()` call on purpose: `page()` runs `JSON.stringify`, which would round both endpoints while building the fixture, and a test written the ordinary way there would pass while proving nothing. Both payloads were captured from live Trino 476 on 2026-08-22.

Live confirmation after the change, same write and read:

```
[{"id":"9223372036854775807","note":"max"},
 {"id":"-9223372036854775808","note":"min"},
 {"id":42,"note":"safe"}]
```

Table statistics and the overview panel are unaffected.

## Docs

`docs/providers/trino.md` section 3.11 gains the `bigint` row, the measurement, and the stated cost. That section claimed "Nothing is re-interpreted", which now has one declared exception, so the sentence was corrected rather than left standing.

## Checks

`format`, `lint`, `typecheck`, `knip`, `test` (33 groups), `build` all pass locally, and coverage stays at 100% (40725/40725 lines).