### PR TITLE
fix(db,ui): the built-in LibreDB sample could not be edited, and ?ssl=true verified nothing

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2397,14 +2397,6 @@ as they are fixed, and a numeral here goes stale silently.
   run `internal` or, on the profile error, `agent-credential-unusable`. Deliberate at #414, which had
   no business changing how the two engines it did not touch fail, and an asymmetry a reader will
   trip over until it is resolved.
-- **B49** — a **LibreDB** connection can never be grounded, and the reason is not the agent's.
-  `lib.open()` takes an exclusive lock on the file, and an execution-profile acquisition is a SECOND
-  provider under its own cache key — so once the connection's ordinary provider is open, which it is
-  from the moment anyone browses it, the grounding read fails to connect at all. Measured live on
-  2026-08-17 against `@libredb/libredb` 0.2.2: `ConnectionError` / `CONNECTION_ERROR`, *"LibreDB file
-  is already open by another process"*, converted by `captureFromProvider` into an honest ungrounded
-  run with no `context-captured` event. The same lock is what makes the connection-test modal report a
-  failed connection (`docs/BACKLOG.md` D3), so the two close together.
 - **B51** — the loop delivers three notices to a model (the reserve warning, the report reminder of
   #416, the present-before-report notice of #417) and records none of them. `recordEvent` is called
   for what the RUN did and never for what the server said to it, so a rescued run and a run that never

--- a/docs/AGENT_DATA_FLOW.md
+++ b/docs/AGENT_DATA_FLOW.md
@@ -234,8 +234,11 @@ Every other "twelve" said about grounding in these docs counts the same thing. T
 NOT count. The wire-compatible engines of
 [`docs/providers/README.md`](./providers/README.md) are not extra members — TiDB is grounded because it
 arrives as `mysql`, and it is that type-id that is counted. And one of the twelve, the embedded
-`libredb`, is reached by this path but cannot complete it: the file takes an exclusive lock, so the
-grounding provider never connects and the run is honestly ungrounded (`docs/BACKLOG.md` B49). What
+`libredb`, reaches this path through a handle it does not open: the file takes an exclusive lock, so
+the grounding acquisition borrows the connection's own open provider rather than opening a second one
+that the lock would refuse (`findOpenSingleWriterProvider`, `src/lib/db/factory.ts`; see
+[`docs/providers/libredb.md`](./providers/libredb.md) §4.2.1). A connection that configures an
+`agentUser` opts out of that borrow, and such a run is still honestly ungrounded. What
 leaves this process is the same KIND of thing either way, identifiers and types and nothing else, but
 two properties differ and are stated here rather than left to be discovered:
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,10 +22,10 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S2–S7 · 5
-- [Drivers and connections](#drivers-and-connections) — D1–D26, U17 · 8
+- [Drivers and connections](#drivers-and-connections) — D1–D29, U17 · 9
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U21 · 11
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U21 · 10
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
 - [Tests](#tests) — T1–T3 · 2
 - [Dependencies](#dependencies) — P1–P5 · 5
@@ -36,7 +36,7 @@ None of it is a GitHub issue.
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C2–C10 · 9
 - [Security Phase 3 deferrals](#security-phase-3-deferrals) — K2–K4 · 2
 - [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A6 · 5
-- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B64 · 42
+- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B66 · 43
 
 ---
 
@@ -125,36 +125,6 @@ pool-level `error` event, and each `connect()` now records that.
 
 Whether the MongoDB, Redis, ClickHouse, Druid, Couchbase, Cassandra or Trino clients expose a fatal
 `error` event that can reach `uncaughtException` is an open question, not a claim.
-
-### D3. Testing a connection to an already-open embedded file fails on its own exclusive lock
-
-`POST /api/db/test-connection` calls `createDatabaseProvider` directly rather than going through the
-cached provider. That is right for credentials the server has never seen, and wrong for an engine
-that permits one writer. If the connection under test points at a file the cached provider already
-holds, the second open is refused:
-
-```
-[DB] Creating libredb provider for "Sample (LibreDB)"      <- cached, holds the file
-[DB] Creating libredb provider for "My Sample"             <- the test, same file
-ConnectionError: LibreDB file is already open by another process (exclusive lock).
-```
-
-Deterministic, not a race. It reproduces every time on the active LibreDB connection.
-
-The consequence is worse than a failed test, because the modal tests before it saves. **Editing the
-built-in LibreDB sample is impossible.** The edit is discarded with a toast about a connection error,
-which reads as if the sample itself were broken. Reproduced against a production build on 2026-08-12
-while verifying #336.
-
-An earlier session recorded this and then retracted it as unreproducible. The retraction of the
-*explanation* stands — it blamed a read-then-write window in the provider cache, which is not what
-happens. The phenomenon is real; those attempts never went through the modal's test path.
-
-Same lock, same fix as B49. Close the two together.
-
-**Done when:** testing a connection that resolves to an already-open single-writer file reuses the
-open provider, or the test is skipped with an honest message. Either way the modal must not present a
-lock conflict as a failed connection test.
 
 ### U17. Four things the Cassandra provider declined to do
 
@@ -312,25 +282,66 @@ and a refusal sentence that has never been seen from the server is exactly what 
 the counts it feeds carry the same distinction - measured against a live cluster with a document-only
 role, not inferred from the code.
 
----
+### D27. On a single-writer file, whichever handle opens first locks the other one out
 
-### D26. `?ssl=true` maps onto `require`, and `require` is the one mode that does not verify
+The reuse D3 and B49 landed runs one way only: `findOpenSingleWriterProvider` reads the **writable**
+cache, so a caller that would open a second handle borrows the editor's. The reverse is still open. If
+an agent run reaches a `libredb` connection nobody has browsed yet, `acquireExecutionProfileProvider`
+opens the file and caches that handle under the PROFILED key — and the editor's own
+`getOrCreateProvider` then fails on the lock, so browsing the connection in the sidebar is refused
+until the profiled entry is evicted (30 minutes idle).
 
-`readBooleanTLS` maps a PostgreSQL `?ssl=true` onto `SSLMode` `require` (2026-08-25, D16). That is
-the honest half of a real choice - the alternative was leaving it on the form's `disable` default and
-sending plaintext - but it weakens what the source spelling asks for: `pg` reads `ssl=true` as TLS
-with Node's default `rejectUnauthorized: true`, while this app's `require` is explicitly
-`rejectUnauthorized: false` (`src/lib/db/providers/sql/postgres.ts:793`, where only `verify-ca` and
-`verify-full` verify).
+Deliberately left: closing it means letting an editor request be served a provider opened under an
+execution profile, which is the isolation invariant `acquireExecutionProfileProvider` exists to keep.
+On this engine that handle carries no actual privilege reduction — `createDatabaseProvider` passes no
+execution context for `libredb` — so the reuse would be safe *for this engine* and wrong as a declared
+rule. Not observed in the browser: the ordinary order is editor-first, because the connection has to be
+selected before a run can be started on it.
 
-The same change REFUSED to map MongoDB's `tls=true` on exactly that argument, so the two arms of one
-commit disagree. Both are defensible on their own - a downgrade beats plaintext, and a downgrade of
-an Atlas connection is worse than a form the user must fill in - and neither is written down as a
-rule. `SSLMode` having no "encrypt and verify with the system roots, no server-name pinning" value is
-what forces the choice.
+**Done when:** either direction of the borrow is safe by construction — for instance a single-writer
+file has ONE cache entry that both callers key off, with the profile deciding how it is used rather
+than which handle it gets — or the agent-first order is refused with a sentence naming the lock.
 
-**Done when:** the two spellings answer to one stated rule, or `SSLMode` gains the mode that makes
-the question disappear.
+### D28. The scheme mappings still choose `require`, which the boolean rule now contradicts
+
+D26 stated the rule for a boolean TLS **parameter**: it maps onto the mode matching what the engine's
+own driver does with it, never onto a weaker one. `withSSLMode` in
+`src/lib/connection-string-parser.ts` maps the TLS **schemes** — `rediss://`, `couchbases://`, and
+ClickHouse's `https://` — onto `require`, which verifies nothing, while ioredis given `rediss://`
+verifies by default. So the same paste is read strongly through one door and weakly through another.
+
+Not changed with D26 on purpose: the existing comments justify `require` on a measured claim about
+self-hosted deployments — a Redis started with `--tls-port` presents a self-signed certificate, so a
+verifying default would refuse the ordinary local setup — and D26's entry names only the boolean
+parameters. `docs/providers/redis.md` now states the boundary rather than leaving the rule looking
+universal, which is why this is a written-down asymmetry and not a silent one.
+
+**Done when:** the schemes answer to the same stated rule as the parameters, or the reason a scheme is
+read more weakly than the parameter beside it is recorded next to `withSSLMode` as a decision rather
+than as an artefact.
+
+### D29. Redis ignores the username, so no ACL user can be used and a pasted one is lost silently
+
+Measured 2026-08-25 against `redis:latest`: `ACL SETUSER probe on >pw ~* +@all -info` creates a user
+whose `INFO` is refused (`NOPERM`), and a connection configured with that user and password still
+reported `Connection successful` with full health — because `RedisProvider.connect()`
+(`src/lib/db/providers/keyvalue/redis.ts:184`) builds `new Redis({ host, port, password, db, ... })`
+and passes **no `username`**, so ioredis authenticates as `default` and the configured user is
+dropped. On a server whose `default` user has no password, that is a connection made as a principal
+the user did not choose.
+
+The parser makes it worse rather than better: `redis://probe:pw@host` fills `user` from the URI
+(`connection-string-parser.ts:507`), so the field is collected, stored, and then ignored at the one
+place it matters. Redis 6 ACLs are how every managed Redis (Redis Cloud, ElastiCache RBAC, Azure
+Cache) issues least-privilege credentials, so this is not an exotic configuration.
+
+Found while looking for a live health failure to verify U19's degraded banner against — which is also
+what the absence rule (#477) would say about it: a health read that succeeds under the wrong principal
+is not the health of the connection that was configured.
+
+**Done when:** a configured Redis username reaches the client, and a server that refuses that user's
+`INFO` produces a degraded connection rather than a green one — measured against an ACL user, not
+inferred.
 
 ---
 
@@ -557,24 +568,6 @@ collapses first. It is not the failure `login-form.tsx`'s comment records — a 
 
 **Done when:** the hero fits at 1280x800 with the relatives line intact, or scrolling at that height
 is accepted deliberately.
-
----
-
-### U19. A caution about a save the app could not verify renders as a green success tick
-
-`use-connection-form.ts:423` emits the degraded-save message - "... Click Save Changes again to save
-it anyway." - as `success: true`, and `ConnectionModal.tsx:874` has exactly two renderings for that
-flag: emerald with a `CircleCheck`, or red with a `CircleX`. So the sentence asking the user to think
-again arrives wearing the affordance of a completed action.
-
-Found 2026-08-25 while fixing the identical shape one branch above it: the connection-string TLS
-refusal was emitted the same way and now emits `success: false`. That fix is available here too and
-was deliberately not applied, because a red cross overstates in the other direction - the save is
-being OFFERED, not refused. The same missing thing explains both: this banner has no warning state.
-`AgentRail`'s posture line (#449) is the precedent for the wording, not for the colour.
-
-**Done when:** a message that is neither a success nor a failure renders as neither, and the degraded
-save uses it.
 
 ---
 
@@ -2248,33 +2241,6 @@ their failure mode is a second decision about a path #414 did not touch. It is s
 reader will trip over.
 
 **Done when:** both grounding paths answer an environment failure the same way.
-
-### B49. A LibreDB connection can never be grounded, because the file takes an exclusive lock
-
-- `lib.open({ path })` takes an **exclusive lock**. Opening the same path a second time in the same
-  process throws `LibreDbError` with `code: "LOCKED"`.
-- `acquireExecutionProfileProvider(connection, "agent-operations")` is a **second provider**, cached
-  under `profiledCacheKey(connection.id, profile)` rather than under the connection id, and it calls
-  `connect()` — which is `lib.open()` on a path the ordinary writable provider already holds open.
-- Driven end to end: with the writable provider connected and returning five namespaces (`config:*`,
-  `people:*`, `project:*`, `users:*`, `session:*`), the profiled acquisition fails with
-  `ConnectionError` / `CONNECTION_ERROR` and the message the provider writes for `LOCKED` — *"LibreDB
-  file is already open by another process (exclusive lock)."*
-- `ConnectionError` extends `DatabaseError`, so `captureFromProvider` converts it into an unavailable
-  capture rather than propagating it. The run continues, honestly, ungrounded — which is why nothing
-  about this looks like a failure anywhere.
-
-The condition is "the connection's ordinary provider is currently connected", which is true from the
-moment anyone browses the connection in the sidebar. So in practice this is every run.
-
-It is not a grounding defect: the same lock defeats any second handle on the same file, which is why D3
-records the connection-test modal presenting it as a failed connection. LibreDB is not a priority, so
-this is recorded rather than fixed.
-
-**Done when:** an execution-profile acquisition on a single-writer embedded engine reuses the
-connection's existing provider instead of opening a second handle — the same answer D3 needs, and the
-reason the two should be closed together — with a test that grounds a plan run on a `libredb` connection
-whose writable provider is already open.
 
 ### B51. The run loop nudges a model three times and records none of it
 

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -284,7 +284,19 @@ STORAGE_POSTGRES_URL=postgresql://user:pass@localhost:5432/your_db?sslmode=disab
 
 # Cloud PostgreSQL
 STORAGE_POSTGRES_URL=postgresql://user:pass@your-pg-host:5432/your_db?sslmode=require
+
+# Cloud PostgreSQL, with the server certificate actually verified
+STORAGE_POSTGRES_URL=postgresql://user:pass@your-pg-host:5432/your_db?sslmode=verify-system
 ```
+
+> **`sslmode=require` here encrypts but does not verify** (`rejectUnauthorized: false`) — this pool
+> has no channel for a CA certificate, so a verifying default would break every deployment whose
+> storage database presents a self-signed certificate. `sslmode=verify-system` is the connection
+> form's own mode name (`SSLMode` in [`src/lib/types.ts`](../src/lib/types.ts)), not a libpq one, and
+> it is the one value this reader treats as "verify the chain against the runtime's trust store" —
+> which is what a managed provider's publicly-signed certificate needs. Before D26 it fell through
+> every branch and landed on the non-local default, `rejectUnauthorized: false`: the opposite of what
+> it says.
 
 ### Verify
 

--- a/docs/providers/cassandra.md
+++ b/docs/providers/cassandra.md
@@ -444,7 +444,7 @@ is reported as the server spelled it rather than guessed into a CQL word.
 | `localDataCenter` | **Yes** | [§3.4](#34-localdatacenter-is-a-required-connection-field-and-nothing-else-here-has-one) |
 | `database` | No | The **keyspace**. Without it there is no schema tree |
 | `user` / `password` | No | Sent only when a user is set. A stock install runs `AllowAllAuthenticator` and ignores credentials entirely (measured: supplying them to an open server connects fine) |
-| `ssl` | No | Any mode but `disable` sends `sslOptions`: `rejectUnauthorized` from the mode, plus the form's CA (`ca`) and client keypair (`cert` / `key`) under Node's own TLS names, which is the same mapping the PostgreSQL, MySQL and Couchbase adapters use — the driver hands `sslOptions` to `tls.connect`. **Not exercised against a TLS cluster** — the probe instances speak plaintext — so it is the driver's documented option shape and no claim about a verified path, mutual TLS included |
+| `ssl` | No | Any mode but `disable` sends `sslOptions`: `rejectUnauthorized` from the mode (`false` for `require`, `true` for `verify-system`/`verify-ca`/`verify-full` — `verify-system` is simply the one that pastes no CA, leaving Node's own trust store to check the chain), plus the form's CA (`ca`) and client keypair (`cert` / `key`) under Node's own TLS names, which is the same mapping the PostgreSQL, MySQL and Couchbase adapters use — the driver hands `sslOptions` to `tls.connect`. **Not exercised against a TLS cluster** — the probe instances speak plaintext — so it is the driver's documented option shape and no claim about a verified path, mutual TLS included |
 
 ### 4.2 There is no connection string, and why that is not fixable by inventing one
 

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -612,6 +612,13 @@ default port from `8123` to `8443`
 separate CA/client-certificate plumbing the way Couchbase's `node:https` path has: the transport
 uses the runtime's own `fetch`, whose TLS trust follows the platform's default certificate store.
 
+`verify-system` (D26) is the mode that DESCRIBES this transport: `fetch` always verifies the chain
+against the platform's certificate store and cannot be told otherwise, so of the four non-`disable`
+modes it is the only one whose name matches the handshake. `require` here does not mean "encrypt
+without checking" the way it does on the driver-based providers — nothing in this transport can skip a
+check — and `verify-ca`/`verify-full` cannot pin against a pasted CA. Nothing in the code branches on
+which one is selected.
+
 Two consequences worth stating plainly:
 
 - **`ssl.caCert`, `ssl.clientCert` and `ssl.rejectUnauthorized` are not honoured.** Global `fetch`

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -475,9 +475,12 @@ project (and must not become one); `node:https` is a built-in that takes `ca`/`c
 `rejectUnauthorized` directly, so self-signed self-hosted clusters work on the Node runtime that
 ships in the Docker image.
 
-`rejectUnauthorized` follows the same rule PostgreSQL and MySQL use: only `verify-ca` and
-`verify-full` verify the chain by default, because a self-hosted Couchbase node ships a self-signed
-certificate — an explicit `ssl.rejectUnauthorized` always wins
+`rejectUnauthorized` follows the same rule PostgreSQL and MySQL use: `require` is the only mode that
+does **not** verify the chain, because a self-hosted Couchbase node ships a self-signed certificate.
+`verify-system` (D26) verifies against the trust store the runtime already has — the mode a Capella
+endpoint can satisfy exactly as pasted, since its certificate is signed by a public root and there is
+no PEM to go looking for — while `verify-ca`/`verify-full` verify against a pasted `caCert`. An
+explicit `ssl.rejectUnauthorized` always wins
 ([http-transport.ts:256](../../src/lib/db/providers/document/couchbase/http-transport.ts)).
 
 ---

--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -777,6 +777,13 @@ first-class `DatabaseConnection` field and is independent of the form's `connect
 applies even though the Druid form shows no TLS row of its own. An explicit `disable` turns TLS
 **off** as firmly as an explicit mode turns it on (the #264 lesson).
 
+`verify-system` (D26) is the mode that DESCRIBES this transport: `fetch` always verifies the chain
+against the platform's certificate store and cannot be told otherwise, so of the four non-`disable`
+modes it is the only one whose name matches the handshake. `require` here does not mean "encrypt
+without checking" the way it does on the driver-based providers — nothing in this transport can skip a
+check — and `verify-ca`/`verify-full` cannot pin against a pasted CA. Nothing in the code branches on
+which one is selected.
+
 The port is **not** changed by TLS, unlike ClickHouse's `8123` → `8443`: a TLS Druid serves on
 whatever `druid.tlsPort` the deployment configured, and there is no well-known value to guess.
 

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -493,6 +493,13 @@ first-class `DatabaseConnection` field and independent of the form's `connection
 even though this form shows no TLS row of its own, and an explicit `disable` turns TLS **off** as
 firmly as an explicit mode turns it on (the #264 lesson).
 
+`verify-system` (D26) is the mode that DESCRIBES this transport: `fetch` always verifies the chain
+against the platform's certificate store and cannot be told otherwise, so of the four non-`disable`
+modes it is the only one whose name matches the handshake. `require` here does not mean "encrypt
+without checking" the way it does on the driver-based providers — nothing in this transport can skip a
+check — and `verify-ca`/`verify-full` cannot pin against a pasted CA. Nothing in the code branches on
+which one is selected.
+
 **The port is not changed by TLS**, unlike ClickHouse's `8123` → `8443`: this product serves HTTPS on
 the same `9200`, so there is no second well-known number, and inventing one would send credentials to
 a port nothing is listening on.

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -276,6 +276,29 @@ condition as a clear `ConnectionError` (see [§10](#10-error-handling)):
   it after 30 minutes idle — the lock is held that whole time. To edit the same file with external
   tooling, disconnect the Studio connection first (or wait for eviction); otherwise the external
   writer gets `LOCKED`.
+- **Studio's own second openers reuse the handle instead.** Inside this server the lock used to
+  defeat three callers that build a provider outside the writable cache, and it did so every time
+  (`docs/BACKLOG.md` D3 and B49):
+  - `POST /api/db/test-connection` reported the lock as a failed connection test. The connection
+    dialog tests before it saves, so **the built-in sample could not be edited at all**: the edit
+    was discarded with a toast about a connection error, as if the sample were broken.
+  - `acquireExecutionProfileProvider(connection, "agent-operations")` — the agent's grounding read —
+    lost its schema capture to the lock. A `ConnectionError` becomes an *unavailable* capture rather
+    than a failure, so every plan run on a LibreDB connection was silently ungrounded from the
+    moment anyone browsed it in the sidebar.
+  - `POST /api/db/schema-snapshot` answered HTTP 503 with the same message, so the Schema Diff tab's
+    **Snapshot** button — its only caller — could not read a schema the sidebar was listing at that
+    moment. Measured in the browser against the released 0.13.4 image on 2026-08-25.
+
+  All three now call `findOpenSingleWriterProvider` (`src/lib/db/factory.ts`) first, which returns the
+  connected provider already holding the file. The lookup is keyed by the **resolved file path**,
+  not the connection id — the second opener is usually a different connection record pointing at
+  the same file, which is exactly how the sample-edit case reproduced. A borrowed handle is never
+  disconnected by its borrower and never cached under the profiled key: it belongs to the live
+  connection. Two bounds keep the agent's isolation invariant intact — only `agent-operations`
+  borrows (it sends no statement of the model's, so `agent-read-only` and `agent-handover` are
+  still refused on this engine), and an acquisition is not borrowed for a connection that
+  configures an `agentUser`, because a reuse cannot substitute one principal for another.
 
 > **DOWNGRADE WARNING:** a file written by `@libredb/libredb` 0.2.x must never be opened by 0.1.3
 > or older. The old recovery cannot parse the header, classifies the whole file as a torn tail,
@@ -579,6 +602,7 @@ for a different reason — the rows are derived groupings, see 5.3.
 | `supportsTransactions` | `false` — the command grammar has no transaction verb at all, so the trio and SANDBOX are not offered (#U13) |
 | `declaresForeignKeys` | `false` — the catalog declares namespaces and columns and nothing that references another namespace, so there is no foreign key to read |
 | `tablesAreDerivedGroupings` | `true` — the namespaces come from a bounded `kv.range` over 10000 keys, grouped by prefix, so they are this server's summary of what one scan reached rather than objects the engine declares. The agent layer states this to a plan run in one sentence |
+| `singleWriterFile` | `true` — `lib.open({ path })` takes an exclusive `<path>.lock`, so this file admits ONE handle and a second open throws `LOCKED`. The three callers that used to open a second one reuse the open handle instead ([§4.2.1](#421-on-disk-format-locking-and-version-compatibility-02x)). The only engine that declares it: SQLite, the other file engine, takes its locks per transaction rather than at open |
 | `supportsMaintenance` | `false` |
 | `maintenanceOperations` | `[]` |
 | `supportsConnectionString` | `false` |
@@ -680,6 +704,18 @@ document collection (`doc()`) alongside the raw kv keys, then asserts: (a) `getS
 its real declared columns with the primary key marked (the relational signal); (c) the document
 collection shows the generic `id`/`document` columns (the document signal); and (d) raw kv
 namespaces still group as `key`/`value` pseudo-tables.
+
+The **single-writer reuse** (D3/B49) is asserted in `tests/unit/db/factory.test.ts` rather than
+here, because it is the factory's behaviour and it needs the real factory — which this file cannot
+import, since `tests/api/db/test-connection.test.ts` replaces `@/lib/db/factory` process-wide with
+`mock.module`. Two suites there run on the real package and real temp files: *single-writer file
+reuse* (the borrow, the resolved-path identity, the control arm proving a second open really is
+refused, and SQLite proving it is not borrowed from) and *grounding a plan run while the writable
+provider holds the file* (a real plan-mode `captureContextSnapshot` comes back `captured` via
+`provider-inventory` with the profiled cache owning nothing; its control arm — the same run with an
+`agentUser`, which opts out of the reuse — comes back `unavailable` / `CATALOG_READ_REFUSED`, which
+is what every run did before this was closed). What this file asserts is the provider's own half:
+`getCapabilities().singleWriterFile === true`.
 
 A **0.2.x error mapping & locking** suite covers the hardened file boundary: a second open of a
 live-locked file is a clear `ConnectionError` (`LOCKED`); `connect()` takes the exclusive

--- a/docs/providers/mongodb.md
+++ b/docs/providers/mongodb.md
@@ -213,12 +213,37 @@ MySQL and Couchbase:
 |------------|---------------|
 | absent / `disable` | none — the client is built as before |
 | `require` | `tls: true`, `rejectUnauthorized: false` |
+| `verify-system` | `tls: true`, `rejectUnauthorized: true`, and **no** `ca` |
 | `verify-ca` / `verify-full` | `tls: true`, `rejectUnauthorized: true` |
 
 `caCert` / `clientCert` / `clientKey` become `ca` / `cert` / `key` when set, each independently — a
 cluster can demand mutual TLS while presenting a self-signed certificate itself. An explicit
 `ssl.rejectUnauthorized` always wins over the mode. `require` does not check the chain because a
-self-hosted replica set presents a self-signed certificate by default.
+self-hosted replica set presents a self-signed certificate by default; `verify-system` is the same
+handshake with verification on and nothing to paste, which is what an Atlas cluster needs (its
+certificate is signed by a public root the runtime already trusts). The driver exposes no separate
+host-name check, so `verify-ca` and `verify-full` build the same options object.
+
+#### `tls=true` in a pasted URI (D26)
+
+The paste box now reads the URI's own TLS options, and maps them by the rule stated in
+`readBooleanTLS` — a boolean TLS spelling lands on the mode that matches what the driver does with it:
+
+| In the pasted URI | SSL Mode set on the form |
+|-------------------|--------------------------|
+| `tls=true` / `ssl=true` | `verify-system` — the driver enables TLS **with** chain verification |
+| `tls=false` / `ssl=false` | `disable` |
+| `mongodb+srv://` with no TLS parameter | `verify-system` — SRV implies TLS in the driver itself |
+| `tlsInsecure=true` / `tlsAllowInvalidCertificates=true` alongside TLS | `require` — both turn `rejectUnauthorized` off |
+| a non-boolean value (`tls=maybe`) | nothing; the paste banner quotes the parameter |
+
+`tls=true` was deliberately **ignored** before this: the only non-`disable` mode that needed no PEM
+was `require`, i.e. `rejectUnauthorized: false`, and because the options object is a second channel
+the driver prefers over the URI, setting it would have stopped an Atlas certificate being verified.
+Leaving it unset had its own cost — the SSL panel read `disable` for a connection that was in fact
+encrypted. `verify-system` removes the trade: the form now says what the URI says.
+`tlsAllowInvalidHostnames` is not in the relaxing set, because this provider never sends
+`checkServerIdentity`, so the URI's own relaxation survives next to a verifying mode.
 
 Measured against a TLS-only server on 2026-08-23 (`mongo:latest --tlsMode requireTLS`): `disable` is
 refused - the server logs *"The server is configured to only allow SSL connections"* - and `require`

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -288,7 +288,15 @@ providers' `connect()`.
 | *(unset)* | `true` | `false` for Azure, **`true`** for non-Azure |
 | `disable` | `false` | — |
 | `require` | `true` | `true` (encrypt, skip cert validation) |
-| `verify-ca` / `verify-full` | `true` | `false` (validate the certificate) |
+| `verify-system` / `verify-ca` / `verify-full` | `true` | `false` (validate the certificate) |
+
+The three verifying modes are **one call** here, and deliberately: tedious exposes a single knob,
+`trustServerCertificate`, and turning it off already means "validate the chain and the name against
+the host's own trust store". There is no separate CA channel — `connection.ssl.caCert` is not read by
+this provider at all — so `verify-system` (D26) needs nothing added, and `verify-ca`/`verify-full` do
+not deliver the CA pinning their names promise. Pinned by
+`tests/integration/db/mssql-provider.test.ts` ("the TLS options handed to tedious"), so a future
+mode cannot fall through to the trusting branch unnoticed.
 
 See the [non-Azure trust caveat](#14-known-limitations--future-work).
 
@@ -318,6 +326,10 @@ values matched case-insensitively because ADO.NET writes `True`:
 
 Any other spelling of either keyword is reported in the paste banner and leaves the form's SSL Mode
 untouched rather than falling back to `disable`.
+
+`verify-system` is not produced by this parser: `Encrypt=True` with `TrustServerCertificate` off is
+`verify-full` already, and since all three verifying modes build the same tedious call, translating it
+to the newer name would change the wording on the form without changing a single option on the wire.
 
 ---
 
@@ -658,7 +670,8 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
   XML ON`) around the statement, then re-enable the capability.
 - **Non-Azure default trusts the server certificate.** With no explicit `connection.ssl`, non-Azure
   hosts use `encrypt: true` + `trustServerCertificate: true` — encrypted but **not** authenticated
-  (MITM-exposed). For verified TLS, set `connection.ssl` mode `verify-ca`/`verify-full`. (Azure hosts
+  (MITM-exposed). For verified TLS, set `connection.ssl` mode `verify-system` (or `verify-ca`/
+  `verify-full`, which build the same call here). (Azure hosts
   validate by default.)
   - **A paste that worked before can now fail against a self-signed on-prem server.**
     `Encrypt=True` with `TrustServerCertificate` absent maps to `verify-full`

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -311,8 +311,13 @@ options ([mysql.ts:114](../../src/lib/db/providers/sql/mysql.ts)):
 discrete-fields form** (the `connectionString` path bypasses it entirely). Note `disable` returns
 `undefined` (mysql2's "off"), not `false`:
 
-1. **Explicit `connection.ssl`** (`SSLConfig`): `disable` → `undefined`; `verify-ca`/`verify-full` →
-   `rejectUnauthorized: true` (otherwise `false`); `caCert`/`clientCert`/`clientKey` → `ca`/`cert`/`key`.
+1. **Explicit `connection.ssl`** (`SSLConfig`): `disable` → `undefined`; `require` →
+   `rejectUnauthorized: false` (the one mode that encrypts without verifying);
+   `verify-system`/`verify-ca`/`verify-full` → `rejectUnauthorized: true`;
+   `caCert`/`clientCert`/`clientKey` → `ca`/`cert`/`key`. `verify-system` passes **no** `ca`, so
+   mysql2 hands `tls.connect` Node's own trust store — that mode exists precisely so a managed
+   endpoint can be verified with no PEM to paste. mysql2 exposes no separate host-name check, so
+   `verify-ca` and `verify-full` build the same object.
 2. **`options.ssl === true` or cloud auto-detect** — `shouldEnableSSL()` (`options.ssl === true` *or*
    a known managed host) enables `{ rejectUnauthorized: false }`.
 3. Otherwise `undefined`.
@@ -326,16 +331,22 @@ matched case-insensitively (MySQL writes them upper-case) and `sslmode` is accep
 `verify-full` (it checks the hostname as well as the chain).
 
 The boolean spellings are read too, and mapped at both ends because a boolean has no opportunistic
-value: `?ssl=true`, `?ssl=1`, `?useSSL=true` → `require`; `?ssl=false`, `?ssl=0`, `?useSSL=false` →
-`disable`. An explicit `ssl-mode` wins when a string carries both. As on Postgres, `require` here
-means `rejectUnauthorized: false` ([mysql.ts:505](../../src/lib/db/providers/sql/mysql.ts)) —
-encrypted, chain unchecked — which is weaker than the driver this provider actually uses: mysql2
-defaults `rejectUnauthorized` to `true` for any `ssl` object it is handed
-(`node_modules/mysql2/lib/connection_config.js:171`). It is **not** weaker than what `useSSL=true`
-means to Connector/J, whose `verifyServerCertificate` is off unless `sslMode` is `VERIFY_CA` /
-`VERIFY_IDENTITY` — so for that spelling the mapping is faithful. The reason it is mapped this way
-regardless of which tool wrote the string is in
-[postgres.md](./postgres.md#sslmode-in-a-pasted-url). mysql2's
+value: `?ssl=true`, `?ssl=1`, `?useSSL=true` → **`verify-system`**; `?ssl=false`, `?ssl=0`,
+`?useSSL=false` → `disable`. An explicit `ssl-mode` wins when a string carries both.
+
+The rule (D26, stated in `readBooleanTLS`) is that a boolean maps onto the mode matching what the
+engine's own driver does with it, never onto a weaker one — and the driver this provider uses is
+mysql2, which defaults `rejectUnauthorized` to `true` for any `ssl` object it is handed
+(`node_modules/mysql2/lib/connection_config.js:171`). `verify-system` is that behaviour exactly:
+verified, with no CA certificate to find. The mapping was `require` until `verify-system` existed —
+`rejectUnauthorized: false` ([mysql.ts](../../src/lib/db/providers/sql/mysql.ts)), encrypted with the
+chain unchecked — because the only verifying modes on the form were the two that demand a PEM.
+
+One spelling is now mapped **stronger** than its writer meant: Connector/J's `useSSL=true` leaves
+`verifyServerCertificate` off unless `sslMode` is `VERIFY_CA`/`VERIFY_IDENTITY`. That direction is the
+deliberate one — a connection refused for an unverifiable certificate says so on screen, while a
+silent downgrade to unverified TLS says nothing at all, and the SSL / TLS panel is one click away for
+a server presenting a self-signed certificate. mysql2's
 object form (`?ssl={"rejectUnauthorized":true}`) is not a boolean and is reported in the banner rather
 than guessed at.
 
@@ -830,7 +841,8 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
 - **`cancelQuery()` returns `true` on `KILL QUERY` success** without confirming the target was
   actually executing.
 - **Cloud SSL auto-detect uses `rejectUnauthorized: false`** — encrypted but **not** authenticated
-  (MITM-exposed). For verified TLS, set an explicit `connection.ssl` with mode `verify-ca`/`verify-full`
+  (MITM-exposed). For verified TLS, set an explicit `connection.ssl` with mode `verify-system` (nothing
+  to paste) or `verify-ca`/`verify-full`
   and a `caCert`.
 
 ---

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -466,6 +466,13 @@ first-class `DatabaseConnection` field and independent of the form's `connection
 even though this form shows no TLS row of its own, and an explicit `disable` turns TLS **off** as
 firmly as an explicit mode turns it on (the #264 lesson).
 
+`verify-system` (D26) is the mode that DESCRIBES this transport: `fetch` always verifies the chain
+against the platform's certificate store and cannot be told otherwise, so of the four non-`disable`
+modes it is the only one whose name matches the handshake. `require` here does not mean "encrypt
+without checking" the way it does on the driver-based providers — nothing in this transport can skip a
+check — and `verify-ca`/`verify-full` cannot pin against a pasted CA. Nothing in the code branches on
+which one is selected.
+
 **The port is not changed by TLS**: this product serves HTTPS on the same `9200`, so there is no
 second well-known number to fall back to, and inventing one would send credentials to a port nothing is
 listening on.

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -240,6 +240,7 @@ things the driver understands:
 |------------|----------------|--------------------|----------------|
 | absent / `disable` | `host:port/service` | not set | — (plaintext) |
 | `require` | `tcps://host:port/service` | `false` | **yes** (unavoidable) |
+| `verify-system` | `tcps://host:port/service` | `true` | yes, against the runtime's own roots |
 | `verify-ca` | `tcps://host:port/service` | `false` | yes |
 | `verify-full` | `tcps://host:port/service` | `true` | yes |
 
@@ -252,6 +253,14 @@ the same string to `tls.createSecureContext()` as `cert`, `key` **and** `ca`.
 > `ssl.rejectUnauthorized: false` has nothing to map to. A server with a self-signed certificate is
 > reachable only by supplying its CA in `caCert`. `require` and `verify-ca` therefore differ from
 > `verify-full` only in the **DN/hostname** match, which is the one check Oracle does expose.
+>
+> `verify-system` (D26) asks for that same match. What separates it from `verify-full` here is what it
+> does NOT send: with no PEM pasted there is no `walletContent`, so `tls.connect` falls back to Node's
+> bundled roots for the chain — which is exactly what the mode means. Audited in the installed driver:
+> `oracledb/lib/thin/sqlnet/ntTcp.js` runs `tls.checkServerIdentity(hostName, cert)` when
+> `sslServerDNMatch` is on and no `sslServerCertDN` is configured. Not exercised against a TLS
+> listener (the probe instance speaks TCP), so this is the driver's audited shape and no claim about a
+> verified handshake.
 
 > Note: a pasted `connectionString` is returned **verbatim**, so its own protocol (or full TNS
 > descriptor) decides whether the transport is encrypted — a `require` selected alongside a `tcp`

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -214,25 +214,32 @@ const connection = {
 
 The paste box ([`connection-string-parser.ts`](../../src/lib/connection-string-parser.ts)) reads the
 query string, so `postgresql://host/db?sslmode=verify-full` arrives on the form with SSL Mode already
-set. `disable`, `require`, `verify-ca` and `verify-full` map one-to-one.
+set. `disable`, `require`, `verify-ca` and `verify-full` map one-to-one. `verify-system` is not in
+that table: it is the form's own mode name, not a libpq one, so `?sslmode=verify-system` is reported
+as a parameter we cannot honour rather than accepted.
 
 `prefer` and `allow` are **not** mapped, and neither is any spelling the map does not know. Both mean
-"encrypt if the server offers it", which the form's four modes cannot express, and both directions of
+"encrypt if the server offers it", which no mode on the form can express, and both directions of
 guess are wrong against a live server: measured on postgres 18 with no server certificate,
 `?sslmode=prefer` connects with `pg_stat_ssl.ssl = f` while `?sslmode=require` is refused outright
 ("server does not support SSL, but SSL was required"). So the mode the form already holds is left
 alone and the paste banner names the parameter it declined to act on — the string is never silently
 downgraded to "disable". Set SSL Mode yourself in the SSL / TLS panel.
 
-`?ssl=true` / `?ssl=false` (the JDBC and Heroku spelling) map to `require` / `disable`, since neither
-is opportunistic. **`require` here means `rejectUnauthorized: false`**
-([postgres.ts:793](../../src/lib/db/providers/sql/postgres.ts)) — encrypted, chain **not** verified —
-while `pg` given `ssl: true` verifies by default, so this mapping is weaker than the pasted string
-asks for. It is kept deliberately: the only stronger modes on the form, `verify-ca`/`verify-full`, are
-the ones that ask for a CA certificate, so mapping `?ssl=true` onto one of them would turn a working
-paste into a connection the user cannot complete without a PEM they may not have. The real fix is a
-mode meaning "verified against the system trust store, no PEM"; until it exists, tick `verify-full`
-yourself when the server has a publicly-trusted certificate. `sslrootcert`, `sslcert` and `sslkey` are ignored: they are paths on the machine
+`?ssl=true` / `?ssl=false` (the JDBC and Heroku spelling) map to **`verify-system`** / `disable`,
+since neither is opportunistic. The rule the parser states for every boolean TLS spelling is: it maps
+onto the mode that matches what the engine's own driver does with it, never onto a weaker one. `pg`
+given `ssl: true` connects with Node's default `rejectUnauthorized: true`, so `verify-system` — chain
+and host name checked against the runtime's trust store, no PEM to paste — is that mode.
+
+This used to map to `require`, which here means `rejectUnauthorized: false` (encrypted, chain **not**
+verified), because the form had no mode that both verified and asked for nothing: `verify-ca` and
+`verify-full` are the modes that want a CA certificate, so pointing `?ssl=true` at one of them turned
+a working paste into a connection the user could not complete. `verify-system` is that missing mode
+(D26), so a Neon / Supabase / RDS URL now arrives verified and complete. Pick `verify-ca`/`verify-full`
+only when the server's certificate is signed by a CA the runtime does not already trust.
+
+`sslrootcert`, `sslcert` and `sslkey` are ignored: they are paths on the machine
 that wrote the string, while the panel holds PEM text and the process that opens the connection is the
 server. Paste the certificate content instead.
 
@@ -280,9 +287,14 @@ oracledb expose no pool-level `error` event at all, which is recorded at each pr
 `buildSSLConfig()` ([postgres.ts:342](../../src/lib/db/providers/sql/postgres.ts)) resolves SSL with
 this precedence:
 
-1. **Explicit `connection.ssl`** (`SSLConfig`, mode = `disable` | `require` | `verify-ca` | `verify-full`):
+1. **Explicit `connection.ssl`** (`SSLConfig`, mode = `disable` | `require` | `verify-system` |
+   `verify-ca` | `verify-full`):
    - `disable` → no SSL.
-   - `verify-ca` / `verify-full` → `rejectUnauthorized: true`; otherwise `false`.
+   - `require` → `rejectUnauthorized: false` — the ONE mode that encrypts without verifying.
+   - `verify-system` / `verify-ca` / `verify-full` → `rejectUnauthorized: true`. `verify-system`
+     passes no `ca`, so Node's own trust store checks the chain and the host name; the other two
+     verify against `caCert` when one is supplied. `pg` exposes no separate name check, so
+     `verify-ca` and `verify-full` build the same object here.
    - `caCert` / `clientCert` / `clientKey` map to `ca` / `cert` / `key`.
 2. **`options.ssl === true` or cloud auto-detect** — `shouldEnableSSL()` returns true when
    `options.ssl === true` *or* the host matches a known managed provider, enabling
@@ -962,8 +974,10 @@ await provider.disconnect();
 - **Cloud SSL auto-detect does not verify the server certificate.** When SSL is enabled by host
   heuristic (`shouldEnableSSL()`), it uses `rejectUnauthorized: false` — the connection is encrypted
   but **not authenticated**, so it is exposed to man-in-the-middle attacks. For verified TLS, set an
-  explicit `connection.ssl` with mode `verify-ca`/`verify-full` and a `caCert`. *Future:* prefer
-  verifying modes by default and treat the heuristic as encryption-only opportunistic TLS.
+  explicit `connection.ssl` with mode `verify-system` (nothing to paste — the runtime's trust store
+  checks the chain, which is what a managed provider's certificate needs) or `verify-ca`/`verify-full`
+  with a `caCert`. *Future:* prefer verifying modes by default and treat the heuristic as
+  encryption-only opportunistic TLS.
 
 ---
 

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -277,12 +277,16 @@ under Node's own names — the same mapping the PostgreSQL, MySQL and Couchbase 
 |------------|--------------|
 | absent / `disable` | **not present at all** — ioredis negotiates TLS whenever `tls` is set, `{}` included |
 | `require` | `{ rejectUnauthorized: false }` |
+| `verify-system` | `{ rejectUnauthorized: true }`, with no `ca` — the runtime's own trust store |
 | `verify-ca` / `verify-full` | `{ rejectUnauthorized: true }` |
 
 `caCert` / `clientCert` / `clientKey` become `ca` / `cert` / `key` when set, each independently — a
 server can demand mutual TLS while presenting a self-signed certificate itself. An explicit
 `ssl.rejectUnauthorized` always wins over the mode. `require` does not check the chain because a
-self-hosted Redis presents a self-signed certificate by default.
+self-hosted Redis presents a self-signed certificate by default; every other mode does check it, and
+`verify-system` (D26) checks it against the trust store the runtime already has, so a managed Redis
+whose certificate a public root signs needs no PEM pasted at all. ioredis exposes no separate
+host-name check, so `verify-ca` and `verify-full` build the same object.
 
 Measured against a TLS-only server on 2026-08-23 (`redis:latest --port 0 --tls-port 6380`, so no
 plaintext port exists): `disable` is refused with *"Connection is closed."* and `require` connects in
@@ -292,8 +296,12 @@ does, so the pair is what distinguishes a wired path from a documented shape.
 > A pasted `rediss://` URL arrives with `mode: 'require'` and a `redis://` one with `disable`
 > ([§4.2](#42-connection-string-nuance)), so the scheme picks the mode and the panel is only needed
 > to go *further* than `require` - a verifying mode, or certificate material. `require` rather than
-> `verify-full` because that is what the ordinary `--tls-port` deployment can satisfy: a paste
-> encrypts, and never silently claims to have checked a chain.
+> `verify-system`/`verify-full` because that is what the ordinary `--tls-port` deployment can satisfy:
+> a paste encrypts, and never silently claims to have checked a chain. That is a claim about the
+> SCHEME, and it is not the rule for a boolean TLS *parameter* (D26, see
+> [postgres.md](./postgres.md#sslmode-in-a-pasted-url)): `rediss://` says only "TLS", while
+> `?ssl=true` says what a specific driver does with it. The scheme mapping is unchanged, and whether
+> it should follow the same rule is an open question on the backlog rather than a settled one.
 >
 > Measured through the parser and the provider together on 2026-08-23, against
 > `redis:latest --port 0 --tls-port 6390` with a self-signed certificate:

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -472,6 +472,7 @@ answers with nothing both while it is in flight and when it failed.
 | `supportsInlineRowEdit` | `true` — `UPDATE t SET c = v WHERE pk = v` is core SQLite DML |
 | `supportsTransactions` | **`false`** — SQLite HAS `BEGIN`, but this provider holds no session across two requests, so `POST /api/db/transaction` refuses the call. The flag describes the provider's surface, not the engine, and the trio and SANDBOX toggle are withheld rather than offered and then failed (#U13) |
 | `declaresForeignKeys` | `true` — inherited from the base capabilities; `PRAGMA foreign_key_list` reads them whether or not enforcement is on |
+| `singleWriterFile` | **absent (not `true`)** — SQLite is a file engine and is *not* single-writer at OPEN. Measured 2026-08-25 on `bun:sqlite`: a second `new Database(path, { readwrite: true })` on a WAL file this process already holds both opens and writes, because SQLite takes its file locks per transaction. LibreDB declares the flag and SQLite must not: the whole point of the agent profile here is a SECOND, `readonly: true` handle on the same file ([§12.1](#121-where-the-boundary-is)), and declaring it would have made the factory hand the agent the writable one instead |
 | `supportsMaintenance` | `true` |
 | `maintenanceOperations` | `['vacuum', 'analyze', 'reindex', 'check']` |
 | `supportsConnectionString` | **`false`** |

--- a/src/app/api/db/schema-snapshot/route.ts
+++ b/src/app/api/db/schema-snapshot/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createDatabaseProvider, withOneShotTunnel } from "@/lib/db/factory";
+import { createDatabaseProvider, findOpenSingleWriterProvider, withOneShotTunnel } from "@/lib/db/factory";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { guardRoute } from "@/lib/api/require-session";
@@ -19,17 +19,39 @@ export async function POST(request: NextRequest) {
     // schema here, and this route builds its provider outside both provider caches,
     // so the tunnel is its own to open and close. See `withOneShotTunnel`.
     return await withOneShotTunnel(connection, async (effective) => {
-      // Declared inside the scope so the provider is always torn down before the
-      // tunnel it runs over.
-      let provider = null;
+      /*
+        The handle already holding this connection's file, on an engine that admits
+        only one (`ProviderCapabilities.singleWriterFile`; `docs/BACKLOG.md` D3).
+
+        This route is the third caller of that shape, after `test-connection` and the
+        profiled acquisition, and it failed the same way: measured 2026-08-25 against
+        the released 0.13.4 image with the built-in LibreDB sample connected, it
+        answered HTTP 503 with the exclusive-lock message - so the Schema Diff tab's
+        Snapshot button, its only caller, could not read a schema the sidebar was
+        listing at that moment.
+
+        A borrowed handle answers the one question this route asks, and it is NOT this
+        route's to close: `borrowed` guards every disconnect below, because closing it
+        would close the file under the session that opened it.
+      */
+      const borrowed = findOpenSingleWriterProvider(effective);
+      // Declared inside the scope so a provider this route opened is always torn down
+      // before the tunnel it runs over.
+      let provider = borrowed;
+      const release = async () => {
+        const own = borrowed ? null : provider;
+        provider = null;
+        if (own) await own.disconnect();
+      };
       try {
-        provider = await createDatabaseProvider(effective);
-        await provider.connect();
+        if (!provider) {
+          provider = await createDatabaseProvider(effective);
+          await provider.connect();
+        }
 
         const schema = await provider.getSchema();
 
-        await provider.disconnect();
-        provider = null;
+        await release();
 
         return NextResponse.json({
           schema,
@@ -39,8 +61,9 @@ export async function POST(request: NextRequest) {
           timestamp: new Date().toISOString(),
         });
       } finally {
-        // Only reached when the block above threw before its own disconnect.
-        if (provider) {
+        // Only reached when the block above threw before its own release, and never
+        // for a borrowed handle - which this route did not open and must not close.
+        if (provider && !borrowed) {
           try {
             await provider.disconnect();
           } catch {

--- a/src/app/api/db/test-connection/route.ts
+++ b/src/app/api/db/test-connection/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createDatabaseProvider, withOneShotTunnel } from "@/lib/db/factory";
+import { createDatabaseProvider, findOpenSingleWriterProvider, withOneShotTunnel } from "@/lib/db/factory";
 import { createErrorResponse } from "@/lib/api/errors";
 import { resolveConnection } from "@/lib/seed/resolve-connection";
 import { guardRoute } from "@/lib/api/require-session";
@@ -29,16 +29,40 @@ export async function POST(req: NextRequest) {
     // tunnel's whole lifetime because nothing here is cached, so no eviction would
     // ever close a pooled one - and every failed test click would strand it.
     return await withOneShotTunnel(connection, async (effective) => {
-      // Declared inside the scope so the provider is always torn down before the
-      // tunnel it runs over, on the success and the failure path alike.
-      let provider = null;
+      /*
+        The handle already holding this connection's file, on an engine that admits
+        only one (`ProviderCapabilities.singleWriterFile`; `docs/BACKLOG.md` D3).
+
+        Building a second provider there does not test the connection - it is refused
+        by the exclusive lock the LIVE connection holds, and this route reported that
+        as a failed connection test. Since the dialog gates its save on this answer,
+        the built-in LibreDB sample could not be edited at all: the modal tested the
+        edited copy, hit the sample's own lock, and discarded the edit with a toast
+        about a connection error.
+
+        A borrowed handle answers both of this route's questions - the file is open,
+        and here is its health - so it is reused. It is NOT this route's to close:
+        `borrowed` guards every disconnect below, because closing it would close the
+        file under the session that opened it.
+      */
+      const borrowed = findOpenSingleWriterProvider(effective);
+      // Both declared inside the scope so a provider this route opened is always torn
+      // down before the tunnel it runs over, on the success and the failure path alike.
+      let provider = borrowed;
+      const release = async () => {
+        const own = borrowed ? null : provider;
+        provider = null;
+        if (own) await own.disconnect();
+      };
       try {
-        provider = await createDatabaseProvider(effective, { queryTimeout: 10000 });
-        // The connection itself: every provider's connect() reaches the server and is
-        // refused by a wrong host, port, credential or database - the SQL ones borrow a
-        // pooled client, and the HTTP ones send a probe statement. So a connect that
-        // returns is the fact this route exists to establish.
-        await provider.connect();
+        if (!provider) {
+          provider = await createDatabaseProvider(effective, { queryTimeout: 10000 });
+          // The connection itself: every provider's connect() reaches the server and is
+          // refused by a wrong host, port, credential or database - the SQL ones borrow a
+          // pooled client, and the HTTP ones send a probe statement. So a connect that
+          // returns is the fact this route exists to establish.
+          await provider.connect();
+        }
 
         /*
           The health read is a SECOND fact, and conflating the two is the defect this
@@ -60,8 +84,7 @@ export async function POST(req: NextRequest) {
         try {
           await provider.getHealth();
         } catch (healthError) {
-          await provider.disconnect();
-          provider = null;
+          await release();
 
           return NextResponse.json({
             success: true,
@@ -73,8 +96,7 @@ export async function POST(req: NextRequest) {
         }
         const latency = Date.now() - startTime;
 
-        await provider.disconnect();
-        provider = null;
+        await release();
 
         return NextResponse.json({
           success: true,
@@ -82,8 +104,9 @@ export async function POST(req: NextRequest) {
           latency,
         });
       } finally {
-        // Only reached when the block above threw before its own disconnect.
-        if (provider) {
+        // Only reached when the block above threw before its own release, and never
+        // for a borrowed handle - which this route did not open and must not close.
+        if (provider && !borrowed) {
           try {
             await provider.disconnect();
           } catch {

--- a/src/components/ConnectionModal.tsx
+++ b/src/components/ConnectionModal.tsx
@@ -21,6 +21,7 @@ import {
   Link,
   CircleCheck,
   CircleX,
+  TriangleAlert,
   ClipboardPaste,
   Lock,
   ChevronDown,
@@ -34,6 +35,24 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useConnectionForm } from "@/hooks/use-connection-form";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { WireCompatibilityHint } from "@/components/WireCompatibilityHint";
+
+/**
+ * What each SSL mode actually does, in the panel where it is chosen.
+ *
+ * `verify-system` is the one that needs the sentence most (D26): without it a reader cannot
+ * tell it from `verify-ca` and goes looking for a CA file that mode does not want. The
+ * SSLMode union is published (src/lib/types.ts), so this Record is exhaustive by type - a
+ * mode added there without copy here fails typecheck rather than rendering an empty hint.
+ */
+const SSL_MODE_HINTS: Record<SSLMode, string> = {
+  disable: "Plaintext. Nothing is encrypted.",
+  require: "Encrypts but verifies nothing - any certificate is accepted, including a forged one.",
+  "verify-system":
+    "Encrypts and verifies the certificate chain and host name against the system trust store - no certificate to paste. Use this for a managed endpoint (Neon, Supabase, Atlas, RDS, Capella).",
+  "verify-ca": "Encrypts and verifies the chain against the CA certificate below. Paste one for a private CA.",
+  "verify-full":
+    "Encrypts and verifies the chain against the CA certificate below, and that it names the host you typed.",
+};
 
 interface ConnectionModalProps {
   isOpen: boolean;
@@ -658,22 +677,27 @@ export function ConnectionModal({
                       <div className="space-y-2">
                         <Label className="text-xs font-mediumr text-fg-muted">SSL Mode</Label>
                         <div className="flex flex-wrap gap-1.5">
-                          {(["disable", "require", "verify-ca", "verify-full"] as SSLMode[]).map((mode) => (
-                            <button
-                              key={mode}
-                              type="button"
-                              onClick={() => setSSLMode(mode)}
-                              className={cn(
-                                "px-2.5 py-1.5 rounded-md text-xs font-mediumr transition-all border",
-                                sslMode === mode
-                                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
-                                  : "border-transparent text-fg-muted hover:text-fg-secondary hover:bg-fill",
-                              )}
-                            >
-                              {mode}
-                            </button>
-                          ))}
+                          {(["disable", "require", "verify-system", "verify-ca", "verify-full"] as SSLMode[]).map(
+                            (mode) => (
+                              <button
+                                key={mode}
+                                type="button"
+                                onClick={() => setSSLMode(mode)}
+                                className={cn(
+                                  "px-2.5 py-1.5 rounded-md text-xs font-mediumr transition-all border",
+                                  sslMode === mode
+                                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                                    : "border-transparent text-fg-muted hover:text-fg-secondary hover:bg-fill",
+                                )}
+                              >
+                                {mode}
+                              </button>
+                            ),
+                          )}
                         </div>
+                        <p data-testid="ssl-mode-hint" className="text-xs text-fg-muted">
+                          {SSL_MODE_HINTS[sslMode]}
+                        </p>
                       </div>
                       {sslMode !== "disable" && (
                         <div className="space-y-3">
@@ -869,15 +893,21 @@ export function ConnectionModal({
                 className="overflow-hidden"
               >
                 <div
+                  data-testid="connection-test-result"
+                  data-tone={testResult.tone}
                   className={cn(
                     "flex items-center gap-2 p-3 rounded-lg border text-xs",
-                    testResult.success
+                    testResult.tone === "success"
                       ? "bg-emerald-500/5 border-emerald-500/20 text-emerald-400"
-                      : "bg-red-500/5 border-red-500/20 text-red-400",
+                      : testResult.tone === "warning"
+                        ? "bg-amber-500/5 border-amber-500/20 text-amber-400"
+                        : "bg-red-500/5 border-red-500/20 text-red-400",
                   )}
                 >
-                  {testResult.success ? (
+                  {testResult.tone === "success" ? (
                     <CircleCheck strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
+                  ) : testResult.tone === "warning" ? (
+                    <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
                   ) : (
                     <CircleX strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
                   )}

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -115,6 +115,16 @@ function degradedSentence(result: TestOutcome): string {
   return result.message ?? result.error ?? "Connected, but this server answered no health data.";
 }
 
+/**
+ * The banner's three renderings. `success` and `error` are the two outcomes the
+ * banner always had; `warning` is the missing third one (#U19) - a caution that is
+ * neither a completed action nor a refusal, such as a degraded connect/save offer or
+ * a paste that filled the form but could not apply one setting. A single field
+ * instead of `success` plus a `degraded` flag, because two booleans read together is
+ * exactly the shape that let a caution wear a green tick in the first place.
+ */
+type TestResultTone = "success" | "warning" | "error";
+
 export function useConnectionForm({ isOpen, onConnect, editConnection, onTestConnection }: UseConnectionFormProps) {
   const [type, setType] = useState<DatabaseType>("postgres");
   const [name, setName] = useState("");
@@ -127,7 +137,9 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
   const [connectionString, setConnectionString] = useState("");
   const [mongoConnectionMode, setMongoConnectionMode] = useState<"host" | "connectionString">("host");
   const [environment, setEnvironment] = useState<ConnectionEnvironment>("local");
-  const [testResult, setTestResult] = useState<{ success: boolean; message: string; latency?: number } | null>(null);
+  const [testResult, setTestResult] = useState<{ tone: TestResultTone; message: string; latency?: number } | null>(
+    null,
+  );
   const [pasteInput, setPasteInput] = useState("");
   const [showPasteInput, setShowPasteInput] = useState(false);
   /** Whether the user has been shown, and clicked past, a connection with no health surface. */
@@ -405,19 +417,21 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       const result = await probeConnection(buildConnection());
 
       setTestResult({
-        success: result.success,
+        // A degraded connection IS connected, so it is not an error - but saying
+        // "Connected successfully" and nothing else is what hid the missing
+        // monitoring surface until the dashboard showed an error page. It is not a
+        // plain success either: it is the same caution `handleConnect` offers below,
+        // so it gets the same warning tone rather than the green tick.
+        tone: !result.success ? "error" : result.degraded ? "warning" : "success",
         message: result.success
-          ? // A degraded connection IS connected, so it stays a success - but saying
-            // "Connected successfully" and nothing else is what hid the missing
-            // monitoring surface until the dashboard showed an error page.
-            result.degraded
+          ? result.degraded
             ? degradedSentence(result)
             : `Connected successfully${result.latency ? ` (${result.latency}ms)` : ""}`
           : result.error || "Connection failed",
         latency: result.latency,
       });
     } catch {
-      setTestResult({ success: false, message: "Network error - could not reach server" });
+      setTestResult({ tone: "error", message: "Network error - could not reach server" });
     } finally {
       setIsTesting(false);
     }
@@ -432,7 +446,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       const result = await probeConnection(conn);
 
       if (!result.success) {
-        setTestResult({ success: false, message: result.error || "Connection failed" });
+        setTestResult({ tone: "error", message: result.error || "Connection failed" });
         return;
       }
 
@@ -452,7 +466,12 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       if (result.degraded === true && !degradedSaveAcknowledged) {
         setDegradedSaveAcknowledged(true);
         setTestResult({
-          success: true,
+          // The save is being OFFERED, not refused, and not yet completed either - a
+          // sentence that asks the user to click again does not belong under a
+          // "success" tick (#U19). This is the same class as the degraded
+          // `handleTestConnection` message above: connected, but the server answered
+          // no health data.
+          tone: "warning",
           // The button's own label, because the dialog renders two of them: "Save
           // Changes" when editing and "Establish Connection" when creating, and naming
           // a button that is not on screen is worse than naming none.
@@ -473,7 +492,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       setMongoConnectionMode("host");
       setTestResult(null);
     } catch {
-      setTestResult({ success: false, message: "Network error - could not reach server" });
+      setTestResult({ tone: "error", message: "Network error - could not reach server" });
     } finally {
       setIsTesting(false);
     }
@@ -486,7 +505,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     const parsed = parseConnectionString(trimmed);
     if (!parsed) {
       setTestResult({
-        success: false,
+        tone: "error",
         // One scheme per branch in connection-string-parser.ts, and nothing else.
         // Elasticsearch, OpenSearch and Trino are absent on purpose: all three are
         // addressed by host and port like Druid, and `http(s)://` already resolves to
@@ -533,21 +552,25 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     // either end is measurably wrong in both directions (see connection-string-parser.ts).
     // So name the parameter, name the mode that is actually in force, and say where to fix it.
     //
-    // `success: false` is the affordance, not a claim that the paste failed: the modal has
-    // exactly two states for this box and renders `true` as a green tick (#449 - an
-    // affordance that contradicts its own sentence is the defect, and a green tick over
-    // "your TLS setting was dropped" is that defect in its most dangerous direction). The
-    // amber third state a warning would deserve is not worth a rendering variant with one
-    // caller, so the sentence carries the nuance: it leads with what was NOT applied and
-    // says outright that the other fields were.
+    // The paste itself worked - every other field is filled in - so this is not a
+    // failure, but a green tick over "your TLS setting was dropped" would be exactly
+    // the defect #449 names (an affordance that contradicts its own sentence), just
+    // in its most dangerous direction. Originally emitted as `success: false` for want
+    // of a third rendering (#U19 found the same missing state one branch below, in
+    // `handleConnect`'s degraded save); now that the warning tone exists for that
+    // caller too, this is the same caution and gets the same tone. The sentence still
+    // leads with what was NOT applied and says outright that the other fields were.
     if (parsed.unmappedTLSParam) {
       setTestResult({
-        success: false,
-        message: `TLS setting not applied: "${parsed.unmappedTLSParam}" has no equivalent among disable, require, verify-ca and verify-full. The other fields were filled in, but SSL Mode stays "${sslMode}" - open SSL / TLS and choose one before connecting.`,
+        tone: "warning",
+        message: `TLS setting not applied: "${parsed.unmappedTLSParam}" has no equivalent among disable, require, verify-system, verify-ca and verify-full. The other fields were filled in, but SSL Mode stays "${sslMode}" - open SSL / TLS and choose one before connecting.`,
       });
       return;
     }
-    setTestResult({ success: true, message: "Connection string parsed successfully. Review the fields and connect." });
+    setTestResult({
+      tone: "success",
+      message: "Connection string parsed successfully. Review the fields and connect.",
+    });
   }, [pasteInput, name, sslMode]);
 
   // Ordered for display (the modal renders these as a 2-column grid), and covering the whole

--- a/src/lib/connection-string-parser.ts
+++ b/src/lib/connection-string-parser.ts
@@ -17,9 +17,11 @@ export interface ParsedConnection {
    * default and the provider then speaks plaintext to a TLS port, which fails with a
    * bare "fetch failed" / "Connection is closed." and nothing pointing at the scheme.
    *
-   * `mongodb+srv://` is the one secure scheme deliberately left unset: the driver gets
-   * the URI verbatim and turns TLS on itself, WITH chain verification, so handing it
-   * our `require` (rejectUnauthorized:false, see the mode note below) would stop an
+   * `mongodb+srv://` is set too, to `verify-system`: the driver gets the URI verbatim and
+   * turns TLS on itself WITH chain verification, so that mode is a description of what
+   * happens rather than an instruction. It was deliberately left UNSET while `require`
+   * (rejectUnauthorized:false) was the only alternative, because the provider also sends
+   * an options object the driver prefers over the URI, and that would have stopped an
    * Atlas certificate being verified. Couchbase used to be excused on the same
    * "the provider re-reads the scheme" grounds, which was simply untrue: its transport
    * is HTTP-only and derives http vs https from `config.ssl` alone.
@@ -189,8 +191,9 @@ interface TLSIntent {
 
 /**
  * libpq's sslmode, minus `prefer` and `allow`. Those two are absent on purpose (see the
- * `unmappedTLSParam` note): they mean "encrypt if the server offers it", which none of the
- * four SSLMode values describes.
+ * `unmappedTLSParam` note): they mean "encrypt if the server offers it", which no SSLMode
+ * value describes. `verify-system` is not in the table either - it is this form's own mode
+ * name and not a libpq one, so a string carrying it is a string we cannot honour.
  */
 const POSTGRES_SSLMODE: Record<string, SSLMode> = {
   disable: "disable",
@@ -235,27 +238,67 @@ function mapTLSValue(param: RawParam, table: Record<string, SSLMode>): TLSIntent
 }
 
 /**
- * The boolean TLS spellings: postgres's JDBC/Heroku `ssl=true`, and MySQL's `ssl` / `useSSL`
- * (Connector/J's pre-`sslMode` switch, still written by several ORMs). A boolean has no
- * opportunistic value, so unlike `sslmode`/`ssl-mode` both ends of it are mappable.
+ * The boolean TLS spellings: postgres's JDBC/Heroku `ssl=true`, MySQL's `ssl` / `useSSL`
+ * (Connector/J's pre-`sslMode` switch, still written by several ORMs) and MongoDB's `tls` /
+ * `ssl`. A boolean has no opportunistic value, so unlike `sslmode`/`ssl-mode` both ends of it
+ * are mappable.
  *
- * DECISION (open, and deliberately not changed here): `true` maps to `require`, which in this
- * codebase means `rejectUnauthorized: false` for both engines - encrypted, chain unchecked
- * (postgres.ts:793, mysql.ts:505). That is weaker than what the pasted string asks for: `pg`
- * given `ssl=true` and mysql2 given `ssl: {}` both verify by default. It is the same weakening
- * the mongodb arm above REFUSES to perform. It is kept because the form has no "encrypted,
- * verified by the system trust store, no PEM pasted" mode: verify-ca/verify-full here are the
- * modes that ask for a CA certificate, so mapping `ssl=true` onto one of them would turn a
- * working paste into a connection the user cannot complete without a file they may not have.
- * The honest fix is a mode that means exactly `rejectUnauthorized: true` with the default trust
- * store; until that exists the mapping is documented rather than silently correct
- * (docs/providers/postgres.md, docs/providers/mysql.md).
+ * THE RULE (D26): a boolean TLS spelling is mapped onto the mode that matches what the
+ * engine's OWN driver does with it, and never onto a weaker one. `true` therefore maps to
+ * `verify-system`, because that is what the drivers do: `pg` given `ssl=true` and mysql2 given
+ * `ssl: {}` both connect with Node's default `rejectUnauthorized: true`, and the mongodb
+ * driver reads `tls=true` as TLS with chain verification. `false` maps to `disable`, which is
+ * the same rule read the other way.
+ *
+ * `require` used to be the answer for `true`, and was wrong in one direction while the mongodb
+ * refusal was wrong in the other: `require` is `rejectUnauthorized: false` in every provider
+ * that has the knob, so a paste that asked for a verified connection got an unverified one,
+ * and there was no mode to map onto that did not also demand a CA PEM the user does not have.
+ * `verify-system` (src/lib/types.ts) is that mode, so the rule above no longer has to trade
+ * security against completability.
  */
 function readBooleanTLS(param: RawParam): TLSIntent {
   const flag = param.value.toLowerCase();
-  if (flag === "true" || flag === "1") return { sslMode: "require" };
+  if (flag === "true" || flag === "1") return { sslMode: "verify-system" };
   if (flag === "false" || flag === "0") return { sslMode: "disable" };
   return { unmappedTLSParam: `${param.name}=${param.value}` };
+}
+
+/**
+ * The MongoDB URI's TLS options, read for both schemes.
+ *
+ * `tls=true` (and the driver's deprecated `ssl=` alias) goes through the boolean rule above,
+ * and `mongodb+srv://` with no TLS parameter carries the same mode: the driver turns TLS on
+ * for every SRV connection itself, WITH verification, so leaving the form on its `disable`
+ * default described a connection that is in fact encrypted as one that is not.
+ *
+ * `tlsInsecure` / `tlsAllowInvalidCertificates` pull the result back down to `require`. Both
+ * turn `rejectUnauthorized` off while leaving TLS on (mongodb.d.ts documents the mapping onto
+ * the Node names), which is exactly what `require` means here - and the provider sends its
+ * options object as a second channel the driver prefers over the URI, so a verifying mode
+ * would break a string that connects today. `tlsAllowInvalidHostnames` is NOT in that set: it
+ * relaxes the name check only, which our options object never sets, so the URI's own
+ * relaxation survives alongside a verifying mode.
+ */
+function readMongoTLS(uri: string): TLSIntent {
+  const params = new Map<string, RawParam>();
+  const queryStart = uri.indexOf("?");
+  if (queryStart >= 0) {
+    for (const [name, value] of new URLSearchParams(uri.slice(queryStart + 1))) {
+      params.set(name.toLowerCase(), { name, value });
+    }
+  }
+
+  const flag = params.get("tls") ?? params.get("ssl");
+  const intent: TLSIntent = flag
+    ? readBooleanTLS(flag)
+    : uri.startsWith("mongodb+srv://")
+      ? { sslMode: "verify-system" }
+      : {};
+
+  if (intent.sslMode === undefined || intent.sslMode === "disable") return intent;
+  const relax = params.get("tlsinsecure") ?? params.get("tlsallowinvalidcertificates");
+  return relax !== undefined && relax.value.toLowerCase() === "true" ? { sslMode: "require" } : intent;
 }
 
 /**
@@ -287,10 +330,10 @@ function readADONetTLS(get: (key: string) => string | undefined): TLSIntent {
 /**
  * The TLS a URL carries in its QUERY STRING, for the engines that put it there.
  *
- * Only postgres, mysql and mssql are read: for `rediss://`, `couchbases://` and ClickHouse's
- * `http(s)://` the scheme IS the transport and already decided, and MongoDB's `tls=true` is
- * deliberately left to the driver, which enables TLS itself WITH chain verification - our
- * `require` means rejectUnauthorized:false, so acting on it would weaken an Atlas connection.
+ * Only postgres, mysql and mssql are read here: for `rediss://`, `couchbases://` and
+ * ClickHouse's `http(s)://` the scheme IS the transport and already decided, and MongoDB's
+ * URI is read by `readMongoTLS`, which parses it by hand because `mongodb+srv://` is not a
+ * URL this function's caller can build.
  *
  * Postgres's sslrootcert/sslcert/sslkey are read by nobody here on purpose: they name files on
  * the machine that wrote the string, while the form holds PEM text and the process that opens
@@ -336,6 +379,7 @@ function parseMongoDBString(uri: string): ParsedConnection {
   const result: ParsedConnection = {
     type: "mongodb",
     connectionString: uri,
+    ...readMongoTLS(uri),
   };
 
   try {

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -14,6 +14,7 @@ import { DatabaseConfigError, ExecutionProfileError } from "./errors";
 import { createSSHTunnel, closeSSHTunnel, hasTunnel } from "@/lib/ssh/tunnel";
 import { readSecret } from "@/lib/storage/encryption";
 import { logger } from "@/lib/logger";
+import * as path from "path";
 
 // ============================================================================
 // Provider Factory
@@ -237,9 +238,59 @@ export async function withOneShotTunnel<T>(
 interface CachedProvider {
   provider: DatabaseProvider;
   lastUsed: number;
+  /**
+   * The file this entry holds open, when the provider declares
+   * `ProviderCapabilities.singleWriterFile` - see `findOpenSingleWriterProvider`.
+   * `null` on every other provider, which is all of them but one.
+   */
+  singleWriterFile?: string | null;
 }
 
 const providerCache = new Map<string, CachedProvider>();
+
+// ============================================================================
+// Single-writer file reuse (docs/BACKLOG.md D3 and B49)
+// ============================================================================
+
+/**
+ * The identity of a database FILE: the engine type plus the resolved absolute path.
+ *
+ * The path is what identifies the open handle, not the connection id, because the
+ * second opener is usually a different connection record pointing at the same file -
+ * which is exactly how D3 reproduced (the built-in "Sample (LibreDB)" holds the file
+ * while the dialog tests the edited copy under a fresh id). The type is in the key so
+ * two engines can never collide over one path.
+ *
+ * `null` when the connection carries no file path at all, which is every
+ * client-server connection and every connection-string one.
+ */
+function fileIdentity(connection: DatabaseConnection): string | null {
+  if (!connection.database) return null;
+  return `${connection.type}::${path.resolve(connection.database)}`;
+}
+
+/**
+ * The connected provider that already holds this connection's file, if there is one.
+ *
+ * Only a provider whose engine declares `ProviderCapabilities.singleWriterFile` ever
+ * registers a file identity here (`getOrCreateProvider` below), so a match means the
+ * engine admits ONE handle per file and the caller's alternative is not a second,
+ * lesser handle - it is no handle at all. Borrowers must NOT disconnect what they get
+ * back: the returned provider is owned by the writable cache and serves the user's
+ * live connection.
+ *
+ * Deliberately reads only the writable cache. The reverse direction - handing an
+ * editor request a provider opened under an execution profile - stays forbidden, so
+ * profiled entries are not offered here.
+ */
+export function findOpenSingleWriterProvider(connection: DatabaseConnection): DatabaseProvider | null {
+  const identity = fileIdentity(connection);
+  if (identity === null) return null;
+  for (const entry of providerCache.values()) {
+    if (entry.singleWriterFile === identity && entry.provider.isConnected()) return entry.provider;
+  }
+  return null;
+}
 
 // ============================================================================
 // Execution-profile provider cache (#328)
@@ -401,8 +452,10 @@ export async function getOrCreateProvider(
     throw error;
   }
 
-  // Cache it
-  providerCache.set(cacheKey, { provider, lastUsed: Date.now() });
+  // Cache it, remembering the file when this engine admits only one handle on it -
+  // that is what lets the callers that would otherwise open a second one find this.
+  const singleWriterFile = provider.getCapabilities().singleWriterFile === true ? fileIdentity(connection) : null;
+  providerCache.set(cacheKey, { provider, lastUsed: Date.now(), singleWriterFile });
 
   // Start idle sweep if not already running
   startIdleSweep();
@@ -531,6 +584,35 @@ export async function acquireExecutionProfileProvider(
   }
 
   const credential = resolveAgentCredential(connection);
+  const acquisition = PROFILE_ACQUISITION[profile];
+
+  /*
+    The single-writer exception (B49), and why it is safe HERE and nowhere else.
+
+    On an engine that declares `singleWriterFile` the file admits one open handle, so
+    opening a second one for this acquisition does not produce a less privileged
+    handle - it throws, and the run continues silently ungrounded (a `ConnectionError`
+    becomes an unavailable capture). Every agent grounding read on a LibreDB
+    connection was lost that way from the moment anyone browsed it in the sidebar.
+
+    Two bounds keep the isolation invariant intact. It is scoped to the profile that
+    sends NO statement of the model's: `agent-operations` calls the curated reporting
+    methods only, so there is nothing here for a read-only statement path to bound,
+    and `agent-read-only` / `agent-handover` are still refused on such an engine
+    rather than served the writable handle. And it is refused when the connection
+    configures an agent credential, because the borrowed handle was opened under the
+    connection's own - a reuse cannot silently substitute one principal for another.
+
+    The provider is returned WITHOUT being cached under the profiled key: it is
+    borrowed, and an entry there would let this cache's idle sweep - or a
+    `removeProvider` for any connection sharing the file - close the file under the
+    session that opened it.
+  */
+  if (!acquisition.requiresReadOnlyStatements && credential === null) {
+    const open = findOpenSingleWriterProvider(connection);
+    if (open) return open;
+  }
+
   let effectiveConnection: DatabaseConnection = credential
     ? { ...connection, user: credential.user, password: credential.password }
     : connection;
@@ -549,7 +631,6 @@ export async function acquireExecutionProfileProvider(
     if (tunnel && !tunnelPreexisted) await tunnel.close().catch(() => {});
   };
 
-  const acquisition = PROFILE_ACQUISITION[profile];
   const provider = await createDatabaseProvider(effectiveConnection, options, acquisition.context);
   if (acquisition.requiresReadOnlyStatements && typeof provider.queryReadOnly !== "function") {
     await closeFreshTunnel();

--- a/src/lib/db/providers/document/couchbase/http-transport.ts
+++ b/src/lib/db/providers/document/couchbase/http-transport.ts
@@ -269,7 +269,10 @@ function buildTlsMaterial(ssl: SSLConfig | undefined): CouchbaseTlsMaterial | nu
   // check the chain, because a self-hosted Couchbase node ships a self-signed
   // certificate by default. An explicit flag always wins.
   const material: CouchbaseTlsMaterial = {
-    rejectUnauthorized: ssl.rejectUnauthorized ?? (ssl.mode === "verify-ca" || ssl.mode === "verify-full"),
+    // `require` encrypts without checking - a self-hosted node ships a self-signed
+    // certificate - while every other mode verifies. `verify-system` verifies against the
+    // runtime's own trust store, which is what a Capella endpoint needs and all it needs (D26).
+    rejectUnauthorized: ssl.rejectUnauthorized ?? ssl.mode !== "require",
   };
   if (ssl.caCert) material.ca = ssl.caCert;
   if (ssl.clientCert) material.cert = ssl.clientCert;

--- a/src/lib/db/providers/document/mongodb.ts
+++ b/src/lib/db/providers/document/mongodb.ts
@@ -322,7 +322,10 @@ export class MongoDBProvider extends BaseDatabaseProvider {
 
     const options: MongoClientOptions = {
       tls: true,
-      rejectUnauthorized: ssl.rejectUnauthorized ?? (ssl.mode === "verify-ca" || ssl.mode === "verify-full"),
+      // `require` encrypts without checking; every other mode verifies. `verify-system`
+      // does it against the runtime's own trust store, which is what an Atlas / `tls=true`
+      // paste needs - no `ca` is set below unless the form carries one (D26).
+      rejectUnauthorized: ssl.rejectUnauthorized ?? ssl.mode !== "require",
     };
     if (ssl.caCert) options.ca = ssl.caCert;
     if (ssl.clientCert) options.cert = ssl.clientCert;

--- a/src/lib/db/providers/embedded/libredb.ts
+++ b/src/lib/db/providers/embedded/libredb.ts
@@ -161,6 +161,12 @@ export class LibreDBProvider extends BaseDatabaseProvider {
       // grouped by their prefix, so the rows are this server's summary of the keys that
       // scan reached rather than objects the engine declares (#414).
       tablesAreDerivedGroupings: true,
+      // `lib.open({ path })` takes an exclusive `<path>.lock` sidecar, so a second
+      // open of a file this process already holds throws `LOCKED` rather than
+      // returning a second handle. The two callers that used to open one - the
+      // connection test and the agent's execution-profile acquisition - reuse the open
+      // handle instead (`findOpenSingleWriterProvider`, D3 and B49).
+      singleWriterFile: true,
       supportsMaintenance: false,
       maintenanceOperations: [],
       supportsConnectionString: false,

--- a/src/lib/db/providers/keyvalue/redis.ts
+++ b/src/lib/db/providers/keyvalue/redis.ts
@@ -168,7 +168,9 @@ export class RedisProvider extends BaseDatabaseProvider {
     if (!ssl || ssl.mode === "disable") return undefined;
 
     const tls: NonNullable<RedisOptions["tls"]> = {
-      rejectUnauthorized: ssl.rejectUnauthorized ?? (ssl.mode === "verify-ca" || ssl.mode === "verify-full"),
+      // `require` encrypts without checking; every other mode verifies. `verify-system`
+      // verifies against the runtime's own trust store, with no CA PEM to paste (D26).
+      rejectUnauthorized: ssl.rejectUnauthorized ?? ssl.mode !== "require",
     };
     if (ssl.caCert) tls.ca = ssl.caCert;
     if (ssl.clientCert) tls.cert = ssl.clientCert;

--- a/src/lib/db/providers/sql/cassandra/driver-transport.ts
+++ b/src/lib/db/providers/sql/cassandra/driver-transport.ts
@@ -378,8 +378,9 @@ export function cassandraClientOptions(config: DatabaseConnection, readTimeoutMs
       ? {}
       : {
           sslOptions: {
-            // `verify-ca` and `verify-full` both mean "check the chain"; `require`
-            // means encrypt without checking. NOT exercised against a TLS cluster -
+            // `verify-system`, `verify-ca` and `verify-full` all mean "check the chain"
+            // (the first against the runtime's own trust store, since it carries no CA PEM);
+            // `require` means encrypt without checking. NOT exercised against a TLS cluster -
             // the probe instances speak plaintext - so this is the documented shape
             // of the driver's own option and no claim about a verified path.
             rejectUnauthorized: tlsMode !== "require",

--- a/src/lib/db/providers/sql/mysql.ts
+++ b/src/lib/db/providers/sql/mysql.ts
@@ -586,7 +586,11 @@ export class MySQLProvider extends SQLBaseProvider {
       if (connSSL.mode === "disable") return undefined;
 
       const ssl: mysql.SslOptions = {
-        rejectUnauthorized: connSSL.mode === "verify-ca" || connSSL.mode === "verify-full",
+        // Every mode except `require` verifies (D26): `verify-system` checks the chain against
+        // the trust store the runtime already has - no `ca` is set below, so Node's bundled
+        // roots decide - while `verify-ca`/`verify-full` check it against the PEM pasted into
+        // the form. `require` is the one mode that encrypts without checking anything.
+        rejectUnauthorized: connSSL.mode !== "require",
       };
 
       if (connSSL.caCert) ssl.ca = connSSL.caCert;

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -494,7 +494,10 @@ export class OracleProvider extends SQLBaseProvider {
     const wallet = [ssl.caCert, ssl.clientCert, ssl.clientKey].filter(Boolean).join("\n");
 
     return {
-      sslServerDNMatch: ssl.mode === "verify-full",
+      // `verify-system` asks for the same server-name match as `verify-full`; what it does
+      // NOT ask for is a wallet, so with no PEM pasted `tls.connect` falls back to Node's
+      // bundled roots for the chain - which is exactly what the mode means (D26).
+      sslServerDNMatch: ssl.mode === "verify-full" || ssl.mode === "verify-system",
       ...(wallet ? { walletContent: wallet } : {}),
     };
   }

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -801,7 +801,11 @@ export class PostgresProvider extends SQLBaseProvider {
       if (connSSL.mode === "disable") return false;
 
       const ssl: Record<string, unknown> = {
-        rejectUnauthorized: connSSL.mode === "verify-ca" || connSSL.mode === "verify-full",
+        // Every mode except `require` verifies (D26): `verify-system` checks the chain against
+        // the trust store the runtime already has - no `ca` is set below, so Node's bundled
+        // roots decide - while `verify-ca`/`verify-full` check it against the PEM pasted into
+        // the form. `require` is the one mode that encrypts without checking anything.
+        rejectUnauthorized: connSSL.mode !== "require",
       };
 
       if (connSSL.caCert) ssl.ca = connSSL.caCert;

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -289,6 +289,42 @@ export interface ProviderCapabilities {
    * reader would guess, and a third would be added to a provider and forgotten here.
    */
   tablesAreDerivedGroupings?: boolean;
+  /**
+   * True when the engine admits exactly ONE open handle per database FILE, because
+   * opening the file takes an exclusive lock: a second open of a file this process
+   * already holds does not return a second handle, it throws.
+   *
+   * `libredb` is the only engine that declares it. `lib.open({ path })` takes an
+   * exclusive `<path>.lock` sidecar and a second open of the same path throws
+   * `LibreDbError` with `code: "LOCKED"` - measured 2026-08-25 against
+   * `@libredb/libredb` 0.2.2, in one process. SQLite is the engine a reader would
+   * expect beside it and does NOT belong: measured the same day on `bun:sqlite`, a
+   * second `new Database(path, { readwrite: true })` on a WAL file this process
+   * already holds both opens and writes, because SQLite takes its file locks per
+   * transaction rather than at open.
+   *
+   * It exists because three code paths open a SECOND handle on a file the connection's
+   * own cached provider is already holding, and on this engine the lock defeated every
+   * one of them every time (`docs/BACKLOG.md` D3 and B49): `POST /api/db/test-connection`
+   * reported the lock as a failed connection test - which made the built-in LibreDB
+   * sample impossible to EDIT, because the dialog tests before it saves;
+   * `acquireExecutionProfileProvider` lost every agent grounding read on the
+   * connection to it, silently, since a `ConnectionError` becomes an unavailable
+   * capture rather than a failure; and `POST /api/db/schema-snapshot` answered 503, so
+   * the Schema Diff tab could not snapshot a schema the sidebar was listing.
+   * `findOpenSingleWriterProvider` (`factory.ts`) now hands all three the handle that
+   * is already open, keyed by the RESOLVED FILE PATH rather than the connection id: the
+   * second opener is usually a different connection record pointing at the same file.
+   *
+   * Optional for the same published-interface reason as `supportsInlineRowEdit`
+   * (`src/exports/types.ts`): a required field added after the fact stops every
+   * external implementer compiling. Consumers therefore gate on `=== true`, so an
+   * absent flag reads as "this engine serves as many handles as we open" - the
+   * ordinary case, and the one every client-server engine is in. Reading
+   * `connection.type` at the consumer was the alternative and is forbidden by
+   * `CLAUDE.md`.
+   */
+  singleWriterFile?: boolean;
   supportsMaintenance: boolean;
   maintenanceOperations: MaintenanceType[];
   /**

--- a/src/lib/seed/types.ts
+++ b/src/lib/seed/types.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 import type { DatabaseConnection } from "@/lib/types";
 
-// SSLMode matches src/lib/types.ts line 21 — NO 'prefer'
-const SSLModeSchema = z.enum(["disable", "require", "verify-ca", "verify-full"]);
+// SSLMode matches the union in src/lib/types.ts — NO 'prefer'. Kept in step BY HAND: a zod
+// enum is a value, so a mode missing here is not a compile error, it is a seed file the
+// server rejects with "invalid enum value" for a mode the product supports.
+const SSLModeSchema = z.enum(["disable", "require", "verify-system", "verify-ca", "verify-full"]);
 
 const SSLConfigSchema = z
   .object({

--- a/src/lib/storage/providers/postgres.ts
+++ b/src/lib/storage/providers/postgres.ts
@@ -162,6 +162,15 @@ export class PostgresStorageProvider implements ServerStorageProvider {
 
     const sslMode = searchParams.get("sslmode")?.toLowerCase();
     if (sslMode === "disable") return false;
+    // `verify-system` is not a libpq sslmode - it is this product's own mode name
+    // (src/lib/types.ts), and someone configuring STORAGE_POSTGRES_URL from the connection
+    // form's vocabulary will write it. It means "verify against the runtime's trust store",
+    // so it is the one value here that turns verification ON; without this branch it fell
+    // through to the non-local default below and got `rejectUnauthorized: false`, i.e. the
+    // opposite of what it says (D26). The libpq spellings keep their existing behaviour: this
+    // pool has no channel for a CA PEM, so a verifying default would break every deployment
+    // whose storage database presents a self-signed certificate.
+    if (sslMode === "verify-system") return { rejectUnauthorized: true };
     if (sslMode === "require" || sslMode === "prefer" || sslMode === "verify-ca" || sslMode === "verify-full") {
       return { rejectUnauthorized: false };
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,7 +52,35 @@ export const ENVIRONMENT_LABELS: Record<ConnectionEnvironment, string> = {
   other: "",
 };
 
-export type SSLMode = "disable" | "require" | "verify-ca" | "verify-full";
+/**
+ * How much TLS a connection asks for.
+ *
+ * `disable` sends plaintext. `require` encrypts and verifies NOTHING: every provider that
+ * has the knob maps it to `rejectUnauthorized: false`, because a self-hosted server
+ * ordinarily presents a self-signed certificate and refusing it would make the ordinary
+ * local TLS deployment unreachable.
+ *
+ * `verify-system` encrypts AND verifies, with nothing to paste: the chain is checked against
+ * the trust store the runtime already has (Node's bundled roots plus whatever the host adds)
+ * and the certificate must name the host we dialled - `rejectUnauthorized: true` with no
+ * `ca`. It is deliberately NOT "verify-ca with the field left blank": `verify-ca` and
+ * `verify-full` exist to pin a chain against a `caCert` PEM the user supplies, which is the
+ * only way to reach a server whose certificate no public root signs, and a form that asks
+ * for a file the user does not have is a connection they cannot complete. `verify-system` is
+ * what a managed endpoint (Neon, Supabase, Atlas, RDS, Capella) can satisfy as pasted, which
+ * is why it is the mode a boolean `?ssl=true` / `?tls=true` in a connection string maps onto
+ * (see `readBooleanTLS` in src/lib/connection-string-parser.ts for the rule).
+ *
+ * `verify-ca` checks the chain and `verify-full` also the server name. That split is honoured
+ * only where the driver exposes the name check on its own - Oracle's `sslServerDNMatch` is
+ * the one that does; the Node TLS drivers cannot separate the two, so both land on
+ * `rejectUnauthorized: true` there and each provider doc says so.
+ *
+ * Adding a member here widens a published type (src/exports/types.ts), so every switch and
+ * lookup table over SSLMode has to answer for it: the providers listed above, the seed schema
+ * (src/lib/seed/types.ts), the PostgreSQL storage backend and the connection form.
+ */
+export type SSLMode = "disable" | "require" | "verify-system" | "verify-ca" | "verify-full";
 
 export interface SSLConfig {
   mode: SSLMode;

--- a/tests/api/db/schema-snapshot.test.ts
+++ b/tests/api/db/schema-snapshot.test.ts
@@ -54,9 +54,12 @@ const mockWithOneShotTunnel = mock(
     await run({ ...connection, host: "127.0.0.1", port: 54321 }),
 );
 
+const mockFindOpenSingleWriterProvider = mock((_connection: Record<string, unknown>) => null as unknown);
+
 mock.module("@/lib/db/factory", () => ({
   getOrCreateProvider: mock(async () => mockProvider),
   createDatabaseProvider: mockCreateDatabaseProvider,
+  findOpenSingleWriterProvider: mockFindOpenSingleWriterProvider,
   withOneShotTunnel: mockWithOneShotTunnel,
 }));
 
@@ -85,6 +88,8 @@ describe("POST /api/db/schema-snapshot", () => {
     // Reset implementations
     (mockProvider.connect as ReturnType<typeof mock>).mockImplementation(async () => {});
     (mockProvider.disconnect as ReturnType<typeof mock>).mockImplementation(async () => {});
+    mockFindOpenSingleWriterProvider.mockClear();
+    mockFindOpenSingleWriterProvider.mockImplementation(() => null);
     mockGetSession.mockClear();
     mockGetSession.mockImplementation(
       async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
@@ -228,5 +233,59 @@ describe("POST /api/db/schema-snapshot", () => {
     expect(mockWithOneShotTunnel).toHaveBeenCalledTimes(1);
     expect(mockWithOneShotTunnel.mock.calls[0]?.[0]).toMatchObject({ host: "db.internal" });
     expect(mockCreateDatabaseProvider.mock.calls[0]?.[0]).toMatchObject({ host: "127.0.0.1", port: 54321 });
+  });
+
+  // ─── Single-writer file reuse (docs/BACKLOG.md D3) ────────────────────────
+  // Measured 2026-08-25 against the released 0.13.4 image: with the built-in LibreDB
+  // sample connected, this route answered HTTP 503 "LibreDB file is already open by
+  // another process (exclusive lock)" - so the Schema Diff tab's Snapshot button, its
+  // only caller, could not read a schema the sidebar was showing at that moment. The
+  // third caller of this shape after test-connection and the profiled acquisition.
+
+  test("borrows the handle already holding a single-writer file instead of opening a second one", async () => {
+    mockCreateDatabaseProvider.mockClear();
+    const borrowed = {
+      connect: mock(async () => {}),
+      disconnect: mock(async () => {}),
+      getSchema: mock(async () => ({ tables: [{ name: "borrowed" }] })),
+    };
+    mockFindOpenSingleWriterProvider.mockImplementation(() => borrowed);
+
+    const req = createMockRequest("/api/db/schema-snapshot", {
+      method: "POST",
+      body: { connection: { ...validConnection, type: "libredb", database: "/tmp/held.libredb" } },
+    });
+
+    const res = await POST(req as never);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.schema).toEqual({ tables: [{ name: "borrowed" }] });
+    // No second handle was built, and the borrowed one was neither opened nor closed
+    // by this route: it belongs to the live connection that opened it.
+    expect(mockCreateDatabaseProvider).not.toHaveBeenCalled();
+    expect(borrowed.connect).not.toHaveBeenCalled();
+    expect(borrowed.disconnect).not.toHaveBeenCalled();
+  });
+
+  test("a borrowed handle is not closed when the schema read fails", async () => {
+    const borrowed = {
+      connect: mock(async () => {}),
+      disconnect: mock(async () => {}),
+      getSchema: mock(async () => {
+        throw new Error("catalog read refused");
+      }),
+    };
+    mockFindOpenSingleWriterProvider.mockImplementation(() => borrowed);
+
+    const req = createMockRequest("/api/db/schema-snapshot", {
+      method: "POST",
+      body: { connection: { ...validConnection, type: "libredb", database: "/tmp/held.libredb" } },
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(500);
+    expect(borrowed.disconnect).not.toHaveBeenCalled();
   });
 });

--- a/tests/api/db/test-connection.test.ts
+++ b/tests/api/db/test-connection.test.ts
@@ -13,6 +13,13 @@ const mockCreateDatabaseProvider = mock(async (connection?: unknown) => {
   return mockProvider;
 });
 
+/**
+ * The writable provider already holding a single-writer file, when one is open
+ * (`docs/BACKLOG.md` D3). Null by default: every engine but LibreDB is in that state.
+ */
+const borrowedProvider = createMockProvider();
+const mockFindOpenSingleWriterProvider = mock((): unknown => null);
+
 const mockGetSession = mock(
   async (): Promise<{ role: string; username: string } | null> => ({ role: "admin", username: "admin" }),
 );
@@ -66,6 +73,7 @@ const mockWithOneShotTunnel = mock(
 // ─── Mock dependencies BEFORE importing route ───────────────────────────────
 mock.module("@/lib/db/factory", () => ({
   createDatabaseProvider: mockCreateDatabaseProvider,
+  findOpenSingleWriterProvider: mockFindOpenSingleWriterProvider,
   withOneShotTunnel: mockWithOneShotTunnel,
   getOrCreateProvider: mock(async () => mockProvider),
   removeProvider: mock(async () => {}),
@@ -96,6 +104,18 @@ describe("POST /api/db/test-connection", () => {
     (mockProvider.connect as ReturnType<typeof mock>).mockClear();
     (mockProvider.disconnect as ReturnType<typeof mock>).mockClear();
     (mockProvider.getHealth as ReturnType<typeof mock>).mockClear();
+    mockFindOpenSingleWriterProvider.mockClear();
+    mockFindOpenSingleWriterProvider.mockImplementation(() => null);
+    for (const method of ["connect", "disconnect", "getHealth"] as const) {
+      (borrowedProvider[method] as ReturnType<typeof mock>).mockClear();
+    }
+    (borrowedProvider.getHealth as ReturnType<typeof mock>).mockImplementation(async () => ({
+      activeConnections: 1,
+      databaseSize: "12 KB",
+      cacheHitRatio: "N/A",
+      slowQueries: [],
+      activeSessions: [],
+    }));
 
     // Reset implementations to defaults
     mockGetSession.mockClear();
@@ -359,5 +379,85 @@ describe("POST /api/db/test-connection", () => {
     await POST(req as never);
 
     expect(disconnectsAtScopeExit).toBe(1);
+  });
+  // ─── Single-writer files (docs/BACKLOG.md D3) ─────────────────────────────
+  // An engine that declares `ProviderCapabilities.singleWriterFile` admits ONE handle
+  // per file, so building a second provider to test it is refused by the lock the live
+  // connection itself holds. The dialog tests before it saves, so that made the
+  // built-in LibreDB sample impossible to EDIT: the edit was discarded with a toast
+  // about a connection error, as if the sample were broken.
+
+  test("reuses the provider already holding a single-writer file instead of opening a second one", async () => {
+    mockFindOpenSingleWriterProvider.mockImplementation(() => borrowedProvider);
+
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: { ...validConnection, type: "libredb", database: "/data/sample.libredb" },
+    });
+
+    const data = await parseResponseJSON<{ success: boolean; message: string; latency: number }>(
+      await POST(req as never),
+    );
+
+    expect(data.success).toBe(true);
+    expect(data.message).toBe("Connection successful");
+    expect(typeof data.latency).toBe("number");
+    // No second handle was built, and the open one was not re-connected.
+    expect(mockCreateDatabaseProvider).not.toHaveBeenCalled();
+    expect(borrowedProvider.connect).not.toHaveBeenCalled();
+    expect(borrowedProvider.getHealth).toHaveBeenCalledTimes(1);
+  });
+
+  test("never disconnects a provider it borrowed", async () => {
+    // Closing it would close the file under the live connection that opened it - the
+    // editor's own session - which is worse than the failed test this replaced.
+    mockFindOpenSingleWriterProvider.mockImplementation(() => borrowedProvider);
+
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: { ...validConnection, type: "libredb", database: "/data/sample.libredb" },
+    });
+
+    await POST(req as never);
+
+    expect(borrowedProvider.disconnect).not.toHaveBeenCalled();
+    expect(disconnectsAtScopeExit).toBe(0);
+  });
+
+  test("a failed health read on a borrowed provider is a degraded success, and still closes nothing", async () => {
+    mockFindOpenSingleWriterProvider.mockImplementation(() => borrowedProvider);
+    (borrowedProvider.getHealth as ReturnType<typeof mock>).mockImplementation(async () => {
+      throw new Error("no monitoring endpoint");
+    });
+
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: { ...validConnection, type: "libredb", database: "/data/sample.libredb" },
+    });
+
+    const data = await parseResponseJSON<{ success: boolean; degraded?: boolean; message: string }>(
+      await POST(req as never),
+    );
+
+    expect(data.success).toBe(true);
+    expect(data.degraded).toBe(true);
+    expect(data.message).toContain("no monitoring endpoint");
+    expect(borrowedProvider.disconnect).not.toHaveBeenCalled();
+  });
+
+  test("builds its own provider when nothing holds the file, and closes that one", async () => {
+    // The other half: reuse is not a new default. With no open handle the route opens,
+    // tests and closes its own, exactly as it does for every client-server engine.
+    const req = createMockRequest("/api/db/test-connection", {
+      method: "POST",
+      body: { ...validConnection, type: "libredb", database: "/data/other.libredb" },
+    });
+
+    await POST(req as never);
+
+    expect(mockFindOpenSingleWriterProvider).toHaveBeenCalledTimes(1);
+    expect(mockCreateDatabaseProvider).toHaveBeenCalledTimes(1);
+    expect(mockProvider.connect).toHaveBeenCalledTimes(1);
+    expect(mockProvider.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/components/ConnectionModal.test.tsx
+++ b/tests/components/ConnectionModal.test.tsx
@@ -512,19 +512,37 @@ describe("ConnectionModal", () => {
   // ── 20. Test result success displayed ──────────────────────────────────
 
   test("test result success message displayed", () => {
-    mockFormOverrides = { testResult: { success: true, message: "Connection successful" } };
+    mockFormOverrides = { testResult: { tone: "success", message: "Connection successful" } };
     const props = createDefaultProps();
-    const { queryByText } = render(React.createElement(ConnectionModal, props));
+    const { queryByText, getByTestId } = render(React.createElement(ConnectionModal, props));
     expect(queryByText("Connection successful")).not.toBeNull();
+    expect(getByTestId("connection-test-result").getAttribute("data-tone")).toBe("success");
   });
 
   // ── 21. Test result failure displayed ──────────────────────────────────
 
   test("test result failure message displayed", () => {
-    mockFormOverrides = { testResult: { success: false, message: "Connection failed: timeout" } };
+    mockFormOverrides = { testResult: { tone: "error", message: "Connection failed: timeout" } };
     const props = createDefaultProps();
-    const { queryByText } = render(React.createElement(ConnectionModal, props));
+    const { queryByText, getByTestId } = render(React.createElement(ConnectionModal, props));
     expect(queryByText("Connection failed: timeout")).not.toBeNull();
+    expect(getByTestId("connection-test-result").getAttribute("data-tone")).toBe("error");
+  });
+
+  // ── 21b. Test result warning displayed (#U19) ────────────────────────────
+
+  test("test result warning message renders as neither success nor failure", () => {
+    // A degraded save/connect asks the user to act again - it is not a completed
+    // action and not a refusal either, so it must not render as the success
+    // (emerald/CircleCheck) or error (red/CircleX) tone.
+    mockFormOverrides = {
+      testResult: { tone: "warning", message: "Connected, but this server answered no health data." },
+    };
+    const props = createDefaultProps();
+    const { queryByText, getByTestId } = render(React.createElement(ConnectionModal, props));
+    expect(queryByText("Connected, but this server answered no health data.")).not.toBeNull();
+    const banner = getByTestId("connection-test-result");
+    expect(banner.getAttribute("data-tone")).toBe("warning");
   });
 
   // ── 22. isTesting shows spinner state ─────────────────────────────────
@@ -597,6 +615,53 @@ describe("ConnectionModal", () => {
     const props = createDefaultProps();
     const { queryByText } = render(React.createElement(ConnectionModal, props));
     expect(queryByText(/postgres:\/\//)).not.toBeNull();
+  });
+
+  // ── 29b. verify-system is offered, and says what it verifies (D26) ──────
+
+  test("the SSL mode row offers verify-system and selecting it reaches the form", () => {
+    mockFormOverrides = { showSSL: true };
+    const props = createDefaultProps();
+    const { getByText } = render(React.createElement(ConnectionModal, props));
+
+    const button = getByText("verify-system").closest("button");
+    expect(button).not.toBeNull();
+    fireEvent.click(button as HTMLButtonElement);
+    expect(mockSetSSLMode).toHaveBeenCalledWith("verify-system");
+  });
+
+  // The copy is the whole point of the mode: a user who cannot tell it from verify-ca will
+  // go looking for the CA file it does not need. Each mode gets its own sentence, so the
+  // panel says what the selected one verifies rather than only naming it.
+  test("each SSL mode explains what it verifies", () => {
+    mockFormOverrides = { showSSL: true, sslMode: "verify-system" };
+    const { queryByTestId } = render(React.createElement(ConnectionModal, createDefaultProps()));
+    expect(queryByTestId("ssl-mode-hint")?.textContent).toContain("system trust store");
+    expect(queryByTestId("ssl-mode-hint")?.textContent).toContain("no certificate");
+  });
+
+  test("the hint for require says it checks nothing", () => {
+    mockFormOverrides = { showSSL: true, sslMode: "require" };
+    const { queryByTestId } = render(React.createElement(ConnectionModal, createDefaultProps()));
+    expect(queryByTestId("ssl-mode-hint")?.textContent).toContain("Encrypts but verifies nothing");
+  });
+
+  test("the hint for disable says the traffic is plaintext", () => {
+    mockFormOverrides = { showSSL: true, sslMode: "disable" };
+    const { queryByTestId } = render(React.createElement(ConnectionModal, createDefaultProps()));
+    expect(queryByTestId("ssl-mode-hint")?.textContent).toContain("Plaintext");
+  });
+
+  test("the hints for verify-ca and verify-full both name the pasted CA", () => {
+    mockFormOverrides = { showSSL: true, sslMode: "verify-ca" };
+    const ca = render(React.createElement(ConnectionModal, createDefaultProps()));
+    expect(ca.queryByTestId("ssl-mode-hint")?.textContent).toContain("CA certificate below");
+    ca.unmount();
+
+    mockFormOverrides = { showSSL: true, sslMode: "verify-full" };
+    const full = render(React.createElement(ConnectionModal, createDefaultProps()));
+    expect(full.queryByTestId("ssl-mode-hint")?.textContent).toContain("CA certificate below");
+    expect(full.queryByTestId("ssl-mode-hint")?.textContent).toContain("names the host you typed");
   });
 
   // ── 30. SSL section for verify-ca shows client cert fields ─────────────

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -336,7 +336,7 @@ describe("useConnectionForm", () => {
     });
 
     expect(result.current.testResult).not.toBeNull();
-    expect(result.current.testResult!.success).toBe(true);
+    expect(result.current.testResult!.tone).toBe("success");
     expect(result.current.testResult!.message).toContain("Connected successfully");
     expect(result.current.testResult!.latency).toBe(25);
   });
@@ -355,7 +355,7 @@ describe("useConnectionForm", () => {
     });
 
     expect(result.current.testResult).not.toBeNull();
-    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.tone).toBe("error");
     expect(result.current.testResult!.message).toBe("Connection refused");
   });
 
@@ -551,7 +551,7 @@ describe("useConnectionForm", () => {
 
     expect(onConnect).not.toHaveBeenCalled();
     expect(result.current.testResult).not.toBeNull();
-    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.tone).toBe("error");
   });
 
   /*
@@ -589,7 +589,10 @@ describe("useConnectionForm", () => {
     });
 
     // Nothing saved yet - but the user is told what was found, in the server's words.
+    // The sentence asks the user to click again, which is neither a success nor a
+    // failure, so it renders neither (#U19): the warning tone, not the green tick.
     expect(onConnect).not.toHaveBeenCalled();
+    expect(result.current.testResult!.tone).toBe("warning");
     expect(result.current.testResult!.message).toContain("Keyspace system_views does not exist");
     expect(result.current.testResult!.message).toContain("again");
 
@@ -642,7 +645,7 @@ describe("useConnectionForm", () => {
     });
 
     expect(onConnect).not.toHaveBeenCalled();
-    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.tone).toBe("error");
   });
 
   test("Test Connection reports the degradation rather than a bare success", async () => {
@@ -654,9 +657,10 @@ describe("useConnectionForm", () => {
       await result.current.handleTestConnection();
     });
 
-    // It connected, so the result is a success - and the sentence says what is missing
-    // instead of the "Connected successfully" that hid it.
-    expect(result.current.testResult!.success).toBe(true);
+    // It connected, so this is not an error - but it is not a plain success either:
+    // the sentence says what is missing instead of the "Connected successfully" that
+    // hid it, so it gets the warning tone (#U19).
+    expect(result.current.testResult!.tone).toBe("warning");
     expect(result.current.testResult!.message).toContain("no health data");
   });
 
@@ -703,6 +707,7 @@ describe("useConnectionForm", () => {
       await result.current.handleConnect();
     });
     expect(onConnect).not.toHaveBeenCalled();
+    expect(result.current.testResult!.tone).toBe("warning");
     expect(result.current.testResult!.message).toContain("no monitoring here");
 
     await act(async () => {
@@ -732,7 +737,7 @@ describe("useConnectionForm", () => {
     expect(result.current.password).toBe("secret");
     expect(result.current.database).toBe("parsed-db");
     expect(result.current.testResult).not.toBeNull();
-    expect(result.current.testResult!.success).toBe(true);
+    expect(result.current.testResult!.tone).toBe("success");
     expect(result.current.testResult!.message).toContain("parsed successfully");
   });
 
@@ -846,11 +851,12 @@ describe("useConnectionForm", () => {
     expect(result.current.sslMode).toBe("require");
   });
 
-  // The refusal has to be VISIBLE, and visible in the right colour. The modal renders
-  // `success: true` as a green box with a tick (ConnectionModal.tsx), so emitting the
-  // refusal as a success told the user - in green, with a tick - that dropping their TLS
-  // request was fine. That is the affordance-contradicts-the-sentence defect of #449.
-  test("handlePasteConnectionString says so when it refuses to map an opportunistic sslmode", () => {
+  // The caution has to be VISIBLE, and visible in the right colour. The paste itself
+  // worked - every other field was filled in - so this is not a red refusal (that was
+  // the affordance-contradicts-the-sentence defect of #449 in the other direction: a
+  // green tick over "your TLS setting was dropped"); it is the amber warning tone
+  // #U19 added, because the parse both worked AND lost something.
+  test("handlePasteConnectionString warns when it refuses to map an opportunistic sslmode", () => {
     const { result } = renderHook(() => useConnectionForm(defaultProps));
 
     act(() => {
@@ -861,10 +867,10 @@ describe("useConnectionForm", () => {
     });
 
     expect(result.current.sslMode).toBe("disable");
-    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.tone).toBe("warning");
     expect(result.current.testResult!.message).toContain("sslmode=prefer");
     expect(result.current.testResult!.message).toContain("SSL Mode");
-    // The banner must not read as a success anywhere in its own text either.
+    // The banner must not read as a plain, unqualified success in its own text either.
     expect(result.current.testResult!.message).not.toContain("parsed successfully");
   });
 
@@ -882,10 +888,10 @@ describe("useConnectionForm", () => {
     });
 
     expect(result.current.sslMode).toBe("verify-ca");
-    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.tone).toBe("warning");
     expect(result.current.testResult!.message).toContain("ssl-mode=PREFERRED");
     expect(result.current.testResult!.message).toContain("verify-ca");
-    // The fields WERE filled, and a red box must not leave the user thinking otherwise.
+    // The fields WERE filled, and the banner must not leave the user thinking otherwise.
     expect(result.current.host).toBe("my.example.com");
     expect(result.current.testResult!.message).toContain("other fields");
   });
@@ -903,9 +909,41 @@ describe("useConnectionForm", () => {
       result.current.handlePasteConnectionString();
     });
 
-    expect(result.current.sslMode).toBe("require");
-    expect(result.current.testResult!.success).toBe(true);
+    expect(result.current.sslMode).toBe("verify-system");
+    expect(result.current.testResult!.tone).toBe("success");
     expect(result.current.testResult!.message).toContain("parsed successfully");
+  });
+
+  // D26: the paste has to land on a mode the user can actually connect with. verify-system
+  // verifies AND asks for no certificate file, so a Neon/Supabase URL is complete as pasted.
+  test("a managed PostgreSQL URL's ssl=true lands on a verifying mode that needs no CA file", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("postgres://user:pw@ep-cool-1.eu-central-1.aws.neon.tech/neondb?ssl=true");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.sslMode).toBe("verify-system");
+    expect(result.current.caCert).toBe("");
+    expect(result.current.testResult!.tone).toBe("success");
+  });
+
+  // The banner names the modes it could not match the parameter to, so the list has to be
+  // the real one - a mode missing from the sentence is a mode the user does not know exists.
+  test("the unmapped-parameter banner names verify-system among the modes on offer", () => {
+    const { result } = renderHook(() => useConnectionForm(defaultProps));
+
+    act(() => {
+      result.current.setPasteInput("postgres://u:p@pg.example.com/app?sslmode=prefer");
+    });
+    act(() => {
+      result.current.handlePasteConnectionString();
+    });
+
+    expect(result.current.testResult!.message).toContain("verify-system");
   });
 
   // ── handlePasteConnectionString shows error for invalid string ─────────────
@@ -922,7 +960,7 @@ describe("useConnectionForm", () => {
     });
 
     expect(result.current.testResult).not.toBeNull();
-    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.tone).toBe("error");
     expect(result.current.testResult!.message).toContain("Could not parse");
   });
 
@@ -1049,7 +1087,7 @@ describe("useConnectionForm", () => {
     });
 
     expect(result.current.testResult).not.toBeNull();
-    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.tone).toBe("error");
     expect(result.current.testResult!.message).toContain("Network error");
   });
 
@@ -1616,7 +1654,7 @@ describe("useConnectionForm", () => {
     });
 
     expect(result.current.testResult).not.toBeNull();
-    expect(result.current.testResult!.success).toBe(false);
+    expect(result.current.testResult!.tone).toBe("error");
     expect(result.current.testResult!.message).toContain("Network error");
   });
 
@@ -1692,7 +1730,7 @@ describe("useConnectionForm", () => {
     // The adapter replaces the built-in fetch entirely
     expect(onTestConnection).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(result.current.testResult?.success).toBe(true);
+    expect(result.current.testResult?.tone).toBe("success");
     expect(result.current.testResult?.message).toBe("Connected successfully (42ms)");
     expect(result.current.testResult?.latency).toBe(42);
   });
@@ -1707,7 +1745,7 @@ describe("useConnectionForm", () => {
       await result.current.handleTestConnection();
     });
 
-    expect(result.current.testResult?.success).toBe(false);
+    expect(result.current.testResult?.tone).toBe("error");
     expect(result.current.testResult?.message).toBe("Auth failed");
   });
 

--- a/tests/integration/db/libredb-provider.test.ts
+++ b/tests/integration/db/libredb-provider.test.ts
@@ -132,6 +132,10 @@ describe("LibreDBProvider — lifecycle & metadata", () => {
     // prefix, so they are this server's summary of what one scan reached rather than
     // objects the engine declares (#414).
     expect(caps.tablesAreDerivedGroupings).toBe(true);
+    // `lib.open({ path })` takes an exclusive `<path>.lock`, so this engine admits ONE
+    // handle per file - the fact the connection test and the agent's grounding read
+    // both borrow the open one instead of opening a second (D3, B49).
+    expect(caps.singleWriterFile).toBe(true);
     expect(caps.supportsExplain).toBe(false);
     expect(caps.explainFormat).toBeUndefined();
     expect(caps.supportsExplain).toBe(caps.explainFormat !== undefined);

--- a/tests/integration/db/mongodb-provider.test.ts
+++ b/tests/integration/db/mongodb-provider.test.ts
@@ -357,6 +357,16 @@ describe("MongoDBProvider", () => {
       expect(options.rejectUnauthorized).toBe(false);
     });
 
+    // D26: the mode a pasted `tls=true` / `mongodb+srv://` lands on. It has to verify with
+    // no CA PEM in hand, which is the whole reason it exists - an Atlas string carries no
+    // certificate file.
+    test("mode verify-system verifies against the runtime trust store, with no ca option", async () => {
+      const options = await connectWithSSL({ mode: "verify-system" });
+      expect(options.tls).toBe(true);
+      expect(options.rejectUnauthorized).toBe(true);
+      expect("ca" in options).toBe(false);
+    });
+
     test("mode verify-ca and verify-full check the chain", async () => {
       expect(await connectWithSSL({ mode: "verify-ca" })).toMatchObject({ tls: true, rejectUnauthorized: true });
       expect(await connectWithSSL({ mode: "verify-full" })).toMatchObject({ tls: true, rejectUnauthorized: true });

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -77,8 +77,12 @@ class MockConnectionPool extends EventEmitter {
  * The provider does `new mssql.ConnectionPool(config)`; recording the instance here lets a
  * test emit on the very emitter the provider attached its listener to.
  */
+/** The config the provider handed the pool, for the TLS assertions below. */
+let lastPoolConfig: { options?: { encrypt?: boolean; trustServerCertificate?: boolean } } = {};
+
 function ConnectionPoolFactory(config: unknown): MockConnectionPool {
   const pool = new MockConnectionPool(config);
+  lastPoolConfig = config as typeof lastPoolConfig;
   lastPool = pool;
   return pool;
 }
@@ -478,6 +482,37 @@ describe("MSSQLProvider", () => {
   // =========================================================================
   // 2. Connect / Disconnect
   // =========================================================================
+
+  // =========================================================================
+  // TLS
+  // =========================================================================
+
+  describe("the TLS options handed to tedious", () => {
+    const connectWithSSL = async (mode: NonNullable<DatabaseConnection["ssl"]>["mode"]) => {
+      provider = new MSSQLProvider({ ...baseConfig, ssl: { mode } });
+      await provider.connect();
+      return lastPoolConfig.options;
+    };
+
+    test("mode disable turns encryption off", async () => {
+      expect(await connectWithSSL("disable")).toMatchObject({ encrypt: false });
+    });
+
+    test("mode require encrypts and trusts whatever certificate is presented", async () => {
+      expect(await connectWithSSL("require")).toMatchObject({ encrypt: true, trustServerCertificate: true });
+    });
+
+    // D26: SQL Server needed no code change to answer for `verify-system`. tedious has one
+    // knob, `trustServerCertificate`, and turning it off is already "validate the chain and
+    // the name against the host's trust store" - there is no separate CA channel here, so
+    // verify-system, verify-ca and verify-full all land on the same call. This pins that the
+    // widened union did not silently fall through to the trusting branch.
+    test("mode verify-system validates the certificate, like the two verify-* modes", async () => {
+      expect(await connectWithSSL("verify-system")).toMatchObject({ encrypt: true, trustServerCertificate: false });
+      expect(await connectWithSSL("verify-ca")).toMatchObject({ encrypt: true, trustServerCertificate: false });
+      expect(await connectWithSSL("verify-full")).toMatchObject({ encrypt: true, trustServerCertificate: false });
+    });
+  });
 
   describe("connect / disconnect", () => {
     test("connect creates pool and marks connected", async () => {

--- a/tests/integration/db/mysql-provider.test.ts
+++ b/tests/integration/db/mysql-provider.test.ts
@@ -64,11 +64,21 @@ const mockPool = {
   execute: (sql: string, params?: unknown[]) => recordCall("execute", sql, params),
 };
 
+/**
+ * The config object the provider handed `createPool`. Recorded because `buildSSLConfig` is
+ * private and its result is only observable here: a test that merely constructs the provider
+ * and asserts it did not throw passes for every SSL mode, including a wrong one.
+ */
+let lastPoolConfig: Record<string, unknown> = {};
+
+const createPool = (config: Record<string, unknown>) => {
+  lastPoolConfig = config;
+  return mockPool;
+};
+
 mock.module("mysql2/promise", () => ({
-  default: {
-    createPool: () => mockPool,
-  },
-  createPool: () => mockPool,
+  default: { createPool },
+  createPool,
 }));
 
 // Dynamic import AFTER mock is installed
@@ -1487,14 +1497,35 @@ describe("MySQLProvider", () => {
       expect(provider).toBeDefined();
     });
 
-    test("explicit ssl mode disable", () => {
+    test("explicit ssl mode disable", async () => {
       provider = new MySQLProvider(
         makeMySQLConfig({
           ssl: { mode: "disable" },
         }),
       );
-      // Should not throw — ssl disabled
-      expect(provider).toBeDefined();
+      await provider.connect();
+      expect(lastPoolConfig.ssl).toBeUndefined();
+    });
+
+    // D26: the mode a pasted `?ssl=true` / `?useSSL=true` lands on. mysql2 gets
+    // `rejectUnauthorized: true` and no `ca`, which is what the driver does with `ssl: {}`
+    // itself - so the paste is honoured instead of quietly downgraded to `require`.
+    test("ssl mode verify-system verifies against the runtime trust store with no ca", async () => {
+      provider = new MySQLProvider(makeMySQLConfig({ ssl: { mode: "verify-system" } }));
+      await provider.connect();
+      expect(lastPoolConfig.ssl).toEqual({ rejectUnauthorized: true });
+    });
+
+    test("ssl mode require encrypts without checking the chain", async () => {
+      provider = new MySQLProvider(makeMySQLConfig({ ssl: { mode: "require" } }));
+      await provider.connect();
+      expect(lastPoolConfig.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    test("ssl mode verify-ca carries the pasted CA alongside the chain check", async () => {
+      provider = new MySQLProvider(makeMySQLConfig({ ssl: { mode: "verify-ca", caCert: "ca-pem" } }));
+      await provider.connect();
+      expect(lastPoolConfig.ssl).toEqual({ rejectUnauthorized: true, ca: "ca-pem" });
     });
   });
 

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -508,6 +508,17 @@ describe("OracleProvider", () => {
       expect(attrs.sslServerDNMatch).toBe(false);
     });
 
+    // D26: Thin mode verifies the chain in every TCPS connection, so what verify-system adds
+    // over `require` is the server-name match - the one check Oracle exposes on its own. With
+    // no walletContent, tls.connect falls back to Node's bundled roots, which is precisely
+    // what "verify against the system trust store" means.
+    test("mode verify-system asks for the DN/hostname match with no wallet", async () => {
+      const attrs = await connectWithSSL({ mode: "verify-system" });
+      expect(attrs.connectString).toBe("tcps://localhost:1521/ORCL");
+      expect(attrs.sslServerDNMatch).toBe(true);
+      expect("walletContent" in attrs).toBe(false);
+    });
+
     test("verify-ca checks the chain without the hostname; verify-full asks for both", async () => {
       // Thin mode always calls tls.connect with rejectUnauthorized: true, so the chain
       // is checked in every TCPS mode and the DN/hostname match is the only knob.

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -53,8 +53,16 @@ class MockPool extends EventEmitter {
 /** The pool handed to the most recently constructed provider. */
 let lastPool: MockPool | undefined;
 
+/**
+ * The config object the provider handed `new Pool(...)`. Recorded because `buildSSLConfig`
+ * is private and its result is only observable here: a test that merely connects and
+ * asserts `isConnected()` passes for every SSL mode, including a wrong one.
+ */
+let lastPoolConfig: Record<string, unknown> = {};
+
 mock.module("pg", () => ({
-  Pool: function () {
+  Pool: function (config: Record<string, unknown>) {
+    lastPoolConfig = config;
     lastPool = new MockPool();
     return lastPool;
   },
@@ -669,6 +677,21 @@ describe("PostgresProvider", () => {
       expect(provider.isConnected()).toBe(true);
     });
 
+    // D26: the mode a pasted `?ssl=true` lands on, and the reason it can: `pg` is handed
+    // `rejectUnauthorized: true` with NO `ca`, so Node's own trust store checks the chain and
+    // there is no PEM for the user to find. `require` is the same call with verification off.
+    test("ssl mode verify-system verifies against the runtime trust store with no ca", async () => {
+      provider = new PostgresProvider(makePgConfig({ ssl: { mode: "verify-system" } }));
+      await provider.connect();
+      expect(lastPoolConfig.ssl).toEqual({ rejectUnauthorized: true });
+    });
+
+    test("ssl mode require encrypts without checking the chain", async () => {
+      provider = new PostgresProvider(makePgConfig({ ssl: { mode: "require" } }));
+      await provider.connect();
+      expect(lastPoolConfig.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
     test("ssl mode verify-ca sets rejectUnauthorized to true", async () => {
       provider = new PostgresProvider(
         makePgConfig({
@@ -677,6 +700,7 @@ describe("PostgresProvider", () => {
       );
       await provider.connect();
       expect(provider.isConnected()).toBe(true);
+      expect(lastPoolConfig.ssl).toEqual({ rejectUnauthorized: true });
     });
 
     test("ssl mode verify-full with certs includes ca, cert, key", async () => {

--- a/tests/integration/db/redis-provider.test.ts
+++ b/tests/integration/db/redis-provider.test.ts
@@ -239,6 +239,13 @@ describe("RedisProvider", () => {
       expect(options.tls).toEqual({ rejectUnauthorized: false });
     });
 
+    // D26: verification without a pasted CA, for a managed endpoint whose certificate a
+    // public root already signs.
+    test("mode verify-system verifies against the runtime trust store, with no ca option", async () => {
+      const options = await connectWithSSL({ mode: "verify-system" });
+      expect(options.tls).toEqual({ rejectUnauthorized: true });
+    });
+
     test("mode verify-ca and verify-full check the chain", async () => {
       expect(await connectWithSSL({ mode: "verify-ca" })).toMatchObject({ tls: { rejectUnauthorized: true } });
       expect(await connectWithSSL({ mode: "verify-full" })).toMatchObject({ tls: { rejectUnauthorized: true } });

--- a/tests/unit/db/cassandra/wire.test.ts
+++ b/tests/unit/db/cassandra/wire.test.ts
@@ -491,6 +491,7 @@ describe("cassandraClientOptions", () => {
   test.each([
     ["disable", undefined],
     ["require", { rejectUnauthorized: false }],
+    ["verify-system", { rejectUnauthorized: true }],
     ["verify-ca", { rejectUnauthorized: true }],
     ["verify-full", { rejectUnauthorized: true }],
   ] as const)("TLS mode %s produces %o", (mode, expected) => {

--- a/tests/unit/db/couchbase/http-transport.test.ts
+++ b/tests/unit/db/couchbase/http-transport.test.ts
@@ -760,6 +760,16 @@ describe("CouchbaseHttpTransport TLS", () => {
     expect(recorded[0].tls).toEqual({ rejectUnauthorized: false });
   });
 
+  // D26: the mode a `couchbases://` Capella endpoint can satisfy as pasted - its certificate
+  // is signed by a public root, so the chain is checkable with nothing to paste.
+  test("verifies the chain in verify-system mode without a pasted CA", async () => {
+    const recorded: RecordedRequest[] = [];
+
+    await makeTransport({ ssl: { mode: "verify-system" } }, tlsDeps(recorded)).query("SELECT 1");
+
+    expect(recorded[0].tls).toEqual({ rejectUnauthorized: true });
+  });
+
   test("honours an explicit rejectUnauthorized override", async () => {
     const recorded: RecordedRequest[] = [];
 

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -1,4 +1,15 @@
 import { describe, test, expect, mock, beforeEach, beforeAll, afterAll } from "bun:test";
+import { open as libreOpen, kv as libreKv } from "@libredb/libredb";
+import { captureContextSnapshot } from "@/lib/agent/context-snapshot";
+import { AgentRunDeadline } from "@/lib/agent/deadline";
+import { AGENT_WORKFLOW_BUDGETS } from "@/lib/agent/execution-policy";
+import { AgentRepairLedger } from "@/lib/agent/repair-ledger";
+import type { AgentToolContext } from "@/lib/agent/tools";
+import { ExecutionArtifactStore } from "@/lib/db/operations/artifacts";
+import { ExecutionBudgetTracker } from "@/lib/db/operations/budgets";
+import { createCanonicalOperationRegistry } from "@/lib/db/operations/descriptors";
+import { createTargetScope } from "@/lib/db/operations/policy";
+import type { DatabaseProvider, QueryResult } from "@/lib/db/types";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -273,6 +284,7 @@ const {
   evictIdleProviders,
   registerShutdownHandlers,
   acquireExecutionProfileProvider,
+  findOpenSingleWriterProvider,
   getExecutionProfileCacheStats,
   withOneShotTunnel,
 } = await import("@/lib/db/factory");
@@ -1297,6 +1309,156 @@ describe("acquireExecutionProfileProvider", () => {
 });
 
 // ============================================================================
+// Single-writer file reuse (docs/BACKLOG.md D3 and B49)
+// ----------------------------------------------------------------------------
+// A provider that declares `singleWriterFile` admits ONE open handle per file, so
+// the two callers that build a SECOND provider on a file the writable cache is
+// already holding do not get a less privileged handle - they get none. These run on
+// the REAL @libredb/libredb package against temp files, so the lock they assert
+// against is the driver's own, not a fixture's.
+// ============================================================================
+
+describe("single-writer file reuse", () => {
+  let dir: string;
+  let seq = 0;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "libredb-factory-single-writer-"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** A fresh libredb connection with a file of its own, so no test inherits a lock. */
+  function libredbConn(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
+    seq += 1;
+    return makeConnection("libredb", {
+      id: `libredb-single-writer-${seq}`,
+      database: join(dir, `single-writer-${seq}.libredb`),
+      ...overrides,
+    });
+  }
+
+  test("a second handle on the same file is refused, which is what makes the borrow load-bearing", async () => {
+    // The control arm. Without it every assertion below could pass on an engine that
+    // never locked anything, and the reuse would be measuring nothing.
+    const conn = libredbConn();
+    await getOrCreateProvider(conn);
+
+    const second = await createDatabaseProvider(conn);
+
+    await expect(second.connect()).rejects.toThrow(/exclusive lock/);
+  });
+
+  test("an operations acquisition borrows the open writable handle instead of opening a second one", async () => {
+    const conn = libredbConn();
+    const writable = await getOrCreateProvider(conn);
+
+    const agent = await acquireExecutionProfileProvider(conn, "agent-operations");
+
+    expect(agent).toBe(writable);
+    // Borrowed, never owned: an entry in the profiled cache would let that cache's
+    // idle sweep, or a removeProvider for any connection sharing the file, close the
+    // file under the session that opened it.
+    expect(getExecutionProfileCacheStats()).toEqual({ size: 0, connections: [] });
+    expect(agent.isConnected()).toBe(true);
+  });
+
+  test("the identity is the resolved file path, not the connection id", async () => {
+    // The D3 reproduction exactly: "Sample (LibreDB)" holds the file and the record
+    // being tested is "My Sample" - a different id pointing at the same file.
+    const held = libredbConn({ id: "sample-libredb", name: "Sample (LibreDB)" });
+    const writable = await getOrCreateProvider(held);
+
+    const underTest: DatabaseConnection = { ...held, id: "my-sample", name: "My Sample" };
+
+    expect(findOpenSingleWriterProvider(underTest)).toBe(writable);
+  });
+
+  test("an unresolved spelling of the same path is the same file", async () => {
+    const held = libredbConn();
+    const writable = await getOrCreateProvider(held);
+
+    // Deliberately not built with path.join, which would normalise it before the
+    // factory ever saw it: the lock is per inode, so the lookup has to resolve.
+    const spelled: DatabaseConnection = {
+      ...held,
+      id: "spelled",
+      database: `${dir}/./${held.database!.split("/").pop()!}`,
+    };
+
+    expect(findOpenSingleWriterProvider(spelled)).toBe(writable);
+  });
+
+  test("a connection with no file path holds no file, and matches nothing", async () => {
+    const conn = libredbConn();
+    await getOrCreateProvider(conn);
+
+    // The shape the test-connection route hands this on every request that is not a
+    // file engine at all (a connection-string connection carries no `database`).
+    expect(findOpenSingleWriterProvider(makeConnection("mongodb", { database: undefined }))).toBeNull();
+  });
+
+  test("an engine that admits many handles is not borrowed from, and keeps its read-only boundary", async () => {
+    // SQLite is the engine a reader would expect to declare singleWriterFile. It does
+    // not, and this is what declaring it would have cost: the agent handle here is a
+    // SECOND, `readonly: true` open of the same file, and the database itself refuses
+    // its writes. Borrowing the writable one would have handed the agent write access.
+    const conn = makeConnection("sqlite", { id: "sqlite-many-handles", database: join(dir, "many-handles.db") });
+    const writable = await getOrCreateProvider(conn);
+    await writable.query("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+
+    const agent = await acquireExecutionProfileProvider(conn, "agent-read-only");
+
+    expect(agent).not.toBe(writable);
+    expect(getExecutionProfileCacheStats()).toEqual({ size: 1, connections: [conn.id] });
+    await expect(agent.queryReadOnly!("INSERT INTO t (id) VALUES (1)", AGENT_BUDGET)).rejects.toThrow();
+  });
+
+  test("a profile that sends statements is still refused rather than handed the writable handle", async () => {
+    // The borrow is scoped to `agent-operations`, the profile that sends no statement
+    // at all. `agent-read-only` and `agent-handover` send one, and an engine with no
+    // read-only statement path is refused as it always was - being able to reuse a
+    // handle is not a reason to run a model's statement through a writable one.
+    const conn = libredbConn();
+    const writable = await getOrCreateProvider(conn);
+
+    const error: unknown = await acquireExecutionProfileProvider(conn, "agent-read-only").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ExecutionProfileError);
+    expect((error as ExecutionProfileError).reasonCode).toBe("PROFILE_UNSUPPORTED_BY_PROVIDER");
+    expect(writable.isConnected()).toBe(true);
+  });
+
+  test("a configured agent credential opts out of borrowing (fail closed)", async () => {
+    // The borrowed handle was opened under the connection's own credentials. An
+    // operator who configured `agentUser` asked for something this reuse cannot give,
+    // so it is not silently ignored: the acquisition opens its own handle and hits the
+    // lock, which leaves the run ungrounded and honest rather than grounded under a
+    // credential nobody asked for.
+    const conn = libredbConn({ agentUser: "agent_ro", agentPassword: "agent-secret" });
+    await getOrCreateProvider(conn);
+
+    await expect(acquireExecutionProfileProvider(conn, "agent-operations")).rejects.toThrow(/exclusive lock/);
+    expect(getExecutionProfileCacheStats().size).toBe(0);
+  });
+
+  test("nothing is borrowed once the writable handle is gone", async () => {
+    const conn = libredbConn();
+    await getOrCreateProvider(conn);
+    await removeProvider(conn.id);
+
+    expect(findOpenSingleWriterProvider(conn)).toBeNull();
+
+    // And the file is free, so the acquisition opens - and OWNS - its own handle.
+    const agent = await acquireExecutionProfileProvider(conn, "agent-operations");
+    expect(agent.isConnected()).toBe(true);
+    expect(getExecutionProfileCacheStats()).toEqual({ size: 1, connections: [conn.id] });
+  });
+});
+
+// ============================================================================
 // One-shot tunnel scope (#457)
 // ----------------------------------------------------------------------------
 // The routes that build a provider outside both caches - test-connection and
@@ -1421,5 +1583,97 @@ describe("withOneShotTunnel", () => {
     await withOneShotTunnel(stringOnly, async () => undefined);
 
     expect(mockCreateSSHTunnel).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Grounding a plan run on a file the editor already has open (`docs/BACKLOG.md` B49).
+ *
+ * The real package, the real factory and a real file: the lock these assert against is
+ * the driver's own. `acquireExecutionProfileProvider` used to open a SECOND handle here
+ * and be refused every time, and because a `ConnectionError` becomes an unavailable
+ * capture rather than a failure, the run went on silently ungrounded. The condition was
+ * "the connection's ordinary provider is connected", which is true from the moment
+ * anyone browses the connection in the sidebar - so in practice it was every run.
+ */
+describe("grounding a plan run while the writable provider holds the file (B49)", () => {
+  const frozenClock = () => 1_700_000_000_000;
+
+  let dir: string;
+  let seq = 0;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "libredb-factory-grounding-"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** A seeded libredb file of its own, so no test inherits another's lock. */
+  function seededConn(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
+    seq += 1;
+    const file = join(dir, `grounding-${seq}.libredb`);
+    const db = libreOpen({ path: file });
+    const store = libreKv(db);
+    store.set("user:1", "Ada");
+    store.set("order:1", "42");
+    store.set("config", "on");
+    db.close();
+    return makeConnection("libredb", { id: `libredb-grounding-${seq}`, database: file, ...overrides });
+  }
+
+  function planContext(connection: DatabaseConnection, provider: DatabaseProvider): AgentToolContext {
+    return {
+      runId: "run-libredb-grounding",
+      modelId: "unmeasured-model-for-tests",
+      // A PLAN run: it is handed no tools, and this schema read is the server's own.
+      mode: "planning",
+      workflowType: "investigation",
+      actor: { sessionId: "session-1", role: "user" },
+      connection,
+      capabilities: provider.getCapabilities(),
+      labels: provider.getLabels(),
+      registry: createCanonicalOperationRegistry(),
+      scope: createTargetScope(connection.id),
+      tracker: new ExecutionBudgetTracker(),
+      artifacts: new ExecutionArtifactStore<QueryResult>({ ttlMs: 60_000, maxArtifacts: 16 }),
+      deadline: new AgentRunDeadline(AGENT_WORKFLOW_BUDGETS.investigation.policy.budgets.maxTotalRunMs, frozenClock),
+      repairs: new AgentRepairLedger(),
+      acquireProvider: acquireExecutionProfileProvider,
+      clock: frozenClock,
+    };
+  }
+
+  test("the run is grounded from the handle the editor already holds", async () => {
+    const connection = seededConn();
+    const writable = await getOrCreateProvider(connection);
+    expect(writable.isConnected()).toBe(true);
+
+    const capture = await captureContextSnapshot(planContext(connection, writable));
+
+    expect(capture.kind).toBe("captured");
+    if (capture.kind !== "captured") throw new Error("unreachable");
+    expect(capture.snapshot.readVia).toBe("provider-inventory");
+    expect(capture.snapshot.tables.map((t) => t.name).sort()).toEqual(["config", "order:*", "user:*"]);
+    // The handle was BORROWED: the profiled cache owns nothing, so no eviction there
+    // can close the file under the editor's own session.
+    expect(getExecutionProfileCacheStats()).toEqual({ size: 0, connections: [] });
+    expect(writable.isConnected()).toBe(true);
+  });
+
+  test("the same run without the reuse is ungrounded, and nothing about it looks like a failure", async () => {
+    // The control arm, and the pre-fix behaviour exactly. An agent credential opts the
+    // acquisition out of borrowing (it cannot substitute one principal for another), so
+    // this run opens its own handle, hits the lock, and the `ConnectionError` becomes an
+    // unavailable capture instead of an error anyone sees.
+    const connection = seededConn({ agentUser: "agent_ro", agentPassword: "secret" });
+    const writable = await getOrCreateProvider(connection);
+
+    const capture = await captureContextSnapshot(planContext(connection, writable));
+
+    expect(capture.kind).toBe("unavailable");
+    if (capture.kind !== "unavailable") throw new Error("unreachable");
+    expect(capture.reasonCode).toBe("CATALOG_READ_REFUSED");
   });
 });

--- a/tests/unit/lib/connection-string-parser.test.ts
+++ b/tests/unit/lib/connection-string-parser.test.ts
@@ -133,14 +133,20 @@ describe("parseConnectionString", () => {
       expect(result!.database).toBeUndefined();
     });
 
-    // Deliberately NOT a mode, unlike rediss:// and couchbases://: the MongoDB driver
-    // gets the URI verbatim and applies `tls=true` for mongodb+srv itself, WITH chain
-    // verification. Handing it our `require` would set rejectUnauthorized:false and
-    // silently stop verifying an Atlas certificate the driver checks today.
-    test("leaves the TLS intent unset for mongodb+srv://, which the driver reads itself", () => {
+    // The driver applies `tls=true` for mongodb+srv itself, WITH chain verification, so the
+    // form has to say the same thing rather than sit on its `disable` default while the
+    // connection is in fact encrypted (D26). This stayed unset while `require` was the only
+    // alternative, because require is rejectUnauthorized:false and the options object is a
+    // second channel the driver reads - it would have stopped an Atlas certificate being
+    // verified.
+    test("mongodb+srv:// carries the verifying mode the scheme itself implies", () => {
       const result = parseConnectionString("mongodb+srv://user:pass@cluster0.abcde.mongodb.net/appdb");
-      expect(result!.sslMode).toBeUndefined();
+      expect(result!.sslMode).toBe("verify-system");
       expect(result!.connectionString).toBe("mongodb+srv://user:pass@cluster0.abcde.mongodb.net/appdb");
+    });
+
+    test("plain mongodb:// with no TLS parameter says nothing about TLS", () => {
+      expect(parseConnectionString("mongodb://user:pass@host:27017/appdb")!.sslMode).toBeUndefined();
     });
   });
 
@@ -791,6 +797,14 @@ describe("parseConnectionString: TLS parameters", () => {
       });
     }
 
+    // `verify-system` is OUR form's mode, not a libpq one: libpq's sslmode has no such
+    // value, so a string carrying it is a string we cannot honour and must report.
+    test("the form's own verify-system is not a libpq sslmode", () => {
+      const result = parseConnectionString("postgres://u:p@host/db?sslmode=verify-system");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("sslmode=verify-system");
+    });
+
     test("an unrecognised sslmode does not become disable", () => {
       const result = parseConnectionString("postgres://u:p@host/db?sslmode=banana");
       expect(result!.sslMode).toBeUndefined();
@@ -808,9 +822,13 @@ describe("parseConnectionString: TLS parameters", () => {
       expect(result!.unmappedTLSParam).toBe("sslmode=constructor");
     });
 
-    test("maps the JDBC/Heroku ssl=true form to require", () => {
-      expect(parseConnectionString("postgres://u:p@host/db?ssl=true")!.sslMode).toBe("require");
-      expect(parseConnectionString("postgres://u:p@host/db?ssl=1")!.sslMode).toBe("require");
+    // D26: `pg` reads `ssl=true` as TLS with Node's default `rejectUnauthorized: true`, so
+    // the mapping has to be the verifying mode that needs no PEM. It used to be `require`,
+    // which is `rejectUnauthorized: false` here - encrypted, chain unchecked - i.e. a paste
+    // that asked for verification silently got none.
+    test("maps the JDBC/Heroku ssl=true form to verify-system, not to require", () => {
+      expect(parseConnectionString("postgres://u:p@host/db?ssl=true")!.sslMode).toBe("verify-system");
+      expect(parseConnectionString("postgres://u:p@host/db?ssl=1")!.sslMode).toBe("verify-system");
       expect(parseConnectionString("postgres://u:p@host/db?ssl=false")!.sslMode).toBe("disable");
       expect(parseConnectionString("postgres://u:p@host/db?ssl=0")!.sslMode).toBe("disable");
     });
@@ -881,17 +899,23 @@ describe("parseConnectionString: TLS parameters", () => {
     // `ssl` and `useSSL` are the boolean spellings the JDBC connector and several ORMs
     // write. Reading only ssl-mode dropped them with no mode AND no banner, which is the
     // silent-downgrade defect this whole parameter exists to prevent.
-    test("maps the boolean ssl=true / useSSL=true forms to require", () => {
-      expect(parseConnectionString("mysql://u:p@host/db?ssl=true")!.sslMode).toBe("require");
-      expect(parseConnectionString("mysql://u:p@host/db?ssl=1")!.sslMode).toBe("require");
-      expect(parseConnectionString("mysql://u:p@host/db?useSSL=true")!.sslMode).toBe("require");
-      expect(parseConnectionString("mysql://u:p@host/db?useSSL=TRUE")!.sslMode).toBe("require");
+    test("maps the boolean ssl=true / useSSL=true forms to verify-system", () => {
+      expect(parseConnectionString("mysql://u:p@host/db?ssl=true")!.sslMode).toBe("verify-system");
+      expect(parseConnectionString("mysql://u:p@host/db?ssl=1")!.sslMode).toBe("verify-system");
+      expect(parseConnectionString("mysql://u:p@host/db?useSSL=true")!.sslMode).toBe("verify-system");
+      expect(parseConnectionString("mysql://u:p@host/db?useSSL=TRUE")!.sslMode).toBe("verify-system");
     });
 
     test("maps the boolean ssl=false / useSSL=false forms to disable", () => {
       expect(parseConnectionString("mysql://u:p@host/db?ssl=false")!.sslMode).toBe("disable");
       expect(parseConnectionString("mysql://u:p@host/db?ssl=0")!.sslMode).toBe("disable");
       expect(parseConnectionString("mysql://u:p@host/db?useSSL=false")!.sslMode).toBe("disable");
+    });
+
+    test("the form's own verify-system is not a MySQL ssl-mode", () => {
+      const result = parseConnectionString("mysql://u:p@host/db?ssl-mode=verify-system");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("ssl-mode=verify-system");
     });
 
     test("an unrecognised boolean value is reported verbatim, in the spelling that was pasted", () => {
@@ -975,13 +999,51 @@ describe("parseConnectionString: TLS parameters", () => {
       expect(parseConnectionString("https://host/default?sslmode=prefer")!.sslMode).toBe("require");
     });
 
-    // The mongodb driver receives the URI verbatim and turns TLS on itself, WITH chain
-    // verification; our `require` means rejectUnauthorized:false, so setting it here
-    // would weaken an Atlas connection rather than describe it.
-    test("mongodb tls=true is left to the driver", () => {
+    // D26: the driver reads `tls=true` as TLS WITH chain verification, and `verify-system`
+    // is the mode that says exactly that, so the paste is now described instead of ignored.
+    // While `require` was the only non-disable mode this had to stay unset: setting it would
+    // have handed the driver rejectUnauthorized:false and stopped an Atlas certificate being
+    // checked.
+    test("mongodb tls=true maps onto the verifying mode the driver already applies", () => {
       const result = parseConnectionString("mongodb://u:p@host:27017/db?tls=true");
-      expect(result!.sslMode).toBeUndefined();
+      expect(result!.sslMode).toBe("verify-system");
       expect(result!.unmappedTLSParam).toBeUndefined();
+    });
+
+    test("mongodb ssl=true, the driver's own deprecated alias, maps the same way", () => {
+      expect(parseConnectionString("mongodb://u:p@host:27017/db?ssl=true")!.sslMode).toBe("verify-system");
+    });
+
+    test("mongodb tls=false is explicit plaintext", () => {
+      expect(parseConnectionString("mongodb://u:p@host:27017/db?tls=false")!.sslMode).toBe("disable");
+    });
+
+    // The driver's own relaxing options (`tlsInsecure`, `tlsAllowInvalidCertificates`) turn
+    // `rejectUnauthorized` OFF while leaving TLS on, which is precisely `require`. Reading
+    // `tls=true` on its own here would have set the verifying mode and, because the provider
+    // passes the options object as a second channel the driver prefers over the URI, broken a
+    // string that connects today.
+    test("a relaxing tls option keeps the paste on require, not on the verifying mode", () => {
+      expect(parseConnectionString("mongodb://h:27017/db?tls=true&tlsInsecure=true")!.sslMode).toBe("require");
+      expect(parseConnectionString("mongodb://h:27017/db?tls=true&tlsAllowInvalidCertificates=true")!.sslMode).toBe(
+        "require",
+      );
+      expect(parseConnectionString("mongodb+srv://h/db?tlsAllowInvalidCertificates=true")!.sslMode).toBe("require");
+    });
+
+    test("a relaxing option that is off does not weaken the mode", () => {
+      expect(parseConnectionString("mongodb://h:27017/db?tls=true&tlsInsecure=false")!.sslMode).toBe("verify-system");
+    });
+
+    test("a relaxing option cannot turn plaintext into TLS", () => {
+      expect(parseConnectionString("mongodb://h:27017/db?tlsInsecure=true")!.sslMode).toBeUndefined();
+      expect(parseConnectionString("mongodb://h:27017/db?tls=false&tlsInsecure=true")!.sslMode).toBe("disable");
+    });
+
+    test("a non-boolean tls value is reported rather than guessed at", () => {
+      const result = parseConnectionString("mongodb://u:p@host:27017/db?tls=maybe");
+      expect(result!.sslMode).toBeUndefined();
+      expect(result!.unmappedTLSParam).toBe("tls=maybe");
     });
   });
 });

--- a/tests/unit/lib/storage/providers/postgres.test.ts
+++ b/tests/unit/lib/storage/providers/postgres.test.ts
@@ -109,6 +109,22 @@ describe("PostgresStorageProvider", () => {
     await cloudProvider.close();
   });
 
+  // D26: `verify-system` is this product's own mode name, and STORAGE_POSTGRES_URL is read
+  // for libpq's sslmode - so a URL naming it used to fall through every branch and land on
+  // the non-local default, `rejectUnauthorized: false`. Someone who typed the verifying mode
+  // got no verification and no complaint. It is now the one value in this reader that
+  // actually verifies.
+  test("initialize verifies the chain when the URL names the form's verify-system mode", async () => {
+    const cloudProvider = new PostgresStorageProvider("postgresql://db.example.com:5432/test?sslmode=verify-system");
+    await cloudProvider.initialize();
+
+    const poolConfig = (mockPoolConstructor.mock.calls as unknown[][])[0]?.[0] as {
+      ssl?: unknown;
+    };
+    expect(poolConfig.ssl).toEqual({ rejectUnauthorized: true });
+    await cloudProvider.close();
+  });
+
   test("initialize enables SSL for non-local hosts by default", async () => {
     const cloudProvider = new PostgresStorageProvider("postgresql://db.internal.example:5432/test");
     await cloudProvider.initialize();

--- a/tests/unit/seed/types.test.ts
+++ b/tests/unit/seed/types.test.ts
@@ -131,6 +131,14 @@ describe("SeedDefaultsSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  // D26: SSLMode gained `verify-system`, and this zod enum is a VALUE kept in step by hand -
+  // a mode missing here is not a compile error, it is a seed file the server rejects for a
+  // mode the product supports.
+  it("accepts ssl mode verify-system", () => {
+    const result = SeedDefaultsSchema.safeParse({ ssl: { mode: "verify-system" } });
+    expect(result.success).toBe(true);
+  });
+
   it("rejects ssl mode prefer (not in SSLMode type)", () => {
     const result = SeedDefaultsSchema.safeParse({
       ssl: { mode: "prefer" },


### PR DESCRIPTION
## What this closes

Four `docs/BACKLOG.md` entries, plus one defect the work uncovered and one that the same reuse fixes.

### D3 + B49 — a single-writer file admitted one handle, and three callers opened a second

`libredb`'s `lib.open({ path })` takes an exclusive lock. Three callers build a provider outside the
writable cache, so each of them hit that lock every time the connection was open — which is from the
moment anyone browses it in the sidebar:

| caller | what the user saw |
|---|---|
| `POST /api/db/test-connection` | the connection dialog tests before it saves, so **the built-in LibreDB sample could not be edited at all** — the edit was discarded with a connection-error toast |
| `acquireExecutionProfileProvider` (agent grounding) | every plan run on a LibreDB connection was silently **ungrounded** (a `ConnectionError` becomes an *unavailable* capture, so nothing looked like a failure) |
| `POST /api/db/schema-snapshot` | HTTP 503, so the Schema Diff tab's **Snapshot** could not read a schema the sidebar was listing |

The third one is not in either entry: the D3 agent found it, and I measured it in the browser against
the released 0.13.4 image before fixing it.

The fix declares the property instead of type-checking the engine: one optional
`ProviderCapabilities.singleWriterFile`, declared `true` by `libredb` only, and
`findOpenSingleWriterProvider()` keyed by the **resolved file path** rather than the connection id —
because the second opener is usually a different connection record pointing at the same file, which is
exactly how the sample-edit case reproduces. A borrowed handle is never disconnected by its borrower
and never cached under the profiled key.

SQLite is the engine a reader would expect beside it and it is deliberately absent: measured the same
day, a second `bun:sqlite` handle on a WAL file this process already holds both opens **and writes**,
because SQLite locks per transaction rather than at open.

Two bounds keep the agent isolation invariant: only `agent-operations` borrows (it sends no
model-authored statement, so `agent-read-only`/`agent-handover` are still refused on this engine), and
a connection configuring an `agentUser` opts out — a reuse must not substitute one principal for
another. That arm doubles as the suite's control.

### D26 — `?ssl=true` asked for verification and got none

`readBooleanTLS` mapped PostgreSQL `?ssl=true` and MySQL `?ssl=true`/`?useSSL=true` onto `require`,
which in this codebase is `rejectUnauthorized: false`. The same commit had REFUSED to map MongoDB's
`tls=true` on exactly that argument, so the two arms of one change disagreed and neither disagreement
was a rule. The root cause was that `SSLMode` had no value meaning "encrypt and verify against the
trust store I already have".

It has one now: **`verify-system`** — `rejectUnauthorized: true` with no `ca`, which is what a managed
endpoint (Neon, Supabase, Atlas, RDS, Capella) satisfies as pasted. The rule is now stated in
`readBooleanTLS`: *a boolean TLS spelling maps onto the mode matching what the engine's own driver does
with it, never onto a weaker one.* MongoDB's `tls=true` and bare `mongodb+srv://` are mapped as well,
and `tlsInsecure`/`tlsAllowInvalidCertificates` pull the result back to `require` so a string that
connects today still connects.

Per engine, honestly: postgres/mysql/mongodb/redis/couchbase express it; Oracle expresses it as
`sslServerDNMatch` (audited in the installed driver's own source); SQL Server needed no code change
because tedious has one knob, and tests now stop the widened union falling through to the trusting
branch; Cassandra already read `!== "require"`; the four `fetch` transports cannot skip verification at
all, and their docs now say `verify-system` is the mode that describes them.

### U19 — a caution wore a green tick

`use-connection-form.ts` emitted "… Click Save Changes again to save it anyway" as `success: true`, and
the banner had exactly two renderings. It has three now (`tone: success | warning | error`, amber +
`TriangleAlert`), and every message that is neither a completed action nor a refusal uses the warning
tone: the degraded save, the degraded connect, and the TLS-parameter-not-applied paste.

## Measured, not assumed

`docs/BACKLOG.md` entries and doc paragraphs were re-verified against the code before acting, and each
item has a before/after measurement. Highlights:

- **D3 baseline, released 0.13.4 in Chrome:** LibreDB sample connected, rename + Test Connection →
  *"LibreDB file is already open by another process (exclusive lock)"*, Save Changes did nothing.
  **After, this branch:** same sequence → `data-tone="success"`, "Connected successfully", and the save
  landed (sidebar and header both read the new name). Non-vacuity: the server log's last line is the
  sidebar click's own provider creation — the test click created **no** provider, so it borrowed.
- **B49:** a real `captureContextSnapshot` in `mode: "planning"` against a file the writable provider
  holds is now `captured` / `readVia: "provider-inventory"` with the profiled cache at `size: 0`; the
  same run with an `agentUser` is still `unavailable` / `CATALOG_READ_REFUSED`, which is what every run
  used to do.
- **D26, live self-signed TLS Postgres:** `?ssl=true` now parses to `VERIFY-SYSTEM` and the connection
  is refused with the driver's own *"self-signed certificate"*; the **control arm** — same server,
  mode switched to `require` — connects in 25 ms. So the refusal is the mode's, not a broken server.
- **U19:** the amber rendering exercised on screen through the paste path. The degraded-connect and
  degraded-save arms are covered by tests only, because all 24 seeded connections answered success
  without degradation today — and the attempt to force a health failure with a Redis ACL user ran into
  a new defect instead (see below).

## Recorded rather than fixed

Three new backlog entries, each with the measurement that produced it:

- **D27** — the borrow runs one way. If an agent run opens a `libredb` file nobody has browsed, the
  editor is then locked out until eviction. Closing it means serving an editor request from a
  profile-opened provider, which is the invariant this PR keeps.
- **D28** — `rediss://` / `couchbases://` / ClickHouse `https://` still map onto `require`, which the
  boolean rule now contradicts. Different function, and their `require` rests on a measured claim about
  self-hosted deployments I could not re-measure here.
- **D29** — `RedisProvider.connect()` passes no `username`, so no Redis 6 ACL user can be used and a
  `redis://user:pw@host` paste loses the user silently, authenticating as `default`. Measured against
  an ACL user whose `INFO` is refused: the app still reported a green connection with full health.

## Gates

All local, on this branch:

| gate | result |
|---|---|
| `bun run format` | 0 — 948 files, no fixes |
| `bun run lint` | 0 — oxlint + ESLint, 0 errors |
| `bun run typecheck` | 0 |
| `bun run knip` | 0 |
| `bun run test` | 0 — **12859 pass / 0 fail** (the chained script, all 35 phases including `run-components.sh`) |
| `bun run build` | 0 |
| `bun run build:lib` + `bun run attw` | 0 / 0 (the published surface changed: `SSLMode`, `ProviderCapabilities`) |
| `bun run test:coverage` + `coverage:check` | 0 / 0 — **43162/43162 lines (100.00%)** |

No `package.json` version change, so no `chart:bump` / operator bundle is due.
