### PR TITLE
fix(mobile): four defects at 390px, starting with the unreachable light theme (#401)

### DIFF
--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -30,7 +30,7 @@ import { buildResultExport, type ResultExportFormat } from "@/lib/export/result-
 import { downloadText } from "@/lib/export/download";
 import { newLocalId } from "@/lib/ids";
 import { resolveAgentRunConnectionId } from "@/hooks/use-connection-payload";
-import { isMobileViewport } from "@/hooks/use-mobile";
+import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
 import { useAgentCapability } from "@/hooks/use-agent-capability";
 import { useAgentArtifact } from "@/components/agent/use-agent-artifact";
 import { useAgentPrefill } from "@/components/agent/use-agent-prefill";
@@ -193,6 +193,8 @@ export default function Studio() {
   const [isSaveQueryModalOpen, setIsSaveQueryModalOpen] = useState(false);
   const [savedKey, setSavedKey] = useState(0);
   const [activeMobileTab, setActiveMobileTab] = useState<"database" | "schema" | "editor">("editor");
+  /** What the panel group may hold: below the breakpoint, only the body panel. */
+  const isMobile = useIsMobile();
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [profilerTable, setProfilerTable] = useState<string | null>(null);
   const [codeGenTable, setCodeGenTable] = useState<string | null>(null);
@@ -394,6 +396,42 @@ export default function Studio() {
     if (conn.activeConnection?.id === id) conn.setActiveConnection(updated[0] || null);
   };
 
+  /**
+   * One rail, two mounts: a panel of the group above the breakpoint, a bare child of
+   * the shell below it. Declared once so the two placements cannot drift apart.
+   */
+  const agentRail = (
+    <AgentRail
+      connectionId={agentConnectionId}
+      connectionName={conn.activeConnection?.name ?? null}
+      sheetOpen={isAgentSheetOpen}
+      onSheetOpenChange={setIsAgentSheetOpen}
+      prefill={agentPrefill.request}
+      connectionType={conn.activeConnection?.type ?? null}
+      onApplyStatement={(sql) => tabMgr.updateCurrentTab({ query: sql })}
+      /*
+          The handover a run's answer can record (§2.1): the statement goes
+          into the editor AND is run there. Through the hook's own entry point
+          rather than `executeQuery`, and the difference is the boundary
+          (#373 review): `executeQuery` goes to the editor's read-WRITE route,
+          where a `SELECT` calling a VOLATILE function that writes would
+          succeed. `executeHandedOverStatement` asks the run's own hand-over
+          route instead, which runs the ledger's statement under the engine's
+          read-only session at the editor's default row limit and with no
+          statement timeout.
+
+          The statement is put in the editor first so the user reads what is
+          running while it runs; the RUN is what is sent, because the text the
+          server executes is the ledger's, not this component's copy of it.
+        */
+      onRunStatement={(sql, runId) => {
+        tabMgr.updateCurrentTab({ query: sql });
+        void queryExec.executeHandedOverStatement(runId, sql);
+      }}
+      onShowArtifact={agentArtifact.show}
+    />
+  );
+
   return (
     <div className="flex h-screen w-full bg-canvas text-fg overflow-hidden font-sans select-none">
       <ResizablePanelGroup id="studio-main" orientation="horizontal" className="h-full">
@@ -401,33 +439,45 @@ export default function Studio() {
             a sibling is conditional (the agent rail); it replaces v3's `order`,
             since v4 keys its layout by panel id. Sizes are strings on purpose:
             v4 reads a bare number as pixels and a unitless string as a percentage. */}
-        <ResizablePanel id="studio-sidebar" defaultSize="22" minSize="15" maxSize="35" className="hidden md:block">
-          <Sidebar
-            connections={conn.connections}
-            activeConnection={conn.activeConnection}
-            schema={conn.schema}
-            isLoadingSchema={conn.isLoadingSchema}
-            onSelectConnection={conn.setActiveConnection}
-            onDeleteConnection={handleDeleteConnection}
-            onEditConnection={(c) => {
-              setEditingConnection(c);
-              setIsConnectionModalOpen(true);
-            }}
-            onAddConnection={() => setIsConnectionModalOpen(true)}
-            onTableClick={onTableClick}
-            onGenerateSelect={tabMgr.handleGenerateSelect}
-            onCreateTableClick={() => setIsCreateTableModalOpen(true)}
-            onShowDiagram={() => setShowDiagram(true)}
-            isAdmin={isAdmin}
-            onOpenMaintenance={openMaintenance}
-            databaseType={conn.activeConnection?.type}
-            metadata={metadata}
-            onProfileTable={(name) => setProfilerTable(name)}
-            onGenerateCode={(name) => setCodeGenTable(name)}
-            onGenerateTestData={(name) => setTestDataTable(name)}
-          />
-        </ResizablePanel>
-        <ResizableHandle className="hidden md:flex w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
+        {/*
+          Not merely hidden: `react-resizable-panels` 4 puts a `Panel`'s `className`
+          on a NESTED div ("Class is applied to nested HTMLDivElement to avoid styles
+          that interfere with Flex layout"), so `hidden md:block` hid the sidebar's
+          CONTENTS while the panel itself kept its 22% of the row. At 390px that left
+          the studio body 211px wide with its own header overlapping. A panel the
+          viewport cannot show has to be out of the group, not styled out of sight.
+        */}
+        {!isMobile && (
+          <>
+            <ResizablePanel id="studio-sidebar" defaultSize="22" minSize="15" maxSize="35">
+              <Sidebar
+                connections={conn.connections}
+                activeConnection={conn.activeConnection}
+                schema={conn.schema}
+                isLoadingSchema={conn.isLoadingSchema}
+                onSelectConnection={conn.setActiveConnection}
+                onDeleteConnection={handleDeleteConnection}
+                onEditConnection={(c) => {
+                  setEditingConnection(c);
+                  setIsConnectionModalOpen(true);
+                }}
+                onAddConnection={() => setIsConnectionModalOpen(true)}
+                onTableClick={onTableClick}
+                onGenerateSelect={tabMgr.handleGenerateSelect}
+                onCreateTableClick={() => setIsCreateTableModalOpen(true)}
+                onShowDiagram={() => setShowDiagram(true)}
+                isAdmin={isAdmin}
+                onOpenMaintenance={openMaintenance}
+                databaseType={conn.activeConnection?.type}
+                metadata={metadata}
+                onProfileTable={(name) => setProfilerTable(name)}
+                onGenerateCode={(name) => setCodeGenTable(name)}
+                onGenerateTestData={(name) => setTestDataTable(name)}
+              />
+            </ResizablePanel>
+            <ResizableHandle className="w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
+          </>
+        )}
         <ResizablePanel id="studio-body" defaultSize={agentEnabled ? "54" : "78"}>
           <div className="flex-1 flex flex-col min-w-0 h-full bg-surface pb-16 md:pb-0">
             <StudioMobileHeader
@@ -669,43 +719,23 @@ export default function Studio() {
           package boundary — the one that matters for what ships to platform — is
           pinned separately in T12.
         */}
-        {agentEnabled && (
+        {agentEnabled && !isMobile && (
           <>
-            <ResizableHandle className="hidden md:flex w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
-            <ResizablePanel id="studio-agent" defaultSize="24" minSize="18" maxSize="45" className="hidden md:block">
-              <AgentRail
-                connectionId={agentConnectionId}
-                connectionName={conn.activeConnection?.name ?? null}
-                sheetOpen={isAgentSheetOpen}
-                onSheetOpenChange={setIsAgentSheetOpen}
-                prefill={agentPrefill.request}
-                connectionType={conn.activeConnection?.type ?? null}
-                onApplyStatement={(sql) => tabMgr.updateCurrentTab({ query: sql })}
-                /*
-                  The handover a run's answer can record (§2.1): the statement goes
-                  into the editor AND is run there. Through the hook's own entry point
-                  rather than `executeQuery`, and the difference is the boundary
-                  (#373 review): `executeQuery` goes to the editor's read-WRITE route,
-                  where a `SELECT` calling a VOLATILE function that writes would
-                  succeed. `executeHandedOverStatement` asks the run's own hand-over
-                  route instead, which runs the ledger's statement under the engine's
-                  read-only session at the editor's default row limit and with no
-                  statement timeout.
-
-                  The statement is put in the editor first so the user reads what is
-                  running while it runs; the RUN is what is sent, because the text the
-                  server executes is the ledger's, not this component's copy of it.
-                */
-                onRunStatement={(sql, runId) => {
-                  tabMgr.updateCurrentTab({ query: sql });
-                  void queryExec.executeHandedOverStatement(runId, sql);
-                }}
-                onShowArtifact={agentArtifact.show}
-              />
+            <ResizableHandle className="w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
+            <ResizablePanel id="studio-agent" defaultSize="24" minSize="18" maxSize="45">
+              {agentRail}{" "}
             </ResizablePanel>
           </>
         )}
       </ResizablePanelGroup>
+
+      {/*
+        Below the breakpoint the rail is not a panel — see the sidebar's note above —
+        but it must still be MOUNTED: its mobile presentation is a sheet it renders
+        itself, and `MobileNav`'s Agent control is what opens it. Dropping it with the
+        panel would take the phone's only agent surface with it.
+      */}
+      {agentEnabled && isMobile && agentRail}
 
       {/* Modals */}
       <ConnectionModal

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Bot, ChevronDown, ChevronRight, LoaderCircle, PencilLine, Play, Square, TriangleAlert } from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, LoaderCircle, PencilLine, Play, Square, TriangleAlert, X } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
 import { renderProse } from "@/components/rich-text";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -1767,6 +1767,9 @@ export function AgentRail({
       ),
   ].join(" · ");
 
+  /** The sheet is the only presentation with something to close. */
+  const inSheet = sheetOpen === true && isMobile;
+
   const content = (
     <div className="flex flex-col h-full min-h-0 bg-surface text-fg">
       <div className="flex items-center justify-between gap-2 px-3 h-9 border-b border-hairline shrink-0">
@@ -1801,6 +1804,21 @@ export function AgentRail({
             </button>
           ))}
         </div>
+        {/*
+          The sheet's own close, in the header row with everything else. `SheetContent`
+          floats one at `top-4 right-4` and this sheet is `p-0`, so that one came down on
+          top of the toggle above - see the class that hides it where the sheet is built.
+        */}
+        {inSheet && (
+          <button
+            type="button"
+            aria-label="Close agent"
+            onClick={() => onSheetOpenChange?.(false)}
+            className="p-1 rounded text-fg-tertiary hover:text-fg-bright hover:bg-fill transition-colors shrink-0"
+          >
+            <X strokeWidth={1.5} className="w-3.5 h-3.5" />
+          </button>
+        )}
       </div>
 
       {/*
@@ -2597,7 +2615,14 @@ export function AgentRail({
         <SheetContent
           side="bottom"
           data-testid="agent-rail-sheet"
-          className="md:hidden h-[85vh] p-0 gap-0 bg-surface border-t border-hairline-strong rounded-t-3xl overflow-hidden"
+          /*
+            `[&>button]:hidden` takes down `SheetContent`'s own floating close - its only
+            direct-child button - which is absolutely placed at `top-4 right-4` and, with
+            `p-0` here, landed on the Plan/Agent toggle. The rail renders its own in the
+            header instead. Done from the caller rather than by adding a prop to
+            `ui/sheet.tsx`, which stays as shadcn ships it.
+          */
+          className="md:hidden h-[85vh] p-0 gap-0 bg-surface border-t border-hairline-strong rounded-t-3xl overflow-hidden [&>button]:hidden"
         >
           <SheetHeader className="sr-only">
             <SheetTitle>Agent</SheetTitle>

--- a/src/components/studio/StudioMobileHeader.tsx
+++ b/src/components/studio/StudioMobileHeader.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { GitHubRepoLink } from "@/components/github-repo-link";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { writeToClipboard } from "@/components/copy-button";
 import { toast } from "sonner";
 
@@ -223,6 +224,15 @@ export function StudioMobileHeader({
                 <DropdownMenuItem onClick={() => router.push("/monitoring")} className="cursor-pointer">
                   <Gauge strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Monitoring
                 </DropdownMenuItem>
+                <div className="border-t border-hairline my-1" />
+                {/*
+                 * A button, deliberately NOT a `DropdownMenuItem`: an item is a
+                 * `menuitem`, and a button inside one is two interactive roles in the
+                 * same row. It also carries its own label rather than borrowing a
+                 * caption from this menu, so the embedded surface — where the toggle
+                 * renders nothing — is left with no orphan row (#401).
+                 */}
+                <ThemeToggle showLabel className="w-full px-2 py-1.5 text-sm" />
                 <div className="border-t border-hairline my-1" />
                 <DropdownMenuItem onClick={onLogout} className="text-red-400 cursor-pointer">
                   <LogOut strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Logout

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -33,12 +33,19 @@ const NEXT_LABEL = {
  * device rather than a theme. The trade is real and accepted: a viewer whose OS
  * is in night mode still starts on studio's own default rather than theirs.
  *
+ * `showLabel` repeats that same destination as visible text inside the button, for
+ * placements where an icon alone is not a control anyone finds — the mobile
+ * overflow menu, where this is a settings row rather than one glyph among several
+ * (#401). The text lives INSIDE the button on purpose: a caller that put its own
+ * caption beside the toggle would leave that caption behind in the embedded case
+ * below, labelling a control that is not there.
+ *
  * Renders NOTHING when no `ThemeProvider` is mounted above it. That is the
  * embedded case: the host app owns the theme, `useTheme()` falls back to
  * next-themes' default context — whose `themes` array is empty — and a toggle
  * that cannot change anything is worse than no toggle at all.
  */
-export function ThemeToggle({ className }: { className?: string }) {
+export function ThemeToggle({ className, showLabel = false }: { className?: string; showLabel?: boolean }) {
   const { theme, setTheme, themes } = useTheme();
   const hydrated = useHydrated();
 
@@ -72,10 +79,14 @@ export function ThemeToggle({ className }: { className?: string }) {
       aria-label={label}
       title={label}
       onClick={() => setTheme(next)}
-      className={cn("p-1 rounded text-fg-tertiary hover:text-fg-bright hover:bg-fill transition-colors", className)}
+      className={cn(
+        "flex items-center gap-2 p-1 rounded text-fg-tertiary hover:text-fg-bright hover:bg-fill transition-colors",
+        className,
+      )}
     >
       {/* The button keeps its size while empty, so the header does not shift. */}
       {hydrated ? <Icon strokeWidth={1.5} className="w-3.5 h-3.5" /> : <span className="block w-3.5 h-3.5" />}
+      {showLabel && <span>{label}</span>}
     </button>
   );
 }

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -18,6 +18,7 @@ import { useConnectionAdapter } from "@/workspace/hooks/use-connection-adapter";
 import { useQueryAdapter } from "@/workspace/hooks/use-query-adapter";
 import { type StudioWorkspaceProps, DEFAULT_WORKSPACE_FEATURES } from "@/workspace/types";
 import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { ChunkBoundary, ViewLoading } from "@/components/LazyView";
 import { lazyRetry } from "@/lib/lazy";
 import { editorLanguageForTabType } from "@/lib/editor/tab-language";
@@ -281,6 +282,9 @@ export function StudioWorkspace({
   );
 
   // === No-op callbacks for disabled features ===
+  /** What the panel group may hold: below the breakpoint, only the body panel. */
+  const isMobile = useIsMobile();
+
   const noop = useCallback(() => {}, []);
 
   return (
@@ -295,30 +299,41 @@ export function StudioWorkspace({
       <ResizablePanelGroup id="workspace-main" orientation="horizontal" className="h-full">
         {/* Sizes are strings on purpose: react-resizable-panels 4 reads a bare
             number as pixels and a unitless string as a percentage. */}
-        <ResizablePanel id="workspace-sidebar" defaultSize="22" minSize="15" maxSize="35" className="hidden md:block">
-          <Sidebar
-            connections={conn.connections}
-            activeConnection={conn.activeConnection}
-            schema={conn.schema}
-            isLoadingSchema={conn.isLoadingSchema}
-            onSelectConnection={conn.setActiveConnection}
-            onDeleteConnection={noop}
-            onEditConnection={noop}
-            onAddConnection={noop}
-            onTableClick={onTableClick}
-            onGenerateSelect={tabMgr.handleGenerateSelect}
-            onCreateTableClick={undefined}
-            onShowDiagram={features.schemaDiagram ? () => setShowDiagram(true) : undefined}
-            isAdmin={false}
-            onOpenMaintenance={noop}
-            databaseType={conn.activeConnection?.type}
-            metadata={conn.metadata}
-            onProfileTable={features.codeGenerator ? (name: string) => setProfilerTable(name) : undefined}
-            onGenerateCode={features.codeGenerator ? (name: string) => setCodeGenTable(name) : undefined}
-            onGenerateTestData={features.testDataGenerator ? (name: string) => setTestDataTable(name) : undefined}
-          />
-        </ResizablePanel>
-        <ResizableHandle className="hidden md:flex w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
+        {/*
+          Out of the group below the breakpoint rather than hidden inside it:
+          react-resizable-panels 4 applies a `Panel`'s `className` to a NESTED div,
+          so `hidden md:block` hid the sidebar's CONTENTS while the panel itself kept
+          its 22% of the row — an empty column beside a squeezed body on a host's
+          phone viewport. `src/components/Studio.tsx` carries the same guard.
+        */}
+        {!isMobile && (
+          <>
+            <ResizablePanel id="workspace-sidebar" defaultSize="22" minSize="15" maxSize="35">
+              <Sidebar
+                connections={conn.connections}
+                activeConnection={conn.activeConnection}
+                schema={conn.schema}
+                isLoadingSchema={conn.isLoadingSchema}
+                onSelectConnection={conn.setActiveConnection}
+                onDeleteConnection={noop}
+                onEditConnection={noop}
+                onAddConnection={noop}
+                onTableClick={onTableClick}
+                onGenerateSelect={tabMgr.handleGenerateSelect}
+                onCreateTableClick={undefined}
+                onShowDiagram={features.schemaDiagram ? () => setShowDiagram(true) : undefined}
+                isAdmin={false}
+                onOpenMaintenance={noop}
+                databaseType={conn.activeConnection?.type}
+                metadata={conn.metadata}
+                onProfileTable={features.codeGenerator ? (name: string) => setProfilerTable(name) : undefined}
+                onGenerateCode={features.codeGenerator ? (name: string) => setCodeGenTable(name) : undefined}
+                onGenerateTestData={features.testDataGenerator ? (name: string) => setTestDataTable(name) : undefined}
+              />
+            </ResizablePanel>
+            <ResizableHandle className="w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
+          </>
+        )}
         <ResizablePanel id="workspace-body" defaultSize="78">
           <div className="flex-1 flex flex-col min-w-0 h-full bg-surface">
             {/* No desktop/mobile headers — platform provides its own */}

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -2142,4 +2142,56 @@ describe("Studio", () => {
     // Applying is not executing: nothing runs until the user runs it.
     expect(mockExecuteQuery).not.toHaveBeenCalled();
   });
+
+  // ===========================================================================
+  // What the panel group holds below the breakpoint
+  // ===========================================================================
+
+  /**
+   * `react-resizable-panels` 4 applies a `Panel`'s `className` to a NESTED div —
+   * "Class is applied to nested HTMLDivElement to avoid styles that interfere with
+   * Flex layout", its own types say — so `hidden md:block` on a panel never hid the
+   * panel. It hid the panel's CONTENTS and left the panel itself holding its desktop
+   * share of the row: at 390px the sidebar kept 22% and the agent rail 24%, which is
+   * why the studio body was 211px wide and its header overlapped itself.
+   *
+   * No class can fix that, on either element. A panel the viewport cannot show must
+   * not be in the group at all.
+   */
+  test("the phone renders no sidebar panel to take a share of the row", () => {
+    setViewportMobile(true);
+    const { queryByTestId } = render(<Studio />);
+    expect(queryByTestId("sidebar")).toBeNull();
+  });
+
+  test("and the sidebar is back above the breakpoint", () => {
+    setViewportMobile(false);
+    const { queryByTestId } = render(<Studio />);
+    expect(queryByTestId("sidebar")).not.toBeNull();
+  });
+
+  /**
+   * The agent rail leaves the GROUP on a phone but stays MOUNTED, because its mobile
+   * presentation is a sheet it renders itself — `MobileNav`'s Agent control opens it
+   * through `sheetOpen`. Dropping the rail with the panel would take the phone's only
+   * agent surface with it.
+   */
+  test("the agent rail leaves the panel group on a phone but keeps rendering", async () => {
+    setViewportMobile(true);
+    mockAgentConfig(true);
+    const { findByTestId, container } = render(<Studio />);
+
+    const rail = await findByTestId("agent-rail");
+    expect(rail.closest('[data-testid="resizable-panel"]')).toBeNull();
+    expect(container.querySelector('[data-testid="agent-rail"]')).not.toBeNull();
+  });
+
+  test("and above the breakpoint it is a panel of the group again", async () => {
+    setViewportMobile(false);
+    mockAgentConfig(true);
+    const { findByTestId } = render(<Studio />);
+
+    const rail = await findByTestId("agent-rail");
+    expect(rail.closest('[data-testid="resizable-panel"]')).not.toBeNull();
+  });
 });

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -339,6 +339,8 @@ const ALL_FEATURES_OFF = {
 // =============================================================================
 
 describe("StudioWorkspace", () => {
+  const originalMatchMedia = window.matchMedia;
+
   beforeEach(() => {
     // Reset prop captures
     capturedSidebarProps = {};
@@ -392,7 +394,21 @@ describe("StudioWorkspace", () => {
 
   afterEach(() => {
     cleanup();
+    window.matchMedia = originalMatchMedia;
   });
+
+  /**
+   * The breakpoint is driven through `window.matchMedia`, as in Studio.test.tsx: a
+   * module mock of `@/hooks/use-mobile` would be process-wide.
+   */
+  function setViewportMobile(matches: boolean) {
+    window.matchMedia = ((query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })) as unknown as typeof window.matchMedia;
+  }
 
   // =========================================================================
   // Rendering
@@ -1019,5 +1035,27 @@ describe("StudioWorkspace", () => {
     const { baseElement } = renderWorkspace();
     expect(baseElement.textContent).toContain("Load all results?");
     expect(baseElement.textContent).toContain("Load All");
+  });
+
+  // =========================================================================
+  // What the panel group holds below the breakpoint
+  // =========================================================================
+
+  /**
+   * The embedded surface carried the same defect as the standalone shell:
+   * `react-resizable-panels` 4 applies a `Panel`'s `className` to a NESTED div, so
+   * `hidden md:block` hid the sidebar's contents while the panel kept its 22% of the
+   * row. The host's phone viewport got a 22% empty column and a squeezed body.
+   */
+  test("the phone renders no sidebar panel to take a share of the row", () => {
+    setViewportMobile(true);
+    const { queryByTestId } = renderWorkspace();
+    expect(queryByTestId("sidebar")).toBeNull();
+  });
+
+  test("and the sidebar is back above the breakpoint", () => {
+    setViewportMobile(false);
+    const { queryByTestId } = renderWorkspace();
+    expect(queryByTestId("sidebar")).not.toBeNull();
   });
 });

--- a/tests/components/ThemeToggle.test.tsx
+++ b/tests/components/ThemeToggle.test.tsx
@@ -126,6 +126,37 @@ describe("ThemeToggle", () => {
     expect(screen.getByRole("button").querySelector("svg")?.getAttribute("class")).toContain("lucide-moon");
   });
 
+  // ── The labelled form (#401) ────────────────────────────────────────────────
+
+  /**
+   * The desktop header has room for an icon beside other icons; a dropdown row does
+   * not read that way, and an unlabelled 14px glyph in a menu is not a control a
+   * viewer finds. `showLabel` puts the destination in the button as visible text.
+   */
+  test("showLabel puts the destination in the button as text", () => {
+    withTheme("dark");
+    render(<ThemeToggle showLabel />);
+    expect(screen.getByRole("button").textContent).toContain("Switch to light theme");
+  });
+
+  test("the visible text follows the theme, as the aria-label does", () => {
+    withTheme("light");
+    render(<ThemeToggle showLabel />);
+    expect(screen.getByRole("button").textContent).toContain("Switch to dark theme");
+  });
+
+  /**
+   * The label lives INSIDE the button rather than beside it, so the embedded
+   * contract survives: no provider means no control AND no orphan caption for a
+   * control that is not there. A caller that wrapped its own text around the
+   * toggle would leave that caption behind.
+   */
+  test("the labelled form still renders nothing without a provider", () => {
+    withTheme(undefined, []);
+    const { container } = render(<ThemeToggle showLabel />);
+    expect(container.innerHTML).toBe("");
+  });
+
   test("accepts a className so the header can place it", () => {
     render(<ThemeToggle className="mr-1" />);
     expect(screen.getByRole("button").className).toContain("mr-1");

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -1282,6 +1282,59 @@ describe("AgentRail", () => {
   });
 
   /**
+   * `SheetContent` floats its own close button at `top-4 right-4`, over whatever the
+   * sheet holds. This rail's header is a full-bleed 36px row (the sheet is `p-0`), so
+   * that X landed ON the Plan/Agent toggle — measured at 390px: the X spanned
+   * 358-374 and the "Agent" pill 328-378.
+   *
+   * The rail therefore offers its own, in the header row where the other controls are,
+   * and takes the floating one down.
+   *
+   * Two assertions because two things have to hold, and jsdom computes no Tailwind: the
+   * rail's control is IN the header, and the sheet carries the rule that removes the
+   * floating one. `hidden` is `display:none`, so in a browser that also takes the
+   * duplicate out of the tab order and the accessibility tree rather than merely making
+   * it invisible — which is why hiding it is enough and a second visible X is not left
+   * behind. The rendered result is checked at 390px in Chrome, not here.
+   */
+  test("the sheet's close control sits in the header rather than over the mode toggle", async () => {
+    const onSheetOpenChange = mock(() => {});
+    media.setMatches(true);
+    const { findByTestId } = render(<AgentRail {...DEFAULT_PROPS} sheetOpen onSheetOpenChange={onSheetOpenChange} />);
+    const sheet = await findByTestId("agent-rail-sheet");
+
+    const own = sheet.querySelector('button[aria-label="Close agent"]');
+    expect(own).not.toBeNull();
+    const header = sheet.querySelector('[data-testid="agent-mode-agent"]')!.closest("div")!.parentElement!;
+    expect(header.contains(own)).toBe(true);
+
+    // `SheetContent`'s own close is its only DIRECT child button, which is what the
+    // rule targets; the rail's own lives deeper, inside the header.
+    expect(sheet.className).toContain("[&>button]:hidden");
+    expect(own!.parentElement).not.toBe(sheet);
+  });
+
+  test("that control closes the sheet", async () => {
+    const onSheetOpenChange = mock(() => {});
+    media.setMatches(true);
+    const { findByTestId, getByLabelText } = render(
+      <AgentRail {...DEFAULT_PROPS} sheetOpen onSheetOpenChange={onSheetOpenChange} />,
+    );
+    await findByTestId("agent-rail-sheet");
+
+    fireEvent.click(getByLabelText("Close agent"));
+
+    expect(onSheetOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  /** The desktop rail is a panel of the layout: there is nothing to close. */
+  test("the desktop rail offers no close control", () => {
+    const { getByTestId, queryByLabelText } = render(<AgentRail {...DEFAULT_PROPS} />);
+    expect(getByTestId("agent-rail-panel")).toBeTruthy();
+    expect(queryByLabelText("Close agent")).toBeNull();
+  });
+
+  /**
    * The window widening past `md` while the sheet is open is the case a CSS-only
    * split gets wrong: `SheetContent` can be told `md:hidden`, but Radix's overlay
    * cannot, and it also sets `pointer-events: none` on the body. The rail would be

--- a/tests/components/studio/StudioMobileHeader.test.tsx
+++ b/tests/components/studio/StudioMobileHeader.test.tsx
@@ -37,6 +37,14 @@ mock.module("@/components/ui/dropdown-menu", () => ({
   DropdownMenuSeparator: ({ className }: { className?: string }) => React.createElement("hr", { className }),
 }));
 
+// The real provider writes to <html> and localStorage; what matters here is only that a
+// provider EXISTS, since `ThemeToggle` renders nothing when `themes` is empty. Group 9 in
+// tests/run-components.sh holds no suite that reaches the real next-themes, so this
+// process-wide mock costs its neighbours nothing.
+mock.module("next-themes", () => ({
+  useTheme: () => ({ theme: "dark", themes: ["dark", "light"], setTheme: () => {} }),
+}));
+
 mock.module("@/components/ui/button", () => ({
   Button: ({ children, onClick, className, disabled, ...rest }: Record<string, unknown>) =>
     React.createElement(
@@ -409,5 +417,30 @@ describe("StudioMobileHeader", () => {
   test("playgroundMode=true shows SANDBOX badge", () => {
     const { queryByText } = render(<StudioMobileHeader {...defaults} playgroundMode />);
     expect(queryByText("SANDBOX")).not.toBeNull();
+  });
+
+  // ── The theme control (#401) ───────────────────────────────────────────────
+
+  /**
+   * `ThemeToggle` was mounted in `StudioDesktopHeader` only, inside a container that
+   * is `hidden md:flex`, so a viewer at 390px started on dark and had no way to
+   * leave it. The user menu is where the other once-per-session settings already
+   * live, and where a theme preference is looked for.
+   */
+  test("the user menu carries a theme control", () => {
+    const { queryByText } = render(<StudioMobileHeader {...defaults} />);
+    expect(queryByText("Switch to light theme")).not.toBeNull();
+  });
+
+  /**
+   * As a button, not as a `menuitem` wrapping one: a button inside a menu item is
+   * two interactive roles in the same place, and the row a screen reader announces
+   * would not be the control it activates.
+   */
+  test("the theme control is a button of its own, not a menu row", () => {
+    const { queryByText } = render(<StudioMobileHeader {...defaults} />);
+    const control = queryByText("Switch to light theme")!.closest("button");
+    expect(control).not.toBeNull();
+    expect(control!.closest('[role="menuitem"]')).toBeNull();
   });
 });


### PR DESCRIPTION
Four mobile defects, all found by driving a production build at 390x844 rather than by reading the code. Closes #401; the other three were found while verifying it.

## 1. The light theme had no control below the md breakpoint (#401)

`ThemeToggle` was mounted in exactly one place -- `StudioDesktopHeader`, inside a container that is `hidden md:flex`. `StudioMobileHeader` rendered no toggle, and `ThemeProvider` runs with `enableSystem={false}`, so a viewer at 390px started on dark with no way out: not through the UI, not by following the OS.

It now also sits in the **mobile user menu**, alongside Admin Dashboard / Monitoring / Logout -- option 1 of the three the issue listed. Option 3 (a slot in the header row) would have cost the connection switcher, RUN/CANCEL or the transaction controls; option 2 (`MobileNav`) is tab navigation, not preferences.

As a **button, not a `DropdownMenuItem`**: an item is a `menuitem`, and a button inside one is two interactive roles in the same row.

`ThemeToggle` gains one prop, `showLabel`, which repeats the destination it already announces as visible text -- an unlabelled 14px glyph in a dropdown is not a control anyone finds. The text lives **inside** the button deliberately: the toggle renders nothing when no `ThemeProvider` is above it, so a caller that put its own caption beside it would leave that caption behind on the embedded surface. Still one component, mounted in two places.

`enableSystem={false}` is untouched. Honouring `prefers-color-scheme` for the *initial* value was the issue's alternative; it changes the default for every viewer, desktop included, and touches storage and hydration behaviour. A reachable toggle closes the gap without any of that.

## 2. A hidden panel kept its share of the row

The reason #401 was hard to see at all: at 390px the studio body was **211px wide, pushed to x=86**, with the top row overlapping itself.

`react-resizable-panels` 4 applies a `Panel`'s `className` to a **nested** div -- *"Class is applied to nested HTMLDivElement to avoid styles that interfere with Flex layout"*, its own types say. So `hidden md:block` hid the sidebar's **contents** while the panel itself kept its 22% of the row, and the agent rail its 24%. No class fixes that, on either element.

Both therefore leave the group below the breakpoint. The embedded surface (`StudioWorkspace`) carried the same defect and is fixed the same way.

## 3. Leaving the group must not unmount the agent rail

Its mobile presentation is a sheet it renders itself, opened from `MobileNav`'s Agent control -- dropping it with the panel would take the phone's only agent surface with it. The rail is declared once and mounted in one of two places: a panel of the group above the breakpoint, a bare child of the shell below it.

## 4. The sheet's X landed on the mode toggle

`SheetContent` floats its own close at `top-4 right-4` and this sheet is `p-0`, so that X came down **on** the Plan/Agent toggle -- measured at 390px, the X spanned 358-374 and the "Agent" pill 328-378.

The rail now offers its own close in the header row with the other controls, and takes the floating one down with `[&>button]:hidden` -- from the caller rather than by adding a prop to `ui/sheet.tsx`, which stays as shadcn ships it. `hidden` is `display:none`, so the duplicate leaves the tab order and the accessibility tree as well, not just the picture.

## Verification

Six gates green locally (`format`, `lint`, `typecheck`, `knip`, `test`, `build`), plus `test:coverage` + `coverage:check` at 100% (42807/42807) and `build:lib`.

Driven in Chrome against a production build:

- **390x844** -- the mobile header is `x=0 w=390` (was `x=86 w=211`) and the group holds only `studio-body`; **1200** and **1717** keep all three panels at their usual sizes;
- crossing the breakpoint in both directions leaves no stuck overlay and no error;
- the theme row appears in the mobile user menu, one tap writes `light` to `<html>` and to `localStorage["libredb-theme"]`, the menu stays open and the label flips to "Switch to dark theme";
- the agent sheet still opens from the mobile nav; its close sits at 356-378 with the pills ending at 333, the floating default computes to `display: none`, and closing leaves no overlay and `pointer-events: auto` on the body.

Tests, all written before the code: three in `ThemeToggle.test.tsx`, two in `StudioMobileHeader.test.tsx`, four in `Studio.test.tsx`, two in `StudioWorkspace.test.tsx`, three in `AgentRail.test.tsx`.
