### PR TITLE
fix(db,ui,docs): a refusal drawn as a measurement, in five places

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,14 +22,14 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S2–S7 · 5
-- [Drivers and connections](#drivers-and-connections) — D1–D41, U17, U22–U23 · 19
+- [Drivers and connections](#drivers-and-connections) — D1–D46, U17, U22 · 19
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U21 · 10
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U24 · 11
 - [Authentication and security headers](#authentication-and-security-headers) — AU4
 - [Tests](#tests) — T1–T5 · 4
 - [Dependencies](#dependencies) — P1–P5 · 5
-- [Documentation](#documentation) — DOC1, DOC3 · 2
+- [Documentation](#documentation) — DOC1, DOC3–DOC4 · 3
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3
 - [Chart configuration surface](#chart-configuration-surface) — N1, N3 · 2
 - [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 9
@@ -428,31 +428,6 @@ to ssh2 - and the mock was written from reading ssh2's source, which is the thin
 run against it, or a note beside the mock records that its fidelity to ssh2 is the assumption CI rests
 on and names the source it was derived from.
 
-### D36. The migration generator emits `ADD CONSTRAINT` for SQLite, which SQLite cannot parse
-
-Found 2026-08-27 while registering the `libsql` type-id (issue #424, Phase 5), and it is the
-`sqlite` dialect's own defect rather than the new one's.
-
-`generateMigrationSQL` declines a foreign key for `cassandra` and, since this run, for `libsql`.
-The `sqlite` dialect falls through to the generic branch and emits
-
-```sql
-ALTER TABLE "users" ADD CONSTRAINT "fk_users_dept_id" FOREIGN KEY ("dept_id") REFERENCES "departments"("id");
-```
-
-SQLite has no ALTER that adds a constraint - a foreign key is declarable only inside `CREATE TABLE` -
-so the statement is a syntax error wherever the file is run. Measured on the sibling engine, which
-shares the grammar exactly: `near CONSTRAINT ... syntax error` on sqld 0.24.33 (SQLite 3.47.0). The
-same file already declines the REMOVED direction for `sqlite` with a comment naming table
-recreation, so only the added half is wrong - which is why it reads as an oversight rather than a
-decision.
-
-Narrow, and it does not throw: the file generates, and the failure happens when someone runs it.
-
-**Done when:** `sqlite` declines an added foreign key the way `libsql` does, with a comment naming
-recreation rather than a statement, and a test pins both directions for it - the way
-`tests/unit/schema-diff/migration-generator.test.ts` now pins them for `libsql` and `cassandra`.
-
 ### D37. Five HTTP providers read the SSL mode and drop the rest of the TLS panel
 
 Found 2026-08-27 in the #511 review (issue #424, Phase 5). Not libSQL's - libSQL is the
@@ -479,26 +454,6 @@ discards, which is the kind of silence a security setting must not have.
 transports route TLS through it, and one test per transport pins that a supplied CA and a
 `verify-*` mode reach the request options - plus one that a `require` mode does not verify.
 
-### D38. `getConnectionInfo` masks a password in a connection string but not a token in a query string
-
-Found 2026-08-27 in the #511 review. Pre-existing, dead today, and cheap to close before it
-is not.
-
-`base-provider.ts`'s `protected getConnectionInfo()` returns
-`connectionString.replace(/:([^:@]+)@/, ":***@")`, which masks `:secret@` in an authority and
-nothing else. A libSQL connection string carries its credential in the query string instead -
-`libsql://db-org.turso.io?authToken=<jwt>` - so the whole token would survive the mask. The
-same is true of any `?password=`/`?sslkey=` form.
-
-It is currently unreachable: the only callers are in `tests/unit/db/base-provider.test.ts`, so
-no production path prints it. That is the reason this is a backlog entry rather than an issue,
-and also the reason it is worth doing - a future health-panel caller would inherit a leak that
-looks redacted.
-
-**Done when:** the mask also strips the value of every credential-shaped query parameter
-(`authToken`, `password`, `token`, `sslkey`), with a test per shape - or the method is deleted,
-since nothing in `src/` calls it.
-
 ### U22. The connection form renders fields the engine does not take, and a comment says otherwise
 
 Found 2026-08-27 in the browser while registering `libsql` (issue #424, Phase 5).
@@ -521,27 +476,6 @@ with the four engines above checked in a browser rather than in a mock - or, if 
 are deliberately universal, the comment in `use-connection-form.ts` says so instead. Either
 way `e2e/libsql-provider.spec.ts` has the assertion that pins today's behaviour and must
 move with it.
-
-### U23. The Storage tab names PostgreSQL internals on every engine
-
-Seen 2026-08-27 on a libSQL connection (issue #424, Phase 5), and it is not libSQL's.
-
-`src/components/monitoring/tabs/StorageTab.tsx:179` labels the remainder of the breakdown
-**"Other (TOAST, FSM)"** unconditionally. TOAST and the free space map are PostgreSQL
-storage structures. SQLite and libSQL have neither - what the remainder actually holds
-there is the schema, the freelist and page overhead - and neither do MySQL, Oracle, SQL
-Server, ClickHouse or any of the HTTP engines. On libSQL it read `4.00 KB` under that
-label against a real 64 KB database, so the number is right and the words are another
-engine's.
-
-The same shape as a shared provider's refusal naming the wrong product: the reading is
-sound, the vocabulary is borrowed. Narrow, cosmetic, and it misleads exactly the reader
-who is trying to account for the bytes.
-
-**Done when:** the label is engine-neutral ("Other" / "Overhead"), or comes from the
-provider's own labels the way the maintenance and slow-query wordings already do
-(`ProviderLabels`), with a component test pinning it for one PostgreSQL and one
-non-PostgreSQL engine.
 
 ---
 
@@ -587,64 +521,159 @@ queries" where the truth is that the profiler is off.
 provider answers a sentence as a row, and no provider answers `[]` for a read that failed - and the
 count of type-ids the type change touched is stated in the PR rather than discovered during it.
 
-### D40. The Overview panel still shows a fabricated zero for a connection count nobody could read
+### D42. The connection-string mask cannot cover a password holding a character RFC 3986 reserves
 
-Found 2026-08-27, one field over from the health fix in the same pass. `HealthInfo.activeConnections`
-is now absent rather than 0 on MSSQL, Oracle and MongoDB when the read is refused. The identical
-defect survives in `getOverview()` on the same three providers, against
-`DatabaseOverview.activeConnections`, which is optional for exactly the same stated reason
-(`src/lib/db/types.ts`, the D17 docblock):
+Found 2026-08-27 while closing the query-string half of the same mask (`getConnectionInfo`, PR
+round 17). The mask now covers the authority and every credential-shaped parameter, in any position.
+What it cannot cover is an authority password containing `@`, `/`, `?` or `#` unencoded:
+`postgres://user:p/w@host/db` is returned in the clear.
 
-- `src/lib/db/providers/sql/mssql.ts:1084` and `src/lib/db/providers/sql/oracle.ts:1160` -
-  `let activeConnections = 0`, with the read's failure swallowed into it.
-- `src/lib/db/providers/document/mongodb.ts:963` and `:975` - `|| 0` and a literal `0`.
+The reason is not an oversight and is written into `redactConnectionString`'s docblock
+(`src/lib/db/base-provider.ts`): `postgres://host:5432/tenant@acme` - a path holding an `@`, which
+carries no secret at all - has the identical shape, and no regular expression separates the two. The
+round chose the safe arm deliberately: drawing `***` over a port asserts a credential the string never
+carried, which is a fabricated reading rather than a mask, and this repo's absence rule (#477) forbids
+the fabrication more strongly than it forbids the miss. `tests/unit/db/base-provider.test.ts` pins the
+gap explicitly, so it is visible rather than assumed closed.
 
-What the user sees is not a hidden number: `src/components/admin/tabs/OverviewTab.tsx` renders `N/A`
-when the field is ABSENT and the figure when it is present, so a denied `VIEW SERVER STATE`, an
-unprivileged `V$SESSION` or a `serverStatus` with no `connections` section shows a confident
-**0 connections** on a server that has plenty. `src/lib/db/providers/sql/cassandra/introspect.ts` is
-the in-repo precedent for the shape, and `measuredNumber` (`src/lib/monitoring-cache-ratio.ts`) is
-the helper that keeps a real 0 while dropping an unanswered row.
+RFC 3986 §3.2.1 requires each of those characters to be percent-encoded in userinfo, so every string
+this misses is malformed - but the drivers accept them, which is why the gap is real rather than
+theoretical.
 
-Deliberately left out of the health fix: the lane that closed it owned `getHealth`, and this one
-drags the three monitoring-panel docs and the Overview component's own tests with it.
+**Done when:** the authority is masked by PARSING rather than by pattern - split on the last `@`
+before the first `/`, `?` or `#` that follows `://`, then mask between the first `:` and that `@` -
+with the two colliding shapes above pinned as separate cases, and the docblock's list of uncovered
+shapes reduced to what remains. The parameter half needs no change.
+### D43. SQLite gained `SET`/`DROP NOT NULL` in 3.53.0, and the generator declines it on both ids
 
-Whoever takes this must also move two OTHER providers' docs:
-[`docs/providers/elasticsearch.md:848`](providers/elasticsearch.md) and
-[`docs/providers/opensearch.md:855`](providers/opensearch.md) both read "`activeConnections` /
-`maxConnections` are 0, the same 'not published' encoding `mssql.ts` and Druid use" - a citation that
-becomes false the moment `mssql.ts` stops encoding it that way.
+Found 2026-08-27 while adding the foreign-key declines for `sqlite` and `libsql`
+(`src/lib/schema-diff/migration-generator.ts`). `NO_COLUMN_MODIFICATION` declines every column
+modification for `libsql`, and the `sqlite` branch beside it declines them too. That was exhaustive
+when it was written and is no longer: measured on SQLite 3.53.0 via `bun:sqlite`,
 
-**Done when:** an unmeasurable overview connection count is absent on all three providers, a real
-zero still reads as zero, each provider's doc records it, and the two search docs no longer cite an
-encoding that is gone.
+```sql
+ALTER TABLE "users" ALTER COLUMN "dept_id" SET NOT NULL
+```
 
-### D41. Two more surfaces read a capped list as a count, one of them to a person
+succeeds, rewrites the stored `CREATE TABLE` text to carry `NOT NULL`, and is enforced on the next
+insert (`NOT NULL constraint failed: users.dept_id`). `DROP NOT NULL` succeeds the same way. A column
+TYPE change is still `near "TYPE": syntax error`, so only nullability moved.
 
-Found 2026-08-27 by the review round that closed the same defect in the agent's curated health
-reading: the projection stopped counting a capped list, and the shape's remaining instances were then
-hunted for rather than assumed gone. Two survive.
+**The blocker is that the version is not a property of the id.** `libsql` reaches sqld 0.24.33, which
+ships SQLite 3.47.0, so the decline is still correct there. The `sqlite` provider runs on whichever
+SQLite its runtime bundles - `bun:sqlite` or `node:sqlite`, selected at runtime with
+`LIBREDB_SQLITE_DRIVER` as an override (`src/lib/db/providers/sql/sqlite.ts`) - so emitting the
+statement would generate a file that runs on one deployment and fails on another. A migration file is
+handed to a human to run elsewhere, which makes the guess worse than the decline.
 
-**The user-facing one.** `src/components/monitoring/tabs/QueriesTab.tsx:87` computes
-`totalQueries = slowQueries.reduce((sum, q) => sum + q.calls, 0)` and renders it on a card labelled
-*Queries*; `:89` computes `slowCount = slowQueries.filter((q) => q.avgTime > 1000).length` and
-renders it as *Slow*. `MonitoringData.slowQueries` is capped at 10 by every provider that fills it
-(`slowQueryLimit = 10` in `src/lib/db/base-provider.ts`, honoured by each `getSlowQueries`), so
-*Queries* is the call total of the ten heaviest digests presented as the database's query count, and
-*Slow* is bounded by 10 no matter how many slow statements the server has. On the MySQL server this
-was measured against - 59 digests for one schema - both cards are the cap wearing a measurement's
-label. The block's own comment reasons carefully about absence versus zero and says nothing about the
-ceiling, which is how it survived: the absence rule was applied, the cap was not.
+**Done when:** either the decline records the version boundary as its reason rather than the absence of
+the feature (cheap, and it is what the comment now does), or the generator learns the connected
+engine's version and emits the nullability change only above 3.53.0, with the emitted statement
+measured against both a 3.47 and a 3.53 build. The second is only worth it if something else needs the
+version too.
+### D44. `databaseSizeBytes` is fabricated as 0 wherever the size is unknown, in 14 of 16 type-ids
 
-**The provider-side one, reachable by the agent.** `TRINO_MAX_STATS_TABLES = 25`
-(`src/lib/db/providers/sql/trino/introspect.ts`) slices the table-stats read, so a Trino catalog with
-500 tables answers exactly 25 rows and the agent's reading reports `rowCount: 25`. Unlike the curated
-path's own row bound - which now refuses rather than truncating - this cut happens inside the provider,
-before the agent layer can see that anything was dropped, so no marker can be added above it.
+Found 2026-08-27 by the sweep that closed the overview connection count's fabricated zero (D40, PR
+round 17). `DatabaseOverview.activeConnections` and `DatabaseOverview.databaseSizeBytes` are optional
+for the SAME stated reason (`src/lib/db/types.ts`, the D17 docblock): absence and zero are different
+facts. The round closed the first field on three providers. The second is unclosed almost everywhere.
 
-**Done when:** neither figure can be read as a count - the cards name what they measure (or drop the
-total no cap-bounded list can supply), and a provider that truncates a reading says so in a way the
-reading's consumer can see.
+**Two providers get it right, and one of them wrote the argument down.**
+`src/lib/db/providers/sql/cassandra/introspect.ts:582` omits the key with the comment "a zero is a
+measurement, and the Storage tab read `?? 0` and rendered '0 B' with a 0.0% breakdown from it", and
+MongoDB's `getOverview()` catch now omits it too.
+
+**The rest fabricate.** Measured by reading every `databaseSizeBytes` assignment under
+`src/lib/db/providers/`:
+- Self-contradicting within one object, and the clearest cases, because the sibling string field
+  already says the figure is unavailable: `sql/trino/introspect.ts:621` pairs a literal `0` with
+  `databaseSize: TRINO_UNAVAILABLE_TEXT`, and `sql/search/index.ts:849` pairs `sizeBytes ?? 0` with
+  `databaseSize: SEARCH_UNKNOWN_TEXT` for both `elasticsearch` and `opensearch`.
+- Swallowed into an initialiser the way D40's connection counts were: `sql/mssql.ts:1111`,
+  `sql/oracle.ts:1178`, `sql/sqlite.ts:808`.
+- Coerced by a helper that returns 0 for an absent row: `sql/druid/introspect.ts:578` and
+  `sql/clickhouse/index.ts:833` through their local `asNumber`.
+- Coerced inline: `sql/postgres.ts:1397` and `sql/mysql.ts:1156` (`parseInt(... || "0")`),
+  `sql/libsql/introspect.ts:399` and `document/couchbase/index.ts:606` (`?? 0`),
+  `keyvalue/redis.ts:603`, and `embedded/libredb.ts:709`, whose `fileSizeBytes()` returns 0 when the
+  `statSync` throws.
+
+**The consumer makes it visible.** `src/components/monitoring/tabs/StorageTab.tsx` keys its entire
+breakdown off `overview?.databaseSizeBytes !== undefined`: present, and the card renders percentages
+against the total; absent, and it draws its own "No storage size information available." So a fabricated
+0 does not hide a number, it replaces an honest refusal with a breakdown over a zero-byte database.
+
+**Done when:** an unknown size is absent rather than 0 on every type-id, a real zero still reads as
+zero, each provider's doc records it, and each provider's test pins both arms - the same shape D40
+used, applied to the field beside it. The blast radius is why this is an entry and not part of that PR:
+14 provider files, 14 provider docs and 14 test files, plus `formatBytes` callers that assume a number.
+Doing it per family, one PR each, is the cheap ordering.
+### D45. On SQL Server 2019 and earlier the connection count is under-reported, not refused
+
+Found 2026-08-27 while making the overview connection count absent instead of 0 (D40, PR round 17).
+That fix is right for what it covers and covers less than the field's failure modes.
+
+`OVERVIEW_CONNECTIONS_SQL` (`src/lib/db/providers/sql/mssql.ts`) reads two objects in one statement:
+
+```sql
+SELECT COUNT(*) AS active_connections,
+       (SELECT CAST(value_in_use AS INT) FROM sys.configurations WHERE name = 'user connections') AS max_connections
+FROM sys.dm_exec_sessions
+WHERE is_user_process = 1
+```
+
+Microsoft Learn, fetched 2026-08-27:
+- `sys.dm_exec_sessions`, Permissions: "Everyone can see their own session information. In SQL Server
+  2019 (15.x) and earlier versions, requires `VIEW SERVER STATE` to see all sessions on the server. In
+  SQL Server 2022 (16.x) and later versions, requires `VIEW SERVER PERFORMANCE STATE` permission on the
+  server." So the DMV is **row-filtered, never refused**.
+- `sys.configurations`, Permissions: "Requires membership in the **public** role", and separately
+  "Permissions for SQL Server 2022 and later: Requires VIEW SERVER PERFORMANCE STATE permission on the
+  server."
+
+So the statement's behaviour splits on the server version, and only one half is an absence:
+- **2022 and later** - `sys.configurations` throws for an ungranted login, the whole statement fails,
+  and the count is now correctly absent. This is the case the round's fixture reproduces.
+- **2019 and earlier** - `sys.configurations` needs only `public` and the DMV filters rows instead of
+  refusing, so the statement SUCCEEDS and returns the caller's own sessions, about 1. A busy server
+  publishes "1 connection" as a measurement. Nothing in the provider can tell that from a real 1.
+
+Azure SQL Database is a third shape: the DMV needs `VIEW DATABASE STATE` to see all connections to the
+current database, and that permission cannot be granted in `master`.
+
+**Done when:** the provider can distinguish a filtered read from a complete one - the cheapest signal is
+`HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW SERVER STATE')` alongside the count, with the version taken from
+`SERVERPROPERTY('ProductMajorVersion')` to pick the permission name - and an incomplete count is absent
+rather than published. Measured on a real instance with a login that has neither grant, because the
+whole entry rests on a permission boundary no fixture can prove.
+### D46. One fabricated connection zero survives the sweep, and five comments cite it as the pattern
+
+Found 2026-08-27 by the sweep that finished D40. After that round, `activeConnections` is honest almost
+everywhere: MSSQL, Oracle, MongoDB and Cassandra omit it when the read is refused; SQLite and the
+embedded LibreDB publish `1`, which is the measurement for a single-writer file; PostgreSQL, Redis,
+Couchbase, ClickHouse, Trino and Druid publish a real count.
+
+`src/lib/db/providers/sql/search/index.ts:846` is the exception, for both `elasticsearch` and
+`opensearch`: `activeConnections: 0` with a comment saying it means "not published". The field is
+optional and its docblock (`src/lib/db/types.ts`, D17) says absence is how "not published" is said, so
+this is the last site where the old encoding survives - and the comment's reason is sound, only its
+encoding is not. A search cluster counts open HTTP connections per node in a stats API this seam does
+not call, so nothing is knowable, which is precisely the case absence exists for.
+
+`maxConnections: 0` beside it stays correct: for that field the type says 0 and absence are the SAME
+fact, which is why Druid's and Trino's comments citing `mssql.ts` for the ceiling remain true.
+
+**The citations are the second half.** Before D40, "0 means not published" was a shared convention with
+`mssql.ts` as its reference, and five places say so:
+`src/lib/db/providers/sql/search/index.ts:840`, `sql/druid/introspect.ts:572`,
+`sql/trino/introspect.ts:612`, `docs/providers/elasticsearch.md` and `docs/providers/opensearch.md`.
+The Druid and Trino ones are about the ceiling and stay true. The search comment and the two search docs
+bundle `activeConnections` into the same sentence, so for that half they now cite an encoding
+`mssql.ts` no longer uses.
+
+**Done when:** the search provider omits `activeConnections` rather than sending 0, its two docs and its
+two test files move with it (the provider triad is per type-id even though one directory serves both),
+and no comment cites `mssql.ts` for an encoding it has stopped using.
 
 ## Value interpolation
 
@@ -886,6 +915,47 @@ is not a free read.
 
 **Done when:** an operation a provider declares globally runnable either has its own card copy or a
 recorded reason it is withheld.
+
+### U24. Two absences the Storage tab still renders as measurements
+
+Found 2026-08-27 while giving the tab the refused-`tables` arm it was missing (PR round 17). Both are
+narrow, both are in `src/components/monitoring/tabs/StorageTab.tsx`, and neither was introduced by that
+change.
+
+**A measured zero total draws the remainder bar full.** The breakdown computes
+
+```ts
+const tablePercent = totalSize > 0 && tableSizeKnown ? (totalTableSize / totalSize) * 100 : 0;
+const otherPercent = breakdownKnown ? Math.max(0, 100 - tablePercent - indexPercent) : 0;
+```
+
+so on a provider that reports a real `databaseSizeBytes` of 0 - Trino and Druid do, and the comment
+above the block names them as the case it handles - the `totalSize > 0` guard forces both shares to 0
+while `breakdownKnown` stays true, and the remainder becomes `100 - 0 - 0`. Measured in the DOM against
+the tab's own measured-zero fixture: the Tables and Indexes indicators read `translateX(-100%)` (empty)
+and the remainder reads `translateX(-0%)` - a full bar over a database with no bytes. Its figure beside
+it correctly reads `0 B`, so nothing numeric is fabricated; the overclaim is entirely in the bar, which
+is why no text assertion could see it.
+
+**A refused overview drops the engine's sentence.** The tab carries `errors.storage` for the
+Tablespaces panel and now `errors.tables` for Largest Tables, but there is no `overviewUnavailable`:
+with `data.overview` absent and `errors.overview` set, the DB Size card falls to `N/A` and the
+breakdown to "No storage size information available." Both are honest - no figure is invented - but the
+engine's own explanation is discarded in a file that surfaces it for two other panels.
+
+**And the same zero total can put `NaN undefined` in the cell beside it.** The remainder's bytes are
+`totalSize - totalTableSize - totalIndexSize`, so a provider reporting a 0 total while its table read
+answers with real per-table bytes makes that negative - and `formatBytes`
+(`src/lib/db/utils/pool-manager.ts`) does not survive a negative: `Math.log(-1536)` is `NaN`, `i` is
+`NaN`, and `sizes[NaN]` is `undefined`, so the cell renders the literal string **`NaN undefined`**
+(measured 2026-08-27). This is reachable wherever D44 is: 14 type-ids send 0 for an unknown size, and
+`getTableStats()` is a separate read that does not share the failure. `formatBytes` guarding its own
+input is the cheaper half of the fix and belongs with this entry rather than with D44.
+
+**Done when:** the remainder's bar is empty rather than full when there is no total to divide, with a
+component test asserting the indicator transform rather than the text (the figure is already right);
+`formatBytes` refuses a negative rather than rendering `NaN undefined`, with a unit test; and a refused
+overview carries its own sentence the way the two sibling panels do.
 
 ---
 
@@ -1148,6 +1218,35 @@ than a reviewer.
 
 **Done when:** each listing has been resubmitted through its own channel. Six submissions, five
 channels - the two Azure files travel together.
+
+### DOC4. 62 line citations in the provider docs are stale, and every checkable one is
+
+Found 2026-08-27 while re-anchoring `docs/providers/mssql.md` and `docs/providers/trino.md` to method
+names (PR round 17). The round established the policy - cite code by NAME, not by line - and pinned it
+with `tests/unit/provider-docs-monitoring-citations.test.ts`, whose scope statement says outright which
+files are not measured yet. This entry is that remainder.
+
+**Measured across `docs/providers/*.md`.** 291 `` `file.ts:N` `` citations before the round, 271 after.
+Of those, 69 were machine-checkable - a `` `method()` `` name paired with a line link, so the cited line
+can be compared with the real declaration - and **68 of the 69 were stale**, the single exception being
+Trino's `getCapabilities()`. After the round's 18 fixes, 62 checkable citations remain and **all 62 are
+stale**, spread over 12 docs. The other 209 point at expressions, comments, table rows and SQL fragments
+rather than a named declaration, so no heuristic can judge them and they were not checked by hand; given
+62 of 62, an inference is available but no figure is claimed for them.
+
+**Why they rot invisibly.** Two mechanisms, both measured:
+- **Stale at birth.** The eight seam rows in both search docs entered in one commit (`25712e68`, #429)
+  as 751/811/831/844/860/873/884/898 while the declarations in that same commit sat at
+  808/868/888/901/917/930/941/955 - a uniform +57. Being wrong by a constant is what hid it: the rows
+  stayed in ascending order and read as a consistent, plausible list. Today the offset is +65.
+- **A correction does not hold.** `docs/providers/redis.md` cited `base-provider.ts:102` (#89, true then),
+  was corrected to `:99` (#122, true then), and has rotted a second time since.
+
+**Done when:** each remaining doc cites declarations by name and is added to `NAMED_CITATIONS` in the
+guard, which is what makes the change stick - the guard bans the FORM, so a correct line number fails it
+too. Cheapest per doc, in descending count: `oracle.md` 16, `mongodb.md` 14, then the nine others. Both
+of those two were rewritten in round 17 and are the natural first pair; the round left them out because
+they were another lane's live files at the time, not because they are correct.
 
 ---
 

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -671,9 +671,10 @@ of the fact, which is why nothing is special-cased. Consequences elsewhere in th
   unimplemented features, so the EDIT toggle and the editable cell are not offered (#269).
 - The schema-diff migration generator emits, in place of a column change:
   *"Elasticsearch SQL reads only; change a field by reindexing into an index whose mapping declares
-  it."* ([`migration-generator.ts:81`](../../src/lib/schema-diff/migration-generator.ts)). It says
-  *reindex* rather than "use the mapping API" for a reason: an existing field's type cannot be changed
-  in place at all, even outside SQL.
+  it."* (the `NO_COLUMN_MODIFICATION` table in
+  [`migration-generator.ts`](../../src/lib/schema-diff/migration-generator.ts)). It says *reindex* rather than
+  "use the mapping API" for a reason: an existing field's type cannot be changed in place at all, even
+  outside SQL.
 - `schemaRefreshPattern` is `\b(DELETE)\b` ([index.ts:193](../../src/lib/db/providers/sql/search/index.ts)),
   which on **this** product can never fire — the grammar has no DELETE — exactly as Druid's
   `INSERT|REPLACE` never fires against its native engine. It is there for the fork, where a cluster
@@ -798,21 +799,24 @@ a relations pass would re-read every mapping to return the same empty arrays.
 ## 7. Monitoring & health
 
 Every read goes through `guarded()`
-([index.ts:694](../../src/lib/db/providers/sql/search/index.ts)), which maps a seam failure onto this
+([`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)), which maps a seam failure onto this
 repo's error classes ([§10](#10-error-handling)). There is no per-category degradation table here as
 Druid has one: the only read allowed to fail quietly is the cluster-wide store size
 ([§7.1](#71-the-one-swallowed-failure)).
 
+Every method in the table lives in that file and is cited **by name, not by line**: the line
+numbers this table used to carry had drifted, and a method name is greppable and stays true.
+
 | Method | Source | Mapping |
 |---|---|---|
-| `getOverview()` ([index.ts:751](../../src/lib/db/providers/sql/search/index.ts)) | `/`, `_cluster/health`, `_cat/indices` — **three seam calls in parallel** | `version` = `"Elasticsearch <number>"` from the connection's product plus the payload's version; `uptime` = **`"N/A"`**; `activeConnections` / `maxConnections` = **0**; `databaseSize(Bytes)` = the cluster's store from `_cluster/stats`; `tableCount` = **user** indices only; `indexCount` = **0** |
-| `getPerformanceMetrics()` ([index.ts:811](../../src/lib/db/providers/sql/search/index.ts)) | — | **`{}`**, and it asks the cluster nothing |
-| `getSlowQueries()` ([index.ts:831](../../src/lib/db/providers/sql/search/index.ts)) | — | **`[]`**. The slow log is written to the node's **log file**, which no API returns |
-| `getIndexStats()` ([index.ts:844](../../src/lib/db/providers/sql/search/index.ts)) | — | **`[]`**. No secondary-index object exists |
-| `getActiveSessions()` ([index.ts:860](../../src/lib/db/providers/sql/search/index.ts)) | — | **`[]`**. A request is one HTTP request; there is no session and no connection catalog |
-| `getTableStats()` ([index.ts:873](../../src/lib/db/providers/sql/search/index.ts)) | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""` |
-| `getStorageStats()` ([index.ts:884](../../src/lib/db/providers/sql/search/index.ts)) | `_cluster/health` + `_cluster/stats` | **one row for the cluster**: `name` = `cluster_name`, `sizeBytes` = `indices.store.size_in_bytes`. **No row at all** when the size was unreported |
-| `getHealth()` ([index.ts:898](../../src/lib/db/providers/sql/search/index.ts)) | the above, composed | `activeConnections`, `databaseSize`; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
+| `getOverview()` | `/`, `_cluster/health`, `_cat/indices` — **three seam calls in parallel** | `version` = `"Elasticsearch <number>"` from the connection's product plus the payload's version; `uptime` = **`"N/A"`**; `activeConnections` / `maxConnections` = **0**; `databaseSize(Bytes)` = the cluster's store from `_cluster/stats`; `tableCount` = **user** indices only; `indexCount` = **0** |
+| `getPerformanceMetrics()` | — | **`{}`**, and it asks the cluster nothing |
+| `getSlowQueries()` | — | **`[]`**. The slow log is written to the node's **log file**, which no API returns |
+| `getIndexStats()` | — | **`[]`**. No secondary-index object exists |
+| `getActiveSessions()` | — | **`[]`**. A request is one HTTP request; there is no session and no connection catalog |
+| `getTableStats()` | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""` |
+| `getStorageStats()` | `_cluster/health` + `_cluster/stats` | **one row for the cluster**: `name` = `cluster_name`, `sizeBytes` = `indices.store.size_in_bytes`. **No row at all** when the size was unreported |
+| `getHealth()` | the above, composed | `activeConnections`, `databaseSize`; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
 
 **Two vocabulary collisions, both counted wrong by the obvious reading:**
 
@@ -825,8 +829,8 @@ Druid has one: the only read allowed to fail quietly is the cluster-wide store s
   name. The schema tree says the same thing from the other side with `indexes: []`.
 
 **`databaseSizeBytes` is the CLUSTER's store including replicas**, while the per-index sizes in the
-schema tree are **primaries only** (`pri.store.size`, chosen deliberately at
-[http-transport.ts:161](../../src/lib/db/providers/sql/search/http-transport.ts)), so they do not sum
+schema tree are **primaries only** (`pri.store.size`, chosen deliberately by `CAT_FIELDS.PRIMARY_SIZE` in
+[`http-transport.ts`](../../src/lib/db/providers/sql/search/http-transport.ts)), so they do not sum
 to it. On the measured single node with one replica requested they happen to be equal, which is
 exactly why the choice had to be made deliberately rather than discovered later.
 
@@ -845,8 +849,11 @@ The honest empties, each with its reason:
 - **`getSlowQueries()` and `getActiveSessions()` return `[]` rather than throwing.** Nothing is broken
   and nothing is misconfigured, so a monitoring tab should render as quiet, not as failed. Only
   `runMaintenance()` throws, because that one is a *request to act*.
-- **`activeConnections` / `maxConnections` are 0**, the same "not published" encoding `mssql.ts` and
-  Druid use. The cluster counts open HTTP connections per node in its stats API, which is not one of
+- **`activeConnections` / `maxConnections` are 0**. For the ceiling that is the repo's encoding, which
+  Druid and Trino share: `maxConnections` treats `0` and absence as one fact. For the count beside it
+  the encoding is now this provider's alone - SQL Server, Oracle, MongoDB and Cassandra omit
+  `activeConnections` when nothing was read, and moving this one is
+  [BACKLOG D46](../BACKLOG.md). The cluster counts open HTTP connections per node in its stats API, which is not one of
   this seam's five calls, and the shard and node counts that *are* here would be a different number
   wearing this field's name. The Connections card reads a zero maximum as "no limit published" rather
   than dividing by it.
@@ -856,7 +863,8 @@ The honest empties, each with its reason:
 **A closed index reads as zero in `getTableStats()` and is omitted in the schema tree**, and the
 asymmetry is deliberate: `TableStats.rowCount` and the size fields are *required* numbers with no way
 to say "unknown", while `TableSchema.rowCount` and `size` are optional. So the tree is the surface
-that keeps the distinction ([index.ts:310-316](../../src/lib/db/providers/sql/search/index.ts)).
+that keeps the distinction (the comment over `toTableStats()` in
+[`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
 
 **Document counts exceed what a `SELECT` returns when a mapping has `nested` fields.** Measured on the
 fork's `probe_shapes`, whose `items` field is `nested`: `_cat` reports **2** documents while
@@ -870,7 +878,7 @@ whose grammar the tree must not depend on, to answer a different question than t
 
 `_cluster/stats` is heavier and more privileged than `_cluster/health`, so a cluster that answers
 health and refuses stats is an ordinary configuration. `storeSizeBytes()`
-([http-transport.ts:973](../../src/lib/db/providers/sql/search/http-transport.ts)) therefore catches
+([`http-transport.ts`](../../src/lib/db/providers/sql/search/http-transport.ts)) therefore catches
 its own failure and returns `null` — the seam's "unknown" — because losing the health status over a
 missing byte count would blank a panel that already had the important number.
 
@@ -903,7 +911,7 @@ altogether:
   cluster keeps working ([§3.8](#38-the-deadline-is-the-clients-and-only-the-clients)), and the task
   API that could really cancel a search is not part of this seam.
 
-`runMaintenance(type)` ([index.ts:931](../../src/lib/db/providers/sql/search/index.ts)) exists because
+`runMaintenance(type)` ([`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)) exists because
 the `DatabaseProvider` interface obliges every provider to implement it, and **not** because a request
 reaches it: `/api/db/maintenance` checks `supportsMaintenance` and answers 400 first. So the message
 below is what a *programmatic* caller of `@libredb/studio` sees:

--- a/docs/providers/mongodb.md
+++ b/docs/providers/mongodb.md
@@ -320,8 +320,8 @@ Every method is wrapped in try/catch. Degradation reports the absence rather tha
 
 | Method | Source | Notes |
 |--------|--------|-------|
-| `getHealth()` | `serverStatus`, `dbStats`, `currentOp`, `system.profile` | connections (**omitted**, never `0`, when the server publishes none — [§7.2](#72-a-connection-count-nobody-published-is-absent-not-zero)), data size, WiredTiger cache-hit % (`"N/A"` when unmeasurable, [§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured)), current ops; slow queries need the profiler (placeholder row if disabled) |
-| `getOverview()` | `serverStatus`, `buildInfo`, `dbStats`, `listCollections` | version, uptime, connections, collection/index counts. `maxConnections` is `connections.current + connections.available`, or `0` — the repo's spelling of *no limit published* — when the server publishes no headroom |
+| `getHealth()` | `serverStatus`, `dbStats`, `currentOp`, `system.profile` | connections (**omitted**, never `0`, when the server publishes none — [§7.2](#72-a-connection-count-nobody-published-is-absent-not-zero)), data size (**`"N/A"`**, never `"0 B"`, when `db.stats()` answers without `dataSize` — [§7.3](#73-a-database-size-nobody-published-is-absent-not-0-b)), WiredTiger cache-hit % (`"N/A"` when unmeasurable, [§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured)), current ops; slow queries need the profiler (placeholder row if disabled) |
+| `getOverview()` | `serverStatus`, `buildInfo`, `dbStats`, `listCollections` | version, uptime, connections (**omitted**, never `0`, on the same two paths as `getHealth()` — [§7.2](#72-a-connection-count-nobody-published-is-absent-not-zero)), database size (`databaseSizeBytes` **omitted**, never `0`, on those same two paths — [§7.3](#73-a-database-size-nobody-published-is-absent-not-0-b)), collection/index counts. `maxConnections` is `connections.current + connections.available`, or `0` — the repo's spelling of *no limit published* — when the server publishes no headroom |
 | `getPerformanceMetrics()` | `serverStatus` (WiredTiger + opcounters) | cache-hit %, **ops/sec** (`query`+`insert`+`update`+`delete` opcounters ÷ uptime — *total operations, not just queries*), buffer-pool % (cache bytes), `deadlocks: 0`. **Every field is optional**: each one is present only if its reading was, and a failed `serverStatus` reports `{}` ([§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured)) |
 | `getSlowQueries()` | `system.profile` | per-op time/returned; **`[]` if the profiler isn't enabled** (`db.setProfilingLevel(1)`); sorted by `millis` (slowest) — note `getHealth()`'s slow-query block instead sorts by `ts` (most recent) and emits a placeholder row when disabled |
 | `getActiveSessions()` | `currentOp` | opid, ns, lock waits, duration — ⚠️ the **`user` field is populated from `op.client`** (the client `host:port`), **not** an authenticated user |
@@ -356,36 +356,116 @@ rendering for).
 
 ### 7.2 A connection count nobody published is absent, not zero
 
-`getHealth().activeConnections` comes from `serverStatus.connections.current`, and there are two
-ordinary ways that reading does not happen:
+`getHealth().activeConnections` and `getOverview().activeConnections` both come from
+`serverStatus.connections.current`, and there are two ordinary ways that reading does not happen:
 
 - the deployment publishes no `connections` section at all — an API-compatible service, or any
   deployment whose `serverStatus` answers without it. This is **not** [§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured)'s
   set: `connections` is a network-layer field of `serverStatus`, not a storage-engine sub-document
   like `wiredTiger`, so the reason that set omits `wiredTiger` does not carry here, and which
-  deployments omit `connections` is not measured in this repo;
-- `serverStatus` (or `db.stats()`, or `currentOp`) fails outright, which is what a user without
-  `clusterMonitor` gets, and the whole health read then falls into its outer catch.
+  deployments omit `connections` is not measured in this repo. The
+  [`serverStatus` manual page](https://www.mongodb.com/docs/manual/reference/command/serverStatus/)
+  offers no guarantee to measure it against either: it notes that "the output fields vary depending
+  on the version of MongoDB, underlying operating system platform, the storage engine, and the kind
+  of node, including `mongos`, `mongod` or replica set member", and describes `connections` only as
+  "a document that reports on the status of the connections" — it promises no top-level field,
+  `connections` included, on every deployment. So the provider treats a `serverStatus` that answers
+  without the section as an ordinary answer, without ruling on which deployments answer that way;
+- `serverStatus` (or `db.stats()`, or `currentOp`, or `buildInfo`) fails outright, which is what a
+  user without `clusterMonitor` gets, and the whole read then falls into its outer catch.
 
-`HealthInfo.activeConnections` is **optional** for exactly this case, so in both the key is now
-**omitted** — absent from the object, absent from the `POST /api/db/health` body, and the admin
-fleet-health row drops its `N conn` figure rather than printing `0 conn`
+`HealthInfo.activeConnections` and `DatabaseOverview.activeConnections` are both **optional** for
+exactly this case, so in all four paths the key is now **omitted** — absent from the object, absent
+from the `POST /api/db/health` body, absent from the monitoring payload, and the admin fleet-health
+row drops its `N conn` figure rather than printing `0 conn`
 ([`src/components/admin/tabs/OverviewTab.tsx`](../../src/components/admin/tabs/OverviewTab.tsx)).
-Both paths used to answer `0`: `connections?.current || 0` on the success path and a literal
-`activeConnections: 0` in the outer catch. That mattered most to the agent, whose curated `health`
-reading forwards this figure to the model: a MongoDB the caller could not query at all arrived as a
-*measured* "no connections open".
+Every one of them used to answer `0`: `connections?.current || 0` on both success paths and a literal
+`activeConnections: 0` in both outer catches. On the `getHealth()` side that reached the model: the
+agent's curated `health` reading is `getHealth()` (`method: "getHealth"` in
+[`src/lib/agent/tools.ts`](../../src/lib/agent/tools.ts), which projects this key with `?? null`), so
+a MongoDB the caller could not query at all arrived as a *measured* "no connections open".
+`getOverview()`'s count does **not** reach the model - nothing under `src/lib/agent` reads
+`getOverview()` - and its readers are the monitoring **Connections** card, that card's trend chart,
+and the connection-threshold rating that colours it. On the Overview tab the `0` was not merely a
+blank in disguise: it printed as the figure `0` on the *Connections* card, and — because that tab
+keeps a history — each refresh added a real `0` point to the connection sparkline, whose `flatMap`
+drops absent samples and plots present ones. With the key absent the card reads `N/A` above *not
+published* and the sample is dropped from the trend
+([`src/components/monitoring/tabs/OverviewTab.tsx`](../../src/components/monitoring/tabs/OverviewTab.tsx)).
+No percentage was ever involved on these paths: whenever `connections.current` is unmeasurable
+`maxConnections` is `0` too, and the card only computes a share when a limit is published.
 
 A server that really has `0` open connections keeps the `0` — it is a reading, and the absence is
-spelled `measuredNumber(...)` plus a conditional spread, never `|| undefined`.
+spelled `measuredNumber(...)` plus a conditional spread, never `|| undefined` and never `|| 0`. The
+`|| 0` form was in fact two defects on one line: it invented a figure where none was published *and*
+flattened a genuinely idle server's measured `0` into the same value, so the two are
+indistinguishable downstream.
 
-The outer catch still **resolves** with a `HealthInfo` rather than rethrowing, and that is deliberate:
-`POST /api/db/health` serialises whatever it resolves with, and `POST /api/admin/fleet-health` reads
-`healthy` from a read that returned, so rethrowing would report a server that is up as an error. What
-it must not do is name a figure it never read. (Its `slowQueries: [{ query: "Error fetching health
-info" }]` placeholder is the same class of fabrication one size down and is still there; it is
-tracked separately, because removing it needs `HealthInfo.slowQueries` to become optional across all
-15 type-ids.)
+Both outer catches still **resolve** rather than rethrowing, but for different reasons, and neither
+reason licenses naming a figure:
+
+- `getHealth()` resolves because `POST /api/db/health` serialises whatever it resolves with and
+  `POST /api/admin/fleet-health` reads `healthy` from a read that returned, so rethrowing would
+  report a server that is up as an error;
+- `getOverview()` resolves because `getMonitoringData()`
+  ([`src/lib/db/base-provider.ts`](../../src/lib/db/base-provider.ts)) reads the panel through
+  `Promise.allSettled`, so a rethrow would replace the whole overview with an `errors.overview`
+  entry instead of the `"MongoDB Unknown"` / `"N/A"` placeholders the tab renders. That is a
+  legitimate alternative rather than a bug, and it is left alone here: it is a cross-provider
+  decision, since every provider's `getOverview()` degrades the same way.
+
+(`getHealth()`'s `slowQueries: [{ query: "Error fetching health info" }]` placeholder is the same
+class of fabrication one size down and is still there; it is tracked separately, because removing it
+needs `HealthInfo.slowQueries` to become optional across all 15 type-ids.)
+
+### 7.3 A database size nobody published is absent, not `0 B`
+
+The byte figure travels the same two paths as the count above and had the same two spellings of a
+fabrication. Both outlived the round that fixed the count, one field over in the same object:
+
+- `getOverview()`'s outer catch returned a literal `databaseSizeBytes: 0`. Nothing was read on that
+  path - `serverStatus`, `db.stats()`, `buildInfo` and `listCollections` are all inside the same
+  `try`, so a user without `clusterMonitor` reaches it - and `DatabaseOverview.databaseSizeBytes` is
+  **optional** precisely so that a provider with no byte figure can say so. The key is now omitted;
+- both success paths formatted `dbStats.dataSize || 0`, which cannot tell a database that measures
+  0 bytes from a `db.stats()` that answered without `dataSize`. Both are now
+  `measuredNumber(dbStats.dataSize)`: absent, the overview omits `databaseSizeBytes` and reports
+  `databaseSize: "N/A"`; measured, a real `0` still formats as `"0 B"`. MongoDB's own
+  [`dbStats` reference](https://www.mongodb.com/docs/manual/reference/command/dbStats/) documents
+  `dataSize` unconditionally - the only output fields it gates are `freeStorageSize`,
+  `indexFreeStorageSize` and `totalFreeStorageSize`, on the command's `freeStorage: 1` option - so
+  this arm is **not** a deployment measured in this repo; it is the input `|| 0` could not
+  distinguish, and the optional field exists to carry it.
+
+**What the absence buys is a whole panel.**
+[`StorageTab.tsx`](../../src/components/monitoring/tabs/StorageTab.tsx) keys its entire breakdown off
+`overview?.databaseSizeBytes !== undefined`. With the key present as `0` it treated the size as
+**known** and drew the breakdown over a `0 B` total: the *Tables* and *Indexes* cards at `0.0%`, and
+an *Other (unattributed)* row computed as `totalSize - totalTableSize - totalIndexSize`. That
+remainder is the part a refused `serverStatus` makes visibly wrong rather than merely empty, because
+the table read does **not** share the failure - `getTableStats()` goes through `listCollections` +
+`collStats`, neither of which needs `clusterMonitor` - so its per-table byte figures arrive, both
+`known` flags are true, and the row formats a **negative** byte count. `formatBytes` does not survive
+one: `Math.log` of a negative is `NaN`, so the size unit indexes out of its own array and a 1 KB
+collection with 512 B of indexes renders the literal string `NaN undefined` (measured 2026-08-27
+against `formatBytes` in `src/lib/db/utils/pool-manager.ts`). With the key absent the tab draws its own *"No storage size
+information available."* instead, and the *Tables* / *Indexes* cards read `N/A`. Both arms are pinned
+in [`tests/components/monitoring/StorageTab.test.tsx`](../../tests/components/monitoring/StorageTab.test.tsx).
+
+`getHealth()`'s size is a required string, so its absence is spelled `"N/A"` - the value that
+method's own catch already returns. That one **does** reach the model: the curated `health` reading
+projects `databaseSize` verbatim, so `"0 B"` told the model a database it could not measure holds
+nothing.
+
+Three `0`s stay in `getOverview()`'s catch, for two different reasons - and neither reason is that
+something was measured:
+
+- `maxConnections` stays `0` because there `0` *means* "no limit published" - absence and zero are
+  the same fact for a published ceiling, which is why the field is a required number
+  ([`DatabaseOverview` in types.ts](../../src/lib/db/types.ts));
+- `tableCount` and `indexCount` are required numbers with no absence to spell, so `0` is the only
+  value the type leaves for a path that counted nothing. They are the one place this object still
+  states more than it read ([§13](#13-known-limitations--future-work)).
 
 ---
 
@@ -572,8 +652,16 @@ Over the API: `POST /api/db/query` (JSON MQL in the `sql` field) and `POST /api/
   appropriate roles (`clusterMonitor`, etc.); without them the affected metrics are reported as
   *unavailable* rather than as numbers ([§7.1](#71-what-the-panel-shows-when-the-cache-cannot-be-measured)),
   the health connection count is omitted rather than reported as `0`
-  ([§7.2](#72-a-connection-count-nobody-published-is-absent-not-zero)), and slow queries require the
+  ([§7.2](#72-a-connection-count-nobody-published-is-absent-not-zero)), the overview's byte figure is
+  omitted rather than reported as `0`
+  ([§7.3](#73-a-database-size-nobody-published-is-absent-not-0-b)), and slow queries require the
   profiler to be enabled.
+- **A failed overview read still reports `tableCount: 0` and `indexCount: 0`.** Both fields are
+  required numbers on `DatabaseOverview`, so `getOverview()`'s catch has no absence to spell for
+  them and a denied `serverStatus` reports two counts nobody took
+  ([§7.3](#73-a-database-size-nobody-published-is-absent-not-0-b)). *Future:* the same change the
+  connection count and the byte figure got, which needs the two fields to become optional across all
+  15 type-ids.
 - **`Binary` values are shown as a placeholder** (`<Binary: N bytes>`), not the raw bytes, and only
   a subset of BSON types are normalised (`Long`/`Timestamp`/`UUID`/`RegExp`/`Code`/`DBRef` render as
   generic objects).
@@ -598,6 +686,7 @@ Over the API: `POST /api/db/query` (JSON MQL in the `sql` field) and `POST /api/
 ## 14. References
 
 - Driver: [`mongodb` (node-mongodb-native)](https://github.com/mongodb/node-mongodb-native)
+- MongoDB manual: [`serverStatus`](https://www.mongodb.com/docs/manual/reference/command/serverStatus/) · [`dbStats`](https://www.mongodb.com/docs/manual/reference/command/dbStats/) — the two commands §7.1–§7.3 read, and the pages the claims about which output fields are guaranteed come from
 - Source: [`src/lib/db/providers/document/mongodb.ts`](../../src/lib/db/providers/document/mongodb.ts)
 - Base class: [`src/lib/db/base-provider.ts`](../../src/lib/db/base-provider.ts)
 - Interface & DTOs: [`src/lib/db/types.ts`](../../src/lib/db/types.ts)

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -533,7 +533,7 @@ agent: its curated `health` reading forwards this figure to the model, so a refu
 *measured* "no connections open" about a server SQL Server had said nothing about.
 
 `DatabaseOverview.activeConnections` is **optional** for the identical reason, and `getOverview()`
-now omits it on the same refusal. It did not until D40: the block was guarded, but the local was
+now omits it on the same refusal. It did not until #515: the block was guarded, but the local was
 initialised to `0`, so the denial was swallowed into a reading and travelled on as one. The count
 itself is the *same* `COUNT(*) FROM sys.dm_exec_sessions`, only bundled with the `sys.configurations`
 ceiling lookup - and that bundling is not cosmetic: it gives the statement a second object carrying
@@ -588,7 +588,7 @@ refusal at all:
 
 - **SQL Server 2022 and later** - the `sys.configurations` subquery alone needs the server grant, so
   the whole statement is refused, the guard runs, and the count is correctly **absent**. This is the
-  path D40 fixes, and it is why the ceiling is absent-shaped too: one statement, one catch.
+  path #515 fixes, and it is why the ceiling is absent-shaped too: one statement, one catch.
 - **SQL Server 2019 and earlier** - `sys.configurations` needs only `public`, so the ceiling lookup
   succeeds; and the session DMV is not documented as *refusing* an ungranted login at all, only as
   showing it its own session. Taken literally, that login gets a row-filtered `COUNT(*)` - its own
@@ -596,7 +596,7 @@ refusal at all:
   bar. **That is a wrong measurement, not an absence, and nothing here catches it: the statement
   succeeded.**
 
-The second case is **not fixed** by D40 and is **not measured** on a live instance - it is what
+The second case is **not fixed** by #515 and is **not measured** on a live instance - it is what
 Microsoft's Permissions wording implies, not an observation. What this round did measure is the
 sibling performance-counter DMV's refusal on 2022 CU26, which is why the caveat above stands
 unchanged: the refusal on `sys.dm_exec_sessions` itself is not measured here, and neither is its

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -67,7 +67,7 @@ DatabaseProvider (interface) → BaseDatabaseProvider → SQLBaseProvider → MS
 
 ### Registration
 
-Loaded on demand by the factory ([`factory.ts:82`](../../src/lib/db/factory.ts)):
+Loaded on demand by `createDatabaseProvider()` ([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case 'mssql': {
@@ -82,7 +82,7 @@ case 'mssql': {
 
 ### 3.1 Encryption on by default, Azure-aware
 
-`buildConfig()` ([mssql.ts:111](../../src/lib/db/providers/sql/mssql.ts)) sets `encrypt: true` by
+`buildConfig()` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) sets `encrypt: true` by
 default (SQL Server 2022+ and the `mssql` v12 driver require encryption), and
 `trustServerCertificate = !isAzure` — i.e. for **non-Azure** hosts it encrypts but **trusts a
 self-signed certificate** (so on-prem dev servers connect without a CA), while **Azure**
@@ -91,7 +91,7 @@ explicit-`ssl` overrides and the [security caveat](#14-known-limitations--future
 
 ### 3.2 T-SQL pagination: `TOP` and `OFFSET … FETCH`
 
-`prepareQuery()` ([mssql.ts:557](../../src/lib/db/providers/sql/mssql.ts)) overrides the base. For a
+`prepareQuery()` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) overrides the base. For a
 limit-less `SELECT`: with no offset it injects `TOP n` right after `SELECT [DISTINCT]`; with an
 offset it appends `OFFSET m ROWS FETCH NEXT n ROWS ONLY` — and because T-SQL requires an `ORDER BY`
 for `OFFSET … FETCH`, it injects `ORDER BY (SELECT NULL)` when the query has none.
@@ -195,7 +195,7 @@ bounding such a statement unless the rule above applies to it.
 
 ### 3.3 Five-query schema introspection, cross-schema
 
-`getSchema()` ([mssql.ts:369](../../src/lib/db/providers/sql/mssql.ts)) runs **five bulk queries**
+`getSchema()` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) runs **five bulk queries**
 (tables via `sys.tables`/`sys.partitions`, columns via `INFORMATION_SCHEMA.COLUMNS`, primary keys,
 foreign keys via `sys.foreign_keys`, indexes via `sys.indexes`) over the connected database, then
 groups them in memory keyed by `schema.table`. Tables in the **`dbo`** schema are shown by bare
@@ -206,8 +206,9 @@ tables. Row counts come from `SUM(sys.partitions.rows)`.
 ### 3.4 `rowsAffected` is surfaced
 
 Unlike the MySQL/Oracle providers (which report `rows.length`), `query()` sets
-`rowCount = result.rowsAffected?.[0] ?? recordset.length` ([mssql.ts:241](../../src/lib/db/providers/sql/mssql.ts)),
-so a non-`SELECT` statement returns its real affected-row count.
+`rowCount = result.rowsAffected?.[0] ?? recordset.length` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)),
+and `queryInTransaction()` repeats the same expression, so a non-`SELECT` statement returns its real
+affected-row count.
 
 ### 3.5 A query timeout *is* wired (driver-enforced)
 
@@ -221,12 +222,12 @@ statement timeout like Postgres's `statement_timeout`. An overrunning query stil
 ### 3.6 No transaction auto-rollback timeout
 
 Like Oracle (and unlike Postgres/MySQL), transactions use an `mssql.Transaction` with **no**
-5-minute auto-rollback timer ([mssql.ts:303](../../src/lib/db/providers/sql/mssql.ts)).
+5-minute auto-rollback timer (`beginTransaction()`, [`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)).
 
 ### 3.7 Named-instance support
 
 If `config.instanceName` is set, it is passed as `options.instanceName` and the explicit `port` is
-**deleted** — the SQL Server Browser service negotiates the port ([mssql.ts:150](../../src/lib/db/providers/sql/mssql.ts)).
+**deleted** — the SQL Server Browser service negotiates the port (`buildConfig()`, [`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)).
 
 ---
 
@@ -244,14 +245,14 @@ const conn = {
 };
 ```
 
-`validate()` ([mssql.ts:94](../../src/lib/db/providers/sql/mssql.ts)) requires `host` **and**
+`validate()` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) requires `host` **and**
 `database` (when no connection string is set — but note [§4.4](#44-connection-string-nuance)).
 SQL authentication only (`user`/`password`); Windows/AAD auth is not wired.
 
 ### 4.2 Connection pooling
 
 `connect()` builds an `mssql.ConnectionPool` and validates it with `SELECT 1`. Mapping
-([mssql.ts:111](../../src/lib/db/providers/sql/mssql.ts)):
+(`buildConfig()`, [`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)):
 
 | `mssql` config | Value | Source |
 |----------------|-------|--------|
@@ -262,7 +263,7 @@ SQL authentication only (`user`/`password`); Windows/AAD auth is not wired.
 | `options.requestTimeout` | 60000 | `ProviderOptions.queryTimeout` |
 
 This is the most complete pool/timeout mapping of any SQL provider. `getPoolStats()`
-([mssql.ts:702](../../src/lib/db/providers/sql/mssql.ts)) exposes
+([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) exposes
 `{ total: size, idle: available, active, waiting: pending }`.
 
 #### Pool errors are handled, not fatal
@@ -337,7 +338,7 @@ to the newer name would change the wording on the form without changing a single
 
 ### 5.1 Execution
 
-`query(sql, params?, queryId?)` ([mssql.ts:203](../../src/lib/db/providers/sql/mssql.ts)) takes a
+`query(sql, params?, queryId?)` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) takes a
 `Request` from the pool, optionally records it under `queryId` for cancellation, binds params as
 `@p1`, `@p2`, … via `request.input()`, runs the query, and returns:
 
@@ -350,14 +351,14 @@ Native `mssql` errors are normalised through `mapDatabaseError()` (see [§11](#1
 ### 5.2 Query cancellation
 
 A query issued with a `queryId` stores its `Request`. `cancelQuery(queryId)`
-([mssql.ts:247](../../src/lib/db/providers/sql/mssql.ts)) returns `false` if no `Request` is tracked
+([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) returns `false` if no `Request` is tracked
 for that id; otherwise it calls `request.cancel()` and returns `true` as long as that call doesn't
 throw — it does **not** confirm the cancellation actually took effect. Exposed via `POST /api/db/cancel`.
 
 ### 5.3 Data-type & parameter handling ⚠️
 
 - **Parameters are bound without an explicit SQL type.** `query()` calls
-  `request.input(\`p${i+1}\`, value)` ([mssql.ts:218](../../src/lib/db/providers/sql/mssql.ts)) and
+  `request.input(\`p${i+1}\`, value)` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) and
   lets `mssql` **infer** the TDS type from the JS value. Inference is convenient but a known
   foot-gun: `null` params, very large integers, and `VARCHAR` vs `NVARCHAR` intent can be guessed
   wrong. Callers needing exact typing would have to bind explicitly (not currently exposed).
@@ -409,7 +410,7 @@ probe table's `BIGINT` and `UNIQUEIDENTIFIER` columns both exported as `NVARCHAR
 
 ## 6. Transactions
 
-Explicit lifecycle via `mssql.Transaction` ([mssql.ts:303](../../src/lib/db/providers/sql/mssql.ts)),
+Explicit lifecycle via `mssql.Transaction` (`beginTransaction()`, [`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)),
 **no auto-rollback timeout** ([§3.6](#36-no-transaction-auto-rollback-timeout)). Surfaced via
 `POST /api/db/transaction`.
 
@@ -531,14 +532,89 @@ It used to be initialised to `0` and the guard left that `0` standing, which mat
 agent: its curated `health` reading forwards this figure to the model, so a refused DMV arrived as a
 *measured* "no connections open" about a server SQL Server had said nothing about.
 
-A count that really is `0` - an instance with no user sessions - is a reading and is reported as `0`.
+`DatabaseOverview.activeConnections` is **optional** for the identical reason, and `getOverview()`
+now omits it on the same refusal. It did not until D40: the block was guarded, but the local was
+initialised to `0`, so the denial was swallowed into a reading and travelled on as one. The count
+itself is the *same* `COUNT(*) FROM sys.dm_exec_sessions`, only bundled with the `sys.configurations`
+ceiling lookup - and that bundling is not cosmetic: it gives the statement a second object carrying
+its own, version-dependent permission requirement, so the two counts do not necessarily fail together
+([below](#which-half-of-the-overview-read-refuses-and-the-case-nothing-catches)).
+
+The monitoring **Connections** card
+([`src/components/monitoring/tabs/OverviewTab.tsx`](../../src/components/monitoring/tabs/OverviewTab.tsx))
+is what the difference buys: on the absence it renders `N/A` over *"not published"* and drops the
+sample from the connection-trend chart, whereas the `0` printed as the figure `0` on that card - a
+busy server reported as idle on the strength of a permission error - and, because that tab keeps a
+history, every refresh added a real `0` point to the connection sparkline, which plots present
+samples and drops absent ones.
+
+**No percentage was involved on this path.** The ceiling comes from the *same* statement, and its
+assignment lives inside the `try` that threw, so a refused read left `maxConnections` at its `0`
+initialiser; the card requires `connectionLimit > 0` for both the `/{limit}` suffix and the
+`<Progress>` + *"N% used"* branch, so what it drew was a bare `0` over *"no limit published"* - no
+ceiling, no bar. A `0/32767` with *"0% used"* is what a **successful** read of an idle instance
+draws, and this fix does not change that rendering.
+
+Nor does this figure reach the model. `getHealth()` runs its own
+`COUNT(*) FROM sys.dm_exec_sessions` rather than composing from `getOverview()`, and the agent's
+curated `health` reading is `getHealth()` as well (`method: "getHealth"` in
+[`src/lib/agent/tools.ts`](../../src/lib/agent/tools.ts); nothing under `src/lib/agent` reads
+`getOverview()`). This count's readers are the monitoring card, its trend chart, and the
+connection-threshold rating that colours the card.
+
+`maxConnections` is deliberately **not** made absent alongside it. It stays a required number because
+`0` there already *means* "no limit published" rather than "no capacity", so absence and zero are the
+same fact for the ceiling and different facts for the count; a denied read therefore leaves the count
+absent and the ceiling `0`.
+
+#### Which half of the overview read refuses, and the case nothing catches
+
+`getOverview()`'s connection read names two objects, and Microsoft documents their permissions
+differently - and differently *per version*:
+
+| Object | SQL Server 2019 and earlier | SQL Server 2022 and later |
+|--------|-----------------------------|---------------------------|
+| `sys.dm_exec_sessions` | *"Everyone can see their own session information."* … *"requires `VIEW SERVER STATE` to see all sessions on the server"* | same first sentence; *"requires `VIEW SERVER PERFORMANCE STATE` permission on the server"* to see all sessions |
+| `sys.configurations` | *"Requires membership in the **public** role."* | *"Requires VIEW SERVER PERFORMANCE STATE permission on the server."* |
+
+(Permissions sections of
+[sys.dm_exec_sessions](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-objects/sys-dm-exec-sessions-transact-sql)
+and
+[sys.configurations](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-configurations-transact-sql),
+read 2026-08-27.)
+
+So the version decides the *shape* an ungranted login gets, and only one of the two shapes is a
+refusal at all:
+
+- **SQL Server 2022 and later** - the `sys.configurations` subquery alone needs the server grant, so
+  the whole statement is refused, the guard runs, and the count is correctly **absent**. This is the
+  path D40 fixes, and it is why the ceiling is absent-shaped too: one statement, one catch.
+- **SQL Server 2019 and earlier** - `sys.configurations` needs only `public`, so the ceiling lookup
+  succeeds; and the session DMV is not documented as *refusing* an ungranted login at all, only as
+  showing it its own session. Taken literally, that login gets a row-filtered `COUNT(*)` - its own
+  connection rather than the server's - and the card draws a confident `1/32767` under a *"0% used"*
+  bar. **That is a wrong measurement, not an absence, and nothing here catches it: the statement
+  succeeded.**
+
+The second case is **not fixed** by D40 and is **not measured** on a live instance - it is what
+Microsoft's Permissions wording implies, not an observation. What this round did measure is the
+sibling performance-counter DMV's refusal on 2022 CU26, which is why the caveat above stands
+unchanged: the refusal on `sys.dm_exec_sessions` itself is not measured here, and neither is its
+row-filtering. Distinguishing the two would need a separate probe - the grant itself
+(`HAS_PERMS_BY_NAME`), or a count cross-checked against a source that cannot be row-filtered - not a
+`try`/`catch`. The same wording applies one layer up: `getHealth()`'s count reads that DMV *alone*,
+with no `sys.configurations` arm to refuse on any version, so its own permission-denial path is the
+less likely of the two shapes there.
+
+A count that really is `0` - an instance with no user sessions - is a reading and is reported as `0`,
+in `getOverview()` as in `getHealth()`.
 The absence is spelled `measuredNumber(...)` plus a conditional spread, never `|| undefined`.
 
 ---
 
 ## 9. Maintenance
 
-`runMaintenance(type, target?)` ([mssql.ts:637](../../src/lib/db/providers/sql/mssql.ts)); targets
+`runMaintenance(type, target?)` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)); targets
 are bracket-escaped (`]` → `]]`):
 
 | Type | With target | Without target |
@@ -580,7 +656,7 @@ render those words and send an operation SQL Server declares (#U9).
 
 ## 10. Capabilities & labels
 
-### `getCapabilities()` ([mssql.ts:57](../../src/lib/db/providers/sql/mssql.ts))
+### `getCapabilities()` ([`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts))
 
 | Capability | Value |
 |------------|-------|
@@ -597,7 +673,7 @@ render those words and send an operation SQL Server declares (#U9).
 | `defaultPort` | `1433` |
 | `schemaRefreshPattern` | `(CREATE\|DROP\|ALTER\|TRUNCATE)\b` (from base) |
 
-### Labels — overridden ([mssql.ts:67](../../src/lib/db/providers/sql/mssql.ts))
+### Labels — overridden (`getLabels()`, [`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts))
 
 `analyzeAction` → *"Update Statistics"*, `vacuumAction` → *"Rebuild Indexes"*, plus the matching
 global labels. The UI display name for the database type is *"SQL Server"* (`db-ui-config.ts`).
@@ -721,7 +797,7 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
     generated self-signed certificate: `{ encrypt: true, trustServerCertificate: true }` connected
     (`sys.dm_exec_connections.encrypt_option = TRUE`) while `{ encrypt: true,
     trustServerCertificate: false }` — what `verify-full` builds
-    ([mssql.ts:483](../../src/lib/db/providers/sql/mssql.ts)) — was refused with *"Failed to connect
+    (`buildConfig()`, [`mssql.ts`](../../src/lib/db/providers/sql/mssql.ts)) — was refused with *"Failed to connect
     to 127.0.0.1:1433 - self signed certificate"*. If your on-prem server has no trusted certificate,
     paste `TrustServerCertificate=True` alongside `Encrypt=True`, or set SSL Mode to `require` on the
     form after pasting.

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -663,9 +663,10 @@ Consequences elsewhere in the product:
   unimplemented features, so the EDIT toggle and the editable cell are not offered (#269).
 - The schema-diff migration generator emits, in place of a column change: *"OpenSearch SQL reads only;
   change a field by reindexing into an index whose mapping declares it."*
-  ([`migration-generator.ts:85`](../../src/lib/schema-diff/migration-generator.ts)). It says *reindex*
-  rather than "use the mapping API" because an existing field's type cannot be changed in place at all,
-  even outside SQL.
+  (the `NO_COLUMN_MODIFICATION` table in
+  [`migration-generator.ts`](../../src/lib/schema-diff/migration-generator.ts)). It says *reindex*
+  rather than "use the mapping API" because an existing field's type cannot be changed in place at
+  all, even outside SQL.
 - `schemaRefreshPattern` is `\b(DELETE)\b`
   ([index.ts:193](../../src/lib/db/providers/sql/search/index.ts)) and **this is the product it exists
   for**: a cluster that switches DELETE on really does change the per-index document counts this
@@ -798,20 +799,23 @@ be byte-identical and a relations pass would re-read every mapping to return the
 ## 7. Monitoring & health
 
 Every read goes through `guarded()`
-([index.ts:694](../../src/lib/db/providers/sql/search/index.ts)), which maps a seam failure onto this
+([`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)), which maps a seam failure onto this
 repo's error classes ([§10](#10-error-handling)). The only read allowed to fail quietly is the
 cluster-wide store size ([§7.1](#71-the-one-swallowed-failure)).
 
+Every method in the table lives in that file and is cited **by name, not by line**: the line
+numbers this table used to carry had drifted, and a method name is greppable and stays true.
+
 | Method | Source | Mapping |
 |---|---|---|
-| `getOverview()` ([index.ts:751](../../src/lib/db/providers/sql/search/index.ts)) | `/`, `_cluster/health`, `_cat/indices` — **three seam calls in parallel** | `version` = `"OpenSearch <number>"`; `uptime` = **`"N/A"`**; `activeConnections` / `maxConnections` = **0**; `databaseSize(Bytes)` = the cluster's store from `_cluster/stats`; `tableCount` = **user** indices only; `indexCount` = **0** |
-| `getPerformanceMetrics()` ([index.ts:811](../../src/lib/db/providers/sql/search/index.ts)) | — | **`{}`**, and it asks the cluster nothing |
-| `getSlowQueries()` ([index.ts:831](../../src/lib/db/providers/sql/search/index.ts)) | — | **`[]`** — and on this product that is a *choice*, not an absence. See below |
-| `getIndexStats()` ([index.ts:844](../../src/lib/db/providers/sql/search/index.ts)) | — | **`[]`**. No secondary-index object exists |
-| `getActiveSessions()` ([index.ts:860](../../src/lib/db/providers/sql/search/index.ts)) | — | **`[]`**. A request is one HTTP request; there is no session and no connection catalog |
-| `getTableStats()` ([index.ts:873](../../src/lib/db/providers/sql/search/index.ts)) | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""` |
-| `getStorageStats()` ([index.ts:884](../../src/lib/db/providers/sql/search/index.ts)) | `_cluster/health` + `_cluster/stats` | **one row for the cluster**: `name` = `cluster_name`, `sizeBytes` = `indices.store.size_in_bytes`. **No row at all** when the size was unreported |
-| `getHealth()` ([index.ts:898](../../src/lib/db/providers/sql/search/index.ts)) | the above, composed | `activeConnections`, `databaseSize`; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
+| `getOverview()` | `/`, `_cluster/health`, `_cat/indices` — **three seam calls in parallel** | `version` = `"OpenSearch <number>"`; `uptime` = **`"N/A"`**; `activeConnections` / `maxConnections` = **0**; `databaseSize(Bytes)` = the cluster's store from `_cluster/stats`; `tableCount` = **user** indices only; `indexCount` = **0** |
+| `getPerformanceMetrics()` | — | **`{}`**, and it asks the cluster nothing |
+| `getSlowQueries()` | — | **`[]`** — and on this product that is a *choice*, not an absence. See below |
+| `getIndexStats()` | — | **`[]`**. No secondary-index object exists |
+| `getActiveSessions()` | — | **`[]`**. A request is one HTTP request; there is no session and no connection catalog |
+| `getTableStats()` | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""` |
+| `getStorageStats()` | `_cluster/health` + `_cluster/stats` | **one row for the cluster**: `name` = `cluster_name`, `sizeBytes` = `indices.store.size_in_bytes`. **No row at all** when the size was unreported |
+| `getHealth()` | the above, composed | `activeConnections`, `databaseSize`; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
 
 **The slow-query panel is empty even though this product keeps top-N queries.** That is the sharpest
 "deliberately unused" decision in the provider: a stock 3.8.0 node ships a `top_queries-<date>` index —
@@ -820,7 +824,7 @@ its slow log to a node **log file** that no API returns. Reading it would be a m
 exists on one of two products behind one code path, i.e. exactly the branch on product identity that
 the seam and `CLAUDE.md` both forbid. **A slow-query panel populated for half the connections of one
 provider type is worse than an honest empty one**
-([index.ts:815-830](../../src/lib/db/providers/sql/search/index.ts)).
+(the comment over `getSlowQueries()` in [`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
 
 **Two vocabulary collisions, both counted wrong by the obvious reading:**
 
@@ -832,8 +836,8 @@ provider type is worse than an honest empty one**
   with `indexes: []`.
 
 **`databaseSizeBytes` is the CLUSTER's store including replicas**, while the per-index sizes are
-**primaries only** (`pri.store.size`, chosen deliberately at
-[http-transport.ts:161](../../src/lib/db/providers/sql/search/http-transport.ts)), so they do not sum to
+**primaries only** (`pri.store.size`, chosen deliberately by `CAT_FIELDS.PRIMARY_SIZE` in
+[`http-transport.ts`](../../src/lib/db/providers/sql/search/http-transport.ts)), so they do not sum to
 it — and `_cluster/stats` is the one place in this transport where a count arrives as a real JSON
 **number** (`indices.store.size_in_bytes`, measured unquoted on both products) rather than a quoted
 string.
@@ -852,8 +856,11 @@ The honest empties, each with its reason:
 - **`getSlowQueries()` and `getActiveSessions()` return `[]` rather than throwing.** Nothing is broken
   and nothing is misconfigured, so a monitoring tab should render as quiet, not as failed. Only
   `runMaintenance()` throws, because that one is a *request to act*.
-- **`activeConnections` / `maxConnections` are 0**, the same "not published" encoding `mssql.ts` and
-  Druid use. The cluster counts open HTTP connections per node in its stats API, which is not one of
+- **`activeConnections` / `maxConnections` are 0**. For the ceiling that is the repo's encoding, which
+  Druid and Trino share: `maxConnections` treats `0` and absence as one fact. For the count beside it
+  the encoding is now this provider's alone - SQL Server, Oracle, MongoDB and Cassandra omit
+  `activeConnections` when nothing was read, and moving this one is
+  [BACKLOG D46](../BACKLOG.md). The cluster counts open HTTP connections per node in its stats API, which is not one of
   this seam's five calls, and the shard and node counts that *are* here would be a different number
   wearing this field's name.
 - **`uptime` is `"N/A"`.** No call in this seam carries one; a `"0s"` would claim the cluster booted
@@ -862,7 +869,7 @@ The honest empties, each with its reason:
 **A closed index reads as zero in `getTableStats()` and is omitted in the schema tree.**
 `TableStats.rowCount` and the size fields are *required* numbers with no way to say "unknown", while
 `TableSchema.rowCount` and `size` are optional, so the tree is the surface that keeps the distinction
-([index.ts:310-316](../../src/lib/db/providers/sql/search/index.ts)).
+(the comment over `toTableStats()` in [`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
 
 **Document counts exceed what a `SELECT` returns when a mapping has `nested` fields**, and this was
 measured here: `probe_shapes` reports **2** documents in `_cat/indices` while `SELECT COUNT(*)` answers
@@ -876,7 +883,7 @@ different question than the panel asks.
 
 `_cluster/stats` is heavier and more privileged than `_cluster/health`, so a cluster that answers
 health and refuses stats is an ordinary configuration. `storeSizeBytes()`
-([http-transport.ts:973](../../src/lib/db/providers/sql/search/http-transport.ts)) therefore catches
+([`http-transport.ts`](../../src/lib/db/providers/sql/search/http-transport.ts)) therefore catches
 its own failure and returns `null` — the seam's "unknown" — because losing the health status over a
 missing byte count would blank a panel that already had the important number. Its null then propagates
 honestly: `getOverview()` shows `"N/A"` for the size, and `getStorageStats()` returns **no row at all**
@@ -907,7 +914,7 @@ altogether:
   cluster keeps working ([§3.8](#38-the-deadline-is-the-clients-and-only-the-clients)), and the task
   API that could really cancel a search is not part of this seam.
 
-`runMaintenance(type)` ([index.ts:931](../../src/lib/db/providers/sql/search/index.ts)) exists because
+`runMaintenance(type)` ([`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)) exists because
 the `DatabaseProvider` interface obliges every provider to implement it, and **not** because a request
 reaches it: `/api/db/maintenance` checks `supportsMaintenance` and answers 400 first. So the message
 below is what a *programmatic* caller of `@libredb/studio` sees:

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -188,9 +188,9 @@ Oracle monitoring reads `V$` dynamic-performance views, which require privileges
 may lack. Every monitoring sub-query is wrapped in its own try/catch and degrades rather than failing
 the whole call — so the dashboard still renders for a low-privilege user, just with gaps. The default
 it degrades to is `N/A` or `[]` where the shape has a place to say "not measured", and — in the
-health reading, where a number would otherwise be invented — **nothing at all**:
-`getHealth().activeConnections` is omitted rather than reported as `0`
-([§7.2](#72-when-the-connection-count-is-not-measurable)).
+health and overview readings, where a number would otherwise be invented — **nothing at all**:
+`getHealth().activeConnections` and `getOverview().activeConnections` are both omitted rather than
+reported as `0` ([§7.2](#72-when-the-connection-count-is-not-measurable)).
 
 ---
 
@@ -759,7 +759,7 @@ sub-query is independently privilege-guarded ([§3.6](#36-privilege-resilient-mo
 | Method | Primary source | Notes / degradation |
 |--------|----------------|---------------------|
 | `getHealth()` | `V$SESSION`, `USER_SEGMENTS`, `V$SYSSTAT`, `V$SQL` | each block guarded → absent/`N/A`/`[]` if no privilege; `activeConnections` is **omitted**, never `0` ([§7.2](#72-when-the-connection-count-is-not-measurable)); `cacheHitRatio` is `N/A`, never `0%` ([§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)) |
-| `getOverview()` | `V$VERSION`, `V$INSTANCE`, `V$SESSION`, `V$PARAMETER`, `USER_SEGMENTS`, `USER_TABLES`/`USER_INDEXES` | each guarded |
+| `getOverview()` | `V$VERSION`, `V$INSTANCE`, `V$SESSION`, `V$PARAMETER`, `USER_SEGMENTS`, `USER_TABLES`/`USER_INDEXES` | each guarded; `activeConnections` is **omitted**, never `0` ([§7.2](#72-when-the-connection-count-is-not-measurable)), while `maxConnections` stays `0` because `0` there means "no limit published" |
 | `getPerformanceMetrics()` | `V$SYSSTAT` | **only** `cacheHitRatio`, and it is **omitted** when `V$SYSSTAT` cannot be read (no QPS/deadlocks/buffer-pool) — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable) |
 | `getSlowQueries()` | `V$SQL` (top-N by `ELAPSED_TIME`) | `sharedBlksHit`=`BUFFER_GETS`, `sharedBlksRead`=`DISK_READS`; `[]` on failure |
 | `getActiveSessions()` | `V$SESSION` ⋈ `V$SQL` | `pid` = `"SID,SERIAL#"`; wait class/event; `[]` on failure |
@@ -802,26 +802,60 @@ them.
 
 ### 7.2 When the connection count is not measurable
 
-The health connection count is `SELECT COUNT(*) FROM V$SESSION WHERE STATUS = 'ACTIVE'`, so it needs
-the same `V_$` grant everything else here does. The refusal measured 2026-08-23 on Oracle AI Database
-26ai Free, against a user granted only `CREATE SESSION`, was on the cache-ratio view
-([§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)) - `V_$SESSION` answers in the same shape:
+**Two methods read a connection count, and both can be refused:**
+
+| Method | Statement | Field |
+|--------|-----------|-------|
+| `getHealth()` | `SELECT COUNT(*) FROM V$SESSION WHERE STATUS = 'ACTIVE'` | `HealthInfo.activeConnections` |
+| `getOverview()` | `SELECT COUNT(*) FROM V$SESSION WHERE TYPE = 'USER'` | `DatabaseOverview.activeConnections` |
+
+Both need the same `V_$` grant everything else here does, and lacking it is the ORDINARY case rather
+than an exotic one. Oracle's own
+[*Database Reference*](https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/about-dynamic-performance-views.html)
+is explicit: "After installation, only user
+`SYS` or anyone with `SYSDBA` privilege has access to the dynamic performance tables"; the views
+themselves carry the `V_$` prefix and what an application queries is the `V$` public synonym over
+them, until a DBA grants a wider set of users access. A plain schema user therefore reads nothing
+from `V$SESSION` at all. The refusal measured 2026-08-23 on Oracle AI Database 26ai Free, against a
+user granted only `CREATE SESSION`, was on the cache-ratio view
+([§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)) - `V_$SESSION` answers in the same shape,
+naming the underlying view rather than the synonym:
 
 ```
 ORA-00942: table or view "SYS"."V_$SYSSTAT" does not exist
 ```
 
-`HealthInfo.activeConnections` is **optional** for this case, so the refused count is **omitted** from
-`getHealth()` - the key is absent from the object and from the `POST /api/db/health` body, and the
-admin fleet-health row drops its `N conn` figure rather than printing `0 conn`
-([`src/components/admin/tabs/OverviewTab.tsx`](../../src/components/admin/tabs/OverviewTab.tsx)).
-It used to be initialised to `0` and the guard left that `0` standing, which mattered most to the
-agent: its curated `health` reading forwards this figure to the model, so `ORA-00942` arrived as a
-*measured* "no active sessions" about an instance Oracle had said nothing about.
+`activeConnections` is **optional on both shapes** for this case, so a refused count is **omitted**
+rather than reported:
 
-An instance that really has no ACTIVE session measures `0`, and that `0` is a reading: it is kept and
+- From `getHealth()` the key is absent from the object and from the `POST /api/db/health` body, and
+  the admin fleet-health row drops its `N conn` figure rather than printing `0 conn`
+  ([`src/components/admin/tabs/OverviewTab.tsx`](../../src/components/admin/tabs/OverviewTab.tsx)).
+- From `getOverview()` the key is absent from the monitoring payload, and the Overview tab's
+  Connections card draws **`N/A` / "not published"** instead of the figure `0`; the connections trend
+  chart drops that sample rather than plotting it at zero
+  ([`src/components/monitoring/tabs/OverviewTab.tsx`](../../src/components/monitoring/tabs/OverviewTab.tsx)).
+  The card's threshold rating is **not** among the things this changes: the `V$PARAMETER` ceiling is
+  read inside the same `try` as the count, so a refusal leaves `maxConnections` at its `0`
+  initialiser too, `connectionPercent` is `null` on both the old and the new path, and the rating is
+  taken from `connectionPercent ?? 0` either way - the same score and the same card border. The drawn
+  figure and the dropped trend sample are the whole of it.
+
+Both used to be initialised to `0` with the guard leaving that `0` standing, so `ORA-00942` arrived
+as a *measured* "no active sessions" about an instance Oracle had said nothing about. For the health
+figure that reached the model: the agent's curated `health` reading forwards this field
+(`src/lib/agent/tools.ts`), so the fabrication was a claim about a server it could not measure. The
+agent does not read `getOverview()`; that count's readers are the monitoring card and its trend
+chart (the threshold rating reads it too, to the same result either way, as above).
+
+An instance that really has no such session measures `0`, and that `0` is a reading: it is kept and
 reported as `0`. The absence is spelled `measuredNumber(...)` plus a conditional spread, never
 `|| undefined`.
+
+`maxConnections` is deliberately **not** optional alongside it. It is a published ceiling
+(`V$PARAMETER` `sessions`), and there `0` MEANS "no limit published" - the same fact as absence - so
+a refused `V$PARAMETER` leaves `0` and the card says "no limit published". The count is read first in
+that shared block precisely so a refused ceiling cannot carry a measured count away with it.
 
 ---
 
@@ -1121,7 +1155,7 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
 - **Row counts (`NUM_ROWS`) are optimizer estimates** populated by `DBMS_STATS`; they can be stale
   or `NULL` until stats are gathered.
 - **Monitoring depends on `V$` privileges.** A low-privilege app user silently gets `N/A`/`[]` for the
-  views it can't read, and no `activeConnections` at all in the health reading
+  views it can't read, and no `activeConnections` at all in either the health or the overview reading
   ([§7.2](#72-when-the-connection-count-is-not-measurable)). `getPerformanceMetrics()` reports only the cache-hit ratio (no QPS,
   deadlocks, or buffer-pool usage), and **omits even that** when `V$SYSSTAT` is unreadable rather
   than substituting a figure — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable).

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -150,8 +150,9 @@ RedisProvider (redis.ts)
 
 `RedisProvider` extends `BaseDatabaseProvider` directly (unlike the SQL providers, which extend an
 intermediate `SQLBaseProvider`). It overrides every abstract method plus the three metadata hooks
-(`getCapabilities`, `getLabels`, `prepareQuery`). It inherits `getMonitoringData()`, which fans the
-individual monitoring methods out in parallel — see [`base-provider.ts:99`](../../src/lib/db/base-provider.ts).
+(`getCapabilities`, `getLabels`, `prepareQuery`). It inherits `getMonitoringData()` from
+[`base-provider.ts`](../../src/lib/db/base-provider.ts), which fans the individual monitoring methods
+out in parallel.
 
 ### 2.3 What the base class gives you for free
 

--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -593,7 +593,7 @@ Everything comes from `system.runtime`, `system.metadata` and — for the two re
 | `getPerformanceMetrics()` | `jmx.current."trino.execution:name=querymanager"` | `queriesPerSecond` only ([§3.10](#310-absent-never-zeroed)) |
 | `getActiveSessions()` | `system.runtime.queries`, non-terminal states | The statements in flight |
 | `getSlowQueries()` | `system.runtime.queries`, `FINISHED` rows by elapsed time | The coordinator's recent history |
-| `getTableStats()` | `SHOW STATS FOR <table>`, one per table, capped at 25 | Real row counts and logical sizes |
+| `getTableStats()` | `SHOW STATS FOR <table>`, one per table, for a scope of at most 25 tables | Real row counts and logical sizes, or a refusal — never a sample |
 | `getStorageStats()` | `system.metadata.catalogs` | One row per catalog, `location` = the connector |
 | `getIndexStats()` | — | `[]`, no statement sent — a MEASUREMENT, not a refusal: no index object exists in any Trino catalog, so zero is the true count |
 | `getHealth()` | The three above | — |
@@ -620,22 +620,25 @@ Five honest blanks, each with its reason:
 - **`getTableStats()` omits a table whose connector published no row count.** Measured,
   `SHOW STATS FOR system.runtime.nodes` returns the six columns with every value null, summary row
   included. `TableStats.rowCount` cannot say "unknown", and "0 rows" is a claim nobody made.
-- **An empty table panel has three causes, and only one of them is an empty panel.** Since
-  **2026-08-25** the two that are refusals leave the panel ABSENT with a sentence under
+- **An empty table panel has four causes, and only one of them is an empty panel.** Since
+  **2026-08-25** the ones that are refusals leave the panel ABSENT with a sentence under
   `MonitoringData.errors`, which is what `PanelUnavailable` renders, instead of an empty table that
   claims the engine answered "no tables":
   - the catalog's table list was **refused** (`unknown-object` or `auth`) — the panel carries the
     server's own wording;
-  - tables were examined and **none** published a row count — the panel names how many were asked.
-    Measured 2026-08-25 against Trino 476: the `jmx` catalog holds **379** tables in schema `current`
-    and a 20-table random sample of them answered `SHOW STATS` with an empty `row_count`, 0 of 20
-    non-null — the jmx connector supplies no statistics at all — so `getTableStats()` refuses the panel there (`None of the 25 tables
-    examined in catalog "jmx" published a row count …`, 25 being the per-pass cap below) while `tpch`
-    (8 rows, `sf1.lineitem` 6,001,215) and `memory` (3 rows) answer unchanged;
+  - the scope holds **more tables than one pass describes** — the panel names how many it holds and
+    what, if anything, is narrow enough to ask for instead
+    ([§7.1](#71-a-scope-too-large-for-one-pass-is-refused-not-sampled));
+  - tables were examined and **none** published a row count — the panel names how many were asked,
+    and that number is now a count rather than a bound, because an oversized scope is refused before
+    any `SHOW STATS` is sent. Measured 2026-08-25 against Trino 476, the `jmx` catalog holds **379**
+    tables in schema `current` and a 20-table random sample of them answered `SHOW STATS` with an
+    empty `row_count`, 0 of 20 non-null — the jmx connector supplies no statistics at all. Since
+    2026-08-27 that catalog is refused on **size** first, one cause earlier; the *"none published"*
+    sentence is what a scope of 25 tables or fewer gets, as `tpch.sf10000` does;
   - the catalog genuinely holds **no table** — `[]`, which is a real measurement and keeps rendering
-    as an empty panel.
-- **`getTableStats()` is capped at 25 tables per pass.** `SHOW STATS` is one statement per table;
-  there is no catalog of sizes to aggregate, so N tables cost N statements.
+    as an empty panel. Live-verified 2026-08-27: the `memory` catalog of a fresh cluster holds 0 user
+    tables and answers `[]` with no refusal.
 - **`StorageStats.size` is `"N/A"` with `sizeBytes: 0`, and `usagePercent` is absent**
   ([§3.9](#39-the-bytes-are-somewhere-else-so-the-size-panels-say-so)). The rows are the catalogs,
   which is where the data really is; there is no capacity for a percentage to be a fraction of.
@@ -643,6 +646,71 @@ Five honest blanks, each with its reason:
 The active-query read **sees itself**, as a `RUNNING` row. That is not a defect to filter: the
 coordinator really is running it, and the only id that could exclude it is one the statement does not
 know while it is being planned.
+
+### 7.1 A scope too large for one pass is refused, not sampled
+
+`SHOW STATS` is **one statement per table** — the reference gives exactly two forms,
+`SHOW STATS FOR <table>` and `SHOW STATS FOR ( <query> )`, with no batch form and no catalog of sizes
+to aggregate — so N tables cost N statements and the pass is bounded at **25**.
+
+Until **2026-08-27** that bound *truncated*: the pass described the first 25 tables of the scope and
+returned those rows as the reading. No consumer could see it. `getTableStats()` answers
+`TableStats[]`, `MonitoringData.tables` is that same array, and the agent's curated reading publishes
+its length as `rowCount` — none of the three has a field a *"there were more"* marker could travel in,
+so 25 rows out of 500 were indistinguishable from a catalog holding exactly 25. **A cap read as a
+count is the absence lie one size up**, so the reading now **refuses** the oversized scope, which is
+the answer the agent's own row bound already gives (`READING_OVER_BUDGET`) and for the same reason.
+
+Live-verified **2026-08-27** against Trino 476 through this provider's own transport — and this is
+the ordinary case, not the exotic one:
+
+| Scope | User tables | Before | Now |
+|---|---|---|---|
+| `tpch` | 72 | 8 rows, presented as the catalog | refused, naming 72 |
+| `tpch.tiny` | 8 | 8 rows when named, but **never reached by the catalog-wide pass** — `tiny` sorts last, behind 64 tables the 25 statements never got to | **8 rows** (`lineitem` 60,175, `nation` 25) |
+| `tpch.sf1` | 8 | 8 rows | 8 rows (`lineitem` 6,001,215) |
+| `system` | 26 | 25 examined | refused, naming 26 |
+| `tpcds` | 250 | 25 examined | refused, naming 250 |
+| `jmx.current` | 379 | 25 examined | refused, naming 379 |
+| `memory` | 0 | `[]` | `[]` — a measurement, not a refusal |
+
+The refusal is also **cheaper** than the cut it replaces: the table list has already answered the
+whole question, so no `SHOW STATS` is sent at all. The bound applies to what was **asked for** and not
+to what the catalog holds, so a schema *inside* the bound is describable in a catalog of any size —
+which is how `tpch.tiny` became readable at all.
+
+Its advice differs by scope, because advice a caller cannot act on is worse than none — and a schema
+is refused by the same bound that refuses a catalog, which the table above measures: `jmx.current`
+holds **379** tables, so "ask for a single schema" would have been a remedy that fails. The sentence
+is therefore **conditional on a figure the reading already has**. The table list is one uncapped read
+that has already answered for the whole catalog, so the per-schema counts are known before any
+`SHOW STATS` is sent, and the refusal says how many schemas a narrowed pass really would describe:
+
+- **Unnarrowed, with schemas inside the bound** — how many there are, and that a larger one is
+  refused the same way. Narrowing is `MonitoringOptions.schemaFilter`, which `POST /api/db/monitoring`
+  accepts, and the agent's curated reading takes a `schema` of its own. On the real `tpch` this reads
+  *"9 of the schemas this catalog's tables are in"*: the connector publishes nine schemas — `tiny`,
+  `sf1`, `sf100`, `sf300`, `sf1000`, `sf3000`, `sf10000`, `sf30000`, `sf100000` — of the same eight
+  tables, which is where the 72 comes from and why every one of them is describable alone.
+- **Unnarrowed, with none inside it** — that narrowing does not help here, plainly, with no scope
+  offered that would be refused too. `jmx` is the shape that reaches this arm: its 379 tables are in
+  `current`, and the `history` schema the connector also publishes carries a table only for an MBean
+  named in `jmx.dump-tables`, so on a cluster that names none there is nothing narrower to send
+  anyone to.
+- **Already narrowed to a schema** — there is no narrower selection to offer, so the sentence gives
+  the statement that answers for a single table: `SHOW STATS FOR "<catalog>"."<schema>"."<table>"`.
+
+A schema holding **no** table is not counted among the describable ones — it is not in the table list
+at all — which is why the sentence says "the schemas this catalog's tables are in" rather than
+counting the catalog's schemas: an empty schema is not somewhere the advice could send anyone. Every
+one of the three sentences ends in the per-table statement, because that is the one route no bound
+applies to.
+
+The monitoring dashboard sets no `schemaFilter` today, so on a catalog over the bound its Tables
+panel is absent with this sentence. That is the intended trade: what it showed before was 8 rows for
+a 72-table catalog, none of them the tables the fixtures use. The true table count is still on the
+Overview panel, which reads it with `count(*)` in one statement, and the tables themselves are still
+in the schema tree.
 
 ---
 
@@ -701,7 +769,7 @@ are undeclared.
 
 ## 9. Capabilities & labels
 
-### `getCapabilities()` ([index.ts:243](../../src/lib/db/providers/sql/trino/index.ts))
+### `getCapabilities()` ([`trino/index.ts`](../../src/lib/db/providers/sql/trino/index.ts))
 
 | Flag | Value | Why |
 |---|---|---|
@@ -720,7 +788,7 @@ are undeclared.
 | `identifierQuoting` | `"double"` | Declared, not derived from a generic port ([§3.13](#313-a-trailing-semicolon-is-a-syntax-error)) |
 | `statementTerminator` | `"none"` | `SELECT 1;` is a syntax error ([§3.13](#313-a-trailing-semicolon-is-a-syntax-error)) |
 
-### `getLabels()` ([index.ts:308](../../src/lib/db/providers/sql/trino/index.ts))
+### `getLabels()` ([`trino/index.ts`](../../src/lib/db/providers/sql/trino/index.ts))
 
 Table and row are already Trino's own words, so the provider spreads `...super.getLabels()` and
 rewrites only the two maintenance blurbs. They must still be strings even though neither operation is
@@ -910,7 +978,10 @@ See [`docs/API_DOCS.md`](../API_DOCS.md) for the full request/response contract.
   `0` beside `size: "N/A"`; if a panel ever renders that as "0 B", the alternative is returning no
   rows at all, which would hide the catalog list too.
 - **No uptime without the `jmx` catalog** ([§7](#7-monitoring--health)).
-- **`getTableStats()` describes at most 25 tables per pass** ([§7](#7-monitoring--health)).
+- **`getTableStats()` describes a scope of at most 25 tables**, and refuses a larger one rather than
+  sampling it ([§7.1](#71-a-scope-too-large-for-one-pass-is-refused-not-sampled)). Ask for one schema
+  that is itself inside the bound — a larger schema is refused too, and the refusal says how many of
+  the catalog's schemas qualify. `SHOW STATS FOR <table>` in the editor answers for any scope.
 - **Agent auto/operate mode is out of scope.** `queryReadOnly()` is not implemented, so
   `acquireExecutionProfileProvider` fails closed for this type-id — explicitly deferred by #424.
 - **The spooled result protocol is refused, not read.** This client never advertises an encoding, and

--- a/src/components/monitoring/tabs/OverviewTab.tsx
+++ b/src/components/monitoring/tabs/OverviewTab.tsx
@@ -319,7 +319,7 @@ function PerformanceSummaryCard({
  * count lost, in a second place.
  *
  * The ceiling on a list that DID answer is the other half of the same rule, and the
- * paragraph above never covered it - the shape D41 names in QueriesTab.tsx survived here
+ * paragraph above never covered it - the shape #515 removed from QueriesTab.tsx survived here
  * three more times. Both lists this card reads are capped in
  * src/lib/db/base-provider.ts: `slowQueryLimit = 10` and `sessionLimit = 50`, passed into
  * `getSlowQueries` and `getActiveSessions`, and MonitoringDashboard overrides neither (it

--- a/src/components/monitoring/tabs/OverviewTab.tsx
+++ b/src/components/monitoring/tabs/OverviewTab.tsx
@@ -309,14 +309,37 @@ function PerformanceSummaryCard({
 }
 
 /**
- * Slow-query and session counts, read straight off the payload.
+ * Slow-query and session figures, read straight off the payload.
  *
- * A count is rendered only when the panel it counts actually answered. `?? 0` used to
+ * A figure is rendered only when the panel it comes from actually answered. `?? 0` used to
  * stand in for both an empty list and a REFUSED read, which are opposite facts: measured
  * in the browser on 2026-08-24 against StarRocks 3.3, whose `getActiveSessions` is
  * "Unknown table 'information_schema.PROCESSLIST'", this card claimed "Active 0 / Idle 0"
  * for a question the engine had declined to answer. Same fabricated zero the connection
  * count lost, in a second place.
+ *
+ * The ceiling on a list that DID answer is the other half of the same rule, and the
+ * paragraph above never covered it - the shape D41 names in QueriesTab.tsx survived here
+ * three more times. Both lists this card reads are capped in
+ * src/lib/db/base-provider.ts: `slowQueryLimit = 10` and `sessionLimit = 50`, passed into
+ * `getSlowQueries` and `getActiveSessions`, and MonitoringDashboard overrides neither (it
+ * sets only the three `include*` flags). The providers that fill the session list apply the
+ * ceiling in SQL or in memory - `$2` in postgres.ts, `LIMIT` in mysql.ts, `SELECT TOP` in
+ * mssql.ts, `ROWNUM <=` in oracle.ts, `.slice(0, limit)` over `currentOp` in mongodb.ts -
+ * so a server past either ceiling hands this card a truncated list and nothing in the
+ * payload says how much was cut.
+ *
+ * This helper cannot fix that: it is handed rows and a counting function, and the length of
+ * a saturated list is the cap whatever it is divided by. What the figures needed was labels
+ * that claim only the rows the dashboard holds, which is what QuickStatsCard now writes, in
+ * the vocabulary QueriesTab.tsx settled on: every figure here is a property of the listed
+ * rows - the same rows the Queries and Sessions tabs put on screen, where a reader can
+ * recount them. So "Slow Queries 10" no longer reads as 10 slow statements on a server with
+ * 59 recorded digests, and the two badges that split one bounded list of sessions no longer
+ * read as the server's active and idle totals. All three still render, and their figures are
+ * unchanged - only the labels are, because the numbers were never the wrong part. A count
+ * below the ceiling is still exactly a count, and reads the same; the
+ * label no longer promises which case it is looking at, because the payload does not say.
  */
 function quickStat(rows: readonly unknown[] | undefined, count: () => number): string {
   return rows === undefined ? "N/A" : String(count());
@@ -335,7 +358,7 @@ function QuickStatsCard({ data }: Readonly<{ data: MonitoringData | null }>) {
       </CardHeader>
       <CardContent className="p-3 sm:p-4 pt-0 space-y-2 sm:space-y-3">
         <div className="flex justify-between items-center">
-          <span className="text-xs sm:text-xs text-muted-foreground">Slow Queries</span>
+          <span className="text-xs sm:text-xs text-muted-foreground">Listed slow queries</span>
           <Badge
             variant={data?.slowQueries?.length ? "outline" : "secondary"}
             className="text-xs"
@@ -345,13 +368,13 @@ function QuickStatsCard({ data }: Readonly<{ data: MonitoringData | null }>) {
           </Badge>
         </div>
         <div className="flex justify-between items-center">
-          <span className="text-xs sm:text-xs text-muted-foreground">Active</span>
+          <span className="text-xs sm:text-xs text-muted-foreground">Active of listed sessions</span>
           <Badge variant="secondary" className="text-xs" data-testid="quick-stat-active">
             {quickStat(sessions, () => (sessions ?? []).filter((s) => s.state === "active").length)}
           </Badge>
         </div>
         <div className="flex justify-between items-center">
-          <span className="text-xs sm:text-xs text-muted-foreground">Idle</span>
+          <span className="text-xs sm:text-xs text-muted-foreground">Idle of listed sessions</span>
           <Badge variant="secondary" className="text-xs" data-testid="quick-stat-idle">
             {quickStat(sessions, () => (sessions ?? []).filter((s) => s.state === "idle").length)}
           </Badge>

--- a/src/components/monitoring/tabs/QueriesTab.tsx
+++ b/src/components/monitoring/tabs/QueriesTab.tsx
@@ -24,6 +24,55 @@ interface QueriesTabProps {
 type SortField = "totalTime" | "avgTime" | "calls" | "rows";
 type SortDir = "asc" | "desc";
 
+const formatTime = (ms: number) => {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(2)}s`;
+  }
+  return `${ms.toFixed(2)}ms`;
+};
+
+/** The figures the stat cards print, as the loaded view computes them below. */
+interface QueryStats {
+  /** False when the list is empty: nothing was measured, so no card may print a number. */
+  statsKnown: boolean;
+  avgTime: number;
+  overOneSecond: number;
+}
+
+interface StatCard {
+  title: string;
+  icon: (stats: QueryStats) => React.ReactNode;
+  value: (stats: QueryStats) => string;
+}
+
+/**
+ * The stat cards, in order, and the only place their number is written down: the loaded
+ * view and QueriesSkeleton both map over this list, so a card added or removed here moves
+ * both grids at once. Two hand-written counts do not stay in step - when this panel dropped
+ * its third card (D41) the skeleton kept `[...Array(3)]` and every gate stayed green, because
+ * `Array(2)` and `Array(3)` are the same executable line to the coverage gate and the only
+ * loading test asserted the absence of a string the skeleton never rendered in either shape.
+ */
+const STAT_CARDS: readonly StatCard[] = [
+  {
+    title: "Avg of listed queries",
+    icon: () => <Clock strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />,
+    value: ({ statsKnown, avgTime }) => (statsKnown ? formatTime(avgTime) : "N/A"),
+  },
+  {
+    title: "Listed queries over 1s",
+    icon: ({ overOneSecond }) => (
+      <TriangleAlert
+        className={`h-3 w-3 sm:h-4 sm:w-4 ${overOneSecond > 0 ? "text-yellow-500" : "text-muted-foreground"}`}
+      />
+    ),
+    value: ({ statsKnown, overOneSecond }) => (statsKnown ? String(overOneSecond) : "N/A"),
+  },
+];
+
+/** Read by both grids, so the loaded cards and their placeholders lay out identically. */
+const STAT_GRID_CLASS = "grid grid-cols-2 gap-2 sm:gap-4";
+
 export function QueriesTab({ data, loading, labels }: QueriesTabProps) {
   const [sortField, setSortField] = useState<SortField>("totalTime");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -58,13 +107,6 @@ export function QueriesTab({ data, loading, labels }: QueriesTabProps) {
     }
   };
 
-  const formatTime = (ms: number) => {
-    if (ms >= 1000) {
-      return `${(ms / 1000).toFixed(2)}s`;
-    }
-    return `${ms.toFixed(2)}ms`;
-  };
-
   const formatNumber = (n: number) => {
     if (n >= 1000000) {
       return `${(n / 1000000).toFixed(1)}M`;
@@ -76,53 +118,57 @@ export function QueriesTab({ data, loading, labels }: QueriesTabProps) {
   };
 
   // Calculate stats. Absence and zero are different inputs: `MonitoringData.slowQueries`
-  // is required, so a provider that keeps no query log at all - Cassandra
-  // (cassandra/index.ts:573-575), Druid (index.ts:486-488), SQLite (sqlite.ts:734-737) -
-  // can only answer `[]`, and reducing that yielded "Queries 0 / Avg Time 0.00ms /
-  // Slow 0", measured 2026-08-21 in Chrome against Apache Cassandra 5.0.9. An average
-  // over an empty set is not 0.00ms and a call total of 0 is a claim about the database,
-  // so with no statistics the three cards read N/A and the sentence below them says why.
-  // Any non-empty list has been measured, zeros included, and keeps today's arithmetic.
+  // is required, so a provider that keeps no query log at all - the `getSlowQueries()` of
+  // Cassandra (cassandra/index.ts), Druid (druid/index.ts) and SQLite (sqlite.ts), named
+  // rather than pinned by line because all three coordinates this comment used to carry
+  // had drifted - can only answer `[]`, and reducing that yielded "Queries 0 / Avg Time
+  // 0.00ms / Slow 0" (the card wording of the day), measured 2026-08-21 in Chrome against
+  // Apache Cassandra 5.0.9. An average over an empty set is not 0.00ms and a call total of
+  // 0 is a claim about the database, so with no statistics the cards read N/A and the
+  // sentence below them says why. Any non-empty list has been measured, zeros included,
+  // and keeps today's arithmetic.
+  //
+  // The same list is also a CAP, which is the other way a figure here can promise more
+  // than it measured, and the paragraph above did not cover it (D41): `slowQueryLimit`
+  // defaults to 10 in src/lib/db/base-provider.ts, MonitoringDashboard overrides nothing,
+  // and every provider that fills the list applies that ceiling - `LIMIT` in postgres.ts
+  // and mysql.ts, `SELECT TOP` in mssql.ts, `ROWNUM <=` in oracle.ts, `.limit()` in
+  // mongodb.ts, and redis.ts asks `SLOWLOG GET 10` outright. So the length of a populated
+  // list is the ceiling, not a count: measured 2026-08-27 on MySQL 26.7.0, the same server
+  // as HEALTH_SLOW_QUERY_LIMIT in providers/sql/mysql.ts, the digest table held 59 rows
+  // for one connected schema and the panel was handed ten of them.
+  //
+  // A card labelled "Queries" therefore used to publish `sum(calls)` over ten digests as
+  // the database's query count, and on MongoDB and Redis - both of which project
+  // `calls: 1` per row - that sum WAS the list length. No label rescues a total the data
+  // cannot supply, so the card is gone rather than renamed; the total belongs to whatever
+  // read can count the whole log, which this one cannot.
+  //
+  // The two figures left are properties of the rows on screen, and their labels say so, so
+  // a reader can recompute both by looking at the table below. Neither survives an
+  // unscoped label: the list is ordered by total time descending and then truncated, so
+  // the mean of the ten heaviest averages is not the server's average query time, and the
+  // over-a-second count is bounded by ten however many slow statements the server holds.
   const statsKnown = slowQueries.length > 0;
-  const totalQueries = slowQueries.reduce((sum, q) => sum + q.calls, 0);
   const avgTime = statsKnown ? slowQueries.reduce((sum, q) => sum + q.avgTime, 0) / slowQueries.length : 0;
-  const slowCount = slowQueries.filter((q) => q.avgTime > 1000).length;
+  const overOneSecond = slowQueries.filter((q) => q.avgTime > 1000).length;
+  const stats: QueryStats = { statsKnown, avgTime, overOneSecond };
 
   return (
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">
       {/* Stats Cards */}
-      <div className="grid grid-cols-3 gap-2 sm:gap-4">
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Queries</CardTitle>
-            <Search strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{statsKnown ? formatNumber(totalQueries) : "N/A"}</div>
-          </CardContent>
-        </Card>
-
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Avg Time</CardTitle>
-            <Clock strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{statsKnown ? formatTime(avgTime) : "N/A"}</div>
-          </CardContent>
-        </Card>
-
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
-            <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Slow</CardTitle>
-            <TriangleAlert
-              className={`h-3 w-3 sm:h-4 sm:w-4 ${slowCount > 0 ? "text-yellow-500" : "text-muted-foreground"}`}
-            />
-          </CardHeader>
-          <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium">{statsKnown ? slowCount : "N/A"}</div>
-          </CardContent>
-        </Card>
+      <div className={STAT_GRID_CLASS}>
+        {STAT_CARDS.map((card) => (
+          <Card key={card.title} className="p-0">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
+              <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">{card.title}</CardTitle>
+              {card.icon(stats)}
+            </CardHeader>
+            <CardContent className="p-2 sm:p-4 pt-0">
+              <div className="text-lg sm:text-2xl font-medium">{card.value(stats)}</div>
+            </CardContent>
+          </Card>
+        ))}
       </div>
 
       {/* Queries Table */}
@@ -260,11 +306,11 @@ export function QueriesTab({ data, loading, labels }: QueriesTabProps) {
 function QueriesSkeleton() {
   return (
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">
-      <div className="grid grid-cols-3 gap-2 sm:gap-4">
-        {[...Array(3)].map((_, i) => (
-          <Card key={i} className="p-0">
+      <div className={STAT_GRID_CLASS}>
+        {STAT_CARDS.map((card) => (
+          <Card key={card.title} className="p-0">
             <CardHeader className="p-2 sm:p-4 pb-1 sm:pb-2">
-              <Skeleton className="h-3 sm:h-4 w-12 sm:w-24" />
+              <Skeleton className="h-3 sm:h-4 w-16 sm:w-32" />
             </CardHeader>
             <CardContent className="p-2 sm:p-4 pt-0">
               <Skeleton className="h-5 sm:h-8 w-10 sm:w-16" />

--- a/src/components/monitoring/tabs/QueriesTab.tsx
+++ b/src/components/monitoring/tabs/QueriesTab.tsx
@@ -49,7 +49,7 @@ interface StatCard {
  * The stat cards, in order, and the only place their number is written down: the loaded
  * view and QueriesSkeleton both map over this list, so a card added or removed here moves
  * both grids at once. Two hand-written counts do not stay in step - when this panel dropped
- * its third card (D41) the skeleton kept `[...Array(3)]` and every gate stayed green, because
+ * its third card (#515) the skeleton kept `[...Array(3)]` and every gate stayed green, because
  * `Array(2)` and `Array(3)` are the same executable line to the coverage gate and the only
  * loading test asserted the absence of a string the skeleton never rendered in either shape.
  */
@@ -129,7 +129,7 @@ export function QueriesTab({ data, loading, labels }: QueriesTabProps) {
   // and keeps today's arithmetic.
   //
   // The same list is also a CAP, which is the other way a figure here can promise more
-  // than it measured, and the paragraph above did not cover it (D41): `slowQueryLimit`
+  // than it measured, and the paragraph above did not cover it (#515): `slowQueryLimit`
   // defaults to 10 in src/lib/db/base-provider.ts, MonitoringDashboard overrides nothing,
   // and every provider that fills the list applies that ceiling - `LIMIT` in postgres.ts
   // and mysql.ts, `SELECT TOP` in mssql.ts, `ROWNUM <=` in oracle.ts, `.limit()` in

--- a/src/components/monitoring/tabs/StorageTab.tsx
+++ b/src/components/monitoring/tabs/StorageTab.tsx
@@ -30,6 +30,16 @@ export function StorageTab({ data, loading }: StorageTabProps) {
   // is not right either - the other panels answered - so this panel alone carries the
   // engine's own sentence. See MonitoringData in src/lib/db/types.ts.
   const storageUnavailable = data?.storage === undefined ? data?.errors?.storage : undefined;
+  const tablesUnavailable = data?.tables === undefined ? data?.errors?.tables : undefined;
+
+  // A refused table read costs more than the Largest Tables panel below, because five figures
+  // on this tab come off those rows. Read as `[]`, a refusal is indistinguishable from a database
+  // that holds no tables: `every()` is vacuously true, so both totals below published a
+  // measured "0 B" at "0.0%" and the remainder row took the whole database at 100%. Gating the
+  // two `known` flags on the refusal routes every one of those figures to the "N/A" this tab
+  // already draws for a byte figure it does not have, and leaves a genuine "no tables" answer
+  // at the 0 B it measured.
+  const statsRefused = tablesUnavailable !== undefined;
 
   // Calculate totals
   //
@@ -42,7 +52,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
   // total is shown only when every table carries a figure; `every()` keeps a genuine
   // "no tables" answer at 0 B.
   const totalTableSize = tables.reduce((sum, t) => sum + (t.tableSizeBytes ?? 0), 0);
-  const tableSizeKnown = tables.every((t) => t.tableSizeBytes !== undefined);
+  const tableSizeKnown = !statsRefused && tables.every((t) => t.tableSizeBytes !== undefined);
   // The index total comes from the per-TABLE figure, not from summing the per-index rows.
   // InnoDB has no separate primary-key index: the clustered index IS the table, so
   // `mysql.innodb_index_stats` reports the PRIMARY row's size as the row data, and summing every
@@ -56,7 +66,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
   // the total is shown only when every table carries a figure - `every()` also keeps a genuine
   // "no tables" answer at 0 B.
   const totalIndexSize = tables.reduce((sum, t) => sum + (t.indexSizeBytes ?? 0), 0);
-  const indexSizeKnown = tables.every((t) => t.indexSizeBytes !== undefined);
+  const indexSizeKnown = !statsRefused && tables.every((t) => t.indexSizeBytes !== undefined);
   const walStorage = storage.find((s) => s.name === "WAL");
 
   const formatBytes = (bytes: number) => {
@@ -176,8 +186,23 @@ export function StorageTab({ data, loading }: StorageTabProps) {
                 <div className="flex items-center justify-between text-xs sm:text-xs mb-1">
                   <span className="flex items-center gap-1 sm:gap-2">
                     <div className="w-2 h-2 sm:w-3 sm:h-3 rounded-sm bg-muted-foreground" />
-                    <span className="hidden sm:inline">Other (TOAST, FSM)</span>
-                    <span className="sm:hidden">Other</span>
+                    {/*
+                      Engine-neutral on purpose. This row is arithmetic - the database bytes the
+                      per-table data and index figures do not account for - and what fills it
+                      differs per engine: TOAST and the free space map on PostgreSQL, the schema,
+                      the freelist and page overhead on SQLite and libSQL, which have neither.
+                      Labelled "Other (TOAST, FSM)" it read "4.00 KB" of PostgreSQL structures
+                      against a real 64 KB libSQL database (U23) - the number was right and the
+                      words were another engine's. The label now names the arithmetic. Varying the
+                      wording per engine would have to come from `ProviderLabels`, the way the
+                      slow-query empty state does, and this tab is passed no labels.
+                    */}
+                    <span className="hidden sm:inline" data-testid="storage-breakdown-other-label">
+                      Other (unattributed)
+                    </span>
+                    <span className="sm:hidden" data-testid="storage-breakdown-other-label-compact">
+                      Other
+                    </span>
                   </span>
                   <span className="font-medium">
                     {breakdownKnown ? formatBytes(totalSize - totalTableSize - totalIndexSize) : "N/A"}
@@ -278,7 +303,9 @@ export function StorageTab({ data, loading }: StorageTabProps) {
           </CardTitle>
         </CardHeader>
         <CardContent className="p-0 sm:p-4 sm:pt-0">
-          {tables.length === 0 ? (
+          {tablesUnavailable ? (
+            <PanelUnavailable message={tablesUnavailable} />
+          ) : tables.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               <Database strokeWidth={1.5} className="h-8 w-8 mx-auto mb-2 opacity-50" />
               <p className="text-xs">No table information available.</p>

--- a/src/components/monitoring/tabs/StorageTab.tsx
+++ b/src/components/monitoring/tabs/StorageTab.tsx
@@ -192,7 +192,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
                       differs per engine: TOAST and the free space map on PostgreSQL, the schema,
                       the freelist and page overhead on SQLite and libSQL, which have neither.
                       Labelled "Other (TOAST, FSM)" it read "4.00 KB" of PostgreSQL structures
-                      against a real 64 KB libSQL database (U23) - the number was right and the
+                      against a real 64 KB libSQL database (#515) - the number was right and the
                       words were another engine's. The label now names the arithmetic. Varying the
                       wording per engine would have to come from `ProviderLabels`, the way the
                       slow-query empty state does, and this tab is passed no labels.

--- a/src/lib/db/base-provider.ts
+++ b/src/lib/db/base-provider.ts
@@ -34,6 +34,77 @@ import { DatabaseConfigError, mapDatabaseError } from "./errors";
 import { mergePoolConfig, formatDuration } from "./utils/pool-manager";
 
 // ============================================================================
+// Connection String Redaction
+// ============================================================================
+
+/**
+ * Substrings that mark a connection-string parameter as carrying a credential.
+ * They are matched case-insensitively anywhere inside the parameter NAME, so a
+ * driver-specific spelling is covered too: `password` also catches libpq's
+ * `sslpassword`, and `token` also catches `authToken` and `accessToken`. The mask
+ * deliberately errs towards hiding, because a non-secret hidden costs a reader one
+ * value while a secret missed costs a leak that looks redacted.
+ */
+const CREDENTIAL_PARAM_SUBSTRINGS = ["password", "token", "sslkey", "secret"];
+
+/**
+ * Redact the credentials a connection string carries, in the two places engines put them.
+ *
+ * PostgreSQL and MongoDB put the credential in the authority
+ * (`scheme://user:password@host`), while libSQL carries the whole token in the query
+ * string (`libsql://<db>-<org>.turso.io?authToken=<jwt>`) and libpq accepts `password`,
+ * `sslpassword` and `sslkey` as URI parameters as well. An ADO-style string
+ * (`Server=host;Database=db;Password=pw`) has neither a scheme nor a query string and
+ * puts its parameters in arbitrary order, so the first parameter is as likely to be the
+ * credential as the last.
+ *
+ * Nothing here parses the input as a URL: a connection string is not always a valid one,
+ * and a redaction that throws on the input it was handed is worse than none.
+ *
+ * What is NOT covered is an authority password containing a character RFC 3986 requires
+ * to be percent-encoded there, because each one collides with a shape that carries no
+ * secret and no regex separates them:
+ * - `@` (`scheme://user:p@ss@host`) leaves the tail after the first `@` visible, because
+ *   the authority's end cannot be located without it;
+ * - `/`, `?` or `#` (`scheme://user:p/w@host/db`) is not masked at all. `/` is the
+ *   instructive one: `scheme://host:5432/tenant@acme` has exactly the same shape, and
+ *   masking it would hide the port behind a `***` asserting a credential the string never
+ *   carried - a fabricated reading rather than a mask, which is the worse of the two. `?`
+ *   and `#` end the authority for the same reason and are excluded with it.
+ *
+ * A scheme-relative string (`//user:pass@host/db`) is not covered either, and no driver
+ * here accepts one.
+ */
+function redactConnectionString(connectionString: string): string {
+  // Anchoring the userinfo to `://` is what keeps this off a path: in
+  // `postgres://host/db:owner@example.com` the only `:`+text+`@` sits in the path, and a
+  // pattern that matched it would replace a path segment while hiding no secret. The
+  // password is bounded by '/' as well for the reason the docblock gives, and the userinfo
+  // before the ':' is bounded by it too, or the host would be swallowed.
+  const withAuthorityMasked = connectionString.replace(
+    /:\/\/([^:@/?#]*):([^@/?#]+)@/,
+    (_whole: string, userinfo: string) => `://${userinfo}:***@`,
+  );
+
+  // Replace the VALUE of a credential-shaped parameter and keep its name, so the reader
+  // can still see which knobs were set. Matching the name between a delimiter and '=' is
+  // what stops a credential word sitting in somebody else's value from triggering a
+  // replacement. ';' counts as a delimiter because ADO-style strings separate their
+  // parameters with it, and `^` counts as one because such a string may LEAD with its
+  // credential - `Password=pw;Server=host` is as valid as the reverse, and matching only
+  // after a delimiter returned the leading one verbatim.
+  return withAuthorityMasked.replace(
+    /(^|[?&#;])([^=&#;?]*)=([^&#;]*)/g,
+    (whole: string, delimiter: string, name: string, value: string) => {
+      const isCredential = CREDENTIAL_PARAM_SUBSTRINGS.some((word) => name.toLowerCase().includes(word));
+      // An empty value stays empty: '***' over a value the string never carried would
+      // assert a secret that is not there, which is a fabricated reading, not a mask.
+      return isCredential && value !== "" ? `${delimiter}${name}=***` : whole;
+    },
+  );
+}
+
+// ============================================================================
 // Base Provider Class
 // ============================================================================
 
@@ -328,11 +399,13 @@ export abstract class BaseDatabaseProvider implements DatabaseProvider {
 
   /**
    * Build connection info for health check
+   *
+   * A connection string is redacted in both of the places a credential can hide - the
+   * authority and the query string - see `redactConnectionString`.
    */
   protected getConnectionInfo(): string {
     if (this.config.connectionString) {
-      // Mask password in connection string
-      return this.config.connectionString.replace(/:([^:@]+)@/, ":***@");
+      return redactConnectionString(this.config.connectionString);
     }
     return `${this.config.host}:${this.config.port}/${this.config.database}`;
   }

--- a/src/lib/db/providers/document/mongodb.ts
+++ b/src/lib/db/providers/document/mongodb.ts
@@ -807,9 +807,20 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       // connected. A server that really has 0 open connections keeps the 0.
       const currentConnections = measuredNumber(serverStatus.connections?.current);
 
+      // The byte figure has the same two inputs, and this is the method whose reading
+      // reaches the model - the curated `health` projection sends `databaseSize` verbatim
+      // - so `dbStats.dataSize || 0` reported a `db.stats()` that answered without the
+      // field as a measured "0 B". `HealthInfo.databaseSize` is a required string, and
+      // "N/A" is the absence this method's own catch below already spells. MongoDB's
+      // dbStats reference documents `dataSize` unconditionally (only the three
+      // `freeStorage*` fields are gated, on the command's own `freeStorage: 1` option), so
+      // this arm is not a deployment measured here; a database that really holds 0 bytes
+      // still formats as "0 B".
+      const healthDataSize = measuredNumber(dbStats.dataSize);
+
       return {
         ...(currentConnections === undefined ? {} : { activeConnections: currentConnections }),
-        databaseSize: formatBytes(dbStats.dataSize || 0),
+        databaseSize: healthDataSize === undefined ? "N/A" : formatBytes(healthDataSize),
         cacheHitRatio:
           healthCacheHitRatio === undefined
             ? CACHE_HIT_RATIO_UNAVAILABLE
@@ -943,9 +954,26 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       // and substituted 100 - a limit no server stated, which the Overview card then
       // divided the live connection count by. 0 is how every provider in this repo
       // spells "no limit published", and the card renders it as exactly that.
+      //
+      // `current` is also the connection count itself, and it stays optional for the
+      // reason `getHealth()` above spells out: a deployment whose serverStatus answers
+      // without a `connections` section publishes no figure, and `?.current || 0`
+      // reported that as zero open connections - while destroying a genuinely idle
+      // server's real 0 into the same value. The Overview card prints the figure and
+      // its history plots one point per refresh, dropping absent samples and plotting
+      // present ones, so a fabricated 0 became a flat line nobody measured.
       const current = measuredNumber(serverStatus.connections?.current);
       const available = measuredNumber(serverStatus.connections?.available);
       const maxConnections = current === undefined || available === undefined ? undefined : current + available;
+
+      // `databaseSizeBytes` is optional and `|| 0` could not tell its two inputs apart:
+      // a database that measures 0 bytes and a `db.stats()` that answers without
+      // `dataSize` both arrived as a measured 0. MongoDB's dbStats reference documents
+      // `dataSize` unconditionally - only the three `freeStorage*` fields are gated, on
+      // the command's own `freeStorage: 1` option - so this arm is not a deployment
+      // measured here; it is the absence the optional field exists to carry, and the
+      // Storage tab keys its whole breakdown off the key being present.
+      const dataSizeBytes = measuredNumber(dbStats.dataSize);
 
       // Get index count
       let indexCount = 0;
@@ -962,23 +990,39 @@ export class MongoDBProvider extends BaseDatabaseProvider {
         version: `MongoDB ${serverInfo.version || "Unknown"}`,
         uptime,
         startTime: new Date(Date.now() - uptimeSeconds * 1000),
-        activeConnections: serverStatus.connections?.current || 0,
+        ...(current === undefined ? {} : { activeConnections: current }),
         maxConnections: maxConnections ?? 0,
-        databaseSize: formatBytes(dbStats.dataSize || 0),
-        databaseSizeBytes: dbStats.dataSize || 0,
+        databaseSize: dataSizeBytes === undefined ? "N/A" : formatBytes(dataSizeBytes),
+        ...(dataSizeBytes === undefined ? {} : { databaseSizeBytes: dataSizeBytes }),
         tableCount: collections.length,
         indexCount,
       };
     } catch (error) {
       this.logError("getOverview", error);
+      // A resolved DatabaseOverview, NOT a rethrow: `getMonitoringData()` in
+      // `base-provider.ts` reads this panel through `Promise.allSettled`, so a rethrow
+      // would drop the whole overview in favour of an `errors.overview` entry instead of
+      // the placeholders the tab renders. What it must not do is name a figure it did
+      // not read, so BOTH optional fields - `activeConnections` and `databaseSizeBytes`
+      // - are omitted entirely rather than resolved as measured 0s. `StorageTab.tsx`
+      // keys its whole breakdown off `databaseSizeBytes !== undefined`: with the key
+      // present as 0 it drew tables, indexes and an "Other (unattributed)" remainder
+      // over a 0 B total, and that remainder is `0 - tables - indexes`, so a table read
+      // that answered (it goes through `listCollections` + `collStats`, not
+      // `serverStatus`) drove it negative - and `formatBytes` renders a negative as the
+      // literal "NaN undefined", because `Math.log` of one is `NaN` and the unit indexes
+      // out of its array. Absent, the tab says "No storage size information available."
+      //
+      // The three figures below stay because their types leave nothing else: `0` MEANS
+      // "no limit published" for `maxConnections` (its docblock in `types.ts` says
+      // absence and zero are the same fact there), and `tableCount` / `indexCount` are
+      // required numbers, so 0 is the only value available on a path that counted
+      // nothing. Those two remain the one place this object states more than it read.
       return {
         version: "MongoDB Unknown",
         uptime: "N/A",
-        activeConnections: 0,
-        // Nothing was read, so no limit is published (see the success path above).
         maxConnections: 0,
         databaseSize: "N/A",
-        databaseSizeBytes: 0,
         tableCount: 0,
         indexCount: 0,
       };

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -927,7 +927,9 @@ export class MSSQLProvider extends SQLBaseProvider {
         // meant to publish. Only an unanswered COUNT stays absent.
         activeConnections = measuredNumber(connRes.recordset[0]?.cnt);
       } catch {
-        /* The DMV needs VIEW SERVER STATE; the figure stays absent, never 0. */
+        /* The figure stays absent, never 0. Which grant this DMV wants is in the note
+           above; that an ungranted login is documented as row-filtered rather than
+           refused - so this guard may never run for one - is in section 7.2. */
       }
 
       // Database size
@@ -1085,7 +1087,25 @@ export class MSSQLProvider extends SQLBaseProvider {
       let version = "SQL Server";
       let uptime = "N/A";
       let startTime: Date | undefined;
-      let activeConnections = 0;
+      // Left UNDEFINED and spread conditionally into the return below, mirroring
+      // getHealth() above: `DatabaseOverview.activeConnections` is optional for the
+      // same reason, so a server whose session DMV was denied omits the figure
+      // instead of publishing a fabricated 0. getHealth() does NOT compose from this
+      // reading - it runs its own COUNT over the same DMV - and the agent's curated
+      // `health` reading is getHealth() too (`method: "getHealth"` in
+      // src/lib/agent/tools.ts; nothing under src/lib/agent reads getOverview()). This
+      // count's readers are the monitoring Connections card, its trend chart and the
+      // connection-threshold rating over them, so an initial 0 made a denial
+      // indistinguishable from an idle instance for all three.
+      // OverviewTab.tsx renders "N/A" over "not published" for the absence and drops
+      // the sample from the connection trend; the 0 printed as the figure 0 on that
+      // card and each refresh added a real 0 point to the trend. No percentage was
+      // involved: the ceiling comes from the SAME statement, so a refused read left
+      // maxConnections at its 0 initialiser and the card said "no limit published",
+      // with no "/32767" and no bar. See docs/providers/mssql.md section 7.2.
+      let activeConnections: number | undefined;
+      // maxConnections stays a required number: 0 MEANS "no limit published" here,
+      // so unlike the count above, 0 and absence are the SAME fact for the ceiling.
       let maxConnections = 0;
       let databaseSize = "0 bytes";
       let databaseSizeBytes = 0;
@@ -1118,11 +1138,25 @@ export class MSSQLProvider extends SQLBaseProvider {
       // Connections
       try {
         const connRes = await this.pool!.request().query(OVERVIEW_CONNECTIONS_SQL);
-        activeConnections = Number(connRes.recordset[0]?.active_connections || 0);
+        // measuredNumber, not `|| 0`: an idle instance answers COUNT(*) = 0 and that
+        // 0 is a reading, so the falsy test threw away the very figure it published.
+        // Only an unanswered COUNT stays absent.
+        activeConnections = measuredNumber(connRes.recordset[0]?.active_connections);
         maxConnections = Number(connRes.recordset[0]?.max_connections || 32767);
         if (maxConnections === 0) maxConnections = 32767; // 0 means unlimited
       } catch {
-        /* ignore */
+        /* The count stays absent, never 0, and the ceiling stays 0, which already
+           reads as "no limit published". Which half of this statement refuses is
+           version-dependent, and Microsoft documents only one of them plainly:
+           sys.configurations requires membership in `public` on SQL Server 2019 and
+           earlier but VIEW SERVER PERFORMANCE STATE on 2022 and later, so on 2022+ an
+           ungranted login lands here on the ceiling lookup alone. sys.dm_exec_sessions
+           is documented as row-filtered rather than refused - "Everyone can see their
+           own session information", the server-state grant only widening that to ALL
+           sessions - so on 2019 and earlier the same login may instead SUCCEED with a
+           COUNT of its own session, an under-reading no guard here can see because
+           nothing failed. That case is unmeasured and unfixed; see
+           docs/providers/mssql.md section 7.2. */
       }
 
       // Database size
@@ -1147,7 +1181,7 @@ export class MSSQLProvider extends SQLBaseProvider {
         version,
         uptime,
         startTime,
-        activeConnections,
+        ...(activeConnections === undefined ? {} : { activeConnections }),
         maxConnections,
         databaseSize,
         databaseSizeBytes,

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -1157,7 +1157,22 @@ export class OracleProvider extends SQLBaseProvider {
       let version = "Oracle";
       let uptime = "N/A";
       let startTime: Date | undefined;
-      let activeConnections = 0;
+      // Left UNDEFINED, and spread conditionally into the return below - the same
+      // shape `getHealth()` above uses, for the same reason. `DatabaseOverview.activeConnections`
+      // is optional precisely so a user who cannot read V$SESSION omits the figure
+      // instead of publishing a fabricated 0, and the monitoring Overview card reads
+      // the absence as "N/A / not published" while a 0 is drawn as a real count and
+      // added as a real sample to the connections trend
+      // (`src/components/monitoring/tabs/OverviewTab.tsx`). The card's threshold rating
+      // is the same either way: the V$PARAMETER ceiling is read inside the same try
+      // below, so a refusal leaves maxConnections 0 as well and the card's percentage
+      // is null on both paths. Oracle's Database Reference
+      // states that after installation only SYS or a SYSDBA can read the dynamic
+      // performance tables, so a plain schema user hitting ORA-00942 here is the
+      // ordinary case rather than an exotic one.
+      let activeConnections: number | undefined;
+      // NOT made optional alongside it: `maxConnections` is a published ceiling where
+      // 0 MEANS "no limit published", so 0 and absence are the SAME fact there.
       let maxConnections = 0;
       let databaseSize = "0 bytes";
       let databaseSizeBytes = 0;
@@ -1199,14 +1214,19 @@ export class OracleProvider extends SQLBaseProvider {
         const sessRes = await conn.execute(`SELECT COUNT(*) AS CNT FROM V$SESSION WHERE TYPE = 'USER'`, [], {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
         });
-        activeConnections = Number(((sessRes.rows || []) as Record<string, unknown>[])[0]?.CNT || 0);
+        // measuredNumber, not `Number(... || 0)`: a COUNT of 0 is a reading, so the
+        // falsy test would have thrown away the very figure it was meant to publish.
+        // Only an unanswered COUNT stays absent. The assignment deliberately precedes
+        // the ceiling read below, so a refused V$PARAMETER cannot carry this count away.
+        activeConnections = measuredNumber(((sessRes.rows || []) as Record<string, unknown>[])[0]?.CNT);
 
         const maxRes = await conn.execute(`SELECT VALUE FROM V$PARAMETER WHERE NAME = 'sessions'`, [], {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
         });
         maxConnections = Number(((maxRes.rows || []) as Record<string, unknown>[])[0]?.VALUE || 0);
       } catch {
-        /* ignore */
+        /* Both V$ views need privileges: a refused count stays absent, never 0, while a
+           refused ceiling leaves the 0 that already means "no limit published". */
       }
 
       // Database size
@@ -1234,7 +1254,7 @@ export class OracleProvider extends SQLBaseProvider {
         version,
         uptime,
         startTime,
-        activeConnections,
+        ...(activeConnections === undefined ? {} : { activeConnections }),
         maxConnections,
         databaseSize,
         databaseSizeBytes,

--- a/src/lib/db/providers/sql/search/index.ts
+++ b/src/lib/db/providers/sql/search/index.ts
@@ -837,7 +837,13 @@ abstract class SearchProvider extends SQLBaseProvider {
         // computed from something else. A "0s" here would claim the cluster booted
         // this instant.
         uptime: SEARCH_UNKNOWN_TEXT,
-        // Zero means "not published", the same encoding `mssql.ts` and `druid` use.
+        // Zero means "not published" here. It is the correct encoding for the ceiling -
+        // `maxConnections` treats 0 and absence as one fact, which is why `druid` and
+        // `trino` cite `mssql.ts` for it - but NOT for the count beside it: `mssql.ts`,
+        // `oracle.ts`, `mongodb.ts` and `cassandra` now OMIT `activeConnections` when
+        // nothing was read, and this is the last provider still sending a 0 for it.
+        // Moving it is docs/BACKLOG.md D46, which needs both search docs and both test
+        // files with it.
         // A search cluster has no sessions and no connection pool: it counts open
         // HTTP connections per node in its stats API, which is not part of this
         // seam, and the shard and node counts that ARE here would be a different

--- a/src/lib/db/providers/sql/trino/index.ts
+++ b/src/lib/db/providers/sql/trino/index.ts
@@ -638,7 +638,7 @@ export class TrinoProvider extends SQLBaseProvider {
    * connector supplies no statistics at all), so that panel reported nothing about a
    * catalog full of data.
    *
-   * The fourth is D41 and used to render as something worse than an empty table: a scope
+   * The fourth (#515) used to render as something worse than an empty table: a scope
    * holding more tables than one pass describes was silently CUT to the first 25, and
    * `TableStats[]` has no field in which the cut could have been declared, so the panel
    * and the agent's curated reading both published 25 as the count. It is now refused

--- a/src/lib/db/providers/sql/trino/index.ts
+++ b/src/lib/db/providers/sql/trino/index.ts
@@ -630,13 +630,19 @@ export class TrinoProvider extends SQLBaseProvider {
   /**
    * The tables that published statistics, or an ABSENT panel with the reason.
    *
-   * An empty array here has three causes and only one of them is a measurement (see
-   * `TrinoTableStatsReading`). The other two used to render as an empty table, which
-   * claims the engine answered "no tables" - measured 2026-08-25 against Trino 476,
+   * An empty array here has four causes and only one of them is a measurement (see
+   * `TrinoTableStatsReading`). Two of the other three used to render as an empty table,
+   * which claims the engine answered "no tables" - measured 2026-08-25 against Trino 476,
    * the jmx catalog holds 379 tables in schema `current` and a 20-table random sample
    * of them answered SHOW STATS with an empty row_count (0 of 20 non-null; the jmx
    * connector supplies no statistics at all), so that panel reported nothing about a
    * catalog full of data.
+   *
+   * The fourth is D41 and used to render as something worse than an empty table: a scope
+   * holding more tables than one pass describes was silently CUT to the first 25, and
+   * `TableStats[]` has no field in which the cut could have been declared, so the panel
+   * and the agent's curated reading both published 25 as the count. It is now refused
+   * with the number of tables the scope really holds.
    */
   public async getTableStats(options: { schema?: string } = {}): Promise<TableStats[]> {
     const transport = this.requireTransport();

--- a/src/lib/db/providers/sql/trino/introspect.ts
+++ b/src/lib/db/providers/sql/trino/introspect.ts
@@ -100,13 +100,19 @@ export const TRINO_DEFAULT_SLOW_QUERY_LIMIT = 20;
 const TRINO_HEALTH_LIMIT = 10;
 
 /**
- * How many tables the stats panel will describe in one pass.
+ * How many tables the stats panel will describe in one pass, and the size past
+ * which it declines to describe them at all.
  *
- * A cap rather than a page, because `SHOW STATS` is per TABLE: there is no
- * catalog of sizes to aggregate, so N tables cost N statements. Twenty-five is
- * enough to fill the panel and small enough that a catalog with ten thousand
- * tables does not turn one panel open into ten thousand queries against the
- * coordinator.
+ * A bound rather than a page, because `SHOW STATS` is per TABLE: the reference
+ * gives exactly two forms, `SHOW STATS FOR <table>` and `SHOW STATS FOR (<query>)`,
+ * with no batch form and no catalog of sizes to aggregate, so N tables cost N
+ * statements. Twenty-five is enough to fill the panel and small enough that a
+ * catalog with ten thousand tables does not turn one panel open into ten thousand
+ * queries against the coordinator.
+ *
+ * It does NOT truncate. A scope holding more than this many tables is refused with
+ * the number it holds - see `tableStatsScopeRefusal` for why a 25-row answer out of
+ * 72 was the worse of the two.
  */
 export const TRINO_MAX_STATS_TABLES = 25;
 
@@ -741,12 +747,19 @@ function readTableStatistics(rows: TrinoRow[]): TableStatistics {
 /**
  * What a table-statistics pass found, and why it found nothing when it found nothing.
  *
- * The panel has three different empty readings and only ONE of them is a measurement:
- * a catalog that really holds no table. The other two - a refused table list, and a
- * catalog full of tables whose connector publishes no statistics - are refusals, and
- * `MonitoringData` requires those to be reported as an ABSENT panel carrying the
- * engine's own sentence rather than as an empty one (#477). The caller turns
- * `refusal` into that sentence; `undefined` means the rows are the answer.
+ * The panel has four different empty readings and only ONE of them is a measurement:
+ * a catalog that really holds no table. The other three - a refused table list, a
+ * catalog full of tables whose connector publishes no statistics, and a scope holding
+ * more tables than one pass describes - are refusals, and `MonitoringData` requires
+ * those to be reported as an ABSENT panel carrying the engine's own sentence rather
+ * than as an empty one (#477). The caller turns `refusal` into that sentence;
+ * `undefined` means the rows are the answer.
+ *
+ * There is deliberately no reading that says "here are some rows, and there were more".
+ * `tables` is what the scope holds or nothing at all, because the consumers of this
+ * reading - `MonitoringData.tables` and the agent's curated reading - are both a plain
+ * `TableStats[]` with nowhere for a partial marker to travel, and a sample they cannot
+ * tell from a whole is read as the whole (D41).
  */
 export interface TrinoTableStatsReading {
   readonly tables: TableStats[];
@@ -758,7 +771,98 @@ function tableListRefusal(catalog: string, reason: string): string {
   return `Trino refused the table list for catalog "${catalog}": ${reason}. This panel therefore has no source rather than no tables, and the schema tree reads the same list.`;
 }
 
-/** Why a catalog full of tables produced no statistics row. */
+/**
+ * Why a scope too large for one pass is refused rather than sampled.
+ *
+ * The cut this replaces was invisible to every consumer of the reading (D41), which
+ * is what made it worse than a refusal: `getTableStats` answers `TableStats[]`,
+ * `MonitoringData.tables` is that same array, and neither has a field a "there were
+ * more" marker could travel in, so 25 rows reached the panel - and reached the
+ * agent's curated reading as `rowCount: 25` - indistinguishable from a catalog that
+ * holds exactly 25 tables. A cap read as a count is the absence lie one size up, so
+ * the reading declines instead, which is the answer the agent's own row bound gives
+ * (`READING_OVER_BUDGET` in `src/lib/agent/tools.ts`) and for the same reason: a
+ * partial reading nobody was told was partial is a misleading one.
+ *
+ * Measured 2026-08-27 against Trino 476, this is the ordinary case and not the
+ * exotic one - `tpch` holds 72 user tables, `system` 26, `tpcds` 250 and `jmx` 379,
+ * every built-in catalog but `memory`. On `tpch` the dropped tables included every
+ * one of `tiny`, which sorts last: the pass spent its 25 statements on sf1, sf100,
+ * sf1000 and sf10000.customer and answered the 8 rows sf1 published.
+ *
+ * The advice differs by scope because advice a caller cannot act on is worse than
+ * none. A read that already named a schema has no narrower selection to offer, so it
+ * offers the statement that answers for a single table instead - which is also the
+ * only route open to the monitoring dashboard, whose own options set no `schemaFilter`
+ * today.
+ *
+ * An unnarrowed read can be asked again for one schema - `MonitoringOptions` carries a
+ * `schemaFilter` that `POST /api/db/monitoring` accepts, and the agent's curated
+ * reading takes a `schema` of its own - but that advice is CONDITIONAL, because the
+ * bound refuses a schema exactly as it refuses a catalog. "Ask for a single schema and
+ * the whole of it is described" was false of every schema over the bound, and this
+ * provider's own measurement names one: jmx holds 379 tables in schema `current`, so
+ * the narrowing the sentence recommended landed on this identical refusal one level
+ * down. A remedy that fails is worse than an honest refusal offering none, so the
+ * sentence now says how many schemas the narrowing really would describe
+ * (`describableSchemaCount`), and where that is none it says so plainly and offers the
+ * per-table statement instead - the one route no bound applies to.
+ */
+function tableStatsScopeRefusal(catalog: string, addresses: TableAddress[], schema: string | undefined): string {
+  const found = addresses.length;
+  const scope = schema === undefined ? `Catalog "${catalog}"` : `Schema "${schema}" of catalog "${catalog}"`;
+  const owner = schema === undefined ? "catalog" : "schema";
+  const advice =
+    schema === undefined
+      ? catalogScopeAdvice(catalog, addresses)
+      : `This reading takes no narrower selection, so one table's figures are one statement away: SHOW STATS FOR ${qualify(catalog, schema, "<table>")} in the editor.`;
+
+  return `${scope} holds ${found} tables, more than the ${TRINO_MAX_STATS_TABLES} one pass describes. SHOW STATS is one statement per table and there is no catalog of sizes to aggregate, so describing all of them would be ${found} statements against the coordinator. The first ${TRINO_MAX_STATS_TABLES} are not offered as the answer, because ${TRINO_MAX_STATS_TABLES} rows read as the ${owner}'s table count rather than as the sample they would be. ${advice}`;
+}
+
+/**
+ * What an unnarrowed caller can actually do next, which depends on the catalog.
+ *
+ * Both sentences end in the per-table statement, because it is the only route that
+ * works whatever the scope holds - `SHOW STATS FOR <table>` is one statement about one
+ * table and no bound applies to it. What differs is whether naming a schema is offered
+ * as the shorter road, and that is answered by the counts rather than assumed.
+ */
+function catalogScopeAdvice(catalog: string, addresses: TableAddress[]): string {
+  const describable = describableSchemaCount(addresses);
+  const narrowing =
+    describable === 0
+      ? "Narrowing to one schema does not help here: every schema this catalog's tables are in is over the bound as well, so this reading has no narrower scope left to describe."
+      : `Narrowing to one schema describes the whole of it when that schema is itself inside the bound, which holds for ${describable} of the schemas this catalog's tables are in; a larger schema is refused the same way.`;
+
+  return `${narrowing} One table's figures are one statement away whatever the scope holds: SHOW STATS FOR ${qualify(catalog, "<schema>", "<table>")} in the editor. The tables themselves are in the schema tree, and the overview's table count is this same figure.`;
+}
+
+/**
+ * How many of the schemas a scope's tables are in are themselves inside the bound.
+ *
+ * A real count and not an estimate: the table list is ONE uncapped read that has
+ * already answered for the whole catalog, so which schemas a narrowed pass would
+ * describe is known here without sending another statement.
+ *
+ * A schema holding no table is not among them - it is not in the list at all - which
+ * is why the sentence built from this figure says "the schemas this catalog's tables
+ * are in" rather than counting the catalog's schemas. An empty schema is not somewhere
+ * the advice could usefully send anyone.
+ */
+function describableSchemaCount(addresses: TableAddress[]): number {
+  const perSchema = new Map<string, number>();
+  for (const address of addresses) perSchema.set(address.schema, (perSchema.get(address.schema) ?? 0) + 1);
+
+  return [...perSchema.values()].filter((tables) => tables <= TRINO_MAX_STATS_TABLES).length;
+}
+
+/**
+ * Why a catalog full of tables produced no statistics row.
+ *
+ * `examined` is a count and not a bound: an oversized scope refuses above before any
+ * `SHOW STATS` is sent, so everything this sentence reports on was really asked.
+ */
 function tableStatsRefusal(catalog: string, examined: number): string {
   return `None of the ${examined} tables examined in catalog "${catalog}" published a row count. Trino answers SHOW STATS with a null row count until ANALYZE has run, and for every connector that cannot supply one at all - the jmx connector never does, measured against Trino 476. So these figures are not knowable here; the tables themselves are in the schema tree.`;
 }
@@ -771,6 +875,10 @@ function tableStatsRefusal(catalog: string, examined: number): string {
  * way to say "unknown", and "0 rows" is a claim nothing made about a Hive table
  * nobody has run `ANALYZE` on. Where that leaves NOTHING at all the panel says so in
  * words instead of rendering an empty table - see `TrinoTableStatsReading`.
+ *
+ * A scope holding more tables than one pass describes is refused for the same reason
+ * one step earlier: what came back would be a bound wearing a count's clothes, and
+ * nothing in `TableStats[]` could have said so (`tableStatsScopeRefusal`).
  */
 export async function getTableStats(
   runner: TrinoQueryRunner,
@@ -789,9 +897,19 @@ export async function getTableStats(
     throw error;
   }
 
-  const addresses = readTableAddresses(tableRows)
-    .filter((address) => options.schema === undefined || address.schema === options.schema)
-    .slice(0, TRINO_MAX_STATS_TABLES);
+  const addresses = readTableAddresses(tableRows).filter(
+    (address) => options.schema === undefined || address.schema === options.schema,
+  );
+
+  // Narrowed first, then bounded: the bound is on what the caller ASKED for, so a
+  // schema inside the bound is describable in a catalog of any size - but a schema over
+  // it is refused exactly as a catalog is, which is why the refusal's advice counts the
+  // schemas that would fit instead of promising that any narrowing works. Over the
+  // bound the pass sends nothing at all rather than its first 25 statements: the refusal
+  // is cheaper than the truncation it replaces, as well as truer.
+  if (addresses.length > TRINO_MAX_STATS_TABLES) {
+    return { tables: [], refusal: tableStatsScopeRefusal(catalog, addresses, options.schema) };
+  }
 
   const answers = await Promise.all(
     addresses.map(async (address) => {

--- a/src/lib/db/providers/sql/trino/introspect.ts
+++ b/src/lib/db/providers/sql/trino/introspect.ts
@@ -759,7 +759,7 @@ function readTableStatistics(rows: TrinoRow[]): TableStatistics {
  * `tables` is what the scope holds or nothing at all, because the consumers of this
  * reading - `MonitoringData.tables` and the agent's curated reading - are both a plain
  * `TableStats[]` with nowhere for a partial marker to travel, and a sample they cannot
- * tell from a whole is read as the whole (D41).
+ * tell from a whole is read as the whole (#515).
  */
 export interface TrinoTableStatsReading {
   readonly tables: TableStats[];
@@ -774,7 +774,7 @@ function tableListRefusal(catalog: string, reason: string): string {
 /**
  * Why a scope too large for one pass is refused rather than sampled.
  *
- * The cut this replaces was invisible to every consumer of the reading (D41), which
+ * The cut this replaces was invisible to every consumer of the reading (#515), which
  * is what made it worse than a refusal: `getTableStats` answers `TableStats[]`,
  * `MonitoringData.tables` is that same array, and neither has a field a "there were
  * more" marker could travel in, so 25 rows reached the panel - and reached the

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -206,7 +206,7 @@ const CASSANDRA_NO_CREATE_TABLE =
  * statement over Hrana on sqld 0.24.33 is `near CONSTRAINT ... syntax error`. Two tokens, one verdict.
  *
  * Both emission paths read this map and answer it DIFFERENTLY, which is the point of naming the fact
- * once (BACKLOG D36). `generateCreateTable` is building the table right there, so it moves the key
+ * once (#515). `generateCreateTable` is building the table right there, so it moves the key
  * INSIDE the statement, where SQLite's grammar does take it; `generateAlterTable` has no such place
  * to put it and declines with a comment. Declining on both paths would throw away a key the engine
  * can perfectly well hold.

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -8,9 +8,11 @@
  * - Dialect-aware: the modified-column path, which branches per engine and names
  *   the limitation in a comment where an engine has no such statement (#269); the
  *   `ADD` / `DROP` keyword, which CQL spells without `COLUMN`; `CREATE TABLE`,
- *   which is refused outright for Cassandra (see CASSANDRA_NO_CREATE_TABLE); and,
- *   for Cassandra only, the transaction wrapper and the foreign-key statements,
- *   both of which CQL has no grammar for.
+ *   which is refused outright for Cassandra (see CASSANDRA_NO_CREATE_TABLE); the
+ *   transaction wrapper, which Cassandra and SQLite's two type ids each do
+ *   without; and the foreign-key statements, which CQL has no grammar for at all
+ *   and which SQLite's grammar takes only inside `CREATE TABLE` (see
+ *   FOREIGN_KEY_ONLY_IN_CREATE_TABLE).
  * - Not yet: the transaction wrapper for everyone ELSE (`BEGIN;` / `COMMIT;` is
  *   only valid for PostgreSQL and MySQL — MSSQL spells it `BEGIN TRANSACTION`,
  *   Oracle opens a PL/SQL block and auto-commits DDL anyway, and five remaining
@@ -74,10 +76,15 @@ const NO_COLUMN_MODIFICATION: Partial<Record<DatabaseType, { label: string; reas
   // Measured over Hrana on sqld 0.24.33, and the entry exists because the PostgreSQL
   // branch this id would otherwise inherit emits text libSQL cannot parse:
   // `ALTER TABLE t ALTER COLUMN c TYPE integer` is "unexpected end of input" and the
-  // MySQL spelling `MODIFY COLUMN` is "syntax error around `MODIFY`". SQLite has no
-  // column modification at all, and libSQL is SQLite - unlike DROP COLUMN and RENAME
-  // COLUMN, which it DOES accept (both measured), so this row is narrower than the
-  // `sqlite` branch below and deliberately so.
+  // MySQL spelling `MODIFY COLUMN` is "syntax error around `MODIFY`". No SQLite has a
+  // column TYPE change, and libSQL is SQLite - unlike DROP COLUMN and RENAME COLUMN,
+  // which it DOES accept (both measured), so this row is narrower than the `sqlite`
+  // branch below and deliberately so. Nullability is the one exception and it does not
+  // reach libSQL: SQLite gained `ALTER COLUMN ... SET/DROP NOT NULL` in 3.53.0 (measured
+  // 2026-08-27 on 3.53.0 - it rewrites the stored schema and is enforced on insert),
+  // while sqld 0.24.33 ships 3.47.0, so declining every modification is still right here.
+  // Whether the `sqlite` branch should emit it is docs/BACKLOG.md D43, not a decision to
+  // take in a comment: the provider runs on whichever SQLite its runtime bundles.
   libsql: {
     label: "libSQL",
     reason: "SQLite cannot retype a column; recreate the table and copy the rows.",
@@ -184,6 +191,37 @@ function generateColumnDef(col: ColumnDiff, dialect: DatabaseType): string {
 const CASSANDRA_NO_CREATE_TABLE =
   "A CQL primary key splits into a partition key and clustering columns, and a schema diff records neither role, so the partitioning cannot be derived; write the CREATE TABLE by hand.";
 
+/**
+ * Canonical type ids whose grammar declares a foreign key ONLY as a `CREATE TABLE` table constraint,
+ * with the label each one's comments carry. `sqlite` is the engine and `libsql` is a fork of it, so
+ * the two answer identically; the labels are spelled out per id anyway, because a reader wants the
+ * name of the engine they connected to (the same reason the neighbouring libSQL branches exist).
+ *
+ * SQLite's ALTER TABLE page enumerates every schema change the engine has - "rename table", "rename
+ * column", "add column", "drop column", plus SET/DROP NOT NULL since 3.53.0 - and adding a constraint
+ * is not among them; it routes such a change through its own 12-step table-recreation procedure.
+ * Measured on sqlite3 3.53.3: `ALTER TABLE "users" ADD CONSTRAINT "fk_users_dept_id" FOREIGN KEY
+ * ("dept_id") REFERENCES "departments"("id")` is `near "FOREIGN": syntax error` - the parser has
+ * already taken `CONSTRAINT` for a column name and the quoted name for its type - and the same
+ * statement over Hrana on sqld 0.24.33 is `near CONSTRAINT ... syntax error`. Two tokens, one verdict.
+ *
+ * Both emission paths read this map and answer it DIFFERENTLY, which is the point of naming the fact
+ * once (BACKLOG D36). `generateCreateTable` is building the table right there, so it moves the key
+ * INSIDE the statement, where SQLite's grammar does take it; `generateAlterTable` has no such place
+ * to put it and declines with a comment. Declining on both paths would throw away a key the engine
+ * can perfectly well hold.
+ */
+const FOREIGN_KEY_ONLY_IN_CREATE_TABLE: Partial<Record<DatabaseType, { label: string; reason: string }>> = {
+  sqlite: {
+    label: "SQLite",
+    reason: "A foreign key is declarable only as a CREATE TABLE constraint; recreate the table and copy the rows.",
+  },
+  libsql: {
+    label: "libSQL",
+    reason: "SQLite declares one only in CREATE TABLE; recreate the table and copy the rows.",
+  },
+};
+
 function generateCreateTable(table: TableDiff, dialect: DatabaseType): string {
   const lines: string[] = [];
   const id = escapeIdentifier(table.tableName, dialect);
@@ -198,10 +236,33 @@ function generateCreateTable(table: TableDiff, dialect: DatabaseType): string {
   // Add primary key constraint
   const pkCols = table.columns.filter((c) => c.targetIsPrimary).map((c) => escapeIdentifier(c.columnName, dialect));
 
+  // A key the target can only declare here has to be emitted here, so the closing paren is not
+  // written until the constraint list is complete.
+  const addedForeignKeys = table.foreignKeys.filter((fk) => fk.action === "added");
+  const keyIsTableConstraint = FOREIGN_KEY_ONLY_IN_CREATE_TABLE[dialect] !== undefined;
+
   lines.push(`CREATE TABLE ${id} (`);
   lines.push(colDefs.join(",\n"));
   if (pkCols.length > 0) {
     lines.push(`,  PRIMARY KEY (${pkCols.join(", ")})`);
+  }
+  if (keyIsTableConstraint) {
+    // SQLite's CREATE TABLE takes "one or more column definitions, optionally followed by a list of
+    // table constraints", one of which is `FOREIGN KEY ( column-name, ... ) REFERENCES ...`. Hence
+    // the position: after the columns AND after the PRIMARY KEY line, never before them - the same
+    // constraint placed ahead of a column definition is `near "FOREIGN": syntax error` (measured on
+    // sqlite3 3.53.3, where the form below is accepted and `PRAGMA foreign_key_list` then reports the
+    // key).
+    //
+    // The `fk_<table>_<column>` name the other dialects carry is dropped rather than translated into
+    // a `CONSTRAINT name` prefix, which SQLite would also accept: the name is this generator's own
+    // invention rather than anything the diff recorded, and SQLite never reads a foreign key's name
+    // back out - `PRAGMA foreign_key_list` has no name column - so it could only ever be write-only.
+    addedForeignKeys.forEach((fk) => {
+      lines.push(
+        `,  FOREIGN KEY (${escapeIdentifier(fk.columnName, dialect)}) REFERENCES ${escapeIdentifier(fk.targetReferencedTable || "", dialect)}(${escapeIdentifier(fk.targetReferencedColumn || "", dialect)})`,
+      );
+    });
   }
   lines.push(");");
 
@@ -214,14 +275,15 @@ function generateCreateTable(table: TableDiff, dialect: DatabaseType): string {
       lines.push(`CREATE ${unique}INDEX ${escapeIdentifier(idx.indexName, dialect)} ON ${id} (${cols});`);
     });
 
-  // Foreign keys
-  table.foreignKeys
-    .filter((fk) => fk.action === "added")
-    .forEach((fk) => {
+  // Foreign keys. Already emitted above for the ids that can only declare one inside the statement;
+  // for everyone else this separate ALTER is the shape that has always been emitted here.
+  if (!keyIsTableConstraint) {
+    addedForeignKeys.forEach((fk) => {
       lines.push(
         `ALTER TABLE ${id} ADD CONSTRAINT ${escapeIdentifier(`fk_${table.tableName}_${fk.columnName}`, dialect)} FOREIGN KEY (${escapeIdentifier(fk.columnName, dialect)}) REFERENCES ${escapeIdentifier(fk.targetReferencedTable || "", dialect)}(${escapeIdentifier(fk.targetReferencedColumn || "", dialect)});`,
       );
     });
+  }
 
   return lines.join("\n");
 }
@@ -380,15 +442,14 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
         );
         return;
       }
-      // libSQL refuses the statement below outright: `ALTER TABLE t ADD CONSTRAINT
-      // fk FOREIGN KEY (c) REFERENCES u(id)` is "near CONSTRAINT ... syntax error"
-      // (measured on sqld 0.24.33). SQLite has no ALTER that adds a constraint - the
-      // key has to be part of the CREATE TABLE - so the honest line names the
-      // recreation. The `sqlite` id has the same limit and still emits the statement
-      // below; that is its own defect rather than something to copy (BACKLOG D36).
-      if (dialect === "libsql") {
+      // No ALTER in SQLite's grammar adds a constraint, so for `sqlite` and `libsql` alike the
+      // honest line names the table recreation instead (see FOREIGN_KEY_ONLY_IN_CREATE_TABLE for the
+      // two measurements). Unlike the created-table path, there is nothing to move the key into: the
+      // table already exists, and this generator does not write the recreation.
+      const declined = FOREIGN_KEY_ONLY_IN_CREATE_TABLE[dialect];
+      if (declined) {
         lines.push(
-          `-- libSQL: Cannot add a foreign key on ${escapeIdentifier(fk.columnName, dialect)}. SQLite declares one only in CREATE TABLE; recreate the table and copy the rows.`,
+          `-- ${declined.label}: Cannot add a foreign key on ${escapeIdentifier(fk.columnName, dialect)}. ${declined.reason}`,
         );
         return;
       }

--- a/tests/components/monitoring/OverviewTab.test.tsx
+++ b/tests/components/monitoring/OverviewTab.test.tsx
@@ -388,7 +388,7 @@ function atCap(): MonitoringData {
 // The other half of the rule the block above pins. A refused read was already an absence
 // rather than a zero, but a list that ANSWERED still had its length published as a count:
 // "Slow Queries" read 10 on a server holding 59 digests, and "Active" plus "Idle" split one
-// 50-row sample under labels that read as the server's session totals. Same defect as D41 in
+// 50-row sample under labels that read as the server's session totals. Same defect as #515 in
 // QueriesTab.tsx, three more times, and the fix is that file's vocabulary: every figure is
 // stated as a property of the listed rows.
 describe("Quick Stats publishes no cap-bounded figure as a count", () => {

--- a/tests/components/monitoring/OverviewTab.test.tsx
+++ b/tests/components/monitoring/OverviewTab.test.tsx
@@ -111,6 +111,13 @@ describe("OverviewTab", () => {
     expect(card.textContent).not.toContain("/100");
     expect(card.textContent).not.toContain("% used");
     expect(card.querySelectorAll('[data-slot="progress"]').length).toBe(0);
+    // The figure itself, exactly: "N/A" alone, greyed to say it is not a reading.
+    // The muted class sits in a one-line ternary on the same JSX attribute as the
+    // present-count arm, so line coverage cannot tell the two apart - only this
+    // assertion and its twin below can.
+    const figure = card.querySelector('[data-slot="card-content"] > div')!;
+    expect(figure.textContent).toBe("N/A");
+    expect(figure.className).toContain("text-muted-foreground");
     // Absence is not a fault: nothing red or yellow on the card.
     expect(card.className).not.toContain("red");
     expect(card.className).not.toContain("yellow");
@@ -129,6 +136,14 @@ describe("OverviewTab", () => {
     expect(card.textContent).toContain("0/100");
     expect(card.textContent).toContain("0% used");
     expect(card.textContent).not.toContain("not published");
+    // The figure reads "0/100" and nothing else - no "N/A" anywhere in it - and it
+    // is NOT greyed out. A falsy test in place of the `=== undefined` one would
+    // grey a measured zero into looking like the absence above while every other
+    // assertion here still passed, which is the whole distinction collapsing in
+    // silence.
+    const figure = card.querySelector('[data-slot="card-content"] > div')!;
+    expect(figure.textContent).toBe("0/100");
+    expect(figure.className).not.toContain("text-muted-foreground");
   });
 
   // Same rule as the cache/buffer/deadlock trends in PerformanceTab: a missing
@@ -337,5 +352,81 @@ describe("Quick Stats never counts a refused read as zero", () => {
     expect(getByTestId("quick-stat-active").textContent).toBe("0");
     expect(getByTestId("quick-stat-idle").textContent).toBe("0");
     expect(getByTestId("quick-stat-slow-queries").textContent).toBe("0");
+  });
+});
+
+/**
+ * Both lists this card reads are capped: `slowQueryLimit = 10` and `sessionLimit = 50` in
+ * src/lib/db/base-provider.ts, and MonitoringDashboard overrides neither. This is the shape
+ * the card receives from any server past both ceilings - ten slow queries, fifty sessions -
+ * and the session split is deliberately lopsided so 29 and 21 are distinctive strings, while
+ * their sum being exactly the ceiling is the point: the two badges partition one truncated
+ * list, they do not count the server.
+ */
+function atCap(): MonitoringData {
+  return {
+    ...makeData(),
+    slowQueries: Array.from({ length: 10 }, (_, i) => ({
+      query: `SELECT ${i} FROM t`,
+      calls: 7,
+      totalTime: 1750,
+      avgTime: 250,
+      rows: 5,
+    })),
+    activeSessions: Array.from({ length: 50 }, (_, i) => ({
+      pid: 100 + i,
+      user: "app",
+      database: "db",
+      state: i < 29 ? "active" : "idle",
+      query: "SELECT 1",
+      duration: "1s",
+      durationMs: 1000,
+    })),
+  } as unknown as MonitoringData;
+}
+
+// The other half of the rule the block above pins. A refused read was already an absence
+// rather than a zero, but a list that ANSWERED still had its length published as a count:
+// "Slow Queries" read 10 on a server holding 59 digests, and "Active" plus "Idle" split one
+// 50-row sample under labels that read as the server's session totals. Same defect as D41 in
+// QueriesTab.tsx, three more times, and the fix is that file's vocabulary: every figure is
+// stated as a property of the listed rows.
+describe("Quick Stats publishes no cap-bounded figure as a count", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // The row is <span>{label}</span><Badge>{value}</Badge>, so the row's own text is the
+  // whole claim - label and figure together, which is the thing that has to stay honest.
+  const claim = (el: HTMLElement): string => el.closest("div")!.textContent ?? "";
+
+  test("each figure is labelled with the rows it counts, and no unscoped label survives", () => {
+    const { getByTestId, queryByText } = render(<OverviewTab data={makeData()} loading={false} />);
+
+    expect(claim(getByTestId("quick-stat-slow-queries"))).toBe("Listed slow queries1");
+    expect(claim(getByTestId("quick-stat-active"))).toBe("Active of listed sessions1");
+    expect(claim(getByTestId("quick-stat-idle"))).toBe("Idle of listed sessions1");
+
+    // Exact matches, so none of these can be satisfied by the longer labels asserted above.
+    expect(queryByText("Slow Queries")).toBeNull();
+    expect(queryByText("Active")).toBeNull();
+    expect(queryByText("Idle")).toBeNull();
+  });
+
+  test("a saturated payload states the ceiling as a property of the listed rows", () => {
+    const data = atCap();
+    const { getByTestId } = render(<OverviewTab data={data} loading={false} />);
+
+    expect(claim(getByTestId("quick-stat-slow-queries"))).toBe("Listed slow queries10");
+    expect(claim(getByTestId("quick-stat-active"))).toBe("Active of listed sessions29");
+    expect(claim(getByTestId("quick-stat-idle"))).toBe("Idle of listed sessions21");
+
+    // The two session figures share one bounded list, which is why neither may be read as a
+    // server total: they add up to the sample, and this fixture has saturated it at the 50
+    // `sessionLimit` allows.
+    expect(data.activeSessions!.length).toBe(50);
+    const total =
+      Number(getByTestId("quick-stat-active").textContent) + Number(getByTestId("quick-stat-idle").textContent);
+    expect(total).toBe(50);
   });
 });

--- a/tests/components/monitoring/QueriesTab.test.tsx
+++ b/tests/components/monitoring/QueriesTab.test.tsx
@@ -231,7 +231,7 @@ describe("QueriesTab", () => {
   });
 
   test("no card publishes a call total, because the list it would total is a cap", () => {
-    // D41. `MonitoringData.slowQueries` is capped - `slowQueryLimit = 10` in
+    // #515. `MonitoringData.slowQueries` is capped - `slowQueryLimit = 10` in
     // src/lib/db/base-provider.ts, applied by every provider that fills the list and never
     // overridden by MonitoringDashboard - so summing `calls` over it is bounded by ten
     // digests however many the server recorded. The card labelled "Queries" published that
@@ -261,7 +261,7 @@ describe("QueriesTab", () => {
   });
 
   test("a list saturated at the cap prints neither the cap nor a sum over it", () => {
-    // The saturating case D41 was measured on: MySQL 26.7.0 held 59 digests for one
+    // The saturating case #515 was measured on: MySQL 26.7.0 held 59 digests for one
     // connected schema, of which the panel receives ten. Every figure on screen must be a
     // property of those ten and nothing else, so neither the list length (10) nor the call
     // total (70) may appear anywhere.

--- a/tests/components/monitoring/QueriesTab.test.tsx
+++ b/tests/components/monitoring/QueriesTab.test.tsx
@@ -38,14 +38,66 @@ function makeData(): MonitoringData {
   } as unknown as MonitoringData;
 }
 
+/**
+ * A list saturated at the ceiling every provider applies: `slowQueryLimit` defaults to 10
+ * in src/lib/db/base-provider.ts and the dashboard overrides nothing, so this is the shape
+ * the panel receives from any server with ten or more recorded statements. Every figure is
+ * uniform so that a sum (70 calls) and the list length (10) are both distinctive strings no
+ * honest reading of these rows can produce.
+ */
+function atCap(): MonitoringData {
+  return {
+    ...makeData(),
+    slowQueries: Array.from({ length: 10 }, (_, i) => ({
+      queryId: `cap${i}`,
+      query: `SELECT ${i} FROM t`,
+      calls: 7,
+      totalTime: 1750,
+      avgTime: 250,
+      rows: 5,
+    })),
+  } as unknown as MonitoringData;
+}
+
+/**
+ * The stat-card grid of whichever state is rendered, loading or loaded: both lay their cards
+ * out as the first child of the panel's root, so one accessor counts either. What the two
+ * states must agree on is that count.
+ */
+function statGrid(container: HTMLElement): Element {
+  return container.firstElementChild?.firstElementChild as Element;
+}
+
+function statCardCount(container: HTMLElement): number {
+  return statGrid(container).querySelectorAll('[data-slot="card"]').length;
+}
+
 describe("QueriesTab", () => {
   afterEach(() => {
     cleanup();
   });
 
-  test("renders skeleton while loading without data", () => {
-    const { queryByText } = render(<QueriesTab data={null} loading />);
-    expect(queryByText("Slowest Queries")).toBeNull();
+  test("the loading skeleton shows one placeholder card per stat card the loaded state renders", () => {
+    // The predecessor of this test asserted that the skeleton does NOT render the string
+    // "Slowest Queries" - a string the skeleton never rendered in any shape, so it would
+    // have passed over an empty fragment, and it did pass when this round dropped a stat
+    // card and left the skeleton's own `[...Array(3)]` behind. So count instead: the
+    // skeleton owes the reader one placeholder per card the loaded state is about to show,
+    // and both grids now read STAT_CARDS in QueriesTab.tsx, which is what keeps them equal.
+    const loadingView = render(<QueriesTab data={null} loading />);
+    const skeletonCards = statCardCount(loadingView.container);
+    const skeletonGridClass = statGrid(loadingView.container).className;
+    // Non-vacuity: placeholders actually rendered, so an empty skeleton cannot satisfy the
+    // equality below by matching zero against zero.
+    expect(loadingView.container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+    expect(skeletonCards).toBeGreaterThan(0);
+    cleanup();
+
+    const loadedView = render(<QueriesTab data={makeData()} loading={false} />);
+
+    expect(statCardCount(loadedView.container)).toBe(2);
+    expect(skeletonCards).toBe(statCardCount(loadedView.container));
+    expect(skeletonGridClass).toBe(statGrid(loadedView.container).className);
   });
 
   test("shows empty state when no slow queries exist", () => {
@@ -104,7 +156,7 @@ describe("QueriesTab", () => {
     expect(queryAllByText("SELECT * FROM users").length).toBeGreaterThan(0);
     expect(queryAllByText("SELECT * FROM events").length).toBeGreaterThan(0);
     expect(queryAllByText("VACUUM users").length).toBeGreaterThan(0);
-    expect(queryByText("Slow")).not.toBeNull();
+    expect(queryByText("Listed queries over 1s")).not.toBeNull();
   });
 
   test("sorts by calls when Calls header is clicked", () => {
@@ -156,7 +208,7 @@ describe("QueriesTab", () => {
 
     expect(queryAllByText("0.00ms").length).toBe(0);
     expect(queryAllByText("0").length).toBe(0);
-    expect(queryAllByText("N/A").length).toBe(3);
+    expect(queryAllByText("N/A").length).toBe(2);
     expect(queryByText("No query statistics available.")).not.toBeNull();
   });
 
@@ -174,8 +226,54 @@ describe("QueriesTab", () => {
 
     expect(queryAllByText("N/A").length).toBe(0);
     expect(queryAllByText("0.00ms").length).toBe(3);
-    expect(queryAllByText("0").length).toBe(4);
+    expect(queryAllByText("0").length).toBe(3);
     expect(queryByText("No query statistics available.")).toBeNull();
+  });
+
+  test("no card publishes a call total, because the list it would total is a cap", () => {
+    // D41. `MonitoringData.slowQueries` is capped - `slowQueryLimit = 10` in
+    // src/lib/db/base-provider.ts, applied by every provider that fills the list and never
+    // overridden by MonitoringDashboard - so summing `calls` over it is bounded by ten
+    // digests however many the server recorded. The card labelled "Queries" published that
+    // sum as the database's query count: 10 + 200 + 2 = 212 for this fixture, and on
+    // MongoDB and Redis, which project `calls: 1` per row, the sum WAS the list length.
+    // There is no honest label for it, so the card is gone rather than renamed.
+    const { queryAllByText, queryByText } = render(<QueriesTab data={makeData()} loading={false} />);
+
+    expect(queryAllByText("212").length).toBe(0);
+    // The card's own title, not a tab or a table heading: the tab trigger lives in
+    // MonitoringDashboard and is not rendered here, so a surviving "Queries" card is the
+    // only thing this can match.
+    expect(queryByText("Queries")).toBeNull();
+  });
+
+  test("the two remaining cards name the statements they summarise", () => {
+    // Each label scopes its figure to the rows on screen, so a reader can recompute it by
+    // looking: the mean of 120, 4.5 and 1500 is 541.5ms, and exactly one of the three
+    // averages over a second. Neither sentence claims anything about the server.
+    const { queryByText } = render(<QueriesTab data={makeData()} loading={false} />);
+
+    expect(queryByText("Avg of listed queries")).not.toBeNull();
+    expect(queryByText("541.50ms")).not.toBeNull();
+    expect(queryByText("Listed queries over 1s")).not.toBeNull();
+    expect(queryByText("Avg Time")).toBeNull();
+    expect(queryByText("Slow")).toBeNull();
+  });
+
+  test("a list saturated at the cap prints neither the cap nor a sum over it", () => {
+    // The saturating case D41 was measured on: MySQL 26.7.0 held 59 digests for one
+    // connected schema, of which the panel receives ten. Every figure on screen must be a
+    // property of those ten and nothing else, so neither the list length (10) nor the call
+    // total (70) may appear anywhere.
+    const { container, queryAllByText, queryByText } = render(<QueriesTab data={atCap()} loading={false} />);
+
+    expect(container.querySelectorAll("tbody tr").length).toBe(10);
+    expect(queryAllByText("10").length).toBe(0);
+    expect(queryAllByText("70").length).toBe(0);
+    // The control: the figures that ARE about these ten rows still render - the card's
+    // average plus the ten per-row badges it was computed from.
+    expect(queryAllByText("250.00ms").length).toBe(11);
+    expect(queryByText("Avg of listed queries")).not.toBeNull();
   });
 });
 

--- a/tests/components/monitoring/StorageTab.test.tsx
+++ b/tests/components/monitoring/StorageTab.test.tsx
@@ -100,6 +100,44 @@ function makeMonitoringData(): MonitoringData {
   } as unknown as MonitoringData;
 }
 
+// A libSQL database as measured for U23: 64 KB total, of which the two tables account for
+// 48 KB of data and 12 KB of indexes, leaving a 4.00 KB remainder. libSQL and SQLite have
+// neither TOAST nor a free space map - their remainder is the schema, the freelist and page
+// overhead - so this fixture is the non-PostgreSQL arm of the breakdown-label test.
+function makeLibsqlMonitoringData(): MonitoringData {
+  const base = makeMonitoringData();
+  return {
+    ...base,
+    overview: { ...base.overview, version: "3.45.1", databaseSize: "64.00 KB", databaseSizeBytes: 65536 },
+    storage: [],
+    indexes: [],
+    tables: [
+      {
+        schemaName: "main",
+        tableName: "orders",
+        rowCount: 120,
+        tableSize: "32.00 KB",
+        tableSizeBytes: 32768,
+        indexSize: "8.00 KB",
+        indexSizeBytes: 8192,
+        totalSize: "40.00 KB",
+        totalSizeBytes: 40960,
+      },
+      {
+        schemaName: "main",
+        tableName: "users",
+        rowCount: 30,
+        tableSize: "16.00 KB",
+        tableSizeBytes: 16384,
+        indexSize: "4.00 KB",
+        indexSizeBytes: 4096,
+        totalSize: "20.00 KB",
+        totalSizeBytes: 20480,
+      },
+    ],
+  } as unknown as MonitoringData;
+}
+
 describe("StorageTab", () => {
   afterEach(() => {
     cleanup();
@@ -252,6 +290,40 @@ describe("StorageTab", () => {
     expect(queryAllByText("-").length).toBe(2); // the two % cells
   });
 
+  test("the breakdown remainder is labelled without naming any engine's storage layout", () => {
+    // The remainder row is arithmetic: the database bytes the per-table data and index
+    // figures do not account for. It was labelled "Other (TOAST, FSM)" unconditionally, and
+    // TOAST and the free space map are PostgreSQL structures - so the wide label named one
+    // engine's storage layout on all fifteen. Both breakpoint labels are asserted by value,
+    // which is what keeps the "no PostgreSQL words" check below non-vacuous: a later rename
+    // cannot satisfy it by moving the wording somewhere this test does not look.
+    const { container, getByTestId } = render(<StorageTab data={makeMonitoringData()} loading={false} />);
+
+    expect(getByTestId("storage-breakdown-other-label").textContent).toBe("Other (unattributed)");
+    expect(getByTestId("storage-breakdown-other-label-compact").textContent).toBe("Other");
+    expect(container.textContent).not.toMatch(/TOAST|FSM|free space map/i);
+    // The PostgreSQL fixture's own remainder still renders: 2 GB less 700 MB of data and
+    // 200 MB of indexes.
+    expect(container.textContent).toContain("1.12 GB");
+  });
+
+  test("a libSQL database gets the same remainder label as PostgreSQL, not another engine's", () => {
+    // Measured for U23: a real 64 KB libSQL database read "4.00 KB" under "Other (TOAST,
+    // FSM)". The number is right and the words belong to PostgreSQL - libSQL has neither
+    // structure. The label must be identical on both engines because this tab is given no
+    // provider labels to vary it by.
+    const { container, getByTestId, queryAllByText } = render(
+      <StorageTab data={makeLibsqlMonitoringData()} loading={false} />,
+    );
+
+    expect(getByTestId("storage-breakdown-other-label").textContent).toBe("Other (unattributed)");
+    expect(getByTestId("storage-breakdown-other-label-compact").textContent).toBe("Other");
+    expect(container.textContent).not.toMatch(/TOAST|FSM|free space map/i);
+    // 65536 bytes less 49152 of data and 12288 of indexes; no other figure in this fixture
+    // formats to 4.00 KB, so the remainder is pinned as well as its label.
+    expect(queryAllByText("4.00 KB").length).toBe(1);
+  });
+
   test("a table reported without an index size does not turn the totals into a measurement", () => {
     // MySQL keeps per-index bytes in `mysql.innodb_index_stats`: a user granted only its own
     // database is denied that table, and a MyISAM table has no row there (both measured
@@ -302,5 +374,92 @@ describe("a refused storage read", () => {
 
     expect(queryByTestId("panel-unavailable")).toBeNull();
     expect(queryByText("No tablespace information available.")).not.toBeNull();
+  });
+});
+
+// A refused getTableStats read costs every figure derived from the table rows, not just the
+// list - the sibling failure mode of the block above, and the one this tab was still getting
+// wrong while `storageUnavailable` handled the tablespace half correctly (2026-08-27).
+describe("a refused table statistics read", () => {
+  // Scoped here as well, for the same reason as the block above: bun:test registers a hook
+  // on the enclosing describe only.
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Whatever `getTableStats()` rejected with, recorded verbatim under `errors.tables` by
+  // `BaseProvider.getMonitoringData` (src/lib/db/base-provider.ts). The two producers in the
+  // tree today are `CASSANDRA_TABLE_STATS_REFUSAL` and Trino's per-catalog
+  // `tableStatsRefusal()`; this stands in for either rather than quoting a PostgreSQL error
+  // text taken from memory instead of from that engine's own documentation.
+  const REFUSAL = "this connection has no source for table statistics";
+
+  function refusedTables(): MonitoringData {
+    const rest: MonitoringData = makeMonitoringData();
+    delete rest.tables;
+    return { ...rest, errors: { tables: REFUSAL } } as MonitoringData;
+  }
+
+  test("shows the engine's own sentence instead of the largest-tables empty state", () => {
+    const { getByTestId, queryByText } = render(<StorageTab data={refusedTables()} loading={false} />);
+
+    expect(getByTestId("panel-unavailable-message").textContent).toBe(REFUSAL);
+    expect(queryByText("No table information available.")).toBeNull();
+  });
+
+  test("the figures derived from the refused rows read N/A, not a measured zero", () => {
+    // `tables === []` after a refusal makes `every()` vacuously true, so both totals used to
+    // read a measured "0 B" at "0.0%" of the database - a measurement the engine declined to
+    // make. Five figures come off those rows: the Tables and Indexes cards, the breakdown's
+    // Tables and Indexes rows, and the remainder computed from both.
+    const { queryAllByText } = render(<StorageTab data={refusedTables()} loading={false} />);
+
+    expect(queryAllByText("N/A").length).toBe(5);
+    expect(queryAllByText("0 B").length).toBe(0);
+    expect(queryAllByText("0.0%").length).toBe(0);
+  });
+
+  test("the remainder row does not absorb the whole database", () => {
+    // With both totals at a fabricated 0, `100 - 0 - 0` handed the remainder every byte of
+    // the database at 100% - the round's relabelled "Other (unattributed)" row asserting
+    // confidently that all 2 GB is unattributed. "2.00 GB" must appear once, on the DB Size
+    // card, which is the one panel that did answer.
+    const { container, queryAllByText, getByTestId } = render(<StorageTab data={refusedTables()} loading={false} />);
+
+    expect(queryAllByText("2.00 GB").length).toBe(1);
+    // The label still renders - the row is drawn, only its figure is an absence.
+    expect(getByTestId("storage-breakdown-other-label").textContent).toBe("Other (unattributed)");
+    // And its bar with it: `Progress` draws its share as `translateX(-(100 - value)%)`, so an
+    // empty remainder bar is "-100%". A full one - "-0%", which is what `100 - 0 - 0` used to
+    // produce here - is the same overclaim in a shape no text assertion can see.
+    const bars = [...container.querySelectorAll('[data-slot="progress-indicator"]')].map(
+      (el) => (el as HTMLElement).style.transform,
+    );
+    expect(bars.slice(0, 3)).toEqual(["translateX(-100%)", "translateX(-100%)", "translateX(-100%)"]);
+  });
+
+  test("an answered empty table list still reads 0 B and 0.0%", () => {
+    // The control arm: a database that genuinely holds no tables has measured every one of
+    // them, so the zeros are real and the breakdown remainder is the whole database. Without
+    // this the refusal fix could be a blanket "N/A whenever the list is empty".
+    const data = { ...makeMonitoringData(), tables: [] } as MonitoringData;
+    const { queryAllByText, queryByTestId, queryByText } = render(<StorageTab data={data} loading={false} />);
+
+    expect(queryByTestId("panel-unavailable")).toBeNull();
+    expect(queryByText("No table information available.")).not.toBeNull();
+    // Tables and Indexes cards, plus the breakdown's two rows.
+    expect(queryAllByText("0 B").length).toBe(4);
+    expect(queryAllByText("0.0%").length).toBe(2);
+    // The remainder is the entire database, and that is the arithmetic, not a fabrication.
+    expect(queryAllByText("2.00 GB").length).toBe(2);
+  });
+
+  test("a populated table list keeps its measured figures", () => {
+    const { queryAllByText, queryByTestId } = render(<StorageTab data={makeMonitoringData()} loading={false} />);
+
+    expect(queryByTestId("panel-unavailable")).toBeNull();
+    // 500 MB + 200 MB of table data, on the Tables card and the breakdown's Tables row.
+    expect(queryAllByText("700.00 MB").length).toBe(2);
+    expect(queryAllByText("N/A").length).toBe(0);
   });
 });

--- a/tests/components/monitoring/StorageTab.test.tsx
+++ b/tests/components/monitoring/StorageTab.test.tsx
@@ -100,7 +100,7 @@ function makeMonitoringData(): MonitoringData {
   } as unknown as MonitoringData;
 }
 
-// A libSQL database as measured for U23: 64 KB total, of which the two tables account for
+// A libSQL database as measured for #515: 64 KB total, of which the two tables account for
 // 48 KB of data and 12 KB of indexes, leaving a 4.00 KB remainder. libSQL and SQLite have
 // neither TOAST nor a free space map - their remainder is the schema, the freelist and page
 // overhead - so this fixture is the non-PostgreSQL arm of the breakdown-label test.
@@ -308,7 +308,7 @@ describe("StorageTab", () => {
   });
 
   test("a libSQL database gets the same remainder label as PostgreSQL, not another engine's", () => {
-    // Measured for U23: a real 64 KB libSQL database read "4.00 KB" under "Other (TOAST,
+    // Measured for #515: a real 64 KB libSQL database read "4.00 KB" under "Other (TOAST,
     // FSM)". The number is right and the words belong to PostgreSQL - libSQL has neither
     // structure. The label must be identical on both engines because this tab is given no
     // provider labels to vary it by.

--- a/tests/integration/db/mongodb-provider.test.ts
+++ b/tests/integration/db/mongodb-provider.test.ts
@@ -116,6 +116,22 @@ const defaultServerStatus = () => ({
 
 let mockServerStatus: () => Record<string, unknown> = defaultServerStatus;
 
+/**
+ * What `db.stats()` answers, a function for the same reason `serverStatus` is one:
+ * `databaseSizeBytes` is optional, so the byte figure has to be driven on a database
+ * that measures 0 bytes AND on a deployment that answers without `dataSize` at all.
+ * Both used to reach the Storage tab as a measured 0.
+ */
+const defaultDbStats = () => ({
+  dataSize: 2048,
+  indexSize: 512,
+  storageSize: 4096,
+  collections: 2,
+  objects: 100,
+});
+
+let mockDbStats: () => Record<string, unknown> = defaultDbStats;
+
 const createMockDb = () => ({
   command: async (cmd: Record<string, unknown>) => {
     if (cmd.ping) return { ok: 1 };
@@ -131,13 +147,7 @@ const createMockDb = () => ({
     toArray: async () => mockCollections,
   }),
   collection: (name?: string) => createMockCollection(name),
-  stats: async () => ({
-    dataSize: 2048,
-    indexSize: 512,
-    storageSize: 4096,
-    collections: 2,
-    objects: 100,
-  }),
+  stats: async () => mockDbStats(),
   admin: () => ({
     serverStatus: async () => mockServerStatus(),
     command: async (cmd: Record<string, unknown>) => {
@@ -246,6 +256,7 @@ describe("MongoDBProvider", () => {
     ];
     mockCurrentOps = [];
     mockServerStatus = defaultServerStatus;
+    mockDbStats = defaultDbStats;
     provider = new MongoDBProvider({ ...baseConfig });
   });
 
@@ -820,6 +831,22 @@ describe("MongoDBProvider", () => {
       expect(health.activeConnections).toBe(0);
     });
 
+    test("a dbStats answer without dataSize reports no size rather than a measured 0 B", async () => {
+      // The byte figure has the same two inputs as the connection count, and this method is
+      // the one whose reading reaches the model: the agent's curated `health` projection
+      // sends `databaseSize` verbatim (`method: "getHealth"`, `fields: [..., "databaseSize",
+      // ...]` in `src/lib/agent/tools.ts`), so `dbStats.dataSize || 0` told it a database it
+      // never measured holds nothing. "N/A" is the spelling this method's own catch uses.
+      mockDbStats = () => ({ indexSize: 512, storageSize: 4096 });
+      expect((await provider.getHealth()).databaseSize).toBe("N/A");
+    });
+
+    test("a database that really measures zero bytes still reports 0 B", async () => {
+      // The anti-vacuity twin: an empty database measured 0 bytes, and that is a reading.
+      mockDbStats = () => ({ dataSize: 0, indexSize: 0, storageSize: 0 });
+      expect((await provider.getHealth()).databaseSize).toBe("0 B");
+    });
+
     test("maps in-progress operations to active sessions", async () => {
       mockCurrentOps = [
         {
@@ -916,6 +943,98 @@ describe("MongoDBProvider", () => {
         throw new Error("not authorized on admin to execute command { serverStatus: 1 }");
       };
       expect((await provider.getOverview()).maxConnections).toBe(0);
+    });
+
+    test("an overview read that failed entirely leaves activeConnections absent, and still resolves", async () => {
+      // The same absence that `getHealth()` already carries, at the field the health
+      // reading is composed from. The catch resolves on purpose - `getMonitoringData()`
+      // reads this panel through `Promise.allSettled`, so a rethrow would replace the
+      // whole overview with an error entry rather than the version/uptime placeholders
+      // the tab renders - but nothing was read, so it must not name a connection count.
+      mockServerStatus = () => {
+        throw new Error("not authorized on admin to execute command { serverStatus: 1 }");
+      };
+      const overview = await provider.getOverview();
+
+      expect("activeConnections" in overview).toBe(false);
+      // Still a resolved DatabaseOverview, so the monitoring panel keeps its shape.
+      expect(overview.version).toBe("MongoDB Unknown");
+      expect(overview.uptime).toBe("N/A");
+    });
+
+    test("a server publishing no connections section leaves activeConnections absent", async () => {
+      // `connections` is a network-layer field, so unlike `wiredTiger` its absence is
+      // not tied to the storage engine, and which deployments omit it is not measured
+      // here. `connections?.current || 0` read the missing section as zero open
+      // connections and the Overview card rated it against the limit.
+      mockServerStatus = () => ({ uptime: 86400 });
+      const overview = await provider.getOverview();
+
+      expect("activeConnections" in overview).toBe(false);
+    });
+
+    test("a server with zero open connections keeps its measured zero", async () => {
+      // The anti-vacuity twin of the two tests above: `|| 0` destroyed a real zero as
+      // well as inventing a fake one, so absence must never be spelled with a falsy
+      // test. An idle server measured 0, and 0 is a reading.
+      mockServerStatus = () => ({ connections: { current: 0, available: 100 }, uptime: 86400 });
+      const overview = await provider.getOverview();
+
+      expect("activeConnections" in overview).toBe(true);
+      expect(overview.activeConnections).toBe(0);
+      // The limit is still the sum of what is open and what is left.
+      expect(overview.maxConnections).toBe(100);
+    });
+
+    test("an overview read that failed entirely publishes no byte figure either", async () => {
+      // `databaseSizeBytes` is optional for the reason its docblock gives: a 0 is a
+      // measurement and the Storage tab formats whatever it is given, so a path that read
+      // nothing must omit it. With the key present as 0 that tab took `sizeKnown` as true
+      // and drew the whole breakdown over a 0 B total - and once the table read answers
+      // (it goes through `listCollections` + `collStats`, not `serverStatus`), its
+      // "Other (unattributed)" row is `0 - tables - indexes`, a negative byte figure.
+      // Absent, the tab draws its own "No storage size information available."
+      mockServerStatus = () => {
+        throw new Error("not authorized on admin to execute command { serverStatus: 1 }");
+      };
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(false);
+      // The required string field says the same thing in the only shape its type allows.
+      expect(overview.databaseSize).toBe("N/A");
+      // `maxConnections` stays 0 because there 0 MEANS "no limit published" - the same
+      // fact as absence - and the two counts are required numbers, so 0 is the only
+      // value the type leaves for them. They are named here so this object's remaining
+      // placeholders are pinned rather than assumed.
+      expect(overview.maxConnections).toBe(0);
+      expect(overview.tableCount).toBe(0);
+      expect(overview.indexCount).toBe(0);
+    });
+
+    test("a database that really measures zero bytes keeps its measured zero", async () => {
+      // The anti-vacuity twin: absence must not be spelled with a falsy test. An empty
+      // database measures 0 bytes, and 0 is a reading the Storage tab may divide by.
+      mockDbStats = () => ({ dataSize: 0, indexSize: 0, storageSize: 0 });
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(true);
+      expect(overview.databaseSizeBytes).toBe(0);
+      expect(overview.databaseSize).toBe("0 B");
+    });
+
+    test("a dbStats answer without dataSize publishes no byte figure", async () => {
+      // MongoDB's own dbStats reference documents `dataSize` unconditionally (only the
+      // three `freeStorage` fields are gated, on the command's `freeStorage: 1` option),
+      // so this is not a measured deployment - it is the one arm `|| 0` could not tell
+      // apart from the zero above, and the optional field exists to carry it.
+      mockDbStats = () => ({ indexSize: 512, storageSize: 4096 });
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(false);
+      expect(overview.databaseSize).toBe("N/A");
+      // Everything the same read DID answer still arrives - this is not a failed read.
+      expect(overview.tableCount).toBe(2);
+      expect(overview.activeConnections).toBe(5);
     });
   });
 

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -113,6 +113,17 @@ function defaultQuery(sql: string) {
     return { recordset: [{ test: 1 }], rowsAffected: [1] };
   }
 
+  // getOverview()'s connections query, which must be matched BEFORE the generic
+  // sessions-COUNT branch below: it selects COUNT(*) FROM sys.dm_exec_sessions too,
+  // so that branch used to answer it with `{ cnt: 12 }` - a column getOverview never
+  // reads. Both this fixture and its duplicate were therefore dead, and the
+  // `typeof activeConnections === "number"` assertion they were written for passed
+  // only on the fabricated 0 the provider fell back to. `sys.configurations` is
+  // unique to this statement, so the guard is exact.
+  if (upper.includes("SYS.CONFIGURATIONS") && upper.includes("USER CONNECTIONS")) {
+    return { recordset: [{ active_connections: 5, max_connections: 32767 }], rowsAffected: [1] };
+  }
+
   if (upper.includes("SYS.DM_EXEC_SESSIONS") && upper.includes("COUNT")) {
     return { recordset: [{ cnt: 12 }], rowsAffected: [1] };
   }
@@ -379,15 +390,6 @@ function defaultQuery(sql: string) {
       recordset: [{ sqlserver_start_time: new Date(Date.now() - 86400 * 1000).toISOString(), uptime_seconds: 86400 }],
       rowsAffected: [1],
     };
-  }
-
-  // Overview connections query (active_connections + max_connections)
-  if (upper.includes("SYS.CONFIGURATIONS") && upper.includes("USER CONNECTIONS")) {
-    return { recordset: [{ active_connections: 5, max_connections: 32767 }], rowsAffected: [1] };
-  }
-
-  if (upper.includes("SYS.CONFIGURATIONS")) {
-    return { recordset: [{ active_connections: 5, max_connections: 32767 }], rowsAffected: [1] };
   }
 
   // Table/index counts for overview
@@ -1450,12 +1452,75 @@ describe("MSSQLProvider", () => {
       expect(overview.version).toContain("Microsoft SQL Server");
       expect(typeof overview.uptime).toBe("string");
       expect(overview.uptime.length).toBeGreaterThan(0);
-      expect(typeof overview.activeConnections).toBe("number");
+      expect(overview.activeConnections).toBe(5);
       expect(typeof overview.maxConnections).toBe("number");
       expect(typeof overview.databaseSize).toBe("string");
       expect(typeof overview.databaseSizeBytes).toBe("number");
       expect(typeof overview.tableCount).toBe("number");
       expect(typeof overview.indexCount).toBe("number");
+    });
+
+    test("a refused connections read leaves overview activeConnections absent, never a measured 0", async () => {
+      // The getHealth() twin of this test has guarded the same figure since D17; the
+      // identical defect survived here because `let activeConnections = 0` swallowed
+      // this block's failure into a reading. Unlike that twin, the statement here
+      // names two objects, and the fixture below refuses exactly one of them: the
+      // `sys.configurations` ceiling subquery, which Microsoft documents as needing
+      // only membership in `public` on SQL Server 2019 and earlier but
+      // VIEW SERVER PERFORMANCE STATE on the server on 2022 and later (Permissions
+      // section of sys.configurations, read 2026-08-27). So this reproduces the
+      // 2022-and-later shape - one refused statement, one catch, count absent - and
+      // speaks for those versions only. It says nothing about a login-wide loss: on
+      // 2019 and earlier that arm needs no grant, and `sys.dm_exec_sessions` is
+      // documented as row-filtered rather than refused ("Everyone can see their own
+      // session information"), so an ungranted login there may instead SUCCEED with a
+      // COUNT of its own session. That under-reading is neither measured nor caught -
+      // see docs/providers/mssql.md section 7.2. The Msg 300 wording below is the
+      // refusal measured 2026-08-23 on SQL Server 2022 CU26 against a login holding
+      // nothing beyond CONNECT; nothing asserts on it, only that it throws.
+      mockQueryFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("SYS.CONFIGURATIONS") && upper.includes("USER CONNECTIONS")) {
+          throw new Error("VIEW SERVER PERFORMANCE STATE permission was denied on object 'server', database 'master'");
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      // Absent, so OverviewTab.tsx's Connections card renders "N/A" over "not
+      // published" instead of a confident 0 with a "0% used" progress bar, and the
+      // sample is dropped from the connection trend rather than plotted as a floor.
+      expect("activeConnections" in overview).toBe(false);
+      // maxConnections is a required number where 0 and absence are the SAME fact -
+      // "no limit published" - so the refusal correctly leaves it 0. Pinned so the
+      // absence above is not widened into this field by a later change.
+      expect(overview.maxConnections).toBe(0);
+      // Only the denied block goes absent; every other reading survives.
+      expect(overview.version).toContain("Microsoft SQL Server");
+      expect(overview.tableCount).toBe(5);
+    });
+
+    test("a server with no user sessions keeps its measured zero overview connections", async () => {
+      // The anti-vacuity twin of the test above: absence must never be spelled with a
+      // falsy test. An idle instance answers COUNT(*) = 0 and that 0 is a reading, so
+      // the `Number(... || 0)` this replaces was destroying the very figure it
+      // published - it could not tell an idle server from a denied DMV.
+      mockQueryFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("SYS.CONFIGURATIONS") && upper.includes("USER CONNECTIONS")) {
+          return { recordset: [{ active_connections: 0, max_connections: 32767 }], rowsAffected: [1] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("activeConnections" in overview).toBe(true);
+      expect(overview.activeConnections).toBe(0);
+      expect(overview.maxConnections).toBe(32767);
     });
 
     test("Azure SQL detection from hostname", () => {

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -1878,11 +1878,81 @@ describe("OracleProvider", () => {
       expect(overview.version).toBe("Oracle");
       expect(overview.uptime).toBe("N/A");
       expect(overview.startTime).toBeUndefined();
-      expect(overview.activeConnections).toBe(0);
+      // Not `toBe(0)` any more: this assertion pinned the fabrication rather than the
+      // degradation. `maxConnections` is different and stays 0 - its own docblock in
+      // src/lib/db/types.ts says 0 MEANS "no limit published" there, so 0 and absence
+      // are the same fact for the ceiling and different facts for the count.
+      expect("activeConnections" in overview).toBe(false);
       expect(overview.maxConnections).toBe(0);
       expect(overview.databaseSizeBytes).toBe(0);
       expect(overview.tableCount).toBe(0);
       expect(overview.indexCount).toBe(0);
+    });
+
+    test("an unprivileged V$SESSION leaves overview activeConnections absent, never a measured 0", async () => {
+      // The same defect getHealth() was already corrected for, in the same file: the
+      // block was guarded but `let activeConnections = 0` published the refusal as an
+      // instance with no user session. Oracle's own Database Reference states that
+      // "after installation, only user SYS or anyone with SYSDBA privilege has access
+      // to the dynamic performance tables", so a plain schema user is the ORDINARY
+      // case here, not an exotic one - and the refusal shape was measured 2026-08-23
+      // on Oracle AI Database 26ai Free against a user granted only CREATE SESSION
+      // (`ORA-00942: table or view "SYS"."V_$SYSSTAT" does not exist`); V_$SESSION
+      // answers in the same shape when the grant is missing.
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("V$SESSION") && upper.includes("COUNT")) {
+          throw new Error('ORA-00942: table or view "SYS"."V_$SESSION" does not exist');
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("activeConnections" in overview).toBe(false);
+      // Only the refused count goes absent; every other read still answers.
+      expect(overview.version).toContain("Oracle");
+      expect(overview.tableCount).toBe(10);
+      expect(overview.databaseSizeBytes).toBe(268435456);
+    });
+
+    test("an instance with no user session keeps its measured zero connections", async () => {
+      // The anti-vacuity twin of the test above. Absence must never be spelled with a
+      // falsy test (`Number(...) || undefined`): an instance whose only USER session is
+      // this very pool's own could still count 0 at the moment of the read, and that 0
+      // is a reading rather than a refusal.
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("V$SESSION") && upper.includes("COUNT")) {
+          return { rows: [{ CNT: 0 }], metaData: [{ name: "CNT" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("activeConnections" in overview).toBe(true);
+      expect(overview.activeConnections).toBe(0);
+    });
+
+    test("keeps the measured count when only the sessions ceiling is refused", async () => {
+      // Both reads share one try block, and the count is assigned before the ceiling
+      // is attempted - so a V$PARAMETER refusal must not carry the count away with it.
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("V$PARAMETER")) {
+          throw new Error('ORA-00942: table or view "SYS"."V_$PARAMETER" does not exist');
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect(overview.activeConnections).toBe(8);
+      expect(overview.maxConnections).toBe(0);
     });
   });
 

--- a/tests/integration/db/trino-provider.test.ts
+++ b/tests/integration/db/trino-provider.test.ts
@@ -1122,6 +1122,57 @@ describe("TrinoProvider monitoring", () => {
     expect(sentAnything('SHOW STATS FOR "tpch"."sf1"."customer"')).toBe(true);
   });
 
+  /*
+    D41: the pass used to describe the first 25 tables of a bigger catalog and hand those
+    rows back as the reading. Nothing in `TableStats[]` or in `MonitoringData.tables`
+    could say more had been dropped, so the panel's count and the agent's `rowCount` both
+    read 25 for a catalog of any size. The provider now refuses the oversized scope, which
+    is why these two tests assert the same sentence in the two shapes it travels in: a
+    thrown `QueryError` for a direct caller, and `errors.tables` beside an absent panel for
+    the dashboard.
+
+    Live-verified 2026-08-27 against Trino 476 through this provider's own transport: the
+    real `tpch` holds 72 user tables and refuses, while `getTableStats({ schema: "tiny" })`
+    answers all 8 of them (lineitem 60175, nation 25) - a reading the catalog-wide pass
+    could never return, `tiny` sorting last behind 64 tables it never reached.
+  */
+  // The 72 in the shape it really has: the tpch connector publishes these nine schemas of
+  // the same eight tables, which is both where the number comes from and why the refusal
+  // can tell this caller that narrowing WILL work - every one of the nine is inside the
+  // bound. A catalog whose schemas are all oversized is told the opposite, in the unit
+  // tests, because there is no fixture shape that makes both sentences true at once.
+  const SEVENTY_TWO = ["tiny", "sf1", "sf100", "sf300", "sf1000", "sf3000", "sf10000", "sf30000", "sf100000"].flatMap(
+    (schema) =>
+      ["customer", "lineitem", "nation", "orders", "part", "partsupp", "region", "supplier"].map((table) => [
+        schema,
+        table,
+      ]),
+  );
+
+  test("a catalog bigger than one stats pass is refused with the number of tables it holds", async () => {
+    const provider = await connectProvider();
+    overrideSurface(trinoTableListSql(CATALOG), rows(TABLE_LIST_COLUMNS, SEVENTY_TWO));
+    sentSql = [];
+
+    await expect(provider.getTableStats()).rejects.toThrow(/Catalog "tpch" holds 72 tables/);
+    // Not one statement per table up to the bound either: the refusal is cheaper than the
+    // truncation it replaces, because the table list already answered the whole question.
+    expect(sentAnything("SHOW STATS FOR")).toBe(false);
+  });
+
+  test("the oversized table panel is ABSENT in the dashboard, carrying the size sentence", async () => {
+    const provider = await connectProvider();
+    overrideSurface(trinoTableListSql(CATALOG), rows(TABLE_LIST_COLUMNS, SEVENTY_TWO));
+    const data = await provider.getMonitoringData({ includeIndexes: false, includeStorage: false });
+
+    expect(data.tables).toBeUndefined();
+    expect(data.errors?.tables).toContain('Catalog "tpch" holds 72 tables');
+    // The advice reaches the dashboard intact, and it is the advice that is TRUE of this
+    // catalog: nine schemas, every one of them describable on its own.
+    expect(data.errors?.tables).toContain("which holds for 9 of the schemas this catalog's tables are in");
+    expect(data.overview).toBeDefined();
+  });
+
   test("the refused table panel is ABSENT with its sentence while the rest of the dashboard answers", async () => {
     // The whole point of the conversion: one panel that cannot be answered costs that
     // panel and carries its reason, instead of rendering as a table of no rows.

--- a/tests/integration/db/trino-provider.test.ts
+++ b/tests/integration/db/trino-provider.test.ts
@@ -1123,7 +1123,7 @@ describe("TrinoProvider monitoring", () => {
   });
 
   /*
-    D41: the pass used to describe the first 25 tables of a bigger catalog and hand those
+    #515: the pass used to describe the first 25 tables of a bigger catalog and hand those
     rows back as the reading. Nothing in `TableStats[]` or in `MonitoringData.tables`
     could say more had been dropped, so the panel's count and the agent's `rowCount` both
     read 25 for a catalog of any size. The provider now refuses the oversized scope, which

--- a/tests/unit/backlog-structure.test.ts
+++ b/tests/unit/backlog-structure.test.ts
@@ -18,7 +18,9 @@
  * listed are the sections present, each listed id exists, each range's endpoints are the real
  * extremes, and the trailing count is the real number of entries. The endpoints are checked as
  * extremes rather than as a canonical rendering because the file writes a prefix's entries as
- * `U17, U22–U23` in one section and `X2–X14` in another, and both are legitimate.
+ * `X2–X14` in one section and as bare ids in another, and both are legitimate. The examples in
+ * this file are illustrative rather than pinned: a closed entry changes them, so they are written
+ * as shapes and the assertions derive the real ones from the document.
  */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -131,7 +133,7 @@ interface Spec {
   readonly count: number | null;
 }
 
-/** `D1–D41, U17, U22–U23 · 19` becomes the six endpoints it names plus the count 19. */
+/** `D1–D39, U17, U22 · 14` becomes the four endpoints it names plus the count 14. */
 const parseSpec = (spec: string): Spec => {
   const [ranges, ...rest] = spec.split(" · ");
   return {

--- a/tests/unit/db/base-provider.test.ts
+++ b/tests/unit/db/base-provider.test.ts
@@ -468,6 +468,9 @@ describe("BaseDatabaseProvider", () => {
   // ─── getConnectionInfo ────────────────────────────────────────────────
 
   describe("getConnectionInfo", () => {
+    const infoFor = (connectionString: string) =>
+      new TestProvider(makeConfig({ connectionString })).callGetConnectionInfo();
+
     test("returns host:port/database when no connectionString", () => {
       const provider = new TestProvider(makeConfig());
       const info = provider.callGetConnectionInfo();
@@ -483,6 +486,125 @@ describe("BaseDatabaseProvider", () => {
       expect(info).not.toContain("s3cret");
       expect(info).toContain(":***@");
       expect(info).toContain("db.example.com");
+    });
+
+    // A connection string does not always carry its credential in the authority. libSQL
+    // passes the whole token as a query parameter, and libpq accepts `password`/`sslkey`
+    // there too, so each shape below is one the authority-only mask used to let through.
+
+    test("masks an authToken carried in the query string", () => {
+      const info = infoFor("libsql://db-org.turso.io?authToken=eyJhbGciOiJFZERTQSJ9.payload.signature");
+
+      expect(info).not.toContain("eyJhbGciOiJFZERTQSJ9");
+      expect(info).toBe("libsql://db-org.turso.io?authToken=***");
+    });
+
+    test("matches credential parameter names case-insensitively", () => {
+      expect(infoFor("libsql://host?AUTHTOKEN=abc")).toBe("libsql://host?AUTHTOKEN=***");
+      expect(infoFor("postgres://host/db?PassWord=abc")).toBe("postgres://host/db?PassWord=***");
+    });
+
+    test("masks every credential parameter when several appear in one string", () => {
+      const info = infoFor("postgres://host/db?sslmode=verify-full&password=pw&sslkey=/client.pem&token=tk");
+
+      expect(info).toBe("postgres://host/db?sslmode=verify-full&password=***&sslkey=***&token=***");
+    });
+
+    test("masks a credential in the authority and in the query string together", () => {
+      const info = infoFor("libsql://admin:s3cret@db-org.turso.io?authToken=jwt");
+
+      expect(info).toBe("libsql://admin:***@db-org.turso.io?authToken=***");
+    });
+
+    test("masks a credential value whole, url-encoded or containing '='", () => {
+      expect(infoFor("libsql://host?authToken=a%2Fb%3Dc")).toBe("libsql://host?authToken=***");
+      // Base64 padding puts a literal '=' inside the value; it must not end the value.
+      expect(infoFor("libsql://host?authToken=YWJj==&mode=ro")).toBe("libsql://host?authToken=***&mode=ro");
+    });
+
+    test("leaves an empty credential value empty rather than inventing a redaction", () => {
+      // '***' over a value that was never there would assert a secret the string does
+      // not carry, which is the absence rule wearing a redaction's clothes.
+      expect(infoFor("libsql://host?authToken=&mode=ro")).toBe("libsql://host?authToken=&mode=ro");
+    });
+
+    test("over-redacts a parameter whose name merely contains a credential word", () => {
+      // Deliberate. A driver spelling we have not seen is far more costly to miss than a
+      // non-secret is to hide, and the second case here is exactly why: `sslpassword` is
+      // a real libpq keyword that an exact-name list would have leaked.
+      expect(infoFor("libsql://host?tokenLifetime=3600")).toBe("libsql://host?tokenLifetime=***");
+      expect(infoFor("postgres://host/db?sslpassword=pw")).toBe("postgres://host/db?sslpassword=***");
+    });
+
+    test("leaves a non-credential parameter whose value contains a credential word intact", () => {
+      // The name is matched between a delimiter and '=', so a credential word sitting in
+      // somebody else's value neither triggers a mask nor mangles the string.
+      expect(infoFor("postgres://host/db?applicationName=my-password-app")).toBe(
+        "postgres://host/db?applicationName=my-password-app",
+      );
+      expect(infoFor("postgres://host/db?options=-c%20statement_timeout=5s")).toBe(
+        "postgres://host/db?options=-c%20statement_timeout=5s",
+      );
+    });
+
+    test("masks a semicolon-delimited credential in a string that is not a valid URL", () => {
+      // An ADO-style SQL Server string has no query string and no scheme, so a redaction
+      // built on URL parsing would throw on it instead of masking it.
+      expect(infoFor("Server=localhost,1433;Database=db;User Id=sa;Password=P4ssw0rd")).toBe(
+        "Server=localhost,1433;Database=db;User Id=sa;Password=***",
+      );
+    });
+
+    test("does not mistake an '@' outside the authority for userinfo", () => {
+      // ':' + text + '@' also occurs in a path and in a parameter value; masking there
+      // would destroy the host the reader needs and redact nothing secret.
+      expect(infoFor("postgres://host:5432/tenant@acme")).toBe("postgres://host:5432/tenant@acme");
+      expect(infoFor("mongodb://host/db?replicaSet=rs:0@node")).toBe("mongodb://host/db?replicaSet=rs:0@node");
+    });
+
+    // An ADO-style string orders its parameters arbitrarily, so the credential is as
+    // likely to lead as to trail. Matching a name only AFTER a delimiter returned the
+    // leading one verbatim, which is the shape a review of this round measured leaking.
+    test.each([
+      ["Password=P4ssw0rd;Server=host", "Password=***;Server=host"],
+      // Deliberately not JWT-shaped. The realistic libSQL token is pinned above, in the
+      // query-string position where it belongs; here the POSITION is the subject, so a
+      // high-entropy literal would buy nothing and trips the secret scanner's
+      // generic-api-key rule (measured: entropy 3.98 in this exact `name=value;` shape).
+      ["authToken=leading-token-value;Server=host", "authToken=***;Server=host"],
+      ["SslKey=/etc/client.pem;Server=host", "SslKey=***;Server=host"],
+      ["ClientSecret=s3cr3t;Server=host", "ClientSecret=***;Server=host"],
+    ])("masks %s, whose credential leads the string", (given, expected) => {
+      expect(infoFor(given)).toBe(expected);
+    });
+
+    test("leaves a password containing an unencoded '/' unmasked, which is the documented limit", () => {
+      // Pinned so the gap is visible rather than assumed closed. RFC 3986 wants that '/'
+      // percent-encoded, and `postgres://host:5432/tenant@acme` - a path holding an '@',
+      // pinned above - has the identical shape, so masking one masks the other. Hiding a
+      // port behind a `***` that asserts a credential the string never carried is the
+      // worse error of the two, so this case is left to the parse-based fix in D42.
+      expect(infoFor("postgres://user:p/w@db.example.com/mydb")).toBe("postgres://user:p/w@db.example.com/mydb");
+    });
+
+    test("masks the authority of a string whose scheme carries its own prefix", () => {
+      // A JDBC-style URL puts a second scheme in front. Anchoring the userinfo to the
+      // START of the string rather than to '://' would leave this password in the clear.
+      expect(infoFor("jdbc:postgresql://user:s3cret@host/db")).toBe("jdbc:postgresql://user:***@host/db");
+    });
+
+    test("leaves an authority that carries no credential exactly as it was", () => {
+      // A user name with no password, and a ':'+text+'@' that lives in the path. Neither
+      // holds a secret, so replacing either would cost the reader the host or the user
+      // and hide nothing - and a mask that eats the '//' is how a scheme goes missing.
+      expect(infoFor("postgres://user@db.example.com/mydb")).toBe("postgres://user@db.example.com/mydb");
+      expect(infoFor("postgres://host/db:owner@example.com")).toBe("postgres://host/db:owner@example.com");
+    });
+
+    test("masks a credential a fragment delimits", () => {
+      // '#' bounds a parameter the same way '&' does, so a credential written after one
+      // must not swallow the rest of the string into its value.
+      expect(infoFor("libsql://host?mode=ro#authToken=jwt")).toBe("libsql://host?mode=ro#authToken=***");
     });
   });
 

--- a/tests/unit/db/trino/introspect.test.ts
+++ b/tests/unit/db/trino/introspect.test.ts
@@ -801,7 +801,7 @@ describe("Trino getTableStats", () => {
   });
 
   /*
-    D41: the pass used to describe the first 25 tables of an oversized scope and return
+    #515: the pass used to describe the first 25 tables of an oversized scope and return
     them as the answer, and no consumer could see that anything had been dropped -
     `TableStats[]` has no field for "there were more", `MonitoringData.tables` is that
     same array, and the agent's curated reading published its length as `rowCount`. A cap

--- a/tests/unit/db/trino/introspect.test.ts
+++ b/tests/unit/db/trino/introspect.test.ts
@@ -800,15 +800,158 @@ describe("Trino getTableStats", () => {
     ]);
   });
 
-  test("bounds the pass, because one table is one statement", async () => {
-    const many: TrinoRow[] = Array.from({ length: TRINO_MAX_STATS_TABLES + 5 }, () => ({
+  /*
+    D41: the pass used to describe the first 25 tables of an oversized scope and return
+    them as the answer, and no consumer could see that anything had been dropped -
+    `TableStats[]` has no field for "there were more", `MonitoringData.tables` is that
+    same array, and the agent's curated reading published its length as `rowCount`. A cap
+    read as a count is the absence lie one size up, so an oversized scope now REFUSES,
+    which is the answer the agent's own row bound already gives (`READING_OVER_BUDGET` in
+    src/lib/agent/tools.ts) and for the same reason.
+
+    Measured 2026-08-27 against Trino 476: every built-in catalog but `memory` is over the
+    bound (`tpch` 72 tables, `system` 26, `tpcds` 250, `jmx` 379), and the tpch pass never
+    reached the `tiny` schema at all - it sorts last, so the 25 statements went to sf1,
+    sf100, sf1000 and sf10000.customer, of which only sf1 publishes row counts. The panel
+    therefore answered 8 rows for a 72-table catalog and named none of the tables the
+    fixtures use.
+  */
+  test("refuses a scope larger than one pass rather than describing the first 25 of it", async () => {
+    const many: TrinoRow[] = Array.from({ length: TRINO_MAX_STATS_TABLES + 1 }, () => ({
+      schemaName: "tiny",
+      tableName: "region",
+    }));
+    const { runner } = fakeRunner({ rows: { tableList: many } });
+    const { tables, refusal } = await getTableStats(runner, CATALOG);
+
+    expect(tables).toEqual([]);
+    expect(refusal).toContain(`Catalog "tpch" holds ${TRINO_MAX_STATS_TABLES + 1} tables`);
+    expect(refusal).toContain(`more than the ${TRINO_MAX_STATS_TABLES} one pass describes`);
+    // The scope word, not just the scope's name: an unnarrowed read is refused because
+    // 25 rows would be read as the CATALOG's table count. The narrowed test below pins
+    // the other arm of the same ternary, which one line of coverage cannot tell apart.
+    expect(refusal).toContain("read as the catalog's table count");
+  });
+
+  /*
+    The catalog-scope advice used to read "Ask for a single schema and the whole of it is
+    described", and that is not true of a schema which is itself over the bound - this
+    provider's own measurements name one, jmx holding 379 tables in schema `current`. The
+    advice is now conditional on a figure the reading already has: the table list is a
+    single uncapped read that has already answered for the whole catalog, so which
+    schemas a narrowed pass would describe is known before any SHOW STATS is sent.
+  */
+  test("names how many schemas a narrowed pass would describe, rather than promising all of them", async () => {
+    // Eight tables in each of nine schemas is the shape the tpch connector publishes -
+    // tiny, sf1, sf100, sf300, sf1000, sf3000, sf10000, sf30000, sf100000, of customer,
+    // lineitem, nation, orders, part, partsupp, region, supplier - and is where the
+    // measured 72 comes from. Two more schemas are added to pin the boundary of the
+    // figure itself: one of exactly the bound, which IS describable, and one of one
+    // more, which is not and must not be counted among the narrowings offered.
+    const eight = ["customer", "lineitem", "nation", "orders", "part", "partsupp", "region", "supplier"];
+    const nine = ["tiny", "sf1", "sf100", "sf300", "sf1000", "sf3000", "sf10000", "sf30000", "sf100000"];
+    const listed: TrinoRow[] = [
+      ...nine.flatMap((schemaName) => eight.map((tableName) => ({ schemaName, tableName }))),
+      ...Array.from({ length: TRINO_MAX_STATS_TABLES }, (_unused, index) => ({
+        schemaName: "at_the_bound",
+        tableName: `t${index}`,
+      })),
+      ...Array.from({ length: TRINO_MAX_STATS_TABLES + 1 }, (_unused, index) => ({
+        schemaName: "over_the_bound",
+        tableName: `t${index}`,
+      })),
+    ];
+    const { runner } = fakeRunner({ rows: { tableList: listed } });
+    const { tables, refusal } = await getTableStats(runner, CATALOG);
+
+    expect(tables).toEqual([]);
+    expect(refusal).toContain('Catalog "tpch" holds 123 tables'); // 72 + 25 + 26
+    expect(refusal).toContain("Narrowing to one schema describes the whole of it when");
+    expect(refusal).toContain("which holds for 10 of the schemas this catalog's tables are in");
+    expect(refusal).toContain('SHOW STATS FOR "tpch"."<schema>"."<table>"');
+  });
+
+  test("says plainly that no narrowing is left when every schema is over the bound as well", async () => {
+    // The shape jmx has: measured 2026-08-27 against Trino 476 it holds 379 tables and
+    // every one of them is in `current`, so the narrowing the advice used to offer lands
+    // on this same refusal one level down. Advice pointing at a scope that is also
+    // refused is worse than no advice, so the sentence offers the per-table statement -
+    // the one route that answers for any scope - and says so instead.
+    const many: TrinoRow[] = Array.from({ length: TRINO_MAX_STATS_TABLES + 1 }, (_unused, index) => ({
+      schemaName: "current",
+      tableName: `mbean${index}`,
+    }));
+    const { runner } = fakeRunner({ rows: { tableList: many } });
+    const { refusal } = await getTableStats(runner, CATALOG);
+
+    expect(refusal).toContain("Narrowing to one schema does not help here");
+    expect(refusal).toContain("every schema this catalog's tables are in is over the bound as well");
+    expect(refusal).toContain('SHOW STATS FOR "tpch"."<schema>"."<table>"');
+  });
+
+  test("sends no SHOW STATS at all for a scope it refuses, so the refusal costs less than the cut did", async () => {
+    const many: TrinoRow[] = Array.from({ length: TRINO_MAX_STATS_TABLES + 1 }, () => ({
       schemaName: "tiny",
       tableName: "region",
     }));
     const { runner, sent } = fakeRunner({ rows: { tableList: many } });
     await getTableStats(runner, CATALOG);
 
+    expect(sent.filter((sql) => sql.startsWith("SHOW STATS FOR"))).toEqual([]);
+  });
+
+  test("describes a scope exactly at the bound in full, because nothing is dropped there", async () => {
+    const exactly: TrinoRow[] = Array.from({ length: TRINO_MAX_STATS_TABLES }, () => ({
+      schemaName: "tiny",
+      tableName: "region",
+    }));
+    const { runner, sent } = fakeRunner({ rows: { tableList: exactly } });
+    const { tables, refusal } = await getTableStats(runner, CATALOG);
+
+    expect(refusal).toBeUndefined();
+    expect(tables).toHaveLength(TRINO_MAX_STATS_TABLES);
     expect(sent.filter((sql) => sql.startsWith("SHOW STATS FOR"))).toHaveLength(TRINO_MAX_STATS_TABLES);
+  });
+
+  test("answers a narrowed schema that fits even when its catalog does not", async () => {
+    // The bound is applied to what was ASKED for, not to what the catalog holds: the
+    // schema filter runs first, so `tiny` is describable in a catalog of any size. That
+    // is what makes the refusal's advice something a caller can act on - the agent's
+    // curated reading takes a `schema` - and it is the ONLY way to see `tiny` at all:
+    // measured, it sorts last in tpch, so the catalog-wide pass spent its 25 statements
+    // 64 tables short of it.
+    const many: TrinoRow[] = Array.from({ length: TRINO_MAX_STATS_TABLES + 5 }, () => ({
+      schemaName: "sf1",
+      tableName: "customer",
+    }));
+    const { runner } = fakeRunner({
+      rows: { tableList: [...many, { schemaName: "tiny", tableName: "region" }] },
+    });
+    const { tables, refusal } = await getTableStats(runner, CATALOG, { schema: "tiny" });
+
+    expect(refusal).toBeUndefined();
+    expect(tables.map((table) => table.tableName)).toEqual(["region"]);
+  });
+
+  test("names the schema, and advises no further narrowing, when the caller already narrowed", async () => {
+    // Advice a caller cannot act on is worse than none, and there IS no narrower
+    // selection than one schema here, so the sentence offers the per-table statement
+    // instead of asking again for something it already has.
+    const many: TrinoRow[] = Array.from({ length: TRINO_MAX_STATS_TABLES + 1 }, () => ({
+      schemaName: "tiny",
+      tableName: "region",
+    }));
+    const { runner } = fakeRunner({ rows: { tableList: many } });
+    const { tables, refusal } = await getTableStats(runner, CATALOG, { schema: "tiny" });
+
+    expect(tables).toEqual([]);
+    expect(refusal).toContain(`Schema "tiny" of catalog "tpch" holds ${TRINO_MAX_STATS_TABLES + 1} tables`);
+    expect(refusal).toContain('SHOW STATS FOR "tpch"."tiny"."<table>"');
+    expect(refusal).toContain("read as the schema's table count");
+    // Not vacuous: "Narrowing to one schema" is the opening of BOTH catalog-scope arms,
+    // each pinned positively above, so renaming it turns those two red before this one
+    // could quietly start passing on a string that no longer exists anywhere.
+    expect(refusal).not.toContain("Narrowing to one schema");
   });
 
   test("degrades one table's failure to that table alone", async () => {

--- a/tests/unit/provider-docs-monitoring-citations.test.ts
+++ b/tests/unit/provider-docs-monitoring-citations.test.ts
@@ -1,0 +1,178 @@
+/**
+ * The provider docs cite code by NAME, not by line.
+ *
+ * A line number hand-copied into prose has nothing measuring it, so it is true only until the
+ * next insertion above it, and nothing goes red when it stops being true.
+ *
+ * `docs/providers/elasticsearch.md` and `docs/providers/opensearch.md` carried a
+ * monitoring-seam table whose eight rows each pinned a method to a line number in
+ * `src/lib/db/providers/sql/search/index.ts`. All eight were written in one commit —
+ * `git log -S"index.ts:811" -- docs/providers/elasticsearch.md` returns 25712e68 (#429) alone —
+ * as 751/811/831/844/860/873/884/898. They were never right: in that same commit the eight
+ * declarations sat at 808/868/888/901/917/930/941/955, a uniform +57, so the numbers had been
+ * read off the file before something above them grew and were shipped stale. Today the offset is
+ * a uniform +65. Being wrong by a constant is what let this survive: the rows stayed in
+ * ascending order and went on reading as a consistent, ordered, plausible list, so there was no
+ * internal contradiction for a reader to notice and no gate measuring the numbers at all.
+ *
+ * `docs/providers/redis.md` shows what hand-correcting such a number buys. #89 wrote
+ * `base-provider.ts:102` for `getMonitoringData()`, true at that commit; #122 corrected it to
+ * `:99`, true at that commit; it has since rotted a second time. A method name is greppable and
+ * survives an insertion above it, so it needs no correction round at all.
+ *
+ * These tests therefore pin the policy rather than any coordinate: the seam rows name real
+ * declarations, they are listed in the order the source declares them, both search docs name the
+ * same eight, and the docs in scope carry no `:<line>` suffix.
+ *
+ * SCOPE, deliberately narrow: the whole of `docs/providers/mssql.md` and
+ * `docs/providers/trino.md`, plus the monitoring seam of the two search docs and the one
+ * `base-provider.ts` citation in `docs/providers/redis.md`. The rest of `docs/providers/` still
+ * cites code by line in quantity — a pre-existing backlog this round did not open — and the two
+ * search docs are guarded only inside their monitoring section. Nothing here asserts that the
+ * uncovered citations are correct; they are simply not measured yet.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "../..");
+
+const read = (relative: string): string => readFileSync(path.join(ROOT, relative), "utf8");
+
+const SEARCH_PROVIDER = "src/lib/db/providers/sql/search/index.ts";
+const BASE_PROVIDER = "src/lib/db/base-provider.ts";
+const MIGRATION_GENERATOR = "src/lib/schema-diff/migration-generator.ts";
+const FACTORY = "src/lib/db/factory.ts";
+
+/**
+ * The docs this round rewrote, the source their prose links to, and the method names that now
+ * stand where a line number used to. The list is the point: renaming any of these breaks the
+ * doc, and a name that is not declared is caught here rather than by a reader.
+ */
+const NAMED_CITATIONS = [
+  {
+    doc: "docs/providers/mssql.md",
+    source: "src/lib/db/providers/sql/mssql.ts",
+    methods: [
+      "getCapabilities",
+      "getLabels",
+      "validate",
+      "buildConfig",
+      "query",
+      "cancelQuery",
+      "prepareQuery",
+      "beginTransaction",
+      "queryInTransaction",
+      "getSchema",
+      "runMaintenance",
+      "getPoolStats",
+    ],
+  },
+  {
+    doc: "docs/providers/trino.md",
+    source: "src/lib/db/providers/sql/trino/index.ts",
+    methods: ["getCapabilities", "getLabels"],
+  },
+] as const;
+
+const SEARCH_DOCS = ["docs/providers/elasticsearch.md", "docs/providers/opensearch.md"] as const;
+
+/** The `## 7. Monitoring & health` block, up to the next top-level section. */
+const monitoringSection = (doc: string): string => {
+  const start = doc.indexOf("## 7. Monitoring & health");
+  expect(start).toBeGreaterThan(-1);
+  const rest = doc.slice(start);
+  const end = rest.indexOf("\n## ", 1);
+  return end === -1 ? rest : rest.slice(0, end);
+};
+
+/** The first column of the `| Method | Source | Mapping |` table, in document order. */
+const seamTableMethods = (section: string): string[] => {
+  const header = section.indexOf("| Method | Source | Mapping |");
+  expect(header).toBeGreaterThan(-1);
+  const rows: string[] = [];
+  for (const line of section.slice(header).split("\n").slice(2)) {
+    if (!line.startsWith("|")) break;
+    const cell = line.split("|")[1].trim();
+    const named = /^`([A-Za-z]+)\(\)`$/.exec(cell);
+    expect(named, `seam row cites something other than a bare method name: ${cell}`).not.toBeNull();
+    rows.push((named as RegExpExecArray)[1]);
+  }
+  return rows;
+};
+
+/** Line number of a method's declaration in a provider source, or -1. */
+const declarationLine = (source: string, method: string): number =>
+  source.split("\n").findIndex((line) => new RegExp(`^\\s*(public|protected|private).*\\b${method}\\(`).test(line));
+
+describe("search provider docs: the monitoring seam table", () => {
+  const provider = read(SEARCH_PROVIDER);
+
+  test("both docs name the same eight methods", () => {
+    const [elasticsearch, opensearch] = SEARCH_DOCS.map((doc) => seamTableMethods(monitoringSection(read(doc))));
+    expect(elasticsearch).toEqual(opensearch);
+    expect(elasticsearch).toHaveLength(8);
+  });
+
+  for (const doc of SEARCH_DOCS) {
+    test(`${doc} rows name real declarations, in the order the source declares them`, () => {
+      const methods = seamTableMethods(monitoringSection(read(doc)));
+      const lines = methods.map((method) => {
+        const line = declarationLine(provider, method);
+        expect(line, `${method}() is not declared in ${SEARCH_PROVIDER}`).toBeGreaterThan(-1);
+        return line;
+      });
+      expect(lines).toEqual([...lines].sort((a, b) => a - b));
+    });
+
+    test(`${doc} cites no line number in the monitoring section`, () => {
+      expect(monitoringSection(read(doc))).not.toMatch(/\.ts:\d/);
+    });
+
+    test(`${doc} names runMaintenance() and the refusal table rather than their lines`, () => {
+      const text = read(doc);
+      expect(text).toContain("`runMaintenance(type)` ([`search/index.ts`]");
+      // The prose wraps, so the name and the un-numbered link are pinned separately.
+      expect(text).toContain("`NO_COLUMN_MODIFICATION` table in");
+      expect(text).toContain("[`migration-generator.ts`](../../src/lib/schema-diff/migration-generator.ts)");
+      expect(text).not.toMatch(/migration-generator\.ts:\d/);
+    });
+  }
+
+  test("NO_COLUMN_MODIFICATION is the real name of the refusal table", () => {
+    expect(read(MIGRATION_GENERATOR)).toMatch(/^const NO_COLUMN_MODIFICATION\b/m);
+  });
+});
+
+describe("redis provider doc", () => {
+  test("names getMonitoringData() rather than a line in base-provider.ts", () => {
+    const text = read("docs/providers/redis.md");
+    expect(text).toContain("`getMonitoringData()` from\n[`base-provider.ts`](../../src/lib/db/base-provider.ts)");
+    expect(text).not.toMatch(/base-provider\.ts:\d/);
+    expect(declarationLine(read(BASE_PROVIDER), "getMonitoringData")).toBeGreaterThan(-1);
+  });
+});
+
+describe("provider docs rewritten this round: code cited by name, whole file", () => {
+  for (const { doc, source, methods } of NAMED_CITATIONS) {
+    test(`${doc} cites no line number anywhere`, () => {
+      expect(read(doc)).not.toMatch(/\.ts:\d/);
+    });
+
+    test(`${doc} names methods that ${source} really declares`, () => {
+      const text = read(doc);
+      const provider = read(source);
+      for (const method of methods) {
+        expect(text.includes(`\`${method}(`), `${doc} no longer names ${method}()`).toBe(true);
+        expect(declarationLine(provider, method), `${method}() is not declared in ${source}`).toBeGreaterThan(-1);
+      }
+    });
+  }
+
+  test("mssql.md names the factory's entry point rather than a line inside it", () => {
+    expect(read("docs/providers/mssql.md")).toContain(
+      "`createDatabaseProvider()` ([`factory.ts`](../../src/lib/db/factory.ts))",
+    );
+    expect(read(FACTORY)).toMatch(/^export async function createDatabaseProvider\(/m);
+  });
+});

--- a/tests/unit/schema-diff/migration-generator.test.ts
+++ b/tests/unit/schema-diff/migration-generator.test.ts
@@ -871,6 +871,133 @@ describe("generateMigrationSQL: Cassandra declines CREATE TABLE rather than gues
 });
 
 /**
+ * D36. Both directions, both ids, because the generator got each of the four cases from a different
+ * place and only one of them was right.
+ *
+ * SQLite's ALTER TABLE page enumerates every schema change the engine has - "rename table", "rename
+ * column", "add column", "drop column", plus SET/DROP NOT NULL since 3.53.0 - and adding a constraint
+ * is not among them; the page routes such a change through its own 12-step table-recreation
+ * procedure. Measured on sqlite3 3.53.3: `ALTER TABLE "users" ADD CONSTRAINT "fk_users_dept_id"
+ * FOREIGN KEY ("dept_id") REFERENCES "departments"("id");` is `near "FOREIGN": syntax error` - the
+ * parser has already taken `CONSTRAINT` for a column name and the quoted name for its type - and the
+ * same statement over Hrana on sqld 0.24.33 is `near CONSTRAINT ... syntax error`. Two tokens, one
+ * verdict.
+ *
+ * The two emission paths still want DIFFERENT answers. In `CREATE TABLE` the key IS expressible, as a
+ * table constraint: SQLite's CREATE TABLE grammar takes "one or more column definitions, optionally
+ * followed by a list of table constraints", one of which is `FOREIGN KEY ( column-name, ... )
+ * REFERENCES ...`. Measured on 3.53.3: the created form below is accepted and `PRAGMA
+ * foreign_key_list("users")` then reports the key, while the same constraint placed BEFORE a column
+ * definition is `near "FOREIGN": syntax error` - which is what the ordering assertion pins. So the
+ * created-table path emits the key and only the alter-table path declines.
+ */
+describe("generateMigrationSQL: SQLite's grammar declares a foreign key only inside CREATE TABLE", () => {
+  function addedTableWithForeignKey(): SchemaDiff {
+    const diff = makeAddedTableDiff();
+    diff.tables[0].foreignKeys = [
+      {
+        action: "added",
+        columnName: "dept_id",
+        targetReferencedTable: "departments",
+        targetReferencedColumn: "id",
+        changes: ["Added FK"],
+      },
+    ];
+    return diff;
+  }
+
+  /**
+   * Total by construction, in the same spirit as `MODIFIED_COLUMN_COVERAGE` below. The
+   * implementation's map is a `Partial<Record<DatabaseType, ...>>`, so a third id added there
+   * typechecks either way and introduces no line of its own - both arms are already covered by these
+   * two dialects, and a per-line coverage gate structurally cannot see an arm that adds no line. This
+   * total `Record` is the mechanism that does notice: a new `DatabaseType` fails typecheck here until
+   * it is classified. The two other states are asserted too, so that moving an EXISTING id into the
+   * implementation's map is red as well: `"key-follows-in-an-alter"` means the key is emitted as a
+   * trailing `ADD CONSTRAINT` statement instead, and `"engine-has-no-foreign-key"` is `cassandra`,
+   * whose whole `CREATE TABLE` is declined ahead of any constraint.
+   *
+   * `distinguishingClause` is the half of each reason that the two ids do NOT share: pinning only the
+   * common "recreate the table and copy the rows" tail would stay green if the two reasons were
+   * swapped between the two ids, which is exactly the confusion the wording exists to prevent.
+   */
+  const GRAMMAR: Record<
+    DatabaseType,
+    { label: string; distinguishingClause: string } | "key-follows-in-an-alter" | "engine-has-no-foreign-key"
+  > = {
+    sqlite: {
+      label: "SQLite",
+      distinguishingClause: "A foreign key is declarable only as a CREATE TABLE constraint;",
+    },
+    libsql: { label: "libSQL", distinguishingClause: "SQLite declares one only in CREATE TABLE;" },
+    postgres: "key-follows-in-an-alter",
+    mysql: "key-follows-in-an-alter",
+    oracle: "key-follows-in-an-alter",
+    mssql: "key-follows-in-an-alter",
+    clickhouse: "key-follows-in-an-alter",
+    couchbase: "key-follows-in-an-alter",
+    druid: "key-follows-in-an-alter",
+    trino: "key-follows-in-an-alter",
+    elasticsearch: "key-follows-in-an-alter",
+    opensearch: "key-follows-in-an-alter",
+    cassandra: "engine-has-no-foreign-key",
+    mongodb: "key-follows-in-an-alter",
+    redis: "key-follows-in-an-alter",
+    libredb: "key-follows-in-an-alter",
+  };
+
+  for (const [dialectId, entry] of Object.entries(GRAMMAR)) {
+    const dialect = dialectId as DatabaseType;
+    if (entry === "engine-has-no-foreign-key") continue;
+    if (entry === "key-follows-in-an-alter") {
+      // The counter-arm, and the reason a third id cannot be added to the implementation's map
+      // unnoticed: for every id NOT under the grammar rule the key leaves the CREATE TABLE and
+      // becomes a statement of its own, so classifying an id here and adding it there is a conflict
+      // one of the two tests reports.
+      test(`${dialect}: the key is a trailing ALTER statement, not a CREATE TABLE constraint`, () => {
+        const sql = generateMigrationSQL(addedTableWithForeignKey(), dialect);
+
+        const createEnd = sql.indexOf("\n);") + 3;
+        expect(sql.slice(sql.indexOf("CREATE TABLE"), createEnd)).not.toContain("FOREIGN KEY");
+        expect(sql.slice(createEnd)).toContain("ADD CONSTRAINT");
+        expect(sql.slice(createEnd)).toContain("FOREIGN KEY");
+      });
+      continue;
+    }
+    const { label, distinguishingClause } = entry;
+    test(`${dialect}: a created table carries the key as a table constraint, not a following ALTER`, () => {
+      const sql = generateMigrationSQL(addedTableWithForeignKey(), dialect);
+
+      const createStatement = sql.slice(sql.indexOf('CREATE TABLE "users" ('), sql.indexOf("\n);") + 3);
+      expect(createStatement).toContain('FOREIGN KEY ("dept_id") REFERENCES "departments"("id")');
+      // The grammar's ordering rule: every table constraint follows every column definition.
+      expect(createStatement.indexOf('"email" varchar(255)')).toBeLessThan(createStatement.indexOf("FOREIGN KEY"));
+      // Not the trailing statement the generic branch emits, in any spelling.
+      expect(sql).not.toContain("ADD CONSTRAINT");
+      expect(sql).not.toContain("ALTER TABLE");
+      // And no synthesized constraint name: `fk_<table>_<column>` is this generator's invention
+      // rather than anything the diff carried, and SQLite never reads a foreign key's name back out
+      // (measured: `PRAGMA foreign_key_list` has no name column), so naming it would be write-only.
+      expect(sql).not.toContain("fk_users_dept_id");
+    });
+
+    test(`${dialect}: an existing table's added key is declined, because no ALTER can carry it`, () => {
+      const sql = generateMigrationSQL(makeModifiedTableDiff(), dialect);
+
+      // The whole line, clause included, so the reason cannot be swapped onto the other id.
+      expect(sql).toContain(
+        `-- ${label}: Cannot add a foreign key on "dept_id". ${distinguishingClause} recreate the table and copy the rows.`,
+      );
+      expect(sql).not.toContain("ADD CONSTRAINT");
+      expect(sql).not.toContain("FOREIGN KEY (");
+      // The refusal is confined to the constraint: both ids accept ADD COLUMN, so the rest of the
+      // migration is still emitted rather than the whole table being declined.
+      expect(sql).toContain('ALTER TABLE "users" ADD COLUMN "phone" varchar(20);');
+    });
+  }
+});
+
+/**
  * Exhaustive by construction, in the spirit of `PICKER_COVERAGE` in
  * `tests/hooks/use-connection-form.test.ts`: a new `DatabaseType` fails typecheck here until it is
  * classified, so it cannot silently re-inherit the generator's PostgreSQL branch — which is the whole

--- a/tests/unit/schema-diff/migration-generator.test.ts
+++ b/tests/unit/schema-diff/migration-generator.test.ts
@@ -871,7 +871,7 @@ describe("generateMigrationSQL: Cassandra declines CREATE TABLE rather than gues
 });
 
 /**
- * D36. Both directions, both ids, because the generator got each of the four cases from a different
+ * #515. Both directions, both ids, because the generator got each of the four cases from a different
  * place and only one of them was right.
  *
  * SQLite's ALTER TABLE page enumerates every schema change the engine has - "rename table", "rename


### PR DESCRIPTION
Round 17. Five backlog entries close, seven open in their place. Every closed one is the same defect in
different clothes: **a reading that could not be taken, or a list that was cut, reaching a reader as a
confident figure.** The absence rule (#477) is house law here; these are the places it was not applied.

## What closes

**D40 — the Overview panel's connection count.** `DatabaseOverview.activeConnections` is optional for the
reason its docblock gives, and SQL Server, Oracle and MongoDB each initialised a local to `0` and
swallowed the read's failure into it. A denied `VIEW SERVER PERFORMANCE STATE`, an unprivileged
`V$SESSION` or a `serverStatus` with no `connections` section drew a confident **0 connections** on a
server with plenty. All three now omit the key; a real zero still reads as zero; both arms pinned per
provider.

> The existing SQL Server test was asserting the fabrication rather than a measurement:
> `expect(typeof overview.activeConnections).toBe("number")` passed *because* the fabricated `0` is a
> number. Its purpose-built fixture was dead code — shadowed by a generic branch matching the same
> statement — so the assertion had never once seen the value it was written for.

**D41 — two surfaces reading a cap as a count.** The Queries tab's *Queries* card summed the calls of a
list every provider caps at ten and labelled it the database's query count; *Slow* was bounded by ten
however many slow statements the server held. Measured against a MySQL server holding 59 digests for one
schema, both cards were the ceiling wearing a measurement's label. On the provider side
`TRINO_MAX_STATS_TABLES` cut the table-stats read *inside* the provider, where no marker above it could
see the cut; it now refuses rather than truncating, and the refusal names the real count.

**D36 — the migration generator emitted DDL SQLite cannot parse.** `ALTER TABLE ... ADD CONSTRAINT ...
FOREIGN KEY` is a syntax error on SQLite wherever the file is run. There were **two** emission sites, not
the one the entry described: the ALTER path, and — undocumented — `generateCreateTable`, which writes a
new table's foreign keys as a separate `ALTER`. libSQL had the same defect there, so its earlier fix was
incomplete. The two sites want different answers: in the CREATE path the key belongs *inside* the
`CREATE TABLE`, where SQLite accepts it and nothing is lost; in the ALTER path it cannot be expressed and
is declined with a comment naming table recreation.

**D38 — `getConnectionInfo` masked an authority password and nothing else,** so a libSQL string carrying
its whole token as `?authToken=` was returned in the clear. The mask now covers the authority and the
value of every credential-shaped parameter, in any position. Two review rounds then found two more shapes
**in the fix itself**: a credential *leading* an ADO-style string was returned verbatim, and narrowing the
authority pattern had stopped masking `postgres://user:p/w@host/db`, which the old one masked.

That second one is **covered rather than hidden**. `postgres://host:5432/tenant@acme` has the identical
shape and holds no secret, so masking one masks the other — and drawing `***` over a port asserts a
credential the string never carried, a fabricated reading, which this rule forbids more strongly than it
forbids the miss. The docblock says so and the test file pins the gap, so it is visible rather than
assumed closed. **D42** carries the parse-based fix.

**U23 — the Storage tab labelled its remainder "Other (TOAST, FSM)" on every engine.** TOAST and the free
space map are PostgreSQL structures; SQLite, libSQL, MySQL, Oracle, SQL Server, ClickHouse and the HTTP
engines have neither.

## Two defects found in the same files while fixing those

- **The Storage tab was the third reader of `errors.tables` and the only one that did not read it.** A
  refused table read arrived as an empty list, `every()` was vacuously true, and the tab drew a measured
  `0 B` for Tables and Indexes with the remainder absorbing the whole database at 100%. It now carries the
  engine's own sentence, the way its two sibling panels already do, while a genuinely empty database still
  reads `0 B`.
- **Quick Stats published three cap-bounded figures as counts** — "Slow Queries" off a list capped at 10,
  and "Active" and "Idle" off one list capped at 50 which the two badges split while reading as the
  server's totals. All three now name the rows they measure. *(The review found one of the three.)*

MongoDB's `getOverview` had a **second** fabricated zero beside the first: `databaseSizeBytes` is optional
for the same stated reason, and the Storage tab keys its entire breakdown off whether that key is present.
So a denied `serverStatus` did not hide a number — it replaced an honest refusal with a breakdown over a
zero-byte database, and with the table read still answering the remainder went negative, which
`formatBytes` renders as the literal string **`NaN undefined`**. The success path had the same shape
through `|| 0`, and so did `getHealth`, whose `databaseSize` string is the one the agent forwards to the
model verbatim.

## A new guard: provider docs cite code by name, not by line

A line number hand-copied into prose has nothing measuring it. The eight seam rows in both search docs
were **stale at birth**: they entered in one commit (`25712e68`, #429) as 751/811/831/844/860/873/884/898
while that same commit's declarations sat at 808/868/888/901/917/930/941/955 — a uniform **+57**, which is
exactly why nobody noticed. The rows stayed in ascending order and read as a consistent, plausible list.
Today the offset is +65. `docs/providers/redis.md` shows what correcting such a number buys: `:102` (#89,
true then) → `:99` (#122, true then) → rotted again.

`tests/unit/provider-docs-monitoring-citations.test.ts` bans the **form**, so a correct line number fails
it too, and its scope statement names what is *not* measured yet rather than implying coverage. Corpus
measurement: of 69 machine-checkable citations, **68 were stale**; 18 are fixed here; **DOC4** carries the
remaining 62, all 62 stale.

## What opens

| ID | Why it is an entry and not part of this PR |
| --- | --- |
| **D42** | The mask cannot cover an authority password holding a character RFC 3986 reserves — the colliding shape holds no secret. The fix is parsing, not a better pattern. |
| **D43** | SQLite gained `ALTER COLUMN ... SET/DROP NOT NULL` in 3.53.0 (measured: it rewrites the stored schema and is enforced on insert). The generator cannot simply emit it — sqld ships 3.47.0, and `sqlite` runs on whichever SQLite its runtime bundles, so a migration file would run on one deployment and fail on another. |
| **D44** | `databaseSizeBytes` is fabricated as `0` wherever the size is unknown, in **14 of 16 type-ids**. Cassandra's own comment is the precedent and states the argument. 14 provider files, 14 docs, 14 test files. |
| **D45** | On SQL Server **2019 and earlier the count is under-reported, not refused**: Microsoft documents `sys.dm_exec_sessions` as row-filtered, and `sys.configurations` as needing only `public` below 2022, so the statement *succeeds* and returns the caller's own session. Distinguishing that needs a permission probe and a live instance with an ungranted login. |
| **D46** | One fabricated connection zero survives the sweep, in the shared search provider. Three of the five comments citing the old encoding are now false and are corrected here; **two remain true** — for `maxConnections` zero and absence really are one fact, which is what Druid and Trino cite. Moving the encoding is the entry. |
| **U24** | A measured zero total draws the Storage remainder bar *full*, and the same zero puts `NaN undefined` in the cell beside it. A refused overview also drops the engine's sentence in a file that carries it for two other panels. |
| **DOC4** | 62 stale line citations over 12 docs; the 209 non-checkable ones are named as unmeasured rather than assumed. |

## Verification

**Gates on the pushed tree:** `format` clean · `lint` 0 errors / 132 pre-existing warnings · `typecheck`
clean · `knip` clean · `bun run test` all 33 groups pass · `bun run build` exit 0 · merged coverage
**44382/44382 lines (100.00%)**.

**Mutation-tested, not just green.** Every lane was required to corrupt the line its test pins, confirm
red, and restore byte-for-byte. Highlights:

- The redaction's two fixes: dropping `^` from the parameter pattern reddens 4 tests; reverting the
  authority anchor reddens 2.
- The Storage absence fix carries an **over-fix guard**: setting `statsRefused = tables.length === 0`
  reddens the measured-empty control arm, so the fix cannot degenerate into "N/A whenever the list is
  empty".
- The citation guard was mutated **six** ways, including reinstating a *correct* line number (still red —
  the form is what is banned) and renaming the cited declaration in the source.

**Driven in real Chrome** against the embedded SQLite sample (796 KB, 6 tables) — the engine U23 is about:

| Check | Result |
| --- | --- |
| `TOAST` / `FSM` anywhere on the page | absent |
| Remainder label, both breakpoints | `Other (unattributed)` / `Other` |
| Breakdown arithmetic | 504 KB + 288 KB + 4 KB = 796 KB, remainder bar `translateX(-99.4975%)` |
| `NaN` / `undefined` in the DOM | absent |
| Quick Stats labels | `Listed slow queries`, `Active of listed sessions`, `Idle of listed sessions` |
| Queries tab | the cap-labelled total card is gone; SQLite refuses with its own sentence, not zeros |
| Application console errors | 0 (the two 404s in the log are my own manual `fetch` probes of paths that do not exist) |

**Engine claims checked against the vendors' own documentation,** not memory: Microsoft Learn for
`sys.dm_exec_sessions` and `sys.configurations` permissions (quoted verbatim in D45), the MongoDB manual
for `serverStatus` and `dbStats`, and SQLite itself via `bun:sqlite` 3.53.0 for the `ALTER TABLE`
repertoire.

## Findings I verified and did **not** adopt

- A review claimed the seam table had been "hand-corrected in one row in a past round, leaving an internal
  contradiction". `git log -S"index.ts:811"` returns **one** commit and the numbers went in monotonic, so
  no committed state ever contradicted itself. The single-row refresh existed only in this round's
  uncommitted tree and would never have appeared in history. The guard's docblock now states the true
  mechanism, which turned out to be stronger: the numbers were wrong the day they were written.
- A review suggested extending the guard to `mongodb.md` and `oracle.md` was "a two-line change". Those
  docs still hold 14 and 16 line citations, and the guard asserts *no line numbers anywhere*, so adding
  them would fail immediately. They are named in DOC4 instead.
- Blanket-repointing the five comments that cite `mssql.ts` for the "0 means not published" encoding would
  have made two of them false: for `maxConnections`, `0` and absence *are* one fact. Only the three about
  `activeConnections` are corrected.
- A derived claim that the negative remainder renders `-1536 B` was wrong in its detail — `formatBytes`
  takes `Math.log` of a negative, so it renders `NaN undefined`. Worse than claimed; corrected in both the
  doc and the code comment, and folded into U24.

Rebased onto `main` after #514; base tree verified identical to the squash, so nothing was resurrected.
