### PR TITLE
fix(sql,api,ui): a bound mentioned in a comment silenced the limiter, and three more

### DIFF
--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -764,7 +764,7 @@ admin routes use.
 |-------|------|----------|-------------|
 | `connection` | object | Yes | Database connection configuration |
 | `type` | string | Yes | Maintenance operation type |
-| `target` | string | No | Target table name or PID (for kill) |
+| `target` | string | No | Target table name or PID (for kill). Also selects the *placement* the request is validated as: absent or empty means whole-database, any name means one object |
 
 **Maintenance Types:**
 
@@ -808,6 +808,17 @@ admin routes use.
 ```
 
 The handler validates against the target provider's capabilities: `type` is required (`{ "error": "Maintenance type is required" }`), the provider must support maintenance at all, and the requested operation must be in that provider's supported set (see the matrix above) — otherwise a `400` is returned listing what the provider does support.
+
+A fourth `400` gates what the operation may be *pointed at*. Each provider declares that separately
+(`maintenanceOperationSpecs`, documented per engine under `docs/providers/`), and `target` selects
+which half of the declaration this request is: absent or empty is a whole-database request, a name
+is a per-object one. When the provider says that placement is not offered for this operation while
+the other one is, nothing is run and the reply names the provider's own wording for the control -
+`{ "error": "Vacuum Database takes no target on this database: it runs over the whole database. Omit 'target'." }`
+for a targeted SQLite `vacuum`, and the mirror-image *"requires a target"* message for a targetless
+operation that has no whole-database form. An operation whose declaration offers *neither* placement
+is not refused: its target is a session or query id that neither half describes (every engine's
+`kill`), so the request passes through.
 
 A `druid` connection fails the second check whatever the `type` is, with `{ "error": "Maintenance operations not supported for this database" }`: no maintenance operation is reachable from Druid SQL, so its supported set is empty by design. Compaction and retention are Coordinator and task concerns, and Druid publishes no catalog of running queries, so there is no id for `kill` to name.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -21,11 +21,11 @@ None of it is a GitHub issue.
 
 **Sections**
 
-- [SQL statement reading](#sql-statement-reading) — S2–S8 · 7
+- [SQL statement reading](#sql-statement-reading) — S2–S7 · 5
 - [Drivers and connections](#drivers-and-connections) — D1–D26, U17 · 8
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U22 · 13
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U21 · 11
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P5 · 5
@@ -76,13 +76,6 @@ The decline that keeps #293 safe keys on an unanchored `OFFSET`/`FETCH` mention 
 refused. The precise alternative — walk forward to where the unresolvable region starts — only helps
 for a mention *before* the bad span, and costs a new shared-reader API.
 
-### S5. The limiter's whole-body probes still read inside comments
-
-`src/lib/db/utils/query-limiter.ts` runs its `ROWNUM` test, its `UNION` test and its subquery
-`SELECT` count over the whole statement text. A statement that merely *mentions* a bound in an
-interior comment therefore reads as already bounded. The statement's *type* stopped being fooled this
-way in maintainer-sweep-4/5; these flags did not.
-
 ### S6. Grammar facts left undecided
 
 `grammar.ts` records a fact as established only when a first-party source was found. Where none was,
@@ -120,16 +113,6 @@ Scanning an unreadable region for destructive vocabulary, and asking only when a
 plausibly be in there. Sound on its face. It substitutes a cleverer reading for the honesty rule #297
 pinned: the gate asks because it *cannot* read the text, not because it guessed what is in it.
 Revisit only with an explicit product decision.
-
-### S8. The confirmation gate's destructive vocabulary is SQL-only
-
-`isDangerousQuery` recognises SQL keywords. It is close to inert for the two non-SQL types it is
-still asked about: a Redis `FLUSHALL` or `DEL key`, and a MongoDB `{"operation":"drop"}`, are
-destructive and match nothing. The span-based half of the gate no longer fires on their text at all,
-which leaves the keyword half as the only check — and it does not speak their languages.
-
-**Done when:** a destructive MongoDB operation and a destructive Redis command each ask before
-running, driven from one type-to-facts place rather than a type test in the component.
 
 ---
 
@@ -593,22 +576,6 @@ being OFFERED, not refused. The same missing thing explains both: this banner ha
 **Done when:** a message that is neither a success nor a failure renders as neither, and the degraded
 save uses it.
 
-### U20. The maintenance API validates that an operation EXISTS, not that it can take the target
-
-`src/app/api/db/maintenance/route.ts` checks `capabilities.maintenanceOperations.includes(type)` and
-nothing else, then calls `provider.runMaintenance(type, target)`. Since 2026-08-25 each provider also
-declares what KIND of target each operation takes (`maintenanceOperationSpecs`), and both UI surfaces
-gate on it - but the route does not, so every mismatch the declaration describes stays reachable by a
-direct request. Measured: `POST {type:"vacuum", target:"users"}` against SQLite still vacuums the whole
-file, which is exactly the reading SQLite's `vacuum: { perEntity: false }` exists to withhold.
-
-Not a security hole - the route is admin-gated and every one of these statements is one an admin may
-run - but the invariant lives in one layer only, and the layer it is missing from is the one an
-integration calls.
-
-**Done when:** the route refuses a target an operation cannot take, or the declaration says why the API
-is deliberately wider than the UI.
-
 ---
 
 ### U21. Two global maintenance cards exist for operations that have no card copy
@@ -628,21 +595,6 @@ recorded reason it is withheld.
 
 ---
 
-### U22. `TableItem`'s deep links are gated on the operation, not on where the operation can be run
-
-`src/components/schema-explorer/TableItem.tsx` reads the maintenance declaration since 2026-08-25, so
-the wording is the provider's own and a per-entity operation is what it offers. What it still cannot
-express is that its two items are DEEP LINKS: they navigate to the maintenance page with a table name,
-and whether that page has a control for the operation is a separate question from whether the operation
-takes a table.
-
-The class is recorded in that file's own comment for Elasticsearch ("clicking Merge Segments landed on
-a page with no maintenance controls, no error and no explanation"), and the same shape returns whenever
-a provider declares an operation `perEntity: true` while the destination page renders it under a
-condition of its own.
-
-**Done when:** the link is offered only where the destination renders the control, tested against the
-destination rather than against the declaration.
 ---
 
 ## Authentication and security headers

--- a/docs/editor/query-optimization.md
+++ b/docs/editor/query-optimization.md
@@ -176,11 +176,22 @@ A rule that could **not** be established is not guessed from a neighbouring dial
 at the compatibility default below, and it is listed here rather than left implicit. The default is per
 **fact**, not per dialect: a dialect whose `#` rule is known can still be undecided about its brackets.
 
-The three non-SQL types, **MongoDB, Redis and LibreDB, have no SQL grammar at all** and are left out of the rows
-below: their providers never reach these readers on the query path, and the confirmation gate — which
-reads whatever is in the editor — asks `readsSqlText()` before applying any span-based rule to their
-text, so a JSON document or a Redis command is not judged by a SQL reader that cannot parse it. The
-gate's keyword tests still run on that text.
+**MongoDB and Redis are the two types whose query text is not SQL at all** — `NON_SQL_DIALECTS` in
+`src/lib/sql/grammar.ts` holds exactly those two, which is what `readsSqlText()` reports on. Their
+providers never reach these readers on the query path, and the confirmation gate — which reads whatever
+is in the editor — asks `readsSqlText()` before applying any span-based rule to their text, so a JSON
+document or a Redis command is not judged by a SQL reader that cannot parse it.
+
+Nor is the gate's SQL keyword reading applied to it. Those two types have a vocabulary of their own in
+`src/lib/db/destructive-commands.ts`: one table per type of the destructive operations the provider can
+actually dispatch (`deleteOne`/`deleteMany`/`updateOne`/`updateMany` and the `$out`/`$merge` pipeline
+stages for MongoDB; `DEL`, `FLUSHALL`, `SET`, `CONFIG SET` and the rest for Redis), and the gate reduces
+the buffer the way the provider would — one JSON document, or Redis's first blank-line-delimited block —
+before looking a name up in it. Text it cannot read as a command at all is not treated as safe: mongosh
+syntax, a half-typed document or a broken JSON command body **asks**. Before that table existed the
+answer for both types was a bare `false`, so a `FLUSHALL` and a `deleteMany` ran with no confirmation
+while a `DELETE FROM` on every SQL engine asked. The embedded LibreDB is not in that set — its text is
+read as SQL, and its undecided grammar facts are rows in the table below.
 
 | Fact | Undecided, so left at the default | Established, and it happens to equal the default |
 |------|-----------------------------------|--------------------------------------------------|
@@ -455,11 +466,13 @@ The accepted cost, pinned by tests rather than left to be discovered, in two cla
 **Not a cost this rule pays: non-SQL query text.** Both execution paths ask about whatever is in the
 editor, so this predicate is handed MongoDB documents and Redis commands as well. A SQL span reader's
 verdict about text that is not SQL is not evidence of anything — the escaped quote in
-`{"filter":{"msg":"say \"hi\""}}` or in `SET k "a\"b"` closes perfectly in the grammar the text is
-actually written in — so the unresolvable-run rule is applied only where `readsSqlText()` says the
-dialect writes SQL. Saying *"could not be read"* about text that reads fine is the false alarm this
-notice exists to avoid, and a gate operators learn to click through protects nothing. The keyword
-tests still run on that text; only the span-based rule is narrowed.
+`{"filter":{"msg":"say \"hi\""}}` or in `GETRANGE k "a\"b" 0 1` closes perfectly in the grammar the
+text is actually written in — so the unresolvable-run rule is applied only where `readsSqlText()` says
+the dialect writes SQL. Saying *"could not be read"* about text that reads fine is the false alarm this
+notice exists to avoid, and a gate operators learn to click through protects nothing. Only the
+span-based rule is narrowed: the non-SQL vocabulary above still answers for that text, which is why the
+Redis half of this example is a `GETRANGE` and not the `SET k "a\"b"` it used to be — `SET` is in that
+vocabulary and now prompts on its own merits, whatever its quoting.
 
 A fourth class arrives with the nesting fact (#300), and it is the reverse of the ones above — a prompt
 the dialect *adds* rather than one it narrows: on PostgreSQL, SQL Server and ClickHouse a block comment

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -788,6 +788,12 @@ declares what its own operations may be pointed at. The monitoring Tables tab re
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
 
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available - a targetless `{type:"optimize"}` is
+that request here, the API-side half of the withheld *"Merge Parts"* card.
+
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|
 | `optimize` | Optimize Table | yes | **no** | `OPTIMIZE TABLE ... FINAL` names one table and `dispatchMaintenance` requires that target; ClickHouse has no "optimize database", and looping every table would merge the whole dataset behind one click |

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -641,6 +641,12 @@ declares what its own operations may be pointed at. The monitoring Tables tab re
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
 
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available - a targetless `{type:"analyze"}` or
+`{type:"reindex"}` is that request here, the API-side half of the two withheld global cards.
+
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|
 | `analyze` | Update Statistics | yes | **no** | `UPDATE STATISTICS FOR <keyspace>` names one collection, and `dispatchMaintenance` requires the target |

--- a/docs/providers/mongodb.md
+++ b/docs/providers/mongodb.md
@@ -98,6 +98,13 @@ Supported operations: `find`, `findOne`, `aggregate`, `count`, `distinct`, `inse
 [`API_DOCS.md` MongoDB Query Format](../API_DOCS.md) section (under `POST /api/db/query`) and
 [`CLAUDE.md`](../../CLAUDE.md) for the request shape.
 
+Since S8 the **execution confirmation gate reads this same shape**:
+`src/lib/db/destructive-commands.ts` names `deleteOne`, `deleteMany`, `updateOne`, `updateMany` and
+the top-level `$out` / `$merge` aggregate stages as the destructive operations here - so each of
+them asks before it runs, exactly as a `DELETE FROM` does on a SQL engine, and a payload the reader
+cannot read as a document with a string `operation` (mongosh syntax such as
+`db.users.deleteMany({})`, a half-typed object) asks as well rather than staying silent.
+
 ### 3.2 BSON serialization for the grid
 
 `serializeDocument()` ([mongodb.ts:388](../../src/lib/db/providers/document/mongodb.ts)) recursively
@@ -347,6 +354,12 @@ declare the same `MaintenanceType` take different kinds of target, so each provi
 declares what its own operations may be pointed at. The monitoring Tables tab renders a
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
+
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available - a targetless `{type:"check"}` is that
+request here.
 
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -508,6 +508,12 @@ declares what its own operations may be pointed at. The monitoring Tables tab re
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
 
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available - `{type:"check", target:"Orders"}` is
+that request here.
+
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|
 | `analyze` | Update Statistics | yes | yes | `UPDATE STATISTICS [<t>]`, or every table without a target |

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -638,6 +638,13 @@ declares what its own operations may be pointed at. The monitoring Tables tab re
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
 
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available. On MySQL it never speaks: every
+declaration above is either both placements or neither, so no request can name a placement this
+provider offers in one place only.
+
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|
 | `analyze` | Analyze Table | yes | yes | `ANALYZE TABLE <t>`, or every table via `getAllTablesForMaintenance()` |

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -815,6 +815,14 @@ declares what its own operations may be pointed at. The monitoring Tables tab re
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
 
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available. On Oracle it never speaks: every
+declaration above is either both placements or neither. `kill` declaring neither is not "takes
+no target" - `SID,SERIAL#` comes from the Sessions panel, which this field says nothing about -
+so those requests pass through.
+
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|
 | `analyze` | Gather Statistics | yes | yes | `GATHER_TABLE_STATS` / `GATHER_SCHEMA_STATS` |

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -581,6 +581,13 @@ declares what its own operations may be pointed at. The monitoring Tables tab re
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
 
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available. On PostgreSQL it never speaks, for the
+same reason both surfaces were already right here: every declaration above is either both
+placements or neither.
+
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|
 | `vacuum` | Vacuum Table | yes | yes | `VACUUM ANALYZE <t>` and bare `VACUUM ANALYZE` both exist |

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -201,6 +201,14 @@ This mirrors the embedded LibreDB provider, and exists so the commented cheatshe
 explorer inserts is directly runnable: selecting one command runs it, and running the whole buffer
 runs its first one (#427).
 
+Since S8 the **execution confirmation gate reads a buffer the same way**:
+`src/lib/db/destructive-commands.ts` drops `#` lines and takes the first block as above, dispatches
+on a leading `{` as §3.4 does, and asks before running any command in its Redis destructive
+vocabulary - key, expiry, string, hash, list, set, sorted-set and stream writes, the scripting
+entry points, and the server and access commands, with container commands such as `CONFIG SET`
+matched on their two-token spelling - while a body it cannot read (broken JSON, a JSON body whose
+`command` is not a string) asks rather than staying silent.
+
 ### 3.5 Reply normalisation into the shared grid
 
 Redis replies are heterogeneous (status strings, integers, nil, flat arrays, hash arrays, bulk
@@ -528,6 +536,12 @@ declare the same `MaintenanceType` take different kinds of target, so each provi
 declares what its own operations may be pointed at. The monitoring Tables tab renders a
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
+
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available - `{type:"analyze", target:"session:"}`
+is that request here, and it is the only one this provider can refuse.
 
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -434,6 +434,12 @@ declares what its own operations may be pointed at. The monitoring Tables tab re
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
 
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available - `{type:"vacuum", target:"users"}` is
+that request here.
+
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|
 | `vacuum` | Vacuum Database | no | yes | `VACUUM` rewrites the whole file and `runMaintenance` drops the target, so a per-table control named one table and acted on the database |

--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -680,6 +680,14 @@ declares what its own operations may be pointed at. The monitoring Tables tab re
 per-row control only where `perEntity` is true, the admin Operations tab a whole-database
 card only where `global` is true, and both take the wording from `label` (#U9).
 
+`POST /api/db/maintenance` reads the same declaration since #U20, and it is the one reader that
+REFUSES rather than hides: it takes the placement from whether the request carries a `target`
+(absent or empty means whole-database) and answers `400` when this provider marks that
+placement unavailable while the other one is available. On Trino it never speaks: `kill`
+declares neither placement, which is not "takes no target" but "the target comes from somewhere
+this field says nothing about", so the request passes through to the query id the Sessions
+panel supplied.
+
 | Operation | Control label | Per-row | Global | Why |
 |-----------|---------------|---------|--------|-----|
 | `kill` | Terminate Query | no | no | the target is the query id the Sessions panel lists; neither a table nor a whole database can supply one |

--- a/src/app/api/db/maintenance/route.ts
+++ b/src/app/api/db/maintenance/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getOrCreateProvider, type MaintenanceType } from "@/lib/db";
 import { emitAuditEvent } from "@/lib/audit";
 import { createErrorResponse } from "@/lib/api/errors";
+import { maintenanceControl, type MaintenancePlacement } from "@/lib/db/types";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { auditRoleDenial, guardRoute } from "@/lib/api/require-session";
 import { logger } from "@/lib/logger";
@@ -45,6 +46,59 @@ export async function POST(request: Request) {
         },
         { status: 400 },
       );
+    }
+
+    // `maintenanceOperations` above says only that the operation EXISTS here. What KIND of
+    // target it takes is a separate declaration - `maintenanceOperationSpecs` - and until
+    // U20 this route never read it, while both UI surfaces gated on it. The gap is the one
+    // the U20 backlog entry reports from a live SQLite run: POST {type:"vacuum",
+    // target:"users"} answered 200 and vacuumed the whole file, which is exactly the reading
+    // `vacuum: { perEntity: false }` exists to withhold. What THIS change measured is
+    // narrower and should not be read as that run repeated: the status code only, against
+    // SQLite-SHAPED mock capabilities rather than a live engine - the request that answered
+    // 200 now answers 400 and never reaches `runMaintenance`. `maintenanceControl` is asked
+    // here rather than the spec read directly so the route cannot disagree with the two
+    // surfaces about what a provider declared.
+    //
+    // A non-empty `target` is the "perEntity" request and its absence the "global" one - the
+    // same reading the audit row below already uses (`target || "all"`), so `target: ""` is a
+    // whole-database request, not an unnamed object.
+    //
+    // Both halves false is NOT "takes no target": every provider that declares `kill`
+    // declares it false/false because its target is a session or query id, which neither a
+    // table row nor a whole-database card can supply. The gate therefore only speaks when the
+    // provider claimed at least one of the two placements it describes; otherwise the target
+    // comes from somewhere this field says nothing about and the request passes through.
+    //
+    // The `labels.vacuumActionOperation` redirect is deliberately NOT honoured here. It is a
+    // wording concern: it says which operation a provider's *vacuum* copy names, and both
+    // callers (`TableItem`, `OperationsTab`) resolve it before sending - the request carries
+    // the resolved operation id, never the literal `vacuum`. Rewriting a caller's stated
+    // operation into a different one is the opposite of what a gate does, and it would make
+    // the existing "operation not supported" 400 unreachable for exactly the four providers
+    // whose vacuum wording names something else.
+    const placement: MaintenancePlacement = target ? "perEntity" : "global";
+    const perEntityControl = maintenanceControl(capabilities, type as MaintenanceType, "perEntity");
+    const globalControl = maintenanceControl(capabilities, type as MaintenanceType, "global");
+    const requestedControl = placement === "perEntity" ? perEntityControl : globalControl;
+
+    if (!requestedControl.offered && (perEntityControl.offered || globalControl.offered)) {
+      // Exactly one placement is available here (the other is the refused one), so the
+      // message can name what the operation does accept, in the provider's own wording.
+      //
+      // The `??` is defensive against untyped capabilities, not a reachable path: entering
+      // this branch requires a spec to exist for `type` - with no spec `maintenanceControl`
+      // reports BOTH placements offered, so neither half of the condition holds - and
+      // `MaintenanceOperationSpec.label` is a required string, so any provider that went
+      // through the type carries a name here. The fallback stands only for a capabilities
+      // object that reached this route without doing so, where inventing a name would put a
+      // word the engine does not use in front of an operator.
+      const name = requestedControl.label ?? `Operation '${type}'`;
+      const error =
+        placement === "perEntity"
+          ? `${name} takes no target on this database: it runs over the whole database. Omit 'target'.`
+          : `${name} requires a target on this database: it runs against one object at a time.`;
+      return NextResponse.json({ error }, { status: 400 });
     }
 
     const startTime = Date.now();

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { ShieldAlert, ShieldCheck, TriangleAlert, LoaderCircle, Play, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { isDestructiveNonSqlQuery } from "@/lib/db/destructive-commands";
 import { readsSqlText, resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
 import { hasUnterminatedSpan } from "@/lib/sql/spans";
@@ -408,6 +409,13 @@ function writesUnderGrammar(text: string, grammar: SqlGrammar): boolean {
  * text (#292, #295): Oracle's `q'{it's}'` and ClickHouse's `[[1,2],[3,4]]` are
  * closed runs under their own grammars and unresolvable under a reader without them.
  *
+ * For the two types whose text is not SQL there is nothing here to read, and this
+ * predicate answered false for them outright - so a Redis `FLUSHALL` or `DEL` and a
+ * MongoDB `deleteMany` ran with no confirmation at all, on both execution paths,
+ * while the same intent on every SQL engine asked (S8). Their vocabulary now comes
+ * from `@/lib/db/destructive-commands`, one table per type read by one function, and
+ * it names only what those two providers can actually dispatch.
+ *
  * `databaseType` is the connection the statement is about to run on, and both
  * call sites hold one (#292). It decides the characters the engines read
  * differently: a write written after a `#` is commented out in MySQL and the
@@ -449,6 +457,11 @@ export function isDangerousQuery(query: string, databaseType?: DatabaseType): bo
     route and a `;` in a Mongo document or a Redis command separates nothing, so
     splitting there could only invent fragments to prompt about (#427).
   */
-  if (!readsSqlText(databaseType)) return false;
+  // Where the text is not SQL, its own vocabulary decides. This used to be a bare
+  // `return false`, which is why a Redis `FLUSHALL` and a Mongo `deleteMany` ran with
+  // no confirmation at all while a `DELETE FROM` on every SQL engine asked (S8). The
+  // facts are a table in `@/lib/db/destructive-commands`, not a type test written
+  // here: this file already learned that lesson for the span rule above.
+  if (!readsSqlText(databaseType)) return isDestructiveNonSqlQuery(query, databaseType);
   return splitStatements(query, grammar).some((statement) => writesUnderGrammar(statement.sql, grammar));
 }

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -61,6 +61,35 @@ const TABLE_ACTIONS: { type: MaintenanceType; label: string; Icon: LucideIcon; h
   { type: "check", label: "Check", Icon: ShieldCheck, hover: "hover:text-green-500" },
 ];
 
+/**
+ * Why no per-table maintenance control is anywhere on this page.
+ *
+ * The schema explorer's two maintenance items are DEEP LINKS, and for an admin they
+ * land HERE - `openMaintenance` in src/components/Studio.tsx pushes
+ * /admin/operations?table=... - not on the monitoring Tables panel. They are gated on
+ * what the OPERATION declares (`maintenanceControl(..., "perEntity")`), which is a
+ * different question from whether this page has a ROW to hang the control on: the
+ * controls render per row of `filteredTables` only, so every empty branch of the panel
+ * below rendered nothing at all about the operation the operator arrived asking for
+ * (U22).
+ *
+ * Unlike the monitoring panel, this page HAS the requested table's name - the `?table=`
+ * search param that seeded the filter - so naming it is a measurement rather than an
+ * invention. It is named only while the filter still holds that param: once the operator
+ * types something else, that table is no longer why the list is empty.
+ */
+function TableMaintenanceUnreachableNote({
+  actions,
+  missingTable,
+}: Readonly<{ actions: string[]; missingTable: string | null }>) {
+  const where = missingTable === null ? "no row to run it on" : `no row for "${missingTable}" to run it on`;
+  return (
+    <p className="px-4 pb-4 text-xs text-fg-muted leading-relaxed" data-testid="operations-maintenance-unreachable">
+      {`Per-table maintenance (${actions.join(", ")}) is run from a row of this list, and this page has ${where}.`}
+    </p>
+  );
+}
+
 interface OperationLogEntry {
   id: string;
   timestamp: Date;
@@ -232,6 +261,25 @@ export function OperationsTab() {
   const tablesUnavailable = data?.tables === undefined ? data?.errors?.tables : undefined;
   const [tableSearch, setTableSearch] = useState(deepLinkedTable ?? "");
   const filteredTables = tables.filter((t) => t.tableName.toLowerCase().includes(tableSearch.toLowerCase()));
+
+  // U22. Both halves have to be true for the dead end: the engine declares a control
+  // that takes ONE table, and this page has no row to offer it on. Which absence it is
+  // decides what the note may say:
+  //  - the deep link named a table and no row here matches it, so the name can be stated;
+  //  - or the read was refused / the engine published no statistics while its own
+  //    overview counts tables - the same reading `TablesTab` uses - and no name is known.
+  // A database that genuinely holds no tables is neither: there is nothing to maintain
+  // and nothing to explain. An empty list the operator's OWN filter produced is neither
+  // either, which is why the deep-link arm requires the filter to still hold the param.
+  const deepLinkRowMissing =
+    deepLinkedTable !== null &&
+    deepLinkedTable !== "" &&
+    tableSearch === deepLinkedTable &&
+    filteredTables.length === 0;
+  const tableStatsAbsent =
+    tablesUnavailable !== undefined || (tables.length === 0 && (data?.overview?.tableCount ?? 0) > 0);
+  const maintenanceUnreachable =
+    tableActions.length > 0 && filteredTables.length === 0 && (deepLinkRowMissing || tableStatsAbsent);
 
   const activeCount = sessions.filter((s) => s.state === "active").length;
   const idleCount = sessions.filter((s) => s.state === "idle").length;
@@ -511,6 +559,12 @@ export function OperationsTab() {
                 </div>
               )}
             </div>
+            {maintenanceUnreachable && (
+              <TableMaintenanceUnreachableNote
+                actions={tableActions.map((a) => a.label)}
+                missingTable={deepLinkRowMissing ? deepLinkedTable : null}
+              />
+            )}
           </div>
         )}
 

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -110,6 +110,41 @@ function VacuumNote({
   return null;
 }
 
+/**
+ * Why a per-table maintenance control is nowhere on this page.
+ *
+ * The two maintenance items in the schema explorer (`src/components/schema-explorer/TableItem.tsx`)
+ * are DEEP LINKS into a maintenance surface, and they are gated on what the OPERATION declares -
+ * `maintenanceControl(..., "perEntity")` - which is a different question from whether the surface
+ * has a ROW to hang the control on. Per-table buttons are rendered for rows of `data.tables` only,
+ * so both absence paths in this panel render none of them, and an operator who arrived asking for
+ * one operation was shown an empty list that said nothing about it (U22).
+ *
+ * The operations are named and the table is not: nothing passes the deep link's table name into
+ * this panel - `MonitoringDashboard` renders it with no search params - so naming a table here
+ * would be an invention. What can be stated honestly is which controls the engine declares per
+ * table and why none of them appears.
+ *
+ * Two things the note deliberately does NOT say:
+ *  - No page to go to instead. The only caller (`MonitoringDashboard`) passes no `isAdmin`, and the
+ *    prop defaults to true, so this component cannot tell an admin from the non-admin that
+ *    /monitoring is the route for - and `src/proxy.ts` denies a non-admin /admin/operations. Of the
+ *    two fixes available (thread the real role down, or drop the clause) dropping it is the smaller
+ *    one and the only one that changes no other behaviour: threading the role would also switch off
+ *    the per-row buttons on that route, which is older behaviour and not this change's business.
+ *  - One cause for two inputs. `refused` is the `errors.tables` branch, where `PanelUnavailable` is
+ *    already showing the engine's own reason - a permission or catalog failure as often as a missing
+ *    statistic - so that branch says only what was measured here: nothing could be read.
+ */
+function MaintenanceUnattachableNote({ actions, refused }: Readonly<{ actions: string[]; refused: boolean }>) {
+  const cause = refused ? "no table statistics could be read" : "this database published no table statistics";
+  return (
+    <p className="text-xs text-muted-foreground text-center px-4 pb-6" data-testid="tables-maintenance-unattachable">
+      {`Per-table maintenance (${actions.join(", ")}) is run from a row of this list, and ${cause} - so there is no row to run it on.`}
+    </p>
+  );
+}
+
 function bloatBadgeVariant(ratio: number): "destructive" | "outline" | "secondary" {
   if (ratio > 20) return "destructive";
   if (ratio > 10) return "outline";
@@ -208,6 +243,13 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
     const control = maintenanceControl(capabilities, action.type, "perEntity");
     return control.offered ? [{ ...action, label: control.label ?? action.label }] : [];
   });
+
+  // Both halves have to be true for the dead end U22 names: the engine declares a control
+  // that takes ONE table, and this panel has no table to offer it on. `statsAbsent` covers
+  // both readings of that absence - the refusal recorded under `errors.tables` and the empty
+  // list an engine returns while its own overview counts tables - and is false for a database
+  // that genuinely holds none, where there is nothing to maintain and nothing to explain.
+  const maintenanceUnattachable = isAdmin && availableActions.length > 0 && statsAbsent;
 
   return (
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">
@@ -366,6 +408,12 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
                 </TableBody>
               </Table>
             </div>
+          )}
+          {maintenanceUnattachable && (
+            <MaintenanceUnattachableNote
+              actions={availableActions.map((a) => a.label)}
+              refused={tablesUnavailable !== undefined}
+            />
           )}
         </CardContent>
       </Card>

--- a/src/components/schema-explorer/TableItem.tsx
+++ b/src/components/schema-explorer/TableItem.tsx
@@ -154,7 +154,20 @@ function renderMenuItems({
           the same dead end with the capability flag switched on (#U9).
 
           Global maintenance is unaffected wherever an engine has any: it lives on the
-          admin Operations page and still runs there. */}
+          admin Operations page and still runs there.
+
+          What this gate CANNOT answer is the rest of U22: both items are deep links, and the
+          destination renders a per-table control only for a ROW it has statistics for. Nothing
+          here knows whether one will arrive: `TableSchema.rowCount` and `.size` are optional and
+          come from the schema read, not from the monitoring statistics the destination lists, and
+          no declared capability says whether an engine publishes per-table figures - so
+          withholding the link would need a new capability flag this repo does not want. The
+          destinations were made to say so instead - `TableMaintenanceUnreachableNote` in
+          src/components/admin/tabs/OperationsTab.tsx, where an admin's link actually lands
+          (Studio.tsx `openMaintenance`), and `MaintenanceUnattachableNote` in
+          src/components/monitoring/tabs/TablesTab.tsx for the /monitoring panel. Each is the only
+          reader that knows whether a row turned up, and its answer is testable against what
+          actually renders rather than against what was declared. */}
       {isAdmin && rowsAreAddressable && (analyzeControl.offered || vacuumControl.offered) && (
         <>
           <Separator />

--- a/src/lib/db/destructive-commands.ts
+++ b/src/lib/db/destructive-commands.ts
@@ -1,0 +1,354 @@
+import type { DatabaseType } from "@/lib/types";
+
+/**
+ * The confirmation gate's vocabulary for the engines whose query text is NOT SQL.
+ *
+ * `isDangerousQuery` reads a statement's SQL keywords, and for `mongodb` and `redis`
+ * it had nothing to read: it returned false outright, so a `FLUSHALL`, a `DEL` and a
+ * `deleteMany` ran with no confirmation at all while a `DELETE FROM` on any SQL
+ * engine asked (S8). The vocabulary lives here rather than in the dialog for the
+ * reason every other by-database difference in this repo does: one type-to-facts
+ * table, read by one function, so the gate carries no type test of its own.
+ *
+ * Scope rule, and the reason this file is short: it names ONLY what these two
+ * providers can really run. Both were read before the tables below were written -
+ * `src/lib/db/providers/keyvalue/redis.ts` and
+ * `src/lib/db/providers/document/mongodb.ts` - and neither was probed against a live
+ * server in this change, so nothing here is claimed as measured behaviour. What each
+ * command or operation DOES is taken from the engines' own command references; what
+ * can REACH the engine is taken from the provider code.
+ */
+
+/** Whether `value` is a JSON object - not an array, not null. */
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * MongoDB operations whose effect is to remove documents or overwrite fields.
+ *
+ * Exactly the destructive members of the provider's own `SUPPORTED_OPERATIONS`, in
+ * the provider's spelling: `find`, `findOne`, `aggregate`, `count`, `distinct`,
+ * `insertOne`, `insertMany`, `updateOne`, `updateMany`, `deleteOne`, `deleteMany` are
+ * the whole set it dispatches, and anything else is refused with
+ * `Unsupported operation` before a collection is touched. So `drop`,
+ * `dropDatabase`, `renameCollection` and the index commands are deliberately absent:
+ * they cannot be run from this editor, and a row for them would be a prompt about
+ * text that is going to error anyway.
+ *
+ * The inserts are absent for the same reason the SQL half has no `INSERT`: this gate
+ * asks about statements that destroy or change what is already there.
+ *
+ * `$out` and `$merge` are pipeline STAGES rather than operations, and they are here
+ * because `aggregate` hands `query.pipeline` to the driver unchanged: `$out`
+ * replaces a whole collection and `$merge` can replace matched documents, which
+ * makes an `aggregate` the one read-shaped operation that can destroy data. The
+ * reader below only looks at TOP-LEVEL stages - neither stage is legal inside a
+ * `$lookup` or `$facet` sub-pipeline.
+ */
+const MONGODB_DESTRUCTIVE_OPERATIONS: ReadonlySet<string> = new Set([
+  "deleteOne",
+  "deleteMany",
+  "updateOne",
+  "updateMany",
+  "$out",
+  "$merge",
+]);
+
+/**
+ * Redis commands whose effect is to remove a key or member, replace an existing
+ * value or part of one, schedule a key's deletion, overwrite a destination key, move
+ * a hash slot away from the node that holds its keys, or change who may reach the
+ * server.
+ *
+ * The bar for a name being here is that the NAME decides it: every spelling of the
+ * command does the destructive thing, so reading the first token (and, for a
+ * container, the second) is enough. `SETBIT` is in for the reason `SETRANGE` is - it
+ * overwrites part of a string that is already there - and `XGROUP DELCONSUMER` for
+ * the reason `XGROUP DESTROY` is: it drops a consumer together with its pending
+ * entries. `CLUSTER SETSLOT` has no reading form at all (`CLUSTER SLOTS` and
+ * `CLUSTER SHARDS` are the reads); every form of it reassigns a slot, which is what
+ * puts it beside `CLUSTER RESET` and `CLUSTER FORGET`.
+ *
+ * Every name here can reach the server: `runCommand` calls
+ * `client.call(command, ...args)` with no allow-list of any kind, so the vocabulary
+ * is bounded by what Redis accepts rather than by what this provider implements.
+ * Container commands are spelled with their subcommand (`CONFIG SET`), which the
+ * reader below looks up as a second name, because the container itself is not
+ * destructive - prompting on `CONFIG GET`, an everyday read, is the false alarm this
+ * gate cannot afford.
+ *
+ * Not covered, said plainly rather than left to be discovered:
+ * - `INCR`/`INCRBY`/`DECR`/`APPEND` and their hash and float variants. They change a
+ *   value by adding to it rather than replacing or removing it, and they are the
+ *   commands a counter dashboard runs constantly.
+ * - The `STORE` option of `SORT`, `GEORADIUS`, `GEORADIUSBYMEMBER` and the
+ *   `SET`/`INCRBY` sub-operations of `BITFIELD`. Each sits at an argument position
+ *   this two-name reading does not reach, and the command without the option is a
+ *   plain read.
+ * - `GETEX`, for exactly that reason. `GETEX key` is byte-for-byte a `GET`; it
+ *   touches the key only when `EX`, `PX`, `EXAT`, `PXAT` or `PERSIST` follows the
+ *   key name, and the second token this reader inspects is the key, never the
+ *   option. It was in the set on its first writing, which would have prompted on
+ *   every plain read spelled that way.
+ * - What a Lua script or a function does. `EVAL`, `EVALSHA` and `FCALL` are IN the
+ *   set instead, because the body is an argument and nothing here reads it; the
+ *   declared read-only spellings (`EVAL_RO`, `EVALSHA_RO`, `FCALL_RO`) are out.
+ */
+const REDIS_DESTRUCTIVE_COMMANDS: ReadonlySet<string> = new Set([
+  // Keys
+  "DEL",
+  "UNLINK",
+  "FLUSHALL",
+  "FLUSHDB",
+  "RENAME",
+  "RENAMENX",
+  "MOVE",
+  "COPY",
+  "SWAPDB",
+  "MIGRATE",
+  "RESTORE",
+  // Expiry - a key with a TTL is a key that will be gone
+  "EXPIRE",
+  "PEXPIRE",
+  "EXPIREAT",
+  "PEXPIREAT",
+  // Strings
+  "SET",
+  "SETEX",
+  "PSETEX",
+  "MSET",
+  "GETSET",
+  "GETDEL",
+  "SETRANGE",
+  "SETBIT",
+  "BITOP",
+  // Hashes
+  "HSET",
+  "HMSET",
+  "HDEL",
+  // Lists
+  "LPOP",
+  "RPOP",
+  "LMPOP",
+  "BLPOP",
+  "BRPOP",
+  "BLMPOP",
+  "LSET",
+  "LREM",
+  "LTRIM",
+  "LMOVE",
+  "BLMOVE",
+  "RPOPLPUSH",
+  "BRPOPLPUSH",
+  // Sets
+  "SPOP",
+  "SREM",
+  "SMOVE",
+  "SINTERSTORE",
+  "SUNIONSTORE",
+  "SDIFFSTORE",
+  // Sorted sets
+  "ZREM",
+  "ZREMRANGEBYSCORE",
+  "ZREMRANGEBYRANK",
+  "ZREMRANGEBYLEX",
+  "ZPOPMIN",
+  "ZPOPMAX",
+  "BZPOPMIN",
+  "BZPOPMAX",
+  "ZMPOP",
+  "BZMPOP",
+  "ZUNIONSTORE",
+  "ZINTERSTORE",
+  "ZDIFFSTORE",
+  "ZRANGESTORE",
+  // Streams
+  "XDEL",
+  "XTRIM",
+  "XGROUP DESTROY",
+  "XGROUP DELCONSUMER",
+  // Scripts and functions
+  "EVAL",
+  "EVALSHA",
+  "FCALL",
+  "SCRIPT FLUSH",
+  "FUNCTION FLUSH",
+  "FUNCTION DELETE",
+  "FUNCTION RESTORE",
+  // Server, replication and access
+  "SHUTDOWN",
+  "CONFIG SET",
+  "ACL SETUSER",
+  "ACL DELUSER",
+  "ACL LOAD",
+  "CLIENT KILL",
+  "REPLICAOF",
+  "SLAVEOF",
+  "FAILOVER",
+  "CLUSTER RESET",
+  "CLUSTER FORGET",
+  "CLUSTER SETSLOT",
+]);
+
+/**
+ * The names a query would run, or `undefined` when the text cannot be read as one.
+ *
+ * `undefined` is not "nothing to run": it means the reader could not tell WHAT would
+ * run, and the gate turns it into a prompt.
+ */
+type OperationReader = (query: string) => readonly string[] | undefined;
+
+interface DestructiveVocabulary {
+  /** The names that ask for a confirmation. */
+  readonly operations: ReadonlySet<string>;
+  /** How this engine's query text names the operations it would run. */
+  readonly read: OperationReader;
+}
+
+/**
+ * The top-level stage names of an aggregate pipeline, as far as they can be read.
+ *
+ * A pipeline that is not an array, or a stage that is not an object, names nothing:
+ * the driver rejects both, so there is no operation to ask about.
+ */
+function pipelineStageNames(pipeline: unknown): string[] {
+  if (!Array.isArray(pipeline)) return [];
+  return pipeline.filter(isJsonObject).flatMap((stage) => Object.keys(stage));
+}
+
+/**
+ * What a MongoDB payload would run.
+ *
+ * The shape is the provider's own: one JSON document with `collection` and
+ * `operation`, dispatched on `operation` case-sensitively (so `DELETEMANY` is refused
+ * rather than run, and matching it here would only prompt about text that errors).
+ * Documented the same way in docs/providers/mongodb.md.
+ *
+ * Anything that does not parse as JSON, or parses as something other than a document
+ * with a string `operation`, is UNREADABLE rather than safe - mongosh syntax
+ * (`db.users.deleteMany({})`), a half-typed document, an array. The provider refuses
+ * all of it, so the cost of asking is one click on text that was not going to run;
+ * the cost of the other answer is the silence this whole file exists to remove. The
+ * one exception is text with nothing in it: an empty editor is not a command, and
+ * both callers hand this predicate the buffer as it stands, so treating blank text as
+ * unreadable would prompt on every execute of an empty tab.
+ */
+const readMongodbOperations: OperationReader = (query) => {
+  const text = query.trim();
+  if (text === "") return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (!isJsonObject(parsed)) return undefined;
+
+  const operation = parsed.operation;
+  if (typeof operation !== "string") return undefined;
+
+  // Only an aggregate can carry a writing stage; every other operation's effect is
+  // its own name.
+  return operation === "aggregate" ? [operation, ...pipelineStageNames(parsed.pipeline)] : [operation];
+};
+
+/**
+ * The ONE command a Redis buffer would run, reduced the way `commandBody` reduces it:
+ * `#` comment lines dropped, then the first blank-line-delimited block. The
+ * schema explorer's "Generate Command" output is a list of alternatives separated by
+ * blank lines and only its first block runs, so reading the whole buffer would prompt
+ * about commands nobody asked for.
+ *
+ * The provider also tracks open quotes across lines, so that a line-leading `#`
+ * inside a quoted argument stays data. That is deliberately not modelled here,
+ * because it cannot change the answer: a quote can only be opened on an earlier line,
+ * and the command NAME is on the block's first line, which no quote precedes.
+ */
+function redisCommandBody(query: string): string {
+  const block: string[] = [];
+  for (const raw of query.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("#")) continue;
+    if (line === "") {
+      // A blank line ends the first block; blank lines before it are padding.
+      if (block.length > 0) break;
+      continue;
+    }
+    block.push(raw);
+  }
+  return block.join("\n").trim();
+}
+
+/**
+ * One token as the plain tokenizer would produce it: quote characters are structure
+ * to that parser, not part of the argument, and both parsers uppercase the command
+ * before calling it - so `del`, `DEL` and `"DEL"` are the same command.
+ */
+function redisToken(raw: string): string {
+  return raw.replaceAll('"', "").replaceAll("'", "").toUpperCase();
+}
+
+/** The command name plus, when there is a second token, the container spelling. */
+function redisNames(command: string, next: string | undefined): string[] {
+  const name = redisToken(command);
+  return next === undefined ? [name] : [name, `${name} ${redisToken(next)}`];
+}
+
+/**
+ * What a Redis buffer would run.
+ *
+ * Both of the provider's two query forms are read here, because both execute: the
+ * JSON form `{"command": "DEL", "args": ["k"]}` - which is also what the
+ * MongoDB-shaped generator emits - and the plain form `DEL k`. A body that starts
+ * with `{` takes the JSON path in the provider too, so a broken JSON body never
+ * falls back to the plain reading; it is unreadable, and unreadable asks.
+ */
+const readRedisOperations: OperationReader = (query) => {
+  const body = redisCommandBody(query);
+  if (body === "") return [];
+
+  if (body.startsWith("{")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      return undefined;
+    }
+    if (!isJsonObject(parsed)) return undefined;
+    const command = parsed.command;
+    if (typeof command !== "string") return undefined;
+    const args = parsed.args;
+    const first = Array.isArray(args) ? args[0] : undefined;
+    return redisNames(command, typeof first === "string" ? first : undefined);
+  }
+
+  const tokens = body.split(/\s+/);
+  return redisNames(tokens[0], tokens[1]);
+};
+
+/**
+ * The single type-to-facts table. A type with no row here is one whose statements the
+ * SQL half of the gate reads; a row would be a second, weaker opinion about the same
+ * text.
+ */
+export const NON_SQL_DESTRUCTIVE_VOCABULARY: Readonly<Partial<Record<DatabaseType, DestructiveVocabulary>>> = {
+  mongodb: { operations: MONGODB_DESTRUCTIVE_OPERATIONS, read: readMongodbOperations },
+  redis: { operations: REDIS_DESTRUCTIVE_COMMANDS, read: readRedisOperations },
+};
+
+/**
+ * Whether this query, on a type whose text is not SQL, asks for a confirmation.
+ *
+ * False for every type with no row - including no type at all, which is the reading a
+ * caller without a connection gets and the one the SQL half already covers.
+ */
+export function isDestructiveNonSqlQuery(query: string, databaseType?: DatabaseType): boolean {
+  const facts = databaseType === undefined ? undefined : NON_SQL_DESTRUCTIVE_VOCABULARY[databaseType];
+  if (facts === undefined) return false;
+
+  const named = facts.read(query);
+  if (named === undefined) return true;
+  return named.some((name) => facts.operations.has(name));
+}

--- a/src/lib/db/utils/query-limiter.ts
+++ b/src/lib/db/utils/query-limiter.ts
@@ -16,6 +16,15 @@
  * `SELECT` let `INSERT INTO ... SELECT` type its own statement as a read, and the
  * appended LIMIT then bounded the rows that statement WROTE (#287).
  *
+ * The three probes that read the statement's whole BODY - the Oracle `ROWNUM`
+ * bound, the UNION test and the nested-SELECT count - read code words through
+ * `lib/sql/words` for the same reason. Run over the text as characters, a word the
+ * statement merely MENTIONS answered for it: `… WHERE note = 'ROWNUM <= 10'` and
+ * `… /* ROWNUM <= 10 *\/ …` both read as already bounded, so no LIMIT was injected
+ * and the whole result set came back, and a UNION or a SELECT written in a comment
+ * mis-shaped the other two answers (S5). The leading comment was already excluded
+ * by hand before that (#289 review); everything after the first keyword was not.
+ *
  * Where the statement ENDS comes from `lib/sql/statement-end`, and both the
  * "already bounded" probes and the injection use that one reading. They used to
  * disagree with each other by accident - each worked on the raw text - and a
@@ -28,7 +37,9 @@
 import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
 import { readOperativeKeyword } from "@/lib/sql/operative-keyword";
+import { hasUnterminatedSpan, readSqlSpan } from "@/lib/sql/spans";
 import { readStatementEnd } from "@/lib/sql/statement-end";
+import { findCodeWord } from "@/lib/sql/words";
 import type { DatabaseType } from "@/lib/types";
 
 // ============================================================================
@@ -77,6 +88,71 @@ export interface LimitedQueryResult {
 /**
  * SQL sorgusunu analiz eder ve türünü, LIMIT/OFFSET durumunu belirler.
  */
+
+/**
+ * The first position at or after `index` that is not trivia.
+ *
+ * Only whitespace and comments are skipped. A literal, a quoted identifier and a
+ * subscript are the statement's own text, so a reader that stepped over one would
+ * let the characters after it answer for the characters inside it. Measured on
+ * valid PostgreSQL: `… WHERE rownum[1] <= 10` reads a column named `rownum`
+ * holding an array, which is not an Oracle row bound, and a reader that took the
+ * subscript for trivia reported that statement already bounded - so no LIMIT was
+ * injected and the whole table came back. Pinned in
+ * `tests/unit/db/query-limiter.test.ts`. Skipping comments is what lets
+ * `ROWNUM /* n *\/ <= 10` be read as the one bound it is.
+ */
+function skipTrivia(sql: string, index: number, grammar: SqlGrammar): number {
+  let i = index;
+
+  while (i < sql.length) {
+    const span = readSqlSpan(sql, i, grammar);
+    if (span === null) return i;
+    if (span.kind !== "whitespace" && span.kind !== "line-comment" && span.kind !== "block-comment") return i;
+    i = span.end;
+  }
+
+  return i;
+}
+
+/**
+ * Whether a `< n` / `<= n` comparison follows the word ending at `index`.
+ *
+ * The shape is the one the regex this replaced accepted, deliberately: `ROWNUM`
+ * on the left, `<` or `<=`, a literal count. The mirrored form (`10 >= ROWNUM`)
+ * was not read as a bound before and is not read as one now - reading it would be
+ * a behaviour change rather than the span fix S5 asks for.
+ */
+function readsRownumBound(sql: string, index: number, grammar: SqlGrammar): boolean {
+  let i = skipTrivia(sql, index, grammar);
+  if (sql[i] !== "<") return false;
+  i++;
+  if (sql[i] === "=") i++;
+  i = skipTrivia(sql, i, grammar);
+  return i < sql.length && sql[i] >= "0" && sql[i] <= "9";
+}
+
+/** Whether the statement's CODE carries an Oracle `ROWNUM <= n` bound at or after `from`. */
+function hasCodeRownumBound(sql: string, from: number, grammar: SqlGrammar): boolean {
+  // Every occurrence is asked, not just the first: `SELECT ROWNUM AS rn FROM t
+  // WHERE ROWNUM <= 10` is bounded by its second one, and the regex this replaced
+  // found it.
+  let found = findCodeWord(sql, "ROWNUM", from, grammar);
+
+  while (found !== null) {
+    if (readsRownumBound(sql, found.end, grammar)) return true;
+    found = findCodeWord(sql, "ROWNUM", found.end, grammar);
+  }
+
+  return false;
+}
+
+/** Whether the statement's code contains `word` more than once at or after `from`. */
+function hasRepeatedCodeWord(sql: string, word: string, from: number, grammar: SqlGrammar): boolean {
+  const first = findCodeWord(sql, word, from, grammar);
+  if (first === null) return false;
+  return findCodeWord(sql, word, first.end, grammar) !== null;
+}
 
 /** The type this module reports for a statement operated by `keyword`. */
 function classifyKeyword(keyword: string | undefined): ParsedQueryInfo["type"] {
@@ -127,11 +203,27 @@ function analyzeUnderGrammar(sql: string, grammar: SqlGrammar): ParsedQueryInfo 
   // statement's TEXT rather than just its leading keyword has to start here, or a
   // word written in the leading comment answers for the statement itself.
   const fromKeyword = leading === null ? statement : statement.slice(leading.start);
-  // Whitespace-collapsed, upper-cased body for the probes that scan text. Built
-  // from `fromKeyword`, NOT from `statement`: a leading comment reading
-  // "switch to ROWNUM <= 10" once marked the statement already bounded, which
-  // left the query unbounded - the very symptom #275 removed (PR #289 review).
+  // Where the statement's own code starts. The body probes below take `statement`
+  // plus this offset rather than the `fromKeyword` slice: `readSqlSpan` looks at
+  // the character BEFORE the position it is asked about to tell an Oracle `q'…'`
+  // tag from the tail of a name, so a suffix slice can answer differently than the
+  // same text in place.
+  const bodyStart = leading === null ? 0 : leading.start;
+  // Whitespace-collapsed, upper-cased body, kept for the ONE case the span reader
+  // cannot serve - see `unresolved` below. Built from `fromKeyword`, NOT from
+  // `statement`: a leading comment reading "switch to ROWNUM <= 10" once marked the
+  // statement already bounded, which left the query unbounded - the very symptom
+  // #275 removed (PR #289 review).
   const normalized = fromKeyword.replace(/\s+/g, " ").toUpperCase();
+  // Whether part of this statement is text no reader over `lib/sql/spans` can
+  // resolve - a run that never closes, which on the `\'` shape is a genuine
+  // dialect disagreement rather than a defect. What is written inside such a run is
+  // unknowable, so the three body probes keep the whole-text reading they had here
+  // instead: declining to SEE a bound is the direction that costs rows, and
+  // `applyQueryLimit` refuses to rewrite such a statement anyway (`readStatementEnd`
+  // reports it unrewritable), so the fallback can only widen what is REPORTED and
+  // can never place a bound.
+  const unresolved = hasUnterminatedSpan(fromKeyword, grammar);
 
   // A `WITH` statement is typed by the keyword its CTE list OPERATES, not by the
   // keyword it opens with and not by a `SELECT` found in its text. Asking whether
@@ -188,8 +280,14 @@ function analyzeUnderGrammar(sql: string, grammar: SqlGrammar): ParsedQueryInfo 
     }
   }
 
-  // Oracle legacy: ROWNUM in WHERE clause
-  if (!hasLimit && /\bROWNUM\s*<=?\s*\d+/i.test(normalized)) {
+  // Oracle legacy: ROWNUM in WHERE clause. Read as code words, so a bound written
+  // in a comment or inside a literal is not the statement's: read as characters,
+  // `… WHERE note = 'ROWNUM <= 10'` said the statement was already bounded and the
+  // limiter injected nothing (S5).
+  if (
+    !hasLimit &&
+    (unresolved ? /\bROWNUM\s*<=?\s*\d+/.test(normalized) : hasCodeRownumBound(statement, bodyStart, grammar))
+  ) {
     hasLimit = true;
   }
 
@@ -201,8 +299,11 @@ function analyzeUnderGrammar(sql: string, grammar: SqlGrammar): ParsedQueryInfo 
     existingOffset = parseInt(offsetOnlyMatch[1]);
   }
 
-  // UNION detection
-  const isUnion = /\bUNION\b/i.test(normalized);
+  // UNION detection - the code word, for the same reason: a comment reading
+  // "UNION ALL with archive later" is not a union.
+  const isUnion = unresolved
+    ? /\bUNION\b/.test(normalized)
+    : findCodeWord(statement, "UNION", bodyStart, grammar) !== null;
 
   // CTE detection (WITH clause) - this answers what the statement LEADS with,
   // which is a different question from what it operates: `WITH t AS (...) INSERT
@@ -210,9 +311,11 @@ function analyzeUnderGrammar(sql: string, grammar: SqlGrammar): ParsedQueryInfo 
   // keyword and is true for every `WITH`, whatever its type turned out to be.
   const hasCTE = keyword === "WITH";
 
-  // Subquery detection (nested SELECT - birden fazla SELECT var mı)
-  const selectCount = (normalized.match(/\bSELECT\b/g) || []).length;
-  const hasSubquery = selectCount > 1;
+  // Subquery detection: a SECOND SELECT in the statement's code. Counting the word
+  // in the text made `… WHERE note = 'SELECT 1'` a subquery.
+  const hasSubquery = unresolved
+    ? (normalized.match(/\bSELECT\b/g) || []).length > 1
+    : hasRepeatedCodeWord(statement, "SELECT", bodyStart, grammar);
 
   return {
     type,

--- a/src/lib/sql/grammar.ts
+++ b/src/lib/sql/grammar.ts
@@ -242,7 +242,9 @@ const ELASTICSEARCH_GRAMMAR: SqlGrammar = {
   // NOT established, and left at the default deliberately. `[` has no meaning at all
   // in this grammar - `SELECT [1, 2]` and `SELECT [customer] FROM probe_orders` are
   // both "extraneous input '['" - so it is neither an identifier quote nor a
-  // subscript, and PD-5 forbids reading one dialect's rule off another's. The name
+  // subscript, and this module's rule 2 forbids reading one dialect's rule off
+  // another's behaviour (see the header, and the undecided table in
+  // `docs/editor/query-optimization.md`). The name
   // reading can only cost a bound on a statement the engine refuses anyway, which is
   // the same fail-safe argument the `mysql` and `oracle` rows make.
   bracket: DEFAULT_SQL_GRAMMAR.bracket,
@@ -252,8 +254,8 @@ const ELASTICSEARCH_GRAMMAR: SqlGrammar = {
   // `SELECT q'{it's}'` is a `parsing_exception` - the form does not exist here.
   alternateQuoting: false,
   // NOT established: this engine was not reachable from the run that probed the other
-  // eight (2026-08-25), and PD-5 forbids reading its rule off the five refusals
-  // measured elsewhere. It keeps the compatibility default, and the direction that
+  // eight (2026-08-25), and this module's rule 2 forbids reading its rule off the
+  // five refusals measured elsewhere. It keeps the compatibility default, and the direction that
   // costs is worth stating: if `//` DOES open a comment here, this dialect's splitter
   // over-splits exactly as `cassandra`'s did.
   doubleSlashComment: DEFAULT_SQL_GRAMMAR.doubleSlashComment,
@@ -514,8 +516,8 @@ const CASSANDRA_GRAMMAR: SqlGrammar = {
  * NOT established, and therefore left at the default: how `mysql` and `oracle` read
  * `[…]`. It is not an identifier quote in either - MySQL gives it no meaning outside
  * a JSON path written inside a string, and Oracle none outside an alternate-quote
- * delimiter - but neither has a SUBSCRIPT rule to read it under instead, and PD-5
- * forbids reading one dialect's rule off another's. The name reading costs them a
+ * delimiter - but neither has a SUBSCRIPT rule to read it under instead, and this
+ * module's rule 2 forbids reading one dialect's rule off another's behaviour. The name reading costs them a
  * bound on a nested bracket run, and it can never misplace one: a run it cannot
  * close is undeterminable, and an undeterminable end is not cut. That is the
  * fail-safe direction, so it is what they keep.
@@ -600,8 +602,8 @@ const NON_SQL_DIALECTS: ReadonlySet<DatabaseType> = new Set<DatabaseType>(["mong
  * document or a Redis command is simply read as SQL under the compatibility
  * grammar. For a reader that only ever declines to act, that costs nothing. For the
  * confirmation gate it cost a false prompt on ordinary reads: the escaped quote in
- * `{"filter":{"msg":"say \"hi\""}}` or in `SET k "a\"b"` is an unresolvable literal
- * to a SQL span reader and a perfectly closed one in the grammar the text is
+ * `{"filter":{"msg":"say \"hi\""}}` or in `GETRANGE k "a\"b" 0 1` is an unresolvable
+ * literal to a SQL span reader and a perfectly closed one in the grammar the text is
  * actually written in - and the dialog then said the statement could not be read
  * about text that reads fine. An operator who learns to click the confirmation away
  * is the one thing that gate cannot survive.

--- a/tests/api/db/maintenance.test.ts
+++ b/tests/api/db/maintenance.test.ts
@@ -352,6 +352,152 @@ describe("POST /api/db/maintenance", () => {
     expect(data.error).toContain("not supported");
   });
 
+  // ─── U20: the route gates on WHAT an operation can be pointed at ──────────
+  //
+  // `maintenanceOperations` says only that an operation EXISTS on this engine; each
+  // provider also declares what KIND of target it takes (`maintenanceOperationSpecs`),
+  // and both UI surfaces already gate on `maintenanceControl`. The route did not, so a
+  // caller reaching the API directly bypassed the only declaration that says a target
+  // is meaningless here. The U20 backlog entry reports that gap from a live SQLite run:
+  // POST {type:"vacuum", target:"users"} answered 200 and vacuumed the whole file - the
+  // reading `perEntity: false` exists to withhold.
+  //
+  // These tests measure the status code and the message, not that run: the capabilities
+  // below are SQLite-SHAPED mocks, so what is asserted is that the route now refuses the
+  // request the declaration says is meaningless and attempts nothing.
+  const sqliteShapedCapabilities = () => ({
+    queryLanguage: "sql",
+    supportsExplain: true,
+    supportsExternalQueryLimiting: true,
+    supportsCreateTable: true,
+    supportsMaintenance: true,
+    maintenanceOperations: ["vacuum", "analyze", "reindex"],
+    maintenanceOperationSpecs: {
+      // SQLite's VACUUM rewrites the whole file and ignores a target entirely.
+      vacuum: { label: "Vacuum Database", perEntity: false, global: true },
+      analyze: { label: "Analyze Database", perEntity: true, global: true },
+      // Couchbase-shaped half of the same field: BUILD INDEX needs one keyspace and
+      // has no whole-database form.
+      reindex: { label: "Build Indexes", perEntity: true, global: false },
+    },
+    supportsConnectionString: true,
+    defaultPort: 0,
+    schemaRefreshPattern: "",
+  });
+
+  test("an operation that takes no target refuses a request that names one", async () => {
+    (mockProvider.getCapabilities as ReturnType<typeof mock>).mockImplementation(sqliteShapedCapabilities);
+
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "vacuum", target: "users", connection: validConnection },
+    });
+
+    const res = await POST(req as never);
+    const data = await parseResponseJSON<{ error: string; success?: boolean }>(res);
+
+    expect(res.status).toBe(400);
+    // The provider's own wording for the control, and what it does accept.
+    expect(data.error).toContain("Vacuum Database");
+    expect(data.error).toContain("whole database");
+    // A client error, not a maintenance verdict: no `success` field for a caller to
+    // read as "the engine refused the work".
+    expect(data.success).toBeUndefined();
+    // Nothing was attempted, so nothing may be recorded as done.
+    expect(mockProvider.runMaintenance).not.toHaveBeenCalled();
+    expect(mockAuditPush).not.toHaveBeenCalled();
+  });
+
+  test("an operation that requires a target refuses a request without one", async () => {
+    (mockProvider.getCapabilities as ReturnType<typeof mock>).mockImplementation(sqliteShapedCapabilities);
+
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "reindex", connection: validConnection },
+    });
+
+    const res = await POST(req as never);
+    const data = await parseResponseJSON<{ error: string }>(res);
+
+    expect(res.status).toBe(400);
+    expect(data.error).toContain("Build Indexes");
+    expect(data.error).toContain("target");
+    expect(mockProvider.runMaintenance).not.toHaveBeenCalled();
+    expect(mockAuditPush).not.toHaveBeenCalled();
+  });
+
+  test("an empty target string reads as the whole-database form, not as a target", async () => {
+    (mockProvider.getCapabilities as ReturnType<typeof mock>).mockImplementation(sqliteShapedCapabilities);
+
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "vacuum", target: "", connection: validConnection },
+    });
+
+    const res = await POST(req as never);
+
+    // Same reading the audit row below already uses (`target || "all"`).
+    expect(res.status).toBe(200);
+    expect(mockProvider.runMaintenance).toHaveBeenCalledTimes(1);
+  });
+
+  test("a target an operation does accept still runs", async () => {
+    (mockProvider.getCapabilities as ReturnType<typeof mock>).mockImplementation(sqliteShapedCapabilities);
+
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "analyze", target: "users", connection: validConnection },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(200);
+    expect(mockProvider.runMaintenance).toHaveBeenCalledTimes(1);
+    expect(mockAuditPush).toHaveBeenCalledTimes(1);
+  });
+
+  // Every provider that declares `kill` declares it `perEntity: false, global: false`:
+  // its target is a session or query id, which no table row and no whole-database card
+  // can supply. Both halves false therefore does NOT mean "takes no target" - it means
+  // the target comes from somewhere neither placement describes (the Sessions panel),
+  // so the placement gate has nothing to say and must not refuse it.
+  test("kill keeps its session-id target, which neither placement describes", async () => {
+    (mockProvider.getCapabilities as ReturnType<typeof mock>).mockImplementation(() => ({
+      ...sqliteShapedCapabilities(),
+      maintenanceOperations: ["vacuum", "kill"],
+      maintenanceOperationSpecs: {
+        vacuum: { label: "Vacuum Database", perEntity: false, global: true },
+        kill: { label: "Terminate Backend", perEntity: false, global: false },
+      },
+    }));
+
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "kill", target: "4711", connection: validConnection },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(200);
+    expect(mockProvider.runMaintenance).toHaveBeenCalledTimes(1);
+    expect((mockAuditPush.mock.calls[0]![0] as { type: string }).type).toBe("kill_session");
+  });
+
+  // A provider that declares no specs at all is offered in both placements - the
+  // documented compatibility reading of the optional field, and what the route did for
+  // every provider before this change.
+  test("a provider declaring no operation specs accepts a target as before", async () => {
+    const req = createMockRequest("/api/db/maintenance", {
+      method: "POST",
+      body: { type: "vacuum", target: "users", connection: validConnection },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(200);
+    expect(mockProvider.runMaintenance).toHaveBeenCalledTimes(1);
+  });
+
   test("DatabaseError from runMaintenance returns 500", async () => {
     (mockProvider.runMaintenance as ReturnType<typeof mock>).mockImplementation(async () => {
       throw new DatabaseError("Internal maintenance failure", "postgres", "DATABASE_ERROR");

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -989,7 +989,43 @@ describe("isDangerousQuery", () => {
   test("does not prompt for non-SQL query text whose escaped quote a SQL reader cannot resolve", () => {
     expect(isDangerousQuery('{"operation":"find","filter":{"msg":"say \\"hi\\""}}', "mongodb")).toBe(false);
     expect(isDangerousQuery('{"operation":"find","filter":{"msg":"hi"}}', "mongodb")).toBe(false);
-    expect(isDangerousQuery('SET k "a\\"b"', "redis")).toBe(false);
+    // A READ whose argument carries the same escaped quote. This case used to be
+    // `SET k "a\"b"`, which the non-SQL vocabulary now prompts for on its own merits
+    // (S8) - so the escaped quote is asserted through a command that asks for nothing.
+    expect(isDangerousQuery('GETRANGE k "a\\"b" 0 1', "redis")).toBe(false);
+  });
+
+  // ── The non-SQL half of the vocabulary (S8) ──────────────────────────────
+  //
+  // Both execution paths ask this predicate about every connection, and for these two
+  // types it answered false whatever the text said: a `FLUSHALL` and a `deleteMany`
+  // reached the engine with no confirmation at all. What each command or operation
+  // means, and which of them these two providers can actually dispatch, is pinned in
+  // tests/unit/db/destructive-commands.test.ts; these rows pin that the GATE reads it.
+
+  test.each<[string, "mongodb" | "redis", string]>([
+    ["a MongoDB deleteMany", "mongodb", '{"collection":"users","operation":"deleteMany","filter":{}}'],
+    ["a MongoDB updateMany", "mongodb", '{"collection":"u","operation":"updateMany","filter":{},"update":{}}'],
+    ["a Redis FLUSHALL", "redis", "FLUSHALL"],
+    ["a Redis DEL", "redis", "DEL session:1"],
+    ["a Redis DEL in the JSON form", "redis", '{"command":"DEL","args":["session:1"]}'],
+  ])("prompts for %s", (_label, type, query) => {
+    expect(isDangerousQuery(query, type)).toBe(true);
+  });
+
+  test.each<[string, "mongodb" | "redis", string]>([
+    ["a MongoDB find", "mongodb", '{"collection":"users","operation":"find","filter":{}}'],
+    ["a MongoDB aggregate that only groups", "mongodb", '{"collection":"o","operation":"aggregate","pipeline":[]}'],
+    ["a Redis SCAN", "redis", "SCAN 0 MATCH session:* COUNT 50"],
+    ["a Redis HGETALL", "redis", "HGETALL user:1"],
+  ])("does not prompt for %s", (_label, type, query) => {
+    expect(isDangerousQuery(query, type)).toBe(false);
+  });
+
+  // An empty tab is not a command, and both call sites hand this predicate the buffer
+  // as it stands - so the unreadable-asks rule must not fire on nothing.
+  test.each<["mongodb" | "redis"]>([["mongodb"], ["redis"]])("does not prompt for an empty %s buffer", (type) => {
+    expect(isDangerousQuery("", type)).toBe(false);
   });
 
   // Only the unresolvable-run half was narrowed. The keyword half still reads the
@@ -1266,9 +1302,30 @@ describe("isDangerousQuery", () => {
    * dialects whose text is not SQL: a `;` in a Mongo document or a Redis command
    * separates nothing, so a fragment cut there is invented (#427) - and the
    * multi-statement route is a SQL route those never take.
+   *
+   * Written so that removing the narrowing changes the answer. The first fixture of
+   * this test put the `;` inside quotes, where the splitter cuts nothing under any
+   * grammar, so both arms produced one fragment either way and the assertion held
+   * with the guard deleted.
    */
-  test("does not split a non-SQL buffer looking for fragments to prompt about", () => {
+  test("does not cut a Redis buffer at a `;` outside quotes to invent a fragment to prompt about", () => {
+    // A Redis key may contain a `;`, and this is one command - `GET`, a read. Cut
+    // under the SQL grammar the same text is `GET migration` plus
+    // `drop table users`, and that second, invented fragment is a write: measured
+    // here as two fragments from `splitStatements`, the second of which
+    // `isDangerousQuery` alone calls dangerous.
+    expect(isDangerousQuery("GET migration;drop table users", "redis")).toBe(false);
+  });
+
+  test("answers a MongoDB buffer from its own vocabulary, not from a split reading", () => {
+    // Valid JSON cannot carry a `;` outside a string, so this is the direction that
+    // shape can produce. mongosh syntax is what the provider refuses, so the
+    // vocabulary reports it unreadable and the gate asks - while a split-and-keyword
+    // reading of the same two fragments finds no operative write at all
+    // (`deleteMany` is not the word DELETE, and `db.notes.drop()` is not DROP TABLE).
+    expect(isDangerousQuery("db.notes.deleteMany({});db.notes.find({})", "mongodb")).toBe(true);
+    // And the everyday read that motivated the narrowing still does not prompt: the
+    // SQL inside the filter is a value, and `find` is not in the vocabulary.
     expect(isDangerousQuery('{"operation":"find","filter":{"note":"; drop table t"}}', "mongodb")).toBe(false);
-    expect(isDangerousQuery('SET note "a; delete from t"', "redis")).toBe(false);
   });
 });

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -1661,4 +1661,121 @@ describe("OperationsTab", () => {
     expect(titles).toContain("Analyze");
     expect(titles).toContain("Vacuum");
   });
+  // =========================================================================
+  // U22: the per-table operation a deep link asked for, with no row to run it on.
+  //
+  // The schema explorer's two maintenance items are DEEP LINKS: an admin clicking
+  // "Optimize Table" lands here (Studio.tsx `openMaintenance` pushes
+  // /admin/operations?table=...), and this page renders a per-table control only for
+  // a ROW it has statistics for. Every empty branch of the Tables panel therefore said
+  // nothing at all about the operation the operator arrived asking for.
+  // =========================================================================
+
+  /** MySQL's declaration: three per-table operations under the engine's own wording. */
+  const perTableSpecs = {
+    capabilities: {
+      supportsMaintenance: true,
+      maintenanceOperations: ["analyze", "optimize", "check", "kill"],
+      maintenanceOperationSpecs: {
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+        optimize: { label: "Optimize Table", perEntity: true, global: true },
+        check: { label: "Check Table", perEntity: true, global: true },
+        kill: { label: "Kill Connection", perEntity: false, global: false },
+      },
+    },
+  };
+
+  test("names the deep-linked table the page has no row for", async () => {
+    mockMetadata = perTableSpecs;
+    monitoringOverride = { data: { activeSessions: defaultSessions, tables: multiTables } };
+    setMockSearchParams(new URLSearchParams("table=archived_events"));
+
+    const { getByTestId } = await render_();
+
+    const note = getByTestId("operations-maintenance-unreachable").textContent ?? "";
+    // The engine's own wording, the same strings the per-row buttons would carry.
+    expect(note).toContain("Analyze Table");
+    expect(note).toContain("Optimize Table");
+    expect(note).toContain("Check Table");
+    // A connection id comes from the Sessions panel, so it was never on offer per table.
+    expect(note).not.toContain("Kill Connection");
+    // The name is a measurement here: it is the search param that seeded the filter.
+    expect(note).toContain("archived_events");
+  });
+
+  test("names the operations and the table when the engine refused the read", async () => {
+    mockMetadata = perTableSpecs;
+    monitoringOverride = {
+      data: { activeSessions: defaultSessions, errors: { tables: "permission denied for relation pg_class" } },
+    };
+    setMockSearchParams(new URLSearchParams("table=orders"));
+
+    const { getByTestId } = await render_();
+
+    // The engine's own refusal still carries the panel; the note adds what it costs.
+    expect(getByTestId("operations-tables-empty").textContent).toBe("permission denied for relation pg_class");
+    const note = getByTestId("operations-maintenance-unreachable").textContent ?? "";
+    expect(note).toContain("Optimize Table");
+    expect(note).toContain("orders");
+  });
+
+  test("names the operations without a table when no deep link carried one", async () => {
+    mockMetadata = perTableSpecs;
+    monitoringOverride = {
+      data: { activeSessions: defaultSessions, errors: { tables: "permission denied for relation pg_class" } },
+    };
+
+    const { getByTestId } = await render_();
+
+    const note = getByTestId("operations-maintenance-unreachable").textContent ?? "";
+    expect(note).toContain("Optimize Table");
+    expect(note).toContain("no row to run it on");
+    // Nothing named a table, so the sentence must not claim one was asked for.
+    expect(note).not.toContain("no row for");
+  });
+
+  test("says nothing on a database that genuinely holds no tables", async () => {
+    mockMetadata = perTableSpecs;
+    monitoringOverride = { data: { activeSessions: defaultSessions, tables: [], overview: { tableCount: 0 } } };
+
+    const { queryByTestId, getByTestId } = await render_();
+
+    expect(getByTestId("operations-tables-empty").textContent).toBe("No tables found.");
+    // Nothing to maintain is not a dead end, so the note would only be noise.
+    expect(queryByTestId("operations-maintenance-unreachable")).toBeNull();
+  });
+
+  test("says nothing where the engine declares no per-table maintenance", async () => {
+    mockMetadata = {
+      capabilities: {
+        supportsMaintenance: true,
+        maintenanceOperations: ["vacuum"],
+        maintenanceOperationSpecs: { vacuum: { label: "Vacuum Database", perEntity: false, global: true } },
+      },
+    };
+    monitoringOverride = {
+      data: { activeSessions: defaultSessions, errors: { tables: "permission denied for relation pg_class" } },
+    };
+    setMockSearchParams(new URLSearchParams("table=orders"));
+
+    const { queryByTestId } = await render_();
+
+    // Nothing was ever offered per table, so there is no per-table dead end to explain.
+    expect(queryByTestId("operations-maintenance-unreachable")).toBeNull();
+  });
+
+  test("says nothing once the operator's own filter is what empties the list", async () => {
+    mockMetadata = perTableSpecs;
+    monitoringOverride = { data: { activeSessions: defaultSessions, tables: multiTables } };
+    setMockSearchParams(new URLSearchParams("table=orders"));
+
+    const { queryByTestId, getByPlaceholderText } = await render_();
+
+    await act(async () => {
+      fireEvent.change(getByPlaceholderText("Filter..."), { target: { value: "zzz" } });
+    });
+
+    // The rows and their controls are there; the operator's own filter hid them.
+    expect(queryByTestId("operations-maintenance-unreachable")).toBeNull();
+  });
 });

--- a/tests/components/monitoring/TablesTab.test.tsx
+++ b/tests/components/monitoring/TablesTab.test.tsx
@@ -585,3 +585,161 @@ describe("per-row controls follow the provider's own declaration", () => {
     expect(titles).toContain("Optimize");
   });
 });
+
+// U22: the two per-table maintenance items in the schema explorer are DEEP LINKS - they
+// navigate to a maintenance surface and nothing more. They are gated on what the OPERATION
+// declares (`maintenanceControl(..., "perEntity")`), which is a different question from
+// whether the destination has a ROW to hang the control on: this panel renders per-table
+// buttons for rows in `data.tables` only, and both of its absence paths render none. So an
+// operator who arrives from "Optimize Table" on an engine that publishes no table
+// statistics reads an empty list and is told nothing about the operation they asked for.
+describe("a per-table operation with no row to run it on (U22)", () => {
+  // Scoped here as well as in the blocks above: bun:test registers a hook on the
+  // enclosing describe only, so without this the first render in this block leaks into
+  // the second and the control arm queries the previous test's DOM.
+  afterEach(() => {
+    cleanup();
+  });
+
+  /** MySQL's declaration: three per-table operations under the engine's own wording. */
+  const perTableCapabilities = () =>
+    makeCapabilities({
+      maintenanceOperations: ["analyze", "optimize", "check", "kill"],
+      maintenanceOperationSpecs: {
+        analyze: { label: "Analyze Table", perEntity: true, global: true },
+        optimize: { label: "Optimize Table", perEntity: true, global: true },
+        check: { label: "Check Table", perEntity: true, global: true },
+        kill: { label: "Kill Connection", perEntity: false, global: false },
+      },
+    });
+
+  /** Statistics refused: tables absent from the payload, the engine's sentence under `errors`. */
+  function refusedData(): MonitoringData {
+    const rest: MonitoringData = makeData();
+    delete rest.tables;
+    return { ...rest, errors: { tables: "no table statistics for this catalog" } } as MonitoringData;
+  }
+
+  /** Statistics not published: an empty list while the overview counts six tables. */
+  function statslessData(): MonitoringData {
+    const base = makeData();
+    return { ...base, overview: { ...base.overview, tableCount: 6 }, tables: [] } as MonitoringData;
+  }
+
+  // Rendered exactly as `MonitoringDashboard` renders it (src/.../MonitoringDashboard.tsx:305):
+  // no `isAdmin` prop at all, so this arm pins the default-prop path every real caller
+  // takes. /monitoring is also the route a non-admin is sent to, which is why the note
+  // below names no page they cannot open.
+  test("names the per-table operations it cannot start when no statistics were published", () => {
+    const { getByTestId, queryByText } = render(
+      <TablesTab
+        data={statslessData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={perTableCapabilities()}
+      />,
+    );
+
+    const note = getByTestId("tables-maintenance-unattachable").textContent ?? "";
+    // The engine's own wording, the same strings the per-row buttons would carry.
+    expect(note).toContain("Analyze Table");
+    expect(note).toContain("Optimize Table");
+    expect(note).toContain("Check Table");
+    // A connection id comes from the Sessions panel, so it was never on offer here.
+    expect(note).not.toContain("Kill Connection");
+    // The existing absence sentence is still what explains the empty list.
+    expect(queryByText("No table statistics available.")).not.toBeNull();
+    // This branch DID get an answer - an empty list - so it may name the cause.
+    expect(note).toContain("published no table statistics");
+    // A non-admin is sent to /monitoring and denied /admin/* by src/proxy.ts, and this
+    // component cannot tell the two apart (the prop defaults to true), so the note must
+    // not send anyone to the admin Operations page.
+    expect(note).not.toContain("Operations page");
+  });
+
+  test("words a refused read as a read, and leaves the cause to the engine", () => {
+    const { getByTestId } = render(
+      <TablesTab
+        data={refusedData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={perTableCapabilities()}
+      />,
+    );
+
+    // The engine's own refusal still carries the panel; the note adds what the refusal
+    // costs the operator who came here to run one operation.
+    expect(getByTestId("panel-unavailable-message").textContent).toBe("no table statistics for this catalog");
+    const note = getByTestId("tables-maintenance-unattachable").textContent ?? "";
+    expect(note).toContain("Optimize Table");
+    // A refusal is not an absence of statistics: the engine's reason is already on the
+    // panel above (it may be a permission or catalog failure), so this sentence states
+    // only what it measured - that nothing could be read - and leaves the cause there.
+    expect(note).toContain("no table statistics could be read");
+    expect(note).not.toContain("published no table statistics");
+    expect(note).not.toContain("Operations page");
+  });
+
+  test("stays silent on a database that genuinely holds no tables", () => {
+    const base = makeData();
+    const { queryByTestId, queryByText } = render(
+      <TablesTab
+        data={{ ...base, overview: { ...base.overview, tableCount: 0 }, tables: [] } as MonitoringData}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={perTableCapabilities()}
+      />,
+    );
+
+    // Nothing to maintain is not a dead end, so the note would only be noise.
+    expect(queryByText("No tables found.")).not.toBeNull();
+    expect(queryByTestId("tables-maintenance-unattachable")).toBeNull();
+  });
+
+  test("stays silent while rows are there to carry the controls", () => {
+    const { queryByTestId } = render(
+      <TablesTab
+        data={makeData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={perTableCapabilities()}
+      />,
+    );
+
+    expect(queryByTestId("tables-maintenance-unattachable")).toBeNull();
+  });
+
+  test("stays silent where the engine declares no per-table maintenance", () => {
+    const { queryByTestId } = render(
+      <TablesTab
+        data={statslessData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        capabilities={makeCapabilities({
+          maintenanceOperations: ["vacuum"],
+          maintenanceOperationSpecs: { vacuum: { label: "Vacuum Database", perEntity: false, global: true } },
+        })}
+      />,
+    );
+
+    // Nothing was ever offered per table, so there is no per-table dead end to explain.
+    expect(queryByTestId("tables-maintenance-unattachable")).toBeNull();
+  });
+
+  // `isAdmin={false}` is a configuration no caller in src/ produces today - the only
+  // caller passes nothing and the prop defaults to true - so this arm pins the GATE
+  // rather than a live path. The live path is the first test in this block.
+  test("stays silent when a caller does declare a non-admin", () => {
+    const { queryByTestId } = render(
+      <TablesTab
+        data={statslessData()}
+        loading={false}
+        onRunMaintenance={mock(async () => true)}
+        isAdmin={false}
+        capabilities={perTableCapabilities()}
+      />,
+    );
+
+    expect(queryByTestId("tables-maintenance-unattachable")).toBeNull();
+  });
+});

--- a/tests/unit/db/destructive-commands.test.ts
+++ b/tests/unit/db/destructive-commands.test.ts
@@ -1,0 +1,230 @@
+import { describe, test, expect } from "bun:test";
+import { NON_SQL_DESTRUCTIVE_VOCABULARY, isDestructiveNonSqlQuery } from "@/lib/db/destructive-commands";
+
+// The facts behind the confirmation gate for the two engines whose query text is
+// not SQL. The gate itself (`isDangerousQuery`) is tested in
+// tests/components/QuerySafetyDialog.test.tsx; this file pins the vocabulary and the
+// two readers it is driven from, because they are what decides whether an operator
+// is asked before a FLUSHALL or a deleteMany runs.
+
+describe("isDestructiveNonSqlQuery", () => {
+  // ── The table decides which types this reader answers about ───────────────
+
+  test.each<["postgres" | "mysql" | "clickhouse" | "couchbase"]>([
+    ["postgres"],
+    ["mysql"],
+    ["clickhouse"],
+    ["couchbase"],
+  ])("answers false for %s, whose text a SQL reader reads", (type) => {
+    // Not "safe": these types have no row in the table, because their statements are
+    // read by the SQL half of the gate. A row here would be a second, weaker opinion.
+    expect(isDestructiveNonSqlQuery("DROP TABLE users", type)).toBe(false);
+  });
+
+  test("answers false with no type at all", () => {
+    expect(isDestructiveNonSqlQuery("FLUSHALL")).toBe(false);
+  });
+
+  // ── MongoDB ──────────────────────────────────────────────────────────────
+
+  test.each<[string, string]>([
+    ["deleteMany", '{"collection":"users","operation":"deleteMany","filter":{}}'],
+    ["deleteOne", '{"collection":"users","operation":"deleteOne","filter":{"_id":1}}'],
+    ["updateMany", '{"collection":"users","operation":"updateMany","filter":{},"update":{"$unset":{"email":""}}}'],
+    ["updateOne", '{"collection":"users","operation":"updateOne","filter":{"_id":1},"update":{"$set":{"a":1}}}'],
+  ])("asks before a MongoDB %s", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "mongodb")).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["find", '{"collection":"users","operation":"find","filter":{"age":{"$gt":18}}}'],
+    ["findOne", '{"collection":"users","operation":"findOne","filter":{}}'],
+    ["count", '{"collection":"users","operation":"count","filter":{}}'],
+    ["distinct", '{"collection":"products","operation":"distinct","field":"category"}'],
+    ["insertOne", '{"collection":"users","operation":"insertOne","documents":[{"name":"J"}]}'],
+    ["insertMany", '{"collection":"users","operation":"insertMany","documents":[{"name":"J"}]}'],
+    ["aggregate", '{"collection":"orders","operation":"aggregate","pipeline":[{"$group":{"_id":"$status"}}]}'],
+  ])("does not ask before a MongoDB %s", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "mongodb")).toBe(false);
+  });
+
+  test.each<[string, string]>([
+    ["$out", '{"collection":"orders","operation":"aggregate","pipeline":[{"$match":{}},{"$out":"orders_copy"}]}'],
+    [
+      "$merge",
+      '{"collection":"orders","operation":"aggregate","pipeline":[{"$merge":{"into":"totals","whenMatched":"replace"}}]}',
+    ],
+  ])("asks before an aggregate whose pipeline carries %s", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "mongodb")).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["a pipeline that is not an array", '{"collection":"o","operation":"aggregate","pipeline":{"$out":"x"}}'],
+    ["a stage that is not an object", '{"collection":"o","operation":"aggregate","pipeline":[1,null,"$out"]}'],
+    ["no pipeline at all", '{"collection":"o","operation":"aggregate"}'],
+  ])("does not ask for an aggregate with %s", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "mongodb")).toBe(false);
+  });
+
+  test.each<[string, string]>([
+    ["a document that never closes", '{"collection":"users","operation":"deleteMany"'],
+    ["a trailing comma", '{"operation":"find",}'],
+    ["mongosh shell syntax", "db.users.deleteMany({})"],
+    ["a bare word", "deleteMany"],
+    ["a JSON array", '[{"operation":"find"}]'],
+    ["a JSON null", "null"],
+    ["a JSON number", "5"],
+    ["an operation that is not a string", '{"collection":"users","operation":7}'],
+    ["no operation key", '{"collection":"users"}'],
+  ])("asks when the payload cannot be read as a command document: %s", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "mongodb")).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["nothing", ""],
+    ["whitespace", "  \n "],
+  ])("does not ask for %s, which is not a command", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "mongodb")).toBe(false);
+  });
+
+  test("matches the operation spelling the provider dispatches on", () => {
+    // `SUPPORTED_OPERATIONS` is checked case-sensitively, so `DELETEMANY` is refused
+    // before any collection is touched: prompting for it would be a prompt about text
+    // that cannot run.
+    expect(isDestructiveNonSqlQuery('{"collection":"users","operation":"DELETEMANY"}', "mongodb")).toBe(false);
+  });
+
+  // ── Redis ────────────────────────────────────────────────────────────────
+
+  test.each<[string]>([
+    ["FLUSHALL"],
+    ["FLUSHDB"],
+    ["DEL session:1"],
+    ["UNLINK session:1"],
+    ["RENAME a b"],
+    ["SET k v"],
+    ["GETDEL k"],
+    ["HDEL h f"],
+    ["LPOP list"],
+    ["LTRIM list 0 0"],
+    ["SREM s member"],
+    ["ZREM z member"],
+    ["XTRIM stream MAXLEN 0"],
+    ["XGROUP DELCONSUMER stream g c"],
+    ["SETBIT k 7 1"],
+    ["CLUSTER SETSLOT 42 NODE abc"],
+    ["EXPIRE k 1"],
+    ["SINTERSTORE dest a b"],
+    ["SHUTDOWN NOSAVE"],
+  ])("asks before the Redis command %s", (query) => {
+    expect(isDestructiveNonSqlQuery(query, "redis")).toBe(true);
+  });
+
+  test.each<[string]>([
+    ["GET k"],
+    ["HGETALL user:1"],
+    ["SCAN 0 MATCH session:* COUNT 50"],
+    ["INFO"],
+    ["TTL k"],
+    ["EXISTS k"],
+    ["SETNX k v"],
+    ["LRANGE list 0 -1"],
+    ["GETBIT k 7"],
+    ["GETRANGE k 0 -1"],
+    ["CLUSTER SLOTS"],
+    ["XINFO STREAM stream"],
+  ])("does not ask before the Redis command %s", (query) => {
+    expect(isDestructiveNonSqlQuery(query, "redis")).toBe(false);
+  });
+
+  test.each<[string, string]>([
+    ["the STORE option of SORT", "SORT mylist STORE dest"],
+    ["a BITFIELD SET sub-operation", "BITFIELD k SET u8 0 255"],
+    ["GETEX with an expiry option", "GETEX k EX 60"],
+  ])("does not ask for %s, an argument position this reading does not inspect", (_label, query) => {
+    // A named gap, not an oversight: the option sits past the two tokens this reader
+    // looks at, and the same command without it is a plain read. Pinned here so that
+    // closing it is a deliberate change rather than a silent one.
+    expect(isDestructiveNonSqlQuery(query, "redis")).toBe(false);
+  });
+
+  test("does not ask for a plain GETEX, which is byte-for-byte a GET", () => {
+    expect(isDestructiveNonSqlQuery("GETEX k", "redis")).toBe(false);
+  });
+
+  test("reads the command name the way the provider does: case-folded", () => {
+    // Both parsers uppercase the command before `client.call`, so a lowercase
+    // `del` reaches the server as DEL.
+    expect(isDestructiveNonSqlQuery("del session:1", "redis")).toBe(true);
+    expect(isDestructiveNonSqlQuery("FlushAll", "redis")).toBe(true);
+  });
+
+  test("reads a quoted first token the way the plain tokenizer does", () => {
+    expect(isDestructiveNonSqlQuery('"DEL" session:1', "redis")).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["a container command whose subcommand writes", "CONFIG SET maxmemory 0"],
+    ["a lowercase subcommand", "acl deluser reader"],
+    ["a script flush", "SCRIPT FLUSH"],
+  ])("asks for %s", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "redis")).toBe(true);
+  });
+
+  test.each<[string, string]>([
+    ["the same container reading", "CONFIG GET maxmemory"],
+    ["an ACL read", "ACL LIST"],
+    ["a script load", 'SCRIPT LOAD "return 1"'],
+  ])("does not ask for %s", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "redis")).toBe(false);
+  });
+
+  test.each<[string, string, boolean]>([
+    ["the JSON command form", '{"command":"DEL","args":["session:1"]}', true],
+    ["the JSON read form", '{"command":"GET","args":["session:1"]}', false],
+    ["a pretty-printed JSON command", '{\n  "command": "FLUSHALL"\n}', true],
+    ["a JSON container command", '{"command":"CONFIG","args":["SET","maxmemory","0"]}', true],
+    ["a JSON container reading", '{"command":"CONFIG","args":["GET","maxmemory"]}', false],
+    ["a JSON command with a non-string first arg", '{"command":"DEL","args":[7]}', true],
+  ])("answers %s with %p", (_label, query, expected) => {
+    expect(isDestructiveNonSqlQuery(query, "redis")).toBe(expected);
+  });
+
+  test.each<[string, string]>([
+    ["a document that never closes", '{"command":"GET","args":["k"]'],
+    ["a command that is not a string", '{"command":7}'],
+    ["no command key at all", '{"args":["k"]}'],
+  ])("asks when a JSON Redis payload cannot be read: %s", (_label, query) => {
+    expect(isDestructiveNonSqlQuery(query, "redis")).toBe(true);
+  });
+
+  test.each<[string, string, boolean]>([
+    ["a comment above the command", "# nightly\nFLUSHALL", true],
+    ["a comment above a read", "# nightly\nGET k", false],
+    ["an indented comment", "   # note\nDEL k", true],
+    ["leading blank lines", "\n\nDEL k", true],
+    ["a command wrapped across lines, named on the first", "HSET k a 1\nb 2", true],
+    ["a wrapped read", "HMGET k a\nb", false],
+    ["a second block after a blank line", "GET k\n\nFLUSHALL", false],
+    ["only comments", "# nothing to run", false],
+    ["nothing at all", "", false],
+  ])("reduces the buffer the way the provider does - %s", (_label, query, expected) => {
+    expect(isDestructiveNonSqlQuery(query, "redis")).toBe(expected);
+  });
+});
+
+describe("NON_SQL_DESTRUCTIVE_VOCABULARY", () => {
+  test("carries a row for exactly the two types whose text is not SQL", () => {
+    expect(Object.keys(NON_SQL_DESTRUCTIVE_VOCABULARY).sort()).toEqual(["mongodb", "redis"]);
+  });
+
+  test("names no MongoDB operation the provider cannot dispatch", () => {
+    // The gate's vocabulary may not invent operations: `drop`, `dropDatabase` and
+    // `createIndex` are absent from `SUPPORTED_OPERATIONS`, so this editor cannot run
+    // them and a row for them would be a prompt about something unreachable.
+    const operations = NON_SQL_DESTRUCTIVE_VOCABULARY.mongodb?.operations;
+    for (const absent of ["drop", "dropCollection", "dropDatabase", "createIndex", "renameCollection"]) {
+      expect(operations?.has(absent)).toBe(false);
+    }
+  });
+});

--- a/tests/unit/db/query-limiter.test.ts
+++ b/tests/unit/db/query-limiter.test.ts
@@ -1256,3 +1256,153 @@ describe("a nested block comment under the dialect that reads it", () => {
     expect(applyQueryLimit(sql, 500, 0, {}, "postgres").sql).toBe(expected);
   });
 });
+
+// ─── S5: the whole-body probes read code only ────────────────────────────────
+//
+// The statement's TYPE stopped being fooled by a word written in a comment when
+// the leading-keyword reader arrived (#275), and the end-anchored bound probes
+// stopped being fooled by the trailing run when the statement-end reader did
+// (#280). Three probes were left reading the whole body as characters: the Oracle
+// ROWNUM bound, the UNION test and the nested-SELECT count. A mention of any of
+// them mid-statement - in a line comment, a block comment, a string literal or a
+// quoted identifier - answered for the statement, and for ROWNUM that answer is
+// "already bounded", so the limiter skipped the bound and the full result set came
+// back. They read through `lib/sql/words` now, which is the same span reader the
+// rest of the module already shares.
+
+describe("analyzeQuery: a mention in a comment or a literal is not the statement's code", () => {
+  describe("the Oracle ROWNUM bound", () => {
+    test.each<[string, string]>([
+      ["a mid-statement line comment", "SELECT *\n-- try ROWNUM <= 10 here\nFROM huge_table WHERE active = 1"],
+      ["a mid-statement block comment", "SELECT * FROM huge_table /* ROWNUM <= 10 */ WHERE active = 1"],
+      ["a string literal", "SELECT * FROM huge_table WHERE note = 'ROWNUM <= 10'"],
+      ["a quoted identifier", 'SELECT "ROWNUM <= 10" FROM huge_table'],
+    ])("%s does not mark the statement bounded", (_label, sql) => {
+      expect(analyzeQuery(sql).hasLimit).toBe(false);
+
+      // The consequence the user sees: the bound is injected, so the statement
+      // does not run unbounded.
+      const result = applyQueryLimit(sql, 500);
+      expect(result.wasLimited).toBe(true);
+      expect(result.sql).toBe(`${sql} LIMIT 500`);
+    });
+
+    test.each<[string, string]>([
+      ["written plainly", "SELECT * FROM t WHERE ROWNUM <= 10"],
+      ["with no spaces", "SELECT * FROM t WHERE ROWNUM<10"],
+      ["with a comment between the name and its comparison", "SELECT * FROM t WHERE ROWNUM /* n */ <= 10"],
+      ["after a mention of the same words in a literal", "SELECT * FROM t WHERE n = 'ROWNUM <= 1' AND ROWNUM <= 10"],
+    ])("a real bound %s is still detected", (_label, sql) => {
+      expect(analyzeQuery(sql).hasLimit).toBe(true);
+      expect(applyQueryLimit(sql, 500).wasLimited).toBe(false);
+    });
+
+    // Every code occurrence is asked, not just the first: the regex this replaced
+    // scanned the whole body, so a bound written after another mention of the same
+    // pseudo-column was found, and it still is.
+    test("a bound after a non-bound mention of ROWNUM is found", () => {
+      expect(analyzeQuery("SELECT ROWNUM AS rn FROM t WHERE ROWNUM <= 10").hasLimit).toBe(true);
+    });
+
+    // Between the name and its comparison only whitespace and comments are
+    // trivia. A literal, a quoted identifier and a subscript are the statement's
+    // own text, and this shape is valid PostgreSQL: `rownum` is an ordinary column
+    // holding an array, so `rownum[1] <= 10` is not an Oracle row bound. A reader
+    // that stepped over the subscript called the statement bounded and injected
+    // nothing, and the whole table came back.
+    test("a span between ROWNUM and its comparison is not stepped over", () => {
+      const sql = "SELECT tags FROM t WHERE rownum[1] <= 10";
+
+      expect(analyzeQuery(sql, "postgres").hasLimit).toBe(false);
+      expect(applyQueryLimit(sql, 500, 0, {}, "postgres").sql).toBe(`${sql} LIMIT 500`);
+    });
+
+    test("a bare ROWNUM with no comparison is not a bound", () => {
+      expect(analyzeQuery("SELECT ROWNUM, id FROM t").hasLimit).toBe(false);
+      expect(analyzeQuery("SELECT * FROM t WHERE ROWNUM = 1").hasLimit).toBe(false);
+      expect(analyzeQuery("SELECT * FROM t WHERE ROWNUM <= x").hasLimit).toBe(false);
+      expect(analyzeQuery("SELECT * FROM t ORDER BY ROWNUM").hasLimit).toBe(false);
+    });
+  });
+
+  describe("the UNION test", () => {
+    test.each<[string, string]>([
+      ["a mid-statement line comment", "SELECT id\n-- UNION ALL with archive later\nFROM users"],
+      ["a mid-statement block comment", "SELECT id FROM users /* UNION archive */ WHERE active = 1"],
+      ["a string literal", "SELECT id FROM users WHERE note = 'UNION'"],
+      ["a quoted identifier", 'SELECT "UNION" FROM users'],
+    ])("%s does not make the statement a union", (_label, sql) => {
+      expect(analyzeQuery(sql).isUnion).toBe(false);
+    });
+
+    test.each<[string, string]>([
+      ["a plain UNION", "SELECT 1 UNION SELECT 2"],
+      ["UNION ALL", "SELECT 1 UNION ALL SELECT 2"],
+      ["a UNION after a literal mentioning it", "SELECT n FROM a WHERE n = 'UNION' UNION SELECT n FROM b"],
+    ])("%s is still a union", (_label, sql) => {
+      expect(analyzeQuery(sql).isUnion).toBe(true);
+    });
+  });
+
+  describe("the nested-SELECT count", () => {
+    test.each<[string, string]>([
+      ["a mid-statement line comment", "SELECT id\n-- SELECT was here\nFROM users"],
+      ["a mid-statement block comment", "SELECT id FROM users /* SELECT id FROM archive */"],
+      ["a string literal", "SELECT id FROM users WHERE note = 'SELECT 1'"],
+      ["a quoted identifier", 'SELECT "SELECT" FROM users'],
+    ])("%s is not a nested SELECT", (_label, sql) => {
+      expect(analyzeQuery(sql).hasSubquery).toBe(false);
+    });
+
+    test.each<[string, string]>([
+      ["a scalar subquery", "SELECT (SELECT 1) AS x"],
+      ["an IN subquery", "SELECT id FROM users WHERE id IN (SELECT user_id FROM orders)"],
+      ["a subquery after a literal mentioning one", "SELECT (SELECT 1) AS x FROM t WHERE n = 'SELECT 2'"],
+    ])("%s still counts", (_label, sql) => {
+      expect(analyzeQuery(sql).hasSubquery).toBe(true);
+    });
+  });
+
+  // The fail-safe direction this module keeps everywhere: where a run does not
+  // close, no reader over `lib/sql/spans` can say what is inside it, so the three
+  // probes keep the whole-text reading they had rather than reporting the bound
+  // as absent. `\'` is the shape that reaches this - the two dialect readings of
+  // it put the end of the string in different places.
+  describe("a run that never closes keeps the conservative reading", () => {
+    test("a real ROWNUM bound behind an unresolvable literal is still reported", () => {
+      const sql = "SELECT * FROM t WHERE name = 'O\\'Brien' AND ROWNUM <= 10";
+
+      expect(analyzeQuery(sql).hasLimit).toBe(true);
+      // Nothing is rewritten either way: the statement's end is undeterminable.
+      expect(applyQueryLimit(sql, 500)).toMatchObject({ sql, wasLimited: false });
+    });
+
+    test("a real UNION behind an unresolvable literal is still reported", () => {
+      expect(analyzeQuery("SELECT n FROM a WHERE n = 'O\\'Brien' UNION SELECT n FROM b").isUnion).toBe(true);
+    });
+
+    test("a real subquery behind an unresolvable literal is still reported", () => {
+      expect(analyzeQuery("SELECT * FROM t WHERE n = 'O\\'Brien' AND id IN (SELECT id FROM u)").hasSubquery).toBe(true);
+    });
+  });
+
+  // The dialect the module already receives decides which runs are not code, and
+  // these probes now get the same answer as the rest of the module: `#` opens a
+  // comment in MySQL and is an operator character in PostgreSQL, so the SAME text
+  // is a note on one engine and the statement's own bound on the other.
+  //
+  // The `#` run sits MID-statement deliberately. Measured on the trailing form
+  // (`SELECT * FROM t WHERE a = 1 # ROWNUM <= 10 is only a note\n`), both dialects
+  // answer the same with and without the code-word reading above: `readStatementEnd`
+  // already trims a trailing MySQL comment off the text these probes read, so that
+  // shape is decided by the statement-end reader and pins nothing here. With the run
+  // mid-statement the mysql arm flips - bounded before the change, unbounded after.
+  test("which runs are comments is the dialect's answer here too", () => {
+    const sql = "SELECT * FROM t WHERE a #> '{b}' AND ROWNUM <= 10";
+    const commented = "SELECT * FROM t WHERE a = 1 # ROWNUM <= 10\nAND b = 2";
+
+    expect(analyzeQuery(sql, "postgres").hasLimit).toBe(true);
+    expect(analyzeQuery(commented, "mysql").hasLimit).toBe(false);
+    expect(analyzeQuery(commented, "postgres").hasLimit).toBe(true);
+  });
+});

--- a/tests/unit/sql/grammar.test.ts
+++ b/tests/unit/sql/grammar.test.ts
@@ -287,7 +287,8 @@ describe("resolveSqlGrammar", () => {
   });
 
   // Neither search engine is reachable from this run, so neither row was
-  // established - and PD-5 forbids reading one dialect's rule off another's, which
+  // established - and grammar.ts's rule 2 forbids reading one dialect's rule off
+  // another's behaviour, which
   // here would mean copying five refusals onto a sixth grammar. They keep the
   // compatibility default, and the direction that costs is stated rather than
   // implied: if `//` DOES open a comment in one of them, its splitter over-splits


### PR DESCRIPTION
Four BACKLOG items closed (S5, S8, U20, U22), each one a layer answering a question it could not see. Every one was driven in Chrome against a production build before this PR was opened, on live engines rather than mocks.

## S5 — a bound mentioned in a comment silenced the limiter

`src/lib/db/utils/query-limiter.ts` ran its Oracle `ROWNUM` probe, its `UNION` probe and its subquery `SELECT` count over the whole statement text. A bound merely *mentioned* inside a comment or a string literal therefore read as a bound the statement already carried, and nothing was injected.

Measured in the browser against the SQLite sample (`salary`, 9.5k rows):

| Statement | Before | After |
|---|---|---|
| `SELECT * FROM salary /* ROWNUM <= 10 */ WHERE amount > 0` | every row | `500 rows (more available)` · `AUTO-LIMITED` |
| `SELECT * FROM salary WHERE amount > 0 AND 'ROWNUM <= 10' <> ''` | every row | `500 rows` · `AUTO-LIMITED` |
| `SELECT * FROM salary WHERE amount > 0 LIMIT 10` | 10 rows | 10 rows, no `AUTO-LIMITED` |

The three probes now read code words through `lib/sql/words` under the grammar the module already resolved. Where a span cannot be resolved the old whole-text reading is kept deliberately: it can only widen what is *reported*, never place a bound (`readStatementEnd` refuses to rewrite such a statement anyway). Twelve of the new tests fail when the fix is reverted — checked, not assumed.

## S8 — `FLUSHALL` asked nothing

`isDangerousQuery` recognised SQL keywords and returned `false` outright for `redis` and `mongodb`. So a Redis `FLUSHALL` and a Mongo `deleteMany` with an empty filter ran with no confirmation, while `DELETE FROM` on every SQL engine asked.

New `src/lib/db/destructive-commands.ts` carries one per-type table plus one reader; the dialog keeps no type test of its own. The vocabulary is grounded in what each provider can actually dispatch:

- MongoDB's `SUPPORTED_OPERATIONS` is exactly 11 names, so `drop` / `dropDatabase` are deliberately **absent** — the provider cannot send them. Covered: `deleteOne`, `deleteMany`, `updateOne`, `updateMany`, plus the `$out` / `$merge` aggregate stages, which are the read-shaped operation that can destroy data.
- Redis' `runCommand` is a bare `client.call` with no allow-list, so the bar is that the command **name** decides it. `GETEX` was removed for failing that bar (a plain `GETEX key` is a `GET`); `SETBIT`, `XGROUP DELCONSUMER` and `CLUSTER SETSLOT` were added for meeting it. What is not covered is named, with the reason.
- A payload the reader cannot parse **asks** rather than staying silent.

Verified in Chrome on live Redis 8 and MongoDB: `SCAN 0 COUNT 5` and `{"operation":"find"}` ran with no prompt; `FLUSHALL` and `{"operation":"deleteMany"}` each raised Query Safety Check and were cancelled. Redis held 496 keys before and after.

## U20 — the maintenance API validated existence, not fit

The route checked `capabilities.maintenanceOperations.includes(type)` and nothing else. Since the per-provider `maintenanceOperationSpecs` declaration landed, both UI surfaces gate on the target KIND and the route did not, so every mismatch stayed reachable by a direct request.

Measured live against the SQLite sample:

| Request | Before | After |
|---|---|---|
| `{type:"vacuum", target:"salary"}` | `200`, whole file vacuumed | `400` — *Vacuum Database takes no target on this database: it runs over the whole database. Omit 'target'.* |
| `{type:"vacuum"}` | `200` | `200` |
| `{type:"analyze", target:"salary"}` | `200` | `200` |

The refusal returns before `runMaintenance` and before the audit event, and carries only `error` so it reads as a client error rather than a maintenance verdict. `kill` is exempt and the code says why: every provider declares it with both placements false, so its target comes from somewhere neither placement describes — gating it would have broken session termination on every engine.

## U22 — a deep link that landed on nothing

`TableItem`'s two maintenance items are deep links. The first attempt put the honest note on the monitoring Tables tab; verifying the route showed that is not where an admin lands — `Studio.tsx` pushes an admin to `/admin/operations?table=…`, so the note was on a page the link never reaches. It now lives on both.

Live PostgreSQL 18, `/admin/operations?table=zzz_dropped_since_the_tree_loaded`:

> Per-table maintenance (Analyze Table, Vacuum Table, Reindex Table) is run from a row of this list, and this page has no row for "zzz_dropped_since_the_tree_loaded" to run it on.

Before: `No tables found.` and nothing about the operation that was asked for.

Two related corrections: `TablesTab`'s note drops the admin-page clause, because `MonitoringDashboard` passes no `isAdmin` and `/monitoring` is the route a non-admin is sent to — telling them to use a page `src/proxy.ts` denies them is worse than saying less. And its refusal branch no longer states an absence of statistics as the cause when the engine reported a different one; `PanelUnavailable` supplies the reason.

**One deviation to flag:** U22's own "Done when" asked for the link to be *withheld* where the destination cannot render the control. Nothing available can answer that in advance — `TableSchema` carries no monitoring statistics and no declared capability says whether an engine publishes per-table figures — so gating would have needed a new capability flag. The note is the smaller honest fix; the reasoning is in both components.

## Also

Four comments cited a rule id `PD-5` that is defined nowhere in this repo, and an external reviewer quoted it back as authority. They now cite the rule itself: `grammar.ts`'s own header rule 2, and the undecided table in `docs/editor/query-optimization.md`. One stale example went with it — `SET k "a\"b"` is now a command the gate prompts about, so the "ordinary read" example is `GETRANGE k "a\"b" 0 1`.

Docs synced in the same PR: the API route added as a reader of `maintenanceOperationSpecs` in all ten provider docs that carry that paragraph, the fourth `400` documented in `docs/API_DOCS.md`, the gate's non-SQL behaviour in `docs/providers/{mongodb,redis}.md`, and the non-SQL paragraph in `docs/editor/query-optimization.md` corrected — it had called LibreDB a non-SQL type while four rows of the table right beneath it read LibreDB as SQL.

## Verification

Six gates green locally plus `build:lib` and `attw`; merged coverage **43100/43100 lines (100.00%)**. No chart file changed, so no `Chart.yaml` bump (`appVersion` 0.13.4 still matches `package.json`).

Each item was implemented by one engineer, then reviewed by an independent reviewer with no shared context; every reviewer found real defects and each cluster was re-worked before this PR. The U22 misplacement above is the one a reviewer caught, and the browser confirmed it.
