### PR TITLE
fix(ssh): the two routes that connect outside the caches never opened the tunnel (#457)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -478,6 +478,31 @@ Cassandra fixture does not close it.
 `e2e/cassandra-provider.spec.ts` exists or a written reason it cannot exist is recorded here.
 ---
 
+### D11. The SSH tunnel accepts any host key it is offered
+
+`createSSHTunnel` (`src/lib/ssh/tunnel.ts`) builds `connectOptions` from host, port, username and
+one of password or private key, and passes no `hostVerifier`. ssh2 has no default: with the callback
+absent the library does not verify the server's key at all, so the tunnel completes against whatever
+answers on that address. Every byte the tunnel carries - the database password among them - is
+readable to anything that can occupy the bastion's address, and nothing in the product ever shows a
+fingerprint the user could have compared.
+
+This is the layer where the check belongs and the only one that can do it: the database driver sees
+`127.0.0.1` and a local port, so its own TLS settings say nothing about who terminated the SSH hop.
+Found while fixing #457 and deliberately kept out of that PR: the fix there is about whether the
+tunnel is opened at all, and a verification policy is a separate decision with a UI consequence.
+
+The open decision is what to do on first contact, since Studio has no known-hosts store: refuse
+unknown keys and require the expected fingerprint to be configured (safe, and unusable until someone
+pastes a fingerprint), or trust-on-first-use pinned per connection (usable, and only as good as the
+first connection was). `SSHTunnelConfig` in `src/lib/types.ts` would carry the pin either way, which
+puts it in the storage secret walk in `src/lib/storage/connection-secrets.ts`.
+
+**Done when:** a tunnel verifies the bastion's host key against something the connection carries, an
+unverifiable key fails the connection with an error naming the fingerprint it saw, and the chosen
+first-contact policy is written in `docs/providers/`-adjacent documentation the dialog can point to.
+---
+
 
 ## Value interpolation
 

--- a/src/app/api/db/provider-meta/route.ts
+++ b/src/app/api/db/provider-meta/route.ts
@@ -38,6 +38,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Valid connection configuration is required" }, { status: 400 });
     }
 
+    // No `withOneShotTunnel` here, unlike test-connection and schema-snapshot (#457):
+    // this route never calls connect(). Capabilities and labels are type-driven and read
+    // off the constructed provider without a socket, so there is nothing to tunnel.
     const provider = await createDatabaseProvider(connection);
 
     return NextResponse.json({

--- a/src/app/api/db/schema-snapshot/route.ts
+++ b/src/app/api/db/schema-snapshot/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createDatabaseProvider } from "@/lib/db/factory";
+import { createDatabaseProvider, withOneShotTunnel } from "@/lib/db/factory";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { guardRoute } from "@/lib/api/require-session";
 
 export async function POST(request: NextRequest) {
-  let provider = null;
-
   // Moved ahead of request.json(): an unauthenticated caller no longer gets a body parsed on its
   // behalf, and the rate limiter sees the request before any work is done for it.
   const guard = await guardRoute({ route: "POST /api/db/schema-snapshot", bucket: "query", request });
@@ -17,30 +15,41 @@ export async function POST(request: NextRequest) {
 
     const connection = await resolveConnection(body, guard.session);
 
-    provider = await createDatabaseProvider(connection);
-    await provider.connect();
+    // Through the tunnel, never around it (#457): the grounding capture reads its
+    // schema here, and this route builds its provider outside both provider caches,
+    // so the tunnel is its own to open and close. See `withOneShotTunnel`.
+    return await withOneShotTunnel(connection, async (effective) => {
+      // Declared inside the scope so the provider is always torn down before the
+      // tunnel it runs over.
+      let provider = null;
+      try {
+        provider = await createDatabaseProvider(effective);
+        await provider.connect();
 
-    const schema = await provider.getSchema();
+        const schema = await provider.getSchema();
 
-    await provider.disconnect();
-    provider = null;
+        await provider.disconnect();
+        provider = null;
 
-    return NextResponse.json({
-      schema,
-      connectionId: connection.id,
-      connectionName: connection.name,
-      databaseType: connection.type,
-      timestamp: new Date().toISOString(),
+        return NextResponse.json({
+          schema,
+          connectionId: connection.id,
+          connectionName: connection.name,
+          databaseType: connection.type,
+          timestamp: new Date().toISOString(),
+        });
+      } finally {
+        // Only reached when the block above threw before its own disconnect.
+        if (provider) {
+          try {
+            await provider.disconnect();
+          } catch {
+            /* ignore */
+          }
+        }
+      }
     });
   } catch (error) {
-    if (provider) {
-      try {
-        await provider.disconnect();
-      } catch {
-        /* ignore */
-      }
-    }
-
     return createErrorResponse(error, { route: "api/db/schema-snapshot" });
   }
 }

--- a/src/app/api/db/test-connection/route.ts
+++ b/src/app/api/db/test-connection/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createDatabaseProvider } from "@/lib/db/factory";
+import { createDatabaseProvider, withOneShotTunnel } from "@/lib/db/factory";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { guardRoute } from "@/lib/api/require-session";
 
 export async function POST(req: NextRequest) {
-  let provider = null;
-
   // Moved ahead of req.json(): an unauthenticated caller no longer gets a body parsed on its
   // behalf, and the rate limiter sees the request before any work is done for it.
   const guard = await guardRoute({ route: "POST /api/db/test-connection", bucket: "query", request: req });
@@ -25,32 +23,44 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ success: false, error: "Connection configuration is required" }, { status: 400 });
     }
 
-    provider = await createDatabaseProvider(connection, { queryTimeout: 10000 });
-    await provider.connect();
+    // Through the tunnel, never around it (#457). This route builds its provider
+    // directly rather than through `getOrCreateProvider`, so it does not inherit that
+    // path's tunnel handling and has to ask for it. `withOneShotTunnel` owns the
+    // tunnel's whole lifetime because nothing here is cached, so no eviction would
+    // ever close a pooled one - and every failed test click would strand it.
+    return await withOneShotTunnel(connection, async (effective) => {
+      // Declared inside the scope so the provider is always torn down before the
+      // tunnel it runs over, on the success and the failure path alike.
+      let provider = null;
+      try {
+        provider = await createDatabaseProvider(effective, { queryTimeout: 10000 });
+        await provider.connect();
 
-    // Run a lightweight query to verify the connection actually works
-    const startTime = Date.now();
-    await provider.getHealth();
-    const latency = Date.now() - startTime;
+        // Run a lightweight query to verify the connection actually works
+        const startTime = Date.now();
+        await provider.getHealth();
+        const latency = Date.now() - startTime;
 
-    await provider.disconnect();
-    provider = null;
+        await provider.disconnect();
+        provider = null;
 
-    return NextResponse.json({
-      success: true,
-      message: "Connection successful",
-      latency,
+        return NextResponse.json({
+          success: true,
+          message: "Connection successful",
+          latency,
+        });
+      } finally {
+        // Only reached when the block above threw before its own disconnect.
+        if (provider) {
+          try {
+            await provider.disconnect();
+          } catch {
+            /* ignore */
+          }
+        }
+      }
     });
   } catch (error) {
-    // Ensure we disconnect on error
-    if (provider) {
-      try {
-        await provider.disconnect();
-      } catch {
-        /* ignore */
-      }
-    }
-
     return createErrorResponse(error, { route: "api/db/test-connection" });
   }
 }

--- a/src/exports/providers.ts
+++ b/src/exports/providers.ts
@@ -1,10 +1,15 @@
 // src/exports/providers.ts
 // Re-export database and LLM provider factories
+// `withOneShotTunnel` is part of the surface on purpose: `createDatabaseProvider` alone
+// does not open a connection's SSH tunnel (only the caching entry points do), so an
+// embedder that builds a provider and connects it needs the scope to reach a tunnelled
+// database at all. See its doc comment in ../lib/db/factory and issue #457.
 export {
   createDatabaseProvider,
   getOrCreateProvider,
   removeProvider,
   clearProviderCache,
   getProviderCacheStats,
+  withOneShotTunnel,
 } from "../lib/db/factory";
 export { createLLMProvider, getDefaultProvider, resetDefaultProvider } from "../lib/llm/factory";

--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -172,6 +172,10 @@ export async function driveAgentRun(runId: string): Promise<AgentInvestigationRe
     // actually runs on is acquired per call through the execution-profile seam.
     // One provider for both, so a run's declared behaviour and its declared
     // vocabulary can never come from two different readings.
+    //
+    // So no `withOneShotTunnel` wrapper here (#457): this provider is never connected.
+    // The one that runs statements comes from `acquireExecutionProfileProvider`, which
+    // opens the connection's pooled tunnel itself.
     const provider = await createDatabaseProvider(connection);
     const capabilities = provider.getCapabilities();
     const labels = provider.getLabels();

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -179,6 +179,58 @@ export async function createDatabaseProvider(
 }
 
 // ============================================================================
+// One-shot tunnel scope (#457)
+// ============================================================================
+
+/**
+ * Run `run` against a connection reachable through its SSH tunnel, then close the
+ * tunnel unconditionally.
+ *
+ * This is the transport for callers that build a provider with
+ * `createDatabaseProvider` directly - outside both provider caches - and connect it:
+ * `POST /api/db/test-connection` and `POST /api/db/schema-snapshot`. Before #457 they
+ * connected to the raw database host, so a tunnelled connection could never be tested
+ * and therefore never be saved at all (the dialog gates its only save button on a
+ * passing test), and the agent's grounding capture could not read a tunnelled schema.
+ *
+ * The tunnel is deliberately NOT pooled, unlike `getOrCreateProvider`'s. Those callers
+ * cache nothing, so nothing would ever evict a pooled tunnel: `removeProvider` and the
+ * idle sweep close the tunnel of a CACHED provider, and the connection dialog mints a
+ * fresh id for every unsaved build - so each test click would strand an SSH client and
+ * a listening local server for the life of the process. Ownership sits with this scope
+ * instead, which is why `run` is a callback rather than a returned endpoint: the close
+ * cannot be forgotten.
+ *
+ * The callback is NOT named `use`: `react-hooks/rules-of-hooks` reads a call to
+ * anything named `use()` as React 19's hook and rejects it outside a component, and
+ * inside a try block on top of that.
+ *
+ * A connection with no tunnel, or with no host and port to forward to (a
+ * connection-string connection, or SQLite), passes straight through untouched - the
+ * same rule the pooled paths apply.
+ */
+export async function withOneShotTunnel<T>(
+  connection: DatabaseConnection,
+  run: (effective: DatabaseConnection) => Promise<T>,
+): Promise<T> {
+  if (!connection.sshTunnel?.enabled || !connection.host || !connection.port) {
+    return await run(connection);
+  }
+
+  const tunnel = await createSSHTunnel(connection.id, connection.sshTunnel, connection.host, connection.port, {
+    shared: false,
+  });
+
+  try {
+    return await run({ ...connection, host: tunnel.localHost, port: tunnel.localPort });
+  } finally {
+    // Swallowed on purpose: a failing teardown must not replace the caller's error,
+    // which is the one that says why the database connection did not work.
+    await tunnel.close().catch(() => {});
+  }
+}
+
+// ============================================================================
 // Provider Cache (for connection reuse)
 // ============================================================================
 

--- a/src/lib/ssh/tunnel.ts
+++ b/src/lib/ssh/tunnel.ts
@@ -18,6 +18,22 @@ export interface TunnelInfo {
 // Cache active tunnels by connection ID
 const activeTunnels = new Map<string, TunnelInfo>();
 
+export interface CreateSSHTunnelOptions {
+  /**
+   * Whether the tunnel joins the by-connection-id pool every other provider for that
+   * connection reuses. Default true, which is the pooled lifecycle: the tunnel outlives
+   * the call, and `removeProvider` / the idle sweep close it once nothing serves the
+   * connection.
+   *
+   * `false` requests a one-shot tunnel for a caller that owns the whole lifecycle and
+   * closes it itself - the routes that build a provider outside both provider caches
+   * (test-connection, schema-snapshot). Pooling those would leak: the connection dialog
+   * mints a fresh id per build for an unsaved connection, so nothing would ever hold the
+   * id needed to close the tunnel again, and neither cache would know to evict it.
+   */
+  shared?: boolean;
+}
+
 /**
  * Create an SSH tunnel for a database connection.
  * Returns the local host/port to connect the database client to.
@@ -27,13 +43,18 @@ export async function createSSHTunnel(
   sshConfig: SSHTunnelConfig,
   remoteHost: string,
   remotePort: number,
+  options: CreateSSHTunnelOptions = {},
 ): Promise<TunnelInfo> {
+  const shared = options.shared !== false;
+
   // Return existing tunnel if already active
   // Note: cached tunnel may be stale if the SSH connection dropped silently.
   // Callers should handle connection errors and call closeSSHTunnel() to evict stale entries.
-  const existing = activeTunnels.get(connectionId);
-  if (existing) {
-    return existing;
+  if (shared) {
+    const existing = activeTunnels.get(connectionId);
+    if (existing) {
+      return existing;
+    }
   }
 
   return new Promise((resolve, reject) => {
@@ -41,7 +62,12 @@ export async function createSSHTunnel(
     let localServer: net.Server | null = null;
 
     const cleanup = async () => {
-      activeTunnels.delete(connectionId);
+      // Only a pooled tunnel owns its map entry. A one-shot tunnel may share the id of a
+      // pooled one serving live providers, and deleting that entry would orphan it: the
+      // SSH client and local server would stay open with nothing left holding a handle.
+      if (shared) {
+        activeTunnels.delete(connectionId);
+      }
       if (localServer) {
         localServer.close();
         localServer = null;
@@ -82,7 +108,9 @@ export async function createSSHTunnel(
           localPort: address.port,
           close: cleanup,
         };
-        activeTunnels.set(connectionId, tunnelInfo);
+        if (shared) {
+          activeTunnels.set(connectionId, tunnelInfo);
+        }
         logger.info(`Tunnel created for ${connectionId}: 127.0.0.1:${address.port} -> ${remoteHost}:${remotePort}`, {
           connectionId,
         });

--- a/tests/api/db/schema-snapshot.test.ts
+++ b/tests/api/db/schema-snapshot.test.ts
@@ -5,7 +5,12 @@ import { clearRateLimitState } from "@/lib/api/rate-limit";
 
 // ─── Mock provider ──────────────────────────────────────────────────────────
 const mockProvider = createMockProvider();
-const mockCreateDatabaseProvider = mock(async () => mockProvider);
+const mockCreateDatabaseProvider = mock(async (connection?: unknown) => {
+  // The parameter is declared so `mock.calls` carries the connection the route built the
+  // provider from - that argument is what proves the SSH tunnel endpoint was used (#457).
+  void connection;
+  return mockProvider;
+});
 
 const mockGetSession = mock(
   async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
@@ -42,9 +47,17 @@ mock.module("@/lib/seed/resolve-connection", () => {
 });
 
 // ─── Mock @/lib/db/factory BEFORE importing the route ───────────────────────
+// Pass-through stand-in for the real scope, which opens an unshared SSH tunnel and
+// rewrites host/port to its local endpoint (#457).
+const mockWithOneShotTunnel = mock(
+  async (connection: Record<string, unknown>, run: (c: Record<string, unknown>) => Promise<unknown>) =>
+    await run({ ...connection, host: "127.0.0.1", port: 54321 }),
+);
+
 mock.module("@/lib/db/factory", () => ({
   getOrCreateProvider: mock(async () => mockProvider),
   createDatabaseProvider: mockCreateDatabaseProvider,
+  withOneShotTunnel: mockWithOneShotTunnel,
 }));
 
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
@@ -188,5 +201,32 @@ describe("POST /api/db/schema-snapshot", () => {
     expect(res.status).toBe(500);
     // disconnect should have been called in the catch block
     expect(mockProvider.disconnect).toHaveBeenCalled();
+  });
+
+  // ─── SSH tunnel (#457) ────────────────────────────────────────────────────
+  // The agent's grounding capture reads its schema here. Like test-connection this
+  // route builds its provider outside both caches, so it needs the tunnel scope
+  // explicitly - otherwise a tunnelled connection has no readable schema at all.
+
+  test("reads the schema through the connection's SSH tunnel rather than the raw host", async () => {
+    mockWithOneShotTunnel.mockClear();
+    mockCreateDatabaseProvider.mockClear();
+
+    const req = createMockRequest("/api/db/schema-snapshot", {
+      method: "POST",
+      body: {
+        connection: {
+          ...validConnection,
+          host: "db.internal",
+          sshTunnel: { enabled: true, host: "bastion", port: 22, username: "jump", authMethod: "password" },
+        },
+      },
+    });
+
+    await POST(req as never);
+
+    expect(mockWithOneShotTunnel).toHaveBeenCalledTimes(1);
+    expect(mockWithOneShotTunnel.mock.calls[0]?.[0]).toMatchObject({ host: "db.internal" });
+    expect(mockCreateDatabaseProvider.mock.calls[0]?.[0]).toMatchObject({ host: "127.0.0.1", port: 54321 });
   });
 });

--- a/tests/api/db/test-connection.test.ts
+++ b/tests/api/db/test-connection.test.ts
@@ -6,7 +6,12 @@ import { clearRateLimitState } from "@/lib/api/rate-limit";
 
 // ─── Create mock objects ────────────────────────────────────────────────────
 const mockProvider = createMockProvider();
-const mockCreateDatabaseProvider = mock(async () => mockProvider);
+const mockCreateDatabaseProvider = mock(async (connection?: unknown) => {
+  // The parameter is declared so `mock.calls` carries the connection the route built the
+  // provider from - that argument is what proves the SSH tunnel endpoint was used (#457).
+  void connection;
+  return mockProvider;
+});
 
 const mockGetSession = mock(
   async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
@@ -42,9 +47,26 @@ mock.module("@/lib/seed/resolve-connection", () => {
   };
 });
 
+// The real scope opens an unshared SSH tunnel and rewrites host/port to its local
+// endpoint. Standing in for it with a pass-through that performs that rewrite is what
+// lets these tests assert the route connects THROUGH the tunnel rather than around it
+// (#457). `disconnectsAtScopeExit` records how many disconnect() calls had happened by
+// the time the scope was about to close its tunnel - the ordering the route must honour.
+let disconnectsAtScopeExit = -1;
+const mockWithOneShotTunnel = mock(
+  async (connection: Record<string, unknown>, run: (c: Record<string, unknown>) => Promise<unknown>) => {
+    try {
+      return await run({ ...connection, host: "127.0.0.1", port: 54321 });
+    } finally {
+      disconnectsAtScopeExit = (mockProvider.disconnect as ReturnType<typeof mock>).mock.calls.length;
+    }
+  },
+);
+
 // ─── Mock dependencies BEFORE importing route ───────────────────────────────
 mock.module("@/lib/db/factory", () => ({
   createDatabaseProvider: mockCreateDatabaseProvider,
+  withOneShotTunnel: mockWithOneShotTunnel,
   getOrCreateProvider: mock(async () => mockProvider),
   removeProvider: mock(async () => {}),
   clearProviderCache: mock(async () => {}),
@@ -69,6 +91,8 @@ describe("POST /api/db/test-connection", () => {
   beforeEach(() => {
     clearRateLimitState();
     mockCreateDatabaseProvider.mockClear();
+    mockWithOneShotTunnel.mockClear();
+    disconnectsAtScopeExit = -1;
     (mockProvider.connect as ReturnType<typeof mock>).mockClear();
     (mockProvider.disconnect as ReturnType<typeof mock>).mockClear();
     (mockProvider.getHealth as ReturnType<typeof mock>).mockClear();
@@ -209,5 +233,57 @@ describe("POST /api/db/test-connection", () => {
 
     expect(mockProvider.connect).toHaveBeenCalledTimes(1);
     expect(mockProvider.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── SSH tunnel (#457) ────────────────────────────────────────────────────
+  // This route builds its provider with createDatabaseProvider, outside both provider
+  // caches, so it does not inherit the tunnel handling the cached paths have. Until
+  // #457 it connected to the raw database host: a tunnelled connection could never be
+  // tested, and because the dialog gates its only save button on a passing test, never
+  // be saved either.
+
+  test("connects through the connection's SSH tunnel rather than to the raw host", async () => {
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: {
+        ...validConnection,
+        host: "db.internal",
+        sshTunnel: { enabled: true, host: "bastion", port: 22, username: "jump", authMethod: "password" },
+      },
+    });
+
+    await POST(req as never);
+
+    expect(mockWithOneShotTunnel).toHaveBeenCalledTimes(1);
+    expect(mockWithOneShotTunnel.mock.calls[0]?.[0]).toMatchObject({ host: "db.internal" });
+    expect(mockCreateDatabaseProvider.mock.calls[0]?.[0]).toMatchObject({ host: "127.0.0.1", port: 54321 });
+  });
+
+  test("disconnects the provider before the tunnel scope tears the tunnel down", async () => {
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: validConnection,
+    });
+
+    await POST(req as never);
+
+    // Closing the tunnel under a still-connected provider would leave the driver
+    // shutting down a socket whose transport is already gone.
+    expect(disconnectsAtScopeExit).toBe(1);
+  });
+
+  test("disconnects the provider inside the tunnel scope when the health check fails", async () => {
+    (mockProvider.getHealth as ReturnType<typeof mock>).mockImplementation(async () => {
+      throw new Error("Health check failed");
+    });
+
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: validConnection,
+    });
+
+    await POST(req as never);
+
+    expect(disconnectsAtScopeExit).toBe(1);
   });
 });

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -274,6 +274,7 @@ const {
   registerShutdownHandlers,
   acquireExecutionProfileProvider,
   getExecutionProfileCacheStats,
+  withOneShotTunnel,
 } = await import("@/lib/db/factory");
 if (nodeEnvBefore === undefined) {
   delete (process.env as Record<string, string>).NODE_ENV;
@@ -1247,5 +1248,133 @@ describe("acquireExecutionProfileProvider", () => {
       expect((error as ExecutionProfileError).reasonCode).toBe("PROFILE_UNSUPPORTED_TARGET");
       expect(getExecutionProfileCacheStats().size).toBe(0);
     });
+  });
+});
+
+// ============================================================================
+// One-shot tunnel scope (#457)
+// ----------------------------------------------------------------------------
+// The routes that build a provider outside both caches - test-connection and
+// schema-snapshot - reach the database through here. Every assertion below is
+// about lifecycle rather than transport: the tunnel must be unshared, and it
+// must close on every exit path, because no cache eviction will ever do it.
+// ============================================================================
+
+describe("withOneShotTunnel", () => {
+  // `mockHasTunnel` is not reset by the file-level beforeEach, and one assertion below
+  // is that this scope never consults the shared pool - a negative that only means
+  // anything against a counter this describe owns.
+  beforeEach(() => {
+    mockHasTunnel.mockClear();
+  });
+
+  const tunnelled = () =>
+    makeConnection("postgres", {
+      id: "one-shot-conn",
+      host: "db.internal",
+      port: 5432,
+      sshTunnel: {
+        enabled: true,
+        host: "bastion.example.com",
+        port: 22,
+        username: "jump",
+        authMethod: "password",
+        password: "pw",
+      },
+    });
+
+  const closeOf = async (call: number) =>
+    ((await mockCreateSSHTunnel.mock.results[call]?.value) as { close: ReturnType<typeof mock> } | undefined)?.close;
+
+  test("runs the callback against the local tunnel endpoint", async () => {
+    const seen: Array<{ host?: string; port?: number }> = [];
+
+    const result = await withOneShotTunnel(tunnelled(), async (effective) => {
+      seen.push({ host: effective.host, port: effective.port });
+      return "done";
+    });
+
+    expect(result).toBe("done");
+    expect(seen).toEqual([{ host: "127.0.0.1", port: 54321 }]);
+    expect(mockCreateSSHTunnel).toHaveBeenCalledTimes(1);
+  });
+
+  test("asks for an unshared tunnel so nothing pools it under the connection id", async () => {
+    await withOneShotTunnel(tunnelled(), async () => undefined);
+
+    expect(mockCreateSSHTunnel).toHaveBeenCalledWith(
+      "one-shot-conn",
+      expect.objectContaining({ host: "bastion.example.com" }),
+      "db.internal",
+      5432,
+      { shared: false },
+    );
+    // The shared pool is never consulted: a one-shot scope must not adopt, or be
+    // mistaken for, the tunnel serving a cached provider of the same connection.
+    expect(mockHasTunnel).not.toHaveBeenCalled();
+  });
+
+  test("closes the tunnel after the callback succeeds", async () => {
+    await withOneShotTunnel(tunnelled(), async () => undefined);
+
+    expect(await closeOf(0)).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes the tunnel and rethrows when the callback fails", async () => {
+    await expect(
+      withOneShotTunnel(tunnelled(), async () => {
+        throw new Error("connect refused");
+      }),
+    ).rejects.toThrow("connect refused");
+
+    expect(await closeOf(0)).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates the callback failure even when closing the tunnel throws", async () => {
+    mockCreateSSHTunnel.mockImplementationOnce(async () => ({
+      localHost: "127.0.0.1",
+      localPort: 54321,
+      close: mock(async () => {
+        throw new Error("close failed");
+      }),
+    }));
+
+    await expect(
+      withOneShotTunnel(tunnelled(), async () => {
+        throw new Error("connect refused");
+      }),
+    ).rejects.toThrow("connect refused");
+  });
+
+  test("opens no tunnel when the connection has none configured", async () => {
+    const plain = makeConnection("postgres", { id: "no-tunnel-conn" });
+
+    const seen = await withOneShotTunnel(plain, async (effective) => effective);
+
+    expect(mockCreateSSHTunnel).not.toHaveBeenCalled();
+    expect(seen).toBe(plain);
+  });
+
+  test("opens no tunnel when the SSH config is present but disabled", async () => {
+    const off = tunnelled();
+    off.sshTunnel!.enabled = false;
+
+    await withOneShotTunnel(off, async (effective) => {
+      expect(effective.host).toBe("db.internal");
+    });
+
+    expect(mockCreateSSHTunnel).not.toHaveBeenCalled();
+  });
+
+  test("opens no tunnel for a connection with no host and port to forward to", async () => {
+    // A connection-string connection (MongoDB, Couchbase, ClickHouse) and SQLite carry
+    // neither, so there is no endpoint to rewrite - the same rule the pooled paths apply.
+    const stringOnly = tunnelled();
+    delete stringOnly.host;
+    delete stringOnly.port;
+
+    await withOneShotTunnel(stringOnly, async () => undefined);
+
+    expect(mockCreateSSHTunnel).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/ssh-tunnel.test.ts
+++ b/tests/unit/ssh-tunnel.test.ts
@@ -258,6 +258,111 @@ describe("SSH Tunnel", () => {
       expect(tunnel2.localPort).toBe(tunnel1.localPort);
     });
 
+    // A one-shot tunnel (`shared: false`) is the transport for the routes that build a
+    // provider outside the caches - test-connection and schema-snapshot. Those carry a
+    // connection id that is thrown away (the connection dialog mints a fresh one per
+    // build), so a cached tunnel under that id would never be evicted by anything:
+    // `removeProvider` and the idle sweep only close tunnels of CACHED providers. Hence
+    // the three invariants below - never read the cache, never write it, and never let
+    // closing an unshared tunnel evict the shared entry that happens to share its id.
+    test("does not reuse the shared tunnel when shared is false", async () => {
+      const connId = "test-oneshot-nocache-" + Date.now();
+      lastConnectionId = connId;
+
+      const shared = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+      );
+
+      const oneShot = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+        { shared: false },
+      );
+
+      expect(oneShot).not.toBe(shared);
+    });
+
+    test("does not register a one-shot tunnel in the active map", async () => {
+      const connId = "test-oneshot-unregistered-" + Date.now();
+
+      const oneShot = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+        { shared: false },
+      );
+
+      expect(hasTunnel(connId)).toBe(false);
+      expect(getTunnelInfo(connId)).toBeUndefined();
+
+      await oneShot.close();
+    });
+
+    test("closing a one-shot tunnel leaves the shared tunnel of the same id registered", async () => {
+      const connId = "test-oneshot-noevict-" + Date.now();
+      lastConnectionId = connId;
+
+      const shared = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+      );
+
+      const oneShot = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+        { shared: false },
+      );
+      await oneShot.close();
+
+      expect(hasTunnel(connId)).toBe(true);
+      expect(getTunnelInfo(connId)).toBe(shared);
+    });
+
     test("rejects on SSH connection error", async () => {
       const connId = "test-ssherr-" + Date.now();
       lastConnectionId = connId;


### PR DESCRIPTION
Fixes #457.

## The bug

`createDatabaseProvider` is a plain provider switch with no tunnel handling. The SSH tunnel is opened by the two **caching** entry points only — `getOrCreateProvider` and `acquireExecutionProfileProvider` — so the two routes that build a provider directly and then connect it went straight to the raw database host:

| Route | Connects? | Tunnel before this PR |
| --- | --- | --- |
| `POST /api/db/test-connection` | yes | none — the reported bug |
| `POST /api/db/schema-snapshot` | yes | none — unreported; the agent's grounding capture reads here |
| `POST /api/db/provider-meta` | no | not needed |
| `lib/agent/runtime.ts` capability read | no | not needed |

The reporter saw `connect ETIMEDOUT` with no `Tunnel created` log line. The consequence is larger than a misleading error: `ConnectionModal`'s only save button (`handleConnect`) runs the same test and saves nothing unless it passes, so **a tunnelled connection could not be saved at all**, and a tunnelled schema could not be captured for plan mode.

## Not fixed, because it is not broken

The issue also asks to stop mapping the driver error to a generic `ETIMEDOUT`. Nothing maps it. `MySQLProvider.connect` passes `error.message` through verbatim — `ETIMEDOUT` was the true mysql2 result of connecting to an unreachable private address, and it becomes the real error (auth, refused, …) once the tunnel is applied. Changing that error path would have broken a correct one.

## Why a new seam rather than a third copy

The pooled tunnel and a one-shot tunnel have **opposite lifecycles**, so copying the pooled block into these routes would have traded the bug for a resource leak:

- `activeTunnels` is keyed by connection id, and a pooled tunnel is closed only by `removeProvider` or the idle sweep — both of which act on a **cached** provider.
- These routes cache nothing, and `use-connection-form` mints a fresh `newLocalId()` for every unsaved build. A pooled tunnel here would be closed by nothing: every failed test click would strand an SSH client and a listening local server for the life of the process.

So `withOneShotTunnel` owns the whole lifetime instead:

- `createSSHTunnel(..., { shared: false })` — never reads the pool, never writes it.
- A **callback** rather than a returned endpoint, so the close cannot be forgotten.
- A guard in `cleanup`: closing an unshared tunnel no longer deletes the pooled entry that happens to share its connection id. That was a real latent bug — a test click would have orphaned the tunnel serving live providers. It has its own test.
- The provider is disconnected **inside** the scope on every path, so the driver never shuts a socket down over a transport that is already gone.

`provider-meta` and `agent/runtime` keep calling `createDatabaseProvider` bare and now state why. `withOneShotTunnel` joins the published package surface for the same reason the routes need it: an embedder that builds a provider and connects it cannot otherwise reach a tunnelled database.

## Verification

`format` · `lint` (0 errors) · `typecheck` · `knip` · `test` (33 groups) · `build` · `build:lib` · `attw` all pass, and `coverage:check` reports **40752/40752 lines (100.00%)**.

**Not verified here: a live bastion.** These tests mock `ssh2`, exactly as the pre-existing tunnel tests do — which is why this class of defect shipped in the first place. Fifteen green tunnel tests all exercised the two paths that already had the code; 100% line coverage cannot measure a behaviour that is absent. A live `sshd` + private-network MySQL probe is running separately, and the reporter has offered to check the branch image against their own jump host.

## Deliberately out of scope

`docs/BACKLOG.md` **D11**: `createSSHTunnel` passes no `hostVerifier`, so the tunnel accepts any host key the bastion offers — the database password included. Found while fixing this, kept out: whether the tunnel opens at all and what policy verifies the far end are separate decisions, and the second one has a UI consequence.
