### PR TITLE
fix(docs,tests): three backlog ids were used twice, and nothing measured it

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,7 +22,7 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S2–S7 · 5
-- [Drivers and connections](#drivers-and-connections)
+- [Drivers and connections](#drivers-and-connections) — D1–D41, U17, U22–U23 · 19
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
 - [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U21 · 10
@@ -545,7 +545,7 @@ non-PostgreSQL engine.
 
 ---
 
-### D36. A slow-query source nobody could read is still a row, and on the other path it is silence
+### D39. A slow-query source nobody could read is still a row, and on the other path it is silence
 
 Found 2026-08-27 by the audit that closed the curated health projection's cap-as-count defect. #512
 removed MySQL's fabricated "Performance schema not available" row; three providers still ship the
@@ -587,7 +587,7 @@ queries" where the truth is that the profiler is off.
 provider answers a sentence as a row, and no provider answers `[]` for a read that failed - and the
 count of type-ids the type change touched is stated in the PR rather than discovered during it.
 
-### D37. The Overview panel still shows a fabricated zero for a connection count nobody could read
+### D40. The Overview panel still shows a fabricated zero for a connection count nobody could read
 
 Found 2026-08-27, one field over from the health fix in the same pass. `HealthInfo.activeConnections`
 is now absent rather than 0 on MSSQL, Oracle and MongoDB when the read is refused. The identical
@@ -619,7 +619,7 @@ becomes false the moment `mssql.ts` stops encoding it that way.
 zero still reads as zero, each provider's doc records it, and the two search docs no longer cite an
 encoding that is gone.
 
-### D38. Two more surfaces read a capped list as a count, one of them to a person
+### D41. Two more surfaces read a capped list as a count, one of them to a person
 
 Found 2026-08-27 by the review round that closed the same defect in the agent's curated health
 reading: the projection stopped counting a capped list, and the shape's remaining instances were then

--- a/tests/unit/backlog-structure.test.ts
+++ b/tests/unit/backlog-structure.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Structural guards for `docs/BACKLOG.md`.
+ *
+ * The file states its own rules and nothing measured them. Two of those rules broke on `main`
+ * within one day of each other, both by the same mechanism, and every CI check stayed green:
+ *
+ *  - **Ids collided.** #511 and #513 branched from the same commit and each appended three driver
+ *    entries. The bodies landed at different offsets, so git merged them without a conflict and
+ *    `main` carried `D36`, `D37` and `D38` twice. The file's own rule is that "Every ID is unique
+ *    across the whole file. Cross-references use the bare ID (`B47`)" — a duplicate id makes every
+ *    such reference ambiguous, and the citation guard in `tests/unit/agent-documentation.test.ts`
+ *    only ever asked whether an id EXISTS.
+ *  - **An index line lost its basis.** The one line both branches did edit conflicted, and the
+ *    resolution dropped its range and count altogether. A section index that says nothing cannot be
+ *    wrong, which is exactly why nothing caught it.
+ *
+ * So these tests derive the index block from the entry bodies rather than trusting it: the sections
+ * listed are the sections present, each listed id exists, each range's endpoints are the real
+ * extremes, and the trailing count is the real number of entries. The endpoints are checked as
+ * extremes rather than as a canonical rendering because the file writes a prefix's entries as
+ * `U17, U22–U23` in one section and `X2–X14` in another, and both are legitimate.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "../..");
+const BACKLOG_PATH = "docs/BACKLOG.md";
+const BACKLOG = readFileSync(path.join(ROOT, BACKLOG_PATH), "utf8");
+
+/** `AU4` is prefix `AU` and number 4, not prefix `A`: the prefix match is greedy on purpose. */
+const ID_PATTERN = /^([A-Z]+)(\d+)$/;
+
+interface BacklogId {
+  readonly id: string;
+  readonly prefix: string;
+  readonly number: number;
+}
+
+const parseId = (id: string): BacklogId => {
+  const match = ID_PATTERN.exec(id);
+  if (match === null) throw new Error(`backlog id ${id} is not <PREFIX><NUMBER>`);
+  return { id, prefix: match[1], number: Number(match[2]) };
+};
+
+interface Section {
+  readonly title: string;
+  readonly ids: readonly BacklogId[];
+}
+
+/** GitHub's heading slug, which is what the index block's `(#anchor)` has to match. */
+const slug = (title: string): string =>
+  title
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+
+const sections: readonly Section[] = BACKLOG.split(/^## /m)
+  .slice(1)
+  .map((block) => {
+    const title = block.slice(0, block.indexOf("\n")).trim();
+    const ids = [...block.matchAll(/^### ([A-Z]+\d+)\./gm)].map((match) => parseId(match[1]));
+    return { title, ids };
+  });
+
+interface IndexLine {
+  readonly title: string;
+  readonly anchor: string;
+  /** The `— …` tail: the id ranges and the optional `· N` count. `null` when the line has none. */
+  readonly spec: string | null;
+}
+
+const indexBlock = BACKLOG.split(/^\*\*Sections\*\*$/m)[1]?.split(/^---$/m)[0] ?? "";
+const indexLines: readonly IndexLine[] = [...indexBlock.matchAll(/^- \[([^\]]+)\]\(#([^)]+)\)(?: — (.+))?$/gm)].map(
+  (match) => ({ title: match[1], anchor: match[2], spec: match[3] ?? null }),
+);
+
+describe("the file was parsed at all", () => {
+  // Every assertion below is a containment or an equality that an empty parse would satisfy
+  // vacuously, so the parse is pinned first.
+  test("the section headings were found", () => {
+    expect(sections.length).toBeGreaterThan(15);
+  });
+
+  test("the entries were found", () => {
+    expect(sections.flatMap((section) => section.ids).length).toBeGreaterThan(100);
+  });
+
+  test("the index block was found", () => {
+    expect(indexLines.length).toBe(sections.length);
+  });
+});
+
+describe("every id is unique across the whole file", () => {
+  test("the rule the file states about itself holds", () => {
+    expect(BACKLOG).toContain("Every ID is unique across the whole file");
+  });
+
+  test("no id is used twice", () => {
+    const seen = new Map<string, string[]>();
+    for (const section of sections) {
+      for (const { id } of section.ids) {
+        seen.set(id, [...(seen.get(id) ?? []), section.title]);
+      }
+    }
+    const duplicates = [...seen.entries()].filter(([, where]) => where.length > 1);
+    expect(duplicates).toEqual([]);
+  });
+});
+
+describe("the section index names the sections that exist", () => {
+  test.each(indexLines.map((line) => [line.title, line.anchor] as const))(
+    "the index entry for %s resolves to a heading",
+    (title, anchor) => {
+      const titles = sections.map((section) => section.title);
+      expect(titles).toContain(title);
+      expect(anchor).toBe(slug(title));
+    },
+  );
+
+  test.each(sections.map((section) => section.title))("the section %s is listed in the index", (title) => {
+    expect(indexLines.map((line) => line.title)).toContain(title);
+  });
+});
+
+interface Spec {
+  /** Every id token the line lists, range endpoints included. */
+  readonly listed: readonly BacklogId[];
+  /** The `· N` tail, or `null` when the line carries no count. */
+  readonly count: number | null;
+}
+
+/** `D1–D41, U17, U22–U23 · 19` becomes the six endpoints it names plus the count 19. */
+const parseSpec = (spec: string): Spec => {
+  const [ranges, ...rest] = spec.split(" · ");
+  return {
+    listed: [...ranges.matchAll(/[A-Z]+\d+/g)].map((match) => parseId(match[0])),
+    count: rest.length === 0 ? null : Number(rest[0]),
+  };
+};
+
+describe("every index line is derived from the entries it summarises", () => {
+  const rows = indexLines.map((line) => {
+    const section = sections.find((candidate) => candidate.title === line.title);
+    return { line, ids: section?.ids ?? [], spec: line.spec === null ? null : parseSpec(line.spec) };
+  });
+
+  test.each(rows.map((row) => [row.line.title, row] as const))("%s states a range and a count", (_title, row) => {
+    // A line with no tail cannot be wrong, which is how the Drivers line survived losing both
+    // (#513's merge). One entry is the only case that needs neither.
+    if (row.ids.length > 1) expect(row.spec).not.toBeNull();
+    if (row.spec === null) expect(row.ids.length).toBe(1);
+  });
+
+  test.each(rows.map((row) => [row.line.title, row] as const))("%s counts its entries", (_title, row) => {
+    if (row.spec === null) return;
+    if (row.spec.count === null) expect(row.ids.length).toBe(1);
+    else expect(row.spec.count).toBe(row.ids.length);
+  });
+
+  test.each(rows.map((row) => [row.line.title, row] as const))("%s lists ids that exist", (_title, row) => {
+    if (row.spec === null) return;
+    const present = row.ids.map((entry) => entry.id);
+    for (const entry of row.spec.listed) expect(present).toContain(entry.id);
+  });
+
+  test.each(rows.map((row) => [row.line.title, row] as const))("%s names the real extremes", (_title, row) => {
+    if (row.spec === null) return;
+    const prefixes = [...new Set(row.ids.map((entry) => entry.prefix))].sort();
+    expect([...new Set(row.spec.listed.map((entry) => entry.prefix))].sort()).toEqual(prefixes);
+    for (const prefix of prefixes) {
+      const present = row.ids.filter((entry) => entry.prefix === prefix).map((entry) => entry.number);
+      const listed = row.spec.listed.filter((entry) => entry.prefix === prefix).map((entry) => entry.number);
+      expect(Math.min(...listed)).toBe(Math.min(...present));
+      expect(Math.max(...listed)).toBe(Math.max(...present));
+    }
+  });
+});


### PR DESCRIPTION
## What broke

`#511` and `#513` branched from the same commit (`8a0797f2`) and each appended three entries to the
"Drivers and connections" section of `docs/BACKLOG.md`. The bodies landed at different offsets, so
git merged them **without reporting a conflict**, and `main` carried `D36`, `D37` and `D38` twice:

| Line | Entry | From |
| --- | --- | --- |
| 431 | `D36. The migration generator emits ADD CONSTRAINT for SQLite...` | #511 |
| 456 | `D37. Five HTTP providers read the SSL mode...` | #511 |
| 482 | `D38. getConnectionInfo masks a password in a connection string...` | #511 |
| 548 | `D36. A slow-query source nobody could read is still a row...` | #513 |
| 590 | `D37. The Overview panel still shows a fabricated zero...` | #513 |
| 622 | `D38. Two more surfaces read a capped list as a count...` | #513 |

The file's own header states the rule: *"Every ID is unique across the whole file. Cross-references
use the bare ID (`B47`), so no two entries may share one."* A duplicate makes every such reference
ambiguous.

There is a second defect from the same merge. The one line both branches **did** edit, the section
index for Drivers and connections, conflicted, and the resolution dropped its id range and count
altogether — leaving `- [Drivers and connections](#drivers-and-connections)` with no basis at all.
A section index that states nothing cannot be wrong, which is why nothing caught it.

## The fix

`#511` reached `main` first, so its three entries keep `D36`-`D38` and `#513`'s are renumbered to
`D39`-`D41`. The single citation in `src/lib/schema-diff/migration-generator.ts:388` names #511's
`D36` and is left alone; nothing in the repository cited the renumbered three, and there are no
in-file prose cross-references to any of the six.

The index line is restored as the entries make it: `D1–D41, U17, U22–U23 · 19`.

## The guard that was missing

`tests/unit/backlog-structure.test.ts` derives the index block from the entry bodies rather than
trusting it:

- no id appears twice anywhere in the file;
- the sections listed are the sections present, in both directions, and each anchor resolves to its
  heading slug;
- every id a line names exists as an entry in that section;
- each range's endpoints are the real extremes for that prefix;
- the trailing `· N` is the real number of entries, and a line may omit it only for a section with a
  single entry.

Endpoints are checked as extremes rather than against one canonical rendering because the file
legitimately writes a prefix two ways — `U17, U22–U23` in one section, `X2–X14` in another.

The existing citation guard in `tests/unit/agent-documentation.test.ts` only ever asked whether a
cited id **exists**, which a duplicate satisfies.

## Verification

Both defects were confirmed to fail the new test before the fix (`no id is used twice`, and
`Drivers and connections states a range and a count`). Each index assertion was then confirmed
non-vacuous by corrupting the line and watching the specific test go red:

| Mutation | Test that failed |
| --- | --- |
| `· 19` → `· 18` | `Drivers and connections counts its entries` |
| `D1–D41` → `D1–D38` | `Drivers and connections names the real extremes` |
| dropped `U22–U23` | `Drivers and connections names the real extremes` |

The document was restored byte-for-byte after each mutation.

Local gates on the pushed tree: `format` clean · `lint` 0 errors · `typecheck` clean · `knip` clean ·
`bun run test` all 33 groups pass · `bun run build` exit 0.

No `src/` behaviour changes.
