### PR TITLE
fix(db,agent,ui): a Redis ACL user was dropped, a right answer was scored wrong, and five more

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -304,7 +304,8 @@ same class as the `seed:<id>` concern above, recorded as `docs/BACKLOG.md` B68. 
 run history across threads.
 
 A run emits a closed set of **semantic events**, and they are the whole of what the UI renders:
-`run-started`, `driver-resolved`, `context-captured`, `statement-drafted`, `plan-statement-drafted`,
+`run-started`, `driver-resolved`, `context-captured`, `context-unavailable`, `statement-drafted`,
+`plan-statement-drafted`,
 `tool-invoked`, `tool-completed`, `tool-refused`, `report-composed`, `closing-statement`,
 `run-finished`, plus the four a single workflow's own tool writes — `plan-comparison`,
 `recommendation`, `table-profiled` and `answer-composed`.
@@ -317,6 +318,20 @@ document's path and a digest of the bytes as read, or `operator-ignored` with th
 document was configured and could not be used. The last is its own case on purpose — a run driven by
 the shipped settings because nobody configured a document, and one driven by them because the
 operator's could not be read, behave identically and mean opposite things.
+
+**`context-unavailable` says a capture was REFUSED**, and it is a separate kind rather than a
+`context-captured` carrying an absence. A refused capture read nothing, so it has no fingerprint and
+no table count - writing `tableCount: 0` would state that the database has no tables - and three
+readers take `context-captured` as proof an inventory exists (`reusableSnapshot`, the grounding check
+the tools layer applies to a citation, and the rail's own capture line). It carries the reason code,
+the capture's own one-sentence diagnosis, and, where the row budget is what refused the read, both
+numbers: rows projected against rows allowed. Before it, a plan run whose capture was refused left
+nothing at all between the drive starting and the run ending, so the rule this document's setup guide
+states about ledgers - that the ledger is the authority on what a run did - held only for captures
+that succeeded, in exactly the case an operator has to diagnose. The reason code and the sentence
+never depend on parsing anything; the two numbers are read back out of the provider's own refusal
+message, which is pinned by a test that drives a real over-budget read rather than by a copy of the
+sentence.
 
 It is written **once per drive** rather than once per run, because a resume picks the model up from
 the configuration as it stands then: a run resumed after an operator changed it carries one entry per
@@ -836,7 +851,7 @@ something that is not an estimating plan of this run, while `PLAN_RESULT_RELEASE
 was honest and the rows have expired — telling a model the first when the second happened would send
 it looking for a mistake it did not make.
 
-Its goal verifier is `agent-query-optimization.2`: the investigation baseline, **and** evidence that
+Its goal verifier is `agent-query-optimization.3`: the investigation baseline, **and** evidence that
 the change it proposes rests on what the engine actually does. The baseline dominates, so a run that
 never reported is told that rather than that it skipped a comparison.
 
@@ -849,6 +864,17 @@ attempted `CREATE INDEX ...; SELECT ...`, was refused as it should be, and was t
 the plan it **diagnosed**, cited by the recommendation itself: `no-plan-evidence` is an index
 recommendation that names no plan this run read. Not merely a plan somewhere on the ledger — the
 citation is what ties the index to the access path it changes.
+
+**A plan is exempt from the baseline's emptiness clause, which is the same lesson a third time.**
+A plan is a description of a statement, it arrives in one column, and the driver reports no
+row count for it - so the artifact is complete and its `rowCount: 0` measures nothing. Driven live on
+2026-08-17, every Optimize run in the drive ended `empty-evidence`, including one that compared real
+PostgreSQL costs, recommended the right index and offered it to the editor, because the plan was the
+only thing those reports had to cite: the product contradicted its own good answer, in its own voice,
+at the end of the run. The exemption is one artifact **kind** and nothing more - an empty bounded read
+cited by an optimization report still ends the run `empty-evidence`, because zero rows from a read is
+the answer that read gave - and it is this rule's alone: `agent-investigation.1` and the two verifiers
+composing on it are untouched, so the id bump is `agent-query-optimization.2` -> `.3`.
 
 ### The database-assessment template
 
@@ -909,10 +935,14 @@ and that is a reversal of a product decision rather than an oversight: epic #325
 set at three and #330 T3 reopened it. Its own id is what lets an operator see profiling in the audit
 stream, and deny it, without denying every read the agent makes.
 
-Three honest limits, each with a backlog entry: SQLite hides constraint-created indexes so
-`fk_unindexed` can fire on a covered key (**B25**); only an email shape is tested, because `LIKE`
+Two honest limits, each with a backlog entry: only an email shape is tested, because `LIKE`
 cannot express a digit run (**B26**); and a profile that times out reports the failure rather than
-falling back to catalog statistics (**B28**).
+falling back to catalog statistics (**B28**). A third is closed: SQLite stores no DDL for the index
+it builds to enforce a `UNIQUE` constraint, so the composed index read cannot see it - the capture
+now reads those out of the table's own `CREATE TABLE` and lists them as `(unique constraint)`, plain
+words rather than a name that could be mistaken for a user's `CREATE INDEX`. `fk_unindexed` remains a
+prefix test: an index serves the column it LEADS on, so `UNIQUE (note, parent_id)` does not cover
+`parent_id`.
 
 ### The operations template
 
@@ -1767,7 +1797,7 @@ build until somebody decides what "answered" means for it.
 | --- | --- | --- |
 | `planning` | The run left non-empty closing prose, **and** that prose was its deliverable: a drafted statement on the ledger, or an explicit `NO STATEMENT:` refusal. That mode is toolless and can never cite evidence, so judging it by the investigation rule would fail every planning run that did its job — but prose alone was how a generic lecture scored `answered` for as long as it did. `operations` planning is exempt: its plan deliverable is prose by decision, and the exemption survives that workflow's rules welcoming a fenced reading — welcome is not required, and a run that produced no block may have answered its objective perfectly, so a bar asking for one would fail it. Which engines can express a reading as a statement is deliberately not the basis: a Redis Operate plan was observed writing `INFO memory` into a block its editor runs. | `no-plan`, `no-statement` |
 | `agent` (investigation) | The run composed at least one claim, **and** the claims do not rest entirely on empty results. | `no-report`, `empty-evidence` |
-| `agent` (query-optimization) | The baseline above, **and** either a plan comparison on the ledger or an index recommendation citing a plan this run read. `agent-query-optimization.2`. | the above, plus `no-plan-comparison`, `no-plan-evidence` |
+| `agent` (query-optimization) | The baseline above with **plans exempt from its emptiness clause** (a plan's row count measures nothing), **and** either a plan comparison on the ledger or an index recommendation citing a plan this run read. `agent-query-optimization.3`. | the above, plus `no-plan-comparison`, `no-plan-evidence` |
 | `agent` (database-assessment) | The baseline above, **and** a table profiled. `agent-database-assessment.1`. | the above, plus `no-table-profile` |
 | `agent` (operations) | A composed report, **and** at least one claim in it citing an artifact this run read. `agent-operations.2`. **Not** composed on the baseline: an empty reading is an answer, so the emptiness clause is dropped — and an empty reading still satisfies the citation arm, because the artifact exists. The arm was added by #411: the run gained a citable schema inventory, so "cite a reading" stopped being enforced by composition alone. See [The operations template](#the-operations-template). | `no-report`, `no-reading`, `cancelled` |
 | `agent` (data-analysis) | The baseline above, **and** an `answer-composed` entry: which result IS the answer, and how to show it — **and at least one claim citing that same artifact**, so the report is about the result it presented. `agent-data-analysis.1`. | the above, plus `no-answer`, `answer-uncited` |
@@ -2438,23 +2468,12 @@ as they are fixed, and a numeral here goes stale silently.
 - **B71** — `@ai-sdk/workflow`'s `WorkflowAgent` offers the durability this repository implements by
   hand, and is not used: it requires the workflow runtime's programming model, which would bind the
   agent to a hosting runtime this product deliberately does not depend on.
-- **B37** — a seed config the server cannot read disables the agent on every connection, and the rail
-  blames the connection: "its settings live in this browser", said of a connection this application
-  seeds itself. The browser cannot tell an empty seed list from a failed one.
 - **B38** — an engine with no read-only execution path is offered a run anyway, and refuses only after
   the run has opened and spent a model turn. The rail withholds every other capability the host
   cannot serve; this is the one it does not.
 - **B39** — a data-analysis run has no honest way to conclude that the question is not about this
   database. Its only route to `answered` is a reading of the data, so a run that establishes the
   question is unanswerable fabricates one — the #356 shape again, in a new place.
-- **B45** — every query-optimization run is scored `unanswered / empty-evidence`, including one that
-  compared two plans, priced both and wrote the correct `CREATE INDEX`. A `sql.explain.estimate`
-  artifact records `rowCount: 0` because a plan arrives in a single column, and
-  `verifyOptimizationGoal` composes on the investigation baseline, which carries the emptiness arm.
-  The operations template was exempted from exactly this, for a reason it states at length — holding
-  an operational reading to the emptiness rule is "precisely backwards" — and that argument applies
-  to a plan artifact verbatim. The #356 shape a third time: a rule stated in terms of an artifact
-  only one valid answer can produce.
 - **B48** — the two grounding paths fail differently. Since #414 a plan run on one of the nine
   provider-path engines survives an unreachable host, a wrong password or a half-configured
   `agentUser`: `captureFromProvider` converts a `DatabaseError` or an `ExecutionProfileError` raised
@@ -2463,6 +2482,20 @@ as they are fixed, and a numeral here goes stale silently.
   run `internal` or, on the profile error, `agent-credential-unusable`. Deliberate at #414, which had
   no business changing how the two engines it did not touch fail, and an asymmetry a reader will
   trip over until it is resolved.
+- **B72** — plans are exempt from the emptiness census for `query-optimization` only. The
+  investigation, database-assessment and data-analysis verifiers still judge a plan-only report by a
+  row count that measures nothing, and `inspect_plan` is offered to all three. Closing it changes what
+  three released verifier ids mean, so it takes the id bumps that implies; the boundary is pinned by a
+  test rather than left ambiguous.
+- **B73** — a refused capture's reason code is structural, but its row-budget pair still travels as
+  prose inside a `QueryError` message and is recovered by regex, with two prose consumers reading the
+  same sentence. Doing it properly touches the error type every provider throws, so the change that
+  recorded the refusal kept the regex and pinned it with a test that drives a real over-budget read.
+- **B74** — `UNIQUE (a COLLATE NOCASE)` is listed as covering a foreign key on `a`, which it cannot
+  serve for a binary equality lookup. A false negative in the direction opposite the constraint-index
+  fix,
+  left unmodelled because the user-index reader drops `COLLATE` too and honouring it in one reader
+  only would make the inventory disagree with itself.
 - **B51** — the loop delivers three notices to a model (the reserve warning, the report reminder of
   #416, the present-before-report notice of #417) and records none of them. `recordEvent` is called
   for what the RUN did and never for what the server said to it, so a rescued run and a run that never
@@ -2507,17 +2540,6 @@ as they are fixed, and a numeral here goes stale silently.
   baseline, so it is PostgreSQL's privilege rule and not an AlloyDB property. The agent is therefore
   unusable out of the box on all three, and the same shape will appear on any PostgreSQL whose image
   ships wide catalogs or wide extension views before the user has created anything.
-- **B54** — a REFUSED grounding capture records nothing in the run's own ledger, so the failure above
-  cannot be diagnosed from the record. A capture that succeeds writes `context-captured` with its
-  fingerprint, table count and snapshot; the `capture.kind === "unavailable"` branch pushes the
-  ungrounded note into the model's prompt and returns without recording anything. Measured on the same
-  AlloyDB Omni run: the ledger holds four events - `run-opened`, `run-started`, `closing-statement`,
-  `run-finished` - and its 849 bytes name no catalog read, no reason code and no row count, while the
-  Vitess ledger beside it carries `context-captured` with `ctx_3ce059ca...` and `tableCount 2`. The
-  reason (`CATALOG_READ_REFUSED`, 536 against 200) is computed, handed to the model and dropped; it is
-  not in the server log either. So the only trace is the model's own sentence, and this repo has
-  already recorded why that is dangerous - a missing event reads as work that was not needed rather
-  than knowledge that was lost.
 - **B55** — a grounded LibreDB plan run drafts `GET users:*`, and `get` is an exact-key lookup with no
   glob: the key does not exist, so the command answers zero rows and no error. The inventory's rows are
   NAMED `users:*`, which reads as a glob the grammar does not have, and LibreDB declares no
@@ -2533,8 +2555,8 @@ as they are fixed, and a numeral here goes stale silently.
   `$shipping.region` and recorded no `context-captured` event at all; a restart fixed it on the first
   run. Redis showed the same shape, refusing an objective about keys that had just been seeded. The
   design intent - a run reasons over the inventory its claims cite - is not the problem; a NEW run
-  inheriting it indefinitely is, and B54's gap means the ledger cannot tell "held, hours old" from
-  "captured just now".
+  inheriting it indefinitely is, and a reused snapshot writes no capture event of its own, so the
+  ledger cannot tell "held, hours old" from "captured just now".
 - **B57** — an operator's tuning document is refused WHOLE when any part of it fails. The argument
   behind that is about merging (half of one measurement beside half of another is a configuration
   nobody has run), and it justifies whole-**entry** replacement rather than whole-**document**

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -173,7 +173,14 @@ investigated. The rail says so rather than offering a Start that must fail:
 
 > *"… cannot be rebuilt on the server: its settings live in this browser. A run re-resolves its
 > connection there after a restart, so it can only investigate a connection the server holds too."*
-> (`AgentRail.tsx:1604-1610`)
+> (`AgentRail.tsx:2098-2104`)
+
+A *different* absence gets a different sentence. When the server could not read its own seed
+configuration, nothing has been established about your connection at all, so the rail says that
+instead of blaming it:
+
+> *"The server could not read its own connection configuration, so it cannot resolve a connection
+> for a run. This is not a problem with … — the server log says what failed."*
 
 ### What a Plan run knows about your database
 

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -1152,6 +1152,20 @@ Auth required. Returns seed/managed connections for the current user's role, wit
 { "connections": [], "cacheHint": 60000 }
 ```
 
+A failure the endpoint attributes to its **own seed configuration** says so, so a client can tell
+"the server serves no seeds" (a `200` with an empty `connections`) from "the server could not read
+its seeds":
+
+```json
+{ "error": "Failed to load managed connections", "reason": "seed-config-unreadable" }
+```
+
+`500` with `reason: "seed-config-unreadable"` means `seed-connections.yaml` could not be read or
+parsed. A `500` **without** `reason` is any other failure of the request and is not a claim about
+that file. The browser holds the second as an unread seed list rather than an empty one, which is
+what stops the agent rail reporting a connection's settings as browser-local when the server's own
+configuration is what failed.
+
 ---
 
 ### Admin API

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,21 +22,21 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S2–S7 · 5
-- [Drivers and connections](#drivers-and-connections) — D1–D29, U17 · 9
+- [Drivers and connections](#drivers-and-connections) — D1–D27, U17 · 7
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
 - [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U21 · 10
 - [Authentication and security headers](#authentication-and-security-headers) — AU2
-- [Tests](#tests) — T1–T3 · 2
+- [Tests](#tests) — T1–T5 · 4
 - [Dependencies](#dependencies) — P1–P5 · 5
 - [Documentation](#documentation) — DOC1, DOC3 · 2
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3
 - [Chart configuration surface](#chart-configuration-surface) — N1–N3 · 3
-- [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 10
+- [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 9
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C2–C10 · 9
 - [Security Phase 3 deferrals](#security-phase-3-deferrals) — K2–K4 · 2
 - [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A6 · 5
-- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B66 · 43
+- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B74 · 46
 
 ---
 
@@ -213,10 +213,6 @@ first-contact policy is written in `docs/providers/`-adjacent documentation the 
 
 ---
 
----
-
----
-
 ### D14. Three providers lost the buffer-pool gauge, because it was the cache hit ratio wearing a second name
 
 Removing the fabricated cache hit ratios exposed that `bufferPoolUsage` was not a second measurement.
@@ -231,10 +227,11 @@ extension not installed by default, `V$BUFFER_POOL_STATISTICS` needs the privile
 needs, and `sys.dm_os_buffer_descriptors` is a full descriptor scan on a large instance. So a gauge
 that reads a real pool has a cost the panel has never paid.
 
-**Done when:** each provider either measures pool occupancy for real, at a cost written down next to
-the query, or the field is dropped from `PerformanceMetrics` so no panel offers a gauge nothing fills.
-
----
+**Done when:** each of the three either measures pool occupancy for real, at a cost written down next
+to the query, or its omission is recorded as the answer. Dropping the field outright is no longer one
+of the options: MySQL, MongoDB, Couchbase and ClickHouse all fill it with a real occupancy figure
+(`mysql.ts`, `mongodb.ts`, `couchbase/index.ts`, `clickhouse/index.ts`), so removing it would delete
+four working gauges to tidy away three absent ones.
 
 ---
 
@@ -301,49 +298,6 @@ selected before a run can be started on it.
 **Done when:** either direction of the borrow is safe by construction — for instance a single-writer
 file has ONE cache entry that both callers key off, with the profile deciding how it is used rather
 than which handle it gets — or the agent-first order is refused with a sentence naming the lock.
-
-### D28. The scheme mappings still choose `require`, which the boolean rule now contradicts
-
-D26 stated the rule for a boolean TLS **parameter**: it maps onto the mode matching what the engine's
-own driver does with it, never onto a weaker one. `withSSLMode` in
-`src/lib/connection-string-parser.ts` maps the TLS **schemes** — `rediss://`, `couchbases://`, and
-ClickHouse's `https://` — onto `require`, which verifies nothing, while ioredis given `rediss://`
-verifies by default. So the same paste is read strongly through one door and weakly through another.
-
-Not changed with D26 on purpose: the existing comments justify `require` on a measured claim about
-self-hosted deployments — a Redis started with `--tls-port` presents a self-signed certificate, so a
-verifying default would refuse the ordinary local setup — and D26's entry names only the boolean
-parameters. `docs/providers/redis.md` now states the boundary rather than leaving the rule looking
-universal, which is why this is a written-down asymmetry and not a silent one.
-
-**Done when:** the schemes answer to the same stated rule as the parameters, or the reason a scheme is
-read more weakly than the parameter beside it is recorded next to `withSSLMode` as a decision rather
-than as an artefact.
-
-### D29. Redis ignores the username, so no ACL user can be used and a pasted one is lost silently
-
-Measured 2026-08-25 against `redis:latest`: `ACL SETUSER probe on >pw ~* +@all -info` creates a user
-whose `INFO` is refused (`NOPERM`), and a connection configured with that user and password still
-reported `Connection successful` with full health — because `RedisProvider.connect()`
-(`src/lib/db/providers/keyvalue/redis.ts:184`) builds `new Redis({ host, port, password, db, ... })`
-and passes **no `username`**, so ioredis authenticates as `default` and the configured user is
-dropped. On a server whose `default` user has no password, that is a connection made as a principal
-the user did not choose.
-
-The parser makes it worse rather than better: `redis://probe:pw@host` fills `user` from the URI
-(`connection-string-parser.ts:507`), so the field is collected, stored, and then ignored at the one
-place it matters. Redis 6 ACLs are how every managed Redis (Redis Cloud, ElastiCache RBAC, Azure
-Cache) issues least-privilege credentials, so this is not an exotic configuration.
-
-Found while looking for a live health failure to verify U19's degraded banner against — which is also
-what the absence rule (#477) would say about it: a health read that succeeds under the wrong principal
-is not the health of the connection that was configured.
-
-**Done when:** a configured Redis username reaches the client, and a server that refuses that user's
-`INFO` produces a degraded connection rather than a green one — measured against an ACL user, not
-inferred.
-
----
 
 ## Value interpolation
 
@@ -588,8 +542,6 @@ recorded reason it is withheld.
 
 ---
 
----
-
 ## Authentication and security headers
 
 ### AU2. Static assets receive no security headers — decided, not implemented
@@ -642,6 +594,47 @@ it — `images: { unoptimized: true }` disables the optimizer's fetch entirely a
 request against a running server. A unit test importing `next.config` cannot exercise the route.
 
 ---
+
+### T4. Eight backlog ids cited in `src/` name entries that no longer exist
+
+Measured 2026-08-26 by sweeping every `B*` id cited under `src/` against the entries in this file.
+Dangling, with the number of source files citing each: **B7** (2), **B8** (2), **B17** (1), **B18**
+(2), **B24** (3), **B27** (1), **B43** (8), **B47** (3). All of them predate this round -
+`git show HEAD:src/lib/agent/table-profile.ts` carries the B7 and B8 citations already.
+
+The mechanism is the asymmetry in the guard. `tests/unit/agent-documentation.test.ts` enforces the
+two-way invariant between `docs/AGENT.md` and this file, so a `B`-id cited by that document must
+exist and vice versa. Nothing checks a citation from a source comment. So the instruction this file
+opens with - delete an entry when the work lands - leaves every code comment pointing at it silently
+wrong, and those comments are not decoration: `table-profile.ts` cites B7 for "PostgreSQL expression
+indexes are absent" and B8 for "the catalog read returns composite keys as the cross product of both
+sides", which are behavioural limits a reader would act on.
+
+Not fixed in the round that found it, on purpose. Each of the eight needs its claim re-verified
+before it can be rewritten or restored, and the two possibilities are opposite: the entry may have
+been deleted because the limitation was fixed (in which case the comment is false), or deleted by
+mistake (in which case the entry should come back). Eight of those judgements is more than one round
+can do honestly.
+
+**Done when:** no id cited in `src/` is missing from this file, and the drift guard covers source
+citations the way it already covers `docs/AGENT.md`.
+
+### T5. The allowlist's provider-free check reads one level deep
+
+`tests/security/route-auth.test.ts` now verifies that every route on `ROUTES_WITHOUT_A_PROVIDER` is
+still provider-free, rather than merely naming a real route (this closed H10). It does that by
+reading each allowlisted route's own source and matching the provider entry points: the `@/lib/db`
+and `@/lib/llm` module specifiers by PREFIX, so a new factory export is covered the day it lands,
+plus the one indirect helper that exists today - `@/lib/api/schema-route`, which is how
+`db/schema/list` and `db/schema/relations` reach a provider without naming `@/lib/db` at all.
+
+The residual is transitive reach. A future route that obtains a provider through a NEW indirect
+helper module would still pass, because nothing follows the import graph. Measured at the time it was
+written: zero allowlisted routes reach a provider, with or without comment stripping, so this is a
+gap in the guard rather than a defect it is hiding.
+
+**Done when:** the check resolves a route's imports transitively, or the set of indirect helpers is
+itself pinned so a new one cannot appear unnoticed.
 
 ## Dependencies
 
@@ -1099,20 +1092,6 @@ considered each introduced a worse flaw.
 **Done when:** a cheaper, audit-visible eviction policy is found that does not reopen the oldest-first
 bypass.
 
-### H10. The route-guard allowlist verifies existence, not truth
-
-`ROUTES_WITHOUT_A_PROVIDER` in `tests/security/route-auth.test.ts` maps a route key to a one-line
-reason the route is exempt from the "requires a session" sweep. The only automated check on it confirms
-each key matches a real route on disk. It does not verify that the *reason* is still true.
-
-Nothing greps an allowlisted route's file for a provider import (`@/lib/db`, `getOrCreateProvider`,
-`createLLMProvider`, …). So a future edit that adds a provider call to one of these routes — say
-`storage/migrate` growing a database-backed feature — would silently escape the sweep the allowlist
-exists to police. Exactly the failure mode the enumeration was built to catch for undiscovered routes.
-
-**Done when:** a second, independent check greps each allowlisted file for provider-reaching imports
-and fails loudly if one appears.
-
 ### H11. `login_account`'s hard cap is an accepted denial-of-login handle on a known account
 
 The `login_account` bucket is keyed on `hmacHex(submittedEmail)`, which makes it immune to
@@ -1265,7 +1244,7 @@ rather than hand-maintained.
 
 ### C9. `elkjs` is EPL-2.0 and a direct production dependency
 
-Every other direct production dependency is permissive. `elkjs@0.11.1` is EPL-2.0 — a file-level
+Every other direct production dependency is permissive. `elkjs@^0.12.0` is EPL-2.0 — a file-level
 reciprocal license with a patent-retaliation clause — and it is ours by choice rather than transitive:
 the schema diagram's layout worker imports it at
 `src/components/schema-diagram/elk.worker.ts`.
@@ -1863,24 +1842,6 @@ overstates.
 against — a fingerprint sent with the request and compared server-side, refusing with a distinct reason
 when it has moved. Until then `docs/AGENT.md` says the comparison is against the last fetch.
 
-### B25. SQLite hides constraint-created indexes, so `fk_unindexed` can fire on a covered key
-
-`composeSqliteIndexes` reads the index inventory from `CREATE INDEX` text (`sql IS NOT NULL`), and the
-indexes SQLite creates for a `UNIQUE` or `PRIMARY KEY` constraint carry no DDL at all. They are absent
-from the captured inventory, so a foreign-key column covered by a `UNIQUE` constraint looks uncovered to
-`findUnindexedForeignKeys` (`src/lib/agent/table-profile.ts`).
-
-The finding is worded to survive this — "no index **in the captured inventory** leads on this
-foreign-key column", not "this foreign key is unindexed" — and the primary key is read from the column
-inventory rather than the index one, so a PK-covered key is already correct. What remains wrong is the
-`UNIQUE` case, which reports a covering index that exists.
-
-**Done when:** the SQLite capture surfaces constraint-created indexes — the information is in the
-table's own stored DDL, which `parseSqliteTableDdl` already reads for columns and foreign keys — or the
-finding is suppressed on SQLite for columns a `UNIQUE` constraint covers.
-
-Related: B7 (PostgreSQL expression indexes absent) and B8 (composite keys skipped entirely).
-
 ### B26. A profile can test for an email shape and not for a digit run
 
 `table-profile.ts` tests one value shape inside the database, `LIKE '%_@_%._%'`, and derives
@@ -2090,27 +2051,6 @@ a run resumed often enough passes any constant.
 per-drive constant — most likely as part of B6 — with a test that drives one run twice past the cap and
 shows the first drive's cited results still readable, or the surface stating that they are not.
 
-### B37. A malformed seed config disables the agent everywhere, and blames the connection
-
-Driven live on 2026-08-15. A `seed-connections.yaml` missing a required field made
-`GET /api/connections/managed` throw. The browser then held an empty `servedSeeds`, so
-`resolveAgentRunConnectionId` returned null for EVERY connection — including the two samples this
-application ships and seeds itself — and the rail said:
-
-> "Sample (Employees) cannot be rebuilt on the server: its settings live in this browser."
-
-False twice over. The connection is a seed, its settings live on the server, and what actually happened
-is that the server could not read its own config. The true cause appeared in the server log and nowhere
-a user can see.
-
-The rail is stating a conclusion drawn from an absence it cannot distinguish from a failure — the same
-shape as an unreadable plan reading as a cheap one (#373) — and it costs an operator the whole agent
-surface while pointing them at the wrong file.
-
-**Done when:** the browser can tell "the server served no seeds" apart from "the server could not load
-its seeds", and the rail says the second one differently, with a test that fails the managed endpoint
-and asserts the copy names the server's configuration rather than the connection.
-
 ### B38. A run is offered on an engine that cannot run it, and refuses only after a model turn
 
 Driven live on 2026-08-15. Starting an agent run on the bundled `libredb` sample opens the run, drafts a
@@ -2169,33 +2109,6 @@ database has answered it, and should be able to say so without inventing a query
 
 **Done when:** a data-analysis run can conclude "not answerable here" and be scored `answered` for it,
 with the rule stated in `WORKFLOW_TOOL_RULES` and an eval asserting no fabricated statement is sent.
-
-### B45. Every optimization run is scored `unanswered`, including one that produced a correct index
-
-Driven live on 2026-08-17. A query-optimization run compared plans with real PostgreSQL costs,
-recommended a `CREATE INDEX` that is the right index, offered it to the editor — and ended *"Run did not
-answer — Every result the report cited came back empty, so the answer rests on nothing."* Every Optimize
-run in that drive ended the same way.
-
-Two mechanisms compose into it. The plan artifact a run cites is `sql.explain.estimate`, and a plan
-arrives in a single column, so the artifact's summary records `rowCount: 0` — the artifact is complete
-and its row count is meaningless. And `verifyOptimizationGoal` composes on the investigation baseline,
-which carries the `empty-evidence` arm: every cited result returning zero rows ends the run unanswered.
-
-**This is structurally the same error the operations template was explicitly exempted from, and the
-exemption's own rationale applies verbatim.** `src/lib/agent/goal-verifier.ts` argues that holding an
-operational reading to the emptiness rule is "precisely backwards" — "no session is blocked" and "no
-index is unused" are answers, and marking a healthy server's run unanswered is "the same error as
-demanding an artifact only some valid answers can produce". A plan with zero rows in it is the same
-shape: emptiness is a property of how a plan is returned, not of whether the question was answered.
-
-The cost is worse than a wrong label, because the verdict is the part of a run a sceptical reader trusts
-most: the product contradicts its own good answer, in its own voice, at the end of the run.
-
-**Done when:** an optimization run whose report cites a plan and recommends an index is scored
-`answered` — either by exempting `sql.explain.estimate` from the emptiness arm or by not composing that
-arm into this template — with an eval that fails if the run above reads `unanswered`, and with the reason
-recorded next to the operations exemption so the two read as one decision.
 
 ### B48. The composed grounding path still loses a plan run to an environment failure
 
@@ -2317,41 +2230,6 @@ extension views before the user creates anything.
 
 **Done when:** a plan run against a stock TimescaleDB, one against a stock Cloudberry and one against a
 stock AlloyDB Omni all report a captured schema naming the user's tables.
-
-### B54. A refused grounding capture leaves no trace in the ledger, so B52 cannot be diagnosed from it
-
-`docs/llms/setup.md` states the rule this breaks: "Every run writes its ledger to `.workflow-data`, and
-that is the authority on what a run did."
-
-For a capture that SUCCEEDS that is true — `investigation.ts` records a `context-captured` event carrying
-the fingerprint, the table count and the whole snapshot. For a capture that is REFUSED it is not: the
-`capture.kind === "unavailable"` branch pushes `planningUngroundedNote(...)` into the model's prompt and
-returns without recording anything.
-
-Measured 2026-08-20 against a live AlloyDB Omni 17.9.0, in the browser, with a least-privilege agent
-role. Two ledgers side by side:
-
-- **Vitess, capture succeeded:** `context-captured`, `fingerprint ctx_3ce059ca...`, `tableCount 2`, plus
-  the full snapshot.
-- **AlloyDB Omni, capture refused:** four events — `run-opened`, `run-started`, `closing-statement`,
-  `run-finished` — and nothing between the second and the third. The 849-byte ledger names no catalog
-  read, no reason code and no row count.
-
-So the only record that the run was ungrounded is the model's own sentence, "This run was given no
-inventory of this database". The reason — `CATALOG_READ_REFUSED`, 536 rows against a 200-row budget, 341
-of them extension views in `public` — is computed in `context-snapshot.ts`, handed to the model, and then
-dropped. It is not in the ledger and not in the server log either: grepping the run's own log for
-`CATALOG_READ_REFUSED`, `row budget` and `536` finds nothing.
-
-Worse than a gap in telemetry, because this repo has already recorded the trap it walks into: a missing
-event reads as work that was not needed rather than knowledge that was lost. An operator diagnosing B52
-today has to reproduce the run outside the product to learn why it had no schema.
-
-Related: B13, where the capture's own SPEND is missing from the ledger for the same structural reason.
-
-**Done when:** a refused capture records an event carrying its `reasonCode` and, where the reason is the
-row budget, the two numbers — rows projected and rows allowed — and a plan run whose capture was refused
-can be explained from its ledger alone.
 
 ### B55. A LibreDB plan run drafts `GET users:*`, a command that answers zero rows rather than failing
 
@@ -2615,3 +2493,63 @@ nothing to do; if the packaging ever separates the durability primitives from th
 this is the entry to revisit.
 
 **Done when:** the packaging separates them, or this entry is deleted as permanently declined.
+
+### B72. Three verifiers still judge a plan-only report by the emptiness census
+
+B45 exempted plans from the emptiness clause for `query-optimization` only, and deliberately stopped
+there. `agent-investigation.1`, `agent-database-assessment.1` and `agent-data-analysis.1` still call
+`restsOnlyOnEmptyResults` with no exemption set, so a report of theirs whose only citation is a plan
+artifact is scored `empty-evidence` for the same wrong reason: a plan arrives in one column, the
+driver reports no row count for it, and that zero measures nothing.
+
+Reachable rather than theoretical - `inspect_plan` is in `AGENT_MODE_TOOLS`, so every one of those
+workflows is offered it. Left out of B45 because closing it means changing what three released
+verifier ids mean, which by this file's own versioning rule (`goal-verifier.ts`: a rule that changes
+its mind takes a new id) forces `agent-investigation.1` to `.2` plus the two ids composing on it,
+and updates across the eval suites and the verifier table. The narrow fix was measured; this one has
+not been.
+
+Pinned today rather than left ambiguous: a test asserts that an investigation citing the same
+plan-only ledger is still judged by the unexempted baseline, so the boundary is stated and a change
+to it is deliberate.
+
+**Done when:** a plan-only report is judged the same way whichever workflow composed it, with the id
+bumps that implies.
+
+### B73. The row-budget pair travels as prose and is recovered by regex
+
+B54 records a refused capture's `reasonCode` and, for a row-budget refusal, the two numbers. The
+reason code is structural. The numbers are not: they are formatted into a `QueryError` MESSAGE by the
+provider (`postgres.ts`, `sqlite.ts` - both refuse rather than truncate) and read back out by
+`rowBudgetIn` in `context-snapshot.ts`. `statementAdvice` (`tools.ts`) reads the same sentence with
+the same anchor, so there are two prose consumers, not one.
+
+Blast radius of doing it properly, measured while closing B54: a structured field on `QueryError`
+(`src/lib/db/errors.ts`, the error type every provider throws, ~40 call sites), the two provider
+formatters, a carrier on the `database-error` variant of `AgentToolRefusal` (pinned closed by the T2
+tests) and a pass-through in `runAuditedAgentCall`. Five files across a shared error type, which is
+why B54 kept the regex.
+
+The failure mode is silence, which is what makes it worth an entry: a reword drops the numbers and
+nothing goes wrong loudly. That is currently held off by a test that drives a REAL over-budget
+`queryReadOnly` through `bun:sqlite` and asserts the parse against the error the provider itself
+threw, plus a source-template assertion for PostgreSQL, which cannot be driven without a server. Both
+go red on a reword.
+
+**Done when:** the two numbers reach the ledger as fields rather than as a parsed sentence, and both
+prose consumers are converted in the same pass.
+
+### B74. A `COLLATE` unique constraint is reported as covering a foreign key it cannot serve
+
+Found while closing B25. `UNIQUE (a COLLATE NOCASE)` creates a real index, and the capture now lists
+it, but that index does not serve a BINARY equality lookup on `a` - so `fk_unindexed` will stay silent
+about a key the engine would still scan for. The direction matters: this is a false negative, the
+same class B25 fixed in the opposite direction.
+
+Deliberately not modelled: `parseSqliteIndexDdl` drops `COLLATE` on user-written indexes too, so
+honouring it for constraint-created ones only would make the inventory disagree with itself about the
+same fact. Consistency was chosen over a distinction that would have to be introduced in both readers
+at once.
+
+**Done when:** collation is part of what an index column carries, in both readers, and coverage
+accounts for it.

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -235,6 +235,7 @@ Redis uses the discrete-field form of `DatabaseConnection` (not `connectionStrin
 |-------|----------|-------|
 | `host` | ✅ | Validated in `validate()` — throws `DatabaseConfigError` if missing |
 | `port` | — | Defaults to `6379` |
+| `user` | — | The **Redis 6 ACL user**, sent as ioredis's `username`; empty means `default` ([§4.1a](#41a-acl-users-d29)) |
 | `password` | — | Sent as `password`; omit for unauthenticated instances |
 | `database` | — | Logical DB index, parsed as int; defaults to `0` |
 | `ssl` | — | `SSLConfig`; becomes the ioredis `tls` option ([§4.3](#43-ssl--tls)) |
@@ -246,11 +247,44 @@ const connection = {
   type: 'redis',
   host: 'localhost',
   port: 6379,
+  user: 'analytics',    // optional — the ACL user; omit to authenticate as `default`
   password: 'secret',   // optional
   database: '0',         // logical DB index
   createdAt: new Date(),
 };
 ```
+
+### 4.1a ACL users (D29)
+
+The modal's **Username** field is the Redis 6 ACL user. `connect()` passes it as ioredis's
+`username` (the field is `user` on the connection, `username` in `RedisOptions`), and passes
+**nothing at all** when it is empty — a plain `requirepass` server has no ACL user to name, and
+ioredis only authenticates as `default` when `username` is absent. A pasted
+`redis://analytics:pw@host:6379/0` fills the same field: `parseGenericURL`
+([`src/lib/connection-string-parser.ts`](../../src/lib/connection-string-parser.ts)) decomposes the
+userinfo into `user` / `password` ([§4.2](#42-connection-string-nuance)).
+
+Measured 2026-08-26 against `redis:latest`, with `default` left `on nopass ~* &* +@all` and a second
+user defined `on >probepw ~* +@all -info`, both arms:
+
+```text
+{host, port, password}            -> ACL WHOAMI = default | INFO succeeds
+{host, port, username, password}  -> ACL WHOAMI = probe   | INFO refused: NOPERM
+```
+
+The first arm is the defect this replaced: the configured principal was dropped silently, the
+session ran as `default`, and health went green under someone else's permissions. Both arms together
+are what make it a measurement — the value was collected by the form and stored on the connection
+already; only `connect()` ignored it.
+
+**A restricted user costs the INFO-derived surfaces.** ioredis's own ready check calls `INFO`, and on
+`NOPERM` it logs *"Skipping the ready check"* and connects anyway — which is the wanted behaviour: a
+least-privilege user must still be able to connect and browse keys. But `getHealth()`,
+`getOverview()` and `getPerformanceMetrics()` all read `INFO` ([§7](#7-monitoring--health)), so for a
+user without `+info` they raise the server's own `NOPERM` sentence rather than answering with
+fabricated zeros. `POST /api/db/test-connection` reports that as a **degraded** (amber) result, not a
+green tick and not a failure: the connection is real, the health read is not. Grant `+info`,
+or expect the monitoring panels to stay empty for that user.
 
 ### 4.2 Connection-string nuance ⚠️
 
@@ -258,8 +292,9 @@ const connection = {
 discrete fields. However, the UI connection-string parser
 ([`src/lib/connection-string-parser.ts`](../../src/lib/connection-string-parser.ts)) *does*
 recognise `redis://` and `rediss://` URLs and **decomposes** them into `host` / `port` (default
-`6379`) / `password` / `database` before they reach the provider. So a user can paste a
-`redis://:pw@host:6379/0` URL into the modal, but the provider never sees the raw string.
+`6379`) / `user` / `password` / `database` before they reach the provider. So a user can paste a
+`redis://:pw@host:6379/0` URL into the modal, but the provider never sees the raw string. A userinfo
+name becomes the ACL user ([§4.1a](#41a-acl-users-d29)).
 
 Because the raw string is dropped, the scheme's TLS intent has to travel as a field: the parser
 returns `sslMode: 'require'` for `rediss://` and `sslMode: 'disable'` for `redis://`, which the
@@ -672,7 +707,10 @@ formats (JSON, plain, empty, `HGETALL`, `INFO`, nil), error handling (malformed 
 `command`, Redis-side error, disconnected provider), schema scanning, health, overview, performance,
 slow queries, active sessions, table/index/storage stats, `getMonitoringData`, maintenance, a
 battery of common commands (`KEYS`, `SET`, `DEL`, `PING`, `DBSIZE`), and **every `ssl.mode` branch**
-asserted against the options object the `Redis` constructor received.
+asserted against the options object the `Redis` constructor received. The same captured options carry
+the **ACL user** assertions ([§4.1a](#41a-acl-users-d29)) — `username` present for a named user,
+absent for both an empty string and an unset field — and a refused `INFO` is asserted to raise the
+server's own `NOPERM` sentence out of `getHealth()`.
 
 ### 11.3 Run it
 
@@ -692,6 +730,16 @@ development:
 ```bash
 docker run --rm -p 6379:6379 redis:7-alpine
 # then point a connection at localhost:6379 in the Studio UI and run e.g. `INFO`, `SCAN 0`
+```
+
+To reproduce the ACL rig of [§4.1a](#41a-acl-users-d29) — a user that can browse keys but not read
+`INFO`:
+
+```bash
+docker run --rm -d --name redis-acl -p 6389:6379 redis:latest
+docker exec redis-acl redis-cli ACL SETUSER probe on '>probepw' '~*' +@all -info
+# Username `probe`, password `probepw`: keys browse, and health reports degraded (amber).
+# Leave Username empty and the same password authenticates as `default`, whose INFO succeeds.
 ```
 
 ---

--- a/src/app/api/connections/managed/route.ts
+++ b/src/app/api/connections/managed/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { getManagedConnections, getPendingSeeds } from "@/lib/seed";
 import { logger } from "@/lib/logger";
+import { SEED_CONFIG_UNREADABLE_REASON } from "@/hooks/use-connection-payload";
 
 export const dynamic = "force-dynamic";
 
@@ -12,7 +13,23 @@ export async function GET() {
       return NextResponse.json({ error: "Authentication required" }, { status: 401 });
     }
 
-    const connections = await getManagedConnections([session.role]);
+    // Read in its own try, so the `reason` below is a claim about the seed
+    // configuration and not a synonym for "this request failed" (B37). A browser told
+    // only "500" cannot tell an unreadable seed file from a server that serves no
+    // seeds, and it then reports the second — of connections this application seeds
+    // itself. The outer catch keeps its unattributed 500 for everything else.
+    let connections;
+    try {
+      connections = await getManagedConnections([session.role]);
+    } catch (error) {
+      logger.error("Failed to load the seed configuration", error, {
+        route: "GET /api/connections/managed",
+      });
+      return NextResponse.json(
+        { error: "Failed to load managed connections", reason: SEED_CONFIG_UNREADABLE_REASON },
+        { status: 500 },
+      );
+    }
 
     const sanitized = connections.map((conn) => {
       if (conn.managed) {

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -5,6 +5,7 @@ import { Bot, ChevronDown, ChevronRight, LoaderCircle, PencilLine, Play, Square,
 import { CopyButton } from "@/components/copy-button";
 import { renderProse } from "@/components/rich-text";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import type { AgentRunConnection } from "@/hooks/use-connection-payload";
 import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
 import { describeAgentCapability } from "@/lib/agent/capability-labels";
 /*
@@ -93,8 +94,15 @@ import { useAgentRun } from "./use-agent-run";
  */
 
 export interface AgentRailProps {
-  /** The run's connection, already narrowed to a server-resolvable id, or null. */
-  readonly connectionId: string | null;
+  /**
+   * The run's connection, already narrowed to a server-resolvable id — or, when there
+   * is none, the reason there is none. `null` when no connection is selected at all.
+   *
+   * The reason is carried rather than derived here because only the shell knows it: the
+   * two absences look identical from this component ("no id"), and they are not the same
+   * sentence to a user (B37).
+   */
+  readonly connectionId: AgentRunConnection | null;
   readonly connectionName: string | null;
   /** Below `md` only: whether the sheet presentation is open. */
   readonly sheetOpen?: boolean;
@@ -694,7 +702,7 @@ function ChangeWorkflowButton({
 }
 
 export function AgentRail({
-  connectionId,
+  connectionId: connection,
   connectionName,
   connectionType = null,
   sheetOpen = false,
@@ -704,6 +712,9 @@ export function AgentRail({
   onShowArtifact,
   prefill = null,
 }: AgentRailProps) {
+  // Everything below asks only "is there an id"; the reason is read once, where the
+  // caveat is written.
+  const connectionId = connection?.id ?? null;
   const [mode, setMode] = useState<AgentRunMode>("planning");
   /**
    * The workflow axis, which is now a choice the user need not make: Automatic until
@@ -2066,13 +2077,32 @@ export function AgentRail({
           )}
         </div>
 
-        {connectionId === null && (
-          <p data-testid="agent-unresolvable-connection" className="mt-2 text-xs text-amber-400/80">
-            {connectionName ?? "This connection"} cannot be rebuilt on the server: its settings live in this browser. A
-            run re-resolves its connection there after a restart, so it can only investigate a connection the server
-            holds too.
-          </p>
-        )}
+        {/*
+          Two absences, and they are not the same sentence (B37). "No id" reads as
+          "the server does not hold this connection" only when the server ANSWERED
+          with the connections it holds. When it could not read its own seed
+          configuration, nothing has been established about this connection at all —
+          and saying its settings live in this browser is false of the samples this
+          application ships and seeds itself, while sending the operator to the wrong
+          file. Which absence it is comes from the shell, because only it asked.
+        */}
+        {connectionId === null &&
+          (connection?.reason === "seed-config-unreadable" ? (
+            <p
+              data-testid="agent-seed-config-unreadable"
+              data-tone="warning"
+              className="mt-2 text-xs text-amber-400/80"
+            >
+              The server could not read its own connection configuration, so it cannot resolve a connection for a run.
+              This is not a problem with {connectionName ?? "this connection"} — the server log says what failed.
+            </p>
+          ) : (
+            <p data-testid="agent-unresolvable-connection" className="mt-2 text-xs text-amber-400/80">
+              {connectionName ?? "This connection"} cannot be rebuilt on the server: its settings live in this browser.
+              A run re-resolves its connection there after a restart, so it can only investigate a connection the server
+              holds too.
+            </p>
+          ))}
 
         {/*
           Next to the status rather than only in the timeline: the timeline scrolls

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -874,6 +874,27 @@ function describeEvent(
         // in the half a user actually reads.
         detail: `${event.tableCount} ${event.tableCount === 1 ? noun.singular : noun.plural}, fingerprint ${event.fingerprint.slice(0, 8)}`,
       };
+    case "context-unavailable":
+      /*
+        The capture that did not happen (B54). `progress` would claim the run got
+        somewhere and a failure tone would claim the run is broken; it is neither — an
+        ungrounded run continues, and on several engines that is its ordinary state.
+
+        The row budget is named where there is one, because "refused" and "refused at
+        536 rows against a bound of 200" ask the reader for different things. The
+        `detail` sentence itself is NOT rendered here: on the composed path it carries
+        the engine's own fenced text, which belongs in the ledger a reader can fetch
+        rather than in a one-line timeline entry.
+      */
+      return {
+        tone: "neutral",
+        chrome: true,
+        headline: "Schema not captured",
+        detail:
+          event.rowBudget === undefined
+            ? event.reasonCode
+            : `${event.reasonCode} — ${event.rowBudget.projected} rows read against a bound of ${event.rowBudget.allowed}`,
+      };
     case "statement-drafted":
       return {
         tone: "neutral",

--- a/src/hooks/use-connection-manager.ts
+++ b/src/hooks/use-connection-manager.ts
@@ -5,7 +5,13 @@ import type { DatabaseConnection, TableSchema, TableRelations } from "@/lib/type
 import { useToast } from "@/hooks/use-toast";
 import { storage } from "@/lib/storage";
 import { logger } from "@/lib/logger";
-import { buildConnectionPayload, type ManagedConnectionPayload } from "./use-connection-payload";
+import {
+  buildConnectionPayload,
+  NO_SERVED_SEEDS,
+  SEED_CONFIG_UNREADABLE_REASON,
+  type ManagedConnectionPayload,
+  type ServedSeeds,
+} from "./use-connection-payload";
 
 /** Pending-seed poll: 1s ticks, give up after 30. NEXT_PUBLIC_MANAGED_POLL_MS
  * shortens the tick in source builds and tests only — NEXT_PUBLIC_ values are
@@ -22,7 +28,7 @@ export function useConnectionManager(storageReady = false) {
    * its seed from one the user has since pointed elsewhere — and that is exactly the
    * question a run has to answer before it may persist a bare `seed:<id>`.
    */
-  const [servedSeeds, setServedSeeds] = useState<ManagedConnectionPayload[]>([]);
+  const [servedSeeds, setServedSeeds] = useState<ServedSeeds>(NO_SERVED_SEEDS);
   const [schema, setSchema] = useState<TableSchema[]>([]);
   const [isLoadingSchema, setIsLoadingSchema] = useState(false);
   const [pulseState, setConnectionPulse] = useState<"healthy" | "degraded" | "error" | null>(null);
@@ -149,12 +155,22 @@ export function useConnectionManager(storageReady = false) {
       // A non-OK response is a transient failure, NOT "nothing pending" — the
       // poll below must keep retrying (bounded by its attempt budget) instead
       // of treating it as an authoritative empty pendingSeeds.
-      if (!managedRes.ok) return { merged: null, pendingSeeds: [], failed: true };
+      if (!managedRes.ok) {
+        // A failure the server ATTRIBUTED to its own seed configuration is recorded as
+        // an unread seed list rather than left as the empty one this state started with
+        // (B37): downstream, "the server serves no seeds" and "nobody could read the
+        // seeds" are different sentences, and only this response can tell them apart.
+        // Any other failure — a 404 where the route does not exist at all, as in the
+        // platform embed — is not evidence about that configuration and says nothing.
+        const body = (await managedRes.json().catch(() => ({}))) as { reason?: string };
+        if (!cancelled && body.reason === SEED_CONFIG_UNREADABLE_REASON) setServedSeeds({ loaded: false });
+        return { merged: null, pendingSeeds: [], failed: true };
+      }
       const { connections: managedConns, pendingSeeds } = (await managedRes.json()) as {
         connections?: ManagedConnectionPayload[];
         pendingSeeds?: string[];
       };
-      if (!cancelled) setServedSeeds(managedConns ?? []);
+      if (!cancelled) setServedSeeds({ loaded: true, seeds: managedConns ?? [] });
       return {
         merged: managedConns && managedConns.length > 0 ? mergeManagedConnections(managedConns) : null,
         pendingSeeds: pendingSeeds ?? [],

--- a/src/hooks/use-connection-payload.ts
+++ b/src/hooks/use-connection-payload.ts
@@ -4,6 +4,49 @@ import type { DatabaseConnection, SSHTunnelConfig, SSLConfig } from "@/lib/types
 export type ManagedConnectionPayload = Omit<DatabaseConnection, "createdAt"> & { createdAt: string; seedId?: string };
 
 /**
+ * The `reason` `GET /api/connections/managed` puts on its 500 when the failure was its
+ * own seed configuration rather than anything else in the request.
+ *
+ * A bare 500 says only "this request failed", and a browser reading that cannot tell it
+ * from "the server serves no seeds" — which is a legitimate answer, and the one a
+ * default deployment gets when no seed file exists. Naming the failure is what lets the
+ * client hold "I do not have the seed list" instead of "the list is empty" (B37).
+ */
+export const SEED_CONFIG_UNREADABLE_REASON = "seed-config-unreadable";
+
+/**
+ * What the browser knows about the server's seed list.
+ *
+ * Deliberately not an array: an array has no way to say "I do not have it", so a load
+ * that failed becomes an empty list, and an empty list is a real answer. Everything
+ * downstream then draws a conclusion from an absence it cannot distinguish from a
+ * failure. The load state is part of the value so that no caller can forget to ask.
+ */
+export type ServedSeeds =
+  | { readonly loaded: true; readonly seeds: readonly ManagedConnectionPayload[] }
+  | { readonly loaded: false };
+
+/** The seed list before anything has been served: loaded, and genuinely empty. */
+export const NO_SERVED_SEEDS: ServedSeeds = { loaded: true, seeds: [] };
+
+/**
+ * Why a connection has no id a run may be started on.
+ *
+ * - `browser-only` — the server cannot rebuild this connection: it has never heard of
+ *   it, or it holds a seed of this id that reaches somewhere else. The settings that
+ *   decide where it points live in this browser.
+ * - `seed-config-unreadable` — the server could not read its own seed configuration, so
+ *   nothing is known about what it can rebuild. Nothing has been established about this
+ *   connection at all.
+ */
+type UnresolvableConnectionReason = "browser-only" | typeof SEED_CONFIG_UNREADABLE_REASON;
+
+/** The id a run may be started on, or the reason there is none. */
+export type AgentRunConnection =
+  | { readonly id: string; readonly reason?: undefined }
+  | { readonly id: null; readonly reason: UnresolvableConnectionReason };
+
+/**
  * Builds the connection portion of an API request body.
  * For managed connections: sends { connectionId: "seed:X" } (no credentials).
  * For user connections: sends { connection: conn } (full object).
@@ -120,8 +163,9 @@ function reachesSameDatabase(conn: DatabaseConnection, served: ManagedConnection
 }
 
 /**
- * The id a run may be STARTED on, or null when the server could not re-resolve this
- * connection to the same database later.
+ * The id a run may be STARTED on, or the reason there is none — the server cannot
+ * re-resolve this connection to the same database later, or it could not read its own
+ * seed configuration and so nothing has been established either way (B37).
  *
  * A different question from `buildConnectionPayload`, which asks how to send a
  * connection ONCE and may hand the server the whole object. A run persists an id and
@@ -136,15 +180,18 @@ function reachesSameDatabase(conn: DatabaseConnection, served: ManagedConnection
  * the user edits it to point somewhere else, starting a run by id would investigate
  * the seed's database and report on it as if it were the one on screen.
  */
-export function resolveAgentRunConnectionId(
-  conn: DatabaseConnection,
-  servedSeeds: readonly ManagedConnectionPayload[],
-): string | null {
-  if (!conn.seedId) return null;
-  if (conn.managed) return `seed:${conn.seedId}`;
+export function resolveAgentRunConnectionId(conn: DatabaseConnection, servedSeeds: ServedSeeds): AgentRunConnection {
+  if (!conn.seedId) return { id: null, reason: "browser-only" };
+  if (conn.managed) return { id: `seed:${conn.seedId}` };
 
-  const served = servedSeeds.find((seed) => seed.seedId === conn.seedId);
-  if (served === undefined) return null;
+  // An unread seed list is not an empty one (B37). Comparing against seeds nobody has
+  // seen would answer "the server does not hold this" from having asked nothing, which
+  // is wrong for exactly the connections this application seeds itself — and it points a
+  // user at their own settings while the server's own configuration is what failed.
+  if (!servedSeeds.loaded) return { id: null, reason: SEED_CONFIG_UNREADABLE_REASON };
 
-  return reachesSameDatabase(conn, served) ? `seed:${conn.seedId}` : null;
+  const served = servedSeeds.seeds.find((seed) => seed.seedId === conn.seedId);
+  if (served === undefined) return { id: null, reason: "browser-only" };
+
+  return reachesSameDatabase(conn, served) ? { id: `seed:${conn.seedId}` } : { id: null, reason: "browser-only" };
 }

--- a/src/lib/agent/context-snapshot.ts
+++ b/src/lib/agent/context-snapshot.ts
@@ -93,6 +93,20 @@ import type {
   TableSchema,
 } from "@/lib/types";
 
+/**
+ * How much of a catalog a refused capture asked for, against how much it may have.
+ *
+ * Its own named shape rather than two loose numbers, because it travels: the capture
+ * carries it, the `context-unavailable` ledger entry records it, and a reader that had
+ * to guess which of two bare integers was the bound is a reader that will guess wrong.
+ */
+export interface AgentContextRowBudget {
+  /** Rows the read produced, or would have. */
+  readonly projected: number;
+  /** Rows this run's policy allows one read to carry. */
+  readonly allowed: number;
+}
+
 /** Why a run has no snapshot. All are states the run continues from, not failures. */
 export type AgentContextUnavailableCode =
   /**
@@ -123,6 +137,12 @@ export type AgentContextCapture =
   | {
       readonly kind: "unavailable";
       readonly reasonCode: AgentContextUnavailableCode;
+      /**
+       * The two numbers a row-budget refusal named, when that is what refused this
+       * capture: how many rows the catalog read projected, and how many the run's
+       * policy allows. Present only for that reason — see `rowBudgetIn`.
+       */
+      readonly rowBudget?: AgentContextRowBudget;
       /**
        * WHY this run has no inventory, in one sentence and with no advice in it.
        *
@@ -262,7 +282,10 @@ function buildSqliteTables(rows: ReadonlyMap<AgentCatalogKind, readonly Record<s
     tables.set(name, {
       name,
       columns: [...definition.columns],
-      indexes: [],
+      // The constraint-created indexes SQLite stores no DDL for: the composed index
+      // read below cannot see them, and they are what kept a UNIQUE-covered foreign
+      // key reading as unindexed (docs/BACKLOG.md B25).
+      indexes: [...definition.indexes],
       foreignKeys: [...definition.foreignKeys],
     });
   }
@@ -316,8 +339,50 @@ function fingerprintTables(tables: readonly TableSchema[]): string {
 // Capture
 // ============================================================================
 
+/**
+ * The row budget a refusal named, read out of the sentence that named it.
+ *
+ * A regex over a message is not the shape anybody would choose, and it is the only
+ * shape available: the two numbers are formatted by the PROVIDER
+ * (`postgres.ts`/`sqlite.ts` both refuse rather than truncate) into a `QueryError`
+ * message, and neither the error nor the tool refusal that wraps it carries them as
+ * fields. Reading them here is what turns the pair from prose the model was shown into
+ * data the ledger can hold — which is the whole of B54's second half, since the reason
+ * code alone says "somebody said no" where the numbers say "narrow the capture".
+ *
+ * Anchored on the whole phrase, so the `200` in the advice sentence the tool layer
+ * appends ("add LIMIT 200") cannot be mistaken for a measurement. `statementAdvice` in
+ * `tools.ts` reads the same message with the same anchor; the duplication is deliberate
+ * rather than shared, because the two answer different questions — one composes advice
+ * for a model, the other records a fact — and either may be given a different source.
+ *
+ * Absent when the refusal was about anything else, and absent is the honest answer:
+ * this run met no budget, so a pair of zeros would be a measurement nobody took (#477).
+ * The REASON CODE never depends on this function, so a message this cannot read still
+ * produces a diagnosable entry — one that says "refused" without inventing a bound.
+ *
+ * EXPORTED so the loop can be closed by a test rather than by a comment. The hazard is
+ * silent: reword the provider's sentence and this returns `undefined` for ever, the
+ * ledger quietly loses the pair, and B54 re-opens with nothing going red. So
+ * `tests/integration/db/sqlite-provider.test.ts` drives a REAL over-budget read through
+ * `bun:sqlite`, catches the error the provider itself threw, and feeds its message
+ * through here — and pins PostgreSQL's copy of the same sentence against its source.
+ */
+export function rowBudgetIn(detail: string): AgentContextRowBudget | undefined {
+  const matched = /row budget: (\d+) rows > (\d+) allowed/.exec(detail);
+  if (matched === null) return undefined;
+  return { projected: Number(matched[1]), allowed: Number(matched[2]) };
+}
+
 function unavailable(reasonCode: AgentContextUnavailableCode, detail: string): AgentContextCapture {
-  return { kind: "unavailable", reasonCode, detail, modelText: `${detail}\n${FALLBACK_ADVICE}` };
+  const rowBudget = rowBudgetIn(detail);
+  return {
+    kind: "unavailable",
+    reasonCode,
+    detail,
+    ...(rowBudget === undefined ? {} : { rowBudget }),
+    modelText: `${detail}\n${FALLBACK_ADVICE}`,
+  };
 }
 
 /**

--- a/src/lib/agent/goal-verifier.ts
+++ b/src/lib/agent/goal-verifier.ts
@@ -58,7 +58,23 @@ export type AgentGoalVerifierId =
    * recommended.
    */
   | "agent-query-optimization.1"
+  /**
+   * Released, and kept for the reason `.1` is kept: it shipped on `main`, real runs
+   * were measured against it, and a reader of one of those ledgers holds this type.
+   * `.2` still means what it meant — the two-arm rule, with a plan judged by the
+   * baseline's emptiness census like any other artifact.
+   */
   | "agent-query-optimization.2"
+  /**
+   * B45: the same two arms, with a plan exempt from the emptiness census.
+   *
+   * A new id rather than a tightening under `.2`, by the test this file states for
+   * `agent-data-analysis.1`: `.2` is on `main`, so somewhere there is a verdict recorded
+   * under it, and the rule it names has changed its mind — a run scored `unanswered` by
+   * `.2` can be `answered` by this one. Two runs' verdicts sharing one id under two
+   * different rules is exactly what a versioned id exists to prevent.
+   */
+  | "agent-query-optimization.3"
   | "agent-database-assessment.1"
   /**
    * Kept for the reason `agent-query-optimization.1` is kept: it shipped on `main` and
@@ -246,19 +262,32 @@ function rowCountsByArtifact(events: readonly AgentRunEvent[]): ReadonlyMap<stri
  * `composeReportTool` refuses an invented correlation id, so this only arises from
  * a hand-written or older ledger, and calling a result empty when nobody has seen
  * it would be the verifier inventing the very evidence it is checking for.
+ *
+ * `unbounded` is the set of artifacts whose row count says nothing about whether the
+ * question was answered, and it is skipped for the same reason: a count that cannot
+ * be read is not a count of zero. The caller names them, because which artifacts
+ * those are is a fact about a WORKFLOW's evidence and not about arithmetic — only the
+ * optimization rule passes any (B45).
  */
-function restsOnlyOnEmptyResults(claims: readonly AgentReportClaim[], events: readonly AgentRunEvent[]): boolean {
+function restsOnlyOnEmptyResults(
+  claims: readonly AgentReportClaim[],
+  events: readonly AgentRunEvent[],
+  unbounded: ReadonlySet<string>,
+): boolean {
   const counts = rowCountsByArtifact(events);
   const cited: number[] = [];
   for (const claim of claims) {
     for (const reference of claim.evidence) {
-      if (reference.source !== "artifact") continue;
+      if (reference.source !== "artifact" || unbounded.has(reference.correlationId)) continue;
       const rowCount = counts.get(reference.correlationId);
       if (rowCount !== undefined) cited.push(rowCount);
     }
   }
   return cited.length > 0 && cited.every((rowCount) => rowCount === 0);
 }
+
+/** No artifact is exempt from the emptiness census, which is every rule but one. */
+const EVERY_COUNT_MEANS_SOMETHING: ReadonlySet<string> = Object.freeze(new Set<string>());
 
 /**
  * The plan bar: the run spoke, and what it said was its deliverable rather than a
@@ -307,11 +336,20 @@ function verifyPlanningGoal(run: VerifiableAgentRun): readonly AgentGoalShortfal
   return run.status === "cancelled" ? ["cancelled"] : ["no-statement"];
 }
 
-/** An investigation answered when it composed claims that rest on something it read. */
-function verifyInvestigationGoal(run: VerifiableAgentRun): readonly AgentGoalShortfall[] {
+/**
+ * An investigation answered when it composed claims that rest on something it read.
+ *
+ * `unbounded` is the composing rules' seam and defaults to empty, so `agent-investigation.1`
+ * means exactly what it meant: a workflow that has an artifact whose row count is not a
+ * measure of its answer says so at the call, and nothing is exempt by default.
+ */
+function verifyInvestigationGoal(
+  run: VerifiableAgentRun,
+  unbounded: ReadonlySet<string> = EVERY_COUNT_MEANS_SOMETHING,
+): readonly AgentGoalShortfall[] {
   const claims = composedClaims(run.events);
   if (claims.length === 0) return run.status === "cancelled" ? ["cancelled"] : ["no-report"];
-  return restsOnlyOnEmptyResults(claims, run.events) ? ["empty-evidence"] : [];
+  return restsOnlyOnEmptyResults(claims, run.events, unbounded) ? ["empty-evidence"] : [];
 }
 
 type GoalRule = (run: VerifiableAgentRun) => readonly AgentGoalShortfall[];
@@ -358,9 +396,27 @@ function planArtifacts(events: readonly AgentRunEvent[]): ReadonlySet<string> {
  * Not merely "a plan is somewhere on the ledger": the citation is what ties this
  * recommendation to that plan, and without it the run is proposing an index beside
  * a plan rather than because of one.
+ *
+ * **A plan is exempt from the baseline's emptiness census, and this is the #356 lesson
+ * for a third time (B45).** A plan is a DESCRIPTION of a statement, arriving in one
+ * column, and the driver reports no row count for it: the artifact is complete and its
+ * `rowCount: 0` measures nothing. Driven live on 2026-08-17, every Optimize run in the
+ * drive ended `empty-evidence` — including one that compared real costs, recommended
+ * the right index and offered it to the editor — because the plan was the only thing
+ * those reports had to cite. The argument the `operations` rule makes below is this
+ * argument: emptiness is a property of how the artifact is RETURNED, and holding a
+ * reading to a rule that does not describe it marks a right answer wrong.
+ *
+ * The exemption is this rule's and stops here. `agent-investigation.1` and the two
+ * verifiers composing on it are untouched — every workflow is offered `inspect_plan`,
+ * so the same shape is reachable for them, and widening an id's meaning for a case
+ * nobody has measured there is not this fix. It also exempts one artifact KIND and
+ * nothing else: an empty bounded read cited by an optimization report still ends the
+ * run `empty-evidence`, because zero rows from a read is the answer that read gave.
  */
 function verifyQueryOptimizationGoal(run: VerifiableAgentRun): readonly AgentGoalShortfall[] {
-  const baseline = verifyInvestigationGoal(run);
+  const plans = planArtifacts(run.events);
+  const baseline = verifyInvestigationGoal(run, plans);
   if (baseline.length > 0) return baseline;
   if (run.events.some((event) => event.kind === "plan-comparison")) return [];
 
@@ -369,7 +425,6 @@ function verifyQueryOptimizationGoal(run: VerifiableAgentRun): readonly AgentGoa
   );
   if (indexes.length === 0) return ["no-plan-comparison"];
 
-  const plans = planArtifacts(run.events);
   const grounded = indexes.some((event) =>
     event.evidence.some((reference) => reference.source === "artifact" && plans.has(reference.correlationId)),
   );
@@ -519,7 +574,7 @@ function verifyOperationsGoal(run: VerifiableAgentRun): readonly AgentGoalShortf
 
 export const AGENT_WORKFLOW_GOALS: Readonly<Record<AgentRunWorkflowType, AgentWorkflowGoal>> = Object.freeze({
   investigation: { verifier: "agent-investigation.1", verify: verifyInvestigationGoal },
-  "query-optimization": { verifier: "agent-query-optimization.2", verify: verifyQueryOptimizationGoal },
+  "query-optimization": { verifier: "agent-query-optimization.3", verify: verifyQueryOptimizationGoal },
   "database-assessment": { verifier: "agent-database-assessment.1", verify: verifyDatabaseAssessmentGoal },
   operations: { verifier: "agent-operations.2", verify: verifyOperationsGoal },
   "data-analysis": { verifier: "agent-data-analysis.1", verify: verifyDataAnalysisGoal },

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -47,6 +47,7 @@ import { createHash } from "node:crypto";
 import { type ModelMessage, Output, type ToolSet, streamText, tool } from "ai";
 import { z } from "zod";
 import {
+  type AgentContextCapture,
   captureContextSnapshot,
   connectionIdentity,
   heldSnapshotForConnection,
@@ -2650,6 +2651,34 @@ export async function runInvestigation(
      * honest: `grounding.schemaKnown` is what decides whether the model is told to
      * write against an inventory or told it has not seen this database at all.
      */
+    /**
+     * The capture that did NOT happen, written down (B54).
+     *
+     * Both refusal paths call this — the planning one and the agent/operations one —
+     * because the gap was identical on each: the branch pushed its note into the prompt
+     * and returned, so the ledger of an ungrounded run held nothing between the drive
+     * starting and the run ending. The rule `docs/llms/setup.md` states about ledgers
+     * ("that is the authority on what a run did") was therefore true only of a capture
+     * that SUCCEEDED, in exactly the case an operator has to diagnose.
+     *
+     * Before the note, not after it, and for the same reason the successful capture
+     * records before it packs: what the run tells the model about its own grounding has
+     * to be something already durably part of the run's history.
+     *
+     * The reason code and the sentence are the capture's own — this function invents
+     * nothing and measures nothing, so there is no count, no fingerprint and no noun
+     * here. A refused capture read no rows, and stating a number about rows nobody read
+     * is the absence failure this repository keeps re-finding (#477).
+     */
+    const recordRefusedCapture = async (capture: AgentContextCapture & { kind: "unavailable" }): Promise<void> => {
+      await service.recordEvent(runId, {
+        kind: "context-unavailable",
+        reasonCode: capture.reasonCode,
+        detail: capture.detail,
+        ...(capture.rowBudget === undefined ? {} : { rowBudget: capture.rowBudget }),
+      });
+    };
+
     const establishPlanningContext = async (): Promise<void> => {
       const recorded = reusableSnapshot(record.events, record.connectionId);
       const held = recorded === null ? heldSnapshotForConnection(connectionIdentity(context.connection)) : null;
@@ -2662,6 +2691,7 @@ export async function runInvestigation(
       if (snapshot === null) {
         const capture = await captureContextSnapshot(context);
         if (capture.kind === "unavailable") {
+          await recordRefusedCapture(capture);
           messages.push({
             role: "user",
             content: operations
@@ -2821,6 +2851,7 @@ export async function runInvestigation(
 
       const capture = await captureContextSnapshot(context);
       if (capture.kind === "unavailable") {
+        await recordRefusedCapture(capture);
         // The capture's own words send a model to `inspect_schema`, which an operations
         // run does not hold: naming a tool the run has not got is the #350 failure, and
         // this workflow is the one that reaches engines where the capture always fails.

--- a/src/lib/agent/run-service.ts
+++ b/src/lib/agent/run-service.ts
@@ -87,6 +87,13 @@ export type AgentRunNarrativeEvent = Extract<
   {
     kind:
       | "context-captured"
+      // The capture that did NOT happen, which is narrative for the same reason the
+      // successful one is: the drive is telling the ledger what it established, or in
+      // this case what it could not (B54). Nothing was executed by a model and no step
+      // was settled — the catalog read that was refused is on the audit stream under
+      // its own operation id, and this entry is the run's own account of being left
+      // ungrounded.
+      | "context-unavailable"
       | "statement-drafted"
       | "report-composed"
       // A call the drive turned back, with what it asked for instead. It belongs here

--- a/src/lib/agent/run-store.ts
+++ b/src/lib/agent/run-store.ts
@@ -101,6 +101,7 @@ const EVENT_KINDS: ReadonlySet<string> = new Set(
     "run-started": true,
     "driver-resolved": true,
     "context-captured": true,
+    "context-unavailable": true,
     "statement-drafted": true,
     "tool-invoked": true,
     "tool-completed": true,

--- a/src/lib/agent/sqlite-ddl.ts
+++ b/src/lib/agent/sqlite-ddl.ts
@@ -31,15 +31,40 @@
  * string the test wrote would only prove the parser agrees with its author.
  */
 
-import type { ColumnSchema, ForeignKeySchema } from "@/lib/types";
+import type { ColumnSchema, ForeignKeySchema, IndexSchema } from "@/lib/types";
 
 /** What one stored `CREATE TABLE` yields. Empty when the text is not one. */
 export interface SqliteTableDefinition {
   readonly columns: readonly ColumnSchema[];
   readonly foreignKeys: readonly ForeignKeySchema[];
+  /**
+   * The indexes SQLite builds to enforce this table's `UNIQUE` constraints.
+   *
+   * They are here because they are NOWHERE ELSE: SQLite stores no DDL for them, so
+   * the composed index read (`sql IS NOT NULL`) cannot see them, and the table's own
+   * DDL — where the constraint is declared — is the only place the agent path can
+   * learn they exist. Leaving them out made a foreign key covered by a `UNIQUE`
+   * constraint read as unindexed (`docs/BACKLOG.md` B25).
+   */
+  readonly indexes: readonly IndexSchema[];
 }
 
-const EMPTY_TABLE: SqliteTableDefinition = Object.freeze({ columns: [], foreignKeys: [] });
+const EMPTY_TABLE: SqliteTableDefinition = Object.freeze({ columns: [], foreignKeys: [], indexes: [] });
+
+/**
+ * What a constraint-created index is CALLED here.
+ *
+ * Not the engine's own `sqlite_autoindex_<table>_<n>`: that name is not derivable
+ * from the DDL — a named `CONSTRAINT uq_x UNIQUE (…)` does not lend the index its
+ * name (measured: the index is still `sqlite_autoindex_…`), and the `<n>` counts
+ * constraints in an order this reader does not model. Inventing one would put a
+ * name in the inventory that might not exist in the database.
+ *
+ * Plain words in parentheses instead, the same convention `IMPLICIT_PRIMARY_KEY`
+ * uses above, so no reader can mistake it for an index somebody wrote a
+ * `CREATE INDEX` for. It IS a real index — it just has no DDL and no author.
+ */
+const IMPLICIT_UNIQUE_INDEX = "(unique constraint)";
 
 /**
  * What a reference names when the DDL omits the referenced column. SQLite then
@@ -288,6 +313,16 @@ interface ParsedItem {
   readonly foreignKeys: readonly ForeignKeySchema[];
   /** Column names a table-level `PRIMARY KEY (…)` named. */
   readonly primaryKeyColumns: readonly string[];
+  /**
+   * Column names one `UNIQUE` constraint covers, IN ORDER — the order is the point,
+   * since a covering test is a prefix test, not a membership test.
+   *
+   * A `PRIMARY KEY` is deliberately not reported the same way: the primary key is
+   * already in the column inventory (`isPrimary`), and an `INTEGER PRIMARY KEY` is
+   * the rowid itself with no index behind it at all, so an index row for it would
+   * name an object that does not exist.
+   */
+  readonly uniqueColumns: readonly string[];
 }
 
 function parseItem(item: string): ParsedItem {
@@ -297,33 +332,44 @@ function parseItem(item: string): ParsedItem {
 
   const head = upper(tokens[0]);
   if (TABLE_CONSTRAINT_HEADS.has(head)) {
-    const list = tokens[2];
+    // `PRIMARY KEY (…)` and `FOREIGN KEY (…)` spell the keyword in two words, so
+    // their list is the third token; `UNIQUE (…)` spells it in one.
+    const list = head === "UNIQUE" ? tokens[1] : tokens[2];
     const names = list?.kind === "paren" ? columnNames(list.value) : [];
-    if (head === "PRIMARY") return { foreignKeys: [], primaryKeyColumns: names };
+    if (head === "PRIMARY") return { foreignKeys: [], primaryKeyColumns: names, uniqueColumns: [] };
+    if (head === "UNIQUE") return { foreignKeys: [], primaryKeyColumns: [], uniqueColumns: names };
     if (head === "FOREIGN") {
       const referencesAt = tokens.findIndex((token) => upper(token) === "REFERENCES");
       return {
         foreignKeys: referencesAt === -1 ? [] : referenceEdges(tokens, referencesAt, names),
         primaryKeyColumns: [],
+        uniqueColumns: [],
       };
     }
-    return { foreignKeys: [], primaryKeyColumns: [] };
+    return { foreignKeys: [], primaryKeyColumns: [], uniqueColumns: [] };
   }
 
   const name = nameOf(tokens[0]);
-  if (name === null) return { foreignKeys: [], primaryKeyColumns: [] };
+  if (name === null) return { foreignKeys: [], primaryKeyColumns: [], uniqueColumns: [] };
 
   const { type, next } = readTypeName(tokens, 1);
   let nullable = true;
   let isPrimary = false;
+  let unique = false;
   const foreignKeys: ForeignKeySchema[] = [];
   for (let index = next; index < tokens.length; index += 1) {
     const word = upper(tokens[index]);
     if (word === "NOT" && upper(tokens[index + 1]) === "NULL") nullable = false;
     else if (word === "PRIMARY" && upper(tokens[index + 1]) === "KEY") isPrimary = true;
+    else if (word === "UNIQUE") unique = true;
     else if (word === "REFERENCES") foreignKeys.push(...referenceEdges(tokens, index, [name]));
   }
-  return { column: { name, type, nullable, isPrimary }, foreignKeys, primaryKeyColumns: [] };
+  return {
+    column: { name, type, nullable, isPrimary },
+    foreignKeys,
+    primaryKeyColumns: [],
+    uniqueColumns: unique ? [name] : [],
+  };
 }
 
 /**
@@ -340,6 +386,7 @@ export function parseSqliteTableDdl(sql: string): SqliteTableDefinition {
   const body = sql.slice(start + 1, matchingParenthesis(sql, start));
   const columns: ColumnSchema[] = [];
   const foreignKeys: ForeignKeySchema[] = [];
+  const indexes: IndexSchema[] = [];
   const tablePrimaryKey = new Set<string>();
 
   for (const item of splitTopLevel(body)) {
@@ -347,11 +394,15 @@ export function parseSqliteTableDdl(sql: string): SqliteTableDefinition {
     if (parsed.column !== undefined) columns.push(parsed.column);
     foreignKeys.push(...parsed.foreignKeys);
     for (const name of parsed.primaryKeyColumns) tablePrimaryKey.add(name);
+    if (parsed.uniqueColumns.length > 0) {
+      indexes.push({ name: IMPLICIT_UNIQUE_INDEX, columns: [...parsed.uniqueColumns], unique: true });
+    }
   }
 
   return {
     columns: columns.map((column) => (tablePrimaryKey.has(column.name) ? { ...column, isPrimary: true } : column)),
     foreignKeys,
+    indexes,
   };
 }
 

--- a/src/lib/agent/table-profile.ts
+++ b/src/lib/agent/table-profile.ts
@@ -343,15 +343,21 @@ function deriveFindings(
 /**
  * Foreign-key columns that no index in the CAPTURED INVENTORY leads on.
  *
- * Stated that precisely because the inventory has two known blind spots, and a
- * finding worded as "this foreign key is unindexed" would overstate both:
+ * Stated that precisely because the inventory still has a known blind spot, and a
+ * finding worded as "this foreign key is unindexed" would overstate it:
+ * **PostgreSQL expression indexes are absent**, and a partly-expression index
+ * appears carrying only its plain columns (`docs/BACKLOG.md` B7).
  *
- *  - **SQLite hides constraint-created indexes.** The catalog read takes indexes
- *    from `CREATE INDEX` text, and the indexes SQLite builds for `UNIQUE` and
- *    `PRIMARY KEY` carry no DDL at all — so a foreign key covered by a `UNIQUE`
- *    constraint is invisible here and would be reported. `docs/BACKLOG.md` B25.
- *  - **PostgreSQL expression indexes are absent** and a partly-expression index
- *    appears carrying only its plain columns (`docs/BACKLOG.md` B7).
+ * SQLite's constraint-created indexes WERE a second blind spot (B25) and are not
+ * one any more: SQLite stores no DDL for them, so the composed index read cannot
+ * see them, and `parseSqliteTableDdl` now reports the ones a `UNIQUE` constraint
+ * creates out of the table's own DDL — as an index named `(unique constraint)`,
+ * which is plain words rather than a name anybody could mistake for a user's
+ * `CREATE INDEX`. A `PRIMARY KEY` needs no such row: it is read from the column
+ * inventory below, not from the index one.
+ *
+ * COVERAGE IS A PREFIX TEST, not a membership test: an index serves a lookup on the
+ * column it LEADS on, so `UNIQUE (note, parent_id)` does not cover `parent_id`.
  *
  * Composite foreign keys are SKIPPED rather than guessed at: PostgreSQL's catalog
  * read returns them as the cross product of both sides (B8), so their columns

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -47,6 +47,7 @@ import type { LLMProviderType } from "@/lib/llm/types";
 import type { PolicyDenyCode } from "@/lib/db/operations/policy";
 import type { AgentStatementViolation } from "@/lib/db/operations/statement-guard";
 import type { AgentChartSpec, DatabaseType, TableSchema } from "@/lib/types";
+import type { AgentContextRowBudget, AgentContextUnavailableCode } from "./context-snapshot";
 import type { AgentGoalShortfall, AgentGoalVerifierId } from "./goal-verifier";
 import type { AgentToolName } from "./tools";
 import type { AgentInventoryNoun } from "./inventory-noun";
@@ -596,6 +597,50 @@ export type AgentRunEvent =
        * claiming a vocabulary nobody recorded.
        */
       readonly noun?: AgentInventoryNoun;
+    })
+  | (AgentRunEventBase & {
+      /**
+       * A capture that was REFUSED, and why (B54).
+       *
+       * Its own kind rather than a `context-captured` carrying an absence, for two
+       * reasons that point the same way. A refused capture read nothing, so it has no
+       * fingerprint and no table count, and the absence rule this repository already
+       * enforces (#477) says a refusal must be representable AS a refusal rather than
+       * as a zero or a fabricated measurement — `tableCount: 0` here would state that
+       * this database has no tables. And every reader that asks
+       * `kind === "context-captured"` — `reusableSnapshot`, the grounding check in
+       * `tools.ts`, the timeline — treats the entry as PROOF that an inventory exists,
+       * so a variant of it carrying a refusal would make all three claim grounding a
+       * run never had. `call-declined` beside `call-held` is the same decision one
+       * layer down: what did NOT happen gets its own entry.
+       *
+       * Written because the ledger is supposed to be the authority on what a run did
+       * (`docs/llms/setup.md`) and, for exactly the case an operator has to diagnose, it
+       * was not: the refusal branch pushed a sentence into the prompt and returned, so a
+       * plan run whose capture was refused left four events and nothing between the
+       * second and the third. The measured cost is B52 — 536 rows against a 200-row
+       * budget on a live AlloyDB Omni — where the reason code, the numbers and the
+       * catalog read were all computed, handed to the model, and then dropped. And a
+       * missing event is worse here than missing telemetry: it reads as work that was
+       * not needed rather than knowledge that was lost.
+       *
+       * `detail` is the capture's OWN sentence — the same one the model was given — so
+       * the ledger and the prompt cannot disagree about why this run had no inventory.
+       * It is needed rather than redundant: `CATALOG_READ_REFUSED` covers four causes
+       * (a denied read, an over-budget one, an unreachable host, a refused execution
+       * profile) and this is what tells them apart. On the composed path it arrives
+       * fenced, because part of it is text the engine wrote, exactly as `tool-refused`
+       * carries an engine's message.
+       *
+       * NOT recorded: the statements the capture composed, and no noun. The first
+       * belongs to the audit stream and to B13; the second describes rows, and there
+       * are none to describe.
+       */
+      readonly kind: "context-unavailable";
+      readonly reasonCode: AgentContextUnavailableCode;
+      readonly detail: string;
+      /** Present only when the row budget is what refused it. */
+      readonly rowBudget?: AgentContextRowBudget;
     })
   | (AgentRunEventBase & {
       readonly kind: "statement-drafted";

--- a/src/lib/connection-string-parser.ts
+++ b/src/lib/connection-string-parser.ts
@@ -369,7 +369,19 @@ function readQueryTLS(url: URL, type: DatabaseType): TLSIntent {
 }
 
 /**
- * Attach a scheme's TLS intent, preserving the null a malformed URL parses to.
+ * Attach a scheme's TLS intent, preserving the null a malformed URL parses to. The mode
+ * overwrites whatever the form was holding - pasting is not a merge.
+ *
+ * A scheme is read more weakly than the boolean *parameter* beside it, and that is a
+ * decision rather than an artefact (D28). D26 settled the rule for a boolean parameter:
+ * it maps onto the mode matching what the engine's own driver does with it, never onto a
+ * weaker one. A scheme cannot answer to that rule, because the secure scheme is the only
+ * spelling a self-hosted deployment has: `rediss://`, `couchbases://` and ClickHouse's
+ * `https://` all describe servers that present a self-signed certificate by default, so
+ * a verifying mode here would refuse the ordinary `--tls-port` install with a chain
+ * error. `require` therefore encrypts without ever claiming to have checked a chain, and
+ * the connection panel stays the one place verification is turned on. The per-scheme
+ * reason is recorded at each call site above; this is the rule they share.
  */
 function withSSLMode(parsed: ParsedConnection | null, sslMode: SSLMode): ParsedConnection | null {
   return parsed && { ...parsed, sslMode };

--- a/src/lib/db/providers/keyvalue/redis.ts
+++ b/src/lib/db/providers/keyvalue/redis.ts
@@ -178,12 +178,29 @@ export class RedisProvider extends BaseDatabaseProvider {
     return tls;
   }
 
+  /**
+   * The connection form's Username is the Redis 6 ACL user, and it has to reach the
+   * driver under ioredis's own name — the field is `user` on the connection and
+   * `username` in `RedisOptions`. Without it ioredis sends a one-argument `AUTH`,
+   * which Redis resolves against `default`.
+   *
+   * Measured 2026-08-26 against `redis:latest` with `default` left `nopass +@all` and
+   * `probe` defined `on >probepw ~* +@all -info`, both arms: with `{password}` alone
+   * `ACL WHOAMI` answered `default` and `INFO` succeeded — the app ran as a principal
+   * the user never chose, and health went green. With `{username, password}` WHOAMI
+   * answered `probe` and `INFO` was refused `NOPERM`. The two arms together are what
+   * make it a measurement rather than a shape (D29).
+   *
+   * `undefined` when the field is empty, never `""`: a plain `requirepass` server has
+   * no ACL user to name, and only an absent `username` authenticates as `default`.
+   */
   public async connect(): Promise<void> {
     try {
       const tls = this.buildTLSOptions();
       this.client = new Redis({
         host: this.config.host,
         port: this.config.port || 6379,
+        username: this.config.user || undefined,
         password: this.config.password || undefined,
         db: this.config.database ? parseInt(this.config.database, 10) : 0,
         connectTimeout: this.queryTimeout,

--- a/tests/api/seed/managed-route.test.ts
+++ b/tests/api/seed/managed-route.test.ts
@@ -18,6 +18,7 @@ import { GET } from "@/app/api/connections/managed/route";
 import { resetCache } from "@/lib/seed/config-loader";
 import { getSession } from "@/lib/auth";
 import { setSqliteSampleSeedState, SQLITE_SAMPLE_SEED_ID } from "@/lib/seed/sqlite-sample";
+import { SEED_CONFIG_UNREADABLE_REASON } from "@/hooks/use-connection-payload";
 
 describe("GET /api/connections/managed", () => {
   beforeEach(() => {
@@ -125,5 +126,44 @@ describe("GET /api/connections/managed", () => {
 
     process.env.SEED_CONFIG_PATH = origPath;
     resetCache();
+  });
+
+  // B37. A 500 alone tells the browser only that this request failed, and a browser
+  // that cannot tell "the server serves no seeds" from "the server could not read its
+  // seed list" ends up saying the first about connections this application seeds
+  // itself. So the failure NAMES itself: the seed configuration is what could not be
+  // read, and that is the sentence a user is owed.
+  it("names the seed configuration as the thing that failed, not just the request", async () => {
+    const origPath = process.env.SEED_CONFIG_PATH;
+    process.env.SEED_CONFIG_PATH = path.join(
+      path.resolve(__dirname, "../../fixtures/seed-connections"),
+      "invalid-config.yaml",
+    );
+    resetCache();
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Failed to load managed connections",
+      reason: SEED_CONFIG_UNREADABLE_REASON,
+    });
+
+    process.env.SEED_CONFIG_PATH = origPath;
+    resetCache();
+  });
+
+  // The other half of the same claim: a failure that is NOT the seed configuration must
+  // not be reported as one. Without this arm the reason would be a synonym for 500 and
+  // the rail would blame a config file for a broken session cookie.
+  it("does not blame the seed configuration for a failure somewhere else", async () => {
+    (getSession as ReturnType<typeof mock>).mockImplementation(() => {
+      throw new Error("session store unreachable");
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; reason?: string };
+    expect(body.error).toBe("Failed to load managed connections");
+    expect(body.reason).toBeUndefined();
   });
 });

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -98,7 +98,7 @@ mock.module("@/hooks/use-auth", () => ({
 mock.module("@/hooks/use-connection-manager", () => ({
   useConnectionManager: mock(() => ({
     connections: [],
-    servedSeeds: [],
+    servedSeeds: { loaded: true, seeds: [] },
     activeConnection: null,
     schema: [],
     schemaContext: "[]",
@@ -1568,7 +1568,7 @@ describe("Studio", () => {
     const { findByTestId } = render(<Studio />);
     await findByTestId("agent-rail");
 
-    expect(capturedAgentRailProps.connectionId).toBe("seed:sales");
+    expect(capturedAgentRailProps.connectionId).toEqual({ id: "seed:sales" });
     expect(capturedAgentRailProps.connectionName).toBe("Sales");
   });
 
@@ -1581,7 +1581,7 @@ describe("Studio", () => {
     const { findByTestId } = render(<Studio />);
     await findByTestId("agent-rail");
 
-    expect(capturedAgentRailProps.connectionId).toBeNull();
+    expect(capturedAgentRailProps.connectionId).toEqual({ id: null, reason: "browser-only" });
     expect(capturedAgentRailProps.connectionName).toBe("TestPG");
   });
 
@@ -1600,21 +1600,29 @@ describe("Studio", () => {
 
   test("an untouched copy of an editable seed reaches the rail as startable", async () => {
     mockAgentConfig(true);
-    connMgrOverride = { activeConnection: seedCopy, connections: [seedCopy], servedSeeds: [servedSeed] };
+    connMgrOverride = {
+      activeConnection: seedCopy,
+      connections: [seedCopy],
+      servedSeeds: { loaded: true, seeds: [servedSeed] },
+    };
     const { findByTestId } = render(<Studio />);
     await findByTestId("agent-rail");
 
-    expect(capturedAgentRailProps.connectionId).toBe("seed:sample");
+    expect(capturedAgentRailProps.connectionId).toEqual({ id: "seed:sample" });
   });
 
   test("a seed copy edited to reach another database reaches the rail as unresolvable", async () => {
     mockAgentConfig(true);
     const edited = { ...seedCopy, database: "somewhere-else" };
-    connMgrOverride = { activeConnection: edited, connections: [edited], servedSeeds: [servedSeed] };
+    connMgrOverride = {
+      activeConnection: edited,
+      connections: [edited],
+      servedSeeds: { loaded: true, seeds: [servedSeed] },
+    };
     const { findByTestId } = render(<Studio />);
     await findByTestId("agent-rail");
 
-    expect(capturedAgentRailProps.connectionId).toBeNull();
+    expect(capturedAgentRailProps.connectionId).toEqual({ id: null, reason: "browser-only" });
   });
 
   test("with no connection selected the rail is told so", async () => {

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -4,11 +4,19 @@ import "../../helpers/mock-navigation";
 
 import React from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, fireEvent, waitFor, act, type RenderResult } from "@testing-library/react";
+import { cleanup, render, renderHook, fireEvent, waitFor, act, type RenderResult } from "@testing-library/react";
 import { AgentRail } from "@/components/agent/AgentRail";
+import { useConnectionManager } from "@/hooks/use-connection-manager";
+import {
+  resolveAgentRunConnectionId,
+  SEED_CONFIG_UNREADABLE_REASON,
+  type ManagedConnectionPayload,
+} from "@/hooks/use-connection-payload";
 import { applyStatementName } from "@/components/agent/rail-parts";
 import { AGENT_WORKFLOW_BUDGETS } from "@/lib/agent/execution-policy";
 import type { AgentRunWorkflowType } from "@/lib/agent/types";
+import type { DatabaseConnection } from "@/lib/types";
+import { mockGlobalFetch, restoreGlobalFetch } from "../../helpers/mock-fetch";
 
 /**
  * The standalone agent rail (#329 T10a): the gated surface, its two modes and the
@@ -148,7 +156,7 @@ const FINISHED_LINE = `${JSON.stringify({
 })}\n`;
 
 const DEFAULT_PROPS = {
-  connectionId: "seed:sales",
+  connectionId: { id: "seed:sales" },
   connectionName: "Sales",
 };
 
@@ -528,7 +536,7 @@ describe("AgentRail", () => {
       expect(view.getByTestId("agent-run-status").textContent).toBe("succeeded");
     });
 
-    view.rerender(<AgentRail {...DEFAULT_PROPS} connectionId="seed:analytics" connectionName="Analytics" />);
+    view.rerender(<AgentRail {...DEFAULT_PROPS} connectionId={{ id: "seed:analytics" }} connectionName="Analytics" />);
     fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "what is blocked" } });
     await act(async () => {
       fireEvent.click(view.getByTestId("agent-start"));
@@ -794,7 +802,9 @@ describe("AgentRail", () => {
   test("a connection the server cannot resolve is refused here, with the reason", () => {
     const fetchMock = mock(async () => jsonResponse({}, 202));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
-    const { getByTestId } = render(<AgentRail connectionId={null} connectionName="Local scratch" />);
+    const { getByTestId } = render(
+      <AgentRail connectionId={{ id: null, reason: "browser-only" }} connectionName="Local scratch" />,
+    );
 
     fireEvent.change(getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
 
@@ -3574,7 +3584,7 @@ describe("AgentRail", () => {
         view.rerender(
           <AgentRail
             {...DEFAULT_PROPS}
-            connectionId="seed:analytics"
+            connectionId={{ id: "seed:analytics" }}
             connectionName="Analytics"
             onRunStatement={onRunStatement}
             onApplyStatement={onApplyStatement}
@@ -3643,7 +3653,7 @@ describe("AgentRail", () => {
         view.rerender(
           <AgentRail
             {...DEFAULT_PROPS}
-            connectionId="seed:analytics"
+            connectionId={{ id: "seed:analytics" }}
             connectionName="Analytics"
             onRunStatement={onRunStatement}
             onApplyStatement={onApplyStatement}
@@ -4503,7 +4513,7 @@ describe("AgentRail", () => {
         view.rerender(
           <AgentRail
             {...DEFAULT_PROPS}
-            connectionId="seed:analytics"
+            connectionId={{ id: "seed:analytics" }}
             connectionName="Analytics"
             onRunStatement={() => {}}
           />,
@@ -4531,7 +4541,7 @@ describe("AgentRail", () => {
         view.rerender(
           <AgentRail
             {...DEFAULT_PROPS}
-            connectionId="seed:analytics"
+            connectionId={{ id: "seed:analytics" }}
             connectionName="Analytics"
             connectionType="postgres"
             onRunStatement={() => {}}
@@ -4557,7 +4567,9 @@ describe("AgentRail", () => {
         const view = render(<AgentRail {...DEFAULT_PROPS} />);
 
         await startWith(view, "what is blocked right now");
-        view.rerender(<AgentRail {...DEFAULT_PROPS} connectionId="seed:analytics" connectionName="Analytics" />);
+        view.rerender(
+          <AgentRail {...DEFAULT_PROPS} connectionId={{ id: "seed:analytics" }} connectionName="Analytics" />,
+        );
         await act(async () => {
           release?.();
         });
@@ -6066,5 +6078,99 @@ describe("AgentRail", () => {
         expect(view.getByTestId("agent-answer-chip-fingerprint").textContent).toBe("ctx_drui");
       });
     });
+  });
+});
+
+/**
+ * B37 — what the rail says when the SERVER could not read its own seed configuration.
+ *
+ * Driven live on 2026-08-15: one malformed `seed-connections.yaml` made
+ * `GET /api/connections/managed` fail, the browser held no seed descriptors, and the rail
+ * therefore said of `Sample (Employees)` — a connection this application ships and seeds
+ * itself — that "its settings live in this browser". False twice, and it pointed the
+ * operator at the wrong file while the real cause reached the server log only.
+ *
+ * These two tests run the WHOLE path rather than the rail alone, because the defect was in
+ * the joint: a failed load and an empty list were the same value, so no component
+ * downstream could have told them apart. The endpoint is failed for real, the real hook
+ * reads it, and the real rule turns that into what the rail is handed.
+ */
+describe("a seed configuration the server could not read (B37)", () => {
+  const SERVED: ManagedConnectionPayload = {
+    id: "seed:employees",
+    seedId: "employees",
+    name: "Sample (Employees)",
+    type: "sqlite",
+    database: "data/sample-employees.db",
+    managed: false,
+    createdAt: "1970-01-01T00:00:00.000Z",
+  };
+  /** The editable copy `use-connection-manager` persists for that seed. */
+  const LOCAL_COPY: DatabaseConnection = { ...SERVED, createdAt: new Date(0) };
+
+  /** The rail, rendered on the copy, after the managed endpoint answered as given. */
+  const railAfterManaged = async (managed: { status?: number; json: unknown }) => {
+    mockGlobalFetch({
+      "/api/connections/managed": managed,
+      "/api/db/health": { json: { status: "healthy" } },
+      "/api/agent/config": { json: { enabled: true } },
+    });
+    const hook = renderHook(() => useConnectionManager(true));
+    await waitFor(() => {
+      expect(hook.result.current.servedSeeds).toBeDefined();
+    });
+    const seeds = hook.result.current.servedSeeds;
+    hook.unmount();
+    const resolved = resolveAgentRunConnectionId(LOCAL_COPY, seeds);
+    const view = render(<AgentRail connectionId={resolved} connectionName={LOCAL_COPY.name} />);
+    return { view, seeds, resolved };
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    restoreGlobalFetch();
+    cleanup();
+    localStorage.clear();
+  });
+
+  test("the rail names the server's configuration, not the connection", async () => {
+    const { view, seeds, resolved } = await railAfterManaged({
+      status: 500,
+      json: { error: "Failed to load managed connections", reason: SEED_CONFIG_UNREADABLE_REASON },
+    });
+
+    // The browser holds "I do not have the seed list", which is not an empty one.
+    expect(seeds).toEqual({ loaded: false });
+    expect(resolved).toEqual({ id: null, reason: SEED_CONFIG_UNREADABLE_REASON });
+
+    const notice = view.getByTestId("agent-seed-config-unreadable").textContent ?? "";
+    expect(notice).toContain("server");
+    expect(notice).toContain("configuration");
+    // The two false claims the entry was written about. The connection is not at fault
+    // and its settings do not live here.
+    expect(notice).not.toContain("this browser");
+    expect(view.queryByTestId("agent-unresolvable-connection")).toBeNull();
+    // Still refused, and still without asking the server for a run it cannot open.
+    expect((view.getByTestId("agent-start") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // The control arm. A server that legitimately serves NO seeds is answering, and the
+  // original sentence is the true one there: this copy exists in this browser and
+  // nowhere else. Without this test the fix could turn every empty list into a false
+  // alarm about a configuration that is fine.
+  test("a server that legitimately serves no seeds still gets the original sentence", async () => {
+    const { view, seeds, resolved } = await railAfterManaged({ json: { connections: [] } });
+
+    expect(seeds).toEqual({ loaded: true, seeds: [] });
+    expect(resolved).toEqual({ id: null, reason: "browser-only" });
+
+    const caveat = view.getByTestId("agent-unresolvable-connection").textContent ?? "";
+    expect(caveat).toContain("Sample (Employees)");
+    expect(caveat).toContain("this browser");
+    expect(view.queryByTestId("agent-seed-config-unreadable")).toBeNull();
+    expect((view.getByTestId("agent-start") as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/tests/components/studio-agent-ask.test.tsx
+++ b/tests/components/studio-agent-ask.test.tsx
@@ -102,7 +102,7 @@ mock.module("@/hooks/use-auth", () => ({
 mock.module("@/hooks/use-connection-manager", () => ({
   useConnectionManager: mock(() => ({
     connections: [],
-    servedSeeds: [],
+    servedSeeds: { loaded: true, seeds: [] },
     activeConnection: null,
     schema: [],
     schemaContext: "[]",

--- a/tests/evals/operations.test.ts
+++ b/tests/evals/operations.test.ts
@@ -73,7 +73,12 @@ describe("the operations arc, on every engine including one agent mode otherwise
       // `context-captured` appears exactly where a catalog can be read (#411): the two
       // engines `CATALOG_PLANS` serves ground the run before its first turn, and every
       // other engine continues ungrounded rather than failing.
-      const grounded = engine === "mysql" ? [] : ["context-captured"];
+      //
+      // Ungrounded is now WRITTEN DOWN rather than left as a hole (B54). The entry the
+      // MySQL preset gets is `context-unavailable`, never a `context-captured` with a
+      // zero count: this run read nothing, and a count would state that this database
+      // has no tables.
+      const grounded = engine === "mysql" ? ["context-unavailable"] : ["context-captured"];
       expect(drive.kinds).toEqual([
         "run-started",
         "driver-resolved",
@@ -342,6 +347,10 @@ describe("an engine that cannot serve a reading", () => {
     expect(drive.kinds).toEqual([
       "run-started",
       "driver-resolved",
+      // The MySQL preset's provider cannot describe itself, so this run is ungrounded —
+      // and since B54 that is an entry rather than a hole. It sits before the first tool
+      // call because the capture is attempted before the first turn.
+      "context-unavailable",
       "tool-invoked",
       "tool-refused",
       "guidance-issued",

--- a/tests/evals/plan-grounding.test.ts
+++ b/tests/evals/plan-grounding.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { forgetHeldSnapshots } from "@/lib/agent/context-snapshot";
+import { QueryError } from "@/lib/db/errors";
+import type { AgentRunEvent } from "@/lib/agent/types";
 import { UNTRUSTED_CONTENT_END } from "@/lib/agent/untrusted-content";
 import {
   DEPARTMENTS,
@@ -174,6 +176,98 @@ describe("a plan run on an engine this server cannot ground says so", () => {
     // planning run has no tools, and naming one it does not have is the #350 failure.
     expect(sent).not.toContain("inspect_schema");
     expect(drive.status).toBe("succeeded");
+  });
+});
+
+/*
+  B54. A refused capture used to leave the ledger silent, which broke the rule
+  `docs/llms/setup.md` states about it: every run writes its ledger, and that is the
+  authority on what the run did. It was the authority only for a capture that
+  SUCCEEDED — the refusal path pushed a sentence into the prompt and returned, so the
+  849-byte ledger of the AlloyDB Omni run the entry measured named no catalog read, no
+  reason code and no row count, and the only record that the run was ungrounded was the
+  model's own prose. The trap that makes it worse is already on file here: a missing
+  event reads as work that was not needed rather than knowledge that was lost.
+
+  `context-unavailable` is its own kind rather than a `context-captured` carrying an
+  absence, and the tests below assert both halves of why. A refused capture has no
+  honest `fingerprint` and no honest `tableCount`, so the absence rule (#477) forbids
+  the variant; and every reader that asks `kind === "context-captured"` —
+  `reusableSnapshot`, the grounding check in `tools.ts`, the timeline — treats the entry
+  as PROOF that an inventory exists, so one that carried a refusal would poison all
+  three.
+*/
+/** One ledger entry of a given kind, narrowed, so an assertion can read its own fields. */
+const eventOfKind = <K extends AgentRunEvent["kind"]>(
+  drive: EvalDrive,
+  kind: K,
+): Extract<AgentRunEvent, { kind: K }> | undefined =>
+  drive.events.find((entry): entry is Extract<AgentRunEvent, { kind: K }> => entry.kind === kind);
+
+describe("a refused capture records why it was refused", () => {
+  test("postgres: the row budget refusal carries both numbers and no fabricated count", async () => {
+    // The measured shape of B52, as the provider itself raises it: `queryReadOnly`
+    // refuses rather than truncating, and the two numbers are the whole diagnosis —
+    // 536 rows against a 200-row budget says "narrow the capture", where the reason
+    // code alone says only "somebody said no".
+    const run = await openEvalRun({
+      engine: "postgres",
+      mode: "planning",
+      objective: "Which department has the most employees?",
+      catalogAnswer: () => {
+        throw new QueryError("Read-only execution exceeded the row budget: 536 rows > 200 allowed", "postgres");
+      },
+    });
+    runs.push(run);
+
+    const drive = await run.drive(PLAN);
+
+    expect(drive.kinds).not.toContain("context-captured");
+    expect(drive.kinds).toContain("context-unavailable");
+    const event = eventOfKind(drive, "context-unavailable");
+    expect(event).toMatchObject({
+      reasonCode: "CATALOG_READ_REFUSED",
+      rowBudget: { projected: 536, allowed: 200 },
+    });
+    // The absence rule, asserted rather than implied: nothing was read, so the entry
+    // states no count and no fingerprint at all.
+    expect(event).not.toHaveProperty("tableCount");
+    expect(event).not.toHaveProperty("fingerprint");
+    expect(drive.status).toBe("succeeded");
+  });
+
+  test("mysql: a provider that cannot describe itself records the reason and states no budget", async () => {
+    // The other refusal family, and the reason `rowBudget` is optional rather than a
+    // pair of zeros: this run met no budget, so a number here would be a measurement
+    // nobody took.
+    const run = await openPlan("mysql");
+
+    const drive = await run.drive(PLAN);
+
+    const event = eventOfKind(drive, "context-unavailable");
+    expect(event?.reasonCode).toBe("CATALOG_READ_REFUSED");
+    expect(event?.rowBudget).toBeUndefined();
+    // The diagnosis the model was given, so the ledger and the prompt cannot disagree
+    // about why this run had no inventory.
+    expect(event?.detail).toContain("this database refused to describe its own schema");
+  });
+
+  test("postgres: a capture that SUCCEEDS records what it always did, and no refusal", async () => {
+    // The control. `context-captured` is the entry every reader of a grounded run
+    // depends on, and the fix above must not have moved any part of it.
+    const run = await openPlan("postgres");
+
+    const drive = await run.drive(PLAN);
+
+    expect(drive.kinds).not.toContain("context-unavailable");
+    const event = eventOfKind(drive, "context-captured");
+    expect(event).toMatchObject({
+      kind: "context-captured",
+      tableCount: DEPARTMENTS.length,
+      noun: { singular: "table", plural: "tables" },
+    });
+    expect(event?.fingerprint).toMatch(/^ctx_[0-9a-f]{32}$/);
+    expect(event?.snapshot?.tables).toHaveLength(DEPARTMENTS.length);
   });
 });
 

--- a/tests/evals/query-optimization.test.ts
+++ b/tests/evals/query-optimization.test.ts
@@ -125,7 +125,7 @@ describe("the optimization arc, on both reference engines", () => {
         "run-finished",
       ]);
       expect(drive.status).toBe("succeeded");
-      expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+      expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
     });
 
     test(`${engine}: the comparison records what the engine's own plan said`, async () => {
@@ -195,7 +195,7 @@ describe("an index answers on the plan it diagnosed", () => {
 
       expect(drive.status).toBe("succeeded");
       expect(drive.stopReason).toBe("report-composed");
-      expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+      expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
       // And it stays read-only: the DDL it proposed reached no database.
       for (const statement of drive.modelStatements) expect(statement).not.toContain("CREATE INDEX");
     });
@@ -218,11 +218,52 @@ describe("an index answers on the plan it diagnosed", () => {
 
       expect(drive.verdict).toEqual({
         outcome: "unanswered",
-        verifier: "agent-query-optimization.2",
+        verifier: "agent-query-optimization.3",
         unmet: ["no-plan-evidence"],
       });
     });
   }
+
+  /**
+   * B45, driven end to end: the plan the engine counts as no rows.
+   *
+   * On 2026-08-17 every Optimize run in a live drive ended *"Run did not answer — Every
+   * result the report cited came back empty"*, over a `CREATE INDEX` that was the right
+   * index. The plan was the only thing those reports had to cite, and the driver reports
+   * no row count for an `EXPLAIN` — so the baseline's arithmetic read a complete plan as
+   * an empty result. The engine's answer here is the live one: the plan's rows, counted
+   * as zero.
+   */
+  test("a plan the engine counts as no rows still grounds the run's answer", async () => {
+    const run = await openEvalRun({
+      engine: "postgres",
+      workflowType: "query-optimization",
+      objective: "Why is the employee listing query slow?",
+      answer: async (sql) => {
+        const explaining = sql.startsWith("EXPLAIN");
+        const rows = explaining ? PLANS.postgres(sql) : [{ emp_no: 10001 }];
+        return {
+          rows,
+          fields: Object.keys(rows[0] ?? {}),
+          rowCount: explaining ? 0 : rows.length,
+          executionTime: 3,
+        };
+      },
+    });
+    runs.push(run);
+
+    const drive = await run.drive([
+      callsTool("inspect_plan", { sql: SLOW }, "call_plan_before"),
+      recommends(),
+      reportOn("The listing reads the whole table because last_name is unindexed."),
+    ]);
+
+    const plan = drive.events.find((event) => event.kind === "tool-completed");
+    if (plan?.kind !== "tool-completed") throw new Error("expected the plan artifact");
+    // The reproduction is only honest if the ledger really carries the zero.
+    expect(plan.artifact.summary.rowCount).toBe(0);
+    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
+  });
 });
 
 describe("THE GATE: the verifier fails the run when the template's own artifact is absent", () => {
@@ -253,7 +294,7 @@ describe("THE GATE: the verifier fails the run when the template's own artifact 
       expect(drive.stopReason).toBe("report-composed");
       expect(drive.verdict).toEqual({
         outcome: "unanswered",
-        verifier: "agent-query-optimization.2",
+        verifier: "agent-query-optimization.3",
         unmet: ["no-plan-comparison"],
       });
     });
@@ -322,7 +363,7 @@ describe("a run holding two plans and reporting without comparing them is asked 
     expect(drive.transcripts[3]).toContain("no comparison is recorded");
     // And the run went on to compare and report, so the notice cost it nothing.
     expect(drive.kinds).toContain("plan-comparison");
-    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
   });
 
   test("a run holding ONE plan is asked for the second one, never for a comparison", async () => {
@@ -359,7 +400,7 @@ describe("a run holding two plans and reporting without comparing them is asked 
     expect(drive.transcripts[2]).toContain("inspect_plan");
     expect(drive.transcripts[2]).not.toContain("Call compare_plans with before=");
     // And the run finished the arc the nudge pointed at.
-    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
   });
 
   test("a run holding no plan IS asked, and the ask is for the reading rather than the comparison", async () => {
@@ -445,7 +486,7 @@ describe("an index recommended on no plan at all is asked for one", () => {
     ]);
 
     expect(drive.transcripts[2]).toContain("inspect_plan");
-    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
   });
 
   test("a report resting on no plans at all is held and told to inspect one", async () => {
@@ -476,7 +517,7 @@ describe("an index recommended on no plan at all is asked for one", () => {
     ]);
 
     expect(drive.transcripts[1]).toContain("inspect_plan");
-    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+    expect(drive.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
   });
 });
 
@@ -525,6 +566,6 @@ describe("a drive that dies after recording a comparison does not make it twice"
     expect(firstTurn).toContain("must not be made again");
     expect(firstTurn).toContain("was already recommended");
     // And the run still answers: the comparison it needs is on its own ledger.
-    expect(resumed.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+    expect(resumed.verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
   });
 });

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -419,7 +419,7 @@ describe("useConnectionForm", () => {
     // alone would not have caught this, because the earlier eligibility tests built
     // their "edited" copy by hand rather than through the editor that produces it.
     const served = { ...seedCopy, createdAt: seedCopy.createdAt.toISOString() };
-    expect(resolveAgentRunConnectionId(saved, [served])).toBe("seed:sample");
+    expect(resolveAgentRunConnectionId(saved, { loaded: true, seeds: [served] })).toEqual({ id: "seed:sample" });
   });
 
   /*
@@ -469,7 +469,9 @@ describe("useConnectionForm", () => {
     expect(saved.password).toBeUndefined();
 
     const served = { ...sqliteSeed, createdAt: sqliteSeed.createdAt.toISOString() };
-    expect(resolveAgentRunConnectionId(saved, [served])).toBe("seed:sqlite-embedded-sample");
+    expect(resolveAgentRunConnectionId(saved, { loaded: true, seeds: [served] })).toEqual({
+      id: "seed:sqlite-embedded-sample",
+    });
   });
 
   // Preserving must not resurrect what the user turned OFF: the form owns TLS and

--- a/tests/hooks/use-connection-manager.test.ts
+++ b/tests/hooks/use-connection-manager.test.ts
@@ -7,6 +7,7 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { mockGlobalFetch, restoreGlobalFetch } from "../helpers/mock-fetch";
 
 import { useConnectionManager } from "@/hooks/use-connection-manager";
+import type { ManagedConnectionPayload } from "@/hooks/use-connection-payload";
 import { logger } from "@/lib/logger";
 import { storage } from "@/lib/storage";
 import type { DatabaseConnection, TableSchema } from "@/lib/types";
@@ -567,7 +568,7 @@ describe("useConnectionManager", () => {
   });
 
   // Server payloads are JSON — createdAt arrives as an ISO string, not a Date.
-  const makeManagedConnection = (overrides: Record<string, unknown> = {}) => ({
+  const makeManagedConnection = (overrides: Partial<ManagedConnectionPayload> = {}): ManagedConnectionPayload => ({
     id: "srv-1",
     name: "Seeded DB",
     type: "postgres",
@@ -651,16 +652,19 @@ describe("useConnectionManager", () => {
     const { result } = renderHook(() => useConnectionManager(true));
 
     await waitFor(() => {
-      expect(result.current.servedSeeds).toHaveLength(1);
+      expect(result.current.servedSeeds).toEqual({ loaded: true, seeds: [served] });
     });
-    expect(result.current.servedSeeds[0]!.seedId).toBe("seed-new");
-    // The server's copy, not the user's: the merged entry is the one that may drift.
-    expect(result.current.servedSeeds[0]!.createdAt).toBe(served.createdAt);
+    // The server's copy, not the user's: the merged entry is the one that may drift,
+    // and it carries the raw `createdAt` string rather than a Date.
+    expect(result.current.servedSeeds).toEqual({ loaded: true, seeds: [{ ...served, createdAt: served.createdAt }] });
   });
 
-  test("serves no descriptors when the managed endpoint is unavailable", async () => {
+  // An answer that carries no connections is an answer: the server served none. That is
+  // what a deployment with no seed file looks like, and it stays LOADED — the empty list
+  // is a measurement, not a gap.
+  test("serves no descriptors when the endpoint answers with no connections", async () => {
     mockGlobalFetch({
-      "/api/connections/managed": { ok: false, json: { error: "nope" } },
+      "/api/connections/managed": { json: {} },
       "/api/db/health": { ok: true, json: { status: "healthy" } },
     });
 
@@ -669,7 +673,63 @@ describe("useConnectionManager", () => {
     await waitFor(() => {
       expect(result.current.connections).toEqual([]);
     });
-    expect(result.current.servedSeeds).toEqual([]);
+    expect(result.current.servedSeeds).toEqual({ loaded: true, seeds: [] });
+  });
+
+  // B37. The endpoint failing is not the endpoint answering "none": one malformed
+  // seed-connections.yaml used to reach the browser as an empty list, and everything
+  // downstream then reported an absence it had never measured.
+  test("holds the seed list as UNREAD when the server says it could not read its own configuration", async () => {
+    mockGlobalFetch({
+      "/api/connections/managed": {
+        status: 500,
+        json: { error: "Failed to load managed connections", reason: "seed-config-unreadable" },
+      },
+      "/api/db/health": { ok: true, json: { status: "healthy" } },
+    });
+
+    const { result } = renderHook(() => useConnectionManager(true));
+
+    await waitFor(() => {
+      expect(result.current.servedSeeds).toEqual({ loaded: false });
+    });
+  });
+
+  // The other arm: a failure the server did NOT attribute to its seed configuration
+  // says nothing about that configuration, so it may not be recorded as one. This is
+  // also the shape the platform embed produces, where the route does not exist at all.
+  test("a failure the server did not attribute to its seed config leaves the list loaded", async () => {
+    mockGlobalFetch({
+      "/api/connections/managed": { status: 404, json: { error: "Not found" } },
+      "/api/db/health": { ok: true, json: { status: "healthy" } },
+    });
+
+    const { result } = renderHook(() => useConnectionManager(true));
+
+    await waitFor(() => {
+      expect(result.current.connections).toEqual([]);
+    });
+    expect(result.current.servedSeeds).toEqual({ loaded: true, seeds: [] });
+  });
+
+  // A gateway's HTML error page is not a server statement about anything: the body does
+  // not parse, so no reason is read from it and the seed list stays a measured empty.
+  test("a failure whose body is not JSON attributes nothing", async () => {
+    mockGlobalFetch({
+      "/api/connections/managed": {
+        status: 502,
+        text: "<html>Bad Gateway</html>",
+        headers: { "content-type": "text/html" },
+      },
+      "/api/db/health": { ok: true, json: { status: "healthy" } },
+    });
+
+    const { result } = renderHook(() => useConnectionManager(true));
+
+    await waitFor(() => {
+      expect(result.current.connections).toEqual([]);
+    });
+    expect(result.current.servedSeeds).toEqual({ loaded: true, seeds: [] });
   });
 
   test("managed merge falls back to the first merged connection when no active ID is persisted", async () => {

--- a/tests/integration/db/redis-provider.test.ts
+++ b/tests/integration/db/redis-provider.test.ts
@@ -83,6 +83,13 @@ const capturedCalls: Array<{ command: string; args: string[] }> = [];
  */
 const capturedRedisOptions: Record<string, unknown>[] = [];
 
+/**
+ * When set, `info()` rejects with this message instead of answering. A Redis 6 ACL
+ * user without `+info` is refused exactly this way, and it is the one shape where
+ * the server is reachable but every INFO-derived surface is not (D29).
+ */
+let infoRefusal: string | null = null;
+
 mock.module("ioredis", () => {
   class MockRedis {
     private _config: unknown;
@@ -101,6 +108,7 @@ mock.module("ioredis", () => {
     }
 
     async info() {
+      if (infoRefusal !== null) throw new Error(infoRefusal);
       return MOCK_INFO_STRING;
     }
 
@@ -207,6 +215,39 @@ describe("RedisProvider", () => {
       await provider.connect();
       await provider.disconnect();
       expect(provider.isConnected()).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // ACL user (D29)
+  // --------------------------------------------------------------------------
+
+  describe("the ACL user handed to ioredis", () => {
+    /** The options object of the connection this test just opened. */
+    const lastOptions = (): Record<string, unknown> => capturedRedisOptions[capturedRedisOptions.length - 1];
+
+    const connectAs = async (user: string | undefined) => {
+      provider = new RedisProvider({ ...baseConfig, user, password: "probepw" });
+      await provider.connect();
+      return lastOptions();
+    };
+
+    // Measured 2026-08-26 against `redis:latest` with `probe` defined as
+    // `on >probepw ~* +@all -info`: without `username` in the options, `ACL WHOAMI`
+    // answers `default` and INFO succeeds - the app authenticated as a principal the
+    // user never chose. With it, WHOAMI answers `probe`.
+    test("the connection's user travels as ioredis's username", async () => {
+      expect(await connectAs("probe")).toMatchObject({ username: "probe", password: "probepw" });
+    });
+
+    // A `requirepass`-only server has no ACL users to name, and ioredis authenticates
+    // as `default` only when `username` is absent. So an empty field must stay empty.
+    test("no username is sent when the connection names no user", async () => {
+      expect((await connectAs(undefined)).username).toBeUndefined();
+    });
+
+    test("an empty user string is sent as no username at all", async () => {
+      expect((await connectAs("")).username).toBeUndefined();
     });
   });
 
@@ -798,6 +839,25 @@ describe("RedisProvider", () => {
       expect(health.databaseSize).toBe("1.95MB");
       // hitRatio: 900/(900+100)*100 = 90.0
       expect(health.cacheHitRatio).toBe("90.0");
+    });
+
+    /*
+      D29's other half. An ACL user without `+info` connects and browses keys, and
+      every INFO-derived surface is refused. `getHealth()` must NOT answer with
+      fabricated zeros for a read that never happened - it raises the server's own
+      sentence, which `POST /api/db/test-connection` turns into the degraded (amber)
+      outcome rather than a green one (that translation is covered in
+      tests/api/db/test-connection.test.ts).
+    */
+    test("a refused INFO raises the server's own NOPERM sentence", async () => {
+      infoRefusal = "NOPERM User probe has no permissions to run the 'info' command";
+      try {
+        await expect(provider.getHealth()).rejects.toThrow(
+          "Failed to get Redis health: NOPERM User probe has no permissions to run the 'info' command",
+        );
+      } finally {
+        infoRefusal = null;
+      }
     });
   });
 

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -19,6 +19,7 @@ import {
   readDbstatSizes,
 } from "@/lib/db/providers/sql/sqlite";
 import { resolveSQLiteDriverName } from "@/lib/db/providers/sql/sqlite-driver";
+import { rowBudgetIn } from "@/lib/agent/context-snapshot";
 import type { DatabaseConnection } from "@/lib/types";
 import type { ReadOnlyStatementBudget } from "@/lib/db/types";
 import { ConnectionError, DatabaseConfigError, ExecutionProfileError, QueryError } from "@/lib/db/errors";
@@ -1223,6 +1224,46 @@ describe("SQLiteProvider agent read-only execution profile (#328)", () => {
         maxResultRows: 2,
       }),
     ).rejects.toThrow(QueryError);
+  });
+
+  test("the row budget refusal a grounding capture records is parsed out of THIS message (B54)", async () => {
+    /*
+      The loop B54 closes, closed at both ends.
+
+      A refused schema capture now writes a `context-unavailable` ledger entry carrying
+      the two numbers — rows projected against rows allowed — and the only place those
+      numbers exist is inside the sentence this provider formats: neither `QueryError`
+      nor the tool refusal that wraps it carries them as fields, so `rowBudgetIn` reads
+      them back out of the message.
+
+      That is a silent-failure shape, which is why this test drives the REAL provider
+      instead of asserting against a hand-typed copy of the sentence. Reword the message
+      in `sqlite.ts` and this goes red here, rather than going quiet in production and
+      re-opening the entry with the ledger blank again.
+    */
+    const dbPath = await seedDatabase();
+    const profile = await openAgent(dbPath);
+
+    const thrown = await profile
+      .queryReadOnly("SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3", { ...AGENT_BUDGET, maxResultRows: 2 })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+    expect(thrown).toBeInstanceOf(QueryError);
+    expect(rowBudgetIn((thrown as QueryError).message)).toEqual({ projected: 3, allowed: 2 });
+
+    /*
+      PostgreSQL formats the same sentence in its own file and cannot be driven from
+      here without a server, so its copy is pinned against the SOURCE. Weaker than the
+      live arm above — it proves the template still reads that way, not that a running
+      engine produces it — and still red on a reword, which is the property that matters.
+    */
+    const postgresSource = await Bun.file("src/lib/db/providers/sql/postgres.ts").text();
+    expect(postgresSource).toContain(
+      "Read-only execution exceeded the row budget: ${result.rows.length} rows > ${budget.maxResultRows} allowed",
+    );
   });
 
   test("enforces the byte budget with a typed error instead of truncating", async () => {

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, mock, spyOn, beforeEach } from "bun:test";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { discoverRoutes } from "./helpers/discover-routes";
 
@@ -246,6 +247,83 @@ describe("routes that reach a provider require a session", () => {
     for (const key of Object.keys(ROUTES_WITHOUT_A_PROVIDER)) {
       expect(ALL_ROUTES.some(([routeKey]) => routeKey === key)).toBe(true);
     }
+  });
+
+  // The check above proves an allowlist key names a real route. It does NOT prove the key's
+  // REASON - "reaches no database or LLM provider" - is still true, so a route already on the
+  // allowlist that later grows a provider call escapes the sweep above forever, silently. This
+  // is the second, independent check: it reads each allowlisted route's own source and fails if
+  // the file reaches any of the provider entry points the non-allowlisted routes use.
+  //
+  // The entry-point set below is not a guess: it is every way a route under src/app/api/ obtains
+  // a provider today - the `@/lib/db` barrel and `@/lib/db/factory`
+  // (getOrCreateProvider, createDatabaseProvider, removeProvider, findOpenSingleWriterProvider,
+  // acquireExecutionProfileProvider, withOneShotTunnel), `@/lib/llm`
+  // (createLLMProvider) and its config helpers, and `@/lib/api/schema-route`
+  // (handleSchemaRequest), which is how db/schema/list and db/schema/relations reach a provider
+  // without naming @/lib/db themselves. Matching on the module specifier prefix rather than on a
+  // fixed list of exported names means a NEW factory export is covered the day it is added.
+  //
+  // Deliberately NOT flagged: `@/lib/api/errors`, which nearly every route imports and which
+  // itself imports @/lib/db/errors and @/lib/llm/types - error mapping reaches no provider, and
+  // treating it as an entry point would make this check fire on all sixteen allowlisted routes.
+  const PROVIDER_ENTRY_POINTS: Array<{ label: string; pattern: RegExp }> = [
+    { label: 'a "@/lib/db" import', pattern: /from\s+"@\/lib\/db(?:\/[^"]*)?"/ },
+    { label: 'a "@/lib/llm" import', pattern: /from\s+"@\/lib\/llm(?:\/[^"]*)?"/ },
+    { label: 'a "@/lib/api/schema-route" import', pattern: /from\s+"@\/lib\/api\/schema-route"/ },
+    { label: "a getOrCreateProvider() call", pattern: /\bgetOrCreateProvider\s*\(/ },
+    { label: "a createDatabaseProvider() call", pattern: /\bcreateDatabaseProvider\s*\(/ },
+    { label: "an acquireExecutionProfileProvider() call", pattern: /\bacquireExecutionProfileProvider\s*\(/ },
+    { label: "a findOpenSingleWriterProvider() call", pattern: /\bfindOpenSingleWriterProvider\s*\(/ },
+    { label: "a withOneShotTunnel() call", pattern: /\bwithOneShotTunnel\s*\(/ },
+    { label: "a removeProvider() call", pattern: /\bremoveProvider\s*\(/ },
+    { label: "a createLLMProvider() call", pattern: /\bcreateLLMProvider\s*\(/ },
+    { label: "a handleSchemaRequest() call", pattern: /\bhandleSchemaRequest\s*\(/ },
+  ];
+
+  // The one allowlist entry whose reason does NOT claim to be provider-free (see the doc comment
+  // on ROUTES_WITHOUT_A_PROVIDER). Skipping it is itself verified below - the assertion requires
+  // the entry's reason to still say so, so this set cannot quietly grow into a second unchecked
+  // allowlist.
+  const ALLOWLISTED_BUT_REACHES_A_PROVIDER = ["agent/drive"];
+
+  /** Blanks out comments while preserving line numbering, so a mention in prose is not a hit. */
+  function withoutComments(source: string): string {
+    return source
+      .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, " "))
+      .replace(/(^|[^:])\/\/.*$/gm, "$1");
+  }
+
+  test("every allowlisted route entry that claims to reach a provider still says so", () => {
+    for (const key of ALLOWLISTED_BUT_REACHES_A_PROVIDER) {
+      expect(ROUTES_WITHOUT_A_PROVIDER[key]).toContain("reaches a provider");
+    }
+  });
+
+  test("every allowlisted route is still provider-free in its own source", () => {
+    const violations: string[] = [];
+
+    for (const key of Object.keys(ROUTES_WITHOUT_A_PROVIDER)) {
+      if (ALLOWLISTED_BUT_REACHES_A_PROVIDER.includes(key)) {
+        continue;
+      }
+      const source = withoutComments(readFileSync(join(API_ROOT_DIR, key, "route.ts"), "utf8"));
+      source.split("\n").forEach((rawLine, index) => {
+        // A type-only import is erased at compile time and can reach nothing at runtime.
+        if (rawLine.trimStart().startsWith("import type ")) {
+          return;
+        }
+        for (const { label, pattern } of PROVIDER_ENTRY_POINTS) {
+          if (pattern.test(rawLine)) {
+            violations.push(
+              `"${key}" is allowlisted as provider-free but route.ts:${index + 1} contains ${label}: ${rawLine.trim()}`,
+            );
+          }
+        }
+      });
+    }
+
+    expect(violations).toEqual([]);
   });
 
   for (const [route, load] of PROVIDER_ROUTES) {

--- a/tests/unit/agent-connection-eligibility.test.ts
+++ b/tests/unit/agent-connection-eligibility.test.ts
@@ -3,8 +3,9 @@
  *
  * A run persists a connection id and no credential, so the process that resumes it
  * re-resolves that id server-side. The question the rail has to answer is therefore
- * not "can I avoid shipping credentials" (that is `buildConnectionPayload`) but "will
- * `seed:<id>` still reach the SAME database later". The two answers coincide for a
+ * not "can I avoid shipping credentials" (that is `buildConnectionPayload`, whose own two
+ * arms are pinned at the bottom of this file) but "will `seed:<id>` still reach the SAME
+ * database later". The two answers coincide for a
  * managed connection and for a browser-only one, and diverge for the editable copy of
  * a seed — which is exactly what a zero-config deployment ships, and what left the
  * rail unable to start anything at all.
@@ -18,7 +19,12 @@
 
 import { describe, expect, test, beforeAll } from "bun:test";
 import type { DatabaseConnection } from "@/lib/types";
-import { resolveAgentRunConnectionId, type ManagedConnectionPayload } from "@/hooks/use-connection-payload";
+import {
+  buildConnectionPayload,
+  resolveAgentRunConnectionId,
+  type ManagedConnectionPayload,
+  type ServedSeeds,
+} from "@/hooks/use-connection-payload";
 
 /** A seed descriptor as `GET /api/connections/managed` serializes it. */
 function descriptor(overrides: Partial<ManagedConnectionPayload> = {}): ManagedConnectionPayload {
@@ -44,6 +50,16 @@ function browserCopy(from: ManagedConnectionPayload, edits: Partial<DatabaseConn
   return { ...serialized, createdAt: new Date(serialized.createdAt), managed: false, ...edits };
 }
 
+/** A seed list the server actually served — the ONLY thing an empty one may mean. */
+function loaded(...seeds: ManagedConnectionPayload[]): ServedSeeds {
+  return { loaded: true, seeds };
+}
+
+/** The id a run may be started on, dropping the reason the tests below do not read. */
+function startableId(conn: DatabaseConnection, servedSeeds: ServedSeeds): string | null {
+  return resolveAgentRunConnectionId(conn, servedSeeds).id;
+}
+
 describe("which connection a run may be started on", () => {
   test("a managed connection is startable by id without consulting any descriptor", () => {
     const managed: DatabaseConnection = {
@@ -55,7 +71,7 @@ describe("which connection a run may be started on", () => {
       createdAt: new Date(0),
     };
 
-    expect(resolveAgentRunConnectionId(managed, [])).toBe("seed:sales");
+    expect(startableId(managed, loaded())).toBe("seed:sales");
   });
 
   test("a connection with no seed origin is not startable", () => {
@@ -67,19 +83,19 @@ describe("which connection a run may be started on", () => {
       createdAt: new Date(0),
     };
 
-    expect(resolveAgentRunConnectionId(own, [descriptor()])).toBeNull();
+    expect(startableId(own, loaded(descriptor()))).toBeNull();
   });
 
   test("an untouched copy of an editable seed is startable by id", () => {
     const server = descriptor();
 
-    expect(resolveAgentRunConnectionId(browserCopy(server), [server])).toBe("seed:sales");
+    expect(startableId(browserCopy(server), loaded(server))).toBe("seed:sales");
   });
 
   test("a copy whose seed the server no longer serves is not startable", () => {
     const server = descriptor();
 
-    expect(resolveAgentRunConnectionId(browserCopy(server), [descriptor({ seedId: "other" })])).toBeNull();
+    expect(startableId(browserCopy(server), loaded(descriptor({ seedId: "other" })))).toBeNull();
   });
 
   // The whole reason the rule is not just "has a seedId": the server would resolve
@@ -88,13 +104,13 @@ describe("which connection a run may be started on", () => {
   test("a copy edited to reach a different database is not startable", () => {
     const server = descriptor();
 
-    expect(resolveAgentRunConnectionId(browserCopy(server, { database: "somewhere-else" }), [server])).toBeNull();
+    expect(startableId(browserCopy(server, { database: "somewhere-else" }), loaded(server))).toBeNull();
   });
 
   test("a copy given different credentials is not startable", () => {
     const server = descriptor();
 
-    expect(resolveAgentRunConnectionId(browserCopy(server, { password: "different" }), [server])).toBeNull();
+    expect(startableId(browserCopy(server, { password: "different" }), loaded(server))).toBeNull();
   });
 
   // The field a hand-written comparison forgets: it changes which role the agent
@@ -103,7 +119,7 @@ describe("which connection a run may be started on", () => {
     const server = descriptor();
     const copy = browserCopy(server, { agentUser: "agent_ro", agentPassword: "pw" });
 
-    expect(resolveAgentRunConnectionId(copy, [server])).toBeNull();
+    expect(startableId(copy, loaded(server))).toBeNull();
   });
 
   test("presentation-only edits leave a copy startable", () => {
@@ -116,34 +132,69 @@ describe("which connection a run may be started on", () => {
       createdAt: new Date("2026-08-12T00:00:00.000Z"),
     });
 
-    expect(resolveAgentRunConnectionId(renamed, [server])).toBe("seed:sales");
+    expect(startableId(renamed, loaded(server))).toBe("seed:sales");
+  });
+
+  // B37. A seed list that was never read is not an empty seed list. Deciding
+  // "browser-only" from it states a conclusion about the SERVER's copy that nothing
+  // measured — and it is wrong for exactly the connections this application seeds itself.
+  test("a seed copy is not judged browser-only while the served list is unread", () => {
+    const copy = browserCopy(descriptor());
+
+    expect(resolveAgentRunConnectionId(copy, { loaded: false })).toEqual({
+      id: null,
+      reason: "seed-config-unreadable",
+    });
+  });
+
+  // The control: a served list that is genuinely empty HAS been measured, so the
+  // browser-only verdict is the honest one there.
+  test("a seed copy the server does not serve is browser-only, empty list and all", () => {
+    const copy = browserCopy(descriptor());
+
+    expect(resolveAgentRunConnectionId(copy, loaded())).toEqual({ id: null, reason: "browser-only" });
+  });
+
+  // An unread list changes nothing for a MANAGED connection: it only exists in the list
+  // because the server served it, and its id is the server's own.
+  test("a managed connection stays startable while the served list is unread", () => {
+    const managed: DatabaseConnection = {
+      id: "seed:sales",
+      seedId: "sales",
+      name: "Sales",
+      type: "postgres",
+      managed: true,
+      createdAt: new Date(0),
+    };
+
+    expect(resolveAgentRunConnectionId(managed, { loaded: false })).toEqual({ id: "seed:sales" });
   });
 
   describe("nested transport settings", () => {
     const withSsl = descriptor({ ssl: { mode: "require", rejectUnauthorized: true } });
 
     test("an identical TLS block leaves a copy startable", () => {
-      expect(resolveAgentRunConnectionId(browserCopy(withSsl), [withSsl])).toBe("seed:sales");
+      expect(startableId(browserCopy(withSsl), loaded(withSsl))).toBe("seed:sales");
     });
 
     test("a changed TLS field makes a copy unstartable", () => {
       const relaxed = browserCopy(withSsl, { ssl: { mode: "require", rejectUnauthorized: false } });
 
-      expect(resolveAgentRunConnectionId(relaxed, [withSsl])).toBeNull();
+      expect(startableId(relaxed, loaded(withSsl))).toBeNull();
     });
 
     test("adding a TLS block the descriptor does not have makes a copy unstartable", () => {
       const server = descriptor();
       const added = browserCopy(server, { ssl: { mode: "disable" } });
 
-      expect(resolveAgentRunConnectionId(added, [server])).toBeNull();
+      expect(startableId(added, loaded(server))).toBeNull();
     });
 
     test("dropping the descriptor's TLS block makes a copy unstartable", () => {
       const dropped = browserCopy(withSsl);
       delete (dropped as { ssl?: unknown }).ssl;
 
-      expect(resolveAgentRunConnectionId(dropped, [withSsl])).toBeNull();
+      expect(startableId(dropped, loaded(withSsl))).toBeNull();
     });
 
     test("a changed SSH tunnel makes a copy unstartable", () => {
@@ -154,7 +205,7 @@ describe("which connection a run may be started on", () => {
         sshTunnel: { enabled: true, host: "other-bastion", port: 22, username: "ops", authMethod: "password" },
       });
 
-      expect(resolveAgentRunConnectionId(rerouted, [tunnelled])).toBeNull();
+      expect(startableId(rerouted, loaded(tunnelled))).toBeNull();
     });
   });
 });
@@ -188,7 +239,60 @@ describe("the connections a default deployment ships", () => {
       const served = JSON.parse(JSON.stringify(build())) as ManagedConnectionPayload;
       const stored = browserCopy(served);
 
-      expect(resolveAgentRunConnectionId(stored, [served])).toBe(`seed:${seedId}`);
+      expect(startableId(stored, loaded(served))).toBe(`seed:${seedId}`);
     }
+  });
+});
+
+/**
+ * `buildConnectionPayload` — the other question, and the reason it belongs beside this
+ * one: both decide what a request body may say about a connection, and they disagree
+ * on purpose. The managed arm is a credential boundary, not a formatting choice: a
+ * seed travels as a bare `seed:<id>` reference so nothing about how to authenticate
+ * leaves the server's own configuration, and a browser-held connection has to travel
+ * whole because the server has no other way to reach it.
+ *
+ * Pinned here rather than in a file of its own because this is the process that
+ * measures this module: a test that only loads it records no line data for it at all.
+ */
+describe("what a request body says about a connection", () => {
+  const plain = (overrides: Partial<DatabaseConnection> = {}): DatabaseConnection => ({
+    id: "conn-1",
+    name: "Sales",
+    type: "postgres",
+    host: "db.internal",
+    port: 5432,
+    user: "reader",
+    password: "secret",
+    database: "sales",
+    createdAt: new Date(0),
+    ...overrides,
+  });
+
+  test("a managed connection travels as a seed reference, carrying no credential", () => {
+    const payload = buildConnectionPayload(plain({ managed: true, seedId: "sales" }));
+
+    expect(payload).toEqual({ connectionId: "seed:sales" });
+    // The point of the arm, asserted rather than assumed: nothing about how to
+    // authenticate is in the body at all.
+    expect(JSON.stringify(payload)).not.toContain("secret");
+  });
+
+  test("a browser-held connection travels whole, because the server cannot rebuild it", () => {
+    const conn = plain();
+
+    expect(buildConnectionPayload(conn)).toEqual({ connection: conn });
+  });
+
+  test("a seedId without `managed` is not a seed reference: the copy may point elsewhere", () => {
+    const conn = plain({ seedId: "sales" });
+
+    expect(buildConnectionPayload(conn)).toEqual({ connection: conn });
+  });
+
+  test("`managed` with no seedId has no id to reference, so it travels whole", () => {
+    const conn = plain({ managed: true });
+
+    expect(buildConnectionPayload(conn)).toEqual({ connection: conn });
   });
 });

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -929,6 +929,57 @@ describe("foldLedgerEntries", () => {
   });
 
   /*
+    The capture that was REFUSED (B54).
+
+    It reads as a capture that did not happen rather than as a failure of the run: an
+    ungrounded run continues, and on the engines this server cannot ground that is its
+    ordinary state. What must never appear is a count — "0 tables" would be this
+    component stating a fact about the database from an event that measured nothing.
+  */
+  test("a refused capture says so, and names the row budget when that is what refused it", () => {
+    const view = foldLedgerEntries([
+      event({
+        kind: "event",
+        event: {
+          kind: "context-unavailable",
+          atMs: 3,
+          reasonCode: "CATALOG_READ_REFUSED",
+          detail: "The columns inventory was refused.",
+          rowBudget: { projected: 536, allowed: 200 },
+        },
+      }),
+    ]);
+
+    expect(view.items[0].headline).toBe("Schema not captured");
+    expect(view.items[0].detail).toBe("CATALOG_READ_REFUSED — 536 rows read against a bound of 200");
+    // Chrome, like the successful capture beside it: it is the run's own scaffolding
+    // rather than something the run found.
+    expect(view.items[0].chrome).toBe(true);
+    // And it is NOT a capture. The fold's `capture` field is what other surfaces read as
+    // the provenance of an answer, and a refusal is provenance for nothing.
+    expect(view.capture).toBeNull();
+  });
+
+  test("a refused capture with no budget in it shows the reason alone", () => {
+    // The other refusal family — a provider that cannot describe itself — where there is
+    // no bound to name. The entry states the reason and stops, rather than printing a
+    // pair of zeros (#477).
+    const view = foldLedgerEntries([
+      event({
+        kind: "event",
+        event: {
+          kind: "context-unavailable",
+          atMs: 3,
+          reasonCode: "PROVIDER_INVENTORY_TIMED_OUT",
+          detail: "This database did not describe its own schema in time.",
+        },
+      }),
+    ]);
+
+    expect(view.items[0].detail).toBe("PROVIDER_INVENTORY_TIMED_OUT");
+  });
+
+  /*
     The word the timeline calls the inventory's rows by (#414).
 
     The prompt half of this was fixed first, and a live drive against a seeded Redis

--- a/tests/unit/lib/agent/goal-verifier.test.ts
+++ b/tests/unit/lib/agent/goal-verifier.test.ts
@@ -321,7 +321,7 @@ describe("a query-optimization run is judged by its own artifact as well as the 
       ),
     );
 
-    expect(verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+    expect(verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
   });
 
   test("THE GATE: a perfect report with no plan comparison does not answer this workflow's question", () => {
@@ -333,7 +333,7 @@ describe("a query-optimization run is judged by its own artifact as well as the 
     expect(verifyRunGoal(run("agent", "succeeded", events, "investigation")).outcome).toBe("answered");
     expect(verifyRunGoal(run("agent", "succeeded", events, "query-optimization"))).toEqual({
       outcome: "unanswered",
-      verifier: "agent-query-optimization.2",
+      verifier: "agent-query-optimization.3",
       unmet: ["no-plan-comparison"],
     });
   });
@@ -420,7 +420,7 @@ describe("a query-optimization run is judged by its own artifact as well as the 
         reportCiting(ARTIFACT(CORRELATION.full)),
       ]);
 
-      expect(verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.2", unmet: [] });
+      expect(verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
     });
 
     test("an index citing a read rather than a plan is not grounded in what the engine does", () => {
@@ -482,6 +482,91 @@ describe("a query-optimization run is judged by its own artifact as well as the 
       ]);
 
       expect(verdict.outcome).toBe("answered");
+    });
+
+    /**
+     * B45: the run that recommended the right index and was told it had not answered.
+     *
+     * Driven live on 2026-08-17. A plan arrives in one column and the engine reports no
+     * row count for it, so the artifact's summary records `rowCount: 0` while the plan
+     * itself is complete — and a report citing that plan rested, by the baseline's
+     * arithmetic, entirely on empty results. Every Optimize run in that drive ended
+     * *"Run did not answer"*, over a correct `CREATE INDEX`.
+     */
+    describe("a plan's row count is not evidence of emptiness", () => {
+      /** The same plan, as the live engine reported it: complete, and counted as no rows. */
+      const planReadCountedEmpty: AgentRunEvent = {
+        kind: "tool-completed",
+        atMs: 20,
+        stepId: "step_plan",
+        artifact: {
+          correlationId: CORRELATION.plan,
+          runId: "arun_1",
+          operationId: "sql.explain.estimate",
+          summary: { rowCount: 0, columnNames: ["QUERY PLAN"], elapsedMs: 4 },
+        },
+      };
+
+      test("a report resting on a plan alone answers, whatever row count the plan carries", () => {
+        const verdict = optimization([
+          contextCaptured,
+          planReadCountedEmpty,
+          recommends("index", ARTIFACT(CORRELATION.plan)),
+          reportCiting(ARTIFACT(CORRELATION.plan)),
+        ]);
+
+        expect(verdict).toEqual({ outcome: "answered", verifier: "agent-query-optimization.3", unmet: [] });
+      });
+
+      test("the exemption is the plan's alone: a report resting on an empty READ is still empty", () => {
+        // The control. Zero rows from a bounded read IS the answer that read gave, and
+        // nothing here widens what counts as evidence — only which artifact's row count
+        // is meaningful.
+        const verdict = optimization([
+          contextCaptured,
+          planReadCountedEmpty,
+          completed(CORRELATION.empty, 0),
+          recommends("index", ARTIFACT(CORRELATION.plan)),
+          reportCiting(ARTIFACT(CORRELATION.empty)),
+        ]);
+
+        expect(verdict.unmet).toEqual(["empty-evidence"]);
+      });
+
+      test("a plan read and nothing reported is still a run that answered nothing", () => {
+        // The second control: the exemption must not turn a missing report into an
+        // answer. `no-report` dominates, as it does everywhere else.
+        expect(optimization([contextCaptured, planReadCountedEmpty]).unmet).toEqual(["no-report"]);
+      });
+
+      test("citing a plan is not by itself the workflow's artifact", () => {
+        // And the third: passing the baseline is not passing the bar. A report on a
+        // plan with no comparison and no recommendation still owes the template's own
+        // artifact, so the exemption cannot answer this workflow's question for it.
+        const verdict = optimization([contextCaptured, planReadCountedEmpty, reportCiting(ARTIFACT(CORRELATION.plan))]);
+
+        expect(verdict.unmet).toEqual(["no-plan-comparison"]);
+      });
+
+      test("an investigation citing the same plan is still judged by the unexempted baseline", () => {
+        // The exemption is the optimization rule's, and `agent-investigation.1` means
+        // what it meant. The same shape is reachable there — every workflow is offered
+        // `inspect_plan` — and widening that id's rule is a separate decision.
+        const verdict = verifyRunGoal(
+          run(
+            "agent",
+            "succeeded",
+            [contextCaptured, planReadCountedEmpty, reportCiting(ARTIFACT(CORRELATION.plan))],
+            "investigation",
+          ),
+        );
+
+        expect(verdict).toEqual({
+          outcome: "unanswered",
+          verifier: "agent-investigation.1",
+          unmet: ["empty-evidence"],
+        });
+      });
     });
   });
 

--- a/tests/unit/lib/agent/sqlite-ddl.test.ts
+++ b/tests/unit/lib/agent/sqlite-ddl.test.ts
@@ -98,7 +98,7 @@ describe("parseSqliteTableDdl — columns", () => {
       "recent",
     );
 
-    expect(parseSqliteTableDdl(ddl)).toEqual({ columns: [], foreignKeys: [] });
+    expect(parseSqliteTableDdl(ddl)).toEqual({ columns: [], foreignKeys: [], indexes: [] });
   });
 
   /**
@@ -120,9 +120,9 @@ describe("parseSqliteTableDdl — columns", () => {
   });
 
   test("text that is not a CREATE statement at all is refused rather than half-read", () => {
-    expect(parseSqliteTableDdl("")).toEqual({ columns: [], foreignKeys: [] });
-    expect(parseSqliteTableDdl("SELECT 1")).toEqual({ columns: [], foreignKeys: [] });
-    expect(parseSqliteTableDdl(undefined as unknown as string)).toEqual({ columns: [], foreignKeys: [] });
+    expect(parseSqliteTableDdl("")).toEqual({ columns: [], foreignKeys: [], indexes: [] });
+    expect(parseSqliteTableDdl("SELECT 1")).toEqual({ columns: [], foreignKeys: [], indexes: [] });
+    expect(parseSqliteTableDdl(undefined as unknown as string)).toEqual({ columns: [], foreignKeys: [], indexes: [] });
   });
 
   /**
@@ -273,5 +273,106 @@ describe("parseSqliteIndexDdl", () => {
   test("text carrying no column list is refused rather than reported as an index on nothing", () => {
     expect(parseSqliteIndexDdl("CREATE INDEX broken ON orders")).toBeNull();
     expect(parseSqliteIndexDdl("")).toBeNull();
+  });
+});
+
+describe("parseSqliteTableDdl — constraint-created indexes (docs/BACKLOG.md B25)", () => {
+  /**
+   * The measurement this whole group exists for: SQLite stores NO DDL for the index
+   * it builds to enforce a `UNIQUE` constraint, so the composed index read — which
+   * is `sql IS NOT NULL` — cannot see it, while `PRAGMA index_list` can. The agent
+   * path cannot use a pragma at all (the statement guard refuses every `PRAGMA_`
+   * word), which is why the table's own DDL is where these indexes come from.
+   */
+  test("SQLite stores no DDL for a UNIQUE constraint's index, so the composed read misses it", () => {
+    const database = new Database(":memory:");
+    try {
+      database.run("CREATE TABLE parents (id INTEGER PRIMARY KEY)");
+      database.run("CREATE TABLE kids (id INTEGER PRIMARY KEY, parent_id INTEGER UNIQUE REFERENCES parents (id))");
+
+      const all = database.prepare("SELECT name, sql FROM sqlite_master WHERE type = 'index'").all() as {
+        name: string;
+        sql: string | null;
+      }[];
+      expect(all).toEqual([{ name: "sqlite_autoindex_kids_1", sql: null }]);
+
+      // The engine knows the index exists; the inventory the agent can compose does not.
+      expect(database.prepare("PRAGMA index_list(kids)").all()).toHaveLength(1);
+      expect(database.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND sql IS NOT NULL").all()).toEqual(
+        [],
+      );
+    } finally {
+      database.close();
+    }
+  });
+
+  test("an inline UNIQUE column yields one implicit index over that column", () => {
+    const ddl = storedDdl(
+      [
+        "CREATE TABLE parents (id INTEGER PRIMARY KEY)",
+        "CREATE TABLE kids (id INTEGER PRIMARY KEY, parent_id INTEGER UNIQUE REFERENCES parents (id))",
+      ],
+      "kids",
+    );
+
+    // Named for what created it, not as though the user had created an index: the
+    // engine's own `sqlite_autoindex_kids_1` is not reproducible from the DDL (a
+    // named `CONSTRAINT` does NOT lend the index its name, and the numbering counts
+    // constraints this reader does not all model), so inventing it would be a guess.
+    expect(parseSqliteTableDdl(ddl).indexes).toEqual([
+      { name: "(unique constraint)", columns: ["parent_id"], unique: true },
+    ]);
+  });
+
+  test("a table-level UNIQUE keeps its column ORDER, so a prefix test can use it", () => {
+    const ddl = storedDdl(["CREATE TABLE kids (parent_id INTEGER, note TEXT, UNIQUE (parent_id, note))"], "kids");
+
+    expect(parseSqliteTableDdl(ddl).indexes).toEqual([
+      { name: "(unique constraint)", columns: ["parent_id", "note"], unique: true },
+    ]);
+  });
+
+  test("a named CONSTRAINT … UNIQUE, and a quoted column, are read the same way", () => {
+    const ddl = storedDdl(['CREATE TABLE kids ("odd name" INTEGER, CONSTRAINT uq_kids UNIQUE ("odd name"))'], "kids");
+
+    expect(parseSqliteTableDdl(ddl).indexes).toEqual([
+      { name: "(unique constraint)", columns: ["odd name"], unique: true },
+    ]);
+  });
+
+  test("every UNIQUE constraint is reported, and nothing else is", () => {
+    const ddl = storedDdl(
+      ["CREATE TABLE kids (a INTEGER UNIQUE, b INTEGER, c INTEGER, CHECK (c > 0), UNIQUE (b, c))"],
+      "kids",
+    );
+
+    expect(parseSqliteTableDdl(ddl).indexes.map((index) => index.columns)).toEqual([["a"], ["b", "c"]]);
+  });
+
+  test("a modifier on the constrained column is dropped, as it is for a user index", () => {
+    // Measured against the engine: an EXPRESSION cannot appear here at all —
+    // `UNIQUE (lower(a))` is refused with "expressions prohibited in PRIMARY KEY and
+    // UNIQUE constraints" — so a modifier is the only thing that can follow the name,
+    // and it is dropped exactly as `parseSqliteIndexDdl` drops it on a user index.
+    const ddl = storedDdl(["CREATE TABLE kids (parent_id TEXT, UNIQUE (parent_id COLLATE NOCASE DESC))"], "kids");
+
+    expect(parseSqliteTableDdl(ddl).indexes).toEqual([
+      { name: "(unique constraint)", columns: ["parent_id"], unique: true },
+    ]);
+  });
+
+  test("a PRIMARY KEY is NOT synthesised, and a plain column yields nothing", () => {
+    // The primary key is read from the COLUMN inventory (`isPrimary`), and an
+    // `INTEGER PRIMARY KEY` is the rowid itself with no index behind it — so an
+    // index row for it would be an object that does not exist.
+    const rowid = storedDdl(["CREATE TABLE kids (id INTEGER PRIMARY KEY, parent_id INTEGER)"], "kids");
+    expect(parseSqliteTableDdl(rowid).indexes).toEqual([]);
+
+    const composite = storedDdl(["CREATE TABLE kids (a TEXT, b TEXT, PRIMARY KEY (a, b)) WITHOUT ROWID"], "kids");
+    expect(parseSqliteTableDdl(composite).indexes).toEqual([]);
+  });
+
+  test("text that is not a CREATE TABLE yields no indexes either", () => {
+    expect(parseSqliteTableDdl("CREATE VIEW v AS SELECT 1").indexes).toEqual([]);
   });
 });

--- a/tests/unit/lib/agent/table-profile.test.ts
+++ b/tests/unit/lib/agent/table-profile.test.ts
@@ -1,4 +1,6 @@
+import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
+import { parseSqliteTableDdl } from "@/lib/agent/sqlite-ddl";
 import {
   HIGH_NULL_RATIO,
   MIN_ROWS_FOR_RATIO_FINDINGS,
@@ -316,5 +318,61 @@ describe("types with no equality operator", () => {
     const sql = composeTableProfile("postgres", { table: "t", depth: "distribution" }, [column("payload", "json")]);
 
     expect(sql).toContain('count("payload")');
+  });
+});
+
+describe("a foreign key covered by a constraint-created index (docs/BACKLOG.md B25)", () => {
+  /**
+   * The SQLite blind spot, end to end and against a real engine.
+   *
+   * SQLite stores NO DDL for the index it builds to enforce a `UNIQUE` constraint,
+   * so the composed index read (`sql IS NOT NULL`) returns nothing for it and the
+   * key looked uncovered. The covering index is declared in the table's own DDL, so
+   * the inventory is assembled here exactly as the SQLite capture assembles it —
+   * columns, foreign keys AND constraint-created indexes all out of one
+   * `CREATE TABLE` — and the control table proves the finding still fires when
+   * there really is no index.
+   */
+  const inventory = (statements: readonly string[], name: string): TableSchema => {
+    const database = new Database(":memory:");
+    try {
+      for (const statement of statements) database.run(statement);
+      const row = database.prepare("SELECT sql FROM sqlite_master WHERE name = ?").get(name) as { sql: string };
+      const definition = parseSqliteTableDdl(row.sql);
+      return {
+        name,
+        columns: [...definition.columns],
+        indexes: [...definition.indexes],
+        foreignKeys: [...definition.foreignKeys],
+      };
+    } finally {
+      database.close();
+    }
+  };
+
+  const SCHEMA = [
+    "CREATE TABLE parents (id INTEGER PRIMARY KEY)",
+    "CREATE TABLE covered (id INTEGER PRIMARY KEY, parent_id INTEGER UNIQUE REFERENCES parents (id))",
+    "CREATE TABLE composite (id INTEGER PRIMARY KEY, parent_id INTEGER, note TEXT, UNIQUE (parent_id, note), FOREIGN KEY (parent_id) REFERENCES parents (id))",
+    "CREATE TABLE trailing (id INTEGER PRIMARY KEY, note TEXT, parent_id INTEGER, UNIQUE (note, parent_id), FOREIGN KEY (parent_id) REFERENCES parents (id))",
+    "CREATE TABLE bare (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parents (id))",
+  ];
+
+  test("a UNIQUE constraint covers the key, and the covering index is not presented as a user index", () => {
+    const table = inventory(SCHEMA, "covered");
+
+    expect(findUnindexedForeignKeys(table)).toEqual([]);
+    expect(table.indexes.map((index) => index.name)).toEqual(["(unique constraint)"]);
+  });
+
+  test("a composite UNIQUE covers the key it LEADS on, and not one it merely mentions", () => {
+    expect(findUnindexedForeignKeys(inventory(SCHEMA, "composite"))).toEqual([]);
+    // Prefix, not membership: `UNIQUE (note, parent_id)` cannot serve a lookup on
+    // `parent_id` alone, so the finding stands.
+    expect(findUnindexedForeignKeys(inventory(SCHEMA, "trailing")).map((f) => f.code)).toEqual(["fk_unindexed"]);
+  });
+
+  test("the control: a key with no index at all is still reported", () => {
+    expect(findUnindexedForeignKeys(inventory(SCHEMA, "bare")).map((f) => f.code)).toEqual(["fk_unindexed"]);
   });
 });

--- a/tests/unit/lib/agent/types.test.ts
+++ b/tests/unit/lib/agent/types.test.ts
@@ -126,6 +126,19 @@ const EVENTS: Record<AgentRunEvent["kind"], AgentRunEvent> = {
     // therefore as inert as the rest of the entry.
     noun: { singular: "key pattern", plural: "key patterns" },
   },
+  // The capture that was REFUSED (B54). Its own kind rather than the entry above
+  // carrying an absence, and the fixture is the row-budget case because that is the
+  // shape with fields to get wrong — and because it is the one an operator has to
+  // diagnose: B52's 536 rows against a 200-row bound. No `tableCount` and no
+  // `fingerprint` exist on it at all, which is the absence rule in the type system
+  // rather than in a convention (#477).
+  "context-unavailable": {
+    kind: "context-unavailable",
+    atMs: 2,
+    reasonCode: "CATALOG_READ_REFUSED",
+    detail: "This run's schema inventory was refused.",
+    rowBudget: { projected: 536, allowed: 200 },
+  },
   "statement-drafted": {
     kind: "statement-drafted",
     atMs: 3,


### PR DESCRIPTION
Round 13 of the `docs/BACKLOG.md` sweep. **Seven entries closed, five new findings recorded.**
Every fix was measured on both arms with a control arm, so no assertion here is vacuous.

Ordered by cost/value, cheapest-and-highest first.

## What is fixed

### D29 - Redis authenticated as a principal the user did not choose (security)

`RedisProvider.connect()` built its ioredis options with `host`, `port`, `password`, `db` and
**no `username`**, so every Redis 6 ACL user was silently replaced by `default`. The connection
form collects the value and `connection-string-parser.ts` fills it from `redis://user:pw@host` -
only the one place that matters ignored it. Every managed Redis (Redis Cloud, ElastiCache RBAC,
Azure Cache) issues least-privilege credentials as ACL users, so this is not exotic.

Measured against `redis:latest` with `default` left `on nopass ~* &* +@all` and `probe` defined
`on >probepw ~* +@all -info`, four arms through the running product:

| arm | result |
|---|---|
| no username (before the fix's shape) | `ACL WHOAMI` = `default`, `INFO` succeeds, **green** |
| `user: probe` (after) | WHOAMI = `probe`, `INFO` refused `NOPERM`, **degraded (amber)** |
| control: `probe` + wrong password | connection **fails** - so the username really is sent |
| control: no username + wrong password | **green** - `default` is `nopass`, any password works |

The second half of the entry's Done-when needed no new machinery: `getHealth()` already throws,
`POST /api/db/test-connection` already separates connect from health, and the amber `data-tone`
banner already existed. It was being fed a lie; now it is fed the truth.

Provider tri-sync honoured: code, `docs/providers/redis.md` (new ACL section with the
measurement and the INFO-derived surfaces a restricted user loses), and the integration tests
move together.

### B45 - a run that produced the right index was told it had not answered

The optimization verifier composed on the investigation baseline, whose emptiness census reads
`rowCount`. A plan artifact legitimately carries `rowCount: 0` - a plan is a *description* of a
statement, arriving in one column - so runs that compared real costs and recommended the correct
index were scored `unanswered / empty-evidence`. The product contradicted its own good answer,
in its own voice, at the end of the run.

The census now takes a caller-supplied exemption set, and **only** the optimization rule passes
one. `agent-investigation.1` and the two verifiers composing on it are deliberately untouched
and pinned by a test, so the boundary is stated rather than implicit. Because the rule changed
its mind about runs already scored on `main`, the id moves `agent-query-optimization.2` -> `.3`.

The exemption is one artifact **kind** and nothing more: an empty *bounded read* cited by an
optimization report still ends the run `empty-evidence`, because zero rows from a read is the
answer that read gave.

### B54 - a refused grounding capture left the ledger silent

The repo's own rule is that the ledger is the authority on what a run did. That held only for
captures that *succeeded*: the refusal branch pushed a sentence into the model's prompt and
returned, so an ungrounded run's ledger had nothing between the drive starting and the run
ending - in exactly the case an operator has to diagnose.

Both refusal sites (found by grepping the mechanism, not the entry) now record
`context-unavailable` carrying the reason code, the capture's own sentence, and - where the row
budget refused the read - rows projected against rows allowed.

Its own event kind rather than a `context-captured` carrying an absence, for two reasons that
point the same way: a refused capture has no honest `fingerprint` or `tableCount` (and
`tableCount: 0` would assert the database has no tables), and **three readers** treat
`context-captured` as proof an inventory exists.

The two numbers still travel as prose inside the provider's refusal message. That is pinned by a
test that drives a **real** over-budget `queryReadOnly` through `bun:sqlite` and asserts the parse
against the error the provider itself threw - so a reword goes red in a test instead of going
quiet in production. Residual recorded as **B73** with its blast radius measured.

### B37 - a server config fault disabled the agent and blamed the connection

A `seed-connections.yaml` the server could not read made `GET /api/connections/managed` throw, so
the browser held an empty `servedSeeds` and the rail said *"Sample (Employees) cannot be rebuilt
on the server: its settings live in this browser"* - of a connection this application seeds
itself. False twice over, and it pointed the operator at the wrong file.

The fault was a joint, not a component: `servedSeeds` was an array, and an array cannot say "I do
not have this", so a failed load and a legitimately empty list were the same value. Fixed at the
three places that lose the distinction - the endpoint attributes its own failure
(`reason: "seed-config-unreadable"`), the browser holds a load state, and the rail reads the
reason rather than guessing it.

**Verified in Chrome** against a real malformed seed file:

> The server could not read its own connection configuration, so it cannot resolve a connection
> for a run. This is not a problem with Sample (Employees) - the server log says what failed.

`data-tone="warning"`, no browser-settings claim, Start disabled. Control: the element is absent
on a healthy config, so the new copy appears only when the server actually failed.

### B25 - a covered foreign key was reported as unindexed

SQLite stores no DDL for the index it builds to enforce a `UNIQUE` constraint, so the composed
index read (`sql IS NOT NULL`) could not see it and `fk_unindexed` fired on a covered key - a
false finding presented to the user as a fact.

The capture now reads those out of the table's own `CREATE TABLE` and lists them as
`(unique constraint)`. Plain words rather than the engine's `sqlite_autoindex_<table>_<n>`,
because that name is not derivable: a named `CONSTRAINT uq_x UNIQUE (...)` does **not** lend the
index its name (measured), and inventing one would put an identifier in the inventory that may
not exist in the database.

Coverage stays a **prefix** test - `UNIQUE (note, parent_id)` does not cover `parent_id`, and the
control fixture asserts the finding still fires there. `PRIMARY KEY` is not synthesized: an
`INTEGER PRIMARY KEY` is the rowid, with no index behind it at all.

`PRAGMA index_list` does list auto-indexes, and was measured to confirm it - but the M1 statement
guard refuses any word beginning `PRAGMA_`, so it is unreachable on the agent path. The DDL is
the only source.

**Two side effects worth a release note:** this changes the inventory fingerprint for any SQLite
database with a `UNIQUE` constraint (a run resumed across this deploy sees a moved descriptor),
and raises the per-table index count for those tables.

### H10 - a security gate asserted something it never checked

`ROUTES_WITHOUT_A_PROVIDER` claimed its entries reach no database or LLM provider, and the test
only verified that each key named a real route. An allowlisted route that later grew a provider
call would have escaped the session sweep forever, silently.

It now reads each allowlisted route's own source and matches the provider entry points by
**module-specifier prefix** (so a new factory export is covered the day it lands), including the
indirect `@/lib/api/schema-route` helper that `db/schema/list` and `db/schema/relations` reach a
provider through without naming `@/lib/db` at all. Proven non-vacuous by temporarily
allowlisting `db/query` and watching it fail with the expected message.

**Zero real violations on the allowlist today.** The one entry that does reach a provider
(`agent/drive`, the durable transport's callback) is documented as such, and a second assertion
keeps that exemption from quietly becoming a new unchecked allowlist.

### D28 - closed by writing the decision down

The scheme-versus-parameter TLS asymmetry now reads as a decision on `withSSLMode` rather than an
artefact: a secure scheme is the only spelling a self-hosted deployment has, so a verifying
default there would refuse the ordinary `--tls-port` install.

## Also

`buildConnectionPayload`'s managed arm is a **credential boundary** - a seed travels as a bare
`seed:<id>` reference so nothing about how to authenticate leaves the server's config - and it
had no direct test, its coverage arriving incidentally through other hooks. Now pinned, including
the assertion that no credential appears in a managed request body.

## New backlog entries (with measurements)

- **B72** - the investigation, database-assessment and data-analysis verifiers still judge a
  plan-only report by the emptiness census. Reachable (`inspect_plan` is offered to all three);
  closing it changes what three released verifier ids mean.
- **B73** - the row-budget pair travels as prose and is recovered by regex, with two prose
  consumers. Doing it properly touches the error type every provider throws (~40 call sites).
- **B74** - `UNIQUE (a COLLATE NOCASE)` is reported as covering a key it cannot serve for a
  binary lookup. A false negative in the direction opposite the one B25 fixed.
- **T4** - **eight** backlog ids cited in `src/` name entries that no longer exist (B7, B8, B17,
  B18, B24, B27, B43 in 8 files, B47 in 3). Pre-existing on `main`; the drift guard enforces the
  two-way invariant only for `docs/AGENT.md`, so source citations rot unnoticed. Not mass-fixed
  here on purpose: each needs its claim re-verified, and the two possibilities are opposite
  (deleted because fixed, or deleted by mistake).
- **T5** - the new allowlist check reads one level deep; a route reaching a provider through a
  *new* indirect helper would still pass.

`D14`'s Done-when was corrected: dropping `bufferPoolUsage` is no longer an option, because
MySQL, MongoDB, Couchbase and ClickHouse all fill it with a real figure.

## Verification

All gates run locally, one command each:

| gate | result |
|---|---|
| `format` | clean |
| `lint` | **0 errors**, 128 warnings (all pre-existing repo-wide) |
| `typecheck` | clean |
| `knip` | clean |
| core tests | **351/351 files** |
| component groups | **33/33** |
| evals | **197 pass** |
| `build` | clean |
| `build:lib` + `attw` | clean |
| `coverage:check` | **43452/43452 lines (100.00%)** |

## What was NOT verified

Stated plainly rather than implied:

- **B45 and B54 were not driven against a live model.** Both are covered by the eval harness on
  both arms, and B54's timeline copy ("Schema not captured") has unit coverage, but neither was
  seen rendered from a real run.
- **D29's amber banner was verified through the API, not by clicking the modal.** The route
  returns `degraded: true` with the server's own NOPERM sentence, and the hook-to-banner chain is
  covered by pre-existing tests; the rendered banner itself was not re-driven in the browser.
- The 8 dangling ids in T4 were **measured, not fixed**.
- `docs/providers/redis.md` still carries stale `redis.ts:<line>` anchors, now ~17 lines further
  out of date below `connect()`. The class is already tracked as DOC1; not partially corrected
  here, because a half-fixed anchor looks authoritative while still being wrong.

Not merged - for review.
