### PR TITLE
fix(providers): every MySQL DDL and DML reported a failure for work it had done, plus five more

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,10 +22,10 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S1–S8 · 8
-- [Drivers and connections](#drivers-and-connections) — D1–D12, U17 · 8
+- [Drivers and connections](#drivers-and-connections) — D1–D16, U17 · 10
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X8, U2–U18 · 9
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X10, U2–U18 · 9
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P5 · 5
@@ -185,31 +185,6 @@ Same lock, same fix as B49. Close the two together.
 **Done when:** testing a connection that resolves to an already-open single-writer file reuses the
 open provider, or the test is skipped with an honest message. Either way the modal must not present a
 lock conflict as a failed connection test.
-
-### D7. Three providers answer the performance panel with a fabricated cache hit ratio
-
-Three sites, all reaching the panel indistinguishable from a measurement:
-
-- **MySQL** — `mysql.ts:853` returns `cacheHitRatio: 99` from a `catch` commented "Fallback if
-  performance_schema is not available". Two more sites default the same way when the row is simply
-  absent: `mysql.ts:648` and `:826` both read `hitRows[0]?.hit_ratio || 99`.
-- **MongoDB** — the same literal in the same position (`document/mongodb.ts`, which at least logs first).
-- **LibreDB** — `embedded/libredb.ts:526` returns `cacheHitRatio: 100` unconditionally.
-
-Measured 2026-08-20 against a live OceanBase Community Edition 4.4.2.1 through the shipped `mysql`
-provider: the tenant has no `performance_schema` database at all (`ERROR 1049`). That `catch` is not
-an edge case there, it is the only path. The panel reports **99 percent cache hit, 0 queries per
-second, 0 buffer pool, 0 deadlocks** on every refresh, forever.
-
-This is the failure class #424 exists to refuse — "a missing panel is honest; a populated wrong one is
-not" — and it is worse here, because the engine is not the author of the number. We are.
-
-**#452 cannot reach this.** That PR taught the five monitoring tabs to render an omitted metric as
-unavailable rather than as zero. A fabricated `99` is not an absence, so there is nothing for a panel
-to detect.
-
-**Done when:** a provider that cannot measure the cache hit ratio reports it as unavailable, on all
-sites listed above.
 
 ### D8. The MySQL provider only uses the prepared protocol, and two engines lose panels to it
 
@@ -385,21 +360,84 @@ first-contact policy is written in `docs/providers/`-adjacent documentation the 
 
 ---
 
-### D12. A pasted `rediss://` URL lands on SSL mode `disable`, so the scheme is silently dropped
+---
 
-`src/lib/connection-string-parser.ts` reads a pasted Redis URL and does not carry its secure scheme
-into `config.ssl`: `rediss://host:6380` produces a connection whose mode is `disable`. Since the
-provider now honours that mode (it did not before 2026-08-23), the paste path is the one place left
-where a user asks for TLS and does not get it — and it looks like it worked, because the connection
-form fills in and saves.
+### D13. Oracle answers every non-SELECT with `rowCount: 0`, including the rows it just wrote
 
-The fix is named and one line: `withSSLMode()` in the same file (`:144`) is the existing precedent
-for a scheme that implies a mode; `postgresql://…?sslmode=` already goes through it.
+`oracle.ts:419` builds the envelope from `rows.length` and never reads `oracledb`'s own
+`result.rowsAffected`, so an `INSERT` that inserted a row, an `UPDATE` that changed one and a `DELETE`
+that removed one all report zero. Measured 2026-08-23 through `createDatabaseProvider({type:"oracle"})`
+against Oracle Free 23ai, with a following `SELECT` proving each statement took effect. Oracle is the
+only one of the five SQL providers that does this: postgres reports `rowCount ?? 0`, mssql
+`rowsAffected[0]`, sqlite `changes`, and mysql was fixed in the same pass that found this.
 
-Scope note: this is a different intake path from the SSL/TLS panel, which is why it was left out of
-the panel work rather than folded into it. `docs/providers/redis.md` records it as a known limitation.
+Milder than the MySQL defect it was found beside - nothing throws, the statement runs, the panel just
+says nothing happened. The user's own count is the only thing that contradicts it.
 
-**Done when:** a pasted `rediss://` URL arrives with mode `require` (or higher), with a parser test.
+**Done when:** a non-SELECT through the Oracle provider reports the affected-row count the driver
+returns, with a live run showing a non-zero count for an `INSERT`.
+
+---
+
+### D14. Three providers lost the buffer-pool gauge, because it was the cache hit ratio wearing a second name
+
+Removing the fabricated cache hit ratios exposed that `bufferPoolUsage` was not a second measurement.
+In Oracle and SQL Server it was literally assigned the ratio itself - the old tests even said "mirrors
+cacheHitRatio in Oracle impl" - so the Performance tab drew and rated one quantity as two independent
+gauges. In PostgreSQL it was `blks_hit / (blks_hit + blks_read)` from `pg_stat_database`, which is also
+a cache hit ratio and not pool occupancy, with a `: 100` fallback when both counters were 0. All three
+now omit the field, which the tab renders as unavailable.
+
+Real occupancy is reachable on each engine and none of the three is free: `pg_buffercache` is an
+extension not installed by default, `V$BUFFER_POOL_STATISTICS` needs the privilege the ratio already
+needs, and `sys.dm_os_buffer_descriptors` is a full descriptor scan on a large instance. So a gauge
+that reads a real pool has a cost the panel has never paid.
+
+**Done when:** each provider either measures pool occupancy for real, at a cost written down next to
+the query, or the field is dropped from `PerformanceMetrics` so no panel offers a gauge nothing fills.
+
+---
+
+### D15. SQLite's table size is `rowCount * 100`, and the storage panel adds it up
+
+`sqlite.ts` computes `tableSizeBytes = rowCount * 100` with the comment "Assume 100 bytes average per
+row". The StorageTab sums it into the *Data* figure it draws next to the database size, so every
+SQLite connection's storage breakdown is a guess presented as a measurement - the same class as the
+cache hit ratios removed on 2026-08-23, and left behind by that change for one reason: both
+`TableStats.tableSize` and `tableSizeBytes` are REQUIRED in `src/lib/db/types.ts`, so an honest absence
+needs a type change, and zeroing them silently re-bases the aggregate for every SQLite connection.
+
+`dbstat` is the real answer and it is not portable: `node:sqlite` has the virtual table
+(`SQLITE_ENABLE_DBSTAT_VTAB`) and `bun:sqlite` does not - measured 2026-08-23, `no such table: dbstat`
+on Bun 1.3.14 / SQLite 3.53.0 against a row from `node:sqlite` 3.51.2. So the per-driver answer
+differs, which is the decision this entry is waiting on.
+
+**Done when:** SQLite reports a table size it measured or reports none, the two fields allow the
+absence, and the storage panel's Data figure is verified against a real file on both drivers.
+
+---
+
+### D16. The TLS a connection string carries in its QUERY STRING is still dropped
+
+`rediss://` and `couchbases://` now reach the form as mode `require` (2026-08-23), which leaves the
+other half of the same intake: `parseGenericURL` drops the query string entirely, so
+`postgresql://host/db?sslmode=verify-full`, MySQL's `?ssl-mode=REQUIRED` and an ADO.NET
+`Encrypt=True;TrustServerCertificate=False` all arrive on the form's `disable` default. The user asked
+for TLS in the string they pasted and the form says plaintext.
+
+Not the same one-line shape as a scheme, which is why it was left out: a scheme implies one mode, a
+parameter carries a VALUE that needs mapping, and two of the values have no representation at all -
+Postgres's `prefer` and `allow` and MySQL's `PREFERRED` mean "encrypt if the server offers it", while
+`SSLMode` is `disable | require | verify-ca | verify-full`. Mapping `prefer` onto either end is a
+security decision, not a translation.
+
+Correcting the record: an earlier version of this entry's predecessor claimed
+"`postgresql://...?sslmode=` already goes through `withSSLMode`". It does not, and never did -
+`withSSLMode`'s only callers were ClickHouse's `http://` / `https://` until the Redis and Couchbase
+schemes joined them.
+
+**Done when:** a pasted string's TLS parameter reaches the form, and either `SSLMode` gains a
+representation for opportunistic TLS or the mapping's refusal to guess is recorded here.
 
 ## Value interpolation
 
@@ -479,44 +517,60 @@ it was not mixed into a correctness PR.
 its rows are recomputed and reordered. The rest need reading one at a time, to tell the stable lists
 (where an index key is fine) from the rest.
 
-### X7. The DDL export types a numeric or a timestamp column as TEXT, because the wire hands it a string
+### X9. What `columnTypes` still cannot name, measured
 
-Measured in the browser against the local `dvdrental` (2026-08-18):
-`SELECT rental_rate, last_update, film_id FROM film` exports as
-`CREATE TABLE … ("rental_rate" TEXT, "last_update" TEXT, "film_id" BIGINT)`.
+The four string-returning drivers fill `QueryResult.columnTypes` since 2026-08-23. Four bounds were
+measured while doing it, and each is a small residue rather than a defect:
 
-Nothing is wrong with the inference. It never sees a number: `pg` returns `numeric` as a string to
-keep its precision, the API serializes to JSON, and a `timestamp` is a string by the time the browser
-reads it. So a value-shaped guess can only recover integer, boolean and text, and the dialect
-spellings #422 added (`NUMBER(19)`, `BINARY_DOUBLE`, `DATETIME2`, …) apply to those three kinds.
+- **A user-defined type has no name.** Postgres's built-in OIDs are a generated static table (they are
+  compiled into the server and never reused), so an enum, a composite or an extension type falls
+  outside it. Measured by walking every table and view in `dvdrental`: 128 result columns, 125 named,
+  0 wrong, 3 absent - all three `mpaa_rating`. Resolving them needs a `pg_catalog.pg_type` round trip,
+  which three of the four call sites cannot make: `query()` releases its pooled client before
+  assembling the result, and `queryReadOnly()` promises EXACTLY ONE statement inside its
+  `BEGIN READ ONLY`. A per-connection OID cache filled on first sight is the shape that would work.
+- **MySQL cannot tell `POINT` from `GEOMETRY`.** Both arrive as code 255 with nothing else to separate
+  them; 38 of the 39 other columns match `information_schema.DATA_TYPE` exactly.
+- **`bit` is exported verbatim, and narrows.** `CREATE TABLE t (c bit)` is `bit(1)` on both Postgres
+  and MySQL, so the DDL export should complete it like the other unbounded families - except `pg`
+  hands a bit string back as the string `"1010"` while `mysql2` hands back a Buffer, so the same
+  declared name needs the text family on one engine and the binary family on the other. One name, two
+  answers, which is why it was left alone.
+- **The mssql transaction path declares types for columns `fields` does not list.** `queryInTransaction`
+  takes `fields` from `Object.keys(recordset[0])`, so a zero-row result has no fields while its
+  `recordset.columns` (which does carry the declaration, even for zero rows - measured) fills
+  `columnTypes`. Harmless today because all three consumers iterate `fields`; taking `fields` from
+  `columns` too would be the right fix and is a behaviour change of its own.
 
-The type is not lost, only unreported. `QueryResult.columnTypes` is the channel, and six provider
-families populate it today: ClickHouse, Druid, Trino, Cassandra and the two search engines. The gap is
-the drivers that hand back strings — `pg`, `mysql2`, `oracledb`, `mssql`.
+**Done when:** each bound is closed or judged settled, with the enum case the only one a user is
+likely to meet.
 
-Guessing from a string's SHAPE is not the fix and should not be attempted: it types a text column
-holding `2026-01-01` as a timestamp.
+### X10. Two providers stringify their bytes before the export can see them, so the binary literal never reaches them
 
-**Done when:** every provider fills `columnTypes` for the columns it declares — the provider triad's
-own work, one PR. It also lets the grid label a column without guessing
-(`ResultsGrid.declaredTypeOf` already reads it).
+The SQL export writes a real per-dialect binary literal since 2026-08-23, and it only reaches a value
+that arrives AS BYTES. Two providers normalise at the driver boundary first:
 
-### X8. The SQL INSERT and DDL exports still write a binary value as its JSON shape
+- `mysql.ts`'s `sanitizeRow` turns a `Buffer` into the string `` `0x${hex}` `` (an empty one into `""`).
+- `cassandra/driver-transport.ts:234` does the same, deliberately - §3.8 of `docs/providers/cassandra.md`
+  records it, because `JSON.stringify` on a `Buffer` gives the wire shape and the CQL literal is `0x…`.
 
-The grid, the row detail sheet and the CSV agree on `\x…` hex (2026-08-23), and `sqlValue` in
-`src/lib/export/result-export.ts` does not: a `bytea`/`BLOB` cell is still written as a quoted
-`{"type":"Buffer","data":[…]}` literal, so a replayed INSERT stores that text rather than the bytes.
+So on those two engines a binary cell is a TEXT value by the time any consumer sees it. Measured in
+the browser (2026-08-23, production build, `SELECT ... b FROM types` on MySQL 26.7.0): the grid shows
+`0x0102ab` where Postgres shows `\x0102ab`, and the SQL INSERT export writes `'0x0102ab'` - the
+eight-character string, not the three bytes. Replayed into a `BLOB` column that stores the text, which
+is the same defect the export just fixed for every other engine, entered one layer earlier.
 
-Not a one-liner, which is why it was left out of the value-rendering work: the hex literal is
-dialect-specific. `\x…` is Postgres, MySQL and SQL Server want `0x…`, and the SQL standard spelling
-is `X'…'`. The export already knows its target dialect for the DDL type names (#422), so the
-literal belongs next to that knowledge.
+It is also the only place the product spells the same value two ways.
 
-The JSON export is deliberately unchanged: the Buffer shape in a `.json` file is at least
-machine-recoverable.
+The fix is to let the bytes through and let `src/lib/export/binary.ts` render them, which is what
+Postgres already does - not to teach the export to recognise a `0x…` string, because that is
+shape-guessing a text column, which this file forbids elsewhere for good reason. The cost is a visible
+change on both engines (`0x…` becomes `\x…` in the grid, the row sheet and the CSV) plus the two docs
+that state the current spelling, and Cassandra's own reason for normalising has to be answered rather
+than reverted.
 
-**Done when:** each dialect the export offers writes a binary literal its own engine accepts, proven
-by replaying an exported file into that engine.
+**Done when:** a binary cell from MySQL and from Cassandra exports as its dialect's binary literal and
+replays into its own engine, with one spelling shown across every surface.
 
 ### U2. The rule that catches an arity change on a JSX handler is configured but not aimed at components
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -25,7 +25,7 @@ None of it is a GitHub issue.
 - [Drivers and connections](#drivers-and-connections) — D1–D16, U17 · 10
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X10, U2–U18 · 9
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X11, U2–U18 · 10
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P5 · 5
@@ -571,6 +571,40 @@ than reverted.
 
 **Done when:** a binary cell from MySQL and from Cassandra exports as its dialect's binary literal and
 replays into its own engine, with one spelling shown across every surface.
+
+### X11. A foreign engine's type name still reaches a target dialect nobody measured
+
+The DDL export re-spells a bare declared type the target dialect does not stand behind, and it can
+only do that for the four dialects whose bare names were measured one `CREATE TABLE probe (c <name>)`
+at a time: postgres, mysql, oracle and mssql (`STANDS_ALONE` in
+`src/lib/export/result-export.ts`). A dialect absent from that table has nothing completed - which is
+right when the DECLARING engine is one of the six wire formats that spell their types out in full,
+and wrong when a bare name arrives from somewhere else.
+
+Measured 2026-08-24, an Oracle result exported under each target:
+
+| Target | `NAME` (Oracle `VARCHAR2`) | `DBL` (`BINARY_DOUBLE`) | `BODY` (`CLOB`) |
+| --- | --- | --- | --- |
+| postgres | `TEXT` | `DOUBLE PRECISION` | `TEXT` |
+| mysql | `TEXT` | `DOUBLE` | `TEXT` |
+| mssql | `NVARCHAR(MAX)` | `FLOAT` | `NVARCHAR(MAX)` |
+| clickhouse | **`VARCHAR2`** | **`BINARY_DOUBLE`** | **`CLOB`** |
+| *(no connection)* | **`VARCHAR2`** | **`BINARY_DOUBLE`** | **`CLOB`** |
+
+The last two rows are files that replay nowhere. Reachable the same way the measured rows are: both
+shells pass the ACTIVE connection's type beside the tab's own result, so querying Oracle and then
+switching to a ClickHouse connection before exporting is enough. The no-connection row is the one
+that regressed - before the four node drivers declared anything, a value-shaped guess wrote
+`TEXT` / `DOUBLE PRECISION` there, which is portable, and an Oracle-only spelling is not.
+
+**It cannot be fixed by widening the rule.** Re-spelling from the family whenever the target is
+unmeasured breaks Trino, whose own bare `varchar` is legal and unbounded and would become the `TEXT`
+Trino does not have. So each remaining dialect needs its own measured `STANDS_ALONE` row -
+clickhouse, trino, cassandra, sqlite, druid and the two search engines - which is a live container
+per engine, the same way the first four were done.
+
+**Done when:** every dialect the export offers has a measured stands-alone set (or a written reason
+it needs none), and an Oracle or MySQL result exported under each of them replays into that engine.
 
 ### U2. The rule that catches an arity change on a JSX handler is configured but not aimed at components
 

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -452,6 +452,11 @@ into discrete fields before the provider sees it:
 | `couchbases://cb.abc123.cloud.couchbase.com` | the host | `18091` | *(none — not invented)* |
 
 Only the **management** port is ever stored: `8091` for `couchbase://`, `18091` for `couchbases://`.
+The scheme also arrives as an SSL mode - `require` for `couchbases://`, `disable` for `couchbase://`
+- because the transport picks `https` vs `http` from `config.ssl` alone and never re-reads the
+pasted string ([§4.3](#43-tls)); without it a `couchbases://` paste posted plain HTTP to 18091.
+`require` and not a verifying mode for the reason §4.3 gives: a self-hosted cluster's certificate is
+self-signed, so only the SSL panel turns verification on.
 A connection that carries *only* a connection string has its hostname lifted out for the transport
 and nothing else — the URL's port is deliberately not used, because a `couchbase://` URL from an
 application config carries the KV port, not the management port, and discovery handles the rest
@@ -567,22 +572,46 @@ enforces uniqueness.
 
 ## 7. Monitoring & health
 
-Every method below degrades to empty/zero on a permission error
-([§3.9](#39-monitoring-degrades-to-empty-never-throws)).
+Every method below degrades to empty on a permission error
+([§3.9](#39-monitoring-degrades-to-empty-never-throws)) — **empty, not zero**: a denied read
+measures nothing, and a metric nobody measured is omitted rather than reported as `0`
+([§7.1](#71-an-unread-metric-is-absent-not-zero)).
 
 | Method | Source | Notes |
 |--------|--------|-------|
 | `getOverview()` | `/pools/default`, `/pools/default/buckets/<bucket>`, `system:keyspaces`, `system:indexes` | version and uptime from the first node; `activeConnections` from the `curr_connections` series |
-| `getPerformanceMetrics()` | bucket stats | cache hit ratio is `100 - ep_cache_miss_rate` (clamped 0..100); `queriesPerSecond` is `cmd_get + cmd_set`; buffer-pool usage is `quotaPercentUsed` |
+| `getPerformanceMetrics()` | bucket stats | cache hit ratio is `100 - ep_cache_miss_rate` (clamped 0..100); `queriesPerSecond` is `cmd_get + cmd_set`; buffer-pool usage is `quotaPercentUsed` — each is **omitted when its source published nothing** ([§7.1](#71-an-unread-metric-is-absent-not-zero)) |
 | `getSlowQueries()` | `system:completed_requests` ordered by `elapsedTime` | one row per recorded request, so `calls` is always 1 — these are individual requests, not aggregates |
 | `getActiveSessions()` | `system:active_requests` | request id, statement, user, remote address, state, elapsed |
 | `getTableStats()` | `/pools/default/buckets/<bucket>` | **bucket level only** — per-collection item counts need a `COUNT(*)` per collection, too expensive for a monitoring poll |
-| `getIndexStats()` | `system:indexes` + `/pools/default/buckets/@index-<bucket>/stats` | index name, scope, collection, keys, type; size and scan counts fall back to 0 because modern servers no longer publish them there |
+| `getIndexStats()` | `system:indexes` + `/pools/default/buckets/@index-<bucket>/stats` | index name, scope, collection, keys, type. Modern servers no longer publish per-index statistics there, so an unpublished size shows as `indexSize: "N/A"` with `indexSizeBytes` **omitted** (a `0 B` read as an empty index, and the Storage tab summed it); `scans` still falls back to `0`, because `IndexStats.scans` is a required field |
 | `getStorageStats()` | `/pools/default/buckets/<bucket>` | Data (`basicStats.diskUsed`) and RAM Quota (`quota.ram` with `quotaPercentUsed`) |
-| `getHealth()` | the four above, in parallel | connections, size, cache hit ratio, top 5 slow queries, top 10 sessions |
+| `getHealth()` | the four above, in parallel | connections, size, cache hit ratio (the string `N/A` when there is none — `formatCacheHitRatio` from `src/lib/monitoring-cache-ratio.ts`), top 5 slow queries, top 10 sessions |
 
 `maxConnections` in the overview is the documented KV default (65536): Couchbase advertises no
 connection ceiling over REST, so the denominator is a constant while the numerator stays measured.
+
+### 7.1 An unread metric is absent, not zero
+
+`PerformanceMetrics.cacheHitRatio`, `queriesPerSecond` and `bufferPoolUsage` are all optional, and
+this provider now omits each one whose source published nothing:
+
+| Field | Reported when | Omitted when |
+|-------|---------------|--------------|
+| `cacheHitRatio` | the `ep_cache_miss_rate` series has a numeric last sample | the series is absent — the stats endpoint was denied, or the bucket is not a Couchbase bucket and publishes no `ep_*` series at all |
+| `queriesPerSecond` | at least one of `cmd_get` / `cmd_set` was published (the other counts as 0) | neither was published |
+| `bufferPoolUsage` | `basicStats.quotaPercentUsed` is a number | `basicStats` is missing, i.e. the bucket endpoint was unreadable |
+
+A **measured** `0` is kept in every case: a bucket with no misses really is at a 100% hit ratio, an
+idle bucket really is doing 0 operations, and an empty bucket really is using none of its quota.
+
+The cache one is why this matters. `DEFAULT_THRESHOLDS` rates the ratio `direction: "below"` with
+`critical: 80`, so the previous `missRate === null ? 0` — a stand-in chosen to avoid "a flattering
+100" — made every bucket whose statistics the connected user may not read show a **red critical
+cache fault the cluster never reported**. Reading the KV stats needs a role many application users
+lack ([§3.9](#39-monitoring-degrades-to-empty-never-throws)), so that was the ordinary case, not an
+edge one. Omitted, the same panels render `N/A` / "Not measured" and score the card as healthy
+(`OverviewTab.tsx`, `PerformanceTab.tsx`).
 
 ---
 
@@ -847,15 +876,17 @@ Everything else:
   is reported as its own type, not expanded into dotted sub-fields.
 - **Table stats are bucket level.** Per-collection item counts would need a `COUNT(*)` per
   collection on every monitoring poll.
-- **Index size and scan counts are usually 0.** Modern servers no longer publish per-index series
-  under `@index-<bucket>`, and the provider does not guess.
+- **Index size is usually unknown and scan counts are usually 0.** Modern servers no longer publish
+  per-index series under `@index-<bucket>`, and the provider does not guess: an unpublished size is
+  `N/A` with no byte count, while `scans` reports `0` only because the field is required.
 - **One bucket per connection.** Multi-bucket browsing from a single connection is out of scope;
   `getSchemaList()` and every monitoring read are scoped to `config.database`.
 - **Analytics/Columnar, Full-Text Search, Eventing and Capella management APIs** (allowed-IP
   administration, cluster provisioning) are not covered.
 - **Monitoring needs privileges.** Without the Query System Catalog role, slow queries and active
-  sessions are `[]` and index statistics fall back to zero — by design
-  ([§3.9](#39-monitoring-degrades-to-empty-never-throws)).
+  sessions are `[]`, index scan counts read `0`, and the performance metrics whose sources are denied
+  are omitted rather than reported as zeroes — by design
+  ([§3.9](#39-monitoring-degrades-to-empty-never-throws), [§7.1](#71-an-unread-metric-is-absent-not-zero)).
 
 ---
 

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -215,7 +215,8 @@ strings are returned as-is. This mirrors how the Redis provider handles structur
 Unlike Redis (`INFO`) or PostgreSQL (system catalogs), LibreDB has no server introspection API.
 Overview and storage stats derive entirely from `fs.statSync` (file size in bytes) and a schema
 scan (prefix group count). There are no sessions, slow queries, or index statistics — those
-methods return empty arrays.
+methods return empty arrays — and no cache statistics either, so there is no cache hit ratio to
+report ([§7.1](#71-there-is-no-cache-hit-ratio-and-there-never-will-be)).
 
 ---
 
@@ -466,9 +467,9 @@ There is no embedded stats API.
 
 | Method | Source | Returns |
 |--------|--------|---------|
-| `getHealth()` | `fs.statSync` | `activeConnections: 1`, file size as `databaseSize`, `cacheHitRatio: 100.0` |
+| `getHealth()` | `fs.statSync` | `activeConnections: 1`, file size as `databaseSize`, `cacheHitRatio: "N/A"` |
 | `getOverview()` | `fs.statSync` + schema scan | `version`, file size, prefix-group count as `tableCount`, `indexCount: 0` |
-| `getPerformanceMetrics()` | — | `cacheHitRatio: 100` |
+| `getPerformanceMetrics()` | — | `{}` — nothing is measurable here |
 | `getSlowQueries()` | — | `[]` (N/A) |
 | `getActiveSessions()` | — | `[]` (N/A — single embedded process) |
 | `getStorageStats()` | `fs.statSync` | one entry: file path + size |
@@ -483,10 +484,21 @@ The `[]` and the absent metrics above now reach the panels as absence rather tha
 know about, with statistics for none of them — so its *Tables* and *Size* cards read `N/A` and the
 list says *No table statistics available.* instead of summing `0` and `0 B`; the **Queries** tab's
 three cards read `N/A` for the same reason, an average over no statements not being `0.00ms`; and
-because `getPerformanceMetrics()` reports only `cacheHitRatio`, the *Buffer* and *Deadlocks* cards on
-the Overview and Performance tabs read `N/A` beside *Not measured* rather than `0%` and a `0` badged
-healthy. `cacheHitRatio: 100` is the one figure here that is stated rather than absent, and it keeps
-its gauge.
+because `getPerformanceMetrics()` returns an empty object, every card on the Overview and Performance
+tabs — *Cache Hit*, *Buffer*, *Deadlocks* — reads `N/A` beside *Not measured* rather than a
+percentage or a `0` badged healthy.
+
+### 7.1 There is no cache hit ratio, and there never will be
+
+`getPerformanceMetrics()` used to report `cacheHitRatio: 100` and `getHealth()` `"100.0"`. Neither
+was a reading. The embedded kernel's entire public surface is `open` / `kv` / `doc` / `table` /
+`catalog` (`@libredb/libredb` 0.2.2) with no statistics call of any kind, and the store the provider
+reads from is this process's own memory rather than a buffer pool with hits and misses — so there is
+no counter to read and nothing a ratio would be a ratio *of*. A number this provider invents is worse
+than a gap, because the panel cannot tell it apart from a measurement (the rule
+[#424](https://github.com/libredb/libredb-studio/issues/424) exists to enforce). Both sites now omit
+it, permanently: the *Cache Hit* card reads `N/A` / *Not measured*, and the agent's health tool
+reports the string `"N/A"`.
 
 ---
 

--- a/docs/providers/mongodb.md
+++ b/docs/providers/mongodb.md
@@ -283,18 +283,44 @@ the collection underneath it.
 ## 7. Monitoring & health
 
 Rich, from `admin().serverStatus()`, `db.stats()`, `currentOp`, `$indexStats`, and the profiler.
-Every method is wrapped in try/catch and degrades to a sensible default on permission errors.
+Every method is wrapped in try/catch. Degradation reports the absence rather than filling it in — see
+[§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured).
 
 | Method | Source | Notes |
 |--------|--------|-------|
-| `getHealth()` | `serverStatus`, `dbStats`, `currentOp`, `system.profile` | connections, data size, WiredTiger cache-hit %, current ops; slow queries need the profiler (placeholder row if disabled) |
-| `getOverview()` | `serverStatus`, `buildInfo`, `dbStats`, `listCollections` | version, uptime, connections, collection/index counts |
-| `getPerformanceMetrics()` | `serverStatus` (WiredTiger + opcounters) | cache-hit %, **ops/sec** (`query`+`insert`+`update`+`delete` opcounters ÷ uptime — *total operations, not just queries*), buffer-pool % (cache bytes), `deadlocks: 0` |
+| `getHealth()` | `serverStatus`, `dbStats`, `currentOp`, `system.profile` | connections, data size, WiredTiger cache-hit % (`"N/A"` when unmeasurable, [§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured)), current ops; slow queries need the profiler (placeholder row if disabled) |
+| `getOverview()` | `serverStatus`, `buildInfo`, `dbStats`, `listCollections` | version, uptime, connections, collection/index counts. `maxConnections` is `connections.current + connections.available`, or `0` — the repo's spelling of *no limit published* — when the server publishes no headroom |
+| `getPerformanceMetrics()` | `serverStatus` (WiredTiger + opcounters) | cache-hit %, **ops/sec** (`query`+`insert`+`update`+`delete` opcounters ÷ uptime — *total operations, not just queries*), buffer-pool % (cache bytes), `deadlocks: 0`. **Every field is optional**: each one is present only if its reading was, and a failed `serverStatus` reports `{}` ([§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured)) |
 | `getSlowQueries()` | `system.profile` | per-op time/returned; **`[]` if the profiler isn't enabled** (`db.setProfilingLevel(1)`); sorted by `millis` (slowest) — note `getHealth()`'s slow-query block instead sorts by `ts` (most recent) and emits a placeholder row when disabled |
 | `getActiveSessions()` | `currentOp` | opid, ns, lock waits, duration — ⚠️ the **`user` field is populated from `op.client`** (the client `host:port`), **not** an authenticated user |
 | `getTableStats()` | `collStats` per collection | row count + data/index/total sizes, `totalIndexSize` carried as the byte figure `indexSizeBytes` and not only as formatted text |
 | `getIndexStats()` | `$indexStats` + `indexes()` | **real `scans`** (`accesses.ops`); `indexSize` `N/A`; **`indexType` only distinguishes `text` vs `btree`** — `hashed`/`2dsphere`/`2d`/wildcard/clustered are all mislabelled `btree` |
 | `getStorageStats()` | `dbStats` + WiredTiger | Data / Indexes / Storage / WiredTiger cache (with usage %) |
+
+### 7.1 What the panel shows when the cache cannot be measured
+
+The cache hit ratio is computed from `serverStatus.wiredTiger.cache` — `pages read into cache` over
+`pages requested from the cache`. Three things can make that unmeasurable, and none of them is a
+number:
+
+- the deployment publishes no `wiredTiger` section at all (`mongos`, the in-memory storage engine,
+  the wire-compatible services);
+- the section is there but `pages requested from the cache` is `0`, on a server that has served
+  nothing yet — no hits and no misses, which is not a perfect hit rate;
+- `serverStatus` fails outright, which is what an unprivileged user gets (`clusterMonitor` is the
+  role it wants).
+
+In all three the field is **omitted** from `getPerformanceMetrics()` and `getHealth()` reports the
+string `"N/A"`; the Overview and Performance tabs then render *Cache Hit* as `N/A` beside *Not
+measured*, and the card border stays neutral instead of being rated. `bufferPoolUsage` follows the
+same rule for the same section. A **measured** `0` — a genuinely cold cache — is kept and rendered as
+`0.0%`, because it is a fact the server reported.
+
+This replaces a hardcoded `cacheHitRatio: 99` that both the no-`wiredTiger` path and the failed-
+`serverStatus` path used to return: a figure the provider invented, indistinguishable at the panel
+from a measurement (the rule [#424](https://github.com/libredb/libredb-studio/issues/424) exists to
+enforce, and [#452](https://github.com/libredb/libredb-studio/pull/452) built the *unavailable*
+rendering for).
 
 ---
 
@@ -455,8 +481,9 @@ Over the API: `POST /api/db/query` (JSON MQL in the `sql` field) and `POST /api/
 - **`collStats` is deprecated** in MongoDB 6.2+ (in favour of the `$collStats` aggregation stage);
   size/stats calls may warn or change on newer servers.
 - **Monitoring needs privileges.** `serverStatus`/`currentOp`/`$indexStats` and the profiler require
-  appropriate roles (`clusterMonitor`, etc.); without them fields degrade to `N/A`/`0`/`[]`, and slow
-  queries require the profiler to be enabled.
+  appropriate roles (`clusterMonitor`, etc.); without them the affected metrics are reported as
+  *unavailable* rather than as numbers ([§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured)),
+  and slow queries require the profiler to be enabled.
 - **`Binary` values are shown as a placeholder** (`<Binary: N bytes>`), not the raw bytes, and only
   a subset of BSON types are normalised (`Long`/`Timestamp`/`UUID`/`RegExp`/`Code`/`DBRef` render as
   generic objects).

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -314,7 +314,7 @@ connection always has discrete fields because the UI populates them.
 `@p1`, `@p2`, … via `request.input()`, runs the query, and returns:
 
 ```ts
-{ rows: recordset, fields, rowCount: rowsAffected[0] ?? recordset.length, executionTime }
+{ rows: recordset, fields, rowCount: rowsAffected[0] ?? recordset.length, executionTime, columnTypes? }
 ```
 
 Native `mssql` errors are normalised through `mapDatabaseError()` (see [§11](#11-error-handling)).
@@ -341,6 +341,40 @@ throw — it does **not** confirm the cancellation actually took effect. Exposed
   as the JSON shape a `Buffer` serializes to and is rendered as hex there (§7).
 - **Only the first result set is returned.** `query()` reads `result.recordset` (singular), so a
   multi-statement batch or a stored procedure returning several result sets surfaces just one.
+
+### 5.4 Declared column types
+
+`mssql` attaches a `columns` map to the recordset, and each entry's `type` carries a `declaration` -
+T-SQL's own lowercase spelling. That is passed through into `QueryResult.columnTypes`
+([column-types.ts](../../src/lib/db/providers/sql/column-types.ts)) by both `query()` and
+`queryInTransaction()`, keyed by the column name. `type` is a factory FUNCTION for some of the
+driver's types and a plain object for others; `declaration` is on both.
+
+Measured on SQL Server 2022 CU26 over the probe table:
+
+| declared | `type.name` | `type.declaration` |
+|---|---|---|
+| `BIGINT` | `BigInt` | `bigint` |
+| `DECIMAL(10,2)` | `Decimal` | `decimal` (with `precision: 10, scale: 2` beside it) |
+| `FLOAT` | `Float` | `float` |
+| `BIT` | `Bit` | `bit` |
+| `NVARCHAR(40)` | `NVarChar` | `nvarchar` (`length: 80` - bytes, not characters) |
+| `VARCHAR(MAX)` | `VarChar` | `varchar` (`length: 65535`, a sentinel rather than the real 2^31-1) |
+| `DATETIME2` / `DATE` | `DateTime2` / `Date` | `datetime2` / `date` |
+| `UNIQUEIDENTIFIER` | `UniqueIdentifier` | `uniqueidentifier` |
+| `VARBINARY(50)` | `VarBinary` | `varbinary` |
+
+`declaration` rather than `type.name`, because it is the word T-SQL uses:
+`INFORMATION_SCHEMA.COLUMNS.DATA_TYPE` answers `bigint`, not `BigInt`, for every one of those
+columns, so a declared type reads like the schema tree's entry. The length, precision and scale are
+left out of the name for the reason the `length` column above shows - they are reported in units that
+do not survive being spelled back (80 bytes for 40 characters, a sentinel for `MAX`).
+
+This is the only source of a type for a computed column or an ad-hoc projection. It matters here
+because `BIGINT` and `DECIMAL` reach the browser as strings (§5.3): measured before this existed, the
+probe table's `BIGINT` and `UNIQUEIDENTIFIER` columns both exported as `NVARCHAR(MAX)` and its
+`DECIMAL(10,2)` as `FLOAT`. Both execution paths fill it from the same column map - including
+`queryInTransaction()`, which had the map available all along and simply never read it.
 
 ---
 
@@ -382,14 +416,50 @@ in parallel. Each sub-query is independently privilege-guarded (DMVs need `VIEW 
 
 | Method | Primary source | Notes |
 |--------|----------------|-------|
-| `getHealth()` | `dm_exec_sessions`, `database_files`, `dm_os_performance_counters`, `dm_exec_query_stats` | connections, size, buffer-cache-hit %, top-5 slow queries, 10 sessions; each block guarded → `N/A`/`0`/`[]` |
+| `getHealth()` | `dm_exec_sessions`, `database_files`, `dm_os_performance_counters`, `dm_exec_query_stats` | connections, size, buffer-cache-hit % (`N/A`, never `0%`, when unreadable — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)), top-5 slow queries, 10 sessions; each block guarded → `N/A`/`0`/`[]` |
 | `getOverview()` | `@@VERSION`, `dm_os_sys_info`, `dm_exec_sessions`, `sys.configurations`, `database_files`, `sys.tables`/`indexes` | `user connections = 0` → reported as 32767 (unlimited) |
-| `getPerformanceMetrics()` | `dm_os_performance_counters` | **only** cache-hit ratio + buffer-pool usage (no QPS/deadlocks); defaults `100` |
+| `getPerformanceMetrics()` | `dm_os_performance_counters` | **only** the cache-hit ratio, and it is **omitted** when the DMV cannot be read (no QPS/deadlocks/buffer-pool) — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable) |
 | `getSlowQueries()` | `dm_exec_query_stats` ⋈ `dm_exec_sql_text` | `sharedBlksHit`=logical reads, `sharedBlksRead`=physical reads; `[]` on failure |
 | `getActiveSessions()` | `dm_exec_sessions` ⋈ `dm_exec_requests` ⋈ `dm_exec_sql_text` | **`blocked` is real** (`blocking_session_id > 0`); wait types; `[]` on failure |
 | `getTableStats()` | `sys.tables`/`partitions`/`allocation_units` | sizes + `lastAnalyze` (`STATS_DATE`); no live/dead tuples; `[]` on failure |
 | `getIndexStats()` | `sys.indexes`/`allocation_units` + `dm_db_index_usage_stats` | **`scans` is real** (seeks+scans+lookups); `[]` on failure |
 | `getStorageStats()` | `sys.database_files` | per-file name/path/size; `[]` on failure |
+
+### 7.1 When the cache hit ratio is not measurable
+
+Two states, both ordinary:
+
+- **The login lacks the server-level grant.** Measured 2026-08-23 on SQL Server 2022 CU26 against a
+  login with nothing beyond `CONNECT`:
+
+  ```
+  Msg 300, Level 14, State 1, Line 1
+  VIEW SERVER PERFORMANCE STATE permission was denied on object 'server', database 'master'.
+  ```
+
+  This is also the Azure SQL Database case, where server-scoped DMVs are restricted.
+
+- **The counter base is zero.** `NULLIF(..., 0)` guards the division, so the query returns one row
+  whose single column is `NULL`. Measured 2026-08-23 on the same instance:
+
+  ```
+  hit_ratio
+  ---------
+       NULL
+  ```
+
+In both cases **`getHealth().cacheHitRatio` is `"N/A"` and `getPerformanceMetrics()` omits
+`cacheHitRatio`** (returning `{}`), and the Overview and Performance tabs render "Not measured". A
+ratio measured as `0` is kept and shown as `0.0%`.
+
+`getHealth()` previously published `"0%"` for an unreadable ratio and `getPerformanceMetrics()`
+defaulted to `100`. The `0%` was the worse of the two: the Overview card rates a low ratio "Needs
+tuning", so a least-privilege login saw a cache fault SQL Server never reported.
+
+`bufferPoolUsage` is **no longer reported**. It was assigned `cacheHitRatio` itself — the same number
+under a second name, drawn and rated as an independent gauge. SQL Server does publish pool occupancy,
+through `sys.dm_os_buffer_descriptors` against `max server memory`, but this method does not query it
+and that scan is not free.
 
 SQL Server is the only provider that reports **real blocked-session detection** (`blocking_session_id`;
 Postgres/Oracle/MySQL report `blocked: false`). For **index scan counts** it joins
@@ -573,7 +643,9 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
 - **SQL authentication only** — Windows Integrated / Azure AD auth is not wired.
 - **No two-phase schema loading** — `/api/db/schema/list` falls back to the full `getSchema()`.
 - **DMV monitoring needs `VIEW SERVER STATE`**; a least-privilege user silently gets `N/A`/`0`/`[]`.
-  `getPerformanceMetrics()` reports only cache-hit ratio (no QPS/deadlocks).
+  `getPerformanceMetrics()` reports only the cache-hit ratio (no QPS, deadlocks, or buffer-pool
+  usage), and **omits even that** when `dm_os_performance_counters` is unreadable rather than
+  substituting a figure — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable).
 
 ---
 

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -133,9 +133,14 @@ on both `query()` and `queryInTransaction()`.
 
 Both query paths use `conn.execute(sql, params)` (mysql2 server-side prepared statements) rather than
 `query()`, so parameterized queries are bound by the server. `rowCount` is `rows.length` **only when
-the driver returns a row array** (i.e. `SELECT`); for non-`SELECT` statements (INSERT/UPDATE/DELETE)
-mysql2 returns a `ResultSetHeader` rather than an array, and the provider reports `rowCount: 0`
-(`Array.isArray(result.rows) ? result.rows.length : 0`) — affected-rows is not surfaced.
+the driver returns a row array** (i.e. `SELECT`); for a non-`SELECT` statement mysql2 returns a
+`ResultSetHeader` rather than an array, and the provider reports its `affectedRows` — see
+[§5.1](#51-execution) for the full envelope.
+
+This section used to say affected-rows was not surfaced and `rowCount` was reported as 0. That
+described the intent of one line; the line beside it called `.map` on the same header and threw, so
+what the user actually got for every DDL and DML statement was an error for work the server had
+already done.
 
 ### 3.5 No server-side query timeout
 
@@ -218,11 +223,43 @@ pooled connection, optionally records its `threadId` for cancellation, runs the 
 sanitizes binary values, and returns the standard envelope:
 
 ```ts
-{ rows, fields: string[], rowCount: rows.length, executionTime }
+{ rows, fields: string[], rowCount: rows.length, executionTime, columnTypes? }
 ```
 
 Native `mysql2` errors are normalised via `mapDatabaseError()` into the shared
 [`errors.ts`](../../src/lib/db/errors.ts) classes.
+
+**A statement that returns no result set** — every DDL statement, and `INSERT`/`UPDATE`/`DELETE` —
+answers a different envelope, because `mysql2` hands back a different thing. `execute`'s first return
+value is an array of rows only when the statement produced a result set; otherwise it is a
+`ResultSetHeader` OBJECT and the field packets arrive as `undefined`. Printed verbatim out of mysql2
+against mysql 26.7.0 for `INSERT INTO r5_hdr (note) VALUES ('a'),('b')`:
+
+```js
+{ fieldCount: 0, affectedRows: 2, insertId: 1,
+  info: "Records: 2  Duplicates: 0  Warnings: 0",
+  serverStatus: 2, warningStatus: 0, changedRows: 0 }
+```
+
+So the answer is no rows, no fields, no `columnTypes`, and the affected-row count in `rowCount`:
+
+```ts
+{ rows: [], fields: [], rowCount: header.affectedRows, executionTime }
+```
+
+That matches what the other SQL providers here already report for the same statements — SQL Server
+uses `rowsAffected[0]`, SQLite `changes`, PostgreSQL `pg`'s own `rowCount` — and `rowCount` is the
+number the results footer renders. `insertId`, `changedRows` and `warningStatus` are dropped:
+`QueryResult` models none of them. `affectedRows` is the **matched** count, so a no-op
+`UPDATE … SET note = note` reports 1 while `changedRows` is 0 — the same way SQL Server's
+`rowsAffected` counts.
+
+Until this was fixed, both this path and `queryInTransaction()` called `.map` on that header and threw
+`result.rows.map is not a function` — **after** the server had already applied the statement. Measured
+through `createDatabaseProvider({type:"mysql"})` on 2026-08-23: `DROP TABLE`, `CREATE TABLE`, `INSERT`,
+`UPDATE` and `DELETE` each failed, and a following `SELECT` returned the row the failed `INSERT` had
+written. Reporting a failure for work that landed is the answer that makes a user retry and
+double-apply it.
 
 ### 5.2 Automatic `LIMIT` injection
 
@@ -259,6 +296,47 @@ A query issued with a `queryId` records its connection `threadId`. `cancelQuery(
 to its caller as a `QueryCancelledError` (MySQL emits *"Query execution was interrupted"*, which
 `mapDatabaseError()` classifies as cancellation). Exposed via `POST /api/db/cancel`.
 
+### 5.4 Declared column types
+
+`mysql2` reports a column's type as a protocol type CODE plus flags, a charset number and a length -
+never a name. The codes are not one type each, so `QueryResult.columnTypes`
+([column-types.ts](../../src/lib/db/providers/sql/column-types.ts)) resolves them from all four
+pieces. Measured on MySQL 26.7.0 over a 40-column probe table, printed straight out of the driver:
+
+| declared | code | length | charset | flags | reported as |
+|---|---|---|---|---|---|
+| `BIGINT` | 8 | 20 | 63 | 0 | `bigint` |
+| `DECIMAL(10,2)` | 246 | 12 | 63 | 0 | `decimal` |
+| `TINYINT` / `TINYINT(1)` / `BOOLEAN` | 1 | 4 / 1 / 1 | 63 | 0 | `tinyint` |
+| `VARCHAR(40)` | 253 | 160 | 224 | 0 | `varchar` |
+| `VARBINARY(9)` | 253 | 9 | 63 | 128 | `varbinary` |
+| `CHAR(10)` / `BINARY(8)` | 254 | 40 / 8 | 224 / 63 | 0 / 128 | `char` / `binary` |
+| `ENUM('a','b')` / `SET('x','y')` | 254 | 4 / 12 | 224 | 256 / 2048 | `enum` / `set` |
+| `TEXT` / `BLOB` | 252 | 262140 / 65535 | 224 / 63 | 16 / 144 | `text` / `blob` |
+| `TINYTEXT` … `LONGTEXT` | 252 | 1020 / 262140 / 67108860 / 4294967295 | 224 | 16 | `tinytext` … `longtext` |
+| `JSON` | 245 | 4294967295 | 63 | 144 | `json` |
+| `GEOMETRY` / `POINT` | 255 | 4294967295 | 63 | 144 | `geometry` (both) |
+
+Two things that table settles, neither of which is guessable from the code alone:
+
+- **Charset 63 (`binary`) separates a character type from a byte type.** The BLOB flag is set for
+  `TEXT` as well as for `BLOB` and cannot do it.
+- **All four text tiers and all four blob tiers arrive as one code, 252.** Only the length tells them
+  apart, so the tier is read from its ceiling (a tier's byte capacity times the charset's maximum
+  bytes per character - 4 for utf8mb4 - and the tiers are 256x apart, so the ranges never overlap).
+
+What the names deliberately leave out: the length, precision or display width (`decimal`, not
+`decimal(10,2)`), the `unsigned` suffix, and the `point` subtype the protocol does not carry.
+Checked column by column against `information_schema.COLUMNS.DATA_TYPE` for the same 40-column
+table - the same source the schema tree shows - **38 of 39 match exactly**; the one difference is
+`POINT`, which arrives as code 255 with nothing to distinguish it from `GEOMETRY`.
+
+`columnTypes` is filled by `query()` and `queryInTransaction()`, and is **absent entirely** when no
+column declared a type. Its consumers are the results grid's column labels, the SQL-DDL export
+(which prefers a declared type over its own value-shaped guess) and the agent's state summary. This
+matters most for the types whose values arrive as strings: a `DECIMAL` reaches the browser as
+`"19.99"`, so before this the DDL export wrote it as `TEXT`.
+
 ---
 
 ## 6. Transactions
@@ -270,7 +348,7 @@ to the pool until commit/rollback). Surfaced via `POST /api/db/transaction`.
 | Method | Behaviour |
 |--------|-----------|
 | `beginTransaction()` | `pool.getConnection()` + `beginTransaction()`, arms a **5-minute auto-rollback** timer ([mysql.ts:41](../../src/lib/db/providers/sql/mysql.ts)). Throws if one is active. |
-| `queryInTransaction(sql, params?)` | Runs on the transaction's connection (with the same binary sanitization). Throws if none active. |
+| `queryInTransaction(sql, params?)` | Runs on the transaction's connection (with the same binary sanitization, and the same non-SELECT envelope as §5.1). Throws if none active. |
 | `commitTransaction()` / `rollbackTransaction()` | Ends it, clears the timer, releases the connection. Throws if none active. |
 | `expireTransaction()` | Timeout callback — auto-`rollback()` to prevent leaked locks. |
 | `isInTransaction()` | Current state. |
@@ -311,14 +389,22 @@ All monitoring reads from `SHOW STATUS`/`SHOW VARIABLES`, `information_schema`, 
 
 **Graceful degradation — note the *different* failure modes:**
 - `getHealth()` slow-queries: try/catch → a single placeholder row (*"Performance schema not available"*).
-- `getHealth()` cache-hit ratio: `formatCacheHitRatio()` → `"N/A"` when nothing was measured.
+- `getHealth()` cache-hit ratio: `formatCacheHitRatio()` → `"N/A"` when nothing was measured, and
+  `"N/A"` again — rather than a failed health read — when the ratio query THROWS. A tenant can be
+  missing the `performance_schema` *database* instead of merely having the schema off, and then the
+  query does not answer NULLs: measured 2026-08-20 on a live OceanBase Community Edition 4.4.2.1
+  tenant through this provider, and reproduced on `mysql:latest` as `ERROR 1049 (42000): Unknown
+  database '...'`. That one throw used to abort the whole of `getHealth()`, so the panel showed
+  nothing where one unavailable metric was the honest answer.
 - `getSlowQueries()`: try/catch → **empty array** `[]`.
 - `getPerformanceMetrics()`: **every field is omitted rather than defaulted.** A server with
   `performance_schema` OFF answers the `global_status` sub-selects with NULL instead of failing, so
   each reading is taken through `measuredNumber()` and a field with nothing behind it is left out of
   the object entirely. `deadlocks` comes from `SHOW STATUS`, which answers either way, so a `0` there
-  is a real measurement and is reported *where the server publishes one*. If `performance_schema` is
-  absent outright the whole method returns `{}`. This is the rule #448 and #452 settled: ABSENCE and
+  is a real measurement and is reported *where the server publishes one*. If the
+  `performance_schema` database is absent outright — the OceanBase case above, where every one of
+  these queries raises `ERROR 1049` — the whole method returns `{}` rather than the `cacheHitRatio:
+  99` it once did. This is the rule #448 and #452 settled: ABSENCE and
   ZERO are different inputs, and only the first is invisible to the panels.
 - `deadlocks` reads `Innodb_deadlocks`, which is **MariaDB's** status variable. MySQL does not publish
   it — measured as an empty `SHOW STATUS` result on both 8.0.46 and 26.7.0 — so the field is absent on
@@ -442,6 +528,11 @@ The `mysql2/promise` module is replaced with an in-process mock via `mock.module
 **before** the provider is imported — there is no live MySQL in the suite. The mock's pool/connection
 returns canned `[rows, fields]` tuples, exercising the same provider code paths as a real server.
 
+One mock shape is load-bearing: a non-SELECT must be mocked as a **`ResultSetHeader` object with
+`undefined` fields**, not as an array. An array-shaped mock is exactly what hid the
+`result.rows.map is not a function` defect described in [§5.1](#51-execution) — the whole suite was
+green while every DDL and DML statement failed against a real server.
+
 > ⚠️ **Mock isolation:** `bun`'s `mock.module()` is process-wide, so files mocking different drivers
 > cross-contaminate when they share a process. A **single file** is safe (one file = one process).
 > The full `bun run test` script runs the core group in **one** process and is load-order flaky, so
@@ -454,7 +545,9 @@ returns canned `[rows, fields]` tuples, exercising the same provider code paths 
 capabilities, `getSchema()` (columns/FKs/indexes, primary-key detection), health, maintenance (all
 types + kill validation), the full transaction lifecycle, `queryInTransaction`, query cancellation,
 overview, performance metrics, slow queries, active sessions, table/index/storage stats, every SSL
-branch, `prepareQuery`, and error mapping (`ER_ACCESS_DENIED`, `ECONNREFUSED`).
+branch, `prepareQuery`, error mapping (`ER_ACCESS_DENIED`, `ECONNREFUSED`), and the non-SELECT envelope
+(DDL, `INSERT`, `UPDATE`, `DELETE`, and the transaction path) driven from real `ResultSetHeader`
+literals.
 
 ### 12.3 Run it
 

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -332,7 +332,7 @@ cancellation, runs `conn.execute(sql, binds, { outFormat: OUT_FORMAT_OBJECT, aut
 and returns:
 
 ```ts
-{ rows, fields: metaData.map(m => m.name), rowCount: rows.length, executionTime }
+{ rows, fields: metaData.map(m => m.name), rowCount: rows.length, executionTime, columnTypes? }
 ```
 
 `rowCount` is `rows.length`. Non-`SELECT` statements (INSERT/UPDATE/DELETE/DDL) return no `rows`
@@ -358,6 +358,38 @@ currently configure `fetchAsString`/`fetchAsBuffer`/`fetchInfo`:
   is a real gap — see [Known limitations](#14-known-limitations--future-work).
 - **`NUMBER`** is returned as a JavaScript `number`; values beyond 2^53 (e.g. `NUMBER(38)` ids or
   high-precision decimals) **lose precision**. Fetching such columns as strings would preserve them.
+
+### 5.4 Declared column types
+
+Oracle is the one engine of the four whose driver hands over a NAME rather than a wire code:
+`result.metaData[].dbTypeName`. It is passed through into `QueryResult.columnTypes` verbatim
+([column-types.ts](../../src/lib/db/providers/sql/column-types.ts)), keyed by the column name in
+`fields`, by both `query()` and `queryInTransaction()`, and it is uppercase - the same spelling
+`ALL_TAB_COLUMNS.DATA_TYPE` uses, so a declared type reads like the schema tree's entry.
+
+Measured on Oracle Free 23ai over the probe table, verbatim from `oracledb`:
+
+| declared | `dbTypeName` | also reported |
+|---|---|---|
+| `NUMBER(19)` | `NUMBER` | `precision: 19, scale: 0` |
+| `NUMBER(10,2)` | `NUMBER` | `precision: 10, scale: 2` |
+| `BINARY_DOUBLE` | `BINARY_DOUBLE` | |
+| `VARCHAR2(40)` | `VARCHAR2` | `byteSize: 40` |
+| `CLOB` / `BLOB` | `CLOB` / `BLOB` | |
+| `TIMESTAMP` / `DATE` | `TIMESTAMP` / `DATE` | `precision: 6` on the timestamp |
+| `SYSTIMESTAMP` (computed) | `TIMESTAMP WITH TIME ZONE` | `precision: 6` |
+| `COUNT(*)` (computed) | `NUMBER` | `precision: 0, scale: 0` |
+| `1/3` (computed) | `NUMBER` | `precision: 0, scale: -127` |
+
+The precision and scale sit right beside the name and are deliberately **not** spelled into it. The
+last two rows are why: a computed column reports precision 0 or scale -127, and a `NUMBER(p,s)`
+built from those would claim something Oracle did not. `DATA_TYPE` is the type; the declaration
+channel carries the type.
+
+This is the only source of a type for a computed column or an ad-hoc projection - the schema tree has
+no catalog entry to answer with - and it is what stops the SQL-DDL export from guessing. Measured
+before this existed, the probe table's `NUMBER(10,2)` column exported as `BINARY_DOUBLE` and its
+`BLOB` as `VARCHAR2(4000)`, both inferred from a value.
 
 ---
 
@@ -401,14 +433,47 @@ sub-query is independently privilege-guarded ([§3.6](#36-privilege-resilient-mo
 
 | Method | Primary source | Notes / degradation |
 |--------|----------------|---------------------|
-| `getHealth()` | `V$SESSION`, `USER_SEGMENTS`, `V$SYSSTAT`, `V$SQL` | each block guarded → `N/A`/`0`/`[]` if no privilege |
+| `getHealth()` | `V$SESSION`, `USER_SEGMENTS`, `V$SYSSTAT`, `V$SQL` | each block guarded → `N/A`/`0`/`[]` if no privilege; `cacheHitRatio` is `N/A`, never `0%` ([§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)) |
 | `getOverview()` | `V$VERSION`, `V$INSTANCE`, `V$SESSION`, `V$PARAMETER`, `USER_SEGMENTS`, `USER_TABLES`/`USER_INDEXES` | each guarded |
-| `getPerformanceMetrics()` | `V$SYSSTAT` | **only** `cacheHitRatio` + `bufferPoolUsage` (no QPS/deadlocks); defaults to `100` if denied |
+| `getPerformanceMetrics()` | `V$SYSSTAT` | **only** `cacheHitRatio`, and it is **omitted** when `V$SYSSTAT` cannot be read (no QPS/deadlocks/buffer-pool) — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable) |
 | `getSlowQueries()` | `V$SQL` (top-N by `ELAPSED_TIME`) | `sharedBlksHit`=`BUFFER_GETS`, `sharedBlksRead`=`DISK_READS`; `[]` on failure |
 | `getActiveSessions()` | `V$SESSION` ⋈ `V$SQL` | `pid` = `"SID,SERIAL#"`; wait class/event; `[]` on failure |
 | `getTableStats()` | `ALL_TABLES` + `USER_SEGMENTS` | sizes + `lastAnalyze`; no live/dead tuples, no bloat; `[]` on failure |
 | `getIndexStats()` | `ALL_INDEXES` + `USER_SEGMENTS` + `ALL_IND_COLUMNS` | **`scans` always `0`** (no usage counter exposed); `isPrimary` always `false`; `[]` on failure |
 | `getStorageStats()` | `DBA_DATA_FILES` → fallback `USER_SEGMENTS` | per-tablespace size; DBA view falls back to user segments without privilege |
+
+### 7.1 When the cache hit ratio is not measurable
+
+Two states, both ordinary:
+
+- **The connected user cannot read `V$SYSSTAT`.** Measured 2026-08-23 on Oracle Free 23ai against a
+  user granted only `CREATE SESSION`:
+
+  ```
+  ORA-00942: table or view "SYS"."V_$SYSSTAT" does not exist
+  ```
+
+- **The counter denominator is zero.** `NULLIF(..., 0)` guards the division, so the statement returns
+  one row whose single column is `NULL`. Measured 2026-08-23 on the same instance:
+
+  ```
+   HIT_RATIO
+  ----------
+  <NULL>
+  ```
+
+In both cases **`getHealth().cacheHitRatio` is `"N/A"` and `getPerformanceMetrics()` omits
+`cacheHitRatio`** (returning `{}` when nothing else was read), and the Overview and Performance tabs
+render "Not measured". A ratio measured as `0` is kept and shown as `0.0%`.
+
+`getHealth()` previously published `"0%"` for an unreadable ratio and `getPerformanceMetrics()`
+defaulted to `100`. The `0%` was worse than the `100`: the Overview card rates a low ratio "Needs
+tuning", so a least-privilege application user saw a cache fault Oracle never reported.
+
+`bufferPoolUsage` is **no longer reported**. It was assigned `cacheHitRatio` itself — the same number
+under a second name, which the Performance tab drew and rated as an independent gauge. Oracle does
+publish pool occupancy, in `V$BUFFER_POOL_STATISTICS`/`V$SGASTAT`, but this method does not query
+them.
 
 ---
 
@@ -591,8 +656,9 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
 - **Row counts (`NUM_ROWS`) are optimizer estimates** populated by `DBMS_STATS`; they can be stale
   or `NULL` until stats are gathered.
 - **Monitoring depends on `V$` privileges.** A low-privilege app user silently gets `N/A`/`0`/`[]`
-  for the views it can't read. `getPerformanceMetrics()` reports only cache-hit ratio (no
-  QPS/deadlocks).
+  for the views it can't read. `getPerformanceMetrics()` reports only the cache-hit ratio (no QPS,
+  deadlocks, or buffer-pool usage), and **omits even that** when `V$SYSSTAT` is unreadable rather
+  than substituting a figure — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable).
 - **No two-phase schema loading** — `/api/db/schema/list` falls back to the full `getSchema()`.
 
 ---

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -163,7 +163,13 @@ Monitoring never hard-fails on a missing optional feature:
   currently-running queries when the extension isn't installed, whereas `getHealth()`'s lighter
   slow-query block returns a single placeholder row (`pg_stat_statements extension not enabled`).
 - WAL size (`getStorageStats`) and `pg_stat_bgwriter` checkpoint times are superuser/version-gated;
-  failures are swallowed and the field is simply omitted or reported as `N/A`.
+  failures are swallowed and the field is simply omitted or reported as `N/A`. PostgreSQL 17 moved
+  `checkpoint_write_time`/`checkpoint_sync_time` from `pg_stat_bgwriter` to `pg_stat_checkpointer`,
+  so on 17+ the query throws and `checkpointWriteTime` is `"N/A"` — measured 2026-08-23 through this
+  provider against `postgres:18`. It is never `"0.0s"` for an unread counter.
+- A metric the statistics views did not publish is **omitted rather than defaulted**
+  ([§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)); `deadlocks` is absent when
+  `pg_stat_database` has no row for the database, rather than reported as zero deadlocks.
 
 ### 3.6 Safe maintenance targets
 
@@ -269,7 +275,7 @@ acquires a pooled client, optionally records its backend PID for cancellation, r
 (optionally parameterized — `$1`, `$2`, …) statement, and returns the standard envelope:
 
 ```ts
-{ rows, fields: string[], rowCount, executionTime }
+{ rows, fields: string[], rowCount, executionTime, columnTypes? }
 ```
 
 Native `pg` errors are normalised through `mapDatabaseError()` into the shared
@@ -374,6 +380,57 @@ A query issued with a `queryId` records its backend PID in a `Map`. `cancelQuery
 `pg_cancel_backend(pid)` on a fresh pooled client, returning whether the cancel signalled. Exposed
 via `POST /api/db/cancel`.
 
+### 5.4 Declared column types
+
+`pg` says exactly one thing about a column's type: `field.dataTypeID`, a `pg_type` OID. There is no
+name on the wire, and no value-shaped guess can supply one — `numeric` arrives as the **string**
+`"4.99"` so that its precision survives, `bigint` arrives as a string for the same reason, and a
+`timestamp` is a string by the time the browser has read the JSON. Measured against the local
+dvdrental before this existed, `SELECT rental_rate, last_update, film_id FROM film` exported as
+`("rental_rate" TEXT, "last_update" TIMESTAMP, "film_id" BIGINT)`: a `numeric` typed as text, and an
+`integer` widened. Guessing from the string's SHAPE is not the answer either — it would type a text
+column holding `2026-01-01` as a timestamp.
+
+So the OID is resolved to a name and reported in `QueryResult.columnTypes`, keyed by the name in
+`fields` ([column-types.ts](../../src/lib/db/providers/sql/column-types.ts)). All three execution
+paths do it: `query()`, `queryInTransaction()` and the agent's `queryReadOnly()`.
+
+- **A static table, not a catalog lookup.** The built-in OIDs are compiled into the server
+  (`pg_type.dat`) and are never reused, so a generated table is correct on every version — a newer
+  server can only add OIDs it does not know. A lookup would also need a round trip that three of the
+  four call sites cannot make: `query()` releases its pooled client before the result is assembled,
+  and `queryReadOnly()` promises EXACTLY ONE statement inside `BEGIN READ ONLY` (§12) — a catalog
+  `SELECT` smuggled in beside it would break that promise for a column label.
+- **`format_type` supplies the spelling**, because it is what PostgreSQL itself prints: OID 20 is
+  `bigint`, not the internal `int8` that `pg`'s own `types.builtins` is keyed by. The table's
+  generating query is in the module's header comment.
+- **A user-defined OID (>= 16384) is absent rather than wrong.** An enum, a composite or an
+  extension type gets its OID per database, so no static table can name it. Measured by running
+  `SELECT *` through `pg` over every table and view in dvdrental — 128 result columns — 125 are
+  named, 0 wrongly, and 3 are absent: the `mpaa_rating` enum in `film` and the two views over it.
+  Arrays are named (`text[]`). A **domain** does not reach that case at all: `film.release_year` is
+  the domain `year` (OID 16516) in `pg_attribute`, and `pg` reports the column as OID 23 — its base
+  type — so the result says `integer`, which is what the wire carries.
+
+| `dataTypeID` | reported as |
+|---|---|
+| 20 / 23 / 21 | `bigint` / `integer` / `smallint` |
+| 1700 | `numeric` |
+| 701 | `double precision` |
+| 16 | `boolean` |
+| 1043 / 25 / 1042 | `character varying` / `text` / `character` |
+| 1114 / 1184 / 1082 | `timestamp without time zone` / `timestamp with time zone` / `date` |
+| 114 / 3802 | `json` / `jsonb` |
+| 2950 / 17 | `uuid` / `bytea` |
+| 1009 | `text[]` |
+| >= 16384 | *absent* |
+
+The names are the base type's, without the type modifier: `character varying`, not
+`character varying(40)`. That is what `information_schema.columns.data_type` — the same source the
+schema tree shows — answers for the same column, and the modifier is not on the wire in a form worth
+reconstructing. `columnTypes` is consumed by the results grid's column labels, by the SQL-DDL export
+(which prefers a declared type over its value-shaped guess) and by the agent's state summary.
+
 ---
 
 ## 6. Schema introspection
@@ -403,9 +460,9 @@ base) fans these out in parallel.
 
 | Method | Primary source | Notes |
 |--------|----------------|-------|
-| `getHealth()` | `pg_stat_activity`, `pg_database_size`, `pg_statio_user_tables`, `pg_stat_statements` | connections, size, cache-hit %, top-5 slow queries (single placeholder row if the extension is absent), 10 sessions |
+| `getHealth()` | `pg_stat_activity`, `pg_database_size`, `pg_statio_user_tables`, `pg_stat_statements` | connections, size, cache-hit % (`N/A` when unmeasurable — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)), top-5 slow queries (single placeholder row if the extension is absent), 10 sessions |
 | `getOverview()` | `version()`, `pg_postmaster_start_time()`, `pg_settings`, `pg_database_size`, `pg_tables`/`pg_indexes` | version, uptime, conns, max_conns, size, table/index counts |
-| `getPerformanceMetrics()` | `pg_statio_user_tables`, `pg_stat_database`, `pg_stat_bgwriter` | cache-hit %, buffer-pool %, deadlocks, checkpoint write time (gated) |
+| `getPerformanceMetrics()` | `pg_statio_user_tables`, `pg_stat_database`, `pg_stat_bgwriter` | cache-hit % (omitted when unmeasurable), deadlocks, checkpoint write time (gated, `N/A`); **no buffer-pool %** — see [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable) |
 | `getSlowQueries()` | `pg_stat_statements` → fallback `pg_stat_activity` | detailed per-statement stats; fallback shows live active queries |
 | `getActiveSessions()` | `pg_stat_activity` | pid, user, state, query, wait events, duration; excludes own backend |
 | `getTableStats()` | `pg_stat_user_tables` + size functions | live/dead tuples, sizes, last (auto)vacuum/analyze, bloat ratio |
@@ -415,6 +472,38 @@ base) fans these out in parallel.
 
 `getTableStats()` / `getIndexStats()` accept an optional `{ schema }` filter; with none they cover
 all user schemas.
+
+### 7.1 When the cache hit ratio is not measurable
+
+The ratio comes from `pg_statio_user_tables`, and there are two ordinary states in which that view
+has nothing to divide:
+
+- **A database with no user tables.** The aggregate is `NULL`, not zero. Measured 2026-08-23 on
+  `postgres:18`, on a freshly created database:
+
+  ```
+   heap_read | heap_hit | raw_ratio
+  -----------+----------+-----------
+             |          |
+  ```
+
+- **A table nothing has read yet.** `heap_blks_hit` and `heap_blks_read` are both `0`, so the ratio
+  is `0/0` — a division by zero, which `NULLIF(..., 0)` turns into the same `NULL`.
+
+In both cases **`getHealth().cacheHitRatio` is `"N/A"` and `getPerformanceMetrics().cacheHitRatio`
+is absent from the object**, and the Overview and Performance tabs render "Not measured" rather
+than a figure. A ratio that *is* measured as `0` is kept and shown as `0.0%`: a cold cache is a real
+reading, and the one the panel most needs to show.
+
+Both SQL statements used to wrap the `NULL` in `COALESCE(..., 100)`, so an unmeasured database
+reported a perfect cache; the panels rated it "Excellent". A missing panel is honest; a populated
+wrong one is not.
+
+`bufferPoolUsage` is **not reported at all**. It used to be `blks_hit / (blks_hit + blks_read)` from
+`pg_stat_database` — which is a cache hit ratio, not pool occupancy, so the Performance tab drew the
+same quantity twice with one of the two mislabelled, and substituted `100` when both counters were
+`0`. PostgreSQL publishes no buffer-pool occupancy without the `pg_buffercache` extension, which is
+not installed by default and whose scan locks `shared_buffers`.
 
 ---
 

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -253,6 +253,12 @@ recognise `redis://` and `rediss://` URLs and **decomposes** them into `host` / 
 `6379`) / `password` / `database` before they reach the provider. So a user can paste a
 `redis://:pw@host:6379/0` URL into the modal, but the provider never sees the raw string.
 
+Because the raw string is dropped, the scheme's TLS intent has to travel as a field: the parser
+returns `sslMode: 'require'` for `rediss://` and `sslMode: 'disable'` for `redis://`, which the
+connection form applies to the SSL panel ([§4.3](#43-ssl--tls)). Both arms are explicit on purpose -
+a paste overwrites the form rather than merging into it, so pasting a plaintext URL clears a
+`require` left over from a previous edit.
+
 ### 4.3 SSL / TLS
 
 `buildTLSOptions()` ([`redis.ts:156`](../../src/lib/db/providers/keyvalue/redis.ts)) maps
@@ -275,9 +281,19 @@ plaintext port exists): `disable` is refused with *"Connection is closed."* and 
 1ms. Both arms matter — before the mode reached the driver, `require` failed the same way `disable`
 does, so the pair is what distinguishes a wired path from a documented shape.
 
-> The paste-parser recognises `rediss://` but does **not** carry the secure scheme into the form
-> ([§4.2](#42-connection-string-nuance)), so a pasted `rediss://` URL still needs a mode picked in
-> the SSL panel.
+> A pasted `rediss://` URL arrives with `mode: 'require'` and a `redis://` one with `disable`
+> ([§4.2](#42-connection-string-nuance)), so the scheme picks the mode and the panel is only needed
+> to go *further* than `require` - a verifying mode, or certificate material. `require` rather than
+> `verify-full` because that is what the ordinary `--tls-port` deployment can satisfy: a paste
+> encrypts, and never silently claims to have checked a chain.
+>
+> Measured through the parser and the provider together on 2026-08-23, against
+> `redis:latest --port 0 --tls-port 6390` with a self-signed certificate:
+>
+> ```text
+> rediss://localhost:6390 -> sslMode require | connected, PING = [{"result":"PONG"}] | 14ms
+> redis://localhost:6390  -> sslMode disable | FAILED: Failed to connect to Redis: Connection is closed.
+> ```
 
 ---
 
@@ -671,11 +687,11 @@ request/response contract.
 
 ## 13. Known limitations & future work
 
-- **A pasted `rediss://` URL does not select TLS by itself.** `connect()` now reads `config.ssl`
-  ([§4.3](#43-ssl--tls)), but the connection-string parser drops the secure scheme when it decomposes
-  the URL into `host`/`port`/`password`/`database`, so a `rediss://` paste still lands with the SSL
-  panel on `disable`. *Future:* have the parser carry `sslMode: 'require'` for `rediss://`, the way
-  it already does for `https://` ClickHouse endpoints.
+- **A pasted `rediss://` URL selects `require`, not a verifying mode.** The parser carries the
+  scheme as `sslMode` ([§4.2](#42-connection-string-nuance)), so the paste is encrypted, but nothing
+  in a `rediss://` URL says whose certificate to trust - and the ordinary self-hosted `--tls-port`
+  node presents a self-signed one, which a verifying mode would refuse. Verification therefore stays
+  an explicit choice in the SSL panel; the URL alone never turns it on.
 - **No Cluster / Sentinel support.** Only a single standalone node is supported.
 - **`SCAN` is capped at 1000 keys** for schema discovery — prefixes that only appear beyond the cap
   won't show as "tables". This is a deliberate bound, not a bug.

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -99,7 +99,7 @@ everything that assumes a server. Read this as a **diff against the [PostgreSQL 
 | `EXPLAIN` | `true` | `true` (EXPLAIN QUERY PLAN) |
 | Connection string | `true` | `false` (path accepted in the field, but flagged unsupported) |
 | Schema scope | many schemas | single (`main`) |
-| Monitoring | rich `pg_stat_*` | minimal (PRAGMAs + file stats; many fields `N/A`/estimated) |
+| Monitoring | rich `pg_stat_*` | minimal (PRAGMAs + file stats; many fields `N/A`, no cache-hit ratio at all) |
 
 ---
 
@@ -333,12 +333,39 @@ Minimal by nature — SQLite keeps almost no server-style runtime statistics.
 |--------|--------|-------|
 | `getHealth()` | `fs.statSync` / page PRAGMAs, `PRAGMA integrity_check`, `PRAGMA journal_mode` | reports integrity + journal mode as info rows; `activeConnections: 1`, cache-hit `N/A` |
 | `getOverview()` | `sqlite_version()`, file size, `sqlite_master` counts | `uptime: N/A`, `maxConnections: 1` |
-| `getPerformanceMetrics()` | `PRAGMA cache_size` | cache-hit is an **estimate** (95/99); QPS/buffer-pool `undefined`; `deadlocks: 0` |
+| `getPerformanceMetrics()` | — | **no cache-hit ratio, no QPS, no buffer-pool usage** — all three are omitted, so both monitoring tabs show "N/A / Not measured" for them ([§7.1](#71-there-is-no-cache-hit-ratio-and-there-cannot-be)); only `deadlocks: 0` is reported, which is a fact about the engine |
 | `getSlowQueries()` | — | always `[]` (SQLite has no query stats) |
 | `getActiveSessions()` | — | the single current process session |
 | `getTableStats()` | `COUNT(*)` per table | **size is a rough estimate** (`rows × 100 bytes`) — SQLite gives no per-table size |
-| `getIndexStats()` | `PRAGMA index_list`/`index_info` | `scans` always `0` (no usage counter); `indexSize` `N/A` |
+| `getIndexStats()` | `PRAGMA index_list`/`index_info` | `scans` always `0` (no usage counter); `indexSize` is `N/A` and `indexSizeBytes` is **omitted** — SQLite publishes no per-index size, and a `0` was summed by the Storage tab as an empty index |
 | `getStorageStats()` | `fs.statSync` on the DB / `-wal` / `-shm` files | per-file sizes (on disk only) |
+
+### 7.1 There is no cache hit ratio, and there cannot be
+
+SQLite's page-cache hit and miss counters exist only behind the C API —
+`sqlite3_db_status()` with `SQLITE_DBSTATUS_CACHE_HIT` / `SQLITE_DBSTATUS_CACHE_MISS` — and **neither
+driver this provider can load exposes it**. Measured 2026-08-23 by walking a live handle's prototype
+chain:
+
+| Driver | Surface | Status call? |
+|--------|---------|--------------|
+| `bun:sqlite` (Bun 1.3.14, SQLite 3.53.0) | `clearQueryCache, close, exec, fileControl, filename, handle, inTransaction, loadExtension, prepare, query, run, serialize, transaction` | none |
+| `node:sqlite` (Node 24.14.0, SQLite 3.51.2) | `aggregate, applyChangeset, close, createSession, createTagStore, enableDefensive, enableLoadExtension, exec, function, isOpen, isTransaction, loadExtension, location, open, prepare, setAuthorizer` | none |
+
+Nothing SQL-reachable stands in either. On both drivers:
+
+| Attempt | Result |
+|---------|--------|
+| `PRAGMA cache_size` | `-2000` — the *configured* page budget (negative = KiB), not a hit count |
+| `PRAGMA cache_hit`, `PRAGMA cache_miss` | `[]` — these are not pragmas; SQLite answers an unknown pragma with zero rows rather than an error, so they *look* like empty readings |
+| `PRAGMA stats` | `[]` |
+| `SELECT * FROM dbstat` | `no such table: dbstat` under `bun:sqlite`; available under `node:sqlite` (`ENABLE_DBSTAT_VTAB`), but it reports page layout, not cache hits |
+
+So the field is **omitted permanently**, not pending a better query. Through 0.13.1 this provider
+reported `95` whenever `PRAGMA cache_size` came back truthy — which it always does — and `99`
+otherwise, and the Performance panel rated that invented figure "Excellent". A missing panel is
+honest; a populated wrong one is not: the number was this provider's, not SQLite's. `getHealth()`
+says the same thing in its own string field: `cacheHitRatio` is `N/A`.
 
 ---
 
@@ -655,8 +682,12 @@ not apply to SQLite ([§3.4](#34-no-transactions-api-no-cancellation-no-pool)).
   API routes don't apply.
 - **No EXPLAIN plan metrics.** `EXPLAIN QUERY PLAN` returns step descriptions only — SQLite does not
   report per-node cost, row estimates, or timing data.
-- **Estimated/absent monitoring:** per-table size is `rows × 100 bytes` (a rough estimate); index
-  `scans` is always `0`; cache-hit ratio is a fixed estimate; slow queries are unavailable.
+- **Absent monitoring:** there is **no cache-hit ratio, no queries-per-second and no buffer-pool
+  usage** — the drivers expose no counters for them, so the panels say "Not measured"
+  ([§7.1](#71-there-is-no-cache-hit-ratio-and-there-cannot-be)); index `scans` is always `0` and
+  per-index size is `N/A`; slow queries are unavailable. Per-table size is still a rough estimate
+  (`rows × 100 bytes`) rather than an absence, because `TableStats.tableSizeBytes` is a required
+  field — making it optional is a change to the shared monitoring types, not to this provider.
 - **`:memory:` is ephemeral** — data is lost on disconnect; intended for trials/tests.
 - **Single schema (`main`)** — `ATTACH`ed databases are not surfaced.
 - **No path sandboxing (by design).** `getDatabasePath()` validates only that the path contains

--- a/src/lib/connection-string-parser.ts
+++ b/src/lib/connection-string-parser.ts
@@ -11,12 +11,18 @@ export interface ParsedConnection {
   /**
    * TLS the scheme asked for, when the fields alone could not express it.
    *
-   * Only set by schemes that ARE the transport, currently `https://` for
-   * ClickHouse: dropping it would leave the form on its "disable" default and the
-   * provider would post plaintext HTTP to a TLS port, which fails with a bare
-   * "fetch failed" and nothing pointing at the scheme. Schemes that carry TLS in
-   * their own connection string (`couchbases://`, `mongodb+srv://`) keep using
-   * `connectionString` instead, because the provider re-reads the scheme there.
+   * Set by every scheme that IS the transport - `https://` for ClickHouse,
+   * `rediss://`, `couchbases://` - and by their plaintext twins, because a paste
+   * overwrites rather than merges. Dropping it leaves the form on its "disable"
+   * default and the provider then speaks plaintext to a TLS port, which fails with a
+   * bare "fetch failed" / "Connection is closed." and nothing pointing at the scheme.
+   *
+   * `mongodb+srv://` is the one secure scheme deliberately left unset: the driver gets
+   * the URI verbatim and turns TLS on itself, WITH chain verification, so handing it
+   * our `require` (rejectUnauthorized:false, see the mode note below) would stop an
+   * Atlas certificate being verified. Couchbase used to be excused on the same
+   * "the provider re-reads the scheme" grounds, which was simply untrue: its transport
+   * is HTTP-only and derives http vs https from `config.ssl` alone.
    */
   sslMode?: SSLMode;
 }
@@ -86,9 +92,20 @@ export function parseConnectionString(input: string): ParsedConnection | null {
     return parseGenericURL(trimmed, "mysql", "3306");
   }
 
-  // Redis
-  if (trimmed.startsWith("redis://") || trimmed.startsWith("rediss://")) {
-    return parseGenericURL(trimmed, "redis", "6379");
+  // Redis - `rediss://` IS TLS (the secure form in Redis's own URI convention,
+  // the one `redis-cli --tls` and every client library reads that way) and ioredis only
+  // negotiates it when a `tls` option is present, which the provider builds from
+  // `config.ssl` alone. `require` rather than a verifying mode: it maps to
+  // `rejectUnauthorized: false`, and a self-hosted Redis presents a self-signed
+  // certificate by default, so a verifying mode would refuse the ordinary
+  // `--tls-port` deployment. A paste therefore encrypts but never silently claims to
+  // have checked a chain; the panel is where verification is chosen. The plain scheme
+  // is the explicit plaintext twin, so it clears a mode the form is still holding.
+  if (trimmed.startsWith("rediss://")) {
+    return withSSLMode(parseGenericURL(trimmed, "redis", "6379"), "require");
+  }
+  if (trimmed.startsWith("redis://")) {
+    return withSSLMode(parseGenericURL(trimmed, "redis", "6379"), "disable");
   }
 
   // Oracle
@@ -101,12 +118,18 @@ export function parseConnectionString(input: string): ParsedConnection | null {
     return parseGenericURL(trimmed, "mssql", "1433");
   }
 
-  // Couchbase — the TLS scheme is checked first, it is not a prefix of the plain one
+  // Couchbase — the TLS scheme is checked first, it is not a prefix of the plain one.
+  // The mode travels for the same reason as ClickHouse's: this provider talks HTTP,
+  // and `CouchbaseHttpTransport` picks `https` vs `http` from `config.ssl`, never from
+  // the pasted string it also stores. Without the mode a `couchbases://` paste posts
+  // plain HTTP to 18091. `require` for the same reason as Redis: Capella's certificate
+  // is CA-signed, a self-hosted cluster's is not, and only the panel should turn
+  // verification on.
   if (trimmed.startsWith("couchbases://")) {
-    return parseCouchbaseString(trimmed, "18091");
+    return withSSLMode(parseCouchbaseString(trimmed, "18091"), "require");
   }
   if (trimmed.startsWith("couchbase://")) {
-    return parseCouchbaseString(trimmed, "8091");
+    return withSSLMode(parseCouchbaseString(trimmed, "8091"), "disable");
   }
 
   // ClickHouse — the HTTP endpoint IS the connection target, so a bare http(s) URL is

--- a/src/lib/db/providers/document/couchbase/index.ts
+++ b/src/lib/db/providers/document/couchbase/index.ts
@@ -605,6 +605,28 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
     };
   }
 
+  /**
+   * Only the readings the cluster actually published.
+   *
+   * Every field here is optional in `PerformanceMetrics` because "not measured"
+   * and "measured as zero" are different facts. This method used to erase that
+   * difference three times over: a `null` miss rate became a `cacheHitRatio` of
+   * 0, an absent `cmd_get`/`cmd_set` pair became 0 operations per second, and an
+   * unreadable `basicStats` became 0% quota used. The cache one is the worst of
+   * the three - `DEFAULT_THRESHOLDS` rates the ratio `direction: "below"` with
+   * `critical: 80`, so a bucket whose statistics the connected user may not read
+   * showed a red critical cache fault that nothing in the cluster reported. A
+   * missing panel is honest; a populated wrong one is not (#424).
+   *
+   * The absences are ordinary here rather than exotic: `degradeTo` turns an RBAC
+   * denial on `/pools/default/buckets/<bucket>/stats` into an empty sample set
+   * (`docs/providers/couchbase.md` §3.9), and a bucket that is not a Couchbase
+   * bucket publishes no `ep_*` series at all.
+   *
+   * A measured 0 is kept in every case: a cold cache with no misses really is at
+   * 100%, an idle bucket really is doing 0 operations, and an empty bucket really
+   * is using none of its quota.
+   */
   public async getPerformanceMetrics(): Promise<PerformanceMetrics> {
     const transport = this.requireTransport();
 
@@ -613,15 +635,20 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
       this.bucketSamples(transport),
     ]);
 
-    // The KV engine reports a miss rate, so the hit ratio is its complement.
-    // An unreadable source reports zero rather than a flattering 100.
+    // The KV engine reports a miss rate as a percentage, so the hit ratio is its
+    // complement; clamped because the series is a moving average and can overshoot.
     const missRate = lastSample(samples, "ep_cache_miss_rate");
-    const operations = (lastSample(samples, "cmd_get") ?? 0) + (lastSample(samples, "cmd_set") ?? 0);
+    // Sampled per-second counters. Either half may be absent on its own, so the
+    // sum exists when at least one was published - and not otherwise.
+    const gets = lastSample(samples, "cmd_get");
+    const sets = lastSample(samples, "cmd_set");
+    const operations = gets === null && sets === null ? null : (gets ?? 0) + (sets ?? 0);
+    const quotaUsed = bucketInfo.basicStats?.quotaPercentUsed;
 
     return {
-      cacheHitRatio: missRate === null ? 0 : round2(Math.max(0, Math.min(100, 100 - missRate))),
-      queriesPerSecond: round2(operations),
-      bufferPoolUsage: round2(bucketInfo.basicStats?.quotaPercentUsed ?? 0),
+      ...(missRate === null ? {} : { cacheHitRatio: round2(Math.max(0, Math.min(100, 100 - missRate))) }),
+      ...(operations === null ? {} : { queriesPerSecond: round2(operations) }),
+      ...(typeof quotaUsed === "number" ? { bufferPoolUsage: round2(quotaUsed) } : {}),
     };
   }
 
@@ -696,8 +723,9 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
         [] as CouchbaseRow[],
       ),
       // Per-index runtime statistics live under the index service's own bucket.
-      // Modern servers no longer publish them there, which is exactly why every
-      // value below falls back to zero instead of failing the listing.
+      // Modern servers no longer publish them there, which is exactly why a
+      // missing series must not fail the listing - but it must not become a
+      // reading either (see the size handling below).
       degradeTo<BucketStatsPayload>(
         () => transport.manage(`/pools/default/buckets/@index-${encodeURIComponent(this.bucket)}/stats`),
         {},
@@ -709,7 +737,11 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
     return rows.map((row) => {
       const name = asString(row.index_name, "unknown");
       const isPrimary = row.is_primary === true;
-      const sizeBytes = lastSample(indexSamples, `index/${name}/data_size`) ?? 0;
+      // Absent, not zero: an index the service publishes no `data_size` for has an
+      // unknown size, and "0 B" read as an empty index - which the Storage tab then
+      // summed into its index total. `IndexStats.indexSizeBytes` is optional for
+      // exactly this, and `indexSize` carries the absence as the repo's "N/A".
+      const sizeBytes = lastSample(indexSamples, `index/${name}/data_size`);
 
       return {
         schemaName: asString(row.scope_name, "_default"),
@@ -720,8 +752,10 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
         // No secondary index enforces uniqueness; only the document key is unique.
         isUnique: isPrimary,
         isPrimary,
-        indexSize: formatBytes(sizeBytes),
-        indexSizeBytes: sizeBytes,
+        // "N/A" is the word every provider in this repo uses for a size it cannot
+        // read (sqlite.ts, mysql.ts), so no new spelling is introduced here.
+        indexSize: sizeBytes === null ? "N/A" : formatBytes(sizeBytes),
+        ...(sizeBytes === null ? {} : { indexSizeBytes: sizeBytes }),
         scans: lastSample(indexSamples, `index/${name}/num_requests`) ?? 0,
       };
     });

--- a/src/lib/db/providers/document/mongodb.ts
+++ b/src/lib/db/providers/document/mongodb.ts
@@ -30,6 +30,7 @@ import {
 } from "../../types";
 import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
 import { formatBytes } from "../../utils/pool-manager";
+import { CACHE_HIT_RATIO_UNAVAILABLE, formatCacheHitRatio, measuredNumber } from "@/lib/monitoring-cache-ratio";
 
 // ============================================================================
 // Types
@@ -96,6 +97,40 @@ const MAX_NESTED_FIELD_DEPTH = 3;
  * the inventory an agent run is given.
  */
 const MAX_INFERRED_FIELDS = 200;
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * The WiredTiger cache hit ratio, or `undefined` when there is nothing to compute
+ * one from.
+ *
+ * Two different absences, and neither is a number: a deployment can publish no
+ * `wiredTiger` section at all (mongos, the in-memory storage engine, the
+ * wire-compatible services), and a freshly opened one publishes the section with a
+ * request count of 0, where there are no hits and no misses rather than perfect
+ * hits. Both used to reach the panel as 99% - a figure this provider invented, not
+ * one the server ever reported (#424, and the rule #448/#452 settled).
+ */
+function wiredTigerCacheHitRatio(cache: Document | undefined): number | undefined {
+  const requested = measuredNumber(cache?.["pages requested from the cache"]);
+  const read = measuredNumber(cache?.["pages read into cache"]);
+  if (requested === undefined || read === undefined || requested === 0) return undefined;
+  return round2(Math.max(0, Math.min(100, (1 - read / requested) * 100)));
+}
+
+/**
+ * How much of the configured WiredTiger cache currently holds data, or `undefined`
+ * when the section is absent. A measured 0 is kept: an untouched cache really does
+ * hold nothing.
+ */
+function wiredTigerCacheUsage(cache: Document | undefined): number | undefined {
+  const bytes = measuredNumber(cache?.["bytes currently in the cache"]);
+  const maxBytes = measuredNumber(cache?.["maximum bytes configured"]);
+  if (bytes === undefined || maxBytes === undefined || maxBytes === 0) return undefined;
+  return round2(Math.max(0, Math.min(100, (bytes / maxBytes) * 100)));
+}
 
 // Maintenance operations runMaintenance() accepts; validated the same way.
 const SUPPORTED_MAINTENANCE_TYPES: ReadonlySet<MaintenanceType> = new Set([
@@ -747,17 +782,15 @@ export class MongoDBProvider extends BaseDatabaseProvider {
         });
       }
 
+      const healthCacheHitRatio = wiredTigerCacheHitRatio(serverStatus.wiredTiger?.cache);
+
       return {
         activeConnections: serverStatus.connections?.current || 0,
         databaseSize: formatBytes(dbStats.dataSize || 0),
-        cacheHitRatio: serverStatus.wiredTiger?.cache
-          ? `${(
-              (1 -
-                (serverStatus.wiredTiger.cache["pages read into cache"] || 0) /
-                  Math.max(1, serverStatus.wiredTiger.cache["pages requested from the cache"] || 1)) *
-                100
-            ).toFixed(1)}%`
-          : "N/A",
+        cacheHitRatio:
+          healthCacheHitRatio === undefined
+            ? CACHE_HIT_RATIO_UNAVAILABLE
+            : `${formatCacheHitRatio(healthCacheHitRatio)}%`,
         slowQueries,
         activeSessions,
       };
@@ -877,6 +910,15 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       // Get collection count
       const collections = await this.db!.listCollections().toArray();
 
+      // The limit is what the server has plus what it is still willing to hand out.
+      // A truthiness test read an exhausted pool (`available: 0`) as "not published"
+      // and substituted 100 - a limit no server stated, which the Overview card then
+      // divided the live connection count by. 0 is how every provider in this repo
+      // spells "no limit published", and the card renders it as exactly that.
+      const current = measuredNumber(serverStatus.connections?.current);
+      const available = measuredNumber(serverStatus.connections?.available);
+      const maxConnections = current === undefined || available === undefined ? undefined : current + available;
+
       // Get index count
       let indexCount = 0;
       for (const coll of collections) {
@@ -893,9 +935,7 @@ export class MongoDBProvider extends BaseDatabaseProvider {
         uptime,
         startTime: new Date(Date.now() - uptimeSeconds * 1000),
         activeConnections: serverStatus.connections?.current || 0,
-        maxConnections: serverStatus.connections?.available
-          ? serverStatus.connections.current + serverStatus.connections.available
-          : 100,
+        maxConnections: maxConnections ?? 0,
         databaseSize: formatBytes(dbStats.dataSize || 0),
         databaseSizeBytes: dbStats.dataSize || 0,
         tableCount: collections.length,
@@ -907,7 +947,8 @@ export class MongoDBProvider extends BaseDatabaseProvider {
         version: "MongoDB Unknown",
         uptime: "N/A",
         activeConnections: 0,
-        maxConnections: 100,
+        // Nothing was read, so no limit is published (see the success path above).
+        maxConnections: 0,
         databaseSize: "N/A",
         databaseSizeBytes: 0,
         tableCount: 0,
@@ -922,43 +963,39 @@ export class MongoDBProvider extends BaseDatabaseProvider {
     try {
       const serverStatus = await this.db!.admin().serverStatus();
 
-      // Calculate cache hit ratio from WiredTiger
-      let cacheHitRatio = 99;
-      if (serverStatus.wiredTiger?.cache) {
-        const pagesRead = serverStatus.wiredTiger.cache["pages read into cache"] || 0;
-        const pagesRequested = serverStatus.wiredTiger.cache["pages requested from the cache"] || 1;
-        cacheHitRatio = Math.max(0, Math.min(100, (1 - pagesRead / Math.max(1, pagesRequested)) * 100));
-      }
+      // Every reading below is optional on purpose: a metric nobody measured must
+      // stay absent rather than arrive as a number the panels would then rate.
+      const cache = serverStatus.wiredTiger?.cache;
+      const cacheHitRatio = wiredTigerCacheHitRatio(cache);
+      const bufferPoolUsage = wiredTigerCacheUsage(cache);
 
-      // Calculate queries per second from opcounters
-      const opcounters = serverStatus.opcounters || {};
-      const uptimeSeconds = serverStatus.uptime || 1;
+      // Queries per second from opcounters. A server that publishes no opcounters
+      // has not counted zero operations, it has counted nothing.
+      const opcounters = serverStatus.opcounters;
+      const uptimeSeconds = measuredNumber(serverStatus.uptime);
       const totalOps =
-        (opcounters.query || 0) + (opcounters.insert || 0) + (opcounters.update || 0) + (opcounters.delete || 0);
-      const queriesPerSecond = totalOps / uptimeSeconds;
-
-      // Get buffer pool usage (WiredTiger cache usage)
-      let bufferPoolUsage = 0;
-      if (serverStatus.wiredTiger?.cache) {
-        const bytesInCache = serverStatus.wiredTiger.cache["bytes currently in the cache"] || 0;
-        const maxCacheBytes = serverStatus.wiredTiger.cache["maximum bytes configured"] || 1;
-        bufferPoolUsage = (bytesInCache / maxCacheBytes) * 100;
-      }
+        opcounters === undefined
+          ? undefined
+          : (measuredNumber(opcounters.query) ?? 0) +
+            (measuredNumber(opcounters.insert) ?? 0) +
+            (measuredNumber(opcounters.update) ?? 0) +
+            (measuredNumber(opcounters.delete) ?? 0);
 
       return {
-        cacheHitRatio: Math.round(cacheHitRatio * 100) / 100,
-        queriesPerSecond: Math.round(queriesPerSecond * 100) / 100,
-        bufferPoolUsage: Math.round(bufferPoolUsage * 100) / 100,
-        deadlocks: 0, // MongoDB doesn't have traditional deadlocks
+        ...(cacheHitRatio === undefined ? {} : { cacheHitRatio }),
+        ...(totalOps === undefined || !uptimeSeconds ? {} : { queriesPerSecond: round2(totalOps / uptimeSeconds) }),
+        ...(bufferPoolUsage === undefined ? {} : { bufferPoolUsage }),
+        // MongoDB has no deadlocks to count: WiredTiger aborts and retries a write
+        // conflict instead of holding two waiters. The 0 is a statement about the
+        // engine, and it is only made when serverStatus answered at all.
+        deadlocks: 0,
       };
     } catch (error) {
       this.logError("getPerformanceMetrics", error);
-      return {
-        cacheHitRatio: 99,
-        queriesPerSecond: 0,
-        bufferPoolUsage: 0,
-        deadlocks: 0,
-      };
+      // serverStatus failed - an unprivileged user, a proxied deployment - so
+      // nothing was measured and nothing is reported. This branch used to answer
+      // the panel with a 99% cache hit ratio and three zeroes.
+      return {};
     }
   }
 

--- a/src/lib/db/providers/embedded/libredb.ts
+++ b/src/lib/db/providers/embedded/libredb.ts
@@ -42,6 +42,7 @@ import {
 } from "../../types";
 import { DatabaseConfigError, ConnectionError, QueryError } from "../../errors";
 import { formatBytes } from "../../utils/pool-manager";
+import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -506,7 +507,7 @@ export class LibreDBProvider extends BaseDatabaseProvider {
     return {
       activeConnections: 1,
       databaseSize: this.fileSizeHuman(),
-      cacheHitRatio: "100.0",
+      cacheHitRatio: CACHE_HIT_RATIO_UNAVAILABLE,
       slowQueries: [],
       activeSessions: [],
     };
@@ -526,9 +527,19 @@ export class LibreDBProvider extends BaseDatabaseProvider {
     };
   }
 
+  /**
+   * Nothing, and permanently so.
+   *
+   * The embedded kernel keeps no cache counters to read: its whole public surface
+   * is `open` / `kv` / `doc` / `table` / `catalog` (`@libredb/libredb` 0.2.2), with
+   * no statistics call of any kind, and the store it reads from is the process's own
+   * memory rather than a buffer pool with hits and misses. A cache hit ratio here
+   * would be a number this provider made up - it used to say 100% - so the panel is
+   * told there is none and renders "Not measured".
+   */
   public async getPerformanceMetrics(): Promise<PerformanceMetrics> {
     this.ensureConnected();
-    return { cacheHitRatio: 100 };
+    return {};
   }
 
   public async getSlowQueries(): Promise<SlowQueryStats[]> {

--- a/src/lib/db/providers/sql/column-types.ts
+++ b/src/lib/db/providers/sql/column-types.ts
@@ -1,0 +1,475 @@
+import type { QueryResult } from "@/lib/types";
+
+/**
+ * The type each column of a result was DECLARED with, for the four drivers that hand
+ * back a wire-format code instead of a name.
+ *
+ * Six provider families already fill `QueryResult.columnTypes` because their wire
+ * format spells the type out (ClickHouse `Nullable(String)`, Trino, Druid, Cassandra,
+ * the two search engines). The four node drivers do not: `pg` reports a `pg_type` OID,
+ * `mysql2` a protocol type code plus flags, and only `oracledb` (`dbTypeName`) and
+ * `mssql` (`type.declaration`) hand over a name - so those two need no table here and
+ * read their metadata directly in their own providers.
+ *
+ * Why this matters, and why nothing here looks at a VALUE: a value-shaped guess can
+ * only ever recover integer, boolean and text, because `pg` returns `numeric` as a
+ * string to keep its precision and a `timestamp` is a string by the time it has been
+ * through JSON. Measured before this module existed, `SELECT rental_rate, last_update,
+ * film_id FROM film` exported as `("rental_rate" TEXT, "last_update" TIMESTAMP,
+ * "film_id" BIGINT)` - one wrong type, one lost precision, and one integer column
+ * widened. Guessing from the string's SHAPE is not an option either: it would type a
+ * text column holding `2026-01-01` as a timestamp.
+ *
+ * The spelling rule is `QueryResult.columnTypes`' own: the way the engine spells it.
+ * Each of the four names its types the way that engine's OWN catalog does, so a
+ * declared type reads the same as the schema tree's entry for the same column
+ * (`information_schema.COLUMNS.DATA_TYPE`, or Oracle's `ALL_TAB_COLUMNS.DATA_TYPE`) -
+ * lowercase for Postgres, MySQL and SQL Server, uppercase for Oracle.
+ *
+ * No value is touched anywhere in this module: a `numeric` stays the string the driver
+ * returned. This only adds the declaration.
+ */
+
+/**
+ * Collects the declared types of one result, dropping the columns that declared none.
+ *
+ * Returns a spreadable object rather than a map, because the established convention
+ * (`toQueryResult` in the Trino and ClickHouse providers) is to omit `columnTypes`
+ * ENTIRELY when it would be empty, so a consumer can decide from the field's presence
+ * alone. Nine call sites across the four providers spread this.
+ *
+ * `Object.fromEntries` rather than assignment into a literal: a column name is
+ * arbitrary SQL output, and `columnTypes["__proto__"] = t` on an object literal
+ * REPLACES the prototype instead of adding a property (measured in bun 1.3.14), which
+ * would leave the key absent for every consumer that asks with `Object.hasOwn`.
+ */
+export function declaredColumnTypes(
+  pairs: Iterable<readonly [string, string | undefined]>,
+): Pick<QueryResult, "columnTypes"> {
+  const declared = new Map<string, string>();
+  for (const [name, type] of pairs) {
+    // Last-wins: `SELECT 1 AS c, 'x' AS c` declares two columns called `c`, and the
+    // row object every one of these drivers builds keeps the last one's value - so the
+    // last one's type is the one that describes what the grid shows.
+    if (type !== undefined) declared.set(name, type);
+  }
+  return declared.size > 0 ? { columnTypes: Object.fromEntries(declared) } : {};
+}
+
+/**
+ * `pg` reports a column's type as a `pg_type` OID (`field.dataTypeID`), never a name.
+ *
+ * A STATIC table rather than a `pg_catalog` lookup, deliberately:
+ *
+ * - The OIDs of the built-in types are compiled into the server (`pg_type.dat`) and
+ *   are never reused for a different type, so a table generated once is correct on
+ *   every version - a newer server can only ever add OIDs this table does not know.
+ * - A lookup would need a round trip that three of the four call sites cannot make.
+ *   `query()` releases its pooled client before the result is assembled, and the
+ *   agent's read-only profile (`queryReadOnly`) promises EXACTLY ONE statement inside
+ *   `BEGIN READ ONLY` before it rolls back and runs `DISCARD ALL` - a catalog SELECT
+ *   smuggled in beside it would break that promise for a column label.
+ *
+ * The table is generated, and reproducing it is the way to extend it:
+ *
+ *   SELECT t.oid, format_type(t.oid, NULL) FROM pg_type t
+ *     JOIN pg_namespace n ON n.oid = t.typnamespace
+ *    WHERE t.oid < 16384 AND n.nspname = 'pg_catalog'
+ *      AND t.typtype IN ('b','r','m','e','d')
+ *      AND format_type(t.oid, NULL) NOT LIKE 'pg\_%'
+ *    ORDER BY t.oid;
+ *
+ * `format_type` is the authority on the spelling because it is what Postgres itself
+ * prints: OID 20 is `bigint`, not the internal `int8` that `pg`'s own
+ * `types.builtins` is keyed by. Excluded from the generated set: the pseudo-types (no
+ * column can have one), the `pg_*` catalog rowtypes and their arrays (unreachable as a
+ * result column's declared type), and the `information_schema` domains, whose OIDs are
+ * assigned per database at initdb and so are NOT stable.
+ *
+ * A user-defined OID (>= 16384: an enum, a composite, an extension type) is absent
+ * rather than wrong. Measured by running `SELECT *` through `pg` over every table and
+ * view in dvdrental's `public` schema - 128 result columns, the largest real database
+ * on hand - 125 are named, none wrongly, and 3 are absent: `film.rating` and the two
+ * views over it, all three the enum `mpaa_rating`. Arrays are named (`text[]`).
+ *
+ * A DOMAIN does not even reach that case: measured, `film.release_year` is the domain
+ * `year` in `pg_attribute` (OID 16516) and `pg` reports it as OID 23, its base type -
+ * so the result says `integer`, which is what the wire actually carries.
+ */
+const PG_BUILTIN_TYPE_NAMES: Record<number, string | undefined> = {
+  16: "boolean",
+  17: "bytea",
+  18: '"char"',
+  19: "name",
+  20: "bigint",
+  21: "smallint",
+  22: "int2vector",
+  23: "integer",
+  24: "regproc",
+  25: "text",
+  26: "oid",
+  27: "tid",
+  28: "xid",
+  29: "cid",
+  30: "oidvector",
+  114: "json",
+  142: "xml",
+  143: "xml[]",
+  199: "json[]",
+  271: "xid8[]",
+  600: "point",
+  601: "lseg",
+  602: "path",
+  603: "box",
+  604: "polygon",
+  628: "line",
+  629: "line[]",
+  650: "cidr",
+  651: "cidr[]",
+  700: "real",
+  701: "double precision",
+  718: "circle",
+  719: "circle[]",
+  774: "macaddr8",
+  775: "macaddr8[]",
+  790: "money",
+  791: "money[]",
+  829: "macaddr",
+  869: "inet",
+  1000: "boolean[]",
+  1001: "bytea[]",
+  1002: '"char"[]',
+  1003: "name[]",
+  1005: "smallint[]",
+  1006: "int2vector[]",
+  1007: "integer[]",
+  1008: "regproc[]",
+  1009: "text[]",
+  1010: "tid[]",
+  1011: "xid[]",
+  1012: "cid[]",
+  1013: "oidvector[]",
+  1014: "character[]",
+  1015: "character varying[]",
+  1016: "bigint[]",
+  1017: "point[]",
+  1018: "lseg[]",
+  1019: "path[]",
+  1020: "box[]",
+  1021: "real[]",
+  1022: "double precision[]",
+  1027: "polygon[]",
+  1028: "oid[]",
+  1033: "aclitem",
+  1034: "aclitem[]",
+  1040: "macaddr[]",
+  1041: "inet[]",
+  1042: "character",
+  1043: "character varying",
+  1082: "date",
+  1083: "time without time zone",
+  1114: "timestamp without time zone",
+  1115: "timestamp without time zone[]",
+  1182: "date[]",
+  1183: "time without time zone[]",
+  1184: "timestamp with time zone",
+  1185: "timestamp with time zone[]",
+  1186: "interval",
+  1187: "interval[]",
+  1231: "numeric[]",
+  1263: "cstring[]",
+  1266: "time with time zone",
+  1270: "time with time zone[]",
+  1560: "bit",
+  1561: "bit[]",
+  1562: "bit varying",
+  1563: "bit varying[]",
+  1700: "numeric",
+  1790: "refcursor",
+  2201: "refcursor[]",
+  2202: "regprocedure",
+  2203: "regoper",
+  2204: "regoperator",
+  2205: "regclass",
+  2206: "regtype",
+  2207: "regprocedure[]",
+  2208: "regoper[]",
+  2209: "regoperator[]",
+  2210: "regclass[]",
+  2211: "regtype[]",
+  2949: "txid_snapshot[]",
+  2950: "uuid",
+  2951: "uuid[]",
+  2970: "txid_snapshot",
+  3614: "tsvector",
+  3615: "tsquery",
+  3642: "gtsvector",
+  3643: "tsvector[]",
+  3644: "gtsvector[]",
+  3645: "tsquery[]",
+  3734: "regconfig",
+  3735: "regconfig[]",
+  3769: "regdictionary",
+  3770: "regdictionary[]",
+  3802: "jsonb",
+  3807: "jsonb[]",
+  3904: "int4range",
+  3905: "int4range[]",
+  3906: "numrange",
+  3907: "numrange[]",
+  3908: "tsrange",
+  3909: "tsrange[]",
+  3910: "tstzrange",
+  3911: "tstzrange[]",
+  3912: "daterange",
+  3913: "daterange[]",
+  3926: "int8range",
+  3927: "int8range[]",
+  4072: "jsonpath",
+  4073: "jsonpath[]",
+  4089: "regnamespace",
+  4090: "regnamespace[]",
+  4096: "regrole",
+  4097: "regrole[]",
+  4191: "regcollation",
+  4192: "regcollation[]",
+  4451: "int4multirange",
+  4532: "nummultirange",
+  4533: "tsmultirange",
+  4534: "tstzmultirange",
+  4535: "datemultirange",
+  4536: "int8multirange",
+  5069: "xid8",
+  6150: "int4multirange[]",
+  6151: "nummultirange[]",
+  6152: "tsmultirange[]",
+  6153: "tstzmultirange[]",
+  6155: "datemultirange[]",
+  6157: "int8multirange[]",
+};
+
+export function postgresColumnType(dataTypeID: number): string | undefined {
+  return PG_BUILTIN_TYPE_NAMES[dataTypeID];
+}
+
+/**
+ * The subset of mysql2's `FieldPacket` that describes a column's type.
+ *
+ * Declared here rather than imported: mysql2 types `flags` as `number | string[]`,
+ * and every field below is optional in its own typings, so a provider passing a real
+ * packet satisfies this shape without a cast.
+ */
+export interface MysqlColumnMetadata {
+  columnType?: number;
+  type?: number;
+  characterSet?: number;
+  columnLength?: number;
+  decimals?: number;
+  flags?: number | string[];
+  extendedTypeName?: string;
+}
+
+/**
+ * mysql2 reports a column's type as a protocol type code, which is NOT one type per
+ * code. Measured on MySQL 26.7.0 over a 40-column probe table, three codes are shared:
+ *
+ *   ti    code=  1 len=         4 cs= 63 flags=    0        -> tinyint
+ *   ti1   code=  1 len=         1 cs= 63 flags=    0        -> tinyint      (TINYINT(1))
+ *   dec1  code=246 len=        12 cs= 63 dec=2              -> decimal
+ *   ch    code=254 len=        40 cs=224 flags=    0        -> char
+ *   bin   code=254 len=         8 cs= 63 flags=  128        -> binary
+ *   en    code=254 len=         4 cs=224 flags=  256 [ENUM] -> enum
+ *   st    code=254 len=        12 cs=224 flags= 2048 [SET]  -> set
+ *   vc    code=253 len=       160 cs=224                    -> varchar
+ *   vb    code=253 len=         9 cs= 63 flags=  128        -> varbinary
+ *   tt    code=252 len=      1020 cs=224 flags=   16        -> tinytext
+ *   tx    code=252 len=    262140 cs=224 flags=   16        -> text
+ *   mt    code=252 len=  67108860 cs=224 flags=   16        -> mediumtext
+ *   lt    code=252 len=4294967295 cs=224 flags=   16        -> longtext
+ *   tb    code=252 len=       255 cs= 63 flags=  144        -> tinyblob
+ *   bl    code=252 len=     65535 cs= 63 flags=  144        -> blob
+ *   mb    code=252 len=  16777215 cs= 63 flags=  144        -> mediumblob
+ *   lb    code=252 len=4294967295 cs= 63 flags=  144        -> longblob
+ *
+ * So: charset 63 (`binary`) is what separates a character type from a byte type - the
+ * BLOB flag is set for both `tx` and `bl` and cannot do it. And all four text tiers
+ * plus all four blob tiers arrive as ONE code, 252; only the length tells them apart,
+ * so the tier is read from the length ceiling.
+ *
+ * Three things this deliberately does not do:
+ *
+ * - No length, precision or display width in the name. `int` reports len=11 and
+ *   `decimal(10,2)` reports len=12/dec=2, and neither number is part of the declared
+ *   type any more (MySQL 8.0.19 deprecated display width). `DATA_TYPE` in
+ *   `information_schema` - which is what our own schema tree shows - is `decimal`, so
+ *   that is what a declared type says here.
+ * - No `unsigned` suffix, for the same reason: `DATA_TYPE` for `int unsigned` is
+ *   plain `int`. Measured, the UNSIGNED flag is also set on `bit` and on `year`
+ *   (`flags=96`), neither of which can be declared unsigned, so the flag is not even a
+ *   reliable signal on its own.
+ * - No distinction between `geometry` and `point`. Measured, both arrive as code 255;
+ *   the protocol simply does not carry the subtype.
+ */
+const MYSQL_TYPE_NAMES: Record<number, string | undefined> = {
+  0: "decimal",
+  1: "tinyint",
+  2: "smallint",
+  3: "int",
+  4: "float",
+  5: "double",
+  6: "null",
+  7: "timestamp",
+  8: "bigint",
+  9: "mediumint",
+  10: "date",
+  11: "time",
+  12: "datetime",
+  13: "year",
+  // NEWDATE, an internal-only DATE representation that no modern server sends.
+  14: "date",
+  15: "varchar",
+  16: "bit",
+  // MySQL 9's VECTOR. Kept because a server newer than the probe can send it.
+  242: "vector",
+  245: "json",
+  // NEWDECIMAL, the only DECIMAL a server has sent since 5.0; MySQL spells it `decimal`.
+  246: "decimal",
+  255: "geometry",
+};
+
+/** `binary`, character set 63 - the marker that a string type is really a byte type. */
+const MYSQL_BINARY_CHARSET = 63;
+const MYSQL_ENUM_FLAG = 256;
+const MYSQL_SET_FLAG = 2048;
+
+/**
+ * The blob/text tiers, keyed by the largest `columnLength` each can report.
+ *
+ * A tier's ceiling is its byte capacity times the charset's maximum bytes per
+ * character (4 for utf8mb4), and the tiers are 256x apart, so a ceiling of `capacity *
+ * 4` never overlaps the next tier's floor: the widest `tinytext` is 1020 and the
+ * narrowest `text` (latin1) is 65535. LONGTEXT is not multiplied - 4294967295 is the
+ * protocol's own maximum.
+ */
+const MYSQL_BLOB_TIERS: readonly (readonly [number, string, string])[] = [
+  [255 * 4, "tinytext", "tinyblob"],
+  [65535 * 4, "text", "blob"],
+  [16777215 * 4, "mediumtext", "mediumblob"],
+  [Number.POSITIVE_INFINITY, "longtext", "longblob"],
+];
+
+export function mysqlColumnType(field: MysqlColumnMetadata): string | undefined {
+  // MariaDB 10.5+ sends the real name of a type the protocol has no code for (`uuid`,
+  // `inet6`, `point`) in the extended metadata. When it is there it is the only
+  // spelling of that column there is, so it wins.
+  if (typeof field.extendedTypeName === "string" && field.extendedTypeName.length > 0) {
+    return field.extendedTypeName;
+  }
+
+  const code = field.columnType ?? field.type;
+  if (code === undefined) return undefined;
+
+  // mysql2's typings allow a string[] here; measured, the driver hands a number. The
+  // array form is read as no flags, which costs precision on ENUM and SET, never
+  // correctness.
+  const flags = typeof field.flags === "number" ? field.flags : 0;
+  const isBinary = field.characterSet === MYSQL_BINARY_CHARSET;
+
+  if (code === 254 || code === 253) {
+    if ((flags & MYSQL_ENUM_FLAG) !== 0) return "enum";
+    if ((flags & MYSQL_SET_FLAG) !== 0) return "set";
+    if (code === 253) return isBinary ? "varbinary" : "varchar";
+    return isBinary ? "binary" : "char";
+  }
+
+  // 249/250/251 are TINY_BLOB/MEDIUM_BLOB/LONG_BLOB. Measured, this server sends 252
+  // for all eight tiers and never these three, but a server that does send them has
+  // named the tier itself, so the code is honoured over the length.
+  if (code === 249) return isBinary ? "tinyblob" : "tinytext";
+  if (code === 250) return isBinary ? "mediumblob" : "mediumtext";
+  if (code === 251) return isBinary ? "longblob" : "longtext";
+  if (code === 252) {
+    // No length at all: name the family the charset already settled rather than
+    // claiming a tier. `blob`/`text` is the tier the plain type name means.
+    const length = field.columnLength ?? 65535;
+    const tier = MYSQL_BLOB_TIERS.find(([ceiling]) => length <= ceiling)!;
+    return isBinary ? tier[2] : tier[1];
+  }
+
+  return MYSQL_TYPE_NAMES[code];
+}
+
+/** `pg`'s `result.fields`, narrowed to what a declared type needs. */
+export interface PgFieldMetadata {
+  name: string;
+  dataTypeID?: number;
+}
+
+/** The declared types of a `pg` result, ready to spread into a `QueryResult`. */
+export function postgresColumnTypes(fields: readonly PgFieldMetadata[] | undefined): Pick<QueryResult, "columnTypes"> {
+  return declaredColumnTypes(
+    (fields ?? []).map((field) => [
+      field.name,
+      field.dataTypeID === undefined ? undefined : postgresColumnType(field.dataTypeID),
+    ]),
+  );
+}
+
+/** The declared types of a mysql2 result, ready to spread into a `QueryResult`. */
+export function mysqlColumnTypes(
+  fields: readonly (MysqlColumnMetadata & { name: string })[] | undefined,
+): Pick<QueryResult, "columnTypes"> {
+  return declaredColumnTypes((fields ?? []).map((field) => [field.name, mysqlColumnType(field)]));
+}
+
+/**
+ * `oracledb`'s `metaData`, which needs no table: it carries `dbTypeName` - Oracle's
+ * own spelling, uppercase as `ALL_TAB_COLUMNS.DATA_TYPE` has it. Measured on Oracle
+ * Free 23ai over `r5_types`: `NUMBER`, `BINARY_DOUBLE`, `VARCHAR2`, `CLOB`,
+ * `TIMESTAMP`, `DATE`, `BLOB`, and `TIMESTAMP WITH TIME ZONE` for `SYSTIMESTAMP`.
+ *
+ * `precision`/`scale` sit beside it (10 and 2 for `NUMBER(10,2)`) and are deliberately
+ * left out, for the reason MySQL's are: `DATA_TYPE` is the type, and a computed column
+ * reports precision 0 (`COUNT(*)`) or scale -127 (`1/3`), which no `NUMBER(p,s)` built
+ * from them would mean.
+ */
+export interface OracleColumnMetadata {
+  name: string;
+  dbTypeName?: unknown;
+}
+
+export function oracleColumnTypes(
+  metaData: readonly OracleColumnMetadata[] | undefined,
+): Pick<QueryResult, "columnTypes"> {
+  return declaredColumnTypes(
+    (metaData ?? []).map((column) => [
+      column.name,
+      typeof column.dbTypeName === "string" ? column.dbTypeName : undefined,
+    ]),
+  );
+}
+
+/**
+ * `mssql`'s `recordset.columns`, which also needs no table: each entry's `type` is the
+ * driver's type object, whose `declaration` is T-SQL's own lowercase spelling.
+ * Measured on SQL Server 2022 CU26 over `types`: `bigint`, `decimal`, `float`, `bit`,
+ * `nvarchar`, `varchar`, `datetime2`, `date`, `uniqueidentifier`, `varbinary` - the
+ * same words as `INFORMATION_SCHEMA.COLUMNS.DATA_TYPE` for those columns.
+ *
+ * `type` is a factory FUNCTION for some types and an object for others, and both carry
+ * `declaration`, so this reads the property off either without caring which.
+ */
+export interface MssqlColumnMetadata {
+  type?: { declaration?: unknown } | (() => unknown);
+}
+
+export function mssqlColumnTypes(
+  columns: Record<string, MssqlColumnMetadata> | undefined,
+): Pick<QueryResult, "columnTypes"> {
+  return declaredColumnTypes(
+    Object.entries(columns ?? {}).map(([name, column]) => {
+      const declaration = (column.type as { declaration?: unknown } | undefined)?.declaration;
+      return [name, typeof declaration === "string" ? declaration : undefined];
+    }),
+  );
+}

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -5,6 +5,7 @@
 
 import mssql from "mssql";
 import { SQLBaseProvider } from "./sql-base";
+import { mssqlColumnTypes } from "./column-types";
 import {
   type DatabaseConnection,
   type TableSchema,
@@ -33,6 +34,7 @@ import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../uti
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
 import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
+import { CACHE_HIT_RATIO_UNAVAILABLE, formatCacheHitRatio, measuredNumber } from "@/lib/monitoring-cache-ratio";
 
 // Row shape used to group foreign keys per table in getSchema().
 type ForeignKeyInfo = { columnName: string; referencedTable: string; referencedColumn: string };
@@ -605,6 +607,7 @@ export class MSSQLProvider extends SQLBaseProvider {
         fields,
         rowCount: result.rowsAffected?.[0] ?? recordset.length,
         executionTime,
+        ...mssqlColumnTypes(recordset.columns),
       };
     });
   }
@@ -769,6 +772,7 @@ export class MSSQLProvider extends SQLBaseProvider {
         fields,
         rowCount: result.rowsAffected?.[0] ?? recordset.length,
         executionTime,
+        ...mssqlColumnTypes(recordset.columns),
       };
     });
   }
@@ -880,7 +884,7 @@ export class MSSQLProvider extends SQLBaseProvider {
     try {
       let activeConnections = 0;
       let databaseSize = "N/A";
-      let cacheHitRatio = "N/A";
+      let cacheHitRatio: string = CACHE_HIT_RATIO_UNAVAILABLE;
       const slowQueries: SlowQuery[] = [];
       const activeSessions: ActiveSession[] = [];
 
@@ -903,12 +907,18 @@ export class MSSQLProvider extends SQLBaseProvider {
         /* ignore */
       }
 
-      // Cache hit ratio
+      // Cache hit ratio. `|| 0` used to publish "0%" for a reading SQL Server never
+      // gave, and the Overview card rates 0 as "Needs tuning". Both absences are
+      // ordinary and both were measured 2026-08-23 on SQL Server 2022 CU26: a login
+      // with only CONNECT gets `Msg 300 ... VIEW SERVER PERFORMANCE STATE permission
+      // was denied on object 'server', database 'master'` (the catch below), and a
+      // zero counter base gives one `NULL` row through NULLIF (measuredNumber).
       try {
         const cacheRes = await this.pool!.request().query(BUFFER_CACHE_HIT_RATIO_SQL);
-        cacheHitRatio = `${cacheRes.recordset[0]?.hit_ratio || 0}%`;
+        const ratio = measuredNumber(cacheRes.recordset[0]?.hit_ratio);
+        if (ratio !== undefined) cacheHitRatio = `${formatCacheHitRatio(ratio)}%`;
       } catch {
-        /* ignore */
+        /* The DMV needs VIEW SERVER PERFORMANCE STATE; the initial "N/A" stands. */
       }
 
       // Slow queries
@@ -1115,20 +1125,23 @@ export class MSSQLProvider extends SQLBaseProvider {
     this.ensureConnected();
 
     try {
-      let cacheHitRatio = 100;
-      let bufferPoolUsage: number | undefined;
+      let cacheHitRatio: number | undefined;
 
       try {
         const cacheRes = await this.pool!.request().query(BUFFER_CACHE_HIT_RATIO_SQL);
-        cacheHitRatio = Number(cacheRes.recordset[0]?.hit_ratio || 100);
-        bufferPoolUsage = cacheHitRatio;
+        cacheHitRatio = measuredNumber(cacheRes.recordset[0]?.hit_ratio);
       } catch {
-        /* ignore */
+        /* DMV permissions; nothing was measured, so nothing is reported. */
       }
 
       return {
-        cacheHitRatio,
-        bufferPoolUsage,
+        ...(cacheHitRatio === undefined ? {} : { cacheHitRatio }),
+        // bufferPoolUsage is gone rather than merely absent. It used to be assigned
+        // `cacheHitRatio` itself - the same number under a second name, drawn and
+        // rated as a separate gauge. SQL Server does publish pool occupancy, through
+        // sys.dm_os_buffer_descriptors against max server memory, but this method
+        // does not query it and that scan is not free; until it does there is nothing
+        // here to report.
       };
     } catch (error) {
       throw mapDatabaseError(error, "mssql");

--- a/src/lib/db/providers/sql/mysql.ts
+++ b/src/lib/db/providers/sql/mysql.ts
@@ -5,6 +5,7 @@
 
 import mysql, { type Pool, type PoolConnection, type RowDataPacket, type FieldPacket } from "mysql2/promise";
 import { SQLBaseProvider } from "./sql-base";
+import { mysqlColumnTypes } from "./column-types";
 import {
   type DatabaseConnection,
   type TableSchema,
@@ -27,7 +28,7 @@ import {
 } from "../../types";
 import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
 import { formatBytes } from "../../utils/pool-manager";
-import { formatCacheHitRatio } from "@/lib/monitoring-cache-ratio";
+import { CACHE_HIT_RATIO_UNAVAILABLE, formatCacheHitRatio, measuredNumber } from "@/lib/monitoring-cache-ratio";
 
 /**
  * mysql2 3.23 narrowed `execute`'s values parameter from `any` to a concrete
@@ -222,21 +223,6 @@ const SELF_IDENTIFYING_VERSION = /mariadb|tidb|vitess|oceanbase/i;
  */
 function labelServerVersion(version: string): string {
   return SELF_IDENTIFYING_VERSION.test(version) ? version : `MySQL ${version}`;
-}
-
-/**
- * A `performance_schema` reading, or `undefined` when there was nothing to read.
- *
- * MariaDB ships `performance_schema` OFF by default and the tables still exist,
- * so the metric queries are a bare `SELECT (subquery)` that answers one row of
- * NULLs rather than throwing. `parseInt(x || "0")` turned each of those NULLs
- * into a measurement nobody took, which is the fault #448 and #452 removed from
- * the panels; this keeps the provider from manufacturing one in the first place.
- */
-function measuredNumber(value: unknown): number | undefined {
-  if (value === null || value === undefined) return undefined;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function round2(value: number): number {
@@ -495,6 +481,50 @@ export class MySQLProvider extends SQLBaseProvider {
     return sanitized;
   }
 
+  /**
+   * Build the query envelope from what mysql2 handed back.
+   *
+   * `execute`'s first return value is an ARRAY of rows only for a statement that
+   * produced a result set. For everything else - DDL, INSERT, UPDATE, DELETE - it
+   * is a `ResultSetHeader` object and `fields` is `undefined`. Measured verbatim
+   * against mysql 26.7.0 on 2026-08-23, `INSERT INTO r5_hdr (note) VALUES
+   * ('a'),('b')` answers
+   * `{fieldCount:0,affectedRows:2,insertId:1,info:"Records: 2  Duplicates: 0  Warnings: 0",serverStatus:2,warningStatus:0,changedRows:0}`.
+   *
+   * Calling `.map` on that object threw `result.rows.map is not a function` AFTER
+   * the server had already applied the statement, so every DDL and DML statement
+   * run from the editor reported a failure for work that had landed - the answer
+   * that makes a user retry and double-apply it.
+   *
+   * The empty-result answer follows what the other SQL providers here already do:
+   * no rows, no fields, and the affected-row count in `rowCount` (mssql reports
+   * `rowsAffected[0]`, sqlite `changes`, postgres `pg`'s own `rowCount`).
+   * `insertId`, `changedRows` and `warningStatus` are deliberately dropped:
+   * `QueryResult` models none of them, and `rowCount` is the field the results
+   * footer renders. `affectedRows` is the matched count, which is why a no-op
+   * UPDATE still reports 1 - matching mssql, whose `rowsAffected` counts the same
+   * way.
+   */
+  private buildQueryResult(rows: unknown, fields: FieldPacket[] | undefined, executionTime: number): QueryResult {
+    if (!Array.isArray(rows)) {
+      const header = rows as { affectedRows?: number };
+      return {
+        rows: [],
+        fields: [],
+        rowCount: header.affectedRows ?? 0,
+        executionTime,
+      };
+    }
+
+    return {
+      rows: (rows as unknown[]).map((row) => this.sanitizeRow(row as Record<string, unknown>)),
+      fields: fields?.map((f: FieldPacket) => f.name) ?? [],
+      ...mysqlColumnTypes(fields),
+      rowCount: rows.length,
+      executionTime,
+    };
+  }
+
   // Track running query thread IDs for cancellation
   private runningQueryThreadIds = new Map<string, number>();
 
@@ -519,12 +549,7 @@ export class MySQLProvider extends SQLBaseProvider {
         }
       });
 
-      return {
-        rows: (result.rows as unknown[]).map((row) => this.sanitizeRow(row as Record<string, unknown>)),
-        fields: result.fields?.map((f: FieldPacket) => f.name) ?? [],
-        rowCount: Array.isArray(result.rows) ? result.rows.length : 0,
-        executionTime,
-      };
+      return this.buildQueryResult(result.rows, result.fields, executionTime);
     });
   }
 
@@ -626,12 +651,7 @@ export class MySQLProvider extends SQLBaseProvider {
         }
       });
 
-      return {
-        rows: (result.rows as unknown[]).map((row) => this.sanitizeRow(row as Record<string, unknown>)),
-        fields: result.fields?.map((f: FieldPacket) => f.name) ?? [],
-        rowCount: Array.isArray(result.rows) ? result.rows.length : 0,
-        executionTime,
-      };
+      return this.buildQueryResult(result.rows, result.fields, executionTime);
     });
   }
 
@@ -716,8 +736,20 @@ export class MySQLProvider extends SQLBaseProvider {
       );
       const databaseSize = `${sizeRows[0]?.size_mb || 0} MB`;
 
-      const [hitRows] = await conn.execute<RowDataPacket[]>(BUFFER_CACHE_HIT_RATIO_SQL);
-      const cacheHitRatio = formatCacheHitRatio(measuredNumber(hitRows[0]?.hit_ratio));
+      // A tenant can be missing the performance_schema DATABASE rather than merely
+      // having the schema off, and then this query does not answer NULLs, it throws:
+      // measured 2026-08-20 on OceanBase Community Edition 4.4.2.1 through this
+      // provider, and reproduced on mysql:latest as
+      // `ERROR 1049 (42000): Unknown database 'performance_schema_absent'`. Uncaught,
+      // it took the whole health read down, so the panel showed nothing at all where
+      // one unavailable metric was the honest answer.
+      let cacheHitRatio = CACHE_HIT_RATIO_UNAVAILABLE;
+      try {
+        const [hitRows] = await conn.execute<RowDataPacket[]>(BUFFER_CACHE_HIT_RATIO_SQL);
+        cacheHitRatio = formatCacheHitRatio(measuredNumber(hitRows[0]?.hit_ratio));
+      } catch {
+        // Nothing to read, so nothing is reported.
+      }
 
       let slowQueries: SlowQuery[] = [];
       try {

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -5,6 +5,7 @@
 
 import oracledb from "oracledb";
 import { SQLBaseProvider } from "./sql-base";
+import { oracleColumnTypes } from "./column-types";
 import {
   type DatabaseConnection,
   type TableSchema,
@@ -32,6 +33,7 @@ import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
 import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
+import { CACHE_HIT_RATIO_UNAVAILABLE, formatCacheHitRatio, measuredNumber } from "@/lib/monitoring-cache-ratio";
 
 // ============================================================================
 // SQL Statements
@@ -417,6 +419,7 @@ export class OracleProvider extends SQLBaseProvider {
         fields,
         rowCount: rows.length,
         executionTime,
+        ...oracleColumnTypes(result.metaData),
       };
     });
   }
@@ -541,6 +544,7 @@ export class OracleProvider extends SQLBaseProvider {
         fields,
         rowCount: rows.length,
         executionTime,
+        ...oracleColumnTypes(result.metaData),
       };
     });
   }
@@ -669,7 +673,7 @@ export class OracleProvider extends SQLBaseProvider {
 
       let activeConnections = 0;
       let databaseSize = "N/A";
-      let cacheHitRatio = "N/A";
+      let cacheHitRatio: string = CACHE_HIT_RATIO_UNAVAILABLE;
       const slowQueries: SlowQuery[] = [];
       const activeSessions: ActiveSession[] = [];
 
@@ -698,13 +702,20 @@ export class OracleProvider extends SQLBaseProvider {
         /* ignore */
       }
 
-      // Cache hit ratio
+      // Cache hit ratio. `|| 0` used to publish "0%" for a reading Oracle never
+      // took, and the Overview card rates 0 as "Needs tuning" - so a user who
+      // simply cannot read V$SYSSTAT saw a cache fault. The two ways the reading
+      // goes absent, both measured 2026-08-23 on Oracle Free 23ai: a user granted
+      // only CREATE SESSION gets `ORA-00942: table or view "SYS"."V_$SYSSTAT" does
+      // not exist` (the catch below), and a zero counter denominator gives one row
+      // of `<NULL>` through NULLIF (measuredNumber).
       try {
         const cacheRes = await conn.execute(CACHE_HIT_RATIO_SQL, [], { outFormat: oracledb.OUT_FORMAT_OBJECT });
         const cacheRows = (cacheRes.rows || []) as Record<string, unknown>[];
-        cacheHitRatio = `${cacheRows[0]?.HIT_RATIO || 0}%`;
+        const ratio = measuredNumber(cacheRows[0]?.HIT_RATIO);
+        if (ratio !== undefined) cacheHitRatio = `${formatCacheHitRatio(ratio)}%`;
       } catch {
-        /* ignore */
+        /* V$SYSSTAT requires privileges; the initial "N/A" stands. */
       }
 
       // Slow queries
@@ -940,21 +951,24 @@ export class OracleProvider extends SQLBaseProvider {
     try {
       conn = await this.pool!.getConnection();
 
-      let cacheHitRatio = 100;
-      let bufferPoolUsage: number | undefined;
+      let cacheHitRatio: number | undefined;
 
       try {
         const cacheRes = await conn.execute(CACHE_HIT_RATIO_SQL, [], { outFormat: oracledb.OUT_FORMAT_OBJECT });
         const rows = (cacheRes.rows || []) as Record<string, unknown>[];
-        cacheHitRatio = Number(rows[0]?.HIT_RATIO || 100);
-        bufferPoolUsage = cacheHitRatio;
+        cacheHitRatio = measuredNumber(rows[0]?.HIT_RATIO);
       } catch {
-        /* ignore */
+        /* V$SYSSTAT requires privileges; nothing was measured, so nothing is reported. */
       }
 
       return {
-        cacheHitRatio,
-        bufferPoolUsage,
+        ...(cacheHitRatio === undefined ? {} : { cacheHitRatio }),
+        // bufferPoolUsage is gone rather than merely absent. It used to be assigned
+        // `cacheHitRatio` itself - the same number under a second name, which the
+        // Performance tab then drew as a separate gauge and rated separately. Oracle
+        // does publish buffer pool occupancy, but in V$BUFFER_POOL_STATISTICS /
+        // V$SGASTAT, which this method does not query; until it does there is
+        // nothing here to report.
       };
     } finally {
       if (conn) await conn.close();

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -36,7 +36,9 @@ import {
   mapDatabaseError,
 } from "../../errors";
 import { assertReadOnlyBudget, measureResultBytes } from "./read-only-budget";
+import { postgresColumnTypes } from "./column-types";
 import { formatBytes } from "../../utils/pool-manager";
+import { CACHE_HIT_RATIO_UNAVAILABLE, formatCacheHitRatio, measuredNumber } from "@/lib/monitoring-cache-ratio";
 
 // ============================================================================
 // Type Definitions
@@ -244,14 +246,24 @@ const SCHEMA_RELATIONS_SQL = `
 // ============================================================================
 
 // getHealth: buffer cache hit ratio across user tables.
+//
+// No COALESCE, deliberately. `NULLIF(..., 0)` is here because the denominator can
+// genuinely be zero, and the statement used to wrap the resulting NULL in
+// `COALESCE(..., 100)` - so a database PostgreSQL had measured nothing about
+// reported a perfect cache. Measured 2026-08-23 on postgres:18, a database with no
+// user tables:
+//
+//   heap_read | heap_hit | raw_ratio | coalesced
+//  -----------+----------+-----------+-----------
+//             |          |           |       100
+//
+// and a table nothing has read yet gives `0 / NULLIF(0, 0)`, the same NULL. The
+// NULL now travels to TypeScript, which reports it as unavailable (#424).
 const HEALTH_CACHE_HIT_SQL = `
         SELECT
           sum(heap_blks_read) as heap_read,
           sum(heap_blks_hit)  as heap_hit,
-          COALESCE(
-            ROUND((sum(heap_blks_hit) * 100.0 / NULLIF(sum(heap_blks_hit) + sum(heap_blks_read), 0)), 1),
-            100
-          ) as ratio
+          ROUND((sum(heap_blks_hit) * 100.0 / NULLIF(sum(heap_blks_hit) + sum(heap_blks_read), 0)), 1) as ratio
         FROM pg_statio_user_tables;
       `;
 
@@ -318,13 +330,11 @@ const OVERVIEW_COUNTS_SQL = `
           (SELECT count(*) FROM pg_indexes WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')) as index_count
       `;
 
-// getPerformanceMetrics: buffer cache hit ratio.
+// getPerformanceMetrics: buffer cache hit ratio. NULL when there is nothing to
+// divide, for the reasons and with the measurement given at HEALTH_CACHE_HIT_SQL.
 const PERF_CACHE_HIT_SQL = `
         SELECT
-          COALESCE(
-            ROUND(sum(heap_blks_hit) * 100.0 / NULLIF(sum(heap_blks_hit) + sum(heap_blks_read), 0), 2),
-            100
-          ) as cache_hit_ratio
+          ROUND(sum(heap_blks_hit) * 100.0 / NULLIF(sum(heap_blks_hit) + sum(heap_blks_read), 0), 2) as cache_hit_ratio
         FROM pg_statio_user_tables
       `;
 
@@ -836,6 +846,7 @@ export class PostgresProvider extends SQLBaseProvider {
       return {
         rows: result.rows,
         fields: result.fields?.map((f) => f.name) ?? [],
+        ...postgresColumnTypes(result.fields),
         rowCount: result.rowCount ?? 0,
         executionTime,
       };
@@ -952,6 +963,7 @@ export class PostgresProvider extends SQLBaseProvider {
       return {
         rows: result.rows,
         fields: result.fields?.map((f) => f.name) ?? [],
+        ...postgresColumnTypes(result.fields),
         rowCount: result.rowCount ?? 0,
         executionTime,
       };
@@ -1044,6 +1056,7 @@ export class PostgresProvider extends SQLBaseProvider {
       return {
         rows: result.rows,
         fields: result.fields?.map((f) => f.name) ?? [],
+        ...postgresColumnTypes(result.fields),
         rowCount: result.rowCount ?? 0,
         executionTime,
       };
@@ -1195,6 +1208,9 @@ export class PostgresProvider extends SQLBaseProvider {
       const sizeRes = await client.query("SELECT pg_size_pretty(pg_database_size($1))", [this.config.database]);
 
       const cacheRes = await client.query(HEALTH_CACHE_HIT_SQL);
+      // A NULL ratio used to arrive here as the SQL's own invented 100; unguarded,
+      // it would now arrive as the string "null%".
+      const healthCacheHitRatio = measuredNumber(cacheRes.rows[0]?.ratio);
 
       let slowQueries: SlowQuery[] = [];
       try {
@@ -1222,7 +1238,10 @@ export class PostgresProvider extends SQLBaseProvider {
       return {
         activeConnections: parseInt(connRes.rows[0].count),
         databaseSize: sizeRes.rows[0].pg_size_pretty,
-        cacheHitRatio: `${cacheRes.rows[0].ratio}%`,
+        cacheHitRatio:
+          healthCacheHitRatio === undefined
+            ? CACHE_HIT_RATIO_UNAVAILABLE
+            : `${formatCacheHitRatio(healthCacheHitRatio)}%`,
         slowQueries,
         activeSessions,
       };
@@ -1379,34 +1398,55 @@ export class PostgresProvider extends SQLBaseProvider {
     try {
       // Get cache hit ratio
       const cacheRes = await client.query(PERF_CACHE_HIT_SQL);
+      const cacheHitRatio = measuredNumber(cacheRes.rows[0]?.cache_hit_ratio);
 
       // Get transaction stats
       const txRes = await client.query(PERF_TRANSACTION_STATS_SQL, [this.config.database]);
 
       // Get checkpoint stats (optional - columns may not exist in older PG versions)
-      let checkpointWriteTime = "0";
+      // "N/A" from the start rather than "0", so an unread counter never leaves
+      // here looking like a checkpoint that took no time.
+      let checkpointWriteTime = "N/A";
       try {
         const checkpointRes = await client.query(PERF_CHECKPOINT_SQL);
-        const checkpointRow = checkpointRes.rows[0] || {};
-        const writeTime = parseFloat(checkpointRow.checkpoint_write_time || "0");
-        const syncTime = parseFloat(checkpointRow.checkpoint_sync_time || "0");
-        checkpointWriteTime = `${((writeTime + syncTime) / 1000).toFixed(1)}s`;
+        const checkpointRow = checkpointRes.rows[0];
+        const writeTime = measuredNumber(checkpointRow?.checkpoint_write_time);
+        const syncTime = measuredNumber(checkpointRow?.checkpoint_sync_time);
+        // Either half alone is a reading; neither is not. PostgreSQL 17 moved both
+        // columns from pg_stat_bgwriter to pg_stat_checkpointer, so on 17+ the query
+        // throws and the catch below answers - measured 2026-08-23 through this
+        // provider against postgres:18, which reported checkpointWriteTime "N/A".
+        if (writeTime !== undefined || syncTime !== undefined) {
+          checkpointWriteTime = `${(((writeTime ?? 0) + (syncTime ?? 0)) / 1000).toFixed(1)}s`;
+        }
       } catch {
-        // checkpoint_write_time doesn't exist in older PostgreSQL versions
+        // The columns do not exist on this server (17+), or the view is not readable.
         checkpointWriteTime = "N/A";
       }
 
-      const txRow = txRes.rows[0] || {};
-      const blksHit = parseInt(txRow.blks_hit || "0");
-      const blksRead = parseInt(txRow.blks_read || "0");
-      const bufferPoolUsage = blksHit + blksRead > 0 ? Math.round((blksHit / (blksHit + blksRead)) * 100) : 100;
+      // No `|| "0"` here: pg_stat_database answers no row at all for a database it
+      // has no entry for, and a deadlock count of 0 is a claim ("this database has
+      // deadlocked zero times") rather than the absence of a reading.
+      const txRow = txRes.rows[0];
+      const deadlocks = measuredNumber(txRow?.deadlocks);
 
       return {
-        cacheHitRatio: parseFloat(cacheRes.rows[0].cache_hit_ratio || "100"),
-        transactionsPerSecond: undefined, // Would need time-based sampling
-        queriesPerSecond: undefined, // Would need time-based sampling
-        bufferPoolUsage,
-        deadlocks: parseInt(txRow.deadlocks || "0"),
+        // `|| "100"` was two bugs in one operator: it invented a perfect cache for a
+        // NULL, and it also discarded a measured 0 - a cold cache reading 0% is a
+        // measurement, and the one the panel most needs to show.
+        ...(cacheHitRatio === undefined ? {} : { cacheHitRatio }),
+        // transactionsPerSecond / queriesPerSecond would need time-based sampling,
+        // which this call does not do, so they stay absent.
+        //
+        // bufferPoolUsage is absent too, and that is a removal rather than a gap:
+        // this method used to report `blks_hit / (blks_hit + blks_read)` from
+        // pg_stat_database under that name, which is a cache hit ratio and not pool
+        // occupancy - so the Performance tab showed the same quantity twice, once
+        // mislabelled, and substituted 100 when both counters were 0. PostgreSQL
+        // publishes no buffer pool occupancy without the pg_buffercache extension
+        // (not installed by default, and scanning it locks shared_buffers), so there
+        // is nothing honest to put here.
+        ...(deadlocks === undefined ? {} : { deadlocks }),
         checkpointWriteTime,
       };
     } finally {

--- a/src/lib/db/providers/sql/sqlite.ts
+++ b/src/lib/db/providers/sql/sqlite.ts
@@ -41,6 +41,7 @@ import {
 import { assertReadOnlyBudget, measureResultBytes } from "./read-only-budget";
 import { formatBytes } from "../../utils/pool-manager";
 import { loadSQLiteDriver, type SQLiteDatabase } from "./sqlite-driver";
+import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -597,7 +598,9 @@ export class SQLiteProvider extends SQLBaseProvider {
     return {
       activeConnections: 1,
       databaseSize,
-      cacheHitRatio: "N/A",
+      // Same word as the performance panel's absent ratio, and now the same
+      // constant, so the two cannot drift apart.
+      cacheHitRatio: CACHE_HIT_RATIO_UNAVAILABLE,
       slowQueries: [
         {
           query: `Integrity: ${isHealthy ? "OK" : "FAILED"}`,
@@ -726,29 +729,44 @@ export class SQLiteProvider extends SQLBaseProvider {
     };
   }
 
+  /**
+   * Only what SQLite can actually be asked, which is no cache hit ratio at all.
+   *
+   * SQLite's hit and miss counters live behind the C API
+   * (`sqlite3_db_status()` with `SQLITE_DBSTATUS_CACHE_HIT` / `CACHE_MISS`), and
+   * neither driver this provider can load surfaces them. Measured 2026-08-23 by
+   * walking the prototype chain of a live handle: `bun:sqlite` 1.3.14 offers
+   * `clearQueryCache, close, exec, fileControl, filename, handle, inTransaction,
+   * loadExtension, prepare, query, run, serialize, transaction`, and
+   * `node:sqlite` on Node 24.14.0 offers `aggregate, applyChangeset, close,
+   * createSession, createTagStore, enableDefensive, enableLoadExtension, exec,
+   * function, isOpen, isTransaction, loadExtension, location, open, prepare,
+   * setAuthorizer`. No status call on either, and nothing SQL-reachable stands
+   * in: `PRAGMA cache_hit` and `PRAGMA cache_miss` are not pragmas (SQLite
+   * answers an unknown pragma with zero rows rather than an error, so they
+   * *look* like empty readings), `PRAGMA stats` returned `[]` on both drivers,
+   * and `PRAGMA cache_size` is the configured page budget - `-2000`, the 2 MiB
+   * default, on both.
+   *
+   * That budget is what the old code turned into a ratio: it reported 95%
+   * whenever `PRAGMA cache_size` came back truthy, which it always does, and 99%
+   * otherwise. Both numbers were this provider's invention, and the panel rated
+   * them "Excellent". A missing panel is honest; a populated wrong one is not
+   * (#424), so the field is omitted - permanently, not pending a better query.
+   */
   public async getPerformanceMetrics(): Promise<PerformanceMetrics> {
     this.ensureConnected();
 
-    let cacheHitRatio = 99;
-
-    try {
-      // Get cache stats
-      const cacheStmt = this.db!.prepare("PRAGMA cache_size");
-      const cacheResult = cacheStmt.get() as { cache_size: number };
-
-      // SQLite doesn't provide detailed cache hit stats, estimate high ratio
-      if (cacheResult?.cache_size) {
-        cacheHitRatio = 95; // Reasonable estimate for in-memory cache
-      }
-    } catch {
-      // Ignore
-    }
-
     return {
-      cacheHitRatio,
-      // SQLite doesn't provide these metrics
-      queriesPerSecond: undefined,
-      bufferPoolUsage: undefined,
+      // `cacheHitRatio`, `queriesPerSecond` and `bufferPoolUsage` are all absent:
+      // SQLite keeps no statement counter and no server-side buffer pool whose
+      // usage could be read, so the monitoring tabs show "Not measured" for each.
+      //
+      // `deadlocks` is different, and stays. It is a statement about the engine
+      // rather than a reading that failed: SQLite serializes writers behind a
+      // single write lock and has no lock-wait graph to deadlock in - a second
+      // writer is refused with SQLITE_BUSY instead - so there are no deadlocks to
+      // count and 0 is the true count.
       deadlocks: 0,
     };
   }
@@ -840,8 +858,13 @@ export class SQLiteProvider extends SQLBaseProvider {
         columns: indexCols.map((c) => c.name),
         isUnique: indexMeta?.unique === 1,
         isPrimary: false, // SQLite auto-creates rowid, explicit PKs are shown differently
+        // SQLite publishes no per-index size: `dbstat` would give page counts but it
+        // is a compile-time option, present on node:sqlite (ENABLE_DBSTAT_VTAB) and
+        // absent on bun:sqlite ("no such table: dbstat", measured 2026-08-23), so it
+        // cannot be relied on. The size string already said so; the companion byte
+        // count said 0, and the Storage tab summed those zeroes into an index total
+        // that read as "every index is empty". The field is optional for this case.
         indexSize: "N/A",
-        indexSizeBytes: 0,
         scans: 0, // SQLite doesn't track index usage
       });
     }

--- a/src/lib/export/result-export.ts
+++ b/src/lib/export/result-export.ts
@@ -1,6 +1,7 @@
 import type { DatabaseType } from "@/lib/types";
 import { isBareIdentifier, quoteIdentifier } from "@/lib/sql/identifier";
 import { quoteLiteral } from "@/lib/sql/values";
+import { asBytes, binaryText } from "./binary";
 import { cellOf, resolveColumns, toCsv } from "./csv";
 import { jsonText } from "./json";
 
@@ -83,7 +84,7 @@ function firstSample(rows: readonly Record<string, unknown>[], column: string): 
 }
 
 /** The kinds of column a value can be inferred to be, before a dialect spells them. */
-type InferredKind = "text" | "integer" | "numeric" | "boolean" | "timestamp";
+type InferredKind = "text" | "integer" | "numeric" | "boolean" | "timestamp" | "binary";
 
 /**
  * How each dialect spells the inferred kinds.
@@ -101,10 +102,18 @@ const STANDARD_TYPES: Record<InferredKind, string> = {
   numeric: "DOUBLE PRECISION",
   boolean: "BOOLEAN",
   timestamp: "TIMESTAMP",
+  // `BLOB` is the standard spelling and MySQL, SQLite, Oracle and Cassandra all take
+  // it verbatim, so the four that would otherwise need a row here do not get one.
+  binary: "BLOB",
 };
 
 const DIALECT_TYPES: Partial<Record<DatabaseType, Partial<Record<InferredKind, string>>>> = {
+  postgres: { binary: "BYTEA" },
   mysql: { numeric: "DOUBLE", timestamp: "DATETIME" },
+  // ClickHouse has no BLOB: its byte container IS `String`, which is a byte sequence
+  // and not a text encoding, and `unhex` (the literal below) returns exactly that.
+  clickhouse: { binary: "String" },
+  trino: { binary: "VARBINARY" },
   oracle: {
     text: "VARCHAR2(4000)",
     integer: "NUMBER(19)",
@@ -116,6 +125,9 @@ const DIALECT_TYPES: Partial<Record<DatabaseType, Partial<Record<InferredKind, s
     numeric: "FLOAT",
     boolean: "BIT",
     timestamp: "DATETIME2",
+    // `BLOB` is not a T-SQL type name at all, and `IMAGE` has been deprecated since
+    // 2005.
+    binary: "VARBINARY(MAX)",
   },
 };
 
@@ -137,7 +149,189 @@ function inferKind(sample: unknown): InferredKind {
   if (typeof sample === "number") return Number.isInteger(sample) ? "integer" : "numeric";
   if (typeof sample === "boolean") return "boolean";
   if (sample instanceof Date) return "timestamp";
+  // Before the text fallback, because a binary value IS an object and fell through to
+  // it: a `bytea` column was recreated as `TEXT`, so the INSERT this same export
+  // writes had nowhere to be replayed into.
+  if (asBytes(sample) !== undefined) return "binary";
   return "text";
+}
+
+/**
+ * The family a BARE declared type belongs to, for the names that cannot stand alone.
+ *
+ * The four biggest providers declare a bare base name — `varchar`, `decimal`,
+ * `VARCHAR2`, `nvarchar`, `varbinary` — because a length or a precision cannot be
+ * recovered from the wire, and `src/lib/db/providers/sql/column-types.ts` says why it
+ * must not be guessed at: a MySQL `varchar(40)` reports `columnLength` 160 under
+ * utf8mb4 and 120 under utf8mb3, `mssql` reports 65535 as its sentinel for
+ * `varchar(MAX)`, and Oracle reports precision 0 for `COUNT(*)` and scale -127 for
+ * `1/3`. So the length is genuinely gone, and a bare name carries exactly as much
+ * information as one of the inferred kinds above — which is what this maps it to, so
+ * that the dialect tables spell it the same way they spell an inferred column.
+ *
+ * Measured by replaying the generated `CREATE TABLE` into the engine it was read from:
+ *
+ *   mysql:  ERROR 1064 … near ',\n  `body` text,'   (the bare `varchar` before it)
+ *   oracle: ORA-00906: missing left parenthesis      (the bare VARCHAR2)
+ *   mssql:  parses, then INFORMATION_SCHEMA.COLUMNS reports nvarchar length 1,
+ *           varchar length 1, varbinary length 1, decimal precision 18 scale 0
+ *
+ * The silent narrowing is the worst of the three: the file replays and the data is
+ * truncated. Two more of the same class were measured and are covered here — `CREATE
+ * TABLE t (c decimal)` is `decimal(10,0)` on MySQL and `NUMBER(*,0)` on Oracle, both
+ * of which round every decimal the column existed for, and `character` is
+ * `character(1)` even on Postgres.
+ *
+ * Only the four families whose parameters the wire drops are listed. `bit` is measured
+ * to narrow to `bit(1)` on Postgres and MySQL and is deliberately NOT here: `pg` hands
+ * a bit string back as `"1010"` and `mysql2` hands it back as a Buffer, so the two
+ * drivers need different families for the same name, and completing it to one of them
+ * would break the INSERT this same export writes for the other.
+ */
+const BARE_TYPE_FAMILY: Record<string, InferredKind> = {
+  "character varying": "text",
+  varchar: "text",
+  varchar2: "text",
+  nvarchar: "text",
+  nvarchar2: "text",
+  character: "text",
+  char: "text",
+  nchar: "text",
+  text: "text",
+  ntext: "text",
+  tinytext: "text",
+  mediumtext: "text",
+  longtext: "text",
+  clob: "text",
+  nclob: "text",
+  enum: "text",
+  set: "text",
+  uniqueidentifier: "text",
+  rowid: "text",
+  binary: "binary",
+  varbinary: "binary",
+  raw: "binary",
+  blob: "binary",
+  tinyblob: "binary",
+  mediumblob: "binary",
+  longblob: "binary",
+  bytea: "binary",
+  image: "binary",
+  numeric: "numeric",
+  decimal: "numeric",
+  number: "numeric",
+  binary_double: "numeric",
+  binary_float: "numeric",
+  money: "numeric",
+  timestamp: "timestamp",
+  "timestamp without time zone": "timestamp",
+  "timestamp with time zone": "timestamp",
+  datetime: "timestamp",
+  datetime2: "timestamp",
+  smalldatetime: "timestamp",
+  datetimeoffset: "timestamp",
+  year: "integer",
+};
+
+/**
+ * The bare names each dialect DOES stand behind, so they are written through verbatim.
+ *
+ * Measured, one `CREATE TABLE probe (c <name>)` per name per engine — Postgres 18.4,
+ * MySQL 26.7.0, Oracle Free 23ai, SQL Server 2022 CU26 — read back out of
+ * `format_type`, `information_schema.COLUMNS.COLUMN_TYPE`, `USER_TAB_COLUMNS` and
+ * `INFORMATION_SCHEMA.COLUMNS`. A name is here only when the engine both accepted it
+ * and stored it unnarrowed: `character varying` on Postgres is unbounded, `text` and
+ * `longtext` on MySQL are whole types already, `NUMBER` on Oracle is the full 38
+ * digits, and `nvarchar` on SQL Server is NOT here because it came back as length 1.
+ *
+ * Two entries are absences worth naming. MySQL's `varchar` is missing because MySQL
+ * refuses it outright, unlike Postgres's, which is legal and unbounded. SQL Server's
+ * `timestamp` is missing because it is not a moment in time at all: measured, `CREATE
+ * TABLE t (c timestamp)` on 2022 CU26 creates a `rowversion`, which no INSERT may
+ * name — so keeping a foreign engine's `timestamp` there would produce a file that
+ * parses and then fails on its own INSERT.
+ *
+ * A dialect absent from this table has nothing completed, which keeps every other
+ * engine exactly as it was: SQLite's column types are advisory affinities, and the six
+ * wire formats that already fill `columnTypes` spell their own types out in full
+ * (`Nullable(String)`, `array(varchar)`), so there is no bare name to complete.
+ */
+const STANDS_ALONE: Partial<Record<DatabaseType, readonly string[]>> = {
+  postgres: [
+    "character varying",
+    "varchar",
+    "text",
+    "bytea",
+    "numeric",
+    "decimal",
+    "money",
+    "timestamp",
+    "timestamp without time zone",
+    "timestamp with time zone",
+  ],
+  mysql: [
+    "text",
+    "tinytext",
+    "mediumtext",
+    "longtext",
+    "blob",
+    "tinyblob",
+    "mediumblob",
+    "longblob",
+    "timestamp",
+    "datetime",
+    "year",
+  ],
+  oracle: ["number", "binary_double", "binary_float", "clob", "nclob", "blob", "timestamp", "timestamp with time zone"],
+  mssql: [
+    "text",
+    "ntext",
+    "image",
+    "money",
+    "uniqueidentifier",
+    "datetime",
+    "datetime2",
+    "smalldatetime",
+    "datetimeoffset",
+  ],
+};
+
+/**
+ * A declared type, spelled so the target dialect can parse it without narrowing it.
+ *
+ * The target dialect is the ACTIVE connection's, not necessarily the one that declared
+ * the type: both shells pass `conn.activeConnection?.type` beside the tab's own result
+ * (`src/components/Studio.tsx`, `src/workspace/StudioWorkspace.tsx`), so running a
+ * query on Oracle, switching connections and then exporting hands this module Oracle's
+ * `VARCHAR2` and `BINARY_DOUBLE` under Postgres's dialect. Written verbatim those are
+ * not types Postgres has, and the whole point of an exported file is that it replays
+ * (#422) — so a bare name the target does not stand behind is re-spelled from its
+ * family rather than kept. The family, not the value: a column that is NULL in every
+ * exported row still declares `VARCHAR2`, where a value-shaped guess has nothing to
+ * look at.
+ *
+ * A type that already carries its parameters is left exactly as it is. It is the
+ * whole spelling the engine gave, `DECIMAL(10, 2)` and `Nullable(Int64)` included,
+ * and there is nothing missing from it to complete. Only the four node drivers hand
+ * over a parameterless name, and all four are covered above; a parameterized type
+ * from a FOREIGN dialect (`NUMBER(10,2)` under Postgres) still goes through verbatim,
+ * which is what it did before and is a translation problem rather than this one.
+ */
+function completeDeclaredType(declared: string, dialect: DatabaseType | undefined): string {
+  if (declared.includes("(")) return declared;
+  const standsAlone = STANDS_ALONE[dialect as DatabaseType];
+  if (standsAlone === undefined) return declared;
+  // `TIMESTAMP WITH TIME ZONE` from Oracle and `timestamp with time zone` from
+  // Postgres are the same name, and a declared type is engine output rather than
+  // something typed here, so neither the case nor the run of spaces is load-bearing.
+  const bare = declared.trim().toLowerCase().replace(/\s+/g, " ");
+  if (standsAlone.includes(bare)) return declared;
+  // `Object.hasOwn`, not a plain lookup: a column declared `constructor` would
+  // otherwise read `Object.prototype.constructor` as its family and, being a function
+  // rather than a kind, put the literal `undefined` where the type belongs.
+  if (!Object.hasOwn(BARE_TYPE_FAMILY, bare)) return declared;
+  const kind = BARE_TYPE_FAMILY[bare];
+  return DIALECT_TYPES[dialect as DatabaseType]?.[kind] ?? STANDARD_TYPES[kind];
 }
 
 /**
@@ -145,7 +339,9 @@ function inferKind(sample: unknown): InferredKind {
  *
  * What the engine declared, when it declared anything plausible: that is the type of
  * THIS result, which is the only source for a computed column or an ad-hoc
- * projection, and it is already spelled the way the engine spells it.
+ * projection, and it is already spelled the way the engine spells it — completed
+ * first, because the spelling the engine uses for a column is not always one that
+ * dialect will take back in a CREATE TABLE (`completeDeclaredType` above).
  *
  * Otherwise inferred from the first row that carries a value rather than from row 0:
  * a column that happens to be NULL in the first row was typed `TEXT` regardless of
@@ -154,10 +350,113 @@ function inferKind(sample: unknown): InferredKind {
 function sqlTypeOf(column: string, rows: readonly Record<string, unknown>[], source: ResultExportSource): string {
   const declared = source.columnTypes;
   if (declared !== undefined && Object.hasOwn(declared, column) && PLAUSIBLE_TYPE.test(declared[column])) {
-    return declared[column];
+    return completeDeclaredType(declared[column], source.dialect);
   }
   const kind = inferKind(firstSample(rows, column));
   return DIALECT_TYPES[source.dialect as DatabaseType]?.[kind] ?? STANDARD_TYPES[kind];
+}
+
+/**
+ * How a dialect spells a binary value inside a statement.
+ *
+ * There is no portable spelling, which is why the value-rendering work that gave the
+ * grid, the detail sheet and the CSV their shared `\x…` hex left the SQL forms out:
+ * the file has to name a dialect before it can name a literal, and this module is
+ * where that knowledge already lives (the DDL type names above).
+ *
+ * - `standard-hex` — `X'0102'`, the SQL standard's binary string literal.
+ * - `zero-x` — `0x0102`, for the dialects that reject `X'…'`.
+ * - `pg-bytea` — `'\x0102'::bytea`. Postgres's `X'…'` is a BIT STRING, not bytea, and
+ *   there is no cast between the two: measured on 18.4, `SELECT pg_typeof(X'0102')`
+ *   answers `bit` and `SELECT X'0102'::bytea` is `ERROR: cannot cast type bit to
+ *   bytea`. The hex-input form is what remains, and it is written as a PLAIN literal
+ *   rather than `E'\\x…'` because it survives `standard_conforming_strings` in both
+ *   positions: with the setting `off`, `SELECT length('\x0102deadbeef'::bytea)` still
+ *   answers 6.
+ * - `hextoraw` — Oracle parses neither of the two literal forms (`SELECT
+ *   rawtohex(x'0102') FROM dual` is `ORA-00907`), so the conversion function is the
+ *   literal. `HEXTORAW('')` is NULL, which is also what Oracle stores for a
+ *   zero-length RAW, so the empty case needs no special spelling.
+ * - `unhex` — same reasoning for ClickHouse, whose byte container is `String`.
+ * - `text` — the dialect has no binary value at all. SQL++ is JSON, and JSON has no
+ *   byte type; the least-wrong option is the same `\x…` text every other surface
+ *   shows, quoted as a string, so a reader can at least decode it by hand.
+ *
+ * The map is total for the same reason `LITERAL_ESCAPE` is
+ * (`src/lib/sql/values.ts`): a new provider must not inherit a silently wrong answer.
+ */
+type BinaryLiteral = "standard-hex" | "zero-x" | "pg-bytea" | "hextoraw" | "unhex" | "text";
+
+const BINARY_LITERAL: Record<DatabaseType, BinaryLiteral> = {
+  postgres: "pg-bytea",
+  // Measured on MySQL 26.7.0: `SELECT HEX(X'0102deadbeef')` answers `0102DEADBEEF` and
+  // `SELECT LENGTH(X'')` answers 0, so MySQL is here rather than in `zero-x` even
+  // though it accepts `0x0102deadbeef` too — a zero-length value has no `0x` spelling
+  // (`SELECT LENGTH(0x)` is `ERROR 1054 … Unknown column '0x'`), and an empty cell is
+  // not a case an export gets to refuse.
+  mysql: "standard-hex",
+  // Measured through `bun:sqlite`: `select hex(X'0102deadbeef')` -> `0102DEADBEEF`,
+  // and `typeof(X'')` -> `blob` with `length(X'')` 0.
+  sqlite: "standard-hex",
+  // Trino measured on 476: `SELECT typeof(X'0102')` answers `varbinary`,
+  // `to_hex(X'0102deadbeef')` answers `0102DEADBEEF`, `length(X'')` answers 0, and the
+  // whole generated pair replays into the memory connector. Druid is the one row here
+  // that is NOT measured — its SQL is Calcite's, which spells a binary literal `X'…'`,
+  // and a standalone Druid takes no INSERT at all (that needs the MSQ extension), so
+  // what is emitted for it is portable SQL meant to run elsewhere.
+  trino: "standard-hex",
+  druid: "standard-hex",
+  // Neither endpoint parses INSERT at all, so what is emitted for them is portable SQL
+  // for somewhere else; their SQL reads its literals the way MySQL's does.
+  elasticsearch: "standard-hex",
+  opensearch: "standard-hex",
+  // `queryLanguage: "json"` — no statement is ever built for these three to read, so
+  // the standard form is the only thing an export can claim (as in `values.ts`).
+  mongodb: "standard-hex",
+  redis: "standard-hex",
+  libredb: "standard-hex",
+  // Measured on SQL Server 2022: `SELECT CONVERT(varchar(64), 0x0102deadbeef, 2)`
+  // answers `0102DEADBEEF`, `DATALENGTH(0x)` answers 0 — so the empty case is spelled
+  // — and `SELECT X'0102'` is `Msg 207 … Invalid column name 'X'`.
+  mssql: "zero-x",
+  // Measured on Cassandra 5.0.9: the generated pair replays, and `SELECT "payload"`
+  // answers `0x0102deadbeef`. Bare `0x` is the empty blob — `blobAsText(0x)` answers
+  // the empty string rather than raising — and `X'…'` is not in the grammar at all.
+  cassandra: "zero-x",
+  oracle: "hextoraw",
+  // Measured on 26.7.1: `unhex('0102deadbeef')` into a `String` column reads back as
+  // `hex(payload)` = `0102DEADBEEF` with `length(payload)` 6, and `length(unhex(''))`
+  // is 0.
+  clickhouse: "unhex",
+  couchbase: "text",
+};
+
+/**
+ * A binary value as a literal the target engine accepts.
+ *
+ * The hex comes from `binaryText`, minus the `\x` prefix that is Postgres's own
+ * spelling rather than every dialect's — sharing that function is what keeps the file
+ * and the screen showing the same bytes. It is `[0-9a-f]*` by construction, so
+ * interpolating it needs no quoting: there is no character in it that could end the
+ * literal it sits in (#290).
+ */
+function binaryLiteral(bytes: Uint8Array, dialect: DatabaseType | undefined): string {
+  const text = binaryText(bytes);
+  const hex = text.slice(2);
+  switch (dialect === undefined ? "standard-hex" : BINARY_LITERAL[dialect]) {
+    case "pg-bytea":
+      return `'${text}'::bytea`;
+    case "zero-x":
+      return `0x${hex}`;
+    case "hextoraw":
+      return `HEXTORAW('${hex}')`;
+    case "unhex":
+      return `unhex('${hex}')`;
+    case "text":
+      return quoteLiteral(text, dialect);
+    default:
+      return `X'${hex}'`;
+  }
 }
 
 /**
@@ -178,6 +477,12 @@ function sqlValue(value: unknown, dialect: DatabaseType | undefined): string {
   if (typeof value === "number") return Number.isFinite(value) ? String(value) : "NULL";
   if (typeof value === "boolean") return String(value);
   if (value instanceof Date) return quoteLiteral(value.toISOString(), dialect);
+  // Before the object branch, which used to write a `bytea`/`BLOB` cell as the quoted
+  // text `{"type":"Buffer","data":[…]}`. Replayed into Postgres 18.4 that INSERT
+  // stored 46 bytes of that JSON where six bytes belonged, and it stored them
+  // successfully — bytea's escape input format accepts the text, so nothing failed.
+  const bytes = asBytes(value);
+  if (bytes !== undefined) return binaryLiteral(bytes, dialect);
   // `jsonText`, not `JSON.stringify`: a bigint or a cycle inside the value would
   // otherwise throw out of the click handler and produce no file at all.
   if (typeof value === "object") return quoteLiteral(jsonText(value), dialect);

--- a/src/lib/export/result-export.ts
+++ b/src/lib/export/result-export.ts
@@ -254,7 +254,12 @@ const BARE_TYPE_FAMILY: Record<string, InferredKind> = {
  * A dialect absent from this table has nothing completed, which keeps every other
  * engine exactly as it was: SQLite's column types are advisory affinities, and the six
  * wire formats that already fill `columnTypes` spell their own types out in full
- * (`Nullable(String)`, `array(varchar)`), so there is no bare name to complete.
+ * (`Nullable(String)`, `array(varchar)`), so there is no bare name of THEIR OWN to
+ * complete. A bare name that arrives from somewhere else still reaches those targets
+ * verbatim - an Oracle result exported under a ClickHouse connection writes
+ * `VARCHAR2` (measured) - and widening the rule is not the fix, because Trino's own
+ * bare `varchar` is legal and unbounded and would become a `TEXT` it does not have.
+ * Each remaining dialect needs its own measured row: BACKLOG X11.
  */
 const STANDS_ALONE: Partial<Record<DatabaseType, readonly string[]>> = {
   postgres: [

--- a/src/lib/monitoring-cache-ratio.ts
+++ b/src/lib/monitoring-cache-ratio.ts
@@ -31,3 +31,40 @@ export const CACHE_HIT_RATIO_UNAVAILABLE = "N/A";
 export function formatCacheHitRatio(ratio: number | undefined): string {
   return ratio === undefined ? CACHE_HIT_RATIO_UNAVAILABLE : ratio.toFixed(1);
 }
+
+/**
+ * A reading a monitoring source actually published, or `undefined` when it
+ * published none.
+ *
+ * This is the guard that keeps the whole "absent is not zero" rule enforceable at
+ * the provider boundary, and it lives here rather than in each provider because
+ * four of them wrote it independently (mysql.ts and mongodb.ts word for word,
+ * couchbase/index.ts as an inline `=== null` pair, and postgres/oracle/mssql not
+ * at all - which is how they came to invent numbers).
+ *
+ * A SQL NULL is the ordinary answer, not an exotic one: every cache-hit query in
+ * this repo guards its division with `NULLIF(..., 0)`, so a source with nothing to
+ * divide answers one row whose single column is NULL. Measured 2026-08-23 on the
+ * live engines: PostgreSQL 18 `pg_statio_user_tables` aggregates to NULL on a
+ * database with no user tables, and to `0 / NULLIF(0, 0)` on a table nothing has
+ * read yet; Oracle Free 23ai and SQL Server 2022 both return a single NULL row
+ * when their counter denominators are 0. `Number(null)` is `0`, and
+ * `DEFAULT_THRESHOLDS` rates a cache hit ratio of 0 as critical - so the naive
+ * coercion turns "nothing was measured" into a red fault the engine never
+ * reported. `value || fallback` is the same bug wearing a friendlier number, and it
+ * additionally discards a legitimate measured 0.
+ *
+ * MySQL/MariaDB reach the same NULL by a different route, recorded here because it
+ * is the case that first motivated this guard: MariaDB ships `performance_schema`
+ * OFF while the tables still exist, so the metric queries are a bare
+ * `SELECT (subquery)` that answers one row of NULLs rather than throwing, and
+ * `parseInt(x || "0")` turned each of those NULLs into a measurement nobody took.
+ *
+ * Non-finite input (NaN from an unparseable string, an Infinity) is absent for the
+ * same reason: it is not a reading either.
+ */
+export function measuredNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/tests/integration/db/couchbase-provider.test.ts
+++ b/tests/integration/db/couchbase-provider.test.ts
@@ -720,15 +720,63 @@ describe("CouchbaseProvider monitoring", () => {
     expect(performance.bufferPoolUsage).toBe(14.6);
   });
 
-  test("getPerformanceMetrics reports zero rather than a perfect score when denied", async () => {
+  // This test used to be named "reports zero rather than a perfect score when
+  // denied" and asserted three zeroes - it is what protected the fabrication. A
+  // denied stats read measures nothing, and 0 is not nothing: the cache-ratio
+  // threshold rates 0% as red-critical, so the panel invented an incident on a
+  // healthy cluster whose statistics the user simply may not read.
+  test("getPerformanceMetrics omits every metric when the stats read is denied", async () => {
     const provider = await connectProvider();
     stubManage(`/pools/default/buckets/${BUCKET}`, {}, 403);
 
     const performance = await provider.getPerformanceMetrics();
 
-    expect(performance.cacheHitRatio).toBe(0);
+    expect("cacheHitRatio" in performance).toBe(false);
+    expect("queriesPerSecond" in performance).toBe(false);
+    expect("bufferPoolUsage" in performance).toBe(false);
+  });
+
+  test("getPerformanceMetrics keeps a measured zero, which is a real reading", async () => {
+    const provider = await connectProvider();
+    // A cluster nobody has touched: no misses (so a perfect hit ratio), no
+    // operations in the last sample, and an empty quota.
+    // Bucket info first: `stubManage` unshifts and the matcher is a substring, so
+    // the narrower `/stats` stub has to be registered last to win.
+    stubManage(`/pools/default/buckets/${BUCKET}`, { ...BUCKET_INFO, basicStats: { quotaPercentUsed: 0 } });
+    stubManage(`/pools/default/buckets/${BUCKET}/stats`, {
+      op: { samples: { ep_cache_miss_rate: [0, 0, 0], cmd_get: [0], cmd_set: [0] } },
+    });
+
+    const performance = await provider.getPerformanceMetrics();
+
+    expect(performance.cacheHitRatio).toBe(100);
     expect(performance.queriesPerSecond).toBe(0);
     expect(performance.bufferPoolUsage).toBe(0);
+  });
+
+  test("getPerformanceMetrics omits only what the sample set is missing", async () => {
+    const provider = await connectProvider();
+    // A bucket whose KV series are absent (a memcached bucket publishes no `ep_*`
+    // stats at all) while the quota the bucket endpoint reports is still readable.
+    stubManage(`/pools/default/buckets/${BUCKET}/stats`, { op: { samples: { curr_connections: [55] } } });
+
+    const performance = await provider.getPerformanceMetrics();
+
+    expect("cacheHitRatio" in performance).toBe(false);
+    expect("queriesPerSecond" in performance).toBe(false);
+    expect(performance.bufferPoolUsage).toBe(14.6);
+  });
+
+  test("getPerformanceMetrics counts a half-published operation pair", async () => {
+    const provider = await connectProvider();
+    stubManage(`/pools/default/buckets/${BUCKET}/stats`, {
+      op: { samples: { ep_cache_miss_rate: [1.5], cmd_get: [7] } },
+    });
+
+    const performance = await provider.getPerformanceMetrics();
+
+    expect(performance.cacheHitRatio).toBe(98.5);
+    expect(performance.queriesPerSecond).toBe(7);
   });
 
   test("getSlowQueries reads system:completed_requests", async () => {
@@ -807,8 +855,9 @@ describe("CouchbaseProvider monitoring", () => {
       columns: [],
       isUnique: true,
       isPrimary: true,
-      indexSize: "0 B",
-      indexSizeBytes: 0,
+      // The index service publishes no `data_size` series for this index, and
+      // "0 B" claimed an empty index where nothing was measured at all.
+      indexSize: "N/A",
       scans: 0,
     });
     expect(stats[1].columns).toEqual(["city"]);
@@ -871,7 +920,9 @@ describe("CouchbaseProvider monitoring", () => {
     expect(data.tables).toEqual([]);
     expect(data.indexes).toEqual([]);
     expect(data.storage).toEqual([]);
-    expect(data.performance.cacheHitRatio).toBe(0);
+    // Nothing was readable, so the panel is told there is no ratio and renders
+    // "Not measured" instead of a red 0%.
+    expect("cacheHitRatio" in data.performance).toBe(false);
   });
 });
 

--- a/tests/integration/db/libredb-provider.test.ts
+++ b/tests/integration/db/libredb-provider.test.ts
@@ -506,16 +506,20 @@ describe("LibreDBProvider — monitoring", () => {
     const health = await provider.getHealth();
     expect(health.activeConnections).toBe(1);
     expect(health.databaseSize).toMatch(/\d/); // human-formatted, e.g. "12.0 KB"
-    expect(health.cacheHitRatio).toBe("100.0");
+    // The kernel publishes no cache statistics, so there is no ratio to report.
+    expect(health.cacheHitRatio).toBe("N/A");
     expect(health.slowQueries).toEqual([]);
     expect(health.activeSessions).toEqual([]);
     await provider.disconnect();
   });
 
-  test("getPerformanceMetrics reports a full cache hit ratio (in-process file)", async () => {
+  test("getPerformanceMetrics measures nothing, so it reports nothing", async () => {
     const provider = new LibreDBProvider(makeConn(tmpFile));
     await provider.connect();
-    expect(await provider.getPerformanceMetrics()).toEqual({ cacheHitRatio: 100 });
+    // The embedded kernel's whole public surface is open/kv/doc/table/catalog: there
+    // is no counter of cache hits or misses anywhere in it, so the panel must show
+    // "Not measured" rather than the 100% this used to assert.
+    expect(await provider.getPerformanceMetrics()).toEqual({});
     await provider.disconnect();
   });
 

--- a/tests/integration/db/mongodb-provider.test.ts
+++ b/tests/integration/db/mongodb-provider.test.ts
@@ -93,6 +93,29 @@ const createMockCollection = (name = "users") => ({
 
 const mockCommandResults: Record<string, unknown> = {};
 
+/**
+ * What `serverStatus` answers, as a function rather than a literal: the metric
+ * paths have to be driven on a server that publishes NO `wiredTiger` section
+ * (mongos, the in-memory storage engine, an API-compatible service) and on one
+ * where the command fails outright. Both used to reach the panel as a cache hit
+ * ratio of 99%.
+ */
+const defaultServerStatus = () => ({
+  connections: { current: 5, available: 95 },
+  uptime: 86400,
+  wiredTiger: {
+    cache: {
+      "pages read into cache": 10,
+      "pages requested from the cache": 1000,
+      "bytes currently in the cache": 5000000,
+      "maximum bytes configured": 10000000,
+    },
+  },
+  opcounters: { query: 100, insert: 50, update: 30, delete: 20 },
+});
+
+let mockServerStatus: () => Record<string, unknown> = defaultServerStatus;
+
 const createMockDb = () => ({
   command: async (cmd: Record<string, unknown>) => {
     if (cmd.ping) return { ok: 1 };
@@ -116,19 +139,7 @@ const createMockDb = () => ({
     objects: 100,
   }),
   admin: () => ({
-    serverStatus: async () => ({
-      connections: { current: 5, available: 95 },
-      uptime: 86400,
-      wiredTiger: {
-        cache: {
-          "pages read into cache": 10,
-          "pages requested from the cache": 1000,
-          "bytes currently in the cache": 5000000,
-          "maximum bytes configured": 10000000,
-        },
-      },
-      opcounters: { query: 100, insert: 50, update: 30, delete: 20 },
-    }),
+    serverStatus: async () => mockServerStatus(),
     command: async (cmd: Record<string, unknown>) => {
       if (cmd.currentOp) return { inprog: mockCurrentOps };
       if (cmd.buildInfo) return { version: "7.0.0" };
@@ -234,6 +245,7 @@ describe("MongoDBProvider", () => {
       { name: "orders", type: "collection" },
     ];
     mockCurrentOps = [];
+    mockServerStatus = defaultServerStatus;
     provider = new MongoDBProvider({ ...baseConfig });
   });
 
@@ -710,7 +722,36 @@ describe("MongoDBProvider", () => {
       const health = await provider.getHealth();
       expect(health.activeConnections).toBe(5);
       expect(typeof health.databaseSize).toBe("string");
-      expect(typeof health.cacheHitRatio).toBe("string");
+      // 10 of 1000 requested pages came from disk: a measured 99.0%.
+      expect(health.cacheHitRatio).toBe("99.0%");
+    });
+
+    test("a server with no wiredTiger section reports the cache hit ratio as unavailable", async () => {
+      mockServerStatus = () => ({ connections: { current: 5, available: 95 }, uptime: 86400 });
+      const health = await provider.getHealth();
+      expect(health.cacheHitRatio).toBe("N/A");
+    });
+
+    test("a cache nothing has been requested from yet reports the ratio as unavailable", async () => {
+      mockServerStatus = () => ({
+        connections: { current: 5, available: 95 },
+        uptime: 86400,
+        wiredTiger: { cache: { "pages read into cache": 0, "pages requested from the cache": 0 } },
+      });
+      const health = await provider.getHealth();
+      // No requests means no hits and no misses - there is no ratio, not a 100%.
+      expect(health.cacheHitRatio).toBe("N/A");
+    });
+
+    test("a cache that served nothing from memory reports a measured zero", async () => {
+      mockServerStatus = () => ({
+        connections: { current: 5, available: 95 },
+        uptime: 86400,
+        wiredTiger: { cache: { "pages read into cache": 400, "pages requested from the cache": 400 } },
+      });
+      const health = await provider.getHealth();
+      // A cold cache measures 0 and that is a measurement, not an absence.
+      expect(health.cacheHitRatio).toBe("0.0%");
     });
 
     test("maps in-progress operations to active sessions", async () => {
@@ -788,6 +829,28 @@ describe("MongoDBProvider", () => {
       expect(typeof overview.tableCount).toBe("number");
       expect(typeof overview.indexCount).toBe("number");
     });
+
+    test("connections.available present makes the limit the sum, and a 0 available is a real zero", async () => {
+      const overview = await provider.getOverview();
+      expect(overview.maxConnections).toBe(100);
+
+      mockServerStatus = () => ({ connections: { current: 5, available: 0 }, uptime: 1 });
+      // A pool with nothing left is a limit of 5, not the fabricated 100.
+      expect((await provider.getOverview()).maxConnections).toBe(5);
+    });
+
+    test("a server publishing no connection headroom publishes no limit", async () => {
+      mockServerStatus = () => ({ connections: { current: 5 }, uptime: 1 });
+      // 0 is how every provider spells "no limit published"; 100 was invented.
+      expect((await provider.getOverview()).maxConnections).toBe(0);
+    });
+
+    test("a failing serverStatus publishes no connection limit either", async () => {
+      mockServerStatus = () => {
+        throw new Error("not authorized on admin to execute command { serverStatus: 1 }");
+      };
+      expect((await provider.getOverview()).maxConnections).toBe(0);
+    });
   });
 
   // --------------------------------------------------------------------------
@@ -801,8 +864,50 @@ describe("MongoDBProvider", () => {
 
     test("returns cache hit ratio and connection pool metrics", async () => {
       const metrics = await provider.getPerformanceMetrics();
-      expect(typeof metrics.cacheHitRatio).toBe("number");
-      expect(metrics.cacheHitRatio).toBeGreaterThanOrEqual(0);
+      expect(metrics.cacheHitRatio).toBe(99);
+      expect(metrics.bufferPoolUsage).toBe(50);
+    });
+
+    test("omits the cache metrics on a server with no wiredTiger section", async () => {
+      mockServerStatus = () => ({ uptime: 100, opcounters: { query: 100 } });
+      const metrics = await provider.getPerformanceMetrics();
+      expect("cacheHitRatio" in metrics).toBe(false);
+      expect("bufferPoolUsage" in metrics).toBe(false);
+      // What IS measurable still arrives: 100 ops over 100 seconds.
+      expect(metrics.queriesPerSecond).toBe(1);
+    });
+
+    test("omits the ratio when nothing has been requested from the cache", async () => {
+      mockServerStatus = () => ({
+        uptime: 100,
+        wiredTiger: { cache: { "pages read into cache": 0, "pages requested from the cache": 0 } },
+      });
+      expect("cacheHitRatio" in (await provider.getPerformanceMetrics())).toBe(false);
+    });
+
+    test("reports a measured zero rather than dropping it", async () => {
+      mockServerStatus = () => ({
+        uptime: 100,
+        wiredTiger: {
+          cache: {
+            "pages read into cache": 400,
+            "pages requested from the cache": 400,
+            "bytes currently in the cache": 0,
+            "maximum bytes configured": 10,
+          },
+        },
+      });
+      const metrics = await provider.getPerformanceMetrics();
+      expect(metrics.cacheHitRatio).toBe(0);
+      expect(metrics.bufferPoolUsage).toBe(0);
+    });
+
+    test("measures nothing and reports nothing when serverStatus fails", async () => {
+      mockServerStatus = () => {
+        throw new Error("not authorized on admin to execute command { serverStatus: 1 }");
+      };
+      // The whole point of the change: this used to answer the panel with 99% cache hit.
+      expect(await provider.getPerformanceMetrics()).toEqual({});
     });
   });
 

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { EventEmitter } from "node:events";
+import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 
 // ---------------------------------------------------------------------------
 // Mock mssql BEFORE importing the provider
@@ -1115,9 +1116,41 @@ describe("MSSQLProvider", () => {
 
       expect(typeof health.activeConnections).toBe("number");
       expect(typeof health.databaseSize).toBe("string");
-      expect(typeof health.cacheHitRatio).toBe("string");
+      expect(health.cacheHitRatio).toBe("99.5%");
       expect(health.slowQueries).toBeArray();
       expect(health.activeSessions).toBeArray();
+    });
+
+    test("reports an unreadable cache hit ratio as unavailable, not as 0%", async () => {
+      // `${recordset[0]?.hit_ratio || 0}%` published "0%" for a NULL, and the
+      // Overview card rates 0 as "Needs tuning" - a fault SQL Server never
+      // reported.
+      mockQueryFn = async (sql: string) => {
+        if (sql.toUpperCase().includes("SYS.DM_OS_PERFORMANCE_COUNTERS")) {
+          return { recordset: [{ hit_ratio: null }], rowsAffected: [1] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const health = await provider.getHealth();
+
+      expect(health.cacheHitRatio).toBe(CACHE_HIT_RATIO_UNAVAILABLE);
+    });
+
+    test("keeps a measured cache hit ratio of zero in the health string", async () => {
+      mockQueryFn = async (sql: string) => {
+        if (sql.toUpperCase().includes("SYS.DM_OS_PERFORMANCE_COUNTERS")) {
+          return { recordset: [{ hit_ratio: 0 }], rowsAffected: [1] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const health = await provider.getHealth();
+
+      expect(health.cacheHitRatio).toBe("0.0%");
+      expect(health.cacheHitRatio).not.toBe(CACHE_HIT_RATIO_UNAVAILABLE);
     });
   });
 
@@ -1338,12 +1371,60 @@ describe("MSSQLProvider", () => {
       await provider.connect();
       const metrics = await provider.getPerformanceMetrics();
 
-      expect(typeof metrics.cacheHitRatio).toBe("number");
-      expect(metrics.cacheHitRatio).toBeGreaterThanOrEqual(0);
-      expect(metrics.cacheHitRatio).toBeLessThanOrEqual(100);
       expect(metrics.cacheHitRatio).toBe(99.5);
-      // bufferPoolUsage mirrors cacheHitRatio in MSSQL impl
-      expect(typeof metrics.bufferPoolUsage).toBe("number");
+      // No longer a second copy of the cache hit ratio under another name.
+      expect("bufferPoolUsage" in metrics).toBe(false);
+    });
+
+    test("reports nothing when the DMV is not readable, rather than a perfect cache", async () => {
+      // Measured 2026-08-23 on SQL Server 2022 CU26 against a login with no
+      // server-level grant beyond CONNECT:
+      //   Msg 300, Level 14, State 1 ... VIEW SERVER PERFORMANCE STATE permission
+      //   was denied on object 'server', database 'master'.
+      mockQueryFn = async (sql: string) => {
+        if (sql.toUpperCase().includes("SYS.DM_OS_PERFORMANCE_COUNTERS")) {
+          throw new Error("VIEW SERVER PERFORMANCE STATE permission was denied on object 'server'");
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const metrics = await provider.getPerformanceMetrics();
+
+      expect("cacheHitRatio" in metrics).toBe(false);
+      expect(metrics).toEqual({});
+    });
+
+    test("omits the ratio when the counter base is zero and the DMV answers NULL", async () => {
+      // Measured 2026-08-23 on SQL Server 2022 CU26 by forcing the NULLIF branch:
+      //   hit_ratio
+      //   ---------
+      //        NULL
+      mockQueryFn = async (sql: string) => {
+        if (sql.toUpperCase().includes("SYS.DM_OS_PERFORMANCE_COUNTERS")) {
+          return { recordset: [{ hit_ratio: null }], rowsAffected: [1] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const metrics = await provider.getPerformanceMetrics();
+
+      expect("cacheHitRatio" in metrics).toBe(false);
+    });
+
+    test("keeps a measured ratio of zero", async () => {
+      mockQueryFn = async (sql: string) => {
+        if (sql.toUpperCase().includes("SYS.DM_OS_PERFORMANCE_COUNTERS")) {
+          return { recordset: [{ hit_ratio: 0 }], rowsAffected: [1] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const metrics = await provider.getPerformanceMetrics();
+
+      expect(metrics.cacheHitRatio).toBe(0);
     });
   });
 
@@ -1506,5 +1587,98 @@ describe("MSSQLProvider", () => {
         expect(err.message).toContain("Database not found");
       }
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Declared column types
+// ---------------------------------------------------------------------------
+
+/**
+ * `mssql` attaches a `columns` map to the recordset ARRAY, and each entry's `type`
+ * carries `declaration` - T-SQL's own lowercase spelling, the same word
+ * `INFORMATION_SCHEMA.COLUMNS.DATA_TYPE` uses. The declarations below are verbatim
+ * from SQL Server 2022 CU26 over `types`.
+ *
+ * `type` is a factory FUNCTION for some of the driver's types and a plain object for
+ * others, so both forms appear here.
+ */
+describe("MSSQLProvider declared column types", () => {
+  let provider: MSSQLProvider;
+
+  /** A recordset the way `mssql` builds one: an array with a `columns` map on it. */
+  function withColumns(
+    rows: Record<string, unknown>[],
+    columns: Record<string, { declaration: string } | (() => unknown)>,
+  ) {
+    const recordset = rows as Record<string, unknown>[] & { columns: unknown };
+    recordset.columns = Object.fromEntries(Object.entries(columns).map(([name, type]) => [name, { name, type }]));
+    return recordset;
+  }
+
+  beforeEach(() => {
+    capturedInputs = [];
+    cancelShouldThrow = false;
+    provider = new MSSQLProvider(baseConfig);
+  });
+
+  afterEach(async () => {
+    try {
+      await provider.disconnect();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  test("query() reports the declaration each column metadata carries", async () => {
+    const nvarcharFactory = Object.assign(() => ({}), { declaration: "nvarchar" });
+    mockQueryFn = async () => ({
+      recordset: withColumns([{ id: "19", price: "19.99", dt: new Date(), name: "x" }], {
+        id: { declaration: "bigint" },
+        price: { declaration: "decimal" },
+        dt: { declaration: "datetime2" },
+        name: nvarcharFactory,
+      }),
+      rowsAffected: [1],
+    });
+
+    await provider.connect();
+    const result = await provider.query("SELECT id, price, dt, name FROM types");
+
+    // `id` and `price` both arrive as STRINGS from tedious - which is exactly why the
+    // value-shaped guess called them NVARCHAR(MAX) and FLOAT before this.
+    expect(result.columnTypes).toEqual({
+      id: "bigint",
+      price: "decimal",
+      dt: "datetime2",
+      name: "nvarchar",
+    });
+  });
+
+  test("the key is omitted entirely when the recordset carries no column map", async () => {
+    mockQueryFn = async () => ({ recordset: [{ a: 1 }], rowsAffected: [1] });
+
+    await provider.connect();
+    const result = await provider.query("SELECT 1 AS a");
+
+    expect(result.columnTypes).toBeUndefined();
+    expect(Object.hasOwn(result, "columnTypes")).toBe(false);
+  });
+
+  test("queryInTransaction() declares them too, from the same column map", async () => {
+    // Measured against a live server: a request made on a Transaction DOES carry
+    // `recordset.columns`, including for a zero-row result - this path had simply
+    // never read it.
+    mockQueryFn = async () => ({
+      recordset: withColumns([], { u: { declaration: "uniqueidentifier" } }),
+      rowsAffected: [0],
+    });
+
+    await provider.connect();
+    await provider.beginTransaction();
+    const result = await provider.queryInTransaction("SELECT u FROM types WHERE 1 = 0");
+
+    expect(result.columnTypes).toEqual({ u: "uniqueidentifier" });
+    await provider.rollbackTransaction();
   });
 });

--- a/tests/integration/db/mysql-provider.test.ts
+++ b/tests/integration/db/mysql-provider.test.ts
@@ -12,7 +12,14 @@ import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 // Mock mysql2/promise BEFORE importing the provider
 // ============================================================================
 
-let mockExecuteFn: (sql: string, params?: unknown[]) => Promise<[unknown[], unknown[]]>;
+/**
+ * The first tuple slot is `unknown`, not `unknown[]`: mysql2 hands back a
+ * `ResultSetHeader` OBJECT for a statement that returns no result set, and the
+ * second slot is `undefined` there. An array-shaped mock is exactly what hid
+ * the `result.rows.map is not a function` defect, so the mock type has to be
+ * able to express the header shape.
+ */
+let mockExecuteFn: (sql: string, params?: unknown[]) => Promise<[unknown, unknown[] | undefined]>;
 
 const mockConnection = {
   threadId: 42,
@@ -370,6 +377,31 @@ function perfSchemaDisabledMockExecute(sql: string): Promise<[unknown[], unknown
   return defaultMockExecute(sql);
 }
 
+/**
+ * What a server with no `performance_schema` DATABASE does - a different fact from
+ * the schema being merely OFF. Measured 2026-08-20 against a live OceanBase
+ * Community Edition 4.4.2.1 tenant through this provider, and reproduced against
+ * `mysql:latest` by naming a schema that is not there:
+ *
+ *   ERROR 1049 (42000) at line 1: Unknown database 'performance_schema_absent'
+ *
+ * The driver rejects rather than answering NULLs, so every reading that goes
+ * through `performance_schema` is a throw on that tenant - not an edge case there,
+ * the only path.
+ */
+function perfSchemaAbsentMockExecute(sql: string): Promise<[unknown[], unknown[]]> {
+  const normalized = sql.trim().toLowerCase();
+
+  if (normalized.includes("performance_schema.")) {
+    const error = new Error("Unknown database 'performance_schema'") as Error & { code: string; errno: number };
+    error.code = "ER_BAD_DB_ERROR";
+    error.errno = 1049;
+    return Promise.reject(error);
+  }
+
+  return defaultMockExecute(sql);
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -592,6 +624,22 @@ describe("MySQLProvider", () => {
       const health = await provider.getHealth();
 
       expect(health.cacheHitRatio).toBe(CACHE_HIT_RATIO_UNAVAILABLE);
+    });
+
+    test("survives a tenant with no performance_schema database and reports the ratio as unavailable", async () => {
+      mockExecuteFn = perfSchemaAbsentMockExecute;
+
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+      const health = await provider.getHealth();
+
+      // The ratio query threw ERROR 1049, which used to take the whole health read
+      // down with it - the OceanBase tenant got no panel at all rather than a panel
+      // with one honest gap in it.
+      expect(health.cacheHitRatio).toBe(CACHE_HIT_RATIO_UNAVAILABLE);
+      expect(health.activeConnections).toBe(5);
+      expect(health.slowQueries[0].query).toBe("Performance schema not available");
+      expect(Array.isArray(health.activeSessions)).toBe(true);
     });
   });
 
@@ -845,6 +893,15 @@ describe("MySQLProvider", () => {
   // --------------------------------------------------------------------------
 
   describe("getPerformanceMetrics()", () => {
+    test("reports nothing at all on a tenant with no performance_schema database", async () => {
+      mockExecuteFn = perfSchemaAbsentMockExecute;
+
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+
+      expect(await provider.getPerformanceMetrics()).toEqual({});
+    });
+
     test("returns cacheHitRatio, bufferPoolUsage, deadlocks, QPS", async () => {
       provider = new MySQLProvider(makeMySQLConfig());
       await provider.connect();
@@ -1338,5 +1395,207 @@ describe("MySQLProvider", () => {
         expect(err.message).toContain("ECONNREFUSED");
       }
     });
+  });
+});
+
+// ============================================================================
+// Declared column types
+// ============================================================================
+
+/**
+ * Every field packet below is verbatim from a live server: `SELECT * FROM types` on
+ * MySQL 26.7.0, printed straight out of mysql2. That matters because the codes are
+ * shared - 252 is every text tier AND every blob tier, and only the charset (63 is
+ * `binary`) and the length tell them apart.
+ */
+describe("MySQLProvider declared column types", () => {
+  test("query() names what the field packets declare", async () => {
+    mockExecuteFn = () =>
+      Promise.resolve([
+        [{ id: 19, price: "19.99", body: "hello", b: null }],
+        [
+          { name: "id", columnType: 8, characterSet: 63, columnLength: 20, decimals: 0, flags: 0 },
+          { name: "price", columnType: 246, characterSet: 63, columnLength: 12, decimals: 2, flags: 0 },
+          { name: "body", columnType: 252, characterSet: 224, columnLength: 262140, decimals: 0, flags: 16 },
+          { name: "b", columnType: 252, characterSet: 63, columnLength: 65535, decimals: 0, flags: 144 },
+        ],
+      ]);
+
+    const provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    const result = await provider.query("SELECT id, price, body, b FROM types");
+
+    // `price` was the reason for all this: a DECIMAL arrives as the string "19.99", so
+    // no value-shaped guess could ever have called it anything but text.
+    expect(result.columnTypes).toEqual({ id: "bigint", price: "decimal", body: "text", b: "blob" });
+    await provider.disconnect();
+  });
+
+  test("the key is omitted entirely when the statement declared no columns", async () => {
+    mockExecuteFn = () => Promise.resolve([[], []]);
+
+    const provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    const result = await provider.query("SELECT id FROM types WHERE 1 = 0");
+
+    expect(result.columnTypes).toBeUndefined();
+    expect(Object.hasOwn(result, "columnTypes")).toBe(false);
+    await provider.disconnect();
+  });
+
+  test("queryInTransaction() declares them too", async () => {
+    mockExecuteFn = () =>
+      Promise.resolve([
+        [{ ts: "2026-08-23 17:46:34" }],
+        [{ name: "ts", columnType: 7, characterSet: 63, columnLength: 19, decimals: 0, flags: 128 }],
+      ]);
+
+    const provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    await provider.beginTransaction();
+    const result = await provider.queryInTransaction("SELECT ts FROM types");
+
+    expect(result.columnTypes).toEqual({ ts: "timestamp" });
+    await provider.rollbackTransaction();
+    await provider.disconnect();
+  });
+});
+
+// ============================================================================
+// Non-SELECT statements (the ResultSetHeader shape)
+// ============================================================================
+/**
+ * Every DDL and DML statement threw `result.rows.map is not a function` before
+ * this block existed, AFTER the server had already applied it. Measured through
+ * `createDatabaseProvider({type:"mysql"})` against mysql 26.7.0 on 2026-08-23:
+ * DROP/CREATE/INSERT/UPDATE/DELETE and the transaction path all failed, and a
+ * following SELECT returned the row the failed INSERT had written.
+ *
+ * The header literals below are printed verbatim out of mysql2 3.15 against that
+ * same server - including `fields` arriving as `undefined`, which is why the
+ * second tuple slot is not an empty array here.
+ */
+function makeResultSetHeader(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    fieldCount: 0,
+    affectedRows: 0,
+    insertId: 0,
+    info: "",
+    serverStatus: 2,
+    warningStatus: 0,
+    changedRows: 0,
+    ...overrides,
+  };
+}
+
+describe("MySQLProvider non-SELECT statements", () => {
+  let provider: InstanceType<typeof MySQLProvider>;
+
+  afterEach(async () => {
+    try {
+      if (provider?.isConnected()) await provider.disconnect();
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  test("CREATE TABLE answers an empty result set, not a throw", async () => {
+    mockExecuteFn = () => Promise.resolve([makeResultSetHeader(), undefined]);
+
+    provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    const result = await provider.query("CREATE TABLE t (id INT PRIMARY KEY)");
+
+    expect(result.rows).toEqual([]);
+    expect(result.fields).toEqual([]);
+    expect(result.rowCount).toBe(0);
+    expect(result.columnTypes).toBeUndefined();
+    expect(typeof result.executionTime).toBe("number");
+  });
+
+  test("DROP TABLE IF EXISTS on an absent table answers zero rows", async () => {
+    // warningStatus 1 is what the live server returns for the absent-table note.
+    mockExecuteFn = () => Promise.resolve([makeResultSetHeader({ warningStatus: 1 }), undefined]);
+
+    provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    const result = await provider.query("DROP TABLE IF EXISTS gone");
+
+    expect(result.rows).toEqual([]);
+    expect(result.rowCount).toBe(0);
+  });
+
+  test("INSERT reports affectedRows as the rowCount", async () => {
+    mockExecuteFn = () =>
+      Promise.resolve([
+        makeResultSetHeader({ affectedRows: 2, insertId: 1, info: "Records: 2  Duplicates: 0  Warnings: 0" }),
+        undefined,
+      ]);
+
+    provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    const result = await provider.query("INSERT INTO t (note) VALUES ('a'),('b')");
+
+    expect(result.rows).toEqual([]);
+    expect(result.rowCount).toBe(2);
+  });
+
+  test("UPDATE reports affectedRows, not changedRows", async () => {
+    // The live server distinguishes them: a no-op UPDATE matches a row
+    // (affectedRows 1) while changing nothing (changedRows 0). `rowCount` is
+    // the matched count, which is what every other provider here reports.
+    mockExecuteFn = () =>
+      Promise.resolve([
+        makeResultSetHeader({ affectedRows: 1, changedRows: 0, info: "Rows matched: 1  Changed: 0  Warnings: 0" }),
+        undefined,
+      ]);
+
+    provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    const result = await provider.query("UPDATE t SET note = note WHERE id = 1");
+
+    expect(result.rowCount).toBe(1);
+  });
+
+  test("DELETE reports affectedRows as the rowCount", async () => {
+    mockExecuteFn = () => Promise.resolve([makeResultSetHeader({ affectedRows: 3 }), undefined]);
+
+    provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    const result = await provider.query("DELETE FROM t WHERE id < 4");
+
+    expect(result.rows).toEqual([]);
+    expect(result.rowCount).toBe(3);
+  });
+
+  test("queryInTransaction() answers the same envelope for a non-SELECT", async () => {
+    mockExecuteFn = () => Promise.resolve([makeResultSetHeader({ affectedRows: 1, insertId: 7 }), undefined]);
+
+    provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    await provider.beginTransaction();
+    const result = await provider.queryInTransaction("INSERT INTO t (note) VALUES ('gamma')");
+
+    expect(result.rows).toEqual([]);
+    expect(result.fields).toEqual([]);
+    expect(result.rowCount).toBe(1);
+    expect(result.columnTypes).toBeUndefined();
+    await provider.rollbackTransaction();
+  });
+
+  test("a SELECT that returns an array is unaffected by the header branch", async () => {
+    mockExecuteFn = () =>
+      Promise.resolve([
+        [{ id: 1 }],
+        [{ name: "id", columnType: 3, characterSet: 63, columnLength: 11, decimals: 0, flags: 0 }],
+      ]);
+
+    provider = new MySQLProvider(makeMySQLConfig());
+    await provider.connect();
+    const result = await provider.query("SELECT id FROM t");
+
+    expect(result.rows).toEqual([{ id: 1 }]);
+    expect(result.rowCount).toBe(1);
+    expect(result.columnTypes).toEqual({ id: "int" });
   });
 });

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { ConnectionError, DatabaseConfigError, QueryError } from "@/lib/db/errors";
 import type { DatabaseConnection } from "@/lib/types";
+import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 
 // ---------------------------------------------------------------------------
 // Mock oracledb BEFORE loading the provider
@@ -885,9 +886,42 @@ describe("OracleProvider", () => {
 
       expect(typeof health.activeConnections).toBe("number");
       expect(typeof health.databaseSize).toBe("string");
-      expect(typeof health.cacheHitRatio).toBe("string");
+      expect(health.cacheHitRatio).toBe("97.5%");
       expect(health.slowQueries).toBeArray();
       expect(health.activeSessions).toBeArray();
+    });
+
+    test("reports an unreadable cache hit ratio as unavailable, not as 0%", async () => {
+      // `${rows[0]?.HIT_RATIO || 0}%` produced "0%" for a NULL reading, which the
+      // Overview card rates "Needs tuning" - a fault Oracle never reported.
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("V$SYSSTAT")) {
+          return { rows: [{ HIT_RATIO: null }], metaData: [{ name: "HIT_RATIO" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const health = await provider.getHealth();
+
+      expect(health.cacheHitRatio).toBe(CACHE_HIT_RATIO_UNAVAILABLE);
+    });
+
+    test("keeps a measured cache hit ratio of zero in the health string", async () => {
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("V$SYSSTAT")) {
+          return { rows: [{ HIT_RATIO: 0 }], metaData: [{ name: "HIT_RATIO" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const health = await provider.getHealth();
+
+      expect(health.cacheHitRatio).toBe("0.0%");
+      expect(health.cacheHitRatio).not.toBe(CACHE_HIT_RATIO_UNAVAILABLE);
     });
 
     test("degrades gracefully when V$ views throw", async () => {
@@ -1234,19 +1268,22 @@ describe("OracleProvider", () => {
       await provider.connect();
       const metrics = await provider.getPerformanceMetrics();
 
-      expect(typeof metrics.cacheHitRatio).toBe("number");
-      expect(metrics.cacheHitRatio).toBeGreaterThanOrEqual(0);
-      expect(metrics.cacheHitRatio).toBeLessThanOrEqual(100);
       expect(metrics.cacheHitRatio).toBe(97.5);
-      // bufferPoolUsage mirrors cacheHitRatio in Oracle impl
-      expect(typeof metrics.bufferPoolUsage).toBe("number");
+      // Not a mirror of the cache hit ratio any more, and not reported at all:
+      // V$SYSSTAT publishes no buffer pool occupancy.
+      expect("bufferPoolUsage" in metrics).toBe(false);
     });
 
-    test("handles graceful degradation without DBA privs", async () => {
+    test("reports nothing when V$SYSSTAT is not readable, rather than a perfect cache", async () => {
+      // The ordinary case, not an exotic one. Measured 2026-08-23 on Oracle Free
+      // 23ai against a user granted only CREATE SESSION:
+      //   ORA-00942: table or view "SYS"."V_$SYSSTAT" does not exist
+      // This assertion used to read `toBe(100)` with the comment "Default
+      // fallback", so the suite protected the fabrication.
       mockExecuteFn = async (sql: string) => {
         const upper = sql.toUpperCase();
         if (upper.includes("V$SYSSTAT")) {
-          throw new Error("ORA-00942: table or view does not exist");
+          throw new Error('ORA-00942: table or view "SYS"."V_$SYSSTAT" does not exist');
         }
         return defaultExecute(sql);
       };
@@ -1254,9 +1291,45 @@ describe("OracleProvider", () => {
       await provider.connect();
       const metrics = await provider.getPerformanceMetrics();
 
-      // Should return default values when V$ views are inaccessible
-      expect(typeof metrics.cacheHitRatio).toBe("number");
-      expect(metrics.cacheHitRatio).toBe(100); // Default fallback
+      expect("cacheHitRatio" in metrics).toBe(false);
+      expect(metrics).toEqual({});
+    });
+
+    test("omits the ratio when V$SYSSTAT answers a NULL row", async () => {
+      // The counter denominator can be 0, which NULLIF turns into one row whose
+      // single column is NULL. Measured 2026-08-23 on Oracle Free 23ai:
+      //    HIT_RATIO
+      //   ----------
+      //   <NULL>
+      // `Number(null || 100)` read that as 100; `Number(null)` would read it as a
+      // red 0.
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("V$SYSSTAT")) {
+          return { rows: [{ HIT_RATIO: null }], metaData: [{ name: "HIT_RATIO" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const metrics = await provider.getPerformanceMetrics();
+
+      expect("cacheHitRatio" in metrics).toBe(false);
+    });
+
+    test("keeps a measured ratio of zero", async () => {
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("V$SYSSTAT")) {
+          return { rows: [{ HIT_RATIO: 0 }], metaData: [{ name: "HIT_RATIO" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const metrics = await provider.getPerformanceMetrics();
+
+      expect(metrics.cacheHitRatio).toBe(0);
     });
   });
 
@@ -1629,5 +1702,78 @@ describe("OracleProvider", () => {
       expect(mockInitOracleClientFn).toHaveBeenCalledTimes(1);
       expect(mockInitOracleClientFn).toHaveBeenCalledWith({ libDir: "/opt/oracle/instantclient" });
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Declared column types
+// ---------------------------------------------------------------------------
+
+/**
+ * `oracledb` is the one driver of the four that hands over a NAME: `metaData[].
+ * dbTypeName`, uppercase, the same word `ALL_TAB_COLUMNS.DATA_TYPE` uses. The names
+ * below are verbatim from Oracle Free 23ai over `r5_types`, plus the
+ * `TIMESTAMP WITH TIME ZONE` that `SYSTIMESTAMP` declares.
+ */
+describe("OracleProvider declared column types", () => {
+  let provider: InstanceType<typeof OracleProvider>;
+
+  beforeEach(() => {
+    mockConnCloseFn = async () => {};
+    mockBreakFn = async () => {};
+    mockPoolCloseFn = async () => {};
+    mockCreatePoolFn = async () => createMockPool();
+    provider = new OracleProvider(baseConfig);
+  });
+
+  afterEach(async () => {
+    if (provider?.isConnected()) await provider.disconnect();
+  });
+
+  test("query() passes dbTypeName through as Oracle's own spelling", async () => {
+    mockExecuteFn = async () => ({
+      rows: [{ PRICE: 19.99, TS: new Date("2026-08-23T17:46:34Z"), N: new Date("2026-08-23T17:46:34Z") }],
+      metaData: [
+        { name: "PRICE", dbTypeName: "NUMBER", precision: 10, scale: 2 },
+        { name: "TS", dbTypeName: "TIMESTAMP", precision: 6 },
+        { name: "N", dbTypeName: "TIMESTAMP WITH TIME ZONE", precision: 6 },
+      ],
+    });
+
+    await provider.connect();
+    const result = await provider.query("SELECT price, ts, SYSTIMESTAMP AS n FROM r5_types");
+
+    // Precision and scale sit right beside the name and are deliberately not spelled
+    // into it: `COUNT(*)` reports precision 0 and `1/3` scale -127, so a `NUMBER(p,s)`
+    // built from them would claim something the engine did not.
+    expect(result.columnTypes).toEqual({
+      PRICE: "NUMBER",
+      TS: "TIMESTAMP",
+      N: "TIMESTAMP WITH TIME ZONE",
+    });
+  });
+
+  test("the key is omitted entirely when the metadata names no type", async () => {
+    mockExecuteFn = async () => ({ rows: [], metaData: [{ name: "X" }] });
+
+    await provider.connect();
+    const result = await provider.query("SELECT x FROM r5_types");
+
+    expect(result.columnTypes).toBeUndefined();
+    expect(Object.hasOwn(result, "columnTypes")).toBe(false);
+  });
+
+  test("queryInTransaction() declares them too", async () => {
+    mockExecuteFn = async () => ({
+      rows: [{ B: null }],
+      metaData: [{ name: "B", dbTypeName: "BLOB" }],
+    });
+
+    await provider.connect();
+    await provider.beginTransaction();
+    const result = await provider.queryInTransaction("SELECT b FROM r5_types");
+
+    expect(result.columnTypes).toEqual({ B: "BLOB" });
+    await provider.rollbackTransaction();
   });
 });

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "node:events";
 import type { DatabaseConnection } from "@/lib/types";
 import type { ReadOnlyStatementBudget } from "@/lib/db/types";
 import { ConnectionError, DatabaseConfigError, ExecutionProfileError } from "@/lib/db/errors";
+import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 
 // ============================================================================
 // Mock pg BEFORE importing the provider
@@ -18,7 +19,9 @@ let mockQueryFn: (
   params?: unknown[],
 ) => Promise<{
   rows: unknown[];
-  fields?: { name: string }[];
+  // `dataTypeID` is a pg_type OID and the ONLY thing pg says about a column's type:
+  // there is no name on the wire at all.
+  fields?: { name: string; dataTypeID?: number }[];
   rowCount?: number;
 }>;
 
@@ -299,20 +302,24 @@ function defaultMockQuery(sql: string): Promise<{ rows: unknown[]; fields?: { na
     });
   }
 
+  // getPerformanceMetrics: pg_statio_user_tables (cache_hit_ratio only).
+  // Checked BEFORE the getHealth branch below, not after: both statements sum
+  // heap_blks_read, so a heap_blks_read test matches this query too and this
+  // branch was unreachable - which is why getPerformanceMetrics() was asserted
+  // against a fabricated 100 instead of against 98.75.
+  if (normalized.includes("pg_statio_user_tables") && normalized.includes("cache_hit_ratio")) {
+    return Promise.resolve({
+      rows: [{ cache_hit_ratio: "98.75" }],
+      fields: [{ name: "cache_hit_ratio" }],
+      rowCount: 1,
+    });
+  }
+
   // getHealth: pg_statio_user_tables (cache ratio with heap_read + heap_hit)
   if (normalized.includes("pg_statio_user_tables") && normalized.includes("heap_blks_read")) {
     return Promise.resolve({
       rows: [{ ratio: 99.5, heap_read: "100", heap_hit: "9900" }],
       fields: [{ name: "ratio" }, { name: "heap_read" }, { name: "heap_hit" }],
-      rowCount: 1,
-    });
-  }
-
-  // getPerformanceMetrics: pg_statio_user_tables (cache_hit_ratio only)
-  if (normalized.includes("pg_statio_user_tables") && normalized.includes("cache_hit_ratio")) {
-    return Promise.resolve({
-      rows: [{ cache_hit_ratio: "98.75" }],
-      fields: [{ name: "cache_hit_ratio" }],
       rowCount: 1,
     });
   }
@@ -1231,6 +1238,49 @@ describe("PostgresProvider", () => {
       expect(Array.isArray(health.activeSessions)).toBe(true);
     });
 
+    test("reports an unmeasurable cache hit ratio as unavailable, not as 100%", async () => {
+      // pg_statio_user_tables aggregates to NULL on a database with no user tables.
+      // Measured 2026-08-23 against postgres:18 on a freshly created database:
+      //   heap_read | heap_hit | raw_ratio | coalesced
+      //  -----------+----------+-----------+-----------
+      //             |          |           |       100
+      // The 100 was ours, produced by a COALESCE in our own SQL.
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+
+      const originalMock = mockQueryFn;
+      mockQueryFn = async (sql: string, params?: unknown[]) => {
+        const normalized = sql.trim().toLowerCase();
+        if (normalized.includes("pg_statio_user_tables")) {
+          return { rows: [{ ratio: null, heap_read: null, heap_hit: null }], fields: [], rowCount: 1 };
+        }
+        return originalMock(sql, params);
+      };
+
+      const health = await provider.getHealth();
+      expect(health.cacheHitRatio).toBe(CACHE_HIT_RATIO_UNAVAILABLE);
+      mockQueryFn = originalMock;
+    });
+
+    test("keeps a measured cache hit ratio of zero, which is a cold cache and not an absence", async () => {
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+
+      const originalMock = mockQueryFn;
+      mockQueryFn = async (sql: string, params?: unknown[]) => {
+        const normalized = sql.trim().toLowerCase();
+        if (normalized.includes("pg_statio_user_tables")) {
+          return { rows: [{ ratio: "0.0", heap_read: "500", heap_hit: "0" }], fields: [], rowCount: 1 };
+        }
+        return originalMock(sql, params);
+      };
+
+      const health = await provider.getHealth();
+      expect(health.cacheHitRatio).toBe("0.0%");
+      expect(health.cacheHitRatio).not.toBe(CACHE_HIT_RATIO_UNAVAILABLE);
+      mockQueryFn = originalMock;
+    });
+
     test("pg_stat_statements fallback when extension is not enabled", async () => {
       provider = new PostgresProvider(makePgConfig());
       await provider.connect();
@@ -1417,8 +1467,9 @@ describe("PostgresProvider", () => {
       await provider.connect();
       const metrics = await provider.getPerformanceMetrics();
 
-      expect(typeof metrics.cacheHitRatio).toBe("number");
-      expect(typeof metrics.bufferPoolUsage).toBe("number");
+      expect(metrics.cacheHitRatio).toBe(98.75);
+      // Not a metric PostgreSQL publishes; see the note in getPerformanceMetrics().
+      expect("bufferPoolUsage" in metrics).toBe(false);
       expect(typeof metrics.deadlocks).toBe("number");
       expect(metrics.deadlocks).toBe(3);
       expect(typeof metrics.checkpointWriteTime).toBe("string");
@@ -1440,6 +1491,91 @@ describe("PostgresProvider", () => {
 
       const metrics = await provider.getPerformanceMetrics();
       expect(metrics.checkpointWriteTime).toBe("N/A");
+    });
+
+    test("omits the cache hit ratio when pg_statio_user_tables has nothing to divide", async () => {
+      // A table nothing has read yet, measured 2026-08-23 on postgres:18:
+      //   hit | read | raw_ratio
+      //  -----+------+-----------
+      //     0 |    0 |
+      // NULLIF turns 0/0 into NULL, so the honest answer is no reading at all.
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+
+      const originalMock = mockQueryFn;
+      mockQueryFn = async (sql: string, params?: unknown[]) => {
+        const normalized = sql.trim().toLowerCase();
+        if (normalized.includes("pg_statio_user_tables")) {
+          return { rows: [{ cache_hit_ratio: null }], fields: [], rowCount: 1 };
+        }
+        return originalMock(sql, params);
+      };
+
+      const metrics = await provider.getPerformanceMetrics();
+      expect("cacheHitRatio" in metrics).toBe(false);
+      mockQueryFn = originalMock;
+    });
+
+    test("keeps a measured cache hit ratio of zero", async () => {
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+
+      const originalMock = mockQueryFn;
+      mockQueryFn = async (sql: string, params?: unknown[]) => {
+        const normalized = sql.trim().toLowerCase();
+        if (normalized.includes("pg_statio_user_tables")) {
+          return { rows: [{ cache_hit_ratio: "0.00" }], fields: [], rowCount: 1 };
+        }
+        return originalMock(sql, params);
+      };
+
+      const metrics = await provider.getPerformanceMetrics();
+      expect(metrics.cacheHitRatio).toBe(0);
+      mockQueryFn = originalMock;
+    });
+
+    test("omits the deadlock count when pg_stat_database has no row for the database", async () => {
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+
+      const originalMock = mockQueryFn;
+      mockQueryFn = async (sql: string, params?: unknown[]) => {
+        const normalized = sql.trim().toLowerCase();
+        if (normalized.includes("pg_stat_database")) {
+          return { rows: [], fields: [], rowCount: 0 };
+        }
+        return originalMock(sql, params);
+      };
+
+      const metrics = await provider.getPerformanceMetrics();
+      expect("deadlocks" in metrics).toBe(false);
+      mockQueryFn = originalMock;
+    });
+
+    test("reports an absent checkpoint reading as N/A rather than as zero seconds", async () => {
+      // pg_stat_bgwriter still exists on PostgreSQL 17+ but the two checkpoint
+      // columns moved to pg_stat_checkpointer, so the query throws there and the
+      // catch already answers "N/A". This is the other shape: the view answers,
+      // and both columns are NULL.
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+
+      const originalMock = mockQueryFn;
+      mockQueryFn = async (sql: string, params?: unknown[]) => {
+        const normalized = sql.trim().toLowerCase();
+        if (normalized.includes("pg_stat_bgwriter")) {
+          return {
+            rows: [{ checkpoint_write_time: null, checkpoint_sync_time: null }],
+            fields: [],
+            rowCount: 1,
+          };
+        }
+        return originalMock(sql, params);
+      };
+
+      const metrics = await provider.getPerformanceMetrics();
+      expect(metrics.checkpointWriteTime).toBe("N/A");
+      mockQueryFn = originalMock;
     });
   });
 
@@ -2519,5 +2655,140 @@ describe("PostgresProvider", () => {
         "DISCARD ALL",
       ]);
     });
+  });
+});
+
+// ============================================================================
+// Declared column types
+// ============================================================================
+
+describe("PostgresProvider declared column types", () => {
+  /**
+   * The OIDs and the names are both measured: `SELECT * FROM r5_types` on PostgreSQL
+   * 18.4 reports exactly these `dataTypeID`s, and `format_type(oid, NULL)` spells them
+   * exactly like this. The value arms matter as much as the type arms - `4.99` and the
+   * timestamp are STRINGS on the wire, which is why nothing value-shaped could have
+   * recovered `numeric` or `timestamp without time zone`.
+   */
+  test("query() reports what pg's OIDs declare", async () => {
+    mockQueryFn = () =>
+      Promise.resolve({
+        rows: [{ price: "4.99", ts: "2013-05-26 14:50:58.951", id: "133" }],
+        fields: [
+          { name: "price", dataTypeID: 1700 },
+          { name: "ts", dataTypeID: 1114 },
+          { name: "id", dataTypeID: 20 },
+        ],
+        rowCount: 1,
+      });
+
+    const provider = new PostgresProvider(makePgConfig());
+    await provider.connect();
+    const result = await provider.query("SELECT price, ts, id FROM r5_types");
+
+    expect(result.columnTypes).toEqual({
+      price: "numeric",
+      ts: "timestamp without time zone",
+      id: "bigint",
+    });
+    await provider.disconnect();
+  });
+
+  test("a user-defined OID is absent rather than wrongly named", async () => {
+    // dvdrental's `film.rating` is the enum `mpaa_rating`, OID 16504 in that database.
+    mockQueryFn = () =>
+      Promise.resolve({
+        rows: [{ rating: "NC-17", film_id: 133 }],
+        fields: [
+          { name: "rating", dataTypeID: 16504 },
+          { name: "film_id", dataTypeID: 23 },
+        ],
+        rowCount: 1,
+      });
+
+    const provider = new PostgresProvider(makePgConfig());
+    await provider.connect();
+    const result = await provider.query("SELECT rating, film_id FROM film");
+
+    expect(result.columnTypes).toEqual({ film_id: "integer" });
+    expect(Object.hasOwn(result.columnTypes!, "rating")).toBe(false);
+    await provider.disconnect();
+  });
+
+  test("the key is omitted entirely when no column declared a type", async () => {
+    mockQueryFn = () => Promise.resolve({ rows: [], fields: [], rowCount: 0 });
+
+    const provider = new PostgresProvider(makePgConfig());
+    await provider.connect();
+    const result = await provider.query("CREATE TABLE t (a int)");
+
+    expect(result.columnTypes).toBeUndefined();
+    expect(Object.hasOwn(result, "columnTypes")).toBe(false);
+    await provider.disconnect();
+  });
+
+  test("queryInTransaction() declares them too", async () => {
+    mockQueryFn = (sql) =>
+      Promise.resolve(
+        sql === "BEGIN"
+          ? { rows: [], fields: [], rowCount: 0 }
+          : { rows: [{ d: "2026-08-23" }], fields: [{ name: "d", dataTypeID: 1082 }], rowCount: 1 },
+      );
+
+    const provider = new PostgresProvider(makePgConfig());
+    await provider.connect();
+    await provider.beginTransaction();
+    const result = await provider.queryInTransaction("SELECT d FROM r5_types");
+
+    expect(result.columnTypes).toEqual({ d: "date" });
+    await provider.rollbackTransaction();
+    await provider.disconnect();
+  });
+
+  test("queryReadOnly() declares them without a catalog round trip", async () => {
+    // The profile promises EXACTLY ONE statement inside BEGIN READ ONLY, so the
+    // statements it sends are asserted here alongside the types: a lookup added for a
+    // column label would show up in this list.
+    const sent: string[] = [];
+    mockQueryFn = (arg) => {
+      // The profile sends its one statement on the extended protocol, which means a
+      // QueryConfig OBJECT rather than a string (`queryMode: "extended"`).
+      const sql = typeof arg === "string" ? arg : (arg as unknown as { text: string }).text;
+      sent.push(sql);
+      return Promise.resolve(
+        sql === "SELECT price FROM r5_types"
+          ? { rows: [{ price: "4.99" }], fields: [{ name: "price", dataTypeID: 1700 }], rowCount: 1 }
+          : {
+              rows: [
+                {
+                  is_superuser: false,
+                  reads_server_files: false,
+                  writes_server_files: false,
+                  executes_programs: false,
+                },
+              ],
+              fields: [],
+              rowCount: 1,
+            },
+      );
+    };
+
+    const provider = new PostgresProvider(makePgConfig(), {}, { readOnly: true });
+    await provider.connect();
+    const result = await provider.queryReadOnly("SELECT price FROM r5_types", {
+      statementTimeoutMs: 4500,
+      maxResultRows: 10,
+      maxResultBytes: 10_000,
+    } as ReadOnlyStatementBudget);
+
+    expect(result.columnTypes).toEqual({ price: "numeric" });
+    expect(sent.slice(-5)).toEqual([
+      "BEGIN READ ONLY",
+      "SET LOCAL statement_timeout = 4500",
+      "SELECT price FROM r5_types",
+      "ROLLBACK",
+      "DISCARD ALL",
+    ]);
+    await provider.disconnect();
   });
 });

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -17,6 +17,7 @@ import { resolveSQLiteDriverName } from "@/lib/db/providers/sql/sqlite-driver";
 import type { DatabaseConnection } from "@/lib/types";
 import type { ReadOnlyStatementBudget } from "@/lib/db/types";
 import { ConnectionError, DatabaseConfigError, ExecutionProfileError, QueryError } from "@/lib/db/errors";
+import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 
 // ============================================================================
 // Helpers
@@ -367,7 +368,9 @@ describe("SQLiteProvider", () => {
       const health = await provider.getHealth();
       expect(health.activeConnections).toBe(1);
       expect(typeof health.databaseSize).toBe("string");
-      expect(typeof health.cacheHitRatio).toBe("string");
+      // Not "100" and not "95": the health card says the ratio is unmeasurable
+      // here in the same word every other provider uses for it.
+      expect(health.cacheHitRatio).toBe(CACHE_HIT_RATIO_UNAVAILABLE);
       expect(Array.isArray(health.slowQueries)).toBe(true);
       expect(Array.isArray(health.activeSessions)).toBe(true);
 
@@ -502,14 +505,41 @@ describe("SQLiteProvider", () => {
   // --------------------------------------------------------------------------
 
   describe("getPerformanceMetrics()", () => {
-    test("returns cacheHitRatio as a number", async () => {
+    // The previous assertion here was `typeof perf.cacheHitRatio === "number"`,
+    // which is exactly what pinned the invented figure in place: the provider
+    // read `PRAGMA cache_size` (a configuration value, `-2000` by default) and
+    // answered the panel with 95% whenever it was truthy. Neither driver exposes
+    // SQLite's cache counters, so the field must be absent, not plausible.
+    test("omits cacheHitRatio: neither driver can read SQLite's cache counters", async () => {
       provider = new SQLiteProvider(makeSQLiteConfig());
       await provider.connect();
 
       const perf = await provider.getPerformanceMetrics();
-      expect(typeof perf.cacheHitRatio).toBe("number");
-      expect(perf.cacheHitRatio).toBeGreaterThanOrEqual(0);
+      expect("cacheHitRatio" in perf).toBe(false);
+      expect(perf.cacheHitRatio).toBeUndefined();
+    });
+
+    test("omits queriesPerSecond and bufferPoolUsage, and keeps the measured deadlock count", async () => {
+      provider = new SQLiteProvider(makeSQLiteConfig());
+      await provider.connect();
+
+      const perf = await provider.getPerformanceMetrics();
+      expect("queriesPerSecond" in perf).toBe(false);
+      expect("bufferPoolUsage" in perf).toBe(false);
+      // SQLite serializes writers behind one write lock and has no deadlock to
+      // count - a statement about the engine, not a reading that failed.
       expect(perf.deadlocks).toBe(0);
+    });
+
+    test("a working PRAGMA cache_size does not become a cache hit ratio", async () => {
+      provider = new SQLiteProvider(makeSQLiteConfig());
+      await provider.connect();
+
+      // The pragma the old code derived 95% from still answers; it is a page
+      // budget in KiB (negative) or pages (positive), never a hit count.
+      const cacheSize = await provider.query("PRAGMA cache_size");
+      expect(cacheSize.rows[0].cache_size).toBe(-2000);
+      expect((await provider.getPerformanceMetrics()).cacheHitRatio).toBeUndefined();
     });
   });
 
@@ -584,6 +614,14 @@ describe("SQLiteProvider", () => {
       const stats = await provider.getIndexStats();
       expect(stats).toBeArray();
       expect(stats.length).toBeGreaterThanOrEqual(2);
+
+      // The size string already said "N/A" while the byte count said 0, which the
+      // Storage tab summed into its index total as if every index were empty.
+      // `IndexStats.indexSizeBytes` is optional for exactly this case.
+      for (const entry of stats) {
+        expect(entry.indexSize).toBe("N/A");
+        expect("indexSizeBytes" in entry).toBe(false);
+      }
     });
   });
 

--- a/tests/unit/lib/connection-string-parser.test.ts
+++ b/tests/unit/lib/connection-string-parser.test.ts
@@ -131,6 +131,16 @@ describe("parseConnectionString", () => {
       expect(result!.type).toBe("mongodb");
       expect(result!.database).toBeUndefined();
     });
+
+    // Deliberately NOT a mode, unlike rediss:// and couchbases://: the MongoDB driver
+    // gets the URI verbatim and applies `tls=true` for mongodb+srv itself, WITH chain
+    // verification. Handing it our `require` would set rejectUnauthorized:false and
+    // silently stop verifying an Atlas certificate the driver checks today.
+    test("leaves the TLS intent unset for mongodb+srv://, which the driver reads itself", () => {
+      const result = parseConnectionString("mongodb+srv://user:pass@cluster0.abcde.mongodb.net/appdb");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.connectionString).toBe("mongodb+srv://user:pass@cluster0.abcde.mongodb.net/appdb");
+    });
   });
 
   // ── Redis ───────────────────────────────────────────────────────────────
@@ -158,6 +168,20 @@ describe("parseConnectionString", () => {
     test("uses default port 6379 when omitted", () => {
       const result = parseConnectionString("redis://host/0");
       expect(result!.port).toBe("6379");
+    });
+
+    // rediss:// IS the transport, exactly as https:// is for ClickHouse: ioredis only
+    // negotiates TLS when a `tls` option is present, and that option is built from
+    // `config.ssl`, so dropping the scheme sends plaintext to a TLS-only port and the
+    // paste fails with a bare "Connection is closed." (measured, redis.md 4.3).
+    test("carries the TLS intent of a rediss:// endpoint", () => {
+      expect(parseConnectionString("rediss://user:pass@tls-host:6380/1")!.sslMode).toBe("require");
+    });
+
+    // The plain scheme is an explicit plaintext choice, not an absent one, so pasting
+    // it must be able to clear a "require" the form is still holding.
+    test("carries the plaintext intent of a redis:// endpoint", () => {
+      expect(parseConnectionString("redis://redis-host:6379/0")!.sslMode).toBe("disable");
     });
   });
 
@@ -297,6 +321,20 @@ describe("parseConnectionString", () => {
       const result = parseConnectionString("couchbase:///travel");
       expect(result!.host).toBe("localhost");
       expect(result!.database).toBe("travel");
+    });
+
+    // The Couchbase provider is HTTP-only and picks its scheme from `config.ssl`
+    // (http-transport.ts buildTlsMaterial / `this.scheme = this.tls ? "https" : "http"`),
+    // never from the pasted string, so couchbases:// has to arrive as a mode or the
+    // request goes out as plain HTTP to the TLS management port 18091.
+    test("carries the TLS intent of a couchbases:// endpoint", () => {
+      expect(parseConnectionString("couchbases://user:pass@cb.abc123.cloud.couchbase.com/travel")!.sslMode).toBe(
+        "require",
+      );
+    });
+
+    test("carries the plaintext intent of a couchbase:// endpoint", () => {
+      expect(parseConnectionString("couchbase://user:pass@cb-host:8091/travel")!.sslMode).toBe("disable");
     });
 
     test("returns null for a malformed couchbase URL", () => {

--- a/tests/unit/lib/db/column-types.test.ts
+++ b/tests/unit/lib/db/column-types.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The declared-type maps for the four drivers that hand back a wire code instead of
+ * a type name. Every expectation here was measured against a live engine - the
+ * probe tables and the verbatim driver metadata are in the module's own comments.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  declaredColumnTypes,
+  mssqlColumnTypes,
+  mysqlColumnType,
+  mysqlColumnTypes,
+  oracleColumnTypes,
+  postgresColumnType,
+  postgresColumnTypes,
+} from "@/lib/db/providers/sql/column-types";
+
+describe("declaredColumnTypes", () => {
+  test("omits the key entirely when no column declared a type", () => {
+    expect(declaredColumnTypes([["a", undefined]])).toEqual({});
+  });
+
+  test("keeps only the columns that declared one", () => {
+    expect(
+      declaredColumnTypes([
+        ["a", "bigint"],
+        ["b", undefined],
+      ]),
+    ).toEqual({ columnTypes: { a: "bigint" } });
+  });
+
+  test("an empty column list declares nothing", () => {
+    expect(declaredColumnTypes([])).toEqual({});
+  });
+
+  test("the last declaration wins for a duplicated column name", () => {
+    // `SELECT 1 AS c, 'x' AS c` really declares two columns called `c`, and the row
+    // object the driver builds keeps the LAST one's value - so the last one's type is
+    // the one that describes what the grid shows.
+    expect(
+      declaredColumnTypes([
+        ["c", "integer"],
+        ["c", "text"],
+      ]),
+    ).toEqual({ columnTypes: { c: "text" } });
+  });
+
+  test("a column named __proto__ becomes an own property, not the prototype", () => {
+    const built = declaredColumnTypes([["__proto__", "text"]]);
+    expect(Object.hasOwn(built.columnTypes!, "__proto__")).toBe(true);
+    expect(Object.getPrototypeOf(built.columnTypes!)).toBe(Object.prototype);
+  });
+});
+
+describe("postgresColumnType", () => {
+  test("names the built-in OIDs the way PostgreSQL names them", () => {
+    // Measured on PostgreSQL 18.4 over `r5_types`: pg reports these OIDs, and
+    // `format_type(oid, NULL)` spells them like this.
+    expect(postgresColumnType(20)).toBe("bigint");
+    expect(postgresColumnType(1700)).toBe("numeric");
+    expect(postgresColumnType(701)).toBe("double precision");
+    expect(postgresColumnType(16)).toBe("boolean");
+    expect(postgresColumnType(1043)).toBe("character varying");
+    expect(postgresColumnType(25)).toBe("text");
+    expect(postgresColumnType(1114)).toBe("timestamp without time zone");
+    expect(postgresColumnType(1184)).toBe("timestamp with time zone");
+    expect(postgresColumnType(1082)).toBe("date");
+    expect(postgresColumnType(3802)).toBe("jsonb");
+    expect(postgresColumnType(2950)).toBe("uuid");
+    expect(postgresColumnType(17)).toBe("bytea");
+    expect(postgresColumnType(23)).toBe("integer");
+  });
+
+  test("names a built-in array type", () => {
+    expect(postgresColumnType(1009)).toBe("text[]");
+  });
+
+  test("is absent for an OID it cannot name rather than guessing", () => {
+    // dvdrental's `film.rating` is the enum `mpaa_rating`, OID 16504 in that database.
+    // A user-defined OID is per-database, so no static table can name it.
+    expect(postgresColumnType(16504)).toBeUndefined();
+  });
+});
+
+describe("mysqlColumnType", () => {
+  test("names the numeric and temporal codes", () => {
+    expect(mysqlColumnType({ columnType: 8 })).toBe("bigint");
+    expect(mysqlColumnType({ columnType: 246, decimals: 2 })).toBe("decimal");
+    expect(mysqlColumnType({ columnType: 5 })).toBe("double");
+    expect(mysqlColumnType({ columnType: 4 })).toBe("float");
+    expect(mysqlColumnType({ columnType: 1, columnLength: 1 })).toBe("tinyint");
+    expect(mysqlColumnType({ columnType: 2 })).toBe("smallint");
+    expect(mysqlColumnType({ columnType: 9 })).toBe("mediumint");
+    expect(mysqlColumnType({ columnType: 3 })).toBe("int");
+    expect(mysqlColumnType({ columnType: 0 })).toBe("decimal");
+    expect(mysqlColumnType({ columnType: 16, flags: 32 })).toBe("bit");
+    expect(mysqlColumnType({ columnType: 7 })).toBe("timestamp");
+    expect(mysqlColumnType({ columnType: 12 })).toBe("datetime");
+    expect(mysqlColumnType({ columnType: 10 })).toBe("date");
+    expect(mysqlColumnType({ columnType: 11 })).toBe("time");
+    expect(mysqlColumnType({ columnType: 13, flags: 96 })).toBe("year");
+    expect(mysqlColumnType({ columnType: 14 })).toBe("date");
+    expect(mysqlColumnType({ columnType: 245 })).toBe("json");
+    expect(mysqlColumnType({ columnType: 255 })).toBe("geometry");
+    expect(mysqlColumnType({ columnType: 242 })).toBe("vector");
+    expect(mysqlColumnType({ columnType: 6 })).toBe("null");
+  });
+
+  test("the binary charset is what separates a string from a byte string", () => {
+    expect(mysqlColumnType({ columnType: 253, characterSet: 224 })).toBe("varchar");
+    expect(mysqlColumnType({ columnType: 253, characterSet: 63, flags: 128 })).toBe("varbinary");
+    expect(mysqlColumnType({ columnType: 254, characterSet: 224 })).toBe("char");
+    expect(mysqlColumnType({ columnType: 254, characterSet: 63, flags: 128 })).toBe("binary");
+  });
+
+  test("the ENUM and SET flags outrank the string code that carries them", () => {
+    expect(mysqlColumnType({ columnType: 254, characterSet: 224, flags: 256 })).toBe("enum");
+    expect(mysqlColumnType({ columnType: 254, characterSet: 224, flags: 2048 })).toBe("set");
+  });
+
+  test("the blob tier comes from the column length, which is the only thing that carries it", () => {
+    // Measured on MySQL 26.7.0: TINYTEXT..LONGTEXT and TINYBLOB..LONGBLOB all arrive
+    // as code 252. utf8mb4 multiplies the byte ceiling by 4.
+    expect(mysqlColumnType({ columnType: 252, characterSet: 224, columnLength: 1020, flags: 16 })).toBe("tinytext");
+    expect(mysqlColumnType({ columnType: 252, characterSet: 224, columnLength: 262140, flags: 16 })).toBe("text");
+    expect(mysqlColumnType({ columnType: 252, characterSet: 224, columnLength: 67108860, flags: 16 })).toBe(
+      "mediumtext",
+    );
+    expect(mysqlColumnType({ columnType: 252, characterSet: 224, columnLength: 4294967295, flags: 16 })).toBe(
+      "longtext",
+    );
+    expect(mysqlColumnType({ columnType: 252, characterSet: 63, columnLength: 255, flags: 144 })).toBe("tinyblob");
+    expect(mysqlColumnType({ columnType: 252, characterSet: 63, columnLength: 65535, flags: 144 })).toBe("blob");
+    expect(mysqlColumnType({ columnType: 252, characterSet: 63, columnLength: 16777215, flags: 144 })).toBe(
+      "mediumblob",
+    );
+    expect(mysqlColumnType({ columnType: 252, characterSet: 63, columnLength: 4294967295, flags: 144 })).toBe(
+      "longblob",
+    );
+  });
+
+  test("a blob code with no length at all still names the family", () => {
+    expect(mysqlColumnType({ columnType: 252, characterSet: 63 })).toBe("blob");
+  });
+
+  test("the legacy per-tier blob codes are honoured when a server sends them", () => {
+    expect(mysqlColumnType({ columnType: 249, characterSet: 63 })).toBe("tinyblob");
+    expect(mysqlColumnType({ columnType: 250, characterSet: 224 })).toBe("mediumtext");
+    expect(mysqlColumnType({ columnType: 251, characterSet: 63 })).toBe("longblob");
+  });
+
+  test("MariaDB's extended type name wins, because it is the only spelling of it", () => {
+    expect(mysqlColumnType({ columnType: 254, characterSet: 63, extendedTypeName: "uuid" })).toBe("uuid");
+  });
+
+  test("falls back to `type` when the packet carries no `columnType`", () => {
+    expect(mysqlColumnType({ type: 8 })).toBe("bigint");
+  });
+
+  test("is absent for a code it cannot name", () => {
+    expect(mysqlColumnType({ columnType: 200 })).toBeUndefined();
+    expect(mysqlColumnType({})).toBeUndefined();
+  });
+
+  test("the string-array flags form declares nothing rather than misreading a number", () => {
+    // mysql2's typings allow `flags: string[]`; measured, the driver hands a number.
+    expect(mysqlColumnType({ columnType: 254, characterSet: 224, flags: [] })).toBe("char");
+  });
+});
+
+describe("the per-driver result wrappers", () => {
+  test("postgres: names what it can and skips the field that carries no OID", () => {
+    expect(postgresColumnTypes([{ name: "a", dataTypeID: 20 }, { name: "b" }])).toEqual({
+      columnTypes: { a: "bigint" },
+    });
+  });
+
+  test("postgres: a result with no fields at all declares nothing", () => {
+    expect(postgresColumnTypes(undefined)).toEqual({});
+  });
+
+  test("mysql: reads the packets", () => {
+    expect(mysqlColumnTypes([{ name: "id", columnType: 8 }])).toEqual({ columnTypes: { id: "bigint" } });
+    expect(mysqlColumnTypes(undefined)).toEqual({});
+  });
+
+  test("oracle: dbTypeName is Oracle's own spelling, taken as it comes", () => {
+    expect(oracleColumnTypes([{ name: "ID", dbTypeName: "NUMBER" }, { name: "X" }])).toEqual({
+      columnTypes: { ID: "NUMBER" },
+    });
+    expect(oracleColumnTypes(undefined)).toEqual({});
+  });
+
+  test("mssql: the declaration is read off a type object and off a type factory alike", () => {
+    const factory = Object.assign(() => ({}), { declaration: "nvarchar" });
+    expect(mssqlColumnTypes({ id: { type: { declaration: "bigint" } }, name: { type: factory }, x: {} })).toEqual({
+      columnTypes: { id: "bigint", name: "nvarchar" },
+    });
+    expect(mssqlColumnTypes(undefined)).toEqual({});
+  });
+});

--- a/tests/unit/lib/export/result-export.test.ts
+++ b/tests/unit/lib/export/result-export.test.ts
@@ -367,3 +367,284 @@ describe("deriveTableName — the generated prefix needs a separator", () => {
     expect(deriveTableName("Query")).toBe(FALLBACK_TABLE_NAME);
   });
 });
+
+describe("buildResultExport — a binary value in a statement", () => {
+  // The grid, the row detail sheet and the CSV all show `\x…` hex
+  // (`src/lib/export/binary.ts`), and the SQL forms wrote the `Buffer` JSON shape
+  // instead. Replayed against Postgres 18.4, that INSERT stored 46 bytes of the text
+  // `{"type":"Buffer","data":[1,2,222,173,190,239]}` in a `bytea` column instead of
+  // the six bytes the column held. Same on MySQL 26.7.0: `LENGTH(payload)` 46.
+  const wire = { type: "Buffer", data: [0x01, 0x02, 0xde, 0xad, 0xbe, 0xef] };
+  const binaryRow = (payload: unknown) => ({ rows: [{ payload }], fields: ["payload"] });
+
+  test("writes a Postgres bytea literal rather than the Buffer JSON shape", () => {
+    const file = buildResultExport("sql-insert", source({ ...binaryRow(wire), dialect: "postgres" }));
+
+    expect(file.content).toBe(`INSERT INTO users ("payload") VALUES ('\\x0102deadbeef'::bytea);`);
+  });
+
+  test("writes the standard X'…' form for the dialects whose engines take it", () => {
+    for (const dialect of ["mysql", "sqlite", "trino", "druid"] as const) {
+      const file = buildResultExport("sql-insert", source({ ...binaryRow(wire), dialect }));
+
+      expect(file.content).toContain("VALUES (X'0102deadbeef');");
+    }
+  });
+
+  test("writes the 0x… form for the dialects that reject X'…'", () => {
+    for (const dialect of ["mssql", "cassandra"] as const) {
+      const file = buildResultExport("sql-insert", source({ ...binaryRow(wire), dialect }));
+
+      expect(file.content).toContain("VALUES (0x0102deadbeef);");
+    }
+  });
+
+  test("writes Oracle's HEXTORAW, the only binary form it parses", () => {
+    const file = buildResultExport("sql-insert", source({ ...binaryRow(wire), dialect: "oracle" }));
+
+    expect(file.content).toContain("VALUES (HEXTORAW('0102deadbeef'));");
+  });
+
+  test("writes ClickHouse's unhex", () => {
+    const file = buildResultExport("sql-insert", source({ ...binaryRow(wire), dialect: "clickhouse" }));
+
+    expect(file.content).toContain("VALUES (unhex('0102deadbeef'));");
+  });
+
+  test("writes the hex as a string where the dialect has no binary type at all", () => {
+    const file = buildResultExport("sql-insert", source({ ...binaryRow(wire), dialect: "couchbase" }));
+
+    expect(file.content).toContain("VALUES ('\\\\x0102deadbeef');");
+  });
+
+  test("uses the standard form when no dialect is connected", () => {
+    const file = buildResultExport("sql-insert", source({ ...binaryRow(wire), dialect: undefined }));
+
+    expect(file.content).toContain("VALUES (X'0102deadbeef');");
+  });
+
+  // A zero-length value is where the spellings stop agreeing: `X''` and `0x` are both
+  // accepted empties (measured), `HEXTORAW('')` is Oracle's NULL, and `0x` alone is a
+  // syntax error on MySQL — which is why MySQL is in the `X'…'` group and not the `0x…` one.
+  test("writes an empty value in each dialect's own accepted empty form", () => {
+    const empty = { type: "Buffer", data: [] };
+
+    expect(buildResultExport("sql-insert", source({ ...binaryRow(empty), dialect: "postgres" })).content).toContain(
+      `VALUES ('\\x'::bytea);`,
+    );
+    expect(buildResultExport("sql-insert", source({ ...binaryRow(empty), dialect: "mysql" })).content).toContain(
+      "VALUES (X'');",
+    );
+    expect(buildResultExport("sql-insert", source({ ...binaryRow(empty), dialect: "mssql" })).content).toContain(
+      "VALUES (0x);",
+    );
+    expect(buildResultExport("sql-insert", source({ ...binaryRow(empty), dialect: "oracle" })).content).toContain(
+      "VALUES (HEXTORAW(''));",
+    );
+  });
+
+  test("writes a NULL binary cell as NULL, not as an empty literal", () => {
+    const file = buildResultExport("sql-insert", source({ ...binaryRow(null), dialect: "postgres" }));
+
+    expect(file.content).toBe('INSERT INTO users ("payload") VALUES (NULL);');
+  });
+
+  // The embeddable shell hands the live object the host passed in, so the bytes reach
+  // this module as a `Uint8Array` rather than as the JSON a `Buffer` serialized to.
+  test("writes the same literal for a live Uint8Array as for the wire shape", () => {
+    const file = buildResultExport(
+      "sql-insert",
+      source({ ...binaryRow(Uint8Array.from([1, 2, 222, 173, 190, 239])), dialect: "postgres" }),
+    );
+
+    expect(file.content).toContain(`VALUES ('\\x0102deadbeef'::bytea);`);
+  });
+
+  // A user's own document may carry a `type` field. Turning it into bytes would lose
+  // it as surely as the defect this closes, so it stays JSON.
+  test("leaves a document that merely looks Buffer-shaped as JSON", () => {
+    const file = buildResultExport(
+      "sql-insert",
+      source({ ...binaryRow({ type: "Buffer", data: [1, "two"] }), dialect: "postgres" }),
+    );
+
+    expect(file.content).toContain(`VALUES ('{"type":"Buffer","data":[1,"two"]}');`);
+  });
+});
+
+describe("buildResultExport — a binary column in the DDL", () => {
+  // The inferred kind fell through to `text`, so a `bytea` column was recreated as
+  // `TEXT` and the INSERT this same export writes could not be replayed into it.
+  const binaryRow = { rows: [{ payload: { type: "Buffer", data: [1, 2] } }], fields: ["payload"] };
+
+  test("types a binary column as the dialect's own binary type", () => {
+    const spellings: [Parameters<typeof buildResultExport>[1]["dialect"], string][] = [
+      ["postgres", '"payload" BYTEA'],
+      ["mysql", "`payload` BLOB"],
+      ["sqlite", '"payload" BLOB'],
+      ["oracle", '"payload" BLOB'],
+      ["mssql", "[payload] VARBINARY(MAX)"],
+      ["clickhouse", '"payload" String'],
+      ["trino", '"payload" VARBINARY'],
+      ["cassandra", '"payload" BLOB'],
+      [undefined, '"payload" BLOB'],
+    ];
+
+    for (const [dialect, expected] of spellings) {
+      expect(buildResultExport("sql-ddl", source({ ...binaryRow, dialect })).content).toContain(expected);
+    }
+  });
+
+  test("still prefers the type the engine declared for the column", () => {
+    const file = buildResultExport(
+      "sql-ddl",
+      source({ ...binaryRow, dialect: "postgres", columnTypes: { payload: "bytea" } }),
+    );
+
+    expect(file.content).toContain('"payload" bytea');
+  });
+});
+
+describe("buildResultExport — a declared type that cannot stand alone", () => {
+  // The four biggest providers declare a BARE BASE NAME (`varchar`, `decimal`,
+  // `VARCHAR2`, `nvarchar`, `varbinary`), because a length or a precision cannot be
+  // recovered from the wire. Measured by replaying the generated CREATE TABLE into the
+  // engine it was read from: MySQL answers `ERROR 1064 … near ','` on the bare
+  // `varchar`, Oracle `ORA-00906: missing left parenthesis` on the bare `VARCHAR2`,
+  // and SQL Server PARSES it and then reports length 1 for `nvarchar`, `varchar` and
+  // `varbinary` and precision 18 scale 0 for `decimal` — a silent narrowing, which is
+  // worse than a refusal.
+  const ddl = (columnTypes: Record<string, string>, dialect: Parameters<typeof buildResultExport>[1]["dialect"]) =>
+    buildResultExport("sql-ddl", source({ rows: [{ c: null }], fields: ["c"], dialect, columnTypes })).content;
+
+  test("spells MySQL's bare character and byte types as its unbounded ones", () => {
+    expect(ddl({ c: "varchar" }, "mysql")).toContain("`c` TEXT");
+    expect(ddl({ c: "char" }, "mysql")).toContain("`c` TEXT");
+    expect(ddl({ c: "varbinary" }, "mysql")).toContain("`c` BLOB");
+    expect(ddl({ c: "binary" }, "mysql")).toContain("`c` BLOB");
+    // Not a refusal but a truncation: measured, `CREATE TABLE t (c decimal)` on MySQL
+    // 26.7.0 is `decimal(10,0)`, so every decimal the column was declared for is
+    // rounded to an integer on the way back in.
+    expect(ddl({ c: "decimal" }, "mysql")).toContain("`c` DOUBLE");
+  });
+
+  test("keeps the MySQL types that already stand for their whole family", () => {
+    for (const bare of ["text", "longtext", "blob", "tinyblob", "datetime", "timestamp", "year"]) {
+      expect(ddl({ c: bare }, "mysql")).toContain(`\`c\` ${bare}`);
+    }
+  });
+
+  test("spells Oracle's bare character and byte types as its unbounded ones", () => {
+    expect(ddl({ c: "VARCHAR2" }, "oracle")).toContain('"c" VARCHAR2(4000)');
+    expect(ddl({ c: "NVARCHAR2" }, "oracle")).toContain('"c" VARCHAR2(4000)');
+    expect(ddl({ c: "CHAR" }, "oracle")).toContain('"c" VARCHAR2(4000)');
+    expect(ddl({ c: "RAW" }, "oracle")).toContain('"c" BLOB');
+  });
+
+  test("keeps the Oracle types that already stand for their whole family", () => {
+    for (const bare of ["NUMBER", "BINARY_DOUBLE", "CLOB", "NCLOB", "BLOB", "TIMESTAMP"]) {
+      expect(ddl({ c: bare }, "oracle")).toContain(`"c" ${bare}`);
+    }
+  });
+
+  test("spells SQL Server's bare character and byte types as its (max) ones", () => {
+    expect(ddl({ c: "nvarchar" }, "mssql")).toContain("[c] NVARCHAR(MAX)");
+    expect(ddl({ c: "varchar" }, "mssql")).toContain("[c] NVARCHAR(MAX)");
+    expect(ddl({ c: "char" }, "mssql")).toContain("[c] NVARCHAR(MAX)");
+    expect(ddl({ c: "varbinary" }, "mssql")).toContain("[c] VARBINARY(MAX)");
+    expect(ddl({ c: "decimal" }, "mssql")).toContain("[c] FLOAT");
+  });
+
+  // `timestamp` in T-SQL is not a moment in time: measured, `CREATE TABLE t (c
+  // timestamp)` on SQL Server 2022 CU26 creates a `rowversion`, which no INSERT may
+  // name — so the pair this export writes parses and then fails on the INSERT.
+  test("does not let a foreign `timestamp` become SQL Server's rowversion", () => {
+    expect(ddl({ c: "timestamp" }, "mssql")).toContain("[c] DATETIME2");
+  });
+
+  test("keeps the SQL Server types that already stand for their whole family", () => {
+    for (const bare of ["text", "ntext", "image", "datetime2", "datetimeoffset", "uniqueidentifier"]) {
+      expect(ddl({ c: bare }, "mssql")).toContain(`[c] ${bare}`);
+    }
+  });
+
+  // Postgres is the one dialect of the four whose own bare spellings are unbounded
+  // already (`character varying`, `numeric`), which is why it needed nothing.
+  test("keeps Postgres's own bare spellings, which are already unbounded", () => {
+    for (const bare of ["character varying", "numeric", "text", "bytea", "timestamp without time zone"]) {
+      expect(ddl({ c: bare }, "postgres")).toContain(`"c" ${bare}`);
+    }
+  });
+
+  // `character` and `nchar` are the exception: measured, both are `character(1)` on
+  // 18.4, so an eight-character value has nowhere to be replayed into.
+  test("completes the two Postgres spellings that do narrow", () => {
+    expect(ddl({ c: "character" }, "postgres")).toContain('"c" TEXT');
+    expect(ddl({ c: "nchar" }, "postgres")).toContain('"c" TEXT');
+  });
+
+  test("leaves a declared type that already carries its parameters untouched", () => {
+    expect(ddl({ c: "DECIMAL(10, 2)" }, "mysql")).toContain("`c` DECIMAL(10, 2)");
+    expect(ddl({ c: "varchar(40)" }, "mysql")).toContain("`c` varchar(40)");
+    expect(ddl({ c: "VARCHAR2(4000)" }, "oracle")).toContain('"c" VARCHAR2(4000)');
+    expect(ddl({ c: "Nullable(Int64)" }, "clickhouse")).toContain('"c" Nullable(Int64)');
+  });
+
+  test("matches the name whatever its case and spacing", () => {
+    expect(ddl({ c: "VarChar" }, "mysql")).toContain("`c` TEXT");
+    expect(ddl({ c: "timestamp  without   time zone" }, "mysql")).toContain("`c` DATETIME");
+  });
+
+  // Both shells pass the ACTIVE connection's type beside the tab's own result
+  // (`Studio.tsx`, `StudioWorkspace.tsx`), so switching connections and then
+  // exporting hands this module one engine's declarations under another's dialect.
+  test("re-spells a declared type the target dialect cannot parse at all", () => {
+    const oracleResult = { rows: [{ s: null, d: null, n: null }], fields: ["s", "d", "n"] };
+    const file = buildResultExport(
+      "sql-ddl",
+      source({ ...oracleResult, dialect: "postgres", columnTypes: { s: "VARCHAR2", d: "BINARY_DOUBLE", n: "NUMBER" } }),
+    );
+
+    expect(file.content).toBe('CREATE TABLE users (\n  "s" TEXT,\n  "d" DOUBLE PRECISION,\n  "n" DOUBLE PRECISION\n);');
+  });
+
+  // The regression: a Postgres result exported as another engine's DDL. Every one of
+  // these three was measured to refuse or to narrow before this.
+  test("writes legal DDL for a Postgres result in each target dialect", () => {
+    const pg = {
+      rows: [{ amount: "4.99", at: null, title: null }],
+      fields: ["amount", "at", "title"],
+      columnTypes: { amount: "numeric", at: "timestamp without time zone", title: "character varying" },
+    };
+
+    expect(buildResultExport("sql-ddl", source({ ...pg, dialect: "postgres" })).content).toBe(
+      'CREATE TABLE users (\n  "amount" numeric,\n  "at" timestamp without time zone,\n  "title" character varying\n);',
+    );
+    expect(buildResultExport("sql-ddl", source({ ...pg, dialect: "mysql" })).content).toBe(
+      "CREATE TABLE users (\n  `amount` DOUBLE,\n  `at` DATETIME,\n  `title` TEXT\n);",
+    );
+    expect(buildResultExport("sql-ddl", source({ ...pg, dialect: "mssql" })).content).toBe(
+      "CREATE TABLE users (\n  [amount] FLOAT,\n  [at] DATETIME2,\n  [title] NVARCHAR(MAX)\n);",
+    );
+    expect(buildResultExport("sql-ddl", source({ ...pg, dialect: "oracle" })).content).toBe(
+      'CREATE TABLE users (\n  "amount" BINARY_DOUBLE,\n  "at" TIMESTAMP,\n  "title" VARCHAR2(4000)\n);',
+    );
+  });
+
+  // Only the four dialects whose bare spellings were measured are completed. SQLite's
+  // column types are advisory affinities, and the wire formats of the other engines
+  // spell their own types out (`Nullable(String)`), so there is nothing to complete.
+  test("leaves a bare type alone for a dialect that was not measured", () => {
+    expect(ddl({ c: "varchar" }, "sqlite")).toContain('"c" varchar');
+    expect(ddl({ c: "varchar" }, "clickhouse")).toContain('"c" varchar');
+    expect(ddl({ c: "varchar" }, undefined)).toContain('"c" varchar');
+  });
+
+  // The completion tables are looked up with `Object.hasOwn`: a column declared
+  // `constructor` would otherwise read `Object.prototype.constructor` — a function —
+  // as its family and write `undefined` into the statement.
+  test("does not read a family off the prototype chain", () => {
+    expect(ddl({ c: "constructor" }, "mysql")).toContain("`c` constructor");
+    expect(ddl({ c: "toString" }, "postgres")).toContain('"c" toString');
+  });
+});

--- a/tests/unit/lib/monitoring-cache-ratio.test.ts
+++ b/tests/unit/lib/monitoring-cache-ratio.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { CACHE_HIT_RATIO_UNAVAILABLE, formatCacheHitRatio } from "@/lib/monitoring-cache-ratio";
+import { CACHE_HIT_RATIO_UNAVAILABLE, formatCacheHitRatio, measuredNumber } from "@/lib/monitoring-cache-ratio";
 
 describe("formatCacheHitRatio", () => {
   test("formats a measured ratio to one decimal place", () => {
@@ -23,5 +23,38 @@ describe("formatCacheHitRatio", () => {
 describe("CACHE_HIT_RATIO_UNAVAILABLE", () => {
   test('uses the spelling the repo already uses for an unavailable ratio ("N/A")', () => {
     expect(CACHE_HIT_RATIO_UNAVAILABLE).toBe("N/A");
+  });
+});
+
+describe("measuredNumber", () => {
+  test("passes a real reading through unchanged", () => {
+    expect(measuredNumber(99.5)).toBe(99.5);
+  });
+
+  test("keeps a measured zero, which is a reading and not an absence", () => {
+    expect(measuredNumber(0)).toBe(0);
+  });
+
+  test("accepts the numeric strings the SQL drivers hand back", () => {
+    // pg returns NUMERIC as a string to preserve precision, and oracledb/mssql
+    // hand back DECIMAL the same way when the value overflows a JS number.
+    expect(measuredNumber("98.75")).toBe(98.75);
+    expect(measuredNumber("0")).toBe(0);
+  });
+
+  test("reports a SQL NULL as absent rather than as zero", () => {
+    // The whole point: every one of these providers reaches a one-row-of-NULLs
+    // answer (NULLIF guards a division by zero), and 0 is a red critical rating.
+    expect(measuredNumber(null)).toBeUndefined();
+  });
+
+  test("reports a missing column as absent", () => {
+    expect(measuredNumber(undefined)).toBeUndefined();
+  });
+
+  test("reports an unparseable value as absent rather than as NaN", () => {
+    expect(measuredNumber("N/A")).toBeUndefined();
+    expect(measuredNumber({})).toBeUndefined();
+    expect(measuredNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Round 5 of the BACKLOG sweep. Six defects fixed, each measured against a live server before the change and re-measured in a browser against a production build after it. Four were BACKLOG entries (**D7, D12, X7, X8**); two were found while closing them, and one of those is the most serious thing in the PR. **BACKLOG 106 -> 108** (four removed, six follow-ups recorded).

## The one a user would have hit first

### Every MySQL DDL and DML statement reported a failure for work it had done

Not a backlog entry - found while filling `columnTypes`. `query()` called `.map` on mysql2's first return value, which is a `ResultSetHeader` **object**, not an array, for anything that returns no rows. Measured through the provider against MySQL 26.7.0, with an interleaved `SELECT` proving the server had already applied each statement:

```
FAIL DROP TABLE ...       -> TypeError: result.rows.map is not a function
FAIL CREATE TABLE ...     -> TypeError: result.rows.map is not a function
FAIL INSERT ...           -> TypeError: result.rows.map is not a function
OK   SELECT * FROM ...    -> rowCount=1 rows=[{"id":1,"note":"beta"}]      <- the "failed" work landed
FAIL tx INSERT            -> TypeError: result.rows.map is not a function
OK   SELECT * FROM ...    -> rowCount=1 rows=[{"id":2,"note":"gamma"}]     <- committed
```

This is a SQL IDE. Reporting an error for a statement the server ran is the worst available answer, because the user retries it. Both sites now go through one envelope builder that branches on the shape, reporting `affectedRows` in `rowCount` - the same answer postgres (`rowCount`), mssql (`rowsAffected[0]`) and sqlite (`changes`) already give.

Browser, production build, MySQL (r5): `CREATE TABLE ui_probe (...)` reports **"0 rows - 22ms"** with the table created (confirmed in `information_schema`), and `INSERT ... VALUES (1,'alpha'),(2,'beta')` reports **"2 rows - 9ms"** with both rows present.

The tests could not see it: they mocked `execute` as returning an array, and the mock's TYPE made the real shape unexpressible. That type is now wide enough, which is the part that keeps it fixed.

### X7 - the DDL export typed a numeric or a timestamp column as TEXT

Nothing was wrong with the inference; it never saw a type. `pg`, `mysql2`, `oracledb` and `mssql` now fill `QueryResult.columnTypes` with the engine's own spelling, joining the six families that already did. Every mapping measured against a live engine rather than remembered:

- **Postgres** resolves OIDs through a generated `pg_type` table (149 built-ins, `format_type` spellings). Verified over all of dvdrental: **128 result columns, 125 named, 0 wrong, 3 absent** - the three being one user-defined enum. A catalog round trip is not available at three of the four call sites (`query()` releases its client first; `queryReadOnly()` promises exactly one statement inside `BEGIN READ ONLY`).
- **MySQL** separates its shared type codes by charset 63 and the length tiers, not by assumption: **38 of 39** columns match `information_schema.DATA_TYPE`, and `POINT` is indistinguishable from `GEOMETRY` on the wire.
- **Oracle** and **SQL Server** pass their own name through; precision and scale are deliberately not spelled back (Oracle reports scale -127 for `1/3`, mssql reports 65535 as a sentinel for `varchar(MAX)`).

Browser, Postgres (r5), `SELECT id, price, dbl, flag, name, ts, tsz, d, j, u, b FROM r5_types`:

```
id bigint · price numeric · dbl double precision · flag boolean · name character varying
ts timestamp without time zone · tsz timestamp with time zone · d date · j jsonb · u uuid · b bytea
```

and the DDL that same result exports:

```sql
CREATE TABLE table_name (
  "id" bigint, "price" numeric, "dbl" double precision, "flag" boolean,
  "name" character varying, "ts" timestamp without time zone, ...  "b" bytea
);
```

`price` and `ts` were `TEXT` before. The backlog entry's own acceptance test.

### The consequence of X7, fixed here rather than left to be found

A declared type is a **bare base name**, because a length cannot be recovered from the wire - and a bare name is not legal DDL everywhere. Measured by replaying the generated `CREATE TABLE` into its own engine:

| Target | Declared type verbatim (before) | After |
| --- | --- | --- |
| Postgres | OK | OK, unchanged |
| MySQL | `ERROR 1064 ... near ',` `` `body` text,'`` | `name text`, `price double` |
| Oracle | `ORA-00906: missing left parenthesis` | `NAME VARCHAR2 4000` |
| SQL Server | parses, then `nvarchar` **length 1**, `varbinary` **length 1**, `decimal(18,0)` - and its own INSERT fails `Msg 2628` | `nvarchar(max)`, `varbinary(max)`, `float` |

A bare name now completes to the target dialect's unbounded form, and a FOREIGN engine's declaration is re-spelled rather than written through - both shells keep the connection type beside the tab's own result, so exporting an Oracle result as Postgres DDL is reachable, and `VARCHAR2` in Postgres DDL replays nowhere. Two dialect corrections came out of the measurements: mssql `char` -> `NVARCHAR(MAX)` (`char(max)` is not legal T-SQL) and oracle `NVARCHAR2` -> `VARCHAR2(4000)` (NVARCHAR2 tops out at 2000).

### X8 - a binary value exported as its JSON shape

`sqlValue` had no binary branch, so a `bytea`/`BLOB` cell was written as a quoted `{"type":"Buffer","data":[...]}`. Replaying that did not fail - it stored **46 bytes of JSON text where six bytes belonged**, because bytea's escape input accepts it. The DDL had the same hole (a binary column was recreated as `TEXT`).

Each dialect now writes a literal its own engine accepts, every spelling measured:

- Postgres `'\x...'::bytea` - `X'...'` there is a **bit string** (`pg_typeof(X'0102')` is `bit`) and cannot be cast to bytea; the plain form survives `standard_conforming_strings = off`.
- MySQL, SQLite, Trino `X'...'` - MySQL has no `0x` spelling for an EMPTY value (`LENGTH(0x)` is `ERROR 1054`), and an empty cell is not a case an export gets to refuse.
- SQL Server, Cassandra `0x...` - both reject `X'...'`.
- Oracle `HEXTORAW('...')` - it parses neither literal form.
- ClickHouse `unhex('...')`; Couchbase is the honest no-binary-type case and gets the `\x...` text a human can decode.

Replayed into **seven** engines, six bytes each. Browser: the exported INSERT for the Postgres row is `... '\x0102ab'::bytea);`, and replaying the browser-produced file gives `hex 0102ab, bytes 3`.

### D7 - a fabricated cache hit ratio, in eight providers rather than three

The entry named MySQL, MongoDB and LibreDB. The sweep found five more, and all eight are honest now.

- **MySQL**: the entry's three sites had already been fixed by #458, so the entry was stale - but `getHealth()` ran the ratio query **uncaught**, and a tenant with no `performance_schema` DATABASE (measured on OceanBase as `ERROR 1049`) lost the whole health panel rather than one metric.
- **SQLite** claimed a fixed **95%** ("Reasonable estimate for in-memory cache") derived from `PRAGMA cache_size`, a configuration value that is `-2000` by default and therefore always truthy. Neither `bun:sqlite` nor `node:sqlite` exposes `sqlite3_db_status`, and no PRAGMA stands in, so it is omitted permanently and the doc says why.
- **Couchbase** published a **0%** when the stats read was denied - and a denial is the ORDINARY case there. `DEFAULT_THRESHOLDS` rates 0 as critical, so the panel invented a cache fault the cluster never reported.
- **Postgres, Oracle, SQL Server**: `COALESCE(..., 100)` inside our own SQL, `|| 100`, `|| 0`. Reproduced both absence arms live for each: a fresh database with NULL counters, and a login holding only `CONNECT` / `CREATE SESSION` (`VIEW SERVER PERFORMANCE STATE permission was denied`, `ORA-00942`).

**Two of these were pinned by tests** - one named "reports zero rather than a perfect score when denied", one commented `// Default fallback`. A third assertion was unreachable behind a branch that matched first, so the suite was asserting the fabrication.

`bufferPoolUsage` went with the ratio in three providers, because it **was** the ratio wearing a second name (Oracle and SQL Server assigned it literally; Postgres computed the same quotient from `pg_stat_database`), so the Performance tab drew and rated one quantity as two independent gauges. What a real occupancy gauge would cost on each engine is recorded in D14 rather than guessed at.

Browser: MySQL **98.8%**, Oracle **99.5%** measured; SQLite **"Cache Hit N/A - Not measured"** where it used to say 95% "Excellent"; Buffer Pool "Not measured" on Oracle and SQLite.

### D12 - a pasted `rediss://` URL landed on SSL mode `disable`

It arrives as `require` now, and so does `couchbases://` - whose excuse for being left out of the panel work ("the provider re-reads the scheme there") was simply untrue: `CouchbaseHttpTransport` picks http vs https from `config.ssl` alone and was posting **plain HTTP to the TLS management port 18091**. `require` rather than a verifying mode, in both cases, because a self-hosted `--tls-port` Redis and a self-hosted Couchbase node present self-signed certificates; a paste encrypts but never silently claims to have checked a chain.

`mongodb+srv://` is the one secure scheme deliberately left unset: the driver receives the URI verbatim and turns TLS on **with** chain verification, so handing it our `require` (`rejectUnauthorized: false`) would have stopped an Atlas certificate being verified. Pinned as a negative test.

Browser, both arms: pasting `rediss://localhost:6390` fills the form with **SSL / TLS: REQUIRE**; pasting `redis://localhost:6379` leaves it on the default. End to end against a TLS-only Redis (`--port 0 --tls-port 6390`, so no plaintext port exists): `rediss://` connects and answers `PONG` in 14ms, `redis://` fails with `Connection is closed.`

## Follow-ups recorded, not smuggled in

- **D13** - Oracle answers every non-SELECT with `rowCount: 0`, including the rows it just wrote (`rows.length` instead of `result.rowsAffected`). Found by the same audit; the only one of the five SQL providers that under-reports DML silently.
- **D14** - what a real buffer-pool gauge costs on each engine (`pg_buffercache` is an extension, `sys.dm_os_buffer_descriptors` is a full scan), so the field is not refilled by guesswork.
- **D15** - SQLite's table size is `rowCount * 100` and the storage panel sums it. Needs a required type to allow absence, and `dbstat` exists on `node:sqlite` but not `bun:sqlite`.
- **D16** - the TLS a connection string carries in its QUERY STRING (`?sslmode=`, `?ssl-mode=`, `Encrypt=True`) is still dropped. Not the same one-line shape: `prefer`/`allow`/`PREFERRED` have no representation in `SSLMode`, and mapping them is a security decision. It also corrects a false claim the old entry carried.
- **X9** - what `columnTypes` still cannot name, with the numbers: the user-defined type, `POINT` vs `GEOMETRY`, `bit` (which needs opposite families on pg and mysql2), and the mssql zero-row path.
- **X10** - MySQL and Cassandra stringify their bytes at the driver boundary, so the new binary literal never reaches them. Measured in the browser: the MySQL grid shows `0x0102ab` where Postgres shows `\x0102ab`, and its INSERT exports the eight-character string. This BOUNDS what X8 closed, which is why it is stated rather than implied.

## Verification

| Gate | Result |
| --- | --- |
| `bun run format` | clean, 921 files |
| `bun run lint` | 0 errors |
| `bun run typecheck` | clean |
| `bun run knip` | clean |
| tests (`run-core.sh` + components) | **11964 pass / 0 fail**, all 334 core files |
| `bun run coverage:check` | **100.00%, 41425/41425 lines** |
| `bun run build` | exit 0 |
| `bun run build:lib` + `attw` | exit 0, node16/bundler green |
| gitleaks (pinned digest, `eb88fad1..HEAD`) | 1 commit scanned, no leaks |

Provider tri-sync held for all nine providers touched: code, `docs/providers/<id>.md` and `tests/integration/db/<id>-provider.test.ts` move together for postgres, mysql, oracle, mssql, sqlite, mongodb, couchbase, libredb and redis.

Live engines used: postgres:18, MySQL 26.7.0, SQL Server 2022 CU26, Oracle Free 23ai, MongoDB, Redis (plus throwaway ClickHouse, Trino and Cassandra containers for the binary replay). One environment note for whoever repeats this: SQL Server would not start until `fs.aio-nr` had room - the two ScyllaDB containers from the previous round held all 65536 aio contexts, and the failure reads `Unable to create a new asynchronous I/O context`.
