### PR TITLE
chore(distribution): record AppImageHub as a channel

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -862,3 +862,32 @@ channels:
         ours, which is why there is no pin here. Sequencing question settled 2026-07-30 - FlatPark
         asks that an app not already be on Flathub, and the Flathub submission was declined, so
         this is now the only Flatpak channel and there is nothing to revisit.
+
+  - id: appimagehub
+    name: AppImageHub catalog (appimage.github.io)
+    short_name: AppImageHub
+    status: pending
+    category: os-desktop
+    platforms: [linux]
+    runtime: channel_supplied
+    tier: 4
+    kind: curated-catalog
+    update:
+      method: upstream_pr
+      sla: on_demand
+    links:
+      first_pr: https://github.com/AppImage/appimage.github.io/pull/3861
+      catalog: https://appimage.github.io/LibreDB_Studio/
+      get: https://github.com/libredb/libredb-studio/releases/latest
+      docs: desktop/README.md
+    pin:
+      strategy: none
+      note: One line in the catalog's data/LibreDB_Studio naming this repository - their worker reads
+        the releases API, takes the first AppImage asset matching x64 and re-reads it on every
+        catalog rebuild, so no release bumps anything here and there is no served version to pin.
+        What the listing depends on instead is the x64 AppImage staying startable for someone other
+        than its builder - the review CI runs it under firejail --appimage on ubuntu-22.04 and fails
+        the submission when no window appears, which is exactly what caught the 0770 AppRun.wrapped
+        mode and the GLIBC_2.38 floor that 0.13.2 and 0.13.3 fixed. Both are now gated in the build
+        (tests/unit/desktop-appimage-portability.test.ts, scripts/check-appimage-perms.mjs). The
+        catalog is what appimagehub.com and the stores consuming its feed read - AppImage Pool, Zap.

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -34,7 +34,7 @@ channel count.
 
 ## Coverage snapshot
 
-**32 channels · 24 live · 7 pending · 1 deprecated**
+**33 channels · 24 live · 8 pending · 1 deprecated**
 
 Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 4 · Kubernetes 2 · Cloud 10**
 
@@ -44,7 +44,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 4 · K
 | Containers | 2 | 0 | 0 |
 | Kubernetes & operators | 2 | 1 | 0 |
 | Package managers | 4 | 1 | 1 |
-| OS / desktop packages | 2 | 0 | 0 |
+| OS / desktop packages | 2 | 1 | 0 |
 | PaaS catalogs (listed) | 8 | 4 | 0 |
 | Deploy recipes | 3 | 0 | 0 |
 | Cloud marketplaces | 1 | 1 | 0 |
@@ -72,6 +72,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 3 · Container 4 · K
 | Flathub | Package managers | Linux | deprecated | — | [packaging/flatpak/README.md](../packaging/flatpak/README.md) |
 | [Desktop app (AppImage, .deb)](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [desktop/README.md](../desktop/README.md) |
 | [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [AppImageHub](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | pending | Manual, on demand | [desktop/README.md](../desktop/README.md) |
 | [CapRover official](https://github.com/caprover/one-click-apps) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/caprover/README.md](../deploy/caprover/README.md) |
 | [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
 | [Dokploy template catalog](https://templates.dokploy.com) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |


### PR DESCRIPTION
## What

Adds `appimagehub` to `distribution/channels.yaml` and regenerates the `docs/CHANNELS.md` matrix (32 channels -> 33, pending 7 -> 8).

## Why now

The submission is open as [AppImage/appimage.github.io#3861](https://github.com/AppImage/appimage.github.io/pull/3861) and its review CI is green against 0.13.3 (`NUMBER_OF_WINDOWS: 3`, `Screenshot taken`, `* * * SUCCESS * * *`). `status: pending` until it merges.

## The two shape decisions

**`kind: curated-catalog`, `update.method: upstream_pr`, `sla: on_demand`.** One PR, then nothing per release: the catalog holds a single line naming this repository, and their worker re-reads the releases API on every rebuild, taking the first AppImage asset matching x64. It is the rare channel with no recurring maintenance cost at all.

**`pin.strategy: none`** - not because the version is awkward to read there, but because there is no served version to read. The catalog page tracks whatever the newest release holds.

## What the note records

The listing does not depend on a version, it depends on the AppImage staying startable for someone other than its builder. Their review CI runs the submitted image under `firejail --appimage` on `ubuntu-22.04`, and that sandbox caught both AppImage defects this release pair fixed:

- the GLIBC_2.38 floor (#467, 0.13.2) - the image could not load a single shared object on the oldest supported LTS
- `AppRun.wrapped` at `0770 root:root` (#470, 0.13.3) - `Permission denied` under any mount that applies real permission checks

Both are now gated in the build (`tests/unit/desktop-appimage-portability.test.ts`, `scripts/check-appimage-perms.mjs`), and the note names those gates so a future maintainer knows what keeps the listing alive rather than rediscovering it from a red PR upstream.

## Verification

`format`, `lint`, `typecheck`, `knip`, `readme:check`, `test` (33/33 groups), `build`. `distribution:check` after the 0.13.3 release: every `every_release` tier 0/1 channel OK at 0.13.3 (github-release, docker-ghcr, docker-hub-mirror, npm, helm, homebrew, snap); the new row renders SKIP, which is what a channel with no pin should render.
