### PR TITLE
fix(editor): an abandoned Monaco load is expected, so stop reporting it as a fault

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useRef, useEffect, useState, useMemo, forwardRef, useImperativeHandle } from "react";
-import Editor, { useMonaco } from "@monaco-editor/react";
+import Editor from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import { Zap, LoaderCircle, TextAlignStart, Trash2, Copy, Play, Hash } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -14,6 +14,7 @@ import { registerLibreDBLanguage } from "@/lib/editor/libredb-language";
 import { registerRedisLanguage } from "@/lib/editor/redis-language";
 import { configureMonacoLoader } from "@/lib/editor/monaco-loader";
 import { useEffectiveTheme } from "@/hooks/use-effective-theme";
+import { useMonacoInstance } from "@/hooks/use-monaco-instance";
 import { logger } from "@/lib/logger";
 import { setLineNumbersPreference, useLineNumbersPreference } from "@/hooks/use-line-numbers-preference";
 import { writeToClipboard } from "@/components/copy-button";
@@ -98,7 +99,7 @@ const getEditorOptions = (showLineNumbers: boolean) => ({
 
 export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
   ({ value, onChange, onContentChange, onExplain, language = "sql", schemaContext, capabilities }, ref) => {
-    const monaco = useMonaco();
+    const monaco = useMonacoInstance();
     const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
     const [hasSelection, setHasSelection] = useState(false);
 

--- a/src/hooks/use-monaco-instance.ts
+++ b/src/hooks/use-monaco-instance.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { loader } from "@monaco-editor/react";
+import { useEffect, useState } from "react";
+import type * as Monaco from "monaco-editor";
+
+/*
+  A replacement for `@monaco-editor/react`'s own `useMonaco`, which loses the
+  cancellation its sibling `Editor` component handles.
+
+  Both entry points call the same `loader.init()`, which `@monaco-editor/loader` wraps
+  in `makeCancelable`. `Editor` filters the resulting rejection; `useMonaco` attaches no
+  rejection handler at all, so every unmount that outruns the load reports the abandoned
+  promise as an unhandled rejection. That is a false alarm in a terminal we read for real
+  ones. Known upstream since 2023 (suren-atoyan/monaco-react#440, #575), closed twice by a
+  stale bot without a fix, and `4.8.0-rc.3` carries the same code — so a version bump does
+  not retire this file. See issue #492 for the full account.
+*/
+
+/** The Monaco namespace, as the loader hands it over. */
+type MonacoNamespace = typeof Monaco;
+
+/*
+  The marker `makeCancelable` rejects with:
+  `{ type: 'cancelation', msg: 'operation is manually canceled' }`.
+  A plain object, not an Error — which is why matching on a message or on `error.name`
+  (the workaround suggested upstream) cannot recognise it.
+*/
+const CANCELLATION_TYPE = "cancelation";
+
+/**
+ * Silences the loader's own cancellation and lets every other rejection through.
+ *
+ * Rethrowing rather than logging is deliberate: a Monaco that genuinely failed to load
+ * means a dead editor, and the failure has to stay loud. It escapes as an unhandled
+ * rejection rather than as a render-time throw because `QueryEditor` sits outside any
+ * error boundary — throwing during render would replace the whole studio page with an
+ * error screen over a broken editor pane, which trades one broken surface for six.
+ *
+ * The match is positive: only the loader's marker is silenced, so a rejection carrying
+ * no inspectable value stays a failure instead of passing as a cancellation.
+ */
+export function rethrowUnlessCancelled(error: unknown): void {
+  if ((error as { type?: unknown } | null | undefined)?.type === CANCELLATION_TYPE) return;
+  throw error;
+}
+
+/**
+ * The Monaco namespace once its AMD bundle has loaded, or `null` until then.
+ *
+ * Monaco is a singleton, so an editor mounted after the first one gets the instance
+ * synchronously and never re-enters the loader.
+ */
+export function useMonacoInstance(): MonacoNamespace | null {
+  const [monaco, setMonaco] = useState<MonacoNamespace | null>(
+    () => loader.__getMonacoInstance() as MonacoNamespace | null,
+  );
+
+  useEffect(() => {
+    if (monaco) return;
+    const pending = loader.init();
+    pending.then((instance) => setMonaco(instance as MonacoNamespace)).catch(rethrowUnlessCancelled);
+    return () => pending.cancel();
+  }, [monaco]);
+
+  return monaco;
+}

--- a/tests/components/QueryEditor.test.tsx
+++ b/tests/components/QueryEditor.test.tsx
@@ -148,7 +148,18 @@ mock.module("@monaco-editor/react", () => ({
     init: mock(() => Promise.resolve()),
     config: mock(() => {}),
   },
-  useMonaco: mock(() => mockUseMonacoReturn),
+}));
+
+/*
+  The Monaco namespace reaches QueryEditor through our own hook, not the package's
+  `useMonaco` — see src/hooks/use-monaco-instance.ts and issue #492. Mocked here rather
+  than mocking the loader underneath it so these tests keep seeing the namespace
+  synchronously: the real hook resolves it from a promise, which would turn every
+  assertion that depends on `monaco` into an awaited one for no gain in coverage. The
+  hook's own load and cancellation behaviour is tested in tests/hooks.
+*/
+mock.module("@/hooks/use-monaco-instance", () => ({
+  useMonacoInstance: mock(() => mockUseMonacoReturn),
 }));
 
 let mockClipboardWriteText = mock((data: string) => {

--- a/tests/helpers/mock-monaco.ts
+++ b/tests/helpers/mock-monaco.ts
@@ -36,8 +36,8 @@ export function setupMonacoMock() {
       loader: {
         init: mock(() => Promise.resolve()),
         config: mock(() => {}),
+        __getMonacoInstance: mock(() => null),
       },
-      useMonaco: mock(() => null),
     };
   });
 }

--- a/tests/hooks/use-monaco-instance.test.ts
+++ b/tests/hooks/use-monaco-instance.test.ts
@@ -1,0 +1,149 @@
+import "../setup-dom";
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+import type * as Monaco from "monaco-editor";
+
+/*
+  What `@monaco-editor/loader`'s `makeCancelable` rejects with when a caller cancels.
+  A plain object, deliberately not an Error — see issue #492 for why that detail is
+  what defeats every string-matching workaround.
+*/
+const CANCELLATION = { type: "cancelation", msg: "operation is manually canceled" };
+
+interface CancelablePromise<T> extends Promise<T> {
+  cancel: () => void;
+}
+
+/** A stand-in for `loader.init()`: a promise this test settles, plus the cancel hook. */
+function makeCancelable<T>(): {
+  promise: CancelablePromise<T>;
+  settle: (value: T) => void;
+  fail: (e: unknown) => void;
+} {
+  let resolveFn: (value: T) => void = () => {};
+  let rejectFn: (reason: unknown) => void = () => {};
+  const base = new Promise<T>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  const promise = base as CancelablePromise<T>;
+  promise.cancel = () => rejectFn(CANCELLATION);
+  return { promise, settle: resolveFn, fail: rejectFn };
+}
+
+/*
+  A minimal Monaco stand-in. Identity is all these tests assert on, so the cast buys the
+  `toBe` comparisons without standing up the real namespace's 17 sub-modules.
+*/
+const MONACO = { languages: {}, editor: {} } as unknown as typeof Monaco;
+
+let loaded: unknown = null;
+let initCalls = 0;
+let inFlight: ReturnType<typeof makeCancelable<unknown>> | null = null;
+
+mock.module("@monaco-editor/react", () => ({
+  default: () => null,
+  loader: {
+    config: () => {},
+    __getMonacoInstance: () => loaded,
+    init: () => {
+      initCalls += 1;
+      inFlight = makeCancelable<unknown>();
+      return inFlight.promise;
+    },
+  },
+}));
+
+const { useMonacoInstance, rethrowUnlessCancelled } = await import("@/hooks/use-monaco-instance");
+
+describe("rethrowUnlessCancelled", () => {
+  /** The whole point: a cancellation is expected control flow, not a failure. */
+  test("swallows the loader's cancellation object", () => {
+    expect(() => rethrowUnlessCancelled(CANCELLATION)).not.toThrow();
+  });
+
+  test("rethrows a genuine failure", () => {
+    const failure = new Error("Failed to fetch /monaco/vs/loader.js");
+    expect(() => rethrowUnlessCancelled(failure)).toThrow(failure);
+  });
+
+  /*
+    A rejection with no value at all must still be loud. Cancellation is recognised by
+    a positive match on `type`, so anything that cannot be inspected is a failure by
+    default — the inverse would make an empty rejection indistinguishable from a cancel.
+  */
+  test("rethrows a rejection carrying no value", () => {
+    expect(() => rethrowUnlessCancelled(undefined)).toThrow();
+    expect(() => rethrowUnlessCancelled(null)).toThrow();
+  });
+
+  /** A near-miss shape is a failure: only the loader's own marker is silenced. */
+  test("rethrows an object whose type is something else", () => {
+    expect(() => rethrowUnlessCancelled({ type: "timeout" })).toThrow();
+  });
+});
+
+describe("useMonacoInstance", () => {
+  beforeEach(() => {
+    loaded = null;
+    initCalls = 0;
+    inFlight = null;
+  });
+
+  test("delivers the instance once the loader resolves", async () => {
+    const { result } = renderHook(() => useMonacoInstance());
+    expect(result.current).toBeNull();
+
+    await act(async () => {
+      inFlight?.settle(MONACO);
+    });
+
+    expect(result.current).toBe(MONACO);
+  });
+
+  /*
+    Monaco is a singleton: an editor mounted after the first one must not re-enter the
+    loader, and must not render a null frame first. That is what the upstream hook's
+    `__getMonacoInstance()` seed buys, and it is why this replacement keeps it.
+  */
+  test("takes an already-loaded instance synchronously, without calling init", () => {
+    loaded = MONACO;
+    const { result } = renderHook(() => useMonacoInstance());
+
+    expect(result.current).toBe(MONACO);
+    expect(initCalls).toBe(0);
+  });
+
+  test("cancels an in-flight load when the component unmounts", () => {
+    const { unmount } = renderHook(() => useMonacoInstance());
+    expect(initCalls).toBe(1);
+
+    // Non-vacuity: the cancellation is observable only because the promise is still pending.
+    unmount();
+    expect(inFlight).not.toBeNull();
+  });
+
+  /*
+    The bug this hook exists for. Unmounting mid-load cancels the loader promise; the
+    upstream hook attaches no rejection handler, so the cancellation surfaces as
+    `unhandledRejection` in the dev terminal on every page that mounts the editor.
+    The collector below is what makes this assertion non-vacuous: it fails if anything
+    reaches the process-level handler.
+  */
+  test("an unmount mid-load produces no unhandled rejection", async () => {
+    const escaped: unknown[] = [];
+    const collect = (reason: unknown) => escaped.push(reason);
+    process.on("unhandledRejection", collect);
+
+    try {
+      const { unmount } = renderHook(() => useMonacoInstance());
+      unmount();
+      // Let the rejection propagate through the microtask queue it would escape on.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(escaped).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", collect);
+    }
+  });
+});

--- a/tests/isolated/monaco-loader-wiring.test.ts
+++ b/tests/isolated/monaco-loader-wiring.test.ts
@@ -18,8 +18,8 @@ mock.module("@monaco-editor/react", () => ({
     config: (config: { paths?: { vs?: string } }) => {
       configCalls.push(config);
     },
+    __getMonacoInstance: () => null,
   },
-  useMonaco: () => null,
 }));
 
 // Imported after the mock so the module-scope loader configuration is observable.


### PR DESCRIPTION
Closes #492.

## The problem

Every development page that mounted the SQL editor printed this:

```
[browser] "unhandledRejection:" { msg: 'operation is manually canceled', type: 'cancelation' }
```

Nothing was wrong. An in-flight Monaco loader promise was being abandoned because its
component unmounted, which is correct behaviour. The defect is that it was *reported as a
fault* in a terminal we read for real ones. It already cost one investigation on #488,
where the line had to be reproduced against a clean `origin/main` worktree just to
establish it was not that PR's doing.

`@monaco-editor/react` handles this cancellation in one of its two entry points and not
the other. Both call the same `loader.init()`, which `@monaco-editor/loader` wraps in
`makeCancelable`. The `Editor` component filters the rejection; `useMonaco` attaches no
rejection handler at all, so `n.then(t => r(t))` leaves a promise with no `catch` and the
cancellation escapes.

## The change

`src/hooks/use-monaco-instance.ts` mirrors the upstream hook and adds the guard the
`Editor` component already has. `QueryEditor` was the only caller of `useMonaco()`, at one
line.

Both `loader.init()` and `loader.__getMonacoInstance()` are declared in
`@monaco-editor/loader`'s own published types (`lib/types.d.ts`), so nothing here reaches
into private API or needs a cast to `any`.

**A rejection that is not the loader's cancellation is rethrown, not logged.** A Monaco
that genuinely failed to load means a dead editor, and on an air-gapped install that is a
real possibility worth being loud about. The match is positive on the marker, so a
rejection carrying no inspectable value stays a failure rather than passing as a
cancellation. It escapes as an unhandled rejection rather than a render-time throw because
`QueryEditor` sits outside any error boundary -- throwing during render would replace the
whole studio page with an error screen over one broken pane.

## Why this cannot be fixed by upgrading

4.7.0 is the latest published release and is what we have. 4.8.0-rc.3 from the `next` tag
carries a byte-identical `useMonaco`. Upstream has had this reported twice and closed it
twice without a fix, both times by a stale bot:

- [suren-atoyan/monaco-react#440](https://github.com/suren-atoyan/monaco-react/issues/440), 2023-01-04, 18 comments, closed 2026-04-12
- [suren-atoyan/monaco-react#575](https://github.com/suren-atoyan/monaco-react/issues/575), 2024-01-22, closed 2025-05-29

The shape of the fix here matches the community workaround the maintainer points people to
in #440; it was arrived at independently before that thread was read, which is some
comfort that it is the right shape.

Note that the `unhandledrejection` listener suggested in #575 tests
`event.reason.name === "Canceled"`. This rejection value is a plain object with no `name`
at all, so that workaround would never have matched -- worth knowing before anyone copies
it and believes it worked.

## Verification

A suppressed symptom and a fixed cause look identical in a green suite, so this was
measured in the browser as well.

| Arm | Measurement |
| --- | --- |
| Control -- package `useMonaco` restored | the line appears: 2 occurrences over 2 page loads |
| Fixed -- fresh dev server | 0 occurrences over 4 page loads plus two round trips through `/monitoring` that unmount the editor |

Non-vacuity, in both directions:

- **The regression test fails without the fix.** Deleting the `.catch` makes
  `tests/hooks/use-monaco-instance.test.ts` fail printing the exact object from the dev
  terminal, so it tests the real thing rather than its own mock.
- **The hook delivers a live namespace, not a permanent null.** A hook stuck at `null`
  would also produce zero rejections while silently killing SQL completion. Triggering
  completion in the running editor returns `actor - Table (200 rows)` -- an item only our
  own provider can produce, since the row count comes from `schemaCompletionCache`, and
  that provider is registered by the effect that depends on the hook's value. Running a
  query returned 16 rows in 82ms.

`window.monaco` being present is deliberately *not* offered as evidence: it is set up by
`beforeMount` on the `Editor` component and would look the same with the hook broken.

## Test-mock note

`useMonaco` was mocked at the package boundary in three places. Moving the call into our
own module means those mocks no longer intercept that path, so they were moved up a level:
`QueryEditor.test.tsx` now mocks `@/hooks/use-monaco-instance` (keeping the namespace
synchronous, as those 103 tests expect), and the two loader mocks gained
`__getMonacoInstance`. A mock is bound to the module boundary it names, not to the idea, so
relocating code silently retargets it -- worth stating explicitly since the tests would
have gone on passing while measuring something else.

## Gates

`format`, `lint`, `typecheck`, `knip`, `test:ci` (344 core files + 33 component groups),
`build`, plus `build:lib` and `attw`. Coverage 42607/42607 lines (100.00%).
