### PR TITLE
fix(db,ui,docs): an unknown size is absent, not zero, and a share needs a total

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,10 +22,10 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S2–S7 · 5
-- [Drivers and connections](#drivers-and-connections) — D1–D49, U17, U22 · 22
+- [Drivers and connections](#drivers-and-connections) — D1–D51, U17, U22 · 23
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U24 · 11
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U26 · 12
 - [Authentication and security headers](#authentication-and-security-headers) — AU4
 - [Tests](#tests) — T1–T5 · 4
 - [Dependencies](#dependencies) — P1–P5 · 5
@@ -571,7 +571,7 @@ the feature (cheap, and it is what the comment now does), or the generator learn
 engine's version and emits the nullability change only above 3.53.0, with the emitted statement
 measured against both a 3.47 and a 3.53 build. The second is only worth it if something else needs the
 version too.
-### D44. `databaseSizeBytes` is fabricated as 0 wherever the size is unknown, in 14 of 16 type-ids
+### D44. `databaseSizeBytes` is fabricated as 0 wherever the size is unknown, in 11 of 17 type-ids
 
 Found 2026-08-27 by the sweep that closed the overview connection count's fabricated zero (D40, PR
 round 17). `DatabaseOverview.activeConnections` and `DatabaseOverview.databaseSizeBytes` are optional
@@ -603,11 +603,30 @@ breakdown off `overview?.databaseSizeBytes !== undefined`: present, and the card
 against the total; absent, and it draws its own "No storage size information available." So a fabricated
 0 does not hide a number, it replaces an honest refusal with a breakdown over a zero-byte database.
 
-**Done when:** an unknown size is absent rather than 0 on every type-id, a real zero still reads as
-zero, each provider's doc records it, and each provider's test pins both arms - the same shape D40
-used, applied to the field beside it. The blast radius is why this is an entry and not part of that PR:
-14 provider files, 14 provider docs and 14 test files, plus `formatBytes` callers that assume a number.
-Doing it per family, one PR each, is the cheap ordering.
+**Three of the fourteen are closed (#517, round 18)** - the ones that contradicted themselves inside a
+single object. `trino/introspect.ts` no longer writes the key beside
+`databaseSize: TRINO_UNAVAILABLE_TEXT`, and `search/index.ts` spreads it conditionally instead of
+`?? 0` beside `SEARCH_UNKNOWN_TEXT`, which is two type-ids (`elasticsearch` and `opensearch`) from one
+file. That round also measured a mechanism this entry had missed: Couchbase does not merely coerce, it
+wraps the read in `degradeTo(..., {})`, so a REFUSED bucket read reaches `basicStats?.diskUsed ?? 0` and
+publishes a measured-looking zero - see D51, which is the same shape on the field beside this one.
+
+**The counts moved for a second reason.** DuckDB arrived as a seventeenth type-id in #516 and gets this
+right without being asked: `duckdb/introspect.ts` spreads the key conditionally and spells the string
+`"N/A"` when the database is in-memory. So it is a fourth correct provider rather than a fifteenth
+fabricating one, and it independently reached the same encoding this entry prescribes.
+
+**Done when:** an unknown size is absent rather than 0 on the remaining eleven type-ids, a real zero
+still reads as zero, each provider's doc records it, and each provider's test pins both arms - the same
+shape D40 used, applied to the field beside it. Remaining: `sql/postgres.ts`, `sql/mysql.ts`,
+`sql/sqlite.ts`, `sql/mssql.ts`, `sql/oracle.ts`, `sql/libsql/introspect.ts`, `sql/druid/introspect.ts`,
+`sql/clickhouse/index.ts`, `document/couchbase/index.ts`, `keyvalue/redis.ts` and `embedded/libredb.ts`.
+MongoDB is NOT on that list: its catch and its success path both spread conditionally already.
+
+Doing it per family, one PR each, is the cheap ordering, and #517 is the pattern to copy - including the
+second test file the triad brief does not name: Trino's own `tests/unit/db/trino/introspect.test.ts`
+asserted the 0, no gate but a test run found it, and the triad invariant names only the integration
+file.
 ### D45. On SQL Server 2019 and earlier the connection count is under-reported, not refused
 
 Found 2026-08-27 while making the overview connection count absent instead of 0 (D40, PR round 17).
@@ -646,34 +665,6 @@ current database, and that permission cannot be granted in `master`.
 `SERVERPROPERTY('ProductMajorVersion')` to pick the permission name - and an incomplete count is absent
 rather than published. Measured on a real instance with a login that has neither grant, because the
 whole entry rests on a permission boundary no fixture can prove.
-### D46. One fabricated connection zero survives the sweep, and five comments cite it as the pattern
-
-Found 2026-08-27 by the sweep that finished D40. After that round, `activeConnections` is honest almost
-everywhere: MSSQL, Oracle, MongoDB and Cassandra omit it when the read is refused; SQLite and the
-embedded LibreDB publish `1`, which is the measurement for a single-writer file; PostgreSQL, Redis,
-Couchbase, ClickHouse, Trino and Druid publish a real count.
-
-`src/lib/db/providers/sql/search/index.ts:846` is the exception, for both `elasticsearch` and
-`opensearch`: `activeConnections: 0` with a comment saying it means "not published". The field is
-optional and its docblock (`src/lib/db/types.ts`, D17) says absence is how "not published" is said, so
-this is the last site where the old encoding survives - and the comment's reason is sound, only its
-encoding is not. A search cluster counts open HTTP connections per node in a stats API this seam does
-not call, so nothing is knowable, which is precisely the case absence exists for.
-
-`maxConnections: 0` beside it stays correct: for that field the type says 0 and absence are the SAME
-fact, which is why Druid's and Trino's comments citing `mssql.ts` for the ceiling remain true.
-
-**The citations are the second half.** Before D40, "0 means not published" was a shared convention with
-`mssql.ts` as its reference, and five places say so:
-`src/lib/db/providers/sql/search/index.ts:840`, `sql/druid/introspect.ts:572`,
-`sql/trino/introspect.ts:612`, `docs/providers/elasticsearch.md` and `docs/providers/opensearch.md`.
-The Druid and Trino ones are about the ceiling and stay true. The search comment and the two search docs
-bundle `activeConnections` into the same sentence, so for that half they now cite an encoding
-`mssql.ts` no longer uses.
-
-**Done when:** the search provider omits `activeConnections` rather than sending 0, its two docs and its
-two test files move with it (the provider triad is per type-id even though one directory serves both),
-and no comment cites `mssql.ts` for an encoding it has stopped using.
 
 ### D47. Nine outward-facing enumerations name the engines by hand, and nothing counts them
 
@@ -784,6 +775,72 @@ change.
 **Done when:** the row passes the qualified name, every one of the twelve providers has been
 measured against a table outside its default schema (or recorded as having no such concept), and a
 component test pins the target the row sends so it cannot silently revert to the bare name.
+
+### D50. The search seam zeroes two OPTIONAL `TableStats` size fields for an index that reported nothing
+
+Found 2026-08-27 in the #517 review, inside the file that PR was already fixing. `toTableStats()`
+(`src/lib/db/providers/sql/search/index.ts`) reads `const sizeBytes = index.sizeBytes ?? 0` and writes
+that zero into `tableSize`, `tableSizeBytes`, `totalSize` and `totalSizeBytes`. Its docblock justified
+all four with "`TableStats` has no way to say 'unknown' - both fields are required numbers".
+
+**That justification was false for half of them.** Measured against `src/lib/db/types.ts`: `rowCount`,
+`totalSize` and `totalSizeBytes` are required, so for those three a closed index genuinely has nowhere
+to read but zero. `tableSize`, `tableSizeBytes`, `indexSize` and `indexSizeBytes` are **optional**, and
+their own docblock says why in as many words - "A `0` would be the same lie in a different digit, so
+absence is the answer, and every consumer of the aggregate gates on it - see `StorageTab`'s
+`tableSizeKnown`". The doc sentence and the docblock were corrected in #517; the code was not, because
+the consequence needs a decision rather than a patch.
+
+**The consequence, and why it is not obvious.** A CLOSED index reports neither a document count nor a
+size (measured: both arrive as JSON null while the listing still names the index). Filling
+`tableSizeBytes` with 0 keeps `StorageTab`'s `tableSizeKnown` true, so the Data figure reads `0 B` for
+that index rather than N/A. But omitting it flips `tableSizeKnown` false for the WHOLE cluster -
+`tables.every(...)` - so one closed index takes the Data figure away from every open one. That is the
+behaviour the type prescribes and SQLite-under-Bun already gets, and it is still a visible change to a
+panel, which is why it is an entry.
+
+**Done when:** the two optional fields are omitted for an index that published no size, both search
+docs record what one closed index does to the cluster's Data figure, and both test files pin an open
+index beside a closed one so the aggregate's behaviour is asserted rather than inferred.
+
+### D51. Four providers degrade a refused monitoring read to no rows, then read the absent row as 0
+
+Found 2026-08-27 in the #517 review, which asked whether the search provider really held the last
+fabricated `activeConnections` zero. It held the last *unconditional literal* one. It did not hold the
+last zero: four providers reach the same encoding by a longer route, and the route is what hides it.
+
+Each one swallows an unavailable monitoring surface into an empty result, and then a helper maps the
+absent row to zero. Measured, all four:
+- `sql/trino/introspect.ts` - `readOptionalRows` returns `[]` for every category in
+  `UNAVAILABLE_CATEGORIES`, `readOptionalRow` turns that into `null`, and
+  `nonNegative(readNumber(active?.activeQueries))` returns 0. A refused `jmx` surface publishes "0
+  active connections".
+- `sql/druid/introspect.ts` - `readRows` catches `isMonitoringUnavailable()` and returns `[]`, and
+  `asNumber(undefined)` is 0. The SQL's own docblock says the empty answer is expected when nothing is
+  running, which is true and is exactly why the refusal is invisible: the two produce the same rows.
+- `sql/clickhouse/index.ts` - `monitoringRows` catches `isMonitoringUnavailable()`, and `asNumber` maps
+  absence to 0 for `activeConnections`, `maxConnections`, `databaseSizeBytes`, `tableCount`,
+  `indexCount` and the uptime. A single refused read therefore publishes a fully-zeroed overview that
+  reads as measured. `startTime` is the one field that already declines (`identity === null ?
+  undefined`), so the correct shape is present in the same object.
+- `document/couchbase/index.ts` - `degradeTo(..., {})` around the pools and bucket reads, then
+  `lastSample(samples, "curr_connections") ?? 0` and `basicStats?.diskUsed ?? 0`.
+
+**Why this is one entry and not four.** The mechanism is identical and so is the fix's shape: the
+degrade step already knows the difference between "answered with no rows" and "declined", and it throws
+that distinction away before the mapper can act on it. Whatever carries it - a sentinel, a tuple, or
+the `errors` channel `getMonitoringData()` already has - is one decision applied four times.
+`sql/druid/introspect.ts`'s `startTime` and `clickhouse`'s show a provider can already tell them apart
+where someone thought to.
+
+Not measured, and deliberately not claimed: `keyvalue/redis.ts` and `sql/postgres.ts` write
+`parseInt(x || "0")` for the same field, but there the read either answers or throws, so a missing
+FIELD inside a successful response is a different question and needs its own measurement.
+
+**Done when:** a refused monitoring read is distinguishable from an empty one in all four providers, the
+optional fields are absent rather than 0 on the refusal, each provider's doc and test move with it, and
+`maxConnections` keeps its 0 - for that field the type says 0 and absence are one fact.
+
 
 ## Value interpolation
 
@@ -1026,46 +1083,65 @@ is not a free read.
 **Done when:** an operation a provider declares globally runnable either has its own card copy or a
 recorded reason it is withheld.
 
-### U24. Two absences the Storage tab still renders as measurements
+### U25. One byte formatter exists three times, and the two local copies draw non-magnitudes as figures
 
-Found 2026-08-27 while giving the tab the refused-`tables` arm it was missing (PR round 17). Both are
-narrow, both are in `src/components/monitoring/tabs/StorageTab.tsx`, and neither was introduced by that
-change.
+Found 2026-08-27 in the #517 review, which fixed the shared one. `formatBytes` exists in three places:
+the exported `src/lib/db/utils/pool-manager.ts` one that every provider calls, and a private
+threshold-cascade copy inside `src/components/monitoring/tabs/StorageTab.tsx` and another inside
+`src/components/monitoring/tabs/TablesTab.tsx`. The two components do NOT import the shared one, which
+is how the closed entry's claim that the Storage remainder rendered `NaN undefined` came to be wrong: that is the
+shared function's output, and the cell that was measured runs the local cascade.
 
-**A measured zero total draws the remainder bar full.** The breakdown computes
+#517 gave the shared one a guard (a negative or non-finite input returns `"N/A"`, and the unit index is
+clamped). The cascade copies have no guard, and their failure is quieter because the output looks like a
+reading. Measured against `TablesTab`'s copy: `-1` renders `"-1 B"`, `NaN` renders `"NaN B"`, `Infinity`
+renders `"Infinity GB"`, and 1 EB renders `"1073741824.00 GB"`. The Storage copy behaves identically;
+#517 closed its one reachable negative by refusing to compute a contradictory remainder at all, so that
+tab no longer feeds it one, but the formatter is unchanged.
+
+`TablesTab` reads the numeric twins (`tableSizeBytes` and its siblings) rather than the engine's own
+strings, so its input is whatever a provider computed - and D44 and D51 are both about providers that
+compute those numbers from an absent row.
+
+**Done when:** one formatter serves all three call sites, or the two copies carry the same guard as the
+shared one; the units agree (the cascade stops at GB, so it spells an exabyte in gigabytes); and a unit
+test pins a negative, a non-finite and a PB-scale input for whatever survives. Deleting the copies is
+the smaller change but not free: they exist at module scope with a comment saying they are there to keep
+the components' cognitive complexity down, and the shared module is a pool manager.
+
+### U26. The fleet total sums display strings, so a terabyte counts as one byte
+
+Found 2026-08-27 in the #517 review. `totalDBSize` in `src/components/admin/tabs/OverviewTab.tsx`
+builds the admin dashboard's total by RE-PARSING each connection's formatted size:
 
 ```ts
-const tablePercent = totalSize > 0 && tableSizeKnown ? (totalTableSize / totalSize) * 100 : 0;
-const otherPercent = breakdownKnown ? Math.max(0, 100 - tablePercent - indexPercent) : 0;
+const s = item.databaseSize.toLowerCase();
+const num = parseFloat(s);
+if (isNaN(num)) continue;
+if (s.includes("gb")) totalBytes += num * 1024 * 1024 * 1024;
+else if (s.includes("mb")) totalBytes += num * 1024 * 1024;
+else if (s.includes("kb")) totalBytes += num * 1024;
+else totalBytes += num;
 ```
 
-so on a provider that reports a real `databaseSizeBytes` of 0 - Trino and Druid do, and the comment
-above the block names them as the case it handles - the `totalSize > 0` guard forces both shares to 0
-while `breakdownKnown` stays true, and the remainder becomes `100 - 0 - 0`. Measured in the DOM against
-the tab's own measured-zero fixture: the Tables and Indexes indicators read `translateX(-100%)` (empty)
-and the remainder reads `translateX(-0%)` - a full bar over a database with no bytes. Its figure beside
-it correctly reads `0 B`, so nothing numeric is fabricated; the overclaim is entirely in the bar, which
-is why no text assertion could see it.
+`tb` is not a branch, so a `"1 TB"` database falls to `else` and contributes **1 byte** to the fleet
+total - and #517 added `PB` and `EB` to the shared formatter's ladder, so two more spellings now reach
+this parser and land in the same arm. The `else` arm is right for a bare `"512"` and cannot tell it from
+a truncated unit, which is the whole problem with parsing a string that was built for a human.
 
-**A refused overview drops the engine's sentence.** The tab carries `errors.storage` for the
-Tablespaces panel and now `errors.tables` for Largest Tables, but there is no `overviewUnavailable`:
-with `data.overview` absent and `errors.overview` set, the DB Size card falls to `N/A` and the
-breakdown to "No storage size information available." Both are honest - no figure is invented - but the
-engine's own explanation is discarded in a file that surfaces it for two other panels.
+The `"N/A"` handling is correct by accident and worth keeping: `parseFloat("n/a")` is `NaN`, so a
+refusal is skipped rather than counted as zero.
 
-**And the same zero total can put `NaN undefined` in the cell beside it.** The remainder's bytes are
-`totalSize - totalTableSize - totalIndexSize`, so a provider reporting a 0 total while its table read
-answers with real per-table bytes makes that negative - and `formatBytes`
-(`src/lib/db/utils/pool-manager.ts`) does not survive a negative: `Math.log(-1536)` is `NaN`, `i` is
-`NaN`, and `sizes[NaN]` is `undefined`, so the cell renders the literal string **`NaN undefined`**
-(measured 2026-08-27). This is reachable wherever D44 is: 14 type-ids send 0 for an unknown size, and
-`getTableStats()` is a separate read that does not share the failure. `formatBytes` guarding its own
-input is the cheaper half of the fix and belongs with this entry rather than with D44.
+**The real defect is that there is no numeric channel to sum.** `FleetHealthItem`
+(`src/app/api/admin/fleet-health/route.ts`) carries `databaseSize?: string` and nothing else, because
+`HealthInfo.databaseSize` is a required string. So the fix is not a `tb` branch - it is carrying the
+bytes the providers already have, which is also what makes an honest absence expressible here.
 
-**Done when:** the remainder's bar is empty rather than full when there is no total to divide, with a
-component test asserting the indicator transform rather than the text (the figure is already right);
-`formatBytes` refuses a negative rather than rendering `NaN undefined`, with a unit test; and a refused
-overview carries its own sentence the way the two sibling panels do.
+**Done when:** `FleetHealthItem` carries an optional byte count beside the string, the route projects it
+from the provider (absent when the provider published none), the total sums those numbers and shows how
+many connections it could not include rather than silently undercounting, and a test pins a TB-scale
+connection plus one with no byte figure at all.
+
 
 ---
 

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -809,14 +809,14 @@ numbers this table used to carry had drifted, and a method name is greppable and
 
 | Method | Source | Mapping |
 |---|---|---|
-| `getOverview()` | `/`, `_cluster/health`, `_cat/indices` — **three seam calls in parallel** | `version` = `"Elasticsearch <number>"` from the connection's product plus the payload's version; `uptime` = **`"N/A"`**; `activeConnections` / `maxConnections` = **0**; `databaseSize(Bytes)` = the cluster's store from `_cluster/stats`; `tableCount` = **user** indices only; `indexCount` = **0** |
+| `getOverview()` | `/`, `_cluster/health`, `_cat/indices` — **three seam calls in parallel** | `version` = `"Elasticsearch <number>"` from the connection's product plus the payload's version; `uptime` = **`"N/A"`**; `activeConnections` = **absent**; `maxConnections` = **0**; `databaseSize(Bytes)` = the cluster's store from `_cluster/stats`, the **byte key absent** when the cluster publishes no size; `tableCount` = **user** indices only; `indexCount` = **0** |
 | `getPerformanceMetrics()` | — | **`{}`**, and it asks the cluster nothing |
 | `getSlowQueries()` | — | **`[]`**. The slow log is written to the node's **log file**, which no API returns |
 | `getIndexStats()` | — | **`[]`**. No secondary-index object exists |
 | `getActiveSessions()` | — | **`[]`**. A request is one HTTP request; there is no session and no connection catalog |
 | `getTableStats()` | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""` |
 | `getStorageStats()` | `_cluster/health` + `_cluster/stats` | **one row for the cluster**: `name` = `cluster_name`, `sizeBytes` = `indices.store.size_in_bytes`. **No row at all** when the size was unreported |
-| `getHealth()` | the above, composed | `activeConnections`, `databaseSize`; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
+| `getHealth()` | the above, composed | `databaseSize`; `activeConnections` **omitted**, carrying the overview's absence across; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
 
 **Two vocabulary collisions, both counted wrong by the obvious reading:**
 
@@ -834,6 +834,14 @@ schema tree are **primaries only** (`pri.store.size`, chosen deliberately by `CA
 to it. On the measured single node with one replica requested they happen to be equal, which is
 exactly why the choice had to be made deliberately rather than discovered later.
 
+**An unpublished store size is an absent key, not a 0.** `databaseSizeBytes` is optional, and
+`getOverview()` omits it whenever `_cluster/stats` reported nothing
+([§7.1](#71-the-one-swallowed-failure)) — it used to pair a `0` with the `"N/A"` its own
+`databaseSize` printed from the same input, one object making two different claims.
+`StorageTab.tsx` keys its refusal off the missing key, so the Storage tab now draws that refusal
+instead of a `0 B` total with a 0.0% breakdown under it. A cluster that really stores nothing
+publishes a real `0` and keeps it.
+
 The honest empties, each with its reason:
 
 - **`getPerformanceMetrics()` returns `{}`, not zeroes**, and this is load-bearing. `cacheHitRatio` is
@@ -849,22 +857,29 @@ The honest empties, each with its reason:
 - **`getSlowQueries()` and `getActiveSessions()` return `[]` rather than throwing.** Nothing is broken
   and nothing is misconfigured, so a monitoring tab should render as quiet, not as failed. Only
   `runMaintenance()` throws, because that one is a *request to act*.
-- **`activeConnections` / `maxConnections` are 0**. For the ceiling that is the repo's encoding, which
-  Druid and Trino share: `maxConnections` treats `0` and absence as one fact. For the count beside it
-  the encoding is now this provider's alone - SQL Server, Oracle, MongoDB and Cassandra omit
-  `activeConnections` when nothing was read, and moving this one is
-  [BACKLOG D46](../BACKLOG.md). The cluster counts open HTTP connections per node in its stats API, which is not one of
-  this seam's five calls, and the shard and node counts that *are* here would be a different number
-  wearing this field's name. The Connections card reads a zero maximum as "no limit published" rather
+- **`activeConnections` is absent, not 0.** The cluster counts open HTTP connections per node in its
+  stats API, which is not one of this seam's five calls, and the shard and node counts that *are* here
+  would be a different number wearing this field's name — so nothing is knowable, and the field is
+  optional precisely so that can be said. `getHealth()` carries the missing key across rather than
+  filling it in, and `OverviewTab.tsx` renders the Connections card as `N/A` over *not published*
+  with no share of the limit, instead of a `0` under a healthy tick. This provider held the last
+  unconditional `activeConnections: 0` in the codebase - SQL Server, Oracle, MongoDB and Cassandra had
+  already omitted it - but not the last zero of any kind: Trino, Druid, ClickHouse and Couchbase each
+  degrade an unavailable monitoring read to no rows and then map the absent row to 0 (BACKLOG D51).
+- **`maxConnections` is 0, and that is the correct encoding** — the opposite one, for the opposite
+  reason: for the ceiling `0` and absence are the **same** fact, which is why Druid and Trino cite
+  `mssql.ts` for it and why the Connections card reads a zero maximum as "no limit published" rather
   than dividing by it.
 - **`uptime` is `"N/A"`.** Neither the health nor the version payload carries one, and no other call
   in this seam does either. A `"0s"` would claim the cluster booted this instant.
 
 **A closed index reads as zero in `getTableStats()` and is omitted in the schema tree**, and the
-asymmetry is deliberate: `TableStats.rowCount` and the size fields are *required* numbers with no way
-to say "unknown", while `TableSchema.rowCount` and `size` are optional. So the tree is the surface
-that keeps the distinction (the comment over `toTableStats()` in
-[`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
+asymmetry is only half deliberate. `TableStats.rowCount`, `totalSize` and `totalSizeBytes` are
+*required* numbers, so for those three a closed index has nowhere to read but zero. `tableSize` and
+`tableSizeBytes` are *optional* and this mapper zeroes them anyway, which turns on `StorageTab`'s
+`tableSizeKnown` and draws a `0 B` Data figure for an index that reported nothing (BACKLOG D50).
+`TableSchema.rowCount` and `size` are optional too, which is why the tree keeps the distinction (the
+comment over `toTableStats()` in [`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
 
 **Document counts exceed what a `SELECT` returns when a mapping has `nested` fields.** Measured on the
 fork's `probe_shapes`, whose `items` field is `nested`: `_cat` reports **2** documents while
@@ -882,9 +897,9 @@ health and refuses stats is an ordinary configuration. `storeSizeBytes()`
 its own failure and returns `null` — the seam's "unknown" — because losing the health status over a
 missing byte count would blank a panel that already had the important number.
 
-Its null then propagates honestly: `getOverview()` shows `"N/A"` for the size, and
-`getStorageStats()` returns **no row at all** rather than a row claiming the cluster stores zero
-bytes.
+Its null then propagates honestly: `getOverview()` shows `"N/A"` for the size **and omits
+`databaseSizeBytes`**, and `getStorageStats()` returns **no row at all** rather than a row claiming
+the cluster stores zero bytes.
 
 ---
 

--- a/docs/providers/mongodb.md
+++ b/docs/providers/mongodb.md
@@ -445,10 +445,10 @@ an *Other (unattributed)* row computed as `totalSize - totalTableSize - totalInd
 remainder is the part a refused `serverStatus` makes visibly wrong rather than merely empty, because
 the table read does **not** share the failure - `getTableStats()` goes through `listCollections` +
 `collStats`, neither of which needs `clusterMonitor` - so its per-table byte figures arrive, both
-`known` flags are true, and the row formats a **negative** byte count. `formatBytes` does not survive
-one: `Math.log` of a negative is `NaN`, so the size unit indexes out of its own array and a 1 KB
-collection with 512 B of indexes renders the literal string `NaN undefined` (measured 2026-08-27
-against `formatBytes` in `src/lib/db/utils/pool-manager.ts`). With the key absent the tab draws its own *"No storage size
+`known` flags are true, and the row draws a **negative** byte count as a measurement. A 1 KB collection
+with 512 B of indexes renders the literal string `-1536 B` (measured 2026-08-27 against the cascade
+itself): the tab formats bytes with its own local threshold cascade, whose last arm returns whatever it
+was given, so a negative passes through intact and reads as a figure the engine reported. With the key absent the tab draws its own *"No storage size
 information available."* instead, and the *Tables* / *Indexes* cards read `N/A`. Both arms are pinned
 in [`tests/components/monitoring/StorageTab.test.tsx`](../../tests/components/monitoring/StorageTab.test.tsx).
 

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -808,14 +808,14 @@ numbers this table used to carry had drifted, and a method name is greppable and
 
 | Method | Source | Mapping |
 |---|---|---|
-| `getOverview()` | `/`, `_cluster/health`, `_cat/indices` — **three seam calls in parallel** | `version` = `"OpenSearch <number>"`; `uptime` = **`"N/A"`**; `activeConnections` / `maxConnections` = **0**; `databaseSize(Bytes)` = the cluster's store from `_cluster/stats`; `tableCount` = **user** indices only; `indexCount` = **0** |
+| `getOverview()` | `/`, `_cluster/health`, `_cat/indices` — **three seam calls in parallel** | `version` = `"OpenSearch <number>"`; `uptime` = **`"N/A"`**; `activeConnections` = **absent**; `maxConnections` = **0**; `databaseSize(Bytes)` = the cluster's store from `_cluster/stats`, the **byte key absent** when the cluster publishes no size; `tableCount` = **user** indices only; `indexCount` = **0** |
 | `getPerformanceMetrics()` | — | **`{}`**, and it asks the cluster nothing |
 | `getSlowQueries()` | — | **`[]`** — and on this product that is a *choice*, not an absence. See below |
 | `getIndexStats()` | — | **`[]`**. No secondary-index object exists |
 | `getActiveSessions()` | — | **`[]`**. A request is one HTTP request; there is no session and no connection catalog |
 | `getTableStats()` | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""` |
 | `getStorageStats()` | `_cluster/health` + `_cluster/stats` | **one row for the cluster**: `name` = `cluster_name`, `sizeBytes` = `indices.store.size_in_bytes`. **No row at all** when the size was unreported |
-| `getHealth()` | the above, composed | `activeConnections`, `databaseSize`; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
+| `getHealth()` | the above, composed | `databaseSize`; `activeConnections` **omitted**, carrying the overview's absence across; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
 
 **The slow-query panel is empty even though this product keeps top-N queries.** That is the sharpest
 "deliberately unused" decision in the provider: a stock 3.8.0 node ships a `top_queries-<date>` index —
@@ -842,6 +842,14 @@ it — and `_cluster/stats` is the one place in this transport where a count arr
 **number** (`indices.store.size_in_bytes`, measured unquoted on both products) rather than a quoted
 string.
 
+**An unpublished store size is an absent key, not a 0.** `databaseSizeBytes` is optional, and
+`getOverview()` omits it whenever `_cluster/stats` reported nothing
+([§7.1](#71-the-one-swallowed-failure)) — it used to pair a `0` with the `"N/A"` its own
+`databaseSize` printed from the same input, one object making two different claims.
+`StorageTab.tsx` keys its refusal off the missing key, so the Storage tab now draws that refusal
+instead of a `0 B` total with a 0.0% breakdown under it. A cluster that really stores nothing
+publishes a real `0` and keeps it.
+
 The honest empties, each with its reason:
 
 - **`getPerformanceMetrics()` returns `{}`, not zeroes**, and this is load-bearing. `cacheHitRatio` is
@@ -856,20 +864,29 @@ The honest empties, each with its reason:
 - **`getSlowQueries()` and `getActiveSessions()` return `[]` rather than throwing.** Nothing is broken
   and nothing is misconfigured, so a monitoring tab should render as quiet, not as failed. Only
   `runMaintenance()` throws, because that one is a *request to act*.
-- **`activeConnections` / `maxConnections` are 0**. For the ceiling that is the repo's encoding, which
-  Druid and Trino share: `maxConnections` treats `0` and absence as one fact. For the count beside it
-  the encoding is now this provider's alone - SQL Server, Oracle, MongoDB and Cassandra omit
-  `activeConnections` when nothing was read, and moving this one is
-  [BACKLOG D46](../BACKLOG.md). The cluster counts open HTTP connections per node in its stats API, which is not one of
-  this seam's five calls, and the shard and node counts that *are* here would be a different number
-  wearing this field's name.
+- **`activeConnections` is absent, not 0.** The cluster counts open HTTP connections per node in its
+  stats API, which is not one of this seam's five calls, and the shard and node counts that *are* here
+  would be a different number wearing this field's name — so nothing is knowable, and the field is
+  optional precisely so that can be said. `getHealth()` carries the missing key across rather than
+  filling it in, and `OverviewTab.tsx` renders the Connections card as `N/A` over *not published*
+  with no share of the limit, instead of a `0` under a healthy tick. This provider held the last
+  unconditional `activeConnections: 0` in the codebase - SQL Server, Oracle, MongoDB and Cassandra had
+  already omitted it - but not the last zero of any kind: Trino, Druid, ClickHouse and Couchbase each
+  degrade an unavailable monitoring read to no rows and then map the absent row to 0 (BACKLOG D51).
+- **`maxConnections` is 0, and that is the correct encoding** — the opposite one, for the opposite
+  reason: for the ceiling `0` and absence are the **same** fact, which is why Druid and Trino cite
+  `mssql.ts` for it and why the Connections card reads a zero maximum as "no limit published" rather
+  than dividing by it.
 - **`uptime` is `"N/A"`.** No call in this seam carries one; a `"0s"` would claim the cluster booted
   this instant.
 
-**A closed index reads as zero in `getTableStats()` and is omitted in the schema tree.**
-`TableStats.rowCount` and the size fields are *required* numbers with no way to say "unknown", while
-`TableSchema.rowCount` and `size` are optional, so the tree is the surface that keeps the distinction
-(the comment over `toTableStats()` in [`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
+**A closed index reads as zero in `getTableStats()` and is omitted in the schema tree**, and the
+asymmetry is only half deliberate. `TableStats.rowCount`, `totalSize` and `totalSizeBytes` are
+*required* numbers, so for those three a closed index has nowhere to read but zero. `tableSize` and
+`tableSizeBytes` are *optional* and this mapper zeroes them anyway, which turns on `StorageTab`'s
+`tableSizeKnown` and draws a `0 B` Data figure for an index that reported nothing (BACKLOG D50).
+`TableSchema.rowCount` and `size` are optional too, which is why the tree keeps the distinction (the
+comment over `toTableStats()` in [`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
 
 **Document counts exceed what a `SELECT` returns when a mapping has `nested` fields**, and this was
 measured here: `probe_shapes` reports **2** documents in `_cat/indices` while `SELECT COUNT(*)` answers
@@ -886,8 +903,9 @@ health and refuses stats is an ordinary configuration. `storeSizeBytes()`
 ([`http-transport.ts`](../../src/lib/db/providers/sql/search/http-transport.ts)) therefore catches
 its own failure and returns `null` — the seam's "unknown" — because losing the health status over a
 missing byte count would blank a panel that already had the important number. Its null then propagates
-honestly: `getOverview()` shows `"N/A"` for the size, and `getStorageStats()` returns **no row at all**
-rather than a row claiming the cluster stores zero bytes.
+honestly: `getOverview()` shows `"N/A"` for the size **and omits `databaseSizeBytes`**, and
+`getStorageStats()` returns **no row at all** rather than a row claiming the cluster stores zero
+bytes.
 
 ---
 

--- a/docs/providers/trino.md
+++ b/docs/providers/trino.md
@@ -331,11 +331,24 @@ reports `34` and `330` for its two varchars and `null` for its `bigint`:
  [null,        null, null, null, 5.0, null, null]]     <- the summary row; column_name is null
 ```
 
-So `DatabaseOverview.databaseSize` is the string `"N/A"` with `databaseSizeBytes: 0`, and
-`HealthInfo.cacheHitRatio` is `"N/A"` as well. Both fields are strings precisely so they can decline
-rather than report a zero that reads as a measurement — and `cacheHitRatio` in particular is scored
-`direction: "below"` with `critical: 80` by `DEFAULT_THRESHOLDS`, so a "neutral" `0` would paint
-every healthy cluster red.
+So `DatabaseOverview.databaseSize` is the string `"N/A"`, and `HealthInfo.cacheHitRatio` is `"N/A"`
+as well. Both fields are strings precisely so they can decline rather than report a zero that reads
+as a measurement — and `cacheHitRatio` in particular is scored `direction: "below"` with
+`critical: 80` by `DEFAULT_THRESHOLDS`, so a "neutral" `0` would paint every healthy cluster red.
+
+`DatabaseOverview.databaseSizeBytes` is **not written at all** — the key is absent from the object
+`getOverview()` returns, not present holding `0`. It is an optional field for exactly this reason:
+absence and zero are different facts, a `0` is a measurement, and the Storage tab formats whatever
+number it is given, so a zero rendered as "0 B" beside a 0.0% breakdown would be the fabricated
+footprint this whole section exists to refuse. Until **2026-08-27** the object stated both at once:
+`databaseSize: "N/A"` — the figure is unavailable — on the line above `databaseSizeBytes: 0` — the
+database holds zero bytes. Apache Cassandra's `getOverview()` omits the key on the same argument for
+a different cause (`system_views.disk_usage` reports whole mebibytes), and that is the precedent this
+follows. There is no conditional spread here, unlike `startTime`: no read could ever supply the
+value, so the key is simply never written.
+
+`maxConnections` stays a plain `0` and is untouched by this: for that field `0` and absence are the
+SAME fact — it means "no ceiling published", which is true, and the field is a required number.
 
 ### 3.10 Absent, never zeroed
 
@@ -974,9 +987,11 @@ See [`docs/API_DOCS.md`](../API_DOCS.md) for the full request/response contract.
 - **No indexes, no foreign keys, no primary keys — permanently.** Not a gap in the provider
   ([§3.8](#38-no-keys-no-indexes--and-why-that-is-a-fact-about-the-engine)).
 - **No database size, and no per-catalog size**
-  ([§3.9](#39-the-bytes-are-somewhere-else-so-the-size-panels-say-so)). `StorageStats.sizeBytes` is
-  `0` beside `size: "N/A"`; if a panel ever renders that as "0 B", the alternative is returning no
-  rows at all, which would hide the catalog list too.
+  ([§3.9](#39-the-bytes-are-somewhere-else-so-the-size-panels-say-so)).
+  `DatabaseOverview.databaseSizeBytes` is absent rather than `0`, because the field is optional and
+  the absence is the honest answer. `StorageStats.sizeBytes` is still `0` beside `size: "N/A"` — it
+  is a required number, so the row cannot decline; if a panel ever renders that as "0 B", the
+  alternative is returning no rows at all, which would hide the catalog list too.
 - **No uptime without the `jmx` catalog** ([§7](#7-monitoring--health)).
 - **`getTableStats()` describes a scope of at most 25 tables**, and refuses a larger one rather than
   sampling it ([§7.1](#71-a-scope-too-large-for-one-pass-is-refused-not-sampled)). Ask for one schema

--- a/src/components/monitoring/tabs/StorageTab.tsx
+++ b/src/components/monitoring/tabs/StorageTab.tsx
@@ -29,6 +29,11 @@ export function StorageTab({ data, loading }: StorageTabProps) {
   // would claim a measurement the engine refused to make. The whole-dashboard error state
   // is not right either - the other panels answered - so this panel alone carries the
   // engine's own sentence. See MonitoringData in src/lib/db/types.ts.
+  //
+  // `overview` is not a panel of its own on this tab: what it feeds is the Storage Breakdown,
+  // so that is where its sentence goes. The DB Size card keeps the "N/A" it already draws for
+  // a byte figure it does not have, because a stat card has nowhere to put a sentence.
+  const overviewUnavailable = data?.overview === undefined ? data?.errors?.overview : undefined;
   const storageUnavailable = data?.storage === undefined ? data?.errors?.storage : undefined;
   const tablesUnavailable = data?.tables === undefined ? data?.errors?.tables : undefined;
 
@@ -81,8 +86,11 @@ export function StorageTab({ data, loading }: StorageTabProps) {
   // `system_views.disk_usage` publishes whole mebibytes, measured as "1 MiB" for a
   // 19,476-byte table (#424) - so there is no total to divide by and no breakdown to
   // draw, and this tab says so instead of formatting a "0 B" the engine never reported.
-  // A provider that sends a real 0 (Trino, Druid) has measured one, and keeps the
-  // arithmetic below unchanged.
+  // A real 0 is a third input and keeps the arithmetic below unchanged - but no provider in
+  // this tree is known to send a measured one. Trino omits the key as of this round, and
+  // Druid's 0 comes out of its local `asNumber`, which returns 0 for an absent row (backlog
+  // D44). The distinction is honoured because the field is optional precisely so the absence
+  // can be said, not because a named engine exercises the zero.
   const sizeKnown = overview?.databaseSizeBytes !== undefined;
   const totalSize = overview?.databaseSizeBytes ?? 0;
   const tablePercent = totalSize > 0 && tableSizeKnown ? (totalTableSize / totalSize) * 100 : 0;
@@ -90,7 +98,25 @@ export function StorageTab({ data, loading }: StorageTabProps) {
   // Without the table or the index bytes the remainder is not computable either, so its bar
   // stays empty instead of absorbing the unknown share.
   const breakdownKnown = tableSizeKnown && indexSizeKnown;
-  const otherPercent = breakdownKnown ? Math.max(0, 100 - tablePercent - indexPercent) : 0;
+  // And a share needs a total to divide by. The two shares above are each guarded on
+  // `totalSize > 0`, so a total of 0 forced both to 0 and `100 - 0 - 0` handed the remainder the
+  // entire bar: measured in the DOM against the tab's own measured-zero fixture, Tables and
+  // Indexes read `translateX(-100%)` while the remainder read `translateX(-0%)` - a full bar over
+  // a database with no bytes. `totalSize > 0` is the honest gate for every share on this tab
+  // because it excludes BOTH inputs that cannot be divided by: an absent size falls to 0 here, so
+  // one test covers the refusal and the measured zero alike.
+  const shareKnown = breakdownKnown && totalSize > 0;
+  const otherPercent = shareKnown ? Math.max(0, 100 - tablePercent - indexPercent) : 0;
+  // The remainder's BYTES are gated differently, and deliberately NOT on `totalSize > 0`: with a
+  // measured 0 total and no tables, `0 - 0 - 0` is an honest 0 B and stays one. What it cannot
+  // survive is a NEGATIVE, which a 0 total beside per-table figures that answered produces -
+  // `getTableStats()` is a separate read and does not share the overview's failure - and the
+  // cascade below returns its input unchanged, so the cell drew "-943718400 B": a negative byte
+  // count presented as a measurement (measured in the DOM). A negative remainder says the two
+  // reads disagree, not that the unattributed share is below zero, so there is no figure to
+  // print. Gating this on the share instead would refuse the honest 0 B as well.
+  const otherBytes = totalSize - totalTableSize - totalIndexSize;
+  const remainderKnown = breakdownKnown && otherBytes >= 0;
 
   return (
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">
@@ -112,10 +138,18 @@ export function StorageTab({ data, loading }: StorageTabProps) {
             <HardDrive strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
+            {/*
+              The FIGURE is this tab's own sum of per-table bytes and stays gated on the size
+              being known at all, which is the card's subject: Tables as part of the database.
+              The percentage below it is gated harder, on `totalSize > 0`, because a share of a
+              zero-byte total is not a smaller share - it is not a share. With a measured 0 and
+              real per-table bytes this line used to read "700.00 MB" over "0.0%", which is a
+              fabricated denominator under an honest numerator (measured in the DOM).
+            */}
             <div className="text-lg sm:text-2xl font-medium truncate">
               {sizeKnown && tableSizeKnown ? formatBytes(totalTableSize) : "N/A"}
             </div>
-            {sizeKnown && tableSizeKnown && (
+            {totalSize > 0 && tableSizeKnown && (
               <p className="text-xs sm:text-xs text-muted-foreground mt-1">{tablePercent.toFixed(1)}%</p>
             )}
           </CardContent>
@@ -130,7 +164,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
             <div className="text-lg sm:text-2xl font-medium truncate">
               {sizeKnown && indexSizeKnown ? formatBytes(totalIndexSize) : "N/A"}
             </div>
-            {sizeKnown && indexSizeKnown && (
+            {totalSize > 0 && indexSizeKnown && (
               <p className="text-xs sm:text-xs text-muted-foreground mt-1">{indexPercent.toFixed(1)}%</p>
             )}
           </CardContent>
@@ -158,7 +192,9 @@ export function StorageTab({ data, loading }: StorageTabProps) {
           </CardTitle>
         </CardHeader>
         <CardContent className="p-3 sm:p-4 pt-0 space-y-3 sm:space-y-4">
-          {sizeKnown ? (
+          {overviewUnavailable ? (
+            <PanelUnavailable message={overviewUnavailable} />
+          ) : sizeKnown ? (
             <div className="space-y-2 sm:space-y-3">
               <div>
                 <div className="flex items-center justify-between text-xs sm:text-xs mb-1">
@@ -204,14 +240,15 @@ export function StorageTab({ data, loading }: StorageTabProps) {
                       Other
                     </span>
                   </span>
-                  <span className="font-medium">
-                    {breakdownKnown ? formatBytes(totalSize - totalTableSize - totalIndexSize) : "N/A"}
-                  </span>
+                  <span className="font-medium">{remainderKnown ? formatBytes(otherBytes) : "N/A"}</span>
                 </div>
                 <Progress value={otherPercent} className="h-1.5 sm:h-2 [&>div]:bg-muted-foreground" />
               </div>
             </div>
           ) : (
+            // The engine answered and published no byte figure - Apache Cassandra is the case
+            // (#424) - which is a different fact from the refusal above and gets this tab's own
+            // copy rather than a sentence there is none of.
             <div className="text-center py-8 text-muted-foreground">
               <HardDrive strokeWidth={1.5} className="h-8 w-8 mx-auto mb-2 opacity-50" />
               <p className="text-xs">No storage size information available.</p>
@@ -331,8 +368,16 @@ export function StorageTab({ data, loading }: StorageTabProps) {
                       // engine that cannot measure the first cannot have measured the sum. When
                       // it is absent the share is left as "-" rather than drawn from the
                       // placeholder the required `totalSizeBytes` field still has to carry.
-                      const bytesReported = table.tableSizeBytes !== undefined;
-                      const percent = totalSize > 0 && bytesReported ? (table.totalSizeBytes / totalSize) * 100 : 0;
+                      //
+                      // A share also needs a database total to divide by, and this cell used to
+                      // draw one without: with `databaseSizeBytes` absent or 0 the guard forced
+                      // the share to 0 and every row rendered "0.0%" beside an empty bar -
+                      // measured against a refused overview, two rows with real bytes each
+                      // claiming to be 0.0% of a database whose size nothing had reported. The
+                      // same defect as the remainder's full bar above, in a shape a text
+                      // assertion CAN see.
+                      const shareKnown = totalSize > 0 && table.tableSizeBytes !== undefined;
+                      const percent = shareKnown ? (table.totalSizeBytes / totalSize) * 100 : 0;
                       return (
                         <TableRow key={`${table.schemaName}.${table.tableName}`}>
                           <TableCell className="py-2">
@@ -345,7 +390,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
                           </TableCell>
                           <TableCell className="text-right text-xs py-2">{table.totalSize}</TableCell>
                           <TableCell className="text-right hidden sm:table-cell py-2">
-                            {bytesReported ? (
+                            {shareKnown ? (
                               <div className="flex items-center justify-end gap-1 sm:gap-2">
                                 <Progress value={percent} className="w-12 sm:w-16 h-1.5 sm:h-2" />
                                 <span className="text-xs w-10 sm:w-12">{percent.toFixed(1)}%</span>

--- a/src/lib/db/providers/document/mongodb.ts
+++ b/src/lib/db/providers/document/mongodb.ts
@@ -1009,9 +1009,10 @@ export class MongoDBProvider extends BaseDatabaseProvider {
       // present as 0 it drew tables, indexes and an "Other (unattributed)" remainder
       // over a 0 B total, and that remainder is `0 - tables - indexes`, so a table read
       // that answered (it goes through `listCollections` + `collStats`, not
-      // `serverStatus`) drove it negative - and `formatBytes` renders a negative as the
-      // literal "NaN undefined", because `Math.log` of one is `NaN` and the unit indexes
-      // out of its array. Absent, the tab says "No storage size information available."
+      // `serverStatus`) drove it negative - and the tab formats bytes with its own local
+      // threshold cascade, whose last arm returns its input unchanged, so the remainder
+      // read "-1536 B": a negative byte count drawn as a measurement (measured against
+      // the cascade). Absent, the tab says "No storage size information available."
       //
       // The three figures below stay because their types leave nothing else: `0` MEANS
       // "no limit published" for `maxConnections` (its docblock in `types.ts` says

--- a/src/lib/db/providers/sql/search/index.ts
+++ b/src/lib/db/providers/sql/search/index.ts
@@ -351,10 +351,14 @@ function toQueryResult(result: SearchQueryResult, executionTime: number): QueryR
  * tree must not depend on, to answer a different question than the panel asks.
  *
  * A CLOSED index reports neither a document count nor a size (measured: both arrive
- * as JSON null while the listing still names the index), and `TableStats` has no way
- * to say "unknown" - both fields are required numbers. So a closed index reads as
- * zero here, and the schema tree is the surface that keeps the distinction: its
- * `rowCount` and `size` are optional, so it OMITS them instead.
+ * as JSON null while the listing still names the index). `TableStats.rowCount`,
+ * `totalSize` and `totalSizeBytes` are required numbers, so for those three a closed
+ * index has nowhere to read but zero. `tableSize` and `tableSizeBytes` are OPTIONAL,
+ * and this mapper fills them with the same zero anyway - a fabricated measurement
+ * rather than a forced one, which turns on `StorageTab`'s `tableSizeKnown` and draws
+ * a `0 B` Data figure for an index that reported nothing (docs/BACKLOG.md D50). The
+ * schema tree is the surface that keeps the distinction today: its `rowCount` and
+ * `size` are optional, so it OMITS them instead.
  */
 function toTableStats(index: SearchIndexInfo): TableStats {
   const sizeBytes = index.sizeBytes ?? 0;
@@ -811,7 +815,8 @@ abstract class SearchProvider extends SQLBaseProvider {
    *
    * `databaseSizeBytes` is the CLUSTER's store including replicas, which is what the
    * cluster occupies; the per-index sizes in the schema tree are primaries only, so
-   * they deliberately do not sum to this number.
+   * they deliberately do not sum to this number. It is ABSENT when the cluster
+   * published no store size at all, which is not the same claim as a measured zero.
    */
   public async getOverview(): Promise<DatabaseOverview> {
     const transport = this.requireTransport();
@@ -837,22 +842,33 @@ abstract class SearchProvider extends SQLBaseProvider {
         // computed from something else. A "0s" here would claim the cluster booted
         // this instant.
         uptime: SEARCH_UNKNOWN_TEXT,
-        // Zero means "not published" here. It is the correct encoding for the ceiling -
+        // `activeConnections` is ABSENT, not 0. A search cluster has no sessions and no
+        // connection pool: it counts open HTTP connections per node in its stats API,
+        // which is not part of this seam, and the shard and node counts that ARE here
+        // would be a different number wearing this field's name. So nothing was read,
+        // and `DatabaseOverview.activeConnections` is optional precisely so that can be
+        // said - `mssql.ts`, `oracle.ts`, `mongodb.ts` and `cassandra` all omit it for
+        // the same reason, and this provider held the last unconditional
+        // `activeConnections: 0` in the codebase - but not the last zero of any kind.
+        // Trino, Druid, ClickHouse and Couchbase still coerce a REFUSED read to 0. Each
+        // degrades an unavailable monitoring surface to no rows, then maps the absent row
+        // to zero through `nonNegative`, a local `asNumber` or a `?? 0`: the same encoding
+        // reached by a different route, and invisible because the refusal was swallowed a
+        // layer earlier (docs/BACKLOG.md D51).
+        //
+        // Zero still means "not published" for the CEILING beside it, and only for that:
         // `maxConnections` treats 0 and absence as one fact, which is why `druid` and
-        // `trino` cite `mssql.ts` for it - but NOT for the count beside it: `mssql.ts`,
-        // `oracle.ts`, `mongodb.ts` and `cassandra` now OMIT `activeConnections` when
-        // nothing was read, and this is the last provider still sending a 0 for it.
-        // Moving it is docs/BACKLOG.md D46, which needs both search docs and both test
-        // files with it.
-        // A search cluster has no sessions and no connection pool: it counts open
-        // HTTP connections per node in its stats API, which is not part of this
-        // seam, and the shard and node counts that ARE here would be a different
-        // number wearing this field's name. The Connections card reads a zero
-        // maximum as "no limit published" rather than dividing by it.
-        activeConnections: 0,
+        // `trino` cite `mssql.ts` for it. The Connections card reads a zero maximum as
+        // "no limit published" rather than dividing by it.
         maxConnections: 0,
         databaseSize: sizeBytes === null ? SEARCH_UNKNOWN_TEXT : formatBytes(sizeBytes),
-        databaseSizeBytes: sizeBytes ?? 0,
+        // Absent rather than `?? 0` for the same distinction: `storeSizeBytes()` returns
+        // null when `_cluster/stats` is refused, and a 0 here said "0 bytes" in the same
+        // object whose `databaseSize` above already said "N/A" from the identical input.
+        // `StorageTab.tsx` keys its own refusal off the missing key, so it now draws that
+        // instead of a 0.0% breakdown over a total the cluster never reported. A cluster
+        // that really stores nothing publishes a real 0 and keeps it.
+        ...(sizeBytes === null ? {} : { databaseSizeBytes: sizeBytes }),
         tableCount: indices.filter((index) => !isSystemIndex(index)).length,
         indexCount: 0,
       };
@@ -970,10 +986,10 @@ abstract class SearchProvider extends SQLBaseProvider {
     const overview = await this.getOverview();
 
     return {
-      // Both DatabaseOverview.activeConnections and HealthInfo.activeConnections
-      // are optional; this provider's overview never omits it, so the value just
-      // passes through unchanged.
-      activeConnections: overview.activeConnections,
+      // No `activeConnections`. Both DatabaseOverview.activeConnections and
+      // HealthInfo.activeConnections are optional, the overview above publishes no
+      // count for the reason stated there, and there is no second source to read it
+      // from: composing a key here would invent the figure this seam cannot measure.
       databaseSize: overview.databaseSize,
       cacheHitRatio: formatCacheHitRatio(undefined),
       slowQueries: [],

--- a/src/lib/db/providers/sql/trino/introspect.ts
+++ b/src/lib/db/providers/sql/trino/introspect.ts
@@ -616,9 +616,13 @@ export async function getOverview(runner: TrinoQueryRunner, catalog: string): Pr
     // Trino stores nothing. The bytes are in the systems its connectors reach, and
     // `SHOW STATS` reports a per-table logical estimate that covers variable-width
     // columns only (shape 2) - summing that into "the database size" would be a
-    // number that is neither a footprint nor complete.
+    // number that is neither a footprint nor complete. So `databaseSizeBytes` is not
+    // written AT ALL, the shape `cassandra/introspect.ts` uses for the same argument:
+    // the key is optional precisely so the absence can be said, and a 0 is a
+    // measurement the Storage tab formats as "0 B" beside a 0.0% breakdown. No
+    // conditional spread here because the value is never knowable - unlike
+    // `startTime` above, there is no reading that could supply it.
     databaseSize: TRINO_UNAVAILABLE_TEXT,
-    databaseSizeBytes: 0,
     tableCount: nonNegative(readNumber(tables?.tableCount)),
     // No index objects exist anywhere in Trino (shape 4).
     indexCount: 0,

--- a/src/lib/db/utils/pool-manager.ts
+++ b/src/lib/db/utils/pool-manager.ts
@@ -215,14 +215,36 @@ export function escapeIdentifier(identifier: string, provider: DatabaseType): st
 }
 
 /**
- * Format bytes to human readable size
+ * Format bytes to human readable size.
+ *
+ * A negative or non-finite input is not a magnitude, so it is refused as "N/A"
+ * rather than drawn as a figure. All five of -1, -1536, NaN, Infinity and
+ * -Infinity measured as the literal "NaN undefined" before this guard, by two
+ * different routes: `Math.log` is NaN for a negative and for NaN, so the unit
+ * index is NaN, while `Math.log(Infinity)` is Infinity, so the index is Infinity
+ * — either way it lands outside the array and the division reduces to NaN. "N/A"
+ * is the string this codebase already uses for a size it does not have (see the
+ * `databaseSize` arms of MongoDBProvider.getHealth). A real 0 stays "0 B"
+ * because zero bytes IS a measurement, and `-0` reaches that arm first
+ * (`-0 === 0` is true), so it never sees the refusal below.
+ *
+ * The ladder gains PB and EB, and the index is CLAMPED to its end. Two rungs is
+ * a judgement, the clamp is the guarantee: a byte count stops being an exact
+ * integer in a double at 2^53, which is 8 PB, so rungs past EB would spell
+ * magnitudes the input can no longer carry - and a double stays finite up to
+ * 1024^102 (measured), so no ladder length can outrun the input range. Without
+ * the clamp a petabyte read as "1 undefined" - a number wearing a missing unit,
+ * which scans as a figure rather than as garbage - and so did every larger
+ * input. ClickHouseProvider's OVERVIEW_SIZE_SQL sums bytes_on_disk over every
+ * active part of the current database, so PB-scale inputs are reachable.
  */
 export function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 B";
+  if (!Number.isFinite(bytes) || bytes < 0) return "N/A";
 
   const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const sizes = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
 
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 }

--- a/tests/components/monitoring/StorageTab.test.tsx
+++ b/tests/components/monitoring/StorageTab.test.tsx
@@ -138,6 +138,15 @@ function makeLibsqlMonitoringData(): MonitoringData {
   } as unknown as MonitoringData;
 }
 
+// `Progress` draws its share as `translateX(-(100 - value)%)` on the inner indicator, so an
+// empty bar is "-100%" and a full one "-0%". A share drawn from a figure the engine never
+// reported is invisible to every text assertion, which is why the bars are read directly.
+function barTransforms(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('[data-slot="progress-indicator"]')].map(
+    (el) => (el as HTMLElement).style.transform,
+  );
+}
+
 describe("StorageTab", () => {
   afterEach(() => {
     cleanup();
@@ -186,9 +195,16 @@ describe("StorageTab", () => {
   });
 
   test("a measured zero still renders as a zero, because absence is the only new input", () => {
-    // Trino (introspect.ts:615) and Druid send a real 0 for `databaseSizeBytes`. That is
-    // a measurement, so it must keep formatting as "0 B" with a 0.0% share and a drawn
-    // breakdown - only the ABSENT field switches to the unavailable copy.
+    // A real 0 and an absent field are different inputs, and the type says so
+    // (`databaseSizeBytes?: number`): a measured 0 keeps formatting as "0 B" and keeps its
+    // breakdown drawn, and only the ABSENT field switches to the unavailable copy. What it does
+    // NOT keep is a share - 0 bytes is not a denominator, so no "0.0%" is drawn beside the
+    // figures (#517). The remainder is the one figure that still reads "0 B" here, because
+    // `0 - 0 - 0` is arithmetic a measured zero answers honestly. No
+    // provider in the tree is known to send a demonstrably measured 0 today - Trino omits the
+    // key as of this round, and Druid's comes out of a local `asNumber` that returns 0 for an
+    // absent row (backlog D44) - so this arm pins the contract rather than standing in for a
+    // named engine.
     const measuredZero = {
       ...makeMonitoringData(),
       overview: { ...makeMonitoringData().overview, databaseSize: "0 bytes", databaseSizeBytes: 0 },
@@ -200,8 +216,105 @@ describe("StorageTab", () => {
     const { queryByText, queryAllByText } = render(<StorageTab data={measuredZero} loading={false} />);
 
     expect(queryAllByText("0 B").length).toBe(5);
-    expect(queryAllByText("0.0%").length).toBe(2);
+    expect(queryAllByText("0.0%").length).toBe(0);
     expect(queryByText("No storage size information available.")).toBeNull();
+  });
+
+  test("a measured zero total draws no share at all, not a full remainder bar", () => {
+    // The remainder's share is `100 - tablePercent - indexPercent`, and both of those carry a
+    // `totalSize > 0` guard of their own - so a total of 0 forced them to 0 and `100 - 0 - 0`
+    // handed the remainder the whole bar. Measured in the DOM against this very fixture
+    // (#517): Tables and Indexes read `translateX(-100%)` (empty) while the remainder read
+    // `translateX(-0%)`, a full bar over a database with no bytes. Against THIS fixture - which
+    // answers `[]` for the tables - the figure beside it reads "0 B" correctly, so the overclaim
+    // lives entirely in the indicator transform, which is why this test asserts the transform.
+    // That is a property of the fixture and not of the defect: the test below feeds the same
+    // measured zero with per-table bytes that answered, and there the figures are wrong too.
+    const measuredZero = {
+      ...makeMonitoringData(),
+      overview: { ...makeMonitoringData().overview, databaseSize: "0 bytes", databaseSizeBytes: 0 },
+      storage: [],
+      tables: [],
+      indexes: [],
+    } as MonitoringData;
+
+    const { container } = render(<StorageTab data={measuredZero} loading={false} />);
+
+    // The fixture answers `[]` for the tablespace and table lists, so the breakdown's three
+    // rows are the only `Progress` bars on the tab.
+    expect(barTransforms(container)).toEqual(["translateX(-100%)", "translateX(-100%)", "translateX(-100%)"]);
+  });
+
+  test("a real total still draws the remainder's own share", () => {
+    // The control arm for the test above: with a total to divide by, the remainder is the
+    // share the two known figures leave - 2 GB less 700 MB of data and 200 MB of indexes, so
+    // 56.0546875%, drawn as `translateX(-43.9453125%)`. Without this the fix could be a
+    // blanket "never draw the remainder".
+    const { container } = render(<StorageTab data={makeMonitoringData()} loading={false} />);
+
+    expect(barTransforms(container).slice(0, 3)).toEqual([
+      "translateX(-65.8203125%)",
+      "translateX(-90.234375%)",
+      "translateX(-43.9453125%)",
+    ]);
+  });
+
+  test("a measured zero total beside per-table bytes that answered draws no figure it cannot support", () => {
+    // The scenario #517's entry stated, and the one the fixture above cannot show. `getTableStats()` is
+    // a separate read from the overview, so a 0 total can arrive beside real per-table figures.
+    // Then `total - tables - indexes` is 0 - 734003200 - 209715200 = -943718400, and the tab's
+    // local byte cascade returns its input unchanged, so the remainder cell rendered
+    // "-943718400 B" - a negative byte count drawn as a measurement. The two Quick Stats shares
+    // were fabricated the other way: real "700.00 MB" and "200.00 MB" figures over a "0.0%"
+    // computed against a zero denominator.
+    const zeroTotalWithTables = {
+      ...makeMonitoringData(),
+      overview: { ...makeMonitoringData().overview, databaseSize: "0 bytes", databaseSizeBytes: 0 },
+    } as MonitoringData;
+
+    const { container, queryAllByText } = render(<StorageTab data={zeroTotalWithTables} loading={false} />);
+
+    // The honest numerators survive: this tab measured those bytes itself.
+    expect(queryAllByText("700.00 MB").length).toBeGreaterThan(0);
+    expect(queryAllByText("200.00 MB").length).toBeGreaterThan(0);
+    // Nothing divided by zero bytes is published, in either direction.
+    expect(container.textContent).not.toContain("-943718400");
+    expect(container.textContent).not.toContain("0.0%");
+    expect(queryAllByText("N/A").length).toBeGreaterThan(0);
+    // And no share is drawn for any of the three breakdown rows.
+    expect(barTransforms(container).slice(0, 3)).toEqual([
+      "translateX(-100%)",
+      "translateX(-100%)",
+      "translateX(-100%)",
+    ]);
+  });
+
+  test("a panel that answered keeps its figures even when an error was recorded for it", () => {
+    // The three `*Unavailable` guards each read `data?.X === undefined ? data?.errors?.X : undefined`,
+    // and the `=== undefined` half is the load-bearing one: without it a recorded error would hide
+    // a panel that DID answer, which is the mirror of the defect this tab exists to avoid - a
+    // refusal drawn over a measurement. Nothing pinned that half, so all three guards survived
+    // being rewritten as a bare `data?.errors?.X`.
+    const answeredWithErrors = {
+      ...makeMonitoringData(),
+      errors: { overview: "overview refused", storage: "storage refused", tables: "tables refused" },
+    } as unknown as MonitoringData;
+
+    const { container, queryAllByTestId, queryAllByText } = render(
+      <StorageTab data={answeredWithErrors} loading={false} />,
+    );
+
+    expect(queryAllByTestId("panel-unavailable").length).toBe(0);
+    expect(container.textContent).not.toContain("overview refused");
+    expect(container.textContent).not.toContain("storage refused");
+    expect(container.textContent).not.toContain("tables refused");
+    // The measured breakdown is still drawn from the overview that answered.
+    expect(queryAllByText("700.00 MB").length).toBeGreaterThan(0);
+    expect(barTransforms(container).slice(0, 3)).toEqual([
+      "translateX(-65.8203125%)",
+      "translateX(-90.234375%)",
+      "translateX(-43.9453125%)",
+    ]);
   });
 
   test("renders storage cards, breakdown, badges and largest tables", () => {
@@ -429,13 +542,14 @@ describe("a refused table statistics read", () => {
     expect(queryAllByText("2.00 GB").length).toBe(1);
     // The label still renders - the row is drawn, only its figure is an absence.
     expect(getByTestId("storage-breakdown-other-label").textContent).toBe("Other (unattributed)");
-    // And its bar with it: `Progress` draws its share as `translateX(-(100 - value)%)`, so an
-    // empty remainder bar is "-100%". A full one - "-0%", which is what `100 - 0 - 0` used to
-    // produce here - is the same overclaim in a shape no text assertion can see.
-    const bars = [...container.querySelectorAll('[data-slot="progress-indicator"]')].map(
-      (el) => (el as HTMLElement).style.transform,
-    );
-    expect(bars.slice(0, 3)).toEqual(["translateX(-100%)", "translateX(-100%)", "translateX(-100%)"]);
+    // And its bar with it: an empty remainder bar is "-100%", and a full one - "-0%", which is
+    // what `100 - 0 - 0` used to produce here - is the same overclaim in a shape no text
+    // assertion can see.
+    expect(barTransforms(container).slice(0, 3)).toEqual([
+      "translateX(-100%)",
+      "translateX(-100%)",
+      "translateX(-100%)",
+    ]);
   });
 
   test("an answered empty table list still reads 0 B and 0.0%", () => {
@@ -461,5 +575,74 @@ describe("a refused table statistics read", () => {
     // 500 MB + 200 MB of table data, on the Tables card and the breakdown's Tables row.
     expect(queryAllByText("700.00 MB").length).toBe(2);
     expect(queryAllByText("N/A").length).toBe(0);
+  });
+});
+
+// A refused getOverview read costs the byte figure the whole breakdown divides by. The tab
+// carried `errors.storage` for Tablespaces and `errors.tables` for Largest Tables while
+// discarding this third message entirely (2026-08-27).
+describe("a refused overview read", () => {
+  // Scoped here as well, for the same reason as the blocks above: bun:test registers a hook on
+  // the enclosing describe only.
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Whatever `getOverview()` rejected with, recorded verbatim under `errors.overview` by
+  // `BaseProvider.getMonitoringData` (src/lib/db/base-provider.ts) - the same channel the two
+  // panels above read. A neutral stand-in rather than a quoted engine message, for the reason
+  // the block above gives: an error text from memory is not that engine's documented text.
+  const REFUSAL = "this connection cannot read the server's own size catalogs";
+
+  function refusedOverview(): MonitoringData {
+    const rest: MonitoringData = makeMonitoringData();
+    delete rest.overview;
+    return { ...rest, errors: { overview: REFUSAL } } as MonitoringData;
+  }
+
+  test("the breakdown shows the engine's own sentence instead of its empty state", () => {
+    const { getByTestId, queryByText } = render(<StorageTab data={refusedOverview()} loading={false} />);
+
+    expect(getByTestId("panel-unavailable-message").textContent).toBe(REFUSAL);
+    // "No ... available." says the engine answered with nothing, which is not what happened.
+    expect(queryByText("No storage size information available.")).toBeNull();
+  });
+
+  test("no figure is drawn from the refused overview", () => {
+    // The DB Size card has no byte figure and neither do the two cards whose percentages are
+    // taken against it, so all three read "N/A" - and no bar is drawn at all, because the
+    // breakdown is replaced rather than emptied.
+    const { container, queryAllByText } = render(<StorageTab data={refusedOverview()} loading={false} />);
+
+    expect(queryAllByText("N/A").length).toBe(3);
+    expect(queryAllByText("0 B").length).toBe(0);
+    expect(queryAllByText("0.0%").length).toBe(0);
+    expect(barTransforms(container).length).toBe(2); // the two tablespace usage bars only
+  });
+
+  test("an overview absent without a recorded reason keeps the empty state", () => {
+    // The guard is on the message, not on the absence: a payload with no overview and nothing
+    // under `errors` has no sentence to show, so the panel falls back to its own copy rather
+    // than rendering an empty refusal.
+    const rest: MonitoringData = makeMonitoringData();
+    delete rest.overview;
+    const { queryByTestId, queryByText } = render(<StorageTab data={rest} loading={false} />);
+
+    expect(queryByTestId("panel-unavailable")).toBeNull();
+    expect(queryByText("No storage size information available.")).not.toBeNull();
+  });
+
+  test("an overview that answered without a byte figure keeps the empty state", () => {
+    // Apache Cassandra (#424): the read succeeded, so there is no message to show - the engine
+    // simply publishes no byte figure. The empty-state copy is the honest rendering there.
+    const base = makeMonitoringData();
+    const overview = { ...base.overview };
+    delete (overview as { databaseSizeBytes?: number }).databaseSizeBytes;
+    const answered = { ...base, overview: { ...overview, databaseSize: "N/A" } } as MonitoringData;
+
+    const { queryByTestId, queryByText } = render(<StorageTab data={answered} loading={false} />);
+
+    expect(queryByTestId("panel-unavailable")).toBeNull();
+    expect(queryByText("No storage size information available.")).not.toBeNull();
   });
 });

--- a/tests/integration/db/elasticsearch-provider.test.ts
+++ b/tests/integration/db/elasticsearch-provider.test.ts
@@ -1872,7 +1872,12 @@ describe("ElasticsearchProvider monitoring", () => {
     // HTTP connections per node live in a stats API this seam does not carry, and the
     // shard and node counts would be a different number wearing this field's name.
     expect(overview.indexCount).toBe(0);
-    expect(overview.activeConnections).toBe(0);
+    // `in` rather than `toBeUndefined()`: a fabricated 0 and a missing key are the two
+    // outcomes being told apart here, and only a presence check fails on the first.
+    expect("activeConnections" in overview).toBe(false);
+    // The ceiling is the opposite encoding on purpose: `DatabaseOverview.maxConnections`
+    // is a required number where 0 MEANS "no limit published", which is why the
+    // Connections card reads it as "no limit" rather than dividing by it.
     expect(overview.maxConnections).toBe(0);
   });
 
@@ -1897,8 +1902,35 @@ describe("ElasticsearchProvider monitoring", () => {
     const overview = await provider.getOverview();
 
     expect(overview.databaseSize).toBe("N/A");
-    expect(overview.databaseSizeBytes).toBe(0);
+    // The string said "N/A" while the number said 0 bytes, in the SAME object
+    // (docs/BACKLOG.md D44). `databaseSizeBytes` is optional so the absence can be said,
+    // and the Storage tab draws its own refusal rather than a 0.0% breakdown from a 0.
+    expect("databaseSizeBytes" in overview).toBe(false);
     expect(overview.tableCount).toBe(3);
+  });
+
+  test("getOverview OMITS activeConnections rather than sending a 0 that reads as a count", async () => {
+    // Nothing in this seam's five calls carries a connection count: the cluster counts
+    // open HTTP connections per node in a stats API this provider never calls, and the
+    // shard and node counts that ARE here would be a different number wearing this
+    // field's name. So there is no measurement to publish, which is the case the
+    // optional field exists for (#517).
+    const provider = await connectProvider();
+
+    const overview = await provider.getOverview();
+
+    expect("activeConnections" in overview).toBe(false);
+    expect(overview.activeConnections).toBeUndefined();
+  });
+
+  test("getHealth omits the connection count too rather than flattening it to 0", async () => {
+    // `HealthInfo.activeConnections` is optional for the identical reason, so the
+    // absence has to survive the composition instead of being filled in by it.
+    const provider = await connectProvider();
+
+    const health = await provider.getHealth();
+
+    expect("activeConnections" in health).toBe(false);
   });
 
   test("getOverview arms one deadline for the whole panel", async () => {
@@ -2096,7 +2128,7 @@ describe("ElasticsearchProvider monitoring", () => {
     const health = await provider.getHealth();
 
     expect(health.cacheHitRatio).toBe("N/A");
-    expect(health.activeConnections).toBe(0);
+    expect("activeConnections" in health).toBe(false);
     expect(health.databaseSize).toBe("82.72 KB");
     expect(health.slowQueries).toEqual([]);
     expect(health.activeSessions).toEqual([]);

--- a/tests/integration/db/opensearch-provider.test.ts
+++ b/tests/integration/db/opensearch-provider.test.ts
@@ -984,6 +984,9 @@ describe("OpenSearchProvider monitoring", () => {
     expect(overview.indexCount).toBe(0);
     expect(overview.databaseSize).toBe("272.56 KB");
     expect(overview.databaseSizeBytes).toBe(279104);
+    // A cluster that publishes the figure keeps it, including a real measured 0: only an
+    // unpublished size is absent.
+    expect("databaseSizeBytes" in overview).toBe(true);
   });
 
   test("excludes the same bookkeeping indices from the table stats", async () => {
@@ -1016,6 +1019,30 @@ describe("OpenSearchProvider monitoring", () => {
     const provider = await connectProvider();
 
     expect(await provider.getStorageStats()).toEqual([]);
-    expect((await provider.getOverview()).databaseSize).toBe("N/A");
+
+    const overview = await provider.getOverview();
+
+    expect(overview.databaseSize).toBe("N/A");
+    // The number used to say 0 bytes while the string beside it said "N/A", in the same
+    // object (docs/BACKLOG.md D44). `in` rather than `toBeUndefined()` because a
+    // fabricated 0 is the other outcome being told apart, and it is not undefined.
+    expect("databaseSizeBytes" in overview).toBe(false);
+  });
+
+  test("OMITS activeConnections rather than sending a 0 that reads as a count", async () => {
+    // Nothing in this seam carries a connection count on either product: the open HTTP
+    // connections per node live in a stats API this provider never calls. Absence is how
+    // the optional field says "not published" (#517), and the composed
+    // health summary has to carry it across rather than fill it in.
+    const provider = await connectProvider();
+
+    const overview = await provider.getOverview();
+    const health = await provider.getHealth();
+
+    expect("activeConnections" in overview).toBe(false);
+    expect("activeConnections" in health).toBe(false);
+    // The ceiling keeps its 0: for `maxConnections` the type says 0 and absence are the
+    // SAME fact, and the Connections card reads it as "no limit published".
+    expect(overview.maxConnections).toBe(0);
   });
 });

--- a/tests/integration/db/trino-provider.test.ts
+++ b/tests/integration/db/trino-provider.test.ts
@@ -1067,6 +1067,22 @@ describe("TrinoProvider monitoring", () => {
     expect(overview.indexCount).toBe(0);
   });
 
+  test("states no size in bytes at all, rather than a zero that reads as a measurement", async () => {
+    const provider = await connectProvider();
+    const overview = await provider.getOverview();
+
+    // The KEY IS ABSENT, not undefined-valued and not zero. `databaseSizeBytes` is
+    // optional exactly so a provider with no byte figure to publish can omit it, and
+    // Trino has none: the bytes live in the systems its connectors reach, and
+    // `SHOW STATS` is a per-table logical estimate covering variable-width columns
+    // only. `toBeUndefined()` alone would pass for a `databaseSizeBytes: undefined`
+    // that still ships the key, so `in` is what pins the absence (docs/BACKLOG.md D44).
+    expect("databaseSizeBytes" in overview).toBe(false);
+    expect(overview.databaseSizeBytes).toBeUndefined();
+    // The string keeps saying the figure is unavailable; only the number is gone.
+    expect(overview.databaseSize).toBe("N/A");
+  });
+
   test("reports the cluster's own completed-query rate and invents no other metric", async () => {
     const provider = await connectProvider();
 

--- a/tests/unit/db/pool-manager.test.ts
+++ b/tests/unit/db/pool-manager.test.ts
@@ -194,6 +194,47 @@ describe("formatBytes", () => {
   test('1099511627776 bytes returns "1 TB"', () => {
     expect(formatBytes(1099511627776)).toBe("1 TB");
   });
+
+  test('a petabyte renders as "1 PB" rather than a number with no unit', () => {
+    expect(formatBytes(1024 ** 5)).toBe("1 PB");
+  });
+
+  test("1.5 PB keeps its fraction and its unit", () => {
+    expect(formatBytes(1.5 * 1024 ** 5)).toBe("1.5 PB");
+  });
+
+  test('an exabyte renders as "1 EB", the last rung on the ladder', () => {
+    expect(formatBytes(1024 ** 6)).toBe("1 EB");
+  });
+
+  test("above the ladder the index clamps to EB instead of indexing past the array", () => {
+    expect(formatBytes(1024 ** 7)).toBe("1024 EB");
+  });
+
+  test("the clamp holds for the largest representable double", () => {
+    const formatted = formatBytes(Number.MAX_VALUE);
+    expect(formatted.endsWith(" EB")).toBe(true);
+    expect(formatted).not.toContain("undefined");
+    expect(formatted).not.toContain("NaN");
+  });
+
+  test('a negative byte count is not a magnitude and returns "N/A"', () => {
+    expect(formatBytes(-1)).toBe("N/A");
+    expect(formatBytes(-1536)).toBe("N/A");
+  });
+
+  test('NaN returns "N/A"', () => {
+    expect(formatBytes(NaN)).toBe("N/A");
+  });
+
+  test('both infinities return "N/A"', () => {
+    expect(formatBytes(Infinity)).toBe("N/A");
+    expect(formatBytes(-Infinity)).toBe("N/A");
+  });
+
+  test("negative zero is still a zero measurement, not a refusal", () => {
+    expect(formatBytes(-0)).toBe("0 B");
+  });
 });
 
 // ============================================================================

--- a/tests/unit/db/trino/introspect.test.ts
+++ b/tests/unit/db/trino/introspect.test.ts
@@ -560,7 +560,11 @@ describe("Trino getOverview", () => {
     const overview = await getOverview(runner, CATALOG);
 
     expect(overview.databaseSize).toBe(TRINO_UNAVAILABLE_TEXT);
-    expect(overview.databaseSizeBytes).toBe(0);
+    // The key is ABSENT, which is what this test's name has always said. It used to
+    // assert 0 - a measurement, in the same object whose `databaseSize` said the figure
+    // is unavailable (docs/BACKLOG.md D44). `in` is the assertion that distinguishes a
+    // missing key from one present holding `undefined`; `toBeUndefined()` passes for both.
+    expect("databaseSizeBytes" in overview).toBe(false);
   });
 
   test("publishes no connection ceiling and no index count", async () => {


### PR DESCRIPTION
Closes the producer side and the consumer side of one defect: an unknown database size reaching a
reader as a confident zero. Three backlog entries close (D44 in part, D46, U24) and four open in their
place (D50, D51, U25, U26), each measured rather than inferred.

## What was wrong

**Two providers stated both facts in one object.** Trino paired `databaseSize: TRINO_UNAVAILABLE_TEXT`
with `databaseSizeBytes: 0`; the search seam paired `SEARCH_UNKNOWN_TEXT` with `sizeBytes ?? 0`. The
string said "unavailable" and the number said "zero bytes", from the same input. Both now omit the key,
which is what the optional field is for, and a real zero still reads as zero.

**The search seam held the last unconditional `activeConnections: 0`** (D46). It is absent now, and
`getHealth()` stops composing a key it has no source for.

**The Storage tab divided by a total it did not have.** Three figures were affected, not the one the
entry named:
- the remainder bar was drawn FULL over a zero-byte database - `100 - 0 - 0` - and nothing numeric was
  wrong, so no text assertion could see it;
- the Tables and Indexes percentages rendered `0.0%` under real megabyte figures, a fabricated
  denominator under an honest numerator;
- the remainder's BYTES rendered `-943718400 B` when a measured-zero total met per-table reads that
  answered, because `getTableStats()` is a separate read that does not share the overview's failure.

A share now requires `totalSize > 0`, which excludes the absent size and the measured zero alike, so one
test covers both. The remainder's bytes are gated on the CONTRADICTION instead, deliberately not on the
share: `0 - 0 - 0` is an honest zero and stays one.

**A refused overview lost the engine's sentence** in a file that surfaces it for two sibling panels. It
has one now.

**The shared `formatBytes` refused nothing.** Measured live: `-1`, `NaN` and both infinities all
rendered `"NaN undefined"`, and a petabyte rendered `"1 undefined"` - a number wearing a missing unit,
which scans as a figure rather than as garbage. Non-magnitudes return `"N/A"`, the ladder gains PB and
EB, and the index is CLAMPED, which makes indexing past the array unreachable rather than moving the
boundary up two rungs.

## Three claims this repo made about itself, corrected

The backlog entry, `docs/providers/mongodb.md` and a `mongodb.ts` comment all said the negative
remainder renders `NaN undefined`. It does not. `StorageTab` defines its OWN local byte formatter and
never imports the shared one, so the cell renders `-1536 B`. A review lane had reported exactly that in
the previous round and was overruled by a measurement of the wrong function.

The search docs asserted that `TableStats` "has no way to say unknown - both fields are required
numbers". Measured against `types.ts`: `rowCount`, `totalSize` and `totalSizeBytes` are required;
`tableSize`, `tableSizeBytes`, `indexSize` and `indexSizeBytes` are optional, and their own docblock
argues for absence. Corrected here; the code half is D50.

A new comment claimed the search provider held "the last zero". It held the last unconditional literal
one. Four providers still reach a zero by a longer route, which is D51.

## New entries, all measured

- **D50** - the search seam zeroes two OPTIONAL `TableStats` size fields for a closed index. Not fixed
  here because omitting them takes the Data figure away from every open index in the cluster
  (`tables.every(...)`), which is a visible panel change and wants its own decision.
- **D51** - Trino, Druid, ClickHouse and Couchbase each degrade a refused monitoring read to no rows and
  then map the absent row to 0. ClickHouse's does it to six fields at once, so one refused read
  publishes a fully-zeroed overview that reads as measured.
- **U25** - `formatBytes` exists three times; the two component-local copies have no guard and render
  `-1 B`, `NaN B`, `Infinity GB`.
- **U26** - the admin fleet total re-parses formatted strings and has no `tb` branch, so a 1 TB database
  contributes **1 byte**. The real defect is that `FleetHealthItem` carries no numeric channel at all.

## Verification

- Six local gates green; coverage 100%.
- Every lane's work was reviewed adversarially, and four review findings were verified before adoption -
  one of them enlarged (Trino belonged in D51 and the reviewer had not measured it), one narrowed.
- Non-vacuity proven by mutation for each new guard: reverting `remainderKnown`'s non-negative check,
  the Quick Stats gate, and the three `*Unavailable` guards' `=== undefined` half each turns the suite
  RED. That last one is a guard shape that had existed for two rounds with nothing pinning it.
- A second test file the triad invariant does not name - `tests/unit/db/trino/introspect.test.ts` -
  asserted the old `0`. Only a test run found it.
