### PR TITLE
fix(monitoring): an empty panel stopped meaning zero, and three more

### DIFF
--- a/deploy/azure/listing/description.html
+++ b/deploy/azure/listing/description.html
@@ -4,14 +4,18 @@ machine, behind an automatically provisioned HTTPS endpoint, in about five minut
 
 <h3>What you get</h3>
 <ul>
-  <li><strong>One workspace for thirteen engines</strong> - PostgreSQL, MySQL/MariaDB/TiDB, Microsoft SQL Server
+  <li><strong>One workspace for fourteen engines</strong> - PostgreSQL, MySQL/MariaDB/TiDB, Microsoft SQL Server
       (including Azure SQL), Oracle, SQLite, MongoDB/FerretDB, Redis, Couchbase, ClickHouse, Apache Druid,
-      Elasticsearch, OpenSearch and Apache Trino.</li>
+      Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra.</li>
   <li><strong>A real editor</strong> - Monaco-based SQL editing with schema-aware autocomplete,
       formatting, query history and virtualized result grids that stay fast on large result sets.</li>
-  <li><strong>AI query assistance</strong> - turn natural language into SQL, explain and optimize
-      existing queries. You supply your own model provider key; no query data is sent anywhere you
-      have not configured.</li>
+  <li><strong>Optional, read-only AI</strong> - an agent that investigates a question you state and
+      cites the result each claim came from, executing SQL on PostgreSQL and SQLite only, in a session
+      the database itself enforces as read-only; on every other engine it drafts a statement and you
+      run it. One-click plain-English explanation of a query is offered on the engines that return an
+      <code>EXPLAIN</code> plan - PostgreSQL, MySQL, SQLite, Couchbase, ClickHouse, Apache Druid and
+      Apache Trino. You supply your own model provider key; the whole surface is off until you do, and
+      no query data is sent anywhere you have not configured.</li>
   <li><strong>Schema and operations tooling</strong> - ERD diagrams, data profiling, EXPLAIN plans,
       slow-query and session views, and code generation.</li>
   <li><strong>Single sign-on</strong> - vendor-agnostic OIDC that works with Microsoft Entra ID,

--- a/deploy/azure/listing/listing-fields.md
+++ b/deploy/azure/listing/listing-fields.md
@@ -31,12 +31,12 @@ LibreDB Studio
 **Search results summary** (limit 100):
 
 <!-- limit:100 -->
-Open-source SQL IDE with AI for 13 engines: PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis+
+Open-source SQL IDE for 14 engines: PostgreSQL, MySQL, SQL Server, Oracle, MongoDB, Redis and more
 
 **Short description** (limit 256):
 
 <!-- limit:256 -->
-Open-source, self-hosted SQL IDE for cloud-native teams. Connect to thirteen engines - PostgreSQL, MySQL, SQL Server, Oracle, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch, Trino - explore schemas and query with AI help.
+Open-source, self-hosted SQL IDE for cloud-native teams. Fourteen engines - PostgreSQL, MySQL, SQL Server, Oracle, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch, Trino, Cassandra - explore and query, with read-only AI.
 
 **Description** (limit 5000, HTML): see [description.html](description.html) —
 the limit is asserted by the unit test.
@@ -67,15 +67,15 @@ and engineering contact (name + phone + email; never shown publicly).
 
 | Asset | Requirement | Status |
 |---|---|---|
-| Large logo | 216×216–350×350 PNG, flat background, no gradient/glow/text | ❌ produce `assets/logo-300.png` (brand decision: human) |
-| Screenshots ×5 | exactly 1280×720 PNG + caption each | ❌ recapture — current `public/screenshots/*.png` are 1440×900 |
+| Large logo | 216×216–350×350 PNG, flat background, no gradient/glow/text | TODO produce `assets/logo-300.png` (brand decision: human) |
+| Screenshots ×5 | exactly 1280×720 PNG + caption each | TODO recapture — current `public/screenshots/*.png` are 1440×900 |
 
 Planned captions:
 
 1. `hero-editor` — "Write and run SQL with schema-aware autocomplete and a virtualized result grid."
-2. `nl2sql` — "Turn a plain-English question into SQL with AI assistance."
+2. `agent-rail` — "Ask the read-only agent a question; every claim in its answer cites the result it came from."
 3. `erd-diagram` — "Explore relationships with an automatically generated ERD."
-4. `connection-modal` — "Connect to thirteen engines, from PostgreSQL and SQL Server to Apache Trino."
+4. `connection-modal` — "Connect to fourteen engines, from PostgreSQL and SQL Server to Apache Cassandra."
 5. `data-profiler` — "Profile table data: distributions, null ratios and outliers at a glance."
 
 ## Plan (§7.6)

--- a/deploy/caprover/libredb-studio.yml
+++ b/deploy/caprover/libredb-studio.yml
@@ -69,10 +69,10 @@ caproverOneClickApp:
     instructions:
         start: |-
             LibreDB Studio is a modern, open-source, web-based SQL IDE for the cloud era.
-            Query thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
+            Query fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server,
             MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch,
-            OpenSearch and Apache Trino - from your browser, with AI-powered query
-            assistance, an ERD viewer, schema diff and more.
+            OpenSearch, Apache Trino and Apache Cassandra - from your browser, with an
+            ERD viewer, schema diff and optional read-only AI on your own model key.
 
             What you can set below (defaults are sensible - you can usually just click Deploy):
               - Version: the image tag to deploy (a tested fixed version by default).
@@ -111,5 +111,5 @@ caproverOneClickApp:
             "App Configs" tab. See https://github.com/libredb/libredb-studio
     displayName: LibreDB Studio
     isOfficial: false
-    description: Open-source web-based SQL IDE. Query thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch & Apache Trino - from your browser, with AI-powered query assistance.
+    description: Open-source web-based SQL IDE. Query fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch, Apache Trino & Apache Cassandra - from your browser, with optional read-only AI on your own model key.
     documentation: Image and docs - https://github.com/libredb/libredb-studio . Uses ghcr.io/libredb/libredb-studio. Deploys with SQLite persistence; supports OIDC SSO and multiple AI providers via extra env vars.

--- a/deploy/digitalocean/assets/description-long.md
+++ b/deploy/digitalocean/assets/description-long.md
@@ -2,12 +2,13 @@
 
 **The open-source SQL IDE built for cloud-native teams.**
 
-LibreDB Studio gives you a full-featured database workspace in your browser — connect to PostgreSQL, MySQL, MongoDB, Redis and more, write and run queries with AI assistance, and share results with your team.
+LibreDB Studio gives you a full-featured database workspace in your browser — connect to PostgreSQL, MySQL, MongoDB, Redis and ten more engines, write and run queries, have the optional AI explain them wherever the engine returns a query plan, and share results with your team.
 
 ## Features
 
-- **Multi-engine support** — PostgreSQL, MySQL, MongoDB, Redis and more from a single interface
-- **AI-assisted SQL** — turn natural language into queries (NL2SQL)
+- **Fourteen engines, one interface** — PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra
+- **Read-only AI agent** — state a question and the agent investigates it, and every claim in its report cites the result it came from; it runs SQL on PostgreSQL and SQLite only, in a session the database enforces as read-only, so writes and DDL are refused by the engine rather than by reading the statement. On every other engine it drafts the statement and you run it, and nothing reaches your editor unless you consent to the hand-over when the run opens
+- **AI query explanation** — one click turns an unfamiliar query into plain English, with your own schema as context, on PostgreSQL, MySQL, SQLite, Couchbase, ClickHouse, Apache Druid and Apache Trino: the write-up is derived from the engine's own `EXPLAIN` plan, so it is offered where an engine returns one (bring your own key: Gemini, OpenAI, Ollama or any OpenAI-compatible endpoint; off unless configured)
 - **Modern editor** — autocomplete, syntax highlighting, query history
 - **Zero-config start** — this 1-Click App boots fully configured; credentials are generated uniquely for your Droplet on first boot
 - **Self-hosted & private** — the app and its configuration store run entirely on your Droplet (local SQLite by default); traffic to the databases and optional AI providers you configure flows directly from your Droplet to those services

--- a/deploy/railway/TEMPLATE_OVERVIEW.md
+++ b/deploy/railway/TEMPLATE_OVERVIEW.md
@@ -1,6 +1,6 @@
 # Deploy and Host libredb-studio on Railway
 
-LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. Query PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch and Apache Trino from your browser — with AI-powered query assistance (natural-language-to-SQL, explain, and fix), an ERD viewer, schema diff, and a data profiler. No desktop client required.
+LibreDB Studio is an open-source, web-based SQL IDE for cloud-native teams. Query PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra from your browser — with an ERD viewer, schema diff, a data profiler, and optional AI on your own model key: a read-only agent that investigates a question and cites the result each claim came from, plus one-click explanation of a query on the engines that return an `EXPLAIN` plan. No desktop client required.
 
 ## About Hosting libredb-studio
 
@@ -10,11 +10,13 @@ Hosting LibreDB Studio means running a single stateless Next.js container that s
 
 - Give a team a browser-based SQL console for cloud databases, with no desktop client to install or update.
 - Spin up an admin/query UI right next to a Railway PostgreSQL or MySQL database in the same project.
-- Use AI assistance to write, explain, and fix SQL across multiple database engines from one interface.
+- Ask the read-only agent a question and get an answer whose every claim cites the result it came from — it executes SQL on PostgreSQL and SQLite only, in a session the database itself enforces as read-only, and on every other connection it drafts a statement for you to run yourself.
+- Draft a statement before anything runs: plan mode executes nothing it drafts, on every engine — its one reach into the database is the schema capture that grounds it, metadata only and no data rows — and the only statement that lands in your editor and runs there is the hand-over you consent to when the run opens.
+- Explain an unfamiliar query in plain English, with the connected schema as context and the engine's own `EXPLAIN` plan as the source — offered on PostgreSQL, MySQL, SQLite, Couchbase, ClickHouse, Apache Druid and Apache Trino, the engines that return a plan.
 
 ## Dependencies for libredb-studio Hosting
 
-- A database to connect to — any of the thirteen engines above (bring your own, or add a Railway database to the project).
+- A database to connect to — any of the fourteen engines above (bring your own, or add a Railway database to the project).
 - A persistent volume mounted at `/app/data` for the SQLite-backed store of saved connections and settings (included in this template).
 
 ### Deployment Dependencies

--- a/deploy/railway/template.json
+++ b/deploy/railway/template.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Reviewable serialization of the LibreDB Studio Railway template. Railway does not ingest this file directly — the marketplace template is built in Railway's template editor (Workspace -> Templates -> New Template, at https://railway.com/workspace/templates). This file is the single source of truth for what to enter there (see PUBLISH.md) and what a future API automation would consume. Mirrors deploy/caprover/libredb-studio.yml.",
   "name": "LibreDB Studio",
-  "description": "Open-source web-based SQL IDE. Query thirteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch & Apache Trino - from your browser, with AI-powered query assistance.",
+  "description": "Open-source web-based SQL IDE. Query fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Druid, Elasticsearch, OpenSearch, Apache Trino & Apache Cassandra - from your browser, with optional read-only AI on your own model key.",
   "tags": ["database", "sql", "ide", "postgres", "mysql", "mongodb", "redis"],
   "services": [
     {

--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -12,26 +12,53 @@ published it on 2026-08-05 from an earlier revision of this file). Edits here do
 propagate automatically — SUSE owns the page, so any change has to be mailed to the
 partner contact.
 
-> **Accuracy gate — engine count.** The wording below says ten engines. That is true
-> from **0.11.0** onwards, the first release shipping ClickHouse and Apache Druid
-> alongside the other eight (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB,
-> Redis, Couchbase); the provider registry in `src/lib/db/factory.ts` at that tag
-> resolves all ten. The catalog entry is version-scoped, so do not publish the
-> ten-engine wording against a version older than 0.11.0 — send the eight-engine
-> variant instead.
+> **Accuracy gate — engine count.** The wording below says fourteen engines. That is true
+> from **0.13.0** onwards, the release that carried Elasticsearch, OpenSearch, Apache Trino
+> and Apache Cassandra ([#424](https://github.com/libredb/libredb-studio/issues/424) Phases
+> 1, 2 and 4) alongside the ten of 0.11.0. The number is the `SHIPPED` record in
+> `src/lib/db/compatibility.ts` minus the embedded `libredb`, which `EXTERNAL` in the same
+> file already splits out; read it from there rather than from this file. The catalog entry
+> is version-scoped, so do not publish the fourteen-engine wording against a version older
+> than 0.13.0 — send the ten-engine variant (0.11.0 onwards) or the eight-engine one instead.
 >
-> **The count is now fourteen on `main`, and that wording waits for a release.**
-> Elasticsearch, OpenSearch and Apache Trino shipped on `main` with
-> [#424](https://github.com/libredb/libredb-studio/issues/424) Phases 1 and 2, and Apache
-> Cassandra with Phase 4; all four are in the `SHIPPED` record in
-> `src/lib/db/compatibility.ts`, but the catalog page describes a released version. So the
-> prose below stays at ten until a tag carries them, and then both the short and long
-> descriptions gain "Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra" and the
-> feature bullet becomes fourteen. Read the number from `SHIPPED` (minus
-> the embedded `libredb`) rather than from this file, and state the scope with it: on the
-> two search engines LibreDB Studio queries and browses — their SQL has no `INSERT`,
-> `UPDATE` or `CREATE TABLE` — so "manage data across …" must not be extended to include
-> them.
+> **The scope goes with the count.** Browsing and querying reach all fourteen; editing data does
+> not, so "manage data across …" must never be written over the whole list. Read the split from
+> the providers: `supportsInlineRowEdit` and `supportsCreateTable` default to `true` in
+> `src/lib/db/base-provider.ts` and each provider that cannot turns them off, which leaves inline
+> row editing on PostgreSQL, MySQL, Oracle, SQL Server and SQLite, and table creation on those
+> five plus Apache Trino. Every other engine — Cassandra, ClickHouse, Couchbase, Druid,
+> Elasticsearch, MongoDB, OpenSearch and Redis — reports those controls as unsupported. The
+> reason differs per engine and the copy must not flatten it: on Elasticsearch no mutation is in
+> the SQL grammar at all, while OpenSearch's grammar carries exactly one — `DELETE`, off by
+> default on the cluster (`docs/providers/opensearch.md` §5.6, and `SEARCH_SCHEMA_REFRESH_PATTERN`
+> in the provider exists for it) — so "the two search engines accept no mutation at all" is false
+> of the fork and must never be written over the pair. Both refuse `CREATE TABLE` and `UPDATE`
+> with HTTP 400, and the error names the PRODUCT rather than the statement: Elasticsearch answers
+> `parsing_exception` to both, OpenSearch `SQLFeatureNotSupportedException` to both — see the
+> header of `src/lib/db/providers/sql/search/index.ts`, points 2 and the `DELETE` note at
+> line 183. On Druid the true sentence is the one `docs/providers/druid.md` and the README both
+> carry: Druid SQL has no `UPDATE`, no `DELETE` and no `CREATE TABLE`. "Druid has no `INSERT`" is
+> false — `INSERT` and `REPLACE` exist there through the MSQ task engine, on an endpoint this
+> provider does not use (`docs/providers/druid.md` §5.5).
+>
+> **Accuracy gate — AI wording.** Natural-language-to-SQL was removed from the product, so
+> no listing may say the assistant writes SQL from a plain-English question. What ships is
+> AI query *explanation*, and it is **not** available on any connection: the write-up is
+> derived from the engine's own `EXPLAIN` plan, and `src/components/studio/BottomPanel.tsx`
+> drops the Explain tab unless the provider declares `explainFormat`. Seven do — PostgreSQL,
+> MySQL, SQLite, Couchbase, ClickHouse, Apache Druid and Apache Trino — so name that set rather
+> than a count, and check it by grepping `explainFormat:` under `src/lib/db/providers/` rather
+> than by trusting this line. Alongside it is the read-only agent rail
+> ([`docs/AGENT.md`](https://github.com/libredb/libredb-studio/blob/main/docs/AGENT.md)),
+> which executes statements on PostgreSQL and SQLite only (`queryReadOnly` exists on those
+> two providers alone) in a session the database enforces as read-only. "Executes nothing it
+> recommends" is an overclaim this product already rejected: the consented editor hand-over
+> runs exactly the recommended statement
+> (`src/app/api/agent/runs/[runId]/handover/route.ts` calls `queryReadOnly(answer.sql, …)`).
+> `src/lib/agent/posture.ts` carries the wording settled in #449 and a listing may reuse it as
+> written: plan mode "executes nothing it **drafts**", and the consented hand-over is "reads
+> only, and one statement in your editor". "Never writes" and "read-only" stay accurate and
+> are enough on their own.
 >
 > **The chart's own `description` is not release-coupled and does name Cassandra.** An
 > earlier revision of this note said it deliberately did not, on the reasoning that
@@ -46,8 +73,11 @@ partner contact.
 > `operator/helm-charts/libredb-studio/` by hand, or the sync guard fails the required check.
 >
 > What *is* release-coupled is every marketplace description that spells the count:
-> `deploy/azure`, `deploy/railway` and `deploy/caprover` still say thirteen, because each
-> describes an artifact a user can already download and 0.12.0 ships no Cassandra provider.
+> `deploy/azure`, `deploy/railway` and `deploy/caprover` all say fourteen as of 2026-08-25 -
+> `deploy/railway/template.json` and `deploy/caprover/libredb-studio.yml` were still on
+> thirteen after the prose files had moved, because each channel spells the count in a second
+> file nobody reads while editing the first. Each of these describes an artifact a user can
+> already download, so the number has to be true at the tag it names.
 > Read the number from `SHIPPED` when a tag carries it. Two groups are no longer in that set.
 > `packaging/winget`, `packaging/chocolatey`, `packaging/homebrew` and
 > `desktop/src-tauri/tauri.conf.json` now carry **no number at all** - nothing regenerates them
@@ -77,17 +107,28 @@ partner contact.
 ## Short description (one sentence)
 
 LibreDB Studio is an MIT-licensed, AI-assisted open source SQL IDE that connects to
-PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse and
-Apache Druid directly from the browser.
+PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse,
+Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra directly from
+the browser.
 
 ## Long description
 
 LibreDB Studio brings a full SQL IDE to Rancher-managed Kubernetes clusters: browse
-schemas, run queries, and manage data across PostgreSQL, MySQL, Oracle, SQL Server,
-SQLite, MongoDB, Redis, Couchbase, ClickHouse and Apache Druid from a single web
-interface, with no desktop client to install. An optional AI assistant (bring your own
-key: Gemini, OpenAI, or a local model) writes and explains SQL from natural language and
-stays off unless configured.
+schemas and run queries across PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB,
+Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and
+Apache Cassandra from a single web interface, with no desktop client to install. Editing
+data follows the engine rather than the IDE: inline row editing on PostgreSQL, MySQL,
+Oracle, SQL Server and SQLite, table creation on those five and Apache Trino, and
+everywhere else the controls are reported as unsupported rather than offered and then
+failed — Elasticsearch SQL has no mutation in its grammar at all, OpenSearch's one
+mutation (`DELETE`) is off by default, and Druid SQL has no `UPDATE`, no `DELETE` and no
+`CREATE TABLE`. An optional AI assistant (bring your own key: Gemini, OpenAI, or a local
+model) writes up a query in plain English from the engine's own EXPLAIN plan, on
+PostgreSQL, MySQL, SQLite, Couchbase, ClickHouse, Apache Druid and Apache Trino — the
+engines that return one — and runs a read-only investigation agent on PostgreSQL and
+SQLite whose every claim cites the result it came from, and that never writes: the session
+is read-only and the database, not the IDE, refuses writes and DDL. It stays off unless
+configured.
 
 The Helm chart installs from the Rancher Apps catalog with default values: first-run
 admin credentials are generated automatically and printed to the pod log, so a working
@@ -99,12 +140,16 @@ versions are documented and validated for every release.
 
 ## Key features (bullet form, if the catalog template asks for them)
 
-- Ten database engines in one browser-based IDE: PostgreSQL, MySQL, Oracle,
-  SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid
+- Fourteen database engines in one browser-based IDE: PostgreSQL, MySQL, Oracle,
+  SQL Server, SQLite, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid,
+  Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra
 - One-click install from the Rancher Apps catalog — deployable with default values,
   zero configuration required
-- Optional AI query assistance (Gemini, OpenAI, or a self-hosted model; off by
-  default)
+- Optional AI assistance (Gemini, OpenAI, or a self-hosted model; off by default):
+  plain-English query explanation on the engines that return an EXPLAIN plan (PostgreSQL,
+  MySQL, SQLite, Couchbase, ClickHouse, Apache Druid, Apache Trino), and a read-only
+  investigation agent on PostgreSQL and SQLite that never writes — the database enforces
+  the read-only session, not the IDE
 - Hardened chart defaults: non-root, read-only root filesystem, NetworkPolicy, PDB,
   HPA, Ingress/TLS
 - Self-hosted and air-gap friendly: no external services required to operate the IDE
@@ -119,9 +164,9 @@ partner contact rather than sending them one at a time.
 
 | Field on the page | Published value | Should be |
 |---|---|---|
-| Version | LibreDB Studio 0.9.44 | 0.11.0, with the release link pointing at <https://github.com/libredb/libredb-studio/releases/tag/0.11.0> |
-| Key features | "Seven database engines" | ten — the accuracy gate above is satisfied as of 0.11.0 |
-| Short and long description | the pre-0.11.0 revision, which names seven engines | the text in this file |
+| Version | LibreDB Studio 0.9.44 | 0.13.4, with the release link pointing at <https://github.com/libredb/libredb-studio/releases/tag/0.13.4> — the fourteen-engine wording in this file needs 0.13.0 or later |
+| Key features | "Seven database engines" | fourteen — the accuracy gate above is satisfied as of 0.13.0 |
+| Short and long description | the pre-0.11.0 revision, which names seven engines and an AI that writes SQL from natural language | the text in this file — fourteen engines, and no natural-language-to-SQL claim: that feature was removed from the product |
 | Hardware Architecture | x86-64 | x86-64 and Arm64 (`ghcr.io/libredb/libredb-studio` is linux/amd64 + linux/arm64) |
 
 Two open questions for the same mail: whether the version field can track the latest

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,10 +22,10 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S1–S8 · 8
-- [Drivers and connections](#drivers-and-connections) — D1–D24, U17 · 9
+- [Drivers and connections](#drivers-and-connections) — D1–D26, U17 · 8
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U18 · 10
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U19 · 11
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P5 · 5
@@ -36,7 +36,7 @@ None of it is a GitHub issue.
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C2–C10 · 9
 - [Security Phase 3 deferrals](#security-phase-3-deferrals) — K2–K4 · 2
 - [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A6 · 5
-- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B56 · 38
+- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B64 · 42
 
 ---
 
@@ -293,30 +293,6 @@ the query, or the field is dropped from `PerformanceMetrics` so no panel offers 
 
 ---
 
-### D16. The TLS a connection string carries in its QUERY STRING is still dropped
-
-`rediss://` and `couchbases://` now reach the form as mode `require` (2026-08-23), which leaves the
-other half of the same intake: `parseGenericURL` drops the query string entirely, so
-`postgresql://host/db?sslmode=verify-full`, MySQL's `?ssl-mode=REQUIRED` and an ADO.NET
-`Encrypt=True;TrustServerCertificate=False` all arrive on the form's `disable` default. The user asked
-for TLS in the string they pasted and the form says plaintext.
-
-Not the same one-line shape as a scheme, which is why it was left out: a scheme implies one mode, a
-parameter carries a VALUE that needs mapping, and two of the values have no representation at all -
-Postgres's `prefer` and `allow` and MySQL's `PREFERRED` mean "encrypt if the server offers it", while
-`SSLMode` is `disable | require | verify-ca | verify-full`. Mapping `prefer` onto either end is a
-security decision, not a translation.
-
-Correcting the record: an earlier version of this entry's predecessor claimed
-"`postgresql://...?sslmode=` already goes through `withSSLMode`". It does not, and never did -
-`withSSLMode`'s only callers were ClickHouse's `http://` / `https://` until the Redis and Couchbase
-schemes joined them.
-
-**Done when:** a pasted string's TLS parameter reaches the form, and either `SSLMode` gains a
-representation for opportunistic TLS or the mapping's refusal to guess is recorded here.
-
----
-
 ### D18. Two engines hand back a number that has already lost digits
 
 Measured 2026-08-24 against Oracle Free 23ai through the provider: `NUMBER(38,0)` holding
@@ -342,45 +318,46 @@ digits intact, and every consumer of a numeric cell has been checked against the
 
 ---
 
-### D23. Every Oracle DATE and TIMESTAMP cell exports as a literal Oracle refuses
+### D25. Couchbase turns an RBAC denial into a zero, which the absence rule now forbids
 
-Found 2026-08-24 while verifying the interval normalisation (the old D19) end to end: the intervals
-now replay, and the timestamps in the same result do not. `buildResultExport` writes a `Date` cell as
-its ISO string, so an exported row reads
-`INSERT INTO t ("TTZ") VALUES ('2026-08-24T07:11:12.345Z');` and Oracle answers **ORA-01843: An
-invalid month was specified**. Measured against Oracle Free 23ai through the real export path, dialect
-`oracle`.
+Found 2026-08-25 by the audit D24 asked for. `degradeTo()`
+(`src/lib/db/providers/document/couchbase/index.ts:196`) swallows a refused management read and
+substitutes a fallback VALUE - `{}` for the pools and bucket payloads, and
+`{ tableCount: 0, indexCount: 0 }` for the catalog counts. Its own comment says why the absences are
+ordinary there: an RBAC role that may read documents may not read `/pools`. But the substitute is a
+measurement the user cannot tell from a real one, so a role without the management grant reads a
+bucket with **0 tables and 0 indexes** rather than "this role may not ask".
 
-It is not specific to `TIMESTAMP WITH TIME ZONE`: `DATE`, `TIMESTAMP` and both zoned forms all arrive
-as `Date` and all export the same unusable string, so a DDL+INSERT export of any ordinary Oracle table
-with a date column cannot be replayed into Oracle. The fix belongs in `src/lib/export/result-export.ts`
-next to the Cassandra and Postgres cases already there - `TO_TIMESTAMP('...','YYYY-MM-DD
-HH24:MI:SS.FF3')` for a timestamp and `TO_DATE` for a date - and it has to decide what a zoned column
-emits, since the offset is already gone by then (see `docs/providers/oracle.md` 5.5).
+`MonitoringData.errors` (#477) is the mechanism the rest of the family now uses, and Cassandra, Trino
+and LibreDB were converted to it in the same round this was found. Couchbase was left out for one
+reason: no Couchbase cluster is running here, so the four refusal categories could not be measured,
+and a refusal sentence that has never been seen from the server is exactly what D21 was fixed for.
 
-**Done when:** an Oracle result exported from the grid replays into Oracle with its date columns
-intact, proven by running the exported file back into the engine it came from.
+**Done when:** a Couchbase panel a role may not read is absent with the cluster's own wording, and
+the counts it feeds carry the same distinction - measured against a live cluster with a document-only
+role, not inferred from the code.
 
 ---
 
-### D24. Cassandra's monitoring degradation still answers an empty panel, now that absence has a shape
+### D26. `?ssl=true` maps onto `require`, and `require` is the one mode that does not verify
 
-The five `system_views` reads degrade to EMPTY on a build with no virtual tables, which was the only
-honest option while `MonitoringData` required every panel. It no longer is: a panel can now be absent
-with the reason recorded under `errors` (2026-08-24), and the browser shows the cost of not using that
-- on ScyllaDB 2026.2.4 the Sessions tab reads *Active 0 / Idle 0 / Wait 0 / Sessions (0) / No active
-sessions found.* for a question the engine cannot answer at all, while StarRocks, which cannot answer
-the same question, says so in the engine's own words.
+`readBooleanTLS` maps a PostgreSQL `?ssl=true` onto `SSLMode` `require` (2026-08-25, D16). That is
+the honest half of a real choice - the alternative was leaving it on the form's `disable` default and
+sending plaintext - but it weakens what the source spelling asks for: `pg` reads `ssl=true` as TLS
+with Node's default `rejectUnauthorized: true`, while this app's `require` is explicitly
+`rejectUnauthorized: false` (`src/lib/db/providers/sql/postgres.ts:793`, where only `verify-ca` and
+`verify-full` verify).
 
-The provider knows which it is: `readServerFacts` establishes `hasVirtualTables` once per connection
-(`src/lib/db/providers/sql/cassandra/introspect.ts`), so the reads that were skipped are exactly the
-ones that should report absence rather than zero. The same question applies to the other providers
-whose surfaces degrade to empty by convention - Druid and Trino return `[]` from `getTableStats` as a
-documented refusal, and `docs/providers/*.md` records each.
+The same change REFUSED to map MongoDB's `tls=true` on exactly that argument, so the two arms of one
+commit disagree. Both are defensible on their own - a downgrade beats plaintext, and a downgrade of
+an Atlas connection is worse than a form the user must fill in - and neither is written down as a
+rule. `SSLMode` having no "encrypt and verify with the system roots, no server-name pinning" value is
+what forces the choice.
 
-**Done when:** a Cassandra-family panel the build cannot answer is absent with its own sentence rather
-than empty, and every other provider that degrades to `[]` has been checked against the same rule.
+**Done when:** the two spellings answer to one stated rule, or `SSLMode` gains the mode that makes
+the question disappear.
 
+---
 
 ## Value interpolation
 
@@ -645,6 +622,24 @@ is accepted deliberately.
 
 ---
 
+### U19. A caution about a save the app could not verify renders as a green success tick
+
+`use-connection-form.ts:423` emits the degraded-save message - "... Click Save Changes again to save
+it anyway." - as `success: true`, and `ConnectionModal.tsx:874` has exactly two renderings for that
+flag: emerald with a `CircleCheck`, or red with a `CircleX`. So the sentence asking the user to think
+again arrives wearing the affordance of a completed action.
+
+Found 2026-08-25 while fixing the identical shape one branch above it: the connection-string TLS
+refusal was emitted the same way and now emits `success: false`. That fix is available here too and
+was deliberately not applied, because a red cross overstates in the other direction - the save is
+being OFFERED, not refused. The same missing thing explains both: this banner has no warning state.
+`AgentRail`'s posture line (#449) is the precedent for the wording, not for the colour.
+
+**Done when:** a message that is neither a success nor a failure renders as neither, and the degraded
+save uses it.
+
+---
+
 ## Authentication and security headers
 
 ### AU2. Static assets receive no security headers — decided, not implemented
@@ -845,33 +840,32 @@ whose own recipe uses `--set-string` for exactly this reason.
 **Done when:** both lines use `--set-string`, and ideally the README's `--set` bracket arguments are
 single-quoted, since unquoted `extraEnv[0]` is a glob pattern in zsh.
 
-### DOC3. Four channel listings still advertise NL2SQL, which the product no longer has
+### DOC3. Six channel listings carry corrected copy that nobody has resubmitted
 
-#331 T2 removed the NL2SQL and Autopilot panels, and #331 T6 rewrote the READMEs, `DOCKERHUB.md` and
-`docs/FEATURES.md` around the agent. The **external channel listings were left out of that PR on
-purpose**: each is a submission to somebody else's marketplace with its own review cycle.
+The false strings are gone from the tree as of 2026-08-25. What is left is the part this repo cannot
+do: each file is a submission to somebody else's marketplace, published from its own review cycle, so
+editing it here changes nothing a user sees until the channel is re-submitted.
 
-Four files, with the strings that are now false:
+| File | What changed |
+| --- | --- |
+| `deploy/railway/TEMPLATE_OVERVIEW.md` | NL2SQL removed; the read-only agent and plan mode named; 13 engines to 14 |
+| `deploy/railway/template.json` | 13 engines to 14; "AI-powered query assistance" to optional read-only AI |
+| `deploy/digitalocean/assets/description-long.md` | NL2SQL bullet replaced by the agent and the plan-derived explanation |
+| `deploy/rancher/CATALOG_LISTING.md` | same, plus an accuracy gate holding each claim to a cited file |
+| `deploy/azure/listing/listing-fields.md` + `listing/description.html` | one Partner Center submission, both halves corrected |
+| `deploy/caprover/libredb-studio.yml` | 13 engines to 14; the AI clause narrowed |
 
-| File | Line | The string |
-| --- | --- | --- |
-| `deploy/railway/TEMPLATE_OVERVIEW.md` | 3 | "with AI-powered query assistance (natural-language-to-SQL, explain, and fix)" |
-| `deploy/digitalocean/assets/description-long.md` | 10 | "**AI-assisted SQL** — turn natural language into queries (NL2SQL)" |
-| `deploy/rancher/CATALOG_LISTING.md` | 87 | "...writes and explains SQL from natural language and" |
-| `deploy/azure/listing/listing-fields.md` | 76 | "2. `nl2sql` — \"Turn a plain-English question into SQL with AI assistance.\"" |
+Two claims had to be narrowed rather than kept, both caught by review rather than by a gate: AI
+explanation is **not** offered on every connection (it is derived from the engine's `EXPLAIN` plan, so
+`BottomPanel.tsx` hides the tab wherever `capabilities.explainFormat` is absent - 7 of the 14
+engines), and "never executes what it recommends" is the formulation #449 already rejected, because
+the consented hand-over runs exactly the recommended statement
+(`src/app/api/agent/runs/[runId]/handover/route.ts`). `tests/unit/marketplace-copy.test.ts` now binds
+the submitted copy to both facts, so a future edit that re-widens either claim fails a gate rather
+than a reviewer.
 
-"Explain" survives the removal and "writes SQL from natural language" does not, so three of the four
-need a rewrite rather than a deletion. The honest replacement is the read-only agent.
-
-**Second staleness in the same files:** the railway line also names 12 engines, and 0.13.0 ships 14
-plus 18 measured relatives. Fix both in one resubmission.
-
-They are four separate submissions rather than one edit: the Azure entry is a numbered item in that
-listing's own field contract, and each of the others is published by its marketplace from the file
-above.
-
-**Done when:** each listing has been resubmitted through its own channel with copy that matches the
-shipped product.
+**Done when:** each listing has been resubmitted through its own channel. Six submissions, five
+channels - the two Azure files travel together.
 
 ---
 

--- a/docs/providers/cassandra.md
+++ b/docs/providers/cassandra.md
@@ -169,7 +169,7 @@ node, the monitoring **Tables** tab still summarised the empty `getTableStats()`
 *0 rows*, *Size* `0 B` over *Total*, and *Vacuum* `0` over *OK*, in the very frame where the Overview
 tab read *Tables 6 / 2 indexes* out of `system_schema`: the `0 B` was the sentinel this section had
 just deleted, surviving one component over, and the *OK* was a clean bill of health for an operation
-Cassandra does not have at all ([§7.4](#74-the-panels-that-report-nothing)). Two other engines are
+Cassandra does not have at all ([§7.4](#74-the-panels-that-report-nothing--and-how-they-say-so)). Two other engines are
 recorded in `compatibility.ts` as failures for doing the opposite (Citus and TimescaleDB report row
 counts and sizes that are wrong rather than missing), and this provider is not going to join them.
 
@@ -304,13 +304,17 @@ own proposal got wrong and a measurement caught. Measured 2026-08-24 through the
 A virtual keyspace is not in `system_schema` on either engine, so keying on that catalog would have
 emptied all five panels on the engine that answers them. `readServerFacts()` in
 [`introspect.ts`](../../src/lib/db/providers/sql/cassandra/introspect.ts) therefore reads the virtual
-catalog and resolves one boolean, `hasVirtualTables`:
+catalog and resolves `virtualTablesAbsence` — **not** a boolean but the REASON, absent when the
+virtual tables are readable, because it is the text the two panels whose only source is a virtual table
+report in place of rows ([§7.4](#74-the-panels-that-report-nothing--and-how-they-say-so)) and the three
+causes send the reader to three different places:
 
-- the catalog answered → the **name** `system_views` is in the list, or it is not;
+- the catalog answered → the **name** `system_views` is in the list, or it is not — and when it is not,
+  the reason says exactly that;
 - the catalog was refused as `invalid` (**code**, not text) → there is no virtual schema, so there are
-  no virtual tables. This is ScyllaDB;
+  no virtual tables. This is ScyllaDB, and the reason names the missing catalog;
 - the catalog was refused as `permission` (8448) → a role that may not read the virtual schema may not
-  read `system_views` either, and the per-read permission arm already answers those panels empty;
+  read `system_views` either, and the reason says it is a grant rather than a dialect;
 - **anything else** — a client timeout, an unreachable host — claims no absence: the reads go out and
   their own failure is what the caller sees, exactly as before the probe existed. The probe therefore
   cannot fail a `connect()`.
@@ -783,19 +787,45 @@ node's request threads.
 keyspace, a driver name and a protocol version — but no statement and no duration, so it is a
 connection list rather than a session list.
 
-### 7.4 The panels that report nothing
+### 7.4 The panels that report nothing — and how they say so
 
-Each of these returns an empty list, and the second column is why. The third is what the panel does
-with it: an empty list is the only way a required field can decline, so a panel that reduces one into
-a total publishes a figure the engine refused to give — which is what the Tables and Queries tabs did
-here until the rule of [§3.2](#32-there-is-no-honest-row-count-and-no-honest-size) reached them.
+**ABSENT is not EMPTY.** `getMonitoringData` reads the seven panels independently, so a panel whose
+read rejects is left out of the payload with the engine's own sentence recorded under
+`MonitoringData.errors`, and `PanelUnavailable` renders that sentence in its place. An empty array
+means the opposite: the engine looked and measured nothing. Until 2026-08-25 this provider answered
+`[]` for three panels it could never fill and for two more on a build with no `system_views`, which
+claimed a measurement in every one of those five cases. The browser showed the cost on ScyllaDB
+2026.2.4: the Sessions tab read *Active 0 / Idle 0 / Wait 0 / Sessions (0) / No active sessions
+found.* for a question that build cannot answer at all.
 
-| Panel | Why empty | What it renders |
+**Three panels are refused on every build.** The objects exist — the schema tree lists the tables and
+the secondary indexes — so what is missing is the figures, and each panel now carries that sentence:
+
+| Panel | The sentence it carries | Statements sent |
 |---|---|---|
-| Slow queries | There is no aggregate of finished statements anywhere CQL can read. `system_views.system_logs` is a tail of the node's log file (0 rows on this image), and the slow-query threshold that exists writes to that log. **No statement is sent** to discover this | *Queries*, *Avg Time* and *Slow* all read `N/A`. They used to read `0`, `0.00ms` and `0`, and an average over no statements is not zero milliseconds |
-| Table statistics | `TableStats` needs a row count and a byte size; see [§3.2](#32-there-is-no-honest-row-count-and-no-honest-size). **No statement is sent** | *Tables* and *Size* read `N/A`, and the list below them says *No table statistics available.* rather than *No tables found.* The tab separates the two cases by the **required** `overview.tableCount`, which `system_schema` fills honestly (6 here): tables the engine knows about, with statistics for none of them, means the figures are not knowable rather than that the keyspace is empty |
-| Index statistics | `system_schema.indexes` gives a name, a table and a target column — all of which the tree already shows — and `IndexStats` also wants a size and a scan count. Nothing reachable from CQL reports either, and a zeroed scan count reads as "never used" | There is no index panel; `IndexStats` feeds the Storage tab's *Indexes* card, which reads `N/A` on the absent `databaseSizeBytes` rather than on this list ([§3.2](#32-there-is-no-honest-row-count-and-no-honest-size)) |
-| Storage statistics | The only storage figures a statement can read are whole mebibytes per table, so `databaseSizeBytes` is omitted rather than zeroed and the tab says so in words ([§3.2](#32-there-is-no-honest-row-count-and-no-honest-size)) | Both size cards read `N/A` with no percentage, and the breakdown is replaced by *No storage size information available.* |
+| Table statistics | A row count would have to come from `system.size_estimates`, which counts **partitions** per token range from flushed SSTables only (measured: 143 for a 500-row clustered table, 525 for a 500-row one), and a size from `system_views.disk_usage`, which reports whole mebibytes (measured: 1 MiB for a 19,476-byte table). See [§3.2](#32-there-is-no-honest-row-count-and-no-honest-size) | none |
+| Index statistics | `system_schema.indexes` names an index, its table and its target column — all of which the tree already shows — and nothing reachable from CQL reports a secondary index's size or how often it was used | none |
+| Storage statistics | `disk_usage`, `max_partition_size` and `max_sstable_size` are whole mebibytes per table, and multiplying a rounded mebibyte would report a 19 KB table as a confident 1 MB | none |
+
+**Two more are refused only where `system_views` is absent** — the performance panel
+(`system_views.caches`) and the sessions panel (`system_views.queries`). The sentence names the
+virtual table AND which of the three measured causes applies: this build has no
+`system_virtual_schema` catalog (every ScyllaDB), its catalog lists no `system_views`, or the
+connected role may not read the catalog. Three causes, three sentences, because they send the reader
+to three different places. See [§3.6](#36-a-monitoring-surface-degrades-on-a-denial-and-on-one-absent-keyspace).
+
+**One panel stays EMPTY on purpose.** Slow queries: there is no aggregate of finished statements
+anywhere CQL can read (`system_views.system_logs` is a tail of the node's log file, 0 rows on this
+image), **no statement is sent**, and `ProviderLabels.slowQueriesEmptyState` already carries
+Cassandra's own sentence into the panel — *"Cassandra keeps no aggregate of finished statements: the
+slow-query threshold writes to the node's log file rather than to a table."* Converting it would move
+the same sentence from a label the tab renders to an error entry, and buy nothing.
+
+`getHealth()` does **not** refuse: it degrades exactly as before, because
+`POST /api/db/test-connection` calls it and the connection dialog's save is gated on that request. A
+throwing health check would lock the whole ScyllaDB family out of the product
+([§3.6](#36-a-monitoring-surface-degrades-on-a-denial-and-on-one-absent-keyspace)). A monitoring
+panel has the opposite obligation — it is the surface that must say what it could not read.
 
 ---
 
@@ -947,9 +977,12 @@ latency.
 
 Two changes, and the second is not about Cassandra at all.
 
-**The five reads degrade.** A monitoring read that needs `system_views` answers empty — without being
-sent — on a build whose virtual-keyspace catalog does not list `system_views`, which is every ScyllaDB
-build. The discriminator was a match on the refusal's wording when this section was written and is a
+**The five reads degrade.** A monitoring read that needs `system_views` is not sent at all on a build
+whose virtual-keyspace catalog does not list `system_views`, which is every ScyllaDB build. It
+answered EMPTY when this section was written; since 2026-08-25 a read whose whole panel depends on a
+virtual table reports that panel ABSENT with the reason instead
+([§11.2](#112-an-empty-panel-was-still-a-claim-d24)), while a read that only contributes a FIELD — the
+connection count — still omits the field and lets the panel answer. The discriminator was a match on the refusal's wording when this section was written and is a
 catalog read since **2026-08-24**; both, the four measured error spellings that are now only a
 regression pin, and the one case it cannot separate are in
 [§3.6](#36-a-monitoring-surface-degrades-on-a-denial-and-on-one-absent-keyspace).
@@ -979,7 +1012,7 @@ then the provider, against both servers:
 
 | Read (connection pinned to the `system` keyspace) | Cassandra 5.0.9 | ScyllaDB 2026.2.4 |
 |---|---|---|
-| `readServerFacts()` | `{ hasVirtualTables: true }`, 4.5 ms | `{ hasVirtualTables: false }`, 1.6 ms |
+| `readServerFacts()` | virtual tables present, 4.5 ms | virtual tables absent, 1.6 ms |
 | `getOverview` | `Apache Cassandra 5.0.9`, uptime `12.49h`, 23 tables, 1 index, connections 1 | `Apache Cassandra 3.0.8`, uptime `12.50h`, 60 tables, 0 indexes, `activeConnections` key **absent** |
 | `getPerformanceMetrics` | `{ cacheHitRatio: 86.97 }` | `{}` |
 | `getActiveSessions` | 1 running statement | `[]` |
@@ -987,6 +1020,30 @@ then the provider, against both servers:
 | `getMonitoringData` | answers with data | answers, `performance: {}` |
 | `getSchema` | answers | answers |
 | `system_views` statements sent per monitoring refresh | 3 | **0** |
+
+The fact was a boolean when this table was written and is a REASON since 2026-08-25
+([§11.2](#112-an-empty-panel-was-still-a-claim-d24)); the readings above are unchanged, only the shape
+of what carries them.
+
+### 11.2 An empty panel was still a claim (D24)
+
+The degradation above stopped the five reads from FAILING. It did not stop them from answering, and
+what they answered was a measurement: `performance: {}` and `activeSessions: []` say the engine looked.
+Re-measured **2026-08-25** through the provider against both live servers, after the panels were
+converted to report absence ([§7.4](#74-the-panels-that-report-nothing--and-how-they-say-so)):
+
+| Surface | Cassandra 5.0.9 | ScyllaDB 2026.2.4 |
+|---|---|---|
+| `getPerformanceMetrics` | `{ cacheHitRatio: 87.19 }` | **refused** — *"This panel is read from system_views.caches, and this server has no system_virtual_schema catalog at all …"* |
+| `getActiveSessions` | 1 running statement | **refused**, same sentence naming `system_views.queries` |
+| `getTableStats` / `getIndexStats` / `getStorageStats` | **refused** with their own reasons | **refused**, identically — the cause is the engine, not the build |
+| `getSlowQueries` | `[]` | `[]` — the panel whose label already carries the sentence |
+| `getHealth` | `cacheHitRatio 87.19%`, 1 connection, 6 sessions | answers: `cacheHitRatio N/A`, no connections key, no sessions |
+| `getMonitoringData` panels PRESENT | `overview`, `performance`, `slowQueries`, `activeSessions` | `overview`, `slowQueries` |
+| `getMonitoringData` `errors` keys | `tables`, `indexes`, `storage` | `performance`, `activeSessions`, `tables`, `indexes`, `storage` |
+
+Both servers still answer `getHealth()`, which is what the connection dialog's save is gated on — the
+regression this section's own §11 records. A panel refuses; the health surface does not.
 
 And the four spellings, re-sent through `provider.query()` — the user's own path, which degrades
 nothing — on the same day, which is what keeps them a live pin rather than a remembered one:
@@ -1011,11 +1068,14 @@ What works:
 
 - `connect`, `query`, `getSchema`, `disconnect` — the editor and the object browser in full, columns
   and index metadata included.
-- `getSlowQueries`, `getTableStats`, `getIndexStats` and `getStorageStats` pass by sending nothing,
-  exactly as they do on Cassandra ([§3.2](#32-there-is-no-honest-row-count-and-no-honest-size),
-  [§7.4](#74-the-panels-that-report-nothing)). They are passes, not working panels: row counts, sizes
-  and the slow-query figures read `N/A` here for the same reason they do on Cassandra, rather than a
-  fabricated zero.
+- `getSlowQueries` answers `[]` and `getTableStats`, `getIndexStats` and `getStorageStats` REFUSE with
+  their reason, both without sending a statement, exactly as they do on Cassandra
+  ([§3.2](#32-there-is-no-honest-row-count-and-no-honest-size),
+  [§7.4](#74-the-panels-that-report-nothing--and-how-they-say-so)). None of the four is a working
+  panel: row counts, sizes and the slow-query figures are not knowable here for the same reason they
+  are not on Cassandra, and the three refusals say so in words rather than as a fabricated zero. They
+  were `[]` when this gate ran (2026-08-24) and were converted on 2026-08-25
+  ([§11.2](#112-an-empty-panel-was-still-a-claim-d24)).
 - All **18 CQL types round-tripped byte-identically** to the 5.0.9 baseline, compared field by field:
   `bigint` 9007199254740993 as a string, `decimal` 1.25, `duration` `3h20m`, `varint`
   123456789012345678901234567890, `blob` `0x00ff` (the stored value; both engines now report it as

--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -1104,6 +1104,15 @@ The honest empties, each with its reason:
   no file holds finished queries. No statement is sent to discover that.
 - **`getIndexStats()` is `[]`** and **`indexCount` is `0`** because no index object exists
   ([§6](#6-schema-introspection)).
+
+Those two empty arrays were re-checked on **2026-08-25** against the ABSENT-is-not-EMPTY rule
+`MonitoringData` states (the rule that converted five Cassandra panels and one Trino one). Both stay
+EMPTY, and the distinction is which fact the panel is reporting: **an absent panel means the engine
+could not answer; an empty one means zero is a real measurement.** Druid has no query log and no index
+object, so the count of listable rows really is zero and an empty panel states it correctly — the
+`slowQueriesEmptyState` label carries the reason into the tab besides. The Cassandra panels were
+different: its tables and secondary indexes *exist* and the schema tree lists them in the same frame,
+so `[]` there denied objects the product was showing.
 - **`maxConnections` is `0`** because Druid publishes no connection limit anywhere in SQL — it has no
   pool. A number here would be invented.
 - **`uptime` says `"unknown"`, not `"0ms"`**, when either clock reading is missing: an uptime of zero

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -45,10 +45,11 @@ generic components render LibreDB-appropriate wording.
 | `query(input)` | A command (`get`/`put`/`delete`/`prefix`/`range`) | `kv` lens methods |
 | `getHealth()` / `getOverview()` | File stats | `fs.statSync` + prefix count |
 | `getStorageStats()` | File path and size on disk | `fs.statSync` |
-| `getSlowQueries()` | Not applicable | returns `[]` |
-| `getActiveSessions()` | Not applicable (single embedded process) | returns `[]` |
+| `getSlowQueries()` | Not applicable | returns `[]`, and the Queries panel shows the engine's own sentence ([§9](#getlabels)) |
+| `getActiveSessions()` | Not applicable (single embedded process) | **refuses** — the panel is absent with its reason |
 | `runMaintenance(type)` | Not supported (throws) | — |
-| Indexes / table stats | Not applicable | returns `[]` |
+| `getTableStats()` | One key-count per namespace | the schema tree's own `kv.range` scan |
+| `getIndexStats()` | No index object exists | **refuses** — the panel is absent with its reason |
 
 ---
 
@@ -213,10 +214,12 @@ strings are returned as-is. This mirrors how the Redis provider handles structur
 ### 3.7 Monitoring is file-stat-based
 
 Unlike Redis (`INFO`) or PostgreSQL (system catalogs), LibreDB has no server introspection API.
-Overview and storage stats derive entirely from `fs.statSync` (file size in bytes) and a schema
-scan (prefix group count). There are no sessions, slow queries, or index statistics — those
-methods return empty arrays — and no cache statistics either, so there is no cache hit ratio to
-report ([§7.1](#71-there-is-no-cache-hit-ratio-and-there-never-will-be)).
+Overview, table and storage stats derive entirely from `fs.statSync` (file size in bytes) and one
+`kv.range` scan of the keyspace (per-namespace key counts). There is no session list and no index
+object — those two panels are **absent with a sentence** rather than answered empty
+([§7.2](#72-the-two-panels-that-are-absent-and-the-one-that-is-empty)) — and no cache statistics
+either, so there is no cache hit ratio to report
+([§7.1](#71-there-is-no-cache-hit-ratio-and-there-never-will-be)).
 
 ---
 
@@ -462,29 +465,24 @@ were written through the raw `kv` lens are never cataloged, so they keep the hon
 
 ## 7. Monitoring & health
 
-All monitoring derives from `fs.statSync` (file size) and a schema scan (prefix group count).
+All monitoring derives from `fs.statSync` (file size) and one `kv.range` scan of the keyspace.
 There is no embedded stats API.
 
 | Method | Source | Returns |
 |--------|--------|---------|
 | `getHealth()` | `fs.statSync` | `activeConnections: 1`, file size as `databaseSize`, `cacheHitRatio: "N/A"` |
-| `getOverview()` | `fs.statSync` + schema scan | `version`, file size, prefix-group count as `tableCount`, `indexCount: 0` |
+| `getOverview()` | `fs.statSync` + schema scan | `version`, file size, namespace count as `tableCount`, `indexCount: 0` |
 | `getPerformanceMetrics()` | — | `{}` — nothing is measurable here |
-| `getSlowQueries()` | — | `[]` (N/A) |
-| `getActiveSessions()` | — | `[]` (N/A — single embedded process) |
+| `getSlowQueries()` | — | `[]`; the Queries panel renders `slowQueriesEmptyState` |
+| `getActiveSessions()` | — | **throws** `LIBREDB_ACTIVE_SESSIONS_REFUSAL` — no session registry exists |
 | `getStorageStats()` | `fs.statSync` | one entry: file path + size |
-| `getTableStats()` | — | `[]` (N/A) |
-| `getIndexStats()` | — | `[]` (N/A) |
+| `getTableStats()` | the schema tree's scan | one row per namespace: lens as `schemaName`, key count as `rowCount`, no bytes |
+| `getIndexStats()` | — | **throws** `LIBREDB_INDEX_STATS_REFUSAL` — no index object exists |
 
 `getOverview().tableCount` calls `getSchema()` internally — it is a full scan, so it honors the
 10 000-key cap and may undercount for very large files.
 
-The `[]` and the absent metrics above now reach the panels as absence rather than as zero. The
-**Tables** tab reads the empty `getTableStats()` against `tableCount` — prefix groups the store does
-know about, with statistics for none of them — so its *Tables* and *Size* cards read `N/A` and the
-list says *No table statistics available.* instead of summing `0` and `0 B`; the **Queries** tab's
-three cards read `N/A` for the same reason, an average over no statements not being `0.00ms`; and
-because `getPerformanceMetrics()` returns an empty object, every card on the Overview and Performance
+Because `getPerformanceMetrics()` returns an empty object, every card on the Overview and Performance
 tabs — *Cache Hit*, *Buffer*, *Deadlocks* — reads `N/A` beside *Not measured* rather than a
 percentage or a `0` badged healthy.
 
@@ -499,6 +497,50 @@ than a gap, because the panel cannot tell it apart from a measurement (the rule
 [#424](https://github.com/libredb/libredb-studio/issues/424) exists to enforce). Both sites now omit
 it, permanently: the *Cache Hit* card reads `N/A` / *Not measured*, and the agent's health tool
 reports the string `"N/A"`.
+
+### 7.2 The two panels that are absent, and the one that is empty
+
+Four monitoring methods used to be `return [];` with no reason attached. LibreDB is the **embedded
+engine of the zero-config first run**, so that dashboard is the first one many users ever open — and
+it reported *zero tables* on a database with tables. Measured before the change, on a file holding a
+25-row relational table, a 7-document collection and 4 raw kv keys, `getMonitoringData()` answered
+`"tableCount": 5` in the Overview and `"tables": []` beside it. Each of the four was decided
+separately:
+
+- **`getTableStats()` — implemented.** A namespace's rows *are* its keys (`employees:1`,
+  `articles:a1`), which is exactly what `getSchema()` already counts, so the panel now reports one
+  row per namespace from that same scan (`scanGroups()` is shared, so the tree and the panel can
+  never disagree). `schemaName` carries the namespace's **lens** — `relational` / `document` / `kv`
+  — because LibreDB has no schema namespace and the lens is the one thing the catalog declares about
+  it. The **byte** fields (`tableSize*`, `indexSize*`) stay absent and `totalSize` is `"N/A"`: the
+  file format keeps no per-namespace size, and a `0` would be summed by the Storage tab as a
+  measurement.
+- **`getTableStats()` above the scan cap — refused.** The scan stops at `LIBREDB_MAX_KEY_SCAN`
+  (10 000 keys). Past it every count is short by an unknown amount, so the panel refuses with
+  `LIBREDB_TABLE_STATS_TRUNCATED` rather than publish a silently low row count. The schema tree
+  still lists the namespaces it reached — a list of namespaces is not a count.
+- **`getActiveSessions()` — refused.** The file is opened inside this server's own process and the
+  engine publishes no session, connection or client call at all (`@libredb/libredb` 0.2.2 — grep its
+  shipped `.d.ts`). The exclusive lock is not a session registry either: measured, `<path>.lock`
+  holds `libredb-lock\n<pid>\n<hostname>\n<nonce>`, where the pid is this very server's and there
+  is no user, statement or start time to build a session row from. `[]` claimed the store was asked
+  who was connected and said nobody; nobody can be asked.
+- **`getIndexStats()` — refused.** The kernel is a single ordered key-value keyspace, where a key's
+  own byte order is the only index there is, and the catalog declares a namespace's lens and a
+  relational table's columns and nothing that indexes them. An empty Indexes panel reads as *this
+  database has no indexes yet*, which invites creating one; this engine can never have one.
+  `getOverview().indexCount: 0` is not the same claim and stays — there genuinely are zero index
+  objects, and that is a measurement.
+- **`getSlowQueries()` — stays empty, deliberately.** `QueriesTab` renders
+  `ProviderLabels.slowQueriesEmptyState` in place of an empty list and this provider declares one
+  ([§9](#getlabels)), so LibreDB's own sentence already reaches the user without an error. This is
+  the one always-empty panel that is allowed to stay empty.
+
+`getHealth()` keeps answering with `activeSessions: []` where the panel refuses, and that is
+deliberate: `POST /api/db/test-connection` calls it and the connection dialog's **Save** is gated on
+that request, so a throwing health check would lock the embedded engine out of the product
+(the lesson of [#455](https://github.com/libredb/libredb-studio/issues/455)). A monitoring panel has
+the opposite obligation — it is the surface that must say what it could not read.
 
 ---
 
@@ -554,8 +596,10 @@ analyze -> "Key Info", search placeholder -> "Search keys...", etc.
 
 One label is about the monitoring tab instead: `slowQueriesEmptyState` -> *"LibreDB keeps no
 statistics about finished statements in this version."* `getSlowQueries()` answers `[]`
-unconditionally ([§7](#7-monitoring--health)), so the Queries panel is always empty here, and its
-sentence was hardcoded to PostgreSQL's `pg_stat_statements` advice (`docs/BACKLOG.md` U12).
+unconditionally ([§7.2](#72-the-two-panels-that-are-absent-and-the-one-that-is-empty)), so the
+Queries panel is always empty here — and this label is why that emptiness is allowed to stand where
+the Sessions and Indexes panels refuse instead. Its sentence was hardcoded to PostgreSQL's
+`pg_stat_statements` advice (`docs/BACKLOG.md` U12).
 
 ---
 
@@ -620,6 +664,15 @@ disconnect), capabilities, labels, `getSchema` (prefix grouping, column definiti
 all five query commands (`get` found, `get` missing, `prefix`, `range`, `put`, `delete`),
 multi-word values, error paths (unknown verb, unmatched quote), and monitoring (`getOverview` file
 size + group count, `getStorageStats` path + size, `runMaintenance` unsupported).
+
+The monitoring suite also pins the panel decisions of
+[§7.2](#72-the-two-panels-that-are-absent-and-the-one-that-is-empty): `getTableStats()` counts each
+namespace and names its lens, reports an empty cataloged table as a real `0`, publishes no byte
+fields, and **refuses** past the 10 000-key cap (seeded in one `db.transact()` — the kv lens fsyncs
+per `set()`, so 10 500 keys cost ~30 ms that way against ~12 s one at a time); `getActiveSessions()`
+and `getIndexStats()` reject with their own sentences while `getHealth()` still answers; and
+`getMonitoringData()` is asserted end to end — the two refused panels absent with their reasons under
+`errors`, the Tables panel populated.
 
 A dedicated **catalog-aware schema** suite seeds a file with a relational table (`table()`) and a
 document collection (`doc()`) alongside the raw kv keys, then asserts: (a) `getSchema()` and
@@ -732,7 +785,10 @@ await provider.disconnect();
   signalled by the columns rather than a label. The reserved catalog namespace is excluded from
   all user-facing views (schema and query results).
 - **Schema scan capped at 10 000 keys.** Prefix groups that only appear beyond the cap won't show
-  as "tables". This is a deliberate bound, not a bug.
+  as "tables", and the row counts in the schema tree are capped with it. This is a deliberate bound,
+  not a bug — but it is why the monitoring **Tables** panel refuses outright above the cap instead of
+  publishing counts that are short by an unknown amount
+  ([§7.2](#72-the-two-panels-that-are-absent-and-the-one-that-is-empty)).
 - **File must be on the Studio server's filesystem.** There is no remote LibreDB connection model.
   The database has no server or wire protocol; embedded-in-process is the only supported mode.
 - **No column modification in a generated migration.** Since

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -303,6 +303,22 @@ See the [non-Azure trust caveat](#14-known-limitations--future-work).
 fail on the missing user/password/database) rather than honouring the URL. In practice the
 connection always has discrete fields because the UI populates them.
 
+The decomposition includes TLS. An ADO.NET keyword string
+(`Server=host,1433;Database=db;Encrypt=True;TrustServerCertificate=True;`) and the query-string form
+(`mssql://host/db?encrypt=true&trustServerCertificate=true`) both reach the form with SSL Mode set,
+values matched case-insensitively because ADO.NET writes `True`:
+
+| `Encrypt` | `TrustServerCertificate` | SSL Mode | Why |
+|-----------|--------------------------|----------|-----|
+| `False` / `No` | any | `disable` | Not encrypted |
+| `True` / `Yes` | `True` / `Yes` | `require` | Encrypted, chain unchecked |
+| `True` / `Yes` | `False` / `No` / absent | `verify-full` | The documented default validates chain **and** name |
+| `Strict` | ignored | `verify-full` | TDS 8.0 always validates |
+| absent | any | *unset* | `System.Data.SqlClient` defaults it to false, `Microsoft.Data.SqlClient` 4.0+ to true — the string does not carry the answer |
+
+Any other spelling of either keyword is reported in the paste banner and leaves the form's SSL Mode
+untouched rather than falling back to `disable`.
+
 ---
 
 ## 5. Query interface
@@ -619,6 +635,19 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
   hosts use `encrypt: true` + `trustServerCertificate: true` — encrypted but **not** authenticated
   (MITM-exposed). For verified TLS, set `connection.ssl` mode `verify-ca`/`verify-full`. (Azure hosts
   validate by default.)
+  - **A paste that worked before can now fail against a self-signed on-prem server.**
+    `Encrypt=True` with `TrustServerCertificate` absent maps to `verify-full`
+    ([§4.4](#44-connection-string-nuance)), which is faithful to `Microsoft.Data.SqlClient` 4.0+ but
+    **changes an outcome**: before the paste box read TLS, such a string left the form on `disable`,
+    the explicit-`ssl` branch never ran, and the default above trusted the certificate. Measured
+    2026-08-25 against SQL Server 2022 (`mcr.microsoft.com/mssql/server:2022-latest`) with its
+    generated self-signed certificate: `{ encrypt: true, trustServerCertificate: true }` connected
+    (`sys.dm_exec_connections.encrypt_option = TRUE`) while `{ encrypt: true,
+    trustServerCertificate: false }` — what `verify-full` builds
+    ([mssql.ts:483](../../src/lib/db/providers/sql/mssql.ts)) — was refused with *"Failed to connect
+    to 127.0.0.1:1433 - self signed certificate"*. If your on-prem server has no trusted certificate,
+    paste `TrustServerCertificate=True` alongside `Encrypt=True`, or set SSL Mode to `require` on the
+    form after pasting.
 - **Binary columns aren't sanitized.** `VARBINARY`/`IMAGE`/`rowversion` come back as Node `Buffer`s
   and cross the wire as `{"type":"Buffer","data":[…]}` (no `0x…` hex conversion like the MySQL
   provider) — see [§5.3](#53-data-type--parameter-handling). The client recovers them: the results

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -317,6 +317,36 @@ discrete-fields form** (the `connectionString` path bypasses it entirely). Note 
    a known managed host) enables `{ rejectUnauthorized: false }`.
 3. Otherwise `undefined`.
 
+#### `ssl-mode` in a pasted URL
+
+The paste box ([`connection-string-parser.ts`](../../src/lib/connection-string-parser.ts)) reads the
+query string, so `mysql://host/db?ssl-mode=REQUIRED` arrives with SSL Mode already set. The values are
+matched case-insensitively (MySQL writes them upper-case) and `sslmode` is accepted as an alias:
+`DISABLED` → `disable`, `REQUIRED` → `require`, `VERIFY_CA` → `verify-ca`, `VERIFY_IDENTITY` →
+`verify-full` (it checks the hostname as well as the chain).
+
+The boolean spellings are read too, and mapped at both ends because a boolean has no opportunistic
+value: `?ssl=true`, `?ssl=1`, `?useSSL=true` → `require`; `?ssl=false`, `?ssl=0`, `?useSSL=false` →
+`disable`. An explicit `ssl-mode` wins when a string carries both. As on Postgres, `require` here
+means `rejectUnauthorized: false` ([mysql.ts:505](../../src/lib/db/providers/sql/mysql.ts)) —
+encrypted, chain unchecked — which is weaker than the driver this provider actually uses: mysql2
+defaults `rejectUnauthorized` to `true` for any `ssl` object it is handed
+(`node_modules/mysql2/lib/connection_config.js:171`). It is **not** weaker than what `useSSL=true`
+means to Connector/J, whose `verifyServerCertificate` is off unless `sslMode` is `VERIFY_CA` /
+`VERIFY_IDENTITY` — so for that spelling the mapping is faithful. The reason it is mapped this way
+regardless of which tool wrote the string is in
+[postgres.md](./postgres.md#sslmode-in-a-pasted-url). mysql2's
+object form (`?ssl={"rejectUnauthorized":true}`) is not a boolean and is reported in the banner rather
+than guessed at.
+
+`PREFERRED` is **not** mapped, and neither is any spelling the map does not know. It means "encrypt if
+the server offers it", and mapping it onto `disable` would downgrade a connection that was in fact
+encrypted: measured over TCP against MySQL with its default self-signed certificate,
+`--ssl-mode=PREFERRED` negotiated `TLS_AES_128_GCM_SHA256` while `--ssl-mode=DISABLED` left
+`Ssl_cipher` empty. Mapping it onto `require` is the mirror-image guess. So the mode the form already
+holds is left alone and the paste banner names the parameter it declined to act on; choose SSL Mode
+yourself in the SSL / TLS panel.
+
 ---
 
 ## 5. Query interface

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -623,11 +623,86 @@ The same `TO_CHAR` recovers the sub-millisecond digits that a `Date` cannot hold
 ZONE` has no stored offset to lose (Oracle normalizes it on write and renders it in the *session's*
 zone), so for that type only the sub-millisecond truncation applies.
 
-**A `Date` cell does not replay through the SQL export into Oracle** — that is a separate defect and
-not fixed here. Measured on the same run: a `TIMESTAMP WITH TIME ZONE` cell exports as
-`'2026-08-24T07:11:12.345Z'` and Oracle refuses it with `ORA-01843: An invalid month was specified`.
-It affects every `DATE`/`TIMESTAMP` column, not just the zoned ones, and it lives in the shared
-export (`src/lib/export/result-export.ts`), not in this provider.
+#### The SQL export writes an Oracle date literal, not an ISO string
+
+A `Date` cell used **not** to replay at all. The shared export wrote it as its ISO string, and every
+one of the four types refuses that — measured 2026-08-25 against the Oracle Free image
+(`Oracle AI Database 26ai Free Release 23.26.2.0.0`) by replaying the exported file:
+
+```
+D     REFUSED  ORA-01861: literal does not match format string
+TS    REFUSED  ORA-01843: An invalid month was specified.
+TTZ   REFUSED  ORA-01843: An invalid month was specified.
+TLTZ  REFUSED  ORA-01843: An invalid month was specified.
+        (all four from INSERT ... VALUES ('2026-08-24T07:11:12.345Z'))
+```
+
+So a DDL+INSERT export of any ordinary Oracle table with a date column was unreplayable. The fix is
+in the shared export (`src/lib/export/result-export.ts`), not in this provider, and the conversion
+function IS the literal — the way `HEXTORAW` already is for a `RAW`. Which function comes from the
+**declared** type (`columnTypes`, [§5.4](#54-declared-column-types)), because the two shapes disagree
+about which fields of the `Date` are the value:
+
+| declared | written as |
+|---|---|
+| `DATE` | `TO_DATE('2026-08-24 10:11:12', 'YYYY-MM-DD HH24:MI:SS')` — the **local** fields |
+| `TIMESTAMP` (and anything else, and no declared type) | `TO_TIMESTAMP('2026-08-24 10:11:12.345', 'YYYY-MM-DD HH24:MI:SS.FF3')` — the **local** fields |
+| `TIMESTAMP WITH TIME ZONE`, `TIMESTAMP WITH LOCAL TIME ZONE` | `FROM_TZ(TO_TIMESTAMP('2026-08-24 17:11:12.345', 'YYYY-MM-DD HH24:MI:SS.FF3'), 'UTC')` — the **UTC** instant |
+
+- **Local fields for a naive column**, because that is the inverse of what the driver did: it built
+  the `Date` by reading the stored wall clock in the *Node process's* zone. Measured above, a `DATE`
+  holding `2026-08-24 10:11:12` arrives as `2026-08-24T07:11:12.000Z` from a process at `+03:00`, so
+  writing the ISO text would move every naive value by the exporter's own offset — and it would parse,
+  which is worse than being refused.
+- **`FROM_TZ(..., 'UTC')` for a zoned column**, because the `Date` there is the true instant and the
+  stored offset is already gone (above). No offset is invented; the instant is preserved *whatever
+  zone the replaying session runs in*, which a plain `TO_TIMESTAMP` is not — it is read in the
+  session's zone. Measured by replaying the same instant into a session at `-07:00` and letting the
+  server compare it against the source row:
+
+  ```
+  fromtz              1999-01-01 18:04:05.006 UTC       EQUAL
+  plain-utc-fields    1999-01-01 18:04:05.006 -07:00    DIFF
+  plain-local-fields  1999-01-01 21:04:05.006 -07:00    DIFF
+  ```
+
+- **What a zoned column loses:** its original zone, and only its zone. A `TIMESTAMP WITH TIME ZONE`
+  that read `2026-08-24 10:11:12.345 -07:00` on the source comes back as
+  `2026-08-24 17:11:12.345 UTC` on the target — the same moment, rendered as UTC, because the offset
+  was gone before the export saw the value. `TIMESTAMP WITH LOCAL TIME ZONE` loses nothing: it has no
+  stored offset, and it renders in the reader's session zone on both sides. A user who needs the
+  original zone must take it from the server with the `TO_CHAR ... TZR` above, in the same result.
+- **Milliseconds are kept** (`FF3`), and a declared `DATE` gets `TO_DATE` because a `DATE` has no
+  fractional second at all. Both were measured: a `TO_TIMESTAMP` literal inserted into a `DATE`
+  column is accepted and silently truncated to the whole second, so the explicit function only says
+  what the column already is.
+
+Verified end to end — read through the provider, exported, replayed into a fresh table, compared **by
+the server**:
+
+```
+PROVIDER ROWS  [{"K":1,"D":"2026-08-24T07:11:12.000Z","TS":"2026-08-24T07:11:12.345Z","TTZ":"2026-08-24T17:11:12.345Z","TLTZ":"2026-08-24T17:11:12.345Z"},
+                {"K":2,"D":"1999-01-01T22:00:00.000Z","TS":"1999-01-02T01:04:05.006Z","TTZ":"1999-01-01T18:04:05.006Z","TLTZ":"1999-01-01T18:04:05.006Z"},
+                {"K":3,"D":null,"TS":null,"TTZ":null,"TLTZ":null}]
+COLUMN TYPES   {"K":"NUMBER","D":"DATE","TS":"TIMESTAMP","TTZ":"TIMESTAMP WITH TIME ZONE","TLTZ":"TIMESTAMP WITH LOCAL TIME ZONE"}
+EXPORT DDL     CREATE TABLE d23_replay ("K" NUMBER, "D" DATE, "TS" TIMESTAMP,
+                 "TTZ" TIMESTAMP WITH TIME ZONE, "TLTZ" TIMESTAMP WITH LOCAL TIME ZONE);
+EXPORT INSERT  INSERT INTO d23_replay ("K", "D", "TS", "TTZ", "TLTZ") VALUES (2,
+                 TO_DATE('1999-01-02 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+                 TO_TIMESTAMP('1999-01-02 03:04:05.006', 'YYYY-MM-DD HH24:MI:SS.FF3'),
+                 FROM_TZ(TO_TIMESTAMP('1999-01-01 18:04:05.006', 'YYYY-MM-DD HH24:MI:SS.FF3'), 'UTC'),
+                 FROM_TZ(TO_TIMESTAMP('1999-01-01 18:04:05.006', 'YYYY-MM-DD HH24:MI:SS.FF3'), 'UTC'));
+REPLAYED       CREATE TABLE and all three INSERTs accepted
+SERVER SAYS    K=2  D_EQ EQUAL  TS_EQ EQUAL  TTZ_EQ EQUAL  TLTZ_EQ EQUAL
+               K=3  (the all-NULL row)       EQUAL on all four
+               K=1  DIFF on the three timestamps, by exactly 00:00:00.000678
+```
+
+That last row is the truncation this section is about, not an export defect: `K=1` was stored with
+`.345678` and a `Date` holds milliseconds, so the server measures the difference as the 678
+microseconds the driver dropped (`TO_CHAR(s."TS" - r."TS")` → `+000000000 00:00:00.000678`, and
+`+000000000 00:00:00.000000` for the millisecond-exact row). **A sub-millisecond digit does not
+survive an export, because it did not survive the driver.**
 
 ---
 
@@ -890,10 +965,13 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
   string form that keeps the offset — measured, asking for one returns the reader process's own time
   zone for every row. `TO_CHAR(col, '… TZR')` is the way to see the stored zone
   ([§5.5](#55-an-interval-is-normalized-to-its-oracle-literal-a-time-zone-cannot-be)).
-- **A `DATE`/`TIMESTAMP` cell does not replay through the SQL export into Oracle.** It is written as
-  the ISO string a `Date` serializes to (`'2026-08-24T07:11:12.345Z'`) and Oracle answers
-  `ORA-01843: An invalid month was specified`. The fix belongs in the shared export
-  (`src/lib/export/result-export.ts`), which has no Oracle date literal, not in this provider.
+- **A zoned timestamp replays as UTC, not in its original zone.** The SQL export writes a date cell
+  through Oracle's own conversion functions, so the file does replay with the instant intact
+  ([§5.5](#55-an-interval-is-normalized-to-its-oracle-literal-a-time-zone-cannot-be)) — but the
+  stored offset is gone before the export sees the value, so a `TIMESTAMP WITH TIME ZONE` written
+  `10:11:12.345 -07:00` comes back rendered `17:11:12.345 UTC`, and the sub-millisecond digits a
+  `Date` cannot hold are not in the file either. Both are the driver's truncation, above, not the
+  export's.
 - **`oracledb` ships no TypeScript declarations, so the driver surface is hand-declared.** Verified
   on 6.10.0: no `types`/`typings` field in its `package.json` and no `.d.ts` anywhere in the package,
   and there is no `@types/oracledb` in this project's dependencies. `src/types/db-drivers.d.ts`

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -210,6 +210,32 @@ const connection = {
 };
 ```
 
+#### `sslmode` in a pasted URL
+
+The paste box ([`connection-string-parser.ts`](../../src/lib/connection-string-parser.ts)) reads the
+query string, so `postgresql://host/db?sslmode=verify-full` arrives on the form with SSL Mode already
+set. `disable`, `require`, `verify-ca` and `verify-full` map one-to-one.
+
+`prefer` and `allow` are **not** mapped, and neither is any spelling the map does not know. Both mean
+"encrypt if the server offers it", which the form's four modes cannot express, and both directions of
+guess are wrong against a live server: measured on postgres 18 with no server certificate,
+`?sslmode=prefer` connects with `pg_stat_ssl.ssl = f` while `?sslmode=require` is refused outright
+("server does not support SSL, but SSL was required"). So the mode the form already holds is left
+alone and the paste banner names the parameter it declined to act on — the string is never silently
+downgraded to "disable". Set SSL Mode yourself in the SSL / TLS panel.
+
+`?ssl=true` / `?ssl=false` (the JDBC and Heroku spelling) map to `require` / `disable`, since neither
+is opportunistic. **`require` here means `rejectUnauthorized: false`**
+([postgres.ts:793](../../src/lib/db/providers/sql/postgres.ts)) — encrypted, chain **not** verified —
+while `pg` given `ssl: true` verifies by default, so this mapping is weaker than the pasted string
+asks for. It is kept deliberately: the only stronger modes on the form, `verify-ca`/`verify-full`, are
+the ones that ask for a CA certificate, so mapping `?ssl=true` onto one of them would turn a working
+paste into a connection the user cannot complete without a PEM they may not have. The real fix is a
+mode meaning "verified against the system trust store, no PEM"; until it exists, tick `verify-full`
+yourself when the server has a publicly-trusted certificate. `sslrootcert`, `sslcert` and `sslkey` are ignored: they are paths on the machine
+that wrote the string, while the panel holds PEM text and the process that opens the connection is the
+server. Paste the certificate content instead.
+
 ### 4.2 Connection pooling
 
 `connect()` builds a `pg.Pool` ([postgres.ts:281](../../src/lib/db/providers/sql/postgres.ts)) and

--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -595,7 +595,7 @@ Everything comes from `system.runtime`, `system.metadata` and — for the two re
 | `getSlowQueries()` | `system.runtime.queries`, `FINISHED` rows by elapsed time | The coordinator's recent history |
 | `getTableStats()` | `SHOW STATS FOR <table>`, one per table, capped at 25 | Real row counts and logical sizes |
 | `getStorageStats()` | `system.metadata.catalogs` | One row per catalog, `location` = the connector |
-| `getIndexStats()` | — | `[]`, no statement sent |
+| `getIndexStats()` | — | `[]`, no statement sent — a MEASUREMENT, not a refusal: no index object exists in any Trino catalog, so zero is the true count |
 | `getHealth()` | The three above | — |
 
 Measured on the probe cluster: `tpch.tiny.lineitem` 60175 rows / 1.51 MB, `tpch.tiny.nation` 25 rows
@@ -620,6 +620,20 @@ Five honest blanks, each with its reason:
 - **`getTableStats()` omits a table whose connector published no row count.** Measured,
   `SHOW STATS FOR system.runtime.nodes` returns the six columns with every value null, summary row
   included. `TableStats.rowCount` cannot say "unknown", and "0 rows" is a claim nobody made.
+- **An empty table panel has three causes, and only one of them is an empty panel.** Since
+  **2026-08-25** the two that are refusals leave the panel ABSENT with a sentence under
+  `MonitoringData.errors`, which is what `PanelUnavailable` renders, instead of an empty table that
+  claims the engine answered "no tables":
+  - the catalog's table list was **refused** (`unknown-object` or `auth`) — the panel carries the
+    server's own wording;
+  - tables were examined and **none** published a row count — the panel names how many were asked.
+    Measured 2026-08-25 against Trino 476: the `jmx` catalog holds **379** tables in schema `current`
+    and a 20-table random sample of them answered `SHOW STATS` with an empty `row_count`, 0 of 20
+    non-null — the jmx connector supplies no statistics at all — so `getTableStats()` refuses the panel there (`None of the 25 tables
+    examined in catalog "jmx" published a row count …`, 25 being the per-pass cap below) while `tpch`
+    (8 rows, `sf1.lineitem` 6,001,215) and `memory` (3 rows) answer unchanged;
+  - the catalog genuinely holds **no table** — `[]`, which is a real measurement and keeps rendering
+    as an empty panel.
 - **`getTableStats()` is capped at 25 tables per pass.** `SHOW STATS` is one statement per table;
   there is no catalog of sizes to aggregate, so N tables cost N statements.
 - **`StorageStats.size` is `"N/A"` with `sizeBytes: 0`, and `usagePercent` is absent**

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -121,6 +121,13 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
   // Calculate totals
   const totalRows = tables.reduce((sum, t) => sum + t.rowCount, 0);
   const totalSize = tables.reduce((sum, t) => sum + t.totalSizeBytes, 0);
+  // The same gate StorageTab has carried since #469: `tableSizeBytes` is what says whether
+  // this engine publishes per-table bytes at all, and `totalSizeBytes` is a required field
+  // that has to carry SOMETHING when it does not - a 0 beside the "N/A" its own `totalSize`
+  // spells. Summing those zeros drew "0 B / Total" for LibreDB over a database with bytes
+  // on disk (measured 2026-08-25: 1,878 file bytes, five namespaces), and bun:sqlite sits
+  // in the same shape wherever `dbstat` is missing. `every()` keeps a genuine "no tables"
+  // answer at 0 B, because there is nothing there to be unknown.
   const tablesNeedingVacuum = tables.filter((t) => (t.bloatRatio ?? 0) > 10).length;
 
   // A panel whose read failed is absent from the payload with its own message under
@@ -130,18 +137,22 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
   // engine's own sentence. See MonitoringData in src/lib/db/types.ts.
   const tablesUnavailable = data?.tables === undefined ? data?.errors?.tables : undefined;
 
-  // ABSENCE and ZERO are different inputs — the rule #448 settled for StorageTab, which
+  // ABSENCE and ZERO are different inputs - the rule #448 settled for StorageTab, which
   // this panel was still breaking one component over. A provider that publishes no table
-  // statistics answers `[]` (Apache Cassandra's `getTableStats` returns an empty array as
-  // a documented refusal; Apache Druid and Apache Trino do the same), and `BaseProvider`
-  // assigns that array whenever `includeTables` is set, so `tables` alone cannot tell a
-  // refusal from an empty database. The required `overview.tableCount` can: Cassandra
-  // populates it from `system_schema`, and it read 6 in the very frame these cards read 0
-  // (measured 2026-08-21 in Chrome against Apache Cassandra 5.0.9). Tables the engine
-  // knows about but reports no statistics for means the figures are not knowable, so the
-  // cards say so rather than publishing a confident zero the engine never measured. A
-  // provider that reports a genuine 0 keeps today's arithmetic and today's rendering.
+  // statistics can still answer `[]` (Apache Druid returns an empty array as a documented
+  // refusal, and so does any Trino catalog whose tables partly publish statistics), and
+  // `BaseProvider` assigns that array whenever `includeTables` is set, so `tables` alone
+  // cannot tell a refusal from an empty database. The required `overview.tableCount` can:
+  // Cassandra populated it from `system_schema` and it read 6 in the very frame these
+  // cards read 0 (measured 2026-08-21 in Chrome against Apache Cassandra 5.0.9). Tables
+  // the engine knows about but reports no statistics for means the figures are not
+  // knowable, so the cards say so rather than publishing a confident zero the engine
+  // never measured. A provider that reports a genuine 0 keeps today's arithmetic and
+  // today's rendering. Cassandra and a wholly unmeasurable Trino catalog no longer reach
+  // this heuristic at all: since 2026-08-25 they REJECT with their own sentence and land
+  // on `tablesUnavailable` above, which is the reading this approximation exists for.
   const statsAbsent = tablesUnavailable !== undefined || (tables.length === 0 && (data?.overview?.tableCount ?? 0) > 0);
+  const sizeAbsent = statsAbsent || !tables.every((t) => t.tableSizeBytes !== undefined);
 
   // Whether the engine HAS vacuum is a capability question, not a data question, so it is
   // read from what the provider declares instead of inferred from the rows. Cassandra
@@ -177,7 +188,9 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
             <Table2 strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{statsAbsent ? "N/A" : tables.length}</div>
+            <div className="text-lg sm:text-2xl font-medium" data-testid="tables-stat-count">
+              {statsAbsent ? "N/A" : tables.length}
+            </div>
             {!statsAbsent && (
               <p className="text-xs sm:text-xs text-muted-foreground mt-1">{formatNumber(totalRows)} rows</p>
             )}
@@ -190,8 +203,10 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
             <Search strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{statsAbsent ? "N/A" : formatBytes(totalSize)}</div>
-            {!statsAbsent && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Total</p>}
+            <div className="text-lg sm:text-2xl font-medium" data-testid="tables-stat-size">
+              {sizeAbsent ? "N/A" : formatBytes(totalSize)}
+            </div>
+            {!sizeAbsent && <p className="text-xs sm:text-xs text-muted-foreground mt-1">Total</p>}
           </CardContent>
         </Card>
 
@@ -270,7 +285,9 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
                           </span>
                         ) : null}
                       </TableCell>
-                      <TableCell className="text-right text-xs py-2">{table.tableSize}</TableCell>
+                      <TableCell className="text-right text-xs py-2" data-testid="table-row-size">
+                        {table.tableSize ?? "-"}
+                      </TableCell>
                       <TableCell className="text-right text-xs hidden md:table-cell py-2">
                         {table.indexSize || "-"}
                       </TableCell>

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -497,8 +497,29 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
 
     setShowPasteInput(false);
     setPasteInput("");
+    // A TLS parameter the parser refused to map is the one thing a green "parsed
+    // successfully" must not swallow: the user asked for encryption and the form is still
+    // showing whatever mode it held. Postgres's `prefer`/`allow` and MySQL's `PREFERRED`
+    // mean "encrypt if the server offers it", which SSL Mode cannot express, and guessing
+    // either end is measurably wrong in both directions (see connection-string-parser.ts).
+    // So name the parameter, name the mode that is actually in force, and say where to fix it.
+    //
+    // `success: false` is the affordance, not a claim that the paste failed: the modal has
+    // exactly two states for this box and renders `true` as a green tick (#449 - an
+    // affordance that contradicts its own sentence is the defect, and a green tick over
+    // "your TLS setting was dropped" is that defect in its most dangerous direction). The
+    // amber third state a warning would deserve is not worth a rendering variant with one
+    // caller, so the sentence carries the nuance: it leads with what was NOT applied and
+    // says outright that the other fields were.
+    if (parsed.unmappedTLSParam) {
+      setTestResult({
+        success: false,
+        message: `TLS setting not applied: "${parsed.unmappedTLSParam}" has no equivalent among disable, require, verify-ca and verify-full. The other fields were filled in, but SSL Mode stays "${sslMode}" - open SSL / TLS and choose one before connecting.`,
+      });
+      return;
+    }
     setTestResult({ success: true, message: "Connection string parsed successfully. Review the fields and connect." });
-  }, [pasteInput, name]);
+  }, [pasteInput, name, sslMode]);
 
   // Ordered for display (the modal renders these as a 2-column grid), and covering the whole
   // DatabaseType union — the same form edits existing connections, so an omitted type leaves the

--- a/src/lib/connection-string-parser.ts
+++ b/src/lib/connection-string-parser.ts
@@ -25,6 +25,23 @@ export interface ParsedConnection {
    * is HTTP-only and derives http vs https from `config.ssl` alone.
    */
   sslMode?: SSLMode;
+  /**
+   * A TLS parameter the pasted string carried that SSLMode cannot express, kept verbatim
+   * (`sslmode=prefer`, `ssl-mode=PREFERRED`, `Encrypt=Maybe`) so the form can say which one
+   * it declined to act on.
+   *
+   * Two classes end up here and both must leave `sslMode` untouched rather than fall to the
+   * form's "disable" default. The opportunistic values are a security decision, not a
+   * translation, and the measurements make the trap concrete: against postgres 18 with no
+   * server certificate `?sslmode=prefer` connects with `pg_stat_ssl.ssl = f` while
+   * `?sslmode=require` is refused outright ("server does not support SSL, but SSL was
+   * required"), so prefer -> require breaks a connection that works; against MySQL over TCP
+   * with its default self-signed certificate `--ssl-mode=PREFERRED` negotiates
+   * TLS_AES_128_GCM_SHA256 while DISABLED leaves Ssl_cipher empty, so PREFERRED -> disable
+   * silently downgrades a connection that was encrypted. The second class is any spelling the
+   * maps below do not know: guessing there is the same defect with less information.
+   */
+  unmappedTLSParam?: string;
 }
 
 /**
@@ -162,6 +179,153 @@ export function parseConnectionString(input: string): ParsedConnection | null {
 }
 
 /**
+ * What a TLS parameter resolved to: a mode the form can hold, or the parameter itself when
+ * it has no representation. Never both, and never a fallback to "disable".
+ */
+interface TLSIntent {
+  sslMode?: SSLMode;
+  unmappedTLSParam?: string;
+}
+
+/**
+ * libpq's sslmode, minus `prefer` and `allow`. Those two are absent on purpose (see the
+ * `unmappedTLSParam` note): they mean "encrypt if the server offers it", which none of the
+ * four SSLMode values describes.
+ */
+const POSTGRES_SSLMODE: Record<string, SSLMode> = {
+  disable: "disable",
+  require: "require",
+  "verify-ca": "verify-ca",
+  "verify-full": "verify-full",
+};
+
+/**
+ * MySQL's --ssl-mode, minus PREFERRED for the same reason. VERIFY_IDENTITY checks the
+ * hostname as well as the chain, which is what verify-full means here.
+ */
+const MYSQL_SSL_MODE: Record<string, SSLMode> = {
+  disabled: "disable",
+  required: "require",
+  verify_ca: "verify-ca",
+  verify_identity: "verify-full",
+};
+
+/**
+ * One query parameter kept in the spelling it was pasted in. The lookup is
+ * case-insensitive, but the banner quotes the parameter back at the user, so what it echoes
+ * has to be their text and not a normalised form of it.
+ */
+interface RawParam {
+  name: string;
+  value: string;
+}
+
+/**
+ * Map a documented value case-insensitively, or hand back the parameter verbatim.
+ *
+ * `Object.hasOwn` rather than a bare lookup: the tables are object literals, so an
+ * all-lowercase Object.prototype key reaches them. `?sslmode=constructor` resolved to the
+ * Object constructor FUNCTION - truthy, so it was written into `sslMode` and set as the
+ * form's SSLMode, smuggling a non-SSLMode value past the banner this function exists to
+ * raise. Pinned by tests/unit/lib/connection-string-parser.test.ts.
+ */
+function mapTLSValue(param: RawParam, table: Record<string, SSLMode>): TLSIntent {
+  const key = param.value.toLowerCase();
+  return Object.hasOwn(table, key) ? { sslMode: table[key] } : { unmappedTLSParam: `${param.name}=${param.value}` };
+}
+
+/**
+ * The boolean TLS spellings: postgres's JDBC/Heroku `ssl=true`, and MySQL's `ssl` / `useSSL`
+ * (Connector/J's pre-`sslMode` switch, still written by several ORMs). A boolean has no
+ * opportunistic value, so unlike `sslmode`/`ssl-mode` both ends of it are mappable.
+ *
+ * DECISION (open, and deliberately not changed here): `true` maps to `require`, which in this
+ * codebase means `rejectUnauthorized: false` for both engines - encrypted, chain unchecked
+ * (postgres.ts:793, mysql.ts:505). That is weaker than what the pasted string asks for: `pg`
+ * given `ssl=true` and mysql2 given `ssl: {}` both verify by default. It is the same weakening
+ * the mongodb arm above REFUSES to perform. It is kept because the form has no "encrypted,
+ * verified by the system trust store, no PEM pasted" mode: verify-ca/verify-full here are the
+ * modes that ask for a CA certificate, so mapping `ssl=true` onto one of them would turn a
+ * working paste into a connection the user cannot complete without a file they may not have.
+ * The honest fix is a mode that means exactly `rejectUnauthorized: true` with the default trust
+ * store; until that exists the mapping is documented rather than silently correct
+ * (docs/providers/postgres.md, docs/providers/mysql.md).
+ */
+function readBooleanTLS(param: RawParam): TLSIntent {
+  const flag = param.value.toLowerCase();
+  if (flag === "true" || flag === "1") return { sslMode: "require" };
+  if (flag === "false" || flag === "0") return { sslMode: "disable" };
+  return { unmappedTLSParam: `${param.name}=${param.value}` };
+}
+
+/**
+ * ADO.NET's Encrypt/TrustServerCertificate pair, from either the keyword string or an
+ * mssql:// query. Encrypt on with TrustServerCertificate on is `require`: encrypted, chain
+ * unchecked. Encrypt on with it off - including absent, which is the documented default -
+ * validates the chain AND the name, so verify-full. `Strict` is TDS 8.0, where the driver
+ * ignores TrustServerCertificate entirely and always validates.
+ *
+ * An absent Encrypt says nothing rather than "disable": System.Data.SqlClient defaults it to
+ * false and Microsoft.Data.SqlClient 4.0+ to true, so the string alone does not carry the answer.
+ */
+function readADONetTLS(get: (key: string) => string | undefined): TLSIntent {
+  const encrypt = get("encrypt");
+  if (encrypt === undefined) return {};
+  const value = encrypt.toLowerCase();
+  if (value === "false" || value === "no") return { sslMode: "disable" };
+  if (value === "strict") return { sslMode: "verify-full" };
+  if (value !== "true" && value !== "yes") return { unmappedTLSParam: `Encrypt=${encrypt}` };
+
+  const trust = get("trustservercertificate");
+  if (trust === undefined) return { sslMode: "verify-full" };
+  const trusted = trust.toLowerCase();
+  if (trusted === "true" || trusted === "yes") return { sslMode: "require" };
+  if (trusted === "false" || trusted === "no") return { sslMode: "verify-full" };
+  return { unmappedTLSParam: `TrustServerCertificate=${trust}` };
+}
+
+/**
+ * The TLS a URL carries in its QUERY STRING, for the engines that put it there.
+ *
+ * Only postgres, mysql and mssql are read: for `rediss://`, `couchbases://` and ClickHouse's
+ * `http(s)://` the scheme IS the transport and already decided, and MongoDB's `tls=true` is
+ * deliberately left to the driver, which enables TLS itself WITH chain verification - our
+ * `require` means rejectUnauthorized:false, so acting on it would weaken an Atlas connection.
+ *
+ * Postgres's sslrootcert/sslcert/sslkey are read by nobody here on purpose: they name files on
+ * the machine that wrote the string, while the form holds PEM text and the process that opens
+ * the connection is the server, which cannot read that path.
+ */
+function readQueryTLS(url: URL, type: DatabaseType): TLSIntent {
+  const params = new Map<string, RawParam>();
+  for (const [name, value] of url.searchParams) params.set(name.toLowerCase(), { name, value });
+
+  if (type === "postgres") {
+    // The explicit mode wins over the boolean: a string carrying both said the specific
+    // thing on purpose.
+    const sslmode = params.get("sslmode");
+    if (sslmode) return mapTLSValue(sslmode, POSTGRES_SSLMODE);
+    const ssl = params.get("ssl");
+    return ssl ? readBooleanTLS(ssl) : {};
+  }
+
+  if (type === "mysql") {
+    const mode = params.get("ssl-mode") ?? params.get("sslmode");
+    if (mode) return mapTLSValue(mode, MYSQL_SSL_MODE);
+    // Reading only ssl-mode dropped `?ssl=true` and `?useSSL=true` with no mode and no
+    // banner - the silent downgrade the whole TLS read exists to prevent. mysql2 also
+    // accepts an OBJECT here (`ssl={"rejectUnauthorized":true}`); that is not a boolean, so
+    // it falls through to the banner rather than being guessed at.
+    const flag = params.get("ssl") ?? params.get("usessl");
+    return flag ? readBooleanTLS(flag) : {};
+  }
+
+  if (type === "mssql") return readADONetTLS((key) => params.get(key)?.value);
+
+  return {};
+}
+
+/**
  * Attach a scheme's TLS intent, preserving the null a malformed URL parses to.
  */
 function withSSLMode(parsed: ParsedConnection | null, sslMode: SSLMode): ParsedConnection | null {
@@ -281,6 +445,7 @@ function parseADONetString(input: string): ParsedConnection | null {
       user: params["user id"] || params["uid"] || undefined,
       password: params["password"] || params["pwd"] || undefined,
       database: params["database"] || params["initial catalog"] || undefined,
+      ...readADONetTLS((key) => params[key]),
     };
   } catch {
     return null;
@@ -298,6 +463,7 @@ function parseGenericURL(uri: string, type: DatabaseType, defaultPort: string): 
       user: url.username ? decodeURIComponent(url.username) : undefined,
       password: url.password ? decodeURIComponent(url.password) : undefined,
       database: url.pathname.slice(1) || undefined, // remove leading /
+      ...readQueryTLS(url, type),
     };
   } catch {
     return null;

--- a/src/lib/db/providers/embedded/libredb.ts
+++ b/src/lib/db/providers/embedded/libredb.ts
@@ -75,6 +75,54 @@ async function loadLibreDB(): Promise<LibreDBModule> {
 }
 
 // ============================================================================
+// The two panels this engine cannot answer, and the one cap that can stop a third
+// ============================================================================
+
+/**
+ * The ceiling on the one keyspace scan every namespace figure is derived from.
+ *
+ * The kernel keeps no per-namespace counter, so "how many rows" here means "how many
+ * keys a scan reached", and the scan is bounded so a large file cannot hang a schema
+ * refresh. Exported because it is also the number `LIBREDB_TABLE_STATS_TRUNCATED`
+ * names to the user.
+ */
+export const LIBREDB_MAX_KEY_SCAN = 10000;
+
+/**
+ * Sessions: refused on every database, because the concept has no source here.
+ *
+ * `@libredb/libredb` 0.2.2 publishes no session, connection or client call at all (grepped
+ * over its shipped `.d.ts`), and the file is opened in this server's own process. The
+ * `<path>.lock` it holds is not a session registry either: measured, it contains
+ * `libredb-lock\n<pid>\n<hostname>\n<nonce>` - the pid is THIS server's, and there is no
+ * user, statement or start time in it to build a session row from. `[]` said the store was
+ * asked who was connected and answered nobody, which is the opposite of the truth: nobody
+ * can be asked.
+ */
+export const LIBREDB_ACTIVE_SESSIONS_REFUSAL =
+  "LibreDB is embedded: the file is opened inside this server's own process, and its API has no session, connection or client call to ask (@libredb/libredb 0.2.2). The exclusive lock it takes admits one process and names only that holder's pid and host - this server's own - with no user, statement or start time to build a session row from, so there is nothing to list here rather than a list that came back empty.";
+
+/**
+ * Indexes: refused on every database, because there is no index object to count.
+ *
+ * The kernel is one ordered key-value keyspace and the catalog records a namespace's
+ * lens plus, for a relational table, its columns and primary key - nothing else. An
+ * empty Indexes panel reads as "this database has no indexes yet", which invites the
+ * user to create one; this engine can never have one to show.
+ */
+export const LIBREDB_INDEX_STATS_REFUSAL =
+  "LibreDB has no secondary indexes: the kernel is a single ordered key-value keyspace, where a key's own byte order is the only index there is, and the catalog declares a namespace's lens and a relational table's columns and nothing that indexes them (@libredb/libredb 0.2.2). This panel has no object to list, rather than a database that has none yet.";
+
+/**
+ * Tables: refused only when the scan was cut off, never otherwise.
+ *
+ * Below the cap the key count IS the row count and the panel answers it. Above the cap
+ * every namespace's figure is short by an unknown amount, and a silently low row count
+ * is the same class of fabrication as the empty panel this work removed.
+ */
+export const LIBREDB_TABLE_STATS_TRUNCATED = `LibreDB keeps no row counter, so this panel counts each namespace's keys - and that scan stops at ${LIBREDB_MAX_KEY_SCAN.toLocaleString("en-US")} keys, which this database exceeds. Every count would be short by an unknown amount, so none is reported. The namespaces themselves are in the schema tree.`;
+
+// ============================================================================
 // LibreDB Provider
 // ============================================================================
 
@@ -246,18 +294,40 @@ export class LibreDBProvider extends BaseDatabaseProvider {
     // kv keys are not cataloged, so anything outside the catalog falls back to
     // key-prefix grouping below.
     const registry: LibreCatalogRegistry = lib.catalog(this.db!);
+    const { groups } = this.scanGroups(registry);
 
+    return groups
+      .map(({ name, rowCount, entry }) => this.schemaForGroup(name, rowCount, entry))
+      .sort((a, b) => (b.rowCount ?? 0) - (a.rowCount ?? 0));
+  }
+
+  /**
+   * The one keyspace scan behind BOTH the schema tree and the Tables panel.
+   *
+   * Sharing it is what keeps the two views consistent: the row count a namespace shows
+   * in the tree and the row count the monitoring panel reports are the same number from
+   * the same pass, so neither can quietly disagree with the other. `truncated` says the
+   * scan hit `LIBREDB_MAX_KEY_SCAN` and stopped - the tree still lists the namespaces it
+   * reached, while the Tables panel refuses (see `getTableStats`).
+   */
+  private scanGroups(registry: LibreCatalogRegistry): {
+    groups: { name: string; rowCount: number; entry: LibreCatalogEntry | undefined }[];
+    truncated: boolean;
+  } {
     // Count keys per scanned group, excluding the reserved catalog namespace.
     const groupCounts = new Map<string, number>();
     let scanned = 0;
-    const MAX_SCAN = 10000;
+    let truncated = false;
     // Empty-string start encodes to the lowest bytes; '\u{10FFFF}' encodes above
     // any UTF-8 text key the lenses produce, so [start, end) covers the keyspace.
     // (kv.prefix cannot be used here — it rejects an empty prefix.)
     for (const { key } of this.kv!.range("", "\u{10FFFF}")) {
-      if (scanned >= MAX_SCAN) break;
       // Skip the database's reserved internal namespace — it is not user data.
       if (this.isReserved(key)) continue;
+      if (scanned >= LIBREDB_MAX_KEY_SCAN) {
+        truncated = true;
+        break;
+      }
       scanned++;
       const name = this.groupName(key);
       groupCounts.set(name, (groupCounts.get(name) ?? 0) + 1);
@@ -267,21 +337,21 @@ export class LibreDBProvider extends BaseDatabaseProvider {
     // colon-prefix), so it is the scanned group "<name>:*". Reconcile the two so
     // a cataloged table/collection always appears even if its group name differs
     // and is rendered with the richer catalog-aware columns.
-    const schemas: TableSchema[] = [];
-    for (const [name, rowCount] of groupCounts) {
-      const entry = this.catalogEntryFor(name, registry);
-      schemas.push(this.schemaForGroup(name, rowCount, entry));
-    }
+    const groups = [...groupCounts].map(([name, rowCount]) => ({
+      name,
+      rowCount,
+      entry: this.catalogEntryFor(name, registry),
+    }));
     // Surface cataloged namespaces that exist but have no scanned rows yet (an
     // empty table/collection), so the catalog view is complete.
     for (const [catalogName, entry] of registry) {
       if (entry.kind === "kv") continue; // kv is the raw layer, never cataloged as a table
       const groupName = `${catalogName}:*`;
       if (groupCounts.has(groupName)) continue;
-      schemas.push(this.schemaForGroup(groupName, 0, entry));
+      groups.push({ name: groupName, rowCount: 0, entry });
     }
 
-    return schemas.sort((a, b) => (b.rowCount ?? 0) - (a.rowCount ?? 0));
+    return { groups, truncated };
   }
 
   /** Group key "user:1" under "user:*"; a key with no ":" is its own group. */
@@ -499,9 +569,21 @@ export class LibreDBProvider extends BaseDatabaseProvider {
   }
 
   // --------------------------------------------------------------------------
-  // Monitoring (filled in Task 5; honest minimal defaults for now)
+  // Monitoring
+  //
+  // Each panel answers a real measurement or is ABSENT with this engine's own sentence
+  // (D24 / #477). Nothing here reports a figure the file does not hold.
   // --------------------------------------------------------------------------
 
+  /**
+   * Health keeps ANSWERING where the monitoring panels refuse.
+   *
+   * `POST /api/db/test-connection` calls this and the connection dialog's save is gated
+   * on that request, so a health check that threw what `getActiveSessions()` throws
+   * would lock the embedded engine out of the product (#455). The two fields it fills
+   * with `[]` are a liveness summary, not the panels: the Sessions and Queries panels
+   * are the surfaces obliged to say what could not be read.
+   */
   public async getHealth(): Promise<HealthInfo> {
     this.ensureConnected();
     return {
@@ -523,6 +605,9 @@ export class LibreDBProvider extends BaseDatabaseProvider {
       databaseSize: this.fileSizeHuman(),
       databaseSizeBytes: this.fileSizeBytes(),
       tableCount: (await this.getSchema()).length,
+      // Not a placeholder: there is no index object in this engine to count, which is
+      // the same fact `getIndexStats()` refuses the Indexes panel with. Zero is the
+      // measurement here, so the Overview card states it.
       indexCount: 0,
     };
   }
@@ -542,17 +627,57 @@ export class LibreDBProvider extends BaseDatabaseProvider {
     return {};
   }
 
+  /**
+   * Empty, and it reads nothing: there is no log of finished statements to read.
+   *
+   * The one always-empty panel that stays empty. `QueriesTab` renders
+   * `ProviderLabels.slowQueriesEmptyState` in place of an empty list and this provider
+   * declares one (`getLabels()` above), so LibreDB's own sentence already reaches the
+   * user here - which is the thing an absent panel exists to deliver.
+   */
   public async getSlowQueries(): Promise<SlowQueryStats[]> {
     return [];
   }
-  public async getActiveSessions(): Promise<ActiveSessionDetails[]> {
-    return [];
+
+  /** ABSENT with its reason rather than an empty list: see `LIBREDB_ACTIVE_SESSIONS_REFUSAL`. */
+  public getActiveSessions(): Promise<ActiveSessionDetails[]> {
+    return Promise.reject(new QueryError(LIBREDB_ACTIVE_SESSIONS_REFUSAL, "libredb"));
   }
+
+  /**
+   * A real measurement: one key-count per namespace, from the schema tree's own scan.
+   *
+   * This panel used to answer `[]` on a database with tables - the embedded engine is
+   * the zero-config first run, so that empty table was the first monitoring dashboard
+   * many users ever saw. The count is honest because a namespace's rows ARE its keys
+   * (`employees:1`, `articles:a1`), which is the same thing `getSchema()` reports; the
+   * bytes are not, so `tableSize*`/`indexSize*` stay absent and `totalSize` carries the
+   * "N/A" placeholder the Storage tab already gates on (`tableSizeKnown`, #469).
+   */
   public async getTableStats(): Promise<TableStats[]> {
-    return [];
+    this.ensureConnected();
+    const lib = await loadLibreDB();
+    const { groups, truncated } = this.scanGroups(lib.catalog(this.db!));
+    // A count cut off by the cap is short by an unknown amount, so refuse instead.
+    if (truncated) throw new QueryError(LIBREDB_TABLE_STATS_TRUNCATED, "libredb");
+
+    return groups
+      .map(({ name, rowCount, entry }) => ({
+        // LibreDB has no schema namespace. The column carries the namespace's LENS -
+        // relational / document / kv - which is the one thing the catalog declares
+        // about it, so the panel says something true instead of a filler "main".
+        schemaName: entry?.kind ?? "kv",
+        tableName: name,
+        rowCount,
+        totalSize: "N/A",
+        totalSizeBytes: 0,
+      }))
+      .sort((a, b) => b.rowCount - a.rowCount);
   }
-  public async getIndexStats(): Promise<IndexStats[]> {
-    return [];
+
+  /** ABSENT with its reason rather than an empty list: see `LIBREDB_INDEX_STATS_REFUSAL`. */
+  public getIndexStats(): Promise<IndexStats[]> {
+    return Promise.reject(new QueryError(LIBREDB_INDEX_STATS_REFUSAL, "libredb"));
   }
 
   public async getStorageStats(): Promise<StorageStats[]> {

--- a/src/lib/db/providers/sql/cassandra/index.ts
+++ b/src/lib/db/providers/sql/cassandra/index.ts
@@ -76,16 +76,17 @@ import { readSqlSpan } from "@/lib/sql/spans";
 import { CASSANDRA_DEFAULT_PORT, CassandraDriverTransport } from "./driver-transport";
 import {
   CASSANDRA_IDENTITY_CQL,
+  CASSANDRA_INDEX_STATS_REFUSAL,
+  CASSANDRA_STORAGE_STATS_REFUSAL,
+  CASSANDRA_TABLE_STATS_REFUSAL,
+  cassandraVirtualTableRefusal,
   type CassandraServerFacts,
   getActiveSessions as readActiveSessions,
   getHealth as readHealth,
-  getIndexStats as readIndexStats,
   getOverview as readOverview,
   getPerformanceMetrics as readPerformanceMetrics,
   getSchema as readSchema,
   getSlowQueries as readSlowQueries,
-  getStorageStats as readStorageStats,
-  getTableStats as readTableStats,
   readServerFacts,
 } from "./introspect";
 import { CassandraTransportError, type CassandraTransport } from "./transport";
@@ -456,6 +457,25 @@ export class CassandraProvider extends SQLBaseProvider {
   }
 
   /**
+   * The facts, or a refusal naming the virtual table this panel would have read.
+   *
+   * The gate is here rather than inside the read because the read is also what
+   * `getHealth()` composes, and health must keep answering on a build with no virtual
+   * tables: `POST /api/db/test-connection` calls it and the connection dialog's save is
+   * gated on that request, so a throwing health check locks the whole ScyllaDB family
+   * out of the product (#455). A monitoring panel has the opposite obligation - it is
+   * the surface that must say what it could not read.
+   */
+  private requireVirtualTables(source: string): CassandraServerFacts {
+    const facts = this.requireFacts();
+    if (facts.virtualTablesAbsence !== undefined) {
+      throw new QueryError(cassandraVirtualTableRefusal(source, facts.virtualTablesAbsence), this.type);
+    }
+
+    return facts;
+  }
+
+  /**
    * The keyspace every catalog read resolves against.
    *
    * The connection's `database` field, exactly as a PostgreSQL connection pins one
@@ -602,34 +622,61 @@ export class CassandraProvider extends SQLBaseProvider {
     return this.guarded(() => readOverview(transport, keyspace, this.requireFacts()));
   }
 
+  /**
+   * ABSENT rather than empty on a build with no `system_views`.
+   *
+   * The key cache's hit ratio is this panel's only source, so a build that does not
+   * publish `system_views.caches` cannot answer the panel at all - and an empty
+   * `PerformanceMetrics` said the opposite, that every field was looked up and found
+   * to have no value. `getMonitoringData` leaves a rejected panel absent with this
+   * sentence under `errors`, which is what `PanelUnavailable` renders (#477).
+   */
   public async getPerformanceMetrics(): Promise<PerformanceMetrics> {
     const transport = this.requireTransport();
-    return this.guarded(() => readPerformanceMetrics(transport, this.requireFacts()));
+    const facts = this.requireVirtualTables("system_views.caches");
+    return this.guarded(() => readPerformanceMetrics(transport, facts));
   }
 
-  /** Empty, and it asks the cluster nothing: there is no slow-query log to read. */
+  /**
+   * Empty, and it asks the cluster nothing: there is no slow-query log to read.
+   *
+   * The one always-empty panel that stays empty. `QueriesTab` renders
+   * `ProviderLabels.slowQueriesEmptyState` in its place, and this provider declares one
+   * (`getLabels()` above), so Cassandra's own sentence already reaches the user here -
+   * which is the thing the absence mechanism exists to deliver.
+   */
   public getSlowQueries(): Promise<SlowQueryStats[]> {
     return Promise.resolve(readSlowQueries());
   }
 
+  /** ABSENT rather than empty on a build with no `system_views`: see `getPerformanceMetrics`. */
   public async getActiveSessions(options: { limit?: number } = {}): Promise<ActiveSessionDetails[]> {
     const transport = this.requireTransport();
-    return this.guarded(() => readActiveSessions(transport, this.requireFacts(), options));
+    const facts = this.requireVirtualTables("system_views.queries");
+    return this.guarded(() => readActiveSessions(transport, facts, options));
   }
 
-  /** Empty, and it asks the cluster nothing: see `introspect.ts` for the two numbers refused. */
+  /**
+   * REFUSED on every build, with the reason, rather than answered empty.
+   *
+   * These three panels never had a source: the tables and the secondary indexes exist
+   * and the schema tree lists them, so `[]` claimed a measurement of nothing where the
+   * truth is that no honest figure is readable from CQL. The panels are absent with
+   * their own sentence for the same reason the ScyllaDB ones above are - the rule
+   * `MonitoringData` states, not a property of any one build.
+   */
   public getTableStats(): Promise<TableStats[]> {
-    return Promise.resolve(readTableStats());
+    return Promise.reject(new QueryError(CASSANDRA_TABLE_STATS_REFUSAL, this.type));
   }
 
-  /** Empty, and it asks the cluster nothing: an index here has no size and no scan counter. */
+  /** Refused with its reason: an index here has no size and no scan counter. */
   public getIndexStats(): Promise<IndexStats[]> {
-    return Promise.resolve(readIndexStats());
+    return Promise.reject(new QueryError(CASSANDRA_INDEX_STATS_REFUSAL, this.type));
   }
 
-  /** Empty, and it asks the cluster nothing: the only storage figures are whole mebibytes. */
+  /** Refused with its reason: the only storage figures are whole mebibytes. */
   public getStorageStats(): Promise<StorageStats[]> {
-    return Promise.resolve(readStorageStats());
+    return Promise.reject(new QueryError(CASSANDRA_STORAGE_STATS_REFUSAL, this.type));
   }
 
   public async getHealth(): Promise<HealthInfo> {

--- a/src/lib/db/providers/sql/cassandra/introspect.ts
+++ b/src/lib/db/providers/sql/cassandra/introspect.ts
@@ -41,12 +41,9 @@ import type {
   ColumnSchema,
   DatabaseOverview,
   HealthInfo,
-  IndexStats,
   PerformanceMetrics,
   SlowQueryStats,
-  StorageStats,
   TableSchema,
-  TableStats,
 } from "@/lib/db/types";
 import type { CassandraRow, CassandraTransport } from "./transport";
 import { CassandraTransportError } from "./transport";
@@ -262,15 +259,78 @@ const CASSANDRA_VIRTUAL_KEYSPACE = "system_views";
 const READS_VIRTUAL_KEYSPACE = new RegExp(`\\bFROM\\s+${CASSANDRA_VIRTUAL_KEYSPACE}\\.`, "i");
 
 /**
+ * Why this build has no virtual tables, in the server's own terms.
+ *
+ * One sentence per measured cause rather than one shared "unavailable": the three are
+ * different facts and send the reader to different places. They are the only text a
+ * user sees where a virtual-table panel would have been, so each names what is missing
+ * rather than that something is.
+ */
+const NO_VIRTUAL_SCHEMA_CATALOG =
+  'this server has no system_virtual_schema catalog at all, so it publishes no virtual tables (measured against scylladb/scylla:2026.2.4, which answers "Keyspace system_virtual_schema does not exist")';
+
+const VIRTUAL_SCHEMA_DENIED =
+  "the connected role may not read system_virtual_schema, so this session cannot reach the virtual tables it describes";
+
+const VIRTUAL_KEYSPACE_ABSENT = "this server's system_virtual_schema.keyspaces does not list a system_views keyspace";
+
+/**
  * What this connection established about the server once, at connect time.
  *
  * One field today, and it is here rather than re-derived per read because the answer
  * cannot change while the session lives (see `CASSANDRA_VIRTUAL_KEYSPACE_CQL`).
+ *
+ * It is a REASON and not a boolean, because a panel that has to report its own absence
+ * needs a sentence and there are three different ones: a build with no virtual-schema
+ * catalog, a build whose catalog lists no `system_views`, and a role that may not read
+ * the catalog are all "no virtual tables here" and none of them says the same thing to
+ * the user. Present means absent - the field holds the reason - and `undefined` means
+ * this build has the keyspace, which is the only state in which a `system_views` read
+ * is sent at all.
  */
 export interface CassandraServerFacts {
-  /** Whether `system_virtual_schema.keyspaces` lists `system_views` on this build. */
-  readonly hasVirtualTables: boolean;
+  /** Why `system_views` cannot be read here, or `undefined` when it can. */
+  readonly virtualTablesAbsence?: string;
 }
+
+/**
+ * The sentence a panel whose only source is a virtual table reports instead of rows.
+ *
+ * ABSENCE is not ZERO (`MonitoringData` in `src/lib/db/types.ts`): a panel left absent
+ * with this sentence under `errors` says the engine could not answer, while the empty
+ * array it used to return said the engine looked and found nothing. Measured
+ * 2026-08-24 in the browser against ScyllaDB 2026.2.4, the second reading rendered as
+ * "Active 0 / Idle 0 / Wait 0 / Sessions (0) / No active sessions found." for a
+ * question that build cannot answer at all.
+ */
+export function cassandraVirtualTableRefusal(source: string, absence: string): string {
+  // No engine name in the sentence: the same provider serves ScyllaDB and every other
+  // relative (#455), and this refusal is the one a ScyllaDB user reads most often - naming
+  // Apache Cassandra there would tell them about a server they are not connected to.
+  return `This panel is read from ${source}, and ${absence}. The statement was not sent, so there is no measurement here rather than a measurement of zero.`;
+}
+
+/**
+ * The three panels this engine refuses on EVERY build, virtual tables or not.
+ *
+ * "This engine family" and not "Apache Cassandra": the same provider serves ScyllaDB and
+ * every other relative (#455), and a ScyllaDB user reading about a server they are not
+ * connected to is the wrong kind of precision. The measurements below were taken on
+ * Apache Cassandra 5.0.9 and the limits are the data model's, not one build's.
+ *
+ * Each one is the reason the corresponding `get*Stats` above used to return `[]`, moved
+ * to where the user can read it: the objects exist - the schema tree lists the tables
+ * and the secondary indexes - so an empty panel claimed a measurement of nothing where
+ * the truth is that the figures the panel requires are not published in any honest unit.
+ */
+export const CASSANDRA_TABLE_STATS_REFUSAL =
+  "This engine family publishes no honest table statistics. A row count would have to come from system.size_estimates, which counts PARTITIONS per token range from flushed SSTables only (measured: 143 for a 500-row clustered table, 525 for a 500-row one), and a size from system_views.disk_usage, which reports whole mebibytes (measured: 1 MiB for a 19,476-byte table). The tables are in the schema tree; these two numbers are not knowable from CQL.";
+
+export const CASSANDRA_INDEX_STATS_REFUSAL =
+  "This engine family publishes no index statistics. system_schema.indexes names an index, its table and its target column - all of which the schema tree already shows - and nothing reachable from CQL reports a secondary index's size or how often it was used. The indexes exist; the numbers this panel requires do not.";
+
+export const CASSANDRA_STORAGE_STATS_REFUSAL =
+  "This engine family publishes no byte-level storage figures. disk_usage, max_partition_size and max_sstable_size are whole mebibytes per table (measured: 1 MiB for a 19,476-byte table, 0 MiB for a table holding 500 unflushed rows), and multiplying a rounded mebibyte would report a 19 KB table as a confident 1 MB.";
 
 /**
  * Ask the server which virtual keyspaces it has. Never throws.
@@ -282,8 +342,11 @@ export interface CassandraServerFacts {
  *   so there are no virtual tables. This is ScyllaDB, measured: the probe itself is
  *   `Keyspace system_virtual_schema does not exist`, and the CODE is what is read;
  * - the catalog was refused as `permission` (8448) -> a role that may not read the
- *   virtual schema is the role that may not read `system_views` either, which the
- *   per-read permission arm below already answers empty for.
+ *   virtual schema is the role that may not read `system_views` either.
+ *
+ * Each of the three absences carries its OWN sentence out, because it is the text the
+ * monitoring panels report in place of rows and the three send the reader to different
+ * places: a dialect difference, a schema this build does not publish, and a grant.
  *
  * Anything else - a client timeout, an unreachable host - says nothing about which
  * keyspaces exist, so it claims no absence: the reads go out and their own failure is
@@ -293,13 +356,16 @@ export interface CassandraServerFacts {
 export async function readServerFacts(transport: CassandraTransport): Promise<CassandraServerFacts> {
   try {
     const { rows } = await transport.execute(CASSANDRA_VIRTUAL_KEYSPACE_CQL);
+    const listed = rows.some((row) => readText(row.keyspace_name) === CASSANDRA_VIRTUAL_KEYSPACE);
 
-    return { hasVirtualTables: rows.some((row) => readText(row.keyspace_name) === CASSANDRA_VIRTUAL_KEYSPACE) };
+    return listed ? {} : { virtualTablesAbsence: VIRTUAL_KEYSPACE_ABSENT };
   } catch (error) {
-    const refused =
-      error instanceof CassandraTransportError && (error.category === "invalid" || error.isMonitoringUnavailable());
+    if (error instanceof CassandraTransportError) {
+      if (error.category === "invalid") return { virtualTablesAbsence: NO_VIRTUAL_SCHEMA_CATALOG };
+      if (error.isMonitoringUnavailable()) return { virtualTablesAbsence: VIRTUAL_SCHEMA_DENIED };
+    }
 
-    return { hasVirtualTables: !refused };
+    return {};
   }
 }
 
@@ -330,7 +396,7 @@ async function readRows(
   cql: string,
   facts: CassandraServerFacts,
 ): Promise<CassandraRow[]> {
-  if (!facts.hasVirtualTables && READS_VIRTUAL_KEYSPACE.test(cql)) return [];
+  if (facts.virtualTablesAbsence !== undefined && READS_VIRTUAL_KEYSPACE.test(cql)) return [];
 
   try {
     return (await transport.execute(cql)).rows;
@@ -599,46 +665,6 @@ export async function getActiveSessions(
       durationMs,
     };
   });
-}
-
-/**
- * Empty, because every figure a table statistic needs is one this engine cannot give
- * honestly.
- *
- * `TableStats` requires a row count and a byte size. The row count would have to come
- * from `system.size_estimates`, which counts PARTITIONS per token range from flushed
- * SSTables - measured at 143 for a 500-row clustered table, 525 for a 500-row one -
- * and the size from `system_views.disk_usage`, which is whole mebibytes and reported
- * "1 MiB" for 19,476 bytes. Either would render as a confident number that is wrong,
- * which is the failure this whole issue exists to avoid; an empty panel is the
- * honest alternative. No statement is sent.
- */
-export function getTableStats(): TableStats[] {
-  return [];
-}
-
-/**
- * Empty, because an index here has no size and no usage counter.
- *
- * `system_schema.indexes` names an index, its table and its target column - all of
- * which the schema tree already shows - and `IndexStats` also requires a size and a
- * scan count. Nothing reachable from CQL reports either for a secondary index, and a
- * zeroed scan count would read as "never used".
- */
-export function getIndexStats(): IndexStats[] {
-  return [];
-}
-
-/**
- * Empty, for the same reason as the database size.
- *
- * The only storage figures a statement can read - `disk_usage`,
- * `max_partition_size`, `max_sstable_size` - are whole mebibytes per table, and
- * `StorageStats` wants a byte figure. Multiplying a rounded mebibyte by 1048576 would
- * turn a 19KB table into a confident 1MB.
- */
-export function getStorageStats(): StorageStats[] {
-  return [];
 }
 
 /**

--- a/src/lib/db/providers/sql/trino/index.ts
+++ b/src/lib/db/providers/sql/trino/index.ts
@@ -621,10 +621,24 @@ export class TrinoProvider extends SQLBaseProvider {
     return this.guarded(() => readActiveSessions(transport, options));
   }
 
+  /**
+   * The tables that published statistics, or an ABSENT panel with the reason.
+   *
+   * An empty array here has three causes and only one of them is a measurement (see
+   * `TrinoTableStatsReading`). The other two used to render as an empty table, which
+   * claims the engine answered "no tables" - measured 2026-08-25 against Trino 476,
+   * the jmx catalog holds 379 tables in schema `current` and a 20-table random sample
+   * of them answered SHOW STATS with an empty row_count (0 of 20 non-null; the jmx
+   * connector supplies no statistics at all), so that panel reported nothing about a
+   * catalog full of data.
+   */
   public async getTableStats(options: { schema?: string } = {}): Promise<TableStats[]> {
     const transport = this.requireTransport();
     const catalog = this.requireCatalog();
-    return this.guarded(() => readTableStats(transport, catalog, options));
+    const reading = await this.guarded(() => readTableStats(transport, catalog, options));
+    if (reading.refusal !== undefined) throw new QueryError(reading.refusal, this.type);
+
+    return reading.tables;
   }
 
   /**

--- a/src/lib/db/providers/sql/trino/introspect.ts
+++ b/src/lib/db/providers/sql/trino/introspect.ts
@@ -739,20 +739,56 @@ function readTableStatistics(rows: TrinoRow[]): TableStatistics {
 }
 
 /**
+ * What a table-statistics pass found, and why it found nothing when it found nothing.
+ *
+ * The panel has three different empty readings and only ONE of them is a measurement:
+ * a catalog that really holds no table. The other two - a refused table list, and a
+ * catalog full of tables whose connector publishes no statistics - are refusals, and
+ * `MonitoringData` requires those to be reported as an ABSENT panel carrying the
+ * engine's own sentence rather than as an empty one (#477). The caller turns
+ * `refusal` into that sentence; `undefined` means the rows are the answer.
+ */
+export interface TrinoTableStatsReading {
+  readonly tables: TableStats[];
+  readonly refusal?: string;
+}
+
+/** Why the table list itself produced nothing. Carries the server's own wording. */
+function tableListRefusal(catalog: string, reason: string): string {
+  return `Trino refused the table list for catalog "${catalog}": ${reason}. This panel therefore has no source rather than no tables, and the schema tree reads the same list.`;
+}
+
+/** Why a catalog full of tables produced no statistics row. */
+function tableStatsRefusal(catalog: string, examined: number): string {
+  return `None of the ${examined} tables examined in catalog "${catalog}" published a row count. Trino answers SHOW STATS with a null row count until ANALYZE has run, and for every connector that cannot supply one at all - the jmx connector never does, measured against Trino 476. So these figures are not knowable here; the tables themselves are in the schema tree.`;
+}
+
+/**
  * Row counts and logical sizes, one `SHOW STATS` per table.
  *
  * A table whose connector published NO row count is left out entirely rather than
  * reported as zero (shape 3): `TableStats.rowCount` is a required number with no
  * way to say "unknown", and "0 rows" is a claim nothing made about a Hive table
- * nobody has run `ANALYZE` on. An empty panel on such a catalog is the honest
- * answer, and it is the same answer the connector would give.
+ * nobody has run `ANALYZE` on. Where that leaves NOTHING at all the panel says so in
+ * words instead of rendering an empty table - see `TrinoTableStatsReading`.
  */
 export async function getTableStats(
   runner: TrinoQueryRunner,
   catalog: string,
   options: { schema?: string } = {},
-): Promise<TableStats[]> {
-  const tableRows = await readOptionalRows(runner, trinoTableListSql(catalog));
+): Promise<TrinoTableStatsReading> {
+  let tableRows: TrinoRow[];
+  try {
+    tableRows = await readRows(runner, trinoTableListSql(catalog));
+  } catch (error) {
+    // The same categories `readOptionalRows` swallows, but the refusal is kept: an
+    // empty list and a refused list are the two readings this panel must not merge.
+    if (error instanceof TrinoTransportError && UNAVAILABLE_CATEGORIES.has(error.category)) {
+      return { tables: [], refusal: tableListRefusal(catalog, error.message) };
+    }
+    throw error;
+  }
+
   const addresses = readTableAddresses(tableRows)
     .filter((address) => options.schema === undefined || address.schema === options.schema)
     .slice(0, TRINO_MAX_STATS_TABLES);
@@ -764,7 +800,7 @@ export async function getTableStats(
     }),
   );
 
-  return answers.flatMap(({ address, statistics }) => {
+  const tables = answers.flatMap(({ address, statistics }) => {
     if (statistics.rowCount === undefined) return [];
     const sizeBytes = statistics.dataSizeBytes;
 
@@ -783,6 +819,15 @@ export async function getTableStats(
       },
     ];
   });
+
+  // Tables were examined and none of them answered: a refusal, not an empty catalog.
+  // A catalog that genuinely holds no table keeps its empty array, which IS a
+  // measurement and renders as one.
+  if (tables.length === 0 && addresses.length > 0) {
+    return { tables, refusal: tableStatsRefusal(catalog, addresses.length) };
+  }
+
+  return { tables };
 }
 
 /**

--- a/src/lib/export/result-export.ts
+++ b/src/lib/export/result-export.ts
@@ -586,6 +586,79 @@ function binaryLiteral(bytes: Uint8Array, dialect: DatabaseType | undefined): st
 }
 
 /**
+ * Which Oracle conversion function a `Date` cell is written through.
+ *
+ * Oracle parses none of the literal forms a `Date` stringifies to: measured through the
+ * real export path on the Oracle Free image (`Oracle AI Database 26ai Free Release
+ * 23.26.2.0.0`), an exported `'2026-08-24T07:11:12.345Z'` is `ORA-01843: An invalid month
+ * was specified` for all three timestamp types and `ORA-01861: literal does not match
+ * format string` for a DATE, so every ordinary Oracle table with a date column produced a
+ * file that could not be replayed. The conversion function IS the literal here, the way
+ * `HEXTORAW` is for a RAW.
+ *
+ * The shape has to come from the DECLARED type, because the two shapes disagree about
+ * which fields of the `Date` are the value:
+ *
+ * - A naive `DATE`/`TIMESTAMP` reaches us as a `Date` the driver built by reading the
+ *   stored wall clock **in the Node process's zone**. Measured, a `DATE` holding
+ *   `2026-08-24 10:11:12` arrived as `2026-08-24T07:11:12.000Z` from a process at
+ *   `+03:00`. So the fields that replay it are the LOCAL ones, and writing the ISO text
+ *   would move every such value by the exporter's own offset - silently, since it still
+ *   parses.
+ * - A zoned column (`WITH TIME ZONE`, `WITH LOCAL TIME ZONE`) reaches us as the true UTC
+ *   instant, its stored offset already gone at the driver boundary
+ *   (`docs/providers/oracle.md` 5.5). `FROM_TZ(..., 'UTC')` is what keeps that instant
+ *   whatever zone the replaying session runs in: a plain `TO_TIMESTAMP` is read in the
+ *   SESSION time zone, so the same file would land on a different instant on a machine
+ *   in another zone. No offset is invented - the value comes back rendered as UTC, and
+ *   the original zone is the thing 5.5 says only the server still has.
+ *
+ * With no declared type - `columnTypes` is optional on `ResultExportSource`, and a host
+ * driving the embeddable surface may supply none - the timestamp form is the fallback:
+ * Oracle's own provider always declares (`metaData[].dbTypeName`, 5.4), the naive types
+ * are the common ones, and the fallback is the shape that is exact for them.
+ */
+type OracleDateShape = "date" | "timestamp" | "zoned";
+
+function oracleDateShape(declared: string | undefined): OracleDateShape {
+  const bare = declared?.trim().toUpperCase().replace(/\s+/g, " ") ?? "";
+  if (bare === "DATE") return "date";
+  return bare.endsWith("TIME ZONE") ? "zoned" : "timestamp";
+}
+
+/** What `source` declared for `column`, or `undefined`. */
+function declaredTypeOf(source: ResultExportSource, column: string): string | undefined {
+  // `Object.hasOwn` for the reason `sqlTypeOf` uses it: a column named `constructor`
+  // would otherwise read `Object.prototype.constructor` as its declared type.
+  const declared = source.columnTypes;
+  return declared !== undefined && Object.hasOwn(declared, column) ? declared[column] : undefined;
+}
+
+/** `value`, two digits at least, so `2026-1-2 3:4:5` never reaches a format mask. */
+function pad(value: number, width = 2): string {
+  return String(value).padStart(width, "0");
+}
+
+/**
+ * An Oracle date literal, from the LOCAL fields for a naive column and the UTC ones for
+ * a zoned column (see `oracleDateShape`).
+ *
+ * The fraction is three digits and `FF3` rather than dropped: a `Date` carries
+ * milliseconds and a `TIMESTAMP(6)` keeps them. `TO_DATE` is used for a declared `DATE`
+ * because a `DATE` has no fractional second at all - measured, a `TO_TIMESTAMP` literal
+ * inserted into a `DATE` column is accepted and silently truncated to the whole second,
+ * so nothing is lost either way and the explicit function says what the column is.
+ */
+function oracleDateLiteral(value: Date, shape: OracleDateShape): string {
+  const utc = shape === "zoned";
+  const date = `${pad(utc ? value.getUTCFullYear() : value.getFullYear(), 4)}-${pad((utc ? value.getUTCMonth() : value.getMonth()) + 1)}-${pad(utc ? value.getUTCDate() : value.getDate())}`;
+  const time = `${pad(utc ? value.getUTCHours() : value.getHours())}:${pad(utc ? value.getUTCMinutes() : value.getMinutes())}:${pad(utc ? value.getUTCSeconds() : value.getSeconds())}`;
+  if (shape === "date") return `TO_DATE('${date} ${time}', 'YYYY-MM-DD HH24:MI:SS')`;
+  const stamp = `TO_TIMESTAMP('${date} ${time}.${pad(utc ? value.getUTCMilliseconds() : value.getMilliseconds(), 3)}', 'YYYY-MM-DD HH24:MI:SS.FF3')`;
+  return utc ? `FROM_TZ(${stamp}, 'UTC')` : stamp;
+}
+
+/**
  * A value as SQL.
  *
  * Everything that is not a number, a bigint or a boolean is quoted through the
@@ -595,14 +668,17 @@ function binaryLiteral(bytes: Uint8Array, dialect: DatabaseType | undefined): st
  * be stringified to a locale-dependent form no engine parses back, and an object to
  * the literal text `[object Object]`.
  */
-function sqlValue(value: unknown, dialect: DatabaseType | undefined): string {
+function sqlValue(value: unknown, dialect: DatabaseType | undefined, oracleShape?: OracleDateShape): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "bigint") return String(value);
   // NaN and ±Infinity are not numbers any of these dialects accepts as a literal,
   // and `String(NaN)` would put the bare word `NaN` where a value belongs.
   if (typeof value === "number") return Number.isFinite(value) ? String(value) : "NULL";
   if (typeof value === "boolean") return String(value);
-  if (value instanceof Date) return quoteLiteral(value.toISOString(), dialect);
+  if (value instanceof Date) {
+    if (oracleShape !== undefined) return oracleDateLiteral(value, oracleShape);
+    return quoteLiteral(value.toISOString(), dialect);
+  }
   // Before the object branch, which used to write a `bytea`/`BLOB` cell as the quoted
   // text `{"type":"Buffer","data":[…]}`. Replayed into Postgres 18.4 that INSERT
   // stored 46 bytes of that JSON where six bytes belonged, and it stored them
@@ -644,8 +720,12 @@ export function buildResultExport(format: ResultExportFormat, source: ResultExpo
 
   if (format === "sql-insert") {
     if (rows.length === 0) return sql(NOTHING_TO_EXPORT.rows);
+    // Resolved once per column rather than per cell: the shape comes from the declared
+    // type, which does not change row to row.
+    const oracleShapes =
+      dialect === "oracle" ? columns.map((column) => oracleDateShape(declaredTypeOf(source, column))) : undefined;
     const statements = rows.map((row) => {
-      const values = columns.map((column) => sqlValue(cellOf(row, column), dialect));
+      const values = columns.map((column, index) => sqlValue(cellOf(row, column), dialect, oracleShapes?.[index]));
       return `INSERT INTO ${tableName} (${quotedColumns.join(", ")}) VALUES (${values.join(", ")});`;
     });
     return sql(statements.join("\n"));

--- a/tests/components/monitoring/TablesTab.test.tsx
+++ b/tests/components/monitoring/TablesTab.test.tsx
@@ -422,3 +422,52 @@ describe("a refused tables read", () => {
     expect(queryByText("No table statistics available.")).not.toBeNull();
   });
 });
+
+describe("tables that carry no per-table bytes", () => {
+  // Scoped here as well as in the blocks above: bun:test registers a hook on the
+  // enclosing describe only, so without this the first render in this block leaks into
+  // the second and the control arm queries the previous test's DOM.
+  afterEach(() => {
+    cleanup();
+  });
+
+  /** Rows shaped the way LibreDB and bun:sqlite answer: real counts, no sizes. */
+  function sizelessData(): MonitoringData {
+    const data = makeData();
+    return {
+      ...data,
+      tables: [
+        { schemaName: "kv", tableName: "employees:*", rowCount: 25, totalSize: "N/A", totalSizeBytes: 0 },
+        { schemaName: "document", tableName: "articles:*", rowCount: 7, totalSize: "N/A", totalSizeBytes: 0 },
+      ],
+    } as unknown as MonitoringData;
+  }
+
+  test("the Size card says N/A rather than summing the placeholder to 0 B", () => {
+    const { getByTestId } = render(
+      <TablesTab data={sizelessData()} loading={false} onRunMaintenance={mock(async () => true)} />,
+    );
+
+    // The rows are a measurement (25 keys really are 25 rows) so the Tables card counts
+    // them, while `totalSizeBytes` is the placeholder a required field has to carry -
+    // summing it drew "0 B" as the total size of a database with bytes on disk.
+    expect(getByTestId("tables-stat-count").textContent).toBe("2");
+    expect(getByTestId("tables-stat-size").textContent).toBe("N/A");
+  });
+
+  test("a table with no size of its own reads as unknown, not as an empty cell", () => {
+    const { getAllByTestId } = render(
+      <TablesTab data={sizelessData()} loading={false} onRunMaintenance={mock(async () => true)} />,
+    );
+
+    expect(getAllByTestId("table-row-size")[0]?.textContent).toBe("-");
+  });
+
+  test("an engine that publishes bytes still gets its total", () => {
+    const { getByTestId } = render(
+      <TablesTab data={makeData()} loading={false} onRunMaintenance={mock(async () => true)} />,
+    );
+
+    expect(getByTestId("tables-stat-size").textContent).toBe("820.00 MB");
+  });
+});

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -638,6 +638,112 @@ describe("useConnectionForm", () => {
     expect(result.current.sslMode).toBe("require");
   });
 
+  // ── TLS carried in the pasted string's query string ────────────────────────
+
+  test("handlePasteConnectionString applies a postgres sslmode from the query string", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("postgresql://u:p@pg.example.com:5432/app?sslmode=verify-full");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.sslMode).toBe("verify-full");
+    expect(result.current.testResult!.message).toContain("parsed successfully");
+    expect(result.current.testResult!.message).not.toContain("SSL Mode");
+  });
+
+  test("handlePasteConnectionString applies MySQL's ssl-mode=REQUIRED", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("mysql://root:pw@my.example.com/app?ssl-mode=REQUIRED");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.sslMode).toBe("require");
+  });
+
+  test("handlePasteConnectionString reads Encrypt out of an ADO.NET string", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("Server=sql.example.com,1433;Database=db;Encrypt=True;TrustServerCertificate=True;");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.type).toBe("mssql");
+    expect(result.current.sslMode).toBe("require");
+  });
+
+  // The refusal has to be VISIBLE, and visible in the right colour. The modal renders
+  // `success: true` as a green box with a tick (ConnectionModal.tsx), so emitting the
+  // refusal as a success told the user - in green, with a tick - that dropping their TLS
+  // request was fine. That is the affordance-contradicts-the-sentence defect of #449.
+  test("handlePasteConnectionString says so when it refuses to map an opportunistic sslmode", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("postgres://u:p@pg.example.com/app?sslmode=prefer");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.sslMode).toBe("disable");
+    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.message).toContain("sslmode=prefer");
+    expect(result.current.testResult!.message).toContain("SSL Mode");
+    // The banner must not read as a success anywhere in its own text either.
+    expect(result.current.testResult!.message).not.toContain("parsed successfully");
+  });
+
+  test("an unmapped TLS parameter does not overwrite a mode the form already holds", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setSSLMode("verify-ca");
+    });
+    act(() => {
+      result.current.setPasteInput("mysql://root:pw@my.example.com/app?ssl-mode=PREFERRED");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.sslMode).toBe("verify-ca");
+    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.message).toContain("ssl-mode=PREFERRED");
+    expect(result.current.testResult!.message).toContain("verify-ca");
+    // The fields WERE filled, and a red box must not leave the user thinking otherwise.
+    expect(result.current.host).toBe("my.example.com");
+    expect(result.current.testResult!.message).toContain("other fields");
+  });
+
+  // A pasted MySQL URL carrying only the boolean spelling used to reach the form with no
+  // mode AND no banner. Both ends of a boolean are mappable, so this one is applied, not
+  // refused - and the banner stays the plain success.
+  test("handlePasteConnectionString applies MySQL's boolean useSSL=true", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("mysql://root:pw@my.example.com/app?useSSL=true");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.sslMode).toBe("require");
+    expect(result.current.testResult!.success).toBe(true);
+    expect(result.current.testResult!.message).toContain("parsed successfully");
+  });
+
   // ── handlePasteConnectionString shows error for invalid string ─────────────
 
   test("handlePasteConnectionString shows error for invalid string", () => {

--- a/tests/integration/db/cassandra-provider.test.ts
+++ b/tests/integration/db/cassandra-provider.test.ts
@@ -49,8 +49,11 @@ import {
   CASSANDRA_CACHE_CQL,
   CASSANDRA_CLIENT_COUNT_CQL,
   CASSANDRA_IDENTITY_CQL,
+  CASSANDRA_INDEX_STATS_REFUSAL,
   CASSANDRA_RUNNING_QUERY_CQL,
   CASSANDRA_SIZE_UNAVAILABLE,
+  CASSANDRA_STORAGE_STATS_REFUSAL,
+  CASSANDRA_TABLE_STATS_REFUSAL,
   CASSANDRA_UNKNOWN_TEXT,
   CASSANDRA_VIRTUAL_KEYSPACE_CQL,
   cassandraColumnListCql,
@@ -1199,16 +1202,26 @@ describe("a server with no system_views keyspace", () => {
     expect("activeConnections" in overview).toBe(false);
   });
 
-  test("no cache ratio is claimed rather than a zero", async () => {
+  test("the performance panel is ABSENT with its own sentence, not an empty reading", async () => {
+    // D24: `{}` said every field was looked up and found to have no value. The key
+    // cache's hit ratio is this panel's only source, and this build publishes no
+    // `system_views.caches` at all, so the panel cannot be answered rather than
+    // answering nothing.
     const { provider } = await connectedProvider(scyllaReplies());
 
-    expect(await provider.getPerformanceMetrics()).toEqual({});
+    await expect(provider.getPerformanceMetrics()).rejects.toThrow(QueryError);
+    await expect(provider.getPerformanceMetrics()).rejects.toThrow(/system_views\.caches/);
+    await expect(provider.getPerformanceMetrics()).rejects.toThrow(/no system_virtual_schema catalog at all/);
   });
 
-  test("the session list is empty rather than a thrown connection", async () => {
+  test("the session panel is ABSENT with its own sentence, not an empty list", async () => {
+    // The reading this entry exists for, measured in the browser against ScyllaDB
+    // 2026.2.4: an empty list rendered as "Active 0 / Idle 0 / Wait 0 / Sessions (0) /
+    // No active sessions found." for a question the build cannot answer at all.
     const { provider } = await connectedProvider(scyllaReplies());
 
-    expect(await provider.getActiveSessions()).toEqual([]);
+    await expect(provider.getActiveSessions()).rejects.toThrow(QueryError);
+    await expect(provider.getActiveSessions()).rejects.toThrow(/system_views\.queries/);
   });
 
   test("health answers, which is what Test Connection and the header badge ride on", async () => {
@@ -1226,13 +1239,21 @@ describe("a server with no system_views keyspace", () => {
   });
 
   test("the monitoring dashboard gets data instead of one connection-error page", async () => {
+    // Still a partial dashboard rather than an error page - the panels this build CAN
+    // answer are unchanged. What changed is the two it cannot: absent, each with the
+    // sentence `PanelUnavailable` renders, instead of a zero and an empty table.
     const { provider } = await connectedProvider(scyllaReplies());
 
     const data = await provider.getMonitoringData();
 
     expect(data.overview?.version).toBe("Apache Cassandra 5.0.9");
-    expect(data.performance).toEqual({});
-    expect(data.activeSessions).toEqual([]);
+    expect(data.performance).toBeUndefined();
+    expect(data.activeSessions).toBeUndefined();
+    expect(data.errors?.performance).toContain("system_views.caches");
+    expect(data.errors?.activeSessions).toContain("system_views.queries");
+    // The panel that is empty by convention on every build keeps its empty array: an
+    // absent slow-query panel would hide the label the tab already renders.
+    expect(data.slowQueries).toEqual([]);
   });
 
   test("a typo in a TABLE name inside system_views still fails loudly", async () => {
@@ -1281,8 +1302,11 @@ describe("a server with no system_views keyspace", () => {
     const { provider, session } = await connectedProvider(scyllaReplies());
 
     await provider.getOverview();
-    await provider.getPerformanceMetrics();
-    await provider.getActiveSessions();
+    await expect(provider.getPerformanceMetrics()).rejects.toThrow(QueryError);
+    await expect(provider.getActiveSessions()).rejects.toThrow(QueryError);
+    // `getHealth` reaches the same two reads and must NOT throw - the connection
+    // dialog's save is gated on it - so it degrades where the panels refuse.
+    await provider.getHealth();
 
     expect(session.asked).not.toContain(CASSANDRA_CLIENT_COUNT_CQL);
     expect(session.asked).not.toContain(CASSANDRA_CACHE_CQL);
@@ -1316,22 +1340,28 @@ describe("a server with no system_views keyspace", () => {
       scyllaReplies({ [CASSANDRA_VIRTUAL_KEYSPACE_CQL]: withoutViews }),
     );
 
-    expect(await provider.getPerformanceMetrics()).toEqual({});
+    // Its own sentence, and not ScyllaDB's: the catalog answered here, it just did not
+    // list the keyspace. Three causes, three sentences.
+    await expect(provider.getPerformanceMetrics()).rejects.toThrow(/does not list a system_views keyspace/);
     expect(session.asked).not.toContain(CASSANDRA_CACHE_CQL);
   });
 
-  test("a role that may not read the virtual catalog gets empty panels, not a broken connection", async () => {
+  test("a role that may not read the virtual catalog gets its own sentence, not a broken connection", async () => {
     // 8448 on the probe, which is the measured shape of a least-privilege role
-    // (§3.6): it cannot establish that the virtual tables are there, and the panels it
-    // would be refused anyway answer empty - the same outcome the per-read permission
-    // arm has always given.
+    // (§3.6): it cannot establish that the virtual tables are there, so the panels whose
+    // only source is one report their own absence - naming the GRANT, because that is a
+    // different place to send the reader than a build that has no virtual schema.
     const denied = responseError(
       8448,
       "User lowpriv has no SELECT permission on <table system_virtual_schema.keyspaces> or any of its parents",
     );
     const { provider } = await connectedProvider(scyllaReplies({ [CASSANDRA_VIRTUAL_KEYSPACE_CQL]: denied }));
 
-    expect(await provider.getPerformanceMetrics()).toEqual({});
+    // A grant, not a dialect: the panel says so rather than telling the user their
+    // server has no virtual tables, which would send them to the wrong place.
+    await expect(provider.getPerformanceMetrics()).rejects.toThrow(/the connected role may not read/);
+    // Health still answers, so the connection can still be created and saved.
+    expect((await provider.getHealth()).activeSessions).toEqual([]);
   });
 
   test("a probe that fails for an unrelated reason leaves the reads exactly as they were", async () => {
@@ -1453,27 +1483,55 @@ describe("getActiveSessions", () => {
 });
 
 describe("the panels that report nothing rather than something wrong", () => {
-  test("table statistics are empty: there is no honest row count and no honest size", async () => {
+  /*
+    ABSENT, not empty (D24). These three used to answer `[]`, which says "the engine
+    looked and found nothing" - and the schema tree in the very same frame lists the
+    tables and the secondary indexes the panel just reported none of. What is missing is
+    the FIGURES, so the panel now carries the reason and `getMonitoringData` leaves it
+    absent under `errors`, exactly as a rejected read from any other engine.
+  */
+  test("table statistics are refused with the reason, and the cluster is still asked nothing", async () => {
     // `size_estimates` counts PARTITIONS from flushed SSTables and was measured at
     // 143 for a 500-row clustered table; `disk_usage` reported 1 MiB for 19,476
     // bytes. Both are numbers that would look exactly like right ones on screen.
     const { provider, session } = await connectedProvider();
     session.asked.length = 0;
 
-    expect(await provider.getTableStats()).toEqual([]);
+    await expect(provider.getTableStats()).rejects.toThrow(QueryError);
+    await expect(provider.getTableStats()).rejects.toThrow(CASSANDRA_TABLE_STATS_REFUSAL);
     expect(session.asked).toEqual([]);
   });
 
-  test("index statistics are empty: an index has no size and no scan counter here", async () => {
-    const { provider } = await connectedProvider();
-
-    expect(await provider.getIndexStats()).toEqual([]);
+  test("the table refusal names both unusable sources rather than saying unavailable", async () => {
+    // The sentence is the only text the user sees where the rows would have been, so
+    // it has to name what was refused and why - not that something was.
+    expect(CASSANDRA_TABLE_STATS_REFUSAL).toContain("system.size_estimates");
+    expect(CASSANDRA_TABLE_STATS_REFUSAL).toContain("system_views.disk_usage");
   });
 
-  test("storage statistics are empty for the same reason as the size", async () => {
+  test("index statistics are refused: an index has no size and no scan counter here", async () => {
     const { provider } = await connectedProvider();
 
-    expect(await provider.getStorageStats()).toEqual([]);
+    await expect(provider.getIndexStats()).rejects.toThrow(QueryError);
+    await expect(provider.getIndexStats()).rejects.toThrow(CASSANDRA_INDEX_STATS_REFUSAL);
+  });
+
+  test("storage statistics are refused for the same reason as the database size", async () => {
+    const { provider } = await connectedProvider();
+
+    await expect(provider.getStorageStats()).rejects.toThrow(QueryError);
+    await expect(provider.getStorageStats()).rejects.toThrow(CASSANDRA_STORAGE_STATS_REFUSAL);
+  });
+
+  test("the slow-query panel stays EMPTY, because its sentence already reaches the user", async () => {
+    // The one always-empty panel that is not converted: `QueriesTab` renders
+    // `ProviderLabels.slowQueriesEmptyState` in place of the empty table, and this
+    // provider declares one. Converting it would move the same sentence from a label
+    // the panel already shows to an error entry, and buy nothing.
+    const { provider } = await connectedProvider();
+
+    expect(await provider.getSlowQueries()).toEqual([]);
+    expect(provider.getLabels().slowQueriesEmptyState).toContain("no aggregate of finished statements");
   });
 });
 
@@ -1533,7 +1591,12 @@ describe("getMonitoringData", () => {
 
     expect(data.overview?.version).toBe("Apache Cassandra 5.0.9");
     expect(data.performance?.cacheHitRatio).toBe(83.05);
-    expect(data.tables).toEqual([]);
+    // The three panels this engine refuses on every build are absent WITH their reason,
+    // and one failing read no longer costs the panels that answered (#477).
+    expect(data.tables).toBeUndefined();
+    expect(data.errors?.tables).toBe(CASSANDRA_TABLE_STATS_REFUSAL);
+    expect(data.errors?.indexes).toBe(CASSANDRA_INDEX_STATS_REFUSAL);
+    expect(data.errors?.storage).toBe(CASSANDRA_STORAGE_STATS_REFUSAL);
   });
 });
 

--- a/tests/integration/db/libredb-provider.test.ts
+++ b/tests/integration/db/libredb-provider.test.ts
@@ -5,7 +5,13 @@
  * so this suite is exempt from the mock-isolation hazard in CLAUDE.md.
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { LibreDBProvider } from "@/lib/db/providers/embedded/libredb";
+import {
+  LIBREDB_ACTIVE_SESSIONS_REFUSAL,
+  LIBREDB_INDEX_STATS_REFUSAL,
+  LIBREDB_MAX_KEY_SCAN,
+  LIBREDB_TABLE_STATS_TRUNCATED,
+  LibreDBProvider,
+} from "@/lib/db/providers/embedded/libredb";
 import { ConnectionError, QueryError } from "@/lib/db/errors";
 import type { DatabaseConnection } from "@/lib/types";
 import { open, kv, doc, table } from "@libredb/libredb";
@@ -523,13 +529,125 @@ describe("LibreDBProvider — monitoring", () => {
     await provider.disconnect();
   });
 
-  test("slow-query/session/table/index stats are honest empty defaults", async () => {
+  test("getSlowQueries stays empty - the label, not an error, carries LibreDB's sentence", async () => {
     const provider = new LibreDBProvider(makeConn(tmpFile));
     await provider.connect();
+    // The one panel that is legitimately empty: `QueriesTab` renders
+    // `ProviderLabels.slowQueriesEmptyState` in place of an empty list, and this provider
+    // declares one, so LibreDB's own sentence already reaches the user here.
     expect(await provider.getSlowQueries()).toEqual([]);
-    expect(await provider.getActiveSessions()).toEqual([]);
-    expect(await provider.getTableStats()).toEqual([]);
-    expect(await provider.getIndexStats()).toEqual([]);
+    expect(provider.getLabels().slowQueriesEmptyState).toMatch(/keeps no statistics/i);
+    await provider.disconnect();
+  });
+
+  test("getActiveSessions is refused with its reason, not answered as an empty session list", async () => {
+    const provider = new LibreDBProvider(makeConn(tmpFile));
+    await provider.connect();
+    await expect(provider.getActiveSessions()).rejects.toThrow(LIBREDB_ACTIVE_SESSIONS_REFUSAL);
+    // Health must keep answering: /api/db/test-connection calls it and the connection
+    // dialog's save is gated on that request (#455).
+    expect((await provider.getHealth()).activeSessions).toEqual([]);
+    await provider.disconnect();
+  });
+
+  test("getIndexStats is refused: this engine has no index object to count", async () => {
+    const provider = new LibreDBProvider(makeConn(tmpFile));
+    await provider.connect();
+    await expect(provider.getIndexStats()).rejects.toThrow(LIBREDB_INDEX_STATS_REFUSAL);
+    await provider.disconnect();
+  });
+
+  test("getTableStats counts every namespace's keys and names the lens it belongs to", async () => {
+    rmDbFile(tmpFile);
+    seedWithCatalog(tmpFile);
+    const provider = new LibreDBProvider(makeConn(tmpFile));
+    await provider.connect();
+
+    const stats = await provider.getTableStats();
+    const byName = new Map(stats.map((s) => [s.tableName, s]));
+    // The same groups the schema tree shows, with the same counts - both read one scan.
+    expect(byName.get("employees:*")?.rowCount).toBe(2);
+    expect(byName.get("articles:*")?.rowCount).toBe(1);
+    expect(byName.get("user:*")?.rowCount).toBe(2);
+    expect(byName.get("order:*")?.rowCount).toBe(1);
+    expect(byName.get("config")?.rowCount).toBe(1);
+    // LibreDB has no schema namespace, so the column carries the namespace's lens - the
+    // one thing the catalog does declare about it.
+    expect(byName.get("employees:*")?.schemaName).toBe("relational");
+    expect(byName.get("articles:*")?.schemaName).toBe("document");
+    expect(byName.get("config")?.schemaName).toBe("kv");
+
+    // No per-namespace bytes exist in the file format, so the byte fields stay ABSENT
+    // rather than carrying a zero the Storage tab would sum as a measurement.
+    for (const row of stats) {
+      expect(row.tableSizeBytes).toBeUndefined();
+      expect(row.indexSizeBytes).toBeUndefined();
+      expect(row.totalSize).toBe("N/A");
+    }
+    await provider.disconnect();
+  });
+
+  test("getTableStats reports an empty cataloged namespace as a real zero", async () => {
+    rmDbFile(tmpFile);
+    const db = open({ path: tmpFile });
+    table(db, "empty_table", { primaryKey: "id", columns: { id: "string" } });
+    db.close();
+
+    const provider = new LibreDBProvider(makeConn(tmpFile));
+    await provider.connect();
+    const stats = await provider.getTableStats();
+    // The catalog declares the table and the scan found none of its keys: zero rows is
+    // the measurement here, which is exactly what an empty answered panel may mean.
+    expect(stats).toEqual([
+      {
+        schemaName: "relational",
+        tableName: "empty_table:*",
+        rowCount: 0,
+        totalSize: "N/A",
+        totalSizeBytes: 0,
+      },
+    ]);
+    await provider.disconnect();
+  });
+
+  test("getTableStats refuses rather than under-count when the key scan hits its cap", async () => {
+    rmDbFile(tmpFile);
+    // One kernel transaction, so seeding past the cap costs ~30ms instead of ~12s: the
+    // kv lens fsyncs per set(), the kernel's own transact() commits the batch once.
+    const db = open({ path: tmpFile });
+    const encoder = new TextEncoder();
+    db.transact((tx) => {
+      for (let i = 0; i < LIBREDB_MAX_KEY_SCAN + 500; i++) {
+        tx.set(encoder.encode(`bulk:${i}`), encoder.encode("x"));
+      }
+    });
+    db.close();
+
+    const provider = new LibreDBProvider(makeConn(tmpFile));
+    await provider.connect();
+    // Assert the exported sentence itself: a regex over a fragment would keep passing if
+    // the user-facing wording drifted, and `knip` fails on an export nothing consumes.
+    await expect(provider.getTableStats()).rejects.toThrow(LIBREDB_TABLE_STATS_TRUNCATED);
+    expect(LIBREDB_TABLE_STATS_TRUNCATED).toContain("10,000 keys");
+    // The schema tree still renders - it is a list of namespaces, not a count.
+    expect((await provider.getSchema()).map((s) => s.name)).toEqual(["bulk:*"]);
+    await provider.disconnect();
+  });
+
+  test("getMonitoringData leaves the two refused panels absent with their sentences", async () => {
+    rmDbFile(tmpFile);
+    seedWithCatalog(tmpFile);
+    const provider = new LibreDBProvider(makeConn(tmpFile));
+    await provider.connect();
+
+    const data = await provider.getMonitoringData();
+    expect(data.activeSessions).toBeUndefined();
+    expect(data.indexes).toBeUndefined();
+    expect(data.errors?.activeSessions).toBe(LIBREDB_ACTIVE_SESSIONS_REFUSAL);
+    expect(data.errors?.indexes).toBe(LIBREDB_INDEX_STATS_REFUSAL);
+    // The panel that fabricated zero tables on a database with tables now answers.
+    expect(data.tables?.length).toBe(5);
+    expect(data.errors?.tables).toBeUndefined();
     await provider.disconnect();
   });
 

--- a/tests/integration/db/trino-provider.test.ts
+++ b/tests/integration/db/trino-provider.test.ts
@@ -1097,10 +1097,28 @@ describe("TrinoProvider monitoring", () => {
 
   test("narrows the stats pass to one schema when asked", async () => {
     const provider = await connectProvider();
-    await provider.getTableStats({ schema: "sf1" });
+    // `sf1.customer` is the fixture's one table whose connector published no row count,
+    // so narrowing to that schema examines a table and gets nothing back - a refusal
+    // (D24), not an empty schema. The assertion here is about WHICH statements went out.
+    await expect(provider.getTableStats({ schema: "sf1" })).rejects.toThrow(/None of the 1 tables examined/);
 
     expect(sentAnything('SHOW STATS FOR "tpch"."tiny"')).toBe(false);
     expect(sentAnything('SHOW STATS FOR "tpch"."sf1"."customer"')).toBe(true);
+  });
+
+  test("the refused table panel is ABSENT with its sentence while the rest of the dashboard answers", async () => {
+    // The whole point of the conversion: one panel that cannot be answered costs that
+    // panel and carries its reason, instead of rendering as a table of no rows.
+    const provider = await connectProvider();
+    const data = await provider.getMonitoringData({
+      schemaFilter: "sf1",
+      includeIndexes: false,
+      includeStorage: false,
+    });
+
+    expect(data.tables).toBeUndefined();
+    expect(data.errors?.tables).toContain("None of the 1 tables examined");
+    expect(data.overview).toBeDefined();
   });
 
   test("describes the catalogs as the storage, because that is where the data is", async () => {

--- a/tests/unit/db/trino/introspect.test.ts
+++ b/tests/unit/db/trino/introspect.test.ts
@@ -758,9 +758,10 @@ describe("Trino getActiveSessions", () => {
 describe("Trino getTableStats", () => {
   test("reads the summary row for the count and the column rows for the size", async () => {
     const { runner } = fakeRunner();
-    const stats = await getTableStats(runner, CATALOG, { schema: "tiny" });
+    const { tables, refusal } = await getTableStats(runner, CATALOG, { schema: "tiny" });
 
-    expect(stats).toEqual([
+    expect(refusal).toBeUndefined();
+    expect(tables).toEqual([
       {
         schemaName: "tiny",
         tableName: "nation",
@@ -784,9 +785,9 @@ describe("Trino getTableStats", () => {
 
   test("omits a table whose connector published no row count, rather than calling it empty", async () => {
     const { runner } = fakeRunner();
-    const stats = await getTableStats(runner, CATALOG);
+    const { tables } = await getTableStats(runner, CATALOG);
 
-    expect(stats.map((table) => table.tableName)).toEqual(["nation", "region"]);
+    expect(tables.map((table) => table.tableName)).toEqual(["nation", "region"]);
   });
 
   test("asks SHOW STATS once per table, never a catalog-wide aggregate", async () => {
@@ -812,15 +813,54 @@ describe("Trino getTableStats", () => {
 
   test("degrades one table's failure to that table alone", async () => {
     const { runner } = fakeRunner({ failures: { nationStats: unavailable("unknown-object") } });
-    const stats = await getTableStats(runner, CATALOG, { schema: "tiny" });
+    const { tables } = await getTableStats(runner, CATALOG, { schema: "tiny" });
 
-    expect(stats.map((table) => table.tableName)).toEqual(["region"]);
+    expect(tables.map((table) => table.tableName)).toEqual(["region"]);
   });
 
-  test("asks nothing when the table list itself is unavailable", async () => {
+  /*
+    D24: an empty reading has three causes and only ONE of them is a measurement. The
+    three tests below pin each cause to its own answer, because the panel renders them
+    differently: a refusal is an ABSENT panel carrying the sentence, an empty catalog is
+    an empty panel.
+  */
+  test("a refused table list is a refusal carrying the server's wording, not no tables", async () => {
     const { runner } = fakeRunner({ failures: { tableList: unavailable("auth") } });
+    const { tables, refusal } = await getTableStats(runner, CATALOG);
 
-    expect(await getTableStats(runner, CATALOG)).toEqual([]);
+    expect(tables).toEqual([]);
+    expect(refusal).toContain('refused the table list for catalog "tpch"');
+  });
+
+  test("a catalog whose tables publish no statistics is a refusal naming how many were asked", async () => {
+    // Measured 2026-08-25 against Trino 476: all 379 tables of the jmx catalog answer
+    // SHOW STATS with an empty row_count, so this panel reported nothing at all about a
+    // catalog full of data.
+    const { runner } = fakeRunner({ rows: { tableList: [{ schemaName: "sf1", tableName: "customer" }] } });
+    const { tables, refusal } = await getTableStats(runner, CATALOG);
+
+    expect(tables).toEqual([]);
+    expect(refusal).toContain("None of the 1 tables examined");
+    expect(refusal).toContain("SHOW STATS with a null row count until ANALYZE has run");
+  });
+
+  test("a table list that fails for any other reason still propagates", async () => {
+    // The refusal arm is narrow on purpose: a timeout or a cancelled query says nothing
+    // about what the catalog holds, and a panel that reported it as "no statistics
+    // published" would hide the fault behind a sentence that sounds settled.
+    const { runner } = fakeRunner({ failures: { tableList: unavailable("timeout") } });
+
+    await expect(getTableStats(runner, CATALOG)).rejects.toThrow(TrinoTransportError);
+  });
+
+  test("a catalog that really holds no table stays an EMPTY measurement", async () => {
+    // The one empty reading that is honest: nothing was examined, so nothing was
+    // refused, and an absent panel here would claim the engine could not answer.
+    const { runner } = fakeRunner({ rows: { tableList: [] } });
+    const { tables, refusal } = await getTableStats(runner, CATALOG);
+
+    expect(tables).toEqual([]);
+    expect(refusal).toBeUndefined();
   });
 });
 

--- a/tests/unit/lib/connection-string-parser.test.ts
+++ b/tests/unit/lib/connection-string-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { parseConnectionString, detectConnectionStringType, ENGINE_URI_SCHEMES } from "@/lib/connection-string-parser";
+import type { SSLMode } from "@/lib/types";
 
 // ─── parseConnectionString ──────────────────────────────────────────────────
 
@@ -747,5 +748,240 @@ describe("parseConnectionString: ADO.NET edge cases", () => {
       // eslint-disable-next-line no-extend-native
       String.prototype.split = originalSplit;
     }
+  });
+});
+
+// ─── TLS carried in the query string / ADO.NET keywords ─────────────────────
+
+// Measured 2026-08-25 against the live engines, and the two measurements are why the
+// opportunistic values below are refused rather than mapped:
+//   postgres 18, no server certificate:
+//     ?sslmode=prefer  -> connects, pg_stat_ssl.ssl = f  (plaintext, and it works)
+//     ?sslmode=require -> "server does not support SSL, but SSL was required"
+//   mysql over TCP, default self-signed certificate:
+//     --ssl-mode=PREFERRED -> Ssl_cipher TLS_AES_128_GCM_SHA256 (encrypted)
+//     --ssl-mode=DISABLED  -> Ssl_cipher empty (plaintext)
+// So "prefer" onto `require` breaks a working Postgres connection, and "PREFERRED"
+// onto `disable` silently downgrades a MySQL connection that was encrypted.
+
+describe("parseConnectionString: TLS parameters", () => {
+  describe("postgres sslmode", () => {
+    const mapped: Array<[string, SSLMode]> = [
+      ["disable", "disable"],
+      ["require", "require"],
+      ["verify-ca", "verify-ca"],
+      ["verify-full", "verify-full"],
+      ["VERIFY-FULL", "verify-full"],
+      ["Require", "require"],
+    ];
+    for (const [value, expected] of mapped) {
+      test(`maps sslmode=${value} to ${expected}`, () => {
+        const result = parseConnectionString(`postgresql://u:p@host/db?sslmode=${value}`);
+        expect(result!.sslMode).toBe(expected);
+        expect(result!.unmappedTLSParam).toBeUndefined();
+        expect(result!.database).toBe("db");
+      });
+    }
+
+    for (const value of ["prefer", "allow", "PREFER"]) {
+      test(`refuses to map the opportunistic sslmode=${value}`, () => {
+        const result = parseConnectionString(`postgres://u:p@host/db?sslmode=${value}`);
+        expect(result!.sslMode).toBeUndefined();
+        expect(result!.unmappedTLSParam).toBe(`sslmode=${value}`);
+      });
+    }
+
+    test("an unrecognised sslmode does not become disable", () => {
+      const result = parseConnectionString("postgres://u:p@host/db?sslmode=banana");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("sslmode=banana");
+    });
+
+    // The map is a plain object literal, so an all-lowercase Object.prototype key reaches
+    // the lookup: `sslmode=constructor` resolved to the Object CONSTRUCTOR FUNCTION, which
+    // is truthy, so it was written into ParsedConnection.sslMode and set as the form's
+    // SSLMode - a non-SSLMode value smuggled past the very banner this refusal exists to
+    // raise. `toString`/`valueOf` do not reach it only because the lookup lower-cases.
+    test("an inherited Object.prototype key is refused, not resolved", () => {
+      const result = parseConnectionString("postgres://u:p@host/db?sslmode=constructor");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("sslmode=constructor");
+    });
+
+    test("maps the JDBC/Heroku ssl=true form to require", () => {
+      expect(parseConnectionString("postgres://u:p@host/db?ssl=true")!.sslMode).toBe("require");
+      expect(parseConnectionString("postgres://u:p@host/db?ssl=1")!.sslMode).toBe("require");
+      expect(parseConnectionString("postgres://u:p@host/db?ssl=false")!.sslMode).toBe("disable");
+      expect(parseConnectionString("postgres://u:p@host/db?ssl=0")!.sslMode).toBe("disable");
+    });
+
+    test("an unrecognised ssl value does not become disable", () => {
+      const result = parseConnectionString("postgres://u:p@host/db?ssl=maybe");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("ssl=maybe");
+    });
+
+    // The banner quotes the parameter back at the user, so it must be the spelling they
+    // pasted: the lookup is case-insensitive but the echo is not normalised.
+    test("reports the parameter in the case it was written", () => {
+      expect(parseConnectionString("postgres://u:p@host/db?SSLMode=prefer")!.unmappedTLSParam).toBe("SSLMode=prefer");
+    });
+
+    test("sslmode wins over ssl when both are present", () => {
+      const result = parseConnectionString("postgres://u:p@host/db?ssl=true&sslmode=verify-full");
+      expect(result!.sslMode).toBe("verify-full");
+    });
+
+    test("says nothing about TLS when the string carries no TLS parameter", () => {
+      const result = parseConnectionString("postgres://u:p@host/db?application_name=studio");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBeUndefined();
+    });
+
+    // sslrootcert/sslcert/sslkey are client-side FILE PATHS; the form holds PEM text and
+    // the server that opens the connection is not the machine the path refers to.
+    test("ignores sslrootcert, which names a file this form cannot read", () => {
+      const result = parseConnectionString("postgres://u:p@host/db?sslmode=verify-ca&sslrootcert=/etc/ca.pem");
+      expect(result!.sslMode).toBe("verify-ca");
+      expect(result!.unmappedTLSParam).toBeUndefined();
+    });
+  });
+
+  describe("mysql ssl-mode", () => {
+    const mapped: Array<[string, SSLMode]> = [
+      ["DISABLED", "disable"],
+      ["REQUIRED", "require"],
+      ["VERIFY_CA", "verify-ca"],
+      ["VERIFY_IDENTITY", "verify-full"],
+      ["required", "require"],
+    ];
+    for (const [value, expected] of mapped) {
+      test(`maps ssl-mode=${value} to ${expected}`, () => {
+        const result = parseConnectionString(`mysql://root:pw@host:3306/app?ssl-mode=${value}`);
+        expect(result!.sslMode).toBe(expected);
+      });
+    }
+
+    test("accepts the sslmode spelling too", () => {
+      expect(parseConnectionString("mysql://root:pw@host/app?sslmode=REQUIRED")!.sslMode).toBe("require");
+    });
+
+    test("refuses to map ssl-mode=PREFERRED", () => {
+      const result = parseConnectionString("mysql://root:pw@host/app?ssl-mode=PREFERRED");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("ssl-mode=PREFERRED");
+    });
+
+    test("an unrecognised ssl-mode does not become disable", () => {
+      const result = parseConnectionString("mysql://root:pw@host/app?ssl-mode=SOMETHING");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("ssl-mode=SOMETHING");
+    });
+
+    // `ssl` and `useSSL` are the boolean spellings the JDBC connector and several ORMs
+    // write. Reading only ssl-mode dropped them with no mode AND no banner, which is the
+    // silent-downgrade defect this whole parameter exists to prevent.
+    test("maps the boolean ssl=true / useSSL=true forms to require", () => {
+      expect(parseConnectionString("mysql://u:p@host/db?ssl=true")!.sslMode).toBe("require");
+      expect(parseConnectionString("mysql://u:p@host/db?ssl=1")!.sslMode).toBe("require");
+      expect(parseConnectionString("mysql://u:p@host/db?useSSL=true")!.sslMode).toBe("require");
+      expect(parseConnectionString("mysql://u:p@host/db?useSSL=TRUE")!.sslMode).toBe("require");
+    });
+
+    test("maps the boolean ssl=false / useSSL=false forms to disable", () => {
+      expect(parseConnectionString("mysql://u:p@host/db?ssl=false")!.sslMode).toBe("disable");
+      expect(parseConnectionString("mysql://u:p@host/db?ssl=0")!.sslMode).toBe("disable");
+      expect(parseConnectionString("mysql://u:p@host/db?useSSL=false")!.sslMode).toBe("disable");
+    });
+
+    test("an unrecognised boolean value is reported verbatim, in the spelling that was pasted", () => {
+      const result = parseConnectionString("mysql://u:p@host/db?useSSL=maybe");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("useSSL=maybe");
+    });
+
+    test("ssl-mode wins over the boolean spellings when both are present", () => {
+      expect(parseConnectionString("mysql://u:p@host/db?ssl=false&ssl-mode=REQUIRED")!.sslMode).toBe("require");
+    });
+
+    test("mysql2's object form of ssl is reported rather than read as a boolean", () => {
+      const result = parseConnectionString('mysql://u:p@host/db?ssl={"rejectUnauthorized":true}');
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe('ssl={"rejectUnauthorized":true}');
+    });
+  });
+
+  describe("SQL Server Encrypt / TrustServerCertificate", () => {
+    test("Encrypt=True with TrustServerCertificate=True is require", () => {
+      const result = parseConnectionString("Server=sql,1433;Database=db;Encrypt=True;TrustServerCertificate=True;");
+      expect(result!.type).toBe("mssql");
+      expect(result!.sslMode).toBe("require");
+    });
+
+    test("Encrypt=True without TrustServerCertificate validates the chain and the name", () => {
+      const result = parseConnectionString("Server=sql;Database=db;Encrypt=True;");
+      expect(result!.sslMode).toBe("verify-full");
+    });
+
+    test("Encrypt=yes with TrustServerCertificate=false is verify-full", () => {
+      const result = parseConnectionString("Server=sql;Encrypt=yes;TrustServerCertificate=no;");
+      expect(result!.sslMode).toBe("verify-full");
+    });
+
+    test("Encrypt=Strict is verify-full", () => {
+      expect(parseConnectionString("Server=sql;Encrypt=Strict;")!.sslMode).toBe("verify-full");
+    });
+
+    test("Encrypt=False is disable", () => {
+      expect(parseConnectionString("Server=sql;Encrypt=False;")!.sslMode).toBe("disable");
+      expect(parseConnectionString("Server=sql;Encrypt=no;")!.sslMode).toBe("disable");
+    });
+
+    test("an absent Encrypt says nothing: the two .NET drivers default it differently", () => {
+      const result = parseConnectionString("Server=sql;Database=db;User Id=sa;Password=pw;");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBeUndefined();
+    });
+
+    test("an unrecognised Encrypt does not become disable", () => {
+      const result = parseConnectionString("Server=sql;Encrypt=Maybe;");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("Encrypt=Maybe");
+    });
+
+    test("an unrecognised TrustServerCertificate is reported rather than guessed", () => {
+      const result = parseConnectionString("Server=sql;Encrypt=True;TrustServerCertificate=Sometimes;");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("TrustServerCertificate=Sometimes");
+    });
+
+    test("the mssql:// URL form carries the same keywords", () => {
+      const result = parseConnectionString("mssql://sa:pw@host:1433/db?encrypt=true&trustServerCertificate=true");
+      expect(result!.sslMode).toBe("require");
+      expect(result!.database).toBe("db");
+    });
+
+    test("sqlserver:// with encrypt=false is disable", () => {
+      expect(parseConnectionString("sqlserver://sa:pw@host/db?encrypt=false")!.sslMode).toBe("disable");
+    });
+  });
+
+  describe("engines whose scheme already decides", () => {
+    test("a rediss:// query string does not override the scheme's require", () => {
+      expect(parseConnectionString("rediss://host:6379?sslmode=disable")!.sslMode).toBe("require");
+    });
+
+    test("an https:// ClickHouse URL keeps require", () => {
+      expect(parseConnectionString("https://host/default?sslmode=prefer")!.sslMode).toBe("require");
+    });
+
+    // The mongodb driver receives the URI verbatim and turns TLS on itself, WITH chain
+    // verification; our `require` means rejectUnauthorized:false, so setting it here
+    // would weaken an Atlas connection rather than describe it.
+    test("mongodb tls=true is left to the driver", () => {
+      const result = parseConnectionString("mongodb://u:p@host:27017/db?tls=true");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBeUndefined();
+    });
   });
 });

--- a/tests/unit/lib/export/result-export.test.ts
+++ b/tests/unit/lib/export/result-export.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { buildResultExport, deriveTableName, FALLBACK_TABLE_NAME } from "@/lib/export/result-export";
 
 const source = (over: Partial<Parameters<typeof buildResultExport>[1]> = {}) => ({
@@ -861,5 +861,83 @@ describe("buildResultExport — Cassandra DDL needs a PRIMARY KEY to run at all"
       expect(lines[i].startsWith("--")).toBe(true);
     }
     expect(file.content.endsWith(";")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Oracle date/timestamp literals (D23)
+// ---------------------------------------------------------------------------
+
+describe("buildResultExport - Oracle date and timestamp literals", () => {
+  // CI runs at UTC, where a local-field literal and an ISO one are the same string and
+  // the assertions below would pass against either (a developer machine sets no TZ
+  // either way). Held at a real offset for this block so they cannot.
+  const runnerZone = process.env.TZ;
+  beforeAll(() => {
+    process.env.TZ = "Asia/Tokyo";
+  });
+  afterAll(() => {
+    if (runnerZone === undefined) delete process.env.TZ;
+    else process.env.TZ = runnerZone;
+  });
+
+  // `oracledb` builds the `Date` for a naive DATE/TIMESTAMP by reading the stored wall
+  // clock in the Node process's zone, so the literal that replays it is the one that
+  // spells those same LOCAL fields back. Under the +09:00 held above this instant is
+  // 2026-08-24 10:11:12.345 locally and 01:11:12.345 in ISO, so the two spellings cannot
+  // be confused for each other.
+  const naive = new Date("2026-08-24T01:11:12.345Z");
+  const instant = new Date("2026-08-24T17:11:12.345Z");
+
+  const oracle = (columnTypes?: Record<string, string>, value: unknown = naive) =>
+    buildResultExport("sql-insert", source({ rows: [{ at: value }], fields: ["at"], dialect: "oracle", columnTypes }))
+      .content;
+
+  test("writes a TIMESTAMP column as TO_TIMESTAMP of its local fields, milliseconds kept", () => {
+    expect(oracle({ at: "TIMESTAMP" })).toContain(
+      `VALUES (TO_TIMESTAMP('2026-08-24 10:11:12.345', 'YYYY-MM-DD HH24:MI:SS.FF3'));`,
+    );
+  });
+
+  test("writes a DATE column as TO_DATE, which is the type that carries no fraction", () => {
+    expect(oracle({ at: "DATE" })).toContain(`VALUES (TO_DATE('2026-08-24 10:11:12', 'YYYY-MM-DD HH24:MI:SS'));`);
+  });
+
+  test("writes a zoned column as the UTC instant through FROM_TZ, not as a fabricated offset", () => {
+    const expected = `VALUES (FROM_TZ(TO_TIMESTAMP('2026-08-24 17:11:12.345', 'YYYY-MM-DD HH24:MI:SS.FF3'), 'UTC'));`;
+    expect(oracle({ at: "TIMESTAMP WITH TIME ZONE" }, instant)).toContain(expected);
+    expect(oracle({ at: "timestamp with local time zone" }, instant)).toContain(expected);
+  });
+
+  test("falls back to the timestamp form when the result declared no type for the column", () => {
+    expect(oracle(undefined)).toContain(
+      `VALUES (TO_TIMESTAMP('2026-08-24 10:11:12.345', 'YYYY-MM-DD HH24:MI:SS.FF3'));`,
+    );
+    expect(oracle({ other: "DATE" })).toContain(
+      `VALUES (TO_TIMESTAMP('2026-08-24 10:11:12.345', 'YYYY-MM-DD HH24:MI:SS.FF3'));`,
+    );
+  });
+
+  test("pads every field, so a single-digit month and a sub-100 millisecond still parse", () => {
+    expect(oracle({ at: "TIMESTAMP" }, new Date("2026-01-01T18:04:05.006Z"))).toContain(
+      `VALUES (TO_TIMESTAMP('2026-01-02 03:04:05.006', 'YYYY-MM-DD HH24:MI:SS.FF3'));`,
+    );
+  });
+
+  test("reads no declared type off the prototype for a column named after one", () => {
+    const file = buildResultExport(
+      "sql-insert",
+      source({ rows: [{ constructor: naive }], fields: ["constructor"], dialect: "oracle", columnTypes: {} }),
+    );
+
+    expect(file.content).toContain(`VALUES (TO_TIMESTAMP('2026-08-24 10:11:12.345', 'YYYY-MM-DD HH24:MI:SS.FF3'));`);
+  });
+
+  test("leaves every other dialect on the ISO literal", () => {
+    const file = buildResultExport(
+      "sql-insert",
+      source({ rows: [{ at: instant }], fields: ["at"], dialect: "postgres", columnTypes: { at: "DATE" } }),
+    );
+    expect(file.content).toContain(`VALUES ('2026-08-24T17:11:12.345Z');`);
   });
 });

--- a/tests/unit/marketplace-copy.test.ts
+++ b/tests/unit/marketplace-copy.test.ts
@@ -1,0 +1,188 @@
+/**
+ * The accuracy gate for outward-facing marketplace copy.
+ *
+ * These four files are submissions to somebody else's catalog: Railway, DigitalOcean,
+ * SUSE PCSC and Azure Partner Center. Nobody in this repo reviews them again once they
+ * are mailed, so the only thing standing between a corrected claim and its return is a
+ * test. A previous revision replaced a false natural-language-to-SQL claim with two new
+ * ones - "AI query explanation on any connection" (true on 7 of the 14 engines) and
+ * "never executes what it recommends" (the consented hand-over runs exactly the
+ * recommended statement) - which is why the gate is phrase-level rather than a review
+ * note in the file itself: a file that audits itself against a false line is worse than
+ * one that does not.
+ *
+ * The explain-capable set is DERIVED from the providers, never listed here. The UI hides
+ * the Explain tab unless the provider declares `explainFormat`
+ * (`src/components/studio/BottomPanel.tsx`), so the set of files declaring it IS the set
+ * of engines the copy may name - and an engine that gains or loses a plan format moves
+ * this test's expectation on its own, the way `src/lib/agent/posture.ts` derives every
+ * engine name it prints.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { DB_UI_CONFIG, getDBConfig } from "@/lib/db-ui-config";
+import type { DatabaseType } from "@/lib/types";
+
+const REPO_ROOT = join(import.meta.dir, "../..");
+const PROVIDER_ROOT = join(REPO_ROOT, "src/lib/db/providers");
+
+const LISTINGS = {
+  railway: "deploy/railway/TEMPLATE_OVERVIEW.md",
+  digitalocean: "deploy/digitalocean/assets/description-long.md",
+  rancher: "deploy/rancher/CATALOG_LISTING.md",
+  azure: "deploy/azure/listing/listing-fields.md",
+} as const;
+
+/**
+ * The part of a file that is actually submitted, with the editorial matter around it cut
+ * away. Only `CATALOG_LISTING.md` has any: its accuracy-gate blockquote and its
+ * outstanding-corrections table exist to NAME the wrong claims, so a phrase ban applied
+ * to the whole file would forbid the note that forbids the phrase. The gate itself is
+ * checked separately, by what it must SAY.
+ */
+function submittedCopy(path: string): string {
+  const content = readFileSync(join(REPO_ROOT, path), "utf8");
+  if (path !== LISTINGS.rancher) return content;
+  const from = content.indexOf("## Short description");
+  const to = content.indexOf("## Outstanding corrections");
+  expect(from).toBeGreaterThan(0);
+  expect(to).toBeGreaterThan(from);
+  return content.slice(from, to);
+}
+
+/** Every `.ts` file under the provider tree, at any depth. */
+function providerFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return providerFiles(full);
+    return full.endsWith(".ts") ? [full] : [];
+  });
+}
+
+/**
+ * The canonical type-id a provider file implements, from its own path: `postgres.ts` is
+ * `postgres`, `druid/index.ts` is `druid`. The repo's 1:1 rule between a type-id and
+ * `providers/<family>/<type-id>.ts` is what makes the path readable as an id.
+ */
+function typeIdOf(file: string): string {
+  const name = basename(file, ".ts");
+  return name === "index" ? basename(dirname(file)) : name;
+}
+
+/**
+ * The engines whose provider declares a plan format. The match is anchored to the start
+ * of the line so the several comment lines that discuss a MISSING `explainFormat` (the
+ * search provider explains at length why it declares none) are not read as declarations.
+ */
+const explainCapable: DatabaseType[] = providerFiles(PROVIDER_ROOT)
+  .filter((file) => /^\s*explainFormat:\s*"/m.test(readFileSync(file, "utf8")))
+  .map(typeIdOf)
+  .filter((id): id is DatabaseType => id in DB_UI_CONFIG)
+  .sort();
+
+/**
+ * The engines a listing may NOT name in an explain sentence. `libredb` is excluded from
+ * both sides: it is the embedded engine, not one of the fourteen a listing counts, and
+ * its label is a substring of the product name in every one of these files.
+ */
+const explainIncapable = (Object.keys(DB_UI_CONFIG) as DatabaseType[])
+  .filter((type) => type !== "libredb" && !explainCapable.includes(type))
+  .sort();
+
+/**
+ * The sentences (or list items) of a markdown file that make an explanation claim.
+ *
+ * `plain[\s-]English` and not `plain English`: the Rancher key-features bullet writes it
+ * attributively — "plain-English query explanation" — and a space-only match left that
+ * bullet, which is submitted copy naming engines, outside the gate entirely.
+ */
+function explainClaims(content: string): string[] {
+  return content
+    .replace(/\n(?![\n\-*|>])/g, " ")
+    .split(/(?<=\.)\s+|\n/)
+    .filter((sentence) => /plain[\s-]English|plain language/i.test(sentence));
+}
+
+describe("the explanation claim names only engines that return a plan", () => {
+  test("the derived capable set is non-trivial and excludes the plan-less engines", () => {
+    // A regex that matched nothing would make every assertion below vacuous.
+    expect(explainCapable.length).toBeGreaterThan(0);
+    expect(explainCapable.length).toBeLessThan(explainIncapable.length + explainCapable.length);
+    for (const type of ["oracle", "mssql", "mongodb", "redis", "cassandra", "elasticsearch", "opensearch"]) {
+      expect(explainCapable).not.toContain(type as DatabaseType);
+    }
+  });
+
+  for (const [name, path] of Object.entries(LISTINGS)) {
+    test(`${name} scopes its explanation claim to those engines`, () => {
+      const content = submittedCopy(path);
+
+      // "on any connection" / "everywhere" / "on any of the engines above" are the three
+      // forms the false claim took. None of them can be true while the tab is gated.
+      expect(content).not.toMatch(/explanation everywhere|on any connection|on any of the engines above/i);
+
+      for (const claim of explainClaims(content)) {
+        for (const type of explainCapable) {
+          expect(claim).toContain(getDBConfig(type).label);
+        }
+        for (const type of explainIncapable) {
+          expect(claim).not.toContain(getDBConfig(type).label);
+        }
+      }
+    });
+  }
+});
+
+describe("no listing claims the agent never runs what it recommends", () => {
+  for (const [name, path] of Object.entries(LISTINGS)) {
+    test(`${name} keeps the drafts/recommends distinction`, () => {
+      // `handover/route.ts` runs `answer.sql` - the recommended statement itself - once
+      // the user consents. `posture.ts` states the true form: plan mode "executes
+      // nothing it DRAFTS", and the hand-over is "reads only, and one statement in your
+      // editor". "never writes" / "read-only" stay accurate and are enough.
+      expect(submittedCopy(path)).not.toMatch(/\bwhat it recommends\b|\bnothing it recommends\b/i);
+    });
+  }
+});
+
+describe("the Druid write claim matches the provider documentation", () => {
+  test("no listing says Druid has no INSERT", () => {
+    // Flattened: the sentence is hard-wrapped in the file, so matching the raw text would
+    // assert on where a line broke and a reflow would read as a lost claim.
+    const rancher = submittedCopy(LISTINGS.rancher).replace(/\s+/g, " ");
+    // `INSERT` and `REPLACE` do exist on Druid through the MSQ task engine
+    // (docs/providers/druid.md §5.5). The precise form is the one the README and the
+    // provider doc both carry.
+    expect(rancher).not.toMatch(/no\s+`?INSERT`?,\s*`?UPDATE`?\s+or\s+`?CREATE TABLE`?/i);
+    expect(rancher).toMatch(/no `UPDATE`, no `DELETE` and no `CREATE TABLE`/);
+  });
+});
+
+describe("the Rancher file's own accuracy gate audits against the corrected claims", () => {
+  /**
+   * The editorial blockquote, which is the half of the file that is NOT submitted, with its
+   * `> ` prefixes and hard wraps flattened: every sentence it must carry is longer than the
+   * column it is wrapped at, so matching the raw text would assert on where a line broke.
+   */
+  const rancher = readFileSync(join(REPO_ROOT, LISTINGS.rancher), "utf8");
+  const gate = rancher.slice(0, rancher.indexOf("## Listing facts")).replace(/^> ?/gm, "").replace(/\s+/g, " ");
+
+  test("it names the mechanism that scopes the explanation claim", () => {
+    // A gate that repeats a corrected claim is worse than no gate: it certifies the
+    // defect. So it has to point at the thing that decides, not at a remembered answer.
+    expect(gate).toContain("explainFormat");
+    expect(gate).toContain("BottomPanel.tsx");
+  });
+
+  test("it records why 'executes nothing it recommends' is an overclaim", () => {
+    expect(gate).toContain("handover/route.ts");
+    expect(gate).toContain("posture.ts");
+    expect(gate).toMatch(/drafts/);
+  });
+
+  test("it carries the true Druid sentence rather than the blanket one", () => {
+    expect(gate).toContain("no `UPDATE`, no `DELETE` and no `CREATE TABLE`");
+    expect(gate).toContain("MSQ task engine");
+  });
+});


### PR DESCRIPTION
Three BACKLOG entries close, one is reduced to the part this repo cannot do, and three findings are recorded rather than smuggled in. Every claim below was measured against a live engine and then verified in Chrome on a production build.

## D24 — an empty panel meant "the engine measured nothing", and three providers used it to mean "cannot answer"

#477 gave a panel a way to be ABSENT with the engine's own sentence. This is the audit that entry asked for.

**Apache Cassandra and relatives.** Three panels can never be filled — the objects exist, the figures do not — and two more need `system_views`, which ScyllaDB has no catalog for. All five now carry a reason instead of `[]`:

```
BEFORE (ScyllaDB 2026.2.4)  Sessions: Active 0 / Idle 0 / In TX 0 / Wait 0 / Sessions (0) / "No active sessions found."
AFTER                       Sessions: Active N/A / Idle N/A / In TX N/A / Wait N/A
                            "This panel is read from system_views.queries, and this server has no
                             system_virtual_schema catalog at all, so it publishes no virtual tables
                             (measured against scylladb/scylla:2026.2.4 ...). The statement was not sent,
                             so there is no measurement here rather than a measurement of zero."
```

Apache Cassandra 5.0.9, which does have the virtual tables, still answers: **6 sessions with real rows** in the same browser session. `getHealth()` is untouched, so the connection dialog's SAVE gate (#455) still works for the whole family.

**Apache Trino.** The table panel had three empty readings and only one was a measurement. A refused table list and a catalog whose connector publishes no statistics are now refusals; a catalog that genuinely holds no table keeps its empty panel. Measured against Trino 476: `jmx` holds 379 tables in schema `current` and a 20-table random sample answered `SHOW STATS` with an empty `row_count`, 0 of 20 non-null, so that panel reported nothing about a catalog full of data.

**LibreDB (embedded).** This is the zero-config first run, so its empty Tables panel was the first monitoring dashboard many users ever saw — on a database with tables. It now reports the real per-namespace key count from the same scan the schema tree uses:

```
Tables 3 / 7 rows     users:* relational 3 · articles:* document 2 · config:* kv 2
```

Sessions and Indexes refuse with what the engine actually is, and a scan cut off by the 10,000-key cap refuses rather than reporting counts short by an unknown amount.

**A fabricated zero the LibreDB rows exposed:** the Tables tab's Size card summed `totalSizeBytes`, a required field that carries a placeholder when an engine publishes no per-table bytes, and drew **"0 B / Total"** over a 1,878-byte database. It now gates the way `StorageTab` has since #469, and a table with no size of its own reads `-` rather than an empty cell. `bun:sqlite` sat in the same hole wherever `dbstat` is missing.

## D23 — every Oracle date cell exported as a literal Oracle refuses

Measured through the real export path against Oracle Free 23ai: all four types refused the ISO string (`ORA-01861` for `DATE`, `ORA-01843` for the three timestamps), so a DDL+INSERT export of any ordinary Oracle table could not be replayed. The conversion function IS the literal now, chosen from the declared type:

| declared | written as |
|---|---|
| `DATE` | `TO_DATE('2026-08-24 10:11:12', 'YYYY-MM-DD HH24:MI:SS')` — local fields |
| `TIMESTAMP` (and the fallback) | `TO_TIMESTAMP('... .345', '... .FF3')` — local fields |
| `... WITH [LOCAL] TIME ZONE` | `FROM_TZ(TO_TIMESTAMP(...), 'UTC')` — the UTC instant |

Local fields for a naive column because that is the inverse of what the driver did; `FROM_TZ` for a zoned one because a plain `TO_TIMESTAMP` is read in the replaying session's zone — measured in a `-07:00` session, `FROM_TZ` compared EQUAL and both plain forms DIFF. Proven end to end by replaying the exported file into a fresh table and comparing **by the server**. A zoned column loses its original zone and only that, and the doc says so.

## D16 — the TLS in a pasted string arrived as plaintext

`postgresql://host/db?sslmode=verify-full` reached the form on `disable`. The documented spellings now map (postgres `sslmode`/`ssl`, MySQL `ssl-mode`/`ssl`/`useSSL`, ADO.NET `Encrypt`/`TrustServerCertificate`, case-insensitively because ADO.NET writes `True`). Browser-verified: the SSL / TLS panel reads **VERIFY-FULL** after the paste.

The opportunistic values are **not** guessed onto either end, and that refusal is measured in both directions: on postgres 18 with no server certificate `?sslmode=prefer` connects with `pg_stat_ssl.ssl = f` while `?sslmode=require` is refused outright; on MySQL over TCP `PREFERRED` negotiates `TLS_AES_128_GCM_SHA256` while `DISABLED` leaves `Ssl_cipher` empty. The refusal is visible rather than silent, and it renders **red with a cross** — a green tick over "your TLS setting was dropped" is the #449 defect in its most dangerous direction.

Also fixed during review: `mapTLSValue` looked values up with a bare index, so `?sslmode=constructor` resolved through `Object.prototype` to the Object constructor — truthy, so it bypassed the banner and was written into form state as the SSL mode.

## DOC3 — reduced to the part this repo cannot do

The false NL2SQL copy is gone from six channel files (the four the entry named, plus `deploy/railway/template.json` and `deploy/caprover/libredb-studio.yml`, which spelled the old engine count in a second file nobody reads while editing the first). What is left is resubmission through each marketplace, so the entry stays with only that step.

Two claims in the replacement copy had to be narrowed, both caught by review rather than by a gate — the same defect class DOC3 exists to remove:

- **"AI explanation on any connection" is false.** It is derived from the engine's `EXPLAIN` plan, and `BottomPanel.tsx:301` hides the tab wherever `capabilities.explainFormat` is absent — 7 of the 14 engines, including Oracle and SQL Server, which the same sentence named.
- **"never executes what it recommends"** is the wording #449 already rejected: the consented hand-over runs exactly the recommended statement (`handover/route.ts`). "Read-only" is accurate and enough.

`tests/unit/marketplace-copy.test.ts` now binds the submitted copy to both facts, so re-widening either fails a gate.

## Recorded rather than fixed

- **D25** — Couchbase's `degradeTo()` substitutes `{ tableCount: 0, indexCount: 0 }` for a refused management read, so a document-only role reads a bucket with zero tables. Same class as the above; no Couchbase cluster is running here, and a refusal sentence never seen from the server is what D21 was fixed for.
- **D26** — `?ssl=true` maps onto `require`, the one mode that means `rejectUnauthorized: false`, while the same commit REFUSES the identical mapping for MongoDB's `tls=true`. Both arms are defensible; neither is written down as a rule, and `SSLMode` has no "verify with the system trust store" value.
- **U19** — the degraded-save banner emits a caution as `success: true`, so "click Save again to save it anyway" arrives wearing a green tick. The TLS fix above is available here, but a red cross overstates in the other direction: this banner has no warning state.

## Gates

| Gate | Result |
| --- | --- |
| `bun run format` | clean (939 files) |
| `bun run lint` | 0 errors |
| `bun run typecheck` | clean |
| `bun run knip` | clean |
| tests | 9171 pass, 0 fail; 33/33 component groups |
| coverage | **100.00% (42654/42654 lines)** |
| `bun run build` | exit 0 |
| `build:lib` + `attw` | exit 0 |
| gitleaks | 1 commit scanned, no leaks |
