### PR TITLE
refactor(agent): the narrative has one home, and two entries stop arguing against their own settings

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2465,9 +2465,6 @@ as they are fixed, and a numeral here goes stale silently.
   gone: the document refuses wording and nothing else can populate it. Refusing unsigned prompt text
   is right; refusing it forever is a decision that has not been taken, and the two objections behind
   it — marker drift and authorship — come apart.
-- **B60** — every bundled entry carries a `summary` that Studio never reads, duplicating the family
-  pages under `docs/llms/`. It is optional now, so it no longer stands between an operator and a
-  working measurement, but roughly half the shipped document is prose nothing renders.
 - **B62** — `schemaVersion` is a literal on both schemas, so the first bump to 2 refuses every
   document in the field and reverts every model in it to the defaults. Deliberately not fixed while
   only one version exists: an accepted range with one member is a knob nothing turns, and the

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2551,20 +2551,6 @@ provenance is a property of the SOURCE rather than of the field.
 from one whose authorship is not — with the trust tier stated as a decision rather than implied by
 which loader happened to read the file.
 
-### B60. `summary` is required reading for nobody
-
-Every bundled entry carries a `summary` array and Studio never reads it: the resolvers take the
-settings and `measured`. It is optional now, so it no longer forces an operator to write prose before
-their measurement can take effect, but the bundled copies remain — roughly half the document — and
-they duplicate the family pages under `docs/llms/`, which say the same things more tightly.
-
-Two ways to settle it, and the choice belongs to whoever wrote the prose: surface it somewhere a
-reader reaches (the rail, or a generated page), or move it to the family pages and let the document
-carry `measured` and `rationale` alone. What should not persist is a third copy that ships inside
-`.next/server` chunks and nothing renders.
-
-**Done when:** the narrative has one home, and the document carries what something reads.
-
 ### B62. `schemaVersion` has no migration path, and the first bump breaks every mounted document
 
 `z.literal(TUNING_SCHEMA_VERSION)` on both schemas. An older Studio refusing a newer document is

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -20,14 +20,6 @@
     {
       "id": "gemini-3.5-flash-lite",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
-      "summary": [
-        "`gemini-3.5-flash-lite` — measured at the defaults, and pinned to them.",
-        "6 of 6 modes locked, 30 of 30 runs passed.",
-        "Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5",
-        "Every mode is locked.",
-        "The one HOSTED model in this directory, and the only reason that is worth saying here is that its numbers were obtained the same way as the nine local ones — same six surfaces, same five consecutive passes per surface, same shipped turn limit — so the ten are one table and not two.",
-        "Nothing here differs from the default, and that is exactly why the file exists. The default is a shared value, and a shared value is what has twice cost this repository a locked cell: pinning sampling to 0 won five cells and lost one, and reordering a workflow's rules won nothing and lost one. Those numbers above were obtained at temperature 0, top_p 1, and a ceiling of 12 unreported calls. Writing them here means a later change to the defaults cannot silently invalidate them — this model keeps what it was measured with until a new measurement says otherwise."
-      ],
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -51,15 +43,6 @@
     {
       "id": "gemma4:26b",
       "measured": "database-assessment, fifteen runs across three configurations: 4/5 at the defaults, 3/5 with an unreported-call ceiling of 9 (never fired, every run made 8 calls), 2/5 with two report reminders (calls rose from 8 to 11 and two runs hit the deadline). The losing runs gather evidence and then produce a turn with neither a call nor a report. The second reminder does reach the model and it goes back to reading rather than filing, so the cause is not a forgotten call or a shortage of turns. Call count does not separate winners from losers either: a run that reported in 26 seconds made 11 calls, as many as one that reported nothing. Its other five surfaces lock 5/5 at these defaults. Measured again at 4/5 once the stopping turn became readable: the losing run profiled nine tables, ran two queries, then returned an EMPTY completion — no call, no text — at eleven calls, one under the general ceiling. Its ceiling is 10 on that reading.",
-      "summary": [
-        "`gemma4:26b` — at the defaults, after two overrides were measured and deleted.",
-        "Five surfaces lock 5/5. `database-assessment` has been measured fifteen times and the losing runs all end the same shape: profile tables, count things, then a turn with neither a tool call nor a report, and the drive concludes `model-stopped` with `no-report` unmet.",
-        "Two fixes were tried on that reading and both are gone, because both were measured:",
-        "defaults 4/5 ceiling of 9 calls 3/5 — every run made 8 calls, so it never fired two report reminders 2/5 — calls rose 8 to 11 and two runs hit the deadline",
-        "The second one is the informative failure. The extra reminder does reach the model: it goes back to work and profiles more tables. It does not report. So the model is not forgetting to file, and it is not short of turns — it is spending the turn it was given on more reading, and on two runs that spending cost the run its deadline.",
-        "Neither call count separates the winners from the losers, which is what rules out narrowing: the run that reported in 26 seconds made 11 calls, exactly as many as the run that reported nothing. A ceiling low enough to catch a loser would catch a winner with it.",
-        "So this file pins the defaults and the numbers stay recorded. What is still unread is the text of the stopping turn — the ledger records calls and settlements, not what the model said when it made no call — and that is what the next attempt here needs before it changes anything."
-      ],
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -89,13 +72,6 @@
     {
       "id": "granite4.1:30b",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
-      "summary": [
-        "`granite4.1:30b` — measured at the defaults, and pinned to them.",
-        "6 of 6 modes locked, 30 of 30 runs passed.",
-        "Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5",
-        "Every mode is locked.",
-        "Nothing here differs from the default, and that is exactly why the file exists. The default is a shared value, and a shared value is what has twice cost this repository a locked cell: pinning sampling to 0 won five cells and lost one, and reordering a workflow's rules won nothing and lost one. Those numbers above were obtained at temperature 0, top_p 1, and a ceiling of 12 unreported calls. Writing them here means a later change to the defaults cannot silently invalidate them — this model keeps what it was measured with until a new measurement says otherwise."
-      ],
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -112,14 +88,7 @@
     },
     {
       "id": "granite4.1:8b",
-      "measured": "3/6 modes locked, 24/30 runs passed at these settings. Investigate 3/5 · Optimize 2/5 · Assess 5/5 · Operate 4/5 · Analyze 5/5 · Plan 5/5.",
-      "summary": [
-        "`granite4.1:8b` — measured at the defaults, and pinned to them.",
-        "3 of 6 modes locked, 24 of 30 runs passed.",
-        "Investigate 3/5 · Optimize 2/5 · Assess 5/5 · Operate 4/5 · Analyze 5/5 · Plan 5/5",
-        "Still open: Investigate, Optimize, Operate.",
-        "Nothing here differs from the default, and that is exactly why the file exists. The default is a shared value, and a shared value is what has twice cost this repository a locked cell: pinning sampling to 0 won five cells and lost one, and reordering a workflow's rules won nothing and lost one. Those numbers above were obtained at temperature 0, top_p 1, and a ceiling of 12 unreported calls. Writing them here means a later change to the defaults cannot silently invalidate them — this model keeps what it was measured with until a new measurement says otherwise."
-      ],
+      "measured": "3/6 modes locked, 24/30 runs passed AT THE DEFAULTS. Investigate 3/5 · Optimize 2/5 · Assess 5/5 · Operate 4/5 · Analyze 5/5 · Plan 5/5. Those are the numbers these settings were added for rather than the numbers they produced: with the worked refusal examples and the empty-turn retry the model locks 6/6 and passes 30/30, every surface 5/5.",
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -145,14 +114,7 @@
     },
     {
       "id": "ornith:9b",
-      "measured": "2/6 modes locked, 25/30 runs passed at these settings. Investigate 4/5 · Optimize 3/5 · Assess 4/5 · Operate 5/5 · Analyze 5/5 · Plan 4/5.",
-      "summary": [
-        "`ornith:9b` — measured at the defaults, and pinned to them.",
-        "2 of 6 modes locked, 25 of 30 runs passed.",
-        "Investigate 4/5 · Optimize 3/5 · Assess 4/5 · Operate 5/5 · Analyze 5/5 · Plan 4/5",
-        "Still open: Investigate, Optimize, Assess, Plan.",
-        "Nothing here differs from the default, and that is exactly why the file exists. The default is a shared value, and a shared value is what has twice cost this repository a locked cell: pinning sampling to 0 won five cells and lost one, and reordering a workflow's rules won nothing and lost one. Those numbers above were obtained at temperature 0, top_p 1, and a ceiling of 12 unreported calls. Writing them here means a later change to the defaults cannot silently invalidate them — this model keeps what it was measured with until a new measurement says otherwise."
-      ],
+      "measured": "2/6 modes locked, 25/30 runs passed on an EARLIER ROUND. Investigate 4/5 · Optimize 3/5 · Assess 4/5 · Operate 5/5 · Analyze 5/5 · Plan 4/5. The plan cell is what the extra turn below was added for. What moved the other four is not recorded here and is not claimed: what is known is that the model now locks 6/6 and passes 30/30, every surface 5/5.",
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -175,13 +137,6 @@
     {
       "id": "qwen3.5:9b",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
-      "summary": [
-        "`qwen3.5:9b` — measured at the defaults, and pinned to them.",
-        "6 of 6 modes locked, 30 of 30 runs passed.",
-        "Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5",
-        "Every mode is locked.",
-        "Nothing here differs from the default, and that is exactly why the file exists. The default is a shared value, and a shared value is what has twice cost this repository a locked cell: pinning sampling to 0 won five cells and lost one, and reordering a workflow's rules won nothing and lost one. Those numbers above were obtained at temperature 0, top_p 1, and a ceiling of 12 unreported calls. Writing them here means a later change to the defaults cannot silently invalidate them — this model keeps what it was measured with until a new measurement says otherwise."
-      ],
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -209,13 +164,6 @@
     {
       "id": "qwen3.8:latest",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
-      "summary": [
-        "`qwen3.8:latest` — measured at the defaults, and pinned to them.",
-        "6 of 6 modes locked, 30 of 30 runs passed.",
-        "Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5",
-        "Every mode is locked.",
-        "Nothing here differs from the default, and that is exactly why the file exists. The default is a shared value, and a shared value is what has twice cost this repository a locked cell: pinning sampling to 0 won five cells and lost one, and reordering a workflow's rules won nothing and lost one. Those numbers above were obtained at temperature 0, top_p 1, and a ceiling of 12 unreported calls. Writing them here means a later change to the defaults cannot silently invalidate them — this model keeps what it was measured with until a new measurement says otherwise."
-      ],
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -233,10 +181,6 @@
     {
       "id": "qwen3:14b",
       "measured": "5/6 modes locked, 29/30 runs passed. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 4/5. The single loss is no-statement on plan: the run described all eight tables, both join tables and the key each relation travels on, then stopped without a fenced statement or the NO STATEMENT refusal that plan mode scores. Its other four plan runs fenced a statement, so it gets one extra turn to be asked for the deliverable — a planning run costs 15 seconds, and no other model is offered it.",
-      "summary": [
-        "`qwen3:14b` — one extra plan turn, to ask for the deliverable it skipped.",
-        "Five surfaces lock 5/5. `plan` is 4 of 5 and loses on one shortfall, `no-statement`, and the losing run is not a bad plan. It lists all eight tables with their columns, names both join tables, says which key every relation travels on, and marks the two column-less tables as views. It answers the objective completely."
-      ],
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -260,13 +204,6 @@
     {
       "id": "qwen3:4b",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
-      "summary": [
-        "`qwen3:4b` — measured at the defaults, and pinned to them.",
-        "6 of 6 modes locked, 30 of 30 runs passed.",
-        "Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5",
-        "Every mode is locked.",
-        "Nothing here differs from the default, and that is exactly why the file exists. The default is a shared value, and a shared value is what has twice cost this repository a locked cell: pinning sampling to 0 won five cells and lost one, and reordering a workflow's rules won nothing and lost one. Those numbers above were obtained at temperature 0, top_p 1, and a ceiling of 12 unreported calls. Writing them here means a later change to the defaults cannot silently invalidate them — this model keeps what it was measured with until a new measurement says otherwise."
-      ],
       "settings": {
         "sampling": {
           "temperature": 0,
@@ -284,10 +221,6 @@
     {
       "id": "qwen3:8b",
       "measured": "query-optimization: 3/5 at temperature 0.8, then 1/5 and 0/5 at temperature 0. All 15 ledgers on that surface read: opening with inspect_plan answers 3/3, opening with inspect_schema answers 1/12, and at temperature 0 it opens with inspect_schema 10 times out of 10. Its other five surfaces lock 5/5 deterministically, so the override is scoped to this one cell and not to the model.",
-      "summary": [
-        "`qwen3:8b` — five surfaces deterministic, `query-optimization` sampled.",
-        "The first model to earn a file of its own, and the measurement that gave it one is the reason this directory exists at all."
-      ],
       "settings": {
         "sampling": {
           "temperature": 0,

--- a/src/lib/agent/model-tuning/schema.ts
+++ b/src/lib/agent/model-tuning/schema.ts
@@ -107,15 +107,6 @@ const modelSchema = z.strictObject({
   id: z.string().min(1),
   /** The runs that earned these settings, in the words of whoever measured them. */
   measured: z.string().min(1),
-  /**
-   * What the model is like, beyond any one setting.
-   *
-   * For whoever READS the document, and Studio never reads it — the resolvers take settings and
-   * `measured`. Optional, because requiring it would make an operator write prose that nothing
-   * consumes before their measurement could take effect. The bundled entries carry it because the
-   * document is also a record, and a record with no narrative is a table of numbers.
-   */
-  summary: z.array(z.string().min(1)).optional(),
   settings: modelSettingsSchema,
   ...entryShape,
 });
@@ -164,7 +155,6 @@ const operatorSettingsSchema = z.looseObject(settingsShape).partial();
 const operatorModelSchema = z.looseObject({
   id: z.string().min(1),
   measured: z.string().min(1),
-  summary: z.array(z.string().min(1)).optional(),
   settings: operatorSettingsSchema,
   /*
     Named so that a LOOSE schema still refuses it.
@@ -269,7 +259,7 @@ export interface ModelTuning {
 const SETTING_NAMES = Object.keys(settingsShape) as (keyof typeof settingsShape)[];
 
 /** Everything an entry itself may say, for spotting a key misspelled outside `settings`. */
-const ENTRY_KEYS = new Set(["id", "measured", "summary", "settings", "rationale"]);
+const ENTRY_KEYS = new Set(["id", "measured", "settings", "rationale"]);
 
 type StatedSettings = Partial<z.infer<typeof modelSettingsSchema>>;
 type RecordedDefaults = TuningDocument["measuredAgainst"]["defaults"];

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -255,13 +255,19 @@ describe("what each model records about the runs that earned its settings", () =
     `measured` is not a resolver's output, so nothing else here would notice it changing. Five
     of the ten share a digest, and that is not a copy-paste: they scored identically — 6/6
     locked, 30/30 — so the sentence that states it is the same sentence.
+
+    Two digests were edited by hand rather than regenerated, which is what this table is for.
+    `granite4.1:8b` and `ornith:9b` recorded pre-override numbers under the words "at these
+    settings", so the field whose job is to justify a setting was arguing against it: the 24/30
+    and 25/30 are what the DEFAULTS produced, which is why the settings exist, and both models
+    lock 6/6 at 30/30 with them.
   */
   const MEASURED_DIGESTS: Readonly<Record<string, string>> = {
     "gemini-3.5-flash-lite": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
     "gemma4:26b": "d8124e9d5b0929364129274fd4f80dea2640773147fdfd834cf2c68a5a08dd76",
     "granite4.1:30b": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
-    "granite4.1:8b": "0b4e97dd11c616dbd8882e1e8fe5582f55144a27337baa8b84611183109c06a8",
-    "ornith:9b": "78ea7b7cf7d303ee8bc6a0bd035e93beb218f237fd27ef6349979323a4e76999",
+    "granite4.1:8b": "a3eea21447a81fbe058e3c18a0f7194c357e5d5f22db9acfe13e6139d9198874",
+    "ornith:9b": "4e14e79cb5fd6572748df90786778ce72280c2bae79a27b5f8636d4eac1dbee7",
     "qwen3.5:9b": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
     "qwen3.8:latest": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
     "qwen3:14b": "b1a344db5ee6b5f78780925657fee571eae510a7b8507bcb8badabaf01718aa3",

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -46,7 +46,6 @@ const COMPLETE = {
 const ENTRY = {
   id: "some-model:9b",
   measured: "five surfaces, five runs each",
-  summary: [] as string[],
   settings: COMPLETE,
 };
 
@@ -161,10 +160,7 @@ describe("what the contract refuses", () => {
       "a turn limit longer than the shortest run",
       { models: [{ ...ENTRY, settings: { ...COMPLETE, turnTimeoutMs: 400_000 } }] },
     ],
-    [
-      "an entry that states none of its settings",
-      { models: [{ id: "x:1b", measured: "m", summary: [], settings: {} }] },
-    ],
+    ["an entry that states none of its settings", { models: [{ id: "x:1b", measured: "m", settings: {} }] }],
     ["an empty measurement", { models: [{ ...ENTRY, measured: "" }] }],
   ])("refuses %s", (_name, overrides) => {
     expect(() => parseTuning(document(overrides), "test")).toThrow(ModelTuningError);


### PR DESCRIPTION
refactor(agent): the narrative has one home, and two entries stop arguing against their own settings

B60 asked where the bundled `summary` prose belongs. Moving it turned up something the
entry beside it was doing wrong, so both are here.

SUMMARY IS GONE, AND NOTHING MOVED WITH IT. Every line of it was already somewhere: the
per-surface tallies and the override stories are on the family pages under `docs/llms/`,
the argument for each setting is in that entry's own `rationale`, and the paragraph seven
entries repeated verbatim — why a model measured at the defaults still gets an entry — is
in `models/index.ts` and `docs/llms/model-tuning.md`. Each page was read before its
entry's lines were dropped rather than assumed to cover them.

Two of the lines should not have moved anywhere. `granite4.1:8b` said "Still open:
Investigate, Optimize, Operate" and `ornith:9b` said "Still open: Investigate, Optimize,
Assess, Plan", and neither is true: both lock all six.

AND THAT IS THE SECOND HALF. `measured` is not decoration — the schema calls it "what was
measured to justify this profile", and it is what separates a setting from a guess. Two
entries had their PRE-OVERRIDE numbers under the words "at these settings":

    granite4.1:8b   "3/6 modes locked, 24/30 runs passed at these settings"
    ornith:9b       "2/6 modes locked, 25/30 runs passed at these settings"

Both carry overrides, and both lock 6/6 at 30/30 with them. So the field whose job is to
justify a setting was reporting the numbers that setting was added to fix, as though the
setting had produced them — arguing against itself. #465 moved the settings when it took
the last cells to 30 of 30; the prose was carried across mechanically and did not move
with them.

Rewritten to say which numbers came from where. `granite4.1:8b` names the defaults and
then the result with its two settings, which the family page supports cell by cell.
`ornith:9b` names an earlier round, attributes the plan cell to the extra turn it was
added for, and explicitly declines to explain the other four: a plan-mode setting cannot
have fixed Investigate, Optimize and Assess, and what did is not recorded anywhere I could
read. Saying so is better than a plausible sentence nobody measured.

The 6/6 and 30/30 figures come from the owner's sweep dashboard, which also settles that
the two "Still open" lines were stale.

Both digests in `model-resolution-table.test.ts` were edited BY HAND, beside a note saying
why — which is the workflow that file documents for itself, and the reason it refuses to be
regenerated.

Verified: format, lint (0 errors), typecheck, knip, `bun run test` (33/33 groups), build,
and coverage:check at 42544/42544 lines.
