### PR TITLE
fix(agent): a plan run scored ANSWERED while handing the user prose glued to its SQL

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2479,6 +2479,12 @@ as they are fixed, and a numeral here goes stale silently.
   only one version exists: an accepted range with one member is a knob nothing turns, and the
   tolerant operator schema removes the pressure by letting Studio add settings without moving it.
 
+- **B64** — an unfenced plan statement with NO terminator still carries prose into the SQL. The
+  splitter closed the demonstrated case (a statement, then its explanation on the next line, came
+  back as one statement with the prose in it) but has nothing to cut on without a semicolon, so
+  the blank line remains the only signal there. It matters because `plan-statement-drafted` is
+  recorded on the reader's verdict alone and the goal verifier reads that event as ANSWERED, so
+  the run is scored answered while its deliverable would not run.
 
 ## Related documentation
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2579,3 +2579,26 @@ so this is a decision to take at the first real bump, not before.
 **Done when:** the first `schemaVersion` change ships with a rule for reading documents written for
 the version before it, and the release notes say what an operator has to do.
 
+
+### B64. An unfenced plan statement with no terminator still carries prose into the SQL
+
+`unfencedStatement` now makes two cuts: the blank line, then the SQL splitter. The splitter is
+what closed the demonstrated case — `SELECT 1;` followed by "This query returns one row." on the
+next line came back as one statement with the prose inside it, and `plan-statement-drafted` is
+recorded on `kind === "statement"` alone while `verifyPlanningGoal` reads that event as the run
+having ANSWERED. So a run was scored answered while its deliverable would not run.
+
+With NO terminator the splitter has nothing to cut on and returns the whole candidate, so the
+blank line is the only signal left. A model that writes `SELECT 1` without a semicolon and
+explains itself on the next line still gets its prose through, and is still scored answered.
+
+Narrower than the fixed case and not demonstrated on a real run, which is why it is pinned as it
+behaves (`tests/unit/lib/agent/plan-statement.test.ts`) rather than guessed at. The wider fix is
+not another line rule: it is gating the event on validation, which the reader's own header
+already names as the thing it deliberately does not do. That is a change to plan mode's pass
+bar — cells that pass today because a statement was drafted would have to be re-measured — so it
+belongs to whoever owns the measurement rather than to a defect fix.
+
+**Done when:** either the reader ends an unterminated statement without a blank line, or the
+verifier stops treating a drafted statement as an answer on its own — with the cells that moves
+re-measured either way.

--- a/src/lib/agent/plan-draft.ts
+++ b/src/lib/agent/plan-draft.ts
@@ -19,6 +19,7 @@
  * end run in a real browser caught it again.
  */
 
+import { splitStatements } from "@/lib/sql/statement-splitter";
 import { fenceTagEngine, isQueryFenceTag } from "@/lib/sql/fence-tags";
 import type { DatabaseType } from "@/lib/types";
 
@@ -255,13 +256,32 @@ export function readPlanStatement(text: string, dialect?: DatabaseType): PlanSta
 
 /**
  * The statement in text that never opened a fence: from the first line that opens one to
- * the last line that still looks like part of it.
+ * where the SQL ends.
  *
- * Ends at the first BLANK line, because that is where these models put the explanation
- * they were also asked for, and carrying prose into the SQL would hand the editor
- * something no engine accepts. No tag is returned: the model named no fence, so there is
- * nothing it told us about the engine, and the recorder stamps the connection's own
- * dialect the way it does for an untagged fence.
+ * TWO CUTS, and the second was missing. The blank line comes first, because that is where
+ * these models put the explanation they were also asked for. Then the SQL SPLITTER, because
+ * a model that explains itself on the very next line leaves no blank line at all — and that
+ * shape walked straight through: `STATEMENT_OPENER` guards the START (a sentence about a
+ * select is not a select) and nothing guarded the END, so `SELECT 1;` followed by "This query
+ * returns one row." came back as one statement with the prose inside it.
+ *
+ * That is not a formatting nicety. `plan-statement-drafted` is recorded whenever this reader
+ * returns a statement, with the validation riding along rather than gating it, and the goal
+ * verifier reads that event as the run having ANSWERED. Prose carried into the SQL therefore
+ * scores a run answered while the user is handed something no engine will run.
+ *
+ * The splitter rather than another line rule because it knows where a statement ends: it
+ * tracks string literals, comments and dollar-quoting, so `SELECT 'a;b' AS pair;` is one
+ * statement and not two. Whitespace knows none of that.
+ *
+ * With NO terminator the splitter has nothing to cut on and returns the whole candidate, so
+ * the blank line remains the only signal — a model that omits the semicolon and explains
+ * itself on the next line still gets its prose through. Narrower, undemonstrated on a real
+ * run, and pinned in the tests as it behaves rather than guessed at.
+ *
+ * No tag is returned: the model named no fence, so there is nothing it told us about the
+ * engine, and the recorder stamps the connection's own dialect the way it does for an
+ * untagged fence.
  */
 function unfencedStatement(lines: readonly string[]): string | null {
   const start = lines.findIndex((line) => STATEMENT_OPENER.test(line));
@@ -271,6 +291,23 @@ function unfencedStatement(lines: readonly string[]): string | null {
     if (line.trim().length === 0) break;
     body.push(line);
   }
-  const sql = body.join("\n").trim();
+  const candidate = body.join("\n").trim();
+  if (candidate.length === 0) return null;
+  /*
+    Cut at the LINE the second statement starts on rather than taking the splitter's first `sql`,
+    so the statement is handed back in the model's own bytes. The splitter strips the terminator,
+    and returning `SELECT 1` where the fenced path returns `SELECT 1;` would change every unfenced
+    draft to fix one — a wider change than the defect.
+
+    A second statement on the SAME line has no line to cut at, so the splitter's text is the only
+    answer left there; it costs that rare draft its semicolon and nothing else.
+  */
+  const [first, second] = splitStatements(candidate);
+  const sql =
+    second === undefined
+      ? candidate
+      : second.startLine > 0
+        ? candidate.split("\n").slice(0, second.startLine).join("\n").trim()
+        : (first?.sql ?? candidate).trim();
   return sql.length === 0 ? null : sql;
 }

--- a/tests/unit/lib/agent/plan-draft-boundary.test.ts
+++ b/tests/unit/lib/agent/plan-draft-boundary.test.ts
@@ -38,11 +38,41 @@ const specifiers = (source: string): readonly string[] =>
  * away from not being — and admitting a module because of where it sits is the same
  * reasoning that admitted the guard.
  */
-const ALLOWED: ReadonlySet<string> = new Set(["@/lib/sql/fence-tags", "@/lib/types"]);
+const ALLOWED: ReadonlySet<string> = new Set([
+  "@/lib/sql/fence-tags",
+  "@/lib/types",
+  /*
+    Added when the unfenced reader stopped cutting statements at a blank line and started cutting
+    them where the SQL ends, which needs a scanner that knows about strings, comments and
+    dollar-quoting.
+
+    Admitted on the ONE ground this file accepts: it imports nothing at all, which the test below
+    asserts rather than this comment claiming. That matters more here than "it is pure today",
+    because the lesson recorded above is precisely that direct imports were inspected and the
+    transitive cost is what the policy measures — and a specifier list for THIS file cannot see a
+    dependency the splitter gains later.
+  */
+  "@/lib/sql/statement-splitter",
+]);
 
 describe("the plan-draft reader stays reachable from a browser", () => {
   test("it imports nothing outside the allowed set", () => {
     expect(specifiers(SOURCE).filter((specifier) => !ALLOWED.has(specifier))).toEqual([]);
+  });
+
+  test("the splitter it now reaches imports nothing, so admitting it costs nothing transitively", () => {
+    /*
+      The half the allowlist cannot check. This file reads `plan-draft.ts`'s own specifiers, so a
+      dependency added to `statement-splitter.ts` would leave that list unchanged and this
+      boundary green while the browser pays for it — which is the exact shape of the zod incident
+      the header describes.
+
+      Zero imports is a stronger property than "pure": it cannot acquire a transitive cost without
+      this assertion going red first.
+    */
+    const splitter = fs.readFileSync(path.join(process.cwd(), "src/lib/sql/statement-splitter.ts"), "utf8");
+
+    expect(specifiers(splitter)).toEqual([]);
   });
 
   test("it does not reach the statement guard, which is where zod enters", () => {

--- a/tests/unit/lib/agent/plan-statement.test.ts
+++ b/tests/unit/lib/agent/plan-statement.test.ts
@@ -554,3 +554,71 @@ describe("a statement the model wrote without a fence", () => {
     expect(readPlanStatement(text, "sqlite").kind).toBe("refusal");
   });
 });
+
+describe("an unfenced statement ends where the SQL ends, not where the prose leaves a gap", () => {
+  /*
+    The gap the blank-line rule left, and it is not a formatting nicety: `plan-statement-drafted`
+    is recorded whenever this reader returns a statement, with validation riding along rather
+    than gating it, and `verifyPlanningGoal` treats that event as the run having ANSWERED. So a
+    reader that hands back prose glued to a statement scores the run answered while the user is
+    handed something no engine will run.
+
+    `unfencedStatement` guarded the START — a sentence about a select is not a select — and
+    nothing guarded the END. A model that writes its statement and explains it on the very next
+    line, which is the shape these models are asked for, walks straight through: the opener is a
+    real SELECT and the explanation is not a blank line.
+
+    Cut with the SQL splitter this repository already has, which knows where a statement ends
+    because it tracks strings, comments and dollar-quoting. Whitespace does not.
+  */
+  test("prose on the line after the statement is not carried into the SQL", () => {
+    const draft = readPlanStatement("SELECT 1;\nThis query returns one row.", "sqlite");
+
+    if (draft.kind !== "statement") throw new Error("expected a statement");
+    expect(draft.sql).toBe("SELECT 1;");
+  });
+
+  test("a statement that spans lines is still read whole", () => {
+    // The case the unfenced reader exists for: no fence, and the SQL wraps. Cutting at the
+    // first newline would break it, which is why the fix is the splitter and not a line rule.
+    const wrapped = "SELECT name\nFROM film\nWHERE rating = 'PG';\nThat is the list.";
+
+    const draft = readPlanStatement(wrapped, "sqlite");
+
+    if (draft.kind !== "statement") throw new Error("expected a statement");
+    expect(draft.sql).toBe("SELECT name\nFROM film\nWHERE rating = 'PG';");
+  });
+
+  test("a semicolon inside a string does not end the statement early", () => {
+    // What a whitespace rule and a naive split both get wrong, and the splitter does not.
+    const quoted = "SELECT 'a;b' AS pair;\nThe literal contains a semicolon.";
+
+    const draft = readPlanStatement(quoted, "sqlite");
+
+    if (draft.kind !== "statement") throw new Error("expected a statement");
+    expect(draft.sql).toBe("SELECT 'a;b' AS pair;");
+  });
+
+  test("two statements on one line cost the first its terminator, and that is the whole cost", () => {
+    // No line to cut at, so the splitter's own text is the only answer left. Pinned because the
+    // implementation comment promises exactly this and a promise nothing checks is a wish.
+    const draft = readPlanStatement("SELECT 1; SELECT 2;", "sqlite");
+
+    if (draft.kind !== "statement") throw new Error("expected a statement");
+    expect(draft.sql).toBe("SELECT 1");
+  });
+
+  test("an unterminated statement still falls back to the blank line", () => {
+    /*
+      Deliberately unchanged, and recorded rather than fixed. With no terminator the splitter has
+      nothing to cut on and returns the whole text, so the blank line is the only signal left —
+      which means prose on the next line still gets through when the model omits the semicolon.
+      Narrower than the case above and not demonstrated on a real run, so it is pinned as it
+      behaves rather than guessed at.
+    */
+    const draft = readPlanStatement("SELECT 1\nstill part of it\n\nProse after the gap.", "sqlite");
+
+    if (draft.kind !== "statement") throw new Error("expected a statement");
+    expect(draft.sql).toBe("SELECT 1\nstill part of it");
+  });
+});


### PR DESCRIPTION
fix(agent): a plan run scored ANSWERED while handing the user prose glued to its SQL

`unfencedStatement` guarded where a statement STARTS — `STATEMENT_OPENER` is checked
against the beginning of the candidate, because a sentence about a select is not a select
— and nothing guarded where it ENDS. A blank line was the only signal, and the shape these
models are actually asked for does not leave one: write the statement, explain it on the
next line.

Reproduced rather than reasoned about:

    readPlanStatement("SELECT 1;\nThis query returns one row.", "sqlite")
    => { kind: "statement", sql: "SELECT 1;\nThis query returns one row." }

That is not a formatting complaint, because of what happens next. `investigation.ts` records
`plan-statement-drafted` on `draft.kind === "statement"` alone, and `goal-verifier.ts` reads
that event as the run having ANSWERED — `run.events.some(…) => return []`, no shortfalls. So
the run is scored answered while the deliverable is something no engine will run.

The file's own header already named this trap: "`plan-statement-drafted` is recorded whenever
this reader returns a statement, with the validation riding along rather than gating it, so a
reader that accepted a sentence would score the run answered while the user reads prose." The
guard was built against prose that LOOKS like a statement. This is a real statement with prose
glued on, which walks past it.

CUT WITH THE SPLITTER THIS REPOSITORY ALREADY HAS. `src/lib/sql/statement-splitter.ts` knows
where a statement ends because it tracks string literals, comments and dollar-quoting —
`SELECT 'a;b' AS pair;` is one statement and not two. Whitespace knows none of that.

Cut at the LINE the second statement starts on rather than taking the splitter's first `sql`:
the splitter strips the terminator, and returning `SELECT 1` where the fenced path returns
`SELECT 1;` would change every unfenced draft in order to fix one. The line boundary hands the
statement back in the model's own bytes.

NOT FIXED, AND PINNED AS IT BEHAVES: with no terminator the splitter has nothing to cut on, so
the blank line remains the only signal and a model that omits the semicolon still gets its
prose through. Narrower, undemonstrated on a real run, and a wider fix — gating the event on
validation — is a change to plan mode's pass bar that would need re-measuring the cells it
moves. That is a decision for whoever owns the measurement, not a side effect of this one.

THE BROWSER BOUNDARY CAUGHT THE IMPORT, which is what it is for. `plan-draft.ts` is reachable
from the rail and carries an exact import allowlist, written after `zod` v4's load-time
`new Function("")` probe put a CSP violation on every page rendering an agent run — past six
local gates and twenty CI checks, found only by a real browser.

So the splitter is admitted on the one ground that file accepts: it imports nothing at all.
And because the recorded lesson there is that DIRECT imports were inspected while the
TRANSITIVE cost is what the policy measures, a second test now asserts the splitter's specifier
list is empty. A dependency added to it goes red here instead of in somebody's browser.

Verified: format, lint (0 errors), typecheck, knip, `bun run test` (33/33 groups), build, and
coverage:check at 42546/42546 lines.
