### PR TITLE
fix(desktop): the x64 AppImage could not start on the oldest supported LTS

### DIFF
--- a/.github/workflows/flatpak-smoke.yml
+++ b/.github/workflows/flatpak-smoke.yml
@@ -54,9 +54,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # x64 tracks the release job's image, not the newest one: this is the
+          # only AppImage build that runs outside a release, so it is the only
+          # place a break on the pinned image surfaces before a tag exists, and
+          # an AppImage built on a newer image than the release uses proves
+          # nothing about the artifact users get. See
+          # tests/unit/desktop-appimage-portability.test.ts.
           - arch: x64
             flatpak_arch: x86_64
-            runner: ubuntu-24.04
+            runner: ubuntu-22.04
           - arch: arm64
             flatpak_arch: aarch64
             runner: ubuntu-24.04-arm

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -873,8 +873,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Pinned to the oldest still-supported LTS, never a floating label: an
+          # AppImage inherits the glibc of its build machine and only degrades
+          # downwards from there. Built on 24.04, the bundled GTK/WebKit stack
+          # requires GLIBC_2.38 and the Tauri binary GLIBC_2.39, so the artifact
+          # cannot load a single shared object on Ubuntu 22.04 (glibc 2.35) -
+          # which is both what enterprise-distribution users still run and what
+          # AppImageHub's review CI executes the submitted AppImage on. Nothing
+          # in the release pipeline can catch that regression, hence the pin and
+          # tests/unit/desktop-appimage-portability.test.ts.
           - arch: x64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
+          # arm64 still builds on 24.04-arm; lowering it (Raspberry Pi OS
+          # bookworm ships glibc 2.36) is tracked in docs/BACKLOG.md.
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -108,6 +108,17 @@ cd desktop/src-tauri && cargo test
   `.github/workflows/release-artifacts.yml`; both artifacts are required release
   assets. `--deb-only` skips the AppImage, which is the way to build on a host
   without the linuxdeploy GTK toolchain (`librsvg2-dev` and friends).
+- **The x64 AppImage is built on the oldest still-supported Ubuntu LTS, and that
+  is load-bearing.** An AppImage inherits the glibc of its build machine, so the
+  runner label sets the floor for every user: built on 24.04 the bundled
+  GTK/WebKit stack requires GLIBC_2.38 and the Tauri binary GLIBC_2.39, which
+  means the loader refuses every shared object on Ubuntu 22.04 (glibc 2.35) with
+  nothing but `version 'GLIBC_2.38' not found` to go on. No release gate can see
+  that - the machine that would notice is not in the pipeline - so the matrix
+  pins `ubuntu-22.04` and `tests/unit/desktop-appimage-portability.test.ts`
+  refuses any floating label. The same applies to AppImageHub, whose review CI
+  runs the submitted AppImage on 22.04. arm64 is still on 24.04-arm; see REL2 in
+  [`docs/BACKLOG.md`](../docs/BACKLOG.md).
 - **The bundled Node sidecar is named `libredb-studio-node`, not `node`.** The
   .deb installs it into the real `/usr/bin`, where `node` is owned by the distro
   `nodejs` package and dpkg would refuse the install. `externalBin` in

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -30,7 +30,7 @@ None of it is a GitHub issue.
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P5 · 5
 - [Documentation](#documentation) — DOC1–DOC3 · 3
-- [Release pipeline](#release-pipeline) — REL1
+- [Release pipeline](#release-pipeline) — REL1–REL2 · 2
 - [Chart configuration surface](#chart-configuration-surface) — N1–N3 · 3
 - [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 10
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C2–C10 · 9
@@ -876,6 +876,29 @@ future Helm 4 packaging change that a Helm 3 client rejects at install time.
 no Helm client at all) also runs a pinned Helm 3.16 `helm repo add` + `helm pull` + `helm install` of
 the published chart version against a kind cluster, or an equivalent post-publish smoke lands
 elsewhere.
+
+---
+
+### REL2. The arm64 AppImage still carries a glibc 2.39 floor
+
+`desktop-appimage` builds x64 on `ubuntu-22.04` (glibc 2.35) so the AppImage loads on the oldest
+still-supported LTS, and `tests/unit/desktop-appimage-portability.test.ts` pins that. The arm64 leg
+still runs on `ubuntu-24.04-arm`, so the arm64 AppImage requires GLIBC_2.38 in every bundled GTK and
+WebKit library and GLIBC_2.39 in the Tauri binary - measured on 0.13.1 for x64, and the arm64 leg
+builds from the same runner generation.
+
+That excludes the arm64 targets the artifact mostly exists for: Raspberry Pi OS bookworm ships glibc
+2.36, Debian 12 arm64 the same, Ubuntu 22.04 arm64 2.35. The failure is the loader refusing every
+shared object, so there is nothing to diagnose from the user's side beyond "it does not start".
+
+Not done with the x64 fix because the `ubuntu-22.04-arm` runner label was never exercised by this
+repo, and `desktop-appimage` is a hard release gate: a bad label fails the whole release, and a
+failed release costs a patch version. It wants one throwaway `workflow_dispatch` run to confirm the
+label and that jammy-arm64 carries `libwebkit2gtk-4.1-dev`, not a blind flip on a release commit.
+
+**Done when:** the arm64 matrix entry builds on `ubuntu-22.04-arm`, the resulting AppImage is
+verified to load on a glibc 2.35 or 2.36 arm64 root filesystem, and the `not.toContain("latest")`
+assertion in the portability test is joined by an explicit arm64 label assertion.
 
 ---
 

--- a/tests/unit/desktop-appimage-portability.test.ts
+++ b/tests/unit/desktop-appimage-portability.test.ts
@@ -28,11 +28,14 @@ interface Job {
   strategy?: { matrix?: { include?: MatrixEntry[] } };
 }
 
-const releaseArtifacts = parseYaml(
-  fs.readFileSync(path.join(__dirname, "../../.github/workflows/release-artifacts.yml"), "utf8"),
-) as { jobs: Record<string, Job> };
+const workflow = (name: string): { jobs: Record<string, Job> } =>
+  parseYaml(fs.readFileSync(path.join(__dirname, "../../.github/workflows", name), "utf8")) as {
+    jobs: Record<string, Job>;
+  };
 
-const desktopMatrix = releaseArtifacts.jobs["desktop-appimage"]?.strategy?.matrix?.include ?? [];
+const desktopMatrix = workflow("release-artifacts.yml").jobs["desktop-appimage"]?.strategy?.matrix?.include ?? [];
+const smokeMatrix = workflow("flatpak-smoke.yml").jobs.appimage?.strategy?.matrix?.include ?? [];
+const x64Runner = (matrix: MatrixEntry[]): string | undefined => matrix.find((entry) => entry.arch === "x64")?.runner;
 
 describe("release-artifacts.yml desktop-appimage glibc floor", () => {
   test("builds every architecture on a pinned runner image, never a floating label", () => {
@@ -47,6 +50,16 @@ describe("release-artifacts.yml desktop-appimage glibc floor", () => {
     // ubuntu-22.04 and fails the submission when no window appears, so this
     // label is what keeps the catalog listing alive as well as the users on
     // enterprise distributions the AppImage exists for.
-    expect(desktopMatrix.find((entry) => entry.arch === "x64")?.runner).toBe("ubuntu-22.04");
+    expect(x64Runner(desktopMatrix)).toBe("ubuntu-22.04");
+  });
+
+  test("the pull-request AppImage smoke builds on the same image the release does", () => {
+    // flatpak-smoke.yml is the only job that builds an AppImage outside a
+    // release, so it is the only place a build break on the pinned image can
+    // surface before a tag exists. Letting the two drift means the release
+    // builds a configuration nothing ever exercised, on a job that is a hard
+    // release gate.
+    expect(smokeMatrix.length).toBeGreaterThan(0);
+    expect(x64Runner(smokeMatrix)).toBe(x64Runner(desktopMatrix));
   });
 });

--- a/tests/unit/desktop-appimage-portability.test.ts
+++ b/tests/unit/desktop-appimage-portability.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the glibc floor of the desktop AppImage.
+ *
+ * Why a test for a runner label: an AppImage inherits the glibc of the machine
+ * that built it, and that dependency only ever points one way. Building on
+ * `ubuntu-latest` silently raises the floor every time GitHub moves the label
+ * to a newer image - the artifact still builds, still uploads, still runs on
+ * the runner and on any recent desktop, and simply stops starting on older
+ * targets with `version 'GLIBC_2.xx' not found`. No release gate can see it,
+ * because the machine that would notice is not in the pipeline.
+ *
+ * Measured on 0.13.1 (built on ubuntu-latest, then 24.04): every bundled GTK
+ * and WebKit library required GLIBC_2.38 and the Tauri binary referenced
+ * GLIBC_2.39, so the AppImage could not load a single shared object on Ubuntu
+ * 22.04 (glibc 2.35) - the oldest still-supported LTS, which is also what
+ * AppImageHub's review CI runs.
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { parse as parseYaml } from "yaml";
+
+interface MatrixEntry {
+  arch: string;
+  runner: string;
+}
+interface Job {
+  strategy?: { matrix?: { include?: MatrixEntry[] } };
+}
+
+const releaseArtifacts = parseYaml(
+  fs.readFileSync(path.join(__dirname, "../../.github/workflows/release-artifacts.yml"), "utf8"),
+) as { jobs: Record<string, Job> };
+
+const desktopMatrix = releaseArtifacts.jobs["desktop-appimage"]?.strategy?.matrix?.include ?? [];
+
+describe("release-artifacts.yml desktop-appimage glibc floor", () => {
+  test("builds every architecture on a pinned runner image, never a floating label", () => {
+    expect(desktopMatrix.length).toBeGreaterThan(0);
+    for (const entry of desktopMatrix) {
+      expect(entry.runner).not.toContain("latest");
+    }
+  });
+
+  test("builds the x64 AppImage on the oldest still-supported LTS", () => {
+    // AppImageHub's review CI (code/worker.sh) runs the submitted AppImage on
+    // ubuntu-22.04 and fails the submission when no window appears, so this
+    // label is what keeps the catalog listing alive as well as the users on
+    // enterprise distributions the AppImage exists for.
+    expect(desktopMatrix.find((entry) => entry.arch === "x64")?.runner).toBe("ubuntu-22.04");
+  });
+});


### PR DESCRIPTION
## What

Pins the x64 `desktop-appimage` build to `ubuntu-22.04` and adds a unit test that refuses a floating runner label on that job.

## Why

An AppImage inherits the glibc of the machine that built it, and the job built x64 on `ubuntu-latest`. Measured on the released 0.13.1 artifact against Ubuntu 22.04 (glibc 2.35, the oldest still-supported LTS):

```
libglib-2.0.so.0:       /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
libgtk-3.so.0:          version `GLIBC_2.38' not found
libwebkit2gtk-4.1.so.0: version `GLIBC_2.38' not found
```

The Tauri binary additionally references `pidfd_getpid` / `pidfd_spawnp` (GLIBC_2.39). The loader refuses every bundled shared object, so the app never opens a window and the user gets nothing but the loader message.

No release gate can see this. The artifact builds, is attested, uploads, and runs on the runner and on any recent desktop. The machine that would notice is not in the pipeline, which is why the label is now pinned and asserted.

## Verification

Measured with the released `libredb-studio-desktop-0.13.1-linux-x64.AppImage`, extracted and resolved against `ubuntu:22.04` (failure above) and run end to end against `ubuntu:24.04` with `--network none`, Xvfb at 800x600:

- window titled "LibreDB Studio" appears within 1 s, `xdotool getactivewindow` selects it, `import -window` writes a valid PNG
- the sidecar boots offline: server healthy, auto-login, SQLite sample seed in 230 ms
- `appdir-lint.sh` exit 0, `desktop-file-validate` exit 0 (warnings only: no metainfo, blacklisted `libwayland-client.so.0`)

Local gates: `format`, `lint`, `typecheck`, `knip`, `test` (33/33 groups), `build`.

## Side effect

`ubuntu-22.04` is what AppImageHub's review CI (`code/worker.sh`) runs a submitted AppImage on, so this unblocks that catalog listing.

## Not in this PR

arm64 still builds on `ubuntu-24.04-arm` and carries the same floor, which excludes Raspberry Pi OS bookworm (glibc 2.36) and Debian 12 arm64. `ubuntu-22.04-arm` has never been exercised here and `desktop-appimage` is a hard release gate, so it wants a throwaway dispatch run first. Tracked as REL2 in `docs/BACKLOG.md`.
