### PR TITLE
feat(agent): a follow-up run is told about the run it follows (B36)

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -80,37 +80,21 @@ Two companion pages carry what this one deliberately does not:
 
 ## Table of Contents
 
-- [Agent Runtime — LibreDB Studio](#agent-runtime--libredb-studio)
-  - [Table of Contents](#table-of-contents)
-  - [Turning it on](#turning-it-on)
-  - [What a run is](#what-a-run-is)
-    - [What a plan run knows](#what-a-plan-run-knows)
-    - [What the inventory is an inventory OF](#what-the-inventory-is-an-inventory-of)
-    - [The statement a plan run drafts](#the-statement-a-plan-run-drafts)
-  - [Durability and resume](#durability-and-resume)
-    - [A drive that dies before the loop](#a-drive-that-dies-before-the-loop)
-  - [The tool set](#the-tool-set)
-    - [The query-optimization template](#the-query-optimization-template)
-    - [The database-assessment template](#the-database-assessment-template)
-    - [The operations template](#the-operations-template)
-    - [The data-analysis template](#the-data-analysis-template)
-    - [Presenting an answer](#presenting-an-answer)
-    - [Handing the answer to the editor (auto-execute)](#handing-the-answer-to-the-editor-auto-execute)
-    - [What the fence is proved to hold against](#what-the-fence-is-proved-to-hold-against)
-  - [What bounds a run](#what-bounds-a-run)
-  - [Supported models](#supported-models)
-  - [The model side](#the-model-side)
-    - [What a refused model looks like in the app](#what-a-refused-model-looks-like-in-the-app)
-  - [Whether the run answered](#whether-the-run-answered)
-    - [The eval harness](#the-eval-harness)
-  - [What the removed AI panels did that a run does not](#what-the-removed-ai-panels-did-that-a-run-does-not)
-  - [HTTP surface](#http-surface)
-  - [The surface in the app](#the-surface-in-the-app)
-  - [Deployment](#deployment)
-  - [Package boundary](#package-boundary)
-  - [Module map](#module-map)
-  - [Known limitations](#known-limitations)
-  - [Related documentation](#related-documentation)
+- [Turning it on](#turning-it-on)
+- [What a run is](#what-a-run-is)
+- [Durability and resume](#durability-and-resume)
+- [The tool set](#the-tool-set)
+- [What bounds a run](#what-bounds-a-run)
+- [Supported models](#supported-models)
+- [The model side](#the-model-side)
+- [Whether the run answered](#whether-the-run-answered)
+- [What the removed AI panels did that a run does not](#what-the-removed-ai-panels-did-that-a-run-does-not)
+- [HTTP surface](#http-surface)
+- [The surface in the app](#the-surface-in-the-app)
+- [Deployment](#deployment)
+- [Package boundary](#package-boundary)
+- [Module map](#module-map)
+- [Known limitations](#known-limitations)
 
 ## Turning it on
 
@@ -267,11 +251,14 @@ The middle case is why this is a comparison and not a bare "has a seed id". The 
 database would investigate the seed and report on it as though it were the one on screen.
 
 A run may also FOLLOW the run before it. The rail sends the previous run's id when the user asks a
-follow-up question on the same connection, the route derives the previous run's objective and report
-from its own ledger, and the new run's header records them as `priorContext`. The context is fenced
-when the model reads it, so a pronoun or a demonstrative ("those groups", "it") either resolves
-against the earlier run or is refused for lack of a referent rather than answered as if the question
-were new ([`src/lib/agent/prior-run-context.ts`](../src/lib/agent/prior-run-context.ts)).
+follow-up question on the same connection, the route derives the previous run's objective and
+report from its own ledger, and the new run's header records them as `priorContext`. The context is
+fenced when the model reads it, so a pronoun or a demonstrative ("those groups", "it") either
+resolves against the earlier run or is refused for lack of a referent rather than answered as if
+the question were new ([`src/lib/agent/prior-run-context.ts`](../src/lib/agent/prior-run-context.ts)).
+The chain is **depth 1**: a third run is told about the second and not the first, because the
+derivation reads a run's objective and report and not its `priorContext`. The surface does not yet
+say which run is being followed — or when none is — which is recorded as `docs/BACKLOG.md` B67.
 
 A run emits a closed set of **semantic events**, and they are the whole of what the UI renders:
 `run-started`, `driver-resolved`, `context-captured`, `statement-drafted`, `plan-statement-drafted`,
@@ -1928,7 +1915,7 @@ rendered, and the first Start is where the operator meets it (B30).
 | Route | Purpose |
 | --- | --- |
 | `GET /api/agent/config` | Whether this server runs agents, and if not, which condition failed: `{"enabled": true, "ledgerVerified": …}` or `{"enabled": false, "reason": …, "detail": "…"}`. The reason is one code per operator action — `OPERATOR_DISABLED`, `NO_MODEL_CONFIGURED`, `LEDGER_UNAVAILABLE`, `UNSANCTIONED_WORLD_TARGET`, `IMPLICIT_HOSTED_WORLD`. The last two are backend refusals and keep their own codes deliberately: neither is a disk problem, and `IMPLICIT_HOSTED_WORLD` fires before anything is asked of a filesystem at all. `ledgerVerified` distinguishes the two kinds of yes: `true` after the writable-path probe passed, `false` for the Postgres carve-out, where the backend is accepted without being contacted (B31). Session-verified. `enabled` is a literal boolean because the rail compares `=== true`. `reason` goes to every session — it names an operator action and no path — while `detail` goes to **admin sessions only**, because `LEDGER_UNAVAILABLE`'s detail carries an absolute server path and an OS error string; every other session gets one stable sentence instead, and loses nothing, since the rail renders nothing when the answer is no. Never 500s, and never names a key's value. The ledger half of the answer is memoised for a few seconds, in-flight promise included — the route sits outside the `ai` rate-limit bucket on purpose, so the memo is what stops an authenticated caller turning a page-load probe into a write per request, including a burst that arrives while one probe is still running. |
-| `POST /api/agent/runs` | Opens a run (mode, optional `workflowType`, objective, `connectionId`) and returns `202` with the run id and the PERSISTED mode and workflow type. An unrecognised `workflowType` is refused rather than defaulted. An inline connection in the body is refused. An agent run whose model was established as unable to call tools is refused `422` before any run is opened. |
+| `POST /api/agent/runs` | Opens a run (mode, optional `workflowType`, objective, `connectionId`, and optional `previousRunId` to follow a run this session opened on the same connection) and returns `202` with the run id and the PERSISTED mode and workflow type. An unrecognised `workflowType` is refused rather than defaulted. An inline connection in the body is refused. A `previousRunId` that does not name a terminal run this session opened on this connection is refused `400`. An agent run whose model was established as unable to call tools is refused `422` before any run is opened. |
 | `GET /api/agent/runs/{runId}` | The run record, folded from its ledger. |
 | `DELETE /api/agent/runs/{runId}` | Requests a stop. Cancellation is enforced by the run loop's own persisted state, not by a driver cancel propagating — so this is "asked to stop", not "has stopped". |
 | `GET /api/agent/runs/{runId}/stream` | The ledger as NDJSON, one entry per line. |
@@ -2392,6 +2379,10 @@ surface (#407) — twenty-six runs over `docs/AGENT_DEMO.md`, which is also wher
 real-world agreement rate was measured. The count is deliberately not stated: entries leave this list
 as they are fixed, and a numeral here goes stale silently.
 
+- **B67** — the rail does not say whether a run follows another. A follow-up run is now TOLD about
+  the run before it — its objective and report, fenced, from that run's own ledger (`docs/BACKLOG.md`
+  B36, closed) — but the surface names neither the run it follows nor the cases where it deliberately
+  does not, and there is still no run history to return to an earlier run.
 - **B37** — a seed config the server cannot read disables the agent on every connection, and the rail
   blames the connection: "its settings live in this browser", said of a connection this application
   seeds itself. The browser cannot tell an empty seed list from a failed one.

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -80,21 +80,37 @@ Two companion pages carry what this one deliberately does not:
 
 ## Table of Contents
 
-- [Turning it on](#turning-it-on)
-- [What a run is](#what-a-run-is)
-- [Durability and resume](#durability-and-resume)
-- [The tool set](#the-tool-set)
-- [What bounds a run](#what-bounds-a-run)
-- [Supported models](#supported-models)
-- [The model side](#the-model-side)
-- [Whether the run answered](#whether-the-run-answered)
-- [What the removed AI panels did that a run does not](#what-the-removed-ai-panels-did-that-a-run-does-not)
-- [HTTP surface](#http-surface)
-- [The surface in the app](#the-surface-in-the-app)
-- [Deployment](#deployment)
-- [Package boundary](#package-boundary)
-- [Module map](#module-map)
-- [Known limitations](#known-limitations)
+- [Agent Runtime — LibreDB Studio](#agent-runtime--libredb-studio)
+  - [Table of Contents](#table-of-contents)
+  - [Turning it on](#turning-it-on)
+  - [What a run is](#what-a-run-is)
+    - [What a plan run knows](#what-a-plan-run-knows)
+    - [What the inventory is an inventory OF](#what-the-inventory-is-an-inventory-of)
+    - [The statement a plan run drafts](#the-statement-a-plan-run-drafts)
+  - [Durability and resume](#durability-and-resume)
+    - [A drive that dies before the loop](#a-drive-that-dies-before-the-loop)
+  - [The tool set](#the-tool-set)
+    - [The query-optimization template](#the-query-optimization-template)
+    - [The database-assessment template](#the-database-assessment-template)
+    - [The operations template](#the-operations-template)
+    - [The data-analysis template](#the-data-analysis-template)
+    - [Presenting an answer](#presenting-an-answer)
+    - [Handing the answer to the editor (auto-execute)](#handing-the-answer-to-the-editor-auto-execute)
+    - [What the fence is proved to hold against](#what-the-fence-is-proved-to-hold-against)
+  - [What bounds a run](#what-bounds-a-run)
+  - [Supported models](#supported-models)
+  - [The model side](#the-model-side)
+    - [What a refused model looks like in the app](#what-a-refused-model-looks-like-in-the-app)
+  - [Whether the run answered](#whether-the-run-answered)
+    - [The eval harness](#the-eval-harness)
+  - [What the removed AI panels did that a run does not](#what-the-removed-ai-panels-did-that-a-run-does-not)
+  - [HTTP surface](#http-surface)
+  - [The surface in the app](#the-surface-in-the-app)
+  - [Deployment](#deployment)
+  - [Package boundary](#package-boundary)
+  - [Module map](#module-map)
+  - [Known limitations](#known-limitations)
+  - [Related documentation](#related-documentation)
 
 ## Turning it on
 
@@ -249,6 +265,13 @@ Which connections qualify is decided in the browser before a run is opened, by
 The middle case is why this is a comparison and not a bare "has a seed id". The server resolves
 `seed:<id>` to its OWN descriptor, so a run started on a copy the user had since pointed at another
 database would investigate the seed and report on it as though it were the one on screen.
+
+A run may also FOLLOW the run before it. The rail sends the previous run's id when the user asks a
+follow-up question on the same connection, the route derives the previous run's objective and report
+from its own ledger, and the new run's header records them as `priorContext`. The context is fenced
+when the model reads it, so a pronoun or a demonstrative ("those groups", "it") either resolves
+against the earlier run or is refused for lack of a referent rather than answered as if the question
+were new ([`src/lib/agent/prior-run-context.ts`](../src/lib/agent/prior-run-context.ts)).
 
 A run emits a closed set of **semantic events**, and they are the whole of what the UI renders:
 `run-started`, `driver-resolved`, `context-captured`, `statement-drafted`, `plan-statement-drafted`,
@@ -2369,9 +2392,6 @@ surface (#407) — twenty-six runs over `docs/AGENT_DEMO.md`, which is also wher
 real-world agreement rate was measured. The count is deliberately not stated: entries leave this list
 as they are fixed, and a numeral here goes stale silently.
 
-- **B36** — a follow-up question is answered as if it were the first. Runs carry no memory of each
-  other, and neither the surface nor the model says so — the model picks a plausible referent and
-  answers a question nobody asked, with the citations a correct answer carries.
 - **B37** — a seed config the server cannot read disables the agent on every connection, and the rail
   blames the connection: "its settings live in this browser", said of a connection this application
   seeds itself. The browser cannot tell an empty seed list from a failed one.

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2380,9 +2380,9 @@ real-world agreement rate was measured. The count is deliberately not stated: en
 as they are fixed, and a numeral here goes stale silently.
 
 - **B67** — the rail does not say whether a run follows another. A follow-up run is now TOLD about
-  the run before it — its objective and report, fenced, from that run's own ledger (`docs/BACKLOG.md`
-  B36, closed) — but the surface names neither the run it follows nor the cases where it deliberately
-  does not, and there is still no run history to return to an earlier run.
+  the run before it — its objective and report, fenced, from that run's own ledger — but the surface
+  names neither the run it follows nor the cases where it deliberately does not, and there is still
+  no run history to return to an earlier run.
 - **B37** — a seed config the server cannot read disables the agent on every connection, and the rail
   blames the connection: "its settings live in this browser", said of a connection this application
   seeds itself. The browser cannot tell an empty seed list from a failed one.

--- a/docs/AGENT_DEMO.md
+++ b/docs/AGENT_DEMO.md
@@ -769,7 +769,6 @@ would close it, so "not yet" means deferred with a reason, not overlooked.
 | Not yet | What happens today | Waiting on |
 | --- | --- | --- |
 | **A verdict that fits an optimization run** | Every Optimize run ends `unanswered`, however good its plans and index recommendation were | B45 — a plan artifact is not an empty result, the same exemption the Operate template already has |
-| **Follow-up questions** | Each run starts fresh, and neither the surface nor the model says so — ask "and how many of those?" and you get a confident answer to a different question | B36 — either carrying the previous run's objective and report into the next as fenced context, or run history |
 | **Causal questions** — "why are sales down?" | Answered from the schema alone, which cannot know which decomposition of a metric is the business one | A per-connection business note, held server-side; sketched in `docs/AGENT_ANALYST_DESIGN.md` §5 |
 | **"This database cannot answer that"** | It does say so, but has to run a throwaway query to be scored as having answered — case 21 spends 5 tool invocations to report that an employees database holds no customer data | B39 — a second arm on the verdict, so a schema-only conclusion counts |
 | **Agent mode on MySQL, Oracle, MongoDB, Redis…** | Only Operate. The other four workflows refuse, correctly and clearly | A database-native read-only statement path per engine — the same `queryReadOnly` PostgreSQL and SQLite implement |

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -975,6 +975,7 @@ Opens a run and returns immediately; the drive happens in the background.
 | `workflowReading` | string | No | How that decision WENT, as against who made it: `"classified"` (a classifier named this workflow), `"unclassified"` (a classifier was asked and reached its fallback) or `"unrecorded"` (nothing classified anything — what a caller naming its own workflow sends). Absent means `"unrecorded"`. An unrecognised value is **refused, not defaulted**, for the reason `workflowSource` is: the surface reads this field back to choose which of three sentences it says about the run, and a fallback presented as a verdict is the one it may not say |
 | `objective` | string | Yes | Non-empty, at most 4000 characters |
 | `connectionId` | string | Yes | Must resolve **server-side**. An inline `connection` object in the body is refused |
+| `previousRunId` | string | No | Follow a run this session already opened: the server derives that run's objective and report from its own ledger, verifies the run belongs to this session, on this connection, and has already ended, and persists the result as fenced `priorContext` on the new run's header. A value that does not name such a run is **refused** with the same `400` as a missing run |
 
 **Response (202 Accepted):**
 
@@ -1001,6 +1002,7 @@ could arrive twice.
 // 400 Bad Request — one message per rule, e.g.
 { "error": "mode must be \"planning\" or \"agent\"" }
 { "error": "An agent run needs a server-resolvable connectionId; an inline connection cannot be resumed" }
+{ "error": "previousRunId does not name a run this session may follow" }
 
 // 404 Not Found — this server runs no agents
 { "error": "The agent runtime is not enabled on this server" }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2612,3 +2612,19 @@ and this one has simply not been tried.
 
 **Done when:** a sweep at a raised per-model turn limit either closes the cell or is recorded in
 the entry as having failed to.
+
+---
+
+### B67. The rail does not say whether a run follows another, and run history is still absent
+
+The model half of B36 is closed: a follow-up run is now TOLD about the run before it — its
+objective and its report, derived server-side and fenced before the model reads them. What is
+left is the surface half B36 named in the same sentence: the rail still says nothing about
+whether a run is following another, or about the cases where it deliberately is not (the
+connection switched, the run was replaced), so a user cannot tell how their follow-up was read.
+And the "run history" larger shape B36 sketched — a user being able to see and return to earlier
+runs — is still unbuilt.
+
+**Done when:** the rail states, for an open run, which run it follows and why it follows no run;
+and run history either exists or is recorded here as deliberately declined rather than
+overlooked.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2155,34 +2155,6 @@ a run resumed often enough passes any constant.
 per-drive constant — most likely as part of B6 — with a test that drives one run twice past the cap and
 shows the first drive's cited results still readable, or the surface stating that they are not.
 
-### B36. A follow-up question is answered as if it were the first one
-
-Driven live on 2026-08-15. An analysis run answered "compare the average salary of employees hired
-before 1990 with those hired after" correctly. The next question typed into the same box — "and how many
-of those employees are there in each group?" — was answered about DEPARTMENTS: nine of them, 289 in
-Development.
-
-"Those groups" had no referent, because a run carries none. `start()` clears the entries and opens a
-fresh ledger, and the model is handed the objective and the schema and nothing else.
-
-The defect is not that runs are independent. It is that the surface does not say so, and the model does
-not either — it silently picks a plausible referent and answers a question nobody asked, with the same
-confident citations a correct answer carries. A user reading the report cannot tell the difference
-without re-reading their own question.
-
-Two shapes would close it, and they are not the same feature:
-
-- **Smaller:** let a run be TOLD about the run before it — its objective and its report — as fenced
-  context, so "those groups" resolves or is honestly refused.
-- **Larger:** run history, so a user can see and return to earlier runs. (Emptying the objective box
-  after a run, which landed with that PR, at least stops the surface reading as a conversation.)
-
-Neither should be built by threading the browser's memory into the prompt: a resumed drive would not
-have it, and the context a run reasons from has to live where the run does.
-
-**Done when:** a follow-up either resolves against the previous run or is refused for lack of a
-referent, with an eval that drives two runs and asserts the second does not answer a different question.
-
 ### B37. A malformed seed config disables the agent everywhere, and blames the connection
 
 Driven live on 2026-08-15. A `seed-connections.yaml` missing a required field made

--- a/src/app/api/agent/runs/route.ts
+++ b/src/app/api/agent/runs/route.ts
@@ -3,6 +3,8 @@ import { admitAgentModel } from "@/lib/agent/capability-gate";
 import { isAgentRuntimeEnabled } from "@/lib/agent/config";
 import { AGENT_MAX_OBJECTIVE_LENGTH } from "@/lib/agent/execution-policy";
 import { derivePriorRunContext } from "@/lib/agent/prior-run-context";
+import type { AgentRunStatusReport } from "@/lib/agent/run-service";
+import { AgentRunStoreError } from "@/lib/agent/run-store";
 import { driveAgentRun, getAgentRunService } from "@/lib/agent/runtime";
 import {
   AGENT_WORKFLOW_PRESENTS_ANSWER,
@@ -221,14 +223,31 @@ export async function POST(req: Request) {
     // A follow-up run is told about the run it follows — its objective and its report —
     // as fenced context (`docs/BACKLOG.md` B36). The context is DERIVED on the server
     // from the previous run's own ledger, never trusted from the request body, and a
-    // caller may only follow a run its own session opened: handing a stranger's report
-    // into a prompt would be a leak the rail cannot see. One answer covers both a run
-    // that does not exist and one that is not the caller's, so the response does not
-    // say which.
+    // caller may only follow a run its own session opened, on the same connection, that
+    // has already ended. One answer covers a run that does not exist, one that is not
+    // the caller's, one on another connection, one still running, and an id the ledger
+    // cannot name — so the response does not say which.
+    const TERMINAL_RUN_STATUSES: ReadonlySet<string> = new Set(["succeeded", "failed", "cancelled"]);
     let priorContext: AgentPriorRunContext | undefined;
     if (previousRunId !== undefined) {
-      const previous = await service.status(previousRunId);
-      if (previous === null || previous.record.actor.sessionId !== guard.session.username) {
+      let previous: AgentRunStatusReport | null;
+      try {
+        previous = await service.status(previousRunId);
+      } catch (error) {
+        // A run id the ledger cannot name is a malformed id, not a missing run; it joins
+        // the same refusal, because the store refuses it before touching anything and a
+        // caller guessing ids must not be able to tell the two apart.
+        if (error instanceof AgentRunStoreError && error.reasonCode === "INVALID_RUN_ID") {
+          return badRequest("previousRunId does not name a run this session may follow");
+        }
+        throw error;
+      }
+      if (
+        previous === null ||
+        previous.record.actor.sessionId !== guard.session.username ||
+        previous.record.connectionId !== connection.id ||
+        !TERMINAL_RUN_STATUSES.has(previous.record.status)
+      ) {
         return badRequest("previousRunId does not name a run this session may follow");
       }
       priorContext = derivePriorRunContext(previous.record);

--- a/src/app/api/agent/runs/route.ts
+++ b/src/app/api/agent/runs/route.ts
@@ -2,10 +2,12 @@ import { NextResponse } from "next/server";
 import { admitAgentModel } from "@/lib/agent/capability-gate";
 import { isAgentRuntimeEnabled } from "@/lib/agent/config";
 import { AGENT_MAX_OBJECTIVE_LENGTH } from "@/lib/agent/execution-policy";
+import { derivePriorRunContext } from "@/lib/agent/prior-run-context";
 import { driveAgentRun, getAgentRunService } from "@/lib/agent/runtime";
 import {
   AGENT_WORKFLOW_PRESENTS_ANSWER,
   DEFAULT_AGENT_WORKFLOW_TYPE,
+  type AgentPriorRunContext,
   type AgentRunMode,
   type AgentRunWorkflowReading,
   type AgentRunWorkflowSource,
@@ -109,7 +111,8 @@ export async function POST(req: Request) {
       return badRequest("Request body must be JSON");
     }
 
-    const { mode, workflowType, workflowSource, workflowReading, autoExecute, objective, connectionId } = body;
+    const { mode, workflowType, workflowSource, workflowReading, autoExecute, objective, connectionId, previousRunId } =
+      body;
     if (typeof mode !== "string" || !MODES.has(mode)) {
       return badRequest('mode must be "planning" or "agent"');
     }
@@ -182,6 +185,13 @@ export async function POST(req: Request) {
     if (typeof connectionId !== "string" || connectionId.trim().length === 0) {
       return badRequest("connectionId must be a non-empty string");
     }
+    // Absent means the run is opened on its own, which is the ordinary case. A
+    // supplied id is REFUSED rather than coerced when it is not a string: it names
+    // a run, and guessing at a run id is how one session could hand another's report
+    // into its own prompt.
+    if (previousRunId !== undefined && (typeof previousRunId !== "string" || previousRunId.trim().length === 0)) {
+      return badRequest("previousRunId must be a non-empty string when provided");
+    }
 
     const connection = await resolveConnection({ connectionId }, guard.session);
 
@@ -207,6 +217,23 @@ export async function POST(req: Request) {
     }
 
     const service = await getAgentRunService();
+
+    // A follow-up run is told about the run it follows — its objective and its report —
+    // as fenced context (`docs/BACKLOG.md` B36). The context is DERIVED on the server
+    // from the previous run's own ledger, never trusted from the request body, and a
+    // caller may only follow a run its own session opened: handing a stranger's report
+    // into a prompt would be a leak the rail cannot see. One answer covers both a run
+    // that does not exist and one that is not the caller's, so the response does not
+    // say which.
+    let priorContext: AgentPriorRunContext | undefined;
+    if (previousRunId !== undefined) {
+      const previous = await service.status(previousRunId);
+      if (previous === null || previous.record.actor.sessionId !== guard.session.username) {
+        return badRequest("previousRunId does not name a run this session may follow");
+      }
+      priorContext = derivePriorRunContext(previous.record);
+    }
+
     const record = await service.start({
       mode: mode as AgentRunMode,
       // Spread rather than passed as `undefined`, so a body that named no workflow
@@ -226,6 +253,10 @@ export async function POST(req: Request) {
       // resumed drive must ask this model the way the first drive asked, and only the
       // start path is in a position to have probed.
       ...(gate.protocol === "native" ? {} : { toolProtocol: gate.protocol }),
+      // Spread for the same reason as the fields above: absent reaches the store as
+      // the request that predates the field, and no run is given a predecessor it
+      // was not opened with.
+      ...(priorContext === undefined ? {} : { priorContext }),
       actor: { sessionId: guard.session.username, role: guard.session.role },
       connectionId: connection.id,
       objective,

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -1053,6 +1053,16 @@ export function AgentRail({
       return;
     }
     setReplaceFailed(false);
+    // A follow-up question follows the run that just ended — and only that one: the
+    // previous run must be terminal, opened on the same connection, and not the run a
+    // "change" click is replacing. The id travels to the route, which re-derives the
+    // context from that run's own ledger rather than trusting anything here
+    // (`docs/BACKLOG.md` B36).
+    const followsPrevious =
+      !decided.replacesOpenRun &&
+      run.runId !== null &&
+      !LIVE_STATUSES.has(run.timeline.status) &&
+      openedOn.current?.id === decided.connection.id;
     openedOn.current = { id: decided.connection.id, name: decided.connection.name };
     setOpenedObjective(decided.objective);
     /*
@@ -1085,6 +1095,9 @@ export function AgentRail({
       autoExecute: handover,
       objective: decided.objective,
       connectionId: decided.connection.id,
+      // Sent only when this run genuinely continues the last one; the route refuses
+      // anything else, and nothing later may change which run this one was told about.
+      ...(followsPrevious && run.runId !== null ? { previousRunId: run.runId } : {}),
     });
   };
 

--- a/src/components/agent/use-agent-run.ts
+++ b/src/components/agent/use-agent-run.ts
@@ -69,6 +69,13 @@ export interface AgentRunStartInput {
    * can widen a run that is already open.
    */
   readonly autoExecute?: boolean;
+  /**
+   * The run this one follows, when the user is asking a follow-up question. A request,
+   * like the fields above: the server DERIVES the context from that run's own ledger and
+   * persists it on the new run's record, so nothing the browser remembers later is
+   * trusted into the prompt (`docs/BACKLOG.md` B36).
+   */
+  readonly previousRunId?: string;
   readonly objective: string;
   readonly connectionId: string;
 }

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -1903,6 +1903,35 @@ function describePriorProgress(record: AgentRunRecord): string | null {
   return `${preamble}\n${lines.join("\n")}`;
 }
 
+/**
+ * What a follow-up run is told about the run it follows (`docs/BACKLOG.md` B36).
+ *
+ * The context is the previous run's objective and its report, both somebody
+ * else's words, so the whole block is fenced rather than narrated in the
+ * server's voice — the same rule the database-error and profile summaries
+ * follow. The instruction half states the one contract B36 pins: a pronoun or
+ * a demonstrative ("those groups", "it", "that result") has to resolve against
+ * the earlier run, and when it cannot, the honest answer is a refusal, not a
+ * guess about a different question.
+ *
+ * `null` when the run has no predecessor, which is the ordinary case.
+ */
+function describePriorRunContext(record: AgentRunRecord): string | null {
+  const prior = record.priorContext;
+  if (prior === undefined) return null;
+  const fenced = fenceUntrustedContent(`previous objective: ${prior.objective}\nprevious report:\n${prior.report}`, {
+    label: "earlier run",
+    operationId: "agent/prior-run",
+    reference: prior.runId,
+  });
+  return [
+    "This run follows an earlier run on the same connection.",
+    'When this objective refers to something the earlier run established — "those groups", "it", "that result", "those rows" — resolve the referent against the earlier run below.',
+    "If the earlier run gives no referent for the words in this objective, say so plainly and refuse to guess: answering a different question is worse than not answering.",
+    fenced,
+  ].join("\n");
+}
+
 const indeterminateText = (stepId: string, toolName: string): string =>
   `Step ${stepId} (${toolName}) was started before this run was interrupted and its outcome was never recorded, so whether it reached the database cannot be known. It will not be repeated. Draft a different call if you still need what it would have produced.`;
 
@@ -2493,6 +2522,14 @@ export async function runInvestigation(
      */
     const notice = (text: string): string => (prompted ? `${text} ${PROMPTED_PROTOCOL_REMINDER}` : text);
     const messages: ModelMessage[] = [{ role: "user", content: record.objective }];
+    // The run this one follows, stated before anything the model does. A USER
+    // message rather than part of `systemPrompt` for the same reason the prompted
+    // contract is: the context carries prose a user and a model wrote, and the
+    // prose path's own guidance keeps every instruction in user messages. It is
+    // also fenced inside `describePriorRunContext`, because neither half of it is
+    // the server's voice.
+    const priorRunContext = describePriorRunContext(record);
+    if (priorRunContext !== null) messages.push({ role: "user", content: priorRunContext });
     /*
       The contract is a USER message, not an addition to the instructions, and that is the
       vendor's own guidance rather than a preference: the model card for the reasoning family

--- a/src/lib/agent/prior-run-context.ts
+++ b/src/lib/agent/prior-run-context.ts
@@ -1,0 +1,44 @@
+/**
+ * Derives the context a follow-up run is handed about the run it follows
+ * (`docs/BACKLOG.md` B36).
+ *
+ * The context is the previous run's objective and its report — the claims it
+ * composed, the statement that WAS its answer when one was presented, and any
+ * closing prose. All of it is somebody else's words (the user's, and a model's),
+ * so `investigation.ts` fences the whole block before a model reads it; this
+ * module only assembles the inert strings, which is what keeps the derivation
+ * testable without a model and the context resumable without a browser.
+ *
+ * A run that answered nothing still yields a context: its report is simply empty,
+ * and the follow-up is told what the previous run was ASKED, so it can either
+ * resolve a referent against that or refuse for lack of one — which is the
+ * second half of what B36 calls "done".
+ */
+
+import type { AgentPriorRunContext, AgentRunRecord } from "./types";
+
+/**
+ * The report half of a prior-run context, assembled from the events that carry
+ * what the previous run concluded. Ordering is the ledger's own order, so a
+ * reader gets the answer, the claims and the closing prose in the order they
+ * were established.
+ */
+export function derivePriorRunContext(record: AgentRunRecord): AgentPriorRunContext {
+  const lines: string[] = [];
+  for (const event of record.events) {
+    if (event.kind === "answer-composed") {
+      lines.push(`Answer statement: ${event.sql}`);
+    } else if (event.kind === "report-composed") {
+      for (const [index, claim] of event.claims.entries()) {
+        lines.push(`Claim ${index + 1}: ${claim.claim}`);
+      }
+    } else if (event.kind === "closing-statement") {
+      lines.push(`Closing: ${event.text}`);
+    }
+  }
+  return {
+    runId: record.runId,
+    objective: record.objective,
+    report: lines.join("\n"),
+  };
+}

--- a/src/lib/agent/run-service.ts
+++ b/src/lib/agent/run-service.ts
@@ -53,6 +53,7 @@ import type { AgentLedgerEntry, AgentRunLedgerView, AgentRunStore, AgentSettledS
 import type { AgentOperationId, AgentToolName } from "./tools";
 import type {
   AgentArtifactReference,
+  AgentPriorRunContext,
   AgentRunActor,
   AgentRunEvent,
   AgentRunMode,
@@ -160,6 +161,8 @@ export interface AgentRunStartInput {
   readonly autoExecute?: boolean;
   /** Defaults to `native`; see `AgentRunRecord.toolProtocol`. */
   readonly toolProtocol?: AgentToolProtocol;
+  /** The run this one follows; the route derives it and the store persists it. */
+  readonly priorContext?: AgentPriorRunContext;
   readonly actor: AgentRunActor;
   readonly connectionId: string;
   readonly objective: string;

--- a/src/lib/agent/run-store.ts
+++ b/src/lib/agent/run-store.ts
@@ -60,6 +60,7 @@ import { randomUUID } from "node:crypto";
 import { getAgentRuntimeConfig } from "./config";
 import { assertPersistableState } from "./state-guard";
 import {
+  type AgentPriorRunContext,
   type AgentRunActor,
   type AgentRunEvent,
   type AgentRunMode,
@@ -167,6 +168,13 @@ export type AgentLedgerEntry =
        * other way to ask.
        */
       readonly toolProtocol?: AgentToolProtocol;
+      /**
+       * Optional on the READ side for the same reason `workflowType` is: `openRun`
+       * writes it only when a follow-up run was opened with a predecessor, and a
+       * header written before this field existed folds to none — which is what was
+       * true of it: no run had a predecessor then.
+       */
+      readonly priorContext?: AgentPriorRunContext;
       readonly actor: AgentRunActor;
       readonly connectionId: string;
       readonly objective: string;
@@ -251,6 +259,8 @@ export interface AgentRunOpenInput {
   readonly autoExecute?: boolean;
   /** Defaults to `native`. Decided by the capability gate at start; see `AgentRunRecord`. */
   readonly toolProtocol?: AgentToolProtocol;
+  /** The run this one follows; written to the header when present. */
+  readonly priorContext?: AgentPriorRunContext;
   readonly actor: AgentRunActor;
   readonly connectionId: string;
   readonly objective: string;
@@ -362,6 +372,7 @@ function foldLedger(runId: string, entries: readonly AgentLedgerEntry[]): AgentR
       // Spread rather than defaulted: `native` is the absence, so writing it would put
       // a field on every record to say what its absence already says.
       ...(header.toolProtocol === undefined ? {} : { toolProtocol: header.toolProtocol }),
+      ...(header.priorContext === undefined ? {} : { priorContext: header.priorContext }),
       status,
       actor: header.actor,
       connectionId: header.connectionId,
@@ -428,6 +439,9 @@ export class AgentRunStore {
       // generation can be read as having permitted something it did not.
       autoExecute: input.autoExecute ?? false,
       ...(input.toolProtocol === undefined ? {} : { toolProtocol: input.toolProtocol }),
+      // Written only when a predecessor exists, so a ledger opened before this
+      // field and one opened with no predecessor are the same bytes.
+      ...(input.priorContext === undefined ? {} : { priorContext: input.priorContext }),
       actor: input.actor,
       connectionId: input.connectionId,
       objective: input.objective,

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -942,6 +942,28 @@ export type AgentRunEvent =
     });
 
 /**
+ * What a follow-up run is TOLD about the run it follows (`docs/BACKLOG.md` B36).
+ *
+ * The content is the previous run's objective and report, both of which are prose
+ * somebody else wrote — the user, and a model — so a run handed this context must
+ * treat it as data, not instruction. Fencing is `investigation.ts`'s job at read
+ * time; this type only carries the inert strings, which is what keeps a run
+ * resumable: the context a resumed drive reasons from is the one its ledger
+ * recorded, never the browser's memory.
+ *
+ * Inert by construction, like every other contract here: two strings and an id.
+ * The state guard therefore admits it exactly as it admits the objective.
+ */
+export interface AgentPriorRunContext {
+  /** The run this one follows. */
+  readonly runId: string;
+  /** The previous run's objective, in the user's own words. */
+  readonly objective: string;
+  /** The previous run's report: its claims, its answer statement, and any closing prose. */
+  readonly report: string;
+}
+
+/**
  * One run, whole. Everything a restarted process needs to continue, and nothing
  * a restarted process could not read: no client, no credential, no result set.
  */
@@ -1008,6 +1030,17 @@ export interface AgentRunRecord {
    * the prose path existed, and of every model that can call a tool.
    */
   readonly toolProtocol?: AgentToolProtocol;
+  /**
+   * The run this one follows, when the user asked a follow-up question.
+   *
+   * Optional, and absent means this run was opened without a predecessor — the
+   * ordinary case. It is on the record for the reason every other header field is:
+   * a resumed drive must be told the same context the drive that died was told, so
+   * the context has to live in the ledger rather than in a request body that only
+   * the opener saw. The strings inside are inert prose, so the state guard admits
+   * them exactly as it admits the objective.
+   */
+  readonly priorContext?: AgentPriorRunContext;
   readonly status: AgentRunStatus;
   readonly actor: AgentRunActor;
   /** The single connection this run may reach; the server builds the scope from it. */

--- a/tests/api/agent/runs.test.ts
+++ b/tests/api/agent/runs.test.ts
@@ -53,6 +53,7 @@ interface FakeRun {
   connectionId: string;
   objective: string;
   events: unknown[];
+  priorContext?: { runId: string; objective: string; report: string };
 }
 
 function fakeRun(overrides: Partial<FakeRun> = {}): FakeRun {
@@ -92,6 +93,7 @@ const mockStart = mock(
     actor: FakeRun["actor"];
     connectionId: string;
     objective: string;
+    priorContext?: { runId: string; objective: string; report: string };
   }) => {
     const record = fakeRun({ ...input, runId: "arun_new" });
     runs.set(record.runId, record);
@@ -188,6 +190,66 @@ afterEach(() => {
 });
 
 describe("POST /api/agent/runs", () => {
+  /*
+    A follow-up run is opened with the previous run's objective and report derived
+    SERVER-SIDE from that run's own ledger (`docs/BACKLOG.md` B36). The request only
+    names the run; the route resolves it, checks it is the caller's, and persists the
+    derived context on the new run's record.
+  */
+  test("a follow-up run is opened with the previous run's objective and report", async () => {
+    runs.set(
+      "arun_1",
+      fakeRun({
+        events: [
+          {
+            kind: "report-composed",
+            atMs: 1,
+            claims: [{ claim: "A fact", evidence: [{ source: "artifact", correlationId: "corr_1" }] }],
+          },
+        ],
+      }),
+    );
+
+    const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "arun_1" }));
+
+    expect(res.status).toBe(202);
+    expect(mockStart.mock.calls.at(-1)?.[0]).toMatchObject({
+      priorContext: { runId: "arun_1", objective: "why is checkout slow", report: "Claim 1: A fact" },
+    });
+  });
+
+  test("a run that is not a follow-up carries no prior-run context", async () => {
+    const res = await POST(startRequest(VALID_BODY));
+
+    expect(res.status).toBe(202);
+    expect(mockStart.mock.calls.at(-1)?.[0].priorContext).toBeUndefined();
+  });
+
+  test("a previousRunId naming no run is refused before a run opens", async () => {
+    const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "arun_missing" }));
+
+    expect(res.status).toBe(400);
+    expect(await parseResponseJSON(res)).toMatchObject({
+      error: "previousRunId does not name a run this session may follow",
+    });
+  });
+
+  test("a previousRunId naming another session's run is refused the same way", async () => {
+    runs.set("arun_other", fakeRun({ actor: { sessionId: "grace", role: "user" } }));
+    const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "arun_other" }));
+
+    expect(res.status).toBe(400);
+    expect(await parseResponseJSON(res)).toMatchObject({
+      error: "previousRunId does not name a run this session may follow",
+    });
+  });
+
+  test("a previousRunId that is not a non-empty string is refused", async () => {
+    const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "" }));
+
+    expect(res.status).toBe(400);
+  });
+
   /*
     A model that cannot call tools is refused BEFORE a run exists, which is the whole
     point of the gate (`docs/BACKLOG.md` B18): otherwise the run opens, spends a drive

--- a/tests/api/agent/runs.test.ts
+++ b/tests/api/agent/runs.test.ts
@@ -267,6 +267,23 @@ describe("POST /api/agent/runs", () => {
     });
   });
 
+  test("a previousRunId the ledger cannot read is a server error, not a follow-up refusal", async () => {
+    // A store failure that is NOT a malformed id — the ledger itself unreachable — is
+    // not something the caller can fix by naming another run, so it is not folded into
+    // the follow-up refusal; it surfaces as the unhandled error the store reported.
+    mockStatus.mockImplementationOnce(async () => {
+      throw new Error("ledger unavailable");
+    });
+
+    const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "arun_1" }));
+
+    expect(res.status).toBe(500);
+    expect(await parseResponseJSON(res)).toMatchObject({
+      error: "ledger unavailable",
+      statusCode: 500,
+    });
+  });
+
   test("a previousRunId on another connection is refused", async () => {
     runs.set("arun_elsewhere", fakeRun({ connectionId: "seed:analytics", status: "succeeded" }));
 

--- a/tests/api/agent/runs.test.ts
+++ b/tests/api/agent/runs.test.ts
@@ -200,6 +200,7 @@ describe("POST /api/agent/runs", () => {
     runs.set(
       "arun_1",
       fakeRun({
+        status: "succeeded",
         events: [
           {
             kind: "report-composed",
@@ -235,7 +236,7 @@ describe("POST /api/agent/runs", () => {
   });
 
   test("a previousRunId naming another session's run is refused the same way", async () => {
-    runs.set("arun_other", fakeRun({ actor: { sessionId: "grace", role: "user" } }));
+    runs.set("arun_other", fakeRun({ actor: { sessionId: "grace", role: "user" }, status: "succeeded" }));
     const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "arun_other" }));
 
     expect(res.status).toBe(400);
@@ -246,6 +247,38 @@ describe("POST /api/agent/runs", () => {
 
   test("a previousRunId that is not a non-empty string is refused", async () => {
     const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "" }));
+
+    expect(res.status).toBe(400);
+  });
+
+  test("a previousRunId the ledger cannot name is refused, not answered as a server error", async () => {
+    // The store refuses an id outside AGENT_RUN_ID_PATTERN before touching anything;
+    // the route has to give that refusal the same 400 as a missing run, because a
+    // caller guessing ids must not be able to tell "malformed" apart from "not yours".
+    mockStatus.mockImplementationOnce(async () => {
+      throw new AgentRunStoreError("INVALID_RUN_ID", 'agent run id "arun-1" is not usable as a ledger name');
+    });
+
+    const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "arun-1" }));
+
+    expect(res.status).toBe(400);
+    expect(await parseResponseJSON(res)).toMatchObject({
+      error: "previousRunId does not name a run this session may follow",
+    });
+  });
+
+  test("a previousRunId on another connection is refused", async () => {
+    runs.set("arun_elsewhere", fakeRun({ connectionId: "seed:analytics", status: "succeeded" }));
+
+    const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "arun_elsewhere" }));
+
+    expect(res.status).toBe(400);
+  });
+
+  test("a previousRunId naming a run that has not ended is refused", async () => {
+    runs.set("arun_running", fakeRun({ status: "running" }));
+
+    const res = await POST(startRequest({ ...VALID_BODY, previousRunId: "arun_running" }));
 
     expect(res.status).toBe(400);
   });

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -377,6 +377,60 @@ describe("AgentRail", () => {
     expect(getByTestId("agent-timeline-empty")).toBeTruthy();
   });
 
+  test("a follow-up start names the run it follows on the same connection", async () => {
+    const fetchMock = mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE]);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(view.getByTestId("agent-start"));
+    });
+    await view.findByTestId("agent-run-id");
+    await waitFor(() => {
+      expect(view.getByTestId("agent-run-status").textContent).toBe("succeeded");
+    });
+
+    // The box emptied when the run opened; the follow-up is a new question in it.
+    fireEvent.change(view.getByTestId("agent-objective"), {
+      target: { value: "and how many of those are there?" },
+    });
+    await act(async () => {
+      fireEvent.click(view.getByTestId("agent-start"));
+    });
+
+    const runCalls = (fetchMock.mock.calls as [RequestInfo | URL, RequestInit?][]).filter(
+      ([url]) => String(url) === "/api/agent/runs",
+    );
+    const lastBody = JSON.parse(String(runCalls.at(-1)?.[1]?.body)) as Record<string, unknown>;
+    expect(lastBody.previousRunId).toBe("arun_1");
+  });
+
+  test("a start after switching connection does not follow the old run", async () => {
+    const fetchMock = mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE]);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(view.getByTestId("agent-start"));
+    });
+    await view.findByTestId("agent-run-id");
+    await waitFor(() => {
+      expect(view.getByTestId("agent-run-status").textContent).toBe("succeeded");
+    });
+
+    view.rerender(<AgentRail {...DEFAULT_PROPS} connectionId="seed:analytics" connectionName="Analytics" />);
+    fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "what is blocked" } });
+    await act(async () => {
+      fireEvent.click(view.getByTestId("agent-start"));
+    });
+
+    const runCalls = (fetchMock.mock.calls as [RequestInfo | URL, RequestInit?][]).filter(
+      ([url]) => String(url) === "/api/agent/runs",
+    );
+    const lastBody = JSON.parse(String(runCalls.at(-1)?.[1]?.body)) as Record<string, unknown>;
+    expect(lastBody.previousRunId).toBeUndefined();
+  });
+
   test("a run cannot start without an objective", () => {
     const fetchMock = mock(async () => jsonResponse({}, 202));
     globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/tests/evals/follow-up-context.test.ts
+++ b/tests/evals/follow-up-context.test.ts
@@ -1,18 +1,28 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { forgetHeldSnapshots } from "@/lib/agent/context-snapshot";
 import { UNTRUSTED_CONTENT_BEGIN } from "@/lib/agent/untrusted-content";
+import { derivePriorRunContext } from "@/lib/agent/prior-run-context";
 import { type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
 import { callsTool, reportOn } from "../isolated/fixtures/agent-scripted-model";
 
 /**
- * B36: a follow-up question is answered against the run it follows, not as if it
- * were the first question of a fresh run (`docs/BACKLOG.md` B36).
+ * B36, the mechanism: a follow-up run is handed the run it follows as fenced
+ * context (`docs/BACKLOG.md` B36).
  *
  * The defect was measured live on 2026-08-15: "and how many of those employees are
  * there in each group?" was answered about DEPARTMENTS, because a run carries no
- * referent for "those groups". These two runs pin the fix end to end: the second
- * run's transcript carries the first run's objective and report as fenced context,
- * so the referent resolves — and a run opened with no predecessor carries none.
+ * referent for "those groups".
+ *
+ * What a SCRIPTED model establishes here, and what it cannot. The second run's
+ * transcript carrying the first run's objective and report — fenced, before
+ * anything is done — is proven directly, because the transcript is what the loop
+ * actually sent. That the model RESOLVED "those groups" against it is not: the
+ * fixture hands the scripted model the SQL it then asserts came back
+ * (`callsTool("run_read_query", { sql: GROUP_COUNT_SQL, ... })`), so nothing in
+ * this path can distinguish a run that resolved the referent from one that did
+ * not. The referent-resolution half belongs to a live measurement
+ * (`tests/evals/real-model.ts`); this scenario pins the transport, not the
+ * judgement.
  */
 
 const runs: EvalRun[] = [];
@@ -41,7 +51,7 @@ const SALARY_SQL = "SELECT hire_year < 1990 AS before_1990, avg(salary) AS avg_s
 const GROUP_COUNT_SQL = "SELECT hire_year < 1990 AS before_1990, count(*) AS headcount FROM employees GROUP BY 1";
 
 describe("B36: a follow-up run is told about the run it follows", () => {
-  test("the second run resolves 'those groups' against the first run's objective and report", async () => {
+  test("the second run is handed the first run's objective and report, fenced, before it does anything", async () => {
     const first = await open({ objective: FIRST_OBJECTIVE });
     const firstDrive = await first.drive([
       callsTool("run_read_query", { sql: SALARY_SQL, rationale: "one read answers the comparison" }),
@@ -49,11 +59,9 @@ describe("B36: a follow-up run is told about the run it follows", () => {
     ]);
     expect(firstDrive.verdict.outcome).toBe("answered");
 
-    const prior = {
-      runId: first.runId,
-      objective: FIRST_OBJECTIVE,
-      report: "Claim 1: Before 1990 averaged 41k; after 1990 averaged 38k.",
-    };
+    // Derived from the first run's own record, the way the route derives it — so the
+    // derivation itself runs here rather than being hand-written past it.
+    const prior = derivePriorRunContext(await first.record());
 
     const second = await open({
       objective: "and how many of those employees are there in each group?",
@@ -70,7 +78,8 @@ describe("B36: a follow-up run is told about the run it follows", () => {
     expect(transcript).toContain("previous report:");
     expect(transcript).toContain(UNTRUSTED_CONTENT_BEGIN);
 
-    // It answered the question the user asked, not a different one.
+    // The scripted model echoes the SQL it was handed, so these two assert the
+    // pipeline ran to a cited answer — not that the model resolved the referent.
     expect(secondDrive.modelStatements).toEqual([GROUP_COUNT_SQL]);
     expect(secondDrive.verdict.outcome).toBe("answered");
   });

--- a/tests/evals/follow-up-context.test.ts
+++ b/tests/evals/follow-up-context.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { forgetHeldSnapshots } from "@/lib/agent/context-snapshot";
+import { UNTRUSTED_CONTENT_BEGIN } from "@/lib/agent/untrusted-content";
+import { type EvalRun, openEvalRun } from "../isolated/fixtures/agent-eval-harness";
+import { callsTool, reportOn } from "../isolated/fixtures/agent-scripted-model";
+
+/**
+ * B36: a follow-up question is answered against the run it follows, not as if it
+ * were the first question of a fresh run (`docs/BACKLOG.md` B36).
+ *
+ * The defect was measured live on 2026-08-15: "and how many of those employees are
+ * there in each group?" was answered about DEPARTMENTS, because a run carries no
+ * referent for "those groups". These two runs pin the fix end to end: the second
+ * run's transcript carries the first run's objective and report as fenced context,
+ * so the referent resolves — and a run opened with no predecessor carries none.
+ */
+
+const runs: EvalRun[] = [];
+let consoleSpy: ReturnType<typeof spyOn<Console, "log">>;
+
+beforeEach(() => {
+  consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+  forgetHeldSnapshots();
+});
+
+afterEach(() => {
+  consoleSpy.mockRestore();
+  for (const run of runs.splice(0)) run.dispose();
+});
+
+async function open(options: Parameters<typeof openEvalRun>[0] = {}): Promise<EvalRun> {
+  const run = await openEvalRun({ engine: "postgres", ...options });
+  runs.push(run);
+  return run;
+}
+
+const FIRST_OBJECTIVE = "compare the average salary of employees hired before 1990 with those hired after";
+
+const SALARY_SQL = "SELECT hire_year < 1990 AS before_1990, avg(salary) AS avg_salary FROM employees GROUP BY 1";
+
+const GROUP_COUNT_SQL = "SELECT hire_year < 1990 AS before_1990, count(*) AS headcount FROM employees GROUP BY 1";
+
+describe("B36: a follow-up run is told about the run it follows", () => {
+  test("the second run resolves 'those groups' against the first run's objective and report", async () => {
+    const first = await open({ objective: FIRST_OBJECTIVE });
+    const firstDrive = await first.drive([
+      callsTool("run_read_query", { sql: SALARY_SQL, rationale: "one read answers the comparison" }),
+      reportOn("Before 1990 averaged 41k; after 1990 averaged 38k."),
+    ]);
+    expect(firstDrive.verdict.outcome).toBe("answered");
+
+    const prior = {
+      runId: first.runId,
+      objective: FIRST_OBJECTIVE,
+      report: "Claim 1: Before 1990 averaged 41k; after 1990 averaged 38k.",
+    };
+
+    const second = await open({
+      objective: "and how many of those employees are there in each group?",
+      priorContext: prior,
+    });
+    const secondDrive = await second.drive([
+      callsTool("run_read_query", { sql: GROUP_COUNT_SQL, rationale: "the groups are the two hire cohorts" }),
+      reportOn("The before-1990 group has 12 employees; the after group has 29."),
+    ]);
+
+    // The second run was TOLD about the first, fenced, before it did anything.
+    const transcript = secondDrive.transcripts.join("\n");
+    expect(transcript).toContain(`previous objective: ${FIRST_OBJECTIVE}`);
+    expect(transcript).toContain("previous report:");
+    expect(transcript).toContain(UNTRUSTED_CONTENT_BEGIN);
+
+    // It answered the question the user asked, not a different one.
+    expect(secondDrive.modelStatements).toEqual([GROUP_COUNT_SQL]);
+    expect(secondDrive.verdict.outcome).toBe("answered");
+  });
+
+  test("a follow-up opened with no predecessor carries no prior-run context into the prompt", async () => {
+    const run = await open({ objective: "and how many of those employees are there in each group?" });
+    const drive = await run.drive([
+      callsTool("run_read_query", { sql: GROUP_COUNT_SQL, rationale: "count per cohort" }),
+      reportOn(),
+    ]);
+
+    expect(drive.transcripts.join("\n")).not.toContain("previous objective:");
+    expect(drive.transcripts.join("\n")).not.toContain("previous report:");
+  });
+});

--- a/tests/isolated/fixtures/agent-eval-harness.ts
+++ b/tests/isolated/fixtures/agent-eval-harness.ts
@@ -45,6 +45,7 @@ import { AgentRepairLedger } from "@/lib/agent/repair-ledger";
 import { AgentRunService } from "@/lib/agent/run-service";
 import { AgentRunStore } from "@/lib/agent/run-store";
 import type {
+  AgentPriorRunContext,
   AgentRunActor,
   AgentRunEvent,
   AgentRunMode,
@@ -395,6 +396,8 @@ export interface EvalRunOptions {
    * PRODUCED and the hand-over is only where that answer was delivered.
    */
   readonly autoExecute?: boolean;
+  /** The run this one follows, for the two-run follow-up scenario (`docs/BACKLOG.md` B36). */
+  readonly priorContext?: AgentPriorRunContext;
   /** What the scripted engine answers a MODEL statement with. Catalog reads are served by the preset. */
   readonly answer?: (sql: string) => Promise<QueryResult>;
   /**
@@ -476,6 +479,7 @@ export async function openEvalRun(options: EvalRunOptions = {}): Promise<EvalRun
     mode,
     ...(options.workflowType === undefined ? {} : { workflowType: options.workflowType }),
     ...(options.autoExecute === undefined ? {} : { autoExecute: options.autoExecute }),
+    ...(options.priorContext === undefined ? {} : { priorContext: options.priorContext }),
     actor,
     connectionId: engine.connection.id,
     objective,

--- a/tests/isolated/fixtures/agent-eval-harness.ts
+++ b/tests/isolated/fixtures/agent-eval-harness.ts
@@ -49,6 +49,7 @@ import type {
   AgentRunActor,
   AgentRunEvent,
   AgentRunMode,
+  AgentRunRecord,
   AgentRunStopReason,
   AgentRunWorkflowType,
   AgentRunTerminalStatus,
@@ -453,6 +454,8 @@ export interface EvalRun {
   /** Records a stop request against the durable ledger, as the HTTP surface would. */
   requestCancellation(): Promise<void>;
   events(): Promise<readonly AgentRunEvent[]>;
+  /** The whole folded record, so a follow-up can be derived from it the way the route does. */
+  record(): Promise<AgentRunRecord>;
   dispose(): void;
 }
 
@@ -612,6 +615,11 @@ export async function openEvalRun(options: EvalRunOptions = {}): Promise<EvalRun
       const view = await boot().store.read(record.runId);
       if (!view) throw new Error(`run ${record.runId} has no ledger`);
       return view.record.events;
+    },
+    async record() {
+      const view = await boot().store.read(record.runId);
+      if (!view) throw new Error(`run ${record.runId} has no ledger`);
+      return view.record;
     },
     dispose() {
       fs.rmSync(dataDir, { recursive: true, force: true });

--- a/tests/unit/lib/agent/prior-run-context.test.ts
+++ b/tests/unit/lib/agent/prior-run-context.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { derivePriorRunContext } from "@/lib/agent/prior-run-context";
+import type { AgentEvidenceReference, AgentRunEvent, AgentRunRecord } from "@/lib/agent/types";
+
+/**
+ * `derivePriorRunContext` is pure: it assembles the previous run's objective and
+ * report from a record. These tests feed it records shaped the way the ledger
+ * folds them, with no store and no model behind them.
+ */
+
+const ACTOR = { sessionId: "sess_1", role: "admin" } as const;
+
+const EVIDENCE: AgentEvidenceReference = { source: "artifact", correlationId: "corr_1" };
+
+function record(events: readonly AgentRunEvent[], objective = "Compare salaries by hire year"): AgentRunRecord {
+  return {
+    runId: "arun_prev",
+    mode: "agent",
+    workflowType: "data-analysis",
+    workflowSource: "chosen",
+    workflowReading: "unrecorded",
+    autoExecute: false,
+    status: "succeeded",
+    actor: ACTOR,
+    connectionId: "conn_1",
+    objective,
+    createdAtMs: 1,
+    updatedAtMs: 2,
+    events,
+  };
+}
+
+function event(kind: AgentRunEvent["kind"], atMs: number, extra: Record<string, unknown>): AgentRunEvent {
+  return { kind, atMs, ...extra } as AgentRunEvent;
+}
+
+describe("derivePriorRunContext", () => {
+  test("carries the previous run's id and objective, and an empty report when it established nothing", () => {
+    const context = derivePriorRunContext(record([]));
+
+    expect(context.runId).toBe("arun_prev");
+    expect(context.objective).toBe("Compare salaries by hire year");
+    expect(context.report).toBe("");
+  });
+
+  test("records the answer statement from an answer-composed event", () => {
+    const context = derivePriorRunContext(
+      record([
+        event("answer-composed", 3, {
+          sql: "SELECT hire_year, avg(salary) FROM employees GROUP BY hire_year",
+          artifact: {
+            correlationId: "corr_1",
+            runId: "arun_prev",
+            operationId: "sql.query.read",
+            summary: { rowCount: 2, columnNames: ["hire_year"], elapsedMs: 4 },
+          },
+          presentation: { kind: "table" },
+          handover: "none",
+        }),
+      ]),
+    );
+
+    expect(context.report).toBe("Answer statement: SELECT hire_year, avg(salary) FROM employees GROUP BY hire_year");
+  });
+
+  test("numbers the claims of a report-composed event in ledger order", () => {
+    const context = derivePriorRunContext(
+      record([
+        event("report-composed", 3, {
+          claims: [
+            { claim: "Before 1990 averaged 41k", evidence: [EVIDENCE] },
+            { claim: "After 1990 averaged 38k", evidence: [EVIDENCE] },
+          ],
+        }),
+      ]),
+    );
+
+    expect(context.report).toBe("Claim 1: Before 1990 averaged 41k\nClaim 2: After 1990 averaged 38k");
+  });
+
+  test("records closing prose as its own line", () => {
+    const context = derivePriorRunContext(record([event("closing-statement", 3, { text: "Both groups are close." })]));
+
+    expect(context.report).toBe("Closing: Both groups are close.");
+  });
+
+  test("joins every kind in the order the ledger produced them", () => {
+    const context = derivePriorRunContext(
+      record([
+        event("answer-composed", 2, {
+          sql: "SELECT 1",
+          artifact: {
+            correlationId: "corr_1",
+            runId: "arun_prev",
+            operationId: "sql.query.read",
+            summary: { rowCount: 1, columnNames: ["?"], elapsedMs: 1 },
+          },
+          presentation: { kind: "table" },
+          handover: "none",
+        }),
+        event("report-composed", 3, {
+          claims: [{ claim: "One row", evidence: [EVIDENCE] }],
+        }),
+        event("closing-statement", 4, { text: "Done." }),
+      ]),
+    );
+
+    expect(context.report).toBe("Answer statement: SELECT 1\nClaim 1: One row\nClosing: Done.");
+  });
+
+  test("ignores events that are not part of the report, like a context capture", () => {
+    const context = derivePriorRunContext(
+      record([
+        event("context-captured", 2, { fingerprint: "ctx_1", tableCount: 3 }),
+        event("report-composed", 3, { claims: [{ claim: "A fact", evidence: [EVIDENCE] }] }),
+      ]),
+    );
+
+    expect(context.report).toBe("Claim 1: A fact");
+  });
+});

--- a/tests/unit/lib/agent/run-service.test.ts
+++ b/tests/unit/lib/agent/run-service.test.ts
@@ -171,6 +171,16 @@ describe("AgentRunService — starting and reporting a run", () => {
     expect((await h.reader().read(runId))?.record.workflowType).toBe("database-assessment");
   });
 
+  test("a run opened with a prior-run context keeps it on the record", async () => {
+    const h = harness();
+    const prior = { runId: "arun_prev", objective: "Compare salaries", report: "Claim 1: 41k" };
+
+    const record = await h.service.start({ ...START_INPUT, priorContext: prior });
+
+    expect(record.priorContext).toEqual(prior);
+    expect((await h.reader().read(record.runId))?.record.priorContext).toEqual(prior);
+  });
+
   test("reports nothing for a run that does not exist", async () => {
     const h = harness();
     expect(await h.service.status("arun_00000000000000000000000000000000")).toBeNull();

--- a/tests/unit/lib/agent/run-store.test.ts
+++ b/tests/unit/lib/agent/run-store.test.ts
@@ -126,6 +126,24 @@ describe("AgentRunStore — opening a run", () => {
     });
   });
 
+  test("persists the prior-run context in the header, so a resumed drive is told the same thing", async () => {
+    const { store } = storeAt();
+    const prior = { runId: "arun_prev", objective: "Compare salaries", report: "Claim 1: 41k" };
+
+    const record = await store.openRun({ ...OPEN_INPUT, priorContext: prior });
+
+    expect(record.priorContext).toEqual(prior);
+    expect((await store.read(record.runId))?.record.priorContext).toEqual(prior);
+  });
+
+  test("leaves priorContext absent when no predecessor was given, so an old ledger and a fresh one stay the same bytes", async () => {
+    const { store } = storeAt();
+
+    const record = await store.openRun(OPEN_INPUT);
+
+    expect(record.priorContext).toBeUndefined();
+  });
+
   test("accepts a caller-supplied run id, so a workflow run and its ledger can share one identity", async () => {
     const { store } = storeAt();
 


### PR DESCRIPTION
## Summary

Closes **B36** from `docs/BACKLOG.md` — a follow-up question was answered as if it were the first one.

A run can now be opened with the previous run's id. The route derives the previous run's objective and report from its own ledger, verifies that the run belongs to the session, and persists the result as `priorContext` on the new run's header. The investigation loop reads that context off the ledger — never the browser's memory — and hands it to the model **fenced**, so a pronoun or a demonstrative ("those groups", "it") either resolves against the earlier run or is refused for lack of a referent.

## Background

Measured live on 2026-08-15: an analysis run answered *"compare the average salary of employees hired before 1990 with those hired after"* correctly, and the follow-up *"and how many of those employees are there in each group?"* was answered about **departments**. "Those groups" had no referent, because a run carried none — and neither the surface nor the model said so.

## Changes

### Core
- [`src/lib/agent/types.ts`](src/lib/agent/types.ts) — `AgentPriorRunContext` and `AgentRunRecord.priorContext`.
- [`src/lib/agent/run-store.ts`](src/lib/agent/run-store.ts) — the ledger header carries `priorContext`; pre-existing ledgers fold unchanged, so no migration is needed.
- [`src/lib/agent/run-service.ts`](src/lib/agent/run-service.ts) — `start()` accepts `priorContext`.
- [`src/app/api/agent/runs/route.ts`](src/app/api/agent/runs/route.ts) — accepts `previousRunId`, derives the context server-side, and refuses a run the session did not open (one answer for both *"does not exist"* and *"not yours"*).
- [`src/lib/agent/prior-run-context.ts`](src/lib/agent/prior-run-context.ts) — `derivePriorRunContext` assembles the inert objective + report.
- [`src/lib/agent/investigation.ts`](src/lib/agent/investigation.ts) — `describePriorRunContext` fences the context into the prompt.

### Surface
- [`src/components/agent/AgentRail.tsx`](src/components/agent/AgentRail.tsx) — a terminal run on the same connection is followed automatically; switching connection drops the referent.
- [`src/components/agent/use-agent-run.ts`](src/components/agent/use-agent-run.ts) — `previousRunId` on the start request.

### Tests & docs
- [`tests/unit/lib/agent/prior-run-context.test.ts`](tests/unit/lib/agent/prior-run-context.test.ts) — derivation.
- [`tests/unit/lib/agent/run-store.test.ts`](tests/unit/lib/agent/run-store.test.ts) and [`tests/unit/lib/agent/run-service.test.ts`](tests/unit/lib/agent/run-service.test.ts) — header round-trip.
- [`tests/api/agent/runs.test.ts`](tests/api/agent/runs.test.ts) — route acceptance and refusals.
- [`tests/components/agent/AgentRail.test.tsx`](tests/components/agent/AgentRail.test.tsx) — follow and connection-switch.
- [`tests/evals/follow-up-context.test.ts`](tests/evals/follow-up-context.test.ts) — a two-run eval asserting the second run does not answer a different question.
- [`docs/AGENT.md`](docs/AGENT.md), [`docs/AGENT_DEMO.md`](docs/AGENT_DEMO.md) — follow-up context documented; [`docs/BACKLOG.md`](docs/BACKLOG.md) — B36 removed (fixed).

## Verification

- `bun run typecheck` ✅
- `bun run lint` (oxlint + eslint) — 0 errors ✅
- `bun run knip` ✅
- `bun run build` ✅
- Unit + API + eval + component suites covering the changed modules ✅
