### PR TITLE
test(db): pin the tunnel boundary as a rule, not two more tests (#457)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -478,6 +478,31 @@ Cassandra fixture does not close it.
 `e2e/cassandra-provider.spec.ts` exists or a written reason it cannot exist is recorded here.
 ---
 
+### D11. The SSH tunnel accepts any host key it is offered
+
+`createSSHTunnel` (`src/lib/ssh/tunnel.ts`) builds `connectOptions` from host, port, username and
+one of password or private key, and passes no `hostVerifier`. ssh2 has no default: with the callback
+absent the library does not verify the server's key at all, so the tunnel completes against whatever
+answers on that address. Every byte the tunnel carries - the database password among them - is
+readable to anything that can occupy the bastion's address, and nothing in the product ever shows a
+fingerprint the user could have compared.
+
+This is the layer where the check belongs and the only one that can do it: the database driver sees
+`127.0.0.1` and a local port, so its own TLS settings say nothing about who terminated the SSH hop.
+Found while fixing #457 and deliberately kept out of that PR: the fix there is about whether the
+tunnel is opened at all, and a verification policy is a separate decision with a UI consequence.
+
+The open decision is what to do on first contact, since Studio has no known-hosts store: refuse
+unknown keys and require the expected fingerprint to be configured (safe, and unusable until someone
+pastes a fingerprint), or trust-on-first-use pinned per connection (usable, and only as good as the
+first connection was). `SSHTunnelConfig` in `src/lib/types.ts` would carry the pin either way, which
+puts it in the storage secret walk in `src/lib/storage/connection-secrets.ts`.
+
+**Done when:** a tunnel verifies the bastion's host key against something the connection carries, an
+unverifiable key fails the connection with an error naming the fingerprint it saw, and the chosen
+first-contact policy is written in `docs/providers/`-adjacent documentation the dialog can point to.
+---
+
 
 ## Value interpolation
 

--- a/src/app/api/db/provider-meta/route.ts
+++ b/src/app/api/db/provider-meta/route.ts
@@ -38,6 +38,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Valid connection configuration is required" }, { status: 400 });
     }
 
+    // No `withOneShotTunnel` here, unlike test-connection and schema-snapshot (#457):
+    // this route never calls connect(). Capabilities and labels are type-driven and read
+    // off the constructed provider without a socket, so there is nothing to tunnel.
     const provider = await createDatabaseProvider(connection);
 
     return NextResponse.json({

--- a/src/app/api/db/schema-snapshot/route.ts
+++ b/src/app/api/db/schema-snapshot/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createDatabaseProvider } from "@/lib/db/factory";
+import { createDatabaseProvider, withOneShotTunnel } from "@/lib/db/factory";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { guardRoute } from "@/lib/api/require-session";
 
 export async function POST(request: NextRequest) {
-  let provider = null;
-
   // Moved ahead of request.json(): an unauthenticated caller no longer gets a body parsed on its
   // behalf, and the rate limiter sees the request before any work is done for it.
   const guard = await guardRoute({ route: "POST /api/db/schema-snapshot", bucket: "query", request });
@@ -17,30 +15,41 @@ export async function POST(request: NextRequest) {
 
     const connection = await resolveConnection(body, guard.session);
 
-    provider = await createDatabaseProvider(connection);
-    await provider.connect();
+    // Through the tunnel, never around it (#457): the grounding capture reads its
+    // schema here, and this route builds its provider outside both provider caches,
+    // so the tunnel is its own to open and close. See `withOneShotTunnel`.
+    return await withOneShotTunnel(connection, async (effective) => {
+      // Declared inside the scope so the provider is always torn down before the
+      // tunnel it runs over.
+      let provider = null;
+      try {
+        provider = await createDatabaseProvider(effective);
+        await provider.connect();
 
-    const schema = await provider.getSchema();
+        const schema = await provider.getSchema();
 
-    await provider.disconnect();
-    provider = null;
+        await provider.disconnect();
+        provider = null;
 
-    return NextResponse.json({
-      schema,
-      connectionId: connection.id,
-      connectionName: connection.name,
-      databaseType: connection.type,
-      timestamp: new Date().toISOString(),
+        return NextResponse.json({
+          schema,
+          connectionId: connection.id,
+          connectionName: connection.name,
+          databaseType: connection.type,
+          timestamp: new Date().toISOString(),
+        });
+      } finally {
+        // Only reached when the block above threw before its own disconnect.
+        if (provider) {
+          try {
+            await provider.disconnect();
+          } catch {
+            /* ignore */
+          }
+        }
+      }
     });
   } catch (error) {
-    if (provider) {
-      try {
-        await provider.disconnect();
-      } catch {
-        /* ignore */
-      }
-    }
-
     return createErrorResponse(error, { route: "api/db/schema-snapshot" });
   }
 }

--- a/src/app/api/db/test-connection/route.ts
+++ b/src/app/api/db/test-connection/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createDatabaseProvider } from "@/lib/db/factory";
+import { createDatabaseProvider, withOneShotTunnel } from "@/lib/db/factory";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { guardRoute } from "@/lib/api/require-session";
 
 export async function POST(req: NextRequest) {
-  let provider = null;
-
   // Moved ahead of req.json(): an unauthenticated caller no longer gets a body parsed on its
   // behalf, and the rate limiter sees the request before any work is done for it.
   const guard = await guardRoute({ route: "POST /api/db/test-connection", bucket: "query", request: req });
@@ -25,32 +23,44 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ success: false, error: "Connection configuration is required" }, { status: 400 });
     }
 
-    provider = await createDatabaseProvider(connection, { queryTimeout: 10000 });
-    await provider.connect();
+    // Through the tunnel, never around it (#457). This route builds its provider
+    // directly rather than through `getOrCreateProvider`, so it does not inherit that
+    // path's tunnel handling and has to ask for it. `withOneShotTunnel` owns the
+    // tunnel's whole lifetime because nothing here is cached, so no eviction would
+    // ever close a pooled one - and every failed test click would strand it.
+    return await withOneShotTunnel(connection, async (effective) => {
+      // Declared inside the scope so the provider is always torn down before the
+      // tunnel it runs over, on the success and the failure path alike.
+      let provider = null;
+      try {
+        provider = await createDatabaseProvider(effective, { queryTimeout: 10000 });
+        await provider.connect();
 
-    // Run a lightweight query to verify the connection actually works
-    const startTime = Date.now();
-    await provider.getHealth();
-    const latency = Date.now() - startTime;
+        // Run a lightweight query to verify the connection actually works
+        const startTime = Date.now();
+        await provider.getHealth();
+        const latency = Date.now() - startTime;
 
-    await provider.disconnect();
-    provider = null;
+        await provider.disconnect();
+        provider = null;
 
-    return NextResponse.json({
-      success: true,
-      message: "Connection successful",
-      latency,
+        return NextResponse.json({
+          success: true,
+          message: "Connection successful",
+          latency,
+        });
+      } finally {
+        // Only reached when the block above threw before its own disconnect.
+        if (provider) {
+          try {
+            await provider.disconnect();
+          } catch {
+            /* ignore */
+          }
+        }
+      }
     });
   } catch (error) {
-    // Ensure we disconnect on error
-    if (provider) {
-      try {
-        await provider.disconnect();
-      } catch {
-        /* ignore */
-      }
-    }
-
     return createErrorResponse(error, { route: "api/db/test-connection" });
   }
 }

--- a/src/exports/providers.ts
+++ b/src/exports/providers.ts
@@ -1,10 +1,15 @@
 // src/exports/providers.ts
 // Re-export database and LLM provider factories
+// `withOneShotTunnel` is part of the surface on purpose: `createDatabaseProvider` alone
+// does not open a connection's SSH tunnel (only the caching entry points do), so an
+// embedder that builds a provider and connects it needs the scope to reach a tunnelled
+// database at all. See its doc comment in ../lib/db/factory and issue #457.
 export {
   createDatabaseProvider,
   getOrCreateProvider,
   removeProvider,
   clearProviderCache,
   getProviderCacheStats,
+  withOneShotTunnel,
 } from "../lib/db/factory";
 export { createLLMProvider, getDefaultProvider, resetDefaultProvider } from "../lib/llm/factory";

--- a/src/lib/agent/runtime.ts
+++ b/src/lib/agent/runtime.ts
@@ -172,6 +172,10 @@ export async function driveAgentRun(runId: string): Promise<AgentInvestigationRe
     // actually runs on is acquired per call through the execution-profile seam.
     // One provider for both, so a run's declared behaviour and its declared
     // vocabulary can never come from two different readings.
+    //
+    // So no `withOneShotTunnel` wrapper here (#457): this provider is never connected.
+    // The one that runs statements comes from `acquireExecutionProfileProvider`, which
+    // opens the connection's pooled tunnel itself.
     const provider = await createDatabaseProvider(connection);
     const capabilities = provider.getCapabilities();
     const labels = provider.getLabels();

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -179,6 +179,58 @@ export async function createDatabaseProvider(
 }
 
 // ============================================================================
+// One-shot tunnel scope (#457)
+// ============================================================================
+
+/**
+ * Run `run` against a connection reachable through its SSH tunnel, then close the
+ * tunnel unconditionally.
+ *
+ * This is the transport for callers that build a provider with
+ * `createDatabaseProvider` directly - outside both provider caches - and connect it:
+ * `POST /api/db/test-connection` and `POST /api/db/schema-snapshot`. Before #457 they
+ * connected to the raw database host, so a tunnelled connection could never be tested
+ * and therefore never be saved at all (the dialog gates its only save button on a
+ * passing test), and the agent's grounding capture could not read a tunnelled schema.
+ *
+ * The tunnel is deliberately NOT pooled, unlike `getOrCreateProvider`'s. Those callers
+ * cache nothing, so nothing would ever evict a pooled tunnel: `removeProvider` and the
+ * idle sweep close the tunnel of a CACHED provider, and the connection dialog mints a
+ * fresh id for every unsaved build - so each test click would strand an SSH client and
+ * a listening local server for the life of the process. Ownership sits with this scope
+ * instead, which is why `run` is a callback rather than a returned endpoint: the close
+ * cannot be forgotten.
+ *
+ * The callback is NOT named `use`: `react-hooks/rules-of-hooks` reads a call to
+ * anything named `use()` as React 19's hook and rejects it outside a component, and
+ * inside a try block on top of that.
+ *
+ * A connection with no tunnel, or with no host and port to forward to (a
+ * connection-string connection, or SQLite), passes straight through untouched - the
+ * same rule the pooled paths apply.
+ */
+export async function withOneShotTunnel<T>(
+  connection: DatabaseConnection,
+  run: (effective: DatabaseConnection) => Promise<T>,
+): Promise<T> {
+  if (!connection.sshTunnel?.enabled || !connection.host || !connection.port) {
+    return await run(connection);
+  }
+
+  const tunnel = await createSSHTunnel(connection.id, connection.sshTunnel, connection.host, connection.port, {
+    shared: false,
+  });
+
+  try {
+    return await run({ ...connection, host: tunnel.localHost, port: tunnel.localPort });
+  } finally {
+    // Swallowed on purpose: a failing teardown must not replace the caller's error,
+    // which is the one that says why the database connection did not work.
+    await tunnel.close().catch(() => {});
+  }
+}
+
+// ============================================================================
 // Provider Cache (for connection reuse)
 // ============================================================================
 

--- a/src/lib/ssh/tunnel.ts
+++ b/src/lib/ssh/tunnel.ts
@@ -18,6 +18,22 @@ export interface TunnelInfo {
 // Cache active tunnels by connection ID
 const activeTunnels = new Map<string, TunnelInfo>();
 
+export interface CreateSSHTunnelOptions {
+  /**
+   * Whether the tunnel joins the by-connection-id pool every other provider for that
+   * connection reuses. Default true, which is the pooled lifecycle: the tunnel outlives
+   * the call, and `removeProvider` / the idle sweep close it once nothing serves the
+   * connection.
+   *
+   * `false` requests a one-shot tunnel for a caller that owns the whole lifecycle and
+   * closes it itself - the routes that build a provider outside both provider caches
+   * (test-connection, schema-snapshot). Pooling those would leak: the connection dialog
+   * mints a fresh id per build for an unsaved connection, so nothing would ever hold the
+   * id needed to close the tunnel again, and neither cache would know to evict it.
+   */
+  shared?: boolean;
+}
+
 /**
  * Create an SSH tunnel for a database connection.
  * Returns the local host/port to connect the database client to.
@@ -27,13 +43,18 @@ export async function createSSHTunnel(
   sshConfig: SSHTunnelConfig,
   remoteHost: string,
   remotePort: number,
+  options: CreateSSHTunnelOptions = {},
 ): Promise<TunnelInfo> {
+  const shared = options.shared !== false;
+
   // Return existing tunnel if already active
   // Note: cached tunnel may be stale if the SSH connection dropped silently.
   // Callers should handle connection errors and call closeSSHTunnel() to evict stale entries.
-  const existing = activeTunnels.get(connectionId);
-  if (existing) {
-    return existing;
+  if (shared) {
+    const existing = activeTunnels.get(connectionId);
+    if (existing) {
+      return existing;
+    }
   }
 
   return new Promise((resolve, reject) => {
@@ -41,7 +62,12 @@ export async function createSSHTunnel(
     let localServer: net.Server | null = null;
 
     const cleanup = async () => {
-      activeTunnels.delete(connectionId);
+      // Only a pooled tunnel owns its map entry. A one-shot tunnel may share the id of a
+      // pooled one serving live providers, and deleting that entry would orphan it: the
+      // SSH client and local server would stay open with nothing left holding a handle.
+      if (shared) {
+        activeTunnels.delete(connectionId);
+      }
       if (localServer) {
         localServer.close();
         localServer = null;
@@ -82,7 +108,9 @@ export async function createSSHTunnel(
           localPort: address.port,
           close: cleanup,
         };
-        activeTunnels.set(connectionId, tunnelInfo);
+        if (shared) {
+          activeTunnels.set(connectionId, tunnelInfo);
+        }
         logger.info(`Tunnel created for ${connectionId}: 127.0.0.1:${address.port} -> ${remoteHost}:${remotePort}`, {
           connectionId,
         });

--- a/tests/api/db/schema-snapshot.test.ts
+++ b/tests/api/db/schema-snapshot.test.ts
@@ -5,7 +5,12 @@ import { clearRateLimitState } from "@/lib/api/rate-limit";
 
 // ─── Mock provider ──────────────────────────────────────────────────────────
 const mockProvider = createMockProvider();
-const mockCreateDatabaseProvider = mock(async () => mockProvider);
+const mockCreateDatabaseProvider = mock(async (connection?: unknown) => {
+  // The parameter is declared so `mock.calls` carries the connection the route built the
+  // provider from - that argument is what proves the SSH tunnel endpoint was used (#457).
+  void connection;
+  return mockProvider;
+});
 
 const mockGetSession = mock(
   async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
@@ -42,9 +47,17 @@ mock.module("@/lib/seed/resolve-connection", () => {
 });
 
 // ─── Mock @/lib/db/factory BEFORE importing the route ───────────────────────
+// Pass-through stand-in for the real scope, which opens an unshared SSH tunnel and
+// rewrites host/port to its local endpoint (#457).
+const mockWithOneShotTunnel = mock(
+  async (connection: Record<string, unknown>, run: (c: Record<string, unknown>) => Promise<unknown>) =>
+    await run({ ...connection, host: "127.0.0.1", port: 54321 }),
+);
+
 mock.module("@/lib/db/factory", () => ({
   getOrCreateProvider: mock(async () => mockProvider),
   createDatabaseProvider: mockCreateDatabaseProvider,
+  withOneShotTunnel: mockWithOneShotTunnel,
 }));
 
 // ─── Import route handler AFTER mocking ─────────────────────────────────────
@@ -188,5 +201,32 @@ describe("POST /api/db/schema-snapshot", () => {
     expect(res.status).toBe(500);
     // disconnect should have been called in the catch block
     expect(mockProvider.disconnect).toHaveBeenCalled();
+  });
+
+  // ─── SSH tunnel (#457) ────────────────────────────────────────────────────
+  // The agent's grounding capture reads its schema here. Like test-connection this
+  // route builds its provider outside both caches, so it needs the tunnel scope
+  // explicitly - otherwise a tunnelled connection has no readable schema at all.
+
+  test("reads the schema through the connection's SSH tunnel rather than the raw host", async () => {
+    mockWithOneShotTunnel.mockClear();
+    mockCreateDatabaseProvider.mockClear();
+
+    const req = createMockRequest("/api/db/schema-snapshot", {
+      method: "POST",
+      body: {
+        connection: {
+          ...validConnection,
+          host: "db.internal",
+          sshTunnel: { enabled: true, host: "bastion", port: 22, username: "jump", authMethod: "password" },
+        },
+      },
+    });
+
+    await POST(req as never);
+
+    expect(mockWithOneShotTunnel).toHaveBeenCalledTimes(1);
+    expect(mockWithOneShotTunnel.mock.calls[0]?.[0]).toMatchObject({ host: "db.internal" });
+    expect(mockCreateDatabaseProvider.mock.calls[0]?.[0]).toMatchObject({ host: "127.0.0.1", port: 54321 });
   });
 });

--- a/tests/api/db/test-connection.test.ts
+++ b/tests/api/db/test-connection.test.ts
@@ -6,7 +6,12 @@ import { clearRateLimitState } from "@/lib/api/rate-limit";
 
 // ─── Create mock objects ────────────────────────────────────────────────────
 const mockProvider = createMockProvider();
-const mockCreateDatabaseProvider = mock(async () => mockProvider);
+const mockCreateDatabaseProvider = mock(async (connection?: unknown) => {
+  // The parameter is declared so `mock.calls` carries the connection the route built the
+  // provider from - that argument is what proves the SSH tunnel endpoint was used (#457).
+  void connection;
+  return mockProvider;
+});
 
 const mockGetSession = mock(
   async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
@@ -42,9 +47,26 @@ mock.module("@/lib/seed/resolve-connection", () => {
   };
 });
 
+// The real scope opens an unshared SSH tunnel and rewrites host/port to its local
+// endpoint. Standing in for it with a pass-through that performs that rewrite is what
+// lets these tests assert the route connects THROUGH the tunnel rather than around it
+// (#457). `disconnectsAtScopeExit` records how many disconnect() calls had happened by
+// the time the scope was about to close its tunnel - the ordering the route must honour.
+let disconnectsAtScopeExit = -1;
+const mockWithOneShotTunnel = mock(
+  async (connection: Record<string, unknown>, run: (c: Record<string, unknown>) => Promise<unknown>) => {
+    try {
+      return await run({ ...connection, host: "127.0.0.1", port: 54321 });
+    } finally {
+      disconnectsAtScopeExit = (mockProvider.disconnect as ReturnType<typeof mock>).mock.calls.length;
+    }
+  },
+);
+
 // ─── Mock dependencies BEFORE importing route ───────────────────────────────
 mock.module("@/lib/db/factory", () => ({
   createDatabaseProvider: mockCreateDatabaseProvider,
+  withOneShotTunnel: mockWithOneShotTunnel,
   getOrCreateProvider: mock(async () => mockProvider),
   removeProvider: mock(async () => {}),
   clearProviderCache: mock(async () => {}),
@@ -69,6 +91,8 @@ describe("POST /api/db/test-connection", () => {
   beforeEach(() => {
     clearRateLimitState();
     mockCreateDatabaseProvider.mockClear();
+    mockWithOneShotTunnel.mockClear();
+    disconnectsAtScopeExit = -1;
     (mockProvider.connect as ReturnType<typeof mock>).mockClear();
     (mockProvider.disconnect as ReturnType<typeof mock>).mockClear();
     (mockProvider.getHealth as ReturnType<typeof mock>).mockClear();
@@ -209,5 +233,57 @@ describe("POST /api/db/test-connection", () => {
 
     expect(mockProvider.connect).toHaveBeenCalledTimes(1);
     expect(mockProvider.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── SSH tunnel (#457) ────────────────────────────────────────────────────
+  // This route builds its provider with createDatabaseProvider, outside both provider
+  // caches, so it does not inherit the tunnel handling the cached paths have. Until
+  // #457 it connected to the raw database host: a tunnelled connection could never be
+  // tested, and because the dialog gates its only save button on a passing test, never
+  // be saved either.
+
+  test("connects through the connection's SSH tunnel rather than to the raw host", async () => {
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: {
+        ...validConnection,
+        host: "db.internal",
+        sshTunnel: { enabled: true, host: "bastion", port: 22, username: "jump", authMethod: "password" },
+      },
+    });
+
+    await POST(req as never);
+
+    expect(mockWithOneShotTunnel).toHaveBeenCalledTimes(1);
+    expect(mockWithOneShotTunnel.mock.calls[0]?.[0]).toMatchObject({ host: "db.internal" });
+    expect(mockCreateDatabaseProvider.mock.calls[0]?.[0]).toMatchObject({ host: "127.0.0.1", port: 54321 });
+  });
+
+  test("disconnects the provider before the tunnel scope tears the tunnel down", async () => {
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: validConnection,
+    });
+
+    await POST(req as never);
+
+    // Closing the tunnel under a still-connected provider would leave the driver
+    // shutting down a socket whose transport is already gone.
+    expect(disconnectsAtScopeExit).toBe(1);
+  });
+
+  test("disconnects the provider inside the tunnel scope when the health check fails", async () => {
+    (mockProvider.getHealth as ReturnType<typeof mock>).mockImplementation(async () => {
+      throw new Error("Health check failed");
+    });
+
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: validConnection,
+    });
+
+    await POST(req as never);
+
+    expect(disconnectsAtScopeExit).toBe(1);
   });
 });

--- a/tests/unit/db-tunnel-discipline.test.ts
+++ b/tests/unit/db-tunnel-discipline.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * The SSH tunnel boundary, made mechanical (#457).
+ *
+ * `createDatabaseProvider` is a provider switch and nothing more: it does NOT open the
+ * connection's SSH tunnel. Only the two caching entry points do that -
+ * `getOrCreateProvider` and `acquireExecutionProfileProvider` - so anything that builds a
+ * provider directly and then CONNECTS it must go through `withOneShotTunnel`, or it
+ * silently dials the raw database host.
+ *
+ * That is not a hypothetical. Two routes followed this pattern and both were written
+ * without the tunnel: `/api/db/test-connection` (reported as #457) and
+ * `/api/db/schema-snapshot` (found while fixing it). Two for two. The unit and route
+ * tests added with the fix pin those two files; nothing pinned the RULE, so a third
+ * route would have repeated it - and fifteen green tunnel tests would not have noticed,
+ * because they all exercised the two paths that already had the code.
+ *
+ * Deliberately a source scan rather than a live probe. A live probe asserts against
+ * named endpoints, so a NEW route that forgets the tunnel is invisible to it - it would
+ * need the same awareness the author was missing. This rule needs none: the violation is
+ * the shape of the file.
+ *
+ * Its limit, stated so nobody over-trusts it: it reads text. A provider obtained through
+ * a helper, or a `connect()` reached by indirection, passes. It catches the careless
+ * repeat, which is the case that actually happened, not a determined one.
+ */
+
+const SRC = path.join(process.cwd(), "src");
+
+/** Import specifiers that resolve to the factory. */
+const FACTORY_SPECIFIERS = ["@/lib/db/factory", "@/lib/db"] as const;
+
+/**
+ * Files exempt from the rule, each with the reason it cannot apply. An entry here is a
+ * reviewed decision, not a silencer: adding one has to survive the question "why does
+ * this connect without a tunnel?".
+ */
+const EXEMPT: Readonly<Record<string, string>> = {
+  // Defines both sides of the rule.
+  "src/lib/db/factory.ts": "the factory itself - it defines createDatabaseProvider and withOneShotTunnel",
+  // Re-export surfaces: they name the symbols, they call nothing.
+  "src/lib/db/index.ts": "re-export barrel, no call sites",
+  "src/exports/providers.ts": "published package surface, no call sites",
+};
+
+interface Violation {
+  file: string;
+  reason: string;
+}
+
+/**
+ * The rule, over one file's text. Returns null when the file is compliant or the rule
+ * does not apply to it.
+ */
+function analyseTunnelDiscipline(relPath: string, source: string): Violation | null {
+  if (EXEMPT[relPath]) return null;
+
+  const importsFactory = FACTORY_SPECIFIERS.some((specifier) =>
+    new RegExp(`import\\s+\\{[^}]*\\bcreateDatabaseProvider\\b[^}]*\\}\\s+from\\s+["']${specifier}["']`, "s").test(
+      source,
+    ),
+  );
+  if (!importsFactory) return null;
+
+  // A provider that is never connected has no transport to tunnel: `provider-meta` and
+  // the agent runtime read type-driven capabilities off a constructed provider and stop
+  // there. Those are correct as they stand, and the rule must not force a tunnel on them.
+  if (!/\.connect\s*\(\s*\)/.test(source)) return null;
+
+  if (/\bwithOneShotTunnel\b/.test(source)) return null;
+
+  return {
+    file: relPath,
+    reason:
+      "builds a provider with createDatabaseProvider and connects it, without withOneShotTunnel - " +
+      "so a connection with an SSH tunnel would dial the raw database host (#457)",
+  };
+}
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, acc);
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe("SSH tunnel discipline (#457)", () => {
+  // ── The rule's own teeth ───────────────────────────────────────────────────
+  // Without these, the tree scan below is a negative assertion that would keep
+  // passing even if the rule stopped detecting anything at all.
+
+  test("flags a file that builds a provider and connects it without the scope", () => {
+    const offender = `
+      import { createDatabaseProvider } from "@/lib/db/factory";
+      export async function POST() {
+        const provider = await createDatabaseProvider(connection);
+        await provider.connect();
+      }
+    `;
+    expect(analyseTunnelDiscipline("src/app/api/db/new-route/route.ts", offender)).not.toBeNull();
+  });
+
+  test("flags it through the barrel specifier too", () => {
+    const offender = `
+      import { createDatabaseProvider } from "@/lib/db";
+      const p = await createDatabaseProvider(c);
+      await p.connect();
+    `;
+    expect(analyseTunnelDiscipline("src/app/api/db/other/route.ts", offender)).not.toBeNull();
+  });
+
+  test("accepts a file that wraps the provider in the scope", () => {
+    const compliant = `
+      import { createDatabaseProvider, withOneShotTunnel } from "@/lib/db/factory";
+      export async function POST() {
+        return await withOneShotTunnel(connection, async (effective) => {
+          const provider = await createDatabaseProvider(effective);
+          await provider.connect();
+        });
+      }
+    `;
+    expect(analyseTunnelDiscipline("src/app/api/db/wrapped/route.ts", compliant)).toBeNull();
+  });
+
+  test("ignores a file that builds a provider but never connects it", () => {
+    // The provider-meta and agent-runtime shape: type-driven reads, no socket.
+    const metadataOnly = `
+      import { createDatabaseProvider } from "@/lib/db";
+      const provider = await createDatabaseProvider(connection);
+      return { capabilities: provider.getCapabilities(), labels: provider.getLabels() };
+    `;
+    expect(analyseTunnelDiscipline("src/app/api/db/meta/route.ts", metadataOnly)).toBeNull();
+  });
+
+  test("ignores a file that connects a provider it did not build with the factory", () => {
+    const pooled = `
+      import { getOrCreateProvider } from "@/lib/db";
+      const provider = await getOrCreateProvider(connection);
+      await provider.connect();
+    `;
+    expect(analyseTunnelDiscipline("src/app/api/db/pooled/route.ts", pooled)).toBeNull();
+  });
+
+  test("respects the exemption list", () => {
+    const barrel = `
+      import { createDatabaseProvider } from "@/lib/db/factory";
+      await x.connect();
+    `;
+    expect(analyseTunnelDiscipline("src/lib/db/index.ts", barrel)).toBeNull();
+  });
+
+  // ── The tree ──────────────────────────────────────────────────────────────
+
+  test("every connecting caller of createDatabaseProvider tunnels", () => {
+    const violations = walk(SRC)
+      .map((full) => {
+        const relPath = path.relative(process.cwd(), full);
+        return analyseTunnelDiscipline(relPath, fs.readFileSync(full, "utf8"));
+      })
+      .filter((v): v is Violation => v !== null);
+
+    expect(violations.map((v) => `${v.file}: ${v.reason}`)).toEqual([]);
+  });
+
+  test("the rule actually reaches the two routes it exists for", () => {
+    // Guards against the scan silently covering nothing - a rename, a moved route or a
+    // changed import specifier would otherwise leave this suite green and blind.
+    const scanned = walk(SRC).map((full) => path.relative(process.cwd(), full));
+    expect(scanned).toContain("src/app/api/db/test-connection/route.ts");
+    expect(scanned).toContain("src/app/api/db/schema-snapshot/route.ts");
+
+    for (const route of ["src/app/api/db/test-connection/route.ts", "src/app/api/db/schema-snapshot/route.ts"]) {
+      const source = fs.readFileSync(path.join(process.cwd(), route), "utf8");
+      // Compliant today, and provably in scope: strip the scope and the rule bites.
+      expect(analyseTunnelDiscipline(route, source)).toBeNull();
+      expect(analyseTunnelDiscipline(route, source.replace(/withOneShotTunnel/g, "somethingElse"))).not.toBeNull();
+    }
+  });
+
+  test("every exemption names a file that exists", () => {
+    // A stale exemption is a hole nobody can see. If a file moves, the entry must move
+    // with it or be deleted.
+    for (const file of Object.keys(EXEMPT)) {
+      expect(fs.existsSync(path.join(process.cwd(), file))).toBe(true);
+    }
+  });
+});

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -274,6 +274,7 @@ const {
   registerShutdownHandlers,
   acquireExecutionProfileProvider,
   getExecutionProfileCacheStats,
+  withOneShotTunnel,
 } = await import("@/lib/db/factory");
 if (nodeEnvBefore === undefined) {
   delete (process.env as Record<string, string>).NODE_ENV;
@@ -1247,5 +1248,133 @@ describe("acquireExecutionProfileProvider", () => {
       expect((error as ExecutionProfileError).reasonCode).toBe("PROFILE_UNSUPPORTED_TARGET");
       expect(getExecutionProfileCacheStats().size).toBe(0);
     });
+  });
+});
+
+// ============================================================================
+// One-shot tunnel scope (#457)
+// ----------------------------------------------------------------------------
+// The routes that build a provider outside both caches - test-connection and
+// schema-snapshot - reach the database through here. Every assertion below is
+// about lifecycle rather than transport: the tunnel must be unshared, and it
+// must close on every exit path, because no cache eviction will ever do it.
+// ============================================================================
+
+describe("withOneShotTunnel", () => {
+  // `mockHasTunnel` is not reset by the file-level beforeEach, and one assertion below
+  // is that this scope never consults the shared pool - a negative that only means
+  // anything against a counter this describe owns.
+  beforeEach(() => {
+    mockHasTunnel.mockClear();
+  });
+
+  const tunnelled = () =>
+    makeConnection("postgres", {
+      id: "one-shot-conn",
+      host: "db.internal",
+      port: 5432,
+      sshTunnel: {
+        enabled: true,
+        host: "bastion.example.com",
+        port: 22,
+        username: "jump",
+        authMethod: "password",
+        password: "pw",
+      },
+    });
+
+  const closeOf = async (call: number) =>
+    ((await mockCreateSSHTunnel.mock.results[call]?.value) as { close: ReturnType<typeof mock> } | undefined)?.close;
+
+  test("runs the callback against the local tunnel endpoint", async () => {
+    const seen: Array<{ host?: string; port?: number }> = [];
+
+    const result = await withOneShotTunnel(tunnelled(), async (effective) => {
+      seen.push({ host: effective.host, port: effective.port });
+      return "done";
+    });
+
+    expect(result).toBe("done");
+    expect(seen).toEqual([{ host: "127.0.0.1", port: 54321 }]);
+    expect(mockCreateSSHTunnel).toHaveBeenCalledTimes(1);
+  });
+
+  test("asks for an unshared tunnel so nothing pools it under the connection id", async () => {
+    await withOneShotTunnel(tunnelled(), async () => undefined);
+
+    expect(mockCreateSSHTunnel).toHaveBeenCalledWith(
+      "one-shot-conn",
+      expect.objectContaining({ host: "bastion.example.com" }),
+      "db.internal",
+      5432,
+      { shared: false },
+    );
+    // The shared pool is never consulted: a one-shot scope must not adopt, or be
+    // mistaken for, the tunnel serving a cached provider of the same connection.
+    expect(mockHasTunnel).not.toHaveBeenCalled();
+  });
+
+  test("closes the tunnel after the callback succeeds", async () => {
+    await withOneShotTunnel(tunnelled(), async () => undefined);
+
+    expect(await closeOf(0)).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes the tunnel and rethrows when the callback fails", async () => {
+    await expect(
+      withOneShotTunnel(tunnelled(), async () => {
+        throw new Error("connect refused");
+      }),
+    ).rejects.toThrow("connect refused");
+
+    expect(await closeOf(0)).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates the callback failure even when closing the tunnel throws", async () => {
+    mockCreateSSHTunnel.mockImplementationOnce(async () => ({
+      localHost: "127.0.0.1",
+      localPort: 54321,
+      close: mock(async () => {
+        throw new Error("close failed");
+      }),
+    }));
+
+    await expect(
+      withOneShotTunnel(tunnelled(), async () => {
+        throw new Error("connect refused");
+      }),
+    ).rejects.toThrow("connect refused");
+  });
+
+  test("opens no tunnel when the connection has none configured", async () => {
+    const plain = makeConnection("postgres", { id: "no-tunnel-conn" });
+
+    const seen = await withOneShotTunnel(plain, async (effective) => effective);
+
+    expect(mockCreateSSHTunnel).not.toHaveBeenCalled();
+    expect(seen).toBe(plain);
+  });
+
+  test("opens no tunnel when the SSH config is present but disabled", async () => {
+    const off = tunnelled();
+    off.sshTunnel!.enabled = false;
+
+    await withOneShotTunnel(off, async (effective) => {
+      expect(effective.host).toBe("db.internal");
+    });
+
+    expect(mockCreateSSHTunnel).not.toHaveBeenCalled();
+  });
+
+  test("opens no tunnel for a connection with no host and port to forward to", async () => {
+    // A connection-string connection (MongoDB, Couchbase, ClickHouse) and SQLite carry
+    // neither, so there is no endpoint to rewrite - the same rule the pooled paths apply.
+    const stringOnly = tunnelled();
+    delete stringOnly.host;
+    delete stringOnly.port;
+
+    await withOneShotTunnel(stringOnly, async () => undefined);
+
+    expect(mockCreateSSHTunnel).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/ssh-tunnel.test.ts
+++ b/tests/unit/ssh-tunnel.test.ts
@@ -258,6 +258,111 @@ describe("SSH Tunnel", () => {
       expect(tunnel2.localPort).toBe(tunnel1.localPort);
     });
 
+    // A one-shot tunnel (`shared: false`) is the transport for the routes that build a
+    // provider outside the caches - test-connection and schema-snapshot. Those carry a
+    // connection id that is thrown away (the connection dialog mints a fresh one per
+    // build), so a cached tunnel under that id would never be evicted by anything:
+    // `removeProvider` and the idle sweep only close tunnels of CACHED providers. Hence
+    // the three invariants below - never read the cache, never write it, and never let
+    // closing an unshared tunnel evict the shared entry that happens to share its id.
+    test("does not reuse the shared tunnel when shared is false", async () => {
+      const connId = "test-oneshot-nocache-" + Date.now();
+      lastConnectionId = connId;
+
+      const shared = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+      );
+
+      const oneShot = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+        { shared: false },
+      );
+
+      expect(oneShot).not.toBe(shared);
+    });
+
+    test("does not register a one-shot tunnel in the active map", async () => {
+      const connId = "test-oneshot-unregistered-" + Date.now();
+
+      const oneShot = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+        { shared: false },
+      );
+
+      expect(hasTunnel(connId)).toBe(false);
+      expect(getTunnelInfo(connId)).toBeUndefined();
+
+      await oneShot.close();
+    });
+
+    test("closing a one-shot tunnel leaves the shared tunnel of the same id registered", async () => {
+      const connId = "test-oneshot-noevict-" + Date.now();
+      lastConnectionId = connId;
+
+      const shared = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+      );
+
+      const oneShot = await createSSHTunnel(
+        connId,
+        {
+          enabled: true,
+          host: "bastion.example.com",
+          port: 22,
+          username: "admin",
+          authMethod: "password",
+          password: "pass",
+        },
+        "db.internal",
+        5432,
+        { shared: false },
+      );
+      await oneShot.close();
+
+      expect(hasTunnel(connId)).toBe(true);
+      expect(getTunnelInfo(connId)).toBe(shared);
+    });
+
     test("rejects on SSH connection error", async () => {
       const connId = "test-ssherr-" + Date.now();
       lastConnectionId = connId;


### PR DESCRIPTION
**Stacked on #461 — merge that first.** The rule asserts a shape that only exists once #461 lands; on `main` today it would fail, correctly, on the two routes #461 fixes.

## What this adds

One test file, `tests/unit/db-tunnel-discipline.test.ts`, pinning the boundary #461 restored:

> a file that builds a provider with `createDatabaseProvider` **and connects it** must go through `withOneShotTunnel`

## Why a rule and not more tests

#461 already has unit and route tests for the two files it fixes. What nothing pinned was the **rule**. The evidence that it needs pinning is not speculation: two routes followed this pattern and both were written without the tunnel — `/api/db/test-connection` (reported as #457) and `/api/db/schema-snapshot` (found while fixing it). Two for two, and fifteen green tunnel tests did not notice, because every one of them exercised the two paths that already had the code.

## Why not a live CI gate

The first proposal here was a docker + `sshd` job reproducing #461's live probe on every PR. That was the wrong instrument, for a reason worth writing down:

**a live probe asserts against named endpoints.** A *new* route that forgets the tunnel is invisible to it — catching it would need the spec to be extended by the same author who was missing the awareness in the first place. So the live gate would have protected exactly the two files the unit tests already protect, at the cost of 2–3 minutes of docker on every PR plus a fixture to maintain.

A source scan needs no such awareness: the violation is the shape of the file. It runs inside the already-required `Unit & Integration Tests` check — so it actually blocks a merge, which `Functional Smoke` would not have — and it costs a file read.

The one thing a live probe uniquely catches is `ssh2` drifting from the contract the mocks pin. That is real but rare, and it is a thing to run by hand on an `ssh2` bump, not on every PR.

## The rule's teeth are tested, not assumed

Six of the nine tests exist so the tree scan cannot rot into a green no-op:

- a violating shape is flagged, through both the `@/lib/db/factory` and `@/lib/db` specifiers
- a compliant shape (wrapped in the scope) is accepted
- a provider built but **never connected** is ignored — the `provider-meta` and agent-runtime shape, correct as it stands
- a provider from `getOrCreateProvider` is ignored — the pooled path tunnels already
- the exemption list is respected, and every exemption must name a file that exists, so a moved file cannot leave a silent hole
- the two routes the rule exists for are asserted to be *in scope*: the real sources pass, and the same sources with `withOneShotTunnel` stripped fail

Beyond that, the tree scan was verified against a real violation — a throwaway `src/app/api/db/__vacuity_probe/route.ts` — which it caught by path and reason before being deleted.

## Its limit, stated in the file

It reads text. A provider obtained through a helper, or a `connect()` reached by indirection, passes. It catches the careless repeat — the case that actually happened — not a determined one. Three files are exempt with reasons: the factory itself and two re-export surfaces that name the symbols and call nothing.

## Verification

`format` · `lint` (0 errors) · `typecheck` · `knip` · `test` (33 groups) · `build` pass, and `coverage:check` stays at 100%.
