### PR TITLE
fix(tests): a mounted tuning document must not decide what the suite asserts

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -11,6 +11,18 @@ process.env.USER_EMAIL = "user@libredb.org";
 process.env.USER_PASSWORD = "LibreDB.2026";
 process.env.NEXT_PUBLIC_AUTH_PROVIDER = "local";
 (process.env as Record<string, string>).NODE_ENV = "test";
+/*
+  Deleted rather than set, because there is no value that means "the shipped measurements" —
+  the variable's own absence is what means it.
+
+  The lines above pin a developer's `.env` out of the way so a local credential cannot decide a
+  test's outcome. This one is the same rule for the agent's model tuning, and it is here because
+  the consequence is worse than a wrong assertion: a mounted document adds its models to the
+  merged register, two pinned tables in `model-resolution-table.test.ts` stop covering it, and
+  the suite goes red on a machine whose code is fine. The pre-commit hook runs that suite, so
+  the operator feature Studio ships would block committing to Studio.
+*/
+delete process.env.AGENT_MODEL_TUNING_PATH;
 
 // ─── In-memory localStorage mock (SSR/test environment) ────────────────────
 if (typeof globalThis.localStorage === "undefined") {


### PR DESCRIPTION
Found by using the feature rather than by reading the code. A local Ollama model sweep needed an operator tuning document, so `AGENT_MODEL_TUNING_PATH` went into `.env` — and the next command came back with two red tests on a tree whose code was fine.

## What happens

`bun test` loads `.env`. `modelProfiles()` returns the MERGED register, so the mounted document's model joins it, and two pinned tables in `model-resolution-table.test.ts` stop covering it:

- "the table covers every registered model" counts eleven where it pinned ten
- the digest table has no entry for a model that was never in the shipped document

Both assertions are correct and are being asked about the wrong universe. They mean what Studio **ships**; they were reading what this machine **runs**.

## Why it is worth a PR

The cost is not two wrong assertions. The pre-commit hook runs the suite, so a mounted document blocks committing to Studio at all: **the operator feature Studio ships locks the operator out of contributing to it**, and the redness reads as a code regression rather than as an environment.

## The fix

`tests/setup.ts` is where this is already solved. It overwrites `JWT_SECRET`, `ADMIN_EMAIL`, `USER_PASSWORD` and the rest for exactly this reason — a developer's `.env` may not decide a test's outcome. `AGENT_MODEL_TUNING_PATH` was simply not on the list.

Deleted rather than set: no value means "the shipped measurements", so the variable's absence is what means it.

The two files that deliberately mount a document — `model-tuning.test.ts` and `api/agent/config.test.ts` — set the variable themselves after the preload has run, so they are unaffected. Verified, not assumed.

## Verification, in the order that makes it evidence

| condition | result |
|---|---|
| document mounted, before this line | **2 failed**, 1252 passed |
| document mounted, after this line | **1254 passed**, 0 failed |
| clean environment, full suite | 33/33 groups |

Plus format, lint (0 errors), typecheck, knip and build.

**The limit, stated plainly:** CI's environment is clean, so CI can never exercise the dirty case. This guard is for the machine that has the variable set, and the measurement above is its only evidence.

## Scope

No production change. `modelProfiles()` has no caller under `src/` at all — it is exported for these tables — so nothing a user reaches was ever affected.
