### PR TITLE
ci(chocolatey): a deep moderation queue must not redden a release that published

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1261,23 +1261,82 @@ jobs:
             packaging/chocolatey/tools/chocolateyinstall.ps1.tmpl \
             dist/SHA256SUMS "$VERSION" pkg/choco/tools/chocolateyinstall.ps1
 
-      - name: Pack and push with the official choco container
+      - name: Pack with the official choco container
+        # Packing is this repository's own work - a broken template or a
+        # missing file is our bug, so this step stays blocking. It also runs
+        # without CHOCO_API_KEY in its environment: the key is only needed by
+        # the push below, and a container that never sees it cannot leak it.
         if: steps.choco.outputs.enabled == 'true'
         env:
-          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
           VERSION: ${{ needs.guard.outputs.version }}
         run: |
           # The image's `choco` wrapper already runs the Mono build with
           # --allow-unofficial; do not pass it again. Pinned by immutable
           # digest (the tag is readability only): a mutable latest-linux
           # would hand CHOCO_API_KEY to whatever the tag points at.
-          docker run --rm -v "$PWD/pkg/choco:/wd" -w /wd -e CHOCO_API_KEY -e VERSION \
+          docker run --rm -v "$PWD/pkg/choco:/wd" -w /wd -e VERSION \
             chocolatey/choco:v2.7.3-linux@sha256:ae878c6e550ed7bd0adfb958f2f54b3aadab585d6a9386ad9e23a1aae06bee3d sh -c '
               set -eu
               choco pack
+            '
+
+      - name: Push to the community repository
+        # Deliberately non-blocking. push.chocolatey.org answers 403 for
+        # reasons that are about ITS queue and not about this release:
+        # "package has a version in moderation and no approved versions" (what
+        # failed the 0.9.60 and 0.9.61 runs) and "package has too many
+        # existing versions in moderation" - and every new version waits for a
+        # human moderator, "a few days to a few weeks", until the package is
+        # granted trusted status. A release that published correctly must not
+        # go red because that queue is deep; the step below reports it instead.
+        id: push
+        continue-on-error: true
+        if: steps.choco.outputs.enabled == 'true'
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          docker run --rm -v "$PWD/pkg/choco:/wd" -w /wd -e CHOCO_API_KEY -e VERSION \
+            chocolatey/choco:v2.7.3-linux@sha256:ae878c6e550ed7bd0adfb958f2f54b3aadab585d6a9386ad9e23a1aae06bee3d sh -c '
+              set -eu
               choco push "libredb-studio.${VERSION}.nupkg" \
                 --source https://push.chocolatey.org/ --api-key="$CHOCO_API_KEY"
             '
+
+      - name: Report the community feed's moderation status
+        # A successful push means "accepted into moderation", not "published":
+        # the version stays unlisted until a moderator approves it, so the
+        # listed feed keeps serving the previous one (measured: a feed-wide
+        # `$filter=IsApproved eq false` returns nothing, while `eq true`
+        # returns rows). The exact-version entity is the one public read that
+        # can answer for a version the feed does not list, so it is what turns
+        # "pushed" into something a human can check without maintainer access.
+        # Informational only - never fails the run, and skipped when the pack
+        # step did not get far enough to push anything.
+        if: always() && steps.choco.outputs.enabled == 'true' && steps.push.outcome != 'skipped'
+        continue-on-error: true
+        env:
+          PUSH_OUTCOME: ${{ steps.push.outcome }}
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          feed="https://community.chocolatey.org/api/v2/Packages(Id='libredb-studio',Version='${VERSION}')"
+          # `|| true`: the default shell is `bash -e`, and an unreachable feed
+          # or an absent entity must degrade to "not visible yet", not kill the
+          # step before it can print the warning below.
+          status=$(curl -sS --max-time 30 "$feed" | grep -o '<d:PackageStatus>[^<]*' | head -1 | cut -d'>' -f2) || true
+          {
+            echo "### Chocolatey"
+            echo ""
+            echo "- push outcome: \`${PUSH_OUTCOME}\`"
+            echo "- community feed status for ${VERSION}: \`${status:-not visible yet}\`"
+            echo ""
+            echo "\`Approved\` means it is installable now; anything else means it is queued for"
+            echo "human moderation and \`choco install libredb-studio\` still serves the previous"
+            echo "version. See [DISTRIBUTION.md](https://github.com/libredb/libredb-studio/blob/main/docs/DISTRIBUTION.md#windows-winget--chocolatey--portable-zip)."
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$PUSH_OUTCOME" != "success" ]; then
+            echo "::warning::choco push for ${VERSION} did not succeed (outcome: ${PUSH_OUTCOME}). A 403 here is normally the moderation queue - too many unapproved versions - and not a fault in this release, which published correctly. Push the back version by hand once the queue drains."
+          fi
 
   winget:
     name: Submit winget update PR

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -791,7 +791,9 @@ channels:
       # moderator flcdrg. Until then push.chocolatey.org answered 403 for EVERY
       # version while an account's first submission is unapproved, which failed
       # the 0.9.60 and 0.9.61 release runs after the releases themselves had
-      # published fine.
+      # published fine. The push step is non-blocking now (a 403 for a deep
+      # moderation queue reports as a warning), so this flag no longer needs to
+      # carry that job alone.
       ci_enabled: true
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/114
@@ -805,7 +807,10 @@ channels:
         feed publishes no floating "latest" document, so the pin filters the OData package list to
         IsLatestVersion - one document, one match, whatever the published version count. It reads
         0.9.59 until the next release publishes through the now-enabled job, which is real lag and
-        not a broken pin.
+        not a broken pin. The feed lists APPROVED versions only, so a drift row here means the
+        version is waiting on human moderation rather than that the push failed; the release run's
+        job summary reports the push outcome and that version's PackageStatus. Trusted status is
+        what removes the wait - docs/BACKLOG.md REL3.
 
   - id: flathub
     name: Flathub community catalog (org.libredb.Studio)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -30,7 +30,7 @@ None of it is a GitHub issue.
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P5 · 5
 - [Documentation](#documentation) — DOC1–DOC3 · 3
-- [Release pipeline](#release-pipeline) — REL1–REL2 · 2
+- [Release pipeline](#release-pipeline) — REL1–REL3 · 3
 - [Chart configuration surface](#chart-configuration-surface) — N1–N3 · 3
 - [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 10
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C2–C10 · 9
@@ -921,6 +921,40 @@ label and that jammy-arm64 carries `libwebkit2gtk-4.1-dev`, not a blind flip on 
 **Done when:** the arm64 matrix entry builds on `ubuntu-22.04-arm`, the resulting AppImage is
 verified to load on a glibc 2.35 or 2.36 arm64 root filesystem, and the `not.toContain("latest")`
 assertion in the portability test is joined by an explicit arm64 label assertion.
+
+---
+
+### REL3. The Chocolatey package is not trusted, so every release waits on a human moderator
+
+The community repository human-reviews **every new version** before approval; only *trusted
+packages* skip that step, and the moderation team's own published figure for the wait is "a few days
+to a few weeks". Until a version is approved it stays unlisted, so a release can publish everywhere
+else while `choco install libredb-studio` still serves the previous version. The drift table shows
+this honestly — the pin reads the feed's approved version — and the release run degrades to a warning
+rather than a failure, so nothing here is broken. It is latency, and it is the only channel that has
+any.
+
+Two routes to trusted status are documented, and LibreDB already qualifies on the first: *"You write
+the underlying software that the package installs"*. But it is granted by hand — *"a manual change by
+a moderator... does not happen immediately even if you are the software author"* — and in most cases
+only *"after a few versions have been approved by moderators without any changes being required"*.
+As of 0.9.59 (approved 2026-08-24 by `flcdrg`) there is exactly one such approval, and the two
+guideline notes that submission raised were fixed in the templates by #208, so the next few should be
+clean.
+
+Not done now because asking after a single approval is asking early, and there is no form to submit:
+the route is the Chocolatey Community Hub `#community-maintainers` channel, or the site-admin contact
+form, identifying ourselves as the software vendor.
+
+The lag also has a second-order cost worth watching: `push.chocolatey.org` answers `403` when a
+package has *"too many existing versions in moderation"*, and the cap is not documented anywhere
+public (the gallery is closed source). A release cadence faster than the queue drains will find it.
+The push step tolerates that failure, but the affected version then needs a manual back-version push
+once the queue clears.
+
+**Done when:** the package carries trusted status — observable as a version reaching `Approved` in
+the feed within minutes of a push, with no human reviewer recorded — or a decision is written down
+that the moderation lag is accepted permanently and this entry is deleted.
 
 ---
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -755,6 +755,15 @@ choco install libredb-studio
 libredb-studio
 ```
 
+> **Organizations:** from **2027-01-01** Chocolatey's Terms of Service restrict *using* the
+> community repository to manage organizational fleets — pull the package into an internal
+> NuGet-compatible repository (Nexus, Artifactory, ProGet) or a proxy that caches the community
+> repository upstream, and install from there
+> ([policy update](https://blog.chocolatey.org/2026/06/updated-tos/)). The restriction is on
+> consumption, not publication: it does not touch this repository's ability to publish, personal
+> use stays permitted, and `choco install libredb-studio` is unchanged when it resolves from an
+> internal mirror. winget carries no equivalent restriction.
+
 Open http://127.0.0.1:3000 and log in with the printed credentials. Both packages install the
 same standalone zip: the server payload, a bundled private Node.js runtime (`node\node.exe`),
 and the `libredb-studio.exe` launcher — nothing else to install.
@@ -1255,11 +1264,52 @@ repo's Actions secrets. The FIRST listing in each community catalog is a one-tim
    set `links.first_pr`, and add a measurable pin where one exists. **Chocolatey is measured by a
    `remote_file` pin** on the community OData feed filtered to `IsLatestVersion`, which is what
    makes a single-match regex possible there: the feed enumerates every published version, so an
-   unfiltered listing would yield as many disagreeing matches as there are versions.
+   unfiltered listing would yield as many disagreeing matches as there are versions. Note what that
+   pin measures: the feed lists approved versions only, so a Chocolatey `DRIFT` row means the
+   version is still in moderation, not that the push failed.
    **winget is measured by a probe, not a regex pin** (`pin.strategy: probe`, `winget-max-version`):
    it publishes no floating "latest" document — the winget-pkgs contents listing enumerates every
    published version — so the checker takes the highest version enumerated there. A regex pin
    cannot express that, because it requires all matches in a source to agree.
+
+### Chocolatey moderation, and why its push step cannot fail a release
+
+`choco push` publishes nothing by itself. The community repository is a moderated feed: **every new
+version is human-reviewed before approval** — only *trusted packages* skip that — and the moderation
+team's own figure for the wait is "a few days to a few weeks"
+([moderation](https://docs.chocolatey.org/en-us/community-repository/moderation/),
+[Behind the Curtain](https://blog.chocolatey.org/2025/06/ccr-moderation-behind-the-curtain/)).
+An unapproved version stays unlisted, so `choco install libredb-studio` keeps serving the previous
+one until a moderator clicks approve.
+
+This is the one structural difference from winget. There is no PR to open and nothing manual per
+release — the community repository takes a `.nupkg` over an API and the `chocolatey` job pushes it —
+but what follows the push is a volunteer's queue, not an automated merge. Two consequences are
+encoded in the release path:
+
+- **The push step is `continue-on-error`; `choco pack` is not.** `push.chocolatey.org` answers `403`
+  for causes that belong to that queue rather than to this repository: *"package has a version in
+  moderation and no approved versions"* (what failed the 0.9.60 and 0.9.61 runs) and *"package has
+  too many existing versions in moderation"*
+  ([common errors](https://docs.chocolatey.org/en-us/community-repository/maintainers/common-errors/)),
+  the second of which becomes reachable whenever releases outpace the queue. A release that
+  published correctly must not go red for that. A pack failure is our own broken template, so it
+  still fails the run. `tests/unit/release-chocolatey.test.ts` locks both halves.
+- **The run's job summary carries a "Chocolatey" section** with the push outcome and what the feed
+  says about that exact version. It reads
+  `Packages(Id='libredb-studio',Version='<version>')` — the only public read that answers for a
+  version the feed does not list yet, since a feed-wide `$filter=IsApproved eq false` returns
+  nothing while `eq true` returns rows.
+
+**Trusted status is the fix, and it is a human decision.** The FAQ names two routes to it — *"You
+write the underlying software that the package installs"* and a track record of clean submissions —
+and is equally clear that switching a package to trusted *"is a manual change by a moderator. It is
+not an automated process, and does not happen immediately even if you are the software author"*, in
+most cases only *"after a few versions have been approved by moderators without any changes being
+required"*. LibreDB qualifies on the first route and has one clean approval (0.9.59). After two or
+three more, ask on the Chocolatey Community Hub (`#community-maintainers`) as the software vendor —
+tracked as REL3 in [`docs/BACKLOG.md`](BACKLOG.md). A trusted package skips human review entirely,
+and the channel then behaves the way winget does today.
 
 ### Channel inventory and drift check
 

--- a/tests/unit/release-chocolatey.test.ts
+++ b/tests/unit/release-chocolatey.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the Chocolatey publish job's failure containment (issue #114).
+ *
+ * Why a test for YAML: the community repository answers `403` to a push for
+ * reasons that are entirely about ITS queue and not about this repository -
+ * documented causes include "package has a version in moderation and no
+ * approved versions" and "package has too many existing versions in
+ * moderation". Every new version is human-reviewed before approval (only
+ * trusted packages skip that), and the moderation team's own figure for the
+ * wait is "a few days to a few weeks". So a release cadence faster than the
+ * queue drains WILL eventually hit that 403 - and an unguarded failure there
+ * turns a release that published perfectly into a red run, which is exactly
+ * the failure mode `update.ci_enabled` was invented to prevent and which the
+ * 0.9.60 and 0.9.61 runs already demonstrated once.
+ *
+ * The split matters as much as the tolerance: `choco pack` failing is OUR bug
+ * (a broken template, a missing file) and must stay loud, while `choco push`
+ * failing is the queue's state and must not. One `docker run` doing both would
+ * force a single verdict on two different kinds of failure.
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { parse as parseYaml } from "yaml";
+
+interface Step {
+  name?: string;
+  run?: string;
+  if?: string;
+  id?: string;
+  uses?: string;
+  "continue-on-error"?: boolean;
+  with?: Record<string, string | boolean>;
+}
+interface Job {
+  name?: string;
+  needs?: string[];
+  steps?: Step[];
+  "continue-on-error"?: boolean;
+}
+
+const workflow = parseYaml(
+  fs.readFileSync(path.join(__dirname, "../../.github/workflows/release-artifacts.yml"), "utf8"),
+) as { jobs: Record<string, Job> };
+
+const chocolatey = workflow.jobs.chocolatey;
+const steps = chocolatey?.steps ?? [];
+const pack = steps.find((s) => s.run?.includes("choco pack"));
+const push = steps.find((s) => s.run?.includes("choco push"));
+const report = steps.find((s) => s.run?.includes("PackageStatus"));
+
+describe("the Chocolatey publish job", () => {
+  test("exists and separates packing from pushing", () => {
+    expect(chocolatey).toBeDefined();
+    expect(pack).toBeDefined();
+    expect(push).toBeDefined();
+    // Two different steps, not one run doing both.
+    expect(pack).not.toBe(push);
+    expect(pack?.run).not.toContain("choco push");
+    expect(push?.run).not.toContain("choco pack");
+  });
+
+  test("fails the run when packing fails, because a broken package is our bug", () => {
+    expect(pack?.["continue-on-error"]).toBeUndefined();
+    // Job-level tolerance would swallow the pack failure just as effectively.
+    expect(chocolatey?.["continue-on-error"]).toBeUndefined();
+  });
+
+  test("tolerates a push failure, because a 403 is the moderation queue's state", () => {
+    expect(push?.["continue-on-error"]).toBe(true);
+    // The outcome has to be addressable for the report step to read it.
+    expect(push?.id).toBeTruthy();
+  });
+
+  test("both container invocations pin the official image by digest", () => {
+    const runs = [pack?.run ?? "", push?.run ?? ""];
+    for (const run of runs) {
+      expect(run).toContain("docker run");
+      expect(run).toContain("chocolatey/choco");
+      expect(run).toMatch(/@sha256:[0-9a-f]{64}/);
+    }
+  });
+
+  test("reports what the community feed says about the pushed version", () => {
+    expect(report).toBeDefined();
+    // The exact-version entity is the only public read that can answer for a
+    // version the feed does not list yet: `Packages()` returns approved
+    // versions only (measured: $filter=IsApproved eq false yields nothing).
+    expect(report?.run).toContain("community.chocolatey.org/api/v2/Packages(Id=");
+    expect(report?.run).toContain("$GITHUB_STEP_SUMMARY");
+  });
+
+  test("the report runs even when the push failed, and never fails the run itself", () => {
+    expect(report?.["continue-on-error"]).toBe(true);
+    // `if` must not be conditioned on the push having succeeded - a failed push
+    // is precisely when the summary line is worth reading.
+    expect(report?.if ?? "").not.toContain("steps.push.outcome == 'success'");
+    expect(report?.if ?? "").toContain("always()");
+  });
+
+  test("the report surfaces a failed push as a warning annotation", () => {
+    expect(report?.run).toContain("::warning::");
+    // The outcome may reach the script through `env` rather than inline
+    // interpolation - what matters is that the step reads it at all.
+    expect(JSON.stringify(report)).toContain("steps.push.outcome");
+  });
+});


### PR DESCRIPTION
Follow-up to #483. Enabling the Chocolatey push armed a job whose failure mode belongs to somebody else's queue; this contains it, reports what a push actually achieved, and writes down the regime that decides when the latency goes away.

## Why the push step must not fail the run

Chocolatey has no PR flow — the community repository takes a `.nupkg` over an API, and the `chocolatey` job already pushes it. What follows the push is the part that differs from winget: **every new version is human-reviewed before approval** (only *trusted packages* skip it), and the moderation team's own published figure for the wait is *"a few days to a few weeks"*.

`push.chocolatey.org` answers `403` for causes that belong to that queue, not to this repository:

- *"package has a version in moderation and no approved versions"* — what took down the 0.9.60 and 0.9.61 runs.
- *"package has too many existing versions in moderation"* — **newly reachable**, now that every release pushes. The cap is not documented anywhere public (the gallery is closed source), so a cadence faster than the queue drains will find it.

A release that published correctly must not go red for either.

## What changed in the job

One `docker run` doing both jobs becomes two, because it was forcing a single verdict on two kinds of failure:

| step | blocking? | why |
| --- | --- | --- |
| `choco pack` | **yes** | a broken template or a missing file is our bug |
| `choco push` | no (`continue-on-error`) | a 403 is the moderation queue's state |
| status report | no | informational |

The split also keeps `CHOCO_API_KEY` out of the pack container's environment, which never needed it. Both invocations keep the digest-pinned official image.

The report step exists because **"pushed" and "published" are different things here**. It reads `Packages(Id='libredb-studio',Version='<version>')` and writes the push outcome plus that version's `PackageStatus` into the run's job summary, turning a failed push into a warning annotation. Smoke-tested against the live feed both ways:

```
- push outcome: `success`
- community feed status for 0.9.59: `Approved`      # and `not visible yet` for an unpushed version
```

That exact-version entity is the only public read that answers for a version the feed does not list yet — measured: a feed-wide `$filter=IsApproved eq false` returns **nothing**, while the control arm `eq true` returns rows. Which also settles what #483's pin measures: **approval, not push**. A Chocolatey drift row now means "waiting on a moderator".

## Tests

`tests/unit/release-chocolatey.test.ts` (7 tests) locks the split, the tolerance on the right step only, the digest pin on *both* container invocations, and the report's existence and non-blocking behaviour. This is YAML that fails the way `release-provenance.test.ts` describes — silently, months later — which is the bar this repo already set for testing workflow files.

## Docs

- **`docs/DISTRIBUTION.md`** — a new subsection on the moderation regime and why the step is tolerant, plus the route out: **trusted status**. We qualify on the documented vendor route (*"You write the underlying software that the package installs"*), but it is *"a manual change by a moderator... does not happen immediately even if you are the software author"*, in most cases only after a few clean approvals. We have one (0.9.59).
- **`docs/DISTRIBUTION.md`, Windows section** — the **2027-01-01** organizational-use policy: it restricts *consuming* the community repository at fleet scale (internal NuGet repo or upstream-caching proxy instead), **not publishing to it**. Worth stating plainly because the summaries circulating say otherwise.
- **`docs/BACKLOG.md` REL3** — tracks the trusted-status ask, with what "done" looks like.
- **`distribution/channels.yaml`** — the pin note records that the feed lists approved versions only.

## Verification

`format` · `lint` · `typecheck` · `knip` · `test` (33/33 groups) · `build` pass locally; `distribution:matrix --check`, `channels:showcase:check` and `distribution:check --strict` clean. The report step's shell was `shellcheck`-clean and executed against the live feed under `bash -e` for both the found and not-found paths.
