### PR TITLE
docs: update the provider tri-sync rule to the shipped provider set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,9 @@ After every code change, run all six locally before claiming done — they match
 
 ### Rules & patterns
 
-> **⚠️ Providers are the lifeblood of this project — keep the triad in lockstep: code ↔ docs ↔ tests**, 1:1 per canonical type-id (`postgres`, `mysql`, `sqlite`, `oracle`, `mssql`, `mongodb`, `redis`, plus the embedded `libredb`):
-> - Code: `src/lib/db/providers/<family>/<type-id>.ts` · Docs: `docs/providers/<type-id>.md` · Tests: `tests/integration/db/<type-id>-provider.test.ts`
+> **⚠️ Providers are the lifeblood of this project — keep the triad in lockstep: code ↔ docs ↔ tests**, 1:1 per canonical type-id — the type-id set is the `DatabaseType` union in [`src/lib/types.ts`](src/lib/types.ts) (`postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `oracle`, `mssql`, `couchbase`, `clickhouse`, `druid`, `elasticsearch`, `opensearch`, `cassandra`, `trino`, plus the embedded `libredb`):
+> - Code: `src/lib/db/providers/<family>/<type-id>.ts`, or `src/lib/db/providers/<family>/<type-id>/index.ts` when the provider is split across modules, as `couchbase`, `clickhouse`, `druid`, `trino` and `cassandra` are · Docs: `docs/providers/<type-id>.md` · Tests: `tests/integration/db/<type-id>-provider.test.ts`
+> - **One directory may serve two type-ids** — `src/lib/db/providers/sql/search/` is both `elasticsearch` and `opensearch` (#424). Docs and tests stay 1:1 anyway: the invariant is per type-id, and each doc is the prime reference for its own product's measured behaviour.
 > - Any change to one side MUST sync the others **in the same PR**. The doc mirrors the code and the code mirrors the doc — never let them drift.
 
 - **DB abstraction:** Strategy Pattern. SQL providers extend `SQLBaseProvider`; MongoDB/Redis extend `BaseDatabaseProvider`. No `=== 'mongodb'` type-checks outside provider classes — drive behaviour through capabilities/labels.


### PR DESCRIPTION
`docs/providers/README.md` sends the reader to `CLAUDE.md` for the provider tri-sync rule, but that rule has not kept up with the providers that shipped after it.

| | Rule said | Repo today |
|---|---|---|
| type-ids | 8 | 15 (`DatabaseType` in `src/lib/types.ts`) |
| code path | only `<family>/<type-id>.ts` | also `<type-id>/index.ts` for `couchbase`, `clickhouse`, `druid`, `trino`, `cassandra` |
| 1:1 mapping | no exception | `providers/sql/search/` serves both `elasticsearch` and `opensearch` |

Read literally, the rule points at a path that seven providers do not use, so someone checking the triad would conclude their code is missing.

Both corrections are already written down in the Conventions section of `docs/providers/README.md`. This PR aligns the rule that doc points at, and names the `DatabaseType` union as the source of truth so the list has somewhere to be checked against.

Verification (docs only, no executable line changes):

- `bun run format` clean
- `bun run lint` exit 0 (128 pre-existing warnings, 0 errors)
- `bun run typecheck` exit 0
- `bun run knip` exit 0
- `bun run readme:check` OK

`bun run test` and `bun run build` were not run, since the diff touches no executable line and coverage is unaffected.
