### PR TITLE
fix(agent): the model sweep reported a pass it had not measured, and a table nobody had re-measured

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1552,24 +1552,18 @@ denial cannot be re-fed to the model as though the SQL were malformed.
 
 Ten models run every agent surface. Each cleared all six — Investigate, Optimize, Assess, Operate,
 Analyze and Plan — five consecutive times, at the turn limit the product ships, which is 30 of 30
-runs. Each has a page of its own with its measured durations and whatever it needs that the others
-do not.
+runs.
 
-| Model | Served through | Median run | Slowest run |
-| --- | --- | --- | --- |
-| [`gemini-3.5-flash-lite`](models/gemini-3-5-flash-lite.md) | Gemini API | 10 s | 24 s |
-| [`granite4.1:8b`](models/granite4-1-8b.md) | Ollama | 10 s | 21 s |
-| [`ornith:9b`](models/ornith-9b.md) | Ollama | 25 s | 82 s |
-| [`qwen3.5:9b`](models/qwen3-5-9b.md) | Ollama | 25 s | 98 s |
-| [`granite4.1:30b`](models/granite4-1-30b.md) | Ollama | 26 s | 46 s |
-| [`qwen3:8b`](models/qwen3-8b.md) | Ollama | 32 s | 132 s |
-| [`qwen3:14b`](models/qwen3-14b.md) | Ollama | 39 s | 151 s |
-| [`gemma4:26b`](models/gemma4-26b.md) | Ollama | 46 s | 180 s |
-| [`qwen3.8:latest`](models/qwen3-8-latest.md) | Ollama | 62 s | 347 s |
-| [`qwen3:4b`](models/qwen3-4b.md) | Ollama | 75 s | 139 s |
+**The table lives in [`docs/llms/README.md`](llms/README.md)**, with each model's page beside it,
+and this page deliberately does not repeat it. There used to be a copy here. Every one of its ten
+rows had drifted from the canonical figures — `gemma4:26b` read 46 s/180 s against a measured
+36 s/92 s, `qwen3:14b` read 39 s/151 s against 41 s/303 s — and all ten of its links pointed at a
+`docs/models/` directory that does not exist. Two homes for one measurement is what produced that,
+so there is one now.
 
-The durations are from one machine and are comparable with each other rather than portable: every
-figure was taken the same way, on the same database, through the same six surfaces.
+Which model to run, what each needs that the others do not, and how to measure one these pages do
+not cover, are all under [`docs/llms/`](llms/README.md).
+
 
 Nothing prevents another model from being configured — the capability probe below decides what any
 given endpoint can do, and there is no allow-list in the code. What the ten have is a measurement.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,10 +26,16 @@ export default defineConfig({
     baseURL: `http://localhost:${port}`,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
-    // Kept for every test rather than only for failures, because the agent specs are the ones
-    // somebody watches: a model sweep runs for over an hour and the question afterwards is what
-    // the rail actually did, which a passing run answers as usefully as a failing one.
-    video: "retain-on-failure",
+    // Kept for every test DURING A MODEL SWEEP, and only then. The agent specs are the ones
+    // somebody watches: a sweep runs for over an hour and the question afterwards is what the
+    // rail actually did, which a passing run answers as usefully as a failing one — so
+    // `retain-on-failure`, which deletes exactly those videos, is the wrong setting there.
+    //
+    // Scoped to the sweep's own variable rather than turned on globally, because `use` reaches
+    // every project and every run: `on` here would have CI keeping a video of every passing test
+    // in every job, which nobody watches and every artifact pays for. The comment used to claim
+    // the first sentence while the value did the opposite; the two now agree.
+    video: process.env.AGENT_MODEL_E2E ? "on" : "retain-on-failure",
     // Watchable when asked for. Unset in CI and in an ordinary run, so nothing slows down by
     // default; `PWSLOWMO=350` puts a beat between actions when somebody is watching the sweep.
     launchOptions: { slowMo: Number(process.env.PWSLOWMO ?? 0) },

--- a/scripts/agent-model-e2e.sh
+++ b/scripts/agent-model-e2e.sh
@@ -39,6 +39,10 @@ restore() {
 }
 trap restore EXIT
 
+# Models whose sweep did not pass, collected rather than exited on: an hour of measurement is
+# worth finishing, and one model's failure is not a reason to stop asking about the other nine.
+FAILED=""
+
 for MODEL in "${MODELS[@]}"
 do
   echo "======== $MODEL ========"
@@ -71,6 +75,18 @@ do
     E2E_PASSWORD="$(grep -E '^USER_PASSWORD=' .env.local | cut -d= -f2-)" \
     npx playwright test e2e/agent-models.spec.ts --project=chromium --reporter=line --workers=1 $HEADED 2>&1 |
     sed "s/^/[$MODEL] /"
-  echo "@@@@ $MODEL done"
+  # Read IMMEDIATELY after the pipeline, because $? here is sed's and sed always succeeds.
+  # Without this a model could fail its whole sweep while the script printed "done" and exited 0,
+  # so anything reading the exit status - a wrapper, CI, or the next person - was told a sweep
+  # passed that had not. The prefix is worth keeping, so the status is captured rather than the
+  # pipe removed.
+  STATUS=${PIPESTATUS[0]}
+  [ "$STATUS" -eq 0 ] || FAILED="$FAILED $MODEL"
+  echo "@@@@ $MODEL done (exit $STATUS)"
 done
+if [ -n "$FAILED" ]; then
+  # Named rather than counted: the question after an hour-long sweep is WHICH model to look at.
+  echo "@@@@ FAILED:$FAILED"
+  exit 1
+fi
 echo "@@@@ done"

--- a/tests/unit/agent-model-sweep-tooling.test.ts
+++ b/tests/unit/agent-model-sweep-tooling.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The model sweep's own tooling, which is what the measured figures are produced with.
+ *
+ * Two defects fixed together, and they share a shape: the tool reported something other than
+ * what happened, and nothing was watching.
+ *
+ * The sweep piped Playwright through `sed` to prefix each line with the model's name, so `$?`
+ * was sed's — and sed always succeeds. A model could fail its entire UI sweep while the script
+ * printed `done` and exited 0. Anything reading that status was told a sweep passed that had not.
+ *
+ * And the config kept video on `retain-on-failure` under a comment saying videos are kept for
+ * every test because somebody watches the sweep afterwards. `retain-on-failure` deletes exactly
+ * the videos of the runs that passed, which is most of an hour-long sweep.
+ *
+ * Grep-shaped rather than executed, like the other script tests here: driving ten models through
+ * a browser is not a unit test. So the assertions are aimed at the properties that actually
+ * break — the ADJACENCY of the status read, and the CONDITION on the video setting — rather than
+ * at the presence of a word.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "../..");
+const read = (relative: string): string => readFileSync(join(ROOT, relative), "utf8");
+
+describe("the sweep script reports the status it was given", () => {
+  const SCRIPT = read("scripts/agent-model-e2e.sh");
+  const lines = SCRIPT.split("\n");
+
+  test("the pipeline's status is read before anything can clobber it", () => {
+    /*
+      The property, not the word. `PIPESTATUS` holds the LAST pipeline's statuses and any command
+      in between replaces it, so a line inserted after the pipeline — an echo, a sleep, a cleanup
+      — would leave this reading whatever that line did. Adjacency is the whole guarantee, and it
+      is the kind an editor breaks without noticing.
+    */
+    const piped = lines.findIndex((line) => line.includes("npx playwright test e2e/agent-models.spec.ts"));
+    expect(piped).toBeGreaterThan(-1);
+
+    const after = lines
+      .slice(piped + 1)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#"));
+    // The pipeline continues onto the `sed` line, so the status read is the first real statement
+    // after it.
+    expect(after[0]).toContain("sed ");
+    expect(after[1]).toBe("STATUS=${PIPESTATUS[0]}");
+  });
+
+  test("a model that failed makes the script exit non-zero, and names which one", () => {
+    // Collected across the loop rather than exited on: an hour of measurement is worth
+    // finishing. But it must still be a failure at the end, or the collection is decoration.
+    expect(SCRIPT).toContain('FAILED="$FAILED $MODEL"');
+    expect(SCRIPT).toMatch(/if \[ -n "\$FAILED" \]; then[\s\S]*?exit 1/);
+  });
+});
+
+describe("the sweep keeps the video its own comment promises", () => {
+  const CONFIG = read("playwright.config.ts");
+
+  test("video is retained for every test during a sweep, and only during one", () => {
+    // Both halves matter. `on` everywhere would have CI keep a video of every passing test in
+    // every job; `retain-on-failure` everywhere deletes the ones the sweep exists to produce.
+    expect(CONFIG).toContain('video: process.env.AGENT_MODEL_E2E ? "on" : "retain-on-failure"');
+  });
+
+  test("the variable it keys on is the one the sweep actually sets", () => {
+    // A condition on a variable nobody sets is a setting that never turns on, which would look
+    // exactly like the fix and behave exactly like the defect.
+    expect(read("scripts/agent-model-e2e.sh")).toContain("AGENT_MODEL_E2E=1");
+  });
+});


### PR DESCRIPTION
fix(agent): the model sweep reported a pass it had not measured, and a table nobody had re-measured

Three defects in what produces and publishes the model figures. They share a shape: the tool
reported something other than what happened, and nothing was watching.

THE SWEEP'S EXIT STATUS WAS SED'S. Playwright was piped through `sed` to prefix each line
with the model's name, so `$?` belonged to sed, which always succeeds — and there was no
`set -e` and no `pipefail`. A model could fail its entire UI sweep while the script printed
`done` and exited 0, so anything reading that status was told a sweep passed that had not.

`${PIPESTATUS[0]}` is now read immediately after the pipeline. Failures are COLLECTED across
the loop rather than exited on — an hour of measurement is worth finishing, and one model
failing is not a reason to stop asking about the other nine — then named and the script exits
non-zero. The `sed` prefix stays: the pipe was never the problem, not reading past it was.

VIDEO WAS DELETED FOR EXACTLY THE RUNS THE SWEEP EXISTS TO PRODUCE. The comment said videos
are kept "for every test rather than only for failures, because the agent specs are the ones
somebody watches", and the value beneath it was `retain-on-failure`, which deletes the video
of every passing test. Now `on` when `AGENT_MODEL_E2E` is set and `retain-on-failure`
otherwise — scoped rather than global, because `use` reaches every project and `on` there
would have CI keep a video of every passing test in every job.

AND `docs/AGENT.md` PUBLISHED A SECOND, STALE COPY OF THE MEASUREMENTS. Ten links into a
`docs/models/` directory that does not exist, and — this is beyond what the review that raised
it claimed — ALL TEN ROWS disagreeing with the canonical table in `docs/llms/README.md`, in
both directions and by wide margins: `gemma4:26b` published 46 s/180 s against a measured
36 s/92 s, `qwen3:14b` 39 s/151 s against 41 s/303 s.

Aligning the numbers was the obvious fix and is the wrong one. The defect is not that a figure
was wrong, it is that one measurement had two homes — which is what produced the drift and
would produce it again. So the copy is gone and the section points at the canonical table,
saying plainly what was removed and why, with two of the drifted figures named so the next
person can tell this was a duplicate rather than a deletion of something.

A test guards both tools, because both defects are the kind that return quietly. It asserts
the properties that actually break rather than the presence of a word: the ADJACENCY of the
status read — `PIPESTATUS` holds the last pipeline's statuses and any command in between
replaces it, so an `echo` inserted there restores the original bug — and the CONDITION on the
video setting, together with the fact that the variable it keys on is one the sweep really
sets. Verified by mutation: inserting a line between the pipeline and the read turns it red.

Verified: format, lint (0 errors), typecheck, knip, `bun run test` (33/33 groups), build,
`bash -n` on the script, and coverage:check at 42537/42537 lines.
