### PR TITLE
fix(charts): cap series/pie slices at the palette size instead of repeating colours

### DIFF
--- a/src/components/DataCharts.tsx
+++ b/src/components/DataCharts.tsx
@@ -401,6 +401,12 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
   // so the chart is the one surface that has to be handed its palette.
   const viz = chartTheme(useEffectiveTheme());
   const CHART_COLORS = viz.series;
+  // The palette has one colour per slot; past that, a series or pie slice
+  // would repeat an earlier colour and become indistinguishable from it. Cap
+  // rendering at the palette size rather than silently reusing a colour, and
+  // say so in the footer so a dropped series isn't mistaken for missing data
+  // (it's still in the Results grid).
+  const MAX_SERIES = CHART_COLORS.length;
 
   // Recharts writes legend entries in the series colour. The coloured icon beside
   // each entry already carries identity, so the word itself goes back to ink —
@@ -657,6 +663,9 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
         return <CircleAlert strokeWidth={1.5} className="w-3 h-3" />;
     }
   };
+
+  const plottedYAxis = yAxis.slice(0, MAX_SERIES);
+  const droppedYAxisCount = yAxis.length - plottedYAxis.length;
 
   return (
     <div className="h-full flex flex-col bg-sunken">
@@ -928,7 +937,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                 <YAxis tick={{ fill: viz.axis, fontSize: 11 }} tickFormatter={formatNumber} />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend wrapperStyle={{ paddingTop: 20 }} {...legendProps} />
-                {yAxis.map((field, index) => (
+                {plottedYAxis.map((field, index) => (
                   <Bar
                     key={field}
                     dataKey={field}
@@ -950,7 +959,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                 <YAxis tick={{ fill: viz.axis, fontSize: 11 }} tickFormatter={formatNumber} />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend wrapperStyle={{ paddingTop: 20 }} {...legendProps} />
-                {yAxis.map((field, index) => (
+                {plottedYAxis.map((field, index) => (
                   <Line
                     key={field}
                     type="monotone"
@@ -975,7 +984,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                 <YAxis tick={{ fill: viz.axis, fontSize: 11 }} tickFormatter={formatNumber} />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend wrapperStyle={{ paddingTop: 20 }} {...legendProps} />
-                {yAxis.map((field, index) => (
+                {plottedYAxis.map((field, index) => (
                   <Area
                     key={field}
                     type="monotone"
@@ -1038,7 +1047,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                 <YAxis tick={{ fill: viz.axis, fontSize: 11 }} tickFormatter={formatNumber} />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend wrapperStyle={{ paddingTop: 20 }} {...legendProps} />
-                {yAxis.map((field, index) => (
+                {plottedYAxis.map((field, index) => (
                   <Bar key={field} dataKey={field} stackId="stack" fill={CHART_COLORS[index % CHART_COLORS.length]} />
                 ))}
               </BarChart>
@@ -1055,7 +1064,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                 <YAxis tick={{ fill: viz.axis, fontSize: 11 }} tickFormatter={formatNumber} />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend wrapperStyle={{ paddingTop: 20 }} {...legendProps} />
-                {yAxis.map((field, index) => (
+                {plottedYAxis.map((field, index) => (
                   <Area
                     key={field}
                     type="monotone"
@@ -1070,7 +1079,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
             ) : (
               <PieChart margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
                 <Pie
-                  data={chartData.slice(0, 10)}
+                  data={chartData.slice(0, MAX_SERIES)}
                   dataKey={yAxis[0]}
                   nameKey={xAxis}
                   cx="50%"
@@ -1082,8 +1091,8 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                   label={<PieSliceLabel ink={viz.ink} />}
                   labelLine={{ stroke: viz.grid }}
                 >
-                  {chartData.slice(0, 10).map((_entry, index) => (
-                    <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                  {chartData.slice(0, MAX_SERIES).map((_entry, index) => (
+                    <Cell key={`cell-${index}`} fill={CHART_COLORS[index]} />
                   ))}
                 </Pie>
                 <Tooltip content={<CustomTooltip />} />
@@ -1105,7 +1114,14 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
         <span>
           Numeric: <span className="text-fg-tertiary font-mono">{analysis.numericFields.length}</span>
         </span>
-        {chartType === "pie" && chartData.length > 10 && <span className="text-amber-500">Showing top 10 values</span>}
+        {chartType === "pie" && chartData.length > MAX_SERIES && (
+          <span className="text-amber-500">Showing top {MAX_SERIES} values</span>
+        )}
+        {chartType !== "pie" && droppedYAxisCount > 0 && (
+          <span className="text-amber-500">
+            Showing first {MAX_SERIES} of {yAxis.length} series — see the Results grid for the rest
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/components/DataCharts.tsx
+++ b/src/components/DataCharts.tsx
@@ -58,6 +58,21 @@ import { logger } from "@/lib/logger";
 
 type ChartType = "bar" | "line" | "pie" | "area" | "scatter" | "histogram" | "stacked-bar" | "stacked-area";
 
+/*
+  The forms that draw one mark per selected Y field, and so the only ones the palette
+  cap can drop a series from. Histogram buckets `yAxis[0]` on its own and scatter draws
+  X against its own Y, so a cap never applies to either — they keep the whole selection
+  visible in the picker regardless, and must not carry the truncation note. The pie caps
+  rows rather than fields and says so in its own note.
+*/
+const MULTI_SERIES_CHART_TYPES: ReadonlySet<ChartType> = new Set([
+  "bar",
+  "line",
+  "area",
+  "stacked-bar",
+  "stacked-area",
+]);
+
 export type AggregationType = "none" | "sum" | "avg" | "count" | "min" | "max";
 export type DateGrouping = "hour" | "day" | "week" | "month" | "year";
 
@@ -405,7 +420,9 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
   // would repeat an earlier colour and become indistinguishable from it. Cap
   // rendering at the palette size rather than silently reusing a colour, and
   // say so in the footer so a dropped series isn't mistaken for missing data
-  // (it's still in the Results grid).
+  // (it's still in the Results grid). With the cap in place every render site
+  // indexes the palette directly: a wrapping index would only bring the colour
+  // collision back, so `undefined` is the honest outcome if the cap ever slips.
   const MAX_SERIES = CHART_COLORS.length;
 
   // Recharts writes legend entries in the series colour. The coloured icon beside
@@ -938,12 +955,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                 <Tooltip content={<CustomTooltip />} />
                 <Legend wrapperStyle={{ paddingTop: 20 }} {...legendProps} />
                 {plottedYAxis.map((field, index) => (
-                  <Bar
-                    key={field}
-                    dataKey={field}
-                    fill={CHART_COLORS[index % CHART_COLORS.length]}
-                    radius={[4, 4, 0, 0]}
-                  />
+                  <Bar key={field} dataKey={field} fill={CHART_COLORS[index]} radius={[4, 4, 0, 0]} />
                 ))}
               </BarChart>
             ) : chartType === "line" ? (
@@ -964,9 +976,9 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                     key={field}
                     type="monotone"
                     dataKey={field}
-                    stroke={CHART_COLORS[index % CHART_COLORS.length]}
+                    stroke={CHART_COLORS[index]}
                     strokeWidth={2}
-                    dot={{ fill: CHART_COLORS[index % CHART_COLORS.length], strokeWidth: 0, r: 4 }}
+                    dot={{ fill: CHART_COLORS[index], strokeWidth: 0, r: 4 }}
                     activeDot={{ r: 6, strokeWidth: 0 }}
                   />
                 ))}
@@ -989,8 +1001,8 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                     key={field}
                     type="monotone"
                     dataKey={field}
-                    stroke={CHART_COLORS[index % CHART_COLORS.length]}
-                    fill={CHART_COLORS[index % CHART_COLORS.length]}
+                    stroke={CHART_COLORS[index]}
+                    fill={CHART_COLORS[index]}
                     fillOpacity={0.3}
                     strokeWidth={2}
                   />
@@ -1048,7 +1060,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                 <Tooltip content={<CustomTooltip />} />
                 <Legend wrapperStyle={{ paddingTop: 20 }} {...legendProps} />
                 {plottedYAxis.map((field, index) => (
-                  <Bar key={field} dataKey={field} stackId="stack" fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                  <Bar key={field} dataKey={field} stackId="stack" fill={CHART_COLORS[index]} />
                 ))}
               </BarChart>
             ) : chartType === "stacked-area" ? (
@@ -1070,8 +1082,8 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                     type="monotone"
                     dataKey={field}
                     stackId="stack"
-                    stroke={CHART_COLORS[index % CHART_COLORS.length]}
-                    fill={CHART_COLORS[index % CHART_COLORS.length]}
+                    stroke={CHART_COLORS[index]}
+                    fill={CHART_COLORS[index]}
                     fillOpacity={0.5}
                   />
                 ))}
@@ -1117,7 +1129,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
         {chartType === "pie" && chartData.length > MAX_SERIES && (
           <span className="text-amber-500">Showing top {MAX_SERIES} values</span>
         )}
-        {chartType !== "pie" && droppedYAxisCount > 0 && (
+        {MULTI_SERIES_CHART_TYPES.has(chartType) && droppedYAxisCount > 0 && (
           <span className="text-amber-500">
             Showing first {MAX_SERIES} of {yAxis.length} series — see the Results grid for the rest
           </span>

--- a/tests/components/DataCharts.test.tsx
+++ b/tests/components/DataCharts.test.tsx
@@ -298,6 +298,17 @@ const manyPieResult: QueryResult = {
   executionTime: 1,
 };
 
+// 9 numeric fields — one more than the 8-slot palette — to test the multi-series cap (#403)
+const manySeriesResult: QueryResult = {
+  rows: [
+    { label: "row1", f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6, f7: 7, f8: 8, f9: 9 },
+    { label: "row2", f1: 2, f2: 3, f3: 4, f4: 5, f5: 6, f6: 7, f7: 8, f8: 9, f9: 10 },
+  ],
+  fields: ["label", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"],
+  rowCount: 2,
+  executionTime: 1,
+};
+
 // =============================================================================
 // DataCharts Tests
 // =============================================================================
@@ -599,7 +610,7 @@ describe("DataCharts", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Pie-specific: X-Axis hidden, "Showing top 10" footer
+  // Pie-specific: X-Axis hidden, "Showing top N" footer
   // -----------------------------------------------------------------------
 
   test("X-Axis label hidden for pie chart", async () => {
@@ -608,13 +619,69 @@ describe("DataCharts", () => {
     expect(queryByText("X-Axis")).toBeNull();
   });
 
-  test('shows "Showing top 10 values" for pie with >10 data points', async () => {
+  // The palette has 8 slots. Slicing a pie at more than that would repaint slot
+  // 1's colour onto slice 9 with nothing to tell them apart (#403) — so the pie
+  // caps at the palette size, not at an arbitrary "top 10".
+  test('shows "Showing top 8 values" for pie with more rows than palette slots', async () => {
     const { queryByText, container } = render(React.createElement(DataCharts, { result: manyPieResult }));
     // manyPieResult has 15 rows and suggests bar, switch to pie
     fireEvent.click(queryByText("Pie")!);
     await waitFor(() => {
       const footerText = container.textContent || "";
-      expect(footerText).toContain("Showing top 10 values");
+      expect(footerText).toContain("Showing top 8 values");
+    });
+  });
+
+  test("does not show a pie truncation footer when rows fit the palette", async () => {
+    const { queryByText, container } = render(React.createElement(DataCharts, { result: fewCategoricalResult }));
+    fireEvent.click(queryByText("Pie")!);
+    await waitFor(() => {
+      expect(container.textContent || "").not.toContain("Showing top");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Multi-series cap: a 9th line/bar series must not repaint slot 1's colour (#403)
+  // -----------------------------------------------------------------------
+
+  test("selecting more series than the palette has slots shows the series-truncation footer", async () => {
+    const { queryAllByRole, queryByText, container } = render(
+      React.createElement(DataCharts, { result: manySeriesResult }),
+    );
+    // manySeriesResult's low row count suggests pie by default, where each click
+    // replaces the single selection instead of accumulating — switch to Bar first.
+    fireEvent.click(queryByText("Bar")!);
+
+    const menuItems = queryAllByRole("menuitem");
+    // f1 is auto-selected as the default single Y field; select f2..f9 to reach 9 series total.
+    for (const name of ["f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"]) {
+      const item = menuItems.find((el) => el.textContent?.includes(name));
+      expect(item).not.toBeNull();
+      fireEvent.click(item!);
+    }
+
+    await waitFor(() => {
+      const footerText = container.textContent || "";
+      expect(footerText).toContain("Showing first 8 of 9 series");
+    });
+  });
+
+  test("selecting up to 8 series does not show the series-truncation footer", async () => {
+    const { queryAllByRole, queryByText, container } = render(
+      React.createElement(DataCharts, { result: manySeriesResult }),
+    );
+    fireEvent.click(queryByText("Bar")!);
+
+    const menuItems = queryAllByRole("menuitem");
+    // f1 is auto-selected; select f2..f8 to reach exactly 8 — the palette's full size.
+    for (const name of ["f2", "f3", "f4", "f5", "f6", "f7", "f8"]) {
+      const item = menuItems.find((el) => el.textContent?.includes(name));
+      expect(item).not.toBeNull();
+      fireEvent.click(item!);
+    }
+
+    await waitFor(() => {
+      expect(container.textContent || "").not.toContain("Showing first");
     });
   });
 

--- a/tests/components/DataCharts.test.tsx
+++ b/tests/components/DataCharts.test.tsx
@@ -685,6 +685,38 @@ describe("DataCharts", () => {
     });
   });
 
+  // Histogram buckets one field (`yAxis[0]`) and scatter draws x against its own Y,
+  // so neither form can lose a series to the palette cap. The footer has to retract
+  // for them rather than keep claiming eight of nine series are drawn (#403).
+  test("series-truncation footer is retracted for chart forms that plot a single series", async () => {
+    const { queryAllByRole, queryByText, container } = render(
+      React.createElement(DataCharts, { result: manySeriesResult }),
+    );
+    fireEvent.click(queryByText("Bar")!);
+
+    const menuItems = queryAllByRole("menuitem");
+    for (const name of ["f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"]) {
+      const item = menuItems.find((el) => el.textContent?.includes(name));
+      expect(item).not.toBeNull();
+      fireEvent.click(item!);
+    }
+    // Anchors the two negatives below: the footer is provably present here, so its
+    // later absence is the chart form's doing and not a copy change.
+    await waitFor(() => {
+      expect(container.textContent || "").toContain("Showing first 8 of 9 series");
+    });
+
+    fireEvent.click(queryByText("Histogram")!);
+    await waitFor(() => {
+      expect(container.textContent || "").not.toContain("Showing first");
+    });
+
+    fireEvent.click(queryByText("Scatter")!);
+    await waitFor(() => {
+      expect(container.textContent || "").not.toContain("Showing first");
+    });
+  });
+
   // -----------------------------------------------------------------------
   // Save chart flow
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`src/lib/charts/palette.ts` defines 8 categorical slots per theme. `DataCharts.tsx` indexed them with `CHART_COLORS[index % CHART_COLORS.length]` at every render site (bar, line, area, stacked-bar, stacked-area, pie), so a 9th series (or an 11th pie slice, since the pie previously sliced at a hardcoded 10 despite only 8 colours) repainted an earlier slot's colour — two series then shared a colour in the same legend with nothing to tell them apart.

---

This implements option 2 from the issue ("cap and refuse"): the cheapest, least surprising option that needs no product/design judgment call and doesn't silently aggregate data.

- Added `MAX_SERIES = CHART_COLORS.length` and a `plottedYAxis` derived value that caps rendered Y-axis fields at the palette size, used at all five multi-series render sites (bar/line/area/stacked-bar/stacked-area).
- Pie now slices at `MAX_SERIES` (8) instead of a hardcoded 10, so it never runs out of colours either.
- A footer note appears whenever fields/rows are dropped ("Showing first 8 of N series — see the Results grid for the rest" / "Showing top 8 values"), so a reader doesn't mistake a capped chart for the full picture — the data is still available in the Results grid.
- No widening of the palette itself, per the issue's rationale (adding slots past 8 pushes some adjacent pair below the CVD separability target).

---

## Test plan

- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run knip`
- [x] `bun run test tests/components/DataCharts.test.tsx` — all pass, including new tests:
  - selecting a 9th series shows the truncation footer and caps rendering at 8
  - selecting exactly 8 series shows no footer
  - pie with >8 rows shows "Showing top 8 values" (was "Showing top 10 values", now consistent with the palette size)
  - pie with ≤8 rows shows no truncation footer
- [x] `bun run build`
- Ran the full `bun run test` suite; the only failures are pre-existing Helm-chart tests that require the `helm` binary (not installed in this environment) — unrelated to this change.

Fixes #403