### PR TITLE
feat(agent): a run records what drove it — the model, and where its settings came from

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -251,10 +251,25 @@ The middle case is why this is a comparison and not a bare "has a seed id". The 
 database would investigate the seed and report on it as though it were the one on screen.
 
 A run emits a closed set of **semantic events**, and they are the whole of what the UI renders:
-`run-started`, `context-captured`, `statement-drafted`, `plan-statement-drafted`, `tool-invoked`,
-`tool-completed`, `tool-refused`, `report-composed`, `closing-statement`, `run-finished`, plus the
-four a single workflow's own tool writes — `plan-comparison`, `recommendation`, `table-profiled` and
-`answer-composed`.
+`run-started`, `driver-resolved`, `context-captured`, `statement-drafted`, `plan-statement-drafted`,
+`tool-invoked`, `tool-completed`, `tool-refused`, `report-composed`, `closing-statement`,
+`run-finished`, plus the four a single workflow's own tool writes — `plan-comparison`,
+`recommendation`, `table-profiled` and `answer-composed`.
+
+**`driver-resolved` says what drove the run**, and it exists because a finished run used to say
+nothing about that: no event and no record field carried the model id, so "these settings were
+measured" — the product's whole claim about a model — was not checkable from the run that used them.
+It carries the model, its provider, and where the settings came from: `bundled`, `operator` with the
+document's path and a digest of the bytes as read, or `operator-ignored` with the path when a
+document was configured and could not be used. The last is its own case on purpose — a run driven by
+the shipped settings because nobody configured a document, and one driven by them because the
+operator's could not be read, behave identically and mean opposite things.
+
+It is written **once per drive** rather than once per run, because a resume picks the model up from
+the configuration as it stands then: a run resumed after an operator changed it carries one entry per
+stretch, and two that disagree are the fact worth finding. The rail renders the model and not the
+provenance — a mounted document's path is server topology, and it belongs to whoever reads
+`GET /api/agent/config` rather than to whoever asked the question.
 
 **`plan-statement-drafted` is planning mode's own**, and is deliberately not `statement-drafted`:
 that kind promises a `stepId` tying a draft to the tool invocation that sent it, and a toolless run
@@ -2466,10 +2481,6 @@ as they are fixed, and a numeral here goes stale silently.
   behind that is about merging (half of one measurement beside half of another is a configuration
   nobody has run), and it justifies whole-**entry** replacement rather than whole-**document**
   rejection: fifty models would be lost to a typo in the thirty-seventh.
-- **B58** — a run records the model it used and nothing about where that model's settings came from,
-  so once a document can arrive from outside Studio, "these settings were measured" is no longer
-  checkable from the run itself. `GET /api/agent/config` answers it for the server at the moment
-  somebody asks, which is not when the question is normally asked.
 - **B59** — per-model WORDING has nowhere to go. A sentence is a measured value here (twice a shared
   change won cells and lost others, and had to be reverted whole), and the per-model override is
   gone: the document refuses wording and nothing else can populate it. Refusing unsigned prompt text

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2519,20 +2519,6 @@ or not at all — so the change is where the refusal is thrown, not what it prot
 **Done when:** a document with one bad entry applies the rest, and the skipped entries are reported
 by id through `operatorTuningStatus()` the way `ignoredKeys` already is.
 
-### B58. No run records which tuning document drove it
-
-The product's whole claim about a model is that its settings were measured. A run's ledger records
-the model id and nothing about where its settings came from, so once a document can arrive from
-outside Studio, "measured" stops being checkable from the run: a support conversation cannot tell a
-run driven by the shipped measurements from one driven by an operator's file, or by an older version
-of that file.
-
-`operatorTuningStatus()` answers it for the SERVER, at the moment somebody asks. It does not answer
-it for a run somebody is reading afterwards, which is when the question is normally asked.
-
-**Done when:** a run records the origin of the tuning that drove it — bundled, or a path plus a
-digest of the document as read — so a finished run says what it was driven with.
-
 ### B59. Per-model instructions have nowhere to go, and the mechanism that held them is gone
 
 Wording is measured, not constant: this repository twice changed a shared sentence, won several

--- a/docs/llms/model-tuning.md
+++ b/docs/llms/model-tuning.md
@@ -33,7 +33,7 @@ session, says which happened:
 
 ```jsonc
 { "modelTuning": { "state": "applied",  "path": "/etc/libredb/model-tuning.json",
-                   "models": 1, "ignoredKeys": [] } }
+                   "models": 1, "ignoredKeys": [], "digest": "9f2c…" } }
 { "modelTuning": { "state": "ignored",  "path": "...", "reason": "models.0.settings.turnTimeoutMs: ..." } }
 { "modelTuning": { "state": "unset" } }
 ```
@@ -41,6 +41,25 @@ session, says which happened:
 `ignoredKeys` is the one to read on a successful load: it lists what your document said that this
 Studio does not implement — a misspelling, or a setting from a newer Studio. The entry was applied
 around those keys rather than because of them.
+
+`digest` is SHA-256 of the document's bytes as they were read, and it is the same value a run
+records. The path says which file drove a run; only the digest says which VERSION of it, and a
+finished run that cannot be told apart from one driven by that path after somebody edited it is
+most of what recording the path was for. So: read the digest here, compare it against the one on
+the run you are explaining, and a mismatch tells you the file changed between them.
+
+## What a run records
+
+Each stretch of a run writes a `driver-resolved` entry naming the model, its provider, and where
+its settings came from — `bundled`, `operator` with the digest above, or `operator-ignored`.
+
+PER MODEL, not per document. A document that names `qwen3:8b` did not drive a run on
+`gemini-3.5-flash-lite`; that run records `bundled`, because the shipped measurements are what
+drove it. Mounting a document does not make it the provenance of everything the server runs.
+
+PER DRIVE, not per run. A run resumed after you changed the configuration ran on two things, and
+its ledger holds two entries that may disagree — which is the fact worth finding, not a
+contradiction to reconcile.
 
 ## The shape
 

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -844,6 +844,24 @@ function describeEvent(
   switch (event.kind) {
     case "run-started":
       return { tone: "neutral", chrome: true, headline: `Run started in ${event.mode} mode` };
+    case "driver-resolved":
+      /*
+        The model, and ONLY the model.
+
+        Worth showing: which model produced a run was not visible anywhere in this interface, and
+        for somebody running several local models that is the first thing they want to know about
+        a run they are reading back.
+
+        Not shown: the tuning provenance this event also carries. A mounted document's path and
+        digest are operator diagnostics — they answer "which settings drove this" for whoever
+        deploys the server, not for whoever asked the question — and a filesystem path in a user's
+        timeline is server topology leaking into a place it has no business being. It stays on the
+        ledger, where `GET /api/agent/config`'s audience reads it.
+
+        A resume writes a second one of these, so a run whose model changed mid-flight shows both
+        lines rather than one. That is the fact, not a duplicate.
+      */
+      return { tone: "neutral", chrome: true, headline: `Driven by ${event.modelId}` };
     case "context-captured":
       return {
         tone: "progress",

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -56,6 +56,7 @@ import {
   reusableSnapshot,
 } from "./context-snapshot";
 import { agentModelTurnTimeoutMs } from "./config";
+import { tuningProvenance } from "./model-tuning";
 import { BASELINE_NOTICES } from "./models/notices";
 import {
   ceilingFor,
@@ -2391,6 +2392,23 @@ export async function runInvestigation(
     }
 
     const record = resumed.record.status === "queued" ? await service.markRunning(runId) : resumed.record;
+
+    /*
+      What this stretch is about to be driven with, before it is driven with it.
+
+      Written per DRIVE and not inside `markRunning`, which fires once: a resume picks the model up
+      from the configuration as it stands now, so a run resumed after an operator changed it ran on
+      two different things and a single entry would name only the first. Each stretch says what it
+      ran on, and a reader who finds two that disagree has found the fact worth finding.
+
+      Before the first turn rather than after the last, because a run that fails or is cancelled is
+      exactly the run somebody asks this question about.
+    */
+    await service.recordDriver(runId, {
+      modelId: model.modelId,
+      provider: model.provider,
+      tuning: tuningProvenance(),
+    });
 
     // Read from the record and not from a module constant: the turn ceiling is one of
     // the four figures the decision table varies per workflow, and a drive that used

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -2407,7 +2407,7 @@ export async function runInvestigation(
     await service.recordDriver(runId, {
       modelId: model.modelId,
       provider: model.provider,
-      tuning: tuningProvenance(),
+      tuning: tuningProvenance(model.modelId),
     });
 
     // Read from the record and not from a module constant: the turn ceiling is one of

--- a/src/lib/agent/model-tuning/index.ts
+++ b/src/lib/agent/model-tuning/index.ts
@@ -75,6 +75,15 @@ export type OperatorTuningStatus =
   | { readonly state: "ignored"; readonly path: string; readonly reason: string };
 
 let active: ModelTuning | null = null;
+/**
+ * The model ids the operator's document supplied, lower-cased.
+ *
+ * Kept because provenance is a question about ONE model: a document that names `mistral-small:24b`
+ * did not drive a run on `gemini-3.5-flash-lite`, and saying it did names a file that never touched
+ * the run. `activeTuning` merges the two maps and forgets which side each entry came from, so the
+ * keys are recorded as they are merged.
+ */
+let operatorModels: ReadonlySet<string> = new Set();
 let operatorStatus: OperatorTuningStatus = { state: "unset" };
 
 /** The operator's document with the digest of what was read, or the reason it is not used. Never throws. */
@@ -82,12 +91,16 @@ function readOperatorDocument(
   path: string,
 ): { readonly doc: ModelTuning; readonly digest: string } | { readonly reason: string } {
   try {
-    const text = readFileSync(path, "utf8");
+    // Read as BYTES and hashed as bytes. `readFileSync(path, "utf8")` decodes, and decoding is
+    // lossy: invalid UTF-8 inside an otherwise parseable document becomes U+FFFD, so two different
+    // files can re-encode to one string and hash the same. A digest that cannot tell two files
+    // apart is not doing the job the path was recorded for.
+    const bytes = readFileSync(path);
     // The tolerant contract, because this document has a different author: see `parseOperatorTuning`.
-    const doc = parseOperatorTuning(JSON.parse(text), path);
+    const doc = parseOperatorTuning(JSON.parse(bytes.toString("utf8")), path);
     // Hashed here rather than by the caller, because THESE are the bytes that were parsed: a
     // second read to hash could get a different file, which is the one thing a digest must rule out.
-    return { doc, digest: createHash("sha256").update(text).digest("hex") };
+    return { doc, digest: createHash("sha256").update(bytes).digest("hex") };
   } catch (error) {
     return { reason: error instanceof Error ? error.message : String(error) };
   }
@@ -123,6 +136,7 @@ export function activeTuning(): ModelTuning {
     return active;
   }
 
+  operatorModels = new Set(Object.keys(read.doc.models));
   active = {
     // Whole entries, later wins.
     models: { ...base.models, ...read.doc.models },
@@ -171,15 +185,21 @@ export function operatorTuningStatus(): OperatorTuningStatus {
  * shipped settings because nobody configured a document and one driven by them because the
  * operator's could not be read behave identically and mean opposite things.
  */
-export function tuningProvenance(): AgentRunTuningProvenance {
+export function tuningProvenance(modelId: string): AgentRunTuningProvenance {
   const status = operatorTuningStatus();
   if (status.state === "unset") return { origin: "bundled" };
-  if (status.state === "ignored") return { origin: "operator-ignored", path: status.path };
-  return { origin: "operator", path: status.path, digest: status.digest };
+  if (status.state === "ignored") return { origin: "operator-ignored" };
+  // Applied, but silent about this model: the run was driven by the shipped settings, and saying
+  // otherwise would attribute it to a document that contributed nothing to it. Lower-cased because
+  // that is how the register is keyed, and a provenance that disagreed with the resolver about
+  // which entry applies would be worse than none.
+  if (!operatorModels.has(modelId.toLowerCase())) return { origin: "bundled" };
+  return { origin: "operator", digest: status.digest };
 }
 
 /** Drops the memo so a test can change the environment and read the result. */
 export function resetTuning(): void {
   active = null;
   operatorStatus = { state: "unset" };
+  operatorModels = new Set();
 }

--- a/src/lib/agent/model-tuning/index.ts
+++ b/src/lib/agent/model-tuning/index.ts
@@ -25,9 +25,11 @@
  * why. `../config.ts` states the same fail-open policy for its own variable: a mistyped setting
  * must not take the runtime down. Fail-open with no diagnosis is just a setting that does nothing.
  */
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { logger } from "@/lib/logger";
 import { agentModelTuningPath } from "../config";
+import type { AgentRunTuningProvenance } from "../types";
 import { type ModelTuning, parseOperatorTuning, parseTuning } from "./schema";
 import bundled from "./measured-profiles.json";
 
@@ -57,17 +59,35 @@ export type OperatorTuningStatus =
        * an operator's `retryEmtpyTurn` would do nothing and say nothing.
        */
       readonly ignoredKeys: readonly string[];
+      /**
+       * SHA-256 of the document's bytes AS READ.
+       *
+       * The path says which file; this says which version of it. A run recorded against a path
+       * alone cannot be told apart from a run against that path after somebody edited it, which
+       * is most of what recording the path was for.
+       *
+       * Of the bytes rather than of the parsed result: a parsed object would have to be
+       * serialised to be hashed, and two serialisations of one document are the same file while
+       * two files that happen to mean the same thing are not the same evidence.
+       */
+      readonly digest: string;
     }
   | { readonly state: "ignored"; readonly path: string; readonly reason: string };
 
 let active: ModelTuning | null = null;
 let operatorStatus: OperatorTuningStatus = { state: "unset" };
 
-/** The operator's document, or the reason it is not being used. Never throws. */
-function readOperatorDocument(path: string): { readonly doc: ModelTuning } | { readonly reason: string } {
+/** The operator's document with the digest of what was read, or the reason it is not used. Never throws. */
+function readOperatorDocument(
+  path: string,
+): { readonly doc: ModelTuning; readonly digest: string } | { readonly reason: string } {
   try {
+    const text = readFileSync(path, "utf8");
     // The tolerant contract, because this document has a different author: see `parseOperatorTuning`.
-    return { doc: parseOperatorTuning(JSON.parse(readFileSync(path, "utf8")), path) };
+    const doc = parseOperatorTuning(JSON.parse(text), path);
+    // Hashed here rather than by the caller, because THESE are the bytes that were parsed: a
+    // second read to hash could get a different file, which is the one thing a digest must rule out.
+    return { doc, digest: createHash("sha256").update(text).digest("hex") };
   } catch (error) {
     return { reason: error instanceof Error ? error.message : String(error) };
   }
@@ -115,6 +135,7 @@ export function activeTuning(): ModelTuning {
     path,
     models: Object.keys(read.doc.models).length,
     ignoredKeys: read.doc.ignoredKeys,
+    digest: read.digest,
   };
   logger.info("Operator model tuning applied over the measurements Studio ships with", {
     route: "agent/model-tuning",
@@ -135,6 +156,26 @@ export function activeTuning(): ModelTuning {
 export function operatorTuningStatus(): OperatorTuningStatus {
   activeTuning();
   return operatorStatus;
+}
+
+/**
+ * The same fact a run needs to record: where the settings that drove it came from.
+ *
+ * Here rather than in the drive, because it is a projection of THIS module's status and belongs
+ * beside the thing it projects. In the drive it would be a four-line mapping nothing could test
+ * without driving a model.
+ *
+ * `unset` becomes `bundled` rather than being left out: a ledger silent about provenance and one
+ * that says "the shipped measurements" are different claims, and only the second is checkable.
+ * `ignored` keeps its own origin for the reason the fail-open policy exists — a run driven by the
+ * shipped settings because nobody configured a document and one driven by them because the
+ * operator's could not be read behave identically and mean opposite things.
+ */
+export function tuningProvenance(): AgentRunTuningProvenance {
+  const status = operatorTuningStatus();
+  if (status.state === "unset") return { origin: "bundled" };
+  if (status.state === "ignored") return { origin: "operator-ignored", path: status.path };
+  return { origin: "operator", path: status.path, digest: status.digest };
 }
 
 /** Drops the memo so a test can change the environment and read the result. */

--- a/src/lib/agent/run-service.ts
+++ b/src/lib/agent/run-service.ts
@@ -127,6 +127,15 @@ export type AgentRunNarrativeEvent = Extract<
 type WithoutTimestamp<T> = T extends unknown ? Omit<T, "atMs"> : never;
 
 /**
+ * The one event `recordDriver` writes, named here so its method's parameter cannot widen.
+ *
+ * Extracted rather than spelled out again: the shape lives in `AgentRunEvent` with the reasoning
+ * for each of its three provenance cases, and a second copy here would be a second place for it
+ * to drift from the ledger it is written into.
+ */
+type AgentRunDriverEvent = Extract<AgentRunEvent, { kind: "driver-resolved" }>;
+
+/**
  * A narrative entry as a CALLER states it: everything but the timestamp, which
  * the service stamps from its own clock. A caller that supplied one could date a
  * run's history from a different clock than the one every other entry uses.
@@ -303,6 +312,33 @@ export class AgentRunService {
     }
     await this.store.appendEvent(runId, { kind: "run-started", atMs: this.clock(), mode: view.record.mode });
     return (await this.readOrThrow(runId)).record;
+  }
+
+  /**
+   * Records WHAT DROVE this stretch of the run: the model, and where its settings came from.
+   *
+   * Its own method rather than an admission to `recordEvent`, on that method's own rule. The
+   * narrative type there is the access control, and this is not something the run narrated — it
+   * is a lifecycle fact, the same class as `run-started`, and it is written by the drive at the
+   * moment it resolves a model rather than by anything the model did.
+   *
+   * Per DRIVE and not per run, which is why it is not folded into `markRunning`: that fires once,
+   * and a resume can pick up a different model after an operator changed the configuration and
+   * restarted. Each stretch writes what it ran on, so a resumed run carries one entry per stretch
+   * and a reader can see them disagree.
+   *
+   * Running only, like every other write here: a queued run's ledger is not open for entries and
+   * a terminal one's is closed.
+   */
+  async recordDriver(runId: string, driver: Omit<AgentRunDriverEvent, "atMs" | "kind">): Promise<void> {
+    const view = await this.readOrThrow(runId);
+    if (view.record.status !== "running") {
+      throw new AgentRunServiceError("RUN_NOT_RUNNING", `agent run "${runId}" is ${view.record.status}`);
+    }
+    // `kind` is the method's, not the caller's: this writes exactly one event, so asking a caller
+    // to restate its name is a field they can only get wrong. `recordEvent` takes it because it
+    // accepts many kinds and the kind is the choice being made there.
+    await this.store.appendEvent(runId, { ...driver, kind: "driver-resolved", atMs: this.clock() });
   }
 
   /**

--- a/src/lib/agent/run-store.ts
+++ b/src/lib/agent/run-store.ts
@@ -98,6 +98,7 @@ export const AGENT_RUN_ID_PATTERN = /^[A-Za-z0-9_]{1,64}$/;
 const EVENT_KINDS: ReadonlySet<string> = new Set(
   Object.keys({
     "run-started": true,
+    "driver-resolved": true,
     "context-captured": true,
     "statement-drafted": true,
     "tool-invoked": true,

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -44,17 +44,6 @@
 import type { Role } from "@/lib/auth";
 import type { LLMProviderType } from "@/lib/llm/types";
 
-/**
- * Where the settings that drove a run came from.
- *
- * A named type rather than an inline union because two places need the same shape: the ledger
- * event that records it, and `model-tuning`'s projection from its own status onto it. Spelled
- * twice, the two would drift, and the drift would be invisible — both sides would still compile.
- */
-export type AgentRunTuningProvenance =
-  | { readonly origin: "bundled" }
-  | { readonly origin: "operator"; readonly path: string; readonly digest: string }
-  | { readonly origin: "operator-ignored"; readonly path: string };
 import type { PolicyDenyCode } from "@/lib/db/operations/policy";
 import type { AgentStatementViolation } from "@/lib/db/operations/statement-guard";
 import type { AgentChartSpec, DatabaseType, TableSchema } from "@/lib/types";
@@ -64,6 +53,29 @@ import type { AgentInventoryNoun } from "./inventory-noun";
 import type { PlanStatementIdentifiers } from "./plan-statement";
 import type { AgentPlanSummary } from "./plan-summary";
 import type { AgentTableProfile } from "./table-profile";
+
+/**
+ * Where the settings that drove a run came from — for THIS model, not for the server.
+ *
+ * A named type rather than an inline union because two places need the same shape: the ledger
+ * event that records it, and `model-tuning`'s projection from its own status onto it. Spelled
+ * twice, the two would drift, and the drift would be invisible — both sides would still compile.
+ *
+ * `operator` means the operator's document supplied THIS model's entry. A document that was applied
+ * but says nothing about the model a run used did not drive that run, and reads `bundled`.
+ *
+ * NO PATH, and that is a boundary rather than an omission. This event is part of the run record,
+ * and `GET /api/agent/runs/[runId]` serves that record — with its events — to the run's OWNER, who
+ * is an ordinary user: `agent-run-access.ts` matches on `actor.sessionId` and asks for no role. An
+ * absolute server path here would be topology handed to every user who starts a run, and hiding it
+ * in the rail would not help, because the API is where it would leak. The digest identifies WHICH
+ * version drove the run without saying where the file lives, and which file that is belongs to
+ * `GET /api/agent/config`, which is admin-only and says so.
+ */
+export type AgentRunTuningProvenance =
+  | { readonly origin: "bundled" }
+  | { readonly origin: "operator"; readonly digest: string }
+  | { readonly origin: "operator-ignored" };
 
 /**
  * Which surface a run drives. Planning is TOOLLESS — the model is handed no tool at
@@ -514,6 +526,9 @@ export type AgentRunEvent =
        * A run driven by the shipped settings because nobody configured a document, and one driven
        * by them because the operator's could not be read, behave identically and mean opposite
        * things — the second is a misconfiguration nobody has noticed yet.
+       *
+       * Per MODEL: see `AgentRunTuningProvenance` for why a document that was applied can still
+       * read `bundled` here, and for why no path is carried.
        */
       readonly tuning: AgentRunTuningProvenance;
     })

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -42,6 +42,19 @@
  */
 
 import type { Role } from "@/lib/auth";
+import type { LLMProviderType } from "@/lib/llm/types";
+
+/**
+ * Where the settings that drove a run came from.
+ *
+ * A named type rather than an inline union because two places need the same shape: the ledger
+ * event that records it, and `model-tuning`'s projection from its own status onto it. Spelled
+ * twice, the two would drift, and the drift would be invisible — both sides would still compile.
+ */
+export type AgentRunTuningProvenance =
+  | { readonly origin: "bundled" }
+  | { readonly origin: "operator"; readonly path: string; readonly digest: string }
+  | { readonly origin: "operator-ignored"; readonly path: string };
 import type { PolicyDenyCode } from "@/lib/db/operations/policy";
 import type { AgentStatementViolation } from "@/lib/db/operations/statement-guard";
 import type { AgentChartSpec, DatabaseType, TableSchema } from "@/lib/types";
@@ -476,6 +489,34 @@ interface AgentRunEventBase {
  */
 export type AgentRunEvent =
   | (AgentRunEventBase & { readonly kind: "run-started"; readonly mode: AgentRunMode })
+  | (AgentRunEventBase & {
+      /**
+       * What drove this stretch of the run: the model, and where its settings came from.
+       *
+       * Written because a finished run said neither. The record carries no model id and no event
+       * did either, so "these settings were measured" — the product's whole claim about a model —
+       * was not checkable from the run that used them. Once a tuning document can arrive from an
+       * operator's disk, neither was "which settings", and `GET /api/agent/config` answers only
+       * for the server at the moment somebody asks rather than for a run read afterwards.
+       *
+       * Per DRIVE rather than per run: a resume can pick up a different model, so a resumed run
+       * carries one of these per stretch and each says what that stretch ran on. A reader takes
+       * the last, or notices they disagree, which is the fact worth noticing.
+       */
+      readonly kind: "driver-resolved";
+      readonly modelId: string;
+      readonly provider: LLMProviderType;
+      /**
+       * `bundled` is written rather than left out: a ledger silent about provenance and one that
+       * says "the shipped measurements" are different claims, and only the second is checkable.
+       *
+       * `operator-ignored` is its own case because the fail-open policy rests on the distinction.
+       * A run driven by the shipped settings because nobody configured a document, and one driven
+       * by them because the operator's could not be read, behave identically and mean opposite
+       * things — the second is a misconfiguration nobody has noticed yet.
+       */
+      readonly tuning: AgentRunTuningProvenance;
+    })
   | (AgentRunEventBase & {
       readonly kind: "context-captured";
       readonly fingerprint: string;

--- a/tests/evals/database-assessment.test.ts
+++ b/tests/evals/database-assessment.test.ts
@@ -81,6 +81,7 @@ describe("the assessment arc, on both reference engines", () => {
       // protection — found by review on #345.
       expect(drive.kinds).toEqual([
         "run-started",
+        "driver-resolved",
         "context-captured",
         "tool-invoked",
         "table-profiled",
@@ -370,6 +371,7 @@ describe("a profile that does not settle cleanly", () => {
     await expect(run.drive([profiles("engineering")])).rejects.toThrow(/pool went away/);
     expect((await run.events()).map((event) => event.kind)).toEqual([
       "run-started",
+      "driver-resolved",
       "context-captured",
       "tool-invoked",
     ]);
@@ -514,6 +516,7 @@ describe("the verdict is previewed before the report lands, not after the run di
 
     expect(drive.kinds).toEqual([
       "run-started",
+      "driver-resolved",
       "context-captured",
       "tool-invoked",
       "table-profiled",

--- a/tests/evals/investigation-arc.test.ts
+++ b/tests/evals/investigation-arc.test.ts
@@ -56,6 +56,7 @@ describe("an investigation that answers, on both reference engines", () => {
 
       expect(drive.kinds).toEqual([
         "run-started",
+        "driver-resolved",
         "context-captured",
         "statement-drafted",
         "tool-invoked",
@@ -134,6 +135,7 @@ describe("a planning run is judged by what planning mode can produce", () => {
     // and `plan-statement-drafted` when the statement became a fact about the run.
     expect(drive.kinds).toEqual([
       "run-started",
+      "driver-resolved",
       "context-captured",
       "closing-statement",
       "plan-statement-drafted",
@@ -150,7 +152,13 @@ describe("a planning run is judged by what planning mode can produce", () => {
 
     const drive = await run.drive([answersProse("First I would ", "read the employees table.")]);
 
-    expect(drive.kinds).toEqual(["run-started", "context-captured", "closing-statement", "run-finished"]);
+    expect(drive.kinds).toEqual([
+      "run-started",
+      "driver-resolved",
+      "context-captured",
+      "closing-statement",
+      "run-finished",
+    ]);
     expect(drive.verdict).toEqual({
       outcome: "unanswered",
       verifier: "agent-planning.1",
@@ -165,7 +173,7 @@ describe("a planning run is judged by what planning mode can produce", () => {
 
     // Grounded and still mute: being given the schema is not being given an answer,
     // which is what keeps the verdict a measurement of what the run PRODUCED.
-    expect(drive.kinds).toEqual(["run-started", "context-captured", "run-finished"]);
+    expect(drive.kinds).toEqual(["run-started", "driver-resolved", "context-captured", "run-finished"]);
     expect(drive.verdict.unmet).toEqual(["no-plan"]);
   });
 
@@ -194,7 +202,13 @@ describe("a planning run is judged by what planning mode can produce", () => {
     expect(reading.statements).toHaveLength(3);
     // No capture, and no catalog re-read: the inventory was given for free. The one
     // statement it did send is the statistics read, which no hold carries.
-    expect(drive.kinds).toEqual(["run-started", "closing-statement", "plan-statement-drafted", "run-finished"]);
+    expect(drive.kinds).toEqual([
+      "run-started",
+      "driver-resolved",
+      "closing-statement",
+      "plan-statement-drafted",
+      "run-finished",
+    ]);
     expect(drive.modelStatements).toEqual([]);
     expect(drive.statements).toHaveLength(1);
     expect(drive.statements[0]).toContain("pg_stats");

--- a/tests/evals/legacy-surface-coverage.test.ts
+++ b/tests/evals/legacy-surface-coverage.test.ts
@@ -94,6 +94,7 @@ describe("NL2SQL's happy path, as an agent run", () => {
 
       expect(drive.kinds).toEqual([
         "run-started",
+        "driver-resolved",
         "context-captured",
         "statement-drafted",
         "tool-invoked",
@@ -293,6 +294,7 @@ describe("Autopilot's happy path, as an agent run", () => {
 
       expect(drive.kinds).toEqual([
         "run-started",
+        "driver-resolved",
         "context-captured",
         "tool-invoked",
         "table-profiled",

--- a/tests/evals/operations.test.ts
+++ b/tests/evals/operations.test.ts
@@ -76,6 +76,7 @@ describe("the operations arc, on every engine including one agent mode otherwise
       const grounded = engine === "mysql" ? [] : ["context-captured"];
       expect(drive.kinds).toEqual([
         "run-started",
+        "driver-resolved",
         ...grounded,
         "tool-invoked",
         "tool-completed",
@@ -340,6 +341,7 @@ describe("an engine that cannot serve a reading", () => {
     // stopped. Which of those three the reader is looking at used to be a guess.
     expect(drive.kinds).toEqual([
       "run-started",
+      "driver-resolved",
       "tool-invoked",
       "tool-refused",
       "guidance-issued",

--- a/tests/evals/query-optimization.test.ts
+++ b/tests/evals/query-optimization.test.ts
@@ -111,6 +111,7 @@ describe("the optimization arc, on both reference engines", () => {
 
       expect(drive.kinds).toEqual([
         "run-started",
+        "driver-resolved",
         "context-captured",
         "statement-drafted",
         "tool-invoked",

--- a/tests/evals/resilience.test.ts
+++ b/tests/evals/resilience.test.ts
@@ -58,6 +58,7 @@ describe("a drive that dies mid-run leaves a run another process can finish", ()
     const afterCrash = (await run.events()).map((event) => event.kind);
     expect(afterCrash).toEqual([
       "run-started",
+      "driver-resolved",
       "context-captured",
       "statement-drafted",
       "tool-invoked",
@@ -257,6 +258,7 @@ describe("a statement that fails at the database is repaired, not repeated", () 
 
     expect(drive.kinds).toEqual([
       "run-started",
+      "driver-resolved",
       "context-captured",
       "statement-drafted",
       "tool-invoked",

--- a/tests/evals/resilience.test.ts
+++ b/tests/evals/resilience.test.ts
@@ -79,6 +79,30 @@ describe("a drive that dies mid-run leaves a run another process can finish", ()
     expect(resumed.statements).toEqual([]);
   });
 
+  test("each stretch of a resumed run records what drove IT, not what drove the first", async () => {
+    const run = await open();
+
+    await expect(run.drive([callsTool("run_read_query", { sql: FIRST, rationale: "count" })])).rejects.toThrow(
+      /died before turn/,
+    );
+
+    // The resume names a DIFFERENT model, which is the case the entry exists for: an
+    // operator changed the configuration between the crash and the restart, and a run
+    // recorded once at its start would attribute the whole of it to the model it opened
+    // on. Driven through `driveModel` rather than `drive` because the model id is what
+    // is under test here and only that entry point lets a drive choose one.
+    const resumed = await run.driveModel(
+      await modelOver(scriptedModel(reportOn()).fetch, "https://api.openai.com/v1", "gpt-4o-nano"),
+    );
+    expect(resumed.status).toBe("succeeded");
+
+    const drivers = (await run.events()).filter((event) => event.kind === "driver-resolved");
+    // Two, in the order they drove, naming what each ran on. One entry — the shape a
+    // once-per-run regression would leave — cannot satisfy this, and neither can two
+    // that both name the opening model.
+    expect(drivers.map((event) => event.modelId)).toEqual(["gpt-4o-mini", "gpt-4o-nano"]);
+  });
+
   test("a resumed run is told what it established, without being handed the rows again", async () => {
     const run = await open();
 

--- a/tests/evals/strategy-defects.test.ts
+++ b/tests/evals/strategy-defects.test.ts
@@ -140,6 +140,7 @@ describe("#341 F2: the run investigates competently and finishes without composi
     // could not tell a model that thought it had reported from one that had simply finished.
     expect(drive.kinds).toEqual([
       "run-started",
+      "driver-resolved",
       "context-captured",
       "statement-drafted",
       "tool-invoked",

--- a/tests/isolated/agent-investigation-e2e.test.ts
+++ b/tests/isolated/agent-investigation-e2e.test.ts
@@ -478,6 +478,7 @@ const kindsOf = (events: readonly AgentRunEvent[]): string[] => events.map((even
  */
 const ARC_LEDGER = [
   "run-started",
+  "driver-resolved",
   // The drive's own schema capture, before the model was asked anything (T8).
   "context-captured",
   // Beat 1: the initial draft, recorded before the call it describes.

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -332,6 +332,7 @@ describe("a fresh run drives the investigation arc", () => {
     expect(result.turns).toBe(2);
     expect(kindsOf(await eventsOf(b.store, run.runId))).toEqual([
       "run-started",
+      "driver-resolved",
       // The drive's own schema capture, before the model was asked anything.
       "context-captured",
       "statement-drafted",
@@ -420,6 +421,7 @@ describe("a fresh run drives the investigation arc", () => {
     const events = await eventsOf(b.store, run.runId);
     expect(kindsOf(events)).toEqual([
       "run-started",
+      "driver-resolved",
       "context-captured",
       "tool-invoked",
       "tool-completed",
@@ -3516,7 +3518,23 @@ describe("the run reads its schema context through the catalog tool", () => {
     expect(catalogStatements(b)[1]).toContain("pg_constraint");
     expect(catalogStatements(b)[2]).toContain("pg_index");
     expect(b.acquireProvider).toHaveBeenCalledTimes(CONTEXT_READS);
-    expect(kindsOf(await eventsOf(b.store, run.runId))[1]).toBe("context-captured");
+    /*
+      "Before the first turn" as an ORDER rather than an index. This read `kinds[1]`, which said
+      the same thing only for as long as exactly one event preceded it — and the day another
+      opening record was added the assertion failed while the property it names still held.
+
+      The property is that nothing the model did comes first: the inventory is captured, and only
+      then does the run have anything to say. Asserted against every event that represents model
+      activity rather than against a position, so a new opening record cannot break it and a
+      capture that genuinely slipped past the first turn cannot pass.
+    */
+    const kinds = kindsOf(await eventsOf(b.store, run.runId));
+    const captured = kinds.indexOf("context-captured");
+    expect(captured).toBeGreaterThan(-1);
+    for (const activity of ["tool-invoked", "statement-drafted", "closing-statement", "report-composed"]) {
+      const at = kinds.indexOf(activity);
+      if (at !== -1) expect(captured).toBeLessThan(at);
+    }
   });
 
   test("the packed inventory reaches the model fenced, carrying the fingerprint a claim can cite", async () => {

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -189,6 +189,44 @@ describe("foldLedgerEntries", () => {
     that says the run stopped without a cited report — which is the difference
     between "succeeded" and "answered".
   */
+  test("the rail names the model that drove the run, and never the document behind it", () => {
+    /*
+      Two halves, and the second is the one worth having.
+
+      SHOWN: which model produced a run was not visible anywhere in this interface. For somebody
+      running several local models it is the first thing they want to know about a run they are
+      reading back, and the ledger now carries it.
+
+      NOT SHOWN: the tuning provenance the same event carries. A mounted document's path is server
+      topology and its digest is an auditing detail — they answer "which settings drove this" for
+      whoever deploys the server, and that reader has `GET /api/agent/config`. A filesystem path
+      rendered into a user's timeline is a leak, and this asserts the absence rather than trusting
+      the mapping to keep omitting it.
+    */
+    const view = foldLedgerEntries([
+      OPENED,
+      event({ kind: "event", event: { kind: "run-started", atMs: 2, mode: "agent" } }),
+      event({
+        kind: "event",
+        event: {
+          kind: "driver-resolved",
+          atMs: 3,
+          modelId: "qwen3:8b",
+          provider: "ollama",
+          tuning: { origin: "operator", path: "/etc/libredb/model-tuning.json", digest: "c".repeat(64) },
+        },
+      }),
+    ]);
+
+    const driver = view.items.at(-1);
+    expect(driver?.headline).toBe("Driven by qwen3:8b");
+    expect(driver?.chrome).toBe(true);
+    expect(driver?.tone).toBe("neutral");
+    const rendered = JSON.stringify(view.items);
+    expect(rendered).not.toContain("/etc/libredb/model-tuning.json");
+    expect(rendered).not.toContain("c".repeat(64));
+  });
+
   test("the model's closing prose becomes an entry of its own", () => {
     const view = foldLedgerEntries([
       OPENED,

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -197,11 +197,10 @@ describe("foldLedgerEntries", () => {
       running several local models it is the first thing they want to know about a run they are
       reading back, and the ledger now carries it.
 
-      NOT SHOWN: the tuning provenance the same event carries. A mounted document's path is server
-      topology and its digest is an auditing detail — they answer "which settings drove this" for
-      whoever deploys the server, and that reader has `GET /api/agent/config`. A filesystem path
-      rendered into a user's timeline is a leak, and this asserts the absence rather than trusting
-      the mapping to keep omitting it.
+      NOT SHOWN: the tuning provenance the same event carries. Its digest is an auditing detail —
+      it answers "which settings drove this" for whoever deploys the server, and that reader has
+      `GET /api/agent/config`. Asserted as an absence rather than trusted to the mapping, which is
+      how the path would have been caught had it stayed on the event at all.
     */
     const view = foldLedgerEntries([
       OPENED,
@@ -213,7 +212,7 @@ describe("foldLedgerEntries", () => {
           atMs: 3,
           modelId: "qwen3:8b",
           provider: "ollama",
-          tuning: { origin: "operator", path: "/etc/libredb/model-tuning.json", digest: "c".repeat(64) },
+          tuning: { origin: "operator", digest: "c".repeat(64) },
         },
       }),
     ]);
@@ -222,9 +221,11 @@ describe("foldLedgerEntries", () => {
     expect(driver?.headline).toBe("Driven by qwen3:8b");
     expect(driver?.chrome).toBe(true);
     expect(driver?.tone).toBe("neutral");
-    const rendered = JSON.stringify(view.items);
-    expect(rendered).not.toContain("/etc/libredb/model-tuning.json");
-    expect(rendered).not.toContain("c".repeat(64));
+    // The digest is the whole of what the event carries about the document now — the path was
+    // removed from the event itself, because this record is served to the run's owner and a
+    // server path is not theirs. The rail still must not print the digest: it identifies a
+    // deployment's configuration and answers a question the user did not ask.
+    expect(JSON.stringify(view.items)).not.toContain("c".repeat(64));
   });
 
   test("the model's closing prose becomes an entry of its own", () => {

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -506,33 +506,43 @@ describe("a document an operator supplies", () => {
     expect(status.state === "ignored" && status.path).toBe(resolve("not-a-real-document.json"));
   });
 
-  test("projects the three states onto what a run records, and loses nothing on the way", () => {
+  test("says operator ONLY for a model the operator's document actually supplied", () => {
     /*
-      The projection a run's ledger is written from. It lives beside the status rather than in the
-      drive because in the drive it would be four lines nothing could test without driving a model.
+      The provenance answers "what drove THIS run", not "what was configured on this server", and
+      the two come apart the moment a document names a model the run is not using.
 
-      All three cases asserted together, because the value of the third is exactly that it is not
-      the first: a run driven by the shipped settings because nobody configured a document and one
-      driven by them because the operator's could not be read behave identically and mean opposite
-      things.
+      Demonstrated by accident before it was fixed: a live check mounted a document for
+      `mistral-small:24b` — chosen precisely so it would not change the running model — drove
+      `gemini-3.5-flash-lite`, and the ledger recorded `operator` with that document's digest while
+      gemini's settings had come from the bundled one. The event named a file that had not touched
+      the run.
+
+      Lower-cased on the way in, because that is how the register is keyed and a provenance that
+      disagreed with the resolver about which entry applies would be worse than no provenance.
     */
+    const body = JSON.stringify(
+      document({ models: [{ id: "Some-Model:9B", measured: "m", settings: { retryEmptyTurn: true } }] }),
+    );
+    process.env[ENV] = writeDocument(body);
     resetTuning();
-    expect(tuningProvenance()).toEqual({ origin: "bundled" });
 
-    const body = JSON.stringify(document());
-    const good = writeDocument(body);
-    process.env[ENV] = good;
-    resetTuning();
-    expect(tuningProvenance()).toEqual({
+    expect(tuningProvenance("some-model:9b")).toEqual({
       origin: "operator",
-      path: good,
       digest: createHash("sha256").update(body).digest("hex"),
     });
+    // Applied, but silent about this model — so this model was driven by the shipped settings.
+    expect(tuningProvenance("gemini-3.5-flash-lite")).toEqual({ origin: "bundled" });
+  });
 
-    const bad = writeDocument("{ not json");
-    process.env[ENV] = bad;
+  test("projects the other two states onto what a run records", () => {
     resetTuning();
-    expect(tuningProvenance()).toEqual({ origin: "operator-ignored", path: bad });
+    expect(tuningProvenance("qwen3:8b")).toEqual({ origin: "bundled" });
+
+    process.env[ENV] = writeDocument("{ not json");
+    resetTuning();
+    // No path: the ledger is readable by any owner of the run, and a server filesystem path is
+    // not theirs to read. Which file it was belongs to `GET /api/agent/config`, which is admin-only.
+    expect(tuningProvenance("qwen3:8b")).toEqual({ origin: "operator-ignored" });
   });
 
   test("reports nothing configured when no path was set", () => {

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -6,10 +6,11 @@
  * also how a document that arrives from somewhere else will be checked.
  */
 import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { activeTuning, operatorTuningStatus, resetTuning } from "@/lib/agent/model-tuning";
+import { activeTuning, operatorTuningStatus, resetTuning, tuningProvenance } from "@/lib/agent/model-tuning";
 import bundled from "@/lib/agent/model-tuning/measured-profiles.json";
 import {
   ModelTuningError,
@@ -463,6 +464,25 @@ describe("a document an operator supplies", () => {
     expect(status.state === "ignored" && status.reason).toContain("JSON");
   });
 
+  test("reports a digest of the document it applied, so a later edit is visible", () => {
+    /*
+      The status says WHICH file; the digest says WHICH VERSION of it. A run recorded against a
+      path alone cannot be told apart from a run against the same path after somebody edited it,
+      which is most of the value of recording the path at all.
+
+      Of the bytes as read, not of the parsed result: a parsed object would have to be serialised
+      to be hashed, and two serialisations of one document are the same file while two files with
+      the same meaning are not the same evidence.
+    */
+    const body = JSON.stringify(document());
+    process.env[ENV] = writeDocument(body);
+    resetTuning();
+    const status = operatorTuningStatus();
+
+    expect(status.state).toBe("applied");
+    expect(status.state === "applied" && status.digest).toBe(createHash("sha256").update(body).digest("hex"));
+  });
+
   test("reports the document it applied, and how many models it carried", () => {
     process.env[ENV] = writeDocument(document());
     resetTuning();
@@ -484,6 +504,35 @@ describe("a document an operator supplies", () => {
     const status = operatorTuningStatus();
     expect(status.state).toBe("ignored");
     expect(status.state === "ignored" && status.path).toBe(resolve("not-a-real-document.json"));
+  });
+
+  test("projects the three states onto what a run records, and loses nothing on the way", () => {
+    /*
+      The projection a run's ledger is written from. It lives beside the status rather than in the
+      drive because in the drive it would be four lines nothing could test without driving a model.
+
+      All three cases asserted together, because the value of the third is exactly that it is not
+      the first: a run driven by the shipped settings because nobody configured a document and one
+      driven by them because the operator's could not be read behave identically and mean opposite
+      things.
+    */
+    resetTuning();
+    expect(tuningProvenance()).toEqual({ origin: "bundled" });
+
+    const body = JSON.stringify(document());
+    const good = writeDocument(body);
+    process.env[ENV] = good;
+    resetTuning();
+    expect(tuningProvenance()).toEqual({
+      origin: "operator",
+      path: good,
+      digest: createHash("sha256").update(body).digest("hex"),
+    });
+
+    const bad = writeDocument("{ not json");
+    process.env[ENV] = bad;
+    resetTuning();
+    expect(tuningProvenance()).toEqual({ origin: "operator-ignored", path: bad });
   });
 
   test("reports nothing configured when no path was set", () => {

--- a/tests/unit/lib/agent/run-service.test.ts
+++ b/tests/unit/lib/agent/run-service.test.ts
@@ -276,14 +276,14 @@ describe("AgentRunService — what drove the run", () => {
     await h.service.recordDriver(runId, {
       modelId: "qwen3:8b",
       provider: "ollama",
-      tuning: { origin: "operator", path: "/etc/libredb/model-tuning.json", digest: "a".repeat(64) },
+      tuning: { origin: "operator", digest: "a".repeat(64) },
     });
 
     expect((await h.store.read(runId))?.record.events.at(-1)).toEqual({
       kind: "driver-resolved",
       modelId: "qwen3:8b",
       provider: "ollama",
-      tuning: { origin: "operator", path: "/etc/libredb/model-tuning.json", digest: "a".repeat(64) },
+      tuning: { origin: "operator", digest: "a".repeat(64) },
       atMs: 1_700_000_500_000,
     });
   });
@@ -320,11 +320,11 @@ describe("AgentRunService — what drove the run", () => {
     await h.service.recordDriver(runId, {
       modelId: "qwen3:4b",
       provider: "ollama",
-      tuning: { origin: "operator-ignored", path: "/etc/libredb/broken.json" },
+      tuning: { origin: "operator-ignored" },
     });
 
     expect((await h.store.read(runId))?.record.events.at(-1)).toMatchObject({
-      tuning: { origin: "operator-ignored", path: "/etc/libredb/broken.json" },
+      tuning: { origin: "operator-ignored" },
     });
   });
 

--- a/tests/unit/lib/agent/run-service.test.ts
+++ b/tests/unit/lib/agent/run-service.test.ts
@@ -253,6 +253,95 @@ describe("AgentRunService — recording what a run narrated", () => {
   });
 });
 
+describe("AgentRunService — what drove the run", () => {
+  /*
+    A finished run used to say nothing about what produced it: no model id anywhere in the record
+    or the ledger, and nothing about where the model's settings came from. So "these settings were
+    measured", which is the product's whole claim about a model, was not checkable from the run —
+    and once a tuning document can arrive from an operator's disk, neither was "which settings".
+
+    Its own method rather than `recordEvent`, on that method's own rule: the narrative type is the
+    access control, and what drove a run is a lifecycle fact rather than something the run
+    narrated. Called once per DRIVE rather than once per run, because a resume can pick up a
+    different model — so a resumed run carries one entry per stretch and each says what that
+    stretch ran on.
+  */
+  test("the model and the tuning it resolved through land in the ledger", async () => {
+    const clock = fakeClock();
+    const h = harness(clock.read);
+    const { runId } = await h.service.start(START_INPUT);
+    await h.service.markRunning(runId);
+
+    clock.set(1_700_000_500_000);
+    await h.service.recordDriver(runId, {
+      modelId: "qwen3:8b",
+      provider: "ollama",
+      tuning: { origin: "operator", path: "/etc/libredb/model-tuning.json", digest: "a".repeat(64) },
+    });
+
+    expect((await h.store.read(runId))?.record.events.at(-1)).toEqual({
+      kind: "driver-resolved",
+      modelId: "qwen3:8b",
+      provider: "ollama",
+      tuning: { origin: "operator", path: "/etc/libredb/model-tuning.json", digest: "a".repeat(64) },
+      atMs: 1_700_000_500_000,
+    });
+  });
+
+  test("a run driven by the shipped measurements says so, with no path to explain", async () => {
+    // `bundled` is the absence of an operator document, and it is written rather than left out:
+    // a ledger silent about provenance and one that says "the shipped ones" are different claims,
+    // and only the second is checkable.
+    const h = harness();
+    const { runId } = await h.service.start(START_INPUT);
+    await h.service.markRunning(runId);
+
+    await h.service.recordDriver(runId, {
+      modelId: "granite4.1:8b",
+      provider: "ollama",
+      tuning: { origin: "bundled" },
+    });
+
+    const event = (await h.store.read(runId))?.record.events.at(-1);
+    expect(event).toMatchObject({ kind: "driver-resolved", tuning: { origin: "bundled" } });
+  });
+
+  test("a document that was IGNORED is recorded as ignored, not as bundled", async () => {
+    /*
+      The distinction the whole fail-open policy rests on. A run driven by the shipped settings
+      because nobody configured a document, and one driven by them because the operator's document
+      could not be read, behave identically and mean opposite things — the second is a
+      misconfiguration nobody has noticed yet.
+    */
+    const h = harness();
+    const { runId } = await h.service.start(START_INPUT);
+    await h.service.markRunning(runId);
+
+    await h.service.recordDriver(runId, {
+      modelId: "qwen3:4b",
+      provider: "ollama",
+      tuning: { origin: "operator-ignored", path: "/etc/libredb/broken.json" },
+    });
+
+    expect((await h.store.read(runId))?.record.events.at(-1)).toMatchObject({
+      tuning: { origin: "operator-ignored", path: "/etc/libredb/broken.json" },
+    });
+  });
+
+  test("refuses a run the loop has not picked up yet, and writes nothing", async () => {
+    // The same rule every other write here obeys: a queued run's ledger is not open for entries.
+    const h = harness();
+    const { runId } = await h.service.start(START_INPUT);
+
+    const error = await captureServiceError(() =>
+      h.service.recordDriver(runId, { modelId: "qwen3:8b", provider: "ollama", tuning: { origin: "bundled" } }),
+    );
+
+    expect(error.reasonCode).toBe("RUN_NOT_RUNNING");
+    expect((await h.store.read(runId))?.record.events).toEqual([]);
+  });
+});
+
 describe("AgentRunService — finishing a run", () => {
   test("a finished run is terminal and releases its budget and its artifacts together", async () => {
     const h = harness();

--- a/tests/unit/lib/agent/types.test.ts
+++ b/tests/unit/lib/agent/types.test.ts
@@ -71,6 +71,16 @@ const DATABASE_ERROR: AgentToolRefusal = {
  */
 const EVENTS: Record<AgentRunEvent["kind"], AgentRunEvent> = {
   "run-started": { kind: "run-started", atMs: 1, mode: "agent" },
+  // What drove a stretch of the run. The `operator` provenance is the fixture rather than
+  // `bundled` because it is the shape with fields to get wrong, and the one an operator's
+  // deployment actually writes.
+  "driver-resolved": {
+    kind: "driver-resolved",
+    atMs: 1,
+    modelId: "qwen3:8b",
+    provider: "ollama",
+    tuning: { origin: "operator", path: "/etc/libredb/model-tuning.json", digest: "f".repeat(64) },
+  },
   // A call the server turned back, carrying the verifier's own name for what was missing.
   // `shortfall` is optional because the purpose-written notices answer conditions the
   // verifier has no vocabulary for — a run holding two plans and citing neither, say.

--- a/tests/unit/lib/agent/types.test.ts
+++ b/tests/unit/lib/agent/types.test.ts
@@ -79,7 +79,7 @@ const EVENTS: Record<AgentRunEvent["kind"], AgentRunEvent> = {
     atMs: 1,
     modelId: "qwen3:8b",
     provider: "ollama",
-    tuning: { origin: "operator", path: "/etc/libredb/model-tuning.json", digest: "f".repeat(64) },
+    tuning: { origin: "operator", digest: "f".repeat(64) },
   },
   // A call the server turned back, carrying the verifier's own name for what was missing.
   // `shortfall` is optional because the purpose-written notices answer conditions the


### PR DESCRIPTION
feat(agent): a run records what drove it — the model, and where its settings came from

B58, and its premise turned out to understate the gap. It said a run's ledger "records
the model id and nothing about where its settings came from". Measured: the record
carries `runId`, `mode`, `workflowType`, `workflowSource`, `workflowReading`,
`autoExecute`, `toolProtocol`, `status`, `actor`, `connectionId`, `objective` — and no
model id. No event carried one either; `run-started` carries only the mode.

So a finished run said neither which model produced it nor with what settings, which
makes "these settings were measured" — the product's whole claim about a model — not
checkable from the run that used them. `GET /api/agent/config` answers for the SERVER at
the moment somebody asks, which is not when the question gets asked.

`driver-resolved` carries the model, its provider, and the provenance of the settings:
`bundled`, `operator` with the document's path and a digest of the bytes as read, or
`operator-ignored` with the path. The third is its own case rather than folded into the
first, because that distinction is what the whole fail-open policy rests on: a run driven
by the shipped settings because nobody configured a document and one driven by them
because the operator's could not be read behave identically and mean opposite things.

FOUR DECISIONS WORTH THE REVIEW:

**An event, not a record field.** `record.events` already carries it, and a second home
for a written-once fact is a second thing to keep in sync. The ledger-compatibility gate
is unaffected either way — an old ledger simply has no such event — and it still folds
the 2026-08-12 fixture to the same timeline.

**Its own lifecycle method.** `recordEvent`'s parameter type is deliberate access
control: "admitting them here would give a caller a second way to write the entries the
durability argument rests on". What drove a run is not something the run narrated, so
`recordDriver` is its own method, and `kind` is the method's rather than the caller's —
one event means restating its name is a field a caller can only get wrong.

**Once per DRIVE, not once per run.** `markRunning` fires once; a resume picks the model
up from the configuration as it stands then. A run resumed after an operator changed it
ran on two things, and a single entry would name only the first. Each stretch says what
it ran on, and two that disagree are the fact worth finding. Written before the first
turn, because the run somebody asks this about is often the one that failed.

**The digest is taken where the bytes are read.** Hashing in the caller would mean a
second read, which could get a different file — the one thing a digest exists to rule out.

The rail renders the model and NOT the provenance, and a test asserts the absence rather
than trusting the mapping to keep omitting it: which model produced a run was not visible
anywhere in this interface and is the first thing somebody running several local models
wants, while a mounted document's path is server topology and belongs to the reader of
`/api/agent/config`.

Sixteen pinned event sequences across `tests/evals` and `tests/isolated` gained the new
kind. They are the ledger's observable shape and they were right to notice; filtering it
out of the eval harness would have kept them green and made the event's disappearance
unobservable. `ledger-compatibility` and its fixture are untouched — that ledger predates
this event and must keep folding without it.

One positional assertion became an ordering one. `kinds[1]` was read as "the inventory is
captured before the first turn", which held only while exactly one event preceded it. It
now asserts the capture precedes every event representing model activity, so a new opening
record cannot break it and a capture that genuinely slipped past the first turn cannot pass.

Verified: format, lint (0 errors), typecheck, knip, `bun run test` (33/33 groups), build,
and coverage:check at 42568/42568 lines.
