### PR TITLE
docs(llms): the eleventh and twelfth models take their rows, and the machine is the one that ran them

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1565,7 +1565,7 @@ denial cannot be re-fed to the model as though the SQL were malformed.
 
 ## Supported models
 
-Ten models run every agent surface. Each cleared all six — Investigate, Optimize, Assess, Operate,
+Twelve models run every agent surface. Each cleared all six — Investigate, Optimize, Assess, Operate,
 Analyze and Plan — five consecutive times, at the turn limit the product ships, which is 30 of 30
 runs.
 

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,15 +8,17 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Ten models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+**Twelve models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
 Operate, Analyze and Plan — five consecutive times, at the 90-second per-turn limit the product
-ships: 300 runs, 300 passes.
+ships: 360 runs, 360 passes.
 
 | Model | Served through | Disk | Median run | Slowest run |
 | --- | --- | --- | --- | --- |
 | [`gemini-3.5-flash-lite`](gemini/gemini-3.5.md) | Gemini API | — | 10s | 21s |
 | [`granite4.1:8b`](granite/granite4.1.md) | Ollama | 5.3 GB | 11s | 22s |
+| [`qwen3.5:4b`](qwen/qwen3.5.md) | Ollama | 3.4 GB | 11s | 156s |
 | [`granite4.1:30b`](granite/granite4.1.md) | Ollama | 17 GB | 26s | 52s |
+| [`nemotron3:33b`](nvidia/nemotron3.md) | Ollama | 27 GB | 21s | 119s |
 | [`ornith:9b`](ornith/ornith.md) | Ollama | 5.5 GB | 31s | 118s |
 | [`qwen3.5:9b`](qwen/qwen3.5.md) | Ollama | 5.8 GB | 33s | 98s |
 | [`gemma4:26b`](gemma/gemma4.md) | Ollama | 16 GB | 36s | 92s |
@@ -27,7 +29,7 @@ ships: 300 runs, 300 passes.
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these ten — the fastest reaches the same verdicts as the slowest in a
+for is choosing between these twelve — the fastest reaches the same verdicts as the slowest in a
 seventh of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -30,7 +30,7 @@ Each model was asked one question per surface, the same wording for every model,
 | Analyze | "Which part of the company costs us the most in salary?" |
 | Plan | "What tables are in this database and how do they relate to each other?" |
 
-Ten models, six surfaces, five runs: **300 runs, and all 300 passed.**
+Twelve models, six surfaces, five runs: **360 runs, and all 360 passed.**
 
 A run passes only when its goal verdict is `answered`. A run that ends `succeeded` having
 answered nothing is a failure here, and the ledger names which bar it missed.
@@ -44,7 +44,7 @@ happens every time somebody asks.
 
 | | |
 | --- | --- |
-| Hardware | Apple M5 Max, 48 GB unified memory |
+| Hardware | Apple M5 Max, 64 GB unified memory |
 | Storage | 2 TB SSD |
 | Power | macOS high-power mode, on AC |
 
@@ -84,7 +84,7 @@ keeps the shipped one. That is on its page.
 
 ## Driven through the interface as well
 
-The 300 runs above were opened over HTTP. A separate sweep drove all ten models through the
+The 360 runs above were opened over HTTP. A separate sweep drove all twelve models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
 for the run to finish on screen — one run per surface: **57 of 60 passed.**
 

--- a/docs/llms/nvidia/nemotron3.md
+++ b/docs/llms/nvidia/nemotron3.md
@@ -1,0 +1,58 @@
+# nemotron3
+
+`ollama pull nemotron3:<size>` · sizes supported: 33b
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+The largest model in the product by a wide margin, and the only one that ended a run by asking
+its user a question.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| nemotron3:33b | 27 GB | 12s | 49s | 20s | 18s | 29s | 14s | **21s** | 1:59 |
+
+Optimize is the cell that took twenty-eight runs across eight sittings to close, and it is the
+one to read the note below about.
+
+## What it needs that the defaults do not give it
+
+### `nemotron3:33b`
+
+**a retry when it stops having read nothing.** Twice it ended a run by asking for the data
+instead of reading it — the clearer of the two ten seconds in, zero tools invoked, closing with
+"Could you please share the exact SQL statement you're running for the employee listing?" while
+holding `inspect_schema` and `inspect_plan`. A run has no user on the other end, so the question
+is a stop. The drive now names the instrument once and gives the turn back.
+
+Free to grant: `compose_report` is one of the tools the drive counts, so a run reaching that
+point with nothing called has already earned `no-report`, and the turn is spent on a run that
+has lost.
+
+**worked refusal examples.** Three of its optimization losses are one refusal repeated until the
+run runs out of time — `claims: expected array`, the same sentence each time, seven times in one
+run. The example is built from the run's own ledger, so a model that copies it verbatim gets a
+call that is accepted.
+
+## Where these figures are softest
+
+The optimization cell is **locked but marginal**, and every sweep since has said so: 5/5, 5/5,
+4/5, 4/5, and 3/5 on a rested machine. Every loss has one signature — the turn after the last
+tool call running long, at 90.0 s, 106 s, 172.7 s, 244.6 s and 430.8 s against a 90-second turn,
+where the passing runs compose in 21 to 100.
+
+A 150-second turn was measured against it directly (`docs/BACKLOG.md` B66): five runs read 3/5
+again, but one of them composed at **114 s** — a run the shipped limit would have killed. So the
+limit is part of the answer and not all of it; what the runs actually show is a report turn whose
+length varies by a factor of twenty on identical input. Assess shows the same shape at 3/5 on the
+same sweep.
+
+Recorded rather than smoothed: the pass/fail figures above are the measurement that locked the
+cell, and these are what a later reader gets when they run it again.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/qwen/qwen3.5.md
+++ b/docs/llms/qwen/qwen3.5.md
@@ -1,9 +1,10 @@
 # qwen3.5
 
-`ollama pull qwen3.5:<size>` · sizes supported: 9b
+`ollama pull qwen3.5:<size>` · sizes supported: 4b, 9b
 
 Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
-runs. One supported size, and the only model in the product with a turn limit of its own.
+runs. Two supported sizes, and the 9b is the only model in the product with a turn limit of its
+own.
 
 ## What it does, and how long it takes
 
@@ -11,11 +12,22 @@ Seconds are the median of the runs that passed, per surface.
 
 | Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| qwen3.5:4b | 3.4 GB | 6s | 44s | 33s | 11s | 13s | 2s | **11s** | 2:36 |
 | qwen3.5:9b | 5.8 GB | 31s | 31s | 52s | 21s | 26s | 1:38 | **33s** | 1:38 |
 
-Every cell is 5/5, so the table says how long rather than whether.
+Every cell is 5/5, so the table says how long rather than whether. The 4b's slowest run is its
+optimization cell, which is also the one that did not reproduce at 5/5 on a later sweep - see
+below.
 
 ## What it needs that the defaults do not give it
+
+### `qwen3.5:4b`
+
+**no reasoning on the plan turn.** Its plan cell was 0/5 at the defaults, and every loss was a
+`model-timeout` with an empty ledger: asked for one statement against a Studio-sized prompt it
+returns 13 188 characters of reasoning against 1 165 of content, in 48 seconds. With
+`reasoning_effort: "none"` the same five runs finish in 2 to 6. Applied to the plan turn only -
+its five agent surfaces were all measured WITH reasoning and pass as they are.
 
 ### `qwen3.5:9b`
 

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -7,7 +7,7 @@ are environment variables read at server startup, which is how everything else i
 is configured. It keeps the choice with whoever operates the server rather than turning it into
 a permission to grant, revoke and audit per user.
 
-Ten models are supported — every one of them clears all six agent surfaces five consecutive
+Twelve models are supported — every one of them clears all six agent surfaces five consecutive
 times. They are listed with their measured durations in the [index](README.md).
 
 ## A local model, through Ollama


### PR DESCRIPTION
The measurement half left outstanding on #487. @cevheri asked for the per-surface figures only a
sweep can produce; these are them, with the rows, pages and counts they let move together.

## The machine was wrong, and every duration rests on it

`methodology.md` recorded **48 GB** of unified memory. The machine that took every figure in
these pages has **64**. Introduced in #415 and unnoticed since — which is its own argument for
writing the host down beside the numbers.

## The numbers

**`nemotron3:33b`** — 27 GB

| Surface | Passed | Median | Slowest |
| --- | --- | --- | --- |
| Investigate | 5/5 | 11.8s | 20.7s |
| Optimize | 3/5 | 49.2s | 118.9s |
| Assess | 3/5 | 20.3s | 23.7s |
| Operate | 5/5 | 17.9s | 38.7s |
| Analyze | 8/9 | 28.5s | 69.7s |
| Plan | 5/5 | 14.4s | 32.6s |
| **overall** | 29 runs | **20.7s** | 118.9s |

**`qwen3.5:4b`** — 3.4 GB

| Surface | Passed | Median | Slowest |
| --- | --- | --- | --- |
| Investigate | 5/5 | 6.1s | 6.1s |
| Optimize | 3/5 | 44.1s | 155.6s |
| Assess | 5/5 | 33.0s | 51.5s |
| Operate | 5/5 | 10.6s | 11.3s |
| Analyze | 5/5 | 13.3s | 14.1s |
| Plan | 5/5 | 1.6s | 3.9s |
| **overall** | 28 runs | **11.2s** | 155.6s |

Analyze has nine runs because three were refused by the rate limiter and re-run; all nine are in
the ledger and none is discarded.

## What moved

Two rows placed **by median**, like every row already there. Ten becomes twelve and 300 runs
becomes 360 — in `README.md`, `setup.md`, `methodology.md` and `AGENT.md` together, because a
count that moves alone is how a table comes to disagree with the sentence above it.

`docs/llms/nvidia/nemotron3.md` is new, following the one-page-per-model-version rule the README
states. `qwen3.5.md` gains its 4b row and its plan-reasoning note; its header said
"sizes supported: 9b" while the code shipped both.

## One section that is not a celebration

`nemotron3:33b`'s optimization cell has now been swept five times: **5/5, 5/5, 4/5, 4/5, and 3/5
on a rested machine.** Every loss carries one signature — the turn after the last tool call
running 90.0 s, 106 s, 172.7 s, 244.6 s or 430.8 s against a 90-second limit, where the passing
runs compose in 21 to 100.

**B66 was measured rather than left as a suggestion.** Five runs at a 150-second turn read 3/5
again — but one composed at **114 s**, a run the shipped limit would have killed. So the limit is
part of the answer and not all of it; underneath it is a report turn whose length varies
twentyfold on identical input. `Assess` reads 3/5 on the same sweep.

Two things were ruled out before reporting this. The model runs **100% on GPU** at ~110 tokens/s
with the machine in high-power mode, and shrinking its context from 131 072 to 16 384 changes
tokens-per-second by under 6% — so this is not configuration and not thermal throttling. The cell
was also re-run on a rested machine, per `methodology.md`'s own rule, and read 3/5 there too.

The pass/fail figures in the entries are the measurement that locked those cells and are not
touched here. This says what a reader gets when they run it again.

## Verified

`format` · `lint` · `typecheck` · `knip` · `chart:check` · `channels:showcase:check` ·
`readme:check` · `security:check` · `build` · `build:lib` · `attw` — all pass.
`bun run test` is **9447/9450**; the three failures are assertions in
`tests/integration/db/sqlite-provider.test.ts` that fail on a clean current-`main` checkout on
this machine and are green in CI. Coverage is unchanged by construction — every file in this diff
is a `.md`.

Measured on: MacBook Pro (Mac17,6), Apple M5 Max, 18 cores, 64 GB unified memory, macOS 26.6
(25G72), Ollama 0.32.13, Bun 1.3.11, at the 90 000 ms turn limit, against the embedded SQLite
sample database.