### PR TITLE
fix(sql): a commented-out DROP stopped becoming a statement, and two more

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra
 type: application
-version: 0.1.49
+version: 0.1.50
 appVersion: "0.13.4"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -39,9 +39,11 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
-  # False: 0.1.49 changes no packaged template at all - 0.1.48's optional model-tuning
-  # ConfigMap and read-only mount are unchanged - and carries only the appVersion move to
-  # 0.13.4. What 0.13.4 fixes is correctness, not security: a MySQL protocol choice, the
+  # False: 0.1.50 changes no packaged template and no value - it corrects the README's own
+  # copy-paste recipes, which rendered an unquoted YAML boolean into `core/v1.EnvVar.value`
+  # and left bracket arguments a zsh user's shell globs away. The README is a packaged file,
+  # so #167 costs it a chart version even though nothing an operator deploys moves.
+  # 0.1.49 carried only the appVersion move to 0.13.4. What 0.13.4 fixes is correctness, not security: a MySQL protocol choice, the
   # monitoring dashboard's all-or-nothing aggregate, a ScyllaDB connection and an Oracle
   # LOB read. Its dependency moves are routine patch bumps with no advisory behind them.
   # 0.13.3's transport fixes (a rediss:// or couchbases:// URL landing on SSL mode disable,

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.49 \
+  --version 0.1.50 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```
@@ -415,9 +415,12 @@ helm install libredb libredb/libredb-studio \
   --set replicaCount=3 \
   --set ingress.enabled=true \
   --set ingress.className=nginx \
-  --set "ingress.annotations.nginx\.ingress\.kubernetes\.io/limit-rpm=120" \
-  --set "ingress.annotations.nginx\.ingress\.kubernetes\.io/limit-burst-multiplier=2"
+  --set-string "ingress.annotations.nginx\.ingress\.kubernetes\.io/limit-rpm=120" \
+  --set-string "ingress.annotations.nginx\.ingress\.kubernetes\.io/limit-burst-multiplier=2"
 ```
+
+`--set-string`, not `--set`: ingress annotations are a `map[string]string`, and plain `--set`
+type-coerces the bare number, rendering `limit-rpm: 120` as an integer that the API server rejects.
 
 With Traefik, attach a `rateLimit` middleware and reference it from the ingress annotations.
 
@@ -429,8 +432,8 @@ it, so pass it through `extraEnv`:
 
 ```bash
 helm install libredb libredb/libredb-studio \
-  --set extraEnv[0].name=ALLOWED_ORIGINS \
-  --set extraEnv[0].value=https://libredb.example.com
+  --set 'extraEnv[0].name=ALLOWED_ORIGINS' \
+  --set-string 'extraEnv[0].value=https://libredb.example.com'
 ```
 
 ### The Content-Security-Policy escape hatch
@@ -442,12 +445,19 @@ passed through `extraEnv`:
 
 ```bash
 helm install libredb libredb/libredb-studio \
-  --set extraEnv[0].name=CSP_REPORT_ONLY \
-  --set extraEnv[0].value="true"
+  --set 'extraEnv[0].name=CSP_REPORT_ONLY' \
+  --set-string 'extraEnv[0].value=true'
 ```
 
 In report-only mode the browser logs the same violation to its console instead of blocking the
 resource. Please also open an issue naming the violated directive.
+
+`--set-string`, not `--set`, and the single quotes are load-bearing in both `extraEnv` recipes above.
+`--set extraEnv[0].value=true` renders `value: true`, an unquoted YAML boolean, and the API server
+rejects the manifest with `invalid type for io.k8s.api.core.v1.EnvVar.value: got "bool", expected
+"string"` — `extraEnv` is typed only as an array of objects in `values.schema.json`, so nothing
+catches it before apply. Unquoted `extraEnv[0]` is also a glob pattern in zsh, which fails the
+command with `no matches found` before helm is reached.
 
 Setting both `ALLOWED_ORIGINS` and `CSP_REPORT_ONLY` at once needs a distinct index per entry —
 `extraEnv` is a list, and `--set` on the same index (`extraEnv[0]` in both examples above) just
@@ -456,10 +466,10 @@ second variable:
 
 ```bash
 helm install libredb libredb/libredb-studio \
-  --set extraEnv[0].name=ALLOWED_ORIGINS \
-  --set extraEnv[0].value=https://libredb.example.com \
-  --set extraEnv[1].name=CSP_REPORT_ONLY \
-  --set extraEnv[1].value="true"
+  --set 'extraEnv[0].name=ALLOWED_ORIGINS' \
+  --set-string 'extraEnv[0].value=https://libredb.example.com' \
+  --set 'extraEnv[1].name=CSP_REPORT_ONLY' \
+  --set-string 'extraEnv[1].value=true'
 ```
 
 ### Separating the storage encryption key
@@ -474,9 +484,9 @@ same directory, alongside the database file):
 
 ```bash
 helm install libredb libredb/libredb-studio \
-  --set extraEnv[0].name=STORAGE_ENCRYPTION_KEY \
-  --set extraEnv[0].valueFrom.secretKeyRef.name=libredb-studio-storage \
-  --set extraEnv[0].valueFrom.secretKeyRef.key=encryption-key
+  --set 'extraEnv[0].name=STORAGE_ENCRYPTION_KEY' \
+  --set 'extraEnv[0].valueFrom.secretKeyRef.name=libredb-studio-storage' \
+  --set 'extraEnv[0].valueFrom.secretKeyRef.key=encryption-key'
 ```
 
 Rotating the key makes existing stored credentials unreadable — the connections survive and their

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -21,15 +21,15 @@ None of it is a GitHub issue.
 
 **Sections**
 
-- [SQL statement reading](#sql-statement-reading) — S1–S8 · 8
+- [SQL statement reading](#sql-statement-reading) — S2–S8 · 7
 - [Drivers and connections](#drivers-and-connections) — D1–D26, U17 · 8
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U19 · 11
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U22 · 13
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P5 · 5
-- [Documentation](#documentation) — DOC1–DOC3 · 3
+- [Documentation](#documentation) — DOC1, DOC3 · 2
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3
 - [Chart configuration surface](#chart-configuration-surface) — N1–N3 · 3
 - [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 10
@@ -44,20 +44,6 @@ None of it is a GitHub issue.
 
 The readers in `src/lib/sql/` decide where a statement starts, where it ends, and what it operates
 on. `src/lib/sql/grammar.ts` gave them a dialect (#292). These are the gaps that channel leaves.
-
-### S1. `statement-splitter.ts` is dialect-blind, and one shape yields a runnable bare `DROP`
-
-`src/lib/sql/statement-splitter.ts` walks spans itself instead of using `spans.ts`, so it disagrees
-with every other reader. A `;` inside a MySQL `#` comment, an Oracle `q'{a'b;c}'` body, a `[a;b]`
-name or a backtick-quoted subscript key each split one statement into fragments.
-
-The sharp case: `/* a /* b */ ; DROP TABLE users; -- */ SELECT 1` splits into three fragments. The
-second is a valid bare `DROP TABLE users` that the multi-statement route would run. `isDangerousQuery`
-answers false, because the confirmation gate reads the whole editor text and never the fragments.
-Same family as #300, wider blast radius.
-
-**Done when:** the splitter reads spans through the shared reader with the caller's dialect, and the
-gate and the splitter agree about what is going to run.
 
 ### S2. Backslash escaping is not a grammar fact
 
@@ -76,8 +62,6 @@ The single largest follow-up from that sweep.
 
 - **MySQL executable comments.** `/*!40000 DELETE FROM t */` is an ordinary comment to every reader
   here. MySQL executes it. Nothing asks first.
-- **ClickHouse `//`.** Accepted as a line comment (live-verified), modelled nowhere. So
-  `// note\nDROP TABLE t` answers not-dangerous. CQL has the same form — see U17.
 - **MySQL connection charset.** On a `latin1` connection a leading U+00A0 executes. `buildPoolConfig`
   passes the user's connection string straight to mysql2 as `uri`, so the charset is outside the
   readers' view.
@@ -124,8 +108,11 @@ bracket rows (HTTP-only provider, no driver to read), MSSQL's block-comment nest
 ships no tokenizer), PostgreSQL's bracket and block-comment rows (`pg` carries no SQL tokenizer), and
 the `nq'…'` spelling of Oracle's alternate quoting.
 
-**Missing fact, not an undecided one:** `SqlGrammar` has no `lineComment` row, so it cannot express
-CQL's `//` or its newline-terminated comments. See U17.1.
+**Closed 2026-08-25:** `SqlGrammar` now carries `doubleSlashComment`, established by live probe on
+Apache Cassandra 5.0.9, ScyllaDB 2026.2.4 and ClickHouse 26.7.1 (a line comment on all three) and
+refused on PostgreSQL 18, MySQL 26.7.0, SQLite, Oracle, SQL Server 2022 and Trino 476. It is undecided
+for elasticsearch and opensearch, and absent with the whole row for couchbase, druid and libredb -
+recorded in the table in `docs/editor/query-optimization.md`.
 
 ### S7. A confirmation refinement that was considered and rejected
 
@@ -192,18 +179,23 @@ The provider shipped in #424 Phase 4 with four bounded absences. None is a defec
 honest answer to something measured on Apache Cassandra 5.0.9. Each is also something a later change
 could take further, and one of them is a shared-reader limitation rather than a provider decision.
 
-**1. `SqlGrammar` cannot express CQL's comment rules, so the provider works around them.** Two facts,
-both measured. CQL has a THIRD line-comment form, `//`, which the readers in `src/lib/sql/` know
-nothing about. And a line comment of EITHER form must be closed by a NEWLINE: `SELECT * FROM
+**1. `SqlGrammar` expresses ONE of CQL's two comment rules since 2026-08-25.** The third
+line-comment form, `//`, is now a grammar fact (`doubleSlashComment`) that every reader in
+`src/lib/sql/` honours - which closed the S1 defect this absence was still producing on this engine:
+`SELECT ... // note; DROP TABLE ...` was cut into a read and a runnable bare `DROP` out of text the
+server reads as one statement. What remains is the SECOND fact: a line comment of either form must be
+closed by a NEWLINE: `SELECT * FROM
 probe.customers LIMIT 3 -- note` with nothing after it is `line 1:45 mismatched character '<EOF>'
 expecting set null`, while the same text plus `\n` returns the rows.
 
 So the shared limiter's insert-before-trailing-trivia rewrite (#280) turns a VALID statement into a
 syntax error on this one engine, because `sql.trim()` drops the newline that closed the comment.
 `CassandraProvider.prepareQuery` declines to rewrite any statement whose rewritten form would end
-inside a line comment. Fail-safe: the statement runs unbounded and `wasLimited: false` says so.
-Widening `SqlGrammar` with a `lineComment` fact would fix it properly and would change how every
-dialect's comments are read, so it is its own change. See S6.
+inside a line comment. Fail-safe: the statement runs unbounded and `wasLimited: false` says so. The
+newline rule is a `spans.ts` question rather than a grammar one - that reader ends a line comment at
+LF, and CQL also ends one at a bare CR (measured 2026-08-25: `-- note\r; DROP` is `line 1:51
+mismatched input 'DROP'` on 5.0.9, so the engine sees two things where the reader sees one). It
+under-splits, which is the safe direction, and the same divergence predates the `//` work. See S6.
 
 **2. A statement whose last clause is `PER PARTITION LIMIT n` is left unbounded.** The shared reader
 sees a trailing `LIMIT n` and reports the statement as already bounded, so nothing is injected. `...
@@ -543,43 +535,6 @@ file's ratio is not the tree's.
 **Done when:** the scope is widened with the benign sites made explicit, or the decision not to is
 recorded here with the number that justified it.
 
-### U9. Four providers point `vacuumAction` at something that is not `vacuum`, and MySQL offers one it lacks
-
-Two mismatches, measured while fixing #427 and left alone.
-
-**(a) MySQL shows the base default it never meant.** The per-row maintenance items are gated on
-`isAdmin` alone, so MySQL renders *"Vacuum Table"* — `BaseDatabaseProvider`'s default wording —
-although its `maintenanceOperations` is `['analyze', 'optimize', 'check', 'kill']`. The item names an
-operation MySQL does not have, and following it reaches an Operations tab with no vacuum card either.
-
-**(b) ClickHouse, SQL Server, Oracle and Couchbase map the LABEL onto another operation.** Their
-`vacuumAction` reads *"Optimize Table"*, *"Rebuild Indexes"*, *"Rebuild Indexes"* and *"Compact"*,
-standing for the `optimize` / `optimize` / `optimize` / `reindex` each declares.
-
-So a label-driven gate is not enough, and a *generic* label-to-operation mapping is actively wrong.
-#427 built one, wired it into the per-table button, and handed Oracle a *"Rebuild Indexes"* control
-that sent `optimize` with a TABLE name — while `oracle.ts` builds `ALTER INDEX "<target>" REBUILD`
-from that target, so every click answered **ORA-01418: specified index does not exist**. A control
-that always fails is worse than the dead end it replaced. The chain was reverted before merge.
-
-What the revert paid for: any future mapping must be **per provider**, declared next to the operation
-it names. The target grammar differs even among providers declaring the same `MaintenanceType`.
-Oracle's `optimize` wants an index name, ClickHouse's wants a table, Couchbase's `reindex` wants a
-keyspace.
-
-**A third mismatch, measured 2026-08-23 while giving the Reindex card per-provider wording.** The
-global Reindex card cannot succeed on Couchbase at all, whatever it is titled. `dispatchMaintenance()`
-routes `reindex` — and `analyze`, and `kill` — through `requireTarget()`, while
-`OperationsTab.handleRunMaintenance("reindex")` sends no target, so the card answers *"The reindex
-operation requires a target"*. That change gave the card honest wording and deliberately left the
-behaviour alone, because a global control over a per-keyspace operation is the same shape of mistake
-the reverted mapping was. Either the card names a keyspace or Couchbase should not offer it globally.
-
-**Done when:** each provider declares which operation its `vacuumAction` (and `analyzeAction`) stands
-for *and* what kind of target it takes, both surfaces gate and title from that declaration, the
-Couchbase Reindex card either carries a target or is withheld, and a live Oracle run proves the
-per-table control succeeds rather than returning ORA-01418.
-
 ### U18. The login hero has no vertical slack left, and the relatives line spends 56px it does not have
 
 Measured on the built app (`next start`, Chromium), before and after the change that added the
@@ -638,6 +593,56 @@ being OFFERED, not refused. The same missing thing explains both: this banner ha
 **Done when:** a message that is neither a success nor a failure renders as neither, and the degraded
 save uses it.
 
+### U20. The maintenance API validates that an operation EXISTS, not that it can take the target
+
+`src/app/api/db/maintenance/route.ts` checks `capabilities.maintenanceOperations.includes(type)` and
+nothing else, then calls `provider.runMaintenance(type, target)`. Since 2026-08-25 each provider also
+declares what KIND of target each operation takes (`maintenanceOperationSpecs`), and both UI surfaces
+gate on it - but the route does not, so every mismatch the declaration describes stays reachable by a
+direct request. Measured: `POST {type:"vacuum", target:"users"}` against SQLite still vacuums the whole
+file, which is exactly the reading SQLite's `vacuum: { perEntity: false }` exists to withhold.
+
+Not a security hole - the route is admin-gated and every one of these statements is one an admin may
+run - but the invariant lives in one layer only, and the layer it is missing from is the one an
+integration calls.
+
+**Done when:** the route refuses a target an operation cannot take, or the declaration says why the API
+is deliberately wider than the UI.
+
+---
+
+### U21. Two global maintenance cards exist for operations that have no card copy
+
+MSSQL and MongoDB declare `check` as globally runnable and MySQL declares `optimize` the same way, but
+`ProviderLabels` has only the `analyzeGlobal*` and `vacuumGlobal*` triads, so a global card can only be
+rendered where the provider's `vacuumActionOperation` happens to redirect the vacuum slot to it. MySQL
+gets an Optimize card that way; MSSQL's and MongoDB's `check` gets nothing.
+
+Deliberately not fixed with U9 (2026-08-25): inventing card copy for five providers without measuring
+what each statement actually does is the generic mapping #427 reverted. What is needed first is the
+measurement, per provider, of what a whole-database `CHECK` costs on a real instance - `DBCC CHECKDB`
+is not a free read.
+
+**Done when:** an operation a provider declares globally runnable either has its own card copy or a
+recorded reason it is withheld.
+
+---
+
+### U22. `TableItem`'s deep links are gated on the operation, not on where the operation can be run
+
+`src/components/schema-explorer/TableItem.tsx` reads the maintenance declaration since 2026-08-25, so
+the wording is the provider's own and a per-entity operation is what it offers. What it still cannot
+express is that its two items are DEEP LINKS: they navigate to the maintenance page with a table name,
+and whether that page has a control for the operation is a separate question from whether the operation
+takes a table.
+
+The class is recorded in that file's own comment for Elasticsearch ("clicking Merge Segments landed on
+a page with no maintenance controls, no error and no explanation"), and the same shape returns whenever
+a provider declares an operation `perEntity: true` while the destination page renders it under a
+condition of its own.
+
+**Done when:** the link is offered only where the destination renders the control, tested against the
+destination rather than against the declaration.
 ---
 
 ## Authentication and security headers
@@ -824,21 +829,6 @@ line-anchoring style, so the fix is a convention change — anchor on symbol nam
 much as a correction.
 
 The same disease is in this file. Prefer symbol names here too.
-
-### DOC2. Two chart README `--set` recipes render a YAML boolean where Kubernetes needs a string
-
-`charts/libredb-studio/README.md`'s Content-Security-Policy escape hatch sets `CSP_REPORT_ONLY` with
-`--set extraEnv[0].value="true"`, twice: the single-variable example and the two-variable one. The
-shell strips the quotes and Helm type-coerces the bare word, so the manifest renders `value: true` —
-an unquoted YAML boolean, while `core/v1.EnvVar.value` is a string. The API server rejects it:
-`invalid type for io.k8s.api.core.v1.EnvVar.value: got "bool", expected "string"`. Reproduced with
-`helm template` on 2026-08-12.
-
-`--set-string` is the fix, one word per line. Found while documenting the agent runtime in #329 T13,
-whose own recipe uses `--set-string` for exactly this reason.
-
-**Done when:** both lines use `--set-string`, and ideally the README's `--set` bracket arguments are
-single-quoted, since unquoted `extraEnv[0]` is a glob pattern in zsh.
 
 ### DOC3. Six channel listings carry corrected copy that nobody has resubmitted
 

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -158,13 +158,16 @@ id, so no reader can grow a dialect test of its own.
 | `[…]` | an **array literal or subscript**: it nests (`[[1,2],[3,4]]`), nothing inside it is escaped, and a literal inside it is a literal (`m['a]b']`) | ClickHouse, PostgreSQL, Trino |
 | `/* … /* … */ … */` | one **nesting** comment: a `/*` inside a comment opens another and the run continues until the depth returns to zero, so a region that already contains comments can be commented out. A run short of a closer is undeterminable rather than closed early | PostgreSQL, SQL Server, ClickHouse |
 | `/* … /* … */ … */` | a **flat** comment: the first `*/` ends it, and everything after that is the statement's own code | MySQL, MariaDB, SQLite, Oracle, and the default |
+| `//` | opens a **line comment**, ending at the newline like `--` | Apache Cassandra (and its relatives), ClickHouse |
+| `//` | **ordinary code** — an operator the parser refuses (`operator does not exist: integer // integer` on PostgreSQL 18), or a character it rejects outright | everything else, including the default |
 
 Each row was established from an authoritative source: the engine's own documentation, or its
 driver's own tokenizer under `node_modules` (node-oracledb accepts `#` inside an identifier; the
 SQLite amalgamation classifies `#` as a bind-variable prefix and `[` as a "`[...]` style quoted id").
 For the engines that ARE an HTTP endpoint — Elasticsearch, OpenSearch and Trino — the grammar was
 asked directly instead: each fact is a statement the live server answered, not an inference. Trino's
-four were probed on 2026-08-20 against 476, and two of them are the opposite of what a neighbouring
+first four were probed on 2026-08-20 against 476 (its fifth, `//`, on 2026-08-25), and two of them are
+the opposite of what a neighbouring
 dialect would have suggested: `SELECT 1 AS a # trailing` is `line 1:15: mismatched input '#'`, so `#`
 hides nothing and is `code`; and `SELECT [customer] FROM tpch.sf1.nation` fails with "Column
 'customer' cannot be resolved" while `SELECT ARRAY[ARRAY[1,2],ARRAY[3,4]][1][2]` answers `2`, so the
@@ -185,6 +188,7 @@ gate's keyword tests still run on that text.
 | `q'…'` | nobody | everything except Oracle: the form is Oracle's alone, so "not a literal" is the correct reading for the rest |
 | `[…]` | MySQL, Oracle, Elasticsearch, Couchbase, Druid, LibreDB | SQL Server, SQLite and OpenSearch, whose rule the default already applied |
 | `/* … */` nesting | Couchbase, Druid, LibreDB | MySQL, SQLite, Oracle, Elasticsearch, OpenSearch and Trino, whose flat rule the default already applied — each established from its own source rather than assumed to agree |
+| `//` | Elasticsearch, OpenSearch, Couchbase, Druid, LibreDB | PostgreSQL, MySQL, SQLite, Oracle, SQL Server and Trino, each refused on a live server: `SELECT 1 // note` is an error there, so "not a comment" is the reading the default already applied |
 
 The distinction is visible in `src/lib/sql/grammar.ts` too: an established fact is written out in that
 dialect's row, an undecided one is written `DEFAULT_SQL_GRAMMAR.<fact>`.
@@ -350,10 +354,16 @@ bounded, a final data-modifying one is not. The route resolves its connection be
 reading is done under **that connection's dialect** and this route and the provider that runs the
 statement cannot disagree about what the statement is.
 
-The splitter itself is a separate, still dialect-blind scan: it inlines its own span walk and reads
-`#` as ordinary code, so a MySQL hash comment carrying a `;` still splits a statement there. Changing
-that moves statement boundaries, which is its own change with its own tests — recorded here rather
-than folded in.
+The splitter reads spans through the shared reader (`src/lib/sql/spans.ts`) under the caller's
+grammar, so it agrees with every other reader here about which `;` is code. It used to inline its own
+scan and know none of the dialect facts, and unlike the other readers its disagreement was not a
+missing bound: this route RUNS what it returns. Measured on postgres 18,
+`/* a /* b */ ; DROP TABLE t; -- */ SELECT 1` is one read (block comments nest there), and the flat
+reading cut it into three whose second was a bare `DROP TABLE t` — which the route executed. Measured
+on MySQL, whose comments are flat, that same text really does drop the table, so the fragment is
+honest there and the confirmation gate is what must see it. Callers pass the connection's dialect
+(this route, and the editor's multi-statement decision); a call that names none keeps the
+compatibility grammar, the same stated default the rest of `src/lib/sql` applies.
 
 Last-only is that route's own policy, and it leaves a hole this section does not close: a non-final
 `SELECT` runs exactly as written, and its **entire** result set travels back in `statements[i].rows`.
@@ -464,7 +474,7 @@ own grammar (#295) and unresolvable only to a reader without it — and it lifts
 cannot read at all: Oracle's `q'{it's}'` (#292). It does nothing for the first class, per that
 bullet.
 
-Three gaps are known and pinned by tests rather than claimed closed:
+Two gaps are known and pinned by tests rather than claimed closed:
 
 - **Only `UPDATE … SET` is looked for inside a read.** A write hidden in a CTE *body* under any
   other keyword (`WITH gone AS (DELETE FROM t RETURNING *) SELECT * FROM gone`) does not prompt.
@@ -479,10 +489,15 @@ Three gaps are known and pinned by tests rather than claimed closed:
   `tests/components/QuerySafetyDialog.test.tsx` ("does not prompt when the statement's shape cannot
   be typed") so the boundary stays a decision — the shipped rule keys on unresolvable *runs*, and
   widening it to every statement the reader cannot type would prompt for an empty editor.
-- **A multi-statement script is read as one statement.** `SELECT 1; DROP TABLE users` does not
-  prompt (its first keyword is the `SELECT`), while `SELECT 1; UPDATE t SET x = 1` does, because
-  the unanchored probe finds it. Executing the destructive statement on its own prompts, as long
-  as that statement's own shape can be typed — the gap above is the exception.
+
+A third gap sat beside them and is closed (S1). A multi-statement script used to be read as one
+statement, so `SELECT 1; DROP TABLE users` did not prompt — its first keyword is the `SELECT` —
+while `SELECT 1; UPDATE t SET x = 1` did, because the unanchored probe happened to find it. The gate
+now splits the editor text with the same splitter and the same grammar the runner uses, and asks
+about **each fragment** the multi-statement route will run. The split is only performed where the dialect's text is SQL — a `;`
+in a Mongo document or a Redis command separates nothing, so a fragment cut there would be invented
+(#427). Pinned by `tests/components/QuerySafetyDialog.test.tsx` ("The gate reads what the RUNNER will
+run").
 
 Four runs bypass the gate on purpose, all on the standalone path
 (`src/hooks/use-query-execution.ts`): an EXPLAIN run (see below), a Load-More page of a result the

--- a/docs/providers/cassandra.md
+++ b/docs/providers/cassandra.md
@@ -524,13 +524,22 @@ SELECT * FROM probe.customers LIMIT 3 -- note\n    -> 3 rows
 SELECT * FROM probe.customers LIMIT 3 // note\n    -> 3 rows
 ```
 
-`//` is a line comment in CQL and the shared span readers know nothing about it. Both facts break the
-limiter's insert-before-trailing-trivia rule (#280) in different ways: for `--` it re-attaches the
-comment after the clause and the trim drops the newline that closed it, turning a **valid** statement
-into a syntax error; for `//` it appends the clause *inside* the comment. So a statement whose
-rewritten form would end inside a line comment is **left exactly as written**, `wasLimited: false`.
-The check walks the shared span reader, so a `//` inside a string literal (`WHERE url =
-'http://x'`) is not mistaken for a comment.
+`//` is a line comment in CQL, and that half **is** a shared grammar fact — `doubleSlashComment` in
+[`src/lib/sql/grammar.ts`](../../src/lib/sql/grammar.ts), measured over the native protocol on
+Cassandra 5.0.9 and ScyllaDB 2026.2.4. It used to be a private scan inside this provider, and while
+it was, the shared readers were blind to it: the statement splitter cut
+`SELECT id FROM probe.customers // note; DROP TABLE probe.customers` — **one** statement to this
+server, the `;` and the write both inside the comment — into a read and a bare `DROP`, and
+`/api/db/multi-query` runs every fragment it is handed.
+
+What stays local to this engine is the OTHER half: neither comment form may be closed by end of
+input. That is a fact about where a statement may **end**, not about what a run is, so both comment
+forms now break the limiter's insert-before-trailing-trivia rule (#280) the same way — the clause
+goes in before the comment and `sql.trim()` drops the newline that closed it, turning a **valid**
+statement into a syntax error. So a statement whose rewritten form would end inside a line comment is
+**left exactly as written**, `wasLimited: false`. The check walks the shared span reader, which is
+also what keeps a `//` inside a string literal (`WHERE url = 'http://x'`) from being read as a
+comment.
 
 **One shape is knowingly left unbounded.** A statement whose last clause is `PER PARTITION LIMIT n`
 reads as already bounded to the shared reader, so nothing is injected — `... PER PARTITION LIMIT 2

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -407,6 +407,17 @@ takes the bound before it rather than inside it. A comment carrying one opener t
 passed through untouched — the same fail-safe direction as an unclosed array, and it costs that
 statement a confirmation prompt as well (#300).
 
+A fourth fact of the same record, and the only one this dialect shares with another engine here:
+**`//` is a single-line comment.** ClickHouse's syntax reference lists it beside `--` and `#`, and the
+shared reader used to read the two slashes as code, so a comment written that way took the row bound
+with it: `SELECT number FROM numbers(1000) // note` emitted `... // note LIMIT 5`, which the server
+reads as an unbounded query inside a comment — measured on 26.7.1, that returned **1000 rows while the
+result claimed it was limited to 5**. It now emits `... LIMIT 5 // note` and returns 5. Apache
+Cassandra is the other engine with this form ([`cassandra.md`](cassandra.md)); every other dialect this
+product reads treats the characters where they stand, PostgreSQL as an operator that does not exist
+(#S1). A `;` behind the comment is not a separator either, which is what stops the multi-statement
+route inventing a fragment out of commented-out text.
+
 The same reading reaches the **destructive-statement confirmation**, because that predicate reads the
 statement under the connection's dialect too. It gains prompts here: a nested array before a
 destructive keyword (`WITH [[1,2],[3,4]] AS x DELETE FROM t`) used to leave the run unterminated and
@@ -769,6 +780,35 @@ operations. A target is qualified through
 `escapeIdentifier()` (`"database"."table"`, defaulting the database to the pinned one when the
 target names none), so a hostile or oddly-named table cannot break out of the generated statement.
 
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `optimize` | Optimize Table | yes | **no** | `OPTIMIZE TABLE ... FINAL` names one table and `dispatchMaintenance` requires that target; ClickHouse has no "optimize database", and looping every table would merge the whole dataset behind one click |
+| `analyze` | Table Statistics | yes | yes | `describeParts` deliberately accepts no target as well as one |
+| `kill` | Cancel Query | no | no | the target is a query id from the Sessions panel |
+
+`vacuumAction` says *"Optimize Table"*, so `vacuumActionOperation: 'optimize'` records that
+the vacuum slot names `optimize` rather than a `vacuum` ClickHouse would reject. The global
+*"Merge Parts"* card stays withheld even so, because `optimize` declares `global: false`.
+
+That makes `vacuumGlobalLabel` / `vacuumGlobalTitle` / `vacuumGlobalDesc` **deliberately
+unreachable here**: no surface can render them while `optimize` has no whole-database form.
+They are kept rather than dropped because `ProviderLabels` requires all three and the
+inherited default is PostgreSQL's *"Removes dead rows and returns space to the operating
+system"* — a statement ClickHouse does not have — so the choice is between wording that is
+wrong if it ever shows and wording that is right if it ever shows. What #U9 removed was
+wording that was written and never shown *without saying so*; the unreachability is asserted
+in `tests/integration/db/clickhouse-provider.test.ts` ("the global vacuum card cannot render,
+so its wording is unreachable by design") so that a future spec change makes it visible
+rather than silent.
+
 ---
 
 ## 9. Capabilities & labels
@@ -802,7 +842,9 @@ not exist: `analyzeAction`/`analyzeGlobalLabel`/`analyzeGlobalTitle` → *"Table
 `vacuumAction` → *"Optimize Table"*, `vacuumGlobalLabel` → *"Optimize"*, `vacuumGlobalTitle` →
 *"Merge Parts"*. The card descriptions name the substituted operation explicitly (`OPTIMIZE TABLE
 ... FINAL`) rather than reusing generic wording that would describe a command ClickHouse does not
-have.
+have. Of those, only `analyzeAction`/`analyzeGlobal*` and `vacuumAction` are reachable — the
+`vacuumGlobal*` triad is unreachable by design
+([§8](#where-each-operation-may-be-offered-maintenanceoperationspecs)).
 
 One more label, and it is about the monitoring tab rather than maintenance:
 `slowQueriesEmptyState` → *"Query stats come from system.query_log, which records nothing while

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -633,6 +633,28 @@ tab since #272, the admin Operations tab since #282.
 Calling `runMaintenance` with one directly throws a `QueryError` naming the three supported
 operations.
 
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `analyze` | Update Statistics | yes | **no** | `UPDATE STATISTICS FOR <keyspace>` names one collection, and `dispatchMaintenance` requires the target |
+| `reindex` | Build Deferred Indexes | yes | **no** | `BUILD INDEX ON <keyspace>` names one collection; there is no whole-bucket form |
+| `kill` | Cancel Request | no | no | the target is a request id from the Sessions panel |
+
+Both global cards are withheld rather than synthesised from a keyspace list this provider
+does not enumerate for maintenance. Before #U9 the global Reindex card rendered for every
+provider that declared `reindex`, so on Couchbase every click answered *"The reindex
+operation requires a target"*; the per-collection control carries the keyspace and runs.
+`vacuumAction` (*"Compact"*) names nothing this provider can run - its own description says
+the server compacts automatically - so `vacuum` stays undeclared, `vacuumActionOperation`
+stays absent, and that card never renders either.
+
 ---
 
 ## 9. Capabilities & labels

--- a/docs/providers/mongodb.md
+++ b/docs/providers/mongodb.md
@@ -340,6 +340,23 @@ maps the generic operations onto MongoDB admin commands:
 `getCapabilities().maintenanceOperations = ['vacuum', 'analyze', 'check']` — so the UI surfaces those
 three, though `runMaintenance` also accepts `optimize`/`kill`/`reindex` when invoked directly.
 
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `vacuum` | Compact Collection | yes | yes | `{compact: <coll>}`, or every collection from `listCollections()` |
+| `analyze` | Validate Collection | yes | yes | `{validate: <coll>}`, same loop without a target |
+| `check` | Check Collection | yes | **no** | `{dbCheck: <coll>}` is not looped and throws without a collection name |
+
+*"Compact Collection"* really is the `vacuum` this provider declares, so
+`vacuumActionOperation` stays absent.
+
 ---
 
 ## 9. Capabilities & labels

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -500,6 +500,25 @@ are bracket-escaped (`]` → `]]`):
 `getCapabilities().maintenanceOperations = ['analyze', 'check', 'optimize', 'kill']`. `kill`
 validates the target parses as an integer SPID.
 
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `analyze` | Update Statistics | yes | yes | `UPDATE STATISTICS [<t>]`, or every table without a target |
+| `check` | Check Database | no | yes | `DBCC CHECKDB` takes no object: `runMaintenance` ignores the target, so a per-table control would name one table and check the database |
+| `optimize` | Rebuild Indexes | yes | yes | `ALTER INDEX ALL ON [<t>] REBUILD`, or every table without a target |
+| `kill` | Kill Session | no | no | the target is a SPID from the Sessions panel |
+
+`vacuumAction` has said *"Rebuild Indexes"* since this provider shipped, and that is
+`optimize`: `vacuumActionOperation: 'optimize'` says so, which is what lets the global card
+render those words and send an operation SQL Server declares (#U9).
+
 ---
 
 ## 10. Capabilities & labels

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -593,6 +593,64 @@ are backtick-quoted via `escapeIdentifier()`:
 `getCapabilities().maintenanceOperations = ['analyze', 'optimize', 'check', 'kill']`. `kill`
 validates that the target parses as an integer connection id.
 
+### The verdict is in the result set, not in the absence of an exception
+
+`ANALYZE`, `OPTIMIZE` and `CHECK TABLE` answer a **result set** — one row per (table, message)
+with `Table` / `Op` / `Msg_type` / `Msg_text` — and a statement the server refuses resolves
+normally. Measured through the driver against MySQL 26.7.0 (`libredb-mysql`) on 2026-08-25:
+
+| Statement | Rows MySQL answers |
+|-----------|--------------------|
+| `OPTIMIZE TABLE \`real1\`` | `note` *"Table does not support optimize, doing recreate + analyze instead"*, then `status` *"OK"* |
+| `OPTIMIZE TABLE \`missing\`` | `Error` *"Table 'u9t.missing' doesn't exist"*, then `status` *"Operation failed"* |
+| `CHECK TABLE \`real1\`` | `status` *"OK"* |
+
+So `await runStatement(conn, sql); return { success: true }` reported a completed operation for
+a statement the server had rejected — `optimize u9t` answered
+`{"success":true,"message":"OPTIMIZE completed successfully"}` while the server's own answer was
+Error / *"Table 'u9t.missing' doesn't exist"* / *"Operation failed"* — and it discarded the
+`Msg_text` that is the entire point of `CHECK TABLE`, whose OK-or-corruption-report is the only
+thing the user asked for. `readMaintenanceReport()` reads those rows:
+
+- **any row with `Msg_type` = `error`** (matched case-insensitively; the server sends `Error`,
+  the manual documents the set in lower case) → `success: false`, and the message quotes those
+  rows **with their table names**, because the whole-database form names every table in one
+  statement and a per-table Error row is the only place the failure appears;
+- **otherwise** → `success: true`, and the message quotes the engine's own texts, deduplicated:
+  over forty tables the OK and InnoDB's *"doing recreate + analyze instead"* note repeat once
+  per table and say the same thing forty times.
+
+After the fix, through the provider: `check real1` → *"CHECK: OK"*, `optimize missing` →
+`success: false` *"OPTIMIZE failed: u9t.missing: Table 'u9t.missing' doesn't exist"*. This is the
+same read SQLite's `check` already did with `PRAGMA integrity_check`.
+
+**A database with no tables runs no statement.** `OPTIMIZE TABLE ${getAllTablesForMaintenance()}`
+string-joined an empty list, and MySQL answered *"You have an error in your SQL syntax … near
+''"* — measured through the provider against an empty database on 2026-08-25. Nothing to do is
+not a failure and it is not a syntax error either, so the whole-database form now answers
+`success: true` with *"OPTIMIZE: no tables in u9empty to run it on."* without sending anything.
+
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `analyze` | Analyze Table | yes | yes | `ANALYZE TABLE <t>`, or every table via `getAllTablesForMaintenance()` |
+| `optimize` | Optimize Table | yes | yes | `OPTIMIZE TABLE <t>`, same loop without a target |
+| `check` | Check Table | yes | yes | `CHECK TABLE <t>`, same loop without a target |
+| `kill` | Kill Connection | no | no | the target is a connection id from the Sessions panel |
+
+MySQL has no `VACUUM`, and the base labels put *"Vacuum Table"* in the explorer's row menu
+and *"Run Vacuum" / "Reclaim Space"* on the Operations tab anyway. The labels now say
+*"Optimize Table"* / *"Run Optimize" / "Optimize Tables"*, and `vacuumActionOperation:
+'optimize'` is what makes the surfaces send `optimize` for them - the global card used to be
+gated on the literal `vacuum`, so MySQL's own wording was written and never shown (#U9).
+
 ---
 
 ## 10. Capabilities & labels
@@ -618,10 +676,19 @@ validates that the target parses as an integer connection id.
 ### Labels
 
 MySQL keeps the default SQL `getLabels()` from `BaseDatabaseProvider` (entity → *Table*, *Select Top
-50*, etc.) for everything a person clicks. (The default `analyzeAction`/`vacuumAction` wording is
-generic SQL phrasing; MySQL's actual maintenance verbs are optimize/check/analyze.)
+50*, etc.) for everything a person clicks. `analyzeAction` is one of them and is correct: MySQL runs
+`ANALYZE TABLE`. The vacuum slot is not, and is overridden.
 
-**One field is overridden** ([mysql.ts:346](../../src/lib/db/providers/sql/mysql.ts)):
+**The vacuum slot** ([mysql.ts](../../src/lib/db/providers/sql/mysql.ts)): `vacuumAction` →
+*"Optimize Table"*, `vacuumGlobalLabel` → *"Run Optimize"*, `vacuumGlobalTitle` → *"Optimize
+Tables"*, `vacuumGlobalDesc` → the OPTIMIZE TABLE sentence, and `vacuumActionOperation` →
+`optimize`. MySQL has no `VACUUM`, so the base default put *"Vacuum Table"* in the explorer's row
+menu and *"Run Vacuum" / "Reclaim Space"* on the admin Operations tab for an engine whose operations
+are analyze/optimize/check/kill — and because that card was gated on the literal `vacuum`, no
+wording MySQL could have declared would have been shown (#U9,
+[§9](#where-each-operation-may-be-offered-maintenanceoperationspecs)).
+
+**And one monitoring field** ([mysql.ts:346](../../src/lib/db/providers/sql/mysql.ts)):
 `slowQueriesEmptyState` → *"Query stats come from
 performance_schema.events_statements_summary_by_digest - enable the Performance Schema to see them."*
 The monitoring Queries panel's empty state was hardcoded to PostgreSQL's `pg_stat_statements` advice

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -38,7 +38,7 @@ providers, with several Oracle-isms that are worth knowing before reading the co
 | Pagination | `LIMIT … OFFSET` | `FETCH FIRST n ROWS ONLY` / `OFFSET m ROWS FETCH NEXT n` |
 | Schema scope | all non-system schemas | the connecting **user's** schema (`OWNER = USER`) |
 | Schema queries | 1 `MATERIALIZED`-CTE round-trip | **5 bulk** `ALL_*` queries grouped in memory |
-| Maintenance | vacuum / analyze / reindex / kill | `analyze` (DBMS_STATS) / `optimize` (index rebuild) / `kill` |
+| Maintenance | vacuum / analyze / reindex / kill | `analyze` (DBMS_STATS) / `optimize` (rebuild one table's indexes, or the schema's) / `kill` |
 | Transaction timeout | 5-minute auto-rollback | **none** |
 | Cancellation | `pg_cancel_backend(pid)` | `connection.break()` (tracked connection) |
 | SSL | `buildSSLConfig()` + cloud auto-detect | `tcps://` + `sslServerDNMatch` + `walletContent` (no cloud auto-detect) |
@@ -345,7 +345,7 @@ selects the other branch of `buildQueryResult()`: the grid is empty (`rows: []`,
 
 Until 2026-08-24 the count was `rows.length` on both branches, so every statement that wrote
 something reported `0` for work it had done. Measured 2026-08-24 through
-`createDatabaseProvider({type:"oracle"})` against Oracle Free 23ai, with an interleaved `SELECT`
+`createDatabaseProvider({type:"oracle"})` against Oracle AI Database 26ai Free, with an interleaved `SELECT`
 proving each statement had landed:
 
 | statement | `rowsAffected` on the wire | `rowCount` before | after |
@@ -375,7 +375,7 @@ actually running). Exposed via `POST /api/db/cancel`.
 ### 5.3 What each Oracle type arrives as
 
 Every row below was measured on 2026-08-24 through `createDatabaseProvider({type:"oracle"})` against
-**Oracle Free 23ai** with **oracledb 6.10.0 in Thin mode**, over a probe table holding one populated
+**Oracle AI Database 26ai Free** with **oracledb 6.10.0 in Thin mode**, over a probe table holding one populated
 row and one all-`NULL` row. The `JSON.stringify` column is what `POST /api/db/query` puts on the wire,
 and therefore what the grid, the row detail sheet, the CSV, the SQL export and the agent's result
 summary all read.
@@ -473,7 +473,7 @@ Oracle is the one engine of the four whose driver hands over a NAME rather than 
 `fields`, by both `query()` and `queryInTransaction()`, and it is uppercase - the same spelling
 `ALL_TAB_COLUMNS.DATA_TYPE` uses, so a declared type reads like the schema tree's entry.
 
-Measured on Oracle Free 23ai over the probe table, verbatim from `oracledb`:
+Measured on Oracle AI Database 26ai Free over the probe table, verbatim from `oracledb`:
 
 | declared | `dbTypeName` | also reported |
 |---|---|---|
@@ -506,7 +506,7 @@ be** and this section says so plainly instead of implying otherwise. This is the
 already took for a CQL `duration`, applied to the one other engine here that has the same shape of
 problem.
 
-Measured 2026-08-24 against **Oracle Free 23ai** with **oracledb 6.10.0 in Thin mode**, through
+Measured 2026-08-24 against **Oracle AI Database 26ai Free** with **oracledb 6.10.0 in Thin mode**, through
 `createDatabaseProvider({type:"oracle"})`:
 
 | Oracle type | stored | before | after |
@@ -759,7 +759,7 @@ sub-query is independently privilege-guarded ([§3.6](#36-privilege-resilient-mo
 
 Two states, both ordinary:
 
-- **The connected user cannot read `V$SYSSTAT`.** Measured 2026-08-23 on Oracle Free 23ai against a
+- **The connected user cannot read `V$SYSSTAT`.** Measured 2026-08-23 on Oracle AI Database 26ai Free against a
   user granted only `CREATE SESSION`:
 
   ```
@@ -797,13 +797,78 @@ them.
 | Type | With target | Without target |
 |------|-------------|----------------|
 | `analyze` | `DBMS_STATS.GATHER_TABLE_STATS(USER, '<t>')` | `DBMS_STATS.GATHER_SCHEMA_STATS(USER)` |
-| `optimize` | `ALTER INDEX "<t>" REBUILD` | rebuild **every** normal user index (`USER_INDEXES`, each in its own try/catch) |
+| `optimize` | rebuild the indexes THAT TABLE owns: `SELECT INDEX_NAME FROM USER_INDEXES WHERE TABLE_NAME = :t AND INDEX_TYPE = 'NORMAL'`, then `ALTER INDEX "<i>" REBUILD` for each (own try/catch) | rebuild **every** normal user index (`USER_INDEXES`, each in its own try/catch) |
 | `kill` | `ALTER SYSTEM KILL SESSION '<SID,SERIAL#>'` | throws (`SID,SERIAL#` required) |
 
 `getCapabilities().maintenanceOperations = ['analyze', 'optimize', 'kill']`. Targets are
 **inline-escaped** (single quotes doubled for the PL/SQL string literal; double quotes doubled for
 the quoted index identifier) rather than routed through `escapeIdentifier()`, because they sit
-inside `DBMS_STATS` arguments / `ALTER` identifiers that can't take bind parameters.
+inside `DBMS_STATS` arguments / `ALTER` identifiers that can't take bind parameters. The
+`optimize` catalog read is the exception: `TABLE_NAME = :tableName` sits in a WHERE clause,
+which does take a bind.
+
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `analyze` | Gather Statistics | yes | yes | `GATHER_TABLE_STATS` / `GATHER_SCHEMA_STATS` |
+| `optimize` | Rebuild Indexes | yes | yes | the target is a TABLE, and its own indexes are rebuilt - the shape SQL Server's identically worded `ALTER INDEX ALL ON [<t>] REBUILD` has |
+| `kill` | Kill Session | no | no | the target is `SID,SERIAL#` from the Sessions panel |
+
+`optimize` used to take an INDEX name, so the per-table button #427 wired up sent a table
+and every click answered **ORA-01418: specified index does not exist** - reproduced against
+`ldb-oracle-r5` on 2026-08-25 and re-run after the fix, which brought an `UNUSABLE` index
+on the named table back to `VALID` both with a target and without one. That container's
+`SELECT BANNER_FULL FROM V$VERSION` answers *"Oracle AI Database 26ai Free Release
+23.26.2.0.0"*, which is the product name used throughout this document. `INDEX_TYPE =
+'NORMAL'` excludes what `ALTER INDEX ... REBUILD` cannot take (the LOB index a CLOB column
+creates was present in that probe) and keeps the B-tree indexes that back UNIQUE and PRIMARY
+KEY constraints. A table with no rebuildable index succeeds having rebuilt nothing: "nothing
+to do" is not a failure, and neither is a heap table.
+
+**An empty index list has two causes, and they are not the same fact.** A target the schema
+does not own answered `{"success": true}` in ~1 ms having done nothing at all - measured
+through the provider on 2026-08-25 for `U9MISSING` (no such table) and for `u9real` (a real
+table spelled in the wrong case, which Oracle stores folded to upper case). Where
+`TABLE_NAME = :t` returns no index, `SELECT TABLE_NAME FROM USER_TABLES WHERE TABLE_NAME = :t`
+is asked as well, and a target that catalog does not know is reported as a failed operation:
+
+| Target | Result |
+|--------|--------|
+| `U9REAL` (one index) | `success: true` · *"OPTIMIZE: rebuilt 1 of 1 indexes."* |
+| `U9HEAP` (no index, real table) | `success: true` · *"OPTIMIZE: rebuilt 0 of 0 indexes."* |
+| `u9real` (case mismatch) | `success: false` · *"this schema owns no TABLE named u9real …"* |
+| `U9MISSING` (absent) | `success: false` · *"this schema owns no TABLE named U9MISSING …"* |
+| a plain VIEW | `success: false` · the same sentence, which is why it names the view case too |
+| no target (whole schema) | `success: true` · *"OPTIMIZE: rebuilt 27 of 30 indexes."* |
+| every index of the table refused | `success: false` · *"rebuilt 0 of 2 indexes. ORA-01647 …"* |
+
+The existence question is asked ONLY when the index list came back empty, so the ordinary
+path stays at one catalog read. `USER_TABLES` is the catalog that answers it because it is
+not narrower than `USER_INDEXES`: measured on the same container, a MATERIALIZED VIEW's
+container appears there under the view's own name and its indexes are keyed to that name,
+while a plain VIEW appears in neither - and a view owns no index for "Rebuild Indexes" to
+have rebuilt. The count in the message is there because tolerating one failed index means
+`success: true` alone cannot distinguish 2 of 2 from 1 of 2.
+
+**None of them rebuilding is a third fact.** One index failing leaves the run completed - an
+offline tablespace or an unusable partition stops that index alone - but a table where EVERY
+rebuild is refused had nothing it was asked to do happen. Measured on 2026-08-25 with the
+table's tablespace put READ ONLY, so every `ALTER INDEX ... REBUILD` answers ORA-01647: this
+reported `{"success": true, "message": "OPTIMIZE: rebuilt 0 of 2 indexes."}` in 14 ms with the
+ORA text discarded in an empty `catch`. It now reports `success: false` and carries the
+engine's first refusal, because the count says how many and only the ORA text says why. A
+table with no index at all keeps its success: nothing to do is still not a failure.
+
+`vacuumAction` has said *"Rebuild Indexes"* since this provider shipped, and that is
+`optimize`, not a `vacuum` Oracle has no statement for: `vacuumActionOperation: 'optimize'`
+is what lets the Operations tab render those words and send an operation Oracle declares.
 
 ---
 

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -573,6 +573,26 @@ with targets quoted via [§3.6](#36-safe-maintenance-targets):
 `getCapabilities().maintenanceOperations = ['vacuum', 'analyze', 'reindex', 'kill']`. `kill`
 validates that the target parses as an integer PID.
 
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `vacuum` | Vacuum Table | yes | yes | `VACUUM ANALYZE <t>` and bare `VACUUM ANALYZE` both exist |
+| `analyze` | Analyze Table | yes | yes | same, for `ANALYZE` |
+| `reindex` | Reindex Table | yes | yes | `REINDEX TABLE <t>` / `REINDEX DATABASE <db>` |
+| `kill` | Terminate Backend | no | no | the target is a backend PID, which only the Sessions panel lists |
+
+PostgreSQL is the engine both surfaces were already right about - every statement here has
+a one-table form and a whole-database form - so these declarations record the baseline the
+other providers are measured against rather than a change in behaviour. `vacuumAction`
+really means `vacuum` here, so `vacuumActionOperation` stays absent.
+
 ---
 
 ## 10. Capabilities & labels

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -521,6 +521,23 @@ Info"* / *"Server Info"* / *"Get Redis server information and statistics."* — 
 query-planner copy. Those `analyzeGlobal*` fields had been declared and set for a long time and read
 by no component (#427).
 
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `analyze` | Server Info | **no** | yes | `runMaintenance(type)` takes no target parameter at all - the operation is `INFO`, which reports on the server and cannot be pointed at a key prefix |
+
+A per-row control here answered with server-wide metrics for one grouping, which is the
+dead end #427 reported for *"Key Info"*. The Operations tab's global card carries Redis's
+own *"Run Info" / "Server Info"* wording. *"Memory Doctor"* names no declared operation, so
+no control offers it.
+
 ---
 
 ## 9. Capabilities & labels

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -426,6 +426,30 @@ and `reindex` targets are quoted via `escapeIdentifier()`:
 `kill` — SQLite has no sessions to terminate. Quoting the target prevents identifier injection in
 `ANALYZE`/`REINDEX` statements (which cannot use bind parameters for object names).
 
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `vacuum` | Vacuum Database | no | yes | `VACUUM` rewrites the whole file and `runMaintenance` drops the target, so a per-table control named one table and acted on the database |
+| `analyze` | Analyze Table | yes | yes | `ANALYZE [<t>]` |
+| `reindex` | Reindex Table | yes | yes | `REINDEX [<t>]` |
+| `check` | Integrity Check | no | yes | `PRAGMA integrity_check` reads the whole file, target ignored |
+
+**The schema explorer's row menu reads the same declaration.** It is the third surface that
+renders this wording, and it used to gate on `supportsMaintenance` alone — so it offered
+*"Vacuum Table"* for ONE table here while the monitoring Tables tab correctly withheld that
+control, and the click deep-linked to a page where no such control exists. `TableItem.tsx`
+now asks `maintenanceControl(capabilities, …, 'perEntity')` for each of its two items, so on
+SQLite the row menu offers *"Analyze Table"* and no vacuum item at all. Unknown capabilities
+read as a denial there, as they already did on the other two surfaces: `/api/db/provider-meta`
+answers with nothing both while it is in flight and when it failed.
+
 ---
 
 ## 9. Capabilities & labels
@@ -451,7 +475,10 @@ and `reindex` targets are quoted via `escapeIdentifier()`:
 ### Labels
 
 Default SQL labels — *Table* / *Select Top 50* / *Vacuum Table* / *Analyze Table*, which match
-SQLite's real `VACUUM`/`ANALYZE`.
+SQLite's real `VACUUM`/`ANALYZE`. `vacuumAction`'s *"Vacuum Table"* is the one word that is
+narrower than the statement: `VACUUM` is not per-table, which is what
+`vacuum: { perEntity: false, label: 'Vacuum Database' }` says, and the per-row surfaces take
+their wording from that `label` rather than from this field.
 
 One field is overridden: `slowQueriesEmptyState` → *"SQLite keeps no statistics about finished
 statements, so there is nothing to enable."* `getSlowQueries()` answers `[]` unconditionally

--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -672,6 +672,23 @@ every connector decides for itself whether it implements it, and measured, the `
 answers `This connector does not support analyze` and no connector on the probe cluster implements
 it. A button that always fails is worse than a stated reason.
 
+### Where each operation may be offered (`maintenanceOperationSpecs`)
+
+Declaring that an operation EXISTS is not enough to put a button on it: two engines that
+declare the same `MaintenanceType` take different kinds of target, so each provider also
+declares what its own operations may be pointed at. The monitoring Tables tab renders a
+per-row control only where `perEntity` is true, the admin Operations tab a whole-database
+card only where `global` is true, and both take the wording from `label` (#U9).
+
+| Operation | Control label | Per-row | Global | Why |
+|-----------|---------------|---------|--------|-----|
+| `kill` | Terminate Query | no | no | the target is the query id the Sessions panel lists; neither a table nor a whole database can supply one |
+
+So no maintenance control is offered anywhere on Trino - which is the same answer the
+labels give in prose: *"Trino Owns No Storage"* and *"Statistics Belong to the Connector"*
+name nothing this engine can run, and both stay unshown because the operations behind them
+are undeclared.
+
 ---
 
 ## 9. Capabilities & labels

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting fourteen engines - PostgreSQL, MySQL, SQLite, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra
 type: application
-version: 0.1.49
+version: 0.1.50
 appVersion: "0.13.4"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -39,9 +39,11 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
-  # False: 0.1.49 changes no packaged template at all - 0.1.48's optional model-tuning
-  # ConfigMap and read-only mount are unchanged - and carries only the appVersion move to
-  # 0.13.4. What 0.13.4 fixes is correctness, not security: a MySQL protocol choice, the
+  # False: 0.1.50 changes no packaged template and no value - it corrects the README's own
+  # copy-paste recipes, which rendered an unquoted YAML boolean into `core/v1.EnvVar.value`
+  # and left bracket arguments a zsh user's shell globs away. The README is a packaged file,
+  # so #167 costs it a chart version even though nothing an operator deploys moves.
+  # 0.1.49 carried only the appVersion move to 0.13.4. What 0.13.4 fixes is correctness, not security: a MySQL protocol choice, the
   # monitoring dashboard's all-or-nothing aggregate, a ScyllaDB connection and an Oracle
   # LOB read. Its dependency moves are routine patch bumps with no advisory behind them.
   # 0.13.3's transport fixes (a rediss:// or couchbases:// URL landing on SSL mode disable,

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.49 \
+  --version 0.1.50 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```
@@ -415,9 +415,12 @@ helm install libredb libredb/libredb-studio \
   --set replicaCount=3 \
   --set ingress.enabled=true \
   --set ingress.className=nginx \
-  --set "ingress.annotations.nginx\.ingress\.kubernetes\.io/limit-rpm=120" \
-  --set "ingress.annotations.nginx\.ingress\.kubernetes\.io/limit-burst-multiplier=2"
+  --set-string "ingress.annotations.nginx\.ingress\.kubernetes\.io/limit-rpm=120" \
+  --set-string "ingress.annotations.nginx\.ingress\.kubernetes\.io/limit-burst-multiplier=2"
 ```
+
+`--set-string`, not `--set`: ingress annotations are a `map[string]string`, and plain `--set`
+type-coerces the bare number, rendering `limit-rpm: 120` as an integer that the API server rejects.
 
 With Traefik, attach a `rateLimit` middleware and reference it from the ingress annotations.
 
@@ -429,8 +432,8 @@ it, so pass it through `extraEnv`:
 
 ```bash
 helm install libredb libredb/libredb-studio \
-  --set extraEnv[0].name=ALLOWED_ORIGINS \
-  --set extraEnv[0].value=https://libredb.example.com
+  --set 'extraEnv[0].name=ALLOWED_ORIGINS' \
+  --set-string 'extraEnv[0].value=https://libredb.example.com'
 ```
 
 ### The Content-Security-Policy escape hatch
@@ -442,12 +445,19 @@ passed through `extraEnv`:
 
 ```bash
 helm install libredb libredb/libredb-studio \
-  --set extraEnv[0].name=CSP_REPORT_ONLY \
-  --set extraEnv[0].value="true"
+  --set 'extraEnv[0].name=CSP_REPORT_ONLY' \
+  --set-string 'extraEnv[0].value=true'
 ```
 
 In report-only mode the browser logs the same violation to its console instead of blocking the
 resource. Please also open an issue naming the violated directive.
+
+`--set-string`, not `--set`, and the single quotes are load-bearing in both `extraEnv` recipes above.
+`--set extraEnv[0].value=true` renders `value: true`, an unquoted YAML boolean, and the API server
+rejects the manifest with `invalid type for io.k8s.api.core.v1.EnvVar.value: got "bool", expected
+"string"` — `extraEnv` is typed only as an array of objects in `values.schema.json`, so nothing
+catches it before apply. Unquoted `extraEnv[0]` is also a glob pattern in zsh, which fails the
+command with `no matches found` before helm is reached.
 
 Setting both `ALLOWED_ORIGINS` and `CSP_REPORT_ONLY` at once needs a distinct index per entry —
 `extraEnv` is a list, and `--set` on the same index (`extraEnv[0]` in both examples above) just
@@ -456,10 +466,10 @@ second variable:
 
 ```bash
 helm install libredb libredb/libredb-studio \
-  --set extraEnv[0].name=ALLOWED_ORIGINS \
-  --set extraEnv[0].value=https://libredb.example.com \
-  --set extraEnv[1].name=CSP_REPORT_ONLY \
-  --set extraEnv[1].value="true"
+  --set 'extraEnv[0].name=ALLOWED_ORIGINS' \
+  --set-string 'extraEnv[0].value=https://libredb.example.com' \
+  --set 'extraEnv[1].name=CSP_REPORT_ONLY' \
+  --set-string 'extraEnv[1].value=true'
 ```
 
 ### Separating the storage encryption key
@@ -474,9 +484,9 @@ same directory, alongside the database file):
 
 ```bash
 helm install libredb libredb/libredb-studio \
-  --set extraEnv[0].name=STORAGE_ENCRYPTION_KEY \
-  --set extraEnv[0].valueFrom.secretKeyRef.name=libredb-studio-storage \
-  --set extraEnv[0].valueFrom.secretKeyRef.key=encryption-key
+  --set 'extraEnv[0].name=STORAGE_ENCRYPTION_KEY' \
+  --set 'extraEnv[0].valueFrom.secretKeyRef.name=libredb-studio-storage' \
+  --set 'extraEnv[0].valueFrom.secretKeyRef.key=encryption-key'
 ```
 
 Rotating the key makes existing stored credentials unreadable — the connections survive and their

--- a/src/app/api/db/maintenance/route.ts
+++ b/src/app/api/db/maintenance/route.ts
@@ -62,7 +62,14 @@ export async function POST(request: Request) {
         target: target || "all",
         connectionName: connection.name || connection.database || "unknown",
         user: guard.session.username || "admin",
-        result: "success",
+        // The engine's verdict, not the request's. `runMaintenance` resolving is only the
+        // statement having reached the engine: since 2026-08-25 MySQL and Oracle read the
+        // server's own answer, so `success: false` on a 200 is the ordinary reply for a
+        // target the engine would not touch - and recording that as a completed operation
+        // is worse than not recording it, because this log is where an operator
+        // reconstructs what was done to a database. A provider that reports no verdict
+        // keeps the old reading: only an explicit `false` is a failure.
+        result: result.success === false ? "failure" : "success",
         duration,
       });
     } catch (auditError) {

--- a/src/app/api/db/multi-query/route.ts
+++ b/src/app/api/db/multi-query/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getOrCreateProvider } from "@/lib/db";
 import { splitStatements } from "@/lib/sql/statement-splitter";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { isSelectQuery } from "@/lib/db/utils/query-limiter";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
@@ -114,7 +115,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Connection and query are required" }, { status: 400 });
     }
 
-    const statements = splitStatements(sql);
+    // The resolved connection's dialect, not the compatibility default: this is the
+    // one surface that EXECUTES what the splitter returns, so a fragment invented by
+    // a reading the engine does not share is a statement the operator never wrote.
+    // Measured on postgres 18, `/* a /* b *\/ ; DROP TABLE t; -- *\/ SELECT 1` is one
+    // read there and the flat reading made its second fragment a bare DROP (S1).
+    const statements = splitStatements(sql, resolveSqlGrammar(connection.type));
 
     if (statements.length === 0) {
       return NextResponse.json({ error: "No valid SQL statements found" }, { status: 400 });

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -18,6 +18,9 @@ import { logger } from "@/lib/logger";
 import { setLineNumbersPreference, useLineNumbersPreference } from "@/hooks/use-line-numbers-preference";
 import { writeToClipboard } from "@/components/copy-button";
 import { toast } from "sonner";
+import { splitStatements } from "@/lib/sql/statement-splitter";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
+import type { DatabaseType } from "@/lib/types";
 
 // Serve Monaco from our own origin rather than @monaco-editor/react's jsdelivr default.
 // Runs at module load so it is in place before the first <Editor> mounts.
@@ -46,6 +49,13 @@ interface QueryEditorProps {
   onContentChange?: (val: string) => void;
   onExplain?: () => void;
   language?: "sql" | "json" | "libredb" | "redis";
+  /**
+   * The connected engine, whose grammar decides where a statement ends.
+   *
+   * Optional, and a caller that omits it gets the compatibility reading - the same
+   * stated default every reader in `src/lib/sql/` applies to a dialect-less call.
+   */
+  databaseType?: DatabaseType;
   schemaContext?: string;
   capabilities?: import("@/lib/db/types").ProviderCapabilities;
 }
@@ -97,7 +107,10 @@ const getEditorOptions = (showLineNumbers: boolean) => ({
 });
 
 export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
-  ({ value, onChange, onContentChange, onExplain, language = "sql", schemaContext, capabilities }, ref) => {
+  (
+    { value, onChange, onContentChange, onExplain, language = "sql", databaseType, schemaContext, capabilities },
+    ref,
+  ) => {
     const monaco = useMonaco();
     const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
     const [hasSelection, setHasSelection] = useState(false);
@@ -261,28 +274,35 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
         }
       }
 
-      // 2. If no selection, try to find the current statement (between semicolons)
+      // 2. No selection: run the statement the cursor is in.
+      //
+      // Read through the shared splitter, under the connection's dialect. This used to be
+      // `lastIndexOf(";")` over the raw text - no spans, no dialect, not even a
+      // string-literal check - which made it the THIRD reader of "where does a statement
+      // end" and the only one whose answer is what gets SENT. Measured in Chrome on
+      // 2026-08-25 against postgres 18: a buffer PostgreSQL reads as one statement was
+      // cut at a `;` inside a nested comment, so what reached the engine was a line
+      // comment plus the SELECT, and the grid read 0 rows where psql answers 2. A `;`
+      // inside a literal (`SELECT 'a;b'`) cut the same way.
       if (language === "sql") {
         const position = editorRef.current.getPosition();
         if (position) {
           const fullText = model.getValue();
           const cursorOffset = model.getOffsetAt(position);
+          const statements = splitStatements(fullText, resolveSqlGrammar(databaseType));
+          // The statement the cursor is inside or immediately after, which is what "run
+          // this one" means with the caret resting at a statement's end. Whitespace
+          // between two statements belongs to neither, so the last one that starts at or
+          // before the cursor wins - and with the caret before the first statement, that
+          // first one does.
+          const current =
+            [...statements].reverse().find((statement) => statement.start <= cursorOffset) ?? statements[0];
 
-          // Find boundaries of the current statement
-          let startOffset = fullText.lastIndexOf(";", cursorOffset - 1);
-          let endOffset = fullText.indexOf(";", cursorOffset);
-
-          if (startOffset === -1) startOffset = 0;
-          else startOffset += 1; // skip the semicolon
-
-          if (endOffset === -1) endOffset = fullText.length;
-
-          const statement = fullText.substring(startOffset, endOffset).trim();
-          if (statement.length > 0) {
-            const startPos = model.getPositionAt(startOffset);
-            const endPos = model.getPositionAt(endOffset);
+          if (current) {
+            const startPos = model.getPositionAt(current.start);
+            const endPos = model.getPositionAt(current.end);
             const range = new monaco.Range(startPos.lineNumber, startPos.column, endPos.lineNumber, endPos.column);
-            return { query: statement, range };
+            return { query: current.sql, range };
           }
         }
       }

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -3,9 +3,10 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { ShieldAlert, ShieldCheck, TriangleAlert, LoaderCircle, Play, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { readsSqlText, resolveSqlGrammar } from "@/lib/sql/grammar";
+import { readsSqlText, resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
 import { hasUnterminatedSpan } from "@/lib/sql/spans";
+import { splitStatements } from "@/lib/sql/statement-splitter";
 import { findCodeWord } from "@/lib/sql/words";
 import type { DatabaseType } from "@/lib/types";
 
@@ -353,6 +354,27 @@ export function QuerySafetyDialog({
 const DANGEROUS_KEYWORDS = new Set(["DELETE", "DROP", "TRUNCATE", "ALTER", "GRANT", "REVOKE", "UPDATE"]);
 
 /**
+ * Whether ONE statement's own code asks for a confirmation, read under `grammar`.
+ *
+ * Its own function because the caller below asks the question twice over different
+ * text: the whole editor buffer, and then each fragment the multi-statement route
+ * will run. Re-deriving the two keyword tests per call site is how the gate and the
+ * runner drifted apart in the first place.
+ */
+function writesUnderGrammar(text: string, grammar: SqlGrammar): boolean {
+  const keyword = readOperativeKeyword(text, grammar)?.keyword;
+  if (keyword !== undefined && DANGEROUS_KEYWORDS.has(keyword)) return true;
+
+  // A write the statement's own keyword does not report: PostgreSQL's data-modifying
+  // CTE is OPERATED by its SELECT (`WITH x AS (UPDATE … SET …) SELECT * FROM x`), so
+  // this probe stays unanchored deliberately. It reads the statement's CODE rather
+  // than its text, so a read that merely quotes or comments the two words - which
+  // the pattern before it treated as a write - no longer asks for a confirmation.
+  const update = findCodeWord(text, "UPDATE", 0, grammar);
+  return update !== null && findCodeWord(text, "SET", update.end, grammar) !== null;
+}
+
+/**
  * Detect if a query is potentially dangerous and should trigger safety analysis.
  *
  * This gates the confirmation dialog on BOTH execution paths - `use-query-execution`
@@ -408,14 +430,25 @@ export function isDangerousQuery(query: string, databaseType?: DatabaseType): bo
   // run: narrowing this rule is not switching the gate off.
   if (readsSqlText(databaseType) && hasUnterminatedSpan(query, grammar)) return true;
 
-  const keyword = readOperativeKeyword(query, grammar)?.keyword;
-  if (keyword !== undefined && DANGEROUS_KEYWORDS.has(keyword)) return true;
+  if (writesUnderGrammar(query, grammar)) return true;
 
-  // A write the statement's own keyword does not report: PostgreSQL's data-modifying
-  // CTE is OPERATED by its SELECT (`WITH x AS (UPDATE … SET …) SELECT * FROM x`), so
-  // this probe stays unanchored deliberately. It reads the statement's CODE rather
-  // than its text, so a read that merely quotes or comments the two words - which
-  // the pattern before it treated as a write - no longer asks for a confirmation.
-  const update = findCodeWord(query, "UPDATE", 0, grammar);
-  return update !== null && findCodeWord(query, "SET", update.end, grammar) !== null;
+  /*
+    The editor text is not always what runs. A buffer holding more than one
+    statement takes `/api/db/multi-query`, which SPLITS it and runs the fragments
+    one by one, and this predicate read only the whole text - so a write in any
+    fragment but the first was invisible to it: the operative keyword of
+    `SELECT 1; DROP TABLE users` is SELECT.
+
+    Measured on MySQL, where the entry's shape is not even hypothetical:
+    `/* a /* b *\/ ; DROP TABLE s1.users; -- *\/ SELECT 1` really does drop the
+    table there (MySQL reads block comments flat), and the whole-text reading found
+    no operative keyword at all because the first code character is the `;`.
+
+    So the gate asks about exactly what the runner will run: the same splitter,
+    under the same grammar. Only for SQL text - the multi-statement route is a SQL
+    route and a `;` in a Mongo document or a Redis command separates nothing, so
+    splitting there could only invent fragments to prompt about (#427).
+  */
+  if (!readsSqlText(databaseType)) return false;
+  return splitStatements(query, grammar).some((statement) => writesUnderGrammar(statement.sql, grammar));
 }

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -595,6 +595,7 @@ export default function Studio() {
                                 : undefined
                             }
                             language={editorLanguageForTabType(tabMgr.currentTab.type)}
+                            databaseType={conn.activeConnection?.type}
                             schemaContext={conn.schemaContext}
                             capabilities={metadata?.capabilities}
                           />

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -29,16 +29,37 @@ import {
   Database,
   ShieldAlert,
   LoaderCircle,
+  Wrench,
+  ShieldCheck,
   CircleCheck,
   CircleX,
   Table2,
+  type LucideIcon,
 } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useMonitoringData } from "@/hooks/use-monitoring-data";
 import { storage } from "@/lib/storage";
 import { useAllConnections } from "@/hooks/use-all-connections";
-import type { ActiveSessionDetails, MaintenanceType } from "@/lib/db/types";
+import { maintenanceControl, type ActiveSessionDetails, type MaintenanceType } from "@/lib/db/types";
 import { useProviderMetadata } from "@/hooks/use-provider-metadata";
+
+/**
+ * The per-row maintenance controls this tab can render, in display order, with the
+ * generic verb each one falls back to where the provider declares no
+ * `maintenanceOperationSpecs`.
+ *
+ * `optimize` and `check` are candidates because five providers declare those
+ * operations and no per-row control anywhere offered them; each is filtered out again
+ * wherever the provider says its statement takes no object (SQL Server's
+ * `DBCC CHECKDB`, SQLite's `VACUUM`) - see `maintenanceControl` (#U9).
+ */
+const TABLE_ACTIONS: { type: MaintenanceType; label: string; Icon: LucideIcon; hover: string }[] = [
+  { type: "analyze", label: "Analyze", Icon: Search, hover: "hover:text-yellow-500" },
+  { type: "vacuum", label: "Vacuum", Icon: HardDrive, hover: "hover:text-blue-500" },
+  { type: "optimize", label: "Optimize", Icon: Wrench, hover: "hover:text-blue-500" },
+  { type: "reindex", label: "Reindex", Icon: RefreshCw, hover: "hover:text-purple-500" },
+  { type: "check", label: "Check", Icon: ShieldCheck, hover: "hover:text-green-500" },
+];
 
 interface OperationLogEntry {
   id: string;
@@ -104,21 +125,44 @@ export function OperationsTab() {
     selectedConnection,
     monitoringOptions,
   );
-  const canRun = (type: MaintenanceType) =>
-    metadata?.capabilities.supportsMaintenance === true && metadata.capabilities.maintenanceOperations.includes(type);
-  const anyMaintenance = canRun("analyze") || canRun("vacuum") || canRun("reindex");
+  // Both maintenance surfaces ask ONE question - `maintenanceControl` in
+  // src/lib/db/types.ts - so that neither can offer a control the other's engine
+  // rejects. `capabilities` may be undefined here (provider-meta in flight, or its
+  // request failed), which that helper reads as a denial.
+  const capabilities = metadata?.capabilities;
+  const offers = (type: MaintenanceType, placement: "perEntity" | "global") =>
+    maintenanceControl(capabilities, type, placement).offered;
   // The six analyze/vacuum global ProviderLabels fields were declared, set by
   // seven providers, and read by no component, so every engine rendered
   // Postgres's query-planner copy (#427).
   //
-  // Which card each provider's wording actually reaches follows from the gates
-  // below, not from the labels: the analyze card renders for every provider that
-  // declares `analyze`, so Redis now says "Server Info" and MongoDB "Validate
-  // Collections"; the GLOBAL vacuum card is gated on the literal `vacuum`, which
-  // among the providers that ship vacuum wording only MongoDB declares.
+  // Which card each provider's wording reaches follows from the gates below, not from
+  // the labels: the analyze card renders wherever `analyze` has a whole-database form,
+  // so Redis says "Server Info" and MongoDB "Validate Collections", while the vacuum
+  // card follows `vacuumActionOperation` and now reaches SQL Server's, Oracle's and
+  // MySQL's own wording too.
   //
   // The `??` fallbacks stay: `metadata` may carry capabilities without labels.
   const labels = metadata?.labels;
+  // The vacuum CARD is the provider's vacuum wording, and four engines point that
+  // wording at an operation that is not `vacuum` (`vacuumActionOperation`, #U9). It is
+  // the operation - not the label - that decides whether the card renders and what the
+  // button sends: gating the card on the literal `vacuum` is what kept SQL Server's,
+  // Oracle's, MySQL's and ClickHouse's own words written and never shown, and sending
+  // `vacuum` to any of those four is a 400 from /api/db/maintenance.
+  const vacuumOperation = labels?.vacuumActionOperation ?? "vacuum";
+  const globalAnalyze = offers("analyze", "global");
+  const globalVacuum = offers(vacuumOperation, "global");
+  // Never twice: where the vacuum slot already names `reindex`, this card would send
+  // the same operation under a second set of words.
+  const globalReindex = vacuumOperation !== "reindex" && offers("reindex", "global");
+  const anyMaintenance = globalAnalyze || globalVacuum || globalReindex;
+
+  // The per-row controls, in the provider's own words.
+  const tableActions = TABLE_ACTIONS.flatMap((action) => {
+    const control = maintenanceControl(capabilities, action.type, "perEntity");
+    return control.offered ? [{ ...action, label: control.label ?? action.label }] : [];
+  });
 
   const handleConnectionChange = (id: string) => {
     const conn = connections.find((c) => c.id === id);
@@ -279,7 +323,10 @@ export function OperationsTab() {
         <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-4 text-red-400 text-sm">{error}</div>
       )}
 
-      {/* Global Operations — hidden entirely where the provider declares none */}
+      {/* Global Operations — hidden entirely where not one operation has a
+          whole-database form. On Couchbase every operation needs a keyspace, so this
+          section is absent rather than three cards that answer "requires a
+          target" (#U9). */}
       {anyMaintenance && (
         <div>
           <div className="flex items-center gap-2 mb-3">
@@ -288,7 +335,7 @@ export function OperationsTab() {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             {/* Analyze */}
-            {canRun("analyze") && (
+            {globalAnalyze && (
               <div className="p-4 rounded-xl border border-hairline bg-fill-subtle hover:bg-fill transition-colors">
                 <div className="flex items-start justify-between mb-3">
                   <div className="w-8 h-8 rounded-lg bg-yellow-500/10 border border-yellow-500/20 flex items-center justify-center">
@@ -313,7 +360,7 @@ export function OperationsTab() {
             )}
 
             {/* Vacuum */}
-            {canRun("vacuum") && (
+            {globalVacuum && (
               <div className="p-4 rounded-xl border border-hairline bg-fill-subtle hover:bg-fill transition-colors">
                 <div className="flex items-start justify-between mb-3">
                   <div className="w-8 h-8 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-center">
@@ -323,10 +370,12 @@ export function OperationsTab() {
                     size="sm"
                     variant="outline"
                     className="h-7 text-xs border-hairline-strong hover:bg-blue-500/10 hover:text-blue-500"
-                    onClick={() => handleRunMaintenance("vacuum")}
+                    onClick={() => handleRunMaintenance(vacuumOperation)}
                     disabled={!!actionLoading || !selectedConnection}
                   >
-                    {actionLoading === "vacuum-global" ? <RefreshCw className="w-3 h-3 animate-spin mr-1" /> : null}
+                    {actionLoading === `${vacuumOperation}-global` ? (
+                      <RefreshCw className="w-3 h-3 animate-spin mr-1" />
+                    ) : null}
                     {labels?.vacuumGlobalLabel ?? "Run Vacuum"}
                   </Button>
                 </div>
@@ -339,8 +388,10 @@ export function OperationsTab() {
 
             {/* Reindex — the triad is OPTIONAL on ProviderLabels (only the three
                 providers that declare the `reindex` operation set it), so the
-                hardcoded strings below stay as the fallback (#U6). */}
-            {canRun("reindex") && (
+                hardcoded strings below stay as the fallback (#U6). Withheld where the
+                vacuum slot above already names `reindex`: one operation, two sets of
+                words, is a second card that does the same thing (#U9). */}
+            {globalReindex && (
               <div className="p-4 rounded-xl border border-hairline bg-fill-subtle hover:bg-fill transition-colors">
                 <div className="flex items-start justify-between mb-3">
                   <div className="w-8 h-8 rounded-lg bg-purple-500/10 border border-purple-500/20 flex items-center justify-center">
@@ -437,38 +488,23 @@ export function OperationsTab() {
                         </div>
                       </div>
                       <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                        {canRun("analyze") && (
+                        {tableActions.map(({ type, label, Icon, hover }) => (
                           <Button
+                            key={type}
                             size="icon"
                             variant="ghost"
-                            className="w-7 h-7 text-fg-muted hover:text-yellow-500"
-                            title="Analyze"
-                            onClick={() => handleRunMaintenance("analyze", table.tableName)}
+                            className={`w-7 h-7 text-fg-muted ${hover}`}
+                            title={label}
+                            onClick={() => handleRunMaintenance(type, table.tableName)}
                             disabled={!!actionLoading}
                           >
-                            {actionLoading === `analyze-${table.tableName}` ? (
+                            {actionLoading === `${type}-${table.tableName}` ? (
                               <LoaderCircle className="w-3 h-3 animate-spin" />
                             ) : (
-                              <Search className="w-3 h-3" />
+                              <Icon className="w-3 h-3" />
                             )}
                           </Button>
-                        )}
-                        {canRun("vacuum") && (
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="w-7 h-7 text-fg-muted hover:text-blue-500"
-                            title="Vacuum"
-                            onClick={() => handleRunMaintenance("vacuum", table.tableName)}
-                            disabled={!!actionLoading}
-                          >
-                            {actionLoading === `vacuum-${table.tableName}` ? (
-                              <LoaderCircle className="w-3 h-3 animate-spin" />
-                            ) : (
-                              <HardDrive className="w-3 h-3" />
-                            )}
-                          </Button>
-                        )}
+                        ))}
                       </div>
                     </div>
                   ))}

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -1,14 +1,29 @@
 "use client";
 
 import React, { useState } from "react";
-import { Table2, Search, TriangleAlert, LoaderCircle, RefreshCw, Zap, type LucideIcon } from "lucide-react";
+import {
+  Table2,
+  Search,
+  TriangleAlert,
+  LoaderCircle,
+  RefreshCw,
+  Zap,
+  Wrench,
+  ShieldCheck,
+  type LucideIcon,
+} from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import type { MaintenanceType, MonitoringData, ProviderCapabilities } from "@/lib/db/types";
+import {
+  maintenanceControl,
+  type MaintenanceType,
+  type MonitoringData,
+  type ProviderCapabilities,
+} from "@/lib/db/types";
 import { PanelUnavailable } from "../PanelUnavailable";
 
 /**
@@ -16,11 +31,22 @@ import { PanelUnavailable } from "../PanelUnavailable";
  * `MaintenanceType` vocabulary a provider declares in `maintenanceOperations`
  * rather than to a loose string — a typo would then be a type error instead of
  * a silently missing control.
+ *
+ * `label` is only the fallback for a provider that declares no
+ * `maintenanceOperationSpecs`: where one exists, `maintenanceControl()` replaces the
+ * generic verb with the engine's own name for it, so MySQL titles its buttons
+ * "Optimize Table" and "Check Table" rather than borrowing PostgreSQL's vocabulary.
+ * `optimize` and `check` are candidates at all because the operations exist on five
+ * providers and had no per-table control anywhere; the ones whose statement takes no
+ * object (SQL Server's `DBCC CHECKDB`, SQLite's `PRAGMA integrity_check`) declare
+ * `perEntity: false` and are filtered out here (#U9).
  */
 const MAINTENANCE_ACTIONS: { type: MaintenanceType; label: string; Icon: LucideIcon; className: string }[] = [
   { type: "analyze", label: "Analyze", Icon: Search, className: "h-6 w-6 sm:h-8 sm:w-8" },
   { type: "vacuum", label: "Vacuum", Icon: RefreshCw, className: "h-6 w-6 sm:h-8 sm:w-8" },
+  { type: "optimize", label: "Optimize", Icon: Wrench, className: "h-6 w-6 sm:h-8 sm:w-8" },
   { type: "reindex", label: "Reindex", Icon: Zap, className: "h-6 w-6 sm:h-8 sm:w-8 hidden sm:inline-flex" },
+  { type: "check", label: "Check", Icon: ShieldCheck, className: "h-6 w-6 sm:h-8 sm:w-8 hidden sm:inline-flex" },
 ];
 
 /**
@@ -172,11 +198,16 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
     setActionLoading(null);
   };
 
-  // Offer only the maintenance a provider declares it can perform: /api/db/maintenance
-  // rejects everything else with 400, so an ungated button can only produce an error.
-  const availableActions = capabilities?.supportsMaintenance
-    ? MAINTENANCE_ACTIONS.filter((action) => capabilities.maintenanceOperations.includes(action.type))
-    : [];
+  // Offer only the maintenance a provider declares it can perform HERE: /api/db/maintenance
+  // rejects an undeclared operation with 400, and a declared one whose target is not a table
+  // rejects the table name the button sends — SQLite's VACUUM ignores it and rewrote the whole
+  // database from a control that named one table, Oracle's index rebuild answered ORA-01418
+  // for every table name there is. `maintenanceControl` reads the provider's own
+  // `perEntity` declaration for each, and hands back the engine's own wording with it (#U9).
+  const availableActions = MAINTENANCE_ACTIONS.flatMap((action) => {
+    const control = maintenanceControl(capabilities, action.type, "perEntity");
+    return control.offered ? [{ ...action, label: control.label ?? action.label }] : [];
+  });
 
   return (
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">

--- a/src/components/schema-explorer/TableItem.tsx
+++ b/src/components/schema-explorer/TableItem.tsx
@@ -15,6 +15,7 @@ import {
   WandSparkles,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { maintenanceControl } from "@/lib/db/types";
 import { cn } from "@/lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -90,6 +91,20 @@ function renderMenuItems({
   // "ordinary objects", matching the flag's own docblock.
   const rowsAreAddressable = capabilities?.tablesAreDerivedGroupings !== true;
 
+  // The SAME question the monitoring Tables tab and the admin Operations tab ask, so
+  // that three surfaces cannot disagree about what a provider declared (#U9). Gating
+  // on `supportsMaintenance` alone is what put "Vacuum Table" on ONE SQLite table
+  // while the Tables tab correctly withheld it - SQLite's VACUUM takes no target, and
+  // the page this item deep-links to therefore has no such control. Unknown
+  // capabilities read as a denial here too: `/api/db/provider-meta` answers with
+  // nothing both while it is in flight and when it failed.
+  //
+  // The vacuum item follows `vacuumActionOperation`, not the literal `vacuum`: four
+  // providers point that wording at an operation that is not a vacuum, and it is the
+  // operation - not the label - whose targeting decides whether a table can be named.
+  const analyzeControl = maintenanceControl(capabilities, "analyze", "perEntity");
+  const vacuumControl = maintenanceControl(capabilities, labels?.vacuumActionOperation ?? "vacuum", "perEntity");
+
   return (
     <>
       <Item onClick={() => callbacks.onTableClick?.(table.name)}>
@@ -128,26 +143,33 @@ function renderMenuItems({
           and for a derived grouping there is no such object to name — which is exactly
           the dead end #427 reported for Redis "Key Info".
 
-          The second half of the condition is the same dead end reached the other way,
-          measured in the browser on 2026-08-19 against Elasticsearch 9.1.4: an index IS
-          addressable, so both items rendered on an engine that declares
-          `supportsMaintenance: false`, and the page they open gates its Global
-          Operations card on that same capability — so clicking "Merge Segments" landed
-          on a page with no maintenance controls, no error and no explanation.
+          The rest of the condition is the same dead end reached the other way, and the
+          #427 gate reached only its first case. Measured in the browser on 2026-08-19
+          against Elasticsearch 9.1.4: an index IS addressable, so both items rendered
+          on an engine that declares `supportsMaintenance: false`, and the page they
+          open gates its Global Operations card on that same capability — so clicking
+          "Merge Segments" landed on a page with no maintenance controls, no error and
+          no explanation. `maintenanceControl` above closes the rest of it: an engine
+          that declares the operation but not for a single table (SQLite's VACUUM) is
+          the same dead end with the capability flag switched on (#U9).
 
           Global maintenance is unaffected wherever an engine has any: it lives on the
           admin Operations page and still runs there. */}
-      {isAdmin && rowsAreAddressable && capabilities?.supportsMaintenance !== false && (
+      {isAdmin && rowsAreAddressable && (analyzeControl.offered || vacuumControl.offered) && (
         <>
           <Separator />
-          <Item onClick={() => callbacks.onOpenMaintenance?.("tables", table.name)}>
-            <Search strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-amber-500" />
-            {labels?.analyzeAction || "Analyze Table"}
-          </Item>
-          <Item onClick={() => callbacks.onOpenMaintenance?.("tables", table.name)}>
-            <Trash2 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-blue-400" />
-            {labels?.vacuumAction || "Vacuum Table"}
-          </Item>
+          {analyzeControl.offered && (
+            <Item onClick={() => callbacks.onOpenMaintenance?.("tables", table.name)}>
+              <Search strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-amber-500" />
+              {analyzeControl.label ?? labels?.analyzeAction ?? "Analyze Table"}
+            </Item>
+          )}
+          {vacuumControl.offered && (
+            <Item onClick={() => callbacks.onOpenMaintenance?.("tables", table.name)}>
+              <Trash2 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-blue-400" />
+              {vacuumControl.label ?? labels?.vacuumAction ?? "Vacuum Table"}
+            </Item>
+          )}
         </>
       )}
     </>

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -24,4 +24,4 @@ export type {
 } from "../lib/types";
 
 // Also export provider types
-export type { ProviderCapabilities, ProviderLabels } from "../lib/db/types";
+export type { ProviderCapabilities, ProviderLabels, MaintenanceOperationSpec } from "../lib/db/types";

--- a/src/hooks/use-monitoring-data.ts
+++ b/src/hooks/use-monitoring-data.ts
@@ -270,6 +270,23 @@ export function useMonitoringData(
           throw new Error(result.error || `Failed to run ${type}`);
         }
 
+        // A 200 says the statement reached the engine, not that the engine did the work:
+        // `MaintenanceResult.success` is the engine's own verdict, and reading only the
+        // status code turned every refusal into a green tick. Measured through the real
+        // MySQL provider on 2026-08-25, OPTIMIZE on a table that is not there answers 200
+        // with `{success:false, message:"OPTIMIZE failed: ... doesn't exist"}` - and
+        // `OperationsTab` writes this boolean straight into its operation log, so the
+        // whole surface recorded a completed operation. A provider that reports no verdict
+        // keeps the old reading: only an explicit `false` is a refusal.
+        if (result.success === false) {
+          toast.error(result.message || `${type} failed`);
+          // Refreshed anyway: a refused operation can still have moved part of the state
+          // it was asked about (Oracle rebuilds index by index), so the panels must not
+          // keep showing what was true before the attempt.
+          await fetchData();
+          return false;
+        }
+
         toast.success(result.message || `${type} completed successfully`);
 
         // Refresh data after maintenance

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -8,6 +8,7 @@ import { useToast } from "@/hooks/use-toast";
 import { storage } from "@/lib/storage";
 import { isDangerousQuery } from "@/components/QuerySafetyDialog";
 import { isMultiStatement } from "@/lib/sql/statement-splitter";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { DEFAULT_QUERY_LIMIT } from "@/lib/db/utils/query-limiter";
 import { shouldRefreshSchema } from "@/lib/query-generators";
 import { ApiErrorCode } from "@/lib/api/error-codes";
@@ -322,7 +323,11 @@ export function useQueryExecution({
           !isPlaygroundRun &&
           !params &&
           dialectIsSql &&
-          isMultiStatement(queryToExecute);
+          // Under the connection's own dialect, the same record the gate above
+          // reads the statement with: whether a `;` is code depends on the
+          // engine's comment, quoting and bracket rules, and a fragment this
+          // disagrees about is a fragment the route RUNS (S1).
+          isMultiStatement(queryToExecute, resolveSqlGrammar(activeConnection.type));
 
         // Use transaction endpoint if a transaction is active or in playground mode
         const useTransaction = (transactionActive || isPlaygroundRun) && !isExplain;

--- a/src/lib/agent/plan-draft.ts
+++ b/src/lib/agent/plan-draft.ts
@@ -19,6 +19,7 @@
  * end run in a real browser caught it again.
  */
 
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { splitStatements } from "@/lib/sql/statement-splitter";
 import { fenceTagEngine, isQueryFenceTag } from "@/lib/sql/fence-tags";
 import type { DatabaseType } from "@/lib/types";
@@ -250,7 +251,7 @@ export function readPlanStatement(text: string, dialect?: DatabaseType): PlanSta
   // only AFTER the fenced and refusal paths, which keeps every existing precedence
   // untouched: a fenced block still wins among several, and a refusal still wins over an
   // illustration the run declined to stand behind.
-  const unfenced = unfencedStatement(plain);
+  const unfenced = unfencedStatement(plain, dialect);
   return unfenced === null ? { kind: "absent" } : { kind: "statement", sql: unfenced, tag: undefined };
 }
 
@@ -274,6 +275,15 @@ export function readPlanStatement(text: string, dialect?: DatabaseType): PlanSta
  * tracks string literals, comments and dollar-quoting, so `SELECT 'a;b' AS pair;` is one
  * statement and not two. Whitespace knows none of that.
  *
+ * Under THIS CONNECTION'S dialect, which this reader already holds and used to pass only
+ * to `fencedBlock`. Where a statement ends is exactly the question `grammar.ts` answers
+ * per engine, and the answers differ on shipped ones: `//` is a line comment in CQL and
+ * ClickHouse and an operator name or a syntax error everywhere else, so a draft whose
+ * comment carried a `;` was cut at that `;` and the run recorded HALF its statement -
+ * scored as a shortfall against a model that wrote a good one. The grammar record is a
+ * pure lookup over a frozen table, so it costs this file's browser boundary nothing;
+ * `plan-draft-boundary.test.ts` checks that rather than trusting it.
+ *
  * With NO terminator the splitter has nothing to cut on and returns the whole candidate, so
  * the blank line remains the only signal — a model that omits the semicolon and explains
  * itself on the next line still gets its prose through. Narrower, undemonstrated on a real
@@ -283,7 +293,7 @@ export function readPlanStatement(text: string, dialect?: DatabaseType): PlanSta
  * engine, and the recorder stamps the connection's own dialect the way it does for an
  * untagged fence.
  */
-function unfencedStatement(lines: readonly string[]): string | null {
+function unfencedStatement(lines: readonly string[], dialect: DatabaseType | undefined): string | null {
   const start = lines.findIndex((line) => STATEMENT_OPENER.test(line));
   if (start === -1) return null;
   const body: string[] = [];
@@ -302,7 +312,7 @@ function unfencedStatement(lines: readonly string[]): string | null {
     A second statement on the SAME line has no line to cut at, so the splitter's text is the only
     answer left there; it costs that rare draft its semicolon and nothing else.
   */
-  const [first, second] = splitStatements(candidate);
+  const [first, second] = splitStatements(candidate, resolveSqlGrammar(dialect));
   const sql =
     second === undefined
       ? candidate

--- a/src/lib/db/providers/document/couchbase/index.ts
+++ b/src/lib/db/providers/document/couchbase/index.ts
@@ -323,6 +323,19 @@ export class CouchbaseProvider extends BaseDatabaseProvider {
       declaresForeignKeys: false,
       supportsMaintenance: true,
       maintenanceOperations: ["analyze", "reindex", "kill"],
+      // All three of `dispatchMaintenance`'s cases go through `requireTarget`, so
+      // every whole-bucket control here answered *"The reindex operation requires a
+      // target"* rather than running anything (#U9). `UPDATE STATISTICS FOR
+      // <keyspace>` and `BUILD INDEX ON <keyspace>` both name ONE collection, which
+      // the collection rows can supply; there is no "every keyspace in the bucket"
+      // form of either statement, so the global cards are withheld instead of
+      // synthesised from a keyspace list this provider does not enumerate for
+      // maintenance.
+      maintenanceOperationSpecs: {
+        analyze: { label: "Update Statistics", perEntity: true, global: false },
+        reindex: { label: "Build Deferred Indexes", perEntity: true, global: false },
+        kill: { label: "Cancel Request", perEntity: false, global: false },
+      },
       supportsConnectionString: true,
       defaultPort: 8091,
       schemaRefreshPattern: "\\b(CREATE|DROP|ALTER)\\s+(COLLECTION|SCOPE|INDEX)\\b",

--- a/src/lib/db/providers/document/mongodb.ts
+++ b/src/lib/db/providers/document/mongodb.ts
@@ -177,6 +177,15 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       declaresForeignKeys: false,
       supportsMaintenance: true,
       maintenanceOperations: ["vacuum", "analyze", "check"],
+      // `validate` and `compact` are both per-collection commands that this provider
+      // also loops over `listCollections()` when no target is named, so both
+      // placements are real. `dbCheck` is not looped and refuses to run without a
+      // collection name, so it is offered on a collection row only (#U9).
+      maintenanceOperationSpecs: {
+        vacuum: { label: "Compact Collection", perEntity: true, global: true },
+        analyze: { label: "Validate Collection", perEntity: true, global: true },
+        check: { label: "Check Collection", perEntity: true, global: false },
+      },
       supportsConnectionString: true,
       defaultPort: 27017,
       schemaRefreshPattern: '"operation"\\s*:\\s*"(insert|delete|update)',

--- a/src/lib/db/providers/keyvalue/redis.ts
+++ b/src/lib/db/providers/keyvalue/redis.ts
@@ -81,6 +81,13 @@ export class RedisProvider extends BaseDatabaseProvider {
       tablesAreDerivedGroupings: true,
       supportsMaintenance: true,
       maintenanceOperations: ["analyze"],
+      // `runMaintenance(type)` takes no target parameter at all: the operation is
+      // `INFO`, which reports on the server and cannot be pointed at a key pattern.
+      // A per-row control here would have named one grouping and answered with
+      // server-wide metrics - the dead end #427 reported for "Key Info" (#U9).
+      maintenanceOperationSpecs: {
+        analyze: { label: "Server Info", perEntity: false, global: true },
+      },
       supportsConnectionString: false,
       defaultPort: 6379,
       schemaRefreshPattern: "(DEL|FLUSHDB|FLUSHALL|RENAME)\\b",

--- a/src/lib/db/providers/sql/cassandra/index.ts
+++ b/src/lib/db/providers/sql/cassandra/index.ts
@@ -25,11 +25,13 @@
  * - `ALLOW FILTERING` IS THE LAST CLAUSE. `… LIMIT 3 ALLOW FILTERING` returns rows;
  *   `… ALLOW FILTERING LIMIT 3` is a syntax error. The shared limiter appends, so the
  *   two clauses are transposed.
- * - A LINE COMMENT NEEDS A NEWLINE TO CLOSE IT, and CQL has a third comment form the
- *   shared readers do not know. `SELECT … LIMIT 3 -- note` with nothing after it is
- *   "line 1:45 mismatched character '<EOF>' expecting set null", and `-- note\n`
- *   returns rows; `//` is a line comment too. The limiter trims the newline, so a
- *   statement that would end inside a comment is left alone.
+ * - A LINE COMMENT NEEDS A NEWLINE TO CLOSE IT. `SELECT … LIMIT 3 -- note` with
+ *   nothing after it is "line 1:45 mismatched character '<EOF>' expecting set null",
+ *   and `-- note\n` returns rows. `sql.trim()` inside the shared limiter drops that
+ *   newline, so a statement that would end inside a comment is left alone here. CQL's
+ *   THIRD comment form, `//`, used to be part of this trap and no longer is: it is a
+ *   grammar fact (`doubleSlashComment`) that every shared reader now honours, so this
+ *   file no longer scans for it - see `endsInsideLineComment`.
  * - THERE IS NO EXPLAIN. `EXPLAIN SELECT …` is "line 1:0 no viable alternative at
  *   input 'EXPLAIN'". The only substitute is `{traceQuery: true}` plus
  *   `system_traces.events`, which profiles a statement that has ALREADY RUN - so it
@@ -123,15 +125,30 @@ const APPENDED_AFTER_ALLOW_FILTERING = /\bALLOW(\s+)FILTERING\s+(LIMIT\s+\d+)/i;
 /**
  * Whether this text ends INSIDE a line comment - i.e. whether CQL would refuse it.
  *
- * Two comment forms, and the second is why this cannot be left to the shared readers:
- * CQL treats `//` as a line comment as well as `--`, and neither may be closed by end
- * of input. Measured on 5.0.9, `SELECT * FROM probe.customers LIMIT 3 -- note` with
- * nothing after it is a syntax error while the same text plus a newline returns the
- * rows.
+ * CQL needs TWO facts about comments that most dialects here do not, and only one of
+ * them is still local to this provider. `//` being a line comment as well as `--` IS
+ * a grammar fact - and not this engine's alone, since ClickHouse reads it the same way
+ * (both measured) - so it is `grammar.ts`'s `doubleSlashComment` now and this function
+ * no longer carries a private scan for it: it asks the shared span reader, which reads
+ * both forms under the `cassandra` grammar. The fact that stays local is the other -
+ * that NEITHER form may be closed by end of input. Measured on 5.0.9,
+ * `SELECT * FROM probe.customers LIMIT 3 -- note` with nothing after it is "line 1:45
+ * mismatched character '<EOF>' expecting set null" while the same text plus a newline
+ * returns the rows. That is a fact about where a statement may END, not about what a
+ * run is: `SqlSpan` calls a line comment closed by end of input terminated, which is
+ * correct everywhere else and is the answer every reader over it wants.
  *
- * It walks with the shared span reader so a `--` or `//` inside a string literal or a
- * quoted name is not mistaken for one - `WHERE url = 'http://x'` is an ordinary
- * statement - and so the walk stays linear rather than backtracking.
+ * The private scan was not merely redundant, and dropping it is why this is a fix
+ * rather than a tidy-up: while `//` was invisible to the shared readers, the row
+ * limiter appended the bound INSIDE the comment on this engine and on ClickHouse
+ * (measured there: `SELECT number FROM numbers(1000) // note` limited to 5 was
+ * emitted as `… // note LIMIT 5` and returned 1000 rows while reporting
+ * `wasLimited: true`), and the statement splitter cut a bare DROP out of one CQL read.
+ *
+ * Walking with the shared reader is also what keeps a `--` or `//` inside a string
+ * literal or a quoted name from being mistaken for a comment - `WHERE url =
+ * 'http://x'` is an ordinary statement - and keeps the walk linear rather than
+ * backtracking.
  */
 function endsInsideLineComment(sql: string, grammar: SqlGrammar): boolean {
   let open = false;
@@ -139,17 +156,10 @@ function endsInsideLineComment(sql: string, grammar: SqlGrammar): boolean {
   for (let at = 0; at < sql.length; ) {
     const span = readSqlSpan(sql, at, grammar);
     if (span !== null) {
-      // A `--` run the shared reader recognises. It is only UNCLOSED if it reaches
-      // the end of the text with no newline to close it.
+      // Either comment form, whichever the grammar recognised. It is only UNCLOSED if
+      // it reaches the end of the text with no newline to close it.
       open = span.kind === "line-comment" && span.end === sql.length && !sql.endsWith("\n");
       at = span.end;
-      continue;
-    }
-
-    if (sql[at] === "/" && sql[at + 1] === "/") {
-      const newline = sql.indexOf("\n", at);
-      open = newline === -1;
-      at = newline === -1 ? sql.length : newline + 1;
       continue;
     }
 

--- a/src/lib/db/providers/sql/clickhouse/index.ts
+++ b/src/lib/db/providers/sql/clickhouse/index.ts
@@ -529,6 +529,16 @@ export class ClickHouseProvider extends SQLBaseProvider {
       declaresForeignKeys: false,
       supportsMaintenance: true,
       maintenanceOperations: ["optimize", "analyze", "kill"],
+      // `OPTIMIZE TABLE ... FINAL` names ONE table and `dispatchMaintenance` requires
+      // that target, so the whole-database form is withheld: ClickHouse has no
+      // "optimize database", and looping every table would merge the entire dataset
+      // behind one click (#U9). `describeParts` deliberately accepts no target as
+      // well as one, which is why analyze is offered in both placements.
+      maintenanceOperationSpecs: {
+        optimize: { label: "Optimize Table", perEntity: true, global: false },
+        analyze: { label: "Table Statistics", perEntity: true, global: true },
+        kill: { label: "Cancel Query", perEntity: false, global: false },
+      },
       supportsConnectionString: true,
       defaultPort: 8123,
       schemaRefreshPattern: "\\b(CREATE|DROP|ALTER|RENAME|TRUNCATE|ATTACH|DETACH)\\b",
@@ -545,10 +555,23 @@ export class ClickHouseProvider extends SQLBaseProvider {
       ...super.getLabels(),
       analyzeAction: "Table Statistics",
       vacuumAction: "Optimize Table",
+      // The vacuum slot names `optimize`, not a vacuum ClickHouse does not have. The
+      // global card stays withheld even so - `optimize` declares `global: false`
+      // above, because OPTIMIZE names one table - and this is what stops the surface
+      // reading the slot as a `vacuum` this provider rejects (#U9).
+      vacuumActionOperation: "optimize",
       analyzeGlobalLabel: "Table Statistics",
       analyzeGlobalTitle: "Table Statistics",
       analyzeGlobalDesc:
         "ClickHouse has no ANALYZE: a MergeTree's statistics are its parts and are always current, so this reports them rather than computing anything.",
+      // DELIBERATELY UNREACHABLE, and kept as the honest thing to inherit rather than
+      // PostgreSQL's "Removes dead rows and returns space to the operating system",
+      // which describes a statement ClickHouse does not have. The global vacuum card
+      // is the `vacuumActionOperation` above, and `optimize` declares `global: false`,
+      // so no surface can render these three - asserted in
+      // tests/integration/db/clickhouse-provider.test.ts rather than left as a claim.
+      // ProviderLabels requires all three, so "drop them" is not available; what U9
+      // removed was wording that was written and never shown WITHOUT saying so.
       vacuumGlobalLabel: "Optimize",
       vacuumGlobalTitle: "Merge Parts",
       vacuumGlobalDesc:

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -413,6 +413,17 @@ export class MSSQLProvider extends SQLBaseProvider {
       // The mssql package's Transaction object over one held pool connection.
       supportsTransactions: true,
       maintenanceOperations: ["analyze", "check", "optimize", "kill"],
+      // `optimize` is `ALTER INDEX ALL ON [<t>] REBUILD`, so its target is a TABLE
+      // even though the wording says indexes - the same words Oracle uses for an
+      // operation that needed a different kind of name (#U9). `check` is
+      // `DBCC CHECKDB`, which takes no object: `runMaintenance` ignores the target,
+      // so only a global control can honestly offer it.
+      maintenanceOperationSpecs: {
+        analyze: { label: "Update Statistics", perEntity: true, global: true },
+        check: { label: "Check Database", perEntity: false, global: true },
+        optimize: { label: "Rebuild Indexes", perEntity: true, global: true },
+        kill: { label: "Kill Session", perEntity: false, global: false },
+      },
     };
   }
 
@@ -421,6 +432,10 @@ export class MSSQLProvider extends SQLBaseProvider {
       ...super.getLabels(),
       analyzeAction: "Update Statistics",
       vacuumAction: "Rebuild Indexes",
+      // The vacuum slot has said "Rebuild Indexes" since this provider shipped, and
+      // that is `optimize`, not `vacuum` - so the global card gated on the literal
+      // `vacuum` never rendered these words at all (#U9).
+      vacuumActionOperation: "optimize",
       analyzeGlobalLabel: "Update Stats",
       analyzeGlobalTitle: "Update Statistics",
       analyzeGlobalDesc: "Updates query optimizer statistics for all tables to improve query performance.",

--- a/src/lib/db/providers/sql/mysql.ts
+++ b/src/lib/db/providers/sql/mysql.ts
@@ -105,6 +105,67 @@ const runStatement = <T extends RowDataPacket[] = RowDataPacket[]>(
     ? queryable.query<T>(sql)
     : queryable.execute<T>(sql, asExecuteParams(params));
 
+/**
+ * One row of MySQL's answer to `ANALYZE`/`OPTIMIZE`/`CHECK TABLE`. These statements
+ * return a RESULT SET, not a header: the outcome is data, and reading it is the only
+ * way to know what happened.
+ */
+interface MaintenanceReportRow extends RowDataPacket {
+  Table: string;
+  Op: string;
+  Msg_type: string;
+  Msg_text: string;
+}
+
+/**
+ * MySQL's verdict on a table maintenance statement, taken from the statement's own
+ * answer.
+ *
+ * The statement does NOT throw when the server refuses it: measured through this
+ * provider against MySQL 26.7.0 (`libredb-mysql`) on 2026-08-25, `OPTIMIZE TABLE
+ * \`missing\`` resolves normally and answers
+ *
+ *   [{ Table: 'u9t.missing', Op: 'optimize', Msg_type: 'Error',
+ *      Msg_text: "Table 'u9t.missing' doesn't exist" },
+ *    { Table: 'u9t.missing', Op: 'optimize', Msg_type: 'status',
+ *      Msg_text: 'Operation failed' }]
+ *
+ * so `await runStatement(...); return { success: true }` reported a completed
+ * operation for a statement the server had rejected - and discarded the `Msg_text`
+ * that is the entire point of `CHECK TABLE`, whose OK-or-corruption-report is the only
+ * thing the user asked for. `Msg_type` is the decision (`'Error'` from the server,
+ * matched case-insensitively because the manual documents the set in lower case), and
+ * the same read is what SQLite's `check` already does with `PRAGMA integrity_check`.
+ *
+ * The whole-database form names every table in one statement, so a failing table is
+ * quoted WITH its name - it is the only place the failure appears - while a successful
+ * run quotes the messages alone and deduplicates them: over forty tables the OK and
+ * InnoDB's "doing recreate + analyze instead" note repeat once per table and say the
+ * same thing forty times.
+ */
+function readMaintenanceReport(
+  type: MaintenanceType,
+  rows: MaintenanceReportRow[],
+): { success: boolean; message: string } {
+  const failures = rows.filter((row) => String(row.Msg_type).toLowerCase() === "error");
+  if (failures.length > 0) {
+    return {
+      success: false,
+      message: `${type.toUpperCase()} failed: ${unique(failures.map((row) => `${row.Table}: ${row.Msg_text}`)).join("; ")}`,
+    };
+  }
+
+  // A statement that answers no row at all leaves nothing to quote; the generic
+  // sentence is then all there is to say.
+  if (rows.length === 0) {
+    return { success: true, message: `${type.toUpperCase()} completed successfully` };
+  }
+
+  return { success: true, message: `${type.toUpperCase()}: ${unique(rows.map((row) => row.Msg_text)).join("; ")}` };
+}
+
+const unique = (values: string[]): string[] => [...new Set(values)];
+
 // ============================================================================
 // SQL Statements
 // ============================================================================
@@ -390,11 +451,28 @@ export class MySQLProvider extends SQLBaseProvider {
       // The driver's own connection.beginTransaction() over one held connection.
       supportsTransactions: true,
       maintenanceOperations: ["analyze", "optimize", "check", "kill"],
+      // MySQL has no VACUUM, and every statement it does have names tables:
+      // `ANALYZE/OPTIMIZE/CHECK TABLE <t>` with a target, the same verb over every
+      // table in the database without one (`getAllTablesForMaintenance`). `kill`
+      // takes a connection id from the Sessions panel.
+      maintenanceOperationSpecs: {
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+        optimize: { label: "Optimize Table", perEntity: true, global: true },
+        check: { label: "Check Table", perEntity: true, global: true },
+        kill: { label: "Kill Connection", perEntity: false, global: false },
+      },
     };
   }
 
   /**
-   * Only the slow-query empty state; every other label is the SQL default and right.
+   * The vacuum slot and the slow-query empty state; every other label is the SQL
+   * default and right.
+   *
+   * MySQL rendered the base default *"Vacuum Table"* in the explorer's per-row menu
+   * and the base *"Run Vacuum" / "Reclaim Space"* copy on the Operations tab, for an
+   * engine whose operations are `analyze`/`optimize`/`check`/`kill` (#U9). The words
+   * below name what MySQL actually runs, and `vacuumActionOperation` says which
+   * operation the surfaces should send for them.
    *
    * `getSlowQueries()` reads `performance_schema.events_statements_summary_by_digest`
    * and answers `[]` when that read fails, which on a server with the Performance
@@ -404,6 +482,12 @@ export class MySQLProvider extends SQLBaseProvider {
   public override getLabels(): ProviderLabels {
     return {
       ...super.getLabels(),
+      vacuumAction: "Optimize Table",
+      vacuumActionOperation: "optimize",
+      vacuumGlobalLabel: "Run Optimize",
+      vacuumGlobalTitle: "Optimize Tables",
+      vacuumGlobalDesc:
+        "Runs OPTIMIZE TABLE over every table in the database, rebuilding its storage and reclaiming the space deleted rows left behind.",
       slowQueriesEmptyState:
         "Query stats come from performance_schema.events_statements_summary_by_digest - enable the Performance Schema to see them.",
     };
@@ -839,21 +923,27 @@ export class MySQLProvider extends SQLBaseProvider {
         let sql = "";
 
         switch (type) {
+          // The three table verbs share one shape: `<VERB> TABLE <list>`, where the
+          // list is the one table the caller named or every table in the database, and
+          // the answer is a RESULT SET carrying the verdict (`readMaintenanceReport`).
           case "analyze":
-            sql = target
-              ? `ANALYZE TABLE ${this.escapeIdentifier(target)}`
-              : `ANALYZE TABLE ${await this.getAllTablesForMaintenance(conn)}`;
-            break;
           case "optimize":
-            sql = target
-              ? `OPTIMIZE TABLE ${this.escapeIdentifier(target)}`
-              : `OPTIMIZE TABLE ${await this.getAllTablesForMaintenance(conn)}`;
-            break;
-          case "check":
-            sql = target
-              ? `CHECK TABLE ${this.escapeIdentifier(target)}`
-              : `CHECK TABLE ${await this.getAllTablesForMaintenance(conn)}`;
-            break;
+          case "check": {
+            const tables = target ? this.escapeIdentifier(target) : await this.getAllTablesForMaintenance(conn);
+            // An empty database joined to an empty list, and `OPTIMIZE TABLE ` alone is
+            // a syntax error - measured through the provider against a database with no
+            // tables on 2026-08-25: "You have an error in your SQL syntax ... near ''".
+            // Nothing to do is not a failure, so it is reported as what it is rather
+            // than as the engine's complaint about a statement we should not have sent.
+            if (!tables) {
+              return {
+                success: true,
+                message: `${type.toUpperCase()}: no tables in ${this.config.database ?? "this database"} to run it on.`,
+              };
+            }
+            const [rows] = await runStatement<MaintenanceReportRow[]>(conn, `${type.toUpperCase()} TABLE ${tables}`);
+            return readMaintenanceReport(type, rows);
+          }
           case "kill":
             if (!target) {
               throw new QueryError("Target connection ID is required for kill operation", "mysql");
@@ -875,7 +965,7 @@ export class MySQLProvider extends SQLBaseProvider {
         }
 
         await runStatement(conn, sql);
-        return { success: true };
+        return { success: true, message: `${type.toUpperCase()} completed successfully` };
       } finally {
         conn.release();
       }
@@ -884,7 +974,7 @@ export class MySQLProvider extends SQLBaseProvider {
     return {
       success: result.success,
       executionTime,
-      message: `${type.toUpperCase()} completed successfully`,
+      message: result.message,
     };
   }
 

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -166,6 +166,33 @@ const STORAGE_USER_SEGMENTS_SQL = `SELECT TABLESPACE_NAME AS NAME,
              GROUP BY TABLESPACE_NAME
              ORDER BY SUM(BYTES) DESC`;
 
+/**
+ * The indexes ONE table owns, for the `optimize` operation.
+ *
+ * `INDEX_TYPE = 'NORMAL'` is the filter the whole-schema form has always used, and it
+ * is the one `ALTER INDEX ... REBUILD` can take: it excludes LOB and domain indexes,
+ * which answer ORA-22864 / ORA-29868 to a rebuild, while keeping the B-tree indexes
+ * that back UNIQUE and PRIMARY KEY constraints, which rebuild normally.
+ */
+const TABLE_INDEXES_SQL = `SELECT INDEX_NAME
+           FROM USER_INDEXES
+           WHERE TABLE_NAME = :tableName AND INDEX_TYPE = 'NORMAL'`;
+
+const SCHEMA_NORMAL_INDEXES_SQL = `SELECT INDEX_NAME FROM USER_INDEXES WHERE INDEX_TYPE = 'NORMAL'`;
+
+/**
+ * Whether the schema owns a table by exactly this name - asked only to tell the two
+ * causes of an empty `TABLE_INDEXES_SQL` answer apart.
+ *
+ * `USER_TABLES` is the right catalog and not a narrower one: measured on
+ * ldb-oracle-r5 on 2026-08-25, a MATERIALIZED VIEW's container appears here under the
+ * view's own name (and its indexes appear in `USER_INDEXES` keyed to that name), so
+ * everything `USER_INDEXES` can be keyed to is visible. A plain VIEW is NOT here, and
+ * that is the honest answer for it: a view owns no index, so there is nothing for
+ * "Rebuild Indexes" to have done.
+ */
+const TABLE_IS_KNOWN_SQL = `SELECT TABLE_NAME FROM USER_TABLES WHERE TABLE_NAME = :tableName`;
+
 // ============================================================================
 // Value shapes
 // ============================================================================
@@ -175,7 +202,7 @@ const STORAGE_USER_SEGMENTS_SQL = `SELECT TABLESPACE_NAME AS NAME,
  *
  * By default oracledb answers a CLOB, an NCLOB and a BLOB with a `Lob` object -
  * a readable stream - and nothing downstream of the provider can read one.
- * Measured on 2026-08-24 against Oracle Free 23ai (oracledb 6.10.0, Thin) through
+ * Measured on 2026-08-24 against Oracle AI Database 26ai Free (oracledb 6.10.0, Thin) through
  * `createDatabaseProvider({type:"oracle"})`: all four LOB columns of a probe table
  * arrived as `Lob`, and serialising the row threw rather than producing a value -
  * `TypeError: Converting circular structure to JSON ... starting at object with
@@ -258,7 +285,7 @@ type IntervalColumn = readonly [name: string, format: (value: unknown) => string
  * boundary - the decision `docs/providers/cassandra.md` 3.8 already took for a CQL
  * `duration`, for the same reason and with the same shape.
  *
- * Measured 2026-08-24 against Oracle Free 23ai (oracledb 6.10.0, Thin): the driver
+ * Measured 2026-08-24 against Oracle AI Database 26ai Free (oracledb 6.10.0, Thin): the driver
  * answers `INTERVAL '3-7' YEAR TO MONTH` with `{"months":7,"years":3}` and
  * `INTERVAL '5 6:7:8.9' DAY TO SECOND` with
  * `{"fseconds":900000000,"seconds":8,"minutes":7,"hours":6,"days":5}`. Both are
@@ -373,6 +400,16 @@ export class OracleProvider extends SQLBaseProvider {
       // Oracle is always in a transaction; the held connection commits or rolls back.
       supportsTransactions: true,
       maintenanceOperations: ["analyze", "optimize", "kill"],
+      // `optimize` now takes a TABLE and rebuilds that table's own indexes, which is
+      // what SQL Server's identically worded control has always done. It used to take
+      // an INDEX name, so the per-table button that #427 wired up sent a table and
+      // every click answered ORA-01418 (reproduced against Oracle AI Database 26ai Free on
+      // 2026-08-25, then fixed and re-run - see runMaintenance below).
+      maintenanceOperationSpecs: {
+        analyze: { label: "Gather Statistics", perEntity: true, global: true },
+        optimize: { label: "Rebuild Indexes", perEntity: true, global: true },
+        kill: { label: "Kill Session", perEntity: false, global: false },
+      },
     };
   }
 
@@ -381,6 +418,10 @@ export class OracleProvider extends SQLBaseProvider {
       ...super.getLabels(),
       analyzeAction: "Gather Statistics",
       vacuumAction: "Rebuild Indexes",
+      // Oracle has no VACUUM; this slot has always said "Rebuild Indexes", which is
+      // `optimize`. Saying so is what lets the two surfaces send that operation
+      // instead of a `vacuum` this provider rejects (#U9).
+      vacuumActionOperation: "optimize",
       analyzeGlobalLabel: "Gather Stats",
       analyzeGlobalTitle: "Gather Statistics",
       analyzeGlobalDesc: "Collects optimizer statistics for all tables to improve query performance.",
@@ -524,7 +565,7 @@ export class OracleProvider extends SQLBaseProvider {
    *
    * oracledb answers a SELECT with a `rows` array and a non-SELECT with no `rows` at
    * all plus its own `rowsAffected` - so the row count of a DML statement is only
-   * readable there. Measured 2026-08-24 against Oracle Free 23ai through
+   * readable there. Measured 2026-08-24 against Oracle AI Database 26ai Free through
    * `createDatabaseProvider({type:"oracle"})`: `INSERT` of one row -> rowsAffected 1,
    * `INSERT ... SELECT` of three -> 3, `UPDATE` touching four -> 4, a `DELETE` that
    * matched nothing -> 0, `CREATE TABLE` and `TRUNCATE` -> 0, a PL/SQL block ->
@@ -869,7 +910,7 @@ export class OracleProvider extends SQLBaseProvider {
       // Cache hit ratio. `|| 0` used to publish "0%" for a reading Oracle never
       // took, and the Overview card rates 0 as "Needs tuning" - so a user who
       // simply cannot read V$SYSSTAT saw a cache fault. The two ways the reading
-      // goes absent, both measured 2026-08-23 on Oracle Free 23ai: a user granted
+      // goes absent, both measured 2026-08-23 on Oracle AI Database 26ai Free: a user granted
       // only CREATE SESSION gets `ORA-00942: table or view "SYS"."V_$SYSSTAT" does
       // not exist` (the catch below), and a zero counter denominator gives one row
       // of `<NULL>` through NULLIF (measuredNumber).
@@ -941,23 +982,7 @@ export class OracleProvider extends SQLBaseProvider {
             }
             break;
           case "optimize":
-            if (target) {
-              sql = `ALTER INDEX "${target.replace(/"/g, '""')}" REBUILD`;
-            } else {
-              // Rebuild all indexes for user
-              const idxRes = await conn.execute(`SELECT INDEX_NAME FROM USER_INDEXES WHERE INDEX_TYPE = 'NORMAL'`, [], {
-                outFormat: oracledb.OUT_FORMAT_OBJECT,
-              });
-              for (const row of (idxRes.rows || []) as Record<string, unknown>[]) {
-                try {
-                  await conn.execute(`ALTER INDEX "${String(row.INDEX_NAME)}" REBUILD`);
-                } catch {
-                  /* individual index rebuild may fail */
-                }
-              }
-              return { success: true };
-            }
-            break;
+            return await this.rebuildIndexes(conn, target);
           case "kill":
             if (!target) {
               throw new QueryError("Target SID,SERIAL# is required for kill operation", "oracle");
@@ -975,7 +1000,7 @@ export class OracleProvider extends SQLBaseProvider {
         }
 
         await conn.execute(sql);
-        return { success: true };
+        return { success: true, message: `${type.toUpperCase()} completed successfully` };
       } finally {
         if (conn) await conn.close();
       }
@@ -984,8 +1009,99 @@ export class OracleProvider extends SQLBaseProvider {
     return {
       success: result.success,
       executionTime,
-      message: `${type.toUpperCase()} completed successfully`,
+      message: result.message,
     };
+  }
+
+  /**
+   * `optimize`: rebuild the indexes ONE table owns, or every normal index in the
+   * schema when the caller named nothing.
+   *
+   * The target is a TABLE NAME, because a table name is the only thing the two
+   * maintenance surfaces have to send - both take it from the object browser's rows.
+   * This used to build `ALTER INDEX "<target>" REBUILD` straight from that argument,
+   * so every per-table click answered *ORA-01418: specified index does not exist*
+   * (reproduced against Oracle AI Database 26ai Free on 2026-08-25). SQL Server's identically
+   * worded control is `ALTER INDEX ALL ON [<t>] REBUILD`, and this is that shape:
+   * Oracle has no `ALTER INDEX ALL`, so the index names come from `USER_INDEXES`
+   * first.
+   *
+   * A table with no rebuildable index succeeds having rebuilt nothing - "nothing to
+   * do" is not a failure, and a heap table with no index is an ordinary state. One
+   * index failing does not fail the run either (an offline tablespace or an unusable
+   * partition stops that index alone), which is the choice the whole-schema form
+   * already made and the reason each rebuild carries its own try/catch; the message
+   * says how many of the table's indexes were rebuilt, because "success" alone cannot
+   * distinguish 2 of 2 from 1 of 2.
+   *
+   * An EMPTY index list has a second cause, and it is not "nothing to do": a target the
+   * catalog does not know. A name that is not a table of this schema - including a real
+   * table spelled in the wrong case, since Oracle stores unquoted names folded to upper
+   * case - answered `{"success": true}` in ~1 ms having done nothing at all (measured
+   * against ldb-oracle-r5, Oracle AI Database 26ai Free Release 23.26.2.0.0, on
+   * 2026-08-25). A target the catalog cannot resolve is a failed operation, so the two
+   * are told apart with `TABLE_IS_KNOWN_SQL` - asked ONLY when the index list came back
+   * empty, so the ordinary path stays at one catalog read.
+   */
+  private async rebuildIndexes(
+    conn: oracledb.Connection,
+    target?: string,
+  ): Promise<{ success: boolean; message: string }> {
+    // The table name is a bind here, unlike the inline-escaped literals elsewhere in
+    // runMaintenance: this one sits in a WHERE clause, which does take a bind.
+    const indexes = target
+      ? await conn.execute(TABLE_INDEXES_SQL, [target], { outFormat: oracledb.OUT_FORMAT_OBJECT })
+      : await conn.execute(SCHEMA_NORMAL_INDEXES_SQL, [], { outFormat: oracledb.OUT_FORMAT_OBJECT });
+
+    const rows = (indexes.rows || []) as Record<string, unknown>[];
+
+    if (target && rows.length === 0) {
+      const known = await conn.execute(TABLE_IS_KNOWN_SQL, [target], { outFormat: oracledb.OUT_FORMAT_OBJECT });
+      if (((known.rows || []) as unknown[]).length === 0) {
+        return {
+          success: false,
+          // Two causes and one sentence, because the catalog cannot tell them apart from
+          // here: a name that is nothing in this schema, and a name that is a VIEW or a
+          // synonym - `USER_TABLES` holds neither, and rebuilding an index is not a thing
+          // either can be asked to do. Measured on ldb-oracle-r5: a real view answers this
+          // too, and blaming only the spelling would misdirect a caller who spelled it
+          // right. `USER_TABLES` does hold a materialized view's container table, so that
+          // case reaches the rebuild rather than this branch.
+          message: `OPTIMIZE failed: this schema owns no TABLE named ${target}. A view or a synonym has no index to rebuild, and an unquoted name is folded to upper case, so a lower-case spelling will not match the catalog.`,
+        };
+      }
+    }
+
+    let rebuilt = 0;
+    // The engine's first refusal, kept rather than discarded: with every rebuild failing,
+    // "rebuilt 0 of 2" states the count and withholds the only part an operator can act
+    // on. Measured on a table whose tablespace is READ ONLY (ldb-oracle-r5, Oracle AI
+    // Database 26ai Free Release 23.26.2.0.0, 2026-08-25): every rebuild answers ORA-01647
+    // and this reported success in 14 ms.
+    let firstFailure: string | undefined;
+    for (const row of rows) {
+      try {
+        await conn.execute(`ALTER INDEX "${String(row.INDEX_NAME).replace(/"/g, '""')}" REBUILD`);
+        rebuilt++;
+      } catch (error) {
+        // One index failing is still a completed run (an offline tablespace or an unusable
+        // partition stops that index alone), which is the choice the whole-schema form
+        // already made - so the reason is recorded and the loop goes on.
+        firstFailure ??= error instanceof Error ? error.message : String(error);
+      }
+    }
+
+    // None of them rebuilding is a different fact from some of them rebuilding: nothing
+    // the operation was asked to do happened, so it did not succeed. A table with no index
+    // at all keeps its success above - `rows.length === 0` never enters this branch.
+    if (rebuilt === 0 && rows.length > 0) {
+      return {
+        success: false,
+        message: `OPTIMIZE failed: rebuilt 0 of ${rows.length} indexes. ${firstFailure ?? ""}`.trim(),
+      };
+    }
+
+    return { success: true, message: `OPTIMIZE: rebuilt ${rebuilt} of ${rows.length} indexes.` };
   }
 
   // ============================================================================

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -640,6 +640,17 @@ export class PostgresProvider extends SQLBaseProvider {
       // BEGIN / COMMIT / ROLLBACK over one held pool client (`beginTransaction()` below).
       supportsTransactions: true,
       maintenanceOperations: ["vacuum", "analyze", "reindex", "kill"],
+      // Every statement below has both forms - `VACUUM ANALYZE <table>` and bare
+      // `VACUUM ANALYZE`, `REINDEX TABLE <table>` and `REINDEX DATABASE` - so
+      // PostgreSQL is the engine whose per-row and global controls were both already
+      // right, and declaring them changes nothing here (#U9). `kill` takes a backend
+      // PID, which only the Sessions panel can supply.
+      maintenanceOperationSpecs: {
+        vacuum: { label: "Vacuum Table", perEntity: true, global: true },
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+        reindex: { label: "Reindex Table", perEntity: true, global: true },
+        kill: { label: "Terminate Backend", perEntity: false, global: false },
+      },
     };
   }
 

--- a/src/lib/db/providers/sql/sqlite.ts
+++ b/src/lib/db/providers/sql/sqlite.ts
@@ -299,6 +299,17 @@ export class SQLiteProvider extends SQLBaseProvider {
       // POST /api/db/transaction refuses the call and the controls stay hidden.
       supportsTransactions: false,
       maintenanceOperations: ["vacuum", "analyze", "reindex", "check"],
+      // `VACUUM` rewrites the whole database file and takes no object at all, and
+      // `PRAGMA integrity_check` reads the whole file the same way - `runMaintenance`
+      // ignores the target for both, so a per-table control there named one table and
+      // acted on the database (#U9). `ANALYZE` and `REINDEX` do take a bare name and
+      // also run over everything without one.
+      maintenanceOperationSpecs: {
+        vacuum: { label: "Vacuum Database", perEntity: false, global: true },
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+        reindex: { label: "Reindex Table", perEntity: true, global: true },
+        check: { label: "Integrity Check", perEntity: false, global: true },
+      },
     };
   }
 

--- a/src/lib/db/providers/sql/trino/index.ts
+++ b/src/lib/db/providers/sql/trino/index.ts
@@ -277,6 +277,12 @@ export class TrinoProvider extends SQLBaseProvider {
       // implements it, and vacuum, reindex, optimize and check belong to storage
       // systems Trino does not own.
       maintenanceOperations: ["kill"],
+      // Trino owns no storage and computes no statistics, so the only operation it
+      // has is terminating a statement - and that needs the query id the Sessions
+      // panel lists, which is neither a table nor a whole database (#U9).
+      maintenanceOperationSpecs: {
+        kill: { label: "Terminate Query", perEntity: false, global: false },
+      },
       // Trino's own JDBC URL is `jdbc:trino://host:port/catalog/schema`, which the
       // shared parser in `connection-string-parser.ts` does not accept. Rather than
       // advertise a field that would reject everything a user pastes, this stays

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -94,6 +94,72 @@ export interface MaintenanceResult {
   message: string;
 }
 
+/**
+ * What ONE maintenance operation can be pointed at on ONE engine, declared next to
+ * that engine's own wording for it.
+ *
+ * `maintenanceOperations` says only that an operation EXISTS here, and #427 measured
+ * what a surface built on that alone offers. Oracle declares `optimize`, so the
+ * per-table button sent `optimize` with a TABLE name - and `oracle.ts` built
+ * `ALTER INDEX "<target>" REBUILD` from it, so every click answered ORA-01418
+ * (reproduced 2026-08-25 against Oracle AI Database 26ai Free before this change). The target
+ * grammar differs between engines that declare the SAME `MaintenanceType`, so a
+ * generic label-to-operation mapping is wrong by construction and the declaration has
+ * to travel with the provider.
+ *
+ * `perEntity` and `global` are independent because both halves occur: Couchbase's
+ * `reindex` is BUILD INDEX for ONE keyspace and has no whole-database form (its global
+ * card answered *"The reindex operation requires a target"*), while SQLite's `VACUUM`
+ * rewrites the whole file and ignores a target entirely (a per-table control there
+ * names one table and vacuums the database). An operation whose target is a session or
+ * query id - every engine's `kill` - is `false` for both: the Sessions panel supplies
+ * that id, and no table or global control can.
+ */
+export interface MaintenanceOperationSpec {
+  /** This engine's own wording for a control that runs the operation. */
+  label: string;
+  /** Runs against ONE object the browser lists: a table, a collection, a keyspace. */
+  perEntity: boolean;
+  /** Runs with no target at all, over the whole database. */
+  global: boolean;
+}
+
+/** Where a surface wants to put a control: on one row, or on a whole-database card. */
+export type MaintenancePlacement = "perEntity" | "global";
+
+/**
+ * Whether ONE maintenance control may be offered in ONE place, and the wording to
+ * give it - the single gate both maintenance surfaces ask, so that they cannot
+ * disagree about what a provider declared.
+ *
+ * `label` is undefined rather than a fallback string on purpose: only the provider
+ * may name the operation, so a caller that gets no name keeps its own generic word.
+ * That is also the whole of the compatibility story for the optional
+ * `maintenanceOperationSpecs` - a provider that declares no spec is offered in both
+ * placements under the caller's own wording, which is what both surfaces did before
+ * #U9.
+ */
+export function maintenanceControl(
+  capabilities: ProviderCapabilities | undefined,
+  type: MaintenanceType,
+  placement: MaintenancePlacement,
+): { offered: boolean; label?: string } {
+  // Unknown capabilities are not a permission: `/api/db/provider-meta` answers with
+  // nothing both while it is in flight and when it failed, and failing open there
+  // puts the dead buttons back on exactly the connections the #272/#282 gates exist
+  // for.
+  if (capabilities?.supportsMaintenance !== true || !capabilities.maintenanceOperations.includes(type)) {
+    return { offered: false };
+  }
+
+  const spec = capabilities.maintenanceOperationSpecs?.[type];
+  if (spec === undefined) {
+    return { offered: true };
+  }
+
+  return { offered: spec[placement], label: spec.label };
+}
+
 // ============================================================================
 // Provider Capabilities & Labels
 // ============================================================================
@@ -225,6 +291,16 @@ export interface ProviderCapabilities {
   tablesAreDerivedGroupings?: boolean;
   supportsMaintenance: boolean;
   maintenanceOperations: MaintenanceType[];
+  /**
+   * Per-operation targeting for the operations above, keyed by `MaintenanceType`.
+   *
+   * Optional for the published-interface reason `supportsInlineRowEdit` records
+   * (`src/exports/types.ts`): a required field added after the fact stops every
+   * external implementer compiling. Absent means "gate on `maintenanceOperations`
+   * alone", which is what both maintenance surfaces did before #U9 - so an
+   * implementation that declares nothing here behaves exactly as it did.
+   */
+  maintenanceOperationSpecs?: Partial<Record<MaintenanceType, MaintenanceOperationSpec>>;
   supportsConnectionString: boolean;
   defaultPort: number | null;
   /**
@@ -279,6 +355,34 @@ export interface ProviderLabels {
   generateAction: string;
   analyzeAction: string;
   vacuumAction: string;
+  /**
+   * Which operation `vacuumAction` and the `vacuumGlobal*` triad actually NAME.
+   *
+   * Four providers point that wording at something that is not `vacuum`: ClickHouse's
+   * *"Optimize Table"* and SQL Server's, Oracle's and MySQL's *"Rebuild Indexes"* /
+   * *"Optimize Table"* each stand for the `optimize` the provider declares. MySQL
+   * rendered the base default *"Vacuum Table"* for an engine whose operations
+   * are `analyze`/`optimize`/`check`/`kill`. The global vacuum card was gated on the
+   * literal `vacuum`, so every one of those provider's own words was written and never
+   * shown, and the per-row item named an operation the page behind it could not run.
+   *
+   * Absent means `vacuum`, so no provider that really vacuums declares anything - and
+   * a provider whose vacuum wording names NOTHING it can run leaves this absent too:
+   * Couchbase's *"Compact"* says in its own description that the server compacts
+   * automatically and there is no manual equivalent, so `vacuum` stays undeclared and
+   * the card stays withheld, which is the honest outcome rather than pointing the
+   * words at the unrelated `reindex` it does declare.
+   * `analyzeAction` needs no twin of this, but not because every engine's analyze
+   * wording stands for `analyze`: read across the providers, three point it at nothing
+   * runnable - Trino's *"Table Statistics"*, the search family's *"Index Statistics"*
+   * and the embedded LibreDB's *"Key Info"*. What makes the twin unnecessary is the
+   * other half of each of those three: none of them declares an `analyze` operation
+   * (`maintenanceOperations` is `['kill']` on Trino and `[]` on the other two), so the
+   * control is withheld there by the declaration alone. Not one provider points its
+   * analyze wording at a DIFFERENT operation it does declare, which is the only case a
+   * twin field would resolve.
+   */
+  vacuumActionOperation?: MaintenanceType;
   searchPlaceholder: string;
   analyzeGlobalLabel: string;
   analyzeGlobalTitle: string;

--- a/src/lib/sql/grammar.ts
+++ b/src/lib/sql/grammar.ts
@@ -103,6 +103,25 @@ export interface SqlGrammar {
    * literal out of ordinary code.
    */
   readonly alternateQuoting: boolean;
+  /**
+   * Whether `//` opens a line comment.
+   *
+   * A form some dialects simply HAVE rather than a disagreement about a character,
+   * the same shape of question as `alternateQuoting` - except that two unrelated
+   * engines have this one: CQL and ClickHouse both read `//` to the end of the line,
+   * and everywhere else those two characters are refused outright or - in
+   * PostgreSQL, where `//` is a real operator NAME - are code the server tries to
+   * resolve.
+   *
+   * It is the fact this record said it could not carry, and the splitter is where
+   * that cost was live rather than merely inconvenient. A comment is what a `;` can
+   * hide inside, `statement-splitter.ts` reads its boundaries through `spans.ts`,
+   * and `/api/db/multi-query` RUNS every fragment the splitter returns - so on the
+   * two engines that have the form, `SELECT … // note; DROP …` was cut into a read
+   * and a bare DROP out of text the server reads as one statement. Measured, not
+   * argued: the probes are quoted on the rows below and in `grammar.test.ts`.
+   */
+  readonly doubleSlashComment: boolean;
 }
 
 /**
@@ -121,6 +140,7 @@ export const DEFAULT_SQL_GRAMMAR: SqlGrammar = {
   bracket: "quoted-identifier",
   blockComment: "flat",
   alternateQuoting: false,
+  doubleSlashComment: false,
 };
 
 /**
@@ -135,36 +155,71 @@ const MYSQL_GRAMMAR: SqlGrammar = {
   bracket: DEFAULT_SQL_GRAMMAR.bracket,
   blockComment: "flat",
   alternateQuoting: false,
+  // Probed 2026-08-25 on 26.7.0: `SELECT 1 AS a // note` is ERROR 1064, "check the
+  // manual … near '// note'". Nothing on that line is hidden.
+  doubleSlashComment: false,
 };
 const CLICKHOUSE_GRAMMAR: SqlGrammar = {
   hash: "comment",
   bracket: "subscript",
   blockComment: "nesting",
   alternateQuoting: false,
+  // A LINE comment, and the one CLICKHOUSE fact here established by probe rather than
+  // from the reference - three probes on 26.7.1 over HTTP, because "the statement still ran"
+  // cannot tell a comment from a token the parser skipped:
+  //   `SELECT 1 AS a // note`             -> 1. So the characters are accepted.
+  //   `SELECT 1 AS a // note; SELECT 999` -> 1, no error, while `SELECT 1; DROP TABLE
+  //                                         nope` is "Syntax error (Multi-statements
+  //                                         are not allowed)". So the `;` was HIDDEN.
+  //   `SELECT 1 AS a // note\n, 2 AS b`   -> TWO columns: the run ends at the
+  //                                         NEWLINE, so it is a line comment.
+  // The cost of the old reading is measurable rather than theoretical: the shared
+  // limiter appends before trailing trivia, so with `//` as code
+  // `SELECT number FROM numbers(1000) // note` was emitted as
+  // `… // note LIMIT 5` - 1000 rows returned while `wasLimited: true` was reported,
+  // the exact shape #280 exists to prevent. With the fact carried it emits
+  // `… LIMIT 5 // note` and returns 5 (both measured).
+  doubleSlashComment: true,
 };
 const POSTGRES_GRAMMAR: SqlGrammar = {
   hash: "code",
   bracket: "subscript",
   blockComment: "nesting",
   alternateQuoting: false,
+  // CODE, and the strongest of the six refusals: `SELECT 1 // 2` on 18 is "operator
+  // does not exist: integer // integer", so `//` is a real OPERATOR NAME here that
+  // merely has no implementation for those argument types - not a comment and not a
+  // syntax error. `SELECT 1 AS a // note` is "syntax error at or near \"//\"".
+  doubleSlashComment: false,
 };
 const ORACLE_GRAMMAR: SqlGrammar = {
   hash: "code",
   bracket: DEFAULT_SQL_GRAMMAR.bracket,
   blockComment: "flat",
   alternateQuoting: true,
+  // Probed 2026-08-25 on Oracle Free through sqlplus: `SELECT 1 AS a // note FROM
+  // dual` is ORA-00923, "FROM keyword not found where expected", with the caret under
+  // the slashes. Nothing on that line is hidden.
+  doubleSlashComment: false,
 };
 const MSSQL_GRAMMAR: SqlGrammar = {
   hash: "code",
   bracket: "quoted-identifier",
   blockComment: "nesting",
   alternateQuoting: false,
+  // Probed 2026-08-25 on 2022 through sqlcmd: `SELECT 1 AS a // note` is Msg 102,
+  // "Incorrect syntax near '/'".
+  doubleSlashComment: false,
 };
 const SQLITE_GRAMMAR: SqlGrammar = {
   hash: "code",
   bracket: "quoted-identifier",
   blockComment: "flat",
   alternateQuoting: false,
+  // Probed 2026-08-25 through the bundled driver: `SELECT 1 AS a // note` and
+  // `SELECT 1 // 2` are both 'near "/": syntax error'. The amalgamation's tokenizer
+  // agrees - `case CC_SLASH` opens a run only on `/*`.
+  doubleSlashComment: false,
 };
 
 /**
@@ -196,6 +251,12 @@ const ELASTICSEARCH_GRAMMAR: SqlGrammar = {
   blockComment: "flat",
   // `SELECT q'{it's}'` is a `parsing_exception` - the form does not exist here.
   alternateQuoting: false,
+  // NOT established: this engine was not reachable from the run that probed the other
+  // eight (2026-08-25), and PD-5 forbids reading its rule off the five refusals
+  // measured elsewhere. It keeps the compatibility default, and the direction that
+  // costs is worth stating: if `//` DOES open a comment here, this dialect's splitter
+  // over-splits exactly as `cassandra`'s did.
+  doubleSlashComment: DEFAULT_SQL_GRAMMAR.doubleSlashComment,
 };
 const OPENSEARCH_GRAMMAR: SqlGrammar = {
   // `#` really is a line comment, and this is where the fork's SQL plugin parts
@@ -218,6 +279,8 @@ const OPENSEARCH_GRAMMAR: SqlGrammar = {
   blockComment: "flat",
   // `SELECT q'{it's}'` is refused, "Illegal SQL expression".
   alternateQuoting: false,
+  // NOT established, same reason and same stated cost as the Elasticsearch row above.
+  doubleSlashComment: DEFAULT_SQL_GRAMMAR.doubleSlashComment,
 };
 /**
  * Established the same way and for the same reason as the two search rows: the engine
@@ -248,6 +311,11 @@ const TRINO_GRAMMAR: SqlGrammar = {
   // `SELECT q'{it''s}'` is "line 1:8: Unknown resolvedType: q" - the form does not
   // exist here, so those characters are a name followed by an ordinary string.
   alternateQuoting: false,
+  // CODE, probed 2026-08-25 on 476: `SELECT 1 AS a // note` is "line 1:15: mismatched
+  // input '/'", and the same text with a newline before a second column is the same
+  // error at the same offset - so the slashes are refused where they stand rather
+  // than hiding what follows.
+  doubleSlashComment: false,
 };
 
 /**
@@ -257,17 +325,31 @@ const TRINO_GRAMMAR: SqlGrammar = {
  * native protocol). Every fact below is a statement the server answered, not a
  * reading taken from a neighbouring dialect.
  *
- * One CQL fact has no field here to hold it, and it is worth naming because it bites
- * the same readers: CQL has a THIRD comment form, `//`, and a line comment of EITHER
- * form must be closed by a NEWLINE. Measured, `SELECT * FROM probe.customers LIMIT 3
- * -- note` with nothing after it is a syntax error ("line 1:45 mismatched character
- * '<EOF>' expecting set null"), and the same text with a trailing `\n` returns the
- * rows. So on this one engine the shared limiter's insert-before-trailing-trivia
- * rewrite (#280) can turn a VALID statement into a syntax error, because it trims the
- * newline that closed the comment. `SqlGrammar` cannot express either fact, and
- * widening it would change how every dialect's comments are read, so the Cassandra
- * provider's own `prepareQuery` declines to rewrite a statement that would end inside
- * a line comment. See `providers/sql/cassandra/index.ts`.
+ * CQL needs TWO facts about comments that the rows above do not, and they are
+ * carried in two different places because only one of them is about WHAT a run is.
+ * The first is shared with exactly one other dialect here, ClickHouse; the second is
+ * this engine's alone.
+ *
+ * 1. A THIRD comment form, `//`, which ClickHouse has too. That IS a grammar fact,
+ *    it is now the
+ *    `doubleSlashComment` field, and this docblock used to say the record could not
+ *    express it - which cost the splitter a manufactured `DROP` (see the field's own
+ *    doc and the row below). It is not widened to the dialects that lack it: five of
+ *    them refuse the characters outright and PostgreSQL reads them as an operator
+ *    name, each measured.
+ * 2. A line comment of EITHER form must be closed by a NEWLINE. That is a fact about
+ *    where a statement may END rather than about what a run is, so it has no field
+ *    here: `SqlSpan` reports a line comment closed by end of input as terminated,
+ *    which is right in every other dialect and is what the readers over it are
+ *    asking. Measured, `SELECT * FROM probe.customers LIMIT 3 -- note` with nothing
+ *    after it is "line 1:45 mismatched character '<EOF>' expecting set null" and the
+ *    same text with a trailing `\n` returns the rows - so the shared limiter's
+ *    insert-before-trailing-trivia rewrite (#280) can turn a VALID statement into a
+ *    syntax error, because `sql.trim()` drops the newline that closed the comment.
+ *    The Cassandra provider's own `prepareQuery` still declines to rewrite a
+ *    statement that would end inside a line comment; what changed is that it now
+ *    finds BOTH comment forms through the shared span reader rather than carrying a
+ *    private `//` scan of its own. See `providers/sql/cassandra/index.ts`.
  */
 const CASSANDRA_GRAMMAR: SqlGrammar = {
   // `#` opens NOTHING and is not an identifier character either. Three probes:
@@ -299,6 +381,19 @@ const CASSANDRA_GRAMMAR: SqlGrammar = {
   // '{it's}'" - the form does not exist here, so those characters are a name followed
   // by an ordinary string.
   alternateQuoting: false,
+  // A LINE comment, which is what the docblock above used to say this record could not
+  // carry. Probed 2026-08-25 over the native protocol on 5.0.9 AND on ScyllaDB
+  // 2026.2.4, which shares this type-id and answered identically:
+  //   `SELECT release_version FROM system.local // note; DROP KEYSPACE nope\n`
+  //     -> the ROW. One read. And the DROP did not run: a bare `DROP KEYSPACE nope`
+  //        answers "Keyspace 'nope' doesn't exist", so the OK is the proof.
+  //   the same text with no trailing newline
+  //     -> "line 1:68 mismatched character '<EOF>' expecting set null" (Scylla: "line
+  //        1:68 : Unexpected ''") - the SECOND CQL fact, stated in the docblock above.
+  //   `SELECT release_version FROM system.local // note\nDROP KEYSPACE nope`
+  //     -> "line 2:0 mismatched input 'DROP' expecting EOF", so the run ended at the
+  //        newline: a LINE comment, not a to-end-of-input one.
+  doubleSlashComment: true,
 };
 
 /**
@@ -311,8 +406,9 @@ const CASSANDRA_GRAMMAR: SqlGrammar = {
  * confirmation gate reads their editor text as SQL only where `readsSqlText` says
  * the text IS SQL, which for those two it does not (#297). Present for one fact and
  * undecided about another: `mysql` and `oracle` carry no established BRACKET
- * reading (see the row below), and `elasticsearch` carries none either - `[` is not
- * in its grammar at all.
+ * reading (see the row below), `elasticsearch` carries none either - `[` is not
+ * in its grammar at all - and neither search row carries a `//` reading, because
+ * neither engine was reachable from the run that probed the other eight.
  *
  * Sources, one per row, all offline or first-party documentation - except
  * `elasticsearch` and `opensearch`, whose rows were established by probing the
@@ -388,6 +484,25 @@ const CASSANDRA_GRAMMAR: SqlGrammar = {
  *   - `oracle` is FLAT - node-oracledb's tokenizer (`_parseMultiLineComment`)
  *     stops at the first `*\/`, and Oracle's PL/SQL Language Reference states that
  *     one multiline comment cannot contain another.
+ *
+ * - `//`, the third line-comment form, and every row here is a LIVE PROBE from
+ *   2026-08-25 rather than a document. It is the fact this record used to say it
+ *   could not carry, and the splitter is where that cost was live: a comment is what
+ *   a `;` can hide inside, and `/api/db/multi-query` runs every fragment the splitter
+ *   returns.
+ *   - `cassandra` (Apache Cassandra 5.0.9 and ScyllaDB 2026.2.4, both over the native
+ *     protocol) and `clickhouse` (26.7.1 over HTTP) read it as a LINE comment. Two
+ *     probes each rather than one, because a statement that still ran does not
+ *     distinguish a comment from a token the parser skipped: the hiding was shown by
+ *     a `;` plus a write that did NOT execute, and the LINE half by a second column
+ *     or clause on the next line that DID.
+ *   - `postgres` (18), `mysql` (26.7.0), `oracle` (Free, sqlplus), `mssql` (2022,
+ *     sqlcmd), `trino` (476) and `sqlite` (the bundled driver) read it as CODE, each
+ *     refusing the characters where they stand. PostgreSQL is the most explicit of
+ *     the six: `SELECT 1 // 2` is "operator does not exist: integer // integer", so
+ *     `//` is an operator NAME there rather than a comment marker or a syntax error.
+ *   The full probe text for every row is quoted on the constants above and in
+ *   `grammar.test.ts`.
  *
  * - `postgres`, brackets - `expression[subscript]` extracts an element and
  *   `expression[lower:upper]` a slice (PostgreSQL manual 4.2.3 Subscripts), and

--- a/src/lib/sql/spans.ts
+++ b/src/lib/sql/spans.ts
@@ -16,29 +16,29 @@
  * `db/utils/query-limiter.ts` hand-writes its semicolon strip for the same
  * reason. A scanner that advances one span at a time cannot backtrack at all.
  *
- * Two older readers in this folder overlap with it and are deliberately left
- * alone, because rewriting either changes behaviour this module is not chartered
- * to change:
+ * `statement-splitter.ts` used to inline the same scan - wound together with the
+ * line counting it needs, and knowing none of the dialect facts below - and the
+ * argument for leaving it alone was that the divergences only ever cost a fragment
+ * its row bound. That argument was wrong about the direction: `/api/db/multi-query`
+ * RUNS each fragment the splitter returns, so a boundary this module does not see is
+ * a statement the operator never wrote. It reads through here now, with the caller's
+ * grammar (S1), which is why the list of readers deliberately left alone is down to
+ * one:
  *
- * - `statement-splitter.ts` inlines the same scan, wound together with the line
- *   counting it needs, and knows none of the dialect facts below: it treats `#`
- *   as ordinary code, so a MySQL hash comment containing a `;` still splits there;
- *   it has no alternate-quoting branch, so an Oracle `q'{a'b;c}'` body splits
- *   at that `;`; and it has no bracket branch of either kind, so a `;` inside a
- *   bracket-quoted NAME (`SELECT [a;b] FROM t`, verified) splits one statement into
- *   two while every reader over this module sees one name. The bracket fact's
- *   SUBSCRIPT half escapes it only where the key is STRING-quoted, and by luck
- *   rather than by design: the splitter reads `'…'` and `"…"` but not backticks, so
- *   `SELECT arr[\`a;b\`] FROM t` splits there exactly as the bracketed name does.
- *   All three divergences are safe in the same direction - the fragments lose a
- *   bound rather than gaining a misplaced one - and reusing this module would move
- *   statement boundaries: a separate bug with its own tests.
  * - `alias-extractor.ts:134-135` blanks literals with a regex that honours
  *   BACKSLASH escapes, which this module reports as undeterminable instead (see
- *   `readQuoted`). Its job is autocomplete, where a wrong alias costs a
- *   suggestion; here a wrong literal boundary costs a bound on a write.
+ *   `readQuoted`). Its comment strip (lines 130-132) knows `--` and the block form
+ *   and no dialect at all, so it does not know `//` either. Its job is autocomplete,
+ *   where a wrong alias costs a suggestion; here a wrong literal boundary costs a
+ *   bound on a write - or, at the splitter, a fragment that gets executed.
  *
- * This module is what every NEW reader builds on, so the count does not grow.
+ * This module is what every reader builds on now, new or not, so the count does not
+ * grow - and a dialect fact added here reaches all of them at once. `//` is the
+ * worked example: it was missing, so on Cassandra, ScyllaDB and ClickHouse the
+ * splitter cut `SELECT … // note; DROP …` into a read and a bare DROP out of text
+ * every one of those servers reads as ONE statement (measured 2026-08-25). One field
+ * on the grammar record fixed the splitter, the confirmation gate, the row limiter
+ * and the statement-end reader together.
  *
  * Where the dialects genuinely disagree about a character, the reading comes from
  * the caller's grammar record (`grammar.ts`) rather than from this file taking one
@@ -80,8 +80,14 @@ export interface SqlSpan {
    * guessing - see `operative-keyword.ts`, where the guess would be a bound
    * appended to a write.
    *
-   * A line comment closed by the end of the input is `true`: end-of-input closes
-   * it in every dialect, and nothing follows it to be wrong about.
+   * A line comment closed by the end of the input is `true`: nothing follows it for
+   * a reader over this module to be wrong about, which is the question this flag
+   * answers. It is not a claim that every SERVER accepts such a statement - CQL does
+   * not, measured (`… LIMIT 3 -- note` with nothing after it is "line 1:45 mismatched
+   * character '<EOF>' expecting set null", and the same text plus a newline returns
+   * the rows). That is a fact about where a statement may END rather than about what
+   * the run is, so the one caller it costs - the Cassandra provider's row-limit
+   * rewrite - holds it itself; see `providers/sql/cassandra/index.ts`.
    */
   terminated: boolean;
 }
@@ -99,15 +105,27 @@ function isHashOperatorTail(ch: string | undefined): boolean {
 /**
  * Whether a line comment opens at `index`.
  *
- * `--` opens one in every dialect here and needs no grammar. `#` is the one this
- * module could not answer on its own, so it asks the grammar record: MySQL and
- * ClickHouse open a comment on any `#`, PostgreSQL, Oracle, SQL Server and SQLite
- * open none, and a caller that named no dialect keeps the hybrid reading this
- * module used to apply to everyone (see `DEFAULT_SQL_GRAMMAR`).
+ * `--` opens one in every dialect here and needs no grammar. The other two forms
+ * are the grammar record's answers, and they are asked in different shapes because
+ * the questions differ:
+ *
+ * - `#` is a DISAGREEMENT about one character. MySQL and ClickHouse open a comment
+ *   on any `#`, PostgreSQL, Oracle, SQL Server and SQLite open none, and a caller
+ *   that named no dialect keeps the hybrid reading this module used to apply to
+ *   everyone (see `DEFAULT_SQL_GRAMMAR`).
+ * - `//` is a form only CQL and ClickHouse HAVE. The other six engines refuse the
+ *   characters where they stand, and PostgreSQL reads them as an operator name
+ *   (`SELECT 1 // 2` is "operator does not exist: integer // integer", measured), so
+ *   reading the run there would hide the rest of a line the server does not.
+ *
+ * A single `/` is never a run under any grammar: it is division everywhere, and the
+ * `/*` opener is read after this by the block-comment branch, which is what keeps
+ * the two slash forms from taking each other's text.
  */
 function opensLineComment(sql: string, index: number, grammar: SqlGrammar): boolean {
   const ch = sql[index];
   if (ch === "-") return sql[index + 1] === "-";
+  if (ch === "/") return grammar.doubleSlashComment && sql[index + 1] === "/";
   if (ch !== "#") return false;
   if (grammar.hash === "code") return false;
   if (grammar.hash === "comment") return true;
@@ -449,6 +467,15 @@ export function readSqlSpan(sql: string, index: number, grammar: SqlGrammar = DE
   // DELETE FROM users` was typed a read and handed a bound, which MySQL applies to
   // the rows the DELETE removes. The grammar record answers it now (#292), and the
   // hybrid survives only as what a caller that named no dialect gets.
+  // The third form, `//`, is CQL's and ClickHouse's and nobody else's, and it is the
+  // fact this module was missing rather than one it resolved wrongly. Read as code,
+  // the `;` a `// note` hides is a statement BOUNDARY to `statement-splitter.ts`, and
+  // `/api/db/multi-query` runs what that returns - so on three shipped engines
+  // `SELECT … // note; DROP …` was cut into a read and a bare DROP out of text every
+  // one of those servers reads as ONE statement (measured 2026-08-25 on Cassandra
+  // 5.0.9, ScyllaDB 2026.2.4 and ClickHouse 26.7.1). The grammar record answers it
+  // now, and it is deliberately NOT widened: PostgreSQL reads `//` as an operator
+  // NAME and the other five refuse the characters where they stand.
   if (opensLineComment(sql, index, grammar)) {
     const newline = sql.indexOf("\n", index);
     // The newline belongs to the comment: it is what closes it.

--- a/src/lib/sql/statement-splitter.ts
+++ b/src/lib/sql/statement-splitter.ts
@@ -1,160 +1,137 @@
 /**
- * SQL Statement Splitter
- * Splits a multi-statement SQL string into individual statements,
- * correctly handling string literals, comments, and dollar-quoted strings (PostgreSQL).
+ * Where a multi-statement buffer's statements begin and end.
+ *
+ * The boundary is a `;` that is CODE, so the whole job is knowing which
+ * characters are code - and that is `spans.ts`'s job, under the dialect facts
+ * `grammar.ts` carries. This module used to inline its own scan of strings,
+ * comments and dollar-quoting instead, wound together with the line counting it
+ * needs, and it knew none of those facts: `#` was code, `q'…'` was a name
+ * followed by a string, `[…]` and `` `…` `` were nothing at all, and a block
+ * comment always ended at the first closer. So it disagreed with every other
+ * reader in this folder about where a statement ends, and unlike them its
+ * disagreement is not a missing bound: `/api/db/multi-query` RUNS each fragment
+ * this returns.
+ *
+ * The sharp shape, and why S1 is a safety fix. Measured on postgres 18, the text
+ *
+ *     /* a /* b *\/ ; DROP TABLE users; -- *\/ SELECT 1
+ *
+ * is ONE read: PostgreSQL nests block comments, so everything up to the second
+ * closer is comment text and the statement is `SELECT 1`. The flat, dialect-blind
+ * reading cut it into three fragments whose SECOND is a bare `DROP TABLE users`,
+ * the multi-statement route ran them in order, and the confirmation gate said
+ * nothing because it reads the whole editor text - where there is no operative
+ * keyword to find. The same family as #300, with the blast radius of an executed
+ * statement rather than a missing row bound.
+ *
+ * S1 fixed the reading and left one fact still missing from the shared module, which
+ * kept the same defect alive on three shipped engines: CQL and ClickHouse read `//`
+ * to the end of the line, so
+ *
+ *     SELECT id FROM probe.customers // note; DROP TABLE probe.customers
+ *
+ * is ONE statement to Cassandra 5.0.9, ScyllaDB 2026.2.4 and ClickHouse 26.7.1
+ * (measured 2026-08-25: the SELECT answers and the DROP does not run), and this
+ * splitter returned two fragments whose second was a bare DROP. The confirmation gate
+ * did prompt - the two readers agreed, which is what S1 bought - but confirming ran a
+ * statement the operator's text never contained. `grammar.ts` carries the fact now
+ * (`doubleSlashComment`), so this file needed no change of its own: reading through
+ * `spans.ts` is what makes a new dialect fact arrive here for free.
+ *
+ * A caller that names no dialect gets `DEFAULT_SQL_GRAMMAR`, the same stated
+ * default every other reader here applies to a dialect-less call, rather than the
+ * ad-hoc reading this file used to have. It is a decision, not an absence: pinned
+ * by its own tests.
  */
+
+import { DEFAULT_SQL_GRAMMAR, type SqlGrammar } from "./grammar";
+import { readSqlSpan } from "./spans";
 
 export interface SplitStatement {
   sql: string;
   /** 0-based line number where this statement starts in the original text */
   startLine: number;
+  /**
+   * Where this statement's TRIMMED text sits in the original input, as a
+   * `[start, end)` offset pair.
+   *
+   * Carried because a caller that has a CURSOR needs to know which statement it is
+   * in, and a line number cannot answer that for a multi-statement line. The editor's
+   * "run the statement I am in" reader used to answer it with `lastIndexOf(";")` -
+   * no spans, no dialect, not even a string-literal check - so it is the third reader
+   * of this question and the one whose answer is what actually gets SENT.
+   */
+  start: number;
+  end: number;
 }
 
-export function splitStatements(input: string): SplitStatement[] {
+/** Newlines in `text[from, to)`, which is how a span's height reaches the line count. */
+function countNewlines(text: string, from: number, to: number): number {
+  let newlines = 0;
+  for (let i = from; i < to; i++) {
+    if (text[i] === "\n") newlines++;
+  }
+  return newlines;
+}
+
+export function splitStatements(input: string, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): SplitStatement[] {
   const statements: SplitStatement[] = [];
-  let current = "";
-  let i = 0;
+  let segmentStart = 0;
   let statementStartLine = 0;
   let currentLine = 0;
+  let i = 0;
+
+  const push = (end: number) => {
+    const raw = input.slice(segmentStart, end);
+    const sql = raw.trim();
+    if (sql.length === 0) return;
+    // The offsets describe the TRIMMED text, so a caller can slice the original and get
+    // back exactly `sql`: the leading whitespace this trim drops is not part of the
+    // statement, and a cursor sitting in it belongs to no statement in particular.
+    const leading = raw.length - raw.trimStart().length;
+    statements.push({
+      sql,
+      startLine: statementStartLine,
+      start: segmentStart + leading,
+      end: segmentStart + leading + sql.length,
+    });
+  };
 
   while (i < input.length) {
-    const ch = input[i];
-    const next = input[i + 1];
-
-    // Track line numbers
-    if (ch === "\n") {
-      currentLine++;
-    }
-
-    // Single-line comment: -- ...
-    if (ch === "-" && next === "-") {
-      const lineEnd = input.indexOf("\n", i);
-      if (lineEnd === -1) {
-        current += input.slice(i);
-        i = input.length;
-      } else {
-        current += input.slice(i, lineEnd + 1);
-        currentLine++; // the \n
-        i = lineEnd + 1;
-      }
+    const span = readSqlSpan(input, i, grammar);
+    if (span !== null) {
+      // An UNTERMINATED span reaches the end of the input, so this branch also
+      // carries the fail-safe direction the rest of this folder keeps: text no
+      // reader can resolve yields no boundary at all rather than a guessed one.
+      // The buffer then takes the single-statement route, and the confirmation
+      // gate already asks about an unresolvable run (#297).
+      currentLine += countNewlines(input, i, span.end);
+      i = span.end;
       continue;
     }
 
-    // Multi-line comment: /* ... */
-    if (ch === "/" && next === "*") {
-      const commentEnd = input.indexOf("*/", i + 2);
-      if (commentEnd === -1) {
-        current += input.slice(i);
-        i = input.length;
-      } else {
-        const commentBlock = input.slice(i, commentEnd + 2);
-        // Count newlines in comment
-        for (const c of commentBlock) {
-          if (c === "\n") currentLine++;
-        }
-        current += commentBlock;
-        i = commentEnd + 2;
-      }
-      continue;
-    }
-
-    // Single-quoted string: '...' with '' escape
-    if (ch === "'") {
-      let j = i + 1;
-      current += "'";
-      while (j < input.length) {
-        if (input[j] === "\n") currentLine++;
-        if (input[j] === "'" && input[j + 1] === "'") {
-          current += "''";
-          j += 2;
-        } else if (input[j] === "'") {
-          current += "'";
-          j++;
-          break;
-        } else {
-          current += input[j];
-          j++;
-        }
-      }
-      i = j;
-      continue;
-    }
-
-    // Double-quoted identifier: "..."
-    if (ch === '"') {
-      let j = i + 1;
-      current += '"';
-      while (j < input.length) {
-        if (input[j] === "\n") currentLine++;
-        if (input[j] === '"' && input[j + 1] === '"') {
-          current += '""';
-          j += 2;
-        } else if (input[j] === '"') {
-          current += '"';
-          j++;
-          break;
-        } else {
-          current += input[j];
-          j++;
-        }
-      }
-      i = j;
-      continue;
-    }
-
-    // PostgreSQL dollar-quoted string: $tag$...$tag$
-    if (ch === "$") {
-      const dollarMatch = input.slice(i).match(/^\$([A-Za-z_]*)\$/);
-      if (dollarMatch) {
-        const tag = dollarMatch[0]; // e.g. $$ or $func$
-        const endIdx = input.indexOf(tag, i + tag.length);
-        if (endIdx === -1) {
-          // No closing tag — consume rest
-          const rest = input.slice(i);
-          for (const c of rest) {
-            if (c === "\n") currentLine++;
-          }
-          current += rest;
-          i = input.length;
-        } else {
-          const block = input.slice(i, endIdx + tag.length);
-          for (const c of block) {
-            if (c === "\n") currentLine++;
-          }
-          current += block;
-          i = endIdx + tag.length;
-        }
-        continue;
-      }
-    }
-
-    // Semicolon — statement boundary
-    if (ch === ";") {
-      const trimmed = current.trim();
-      if (trimmed.length > 0) {
-        statements.push({ sql: trimmed, startLine: statementStartLine });
-      }
-      current = "";
+    if (input[i] !== ";") {
       i++;
-      // Skip whitespace to find next statement start
-      while (i < input.length && /\s/.test(input[i])) {
-        if (input[i] === "\n") currentLine++;
-        i++;
-      }
-      statementStartLine = currentLine;
       continue;
     }
 
-    // Regular character
-    current += ch;
+    push(i);
     i++;
+    // A statement's reported line is where its TEXT starts, so the run of
+    // whitespace after the terminator belongs to neither statement. Comments are
+    // deliberately not skipped: a note above a statement is part of it, which is
+    // what keeps an annotated final SELECT recognisable to the route's limiter
+    // (#281).
+    const trivia = readSqlSpan(input, i, grammar);
+    if (trivia !== null && trivia.kind === "whitespace") {
+      currentLine += countNewlines(input, i, trivia.end);
+      i = trivia.end;
+    }
+    segmentStart = i;
+    statementStartLine = currentLine;
   }
 
-  // Remaining content
-  const trimmed = current.trim();
-  if (trimmed.length > 0) {
-    statements.push({ sql: trimmed, startLine: statementStartLine });
-  }
+  push(input.length);
 
   return statements;
 }
@@ -162,6 +139,6 @@ export function splitStatements(input: string): SplitStatement[] {
 /**
  * Check if input contains multiple statements
  */
-export function isMultiStatement(input: string): boolean {
-  return splitStatements(input).length > 1;
+export function isMultiStatement(input: string, grammar: SqlGrammar = DEFAULT_SQL_GRAMMAR): boolean {
+  return splitStatements(input, grammar).length > 1;
 }

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -398,6 +398,7 @@ export function StudioWorkspace({
                             value={tabMgr.currentTab.query}
                             onContentChange={(val) => tabMgr.updateTabById(tabMgr.currentTab.id, { query: val })}
                             language={editorLanguageForTabType(tabMgr.currentTab.type)}
+                            databaseType={conn.activeConnection?.type}
                             schemaContext={conn.schemaContext}
                             capabilities={conn.metadata?.capabilities}
                           />

--- a/tests/api/db/maintenance.test.ts
+++ b/tests/api/db/maintenance.test.ts
@@ -185,6 +185,34 @@ describe("POST /api/db/maintenance", () => {
     expect(data.message).toBe("OK");
   });
 
+  // The audit log is where an operator reconstructs what was done to a database, so a
+  // refusal recorded as a completed operation is worse than no record. This became routine
+  // rather than theoretical on 2026-08-25: MySQL and Oracle now read the engine's own
+  // verdict, so `success: false` on an HTTP 200 is the ordinary answer for a target the
+  // engine would not touch.
+  test("an operation the engine refused is audited as a failure, not as success", async () => {
+    (mockProvider.runMaintenance as ReturnType<typeof mock>).mockImplementation(async () => ({
+      success: false,
+      executionTime: 3,
+      message: "OPTIMIZE failed: u9v.missing: Table 'u9v.missing' doesn't exist",
+    }));
+
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "vacuum", target: "missing", connection: validConnection },
+    });
+
+    const res = await POST(req as never);
+    const data = await parseResponseJSON<{ success: boolean }>(res);
+
+    // Still a 200: the request was well formed and the statement reached the engine. What
+    // the engine answered travels in the body, and in the audit row.
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(false);
+    expect(mockAuditPush).toHaveBeenCalledTimes(1);
+    expect((mockAuditPush.mock.calls[0]![0] as { result: string }).result).toBe("failure");
+  });
+
   test("non-admin user returns 403", async () => {
     mockGetSession.mockImplementation(
       async (): Promise<{ role: string; username: string } | null> => ({ role: "user", username: "user" }),

--- a/tests/api/db/multi-query.test.ts
+++ b/tests/api/db/multi-query.test.ts
@@ -407,6 +407,48 @@ describe("POST /api/db/multi-query", () => {
   // to `prepareQuery` and that it executes the prepared text. The bound a real
   // provider produces for these same statements is pinned at the shared seam, in
   // `tests/unit/db/query-limiter.test.ts` and `tests/unit/db/sql-base.test.ts`.
+  // ── The split happens under the resolved connection's dialect (S1) ────────
+  //
+  // This is the one surface that EXECUTES what the splitter returns, so a fragment
+  // invented by a reading the engine does not share is a statement the operator never
+  // wrote. Measured on postgres 18 (container libredb-postgres): block comments nest,
+  // so `/* a /* b */ ; DROP TABLE users; -- */ SELECT 1` is ONE read there - `ran = 1`,
+  // and the table still in `pg_class` afterwards. The dialect-blind splitter cut it
+  // into three and this route ran fragment two, a bare `DROP TABLE users`.
+  describe("dialect-aware splitting", () => {
+    const attack = "/* a /* b */ ; DROP TABLE users; -- */ SELECT 1";
+
+    test("a PostgreSQL connection runs one statement and never the hidden DROP", async () => {
+      const req = createMockRequest("/api/db/multi-query", {
+        method: "POST",
+        body: { connection: validConnection, sql: attack },
+      });
+
+      const res = await POST(req as never);
+      const data = await parseResponseJSON<{ statementCount: number; statements: { sql: string }[] }>(res);
+      const executed = (mockProvider.query as ReturnType<typeof mock>).mock.calls.map((call) => call[0]);
+
+      expect(data.statementCount).toBe(1);
+      expect(executed).not.toContain("DROP TABLE users");
+      expect(data.statements[0].sql).toBe(attack);
+    });
+
+    test("a MySQL connection reads the same text flat, which is that engine's own answer", async () => {
+      // Measured on MySQL (container libredb-mysql): the DROP really does run there -
+      // the schema's table count went to 0 - so three fragments is the honest split and
+      // the confirmation gate is what must ask about it, not this route.
+      const req = createMockRequest("/api/db/multi-query", {
+        method: "POST",
+        body: { connection: { ...validConnection, type: "mysql", port: 3306 }, sql: attack },
+      });
+
+      const res = await POST(req as never);
+      const data = await parseResponseJSON<{ statementCount: number }>(res);
+
+      expect(data.statementCount).toBe(3);
+    });
+  });
+
   describe("final-statement classification", () => {
     test("comment-led final SELECT is prepared and the bounded SQL reaches the engine", async () => {
       const finalStatement = "-- final read\nSELECT * FROM users";

--- a/tests/components/QueryEditor.test.tsx
+++ b/tests/components/QueryEditor.test.tsx
@@ -793,6 +793,49 @@ describe("QueryEditor", () => {
     window.removeEventListener("execute-query", handler);
   });
 
+  test("getEffectiveQuery reads the statement boundary under the connection's dialect", () => {
+    /*
+      The third reader of "where does a statement end", and the one whose answer is what
+      gets SENT. It used to be `lastIndexOf(";")` over the raw text - no spans, no
+      dialect, not even a string-literal check - so on this buffer, which PostgreSQL
+      reads as the single statement `SELECT 1`, it cut at the `;` inside the nested
+      comment and sent only the tail: a line comment followed by the SELECT. Measured in
+      Chrome on 2026-08-25 against postgres 18, the request body carried that tail and
+      the grid read 0 rows where psql answers 2, because the engine sees a line comment
+      and nothing else. The splitter and the confirmation gate already agreed (S1); this
+      reader did not.
+
+      (This comment says "the tail" rather than quoting it, because quoting it would put
+      a comment closer inside this comment - which is the same reading the fix is about.)
+    */
+    mockUseMonacoReturn = {
+      Range: class {
+        constructor(
+          public startLineNumber: number,
+          public startColumn: number,
+          public endLineNumber: number,
+          public endColumn: number,
+        ) {}
+      },
+    };
+
+    let eventDetail: { query: string } | null = null;
+    const handler = ((e: CustomEvent) => {
+      eventDetail = e.detail;
+    }) as EventListener;
+    window.addEventListener("execute-query", handler);
+
+    const buffer = "/* a /* b */ ; DROP TABLE users; -- */ SELECT 1";
+    render(React.createElement(QueryEditor, createDefaultProps({ value: buffer, databaseType: "postgres" as const })));
+    act(() => {
+      capturedCommands[0].handler();
+    });
+
+    expect(eventDetail).not.toBeNull();
+    expect(eventDetail!.query).toBe(buffer);
+    window.removeEventListener("execute-query", handler);
+  });
+
   test("getEffectiveQuery returns selected text when selection exists", () => {
     mockUseMonacoReturn = {
       Range: class {
@@ -1346,7 +1389,7 @@ describe("QueryEditor", () => {
     window.removeEventListener("execute-query", handler);
   });
 
-  test("getEffectiveQuery: empty statement between semicolons falls through to full value", () => {
+  test("getEffectiveQuery: a caret between two semicolons runs the statement before it", () => {
     mockUseMonacoReturn = {
       Range: class {
         constructor(
@@ -1370,8 +1413,18 @@ describe("QueryEditor", () => {
       capturedCommands[0].handler();
     });
 
-    // Empty statement between ;; → falls through to full editor value
-    expect(eventDetail!.query).toBe("SELECT 1;;SELECT 2");
+    /*
+      The caret sits in the empty statement between the two `;`, so there is no statement
+      it is INSIDE - and the answer is the one it is immediately after.
+
+      This is a deliberate policy change (2026-08-25). Falling through to the whole editor
+      value, which is what the `indexOf(";")` reader did here, means "run the statement I
+      am in" silently runs EVERY statement in the buffer: with a `DROP` in the second one
+      that is a destructive surprise, and it is the same all-or-nothing reading the
+      multi-statement route exists to make explicit. The nearest preceding statement is
+      what the caret is actually pointing at.
+    */
+    expect(eventDetail!.query).toBe("SELECT 1");
     window.removeEventListener("execute-query", handler);
   });
 

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -857,12 +857,18 @@ describe("isDangerousQuery", () => {
    *
    * The write-inside-a-read probe looks for `UPDATE … SET` only, because widening it
    * to the other write keywords would make every read whose code names one of them
-   * prompt. And the whole editor text is read as one statement, so a destructive
-   * statement later in a script is only caught by that same unanchored probe.
+   * prompt.
+   *
+   * The gap this list used to record beside it - "the whole editor text is read as one
+   * statement, so a destructive statement later in a script is only caught by that same
+   * unanchored probe" - is closed (S1): the predicate now reads the SAME fragments
+   * `/api/db/multi-query` will run, so a later `DROP` is answered by its own fragment's
+   * keyword rather than by luck. The row below is kept, with the answer it now has,
+   * because a regression there is silence on a script's second statement.
    */
   test.each<[string, string, boolean]>([
     ["a DELETE hidden in a CTE body", "WITH gone AS (DELETE FROM t RETURNING *) SELECT * FROM gone", false],
-    ["a DROP after a leading SELECT", "SELECT 1; DROP TABLE users", false],
+    ["a DROP after a leading SELECT", "SELECT 1; DROP TABLE users", true],
     ["an UPDATE after a leading SELECT", "SELECT 1;\nUPDATE t SET x = 1", true],
   ])("answers %s with %p", (_label, query, expected) => {
     expect(isDangerousQuery(query)).toBe(expected);
@@ -1056,6 +1062,51 @@ describe("isDangerousQuery", () => {
     expect(isDangerousQuery(query, "clickhouse")).toBe(true);
   });
 
+  // ── `//` is a line comment on two engines and an operator on the rest (S1) ──
+  //
+  // The fourth grammar fact, and the only one two unrelated engines share: CQL and
+  // ClickHouse read `//` to end of line, so a `;` behind it separates nothing and a
+  // statement behind it is text nobody wrote. Measured 2026-08-25 - Cassandra 5.0.9
+  // and ScyllaDB 2026.2.4 return the row for `SELECT release_version FROM
+  // system.local // note; DROP KEYSPACE nope`, and ClickHouse 26.7.1 answers 1 for
+  // `SELECT 1 // note; DROP TABLE nope` while the bare DROP is refused on both. Every
+  // other dialect here reads the characters where they stand: PostgreSQL 18 answers
+  // "operator does not exist: integer // integer".
+  //
+  // This predicate splits the buffer and asks about each fragment, so the fact decides
+  // whether there IS a second fragment to ask about - which is what makes the answer
+  // differ by dialect for one identical string.
+
+  test.each<["cassandra" | "clickhouse"]>([["cassandra"], ["clickhouse"]])(
+    "stays silent on %s, where the destructive half is commented out",
+    (type) => {
+      expect(isDangerousQuery("SELECT 1 // note; DROP TABLE users", type)).toBe(false);
+    },
+  );
+
+  test.each<[string]>([["postgres"], ["mysql"], ["trino"], ["mssql"]])(
+    "prompts on %s, where `//` is not a comment and the DROP is a statement",
+    (type) => {
+      expect(isDangerousQuery("SELECT 1 // note; DROP TABLE users", type as "postgres")).toBe(true);
+    },
+  );
+
+  // The compatibility default, for a dialect this product has not measured: `//` is
+  // not a comment there either, so the fragment behind it is asked about. Silence
+  // would be the answer that needs the evidence, not the prompt.
+  test("prompts with no dialect at all, which is the unmeasured reading", () => {
+    expect(isDangerousQuery("SELECT 1 // note; DROP TABLE users")).toBe(true);
+  });
+
+  // The line comment ENDS at the newline, so what follows is code again - the same
+  // reading `--` gets, and the reason `//` is not a to-end-of-buffer rule. The `;` here
+  // sits on the second line, so it really is a boundary and the DROP really is a
+  // statement: Cassandra 5.0.9 answers "line 2:0 mismatched input 'DROP'" for the same
+  // text, which is the engine agreeing there are two things here.
+  test("prompts on cassandra where the separator is on the line after the comment", () => {
+    expect(isDangerousQuery("SELECT 1 // note\n; DROP TABLE users", "cassandra")).toBe(true);
+  });
+
   // ── Where a block comment ends decides what this predicate reads (#300) ──
   //
   // The third grammar fact, and the one that reaches this predicate through the
@@ -1157,5 +1208,67 @@ describe("isDangerousQuery", () => {
 
     expect(dangerous).toBe(false);
     expect(elapsed, `took ${elapsed.toFixed(1)}ms`).toBeLessThan(200);
+  });
+
+  // ── The gate reads what the RUNNER will run (S1) ─────────────────────────
+
+  /**
+   * A buffer holding more than one statement does not run as one: the editor sends it
+   * to `/api/db/multi-query`, which splits it and runs the fragments in order. This
+   * predicate read only the whole text, so the operative keyword of
+   * `SELECT 1; DROP TABLE users` is SELECT and the DROP ran unconfirmed - the gate and
+   * the runner disagreed about what was going to run.
+   *
+   * The fix is the shared splitter under the same grammar, so the two ask about the
+   * same fragments.
+   */
+  test.each<[string, string]>([
+    ["a DROP in the second statement", "SELECT 1; DROP TABLE users"],
+    ["a DELETE after a read", "SELECT count(*) FROM users;\nDELETE FROM sessions"],
+    ["an UPDATE ... SET in the last statement", "SELECT 1; SELECT 2; UPDATE t SET x = 1"],
+    ["a write behind a comment in a later fragment", "SELECT 1;\n-- cleanup\nTRUNCATE TABLE audit"],
+  ])("prompts for %s, which only a fragment carries", (_label, query) => {
+    expect(isDangerousQuery(query, "postgres")).toBe(true);
+  });
+
+  test("a script of reads still does not prompt", () => {
+    expect(isDangerousQuery("SELECT 1; SELECT 2;\nSELECT * FROM users", "postgres")).toBe(false);
+  });
+
+  /**
+   * The entry's own attack, from both sides - and the two dialects answer differently
+   * because the ENGINES do, which is the whole point of threading the grammar.
+   *
+   * Measured on postgres 18 (container libredb-postgres): block comments nest, so the
+   * operator's text is one read and the table survives it - `ran = 1`, and the table
+   * still in `pg_class` afterwards. The splitter now agrees, so no bare DROP fragment
+   * exists to run and the gate has nothing to ask about.
+   *
+   * Measured on MySQL (container libredb-mysql): comments are flat, so the same text
+   * really does drop the table - `information_schema.tables` for that schema went to
+   * 0 - and the whole-text reading found no operative keyword at all, because the
+   * first code character there is the `;`. That is the silence this test closes.
+   */
+  test("the S1 attack: silent under PostgreSQL because nothing destructive runs", () => {
+    const attack = "/* a /* b */ ; DROP TABLE users; -- */ SELECT 1";
+
+    expect(isDangerousQuery(attack, "postgres")).toBe(false);
+  });
+
+  test("the S1 attack: prompts under MySQL, where the DROP really is a statement", () => {
+    const attack = "/* a /* b */ ; DROP TABLE users; -- */ SELECT 1";
+
+    expect(isDangerousQuery(attack, "mysql")).toBe(true);
+  });
+
+  /**
+   * The narrowing that keeps this from becoming a false-prompt machine on the two
+   * dialects whose text is not SQL: a `;` in a Mongo document or a Redis command
+   * separates nothing, so a fragment cut there is invented (#427) - and the
+   * multi-statement route is a SQL route those never take.
+   */
+  test("does not split a non-SQL buffer looking for fragments to prompt about", () => {
+    expect(isDangerousQuery('{"operation":"find","filter":{"note":"; drop table t"}}', "mongodb")).toBe(false);
+    expect(isDangerousQuery('SET note "a; delete from t"', "redis")).toBe(false);
   });
 });

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -1460,4 +1460,205 @@ describe("OperationsTab", () => {
 
     expect(getByTestId("operations-tables-empty").textContent).toBe("No tables found.");
   });
+  // ── Every control is gated and titled by the provider's own declaration (#U9) ──
+  //
+  // #427 reverted a generic label-to-operation mapping, and the reason is here: two
+  // engines that declare the same `MaintenanceType` take different kinds of target,
+  // so only the provider can say what a control may be pointed at. These tests use
+  // the shapes the real providers declare.
+
+  const render_ = async () => {
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+    return renderResult!;
+  };
+
+  const titlesIn = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("button"))
+      .map((b) => b.getAttribute("title"))
+      .filter((t): t is string => t !== null);
+
+  test("MySQL renders its own maintenance words and never 'Vacuum Table'", async () => {
+    // MySQL has no VACUUM at all: the base default put "Run Vacuum / Reclaim Space"
+    // on this tab and "Vacuum" on every table row for an engine whose operations are
+    // analyze/optimize/check/kill.
+    mockMetadata = {
+      capabilities: {
+        supportsMaintenance: true,
+        maintenanceOperations: ["analyze", "optimize", "check", "kill"],
+        maintenanceOperationSpecs: {
+          analyze: { label: "Analyze Table", perEntity: true, global: true },
+          optimize: { label: "Optimize Table", perEntity: true, global: true },
+          check: { label: "Check Table", perEntity: true, global: true },
+          kill: { label: "Kill Connection", perEntity: false, global: false },
+        },
+      },
+      labels: {
+        analyzeGlobalLabel: "Run Analyze",
+        analyzeGlobalTitle: "Update Statistics",
+        analyzeGlobalDesc: "Runs ANALYZE TABLE over every table.",
+        vacuumActionOperation: "optimize",
+        vacuumGlobalLabel: "Run Optimize",
+        vacuumGlobalTitle: "Optimize Tables",
+        vacuumGlobalDesc: "Runs OPTIMIZE TABLE over every table in the database.",
+      },
+    };
+
+    const { queryByText, container } = await render_();
+
+    // The global card the provider's wording was written for now renders...
+    expect(queryByText("Run Optimize")).not.toBeNull();
+    expect(queryByText("Optimize Tables")).not.toBeNull();
+    // ...and the words for an operation MySQL does not have are gone.
+    expect(queryByText("Run Vacuum")).toBeNull();
+    expect(queryByText("Reclaim Space")).toBeNull();
+
+    const titles = titlesIn(container);
+    expect(titles).toContain("Analyze Table");
+    expect(titles).toContain("Optimize Table");
+    expect(titles).toContain("Check Table");
+    expect(titles).not.toContain("Vacuum");
+    expect(titles).not.toContain("Vacuum Table");
+    // `kill` declares neither placement: its target is a connection id, which only
+    // the Sessions panel below can supply.
+    expect(titles).not.toContain("Kill Connection");
+  });
+
+  test("the global card whose label was redirected SENDS the redirected operation", async () => {
+    // Sending `vacuum` to SQL Server, Oracle, MySQL or ClickHouse is a 400 from
+    // /api/db/maintenance: none of them declares it.
+    mockMetadata = {
+      capabilities: {
+        supportsMaintenance: true,
+        maintenanceOperations: ["analyze", "optimize", "kill"],
+        maintenanceOperationSpecs: {
+          analyze: { label: "Gather Statistics", perEntity: true, global: true },
+          optimize: { label: "Rebuild Indexes", perEntity: true, global: true },
+          kill: { label: "Kill Session", perEntity: false, global: false },
+        },
+      },
+      labels: { vacuumActionOperation: "optimize", vacuumGlobalLabel: "Rebuild Indexes" },
+    };
+
+    const { queryByText } = await render_();
+    const button = queryByText("Rebuild Indexes");
+    expect(button).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.click(button!);
+    });
+
+    expect(mockRunMaintenance).toHaveBeenCalledWith("optimize", undefined);
+  });
+
+  test("an operation with no whole-database form gets no global card", async () => {
+    // ClickHouse: OPTIMIZE names one table, so the "Merge Parts" card would always
+    // have answered *"The optimize operation requires a target"*. Its analyze does
+    // take both, so the section itself still renders - which is what makes the
+    // absence of the optimize card a gate rather than a blanket denial.
+    mockMetadata = {
+      capabilities: {
+        supportsMaintenance: true,
+        maintenanceOperations: ["optimize", "analyze", "kill"],
+        maintenanceOperationSpecs: {
+          optimize: { label: "Optimize Table", perEntity: true, global: false },
+          analyze: { label: "Table Statistics", perEntity: true, global: true },
+          kill: { label: "Cancel Query", perEntity: false, global: false },
+        },
+      },
+      labels: {
+        vacuumActionOperation: "optimize",
+        vacuumGlobalLabel: "Optimize",
+        vacuumGlobalTitle: "Merge Parts",
+        analyzeGlobalLabel: "Table Statistics",
+      },
+    };
+
+    const { queryByText, container } = await render_();
+
+    expect(queryByText("Global Operations")).not.toBeNull();
+    expect(queryByText("Table Statistics")).not.toBeNull();
+    expect(queryByText("Optimize")).toBeNull();
+    expect(queryByText("Merge Parts")).toBeNull();
+    // The per-table control is the one that CAN succeed, so it stays.
+    expect(titlesIn(container)).toContain("Optimize Table");
+  });
+
+  test("Couchbase's global Reindex card is withheld and the per-collection item carries the target", async () => {
+    // The #U6 card rendered for every provider declaring `reindex` and answered
+    // *"The reindex operation requires a target"* on Couchbase, whose BUILD INDEX
+    // names one keyspace and has no whole-bucket form.
+    mockMetadata = {
+      capabilities: {
+        supportsMaintenance: true,
+        maintenanceOperations: ["analyze", "reindex", "kill"],
+        maintenanceOperationSpecs: {
+          analyze: { label: "Update Statistics", perEntity: true, global: false },
+          reindex: { label: "Build Deferred Indexes", perEntity: true, global: false },
+          kill: { label: "Cancel Request", perEntity: false, global: false },
+        },
+      },
+      labels: {
+        reindexGlobalLabel: "Build Indexes",
+        reindexGlobalTitle: "Build Deferred GSI Indexes",
+        analyzeGlobalLabel: "Update Statistics",
+      },
+    };
+
+    const { queryByText, container } = await render_();
+
+    // Not one global control can succeed here, so the whole section is absent.
+    expect(queryByText("Global Operations")).toBeNull();
+    expect(queryByText("Build Indexes")).toBeNull();
+    expect(queryByText("Update Statistics")).toBeNull();
+
+    const titles = titlesIn(container);
+    expect(titles).toContain("Build Deferred Indexes");
+    expect(titles).toContain("Update Statistics");
+
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[title="Build Deferred Indexes"]')!);
+    });
+
+    // The target is what made this control honest: "users" is the collection row.
+    expect(mockRunMaintenance).toHaveBeenCalledWith("reindex", "users");
+  });
+
+  test("an operation that ignores its target gets no per-row control", async () => {
+    // Redis: `runMaintenance(type)` takes no target parameter at all, so a per-row
+    // "Key Info" answered with server-wide metrics for one key prefix (#427). Rows
+    // here are addressable, so nothing but the declaration withholds the control.
+    mockMetadata = {
+      capabilities: {
+        supportsMaintenance: true,
+        maintenanceOperations: ["analyze"],
+        maintenanceOperationSpecs: { analyze: { label: "Server Info", perEntity: false, global: true } },
+      },
+      labels: { analyzeGlobalLabel: "Run Info", analyzeGlobalTitle: "Server Info" },
+    };
+
+    const { queryByText, container } = await render_();
+
+    expect(queryByText("Run Info")).not.toBeNull();
+    expect(titlesIn(container)).not.toContain("Server Info");
+  });
+
+  test("a provider that declares no specs keeps the pre-#U9 controls", async () => {
+    // `maintenanceOperationSpecs` is optional on the published interface, so an
+    // implementation that declares nothing must behave exactly as it did.
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze", "vacuum", "reindex"] },
+    };
+
+    const { queryByText, container } = await render_();
+
+    expect(queryByText("Run Analyze")).not.toBeNull();
+    expect(queryByText("Run Vacuum")).not.toBeNull();
+    expect(queryByText("Run Reindex")).not.toBeNull();
+    const titles = titlesIn(container);
+    expect(titles).toContain("Analyze");
+    expect(titles).toContain("Vacuum");
+  });
 });

--- a/tests/components/monitoring/TablesTab.test.tsx
+++ b/tests/components/monitoring/TablesTab.test.tsx
@@ -471,3 +471,117 @@ describe("tables that carry no per-table bytes", () => {
     expect(getByTestId("tables-stat-size").textContent).toBe("820.00 MB");
   });
 });
+
+describe("per-row controls follow the provider's own declaration", () => {
+  // Scoped here as well as in the blocks above: bun:test registers a hook on the
+  // enclosing describe only, so without this the first render in this block leaks into
+  // the second and the control arm queries the previous test's DOM.
+  afterEach(() => {
+    cleanup();
+  });
+
+  const titlesFrom = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("button"))
+      .map((b) => b.getAttribute("title"))
+      .filter((t): t is string => t !== null);
+
+  test("MySQL gets its own three verbs and no vacuum control at all", () => {
+    // MySQL has no VACUUM: the generic list offered "Analyze" alone and named nothing
+    // it could run for the OPTIMIZE and CHECK it does have (#U9).
+    const { container } = render(
+      <TablesTab
+        data={makeData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities({
+          maintenanceOperations: ["analyze", "optimize", "check", "kill"],
+          maintenanceOperationSpecs: {
+            analyze: { label: "Analyze Table", perEntity: true, global: true },
+            optimize: { label: "Optimize Table", perEntity: true, global: true },
+            check: { label: "Check Table", perEntity: true, global: true },
+            kill: { label: "Kill Connection", perEntity: false, global: false },
+          },
+        })}
+      />,
+    );
+
+    const titles = titlesFrom(container);
+    expect(titles).toContain("Analyze Table");
+    expect(titles).toContain("Optimize Table");
+    expect(titles).toContain("Check Table");
+    expect(titles).not.toContain("Vacuum");
+    expect(titles).not.toContain("Vacuum Table");
+    // A connection id comes from the Sessions panel, so no table row may offer it.
+    expect(titles).not.toContain("Kill Connection");
+  });
+
+  test("an operation that ignores the target it is handed gets no per-row control", () => {
+    // SQLite's VACUUM rewrites the whole database file and `runMaintenance` drops the
+    // target, so this button named one table and acted on all of them.
+    const { container } = render(
+      <TablesTab
+        data={makeData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities({
+          maintenanceOperations: ["vacuum", "analyze", "reindex", "check"],
+          maintenanceOperationSpecs: {
+            vacuum: { label: "Vacuum Database", perEntity: false, global: true },
+            analyze: { label: "Analyze Table", perEntity: true, global: true },
+            reindex: { label: "Reindex Table", perEntity: true, global: true },
+            check: { label: "Integrity Check", perEntity: false, global: true },
+          },
+        })}
+      />,
+    );
+
+    const titles = titlesFrom(container);
+    expect(titles).toContain("Analyze Table");
+    expect(titles).toContain("Reindex Table");
+    expect(titles).not.toContain("Vacuum Database");
+    expect(titles).not.toContain("Integrity Check");
+  });
+
+  test("the button sends the operation its label was declared for", async () => {
+    const onRunMaintenance = mock(async () => true);
+    const { container } = render(
+      <TablesTab
+        data={makeData()}
+        loading={false}
+        onRunMaintenance={onRunMaintenance}
+        capabilities={makeCapabilities({
+          maintenanceOperations: ["analyze", "optimize"],
+          maintenanceOperationSpecs: {
+            analyze: { label: "Gather Statistics", perEntity: true, global: true },
+            optimize: { label: "Rebuild Indexes", perEntity: true, global: true },
+          },
+        })}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('button[title="Rebuild Indexes"]')!);
+
+    // Oracle's "Rebuild Indexes" is `optimize`, and the target is the TABLE - the
+    // shape that answered ORA-01418 for a table name before this change.
+    await waitFor(() => expect(onRunMaintenance).toHaveBeenCalledWith("optimize", "users"));
+  });
+
+  test("a provider that declares no specs keeps the pre-#U9 three controls", () => {
+    // `maintenanceOperationSpecs` is optional on the published interface: an
+    // implementation that declares nothing must behave exactly as it did.
+    const { container } = render(
+      <TablesTab
+        data={makeData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities({ maintenanceOperations: ["vacuum", "analyze", "reindex", "optimize"] })}
+      />,
+    );
+
+    const titles = titlesFrom(container);
+    expect(titles).toContain("Analyze");
+    expect(titles).toContain("Vacuum");
+    expect(titles).toContain("Reindex");
+    expect(titles).toContain("Optimize");
+  });
+});

--- a/tests/components/schema-explorer/TableItem.test.tsx
+++ b/tests/components/schema-explorer/TableItem.test.tsx
@@ -95,6 +95,31 @@ const libredbCaps = caps({
  * and the engine still declares no maintenance of any kind.
  */
 const searchCaps = caps({ supportsMaintenance: false, maintenanceOperations: [] });
+/**
+ * SQLite-shaped (#U9): `VACUUM` rewrites the whole file and takes no target, so the
+ * provider declares `vacuum: { perEntity: false }` — and the monitoring Tables tab
+ * already withholds that control while this menu still offered it for ONE table.
+ */
+const sqliteCaps = caps({
+  supportsMaintenance: true,
+  maintenanceOperations: ["vacuum", "analyze", "reindex", "check"],
+  maintenanceOperationSpecs: {
+    vacuum: { label: "Vacuum Database", perEntity: false, global: true },
+    analyze: { label: "Analyze Table", perEntity: true, global: true },
+  },
+});
+/**
+ * MySQL-shaped (#U9): no `vacuum` at all, and the vacuum SLOT names `optimize` —
+ * which is the operation whose `perEntity` decides whether the item may appear.
+ */
+const mysqlCaps = caps({
+  supportsMaintenance: true,
+  maintenanceOperations: ["analyze", "optimize", "check", "kill"],
+  maintenanceOperationSpecs: {
+    analyze: { label: "Analyze Table", perEntity: true, global: true },
+    optimize: { label: "Optimize Table", perEntity: true, global: true },
+  },
+});
 
 /**
  * Labels are partial for the same reason capabilities are: TableItem reads four
@@ -700,6 +725,88 @@ describe("TableItem", () => {
       // derived grouping stays: this gate is about maintenance and nothing else.
       expect(dropdown.queryByText("Profile Table")).not.toBeNull();
       expect(dropdown.queryByText("Generate Test Data")).not.toBeNull();
+    });
+
+    /*
+      A THIRD surface renders the same wording (#U9). This menu gated both items on
+      `supportsMaintenance` alone, so on SQLite it offered "Vacuum Table" for ONE table
+      while the monitoring Tables tab correctly withheld that control — SQLite declares
+      `vacuum: { perEntity: false }` because `VACUUM` rewrites the whole file and
+      ignores a target. Clicking it deep-linked to a page with no such control: the
+      exact dead end this file's own comment above records as fixed for Elasticsearch.
+    */
+    test("withholds the vacuum item where the provider says vacuum takes no table", () => {
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin
+          capabilities={sqliteCaps}
+          labels={labelsFor({})}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Vacuum Table")).toBeNull();
+      // Analyze DOES take a table here, so this is not the blanket withholding the
+      // no-maintenance engines get.
+      expect(dropdown.queryByText("Analyze Table")).not.toBeNull();
+    });
+
+    test("follows the vacuum slot to the operation it actually names", () => {
+      // MySQL declares no `vacuum`; its vacuum slot says "Optimize Table" and
+      // `vacuumActionOperation` says that is `optimize`, which IS per-table here.
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin
+          capabilities={mysqlCaps}
+          labels={labelsFor({ vacuumAction: "Optimize Table", vacuumActionOperation: "optimize" })}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Optimize Table")).not.toBeNull();
+      expect(dropdown.queryByText("Vacuum Table")).toBeNull();
+    });
+
+    test("takes the wording from the provider's own declaration, not from the label slot", () => {
+      // `label` on the spec is the engine's own name for the control and it wins over
+      // BOTH `labels.analyzeAction` and this component's generic fallback, exactly as
+      // it does on the other two surfaces. All three strings are different here on
+      // purpose: asserting the spec label while it reads the same as the fallback
+      // ("Analyze Table") cannot fail, whichever branch the component took.
+      const { getByTestId } = render(
+        <TableItem
+          table={largeTable}
+          isExpanded={false}
+          onToggle={mock(() => {})}
+          isAdmin
+          capabilities={caps({
+            supportsMaintenance: true,
+            maintenanceOperations: ["analyze"],
+            maintenanceOperationSpecs: { analyze: { label: "Refresh Statistics", perEntity: true, global: true } },
+          })}
+          labels={labelsFor({ analyzeAction: "Gather Statistics" })}
+        />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Refresh Statistics")).not.toBeNull();
+      expect(dropdown.queryByText("Gather Statistics")).toBeNull();
+      expect(dropdown.queryByText("Analyze Table")).toBeNull();
+    });
+
+    test("offers nothing while the capabilities are still unknown", () => {
+      // `/api/db/provider-meta` answers with nothing both while it is in flight and
+      // when it failed, and both maintenance surfaces read that as a denial. A menu
+      // that guessed "offer it" is how the dead buttons came back.
+      const { getByTestId } = render(
+        <TableItem table={largeTable} isExpanded={false} onToggle={mock(() => {})} isAdmin labels={labelsFor({})} />,
+      );
+      const dropdown = within(getByTestId("dropdown"));
+      expect(dropdown.queryByText("Analyze Table")).toBeNull();
+      expect(dropdown.queryByText("Vacuum Table")).toBeNull();
     });
 
     test("hides maintenance from a non-admin even when declared", () => {

--- a/tests/hooks/use-monitoring-data.test.ts
+++ b/tests/hooks/use-monitoring-data.test.ts
@@ -310,6 +310,44 @@ describe("useMonitoringData", () => {
     expect(mockToastSuccess).toHaveBeenCalled();
   });
 
+  // ── a refused operation is reported as refused, not as a green tick ────────
+
+  test("runMaintenance reports an HTTP 200 carrying success:false as a failure", async () => {
+    /*
+      The route answers 200 whenever the STATEMENT reached the engine; whether the engine
+      DID the work is `result.success`, and reading only the status code made every
+      refusal a green success toast. Measured through the real MySQL provider on
+      2026-08-25: OPTIMIZE on a table that is not there answers
+      `{"success":false,"message":"OPTIMIZE failed: u9v.missing: Table 'u9v.missing'
+      doesn't exist"}` with a 200, so the operator was told the optimize completed and
+      the Operations tab logged it as a success.
+    */
+    mockGlobalFetch({
+      "/api/db/monitoring": { ok: true, json: mockMonitoringResponse },
+      "/api/db/maintenance": {
+        ok: true,
+        json: { success: false, message: "OPTIMIZE failed: u9v.missing: Table 'u9v.missing' doesn't exist" },
+      },
+    });
+
+    const { result } = renderHook(() => useMonitoringData(mockConnection));
+
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+
+    let maintenanceResult = true;
+    await act(async () => {
+      maintenanceResult = await result.current.runMaintenance("optimize", "missing");
+    });
+
+    // The boolean is what OperationsTab writes into its own log, so it has to carry the
+    // engine's verdict rather than the transport's.
+    expect(maintenanceResult).toBe(false);
+    expect(mockToastError).toHaveBeenCalledWith("OPTIMIZE failed: u9v.missing: Table 'u9v.missing' doesn't exist");
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
   // ── history is empty initially ─────────────────────────────────────────────
 
   test("history is empty initially", () => {

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -658,6 +658,49 @@ describe("useQueryExecution", () => {
     expect(multiCall).toBeDefined();
   });
 
+  // ── the multi-statement decision reads the connection's dialect (S1) ───────
+
+  test("executeQuery keeps a PostgreSQL nested-comment buffer on /api/db/query", async () => {
+    /*
+      Measured on postgres 18 (container libredb-postgres): block comments NEST there,
+      so `/* a /* b *\/ ; DROP TABLE users; -- *\/ SELECT 1` is one read - the statement
+      ran as `SELECT 1` and the table was still in `pg_class` afterwards. The
+      dialect-blind splitter said 3, so this buffer took the multi-statement route and
+      it executed a bare `DROP TABLE users` the operator's text never contained.
+
+      The active connection here is `postgres`, so the decision is made under that
+      dialect's grammar and the buffer stays on the single-statement endpoint.
+
+      The buried statement is an UPDATE rather than the entry's DROP for a mock reason,
+      not a behavioural one: the file-wide `isDangerousQuery` stub above flags any text
+      CONTAINING the word DROP, so that buffer would stop at the confirmation dialog
+      before any endpoint was chosen and this test would assert nothing about routing.
+      What the real predicate answers for the entry's own shape is pinned in
+      tests/components/QuerySafetyDialog.test.tsx, against the real grammar.
+    */
+    const fetchMock = mockGlobalFetch({
+      "/api/db/multi-query": { ok: true, json: mockQueryResult },
+      "/api/db/query": { ok: true, json: mockQueryResult },
+    });
+
+    const params = createDefaultParams();
+
+    const { result } = renderHook(() => useQueryExecution(params));
+
+    await act(async () => {
+      await result.current.executeQuery("/* a /* b */ ; UPDATE users SET admin = true; -- */ SELECT 1");
+    });
+
+    const multiCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/multi-query"),
+    );
+    expect(multiCall).toBeUndefined();
+    const singleCall = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/db/query"),
+    );
+    expect(singleCall).toBeDefined();
+  });
+
   // ── a non-SQL dialect never takes the statement splitter ──────────────────
 
   test("executeQuery keeps a JSON-dialect buffer on /api/db/query, semicolons and all (#427)", async () => {

--- a/tests/integration/db/cassandra-provider.test.ts
+++ b/tests/integration/db/cassandra-provider.test.ts
@@ -899,9 +899,11 @@ describe("prepareQuery", () => {
   });
 
   test("a statement ending in a `//` comment is not rewritten either", () => {
-    // CQL has a THIRD line-comment form the shared readers know nothing about, so
-    // the limiter appends the clause INSIDE the comment: measured,
-    // `SELECT * FROM probe.customers // note LIMIT 3` is a syntax error.
+    // CQL's THIRD line-comment form, and it is a shared grammar fact now
+    // (`doubleSlashComment`) rather than a scan this provider kept to itself - so the
+    // mechanism here is exactly the `--` one above: the limiter inserts before the
+    // comment and `sql.trim()` drops the newline that closed it, leaving
+    // `… LIMIT 500 // note` at end of input, which CQL refuses. Left as written.
     const prepared = provider.prepareQuery("SELECT * FROM probe.customers // note\n", { limit: 500 });
 
     expect(prepared.query).toBe("SELECT * FROM probe.customers // note\n");
@@ -909,6 +911,8 @@ describe("prepareQuery", () => {
   });
 
   test("a `//` inside a string literal is not a comment", () => {
+    // The shared span reader is what makes this true, and it is the reason the private
+    // `//` scan could be dropped: a literal reader sits in front of the comment branch.
     const prepared = provider.prepareQuery("SELECT * FROM probe.customers WHERE name = 'http://x'", { limit: 5 });
 
     expect(prepared.query).toBe("SELECT * FROM probe.customers WHERE name = 'http://x' LIMIT 5");

--- a/tests/integration/db/clickhouse-provider.test.ts
+++ b/tests/integration/db/clickhouse-provider.test.ts
@@ -24,6 +24,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import type { DatabaseConnection, DatabaseType } from "@/lib/types";
 import { ClickHouseProvider } from "@/lib/db/providers/sql/clickhouse";
+import { maintenanceControl } from "@/lib/db/types";
 import {
   AuthenticationError,
   ConnectionError,
@@ -404,6 +405,18 @@ afterEach(() => {
 // ============================================================================
 
 describe("ClickHouseProvider metadata", () => {
+  // #U9: "Optimize Table" is `optimize`, not a vacuum ClickHouse does not have. The
+  // global card stays withheld even so, because OPTIMIZE names one table - the
+  // redirection is what stops the surface sending a `vacuum` this provider rejects.
+  test("the vacuum label names OPTIMIZE, whose global form is still withheld", () => {
+    const provider = new ClickHouseProvider(makeConnection());
+    const labels = provider.getLabels();
+
+    expect(labels.vacuumAction).toBe("Optimize Table");
+    expect(labels.vacuumActionOperation).toBe("optimize");
+    expect(provider.getCapabilities().maintenanceOperations).toContain("optimize");
+    expect(provider.getCapabilities().maintenanceOperationSpecs?.optimize?.global).toBe(false);
+  });
   test("declares the capabilities the design spec settled on", () => {
     const capabilities = new ClickHouseProvider(makeConnection()).getCapabilities();
 
@@ -418,6 +431,13 @@ describe("ClickHouseProvider metadata", () => {
       declaresForeignKeys: false,
       supportsMaintenance: true,
       maintenanceOperations: ["optimize", "analyze", "kill"],
+      // OPTIMIZE names one table and `dispatchMaintenance` requires that target, so
+      // there is no whole-database form to offer; `describeParts` accepts both (#U9).
+      maintenanceOperationSpecs: {
+        optimize: { label: "Optimize Table", perEntity: true, global: false },
+        analyze: { label: "Table Statistics", perEntity: true, global: true },
+        kill: { label: "Cancel Query", perEntity: false, global: false },
+      },
       supportsConnectionString: true,
       defaultPort: 8123,
       schemaRefreshPattern: "\\b(CREATE|DROP|ALTER|RENAME|TRUNCATE|ATTACH|DETACH)\\b",
@@ -453,6 +473,23 @@ describe("ClickHouseProvider metadata", () => {
     expect(labels.vacuumAction).toBe("Optimize Table");
     expect(labels.vacuumGlobalDesc).toContain("OPTIMIZE");
     expect(labels.analyzeGlobalDesc).toContain("no ANALYZE");
+  });
+
+  // The `vacuumGlobal*` triad above is DELIBERATELY unreachable, which is a claim that
+  // has to be executable rather than a comment: the global vacuum card follows
+  // `vacuumActionOperation`, and that operation declares no whole-database form here.
+  // Written-and-never-shown wording is the condition #U9 set out to remove, so if a
+  // future spec change makes `optimize` global, this test says the words are live again
+  // and must be checked against what the card would then run.
+  test("the global vacuum card cannot render, so its wording is unreachable by design", () => {
+    const provider = new ClickHouseProvider(makeConnection());
+    const capabilities = provider.getCapabilities();
+    const vacuumOperation = provider.getLabels().vacuumActionOperation ?? "vacuum";
+
+    expect(vacuumOperation).toBe("optimize");
+    expect(maintenanceControl(capabilities, vacuumOperation, "global").offered).toBe(false);
+    // The per-row control IS reachable, so this is not a provider with no maintenance.
+    expect(maintenanceControl(capabilities, vacuumOperation, "perEntity").offered).toBe(true);
   });
 
   // Until #U12 the monitoring Queries panel told a ClickHouse operator to install a
@@ -952,6 +989,28 @@ describe("ClickHouseProvider query preparation", () => {
     const prepared = provider().prepareQuery("SELECT * FROM users -- daily check", { limit: 25 });
 
     expect(prepared.query).toBe("SELECT * FROM users LIMIT 25 -- daily check");
+    expect(prepared.wasLimited).toBe(true);
+  });
+
+  // ── `//` is a line comment here too (S1) ──────────────────────────────────
+  //
+  // The fourth form of the same record. Reading the two slashes as code put the
+  // bound INSIDE the comment, so the server saw an unbounded query: measured on
+  // ClickHouse 26.7.1, `SELECT number FROM numbers(1000) // note` emitted with
+  // `... // note LIMIT 5` returned all 1000 rows while `wasLimited` said 5. The
+  // grammar fact is shared with Apache Cassandra and with no other dialect here.
+
+  test("bounds a statement that ends in a `//` comment, before the comment", () => {
+    const prepared = provider().prepareQuery("SELECT number FROM numbers(1000) // note", { limit: 5 });
+
+    expect(prepared.query).toBe("SELECT number FROM numbers(1000) LIMIT 5 // note");
+    expect(prepared.wasLimited).toBe(true);
+  });
+
+  test("reads a `//` comment as ending at its newline, not at the end of the buffer", () => {
+    const prepared = provider().prepareQuery("SELECT number // note\nFROM numbers(1000)", { limit: 5 });
+
+    expect(prepared.query).toBe("SELECT number // note\nFROM numbers(1000) LIMIT 5");
     expect(prepared.wasLimited).toBe(true);
   });
 

--- a/tests/integration/db/couchbase-provider.test.ts
+++ b/tests/integration/db/couchbase-provider.test.ts
@@ -284,6 +284,14 @@ describe("CouchbaseProvider metadata", () => {
       declaresForeignKeys: false,
       supportsMaintenance: true,
       maintenanceOperations: ["analyze", "reindex", "kill"],
+      // All three go through `requireTarget`, so all three are per-keyspace only.
+      // The global Reindex card that #U6 wired up answered *"The reindex operation
+      // requires a target"* on every click, which is what `global: false` withholds.
+      maintenanceOperationSpecs: {
+        analyze: { label: "Update Statistics", perEntity: true, global: false },
+        reindex: { label: "Build Deferred Indexes", perEntity: true, global: false },
+        kill: { label: "Cancel Request", perEntity: false, global: false },
+      },
       supportsConnectionString: true,
       defaultPort: 8091,
       schemaRefreshPattern: "\\b(CREATE|DROP|ALTER)\\s+(COLLECTION|SCOPE|INDEX)\\b",

--- a/tests/integration/db/mongodb-provider.test.ts
+++ b/tests/integration/db/mongodb-provider.test.ts
@@ -422,6 +422,22 @@ describe("MongoDBProvider", () => {
   // --------------------------------------------------------------------------
 
   describe("getCapabilities()", () => {
+    // #U9: `validate` and `compact` are per-collection commands this provider also
+    // loops over `listCollections()`, so both placements are real. `dbCheck` is not
+    // looped and refuses to run without a collection name.
+    test("declares the target grammar of every maintenance operation", () => {
+      const caps = provider.getCapabilities();
+
+      expect(caps.maintenanceOperationSpecs).toEqual({
+        vacuum: { label: "Compact Collection", perEntity: true, global: true },
+        analyze: { label: "Validate Collection", perEntity: true, global: true },
+        check: { label: "Check Collection", perEntity: true, global: false },
+      });
+      expect(Object.keys(caps.maintenanceOperationSpecs ?? {}).sort()).toEqual([...caps.maintenanceOperations].sort());
+      // MongoDB's "Compact Collection" really is the `vacuum` it declares, so the
+      // label needs no redirection.
+      expect(provider.getLabels().vacuumActionOperation).toBeUndefined();
+    });
     test("returns correct capability metadata", () => {
       const caps = provider.getCapabilities();
       expect(caps.queryLanguage).toBe("json");

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -566,6 +566,30 @@ describe("MSSQLProvider", () => {
   // =========================================================================
 
   describe("getCapabilities()", () => {
+    // #U9: DBCC CHECKDB takes no object, and `runMaintenance` ignores the target for
+    // it - a per-table Check control would have named one table and checked the
+    // database.
+    test("declares the target grammar of every maintenance operation", () => {
+      const caps = provider.getCapabilities();
+
+      expect(caps.maintenanceOperationSpecs).toEqual({
+        analyze: { label: "Update Statistics", perEntity: true, global: true },
+        check: { label: "Check Database", perEntity: false, global: true },
+        optimize: { label: "Rebuild Indexes", perEntity: true, global: true },
+        kill: { label: "Kill Session", perEntity: false, global: false },
+      });
+      expect(Object.keys(caps.maintenanceOperationSpecs ?? {}).sort()).toEqual([...caps.maintenanceOperations].sort());
+    });
+
+    test("the vacuum label names the index rebuild, and the surfaces send that", () => {
+      const labels = provider.getLabels();
+
+      expect(labels.vacuumAction).toBe("Rebuild Indexes");
+      expect(labels.vacuumActionOperation).toBe("optimize");
+      // A redirected slot must name an operation the provider really declares,
+      // otherwise the card it gates could only ever produce a 400.
+      expect(provider.getCapabilities().maintenanceOperations).toContain("optimize");
+    });
     test("returns correct capabilities for MSSQL", () => {
       const caps = provider.getCapabilities();
       expect(caps.defaultPort).toBe(1433);

--- a/tests/integration/db/mysql-provider.test.ts
+++ b/tests/integration/db/mysql-provider.test.ts
@@ -350,13 +350,47 @@ function defaultMockExecute(sql: string): Promise<[unknown[], unknown[]]> {
     return Promise.resolve([[], []]);
   }
 
-  // ANALYZE TABLE / OPTIMIZE TABLE / CHECK TABLE
+  // ANALYZE TABLE / OPTIMIZE TABLE / CHECK TABLE answer a RESULT SET, one row per
+  // (table, message), and the verdict lives in Msg_type/Msg_text. Measured through the
+  // driver against MySQL 26.7.0 (`libredb-mysql`) on 2026-08-25:
+  //   OPTIMIZE TABLE `real1`   -> note "Table does not support optimize, doing recreate
+  //                               + analyze instead" then status "OK"
+  //   OPTIMIZE TABLE `missing` -> Error "Table 'u9t.missing' doesn't exist" then
+  //                               status "Operation failed"
+  // The empty array this used to answer is what made the "reports success when MySQL
+  // reported failure" defect untestable: no row means no verdict to read.
   if (
     normalized.startsWith("analyze table") ||
     normalized.startsWith("optimize table") ||
     normalized.startsWith("check table")
   ) {
-    return Promise.resolve([[], []]);
+    const op = normalized.split(" ")[0];
+    const named = [...sql.matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+    return Promise.resolve([
+      named.flatMap((name) =>
+        name === "missing"
+          ? [
+              { Table: `testdb.${name}`, Op: op, Msg_type: "Error", Msg_text: `Table 'testdb.${name}' doesn't exist` },
+              { Table: `testdb.${name}`, Op: op, Msg_type: "status", Msg_text: "Operation failed" },
+            ]
+          : [
+              // InnoDB has no in-place OPTIMIZE, so the server prepends this note to
+              // every optimize it does perform - a non-error row the user should see.
+              ...(op === "optimize"
+                ? [
+                    {
+                      Table: `testdb.${name}`,
+                      Op: op,
+                      Msg_type: "note",
+                      Msg_text: "Table does not support optimize, doing recreate + analyze instead",
+                    },
+                  ]
+                : []),
+              { Table: `testdb.${name}`, Op: op, Msg_type: "status", Msg_text: "OK" },
+            ],
+      ),
+      [],
+    ]);
   }
 
   // Default: generic SELECT result
@@ -582,6 +616,35 @@ describe("MySQLProvider", () => {
   // --------------------------------------------------------------------------
 
   describe("getCapabilities()", () => {
+    // #U9: MySQL has no VACUUM at all, and every statement it does have names tables.
+    test("declares the target grammar of every maintenance operation", () => {
+      provider = new MySQLProvider(makeMySQLConfig());
+      const caps = provider.getCapabilities();
+
+      expect(caps.maintenanceOperationSpecs).toEqual({
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+        optimize: { label: "Optimize Table", perEntity: true, global: true },
+        check: { label: "Check Table", perEntity: true, global: true },
+        kill: { label: "Kill Connection", perEntity: false, global: false },
+      });
+      expect(Object.keys(caps.maintenanceOperationSpecs ?? {}).sort()).toEqual([...caps.maintenanceOperations].sort());
+      // The engine has no `vacuum`, so nothing may be offered under that name.
+      expect(caps.maintenanceOperations).not.toContain("vacuum");
+    });
+
+    test("the vacuum label names OPTIMIZE, and the surfaces send that", () => {
+      // The base default put "Vacuum Table" in the explorer's per-row menu and
+      // "Run Vacuum / Reclaim Space" on the Operations tab for an engine that has
+      // neither, and the global card was gated on the literal `vacuum`, so MySQL's
+      // own wording could never appear (#U9).
+      const labels = new MySQLProvider(makeMySQLConfig()).getLabels();
+
+      expect(labels.vacuumAction).toBe("Optimize Table");
+      expect(labels.vacuumActionOperation).toBe("optimize");
+      expect(labels.vacuumGlobalLabel).toBe("Run Optimize");
+      expect(labels.vacuumGlobalTitle).toBe("Optimize Tables");
+      expect(labels.vacuumGlobalDesc).toContain("OPTIMIZE TABLE");
+    });
     test("returns correct MySQL capabilities", () => {
       provider = new MySQLProvider(makeMySQLConfig());
       const caps = provider.getCapabilities();
@@ -786,6 +849,130 @@ describe("MySQLProvider", () => {
       await expect(provider.runMaintenance("vacuum" as unknown as "analyze", "users")).rejects.toThrow(
         "Unsupported maintenance type for MySQL",
       );
+    });
+
+    // ------------------------------------------------------------------------
+    // The verdict is in the RESULT SET, not in the absence of a throw
+    // ------------------------------------------------------------------------
+    // `await runStatement(conn, sql); return { success: true }` discarded the rows
+    // MySQL answers with, so a statement the server refused was reported as a
+    // completed operation and CHECK TABLE's whole purpose - its Msg_text - never
+    // reached the user. Measured through the provider against MySQL 26.7.0 on
+    // 2026-08-25: `optimize u9t` answered `{"success":true,"message":"OPTIMIZE
+    // completed successfully"}` while the server's own answer for the same statement
+    // was Error / "Table 'u9t.missing' doesn't exist" / "Operation failed".
+
+    test("check reports the engine's own verdict rather than a generic sentence", async () => {
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+      const result = await provider.runMaintenance("check", "users");
+
+      expect(result.success).toBe(true);
+      // The Msg_text is the point of CHECK TABLE: "OK" here, a corruption report on a
+      // damaged table.
+      expect(result.message).toContain("OK");
+    });
+
+    test("a table MySQL says does not exist is a failure, and says why", async () => {
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize", "missing");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Table 'testdb.missing' doesn't exist");
+    });
+
+    test("check on a missing table fails too", async () => {
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+      const result = await provider.runMaintenance("check", "missing");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("doesn't exist");
+    });
+
+    test("one failing table fails the whole-database run and names that table", async () => {
+      // The global card sends no target and the statement names every table, so a
+      // per-table Error row is the only place the failure appears.
+      mockExecuteFn = (sql: string) => {
+        if (sql.includes("SELECT TABLE_NAME")) {
+          return Promise.resolve([[{ TABLE_NAME: "users" }, { TABLE_NAME: "missing" }], []]);
+        }
+        return defaultMockExecute(sql);
+      };
+
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("testdb.missing");
+      // The table that DID optimize is not reported as a failure.
+      expect(result.message).not.toContain("testdb.users");
+    });
+
+    test("the non-error rows MySQL adds are kept, deduplicated", async () => {
+      // InnoDB prepends a note to every OPTIMIZE it performs; over many tables that
+      // note and the OK repeat once per table, which is one sentence, not forty.
+      mockExecuteFn = (sql: string) => {
+        if (sql.includes("SELECT TABLE_NAME")) {
+          return Promise.resolve([[{ TABLE_NAME: "users" }, { TABLE_NAME: "orders" }], []]);
+        }
+        return defaultMockExecute(sql);
+      };
+
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize");
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("Table does not support optimize");
+      expect(result.message).toContain("OK");
+      expect(result.message.match(/OK/g)).toHaveLength(1);
+    });
+
+    test("the whole-database form on a database with no tables runs no statement", async () => {
+      // `OPTIMIZE TABLE ${await this.getAllTablesForMaintenance(conn)}` string-joined an
+      // empty list, and MySQL answered "You have an error in your SQL syntax ... near ''"
+      // - measured through the provider against an empty database on 2026-08-25.
+      const statements: string[] = [];
+      mockExecuteFn = (sql: string) => {
+        statements.push(sql);
+        if (sql.includes("SELECT TABLE_NAME")) {
+          return Promise.resolve([[], []]);
+        }
+        return defaultMockExecute(sql);
+      };
+
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize");
+
+      // Nothing to do is not a failure, and it is not a syntax error either.
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("no tables");
+      expect(statements.some((sql) => sql.startsWith("OPTIMIZE TABLE"))).toBe(false);
+    });
+
+    test("a statement that answers a header rather than a result set still succeeds", async () => {
+      // KILL is the one maintenance statement here that does NOT answer a result set -
+      // mysql2 hands back a `ResultSetHeader` object - so it never reaches the row reader
+      // and keeps the generic sentence. The three that do (ANALYZE/OPTIMIZE/CHECK TABLE)
+      // always answer rows, measured on 26.7.0, which is why the reader does not have to
+      // defend against a header shape it is never given.
+      mockExecuteFn = (sql: string) => {
+        if (sql.startsWith("KILL")) {
+          return Promise.resolve([{ affectedRows: 0, warningStatus: 0 }, undefined]);
+        }
+        return defaultMockExecute(sql);
+      };
+
+      provider = new MySQLProvider(makeMySQLConfig());
+      await provider.connect();
+      const result = await provider.runMaintenance("kill", "1234");
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("KILL completed successfully");
     });
   });
 

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -647,7 +647,7 @@ describe("OracleProvider", () => {
     // oracledb answers a non-SELECT with no `rows` array at all and its own
     // `rowsAffected`; the envelope used to be built from `rows.length`, so every
     // INSERT, UPDATE and DELETE reported 0 for work it had done. Measured through
-    // `createDatabaseProvider({type:"oracle"})` against Oracle Free 23ai on
+    // `createDatabaseProvider({type:"oracle"})` against Oracle AI Database 26ai Free on
     // 2026-08-24 (rowsAffected 1 / 3 / 4 / 0 for the shapes below), with an
     // interleaved SELECT proving each statement had landed.
     test("reports the driver's rowsAffected for an INSERT", async () => {
@@ -721,7 +721,7 @@ describe("OracleProvider", () => {
     // LOB columns. Without a fetch type handler oracledb answers a CLOB, an
     // NCLOB and a BLOB with a `Lob` stream object, and the row cannot be
     // serialised at all - measured on 2026-08-24 through
-    // `createDatabaseProvider({type:"oracle"})` against Oracle Free 23ai with
+    // `createDatabaseProvider({type:"oracle"})` against Oracle AI Database 26ai Free with
     // oracledb 6.10.0 Thin: every one of the four LOB columns of `r6_lob` came
     // back with `constructor.name === "Lob"`, and `JSON.stringify` of the row
     // threw `TypeError: Converting circular structure to JSON ... starting at
@@ -818,7 +818,7 @@ describe("OracleProvider", () => {
 
     // INTERVAL columns. oracledb answers them with its own `IntervalYM` /
     // `IntervalDS` objects, which no surface here reconstructs and which Oracle
-    // refuses back. Measured 2026-08-24 against Oracle Free 23ai (oracledb 6.10.0,
+    // refuses back. Measured 2026-08-24 against Oracle AI Database 26ai Free (oracledb 6.10.0,
     // Thin) over `d19_probe`: `INTERVAL '3-7' YEAR TO MONTH` arrived as
     // `{"months":7,"years":3}` and `INTERVAL '5 6:7:8.9' DAY TO SECOND` as
     // `{"fseconds":900000000,"seconds":8,"minutes":7,"hours":6,"days":5}`. The
@@ -946,6 +946,28 @@ describe("OracleProvider", () => {
   // =========================================================================
 
   describe("getCapabilities()", () => {
+    // #U9: `optimize` takes a TABLE and rebuilds that table's own indexes. It used to
+    // take an INDEX name, so the per-table button #427 wired up sent a table and every
+    // click answered ORA-01418 (reproduced against Oracle AI Database 26ai Free on 2026-08-25).
+    test("declares the target grammar of every maintenance operation", () => {
+      const caps = provider.getCapabilities();
+
+      expect(caps.maintenanceOperationSpecs).toEqual({
+        analyze: { label: "Gather Statistics", perEntity: true, global: true },
+        optimize: { label: "Rebuild Indexes", perEntity: true, global: true },
+        kill: { label: "Kill Session", perEntity: false, global: false },
+      });
+      expect(Object.keys(caps.maintenanceOperationSpecs ?? {}).sort()).toEqual([...caps.maintenanceOperations].sort());
+    });
+
+    test("the vacuum label names the index rebuild, and the surfaces send that", () => {
+      // Oracle has no VACUUM; this slot has said "Rebuild Indexes" since the provider
+      // shipped, and the global card gated on the literal `vacuum` never showed it.
+      const labels = provider.getLabels();
+
+      expect(labels.vacuumAction).toBe("Rebuild Indexes");
+      expect(labels.vacuumActionOperation).toBe("optimize");
+    });
     test("returns correct capabilities for Oracle", () => {
       const caps = provider.getCapabilities();
       expect(caps.defaultPort).toBe(1521);
@@ -1318,18 +1340,219 @@ describe("OracleProvider", () => {
       expect(capturedSql).toContain("GATHER_SCHEMA_STATS");
     });
 
-    test("optimize with target rebuilds that index", async () => {
+    // The target is a TABLE name, because a table name is the only thing either
+    // maintenance surface has to send. Building `ALTER INDEX "<target>" REBUILD` from
+    // it answered ORA-01418 for every table there is - measured against Oracle AI
+    // Database 26ai Free on 2026-08-25, then re-run after this fix (#U9).
+    test("optimize with a table target rebuilds the indexes THAT TABLE owns", async () => {
       const captured: string[] = [];
-      mockExecuteFn = async (sql: string) => {
+      let indexQueryBinds: unknown;
+      mockExecuteFn = async (sql: string, binds?: unknown) => {
         captured.push(sql);
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_INDEXES") && upper.includes("TABLE_NAME =")) {
+          indexQueryBinds = binds;
+          return {
+            rows: [{ INDEX_NAME: "SYS_C008646" }, { INDEX_NAME: "U9_PROBE_NAME_IX" }],
+            metaData: [{ name: "INDEX_NAME" }],
+          };
+        }
         return defaultExecute(sql);
       };
 
       await provider.connect();
-      const result = await provider.runMaintenance("optimize", "IDX_USERS_NAME");
+      const result = await provider.runMaintenance("optimize", "U9_PROBE");
 
       expect(result.success).toBe(true);
-      expect(captured.some((sql) => sql.includes('ALTER INDEX "IDX_USERS_NAME" REBUILD'))).toBe(true);
+      // The table is looked up, with its name bound rather than interpolated.
+      expect(indexQueryBinds).toEqual(["U9_PROBE"]);
+      // Both of the table's own indexes are rebuilt, and the TABLE name is never
+      // handed to ALTER INDEX - the assertion that used to hold and produced ORA-01418.
+      expect(captured).toContain('ALTER INDEX "SYS_C008646" REBUILD');
+      expect(captured).toContain('ALTER INDEX "U9_PROBE_NAME_IX" REBUILD');
+      expect(captured.some((sql) => sql.includes('ALTER INDEX "U9_PROBE" REBUILD'))).toBe(false);
+    });
+
+    test("optimize on a table with no rebuildable index succeeds having rebuilt nothing", async () => {
+      // A heap table with no index is an ordinary state, and so is a table whose only
+      // index is the LOB index the catalog query filters out (the live probe's
+      // SYS_IL0000073772C00003$$). "Nothing to do" is not a failure - but only for a
+      // table the catalog KNOWS, which is why USER_TABLES answers a row here.
+      const captured: string[] = [];
+      mockExecuteFn = async (sql: string) => {
+        captured.push(sql);
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_INDEXES") && upper.includes("TABLE_NAME =")) {
+          return { rows: [], metaData: [{ name: "INDEX_NAME" }] };
+        }
+        if (upper.includes("USER_TABLES") && upper.includes("TABLE_NAME =")) {
+          return { rows: [{ TABLE_NAME: "U9_HEAP" }], metaData: [{ name: "TABLE_NAME" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize", "U9_HEAP");
+
+      expect(result.success).toBe(true);
+      expect(captured.some((sql) => sql.toUpperCase().startsWith("ALTER INDEX"))).toBe(false);
+    });
+
+    // An empty USER_INDEXES answer has TWO causes and they are different facts: a table
+    // with no rebuildable index, and a target that is not a table of this schema at
+    // all. Both answered `{"success":true}` in ~1 ms having done nothing - measured
+    // through the provider against ldb-oracle-r5 (Oracle AI Database 26ai Free Release
+    // 23.26.2.0.0) on 2026-08-25 for a name that does not exist AND for a real table
+    // spelled in the wrong case.
+    test("optimize on a target the catalog does not know is not a completed operation", async () => {
+      const captured: string[] = [];
+      let existenceBinds: unknown;
+      mockExecuteFn = async (sql: string, binds?: unknown) => {
+        captured.push(sql);
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_INDEXES") && upper.includes("TABLE_NAME =")) {
+          return { rows: [], metaData: [{ name: "INDEX_NAME" }] };
+        }
+        if (upper.includes("USER_TABLES") && upper.includes("TABLE_NAME =")) {
+          existenceBinds = binds;
+          return { rows: [], metaData: [{ name: "TABLE_NAME" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize", "u9real");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("u9real");
+      // Case is Oracle's rule, not ours: the name is bound exactly as the caller wrote
+      // it, so a lower-case spelling of an upper-case table is reported as unknown
+      // rather than silently succeeding.
+      expect(existenceBinds).toEqual(["u9real"]);
+      expect(captured.some((sql) => sql.toUpperCase().startsWith("ALTER INDEX"))).toBe(false);
+    });
+
+    test("the whole-schema form asks no existence question", async () => {
+      // There is no target to check, and an empty schema is not an error.
+      const captured: string[] = [];
+      mockExecuteFn = async (sql: string) => {
+        captured.push(sql);
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_INDEXES")) {
+          return { rows: [], metaData: [{ name: "INDEX_NAME" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize");
+
+      expect(result.success).toBe(true);
+      expect(captured.some((sql) => sql.toUpperCase().includes("USER_TABLES"))).toBe(false);
+    });
+
+    test("optimize reports how many indexes it rebuilt", async () => {
+      // One index failing is tolerated, so "success" alone hides how much of the
+      // operation actually happened.
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_INDEXES") && upper.includes("TABLE_NAME =")) {
+          return {
+            rows: [{ INDEX_NAME: "BAD_IDX" }, { INDEX_NAME: "GOOD_IDX" }],
+            metaData: [{ name: "INDEX_NAME" }],
+          };
+        }
+        if (sql.startsWith('ALTER INDEX "BAD_IDX"')) {
+          throw new Error("ORA-01502: index is in unusable state");
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize", "U9_PROBE");
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("1 of 2");
+    });
+
+    test("optimize on a table tolerates one index failing", async () => {
+      // An offline tablespace or an unusable partition stops that index alone; the
+      // remaining ones still rebuild, which is the choice the whole-schema form made.
+      const rebuilt: string[] = [];
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_INDEXES") && upper.includes("TABLE_NAME =")) {
+          return {
+            rows: [{ INDEX_NAME: "BAD_IDX" }, { INDEX_NAME: "GOOD_IDX" }],
+            metaData: [{ name: "INDEX_NAME" }],
+          };
+        }
+        if (sql.startsWith('ALTER INDEX "BAD_IDX"')) {
+          throw new Error("ORA-01502: index is in unusable state");
+        }
+        if (upper.startsWith("ALTER INDEX")) {
+          rebuilt.push(sql);
+          return { rows: [], metaData: [] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize", "U9_PROBE");
+
+      expect(result.success).toBe(true);
+      expect(rebuilt).toEqual(['ALTER INDEX "GOOD_IDX" REBUILD']);
+    });
+
+    test("optimize reports failure when EVERY index of the table failed", async () => {
+      /*
+        Tolerating one failure and tolerating all of them are different facts. Measured
+        against ldb-oracle-r5 (Oracle AI Database 26ai Free Release 23.26.2.0.0) on
+        2026-08-25: a table whose tablespace is READ ONLY answers ORA-01647 for every
+        `ALTER INDEX ... REBUILD`, and this reported `{"success":true,"message":"OPTIMIZE:
+        rebuilt 0 of 2 indexes."}` in 14 ms with the ORA text discarded - the same
+        success-reporting shape this whole pass exists to remove, one level in.
+
+        The engine's own first refusal travels in the message: "rebuilt 0 of 2" says the
+        count and nothing about why, and why is the only part an operator can act on.
+      */
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_INDEXES") && upper.includes("TABLE_NAME =")) {
+          return {
+            rows: [{ INDEX_NAME: "BAD_IDX" }, { INDEX_NAME: "ALSO_BAD_IDX" }],
+            metaData: [{ name: "INDEX_NAME" }],
+          };
+        }
+        if (upper.startsWith("ALTER INDEX")) {
+          throw new Error("ORA-01647: tablespace 'V9RO_TS' is read-only, cannot allocate space in it");
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const result = await provider.runMaintenance("optimize", "V9RO");
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("0 of 2");
+      expect(result.message).toContain("ORA-01647");
+    });
+
+    test("optimize quotes an index name that contains a double quote", async () => {
+      const captured: string[] = [];
+      mockExecuteFn = async (sql: string) => {
+        captured.push(sql);
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_INDEXES") && upper.includes("TABLE_NAME =")) {
+          return { rows: [{ INDEX_NAME: 'ODD"NAME' }], metaData: [{ name: "INDEX_NAME" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      await provider.runMaintenance("optimize", "U9_PROBE");
+
+      expect(captured).toContain('ALTER INDEX "ODD""NAME" REBUILD');
     });
 
     test("optimize without target rebuilds all indexes and tolerates individual failures", async () => {
@@ -1618,8 +1841,8 @@ describe("OracleProvider", () => {
     });
 
     test("reports nothing when V$SYSSTAT is not readable, rather than a perfect cache", async () => {
-      // The ordinary case, not an exotic one. Measured 2026-08-23 on Oracle Free
-      // 23ai against a user granted only CREATE SESSION:
+      // The ordinary case, not an exotic one. Measured 2026-08-23 on Oracle AI
+      // Database 26ai Free against a user granted only CREATE SESSION:
       //   ORA-00942: table or view "SYS"."V_$SYSSTAT" does not exist
       // This assertion used to read `toBe(100)` with the comment "Default
       // fallback", so the suite protected the fabrication.
@@ -1640,7 +1863,7 @@ describe("OracleProvider", () => {
 
     test("omits the ratio when V$SYSSTAT answers a NULL row", async () => {
       // The counter denominator can be 0, which NULLIF turns into one row whose
-      // single column is NULL. Measured 2026-08-23 on Oracle Free 23ai:
+      // single column is NULL. Measured 2026-08-23 on Oracle AI Database 26ai Free:
       //    HIT_RATIO
       //   ----------
       //   <NULL>
@@ -2055,7 +2278,7 @@ describe("OracleProvider", () => {
 /**
  * `oracledb` is the one driver of the four that hands over a NAME: `metaData[].
  * dbTypeName`, uppercase, the same word `ALL_TAB_COLUMNS.DATA_TYPE` uses. The names
- * below are verbatim from Oracle Free 23ai over `r5_types`, plus the
+ * below are verbatim from Oracle AI Database 26ai Free over `r5_types`, plus the
  * `TIMESTAMP WITH TIME ZONE` that `SYSTIMESTAMP` declares.
  */
 describe("OracleProvider declared column types", () => {

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -1858,6 +1858,32 @@ describe("PostgresProvider", () => {
   // --------------------------------------------------------------------------
 
   describe("getCapabilities()", () => {
+    // #U9: the target grammar of each operation, declared next to it. PostgreSQL is
+    // the engine both surfaces were already right about - every statement here has a
+    // one-table form and a whole-database form - so this records the baseline the
+    // other providers are measured against rather than a change in behaviour.
+    test("declares the target grammar of every maintenance operation", () => {
+      provider = new PostgresProvider(makePgConfig());
+      const specs = provider.getCapabilities().maintenanceOperationSpecs;
+
+      expect(specs).toEqual({
+        vacuum: { label: "Vacuum Table", perEntity: true, global: true },
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+        reindex: { label: "Reindex Table", perEntity: true, global: true },
+        // A backend PID comes from the Sessions panel; no table row and no global
+        // card can supply one.
+        kill: { label: "Terminate Backend", perEntity: false, global: false },
+      });
+      // Every declared operation carries a spec, and no spec names an operation the
+      // provider does not declare.
+      expect(Object.keys(specs ?? {}).sort()).toEqual([...provider.getCapabilities().maintenanceOperations].sort());
+    });
+
+    test("the vacuum label really means vacuum here", () => {
+      // Absent is the default, so the four engines whose vacuum wording names
+      // something else are the ones that have to say so (#U9).
+      expect(new PostgresProvider(makePgConfig()).getLabels().vacuumActionOperation).toBeUndefined();
+    });
     test("returns correct PostgreSQL capabilities", () => {
       provider = new PostgresProvider(makePgConfig());
       const caps = provider.getCapabilities();

--- a/tests/integration/db/redis-provider.test.ts
+++ b/tests/integration/db/redis-provider.test.ts
@@ -275,6 +275,17 @@ describe("RedisProvider", () => {
   // --------------------------------------------------------------------------
 
   describe("getCapabilities()", () => {
+    // #U9: `runMaintenance(type)` takes no target parameter at all - the operation is
+    // INFO, which reports on the server and cannot be pointed at a key pattern. A
+    // per-row control here answered with server-wide metrics for one grouping.
+    test("declares the target grammar of its one maintenance operation", () => {
+      const caps = provider.getCapabilities();
+
+      expect(caps.maintenanceOperationSpecs).toEqual({
+        analyze: { label: "Server Info", perEntity: false, global: true },
+      });
+      expect(Object.keys(caps.maintenanceOperationSpecs ?? {}).sort()).toEqual([...caps.maintenanceOperations].sort());
+    });
     test("returns correct capability metadata", () => {
       const caps = provider.getCapabilities();
       expect(caps.queryLanguage).toBe("json");

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -266,6 +266,20 @@ describe("SQLiteProvider", () => {
   // --------------------------------------------------------------------------
 
   describe("getCapabilities()", () => {
+    // #U9: VACUUM rewrites the whole file and `runMaintenance` ignores the target, so
+    // the per-table control named one table and acted on the database. The same is
+    // true of PRAGMA integrity_check.
+    test("declares the target grammar of every maintenance operation", () => {
+      const caps = new SQLiteProvider(makeSQLiteConfig()).getCapabilities();
+
+      expect(caps.maintenanceOperationSpecs).toEqual({
+        vacuum: { label: "Vacuum Database", perEntity: false, global: true },
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+        reindex: { label: "Reindex Table", perEntity: true, global: true },
+        check: { label: "Integrity Check", perEntity: false, global: true },
+      });
+      expect(Object.keys(caps.maintenanceOperationSpecs ?? {}).sort()).toEqual([...caps.maintenanceOperations].sort());
+    });
     test("returns correct SQLite capabilities", () => {
       provider = new SQLiteProvider(makeSQLiteConfig());
       const caps = provider.getCapabilities();

--- a/tests/integration/db/trino-provider.test.ts
+++ b/tests/integration/db/trino-provider.test.ts
@@ -515,6 +515,22 @@ afterEach(() => {
 // ============================================================================
 
 describe("TrinoProvider metadata", () => {
+  // #U9: the only operation Trino has is terminating a statement, and that needs the
+  // query id the Sessions panel lists - neither a table nor a whole database. So no
+  // maintenance control is offered anywhere, which is what the two `false`s say.
+  test("declares its one maintenance operation as neither per-table nor global", () => {
+    const caps = new TrinoProvider(makeConnection()).getCapabilities();
+
+    expect(caps.maintenanceOperationSpecs).toEqual({
+      kill: { label: "Terminate Query", perEntity: false, global: false },
+    });
+    expect(Object.keys(caps.maintenanceOperationSpecs ?? {}).sort()).toEqual([...caps.maintenanceOperations].sort());
+    // "Reclaim Space" and "Table Statistics" name nothing this engine can run, and
+    // both stay unshown because the operations behind them are undeclared - not
+    // because the wording is redirected anywhere.
+    expect(new TrinoProvider(makeConnection()).getLabels().vacuumActionOperation).toBeUndefined();
+    expect(caps.maintenanceOperations).toEqual(["kill"]);
+  });
   test("declares SQL on port 8080, with double-quoted identifiers and no statement terminator", () => {
     const capabilities = new TrinoProvider(makeConnection()).getCapabilities();
 

--- a/tests/unit/db/base-provider.test.ts
+++ b/tests/unit/db/base-provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, spyOn } from "bun:test";
 import { BaseDatabaseProvider } from "@/lib/db/base-provider";
+import { maintenanceControl } from "@/lib/db/types";
 import { AuthenticationError, ConnectionError, DatabaseConfigError, DatabaseError } from "@/lib/db/errors";
 import type {
   DatabaseConnection,
@@ -774,5 +775,90 @@ describe("getMonitoringData partial failures", () => {
 
     expect(data.slowQueries).toBeUndefined();
     expect(data.errors?.slowQueries).toBe("slow log unavailable");
+  });
+});
+
+// ============================================================================
+// maintenanceControl() — the one gate both maintenance surfaces ask (#U9)
+// ============================================================================
+
+describe("maintenanceControl", () => {
+  const caps = (overrides: Partial<ProviderCapabilities> = {}): ProviderCapabilities =>
+    ({
+      supportsMaintenance: true,
+      maintenanceOperations: ["vacuum", "analyze"],
+      ...overrides,
+    }) as ProviderCapabilities;
+
+  test("undefined capabilities are a denial, not a permission", () => {
+    // /api/db/provider-meta answers with nothing both while it is in flight and when
+    // it failed, and failing open there is what put the dead buttons on the very
+    // connections the #272/#282 gates exist for.
+    expect(maintenanceControl(undefined, "vacuum", "perEntity")).toEqual({ offered: false });
+    expect(maintenanceControl(undefined, "vacuum", "global")).toEqual({ offered: false });
+  });
+
+  test("an engine with no maintenance offers nothing in either placement", () => {
+    const cassandraShaped = caps({ supportsMaintenance: false, maintenanceOperations: [] });
+
+    expect(maintenanceControl(cassandraShaped, "vacuum", "perEntity").offered).toBe(false);
+    expect(maintenanceControl(cassandraShaped, "analyze", "global").offered).toBe(false);
+  });
+
+  test("an operation the provider does not declare is never offered", () => {
+    expect(maintenanceControl(caps(), "reindex", "perEntity").offered).toBe(false);
+    expect(maintenanceControl(caps(), "reindex", "global").offered).toBe(false);
+  });
+
+  test("no spec means both placements under the CALLER's wording", () => {
+    // The compatibility promise `maintenanceOperationSpecs` was made optional for:
+    // an implementation that declares nothing behaves exactly as it did before #U9,
+    // and gets no label of its own, so the surface keeps its generic verb.
+    expect(maintenanceControl(caps(), "vacuum", "perEntity")).toEqual({ offered: true });
+    expect(maintenanceControl(caps(), "vacuum", "global")).toEqual({ offered: true });
+  });
+
+  test("a spec decides each placement independently and names the control", () => {
+    const sqliteShaped = caps({
+      maintenanceOperations: ["vacuum", "analyze"],
+      maintenanceOperationSpecs: {
+        vacuum: { label: "Vacuum Database", perEntity: false, global: true },
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+      },
+    });
+
+    expect(maintenanceControl(sqliteShaped, "vacuum", "perEntity")).toEqual({
+      offered: false,
+      label: "Vacuum Database",
+    });
+    expect(maintenanceControl(sqliteShaped, "vacuum", "global")).toEqual({
+      offered: true,
+      label: "Vacuum Database",
+    });
+    expect(maintenanceControl(sqliteShaped, "analyze", "perEntity")).toEqual({
+      offered: true,
+      label: "Analyze Table",
+    });
+  });
+
+  test("an operation whose target is a session id is offered in neither placement", () => {
+    const withKill = caps({
+      maintenanceOperations: ["kill"],
+      maintenanceOperationSpecs: { kill: { label: "Terminate Backend", perEntity: false, global: false } },
+    });
+
+    expect(maintenanceControl(withKill, "kill", "perEntity").offered).toBe(false);
+    expect(maintenanceControl(withKill, "kill", "global").offered).toBe(false);
+  });
+
+  test("a spec for an operation the provider does not declare cannot resurrect it", () => {
+    // The two lists can drift; `maintenanceOperations` stays the authority, because
+    // /api/db/maintenance validates against it and answers 400 for anything else.
+    const drifted = caps({
+      maintenanceOperations: ["analyze"],
+      maintenanceOperationSpecs: { vacuum: { label: "Vacuum Table", perEntity: true, global: true } },
+    });
+
+    expect(maintenanceControl(drifted, "vacuum", "perEntity").offered).toBe(false);
   });
 });

--- a/tests/unit/helm-chart-readme-recipes.test.ts
+++ b/tests/unit/helm-chart-readme-recipes.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Static lint over the copy-paste `helm` recipes in charts/libredb-studio/README.md.
+ *
+ * A README recipe is not executable, so nothing rendered it and both hazards below
+ * shipped. Measured on 2026-08-25 against helm v4.1.3 and the real chart:
+ *
+ *  1. **Type coercion.** `--set extraEnv[0].value=true` renders `value: true`, an
+ *     unquoted YAML boolean, and `core/v1.EnvVar.value` is a string - the API server
+ *     rejects the manifest with `invalid type for io.k8s.api.core.v1.EnvVar.value: got
+ *     "bool", expected "string"`. The shell strips the README's `"true"` quotes before
+ *     helm ever sees them, so writing them in the recipe does not help. Nor does the
+ *     chart's own schema: `values.schema.json` types `extraEnv` as an array of plain
+ *     objects, so the boolean passes `helm template` and `helm lint --strict` alike.
+ *     The same holds for `ingress.annotations.*`, which is a `map[string]string`:
+ *     `--set …/limit-rpm=120` rendered `limit-rpm: 120` as an integer.
+ *     `--set-string` is the fix, and it is why tests/unit/helm-chart-agent.test.ts
+ *     records the agent off-switch being moved to a values field that renders a quoted
+ *     string - to delete this trap rather than keep explaining it.
+ *  2. **Shell globbing.** An unquoted `extraEnv[0]` is a glob pattern in zsh, the
+ *     default shell on macOS and on this project's dev machines. It does not reach
+ *     helm at all: the command dies with `zsh: no matches found:
+ *     extraEnv[0].name=CSP_REPORT_ONLY`. Bash without `failglob` passes it through, so
+ *     the recipe works for some readers and not others.
+ *
+ * Both are mechanical, so they are checked mechanically here rather than left to the
+ * next reviewer's eye. This test deliberately does NOT require `--set-string`
+ * everywhere: a value that cannot coerce (a URL, `websecure`) is correct with plain
+ * `--set`, and demanding otherwise would train the rule into noise.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "../..");
+const README = "charts/libredb-studio/README.md";
+
+interface SetArg {
+  /** "--set" or "--set-string" */
+  flag: string;
+  /** the argument as written, quotes included */
+  raw: string;
+  /** the argument with one layer of surrounding quotes removed */
+  value: string;
+  quoted: boolean;
+  line: number;
+}
+
+/**
+ * Collects every --set/--set-string argument inside ```bash fences. Only fenced
+ * shell blocks are recipes; prose mentions `extraEnv[0]` in backticks and must not
+ * be flagged.
+ */
+function collectSetArgs(markdown: string): SetArg[] {
+  const args: SetArg[] = [];
+  let inBash = false;
+  const lines = markdown.split("\n");
+
+  for (const [index, line] of lines.entries()) {
+    if (line.startsWith("```")) {
+      inBash = line.startsWith("```bash");
+      continue;
+    }
+    if (!inBash) continue;
+
+    // A quoted argument may contain spaces, so match the quoted form first. The bare
+    // form must accept backslashes: an annotation key escapes its dots, and excluding
+    // `\` truncated the token before the `=`, hiding the very defect this file lints.
+    // matchAll, not exec: two --set flags can share one line.
+    for (const match of line.matchAll(/--set(-string)?\s+("([^"]*)"|'([^']*)'|(\S+))/g)) {
+      const bare = match[5];
+      args.push({
+        flag: match[1] ? "--set-string" : "--set",
+        raw: match[2],
+        value: match[3] ?? match[4] ?? bare ?? "",
+        quoted: bare === undefined,
+        line: index + 1,
+      });
+    }
+  }
+
+  return args;
+}
+
+/**
+ * YAML 1.1 plain scalars that are NOT strings - what `--set` hands the API server.
+ *
+ * The inner quotes are stripped first because the shell strips them too: the original
+ * `--set extraEnv[0].value="true"` LOOKS quoted in the README and still rendered
+ * `value: true`. A recipe that writes them is the defect, not the cure.
+ */
+function coercesToNonString(rawValue: string): boolean {
+  const value = /^(["'])(.*)\1$/.exec(rawValue)?.[2] ?? rawValue;
+  if (/^-?\d+(\.\d+)?$/.test(value)) return true;
+  return ["true", "false", "yes", "no", "on", "off", "null", "~"].includes(value.toLowerCase());
+}
+
+/** Chart paths whose Kubernetes destination is typed as a string. */
+function needsString(key: string): boolean {
+  return /^extraEnv\[\d+\]\.value$/.test(key) || key.startsWith("ingress.annotations.");
+}
+
+const setArgs = collectSetArgs(readFileSync(join(ROOT, README), "utf8"));
+
+describe("chart README helm recipes", () => {
+  test("the fenced recipes are found at all (guards the fence parser itself)", () => {
+    // A parser that silently matched nothing would make every assertion below vacuous.
+    expect(setArgs.length).toBeGreaterThan(40);
+    expect(setArgs.some((a) => a.value.startsWith("extraEnv["))).toBe(true);
+    expect(setArgs.some((a) => a.flag === "--set-string")).toBe(true);
+  });
+
+  test("every bracket argument is quoted, or zsh globs it before helm runs", () => {
+    const unquoted = setArgs
+      .filter((a) => a.value.includes("[") && !a.quoted)
+      .map((a) => `${README}:${a.line}  ${a.flag} ${a.raw}`);
+
+    expect(unquoted).toEqual([]);
+  });
+
+  test("no --set passes a coercible value into a string-typed field", () => {
+    const coerced = setArgs
+      .filter((a) => a.flag === "--set")
+      .map((a) => ({ arg: a, eq: a.value.indexOf("=") }))
+      .filter(
+        ({ arg, eq }) => eq > 0 && needsString(arg.value.slice(0, eq)) && coercesToNonString(arg.value.slice(eq + 1)),
+      )
+      .map(({ arg }) => `${README}:${arg.line}  ${arg.flag} ${arg.raw}`);
+
+    expect(coerced).toEqual([]);
+  });
+});

--- a/tests/unit/lib/agent/plan-draft-boundary.test.ts
+++ b/tests/unit/lib/agent/plan-draft-boundary.test.ts
@@ -53,6 +53,20 @@ const ALLOWED: ReadonlySet<string> = new Set([
     dependency the splitter gains later.
   */
   "@/lib/sql/statement-splitter",
+  /*
+    Added when the unfenced cut started reading the CONNECTION'S dialect instead of the
+    compatibility default. Where a statement ends is exactly what this record decides, and its
+    answers differ on shipped engines — `//` is a line comment in CQL and ClickHouse and an
+    operator name or a syntax error everywhere else — so a draft whose comment carried a `;` was
+    cut at that `;` and the run recorded half its statement.
+
+    Admitted on the same ground as the splitter, and the ground is already MEASURED here rather
+    than argued: the closure test below walks `./statement-splitter` and finds `./grammar` in it
+    with `@/lib/types` as its only reach, then asserts that reach is type-only. So this specifier
+    adds nothing to the browser bundle that the previous entry had not already brought — the
+    module was one hop away and is now zero.
+  */
+  "@/lib/sql/grammar",
 ]);
 
 describe("the plan-draft reader stays reachable from a browser", () => {
@@ -60,19 +74,40 @@ describe("the plan-draft reader stays reachable from a browser", () => {
     expect(specifiers(SOURCE).filter((specifier) => !ALLOWED.has(specifier))).toEqual([]);
   });
 
-  test("the splitter it now reaches imports nothing, so admitting it costs nothing transitively", () => {
+  test("everything the splitter reaches is a pure SQL reader, so admitting it costs nothing transitively", () => {
     /*
       The half the allowlist cannot check. This file reads `plan-draft.ts`'s own specifiers, so a
       dependency added to `statement-splitter.ts` would leave that list unchanged and this
       boundary green while the browser pays for it — which is the exact shape of the zod incident
       the header describes.
 
-      Zero imports is a stronger property than "pure": it cannot acquire a transitive cost without
-      this assertion going red first.
+      This used to assert ZERO imports, which was the stronger property. S1 spent it deliberately:
+      the splitter was walking spans itself, disagreeing with every other reader about which `;` is
+      code, and one shape yielded a runnable bare `DROP` fragment — so it now reads through
+      `spans.ts` under a `grammar.ts` record. Zero is therefore replaced by the CLOSURE, computed
+      here rather than named at one level: every module reachable from the splitter must be one of
+      these two readers, whose own only reach is a TYPE-ONLY import of the shared type module. That
+      is checked below, so a value import appearing anywhere in the closure fails this test rather
+      than a browser.
     */
-    const splitter = fs.readFileSync(path.join(process.cwd(), "src/lib/sql/statement-splitter.ts"), "utf8");
+    const read = (specifier: string) =>
+      fs.readFileSync(path.join(process.cwd(), "src/lib/sql", `${specifier.replace("./", "")}.ts`), "utf8");
 
-    expect(specifiers(splitter)).toEqual([]);
+    const closure = new Set<string>();
+    const pending = ["./statement-splitter"];
+    while (pending.length > 0) {
+      const current = pending.pop() as string;
+      for (const specifier of specifiers(read(current))) {
+        if (closure.has(specifier)) continue;
+        closure.add(specifier);
+        if (specifier.startsWith("./")) pending.push(specifier);
+      }
+    }
+
+    expect([...closure].sort()).toEqual(["./grammar", "./spans", "@/lib/types"]);
+    // The one non-relative member, and it is erased at build time: a VALUE import of the shared
+    // type module would pull the whole type barrel into the browser bundle.
+    expect(read("./grammar")).toContain('import type { DatabaseType } from "@/lib/types"');
   });
 
   test("it does not reach the statement guard, which is where zod enters", () => {

--- a/tests/unit/lib/agent/plan-draft-dialect.test.ts
+++ b/tests/unit/lib/agent/plan-draft-dialect.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { readPlanStatement } from "@/lib/agent/plan-draft";
+
+/**
+ * The unfenced reader's SQL cut is a dialect question, and it was asking it without one.
+ *
+ * `readPlanStatement(text, dialect)` already holds the connection's own dialect — it is
+ * what `fencedBlock` checks a fence tag against, and its docblock talks about stamping
+ * "the connection's own dialect" on an untagged fence. The second cut, the one that ends
+ * an unfenced statement where the SQL ends, called `splitStatements(candidate)` with no
+ * grammar, so it read every model's draft under the compatibility default.
+ *
+ * That is not a cosmetic inconsistency. Where a statement ENDS is exactly what the
+ * grammar record decides, and the two answers differ on shipped engines: `//` is a line
+ * comment in CQL and in ClickHouse (measured 2026-08-25 on Cassandra 5.0.9, ScyllaDB
+ * 2026.2.4 and ClickHouse 26.7.1) and is code or an operator name everywhere else. So a
+ * draft whose comment carried a `;` was cut at that `;` and the run recorded HALF the
+ * statement as its deliverable — a shortfall reported against a model that wrote a
+ * perfectly good statement.
+ */
+describe("the unfenced cut reads the connection's own dialect", () => {
+  // ClickHouse first, because there the whole line is not merely one statement to the
+  // splitter but a statement the server runs: measured on 26.7.1,
+  // `SELECT 1 AS a // note; SELECT 999` answers `1` with no error, while
+  // `SELECT 1; DROP TABLE nope` is refused with "Multi-statements are not allowed".
+  test("a `//` comment carrying a semicolon does not end the statement on ClickHouse", () => {
+    const text = "SELECT count() FROM events // rows; not a second statement";
+
+    expect(readPlanStatement(text, "clickhouse")).toEqual({
+      kind: "statement",
+      sql: "SELECT count() FROM events // rows; not a second statement",
+      tag: undefined,
+    });
+  });
+
+  // The sharper shape, because the dialect-blind reading here does not merely keep too
+  // much - it throws the FROM clause away and records `SELECT id` as what the run
+  // delivered.
+  test("a wrapped statement whose comment hides a semicolon survives on Cassandra", () => {
+    const text = "SELECT id\nFROM probe.customers // note; DROP TABLE probe.customers";
+
+    expect(readPlanStatement(text, "cassandra")).toEqual({
+      kind: "statement",
+      sql: "SELECT id\nFROM probe.customers // note; DROP TABLE probe.customers",
+      tag: undefined,
+    });
+    // What the same text answered before the dialect reached the cut, kept as the
+    // contrast rather than described: a deliverable missing its FROM clause.
+    expect(readPlanStatement(text)).toEqual({ kind: "statement", sql: "SELECT id", tag: undefined });
+  });
+
+  // The other direction, and the reason this is a per-dialect fact rather than a widened
+  // reading: `//` is an operator NAME in PostgreSQL (`SELECT 1 // 2` is "operator does
+  // not exist: integer // integer" on 18, not a syntax error), so the `;` after it
+  // really is where the statement ends and the tail really is a second one.
+  test("a dialect without the form still ends the statement at that semicolon", () => {
+    const text = "SELECT id FROM t // note; DROP TABLE t";
+
+    expect(readPlanStatement(text, "postgres")).toEqual({
+      kind: "statement",
+      sql: "SELECT id FROM t // note",
+      tag: undefined,
+    });
+  });
+
+  // A draft with no dialect at all is what an untagged, connectionless call still gets,
+  // and it keeps the compatibility default the rest of `lib/sql` applies - a decision,
+  // pinned, not an absence.
+  test("a call that names no dialect keeps the compatibility reading", () => {
+    // The default's own hybrid `#` rule, asserted rather than assumed: a plainly-written
+    // hash comment IS a comment there, so the `;` inside it is not a boundary and the
+    // whole line is the draft. That is what a dialect-less call answered before this
+    // threading and what it answers after.
+    const hidden = "SELECT 1 # note; SELECT 2";
+
+    expect(readPlanStatement(hidden)).toEqual({ kind: "statement", sql: hidden, tag: undefined });
+    // And the operator-tailed spelling, which the same default reads as code - so there
+    // the `;` is a boundary and the tail is a second statement.
+    expect(readPlanStatement("SELECT meta #> '{a}'; SELECT 2")).toEqual({
+      kind: "statement",
+      sql: "SELECT meta #> '{a}'",
+      tag: undefined,
+    });
+  });
+
+  // The fenced path was already dialect-aware and must stay untouched by the threading:
+  // a tag naming ANOTHER engine is still rejected, so the relaxed unfenced reading below
+  // it is what answers.
+  test("threading the dialect changes nothing about the fenced path", () => {
+    const fenced = "```sql\nSELECT count() FROM events // rows; tail\n```";
+
+    expect(readPlanStatement(fenced, "clickhouse")).toEqual({
+      kind: "statement",
+      sql: "SELECT count() FROM events // rows; tail",
+      tag: "sql",
+    });
+  });
+});

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -232,6 +232,79 @@ describe("resolveSqlGrammar", () => {
     // were written against.
     expect(DEFAULT_SQL_GRAMMAR.blockComment).toBe("flat");
   });
+
+  // ── `//`: a THIRD line-comment form (S1 follow-up) ───────────────────────
+  //
+  // The one fact `grammar.ts` said it could not carry, and the splitter is where
+  // that cost was live: `//` hides the rest of the line on TWO shipped engines, so
+  // a `;` written inside such a comment is not a statement boundary - and
+  // `/api/db/multi-query` RUNS every fragment the splitter returns, so the
+  // dialect-blind reading manufactured a bare `DROP` out of text the server reads
+  // as one statement. Every row below was probed 2026-08-25 against a live engine,
+  // through the surface the provider itself uses, because "it is documented" is not
+  // the same claim as "it is what the server does".
+  //
+  // A comment: two engines, and both halves measured rather than one inferred.
+  //  - `cassandra` (Apache Cassandra 5.0.9 and ScyllaDB 2026.2.4, which shares this
+  //    type-id, both over the native protocol):
+  //    `SELECT release_version FROM system.local // note; DROP KEYSPACE nope\n`
+  //    returns the ROW - one read - and the DROP does not run (a bare
+  //    `DROP KEYSPACE nope` answers "Keyspace 'nope' doesn't exist", so the OK is
+  //    proof it was hidden). Without the trailing newline the same text is "line
+  //    1:68 mismatched character '<EOF>' expecting set null", which is the SECOND
+  //    CQL fact - a line comment needs a newline to close it - and that one still
+  //    has no field here (see `CASSANDRA_GRAMMAR`).
+  //  - `clickhouse` (26.7.1, over HTTP): `SELECT 1 AS a // note; SELECT 999`
+  //    answers `1` with no error, while `SELECT 1; DROP TABLE nope` is refused with
+  //    "Syntax error (Multi-statements are not allowed)" - so the `;` was inside the
+  //    comment rather than ignored. `SELECT 1 AS a // note\n, 2 AS b` answers TWO
+  //    columns, so the run ends at the NEWLINE: it is a LINE comment, not a
+  //    to-end-of-input one. Unlike CQL, end of input closes it (`SELECT 1 AS a //
+  //    note` answers 1).
+  //
+  // Code: five engines plus SQLite, each refusing the characters outright, so
+  // nothing on that line is hidden - which is the only thing these readers ask.
+  //  - `postgres` (18): `SELECT 1 // 2` is "operator does not exist: integer //
+  //    integer", so `//` is an OPERATOR NAME there, and `SELECT 1 AS a // note` is
+  //    "syntax error at or near \"//\"".
+  //  - `mysql` (26.7.0): ERROR 1064 near '// note'.
+  //  - `oracle` (Oracle Free 23, via sqlplus): ORA-00923 "FROM keyword not found
+  //    where expected".
+  //  - `mssql` (2022, via sqlcmd): Msg 102 "Incorrect syntax near '/'".
+  //  - `trino` (476, `POST /v1/statement`): "line 1:15: mismatched input '/'".
+  //  - `sqlite` (the bundled driver): 'near "/": syntax error'.
+  test.each<[DatabaseType, boolean]>([
+    ["cassandra", true],
+    ["clickhouse", true],
+    ["postgres", false],
+    ["mysql", false],
+    ["oracle", false],
+    ["mssql", false],
+    ["trino", false],
+    ["sqlite", false],
+  ])("%s reads `//` as a line comment: %s", (type, doubleSlashComment) => {
+    expect(resolveSqlGrammar(type).doubleSlashComment).toBe(doubleSlashComment);
+  });
+
+  // Neither search engine is reachable from this run, so neither row was
+  // established - and PD-5 forbids reading one dialect's rule off another's, which
+  // here would mean copying five refusals onto a sixth grammar. They keep the
+  // compatibility default, and the direction that costs is stated rather than
+  // implied: if `//` DOES open a comment in one of them, its splitter over-splits
+  // exactly as `cassandra`'s did.
+  test.each<DatabaseType>(["elasticsearch", "opensearch"])(
+    "%s is left at the compatibility default for `//`",
+    (type) => {
+      expect(resolveSqlGrammar(type).doubleSlashComment).toBe(DEFAULT_SQL_GRAMMAR.doubleSlashComment);
+    },
+  );
+
+  test("the compatibility default does not read `//` as a comment", () => {
+    // Today's reading once more: no reader in this folder had a `//` branch before
+    // this fact existed, so keeping it out is what leaves every dialect-less
+    // fixture answering what it answered.
+    expect(DEFAULT_SQL_GRAMMAR.doubleSlashComment).toBe(false);
+  });
 });
 
 describe("hashRunIsAmbiguous", () => {

--- a/tests/unit/sql/spans.test.ts
+++ b/tests/unit/sql/spans.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
+import { DEFAULT_SQL_GRAMMAR, resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { hasUnterminatedSpan, readSqlSpan } from "@/lib/sql/spans";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -717,5 +717,101 @@ describe("hasUnterminatedSpan", () => {
 
     expect(unresolved).toBe(false);
     expect(elapsed, `took ${elapsed.toFixed(1)}ms`).toBeLessThan(200);
+  });
+});
+
+// ── `//`: the third line-comment form, and only where a dialect has it ──────
+//
+// The fact `grammar.ts` used to say it could not carry. It matters here rather
+// than only in the provider that worked around it, because a comment is what a
+// `;` can hide INSIDE - and `statement-splitter.ts` reads its boundaries through
+// this module, so a `//` read as code hands `/api/db/multi-query` a fragment the
+// operator never wrote.
+//
+// Measured 2026-08-25: a line comment on Cassandra 5.0.9, ScyllaDB 2026.2.4 and
+// ClickHouse 26.7.1; refused outright by PostgreSQL 18, MySQL 26.7.0, Oracle Free,
+// SQL Server 2022, Trino 476 and SQLite. The rows and their probes are in
+// `grammar.test.ts`.
+
+describe("readSqlSpan: `//` line comments", () => {
+  const CASSANDRA = resolveSqlGrammar("cassandra");
+  const CLICKHOUSE_SLASH = resolveSqlGrammar("clickhouse");
+  const POSTGRES_SLASH = resolveSqlGrammar("postgres");
+  const TRINO = resolveSqlGrammar("trino");
+
+  test.each<[string, SqlGrammar]>([
+    ["cassandra", CASSANDRA],
+    ["clickhouse", CLICKHOUSE_SLASH],
+  ])("a dialect that has the form reads it as a comment (%s)", (_label, grammar) => {
+    expect(spanOf("// note\nSELECT 1", 0, grammar)).toBe("line-comment|// note\n");
+    expect(spanOf("SELECT 1 // note\n, 2", 9, grammar)).toBe("line-comment|// note\n");
+  });
+
+  // The newline ENDS the run, measured on both engines that have the form:
+  // `SELECT 1 AS a // note\n, 2 AS b` answers two columns on ClickHouse, and the
+  // same shape returns rows on Cassandra. A run to end-of-input would have hidden
+  // the second column.
+  test.each<[string, SqlGrammar]>([
+    ["cassandra", CASSANDRA],
+    ["clickhouse", CLICKHOUSE_SLASH],
+  ])("the run ends at the newline rather than at the end of the text (%s)", (_label, grammar) => {
+    const span = readSqlSpan("SELECT 1 // note\n, 2", 9, grammar);
+
+    expect(span).toEqual({ kind: "line-comment", end: 17, terminated: true });
+  });
+
+  test.each<[string, SqlGrammar]>([
+    ["postgres", POSTGRES_SLASH],
+    ["trino", TRINO],
+    ["no dialect named", DEFAULT_SQL_GRAMMAR],
+  ])("a dialect without the form reads it as code (%s)", (_label, grammar) => {
+    expect(readSqlSpan("SELECT 1 // note", 9, grammar)).toBeNull();
+  });
+
+  // `/` is division everywhere and `//` is a real OPERATOR NAME in PostgreSQL
+  // (measured: `SELECT 1 // 2` is "operator does not exist: integer // integer",
+  // not a syntax error), so a single slash must never open a run under any grammar.
+  test("a lone slash is code even where `//` is a comment", () => {
+    expect(readSqlSpan("SELECT 1 / 2", 9, CASSANDRA)).toBeNull();
+    expect(readSqlSpan("SELECT 1 /", 9, CASSANDRA)).toBeNull();
+  });
+
+  // The branch order has to keep `/*` reachable: both forms open with a slash, and
+  // reading `/*` as a `//` run would swallow the rest of the line and lose the
+  // comment's real end.
+  test("a block comment still opens where `//` is a comment", () => {
+    expect(spanOf("/* a */ SELECT 1", 0, CASSANDRA)).toBe("block-comment|/* a */");
+    expect(spanOf("/* a\nb */ SELECT 1", 0, CLICKHOUSE_SLASH)).toBe("block-comment|/* a\nb */");
+  });
+
+  // `WHERE url = 'http://x'` is an ordinary statement on both engines, so the
+  // literal readers stay in front of this one.
+  test("a `//` inside a literal or a quoted name is not a comment", () => {
+    expect(spanOf("'http://x'", 0, CASSANDRA)).toBe("string|'http://x'");
+    expect(spanOf('"a//b" FROM t', 0, CLICKHOUSE_SLASH)).toBe('quoted-identifier|"a//b"');
+  });
+
+  // End of input closes it HERE, the same answer this module gives every line
+  // comment - and on ClickHouse that is the server's answer too (`SELECT 1 AS a //
+  // note` returns 1). CQL disagrees, which is a fact about where a statement may
+  // END rather than about what the run is, and the reason is on `SqlSpan.terminated`.
+  test("a `//` comment with no newline runs to the end and is terminated", () => {
+    expect(readSqlSpan("SELECT 1 // note", 9, CLICKHOUSE_SLASH)).toEqual({
+      kind: "line-comment",
+      end: 16,
+      terminated: true,
+    });
+  });
+});
+
+describe("hasUnterminatedSpan: `//`", () => {
+  // A `//` run read as CODE leaves whatever follows it to be scanned as SQL, so an
+  // apostrophe inside the comment opened a literal that never closed and the
+  // confirmation gate asked about a statement CQL reads without trouble.
+  test("a comment carrying an apostrophe is resolvable where the dialect has the form", () => {
+    const sql = "SELECT id FROM probe.customers // it's fine\n";
+
+    expect(hasUnterminatedSpan(sql, resolveSqlGrammar("cassandra"))).toBe(false);
+    expect(hasUnterminatedSpan(sql, DEFAULT_SQL_GRAMMAR)).toBe(true);
   });
 });

--- a/tests/unit/sql/statement-splitter.test.ts
+++ b/tests/unit/sql/statement-splitter.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { splitStatements, isMultiStatement } from "@/lib/sql/statement-splitter";
 import type { SplitStatement } from "@/lib/sql/statement-splitter";
+import { resolveSqlGrammar } from "@/lib/sql/grammar";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -344,5 +345,231 @@ describe("isMultiStatement", () => {
 
   test("returns true for statements separated by newlines", () => {
     expect(isMultiStatement("SELECT 1;\nSELECT 2;")).toBe(true);
+  });
+});
+
+// ─── Dialect-blind splitting (S1) ────────────────────────────────────────────
+
+/**
+ * The splitter used to walk spans itself, and it knew none of the dialect facts
+ * `grammar.ts` carries: `#` was code, `q'…'` was a name plus a string, `[…]` and
+ * `` `…` `` were nothing at all, and a block comment was always flat. So it
+ * disagreed with every other reader in this folder about which `;` is code, and
+ * each disagreement cut one statement into fragments that `/api/db/multi-query`
+ * then RAN one by one.
+ *
+ * Every shape below was measured against the engine that owns it rather than
+ * argued from a document; the commands and their answers are quoted on the cases.
+ */
+describe("reads spans under the caller's dialect", () => {
+  test("a ';' inside a MySQL hash comment does not split", () => {
+    /*
+      Measured on MySQL (container libredb-mysql): `#` runs to end of line, so the
+      `;` is comment text. PostgreSQL gives `#` no comment meaning at all, so there
+      the same `;` really is a boundary - which is why this is a dialect fact.
+    */
+    const sql = "SELECT 1 # note; not a statement\nFROM t";
+
+    expect(sqlsOf(splitStatements(sql, resolveSqlGrammar("mysql")))).toEqual([sql]);
+    expect(splitStatements(sql, resolveSqlGrammar("postgres"))).toHaveLength(2);
+  });
+
+  test("a ';' inside an Oracle q'{}' body does not split", () => {
+    /*
+      Measured on Oracle Free 23ai (container ldb-oracle-r5):
+        SQL> SELECT q'{a'b;c}' AS body FROM dual;
+        a'b;c
+      One literal, one statement. Cut at that `;` the first fragment is
+      `SELECT q'{a'b` - a syntax error - and the second is nonsense.
+    */
+    const sql = "SELECT q'{a'b;c}' AS body FROM dual";
+
+    expect(sqlsOf(splitStatements(sql, resolveSqlGrammar("oracle")))).toEqual([sql]);
+  });
+
+  test("a ';' inside a bracket-quoted name does not split", () => {
+    /*
+      Measured on SQL Server 2022 (container ldb-mssql-r5):
+        sqlcmd -Q "SELECT 1 AS [a;b]"  ->  1, "(1 rows affected)"
+      So `[a;b]` is one column NAME and the text is one statement.
+    */
+    const sql = "SELECT 1 AS [a;b]";
+
+    expect(sqlsOf(splitStatements(sql, resolveSqlGrammar("mssql")))).toEqual([sql]);
+    expect(sqlsOf(splitStatements(sql, resolveSqlGrammar("sqlite")))).toEqual([sql]);
+  });
+
+  test("a ';' inside a PostgreSQL subscript key does not split", () => {
+    // The same characters are a subscript there, and a literal inside one is a
+    // literal - so this `;` is part of the key, not a boundary between statements.
+    const sql = "SELECT j['a;b'] FROM t";
+
+    expect(sqlsOf(splitStatements(sql, resolveSqlGrammar("postgres")))).toEqual([sql]);
+  });
+
+  test("a ';' inside a backtick-quoted name does not split", () => {
+    /*
+      Measured on MySQL (container libredb-mysql):
+        mysql> SELECT 1 AS `a;b`;
+        a;b
+        1
+      The old splitter read `'…'` and `"…"` but not backticks, so this cut in two.
+    */
+    const sql = "SELECT 1 AS `a;b`";
+
+    expect(sqlsOf(splitStatements(sql, resolveSqlGrammar("mysql")))).toEqual([sql]);
+  });
+
+  test("a nesting dialect keeps the whole nested block comment together", () => {
+    /*
+      Measured, and the two answers are why this is a dialect fact rather than a
+      reading the text could settle:
+        postgres 18: SELECT /* a /* b *\/ 1 *\/ 2 AS pg_nests;  ->  2
+        mysql:       the same text -> ERROR 1064 near '/ 2 AS mysql_flat'
+      PostgreSQL closes the run at the SECOND `*\/`, MySQL at the first.
+    */
+    const sql = "/* a /* b */ ; DROP TABLE users; -- */ SELECT 1";
+
+    expect(sqlsOf(splitStatements(sql, resolveSqlGrammar("postgres")))).toEqual([sql]);
+    // MySQL's flat reading really does make that DROP a statement of its own -
+    // measured, the table was gone - which is the other half of the fix: the
+    // confirmation gate has to see the fragment (QuerySafetyDialog).
+    expect(sqlsOf(splitStatements(sql, resolveSqlGrammar("mysql")))).toEqual([
+      "/* a /* b */",
+      "DROP TABLE users",
+      "-- */ SELECT 1",
+    ]);
+  });
+
+  test("the entry's attack yields no runnable bare DROP on PostgreSQL", () => {
+    /*
+      The sharp case, and the reason this is a safety fix rather than a tidy-up.
+      Measured on postgres 18 (container libredb-postgres) the operator's own text
+      is ONE read and the table survives it:
+        psql -c "CREATE TABLE IF NOT EXISTS s1_users(id int);"
+             -c "/* a /* b *\/ ; DROP TABLE s1_users; -- *\/ SELECT 1 AS ran;"
+             -c "SELECT count(*) FROM pg_class WHERE relname='s1_users';"
+        ran = 1, count = 1
+      The dialect-blind splitter cut it into three and the multi-statement route ran
+      fragment two: a bare `DROP TABLE users` the engine would have honoured.
+    */
+    const attack = "/* a /* b */ ; DROP TABLE users; -- */ SELECT 1";
+    const fragments = splitStatements(attack, resolveSqlGrammar("postgres"));
+
+    expect(fragments).toHaveLength(1);
+    expect(isMultiStatement(attack, resolveSqlGrammar("postgres"))).toBe(false);
+    expect(sqlsOf(fragments)).not.toContain("DROP TABLE users");
+  });
+
+  test("a call naming no dialect gets the compatibility grammar", () => {
+    // The stated default, the same one every other reader here applies: `#` is a
+    // comment unless it opens a PostgreSQL operator, `[…]` is a name, block
+    // comments are flat, and there is no alternate quoting. Pinned so that it is a
+    // decision rather than an accident.
+    expect(splitStatements("SELECT 1 # note; two\nFROM t")).toHaveLength(1);
+    expect(splitStatements("SELECT meta #> '{a}'; SELECT 2")).toHaveLength(2);
+    expect(splitStatements("SELECT 1 AS [a;b]")).toHaveLength(1);
+  });
+
+  test("an undeterminable literal swallows the rest rather than inventing a boundary", () => {
+    /*
+      `spans.ts` reports any closing quote behind an odd backslash run as
+      undeterminable, because MySQL escapes with backslashes and PostgreSQL does
+      not and the two readings put the string's end in different places. The
+      splitter inherits that: no boundary is invented inside text it cannot read,
+      so the buffer stays one statement and takes the single-statement route. The
+      confirmation gate already asks about this shape (#297).
+    */
+    const result = splitStatements("SELECT 'a\\'; DROP TABLE users");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sql).toBe("SELECT 'a\\'; DROP TABLE users");
+  });
+
+  test("startLine still counts newlines the dialect hid inside a span", () => {
+    // The line counting is what the splitter wound its own scan around, so it is
+    // asserted over a span the SHARED reader consumes: a MySQL hash comment.
+    const result = splitStatements("SELECT 1 # a;b\n;\nSELECT 2", resolveSqlGrammar("mysql"));
+
+    expect(sqlsOf(result)).toEqual(["SELECT 1 # a;b", "SELECT 2"]);
+    expect(linesOf(result)).toEqual([0, 2]);
+  });
+});
+
+// ── `//` hides a boundary on two shipped engines (S1 follow-up) ─────────────
+//
+// The reviewer's finding on S1: the entry closed the block-comment shape and left
+// the same defect class alive on Cassandra and ScyllaDB, because CQL's third
+// comment form was not a span. Reproduced 2026-08-25 over the native protocol -
+// `SELECT release_version FROM system.local // note; DROP KEYSPACE nope\n` returns
+// the ROW on Cassandra 5.0.9 and on ScyllaDB 2026.2.4 (which shares the
+// `cassandra` type-id), and the DROP does not run: a bare `DROP KEYSPACE nope`
+// answers "Keyspace 'nope' doesn't exist", so the OK proves the `//` hid both the
+// `;` and the write. `/api/db/multi-query` loops over every fragment this returns,
+// so a second fragment here is a statement the operator's text never contained.
+
+describe("splitStatements: a `//` comment hides the boundary where the dialect has one", () => {
+  const CASSANDRA = resolveSqlGrammar("cassandra");
+  const CLICKHOUSE = resolveSqlGrammar("clickhouse");
+  const POSTGRES = resolveSqlGrammar("postgres");
+
+  test.each<[string, ReturnType<typeof resolveSqlGrammar>]>([
+    ["cassandra", CASSANDRA],
+    ["clickhouse", CLICKHOUSE],
+  ])("no bare DROP is manufactured on %s", (_label, grammar) => {
+    const buffer = "SELECT id FROM probe.customers // note; DROP TABLE probe.customers";
+    const result = splitStatements(buffer, grammar);
+
+    expect(sqlsOf(result)).toEqual([buffer]);
+    expect(isMultiStatement(buffer, grammar)).toBe(false);
+  });
+
+  // The other direction, and it is the reason this is a per-dialect fact rather
+  // than a widened reading: `//` is an OPERATOR NAME in PostgreSQL (measured on 18,
+  // `SELECT 1 // 2` is "operator does not exist: integer // integer", not a syntax
+  // error), so the `;` after it really is a boundary there and the second statement
+  // really is the operator's own.
+  test("a dialect without the form still splits at the same semicolon", () => {
+    const result = splitStatements("SELECT id FROM t // note; DROP TABLE t", POSTGRES);
+
+    expect(sqlsOf(result)).toEqual(["SELECT id FROM t // note", "DROP TABLE t"]);
+  });
+
+  test("a caller that names no dialect keeps today's reading, as a decision", () => {
+    // Same rule as the `#` and `[…]` defaults: no reader here had a `//` branch
+    // before this fact existed, so a dialect-less call answers what it answered.
+    expect(splitStatements("SELECT id FROM t // note; DROP TABLE t")).toHaveLength(2);
+  });
+
+  test("startLine still counts the newlines a `//` comment carried", () => {
+    const result = splitStatements("SELECT 1 // a;b\n;\nSELECT 2", CASSANDRA);
+
+    expect(sqlsOf(result)).toEqual(["SELECT 1 // a;b", "SELECT 2"]);
+    expect(linesOf(result)).toEqual([0, 2]);
+  });
+});
+
+describe("splitStatements offsets", () => {
+  // The offsets exist for the editor's cursor reader, so what they have to guarantee is
+  // that slicing the original by them returns the statement verbatim - a caller that
+  // re-derives the text from a line number cannot.
+  test("slicing the input by a statement's offsets returns its own sql", () => {
+    const input = "  SELECT 1;\n\n  SELECT 'a;b' AS x;\nDROP TABLE t";
+    const statements = splitStatements(input);
+
+    expect(statements).toHaveLength(3);
+    for (const statement of statements) {
+      expect(input.slice(statement.start, statement.end)).toBe(statement.sql);
+    }
+  });
+
+  test("the offsets follow the dialect, not the raw semicolons", () => {
+    // One statement under PostgreSQL's nesting rule; the `;` inside the comment is not a
+    // boundary, so there is one span covering the whole buffer.
+    const input = "/* a /* b */ ; DROP TABLE users; -- */ SELECT 1";
+    const [only, ...rest] = splitStatements(input, resolveSqlGrammar("postgres"));
+
+    expect(rest).toHaveLength(0);
+    expect(input.slice(only!.start, only!.end)).toBe(input);
   });
 });


### PR DESCRIPTION
Three BACKLOG entries close. Every claim was measured against a live engine and then verified in Chrome on a production build, and the browser found a defect three passes of gates did not.

## S1 — a commented-out `DROP` became a statement the route ran

`statement-splitter.ts` walked spans itself instead of using `spans.ts`, so it disagreed with every other reader about where a statement ends — and unlike them, its disagreement is **executed**: `/api/db/multi-query` runs each fragment it returns.

```
postgres 18, the entry's own shape:
  /* a /* b */ ; DROP TABLE s1_victim; -- */ SELECT count(*) FROM s1_victim
  psql        -> 1 row, survived = 2        (block comments NEST: one statement)
  old reading -> 3 fragments, #2 = `DROP TABLE s1_victim`, and the route ran them
  the gate    -> silent, because it read the whole editor text, where the
                 operative keyword is nothing at all
```

The splitter now reads through the shared reader under the caller's dialect, and `isDangerousQuery` asks about the same fragments the runner will run. Every caller passes a dialect, including the agent's own draft reader.

**The same defect survived on three shipped engines,** because `SqlGrammar` could not carry CQL's third comment form. `//` is a line comment on Apache Cassandra 5.0.9, ScyllaDB 2026.2.4 and ClickHouse 26.7.1 — each probed with a control arm, so "the statement still ran" cannot be mistaken for "the `;` was hidden" — and is refused or is an operator everywhere else (PostgreSQL 18: *operator does not exist: integer // integer*). `SELECT ... // note; DROP ...` was therefore cut into a read and a runnable bare `DROP` out of text the server reads as one statement.

`doubleSlashComment` is now a grammar fact, which the splitter got for free by reading through `spans.ts` — and it closed a silent ClickHouse bug in passing:

```
ClickHouse 26.7.1, prepareQuery(..., limit 5)
  before: SELECT number FROM numbers(1000) // note LIMIT 5   -> 1000 rows, wasLimited: true
  after:  SELECT number FROM numbers(1000) LIMIT 5 // note   ->    5 rows
```

**A third reader, found in the browser and by no gate.** `QueryEditor.getEffectiveQuery` picks the statement at the cursor with raw `lastIndexOf(";")` — no spans, no dialect, not even a string-literal check — and it decides the text that is **sent**. On the buffer above the request body carried a line comment plus the SELECT, and the grid read **0 rows** where `psql` answers 2. It now reads through the shared splitter, so `SplitStatement` carries offsets. Re-verified in Chrome after the fix: `survived = 2`, 1 row, and the request still goes to `/api/db/query`.

One pinned policy changed deliberately: with the caret in an empty statement between two `;`, the old reader fell through to the **whole buffer** — so "run the statement I am in" silently ran every statement, which with a `DROP` in the second one is a destructive surprise. It now runs the statement the caret is immediately after.

## U9 — a control that named an operation the page behind it could not run

Four providers pointed `vacuumAction` at something that is not a vacuum (ClickHouse *Optimize Table*, SQL Server and Oracle *Rebuild Indexes*, Couchbase *Compact*), and MySQL rendered `BaseDatabaseProvider`'s default *"Vacuum Table"* although its operations are `analyze/optimize/check/kill`.

Each provider now declares, next to the operation, which `MaintenanceType` its wording stands for **and what kind of target it takes**. #427's generic label-to-operation mapping is not repeated — it handed Oracle a table where `ALTER INDEX` wanted an index and answered **ORA-01418** on every click, and was reverted. Oracle's per-table `optimize` was rebuilt to read `USER_INDEXES WHERE TABLE_NAME = :t` and proven against the live engine:

```
Oracle AI Database 26ai Free Release 23.26.2.0.0, through the provider
  old statement  ALTER INDEX "U9_PROBE" REBUILD    -> ORA-01418
  new            optimize U9_PROBE                 -> success, rebuilt 2 of 2
                 an UNUSABLE index                 -> VALID
                 LAST_DDL_TIME moved for the named table's indexes and no others
```

All three surfaces gate and title from the declaration — the monitoring Tables tab, the admin Operations tab and the schema explorer's row menu, which was still offering SQLite *"Vacuum Table"* for one table while the Tables tab correctly withheld it. Browser-verified: MySQL's Operations tab reads **Run Optimize / Optimize Tables**, with no vacuum card and no reindex card; PostgreSQL, which does vacuum, is unchanged.

**Then the refusals those new controls exposed.** MySQL discarded `OPTIMIZE`/`CHECK TABLE`'s result rows, so a missing table answered *"OPTIMIZE completed successfully"* and `CHECK`'s verdict — the entire point of the control — never reached anyone. Oracle reported success for a target the catalog does not know, and for a table where **every** index rebuild was refused (measured with a READ ONLY tablespace: `success: true`, "rebuilt 0 of 2", ORA-01647 discarded).

And none of it reached the user: `use-monitoring-data` toasted `success` on any HTTP 200 and the audit event hardcoded `result: "success"`, so a refused operation showed a **green tick reading "OPTIMIZE failed: ..."** and was logged as completed. Verified end to end in the browser:

```
POST /api/db/maintenance {type:"optimize", target:"no_such_table_r10"}
  -> 200 {"success":false,"message":"OPTIMIZE failed: mysql.no_such_table_r10:
          Table 'mysql.no_such_table_r10' doesn't exist"}
  audit page: Total 1 ops, Success 0%      (before: 100%)
```

## DOC2 — a copy-paste recipe the API server rejects

`--set extraEnv[0].value="true"` renders `value: true`, an unquoted YAML boolean, while `core/v1.EnvVar.value` is a string. Reproduced with helm v4.1.3 and the real chart, parsing the rendered value rather than eyeballing the quotes. Nothing catches it earlier: `values.schema.json` types `extraEnv` as plain objects, so `helm lint --strict` passes.

Both recipes use `--set-string`, plus **two more coercion sites the entry did not name** (`ingress.annotations` is a `map[string]string`; `limit-rpm=120` rendered as an integer) and **eleven** bracket arguments that zsh globs away before helm is reached. A static lint over the README's bash fences pins the class, non-vacuous by mutation.

The chart is a released version, so a packaged-file change costs `version: 0.1.50` and the operator mirror — the operator ships its own copy of this README and was still carrying the broken recipes.

## Recorded rather than fixed

- **U20** — the maintenance API validates that an operation *exists*, not that it can take the target, so `POST {type:"vacuum", target:"users"}` still vacuums the whole SQLite file. Admin-gated; the invariant just lives in one layer only.
- **U21** — MSSQL and MongoDB declare `check` globally runnable and there is no card copy for it. Inventing copy for five providers without measuring what a whole-database `DBCC CHECKDB` costs is the mapping #427 reverted.
- **U22** — `TableItem`'s items are deep links, so "the operation takes a table" and "the destination renders the control" are different questions.

## Gates

| Gate | Result |
| --- | --- |
| `bun run format` | clean (943 files) |
| `bun run lint` | 0 errors |
| `bun run typecheck` | clean |
| `bun run knip` | clean |
| `bun run chart:check` | chart 0.1.50 / appVersion 0.13.4 in sync |
| tests | 0 fail; 33/33 component groups |
| coverage | **100.00% (42786/42786 lines)** |
| `bun run build` | exit 0 |
| `build:lib` + `attw` | exit 0 |
| gitleaks | 1 commit scanned, no leaks |

One note for review: the first implementation pass was killed mid-edit by a session limit and left the tree not compiling (Oracle called a method that was never written). It was finished from that point, and the three reviews then ran against the completed work — the CQL residual, the success-reporting defects and the chart blocker all come from those reviews rather than from the original passes.
