### PR TITLE
chore(helm): make chart release notes explain the two version streams

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -290,7 +290,11 @@ jobs:
           asset_path=$(ls .cr-release-packages/*.tgz)
           asset=$(basename "$asset_path")
           tag="${asset%.tgz}"
-          desc=$(grep '^description:' charts/libredb-studio/Chart.yaml | cut -d' ' -f2-)
+          # grep/awk for the same reason as the preflight reads above: yq is
+          # not preinstalled. Both fields come from the very Chart.yaml that
+          # `helm package` just packaged, so they cannot drift from the tag.
+          version=$(grep '^version:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
+          app_version=$(grep '^appVersion:' charts/libredb-studio/Chart.yaml | awk '{print $2}' | tr -d '"')
           if IS_DRAFT=$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null); then
             if [ "$IS_DRAFT" != "true" ]; then
               if gh release view "$tag" --json assets --jq '.assets[].name' | grep -Fqx "$asset"; then
@@ -302,7 +306,55 @@ jobs:
             fi
             echo "Reusing existing draft release '$tag'."
           else
-            gh release create "$tag" --draft --title "$tag" --notes "$desc"
+            # Release copy is the only explanation a visitor to the Releases
+            # page gets for the two version streams this repo publishes: the
+            # application (tag `0.13.4`) and this chart (tag
+            # `libredb-studio-0.1.49`, because `helm package` names its
+            # artifact `<chart-name>-<chart-version>.tgz`). The old body -
+            # the chart's `description:` line, identical on every chart
+            # release - answered a question nobody asked.
+            #
+            # Quoted heredoc on purpose: the body is markdown whose backticks
+            # and code fences must reach the release page literally, so the
+            # two version numbers are substituted afterwards rather than
+            # interpolated by the shell.
+            notes="${RUNNER_TEMP}/chart-release-notes.md"
+            cat > "$notes" <<'NOTES'
+          LibreDB Studio Helm chart `__CHART_VERSION__`, deploying application version `__APP_VERSION__` by default.
+
+          ## Install
+
+          From the Helm repository:
+
+          ```bash
+          helm repo add libredb https://libredb.org/libredb-studio/
+          helm repo update
+          helm install libredb libredb/libredb-studio --version __CHART_VERSION__
+          ```
+
+          Or straight from the OCI registry:
+
+          ```bash
+          helm install libredb oci://ghcr.io/libredb/charts/libredb-studio --version __CHART_VERSION__
+          ```
+
+          Both commands work with default values: the chart bootstraps its own JWT secret and admin credentials on first boot. Every value is documented in [charts/libredb-studio/README.md](https://github.com/libredb/libredb-studio/blob/main/charts/libredb-studio/README.md).
+
+          ## Why two version numbers?
+
+          This repository publishes two independent release streams, so the Releases page carries two tag shapes:
+
+          | Tag | What it releases |
+          | --- | --- |
+          | `__APP_VERSION__` | the LibreDB Studio application - npm, Docker, desktop and OS packages |
+          | `libredb-studio-__CHART_VERSION__` | this Helm chart - `helm package` names its artifact `<chart-name>-<chart-version>.tgz`, and the release tag follows it |
+
+          The chart version moves on its own so a chart-only fix ships without forcing an application release. The application version a given chart deploys is its `appVersion` - shown in the `APP VERSION` column of `helm search repo` and on ArtifactHub. The full rationale is in [docs/HELM_CHART.md](https://github.com/libredb/libredb-studio/blob/main/docs/HELM_CHART.md#versioning-policy-version-and-appversion-stay-independent-researched-2026-07).
+          NOTES
+            sed -i "s|__CHART_VERSION__|${version}|g; s|__APP_VERSION__|${app_version}|g" "$notes"
+            gh release create "$tag" --draft \
+              --title "Helm chart ${version} (app ${app_version})" \
+              --notes-file "$notes"
           fi
           # Immutable releases require the git tag to exist at publish time.
           if ! git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null; then

--- a/tests/unit/helm-release-notes.test.ts
+++ b/tests/unit/helm-release-notes.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the chart release's title and notes in helm-release.yml.
+ *
+ * Why a test for release copy: this text is the only explanation a visitor to
+ * the Releases page ever gets for why the repository carries two version
+ * streams - the application (`0.13.4`) and the chart
+ * (`libredb-studio-0.1.49`). It used to be the chart's one-line `description:`
+ * repeated verbatim on every chart release, which answers a question nobody
+ * asked. The failure mode of the replacement is equally silent: a stale
+ * version placeholder still renders (as literal `__CHART_VERSION__`), a
+ * doc link whose anchor drifted still renders (as a link to the top of the
+ * file), and an unquoted heredoc silently executes the `$(...)` and backticks
+ * inside the markdown instead of printing them. None of these fails a run.
+ *
+ * Same asymmetry as tests/unit/security-scan-workflow.test.ts, applied to the
+ * one workflow step whose output is read by humans rather than by tooling.
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { parse as parseYaml } from "yaml";
+
+interface Step {
+  name?: string;
+  run?: string;
+  env?: Record<string, string>;
+}
+interface Workflow {
+  jobs: Record<string, { steps?: Step[] }>;
+}
+
+const repoRoot = path.join(__dirname, "../..");
+const workflowFile = path.join(repoRoot, ".github/workflows/helm-release.yml");
+const workflow = parseYaml(fs.readFileSync(workflowFile, "utf8")) as Workflow;
+
+const publishStep = (workflow.jobs["release-github-pages"]?.steps ?? []).find((s) =>
+  s.name?.startsWith("Publish chart release"),
+);
+const script = publishStep?.run ?? "";
+
+/**
+ * The notes markdown, extracted from the quoted heredoc that writes it. Kept
+ * as a separate extraction (rather than asserting against the whole script)
+ * so a match can never be satisfied by a shell comment elsewhere in the step.
+ */
+function notesBody(): string {
+  const match = /<<'NOTES'\n([\s\S]*?)\nNOTES\n/.exec(script);
+  return match?.[1] ?? "";
+}
+
+/** GitHub's heading-anchor slug: lowercase, drop punctuation, spaces to hyphens. */
+function slug(heading: string): string {
+  return heading
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\- ]+/g, "")
+    .replace(/ /g, "-");
+}
+
+describe("helm-release.yml chart release notes", () => {
+  test("the publish step exists and is the one that creates the release", () => {
+    expect(publishStep).toBeDefined();
+    expect(script).toContain("gh release create");
+  });
+
+  test("notes are not the chart's description line repeated", () => {
+    // The old body: `desc=$(grep '^description:' ... )` passed as --notes.
+    expect(script).not.toContain("^description:");
+  });
+
+  test("the heredoc is quoted, so backticks and $(...) stay literal markdown", () => {
+    // An unquoted heredoc would run the command substitutions in the install
+    // snippets and swallow every backtick-quoted term in the prose.
+    expect(script).toContain("<<'NOTES'");
+    expect(notesBody().length).toBeGreaterThan(0);
+  });
+
+  test("both version numbers are substituted, not left as placeholders", () => {
+    const body = notesBody();
+    expect(body).toContain("__CHART_VERSION__");
+    expect(body).toContain("__APP_VERSION__");
+    // Every placeholder the body uses must have a substitution in the script.
+    for (const placeholder of new Set(body.match(/__[A-Z_]+__/g) ?? [])) {
+      expect(script).toContain(`s|${placeholder}|`);
+    }
+  });
+
+  test("the title carries both versions instead of repeating the tag", () => {
+    expect(script).toMatch(/--title "[^"]*\$\{?version\}?[^"]*"/);
+    expect(script).toMatch(/--title "[^"]*\$\{?app_version\}?[^"]*"/);
+  });
+
+  test("the notes tell the reader how to install this exact chart version", () => {
+    const body = notesBody();
+    expect(body).toContain("helm repo add libredb https://libredb.org/libredb-studio/");
+    expect(body).toContain("oci://ghcr.io/libredb/charts/libredb-studio");
+    // Pinned installs only: an unpinned command on a versioned release page
+    // would install something other than the release being read.
+    for (const line of body.split("\n").filter((l) => l.includes("helm install"))) {
+      expect(line).toContain("--version __CHART_VERSION__");
+    }
+  });
+
+  test("the notes explain the two release streams and name appVersion", () => {
+    const body = notesBody();
+    expect(body).toContain("appVersion");
+    expect(body).toContain("__APP_VERSION__");
+  });
+
+  test("the rationale link resolves to a real heading in docs/HELM_CHART.md", () => {
+    const link = /docs\/HELM_CHART\.md#([a-z0-9-]+)/.exec(notesBody());
+    expect(link).not.toBeNull();
+    const doc = fs.readFileSync(path.join(repoRoot, "docs/HELM_CHART.md"), "utf8");
+    const anchors = (doc.match(/^#{1,6} .+$/gm) ?? []).map((h) => slug(h.replace(/^#+ /, "")));
+    // No link means the fallback "" - which no heading can produce, so the
+    // assertion still fails rather than passing vacuously.
+    expect(anchors).toContain(link?.[1] ?? "");
+  });
+});


### PR DESCRIPTION
## Why

Every Helm chart release published the same body: the chart's one-line `description:` from `Chart.yaml`, repeated verbatim. It answers a question nobody asked, while the question contributors actually ask - why the Releases page carries both `0.13.4` and `libredb-studio-0.1.49` - went unanswered anywhere a visitor to that page would look.

## What this does not change

The tag shape. `helm package` names its artifact `<chart-name>-<chart-version>.tgz` and the release tag follows it, which is both the chart-releaser convention across the ecosystem and the invariant `Verify chart release asset was published` relies on (it re-packages the chart and derives the tag from the filename, parsing no version string). Two alternatives were considered and rejected:

- **Renaming the chart** changes the install identity (`helm upgrade` breaks for existing users), splits `index.yaml` into a second `entries` key, and re-registers the ArtifactHub package from zero.
- **Renaming only the git tag** is technically feasible (`helm repo index --merge` keeps prior URLs, ArtifactHub reads the index, OCI tags are version-only) but the release asset would still be named `libredb-studio-<version>.tgz`, so the Releases page keeps two shapes. It moves the confusion instead of removing it.

So this fixes the copy, not the identity.

## What changed

`.github/workflows/helm-release.yml`, publish step:

- Title is now `Helm chart 0.1.49 (app 0.13.4)` instead of the bare tag.
- Body carries pinned install commands for both the Helm repository and the OCI registry, a table naming the two release streams, and a link to the versioning rationale in `docs/HELM_CHART.md`.
- The heredoc is quoted, so the markdown's backticks and code fences reach the release page literally; both versions are substituted afterwards with `sed`.

Rendered locally against the current `Chart.yaml` (0.1.49 / 0.13.4):

> LibreDB Studio Helm chart `0.1.49`, deploying application version `0.13.4` by default.
>
> **Install** - `helm install libredb libredb/libredb-studio --version 0.1.49`, or `helm install libredb oci://ghcr.io/libredb/charts/libredb-studio --version 0.1.49`. Both work with default values.
>
> **Why two version numbers?** - a table mapping `0.13.4` to the application stream and `libredb-studio-0.1.49` to the chart stream, then the `appVersion` explanation and the docs link.

## Tests

`tests/unit/helm-release-notes.test.ts` covers the failure modes that are silent by construction - each one still renders a release page, just a wrong one:

- an unsubstituted `__CHART_VERSION__` / `__APP_VERSION__` placeholder (every placeholder in the body must have a matching `sed` substitution),
- an unquoted heredoc, which would execute the `$(...)` and swallow the backticks,
- an unpinned `helm install` on a versioned release page,
- a `docs/HELM_CHART.md` anchor that no longer matches a heading in that file.

## Verification

`format` · `lint` · `typecheck` · `knip` · `test` (33 groups) · `build` all pass locally. The notes body was additionally extracted from the YAML and rendered through `bash` to confirm the markdown comes out intact, rather than only asserting on the script text.

No `charts/**` path changed, so this does not trigger `helm-release`: it takes effect on the next chart version bump.
