### PR TITLE
chore(backlog): settle forty entries, and the Redis ACL user that never reached its driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -237,6 +237,11 @@ LLM_MODEL=gemini-2.5-flash
 # LLM_API_KEY=AIzaSy...
 # LLM_MODEL=gemini-2.5-flash
 # LLM_API_URL=https://gemini-proxy.internal/v1beta  # optional; only to leave Google's endpoint
+#   The version segment is optional and a path prefix is kept: `https://gw.internal/api/google`
+#   works too. One variable feeds two SDKs that spell the endpoint differently - the chat surface
+#   takes an origin and appends the version itself, the agent adapter takes a base URL that
+#   carries it - so `/v1beta` is stripped for one and appended for the other as needed
+#   (`src/lib/llm/utils/gemini-endpoint.ts`). Unset leaves each SDK on its own Google default.
 
 # --- OpenAI ---
 # LLM_PROVIDER=openai

--- a/.env.example
+++ b/.env.example
@@ -210,8 +210,9 @@ LLM_API_KEY=your_api_key_here
 # Ollama: llama3.2, mistral, codellama, deepseek-coder
 LLM_MODEL=gemini-2.5-flash
 
-# API URL (optional - only needed for ollama or custom providers)
+# API URL (optional - required for the custom provider, and read by every kind)
 # Default URLs:
+# - Gemini: https://generativelanguage.googleapis.com/v1beta
 # - Ollama: http://localhost:11434/v1
 # - OpenAI: https://api.openai.com/v1
 #
@@ -220,6 +221,11 @@ LLM_MODEL=gemini-2.5-flash
 # - LMStudio: http://localhost:1234/v1
 # - vLLM: http://localhost:8000/v1
 # - LocalAI: http://localhost:8080/v1
+#
+# Gemini reads it too, so an egress proxy or a regional endpoint is configurable
+# (chat surface and agent alike). Give the versioned URL - a bare origin also works,
+# /v1beta is appended for you. Example:
+# - Gemini behind a proxy: https://gemini-proxy.internal/v1beta
 #LLM_API_URL=http://localhost:11434/v1
 
 # ===========================================
@@ -230,6 +236,7 @@ LLM_MODEL=gemini-2.5-flash
 # LLM_PROVIDER=gemini
 # LLM_API_KEY=AIzaSy...
 # LLM_MODEL=gemini-2.5-flash
+# LLM_API_URL=https://gemini-proxy.internal/v1beta  # optional; only to leave Google's endpoint
 
 # --- OpenAI ---
 # LLM_PROVIDER=openai

--- a/README.md
+++ b/README.md
@@ -423,6 +423,49 @@ journalctl -u libredb-studio
    ```
    Open [http://localhost:3000](http://localhost:3000)
 
+  ### Embedding in your own app (`@libredb/studio`)
+
+  Studio is published as an npm package as well as a server, so the editor can live inside your own
+  product:
+
+  ```bash
+  npm i @libredb/studio
+  ```
+
+  **Adopt Studio's security headers from your own Next.js config.** The `@libredb/studio/security`
+  subpath publishes the header policy as pure data — `securityHeaders()` returns a plain
+  `Record<string, string>`, and the module it comes from imports nothing, so it is safe to load from
+  a `next.config.ts` where no path alias and no Studio runtime exist yet:
+
+  ```ts
+  // next.config.ts
+  import { securityHeaders } from "@libredb/studio/security";
+
+  export default {
+    async headers() {
+      return [
+        {
+          source: "/:path*",
+          headers: Object.entries(securityHeaders()).map(([key, value]) => ({ key, value })),
+        },
+      ];
+    },
+  };
+  ```
+
+  Options: `reportOnly` emits `Content-Security-Policy-Report-Only` instead of the enforcing header;
+  `hsts: false` disables HSTS (or an object customises it); `allowEval` adds `'unsafe-eval'`, which
+  React's *development* build needs; `monacoVsPath` adds the origin serving Monaco's bundle when it
+  is not same-origin; and `extra` merges your own sources per directive. `studioCspDirectives()` and
+  `HSTS_MAX_AGE_SECONDS` are exported too, for a config that needs to compose the policy rather than
+  send it.
+
+  Read the policy before you inherit it: the CSP permits inline scripts, because every document
+  route is statically prerendered with nonce-less hydration scripts, so what it contains is where an
+  injected script could *send* data, not whether one can run. That trade-off, and the two delivery
+  paths a Next.js app has for these headers, are argued in
+  [`docs/SECURITY.md`](docs/SECURITY.md).
+
 ---
 
 ## Development Databases

--- a/README_ja.md
+++ b/README_ja.md
@@ -231,6 +231,28 @@ npm i @libredb/studio
 
 Studioはnpmパッケージとしても配布されているので、自分のアプリケーションの中に直接埋め込めます。ユーザーのためにデータベースを作る製品なら、エディタが最も役に立つのはその内側です。
 
+**Studioのセキュリティヘッダを自分のNext.js設定から使う。** `@libredb/studio/security` サブパスは、このポリシーを純粋なデータとして公開しています。`securityHeaders()` が返すのはただの `Record<string, string>` で、その定義元モジュールは何もimportしていません。パスエイリアスもStudioのランタイムもまだ存在しない `next.config.ts` から読み込んでも安全です。
+
+```ts
+// next.config.ts
+import { securityHeaders } from "@libredb/studio/security";
+
+export default {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: Object.entries(securityHeaders()).map(([key, value]) => ({ key, value })),
+      },
+    ];
+  },
+};
+```
+
+オプション：`reportOnly` は強制ではなく `Content-Security-Policy-Report-Only` を送ります。`hsts: false` はHSTSを無効化（オブジェクトを渡せばカスタマイズ）。`allowEval` は `'unsafe-eval'` を追加するもので、Reactの**開発**ビルドがこれを必要とします。`monacoVsPath` はMonacoのバンドルが同一オリジンでない場合にそのoriginを追加します。`extra` はディレクティブごとに独自のソースをマージします。`studioCspDirectives()` と `HSTS_MAX_AGE_SECONDS` もエクスポートされており、ポリシーをそのまま送るのではなく組み立てたい設定で使えます。
+
+継承する前にポリシーそのものを読んでください。このCSPはインラインスクリプトを許可します。すべてのドキュメントルートが静的にプリレンダされ、ハイドレーション用のインラインスクリプトにnonceを付けられないからです。したがってこのポリシーが縛るのは、注入されたスクリプトがデータを**どこへ送れるか**であって、実行できるかどうかではありません。このトレードオフと、Next.jsアプリがこれらのヘッダを配送する2つの経路については [`docs/SECURITY.md`](docs/SECURITY.md) で論じています。
+
 ## 有料との線引きについて
 
 StudioがMITなのは、あらゆる場所に置ける必要があるからです。有料なのはlibredb-platformで、そこで売っているのは「運用の代行」、つまりホスティング、テナント管理、課金、サポートであって、有料の壁の向こうに移された機能ではありません。

--- a/README_zh.md
+++ b/README_zh.md
@@ -227,6 +227,28 @@ npm i @libredb/studio
 
 Studio 同时以 npm 包形式发布，可以直接嵌进你的应用。如果你的产品会替用户创建数据库，这是编辑器最该待的地方。
 
+**在你自己的 Next.js 配置里复用 Studio 的安全响应头。** `@libredb/studio/security` 这个子路径把整套策略以纯数据的形式发布出来：`securityHeaders()` 返回一个普通的 `Record<string, string>`，而它所在的模块不 import 任何东西，所以可以直接在 `next.config.ts` 里加载——那里还没有路径别名，也没有 Studio 运行时。
+
+```ts
+// next.config.ts
+import { securityHeaders } from "@libredb/studio/security";
+
+export default {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: Object.entries(securityHeaders()).map(([key, value]) => ({ key, value })),
+      },
+    ];
+  },
+};
+```
+
+可选项：`reportOnly` 发送 `Content-Security-Policy-Report-Only` 而不是强制生效的那个头；`hsts: false` 关闭 HSTS（传对象则是自定义）；`allowEval` 加上 `'unsafe-eval'`，React 的**开发**构建需要它；`monacoVsPath` 在 Monaco 的产物不同源时把那个 origin 加进来；`extra` 按指令合并你自己的来源。另外还导出了 `studioCspDirectives()` 和 `HSTS_MAX_AGE_SECONDS`，供需要自己拼装策略而不是直接下发的配置使用。
+
+继承之前请先读一遍这套策略：CSP 是允许内联脚本的，因为每个文档路由都是静态预渲染的、水合脚本没有 nonce。所以它约束的是被注入的脚本能把数据**发到哪里**，而不是能不能跑起来。这个取舍，以及 Next.js 应用下发这些头的两条路径，都写在 [`docs/SECURITY.md`](docs/SECURITY.md) 里。
+
 ## 关于收费的那条线
 
 Studio 是 MIT，因为它必须能去任何地方。付费的是 libredb-platform，它卖的是“别人替你运维”：托管、多租户、计费和支持，而不是某个被挪到付费墙后面的功能。

--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -815,10 +815,15 @@ The integration points, all of which need an entry. This is the list the Strateg
       so the compiler will at least stop you from *forgetting* that a decision exists
 
 **Published where a human reads it, and this is the block with the fewest gates.** `readme:check`
-compares the translated READMEs against `README.md` and `chart:check` compares versions; nothing
-counts the engines in a catalog listing, so an engine can ship while three storefronts still name the
-previous set (measured in the #511 review, which found all of these stale after libSQL had already
-landed everywhere the compiler looks):
+compares the translated READMEs against `README.md` and `chart:check` compares versions. Nine of the
+catalog files below are now counted as well:
+[`tests/unit/lib/catalog-copy-engine-count.test.ts`](../tests/unit/lib/catalog-copy-engine-count.test.ts)
+walks them, refuses a numeral qualifying "engines" that is not `EXTERNAL_DATABASE_TYPES.length`, and
+where that numeral introduces a list, refuses a list that does not name every one of them by its
+`DB_UI_CONFIG` label (#D47 - added after three consecutive PRs corrected the same class by hand; the
+#511 review found all nine stale after libSQL had already landed everywhere the compiler looks). The
+files NOT in that walk have no gate at all, and an abridged list ("and more", or a "from X to Y"
+range) is still checked on its numeral only, deliberately, so that no numeral goes stale (#445):
 
 - [ ] `charts/libredb-studio/Chart.yaml` — the `description`, which is what **ArtifactHub** shows, AND
       the `keywords` list, which is what ArtifactHub **searches**. An engine absent from the keywords is

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1964,8 +1964,8 @@ model passed the capability probe**; for anybody else the answer is that there i
 | **MongoDB, MySQL and every other engine.** Both panels ran against whatever the connection was, and NL2SQL emitted Mongo query documents when the connection's query language was JSON. | The agent composes SQL for **two** dialects. `CATALOG_COMPOSERS` and `CATALOG_PLANS` carry `postgres` and `sqlite` only, and an unlisted dialect is never guessed at — since #414 it is read a different way instead of being refused. **A run whose workflow sends statements is refused on another engine before it opens**: `POST /api/agent/runs` answers 400 with the posture's own sentence when the mode is agent and `AGENT_WORKFLOW_SENDS_STATEMENTS` holds for the requested workflow, so no run id and no model turn are spent on a refusal the connection's type already decided. What an engine that IS admitted can then do differs by MODE. **Agent mode is still the two dialects**: its read-class tools reach the database through `provider.queryReadOnly`, which is the same fact the refusal reads. **Plan mode is now every engine**: its grounding acquires `agent-operations` and calls `provider.getSchema()` (`db.schema.read`), so a plan run on MongoDB is ordinarily grounded and is asked for one statement or command **in that engine's own language**, in a block still tagged with the canonical type-id. What the engine decides is no longer whether a plan is grounded but HOW — a composed catalog statement or a provider inventory, and whether estimated statistics exist at all — and the four prefaces say which. Where the reading itself fails, the run is steered to the `NO STATEMENT:` refusal with the capture's own diagnosis. **The `operations` workflow reaches every engine in both modes**, because it composes no SQL at all, and since #411 it is grounded under the same rule as everything else. | `src/lib/agent/composed-sql.ts`, `src/lib/agent/context-snapshot.ts` (`captureContextSnapshot`, `captureFromProvider`, `packOperationsInventory`), `src/lib/db/operations/descriptors.ts` (`db.schema.read`); `tests/unit/lib/agent/context-snapshot.test.ts` — the provider path, its timeout and its refusals; `tests/unit/lib/agent/composed-sql.test.ts` — `UNSUPPORTED_DIALECT`; `tests/evals/plan-grounding.test.ts` — a plan run whose provider cannot describe itself runs no statement and says it is ungrounded; `tests/isolated/agent-investigation.test.ts` — a plan run grounded through the engine's own schema inspection. |
 
 One of these has since been restored under its own workflow (the monitoring row, which closed both
-deferrals that tracked it), and the first row is Phase 1's own boundary rather than a defect (B21 is
-its one residual). The rest are consequences
+deferrals that tracked it), and the first row is Phase 1's own boundary rather than a defect, and its one
+residual is recorded in the module map. The rest are consequences
 of the removal rather than work in progress: they are what the product decided not to do, and that
 decision is only honest while they are written down where a maintainer will find them.
 
@@ -2374,7 +2374,7 @@ standalone-only. The reason is a comment above the interface, where a reader wou
 
 One residual: the shared `BottomPanel` component ships in the package with its agent-provenance
 branch present but inert — an optional prop the embedded shell never passes, on a component no entry
-point exports (B21).
+point exports.
 
 ## Module map
 
@@ -2433,7 +2433,6 @@ the role's own grants are the whole boundary (A3).
 
 **From this milestone:**
 
-- **B1** — a credential classification map kept module-private would be invisible to the state guard.
 - **B2** — the Anthropic kind is ratified and installed but not offered; serving it means giving the
   chat surface an Anthropic provider first.
 - **B3** — a scope allowlist on a target dimension denies every tool that cannot declare it.
@@ -2454,8 +2453,6 @@ the role's own grants are the whole boundary (A3).
   so it cannot load in the container image or the npx payload.
 - **B20** — a Gemini deployment behind a proxy is not configurable: `LLM_API_URL` is unread for that
   kind, in the chat surface as much as in the agent.
-- **B21** — the published package's `BottomPanel` carries the agent-provenance branch as dormant
-  markup.
 - **B23** — seed eligibility is decided against the browser's last descriptor fetch, so a seed
   repointed server-side mid-session is not seen until the next fetch.
 - **B29** — an identifier the model quotes back into its own tool arguments reaches the transcript
@@ -2496,9 +2493,6 @@ as they are fixed, and a numeral here goes stale silently.
   step's claims verbatim and truncates at a claim boundary; a model-written `carryForward` sentence
   was considered and declined, because a claim is evidence and a summary is a lossy compression of
   it.
-- **B71** — `@ai-sdk/workflow`'s `WorkflowAgent` offers the durability this repository implements by
-  hand, and is not used: it requires the workflow runtime's programming model, which would bind the
-  agent to a hosting runtime this product deliberately does not depend on.
 - **B39** — a data-analysis run has no honest way to conclude that the question is not about this
   database. Its only route to `answered` is a reading of the data, so a run that establishes the
   question is unanswerable fabricates one — the #356 shape again, in a new place.
@@ -2594,11 +2588,6 @@ as they are fixed, and a numeral here goes stale silently.
   gone: the document refuses wording and nothing else can populate it. Refusing unsigned prompt text
   is right; refusing it forever is a decision that has not been taken, and the two objections behind
   it — marker drift and authorship — come apart.
-- **B62** — `schemaVersion` is a literal on both schemas, so the first bump to 2 refuses every
-  document in the field and reverts every model in it to the defaults. Deliberately not fixed while
-  only one version exists: an accepted range with one member is a knob nothing turns, and the
-  tolerant operator schema removes the pressure by letting Studio add settings without moving it.
-
 - **B64** — an unfenced plan statement with NO terminator still carries prose into the SQL. The
   splitter closed the demonstrated case (a statement, then its explanation on the next line, came
   back as one statement with the prose in it) but has nothing to cut on without a semicolon, so

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -947,9 +947,11 @@ and that is a reversal of a product decision rather than an oversight: epic #325
 set at three and #330 T3 reopened it. Its own id is what lets an operator see profiling in the audit
 stream, and deny it, without denying every read the agent makes.
 
-Two honest limits, each with a backlog entry: only an email shape is tested, because `LIKE`
-cannot express a digit run (**B26**); and a profile that times out reports the failure rather than
-falling back to catalog statistics (**B28**). A third is closed: SQLite stores no DDL for the index
+One honest limit, with a backlog entry: a profile that times out reports the failure rather than
+falling back to catalog statistics (**B28**). Two others are closed. A digit run is now asked for in
+each dialect's own spelling — PostgreSQL `~ '[0-9]{9,}'`, SQLite `GLOB '*[0-9]...*'` — because `LIKE`
+can say "any character" but not "any digit", and testing an email shape alone was the consequence of
+that rather than a decision. And SQLite stores no DDL for the index
 it builds to enforce a `UNIQUE` constraint, so the composed index read cannot see it - the capture
 now reads those out of the table's own `CREATE TABLE` and lists them as `(unique constraint)`, plain
 words rather than a name that could be mistaken for a user's `CREATE INDEX`. `fk_unindexed` remains a
@@ -2205,9 +2207,9 @@ Two further rules govern it:
   repair attempts — and states the SQLite non-preemption caveat rather than implying that an
   overrunning statement is cut short. It reports no token budget because none is enforced (B10). A statement that
   failed at the database now carries the span the tracker charged for it, so the database-time figure
-  no longer counts completed reads only; what is left uncounted is the catalog capture's own reads
-  and the difference between an engine's elapsed time and the span measured around the call (B13),
-  which is why the figure is still stated as a floor.
+  no longer counts completed reads only, and a schema capture contributes the statements and the span
+  the tracker charged it. What is left uncounted is the difference between an engine's elapsed time
+  and the span measured around the whole call, which is why the figure is still stated as a floor.
 
 Results the agent stored **hydrate the existing surfaces**: the results grid, the explain view and the
 charts view in the bottom panel, carrying a read-only provenance badge that names the run. There is
@@ -2222,9 +2224,10 @@ specification the model emitted is validated against the artifact's columns befo
 validated again in the browser against the rows actually delivered — two guards, because
 `DataCharts` turns a column it cannot read into `0` rather than into an error, and a chart of the
 wrong column draws a confident flat line rather than failing. A specification that does not survive the
-second check is dropped and the view's own inference draws the chart instead. Exporting a hydrated
-result is not wired (B34), and a run's stored results are released when the run ends, so a report can
-outlive the rows its citations point at (B15).
+second check is dropped and the view's own inference draws the chart instead. A hydrated result can be
+exported: the menu is retargeted rather than hidden, the file is named after the run that produced
+the rows, and the SQL forms are not attributed to the tab's own table. A run's stored results are
+still released when the run ends, so a report can outlive the rows its citations point at (B15).
 
 **Those results live in process memory, and the store that holds them is bounded.** It keeps 180
 entries at once — the largest statement ceiling any workflow may be given (45) times the four
@@ -2443,7 +2446,6 @@ the role's own grants are the whole boundary (A3).
 - **B9** — nothing enqueues a drive, so an interrupted run is resumable but never resumed.
 - **B10** — no token budget is enforced, so the meter reports none.
 - **B11** — the rail can stop a run but cannot pause or resume one.
-- **B13** — three spends the ledger never records, so the meter reads low.
 - **B79** — the re-pointed decline has never been reached from the UI: in the default storage mode
   the only server-held connections are the seeds, and editing a seed makes it browser-local, which
   the rail refuses before any thread check.
@@ -2451,8 +2453,6 @@ the role's own grants are the whole boundary (A3).
   rows.
 - **B16** — the opt-in `@workflow/world-postgres` backend is not present in the standalone payload,
   so it cannot load in the container image or the npx payload.
-- **B20** — a Gemini deployment behind a proxy is not configurable: `LLM_API_URL` is unread for that
-  kind, in the chat surface as much as in the agent.
 - **B23** — seed eligibility is decided against the browser's last descriptor fetch, so a seed
   repointed server-side mid-session is not seen until the next fetch.
 - **B29** — an identifier the model quotes back into its own tool arguments reaches the transcript
@@ -2468,17 +2468,6 @@ the role's own grants are the whole boundary (A3).
 - **B33** — a run is observable only from its own ledger. There is no OpenTelemetry export and no
   metrics: the record described above is complete, and getting it into a stack the operator already
   runs is designed (#332) and deliberately unbuilt.
-- **B34** — a hydrated result cannot be exported: the Export menu serializes the tab's own rows, so it
-  is hidden while a run's result is shown.
-
-The entries below were found by driving the product against a live model in a browser, which is the
-only way any of them could have been found: every one of them passes every gate. A few were found
-later and by other routes, and are listed here because they are the same kind of thing — a defect no
-gate in this repository objects to. Several came from repeating that exercise against the inference
-surface (#407) — twenty-six runs over `docs/AGENT_DEMO.md`, which is also where the classifier's
-real-world agreement rate was measured. The count is deliberately not stated: entries leave this list
-as they are fixed, and a numeral here goes stale silently.
-
 - **B67** — there is no run history across conversations. The rail names the conversation a run
   continues and lists its steps from the run's own header, but a user cannot see the conversations
   they had yesterday or return to one: the store has no enumeration, there is no list route, and
@@ -2487,8 +2476,6 @@ as they are fixed, and a numeral here goes stale silently.
   re-checked, so a resumed drive can read a repointed database while carrying a conversation and a
   captured schema established against the old one. The record now carries the identity needed to close
   it; what a run should DO when its connection moves under it is the undecided part.
-- **B69** — a reload ends a conversation and the rail does not say so before the next question. The
-  result is honest (no thread, no strip); the transition is silent.
 - **B70** — a run writes no summary for the step after it. The conversation carries the previous
   step's claims verbatim and truncates at a claim boundary; a model-written `carryForward` sentence
   was considered and declined, because a claim is evidence and a summary is a lossy compression of
@@ -2496,14 +2483,6 @@ as they are fixed, and a numeral here goes stale silently.
 - **B39** — a data-analysis run has no honest way to conclude that the question is not about this
   database. Its only route to `answered` is a reading of the data, so a run that establishes the
   question is unanswerable fabricates one — the #356 shape again, in a new place.
-- **B48** — the two grounding paths fail differently. Since #414 a plan run on one of the nine
-  provider-path engines survives an unreachable host, a wrong password or a half-configured
-  `agentUser`: `captureFromProvider` converts a `DatabaseError` or an `ExecutionProfileError` raised
-  before the reading leaves into an unavailable capture, and the run answers ungrounded with that
-  diagnosis. The composed path — PostgreSQL and SQLite — still lets the same failure out, ending the
-  run `internal` or, on the profile error, `agent-credential-unusable`. Deliberate at #414, which had
-  no business changing how the two engines it did not touch fail, and an asymmetry a reader will
-  trip over until it is resolved.
 - **B72** — plans are exempt from the emptiness census for `query-optimization` only. The
   investigation, database-assessment and data-analysis verifiers still judge a plan-only report by a
   row count that measures nothing, and `inspect_plan` is offered to all three. Closing it changes what
@@ -2518,17 +2497,6 @@ as they are fixed, and a numeral here goes stale silently.
   fix,
   left unmodelled because the user-index reader drops `COLLATE` too and honouring it in one reader
   only would make the inventory disagree with itself.
-- **B51** — the loop delivers three notices to a model (the reserve warning, the report reminder of
-  #416, the present-before-report notice of #417) and records none of them. `recordEvent` is called
-  for what the RUN did and never for what the server said to it, so a rescued run and a run that never
-  needed rescuing leave the same ledger — and a `compose_report` the loop withheld leaves no trace
-  that a call was made. That is a measurement problem first: [`docs/llms/`](./llms/) is built by
-  reading those ledgers, and its whole claim is that each figure comes from an observed run. Each
-  notice is sent once per DRIVE and not once per run, and the missing entry is why: the three booleans
-  live inside `runInvestigation`, which is also what resumes a run a dead process left running, so a
-  resumed drive starts with all three false. The guards are the part that keeps being got wrong —
-  both new notices shipped with a condition that named one thing and read another, and both were
-  caught in review rather than by a gate.
 - **B52** — the composed PostgreSQL grounding capture is refused by what the IMAGE ships rather
   than by a wide user schema, and it has now been measured on three different servers.
   `composeCatalogRead` projects one row per COLUMN against `maxResultRows: 200` and refuses rather
@@ -2562,27 +2530,6 @@ as they are fixed, and a numeral here goes stale silently.
   baseline, so it is PostgreSQL's privilege rule and not an AlloyDB property. The agent is therefore
   unusable out of the box on all three, and the same shape will appear on any PostgreSQL whose image
   ships wide catalogs or wide extension views before the user has created anything.
-- **B55** — a grounded LibreDB plan run drafts `GET users:*`, and `get` is an exact-key lookup with no
-  glob: the key does not exist, so the command answers zero rows and no error. The inventory's rows are
-  NAMED `users:*`, which reads as a glob the grammar does not have, and LibreDB declares no
-  `statementLanguage`, so the five verbs (`get`, `put`, `delete`, `prefix`, `range`) are left to be
-  guessed. MongoDB and Redis were fixed the same way in 0.13.1 - each declares the sentence its
-  statement form needs - and LibreDB's turn was deferred by the owner on 2026-08-22 until the other
-  providers are done.
-- **B56** — a planning run's grounding is HELD for the process lifetime, so a schema that changes is
-  invisible to plan mode until a restart. `holdSnapshotForConnection` keeps one inventory per
-  connection identity with no expiry, and it is consulted before any capture. Measured twice on
-  2026-08-22: after MongoDB's inference began expanding subdocuments, `schema/list` returned
-  `shipping.city` at once and the schema tree showed it, while two plan runs still grouped by
-  `$shipping.region` and recorded no `context-captured` event at all; a restart fixed it on the first
-  run. Redis showed the same shape, refusing an objective about keys that had just been seeded. The
-  design intent - a run reasons over the inventory its claims cite - is not the problem; a NEW run
-  inheriting it indefinitely is, and a reused snapshot writes no capture event of its own, so the
-  ledger cannot tell "held, hours old" from "captured just now".
-- **B57** — an operator's tuning document is refused WHOLE when any part of it fails. The argument
-  behind that is about merging (half of one measurement beside half of another is a configuration
-  nobody has run), and it justifies whole-**entry** replacement rather than whole-**document**
-  rejection: fifty models would be lost to a typo in the thirty-seventh.
 - **B59** — per-model WORDING has nowhere to go. A sentence is a measured value here (twice a shared
   change won cells and lost others, and had to be reverted whole), and the per-model override is
   gone: the document refuses wording and nothing else can populate it. Refusing unsigned prompt text

--- a/docs/AGENT_DATA_FLOW.md
+++ b/docs/AGENT_DATA_FLOW.md
@@ -65,8 +65,8 @@ that can disagree (`src/lib/agent/model-adapter.ts`).
 
 | Kind | Endpoint | Call site |
 | --- | --- | --- |
-| `gemini` | Google's own Generative AI endpoint. **No `baseURL` is passed, deliberately**, so an `LLM_API_URL` left over from another setup cannot redirect Gemini traffic — carrying your key — to that host | `src/lib/agent/provider-registry.ts:134-146` |
-| `openai`, `ollama`, `custom` | `{LLM_API_URL}/chat/completions` — whatever host you named | `src/lib/agent/provider-registry.ts:121-132` |
+| `gemini` | `{LLM_API_URL}` when you set one, Google's own Generative AI endpoint otherwise. The variable is read on both Gemini surfaces, so a proxy configured for the chat surface is also where a run goes — nothing routes to a host you did not name, and nothing silently keeps talking to Google either | `src/lib/agent/provider-registry.ts:136-150`, `src/lib/llm/utils/gemini-endpoint.ts` |
+| `openai`, `ollama`, `custom` | `{LLM_API_URL}/chat/completions` — whatever host you named | `src/lib/agent/provider-registry.ts:123-134` |
 
 Two properties of that seam are enforced rather than assumed:
 
@@ -74,14 +74,18 @@ Two properties of that seam are enforced rather than assumed:
   `OPENAI_BASE_URL` when they are undefined, and `@ai-sdk/google` reads
   `GOOGLE_GENERATIVE_AI_API_KEY`. Every setting is therefore passed explicitly, so none of those
   reads can happen — a keyless Ollama gets a placeholder token and a keyless custom endpoint gets no
-  `Authorization` header at all (`provider-registry.ts:81-111`, asserted on the wire in
+  `Authorization` header at all (`provider-registry.ts:83-113`, asserted on the wire in
   `tests/isolated/agent-model-adapter.test.ts`).
 - **The SDK's hosted gateway is unreachable by construction.** The AI SDK also accepts a bare model
   id, which it resolves through its own gateway — a third party nothing in this repository
-  configures. The type excludes that arm (`AgentLanguageModel`, `provider-registry.ts:53-61`).
+  configures. The type excludes that arm (`AgentLanguageModel`, `provider-registry.ts:55-63`).
 
-`LLM_API_URL` is unread for the `gemini` kind, on the agent path exactly as on the chat surface. A
-Gemini deployment behind a proxy is therefore not configurable (`docs/BACKLOG.md` B20).
+`LLM_API_URL` reaches the `gemini` kind on the agent path exactly as on the chat surface, so a Gemini
+deployment behind an egress proxy or on a regional endpoint is configurable from the one variable. The
+two installed SDKs disagree about whether the version segment belongs to the base URL —
+`@google/generative-ai` appends it, `@ai-sdk/google` does not — so one value is normalised into both
+spellings in `src/lib/llm/utils/gemini-endpoint.ts`. Give the versioned URL; a bare origin also works,
+`/v1beta` is composed for it.
 
 ---
 
@@ -572,11 +576,11 @@ output cap, and what it sends is one objective — see
   **One credential does leave, necessarily: your `LLM_API_KEY`.** It is not in a prompt — it is in
   the request's authentication metadata, because that is how the provider authenticates you. The
   OpenAI-compatible kinds send it as the `Authorization` header
-  (`src/lib/agent/provider-registry.ts:106,123-126`) and Gemini passes it to the Google provider
-  (`:141`). Two consequences worth stating: a keyless Ollama gets a placeholder token and a keyless
-  custom endpoint gets no `Authorization` header at all (`:107,110`), so neither invents a
-  credential; and Gemini is deliberately given no `baseURL`, so a stale `LLM_API_URL` cannot
-  redirect that key to another host (`:134-146`). "No credentials leave" would be the wrong claim
+  (`src/lib/agent/provider-registry.ts:108,125-128`) and Gemini passes it to the Google provider
+  (`:143`). Two consequences worth stating: a keyless Ollama gets a placeholder token and a keyless
+  custom endpoint gets no `Authorization` header at all (`:109,112`), so neither invents a
+  credential; and Gemini's `baseURL` comes from `LLM_API_URL` — the host you configured for the chat
+  surface and no other (`:136-150`). "No credentials leave" would be the wrong claim
   here — the accurate one is that **no database credential** reaches the model, while the model
   provider's own key reaches the model provider and nothing else.
 - **Cell values from a table's own columns.** No agent path reads a row out of a user table and

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -376,9 +376,16 @@ For the state of the data itself — where it is incomplete, inconsistent or sur
 reading before you point it at a table of personal data:
 
 **A profile records counts, never values.** Row counts, present counts, distinct counts, and how
-many values match a shape — computed inside the database with `count(CASE WHEN … LIKE …)`, so no
+many values match a shape — computed inside the database with `count(CASE WHEN <predicate> …)`, so no
 matching value leaves it. There is deliberately no `min`/`max`, because on a text column those
-return real values (`src/lib/agent/table-profile.ts:1-27`). The findings — `high_null`, `constant`,
+return real values (`src/lib/agent/table-profile.ts:1-30`).
+
+Two shapes are tested at `pattern` depth, and each is the **dialect's own** predicate rather than one
+shared operator: an email address (`LIKE '%_@_%._%'`, spelled the same on both engines) and a run of
+nine or more digits — a phone number, a national id, a card — which PostgreSQL spells `~ '[0-9]{9,}'`
+and SQLite spells `GLOB '*[0-9]…*'`. Nine is the shortest of the identifiers worth suspecting, so a
+shorter bound would match years, prices and quantities. `LIKE` cannot express a digit run at all: `_`
+in it means "any character". The findings — `high_null`, `constant`,
 `low_cardinality`, `suspected_pii`, `fk_unindexed` — are the server's own mechanical predicates over
 those counts, with stated thresholds; the model may interpret them and cannot invent one.
 
@@ -806,8 +813,9 @@ gauges it is about:
 - **Every ceiling is per drive.** A run resumed after a restart starts each of them again, so these
   totals can read past a single drive's ceiling.
 - **Every figure is a floor, never a ceiling.** The ledger records less than the server charges: the
-  schema capture's catalog reads are not itemized, and a completed read reports the engine's own
-  elapsed time rather than the span the budget was charged (`docs/BACKLOG.md` B13). A statement that
+  schema capture now contributes the statements and the span it was charged, but a call that failed
+  while acquiring its provider settles no step and so cannot be seen, and a completed read reports the
+  engine's own elapsed time rather than the span the budget was charged. A statement that
   failed at the database DOES record its span since #512; a refusal written before that build
   carries none, and those are counted rather than summed as zero.
 - **On SQLite a statement over its timeout is refused once it returns, not interrupted while it
@@ -848,9 +856,9 @@ start the run and are reported by the drive as `model-unauthorized`, `model-rate
 
 Ollama is a first-class path: `LLM_PROVIDER=ollama` with `LLM_API_URL=http://localhost:11434/v1`
 reaches the OpenAI-compatible endpoint through the same adapter as the `openai` and `custom` kinds
-(`src/lib/agent/provider-registry.ts:121-132,154-159`), and no key is required — the adapter sends a
+(`src/lib/agent/provider-registry.ts:123-134,156-161`), and no key is required — the adapter sends a
 placeholder rather than leaving `apiKey` undefined, so an ambient `OPENAI_API_KEY` cannot leak in
-(`provider-registry.ts:86,107,110`).
+(`provider-registry.ts:88,109,112`).
 
 **The model decides whether a local deployment can run the agent — not the endpoint.** This is
 worth stating precisely, because it is the opposite of what the mechanism suggests. The capability

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -1637,7 +1637,7 @@ async function streamAIExplanation(query: string, explainPlan: string) {
 | `LLM_PROVIDER` | No | AI provider: gemini, openai, ollama, custom |
 | `LLM_API_KEY` | No | AI provider API key |
 | `LLM_MODEL` | No | AI model name |
-| `LLM_API_URL` | No | Custom AI endpoint URL. Read for the `openai`, `ollama` and `custom` kinds, on the chat surface and in the agent alike; **unread for `gemini`** ([`docs/BACKLOG.md`](BACKLOG.md) B20) |
+| `LLM_API_URL` | No | Custom AI endpoint URL. Read for every kind, on the chat surface and in the agent alike. For `gemini` give the versioned URL (`https://host/v1beta`); a bare origin also works, the version segment is composed for it (`src/lib/llm/utils/gemini-endpoint.ts`) |
 | `LIBREDB_AGENT_ENABLED` | No | The agent's explicit **off**-switch. Availability is otherwise derived from the AI configuration and a writable ledger — see [`docs/AGENT.md`](AGENT.md) |
 | `WORKFLOW_TARGET_WORLD` | No | Durable backend for agent run state: `local` (default, single instance) or `@workflow/world-postgres` |
 | `WORKFLOW_LOCAL_DATA_DIR` | No | Where the `local` backend keeps run state (`/app/data/workflow` in the container image) |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,21 +22,21 @@ None of it is a GitHub issue.
 **Sections**
 
 - [SQL statement reading](#sql-statement-reading) — S2–S6 · 4
-- [Drivers and connections](#drivers-and-connections) — D1–D51, U17, U22 · 21
+- [Drivers and connections](#drivers-and-connections) — D1–D51, U17 · 14
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U26 · 10
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U26 · 9
 - [Authentication and security headers](#authentication-and-security-headers) — AU4
-- [Tests](#tests) — T1–T5 · 3
+- [Tests](#tests) — T4
 - [Dependencies](#dependencies) — P1–P5 · 5
 - [Documentation](#documentation) — DOC3, DOC4 · 2
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3
 - [Chart configuration surface](#chart-configuration-surface) — N1, N3 · 2
-- [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H8 · 4
+- [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H8 · 3
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C3–C10 · 8
 - [Security Phase 3 deferrals](#security-phase-3-deferrals) — K4
 - [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A5 · 4
-- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B2–B79 · 40
+- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B2–B79 · 30
 
 ---
 
@@ -277,48 +277,6 @@ panels on Doris show absence rather than an error, and the reading is unchanged 
 and one analytics relative — each verified against the live container, not inferred from the
 statement text.
 
-### D31. A failed schema read leaves the previous connection's tables on screen as this one's
-
-Measured 2026-08-26 in Chrome against the built app, with the network captured (issue #424, the
-QuestDB probe). The sequence needs no unusual state - a fresh browser context reproduces it:
-
-1. the workspace auto-selects the first connection and loads its schema
-   (`200 POST /api/db/schema/list {"connectionId":"seed:doris-probe"}` -> `probe_customers`,
-   `probe_orders`);
-2. the user clicks a second connection whose schema read fails
-   (`500 POST /api/db/schema/list {"connectionId":"seed:questdb-probe"}` -> `'(' expected`);
-3. the header switches to the second connection and **the object browser keeps showing the first
-   connection's tables, with its row counts** - measured: `probe_customers 3` and
-   `probe_orders 2.0k` under a header reading *QuestDB 10.0.1 (probe)*, while QuestDB's own
-   `questdb_only_marker` never appears and QuestDB has no `probe_customers` at all.
-
-`fetchSchema` in `src/hooks/use-connection-manager.ts` toasts the error and `return`s without
-touching `schema`, so the previous value survives the connection change. `Studio.tsx`'s
-connection-change effect clears it only in the `else` branch, when the active connection becomes
-null - never when the fetch for a new one fails. Storage is not involved: `/api/storage/config`
-answers `serverMode: false`, `libredb_schema_snapshots` was empty, and the tree is React state.
-
-**Reproduced a second time on a different engine, 2026-08-27.** Selecting the Databend connection
-after an OrioleDB one showed OrioleDB's `probe_customers 3` / `probe_orders 2.0k` under Databend's
-name, with `500 POST /api/db/schema/list :: Prepare is not support in Databend` in the network log -
-same shape, different cause for the failing read, which is the point: any failing schema read does
-this.
-
-**Why this is worse than an empty tree, and why it is not a QuestDB problem.** An empty object
-browser is the honest reading the absence rule (#477) asks for. This one attributes real objects,
-with real row counts, to a database that does not contain them - and the tables are clickable, so
-the next query is written against a schema the connection does not have. Every engine whose object
-browser fails inherits it: CockroachDB (no `pg_total_relation_size()`), Materialize and RisingWave
-(reserved `MATERIALIZED`), QuestDB (both), and any engine having a bad day.
-
-Noticed in the same capture and not filed separately: one connection selection issues the same
-`schema/list` read **two or three times** - two for the auto-selected connection, three for the
-clicked one. Worth confirming while this is open, since the fix touches the same call.
-
-**Done when:** selecting a connection whose schema read fails shows an empty object browser
-carrying the engine's own error, never the previous connection's tables - verified in a browser
-across two connections where the second one's read fails, not through the hook in isolation.
-
 ---
 
 ### D33. Every parameterised read still prepares, so an engine without PREPARE loses all of them
@@ -382,25 +340,6 @@ entry, which is why citing it is no longer safe - and lost the same day: #510 br
 merge and its copy of this file overwrote both entries, which is also why they are renumbered.
 Restored 2026-08-27 from `35294140`.
 
-### D35. The live SSH arm was driven once by hand, and no fixture keeps it true
-
-The mismatch arm HAS been measured against a real server. 2026-08-26, `openssh-server` on port 2226,
-through the real `createSSHTunnel`, three arms: no pin accepted and reported
-`SHA256:JWLQciyX8RYEeuK+bwRLW/YSpStz0/L7BlbVcejL1/U`, byte-identical to
-`ssh-keyscan -p 2226 127.0.0.1 | ssh-keygen -lf -`; the correct pin connected; a wrong pin was refused
-with both fingerprints in the message. So the fingerprint format and the refusal are confirmed
-end-to-end against a live sshd, not only against generated key files and a mocked handshake, and
-`docs/providers/README.md` records that measurement.
-
-What does not exist is a STANDING fixture. `tests/unit/ssh-tunnel.test.ts` still drives a mocked `ssh2`,
-which is what runs in CI, so the live result is a one-time observation rather than a property the suite
-holds. A regression in the verifier would be caught by the mock only to the extent the mock is faithful
-to ssh2 - and the mock was written from reading ssh2's source, which is the thing most likely to drift.
-
-**Done when:** an sshd service exists alongside the other container fixtures and the three arms above
-run against it, or a note beside the mock records that its fidelity to ssh2 is the assumption CI rests
-on and names the source it was derived from.
-
 ### D37. Five HTTP providers read the SSL mode and drop the rest of the TLS panel
 
 Found 2026-08-27 in the #511 review (issue #424, Phase 5). Not libSQL's - libSQL is the
@@ -426,29 +365,6 @@ discards, which is the kind of silence a security setting must not have.
 **Done when:** the TLS material mapping is shared rather than copied, the five `fetch`
 transports route TLS through it, and one test per transport pins that a supplied CA and a
 `verify-*` mode reach the request options - plus one that a `require` mode does not verify.
-
-### U22. The connection form renders fields the engine does not take, and a comment says otherwise
-
-Found 2026-08-27 in the browser while registering `libsql` (issue #424, Phase 5).
-
-`DB_UI_CONFIG[type].connectionFields` decides what a save WRITES
-(`buildConnection` in `src/hooks/use-connection-form.ts`), and its comment there says it is
-"the same list the modal renders inputs from". It is not. `ConnectionModal.tsx` draws Host,
-Username, Password and Database for every engine that is not file-based, so:
-
-- **libSQL** shows a Username box for an engine that has no user names at all,
-- **Druid**, **Elasticsearch** and **OpenSearch** show a Database box none of them takes.
-
-Nothing is written from those boxes, so a connection is not corrupted by typing in one - the
-cost is a user filling a field that is silently discarded, and a comment that misdescribes
-the code beside it. Measured for libSQL: `#user` and `#database` both render, and neither
-value reaches the saved connection.
-
-**Done when:** the modal renders an addressing input only when `connectionFields` names it,
-with the four engines above checked in a browser rather than in a mock - or, if the fields
-are deliberately universal, the comment in `use-connection-form.ts` says so instead. Either
-way `e2e/libsql-provider.spec.ts` has the assertion that pins today's behaviour and must
-move with it.
 
 ---
 
@@ -494,29 +410,6 @@ queries" where the truth is that the profiler is off.
 provider answers a sentence as a row, and no provider answers `[]` for a read that failed - and the
 count of type-ids the type change touched is stated in the PR rather than discovered during it.
 
-### D42. The connection-string mask cannot cover a password holding a character RFC 3986 reserves
-
-Found 2026-08-27 while closing the query-string half of the same mask (`getConnectionInfo`, PR
-round 17). The mask now covers the authority and every credential-shaped parameter, in any position.
-What it cannot cover is an authority password containing `@`, `/`, `?` or `#` unencoded:
-`postgres://user:p/w@host/db` is returned in the clear.
-
-The reason is not an oversight and is written into `redactConnectionString`'s docblock
-(`src/lib/db/base-provider.ts`): `postgres://host:5432/tenant@acme` - a path holding an `@`, which
-carries no secret at all - has the identical shape, and no regular expression separates the two. The
-round chose the safe arm deliberately: drawing `***` over a port asserts a credential the string never
-carried, which is a fabricated reading rather than a mask, and this repo's absence rule (#477) forbids
-the fabrication more strongly than it forbids the miss. `tests/unit/db/base-provider.test.ts` pins the
-gap explicitly, so it is visible rather than assumed closed.
-
-RFC 3986 §3.2.1 requires each of those characters to be percent-encoded in userinfo, so every string
-this misses is malformed - but the drivers accept them, which is why the gap is real rather than
-theoretical.
-
-**Done when:** the authority is masked by PARSING rather than by pattern - split on the last `@`
-before the first `/`, `?` or `#` that follows `://`, then mask between the first `:` and that `@` -
-with the two colliding shapes above pinned as separate cases, and the docblock's list of uncovered
-shapes reduced to what remains. The parameter half needs no change.
 ### D44. `databaseSizeBytes` is fabricated as 0 wherever the size is unknown, in 11 of 17 type-ids
 
 Found 2026-08-27 by the sweep that closed the overview connection count's fabricated zero (D40, PR
@@ -612,75 +505,6 @@ current database, and that permission cannot be granted in `master`.
 rather than published. Measured on a real instance with a login that has neither grant, because the
 whole entry rests on a permission boundary no fixture can prove.
 
-### D47. Nine outward-facing enumerations name the engines by hand, and nothing counts them
-
-Found 2026-08-27 while registering `duckdb` (issue #424). Not DuckDB's defect - DuckDB is the
-second engine in a row to walk into it, and the first (libSQL, #511) left nine files still
-naming the previous set. Measured on this branch's parent commit, every one of these was
-missing libSQL two weeks after it shipped everywhere the compiler looks:
-
-| File | What it said | True at the time |
-| --- | --- | --- |
-| `packaging/linux/nfpm.yaml` | "fourteen engines", 14 names | 15 external engines |
-| `packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl` | 14 names in `Description` | 15 |
-| `packaging/chocolatey/libredb-studio.nuspec.tmpl` | 14 names in `<description>` | 15 |
-| `desktop/src-tauri/tauri.conf.json` | 14 names in `longDescription` | 15 |
-| `deploy/caprover/libredb-studio.yml` | "fourteen engines" twice | 15 |
-| `deploy/railway/template.json` | "fourteen engines" | 15 |
-| `deploy/azure/listing/listing-fields.md` | "14 engines" / "Fourteen engines" / "fourteen engines" | 15 |
-| `deploy/azure/listing/description.html` | "fourteen engines" | 15 |
-| `deploy/rancher/CATALOG_LISTING.md` (key-features bullet) | "Fourteen database engines" | 15 |
-
-All nine are corrected in this PR, which is the third consecutive PR to correct the same
-class by hand. `scripts/readme-check.mjs` proves the mechanism works - it locates the engine
-table structurally and fails when the three READMEs disagree - and `chart:check` proves a
-version can be pinned across files. Nothing does the equivalent for the catalog copy, and
-`docs/ADDING_A_PROVIDER.md` says so in as many words: *"nothing counts the engines in a
-catalog listing, so an engine can ship while three storefronts still name the previous set"*.
-
-The gate has to be tolerant of abridgement, because these files are not all exhaustive by
-design: the winget and chocolatey **summaries** deliberately name a few engines and "and
-more" (#445, so that no numeral goes stale), while their **descriptions** are exhaustive. So
-the check is not "every file names every engine" - it is "a file that publishes a NUMERAL
-must publish the right one, and a list introduced by that numeral must have that many names",
-with the numeral derived from `EXTERNAL_DATABASE_TYPES.length` and the names from
-`DB_UI_CONFIG` labels.
-
-**Done when:** one test walks a declared list of outward-facing copy files, extracts each
-English or digit numeral that qualifies the word "engines", compares it to
-`EXTERNAL_DATABASE_TYPES.length`, and - where that numeral introduces a list - counts the
-`DB_UI_CONFIG` labels in it; with a non-vacuity assertion that a fixture naming one engine
-too few fails.
-
-### D48. There is no `sessionsEmptyState`, so an engine with no session list cannot say so
-
-Found 2026-08-27 while registering `duckdb` (issue #424), and it is not DuckDB's defect.
-
-`ProviderLabels` carries `slowQueriesEmptyState` (#U12), so a provider whose engine keeps no store
-of finished statements replaces the Queries panel's PostgreSQL sentence - *"Enable
-pg_stat_statements extension to see query stats."* - with its own. **There is no equivalent for
-sessions.** `SessionsTab.tsx:160` and `OperationsTab.tsx:612` print the hardcoded *"No active
-sessions found."* for every provider that answers `getActiveSessions()` with an empty list. The
-`sessionsUnavailable` branch beside it is not a way in: it renders a reason only when the reading
-FAILED (`data.activeSessions === undefined`, the reason taken from `data.errors.activeSessions`),
-which is a different fact from an engine that has no sessions to publish.
-
-So the two halves of the same absence read differently on the same connection. On DuckDB the
-Queries panel says why in DuckDB's own words, and the Sessions panel says *"No active sessions
-found."* - which a reader takes as "nothing is running right now", when the truth is that
-`duckdb_connections()` does not exist and the panel can never show a row (measured: `Catalog Error:
-Table Function with name duckdb_connections does not exist!`). The same wrong reading is available
-today on every engine that publishes no session list.
-
-Not urgent, and deliberately not solved by making `getActiveSessions()` throw: an absence is not an
-error, and the failure branch already means something else.
-
-**Done when:** `ProviderLabels` gains an optional `sessionsEmptyState`, both panels prefer it over
-their hardcoded sentence, DuckDB declares one naming `duckdb_connections()`, and a component test
-pins both branches - a provider that declares the label and one that does not - so the fallback
-cannot quietly become the only path again. `docs/providers/duckdb.md` §3.7 states today's behaviour
-and must move with it.
-
 ### D49. Per-table maintenance drops the schema, so every table outside the default one refuses
 
 Found 2026-08-27 in the BROWSER while registering `duckdb` (issue #424). Not DuckDB's defect - the
@@ -721,33 +545,6 @@ change.
 **Done when:** the row passes the qualified name, every one of the twelve providers has been
 measured against a table outside its default schema (or recorded as having no such concept), and a
 component test pins the target the row sends so it cannot silently revert to the bare name.
-
-### D50. The search seam zeroes two OPTIONAL `TableStats` size fields for an index that reported nothing
-
-Found 2026-08-27 in the #517 review, inside the file that PR was already fixing. `toTableStats()`
-(`src/lib/db/providers/sql/search/index.ts`) reads `const sizeBytes = index.sizeBytes ?? 0` and writes
-that zero into `tableSize`, `tableSizeBytes`, `totalSize` and `totalSizeBytes`. Its docblock justified
-all four with "`TableStats` has no way to say 'unknown' - both fields are required numbers".
-
-**That justification was false for half of them.** Measured against `src/lib/db/types.ts`: `rowCount`,
-`totalSize` and `totalSizeBytes` are required, so for those three a closed index genuinely has nowhere
-to read but zero. `tableSize`, `tableSizeBytes`, `indexSize` and `indexSizeBytes` are **optional**, and
-their own docblock says why in as many words - "A `0` would be the same lie in a different digit, so
-absence is the answer, and every consumer of the aggregate gates on it - see `StorageTab`'s
-`tableSizeKnown`". The doc sentence and the docblock were corrected in #517; the code was not, because
-the consequence needs a decision rather than a patch.
-
-**The consequence, and why it is not obvious.** A CLOSED index reports neither a document count nor a
-size (measured: both arrive as JSON null while the listing still names the index). Filling
-`tableSizeBytes` with 0 keeps `StorageTab`'s `tableSizeKnown` true, so the Data figure reads `0 B` for
-that index rather than N/A. But omitting it flips `tableSizeKnown` false for the WHOLE cluster -
-`tables.every(...)` - so one closed index takes the Data figure away from every open one. That is the
-behaviour the type prescribes and SQLite-under-Bun already gets, and it is still a visible change to a
-panel, which is why it is an entry.
-
-**Done when:** the two optional fields are omitted for an index that published no size, both search
-docs record what one closed index does to the cluster's Data figure, and both test files pin an open
-index beside a closed one so the aggregate's behaviour is asserted rather than inferred.
 
 ### D51. Four providers degrade a refused monitoring read to no rows, then read the absent row as 0
 
@@ -1016,32 +813,6 @@ is not a free read.
 **Done when:** an operation a provider declares globally runnable either has its own card copy or a
 recorded reason it is withheld.
 
-### U25. One byte formatter exists three times, and the two local copies draw non-magnitudes as figures
-
-Found 2026-08-27 in the #517 review, which fixed the shared one. `formatBytes` exists in three places:
-the exported `src/lib/db/utils/pool-manager.ts` one that every provider calls, and a private
-threshold-cascade copy inside `src/components/monitoring/tabs/StorageTab.tsx` and another inside
-`src/components/monitoring/tabs/TablesTab.tsx`. The two components do NOT import the shared one, which
-is how the closed entry's claim that the Storage remainder rendered `NaN undefined` came to be wrong: that is the
-shared function's output, and the cell that was measured runs the local cascade.
-
-#517 gave the shared one a guard (a negative or non-finite input returns `"N/A"`, and the unit index is
-clamped). The cascade copies have no guard, and their failure is quieter because the output looks like a
-reading. Measured against `TablesTab`'s copy: `-1` renders `"-1 B"`, `NaN` renders `"NaN B"`, `Infinity`
-renders `"Infinity GB"`, and 1 EB renders `"1073741824.00 GB"`. The Storage copy behaves identically;
-#517 closed its one reachable negative by refusing to compute a contradictory remainder at all, so that
-tab no longer feeds it one, but the formatter is unchanged.
-
-`TablesTab` reads the numeric twins (`tableSizeBytes` and its siblings) rather than the engine's own
-strings, so its input is whatever a provider computed - and D44 and D51 are both about providers that
-compute those numbers from an absent row.
-
-**Done when:** one formatter serves all three call sites, or the two copies carry the same guard as the
-shared one; the units agree (the cascade stops at GB, so it spells an exabyte in gigabytes); and a unit
-test pins a negative, a non-finite and a PB-scale input for whatever survives. Deleting the copies is
-the smaller change but not free: they exist at module scope with a comment saying they are there to keep
-the components' cognitive complexity down, and the shared module is a pool manager.
-
 ### U26. The fleet total sums display strings, so a terabyte counts as one byte
 
 Found 2026-08-27 in the #517 review. `totalDBSize` in `src/components/admin/tabs/OverviewTab.tsx`
@@ -1110,16 +881,6 @@ or the exposure is accepted in writing with the sibling-subdomain trust assumpti
 
 ## Tests
 
-### T1. Two disjuncts are pinned by almost nothing
-
-`isStatementText` (`src/lib/sql/statement-end.ts`) has a `dollar-string` disjunct pinned by exactly
-one assertion. That is the same hole that, for the `subscript` disjunct, let a statement-corrupting
-emission through the full gate, CI, 100% line coverage and five reviews — deleting the disjunct failed
-zero tests. Line coverage cannot see a missing disjunct in a one-line predicate. Only a fixture where
-the two readings *disagree* can pin it.
-
-**Done when:** deleting any single disjunct of `isStatementText` fails a test.
-
 ---
 
 ### T4. Eight backlog ids cited in `src/` name entries that no longer exist
@@ -1145,23 +906,6 @@ can do honestly.
 
 **Done when:** no id cited in `src/` is missing from this file, and the drift guard covers source
 citations the way it already covers `docs/AGENT.md`.
-
-### T5. The allowlist's provider-free check reads one level deep
-
-`tests/security/route-auth.test.ts` now verifies that every route on `ROUTES_WITHOUT_A_PROVIDER` is
-still provider-free, rather than merely naming a real route (this closed H10). It does that by
-reading each allowlisted route's own source and matching the provider entry points: the `@/lib/db`
-and `@/lib/llm` module specifiers by PREFIX, so a new factory export is covered the day it lands,
-plus the one indirect helper that exists today - `@/lib/api/schema-route`, which is how
-`db/schema/list` and `db/schema/relations` reach a provider without naming `@/lib/db` at all.
-
-The residual is transitive reach. A future route that obtains a provider through a NEW indirect
-helper module would still pass, because nothing follows the import graph. Measured at the time it was
-written: zero allowlisted routes reach a provider, with or without comment stripping, so this is a
-gap in the guard rather than a defect it is hiding.
-
-**Done when:** the check resolves a route's imports transitively, or the set of indirect helpers is
-itself pinned so a new one cannot appear unnoticed.
 
 ## Dependencies
 
@@ -1512,19 +1256,6 @@ the channels that serve Studio from a small box.
 
 **Done when:** the measurement says the trade is worth it and the nonce ships, or the measurement is
 recorded here as the reason it does not.
-
-### H4. The `@libredb/studio/security` usage note is not in the published README
-
-An npm consumer reading `README.md` on npmjs.com sees nothing about `securityHeaders()`.
-
-It used to live in `.claude/rules/platform-integration.md`, which was deleted with the
-platform/studio decoupling, so there is no longer a second home for it at all.
-
-It is out of `README.md` because `README_zh.md` and `README_ja.md` (`scripts/readme-check.mjs`'s
-`LOCALIZED` pair) would then drift, and that script guards the pair structurally rather than by
-heading.
-
-**Done when:** the note lands in all three READMEs together.
 
 ### H7. `sanitizeAuditInput` does not recurse, so a nested secret survives inside the coerced string
 
@@ -2054,40 +1785,6 @@ is the path B6 already complicates.
 **Done when:** either control exists in the service with its own ledger record, and the rail renders it
 because the service can honour it.
 
-### B13. Three spends the agent run ledger never records, so the budget meter reads low
-
-Opened by #329 T10b, found by the task's own fresh-context review.
-
-**The schema capture is the largest.** `captureContextSnapshot` calls `inspectSchemaTool` directly, once
-per catalog kind — three reads on PostgreSQL, two on SQLite — and each goes through
-`executeAuditedOperation` and is charged `statements: 1` plus its elapsed time against exactly the
-budget the meter displays. What it does NOT go through is `runStep`, the only writer of
-`tool-completed`. The capture records one summary `context-captured` entry instead.
-
-So on an agent-mode drive with no reusable snapshot, a ledger-folded meter reads "0 / 20 statements"
-when two or three are already spent, before the model's first turn. A capture that FAILS records no
-entry at all while still having paid for its reads (see B54).
-
-Two smaller mismatches belong with it:
-
-- An acquisition failure is accounted as one executed statement although nothing ran. `tools.ts`
-  acquires the provider inside the allowed callback deliberately, so a denied call never opens a pool,
-  and the failure propagates out of the tool leaving the step with a `tool-invoked` entry and no
-  settlement. The fold cannot see it.
-- A `tool-completed` entry carries the provider's own `summary.elapsedMs`, while `maxTotalRunMs` is
-  charged the span the execution layer measured around the whole call, which also covers acquisition.
-
-All three run in the same direction — the meter under-reports — which is why the rail states its figures
-as a floor, and why the caveat it shows is a list of what is known rather than a proof the list is
-complete.
-
-Either half closes the same way: give the capture path a durable per-read record, or read the meter
-from the tracker's own accounting. The second is not a drop-in, because the tracker is process-local
-and `releaseExecutionRun` drops a run's accounting when it ends, so a finished run would report zero.
-
-**Done when:** a run that has captured its schema shows the catalog reads it paid for, with a test that
-fails on the current under-count.
-
 ### B15. A run's stored results are gone once the run ends, so a report's citations can outlive its rows
 
 Surfaced by #329 T11 rather than introduced by it. `ExecutionArtifactStore` holds results in process
@@ -2138,24 +1835,6 @@ The remedy pattern already exists here: the explicit copies in `Dockerfile` and
 (`tests/unit/packaging-payload-prune.test.ts` is the nearest existing home), and `docs/AGENT.md`'s
 deployment section loses the caveat that points here.
 
-### B20. A Gemini deployment behind a proxy is not configurable, on either surface
-
-`resolveApiUrl` (`src/lib/llm/utils/config.ts`) returns `LLM_API_URL` for every provider kind, so the
-resolved configuration carries it — and both Gemini consumers ignore it. The chat provider constructs
-`new GoogleGenerativeAI(apiKey)`, which has no base-URL option at all. The agent's adapter deliberately
-passes no `baseURL`, because leaving it undefined is what keeps the SDK's own environment fallback
-unreachable.
-
-So an operator who must reach Gemini through an egress proxy or a regional endpoint can set the
-variable, see no error, and be routed to Google directly.
-
-Pre-existing behaviour the agent inherited; noticed in #329 T4. Fixing it means threading
-`config.apiUrl` into both consumers and deciding what an explicitly-set `LLM_API_URL` means for a
-provider whose SDK has no base-URL seam — a settings-surface change.
-
-**Done when:** a proxied Gemini endpoint is reachable from the configuration the user already entered,
-or the settings surface says plainly that the variable does not apply to that kind.
-
 ### B23. Seed eligibility is decided against a browser snapshot, not the live descriptor
 
 `resolveAgentRunConnectionId` (`src/hooks/use-connection-payload.ts`) decides whether an editable seed
@@ -2178,21 +1857,6 @@ overstates.
 **Done when:** the run-start route validates the descriptor the browser believed it was starting
 against — a fingerprint sent with the request and compared server-side, refusing with a distinct reason
 when it has moved. Until then `docs/AGENT.md` says the comparison is against the last fetch.
-
-### B26. A profile can test for an email shape and not for a digit run
-
-`table-profile.ts` tests one value shape inside the database, `LIKE '%_@_%._%'`, and derives
-`suspected_pii` from the ratio of matches. A run of digits — a phone number, a national id, a card
-number — is the other shape worth suspecting, and `LIKE` cannot express it: `_` means "any character",
-so a length test would match almost any text. PostgreSQL spells it `~ '[0-9]{9}'`; SQLite spells it
-`GLOB '*[0-9][0-9][0-9]…*'`.
-
-An earlier draft shipped `LIKE '%_________%'` as a "nine digits" test, which would have produced a
-`suspected_pii` finding for essentially every text column. It was removed before it landed rather than
-approximated.
-
-**Done when:** the shape tests are per-dialect predicates rather than one shared `LIKE`, with the digit
-run among them and each verified against that engine's grammar.
 
 ### B28. A profile that times out reports nothing rather than falling back to catalog statistics
 
@@ -2315,23 +1979,6 @@ depends on it and no user is waiting on it.
 **Done when:** the event model has settled and somebody is running Studio beside a stack that wants
 agent runs in it. #332 holds the full scope.
 
-### B34. A hydrated agent result cannot be exported, because Export serializes the tab's own rows
-
-A run's rows now reach the results grid, the explain view and the charts view, each with a provenance
-badge naming the run. But `exportResults` in `src/components/Studio.tsx` serializes
-`currentTab.result`, so offering the Export menu over a hydrated view would write the tab's rows to a
-file while the user is looking at the run's.
-
-The menu is therefore hidden while an artifact is shown, which is correct and is not the same thing as
-being able to export what is on screen.
-
-The pivot and dashboard views are unhydrated for a related reason and are not part of this: both are
-configured against the columns of the result they were opened on.
-
-**Done when:** the export path can take an explicitly hydrated result, with the file still attributable
-to the run. An exported file that came from an agent run and is indistinguishable from one the user ran
-is the thing to avoid.
-
 ### B35. A resumed run can evict its own still-cited results: the artifact cap is per drive
 
 `AGENT_MAX_ARTIFACTS` (`src/lib/agent/runtime.ts`) is `45 × 4 = 180`: the largest per-workflow statement
@@ -2384,67 +2031,6 @@ database has answered it, and should be able to say so without inventing a query
 
 **Done when:** a data-analysis run can conclude "not answerable here" and be scored `answered` for it,
 with the rule stated in `WORKFLOW_TOOL_RULES` and an eval asserting no fabricated statement is sent.
-
-### B48. The composed grounding path still loses a plan run to an environment failure
-
-`captureFromProvider` (`src/lib/agent/context-snapshot.ts`) converts a `DatabaseError` or an
-`ExecutionProfileError` raised before the reading leaves into an unavailable capture. So a plan run on
-one of the nine provider-path engines survives an unreachable host, a wrong password or a
-half-configured `agentUser`, and answers ungrounded with the capture's own diagnosis.
-
-The composed path — PostgreSQL and SQLite — does not. The same failure propagates out of
-`readCatalogForGrounding`, through `captureContextSnapshot` and `establishPlanningContext`, and ends the
-run `internal`, or `engine-unsupported` on the profile error (see B47).
-
-The asymmetry was deliberate at #414: those two engines have never reached the new line, and changing
-their failure mode is a second decision about a path #414 did not touch. It is still an asymmetry a
-reader will trip over.
-
-**Done when:** both grounding paths answer an environment failure the same way.
-
-### B51. The run loop nudges a model three times and records none of it
-
-`runInvestigation` delivers three notices, each one-shot per DRIVE, each with its own boolean, guard set
-and delivery mechanism:
-
-| Notice | When | Delivered as |
-| --- | --- | --- |
-| `AGENT_REPORT_RESERVE_NOTICE` | within the turn or time reserve of a ceiling | a `user` message, riding the turn about to be taken |
-| `AGENT_REPORT_REMINDER_NOTICE` | a prose turn after a tool this run holds was called | a `user` message, and the turn is taken again |
-| `AGENT_PRESENT_BEFORE_REPORT_NOTICE` | a `compose_report` on an answering workflow with a presentable read and no presentation | a `tool` result, INSTEAD of running the call |
-
-None of the three writes to the ledger. `service.recordEvent` is called for the schema capture, the
-drafted statement, the closing prose, the recommendation, the answer and the report — and for nothing the
-server said to the model. So a run's timeline shows a model that read, narrated and then reported, with
-no entry saying it was told to report. And a `compose_report` the loop withheld leaves no record that a
-call was made at all.
-
-**"Once" means once per drive, and the missing entry is why.** All three booleans are `let`s inside
-`runInvestigation`, and that function is what RESUMES an already-running run. A resumed drive starts with
-every flag false and can deliver a notice the previous drive already delivered. Two of the three have a
-partial durable guard by accident: the present-before-report notice reads `answer-composed` off the
-ledger, so a run that presented is not told to again — but a run whose `present_answer` was REFUSED
-writes no event, and is. Nothing bounds the report reminder or the reserve notice across a resume.
-
-**That is a measurement problem before it is a design one.** `docs/llms/` is built by reading run
-ledgers out of `.workflow-data`, and its whole claim is that each figure comes from an observed run.
-After #416 and #417 a ledger can no longer answer "did this model do that by itself?" — the exact
-question those pages exist to answer, and the question that decides whether a nudge is worth keeping.
-`methodology.md` already warns that one run per cell is the weakest part of the method; an
-unattributable rescue is weaker still, because re-running does not reveal it either.
-
-**The second half is the shape.** Each notice's GUARDS are the load-bearing part, and the part that keeps
-being got wrong. #416 arrived without the tool-set bound (a planning run, which holds no tools, was told
-to call `compose_report`) and without the turn bound (a run narrating at the ceiling was turned from
-`succeeded` / `model-stopped` into `failed` / `turn-limit`). #417 arrived with a condition that named "a
-result this run can present" and read an operation id that `inspect_schema` shares. Both were caught in
-review rather than by a gate, and a fourth notice will be written by someone reading the third.
-
-**Done when:** a delivery is an entry on the ledger — one event kind, carrying which notice and what the
-run had done when it arrived — read back at the head of a drive so a resumed run is not told twice, and
-the three share one declared shape so a new one states its condition, scope and delivery in the same
-place. Whether the rail SHOWS the entry is a separate question and probably a no: the notices exist to
-be invisible to a user, and the timeline is not the same surface as the ledger.
 
 ### B52. The grounding capture's row cap is reached by what the image ships, not by a wide user schema
 
@@ -2505,79 +2091,6 @@ extension views before the user creates anything.
 
 **Done when:** a plan run against a stock TimescaleDB, one against a stock Cloudberry and one against a
 stock AlloyDB Omni all report a captured schema naming the user's tables.
-
-### B55. A LibreDB plan run drafts `GET users:*`, a command that answers zero rows rather than failing
-
-Measured 2026-08-22 on the embedded LibreDB sample, plan mode, objective *"list every entry under the
-users prefix and read one user by key"*. The run was grounded — `context-captured`, three prefixes
-(`articles:*`, `config:*`, `users:*`) — and drafted:
-
-```libredb
-GET users:*
-```
-
-`dispatchCommand` gives `get` exactly one meaning: `kv.get(parts[1])`, an exact-key lookup with no glob
-of any kind. The key `users:*` does not exist, so the command returns **zero rows and no error** — the
-same silently-wrong class as the MongoDB `$shipping.region` case, and harder to notice because an empty
-result on a key-value store reads as "nothing stored there". The runnable form is `prefix users:`, which
-is what `generateTableQuery` already emits for the same row when a person clicks it.
-
-The cause is the one Redis has too: the inventory's rows are named `users:*`, which reads as a glob the
-grammar does not have. Redis's half was fixed by declaring `ProviderLabels.statementLanguage`
-(`redis.ts`); LibreDB declares none, so the plan contract tells the model only "this engine speaks no
-SQL" and leaves the five verbs — `get`, `put`, `delete`, `prefix`, `range` — to be guessed.
-
-Deferred by the owner on 2026-08-22, explicitly: LibreDB's agent and plan-mode behaviour waits until the
-other providers are done. Recorded here so the deferral is a decision rather than an omission.
-
-**Done when:** `LibreDbProvider.getLabels()` declares a `statementLanguage` that names the five verbs and
-says a key is exact (no glob, no wildcard), with a test pinning it the way `mongodb.ts` and `redis.ts` are
-pinned — and a live plan run on the embedded sample drafts `prefix users:` for this objective.
-
-### B56. Plan grounding is held for the process lifetime, so a schema change is invisible until a restart
-
-`holdSnapshotForConnection` keeps one inventory per connection identity in a bounded map with **no
-expiry**: newest reading wins, eviction is by use, and nothing re-reads. `heldSnapshotForConnection` is
-one of the three places a planning run's grounding comes from, and it is consulted before any capture.
-
-Measured 2026-08-22, twice in one session. MongoDB's schema inference was changed to expand subdocuments
-into dotted paths; `POST /api/db/schema/list` returned `shipping.city` immediately, and the schema tree
-showed it. Two plan runs afterwards still grouped by `$shipping.region`, and their ledgers carry **no**
-`context-captured` event at all — the hold answered, from an inventory read before the change. Restarting
-the process fixed it on the first run: `context-captured` appeared and the draft named `$shipping.city`.
-
-The same shape hit Redis: keys seeded into an empty database were invisible to a plan run until a restart,
-which is what "NO STATEMENT: the `session:*` key pattern is not present in the inventory" meant — a
-correct refusal against a stale inventory.
-
-Two properties make this hard to see rather than merely stale. The hold has no TTL, so on a long-lived
-server the window is unbounded; and B54's gap means a run that used the hold records nothing about where
-its inventory came from, so the ledger cannot distinguish "held, hours old" from "captured just now".
-
-The design intent is real and documented (`context-snapshot.ts`: a run reasons over the inventory its
-claims cite, and a mid-run re-read would leave those claims describing a schema the report no longer
-shows). What is not intended is that a NEW run inherits it indefinitely.
-
-**Done when:** a new run's grounding is either re-captured or explicitly recorded as reused with the age
-of the reading it reused, so a user who just added a collection is not silently planned against the
-database as it was.
-
-### B57. A tuning document is refused whole, which is the wrong granularity for a catalog
-
-`parseOperatorTuning` refuses a document that fails anywhere. The argument for that is real and is
-about MERGING — half of one measurement beside half of another is a configuration nobody has run —
-but it justifies whole-**entry** replacement, not whole-**document** rejection. A document holding
-fifty models loses all fifty to a typo in the thirty-seventh.
-
-That is tolerable while a document is a short overlay an operator wrote. It stops being tolerable if
-these are ever published as a catalog: the failure lands on everyone who mounted it, for a fault in
-one entry nobody using the other forty-nine cares about.
-
-The rule that actually matters survives per-entry validation intact — an entry is still taken whole
-or not at all — so the change is where the refusal is thrown, not what it protects.
-
-**Done when:** a document with one bad entry applies the rest, and the skipped entries are reported
-by id through `operatorTuningStatus()` the way `ignoredKeys` already is.
 
 ### B59. Per-model instructions have nowhere to go, and the mechanism that held them is gone
 
@@ -2676,21 +2189,6 @@ is a persistence surface, not a rail change.
 
 **Done when:** a user can see their earlier conversations and open one, with the store's
 enumeration, the route and the retention rule each decided rather than inherited.
-
-### B69. A reload ends a conversation, and nothing says it will
-
-A reload clears the browser's `runId`, so the next question starts a new thread. The rail is honest
-about the RESULT — with no thread there is no strip, which is the correct signal — but it is silent
-about the transition: a user mid-conversation who reloads is not told that what they were doing has
-ended, and their next question is answered as a fresh one.
-
-Accepted deliberately when the conversation model landed, because the alternative opens two
-questions this work did not want to answer: where a thread id lives client-side (`localStorage`, the
-same write-through cache every other preference uses), and what "resume this conversation?" should
-do when the runs behind it may have been evicted. Worth doing; not worth bundling.
-
-**Done when:** either a reload resumes the conversation it interrupted, or the rail says the
-conversation ended before the next question is asked.
 
 ### B70. A run writes no summary for the step after it
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -21,22 +21,22 @@ None of it is a GitHub issue.
 
 **Sections**
 
-- [SQL statement reading](#sql-statement-reading) — S2–S7 · 5
-- [Drivers and connections](#drivers-and-connections) — D1–D51, U17, U22 · 23
+- [SQL statement reading](#sql-statement-reading) — S2–S6 · 4
+- [Drivers and connections](#drivers-and-connections) — D1–D51, U17, U22 · 21
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U26 · 12
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U26 · 10
 - [Authentication and security headers](#authentication-and-security-headers) — AU4
-- [Tests](#tests) — T1–T5 · 4
+- [Tests](#tests) — T1–T5 · 3
 - [Dependencies](#dependencies) — P1–P5 · 5
-- [Documentation](#documentation) — DOC1, DOC3–DOC4 · 3
+- [Documentation](#documentation) — DOC3, DOC4 · 2
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3
 - [Chart configuration surface](#chart-configuration-surface) — N1, N3 · 2
-- [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H13 · 9
-- [Security Phase 2 deferrals](#security-phase-2-deferrals) — C2–C10 · 9
-- [Security Phase 3 deferrals](#security-phase-3-deferrals) — K2–K4 · 2
-- [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A6 · 5
-- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B1–B79 · 44
+- [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H8 · 4
+- [Security Phase 2 deferrals](#security-phase-2-deferrals) — C3–C10 · 8
+- [Security Phase 3 deferrals](#security-phase-3-deferrals) — K4
+- [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A5 · 4
+- [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B2–B79 · 40
 
 ---
 
@@ -106,13 +106,6 @@ Apache Cassandra 5.0.9, ScyllaDB 2026.2.4 and ClickHouse 26.7.1 (a line comment 
 refused on PostgreSQL 18, MySQL 26.7.0, SQLite, Oracle, SQL Server 2022 and Trino 476. It is undecided
 for elasticsearch and opensearch, and absent with the whole row for couchbase, druid and libredb -
 recorded in the table in `docs/editor/query-optimization.md`.
-
-### S7. A confirmation refinement that was considered and rejected
-
-Scanning an unreadable region for destructive vocabulary, and asking only when a write could
-plausibly be in there. Sound on its face. It substitutes a cleverer reading for the honesty rule #297
-pinned: the gate asks because it *cannot* read the text, not because it guessed what is in it.
-Revisit only with an explicit product decision.
 
 ---
 
@@ -186,26 +179,6 @@ Cassandra fixture does not close it.
 `e2e/cassandra-provider.spec.ts` exists or a written reason it cannot exist is recorded here.
 
 ---
-
-### D14. Three providers lost the buffer-pool gauge, because it was the cache hit ratio wearing a second name
-
-Removing the fabricated cache hit ratios exposed that `bufferPoolUsage` was not a second measurement.
-In Oracle and SQL Server it was literally assigned the ratio itself - the old tests even said "mirrors
-cacheHitRatio in Oracle impl" - so the Performance tab drew and rated one quantity as two independent
-gauges. In PostgreSQL it was `blks_hit / (blks_hit + blks_read)` from `pg_stat_database`, which is also
-a cache hit ratio and not pool occupancy, with a `: 100` fallback when both counters were 0. All three
-now omit the field, which the tab renders as unavailable.
-
-Real occupancy is reachable on each engine and none of the three is free: `pg_buffercache` is an
-extension not installed by default, `V$BUFFER_POOL_STATISTICS` needs the privilege the ratio already
-needs, and `sys.dm_os_buffer_descriptors` is a full descriptor scan on a large instance. So a gauge
-that reads a real pool has a cost the panel has never paid.
-
-**Done when:** each of the three either measures pool occupancy for real, at a cost written down next
-to the query, or its omission is recorded as the answer. Dropping the field outright is no longer one
-of the options: MySQL, MongoDB, Couchbase and ClickHouse all fill it with a real occupancy figure
-(`mysql.ts`, `mongodb.ts`, `couchbase/index.ts`, `clickhouse/index.ts`), so removing it would delete
-four working gauges to tidy away three absent ones.
 
 ---
 
@@ -544,33 +517,6 @@ theoretical.
 before the first `/`, `?` or `#` that follows `://`, then mask between the first `:` and that `@` -
 with the two colliding shapes above pinned as separate cases, and the docblock's list of uncovered
 shapes reduced to what remains. The parameter half needs no change.
-### D43. SQLite gained `SET`/`DROP NOT NULL` in 3.53.0, and the generator declines it on both ids
-
-Found 2026-08-27 while adding the foreign-key declines for `sqlite` and `libsql`
-(`src/lib/schema-diff/migration-generator.ts`). `NO_COLUMN_MODIFICATION` declines every column
-modification for `libsql`, and the `sqlite` branch beside it declines them too. That was exhaustive
-when it was written and is no longer: measured on SQLite 3.53.0 via `bun:sqlite`,
-
-```sql
-ALTER TABLE "users" ALTER COLUMN "dept_id" SET NOT NULL
-```
-
-succeeds, rewrites the stored `CREATE TABLE` text to carry `NOT NULL`, and is enforced on the next
-insert (`NOT NULL constraint failed: users.dept_id`). `DROP NOT NULL` succeeds the same way. A column
-TYPE change is still `near "TYPE": syntax error`, so only nullability moved.
-
-**The blocker is that the version is not a property of the id.** `libsql` reaches sqld 0.24.33, which
-ships SQLite 3.47.0, so the decline is still correct there. The `sqlite` provider runs on whichever
-SQLite its runtime bundles - `bun:sqlite` or `node:sqlite`, selected at runtime with
-`LIBREDB_SQLITE_DRIVER` as an override (`src/lib/db/providers/sql/sqlite.ts`) - so emitting the
-statement would generate a file that runs on one deployment and fails on another. A migration file is
-handed to a human to run elsewhere, which makes the guess worse than the decline.
-
-**Done when:** either the decline records the version boundary as its reason rather than the absence of
-the feature (cheap, and it is what the comment now does), or the generator learns the connected
-engine's version and emits the nullability change only above 3.53.0, with the emitted statement
-measured against both a 3.47 and a 3.53 build. The second is only worth it if something else needs the
-version too.
 ### D44. `databaseSizeBytes` is fabricated as 0 wherever the size is unknown, in 11 of 17 type-ids
 
 Found 2026-08-27 by the sweep that closed the overview connection count's fabricated zero (D40, PR
@@ -841,7 +787,6 @@ FIELD inside a successful response is a different question and needs its own mea
 optional fields are absent rather than 0 on the refusal, each provider's doc and test move with it, and
 `maxConnections` keeps its 0 - for that field the type says 0 and absence are one fact.
 
-
 ## Value interpolation
 
 ### V1. Query history records the placeholders, not the values that were bound
@@ -899,12 +844,6 @@ writers. `csv.ts` and `result-export.ts` are pure and hold no browser reference 
 can reuse them; `download.ts` is the only browser-bound module there. Worth costing against the
 agent's own export gap (B33, B34), which wants the same route.
 
-### X4. Four modals stay mounted while closed, so their code cannot be split
-
-`DataProfiler`, `CodeGenerator`, `TestDataGenerator` and `DataImportModal` render `null` when closed
-but are always mounted. Lazy-loading them buys nothing until the mount is gated, and gating the mount
-changes their semantics (state resets on close). A behaviour change, not a bundling one.
-
 ### X5. `Studio.tsx` re-renders its whole tree on every keystroke
 
 14 `useState`, no `useMemo`/`useCallback`, no memoized children, React Compiler off. #422's
@@ -913,12 +852,6 @@ it was not mixed into a correctness PR.
 
 `framer-motion` is also still in the first load: `Studio.tsx`, `ConnectionModal`, `SchemaExplorer`,
 `ConnectionItem` and `TableItem` all import it statically and all mount on arrival.
-
-### X6. 43 lists outside `SchemaDiff` are still keyed by index
-
-`VisualExplain`, `DatabaseDocs` and the monitoring/admin tabs. `SchemaDiff` was fixed in #422 because
-its rows are recomputed and reordered. The rest need reading one at a time, to tell the stable lists
-(where an index key is fine) from the rest.
 
 ### X9. What `columnTypes` still cannot name, measured
 
@@ -1142,7 +1075,6 @@ from the provider (absent when the provider published none), the total sums thos
 many connections it could not include rather than silently undercounting, and a test pins a TB-scale
 connection plus one with no byte figure at all.
 
-
 ---
 
 ## Authentication and security headers
@@ -1187,21 +1119,6 @@ zero tests. Line coverage cannot see a missing disjunct in a one-line predicate.
 the two readings *disagree* can pin it.
 
 **Done when:** deleting any single disjunct of `isStatementText` fails a test.
-
-### T3. `tests/security/image-proxy.test.ts` asserts a configuration invariant, not the threat
-
-The design it protects: `/_next/image?url=http://169.254.169.254/` (or any attacker-chosen URL) must
-be rejected, because `next/image`'s optimizer would otherwise perform an unauthenticated server-side
-fetch of it.
-
-What it asserts is narrower — `nextConfig.images` is `undefined`. That is sufficient today only
-because nothing in `src/` imports `next/image` at all, so the control is closed and correctly verified
-for the current codebase.
-
-The gap: the assertion is a proxy for the threat. A future, strictly safer configuration would fail
-it — `images: { unoptimized: true }` disables the optimizer's fetch entirely and would still trip
-`toBeUndefined()`. The real assertion belongs with the Playwright work, which can make an actual HTTP
-request against a running server. A unit test importing `next.config` cannot exercise the route.
 
 ---
 
@@ -1368,15 +1285,6 @@ so in `CLAUDE.md`, which today says nothing about it, or sweep the orphans and t
 component nothing renders. Reproduce the list with a per-file importer count over `src/components/ui/`.
 
 ## Documentation
-
-### DOC1. Provider-doc line references are stale across the board
-
-`docs/providers/mssql.md` puts `getCapabilities()` at :57 and `getSchema()` at :369, where they are at
-391 and 749. The drift predates any recent milestone and every provider doc uses the same
-line-anchoring style, so the fix is a convention change — anchor on symbol names, not line numbers — as
-much as a correction.
-
-The same disease is in this file. Prefer symbol names here too.
 
 ### DOC3. Six channel listings carry corrected copy that nobody has resubmitted
 
@@ -1605,15 +1513,6 @@ the channels that serve Studio from a small box.
 **Done when:** the measurement says the trade is worth it and the nonce ships, or the measurement is
 recorded here as the reason it does not.
 
-### H3. Audit events do not record a user agent
-
-`AuditEvent` (`src/lib/audit.ts`) deliberately has no `userAgent` field. It is attacker-controlled free
-text with marginal value for a single-operator product, and adding it means adding the redaction
-question the closed `AuditReason` union exists to avoid.
-
-**Done when:** a real investigation needs it, at which point it is added as a truncated, explicitly
-allowlisted field.
-
 ### H4. The `@libredb/studio/security` usage note is not in the published README
 
 An npm consumer reading `README.md` on npmjs.com sees nothing about `securityHeaders()`.
@@ -1626,43 +1525,6 @@ It is out of `README.md` because `README_zh.md` and `README_ja.md` (`scripts/rea
 heading.
 
 **Done when:** the note lands in all three READMEs together.
-
-### H5. No env var can turn HSTS off, and that is deliberate
-
-`readSecurityHeaderOptions()` always sends `Strict-Transport-Security`. Unlike `CSP_REPORT_ONLY` there
-is no `HSTS_DISABLE`, and one should not be added in the shape an operator would expect.
-
-An escape hatch that merely *stops sending* the header is useless against the failure it would be
-built for. A browser that already cached the HSTS pin keeps enforcing HTTPS-only for the remainder of
-the 180-day `max-age`, whatever the server does next. And a server that has reverted to plain HTTP may
-not be reachable by that browser at all, because HTTPS-only means the plain-HTTP origin is refused
-before any response body is read.
-
-The only hatch that works emits `Strict-Transport-Security: max-age=0` over a still-live HTTPS
-listener, which is what tells a visiting browser to drop the pin.
-
-**Done when:** a real report of a stuck pin needs this, at which point it is a `max-age=0` mode, never
-a header omission.
-
-### H6. A coverage phantom recurs wherever a rarely-covered function has a multi-line inline param type
-
-`scripts/merge-lcov.mjs` picks one "authority" record per source file — whichever test run has the most
-executed lines — to decide which lines are coverable (`docs/TOOLCHAIN.md`).
-
-A function with a multi-line inline parameter type (`function f(opts: { a?: string; b?: string; … })`)
-exercised by only one test file reads as fully covered, because that file wins the authority vote.
-Adding a second test file that exercises a large *new* surface in the same source file — without ever
-calling that function — can tip the vote. The new file's own run reports the old function as a coarse,
-never-executed block whose zero-hit lines include the parameter type's continuation lines. It looks
-like a coverage regression in code nobody touched.
-
-`src/lib/audit.ts`'s `AuditRingBuffer.filter` hit this during Phase 1. Extracting the inline type to a
-module-scope interface fixed it permanently, because module-scope type members are erased before any
-function's coverage span exists.
-
-**The general fix:** hoist a multi-line inline parameter or return type to a module-scope
-`interface`/`type`. Do not chase it by adding a test that calls the under-covered function for
-coverage's sake.
 
 ### H7. `sanitizeAuditInput` does not recurse, so a nested secret survives inside the coerced string
 
@@ -1709,65 +1571,12 @@ considered each introduced a worse flaw.
 **Done when:** a cheaper, audit-visible eviction policy is found that does not reopen the oldest-first
 bypass.
 
-### H11. `login_account`'s hard cap is an accepted denial-of-login handle on a known account
-
-The `login_account` bucket is keyed on `hmacHex(submittedEmail)`, which makes it immune to
-`X-Forwarded-For` spoofing. It throws before the credential comparison runs, and is cleared only by a
-*successful* login — which cannot happen while it is tripped.
-
-So anyone who knows or guesses a real address can lock that account out for the rest of the window with
-the bucket's default (20 wrong guesses), and renew the lockout indefinitely at roughly one guess per
-window. The published default `admin@libredb.org` when `ADMIN_EMAIL` is unset makes this free.
-
-`login_client`, the address-keyed bucket, does not help: it is bypassed in any topology where an
-attacker can set or rotate `X-Forwarded-For` — direct exposure, or a proxy that appends rather than
-overwrites (Caddy and Traefik defaults, and the common nginx `proxy_add_x_forwarded_for` recipe).
-
-This is inherent to a hard per-account cap. Bounding brute force against an operator-set password and
-bounding this lockout are in direct tension, and no design removes one side without giving up the
-other. `.env.example` documents `RATE_LIMIT_LOGIN_ACCOUNT_MAX=0` as the break-glass (verified:
-`decide()` returns `allowed: true` unconditionally for `max === 0`, for both `peekRateLimit` and
-`consumeRateLimit`, so the bucket is fully inert). Phase 1 narrowed the window from 900 to 300 seconds
-to shrink the blast radius without loosening the guess ceiling.
-
-**Done when:** a design keeps this bucket immune to header spoofing without also being a stranger's
-denial-of-login switch. Unknown at the time of writing.
-
-### H13. No rate-limit bucket is a global, unkeyed ceiling — on purpose
-
-Every bucket in `src/lib/api/rate-limit.ts` is keyed on something the caller supplies:
-`login_client`/`anon` on the derived client address (attacker-controlled in any topology without a
-correctly configured `TRUSTED_PROXY_HOPS`), `login_account` on a hash of the submitted email (fully
-attacker-chosen, see H11), `query`/`ai` on the session's username.
-
-A global, unkeyed ceiling is the one shape that cannot be evaded by picking a favourable key, because
-there is no key to pick. Phase 1 does not add one, deliberately: a global ceiling on `login_client` or
-`anon` turns one attacker's flood into a lockout for every other concurrent user of the same bucket,
-which is strictly worse than the keyed floods it would prevent. And getting the sizing right — loose
-enough not to bite a legitimate multi-tenant deployment, tight enough to bound an attacker — is its own
-design problem this wave did not scope.
-
-**Done when:** a real, measured flood makes the keyed buckets' residual insufficient and a global
-ceiling's sizing can be grounded in that data rather than guessed.
-
 ---
 
 ## Security Phase 2 deferrals
 
 Each was decided during Phase 2, not overlooked. Lettered `C` (supply **C**hain) because the SQL
 section already owns `S1`–`S8`.
-
-### C2. A failing scheduled scan notifies nobody but the owner
-
-`security-scan.yml`'s daily run fails when a critical fixable advisory lands, and GitHub emails the
-repository owner for a failed scheduled run. That is the whole notification path.
-
-`helm-index-check.yml` shows the alternative in this repository — a job with `issues: write` that
-maintains a single rolling issue. It was not copied here because an auto-filed issue per advisory is
-how a security label becomes noise.
-
-**Done when:** a real missed advisory shows the email is insufficient, at which point the rolling-issue
-pattern is the thing to copy.
 
 ### C3. The image SBOM is a 30-day workflow artifact, not a durable asset
 
@@ -1910,20 +1719,6 @@ by grepping the staged bundle for the version literal rather than trusting the l
 
 Each was decided during Phase 3, not overlooked.
 
-### K2. A legacy plaintext password shaped exactly like an envelope is treated as corruption
-
-`src/lib/storage/encryption.ts`'s `readSecret` treats a three-segment value whose first segment matches
-`/^v\d+$/` as an envelope. A password stored before this feature existed that happens to be literally
-`v1:<base64url>:<base64url>`, with a 12-byte first segment and a second of at least 16 bytes, is
-classified `undecryptable` and omitted.
-
-The compounded probability is negligible and the failure is recoverable: the connection survives and
-the user retypes the password once. The alternative — passing an unrecognised value through — would hand
-`v1:abc:def` to a driver as a password.
-
-**Done when:** the envelope format is versioned forward for an unrelated reason, at which point a
-longer, non-colliding prefix costs nothing.
-
 ### K4. Rotating the key back does not recover credentials once the app has written
 
 `decryptConnections` omits an unreadable secret and keeps the record, which is correct: dropping the
@@ -2011,47 +1806,9 @@ engine in the pipeline is the throwaway PostgreSQL container behind
 a multi-command escape are rejected through the profile under the resolved role. Cheapest path is
 extending the functional-smoke container, not adding a service to every CI test job.
 
-### A6. Druid's hand-written bigint serializer predates the Node 24 floor
-
-`druid/http-transport.ts` splices the parameters array into the query envelope by hand so a `bigint`
-literal reaches Druid unquoted. The reason recorded in `docs/providers/druid.md` was that
-`JSON.rawJSON` (ES2025, V8 12.4 / Node 22.2) could not be depended on while `engines.node` was
-`">=20.9.0"`.
-
-That constraint is gone: #326 raised the floor to `">=24.0.0"`. The hand-serializer is not wrong and is
-fully covered, so it was left alone rather than rewritten inside a runtime-baseline change — swapping a
-correctness-critical escaping path belongs in a change whose tests are about that path.
-
-**Done when:** the splice is replaced by `JSON.rawJSON` with the existing bigint fixtures still green,
-or this entry is deleted with a note that the hand-serializer is preferred.
-
-> TypeScript 7 was the seventh entry here. It is the same finding as P2, which now carries it.
-
 ---
 
 ## Agent M2 deferrals (#329)
-
-### B1. A module-private credential map would be invisible to the agent state guard
-
-`src/lib/agent/state-guard.ts` derives its credential key names from `SECRET_FIELD_MAPS` in
-`src/lib/storage/connection-secrets.ts`, so a field promoted to `secret` in one of the three
-classification maps is covered without an edit. The aggregate itself is a hand-maintained array: each
-individual map fails `bun run typecheck` when a field goes unclassified, but nothing makes a fourth MAP
-appear in the array.
-
-The direction that loses coverage silently is ADDING a map, not removing one — the storage layer would
-seal the new field while the guard happily persisted it. `tests/unit/lib/agent/state-guard.test.ts`
-closes that by reflection: it walks the storage module's exports, recognises a classification map
-structurally, and fails when one is not registered. Verified to fire by temporarily exporting a fourth.
-
-What remains is narrower. The check sees **exported** maps only. A map kept module-private and wired
-straight into `walkConnection` is invisible to it. All three existing maps are exported for consumers,
-so this is a convention rather than an enforced rule.
-
-**Done when:** a new classification map cannot be added without the guard learning about it — most
-directly by having `walkConnection` iterate a registry instead of three derived key lists. That
-registry has to carry each map's nesting location (root, `ssl`, `sshTunnel`), so it is a change to a
-security-critical encrypt/decrypt path with its own test obligations.
 
 ### B2. The Anthropic provider kind is ratified and installed, but not offered
 
@@ -2398,24 +2155,6 @@ provider whose SDK has no base-URL seam — a settings-surface change.
 
 **Done when:** a proxied Gemini endpoint is reachable from the configuration the user already entered,
 or the settings surface says plainly that the variable does not apply to that kind.
-
-### B21. The published package carries the agent-provenance branch as dormant markup
-
-`BottomPanel` is shared by both shells, and #329 T11 added its agent-provenance branch: an optional
-`agentArtifact` prop, the provenance badge and its test ids. `bun run build:lib` therefore emits that
-markup inside `dist/workspace.mjs`.
-
-It is inert and the package boundary is intact. The prop is optional, the embedded shell never passes
-it, no entry point exports `BottomPanel` (asserted through a transitive `export … from` closure in
-`tests/unit/agent-package-boundary.test.ts`), and the package gains no agent module, no agent type and
-none of the runtime packages.
-
-What remains is dead bytes in a consumer's bundle, and a small honesty cost: a reader grepping the
-published output finds strings suggesting an agent capability the embedded shell cannot reach.
-
-**Done when:** the provenance branch lives in a standalone-only component and `BottomPanel` takes it as
-children — or Phase 4's surface unification decides the embedded shell gets an agent surface after all,
-at which point this stops being dormant rather than being removed.
 
 ### B23. Seed eligibility is decided against a browser snapshot, not the live descriptor
 
@@ -2823,7 +2562,6 @@ shows). What is not intended is that a NEW run inherits it indefinitely.
 of the reading it reused, so a user who just added a collection is not silently planned against the
 database as it was.
 
-
 ### B57. A tuning document is refused whole, which is the wrong granularity for a catalog
 
 `parseOperatorTuning` refuses a document that fails anywhere. The argument for that is real and is
@@ -2858,21 +2596,6 @@ provenance is a property of the SOURCE rather than of the field.
 **Done when:** wording can arrive from a source whose authorship is established, and cannot arrive
 from one whose authorship is not — with the trust tier stated as a decision rather than implied by
 which loader happened to read the file.
-
-### B62. `schemaVersion` has no migration path, and the first bump breaks every mounted document
-
-`z.literal(TUNING_SCHEMA_VERSION)` on both schemas. An older Studio refusing a newer document is
-correct and deliberate. A newer Studio refusing an OLDER one is not: the day this moves to 2, every
-document in the field is refused whole and every model in it silently reverts to the defaults.
-
-Deliberately not fixed here. With one version in existence, an accepted range has exactly one member,
-and a migration written before anything needs migrating is a guess about a shape nobody has seen. The
-tolerant operator schema removes the pressure — Studio can add settings without moving the version —
-so this is a decision to take at the first real bump, not before.
-
-**Done when:** the first `schemaVersion` change ships with a rule for reading documents written for
-the version before it, and the release notes say what an operator has to do.
-
 
 ### B64. An unfenced plan statement with no terminator still carries prose into the SQL
 
@@ -2992,24 +2715,6 @@ against a small-context model.
 **Done when:** either a measurement shows truncation costing more than compression would, and a
 carried summary lands with the fallback stated; or this entry is deleted with the measurement that
 settled it.
-
-### B71. The workflow runtime's own durable agent is not used, and the reason is a deployment one
-
-`@ai-sdk/workflow`'s `WorkflowAgent` offers durable, resumable agents with automatic state
-persistence across restarts — which is what `run-store.ts`, `run-service.ts` and the resume rule in
-`investigation.ts` implement by hand. Anybody reading those three modules will eventually ask why.
-
-Because it requires the workflow runtime's programming model: `'use workflow'`, `'use step'`,
-`getWritable()`. This product's positioning is that it deploys next to the data — Docker, Helm,
-Kubernetes, air-gapped — so binding the agent's durability to a hosting runtime would cut the
-deployment story the rest of the product is built on. The hand-written ledger is also what makes the
-run auditable in this repository's own terms: append-only, one file per run, foldable by anything.
-
-Recorded so the question is answered once rather than reopened. It is not a defect and there is
-nothing to do; if the packaging ever separates the durability primitives from the hosting runtime,
-this is the entry to revisit.
-
-**Done when:** the packaging separates them, or this entry is deleted as permanently declined.
 
 ### B72. Three verifiers still judge a plan-only report by the emptiness census
 

--- a/docs/llms/model-tuning.md
+++ b/docs/llms/model-tuning.md
@@ -26,21 +26,33 @@ you never have to guess which one it was.
 
 ## Checking that it took effect
 
-**Do this rather than assume it.** A document that is missing, unreadable or off-schema is
-IGNORED and the shipped measurements stand — which is what stops a bad file from breaking a
-working agent, and also what makes silence ambiguous. `GET /api/agent/config`, as an **admin**
-session, says which happened:
+**Do this rather than assume it.** A document that is missing, unreadable or off-schema in its
+ENVELOPE is IGNORED and the shipped measurements stand — which is what stops a bad file from
+breaking a working agent, and also what makes silence ambiguous. `GET /api/agent/config`, as an
+**admin** session, says which happened:
 
 ```jsonc
 { "modelTuning": { "state": "applied",  "path": "/etc/libredb/model-tuning.json",
-                   "models": 1, "ignoredKeys": [], "digest": "9f2c…" } }
-{ "modelTuning": { "state": "ignored",  "path": "...", "reason": "models.0.settings.turnTimeoutMs: ..." } }
+                   "models": 1, "ignoredKeys": [], "skippedEntries": [], "digest": "9f2c…" } }
+{ "modelTuning": { "state": "ignored",  "path": "...", "reason": "schemaVersion: Invalid input: expected 1" } }
 { "modelTuning": { "state": "unset" } }
 ```
 
 `ignoredKeys` is the one to read on a successful load: it lists what your document said that this
 Studio does not implement — a misspelling, or a setting from a newer Studio. The entry was applied
 around those keys rather than because of them.
+
+`skippedEntries` is the other one, and it is the difference between `models` and how many entries
+you wrote. An entry that does not read is dropped and named here; the entries beside it apply. So a
+`"state": "applied"` with `"models": 49` on a fifty-model document is not a success — read this
+list, and it will tell you which entry and which value:
+
+```jsonc
+{ "skippedEntries": ["qwen3:8b: settings.turnTimeoutMs: Too big: expected number to be <=179999"] }
+```
+
+An entry whose `id` is what is wrong is named by its POSITION instead — `#37: id: ...` — because
+there is no id to search the file for, and inventing one would name a model you never configured.
 
 `digest` is SHA-256 of the document's bytes as they were read, and it is the same value a run
 records. The path says which file drove a run; only the digest says which VERSION of it, and a
@@ -135,9 +147,15 @@ written for a newer Studio keep working on an older one, and a document written 
 after Studio gains a setting. It is also why you should read `ignoredKeys`: a misspelled
 `retryEmtpyTurn` lands there rather than doing anything.
 
+**Refused per ENTRY, not per document.** The whole-and-nothing rule above is about MERGING, so it
+protects the entry and stops there. An entry that breaks a bound, misses `measured` or repeats an
+id already taken is skipped and listed in `skippedEntries`; the rest of the document applies. Until
+this changed, a fifty-model document lost all fifty to a typo in the thirty-seventh — tolerable for
+a short overlay you wrote, not for a catalog somebody else mounted.
+
 **What does not relax:** every bound in the table above, `measured` on every entry, and one entry
-per model id — two spellings of one id is refused rather than last-wins, because no reader of the
-file could say which had been used.
+per model id — two spellings of one id skips the second rather than last-wins, because no reader of
+the file could say which had been used.
 
 **Wording never travels.** The sentences Studio says to a model live in Studio. A document has
 nowhere to put one, and that is deliberate: those sentences are pushed verbatim into the model's

--- a/docs/providers/duckdb.md
+++ b/docs/providers/duckdb.md
@@ -275,20 +275,20 @@ SELECT * FROM duckdb_queries();      -- Catalog Error: Table Function with name 
 SELECT * FROM duckdb_connections();  -- Catalog Error: Table Function with name duckdb_connections does not exist!
 ```
 
-Both therefore answer `[]`, and neither fabricates a zero. **What the two empties say to the reader
-differs, and only one of them is DuckDB's own words:**
+Both therefore answer `[]`, and neither fabricates a zero. **Both empties are DuckDB's own words on
+screen**, through the two `ProviderLabels` fields the provider declares:
 
 - `getSlowQueries()` returns `[]` and the provider declares `slowQueriesEmptyState`, so the Queries
   panel prints *"DuckDB keeps no store of finished statements — it publishes no `duckdb_queries()`
   table function — so there is nothing to enable."* Without it that panel tells every engine to
   install `pg_stat_statements`, which for DuckDB is nonsense (#U12).
-- `getActiveSessions()` returns `[]` and there **is no sessions equivalent of that label in this
-  product**: `ProviderLabels` has no `sessionsEmptyState`, and `SessionsTab` / `OperationsTab` fall
-  back to the generic **"No active sessions found."** for any provider that answers with an empty
-  list. (Their `sessionsUnavailable` path renders a reason only when the reading *failed*, which is
-  not this case.) So the Sessions panel is permanently empty in the product's generic wording, and
-  the reason lives here rather than on screen — filed as **D48** in
-  [`docs/BACKLOG.md`](../BACKLOG.md).
+- `getActiveSessions()` returns `[]` and the provider declares `sessionsEmptyState`, so `SessionsTab`
+  and `OperationsTab` print *"DuckDB publishes no session list — there is no `duckdb_connections()`
+  table function — so this panel can never show a row."* in place of the generic **"No active
+  sessions found."** they used for every provider until D48. That generic sentence reads as "nothing
+  is running right now", which is a different claim from "this panel can never show a row". A
+  provider that declares neither label keeps the generic wording. (The `sessionsUnavailable` path
+  beside it is a third fact again: it renders a reason only when the reading *failed*.)
 
 `sqlite.ts` answers this panel with a row describing its own handle. That row would be true here
 too, but it would be the only row the panel could ever show, and "the engine reports one session"
@@ -537,7 +537,7 @@ and one index.
 | Temporary files | Empty, from `duckdb_temporary_files()` — a real reading, not a gap |
 | Settings | `access_mode`, `memory_limit`, `threads`, from `duckdb_settings()` |
 | Slow queries | **Empty, permanently** — `duckdb_queries()` does not exist, and the panel says so in DuckDB's own words through `slowQueriesEmptyState` (§3.7) |
-| Active sessions | **Empty, permanently** — `duckdb_connections()` does not exist. The panel prints the product's generic *"No active sessions found."*: there is no `sessionsEmptyState` label to carry the reason (§3.7, BACKLOG D48) |
+| Active sessions | **Empty, permanently** — `duckdb_connections()` does not exist, and the panel says so in DuckDB's own words through `sessionsEmptyState` (§3.7) |
 | Table bytes | Only via `PRAGMA storage_info('<table>')`, per column segment |
 
 Where a reading is absent it is reported as absent with the reason, never as `0`: a zero on a size

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -814,7 +814,7 @@ numbers this table used to carry had drifted, and a method name is greppable and
 | `getSlowQueries()` | — | **`[]`**. The slow log is written to the node's **log file**, which no API returns |
 | `getIndexStats()` | — | **`[]`**. No secondary-index object exists |
 | `getActiveSessions()` | — | **`[]`**. A request is one HTTP request; there is no session and no connection catalog |
-| `getTableStats()` | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""` |
+| `getTableStats()` | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""`; `tableSize(Bytes)` **omitted** when the index published no size ([§7](#7-monitoring--health)) |
 | `getStorageStats()` | `_cluster/health` + `_cluster/stats` | **one row for the cluster**: `name` = `cluster_name`, `sizeBytes` = `indices.store.size_in_bytes`. **No row at all** when the size was unreported |
 | `getHealth()` | the above, composed | `databaseSize`; `activeConnections` **omitted**, carrying the overview's absence across; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
 
@@ -873,13 +873,22 @@ The honest empties, each with its reason:
 - **`uptime` is `"N/A"`.** Neither the health nor the version payload carries one, and no other call
   in this seam does either. A `"0s"` would claim the cluster booted this instant.
 
-**A closed index reads as zero in `getTableStats()` and is omitted in the schema tree**, and the
-asymmetry is only half deliberate. `TableStats.rowCount`, `totalSize` and `totalSizeBytes` are
-*required* numbers, so for those three a closed index has nowhere to read but zero. `tableSize` and
-`tableSizeBytes` are *optional* and this mapper zeroes them anyway, which turns on `StorageTab`'s
-`tableSizeKnown` and draws a `0 B` Data figure for an index that reported nothing (BACKLOG D50).
-`TableSchema.rowCount` and `size` are optional too, which is why the tree keeps the distinction (the
-comment over `toTableStats()` in [`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
+**A closed index zeroes only the *required* `getTableStats()` fields, and omits the optional ones.**
+`TableStats.rowCount`, `totalSize` and `totalSizeBytes` are required numbers, so for those three a
+closed index has nowhere to read but zero. `tableSize` and `tableSizeBytes` are *optional*, so they
+are **absent** rather than `0`: a zero there would be a fabricated measurement rather than a forced
+one. The schema tree makes the same distinction with its own optional `TableSchema.rowCount` and
+`size` (the comment over `toTableStats()` in
+[`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
+
+**One closed index takes the Data figure away from the whole cluster**, and that cost is deliberate.
+`StorageTab` gates that figure on `tables.every((t) => t.tableSizeBytes !== undefined)`, so as soon
+as one index publishes no size the Tables card reads **N/A** for every open index beside it instead
+of a sum over the indices that did answer. A partial sum would read as a measurement of the cluster,
+which is the same lie the `0 B` it replaced told about the one index, one digit larger. The
+open-beside-closed pair is pinned in
+[`elasticsearch-provider.test.ts`](../../tests/integration/db/elasticsearch-provider.test.ts) so the
+aggregate is asserted, not inferred.
 
 **Document counts exceed what a `SELECT` returns when a mapping has `nested` fields.** Measured on the
 fork's `probe_shapes`, whose `items` field is `nested`: `_cat` reports **2** documents while

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -618,6 +618,23 @@ The label map relabels the generic schema-explorer UI for key-value semantics: e
 "Key Prefix", row -> "key", select -> "Scan Keys", generate -> "Generate Command",
 analyze -> "Key Info", search placeholder -> "Search keys...", etc.
 
+`statementLanguage` is the one label no person sees: the agent's plan contract states it verbatim to
+the model. It exists for the reason Redis's does. Measured 2026-08-22 in plan mode against the
+embedded sample, objective *"list every entry under the users prefix and read one user by key"*: the
+run was grounded — three prefixes captured, `articles:*`, `config:*`, `users:*` — and drafted
+
+```
+GET users:*
+```
+
+`dispatchCommand` gives `get` exactly one meaning, `kv.get(parts[1])`, an exact-key lookup with no
+glob of any kind ([§5.1](#51-command-grammar)), so that command answers **zero rows and no error** —
+which on a key-value store reads as "nothing stored there" rather than as a mistake. The label
+therefore names all five verbs, so none has to be guessed, and states that a key is matched exactly
+with no wildcard, repeating in words what `tablesAreDerivedGroupings` says in a flag: a `users:*` row
+is this engine's grouping, so every entry under it is reached with `prefix users:` — the form
+`generateTableQuery` already emits when a person clicks the same row.
+
 One label is about the monitoring tab instead: `slowQueriesEmptyState` -> *"LibreDB keeps no
 statistics about finished statements in this version."* `getSlowQueries()` answers `[]`
 unconditionally ([§7.2](#72-the-two-panels-that-are-absent-and-the-one-that-is-empty)), so the

--- a/docs/providers/libsql.md
+++ b/docs/providers/libsql.md
@@ -263,7 +263,10 @@ facts was re-measured over Hrana rather than assumed:
 | `ssl` | no | Any mode other than `disable` selects HTTPS |
 | `connectionString` | no | A `libsql://` URL, resolved into the fields above |
 
-There is no `user` (libSQL has no user names) and no `database` (the database is the host).
+There is no `user` (libSQL has no user names) and no `database` (the database is the host), and the
+connection form renders no input for either: it gates its Username and Database boxes on this same
+list, so a box appears exactly where a value is written. It used to draw both regardless, and the save
+discarded whatever was typed into them.
 
 ### 4.2 Connection strings
 

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -813,7 +813,7 @@ numbers this table used to carry had drifted, and a method name is greppable and
 | `getSlowQueries()` | — | **`[]`** — and on this product that is a *choice*, not an absence. See below |
 | `getIndexStats()` | — | **`[]`**. No secondary-index object exists |
 | `getActiveSessions()` | — | **`[]`**. A request is one HTTP request; there is no session and no connection catalog |
-| `getTableStats()` | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""` |
+| `getTableStats()` | `_cat/indices` | one row per **user** index: `rowCount` = `docs.count`, `tableSize(Bytes)` = `totalSize(Bytes)` = `pri.store.size`, `schemaName` = `""`; `tableSize(Bytes)` **omitted** when the index published no size ([§7](#7-monitoring--health)) |
 | `getStorageStats()` | `_cluster/health` + `_cluster/stats` | **one row for the cluster**: `name` = `cluster_name`, `sizeBytes` = `indices.store.size_in_bytes`. **No row at all** when the size was unreported |
 | `getHealth()` | the above, composed | `databaseSize`; `activeConnections` **omitted**, carrying the overview's absence across; `cacheHitRatio` = the repo's word for "not measured"; `slowQueries` = `[]`; `activeSessions` = `[]` |
 
@@ -880,13 +880,22 @@ The honest empties, each with its reason:
 - **`uptime` is `"N/A"`.** No call in this seam carries one; a `"0s"` would claim the cluster booted
   this instant.
 
-**A closed index reads as zero in `getTableStats()` and is omitted in the schema tree**, and the
-asymmetry is only half deliberate. `TableStats.rowCount`, `totalSize` and `totalSizeBytes` are
-*required* numbers, so for those three a closed index has nowhere to read but zero. `tableSize` and
-`tableSizeBytes` are *optional* and this mapper zeroes them anyway, which turns on `StorageTab`'s
-`tableSizeKnown` and draws a `0 B` Data figure for an index that reported nothing (BACKLOG D50).
-`TableSchema.rowCount` and `size` are optional too, which is why the tree keeps the distinction (the
-comment over `toTableStats()` in [`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
+**A closed index zeroes only the *required* `getTableStats()` fields, and omits the optional ones.**
+`TableStats.rowCount`, `totalSize` and `totalSizeBytes` are required numbers, so for those three a
+closed index has nowhere to read but zero. `tableSize` and `tableSizeBytes` are *optional*, so they
+are **absent** rather than `0`: a zero there would be a fabricated measurement rather than a forced
+one. The schema tree makes the same distinction with its own optional `TableSchema.rowCount` and
+`size` (the comment over `toTableStats()` in
+[`search/index.ts`](../../src/lib/db/providers/sql/search/index.ts)).
+
+**One closed index takes the Data figure away from the whole cluster**, and that cost is deliberate.
+`StorageTab` gates that figure on `tables.every((t) => t.tableSizeBytes !== undefined)`, so as soon
+as one index publishes no size the Tables card reads **N/A** for every open index beside it instead
+of a sum over the indices that did answer. A partial sum would read as a measurement of the cluster,
+which is the same lie the `0 B` it replaced told about the one index, one digit larger. The
+open-beside-closed pair is pinned in
+[`opensearch-provider.test.ts`](../../tests/integration/db/opensearch-provider.test.ts) so the
+aggregate is asserted, not inferred.
 
 **Document counts exceed what a `SELECT` returns when a mapping has `nested` fields**, and this was
 measured here: `probe_shapes` reports **2** documents in `_cat/indices` while `SELECT COUNT(*)` answers

--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -328,6 +328,17 @@ ioredis only authenticates as `default` when `username` is absent. A pasted
 ([`src/lib/connection-string-parser.ts`](../../src/lib/connection-string-parser.ts)) decomposes the
 userinfo into `user` / `password` ([§4.2](#42-connection-string-nuance)).
 
+**A connection saved before the field was writable keeps authenticating as `default`, and there is
+nothing to migrate.** `connectionFields` in [`src/lib/db-ui-config.ts`](../../src/lib/db-ui-config.ts)
+decides what a save WRITES, and it omitted `user` for `redis` until the settlement round of
+2026-08-27 — so the ACL user a person typed was discarded between the box and the driver, and the
+value simply was never captured. No migration can restore a credential that was never stored: an
+existing connection authenticates as `default` until someone opens it and types a user name, which
+now persists. What the same change also stopped is an EDIT losing one: `user` is form-owned rather
+than preserved (`FIELD_OWNERSHIP` in [`src/hooks/use-connection-form.ts`](../../src/hooks/use-connection-form.ts)),
+so a connection that had a `user` from a pasted URL had it loaded into the box, shown, and then
+dropped on save. It is written now.
+
 Measured 2026-08-26 against `redis:latest`, with `default` left `on nopass ~* &* +@all` and a second
 user defined `on >probepw ~* +@all -info`, both arms:
 

--- a/e2e/libsql-provider.spec.ts
+++ b/e2e/libsql-provider.spec.ts
@@ -65,20 +65,24 @@ test.describe("libSQL in the connection dialog", () => {
     await expect(dialog.locator('input[placeholder*="turso.io"]')).toBeVisible();
   });
 
-  test("renders the Username and Database inputs even though libSQL takes neither", async ({ page }) => {
-    // Pinned as it IS rather than as it should be, because the browser is what settled
-    // it: `connectionFields` in `db-ui-config.ts` decides what a save WRITES, not what
-    // the form renders - `ConnectionModal` draws Host, Username, Password and Database
-    // for every engine that is not file-based. So libSQL shows a Username box it has no
-    // user names for, exactly as Druid and the two search engines show a Database box
-    // they do not take. Nothing is written from either (BACKLOG U22), and a test that
-    // asserted these were absent would have been asserting a comment rather than the
-    // product.
+  test("renders neither a Username nor a Database input, because libSQL takes neither", async ({ page }) => {
+    // This assertion is the inverse of the one it replaces, and the inversion is the fix.
+    // `connectionFields` in `db-ui-config.ts` decides what a save WRITES, and the modal
+    // now gates its Username and Database inputs on the same list, so a box exists
+    // exactly where a value is carried. Before, libSQL showed a Username box for an
+    // engine that has no user names at all - it authenticates with a token the server
+    // minted - and a Database box for one addressed entirely by URL, and a save silently
+    // dropped both.
+    //
+    // Host and Password are asserted present in the same breath so this cannot pass by
+    // the dialog having failed to render its addressing section at all.
     const dialog = page.locator('[role="dialog"]');
     await dialog.getByRole("button", { name: "libSQL", exact: true }).click();
 
-    await expect(dialog.locator("#user")).toHaveCount(1);
-    await expect(dialog.locator("#database")).toHaveCount(1);
+    await expect(dialog.locator("#host")).toHaveCount(1);
+    await expect(dialog.locator("#password")).toHaveCount(1);
+    await expect(dialog.locator("#user")).toHaveCount(0);
+    await expect(dialog.locator("#database")).toHaveCount(0);
   });
 
   test("claims no wire-compatible relative it has not probed", async ({ page }) => {

--- a/src/components/ConnectionModal.tsx
+++ b/src/components/ConnectionModal.tsx
@@ -30,7 +30,7 @@ import {
   Server,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { getDBConfig, isFileBased } from "@/lib/db-ui-config";
+import { getDBConfig, isFileBased, takesConnectionField } from "@/lib/db-ui-config";
 import { motion, AnimatePresence } from "framer-motion";
 import { useConnectionForm } from "@/hooks/use-connection-form";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -453,23 +453,30 @@ export function ConnectionModal({
                   </div>
 
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-2 mb-1">
-                        <Key strokeWidth={1.5} className="w-3 h-3 text-fg-muted" />
-                        <Label htmlFor="user" className="text-xs font-mediumr text-fg-muted">
-                          Username
-                        </Label>
+                    {/*
+                      Only when the engine takes it. libSQL authenticates with a token the
+                      server minted and has no user names at all, so a Username box there
+                      collected a value `buildConnection` then discarded.
+                    */}
+                    {takesConnectionField(type, "user") && (
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2 mb-1">
+                          <Key strokeWidth={1.5} className="w-3 h-3 text-fg-muted" />
+                          <Label htmlFor="user" className="text-xs font-mediumr text-fg-muted">
+                            Username
+                          </Label>
+                        </div>
+                        <Input
+                          id="user"
+                          value={user}
+                          onChange={(e) => setUser(e.target.value)}
+                          placeholder="user"
+                          autoComplete="off"
+                          className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs"
+                        />
                       </div>
-                      <Input
-                        id="user"
-                        value={user}
-                        onChange={(e) => setUser(e.target.value)}
-                        placeholder="user"
-                        autoComplete="off"
-                        className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs"
-                      />
-                    </div>
-                    <div className="space-y-2">
+                    )}
+                    <div className={takesConnectionField(type, "user") ? "space-y-2" : "space-y-2 md:col-span-2"}>
                       <div className="flex items-center gap-2 mb-1">
                         <ShieldCheck strokeWidth={1.5} className="w-3 h-3 text-fg-muted" />
                         <Label htmlFor="password" className="text-xs font-mediumr text-fg-muted">
@@ -511,32 +518,40 @@ export function ConnectionModal({
                     </div>
                   </div>
 
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2 mb-1">
-                      <Database strokeWidth={1.5} className="w-3 h-3 text-fg-muted" />
-                      <Label htmlFor="database" className="text-xs font-mediumr text-fg-muted">
-                        {databaseFieldLabel} Name
-                      </Label>
+                  {/*
+                    Only when the engine takes it. Druid and the two search engines address
+                    a datasource or an index by name in the statement, and libSQL addresses
+                    the whole database by URL, so none of the four has a database to name
+                    here - and `buildConnection` never wrote what this box collected.
+                  */}
+                  {takesConnectionField(type, "database") && (
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2 mb-1">
+                        <Database strokeWidth={1.5} className="w-3 h-3 text-fg-muted" />
+                        <Label htmlFor="database" className="text-xs font-mediumr text-fg-muted">
+                          {databaseFieldLabel} Name
+                        </Label>
+                      </div>
+                      <Input
+                        id="database"
+                        value={database}
+                        onChange={(e) => setDatabase(e.target.value)}
+                        placeholder={databaseFieldPlaceholder}
+                        className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
+                      />
+                      {isTrino && (
+                        <p className="text-xs text-fg-muted">
+                          The Trino catalog to open, such as tpch or hive. Its schemas are the level below.
+                        </p>
+                      )}
+                      {isCassandra && (
+                        <p className="text-xs text-fg-muted">
+                          The keyspace to open. Tables inside it are the level below; statements can still name any
+                          keyspace in full.
+                        </p>
+                      )}
                     </div>
-                    <Input
-                      id="database"
-                      value={database}
-                      onChange={(e) => setDatabase(e.target.value)}
-                      placeholder={databaseFieldPlaceholder}
-                      className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
-                    />
-                    {isTrino && (
-                      <p className="text-xs text-fg-muted">
-                        The Trino catalog to open, such as tpch or hive. Its schemas are the level below.
-                      </p>
-                    )}
-                    {isCassandra && (
-                      <p className="text-xs text-fg-muted">
-                        The keyspace to open. Tables inside it are the level below; statements can still name any
-                        keyspace in full.
-                      </p>
-                    )}
-                  </div>
+                  )}
 
                   {/*
                     In the open rather than behind the Advanced accordion for the

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -26,12 +26,18 @@ import { DatabaseConnection, SavedQuery } from "@/lib/types";
 import { ChunkBoundary, ViewLoading } from "@/components/LazyView";
 import { lazyRetry } from "@/lib/lazy";
 import { editorLanguageForTabType, resolveTabType } from "@/lib/editor/tab-language";
-import { buildResultExport, type ResultExportFormat } from "@/lib/export/result-export";
+import {
+  buildResultExport,
+  FALLBACK_TABLE_NAME,
+  resultExportFileName,
+  type ResultExportFormat,
+} from "@/lib/export/result-export";
 import { downloadText } from "@/lib/export/download";
 import { newLocalId } from "@/lib/ids";
 import { resolveAgentRunConnectionId } from "@/hooks/use-connection-payload";
 import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile";
 import { useAgentCapability } from "@/hooks/use-agent-capability";
+import type { AgentArtifactHydration } from "@/components/agent/hydration";
 import { useAgentArtifact } from "@/components/agent/use-agent-artifact";
 import { useAgentPrefill } from "@/components/agent/use-agent-prefill";
 import { useToast } from "@/hooks/use-toast";
@@ -349,28 +355,40 @@ export default function Studio() {
     toast({ title: "Query Saved", description: `"${name}" has been added to your saved queries.` });
   };
 
-  const exportResults = (format: ResultExportFormat) => {
-    if (!tabMgr.currentTab.result) return;
+  /**
+   * Write what is on screen to a file.
+   *
+   * `hydrated` is the agent artifact the bottom panel is showing, or null when the
+   * tab's own rows are what the user is looking at. It is passed in rather than read
+   * back off the tab because the two disagree exactly when it matters (B34): a run's
+   * result is hydrated into the grid without touching the tab, so an export that read
+   * `currentTab.result` wrote rows nobody was looking at. That is why the menu used to
+   * be hidden over a hydrated view instead of retargeted.
+   */
+  const exportResults = (format: ResultExportFormat, hydrated: AgentArtifactHydration | null = null) => {
+    const source = hydrated?.result ?? tabMgr.currentTab.result;
+    if (!source) return;
     // The columns the engine declared for THIS result. The writers read every row by
     // these names rather than by whatever keys row 0 happens to carry, so a row with
     // a different key order — or a document store's row missing a field entirely —
     // lands in the right column instead of shifting the rest.
-    const fields = tabMgr.currentTab.result.fields;
+    const fields = source.fields;
     const sensitiveColumns = detectSensitiveColumnsFromConfig(fields, maskingConfig);
-    const rows = effectiveMasking
-      ? applyMaskingToRows(tabMgr.currentTab.result.rows, fields, sensitiveColumns)
-      : tabMgr.currentTab.result.rows;
+    const rows = effectiveMasking ? applyMaskingToRows(source.rows, fields, sensitiveColumns) : source.rows;
 
     const file = buildResultExport(format, {
       rows,
       fields,
-      tabName: tabMgr.currentTab.name,
+      // A run's rows did not come from this tab, so the SQL forms take the neutral
+      // fallback name: naming the tab's table would attribute them to a table that
+      // never produced them.
+      tabName: hydrated === null ? tabMgr.currentTab.name : FALLBACK_TABLE_NAME,
       dialect: conn.activeConnection?.type,
       // The types the engine declared for THIS result, which is what the DDL form
       // writes when they are there — the only source for a computed column.
-      columnTypes: tabMgr.currentTab.result.columnTypes,
+      columnTypes: source.columnTypes,
     });
-    downloadText(file.content, file.mimeType, `query_result_export.${file.extension}`);
+    downloadText(file.content, file.mimeType, resultExportFileName(file.extension, hydrated?.runId));
   };
 
   const onTableClick = (tableName: string) => {
@@ -455,6 +473,7 @@ export default function Studio() {
                 activeConnection={conn.activeConnection}
                 schema={conn.schema}
                 isLoadingSchema={conn.isLoadingSchema}
+                schemaError={conn.schemaError}
                 onSelectConnection={conn.setActiveConnection}
                 onDeleteConnection={handleDeleteConnection}
                 onEditConnection={(c) => {
@@ -587,6 +606,7 @@ export default function Studio() {
                     <SchemaExplorer
                       schema={conn.schema}
                       isLoadingSchema={conn.isLoadingSchema}
+                      schemaError={conn.schemaError}
                       onTableClick={(tableName) => {
                         onTableClick(tableName);
                         setActiveMobileTab("editor");

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -609,7 +609,10 @@ export function OperationsTab() {
               </div>
             ) : sessions.length === 0 ? (
               <div className="p-8 text-center text-fg-subtle text-sm" data-testid="operations-sessions-empty">
-                {sessionsUnavailable ?? "No active sessions found."}
+                {/* The order is deliberate: `sessionsUnavailable` is set only when the
+                    READ failed, while `sessionsEmptyState` explains an engine that
+                    publishes no session list at all (#D48). */}
+                {sessionsUnavailable ?? labels?.sessionsEmptyState ?? "No active sessions found."}
               </div>
             ) : (
               <Table>

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -1122,6 +1122,12 @@ export function AgentRail({
   const threadSteps = run.thread?.steps ?? [];
   const threadDeclined = run.thread?.declined;
   /*
+    A conversation this browser was in and is not following any more: the stored thread id
+    while no run has opened. The hook owns the reading; the rail owns the sentence, because
+    what is lost is a rail affordance — the follow-up id it would have sent (#B69).
+  */
+  const interruptedThread = run.interrupted;
+  /*
     Computed here rather than inside the JSX guard below, and that is a coverage
     decision as much as a readability one: under the guard, `threadDeclineNotice`'s
     `return null` line would be unreachable and would sit uncovered forever (#513).
@@ -2315,8 +2321,27 @@ export function AgentRail({
           `unavailable` (#512) — and the step list is the run's own
           header.
         */}
-        {(threadSteps.length > 0 || declineNotice !== null) && (
+        {(threadSteps.length > 0 || declineNotice !== null || interruptedThread !== null) && (
           <div data-testid="agent-thread" className="mt-2 text-[0.625rem] text-fg-muted">
+            {/*
+              Said BEFORE the next question rather than discovered after it. A reload clears
+              the run this rail was following, so the id a follow-up would have carried is
+              gone and the next question opens a fresh conversation — which the rail used to
+              be silent about, leaving a user mid-conversation to find out from an answer
+              that had forgotten what they asked (#B69).
+
+              It names the conversation and how many questions it had reached, because those
+              are the two things a person can check against the strip they were reading. It
+              does not offer to resume: the runs behind a stored thread may have been
+              evicted, so an offer this rail cannot keep would be worse than the notice.
+            */}
+            {interruptedThread !== null && (
+              <p data-testid="agent-thread-ended" className="text-amber-400/80">
+                {`The conversation this browser was in (${interruptedThread.steps} question${
+                  interruptedThread.steps === 1 ? "" : "s"
+                }, ${interruptedThread.threadId}) ended when the page reloaded. Your next question starts a new one.`}
+              </p>
+            )}
             {threadSteps.length > 0 && (
               <>
                 <p>

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -1,3 +1,4 @@
+import type { AgentContextCharge } from "@/lib/agent/context-snapshot";
 import { AGENT_MAX_REPAIR_ATTEMPTS, AGENT_WORKFLOW_BUDGETS } from "@/lib/agent/execution-policy";
 import type { AgentGoalShortfall } from "@/lib/agent/goal-verifier";
 import { type AgentInventoryNoun, TABLE_INVENTORY_NOUN } from "@/lib/agent/inventory-noun";
@@ -75,6 +76,16 @@ const GUIDANCE_HEADLINE: Record<Extract<AgentRunEvent, { kind: "guidance-issued"
   "plan-statement": "Asked for a runnable statement",
   "report-reserve": "Told this is its last turn",
   "unread-stop": "Asked to read the database itself",
+  /*
+    The three notices delivered INSTEAD of running a call. They reach a reader through the
+    `call-held` entry that records the hold, which is where the rail shows them — one entry
+    per delivery, and the tone that says the server did not run the call. Their names are
+    here because the vocabulary is one union (B51) and a reader of a ledger written by a
+    later build must not meet an id this table has no word for.
+  */
+  "present-before-report": "Asked to present the result first",
+  "cite-what-you-read": "Asked to cite what it read",
+  "compare-before-report": "Asked to compare the plans it holds",
 };
 
 /**
@@ -849,6 +860,27 @@ function describeRefusal(refusal: AgentToolRefusal): Omit<AgentTimelineItem, "id
 }
 
 /**
+ * How old a reused inventory was, in the coarsest unit that is still true (B56).
+ *
+ * Coarse on purpose. What a reader has to decide is whether the reading predates a
+ * change they made, and "3 hours old" answers that where "11,437,208 ms" does not.
+ * Every step rounds DOWN, so the line never claims the reading is older than it is.
+ *
+ * Under a minute is said in words rather than as "0 minutes old": a capture taken in
+ * this same drive is not a stale one, and a zero would read as a measurement that
+ * failed.
+ */
+function ageText(ms: number): string {
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return "under a minute old";
+  if (minutes < 60) return `${minutes} ${minutes === 1 ? "minute" : "minutes"} old`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} ${hours === 1 ? "hour" : "hours"} old`;
+  const days = Math.floor(hours / 24);
+  return `${days} ${days === 1 ? "day" : "days"} old`;
+}
+
+/**
  * `stopRequested` is the fold's state at THIS entry, not the run's final state, and
  * it can only be true for an entry that follows the request — which is the only
  * ordering that makes the sentence it produces true.
@@ -890,6 +922,23 @@ function describeEvent(
         // had been told key patterns — the same defect the prompt half of #414 fixed,
         // in the half a user actually reads.
         detail: `${event.tableCount} ${event.tableCount === 1 ? noun.singular : noun.plural}, fingerprint ${event.fingerprint.slice(0, 8)}`,
+      };
+    case "context-reused":
+      return {
+        /*
+          The inventory this run did NOT read (B56). `progress` for the same reason a
+          capture is: the run is grounded and got there, and the entry exists so a reader
+          can see WHERE the ground came from.
+
+          The age is the whole point of the line. `heldSnapshotForConnection` has no
+          expiry, so on a long-lived server a plan run can be grounded on a reading taken
+          before the user added the collection they are now asking about — and until this
+          entry the ledger held nothing at all about such a run's grounding, which reads as
+          a run that needed none.
+        */
+        tone: "progress",
+        headline: "Schema reused",
+        detail: `${event.tableCount} ${event.tableCount === 1 ? noun.singular : noun.plural}, fingerprint ${event.fingerprint.slice(0, 8)}, read by an earlier run and ${ageText(event.ageMs)}`,
       };
     case "context-unavailable":
       /*
@@ -1319,7 +1368,7 @@ function reportOf(claims: readonly AgentReportClaim[], index: LedgerIndex): Agen
  *    this is wider than "reached the database": `tools.ts` acquires the provider
  *    inside the allowed callback on purpose, so an acquisition failure is accounted
  *    as a spent statement although nothing ran — and it settles no step, so this
- *    fold cannot see it either (`docs/BACKLOG.md` B13).
+ *    fold cannot see it either.
  *  - A policy denial and an approval requirement charge nothing at all:
  *    `execution.ts` returns before `tracker.beginExecution` on any non-allow, and
  *    `AgentRepairLedger` consumes a repair attempt only for a database error.
@@ -1327,6 +1376,10 @@ function reportOf(claims: readonly AgentReportClaim[], index: LedgerIndex): Agen
  *    inside the invoke callback, after the pipeline allowed the call and
  *    `beginExecution` ran, so the tracker has already counted it; and no rewording
  *    could have changed the answer, so the repair ledger does not.
+ *  - A schema capture contributes the statements and the span the TRACKER charged it,
+ *    read off its own entry (B13). Its reads settle no step and write no
+ *    `tool-completed`, so before that measurement was recorded a run whose first two or
+ *    three statements were catalog reads folded to zero.
  *  - Database time is the elapsed time each CHARGED statement recorded: a completed
  *    read's own `summary.elapsedMs`, and, for the two refusal classes the tracker
  *    charged, the span it charged them (#512). An entry carrying no
@@ -1335,14 +1388,14 @@ function reportOf(claims: readonly AgentReportClaim[], index: LedgerIndex): Agen
  *    can name what the figure is missing instead of presenting an invented one (#477).
  *
  * Every figure this produces is therefore a FLOOR on what the run has spent, and
- * the rail says so rather than presenting it as exact. The ledger is narrower than
- * the tracker in three known ways, all recorded in B13: the run's schema capture
- * reaches `executeAuditedOperation` through `captureContextSnapshot` rather than
- * through the run loop's `runStep`, so its two-to-three catalog reads are charged
- * without writing a `tool-completed` entry; an acquisition failure is charged a
- * statement and settles no step; and a completed read reports the engine's own
- * elapsed time while the tracker charges the span around the whole call. The list is
- * what is KNOWN, not a proof that nothing else is missing.
+ * the rail says so rather than presenting it as exact. Two of the three ways B13
+ * recorded the ledger as narrower than the tracker remain: an acquisition failure is
+ * charged a statement and settles no step, so nothing here can see it; and a completed
+ * read reports the engine's own elapsed time while the tracker charges the span around
+ * the whole call. The third — the schema capture's charged reads — is folded above from
+ * the measurement the capture now records, which leaves a ledger written before that
+ * field as the case where a capture still contributes nothing. The list is what is
+ * KNOWN, not a proof that nothing else is missing.
  */
 export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRunTimeline {
   const items: AgentTimelineItem[] = [];
@@ -1355,6 +1408,29 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
   let statementsWithoutDuration = 0;
   let repairs = 0;
   let claims: readonly AgentReportClaim[] | null = null;
+
+  /**
+   * What a schema capture spent, folded from the entry's own measurement (B13).
+   *
+   * The capture's catalog reads never wrote a `tool-completed` entry — they reach the
+   * execution layer through `captureContextSnapshot` rather than through `runStep` —
+   * so a run that had spent two or three statements before its first model turn read
+   * "0 statements" here. There is one figure per capture and not one per read, because
+   * the tracker charges the run and not the statement, and an itemised list would be
+   * this fold inventing reads it never saw.
+   *
+   * An entry carrying NO charge contributes nothing, which is the same rule the missing
+   * durations follow: a ledger written before the field measured no spend, and folding a
+   * zero would state that its reading was free (#477).
+   *
+   * A refused capture is folded too. It was admitted and charged before it was answered,
+   * so leaving it out would put the meter below the ceiling being enforced.
+   */
+  const chargeCapture = (charged: AgentContextCharge | undefined): void => {
+    if (charged === undefined) return;
+    statements += charged.statements;
+    databaseMs += charged.elapsedMs;
+  };
 
   const artifacts = new Map<string, CitedArtifact>();
   const statementsByStep = new Map<string, string>();
@@ -1470,7 +1546,21 @@ export function foldLedgerEntries(entries: readonly AgentLedgerEntry[]): AgentRu
         // Overwritten rather than kept, so a run that captured twice reports the
         // reading that was in hand when it finished. See `AgentCaptureView`.
         capture = { fingerprint: event.fingerprint, tableCount: event.tableCount, noun };
-      } else if (event.kind === "statement-drafted") statementsByStep.set(event.stepId, event.sql);
+        chargeCapture(event.charged);
+      } else if (event.kind === "context-reused") {
+        /*
+          A reused inventory grounds the run exactly as a captured one does, so the
+          provenance surfaces read it the same way (B56): the fingerprint a claim cites
+          resolves, and the word the later entries are written in is this reading's own.
+
+          It charges NOTHING, and that is the fact rather than an omission — the reuse is
+          why the run performed no catalog read at all.
+        */
+        noun = event.noun ?? TABLE_INVENTORY_NOUN;
+        captures.set(event.fingerprint, { tableCount: event.tableCount, noun });
+        capture = { fingerprint: event.fingerprint, tableCount: event.tableCount, noun };
+      } else if (event.kind === "context-unavailable") chargeCapture(event.charged);
+      else if (event.kind === "statement-drafted") statementsByStep.set(event.stepId, event.sql);
       else if (event.kind === "report-composed") claims = event.claims;
       else if (event.kind === "tool-completed") {
         statements += 1;

--- a/src/components/agent/use-agent-run.ts
+++ b/src/components/agent/use-agent-run.ts
@@ -623,8 +623,16 @@ export function useAgentRun(): AgentRunFollower {
 
     A start writes the new conversation to the store, so the snapshot moves to it — and
     `runId` is what keeps that from being announced as interrupted the moment it begins.
+
+    `runId` alone was not enough. `start()` clears it BEFORE it fetches, so for as long as
+    the POST was in flight this read the previous conversation out of the store and the rail
+    said it "ended when the page reloaded" — about the conversation the user was in the act
+    of continuing, and with no page having reloaded. `isBusy` is the missing half: while a
+    start is in flight a run IS being opened, so nothing is un-followed. It also restores
+    what this property documents about itself, because `thread` keeps its previous value
+    across that same window and the two would otherwise both name one conversation.
   */
-  const interrupted = runId === null ? storedThread : null;
+  const interrupted = runId === null && !isBusy ? storedThread : null;
 
   return { runId, thread, interrupted, isBusy, isStopping, timeline, error, errorCode, refusal, start, cancel };
 }

--- a/src/components/agent/use-agent-run.ts
+++ b/src/components/agent/use-agent-run.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { isAgentModelCapability } from "@/lib/agent/capability-labels";
 // Type-only, so nothing of the probe — or of the AI SDK it runs — reaches this bundle.
 import type { AgentModelCapability } from "@/lib/agent/capability-probe";
@@ -93,6 +93,16 @@ export interface AgentRunFollower {
    * inferred: the thread has one writer, and it is the route.
    */
   readonly thread: AgentThreadContext | null;
+  /**
+   * The conversation this browser was in when it last held one, and that nothing here is
+   * following now — the stored id, while `runId` is still null.
+   *
+   * It exists because a reload clears `runId`, so the next question is answered as a
+   * fresh one. The rail was honest about the RESULT — no thread, no strip — and silent
+   * about the TRANSITION, which is the half a user mid-conversation needs (#B69). Null
+   * whenever `thread` is set: the two never describe the same conversation.
+   */
+  readonly interrupted: AgentInterruptedThread | null;
   /** A start is in flight, or its ledger is still open. */
   readonly isBusy: boolean;
   /**
@@ -183,6 +193,115 @@ const ENGINE_UNSUPPORTED_CODE: AgentStartRefusalCode = "engine-unsupported";
  * which reaches for the hook rather than the rail for exactly that reason.
  */
 const isStartRefusalCode = (value: unknown): value is AgentStartRefusalCode => value === ENGINE_UNSUPPORTED_CODE;
+
+/**
+ * Where this browser remembers which conversation it was in.
+ *
+ * localStorage only, and per browser rather than per user: it is a resumption hint, not
+ * user data, so it must never reach the storage layer or a server — the rule
+ * `lib/community/star-prompt.ts` states for the same reason. Every access is wrapped, and
+ * every failure degrades to "nothing was interrupted", which is the behaviour before this
+ * existed: a rail that cannot say a conversation ended is strictly better than one that
+ * cannot open a run (#B69).
+ */
+const THREAD_STORAGE_KEY = "libredb_agent_thread";
+
+/** A conversation this browser was in and is no longer following. */
+export interface AgentInterruptedThread {
+  /** The conversation the server named, as this browser last saw it. */
+  readonly threadId: string;
+  /**
+   * How many questions it had asked by then: the steps the server reported before the
+   * last run, plus that run itself.
+   */
+  readonly steps: number;
+}
+
+/*
+  Held as an external store rather than read into state by a mount effect, which is the
+  same shape `use-line-numbers-preference.ts` uses and for the same reason: the value has
+  to be SSR-stable and only become the stored one at hydration. React provides
+  `useSyncExternalStore` for exactly that, and an effect that called `setState` would be a
+  cascading render the React Compiler rules refuse (#488).
+
+  localStorage's own `storage` event fires only in OTHER tabs, so the writer below is what
+  notifies this one. Deliberately NOT subscribed to `storage`: picking up another tab's
+  conversation would be new behaviour, and a tab is not the thing the notice is about.
+*/
+const threadListeners = new Set<() => void>();
+
+function subscribeStoredThread(onStoreChange: () => void): () => void {
+  threadListeners.add(onStoreChange);
+  return () => {
+    threadListeners.delete(onStoreChange);
+  };
+}
+
+/**
+ * The last raw value read, and what it parsed to.
+ *
+ * `useSyncExternalStore` calls the snapshot on every render and compares by identity, so a
+ * fresh object each time is an infinite loop rather than a slow read. Keyed on the raw
+ * string, which is also what makes a write visible: the bytes change, so the object does.
+ */
+let cachedRaw: string | null = null;
+let cachedThread: AgentInterruptedThread | null = null;
+
+/** The stored conversation, or null — absent, unreadable, and off-shape all mean the same here. */
+function storedThreadSnapshot(): AgentInterruptedThread | null {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(THREAD_STORAGE_KEY);
+  } catch {
+    // A store that cannot be read holds no conversation, as far as anything here can say.
+    raw = null;
+  }
+  if (raw === cachedRaw) return cachedThread;
+  cachedRaw = raw;
+  cachedThread = parseStoredThread(raw);
+  return cachedThread;
+}
+
+/** No localStorage on the server, and nothing there was interrupted. */
+function serverThreadSnapshot(): AgentInterruptedThread | null {
+  return null;
+}
+
+function parseStoredThread(raw: string | null): AgentInterruptedThread | null {
+  if (raw === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const candidate = parsed as Record<string, unknown> | null;
+  // Narrowed rather than trusted, for the reason `readThread` narrows the wire: this value
+  // survives an upgrade, so a build that shaped it differently must read as absent instead
+  // of putting a half-read object behind a sentence about it.
+  if (candidate === null || typeof candidate.threadId !== "string" || typeof candidate.steps !== "number") return null;
+  return { threadId: candidate.threadId, steps: candidate.steps };
+}
+
+/** Remember the conversation this run belongs to, or forget the one that no longer applies. */
+function rememberThread(thread: AgentThreadContext | null): void {
+  try {
+    // Removed rather than left standing when a run belongs to no conversation: a stale
+    // entry would tell the next mount a conversation was interrupted that had already ended.
+    if (thread === null) localStorage.removeItem(THREAD_STORAGE_KEY);
+    // `steps + 1` counts the run just opened as well. The server reports the steps BEFORE
+    // it, so storing that number verbatim would have the notice say "two questions" about a
+    // conversation whose strip the user had just read as three.
+    else
+      localStorage.setItem(
+        THREAD_STORAGE_KEY,
+        JSON.stringify({ threadId: thread.threadId, steps: thread.steps.length + 1 }),
+      );
+  } catch {
+    // A store that refuses a write costs the notice, never the run.
+  }
+  for (const listener of threadListeners) listener();
+}
 
 /**
  * The conversation the SERVER says this run belongs to.
@@ -307,6 +426,7 @@ function messageFor(error: unknown): string {
 export function useAgentRun(): AgentRunFollower {
   const [runId, setRunId] = useState<string | null>(null);
   const [thread, setThread] = useState<AgentThreadContext | null>(null);
+  const storedThread = useSyncExternalStore(subscribeStoredThread, storedThreadSnapshot, serverThreadSnapshot);
   const [entries, setEntries] = useState<readonly AgentLedgerEntry[]>([]);
   const [isBusy, setIsBusy] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
@@ -426,6 +546,11 @@ export function useAgentRun(): AgentRunFollower {
 
       setRunId(openedRunId);
       setThread(openedThread);
+      // Written from what the SERVER said this run belongs to, like everything else about
+      // the thread. The notice this feeds is about the ABSENCE of a run, so nothing has to
+      // clear it: `runId` above is what stops the conversation just begun being announced
+      // as one that ended.
+      rememberThread(openedThread);
 
       try {
         await follow(openedRunId, controller.signal);
@@ -491,5 +616,15 @@ export function useAgentRun(): AgentRunFollower {
   */
   const timeline = useMemo(() => foldLedgerEntries(entries), [entries]);
 
-  return { runId, thread, isBusy, isStopping, timeline, error, errorCode, refusal, start, cancel };
+  /*
+    Derived rather than held: what makes a stored conversation INTERRUPTED is that nothing
+    here is following one, and `runId` is that fact. Held in state it would need clearing
+    from the start path, which is a second writer for something already knowable.
+
+    A start writes the new conversation to the store, so the snapshot moves to it — and
+    `runId` is what keeps that from being announced as interrupted the moment it begins.
+  */
+  const interrupted = runId === null ? storedThread : null;
+
+  return { runId, thread, interrupted, isBusy, isStopping, timeline, error, errorCode, refusal, start, cancel };
 }

--- a/src/components/monitoring/MonitoringDashboard.tsx
+++ b/src/components/monitoring/MonitoringDashboard.tsx
@@ -299,7 +299,7 @@ export function MonitoringDashboard({ isEmbedded = false }: MonitoringDashboardP
                 <QueriesTab data={data} loading={loading} labels={metadata?.labels} />
               </TabsContent>
               <TabsContent value="sessions" className="h-full m-0 p-0">
-                <SessionsTab data={data} loading={loading} onKillSession={killSession} />
+                <SessionsTab data={data} loading={loading} onKillSession={killSession} labels={metadata?.labels} />
               </TabsContent>
               <TabsContent value="tables" className="h-full m-0 p-0">
                 <TablesTab

--- a/src/components/monitoring/tabs/SessionsTab.tsx
+++ b/src/components/monitoring/tabs/SessionsTab.tsx
@@ -18,7 +18,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import type { MonitoringData, ActiveSessionDetails } from "@/lib/db/types";
+import type { MonitoringData, ActiveSessionDetails, ProviderLabels } from "@/lib/db/types";
 import { PanelUnavailable } from "../PanelUnavailable";
 
 interface SessionsTabProps {
@@ -26,9 +26,14 @@ interface SessionsTabProps {
   loading: boolean;
   onKillSession: (pid: number | string) => Promise<boolean>;
   isAdmin?: boolean;
+  /**
+   * The connected provider's own labels. Absent while /api/db/provider-meta is in
+   * flight, so every read of it stays optional.
+   */
+  labels?: ProviderLabels;
 }
 
-export function SessionsTab({ data, loading, onKillSession, isAdmin = true }: SessionsTabProps) {
+export function SessionsTab({ data, loading, onKillSession, isAdmin = true, labels }: SessionsTabProps) {
   const [killingPid, setKillingPid] = useState<number | string | null>(null);
   const [confirmKill, setConfirmKill] = useState<ActiveSessionDetails | null>(null);
 
@@ -157,7 +162,11 @@ export function SessionsTab({ data, loading, onKillSession, isAdmin = true }: Se
           ) : sessions.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               <Users strokeWidth={1.5} className="h-8 w-8 mx-auto mb-2 opacity-50" />
-              <p className="text-xs">No active sessions found.</p>
+              {/* An engine that publishes no session list says so in its own words
+                  (#D48). The default reads as "nothing is running right now", which is
+                  false on a panel that can never show a row. Absent label = today's
+                  wording, so `postgres` is unchanged. */}
+              <p className="text-xs">{labels?.sessionsEmptyState ?? "No active sessions found."}</p>
             </div>
           ) : (
             <div className="overflow-x-auto">

--- a/src/components/monitoring/tabs/StorageTab.tsx
+++ b/src/components/monitoring/tabs/StorageTab.tsx
@@ -8,6 +8,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import type { MonitoringData } from "@/lib/db/types";
+// The formatter is shared with `TablesTab` and every provider rather than local to this
+// tab: both tabs used to keep a byte-identical threshold cascade that stopped at GB and
+// guarded nothing, so a negative rendered as "-1 B", a non-finite as "NaN B" and an
+// exabyte as "1073741824.00 GB". The shared one refuses a negative or a non-finite with
+// "N/A" and spells PB and EB, which is the distinction this whole tab is about.
+import { formatBytes } from "@/lib/db/utils/pool-manager";
 import { PanelUnavailable } from "../PanelUnavailable";
 
 interface StorageTabProps {
@@ -74,13 +80,6 @@ export function StorageTab({ data, loading }: StorageTabProps) {
   const indexSizeKnown = !statsRefused && tables.every((t) => t.indexSizeBytes !== undefined);
   const walStorage = storage.find((s) => s.name === "WAL");
 
-  const formatBytes = (bytes: number) => {
-    if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
-    if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(2)} MB`;
-    if (bytes >= 1024) return `${(bytes / 1024).toFixed(2)} KB`;
-    return `${bytes} B`;
-  };
-
   // Calculate storage breakdown. Absence and zero are different inputs: a provider that
   // OMITS `databaseSizeBytes` is saying no byte figure is knowable - Apache Cassandra's
   // `system_views.disk_usage` publishes whole mebibytes, measured as "1 MiB" for a
@@ -111,8 +110,10 @@ export function StorageTab({ data, loading }: StorageTabProps) {
   // measured 0 total and no tables, `0 - 0 - 0` is an honest 0 B and stays one. What it cannot
   // survive is a NEGATIVE, which a 0 total beside per-table figures that answered produces -
   // `getTableStats()` is a separate read and does not share the overview's failure - and the
-  // cascade below returns its input unchanged, so the cell drew "-943718400 B": a negative byte
-  // count presented as a measurement (measured in the DOM). A negative remainder says the two
+  // local cascade this tab used to format with returned its input unchanged, so the cell drew
+  // "-943718400 B": a negative byte count presented as a measurement (measured in the DOM). The
+  // shared formatter now answers "N/A" for a negative, which is the same refusal one layer down
+  // and no reason to stop refusing here. A negative remainder says the two
   // reads disagree, not that the unattributed share is below zero, so there is no figure to
   // print. Gating this on the share instead would refuse the honest 0 B as well.
   const otherBytes = totalSize - totalTableSize - totalIndexSize;
@@ -146,7 +147,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
               real per-table bytes this line used to read "700.00 MB" over "0.0%", which is a
               fabricated denominator under an honest numerator (measured in the DOM).
             */}
-            <div className="text-lg sm:text-2xl font-medium truncate">
+            <div className="text-lg sm:text-2xl font-medium truncate" data-testid="storage-stat-tables">
               {sizeKnown && tableSizeKnown ? formatBytes(totalTableSize) : "N/A"}
             </div>
             {totalSize > 0 && tableSizeKnown && (
@@ -161,7 +162,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
             <Archive strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-purple-500" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
-            <div className="text-lg sm:text-2xl font-medium truncate">
+            <div className="text-lg sm:text-2xl font-medium truncate" data-testid="storage-stat-indexes">
               {sizeKnown && indexSizeKnown ? formatBytes(totalIndexSize) : "N/A"}
             </div>
             {totalSize > 0 && indexSizeKnown && (
@@ -202,7 +203,9 @@ export function StorageTab({ data, loading }: StorageTabProps) {
                     <div className="w-2 h-2 sm:w-3 sm:h-3 rounded-sm bg-green-500" />
                     Tables
                   </span>
-                  <span className="font-medium">{tableSizeKnown ? formatBytes(totalTableSize) : "N/A"}</span>
+                  <span className="font-medium" data-testid="storage-breakdown-tables">
+                    {tableSizeKnown ? formatBytes(totalTableSize) : "N/A"}
+                  </span>
                 </div>
                 <Progress value={tablePercent} className="h-1.5 sm:h-2" />
               </div>
@@ -213,7 +216,9 @@ export function StorageTab({ data, loading }: StorageTabProps) {
                     <div className="w-2 h-2 sm:w-3 sm:h-3 rounded-sm bg-purple-500" />
                     Indexes
                   </span>
-                  <span className="font-medium">{indexSizeKnown ? formatBytes(totalIndexSize) : "N/A"}</span>
+                  <span className="font-medium" data-testid="storage-breakdown-indexes">
+                    {indexSizeKnown ? formatBytes(totalIndexSize) : "N/A"}
+                  </span>
                 </div>
                 <Progress value={indexPercent} className="h-1.5 sm:h-2 [&>div]:bg-purple-500" />
               </div>
@@ -240,7 +245,9 @@ export function StorageTab({ data, loading }: StorageTabProps) {
                       Other
                     </span>
                   </span>
-                  <span className="font-medium">{remainderKnown ? formatBytes(otherBytes) : "N/A"}</span>
+                  <span className="font-medium" data-testid="storage-breakdown-other">
+                    {remainderKnown ? formatBytes(otherBytes) : "N/A"}
+                  </span>
                 </div>
                 <Progress value={otherPercent} className="h-1.5 sm:h-2 [&>div]:bg-muted-foreground" />
               </div>

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -24,6 +24,7 @@ import {
   type MonitoringData,
   type ProviderCapabilities,
 } from "@/lib/db/types";
+import { formatBytes } from "@/lib/db/utils/pool-manager";
 import { PanelUnavailable } from "../PanelUnavailable";
 
 /**
@@ -53,14 +54,14 @@ const MAINTENANCE_ACTIONS: { type: MaintenanceType; label: string; Icon: LucideI
  * Pure formatters, at module scope rather than re-created inside `TablesTab` on every
  * render. They also keep the component's own cognitive complexity to the decisions it
  * actually makes about absence, which is what this panel is about.
+ *
+ * `formatBytes` is NOT one of them and is imported instead: this tab and `StorageTab`
+ * each carried a byte-identical threshold cascade that stopped at GB and had no guard,
+ * so a negative rendered as "-1 B", a non-finite as "NaN B" and an exabyte as
+ * "1073741824.00 GB" - a non-magnitude drawn as a figure, in the panel whose whole
+ * subject is telling a reading from an absence. The shared one refuses a negative or a
+ * non-finite with "N/A" and spells PB and EB.
  */
-function formatBytes(bytes: number): string {
-  if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
-  if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(2)} MB`;
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(2)} KB`;
-  return `${bytes} B`;
-}
-
 function formatNumber(n: number): string {
   if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
   if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;

--- a/src/components/schema-explorer/SchemaExplorer.tsx
+++ b/src/components/schema-explorer/SchemaExplorer.tsx
@@ -12,6 +12,12 @@ import { TableItem } from "./TableItem";
 interface SchemaExplorerProps {
   schema: TableSchema[];
   isLoadingSchema: boolean;
+  /**
+   * Why the schema read produced nothing, in the engine's own words. Optional so the
+   * embedded shell, which has no error to hand over, is unchanged — undefined and null
+   * both mean "nothing failed", not "nothing was wrong".
+   */
+  schemaError?: string | null;
   onTableClick?: (tableName: string) => void;
   onGenerateSelect?: (tableName: string) => void;
   onCreateTableClick?: () => void;
@@ -27,6 +33,7 @@ interface SchemaExplorerProps {
 export function SchemaExplorer({
   schema,
   isLoadingSchema,
+  schemaError = null,
   onTableClick,
   onGenerateSelect,
   onCreateTableClick,
@@ -73,6 +80,25 @@ export function SchemaExplorer({
           <Database strokeWidth={1.5} className="w-3.5 h-3.5 absolute inset-0 m-auto text-blue-500 animate-pulse" />
         </div>
         <span className="text-xs font-medium animate-pulse">Scanning Schema...</span>
+      </div>
+    );
+  }
+
+  // A failed read is not an empty database (D31). The tree is empty either way, so
+  // the message is the only thing that can say which happened — and it is checked
+  // BEFORE the empty state, because "no tables found" over a refused read attributes
+  // an absence to the database that was never measured.
+  if (schemaError !== null && schema.length === 0) {
+    return (
+      <div
+        data-testid="schema-read-failed"
+        className="flex flex-col items-center justify-center py-12 px-6 text-center"
+      >
+        <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4 border border-border">
+          <CircleAlert strokeWidth={1.5} className="w-6 h-6 text-amber-400" />
+        </div>
+        <h3 className="text-foreground text-xs font-medium mb-1">Schema could not be read</h3>
+        <p className="text-xs text-muted-foreground leading-relaxed break-words">{schemaError}</p>
       </div>
     );
   }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -16,6 +16,8 @@ interface SidebarProps {
   activeConnection: DatabaseConnection | null;
   schema: TableSchema[];
   isLoadingSchema: boolean;
+  /** Why the schema read produced nothing, passed straight to the explorer (D31). */
+  schemaError?: string | null;
   onSelectConnection: (connection: DatabaseConnection) => void;
   onDeleteConnection: (id: string) => void;
   onEditConnection?: (conn: DatabaseConnection) => void;
@@ -38,6 +40,7 @@ export function Sidebar({
   activeConnection,
   schema,
   isLoadingSchema,
+  schemaError,
   onSelectConnection,
   onDeleteConnection,
   onEditConnection,
@@ -101,6 +104,7 @@ export function Sidebar({
             <SchemaExplorer
               schema={schema}
               isLoadingSchema={isLoadingSchema}
+              schemaError={schemaError}
               onTableClick={onTableClick}
               onGenerateSelect={onGenerateSelect}
               onCreateTableClick={onCreateTableClick}

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -162,7 +162,11 @@ interface BottomPanelProps {
   isLoadingMore: boolean | undefined;
   // The writer's own type, so a format added there cannot silently fail to reach this
   // menu — the drift between two spellings of one list is what this PR is about.
-  onExportResults: (format: ResultExportFormat) => void;
+  //
+  // The second argument is the artifact the rows on screen came from, or null when
+  // they are the tab's own: the export writes what it is GIVEN rather than reading the
+  // tab back, which is what lets the menu stay open over a hydrated result (B34).
+  onExportResults: (format: ResultExportFormat, hydrated: AgentArtifactHydration | null) => void;
   /**
    * A result an agent run stored, shown in the surface that already renders that
    * kind of result (#329 T11). Optional so every other caller — the embedded shell
@@ -210,8 +214,9 @@ export function BottomPanel({
 
     While one is shown the view is read-only: inline editing writes rows back through
     the tab's connection and pagination continues the tab's own query, so neither
-    means anything for a stored result. Export is absent for the same reason — it
-    exports the tab's result, which is not what the user is looking at.
+    means anything for a stored result. Export is the exception, and used to be hidden
+    with them: it is retargeted instead (B34), handed the artifact so it writes the
+    rows on screen into a file named after the run.
   */
   const hydratedResult = agentArtifact?.surface === "results" ? agentArtifact.result : null;
   const hydratedPlan = useMemo(
@@ -233,6 +238,12 @@ export function BottomPanel({
       (mode === "explain" && hydratedPlan !== null) ||
       (mode === "charts" && hydratedChart !== null));
   const displayedResult = hydratedResult ?? currentTab.result;
+  /**
+   * What an export must be attributed to: the artifact when the run's rows are the
+   * ones on screen, null when they are the tab's own. Only the results surface has an
+   * export, so this is the grid's artifact and no other's.
+   */
+  const exportArtifact = mode === "results" && hydratedResult !== null ? agentArtifact : null;
   // How much of the result an export would write — the count the button carries and
   // the shortfall the menu states. Derived here so both read the same numbers.
   const exportScope = describeExportScope(displayedResult ?? { rows: [] });
@@ -338,49 +349,67 @@ export function BottomPanel({
             <span className="hidden @4xl/panel:inline text-xs font-mono text-fg-muted mr-2">
               {displayedResult.rowCount} rows • {displayedResult.executionTime}ms
             </span>
-            {!hydratedHere && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-2"
-                  >
-                    {/*
-                      The count belongs ON the button because it is what the button
-                      does: an export writes the rows the grid HOLDS, which is one
-                      page, and a file of 500 rows off a table of two million looks
-                      exactly like a complete answer once it has left the product.
-                    */}
-                    <Download strokeWidth={1.5} className="w-3 h-3" /> Export
-                    <span data-testid="export-row-count" className="font-mono text-fg-subtle">
-                      {exportScope.countLabel}
-                    </span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="bg-raised border-hairline-strong text-fg-secondary">
-                  <div data-testid="export-scope" className="px-2 py-1.5 text-xs text-fg-muted max-w-[15rem]">
-                    {exportScope.summary}
-                    {exportScope.shortfall !== null && (
-                      <span className="block mt-1 text-amber-400/80">{exportScope.shortfall}</span>
-                    )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs font-medium text-fg-muted hover:text-fg-bright gap-2"
+                >
+                  {/*
+                    The count belongs ON the button because it is what the button
+                    does: an export writes the rows the grid HOLDS, which is one
+                    page, and a file of 500 rows off a table of two million looks
+                    exactly like a complete answer once it has left the product.
+                  */}
+                  <Download strokeWidth={1.5} className="w-3 h-3" /> Export
+                  <span data-testid="export-row-count" className="font-mono text-fg-subtle">
+                    {exportScope.countLabel}
+                  </span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="bg-raised border-hairline-strong text-fg-secondary">
+                <div data-testid="export-scope" className="px-2 py-1.5 text-xs text-fg-muted max-w-[15rem]">
+                  {exportScope.summary}
+                  {exportScope.shortfall !== null && (
+                    <span className="block mt-1 text-amber-400/80">{exportScope.shortfall}</span>
+                  )}
+                </div>
+                {exportArtifact !== null && (
+                  // Stated before the formats, because it changes what the file IS:
+                  // these are a run's rows, and the name will say so.
+                  <div data-testid="export-provenance" className="px-2 pb-1.5 text-xs text-blue-300/90">
+                    Saved as agent run <span className="font-mono text-[0.625rem]">{exportArtifact.runId}</span>&apos;s
+                    own file.
                   </div>
-                  <DropdownMenuSeparator className="bg-hairline" />
-                  <DropdownMenuItem onClick={() => onExportResults("csv")} className="text-xs cursor-pointer">
-                    Export as CSV
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => onExportResults("json")} className="text-xs cursor-pointer">
-                    Export as JSON
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => onExportResults("sql-insert")} className="text-xs cursor-pointer">
-                    Export as SQL INSERT
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => onExportResults("sql-ddl")} className="text-xs cursor-pointer">
-                    Export as DDL (CREATE TABLE)
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+                )}
+                <DropdownMenuSeparator className="bg-hairline" />
+                <DropdownMenuItem
+                  onClick={() => onExportResults("csv", exportArtifact)}
+                  className="text-xs cursor-pointer"
+                >
+                  Export as CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => onExportResults("json", exportArtifact)}
+                  className="text-xs cursor-pointer"
+                >
+                  Export as JSON
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => onExportResults("sql-insert", exportArtifact)}
+                  className="text-xs cursor-pointer"
+                >
+                  Export as SQL INSERT
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => onExportResults("sql-ddl", exportArtifact)}
+                  className="text-xs cursor-pointer"
+                >
+                  Export as DDL (CREATE TABLE)
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         )}
       </div>

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -316,7 +316,12 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
 
     /*
       Write only the addressing fields this engine actually takes — the same list the
-      modal renders inputs from. A file-addressed engine (SQLite, LibreDB) takes a
+      modal renders inputs from, which is now true: `ConnectionModal` gates its Username
+      and Database inputs on `takesConnectionField`, so a box exists exactly where a value
+      is written. It did not hold when this comment was first written, and the gap was
+      silent in both directions — libSQL and the search engines drew boxes nothing carried,
+      while Redis had its ACL user discarded by a list that omitted the field its own
+      provider authenticates with. A file-addressed engine (SQLite, LibreDB) takes a
       path and nothing else, yet this used to write `host: "localhost"`, an empty user
       and password, and a port parsed out of an empty string. That looks harmless and
       is not: a seed descriptor carries none of them, so a copy the editor had touched

--- a/src/hooks/use-connection-manager.ts
+++ b/src/hooks/use-connection-manager.ts
@@ -30,6 +30,17 @@ export function useConnectionManager(storageReady = false) {
    */
   const [servedSeeds, setServedSeeds] = useState<ServedSeeds>(NO_SERVED_SEEDS);
   const [schema, setSchema] = useState<TableSchema[]>([]);
+  /**
+   * Why the object browser is empty, in the engine's own words, or null when it is
+   * empty because the database really has nothing in it.
+   *
+   * Kept because a failed read used to leave the PREVIOUS connection's tables on
+   * screen under the new connection's name, row counts and all (D31, measured in
+   * Chrome across two connections). Clearing the tree alone would fix the lie and
+   * leave a second one: an empty explorer reads as "no tables here", which is not
+   * what happened.
+   */
+  const [schemaError, setSchemaError] = useState<string | null>(null);
   const [isLoadingSchema, setIsLoadingSchema] = useState(false);
   const [pulseState, setConnectionPulse] = useState<"healthy" | "degraded" | "error" | null>(null);
 
@@ -58,8 +69,13 @@ export function useConnectionManager(storageReady = false) {
         }
         const list: TableSchema[] = await response.json();
         setSchema(list);
+        setSchemaError(null);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        // Nothing read for THIS connection, so nothing may stay on screen as its
+        // tables — the previous connection's list is not evidence about this one.
+        setSchema([]);
+        setSchemaError(errorMessage);
         toast({ title: "Schema Error", description: errorMessage, variant: "destructive" });
         return; // finally still clears the loading flag; skip relations
       } finally {
@@ -304,6 +320,7 @@ export function useConnectionManager(storageReady = false) {
     setActiveConnection,
     schema,
     setSchema,
+    schemaError,
     isLoadingSchema,
     // Derived rather than reset in the pulse effect: with no active connection
     // there is nothing to report on, and the render already knows that.

--- a/src/lib/agent/context-snapshot.ts
+++ b/src/lib/agent/context-snapshot.ts
@@ -132,8 +132,47 @@ export type AgentContextUnavailableCode =
    */
   | "PROVIDER_INVENTORY_TIMED_OUT";
 
+/**
+ * What a capture SPENT, taken from the tracker's own accounting (B13).
+ *
+ * The capture's reads reach `executeAuditedOperation` through
+ * `readCatalogForGrounding` and `readProviderSchemaForGrounding` rather than through
+ * the run loop's `runStep`, and `runStep` is the only writer of `tool-completed`. So
+ * two or three catalog statements were charged against exactly the ceilings the rail
+ * displays and left no entry the rail could fold: an agent-mode drive with no
+ * reusable snapshot read "0 of 20 statements" with three already spent, before the
+ * model's first turn.
+ *
+ * MEASURED rather than counted here, and the difference is the whole reason this is a
+ * delta of `tracker.usage` around the reading instead of `plan.kinds.length`: what the
+ * budget enforces is what the tracker holds, and a read the pipeline denied before
+ * `beginExecution` charges nothing while an acquisition failure charges a statement
+ * for a call that never ran. A figure composed from the plan would state the reads
+ * this module INTENDED; this one states the reads the run paid for.
+ *
+ * `elapsedMs` is the span the tracker charged the whole capture, which is what
+ * `maxTotalRunMs` is measured against — not the engine's own elapsed time, which is
+ * the narrower figure a `tool-completed` entry carries.
+ */
+export interface AgentContextCharge {
+  /** Statements the tracker charged this run while the capture was reading. */
+  readonly statements: number;
+  /** The span it charged them, in milliseconds. */
+  readonly elapsedMs: number;
+}
+
 export type AgentContextCapture =
-  | { readonly kind: "captured"; readonly snapshot: AgentContextSnapshot }
+  | {
+      readonly kind: "captured";
+      readonly snapshot: AgentContextSnapshot;
+      /**
+       * What the reading cost, so the caller can record it (B13). Absent only where
+       * a capture was composed by something other than `captureContextSnapshot` —
+       * a fixture, or a test driving one of the two inner paths — and an absent
+       * charge is recorded as no charge at all rather than as a zero spend.
+       */
+      readonly charged?: AgentContextCharge;
+    }
   | {
       readonly kind: "unavailable";
       readonly reasonCode: AgentContextUnavailableCode;
@@ -143,6 +182,12 @@ export type AgentContextCapture =
        * policy allows. Present only for that reason — see `rowBudgetIn`.
        */
       readonly rowBudget?: AgentContextRowBudget;
+      /**
+       * What the refused reading cost anyway (B13). A read the engine rejected was
+       * admitted, charged and only then answered, so the spend is real even where the
+       * inventory is not.
+       */
+      readonly charged?: AgentContextCharge;
       /**
        * WHY this run has no inventory, in one sentence and with no advice in it.
        *
@@ -433,7 +478,9 @@ export function reusableSnapshot(events: readonly AgentRunEvent[], connectionId:
  * Runs before the first model turn of a drive that has no recorded inventory to
  * reuse. It costs one statement per catalog kind out of the run's budget on the
  * composed path and exactly one on the provider path, which is why the result is
- * persisted rather than re-read.
+ * persisted rather than re-read — and what it actually cost is returned with the
+ * snapshot, measured off the tracker, so the caller can record it (see
+ * `AgentContextCharge`).
  *
  * PLANNING RUNS REACH THIS TOO, since the plan-mode grounding design of 2026-08-15.
  * Until then a planning run was refused here by the mode gate in `tools.ts` and was
@@ -446,6 +493,31 @@ export function reusableSnapshot(events: readonly AgentRunEvent[], connectionId:
  * mode.
  */
 export async function captureContextSnapshot(context: AgentToolContext): Promise<AgentContextCapture> {
+  // Around the reading and not inside either path, because the two paths spend
+  // differently — one statement per catalog kind against exactly one — and the
+  // question the meter asks is what the capture cost, not which route it took.
+  const before = context.tracker.usage(context.runId);
+  const capture = await readInventory(context);
+  const after = context.tracker.usage(context.runId);
+  // A REFUSED capture is charged too, and that is the half of B13 the ledger's own
+  // `context-unavailable` docblock deferred: a read the engine rejected, and a read
+  // whose rows overran the budget, both spent a statement before saying no.
+  return {
+    ...capture,
+    charged: {
+      statements: after.executedStatements - before.executedStatements,
+      elapsedMs: after.totalElapsedMs - before.totalElapsedMs,
+    },
+  };
+}
+
+/**
+ * The reading itself, through whichever of the two paths this dialect has.
+ *
+ * Separate from the measurement above so the delta cannot be taken around part of a
+ * capture: every `return` in here and in `captureFromProvider` is inside the span.
+ */
+async function readInventory(context: AgentToolContext): Promise<AgentContextCapture> {
   const plan = CATALOG_PLANS[context.connection.type];
   const nowMs = context.clock?.() ?? Date.now();
   // No composed catalog for this dialect, which used to end the capture here with
@@ -455,17 +527,31 @@ export async function captureContextSnapshot(context: AgentToolContext): Promise
 
   const rows = new Map<AgentCatalogKind, readonly Record<string, unknown>[]>();
 
-  for (const kind of plan.kinds) {
-    const outcome = await readCatalogForGrounding(context, { kind });
-    if (outcome.kind !== "completed") return unavailable("CATALOG_READ_REFUSED", outcome.modelText);
-    const artifact = context.artifacts.get(outcome.artifact.correlationId, nowMs);
-    if (artifact === undefined) {
-      return unavailable(
-        "CATALOG_RESULT_UNAVAILABLE",
-        `The ${kind} inventory was read but its rows are no longer held by this run.`,
-      );
+  // The same catch the provider path has, and B48 is the record of it having been
+  // absent here: a failure raised BEFORE the statement left — an unreachable host, a
+  // wrong password, a refused execution profile — propagates out of
+  // `readCatalogForGrounding` by design (`tools.ts`), so on PostgreSQL and SQLite it
+  // ended the whole run `internal`, or `engine-unsupported` on the profile error,
+  // where the same environment on the other nine engines lost only the grounding.
+  // `environmentFailure` is shared with `captureFromProvider` so the two paths cannot
+  // come to answer one environment in two voices.
+  try {
+    for (const kind of plan.kinds) {
+      const outcome = await readCatalogForGrounding(context, { kind });
+      if (outcome.kind !== "completed") return unavailable("CATALOG_READ_REFUSED", outcome.modelText);
+      const artifact = context.artifacts.get(outcome.artifact.correlationId, nowMs);
+      if (artifact === undefined) {
+        return unavailable(
+          "CATALOG_RESULT_UNAVAILABLE",
+          `The ${kind} inventory was read but its rows are no longer held by this run.`,
+        );
+      }
+      rows.set(kind, artifact.value.rows);
     }
-    rows.set(kind, artifact.value.rows);
+  } catch (error) {
+    const failure = environmentFailure(error, context);
+    if (failure === null) throw error;
+    return failure;
   }
 
   const tables = finalize(plan.build(rows));
@@ -509,8 +595,9 @@ export async function captureContextSnapshot(context: AgentToolContext): Promise
  * complete is the failure this module exists to avoid, and it is no less one for
  * having been read a second way.
  *
- * A failure raised BEFORE the reading left is caught here and becomes an unavailable
- * capture, rather than propagating and ending the run. That is a decision, and the
+ * A failure raised BEFORE the reading left becomes an unavailable capture, rather than
+ * propagating and ending the run — `environmentFailure` is where that is read, and the
+ * composed path asks it too now (B48). That is a decision, and the
  * reason is what plan mode promises: it opens and answers on every engine, and it did
  * on these nine before this change, because nothing was reached at all. Letting an
  * unreachable host, a wrong password, a refused `connect()` or an `ExecutionProfileError`
@@ -524,10 +611,10 @@ export async function captureContextSnapshot(context: AgentToolContext): Promise
  * a `TypeError` here is this server's bug and must not be reported to a user as a
  * property of their database.
  *
- * The COMPOSED path still propagates such a failure, and this change deliberately
- * leaves it alone: PostgreSQL and SQLite have never reached this line and changing
- * their failure mode is not what #414 is about. The asymmetry is filed in
- * `docs/BACKLOG.md` rather than resolved here.
+ * The COMPOSED path answers the same environment the same way, which it did not when
+ * this was written: #414 left PostgreSQL and SQLite propagating such a failure on the
+ * argument that they had never reached this line, and B48 is the record of a reader
+ * tripping over the asymmetry. Both paths now read it through `environmentFailure`.
  *
  * Neither sentence carries the error's own message. `detail` is spliced into the note
  * a plan run reads as the server's own voice, and a driver message is text the database
@@ -539,19 +626,9 @@ async function captureFromProvider(context: AgentToolContext, nowMs: number): Pr
   try {
     read = await readProviderSchemaForGrounding(context);
   } catch (error) {
-    if (error instanceof ExecutionProfileError) {
-      return unavailable(
-        "CATALOG_READ_REFUSED",
-        `This server could not open a connection to this ${context.connection.type} database under the execution profile a grounding read takes, so its schema was not read for this run.`,
-      );
-    }
-    if (error instanceof DatabaseError) {
-      return unavailable(
-        "CATALOG_READ_REFUSED",
-        `This run could not reach this ${context.connection.type} database to ask it for its schema, so nothing was read for this run.`,
-      );
-    }
-    throw error;
+    const failure = environmentFailure(error, context);
+    if (failure === null) throw error;
+    return failure;
   }
   if (read.kind === "timed-out") {
     return unavailable(
@@ -572,6 +649,38 @@ async function captureFromProvider(context: AgentToolContext, nowMs: number): Pr
       readVia: "provider-inventory",
     },
   };
+}
+
+/**
+ * An environment failure read as an unavailable capture, or `null` when it is not one.
+ *
+ * BOTH grounding paths ask this, which is the whole of B48: the same unreachable host
+ * lost only the grounding on the nine provider-path engines and lost the RUN on
+ * PostgreSQL and SQLite, and the difference was one catch block. One reading rather
+ * than two also means the sentence a plan run is shown does not depend on which route
+ * its dialect takes.
+ *
+ * Two classes and no others. Anything else is this server's bug — a `TypeError` here is
+ * not a property of the user's database and must not be reported to them as one — so it
+ * is handed back for the caller to rethrow rather than swallowed.
+ *
+ * Neither sentence carries the error's own message: `detail` is spliced into a note the
+ * run reads as the server's own voice, and a driver message is text the database wrote.
+ */
+function environmentFailure(error: unknown, context: AgentToolContext): AgentContextCapture | null {
+  if (error instanceof ExecutionProfileError) {
+    return unavailable(
+      "CATALOG_READ_REFUSED",
+      `This server could not open a connection to this ${context.connection.type} database under the execution profile a grounding read takes, so its schema was not read for this run.`,
+    );
+  }
+  if (error instanceof DatabaseError) {
+    return unavailable(
+      "CATALOG_READ_REFUSED",
+      `This run could not reach this ${context.connection.type} database to ask it for its schema, so nothing was read for this run.`,
+    );
+  }
+  return null;
 }
 
 /**

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -122,6 +122,7 @@ import {
 import {
   AGENT_WORKFLOW_PRESENTS_ANSWER,
   type AgentContextSnapshot,
+  type AgentGuidanceNotice,
   type AgentReportClaim,
   type AgentRunEvent,
   type AgentRunMode,
@@ -2411,6 +2412,44 @@ type CallResult =
  *         anything — cannot reach the database at all. Same reasoning: the run stays
  *         running because the failure is not the run's own decision.
  */
+/**
+ * How many times each notice has already been delivered to this run (B51).
+ *
+ * The half of B51 that makes "once" mean once. Every notice bound is a `let` inside
+ * `runInvestigation`, and that function is also what RESUMES a run a dead process left
+ * running — so a resumed drive started with every flag false and could deliver a notice
+ * the previous drive had already delivered. Two of the three had a partial durable guard
+ * by accident, and only by accident: the present-before-report notice read `answer-composed`
+ * off the ledger, which meant a run whose `present_answer` was REFUSED writes no event and
+ * was told again.
+ *
+ * It reads BOTH kinds that carry a notice id, because a delivery lands on the entry that
+ * records what happened to the call: a sentence sent as a `user` message writes
+ * `guidance-issued`, and one sent INSTEAD of running a call is the `notice` on that hold.
+ * A `call-held` with no notice on it — a verdict-preview hold, or an entry written before
+ * the field existed — counts towards nothing, which is the honest reading: it says a hold
+ * happened, not which sentence it carried.
+ *
+ * A total record rather than a lookup that can answer `undefined`, so a new notice id
+ * cannot be added to `AgentGuidanceNotice` and silently read as "never delivered" here.
+ */
+export function guidanceDelivered(events: readonly AgentRunEvent[]): Readonly<Record<AgentGuidanceNotice, number>> {
+  const counts: Record<AgentGuidanceNotice, number> = {
+    "report-reminder": 0,
+    "plan-statement": 0,
+    "report-reserve": 0,
+    "unread-stop": 0,
+    "present-before-report": 0,
+    "cite-what-you-read": 0,
+    "compare-before-report": 0,
+  };
+  for (const event of events) {
+    if (event.kind === "guidance-issued") counts[event.notice] += 1;
+    else if (event.kind === "call-held" && event.notice !== undefined) counts[event.notice] += 1;
+  }
+  return counts;
+}
+
 export async function runInvestigation(
   runId: string,
   options: AgentInvestigationOptions,
@@ -2577,8 +2616,15 @@ export async function runInvestigation(
     let narrowedAtEvent = Number.POSITIVE_INFINITY;
     /** Whether this drive has already re-asked an empty turn; see `retryEmptyTurn`. */
     let emptyTurnRetried = false;
-    /** Whether this drive has already answered a stop that read nothing; see `retryUnreadStop`. */
-    let unreadStopRetried = false;
+    /*
+    Every notice this run has already been delivered, read once (B51). The counters it
+    seeds are declared in two places — this one and the block before the turn loop — and
+    both are bounds on the RUN rather than on the drive, which is the whole point of
+    reading them back.
+    */
+    const delivered = guidanceDelivered(record.events);
+    /** Whether this RUN has already answered a stop that read nothing; see `retryUnreadStop`. */
+    let unreadStopRetried = delivered["unread-stop"] > 0;
     const priorProgress = describePriorProgress(record);
     if (priorProgress !== null) messages.push({ role: "user", content: priorProgress });
 
@@ -2676,6 +2722,10 @@ export async function runInvestigation(
         reasonCode: capture.reasonCode,
         detail: capture.detail,
         ...(capture.rowBudget === undefined ? {} : { rowBudget: capture.rowBudget }),
+        // What the refused reading cost anyway (B13). Spread rather than defaulted: a
+        // capture that carries no measurement records none, because a zero here would
+        // say the refusal was free.
+        ...(capture.charged === undefined ? {} : { charged: capture.charged }),
       });
     };
 
@@ -2687,6 +2737,33 @@ export async function runInvestigation(
       // own earlier drive, and telling the model otherwise would be a false
       // self-description of exactly the kind this mode keeps being caught in.
       const readBy: PlanningGrounding["readBy"] = held === null ? "this-run" : "earlier-run";
+
+      if (held !== null) {
+        /*
+          The reading this run took instead of taking one of its own, written down (B56).
+
+          `heldSnapshotForConnection` has no expiry, so a plan run can be grounded on an
+          inventory read before the user added the collection they are asking about — and
+          until this entry such a run's ledger held NOTHING between the drive starting and
+          the run ending, which reads as a run that needed no grounding. The model is
+          already told (`readBy: "earlier-run"`); this tells the record, with the one fact
+          the model is not given because it cannot act on it: how old the reading is.
+
+          The age is measured HERE, against this drive's own clock, because the entry is
+          about the moment of reuse. `Math.max` guards the only way in a negative could
+          arrive — a clock reading that went backwards — rather than recording an age that
+          says the reading has not been taken yet.
+        */
+        await service.recordEvent(runId, {
+          kind: "context-reused",
+          fingerprint: held.fingerprint,
+          tableCount: held.tables.length,
+          ageMs: Math.max(0, (context.clock?.() ?? Date.now()) - held.capturedAtMs),
+          // The same noun the capture entry records, and from the same source: what this
+          // engine calls these rows is part of what the run was shown.
+          noun: engine.noun,
+        });
+      }
 
       if (snapshot === null) {
         const capture = await captureContextSnapshot(context);
@@ -2709,6 +2786,9 @@ export async function runInvestigation(
           // The same noun this run's own prompt blocks are written with, recorded
           // where the timeline can read it: the rail has no provider to ask.
           noun: engine.noun,
+          // And what the reading cost, so the meter is not short by the two or three
+          // catalog statements this run has already spent (B13).
+          ...(capture.charged === undefined ? {} : { charged: capture.charged }),
         });
       }
       // After the ledger on the capture path, for the reason the agent path records:
@@ -2870,6 +2950,8 @@ export async function runInvestigation(
         // As on the planning path: what the engine calls these rows is part of what was
         // read, so it is written down with the reading rather than guessed at later.
         noun: engine.noun,
+        // As on the planning path, and for the same reason (B13).
+        ...(capture.charged === undefined ? {} : { charged: capture.charged }),
       });
       // After the ledger, never before it: what a plan run may later be handed is an
       // inventory that is durably part of some run's own history, not one this process
@@ -2882,16 +2964,21 @@ export async function runInvestigation(
     let turns = 0;
     let text = "";
     /*
-    The three notice flags below are one-shots per DRIVE, not per run, and the
-    distinction is worth stating where they are declared: this function is also what
-    RESUMES a run a dead process left running (`service.resume`, at its head), so a
-    resumed drive starts with all three false and can say again what the previous drive
-    already said. Nothing durable bounds them, because a delivery writes no ledger entry
-    — `docs/BACKLOG.md` B51 records both halves as one item, since recording delivery is
-    what would make "once" mean once.
+    The notice bounds below are per RUN and not per drive, and that is what B51 changed.
+
+    This function is also what RESUMES a run a dead process left running (`service.resume`,
+    at its head), so every one of these used to start false on a resumed drive and could
+    say again what the previous drive already said — and nothing durable bounded them,
+    because a delivery wrote no ledger entry at all. Now every delivery is recorded under a
+    name from one vocabulary (`AgentGuidanceNotice`) and the counters are SEEDED from what
+    this run's ledger already holds. A drive that is not a resume reads zeroes, which is
+    exactly what it used to start with.
+
+    What is NOT seeded is `anyToolCalled` and the narrowing: those are read from the run's
+    own settled steps and its event count, and are not deliveries.
     */
-    /** The reserve notice is a one-shot: a drive tells the run once that it is out of room. */
-    let reserveAnnounced = false;
+    /** The reserve notice is a one-shot: a run is told once that it is out of room. */
+    let reserveAnnounced = delivered["report-reserve"] > 0;
     /** Whether a tool this run HOLDS has been called; see `remindToReport`. */
     let anyToolCalled = false;
     /**
@@ -2905,17 +2992,17 @@ export async function runInvestigation(
      * A count rather than a flag because the limit is the model's, not the drive's:
      * `reportReminderLimitFor` reads it, and it is 1 for every model but one.
      */
-    let reportReminders = 0;
-    /** The present-before-report notice, once per drive; see `notices.presentBeforeReport`. */
-    let presentReminders = 0;
-    /** The compare-before-report notice, once per drive; see `compareBeforeReportNotice`. */
-    let compareReminders = 0;
-    /** The cite-what-you-read notice, once per drive; see `citeWhatYouReadNotice`. */
-    let citeReminded = false;
+    let reportReminders = delivered["report-reminder"];
+    /** The present-before-report notice; see `notices.presentBeforeReport`. */
+    let presentReminders = delivered["present-before-report"];
+    /** The compare-before-report notice, once per run; see `compareBeforeReportNotice`. */
+    let compareReminders = delivered["compare-before-report"];
+    /** The cite-what-you-read notice, once per run; see `citeWhatYouReadNotice`. */
+    let citeReminded = delivered["cite-what-you-read"] > 0;
     /** How many times a report has been held for the verdict it would earn; see `shortfallsIfReported`. */
     let previewHolds = 0;
-    /** How many times this drive has asked a PLAN run for its statement; see `askForPlanStatement`. */
-    let planStatementAsks = 0;
+    /** How many times this run has been asked for its statement; see `askForPlanStatement`. */
+    let planStatementAsks = delivered["plan-statement"];
     /**
      * Whether the run has been narrowed to what would finish it; see
      * `AGENT_NARROWED_EXTRA_TOOLS`. Set once and never cleared — a run narrowed for
@@ -2925,6 +3012,23 @@ export async function runInvestigation(
     let narrowed = false;
     /** Tool calls made so far, which is what this model's own ceiling is read against. */
     let toolCallsMade = 0;
+
+    /**
+     * Records a sentence the drive said on a turn where it refused nothing (B51).
+     *
+     * One function for all of them, because the fields are not the caller's to choose:
+     * every such delivery is the same fact — this notice, at this point in the run — and a
+     * site that recorded the id and forgot where it landed would be the gap this closes
+     * reopening one field at a time. A hold is the other delivery shape and records itself,
+     * on the `call-held` entry that says the call was not run.
+     *
+     * The counters are the drive's own at the moment of delivery, which is what makes the
+     * entry answer the question `docs/llms/` asks of a ledger: a reminder on the second
+     * turn and one on the last are different facts about a model.
+     */
+    const issueGuidance = async (notice: AgentGuidanceNotice): Promise<void> => {
+      await service.recordEvent(runId, { kind: "guidance-issued", notice, atTurn: turns, toolCalls: toolCallsMade });
+    };
 
     /**
      * Tells the run, once, that it has come within the reserve of a ceiling.
@@ -2940,7 +3044,7 @@ export async function runInvestigation(
       if (maxTurns - turns > AGENT_REPORT_RESERVE_TURNS && remainingMs > AGENT_REPORT_RESERVE_MS) return;
       reserveAnnounced = true;
       messages.push({ role: "user", content: notice(AGENT_REPORT_RESERVE_NOTICE) });
-      await service.recordEvent(runId, { kind: "guidance-issued", notice: "report-reserve" });
+      await issueGuidance("report-reserve");
     };
 
     /**
@@ -2966,12 +3070,25 @@ export async function runInvestigation(
      * It cost real time to lack: a notice measured as having no effect on two models could
      * not be told apart from a notice that never fired, because neither leaves a trace.
      */
-    const holdCall = async (tool: AgentToolName, reason: string, shortfall?: AgentGoalShortfall): Promise<void> => {
+    const holdCall = async (
+      tool: AgentToolName,
+      reason: string,
+      shortfall?: AgentGoalShortfall,
+      /*
+        Which NOTICE the hold answered with (B51). The three purpose-written sentences are
+        deliveries of a named notice and are bounded across a resume by this entry; the
+        verdict-preview holds speak for a `shortfall` instead and pass none, which is why
+        this is a parameter and not derived from `reason` — two of the three name artifact
+        ids, so the prose cannot be matched against later.
+      */
+      notice?: AgentGuidanceNotice,
+    ): Promise<void> => {
       await service.recordEvent(runId, {
         kind: "call-held",
         tool,
         reason,
         ...(shortfall === undefined ? {} : { shortfall }),
+        ...(notice === undefined ? {} : { notice }),
       });
     };
 
@@ -2987,7 +3104,7 @@ export async function runInvestigation(
       narrowed = true;
       messages.push(...assistant);
       messages.push({ role: "user", content: notice(BASELINE_NOTICES.reportReminder) });
-      await service.recordEvent(runId, { kind: "guidance-issued", notice: "report-reminder" });
+      await issueGuidance("report-reminder");
       return true;
     };
 
@@ -3012,7 +3129,7 @@ export async function runInvestigation(
       planStatementAsks += 1;
       messages.push(...assistant);
       messages.push({ role: "user", content: notice(BASELINE_NOTICES.planStatement) });
-      await service.recordEvent(runId, { kind: "guidance-issued", notice: "plan-statement" });
+      await issueGuidance("plan-statement");
       return true;
     };
 
@@ -3290,7 +3407,7 @@ export async function runInvestigation(
           unreadStopRetried = true;
           messages.push(...turn.assistantMessages);
           messages.push({ role: "user", content: notice(BASELINE_NOTICES.unreadStop) });
-          await service.recordEvent(runId, { kind: "guidance-issued", notice: "unread-stop" });
+          await issueGuidance("unread-stop");
           return null;
         }
         return conclude("succeeded", "model-stopped");
@@ -3306,7 +3423,7 @@ export async function runInvestigation(
         if (reportReminders === 0) {
           reportReminders += 1;
           messages.push({ role: "user", content: notice(BASELINE_NOTICES.reportReminder) });
-          await service.recordEvent(runId, { kind: "guidance-issued", notice: "report-reminder" });
+          await issueGuidance("report-reminder");
         }
       }
 
@@ -3384,7 +3501,7 @@ export async function runInvestigation(
             // This model's own wording, from its own file.
             const text = BASELINE_NOTICES.presentBeforeReport;
             presentReminders += 1;
-            await holdCall(call.toolName, text);
+            await holdCall(call.toolName, text, undefined, "present-before-report");
             messages.push(prompted ? promptedResultMessage(call, notice(text)) : toolResultMessage(call, text));
             continue;
           }
@@ -3487,7 +3604,7 @@ export async function runInvestigation(
             const offer = useful.length > 0 ? useful : [...held.keys()];
             citeReminded = true;
             const text = citeWhatYouReadNotice(offer, citedOnlyEmpty);
-            await holdCall(call.toolName, text);
+            await holdCall(call.toolName, text, undefined, "cite-what-you-read");
             messages.push(prompted ? promptedResultMessage(call, notice(text)) : toolResultMessage(call, text));
             continue;
           }
@@ -3533,7 +3650,7 @@ export async function runInvestigation(
                 : compareBeforeReportNotice(before, after);
           if (text !== null) {
             compareReminders += 1;
-            await holdCall(call.toolName, text);
+            await holdCall(call.toolName, text, undefined, "compare-before-report");
             messages.push(prompted ? promptedResultMessage(call, notice(text)) : toolResultMessage(call, text));
             continue;
           }

--- a/src/lib/agent/model-tuning/index.ts
+++ b/src/lib/agent/model-tuning/index.ts
@@ -17,8 +17,10 @@
  * field to it. Half of one measurement beside half of another is a configuration nobody has ever
  * run, and it would resolve without anybody being able to say what it was.
  *
- * A BAD OPERATOR DOCUMENT IS IGNORED, AND SAYS SO. It is refused whole, the bundled document
- * stands — which is a measured configuration, where a half-applied one is not — and the reason is
+ * A BAD OPERATOR DOCUMENT IS IGNORED, AND SAYS SO. Whole where nothing in it survives — bad JSON,
+ * a wrong `schemaVersion`, an unreadable path — and per ENTRY otherwise: an entry that does not
+ * read is dropped and reported by id, and the entries beside it apply (`schema.ts` rule 3). Where
+ * the document is refused whole the bundled document stands — which is a measured configuration, where a half-applied one is not — and the reason is
  * both logged AND returned by `operatorTuningStatus()`. Two surfaces because they answer to
  * different people: the log is for whoever is tailing it at the moment it happens, and the status
  * is for the operator who mounted a file, sees the shipped behaviour instead, and has to find out
@@ -59,6 +61,15 @@ export type OperatorTuningStatus =
        * an operator's `retryEmtpyTurn` would do nothing and say nothing.
        */
       readonly ignoredKeys: readonly string[];
+      /**
+       * Entries that did not read, by id, and so were not applied — `"<id>: <what was wrong>"`.
+       *
+       * Reported for the reason `ignoredKeys` is: the document was applied AROUND them, and
+       * `models` above counts what DID apply, so without this an entry would vanish silently.
+       * Empty is the ordinary case, and it is not the same statement as an absent field: this is
+       * present on every applied document, so an empty list means every entry read.
+       */
+      readonly skippedEntries: readonly string[];
       /**
        * SHA-256 of the document's bytes AS READ.
        *
@@ -143,12 +154,16 @@ export function activeTuning(): ModelTuning {
     measuredAgainst: base.measuredAgainst,
     undocumentedOverrides: [...base.undocumentedOverrides, ...read.doc.undocumentedOverrides],
     ignoredKeys: read.doc.ignoredKeys,
+    skippedEntries: read.doc.skippedEntries,
   };
+  // `applied` even when every entry was skipped: the document parsed and was layered on, which is
+  // a different fact from `ignored`, and `models` plus `skippedEntries` say exactly what it added.
   operatorStatus = {
     state: "applied",
     path,
     models: Object.keys(read.doc.models).length,
     ignoredKeys: read.doc.ignoredKeys,
+    skippedEntries: read.doc.skippedEntries,
     digest: read.digest,
   };
   logger.info("Operator model tuning applied over the measurements Studio ships with", {
@@ -156,6 +171,7 @@ export function activeTuning(): ModelTuning {
     path,
     models: operatorStatus.models,
     ignoredKeys: read.doc.ignoredKeys.length,
+    skippedEntries: read.doc.skippedEntries.length,
   });
   return active;
 }

--- a/src/lib/agent/model-tuning/schema.ts
+++ b/src/lib/agent/model-tuning/schema.ts
@@ -30,9 +30,14 @@
  *    "undocumented overrides" at once. That the recorded and compiled defaults still agree is
  *    its own assertion, in its own test, where the failure is a question for a person.
  *
- * 3. ALL OR NOTHING. A document that fails anywhere is refused entirely. Partial acceptance
- *    would leave a run driven by a configuration that is half one source and half another, which
- *    is a combination nobody has ever measured.
+ * 3. ALL OR NOTHING, PER ENTRY. An entry is taken whole or not at all: partial acceptance would
+ *    leave a run driven by a configuration that is half one source and half another, which is a
+ *    combination nobody has ever measured. That is an argument about MERGING, so it protects
+ *    whole-ENTRY replacement and nothing wider. Studio's own document is still refused whole,
+ *    because a fault in it is a repo fault this suite catches before anybody runs it; a document
+ *    from outside applies the entries that read and reports the rest — a fifty-model document
+ *    used to lose all fifty to a typo in the thirty-seventh, and once these are published as a
+ *    catalog that failure lands on everyone who mounted it.
  */
 import { z } from "zod";
 import type { AgentRunWorkflowType } from "../types";
@@ -230,7 +235,15 @@ const operatorDocumentSchema = z.strictObject({
     a compiled default moves. The discipline belongs to the document this repository writes.
   */
   measuredAgainst: operatorMeasuredAgainstSchema.optional(),
-  models: z.array(operatorModelSchema),
+  /*
+    UNREAD here, and validated one entry at a time in `parseOperatorTuning`.
+
+    `z.array(operatorModelSchema)` fails the array on its first bad element, which is the
+    whole-document rejection this document is not held to any more (rule 3). The envelope around
+    the entries stays strict: a wrong `schemaVersion` means Studio cannot say what ANY entry in the
+    file means, and a `models` that is not an array leaves nothing to walk.
+  */
+  models: z.array(z.unknown()),
 });
 
 type TuningDocument = z.infer<typeof documentSchema>;
@@ -271,6 +284,15 @@ export interface ModelTuning {
    * was for. So it is reported, and `GET /api/agent/config` carries it to the operator.
    */
   readonly ignoredKeys: readonly string[];
+  /**
+   * `"<id>: <what was wrong>"` for every entry that did not read, and so was not applied.
+   *
+   * Always empty for the bundled document, which is refused whole rather than walked around. It
+   * exists for the same reason `ignoredKeys` does, one level up: the document was applied AROUND
+   * the fault, so an entry that vanished silently would be the quietness the strict schema was
+   * written to prevent. Named by `id`, or by `#<position>` when the id is itself what is wrong.
+   */
+  readonly skippedEntries: readonly string[];
 }
 
 /** Every setting a model may state, so the justification rule can walk them by name. */
@@ -349,8 +371,13 @@ interface ReadDocument {
   }[];
 }
 
-/** Turns a validated document into the register, applying the rules that do not depend on origin. */
-function assemble(doc: ReadDocument, origin: string): ModelTuning {
+/**
+ * Turns a validated document into the register, applying the rules that do not depend on origin.
+ *
+ * `skipped` is passed in rather than produced here: only the operator path walks entries one at a
+ * time, and Studio's own document reaches this with every entry already known to read.
+ */
+function assemble(doc: ReadDocument, origin: string, skipped: readonly string[] = []): ModelTuning {
   const models: Record<string, AgentModelProfile> = {};
   /** Collected rather than thrown on; see rule 2 in this file's header. */
   const unjustified: string[] = [];
@@ -383,13 +410,37 @@ function assemble(doc: ReadDocument, origin: string): ModelTuning {
     measuredAgainst: doc.measuredAgainst,
     undocumentedOverrides: unjustified,
     ignoredKeys: ignored,
+    skippedEntries: skipped,
   };
 }
 
-function refuse(origin: string, error: z.ZodError): never {
+/**
+ * The first issue as `"<path>: <message>"`.
+ *
+ * Shared by the whole-document refusal and by a skipped entry, so the two read alike: an operator
+ * comparing a refusal to a skip is looking at the same fault described the same way.
+ */
+function firstIssue(error: z.ZodError): string {
   const first = error.issues[0];
   const where = first === undefined ? "unknown" : first.path.join(".");
-  throw new ModelTuningError(origin, `${where}: ${first?.message ?? "invalid"}`);
+  return `${where}: ${first?.message ?? "invalid"}`;
+}
+
+function refuse(origin: string, error: z.ZodError): never {
+  throw new ModelTuningError(origin, firstIssue(error));
+}
+
+/**
+ * How an entry that did not read is named.
+ *
+ * By `id` wherever there is one, because that is the string the operator wrote and the one they
+ * will search the file for. By POSITION when the id is itself what is wrong — `#3` is checkable,
+ * where inventing an id would name a model nobody configured. The entry is `unknown` at this
+ * point, so a bare number or a `null` in the array reaches here and must not throw.
+ */
+function entryLabel(entry: unknown, index: number): string {
+  const id = (entry as { id?: unknown } | null | undefined)?.id;
+  return typeof id === "string" && id.length > 0 ? id : `#${index}`;
 }
 
 /**
@@ -414,5 +465,33 @@ export function parseTuning(document: unknown, origin: string): ModelTuning {
 export function parseOperatorTuning(document: unknown, origin: string): ModelTuning {
   const parsed = operatorDocumentSchema.safeParse(document);
   if (!parsed.success) refuse(origin, parsed.error);
-  return assemble(parsed.data as ReadDocument, origin);
+
+  const models: ReadDocument["models"][number][] = [];
+  const skipped: string[] = [];
+  /** Lower-cased, because the register is keyed that way and two spellings are one entry. */
+  const seen = new Set<string>();
+
+  for (const [index, entry] of parsed.data.models.entries()) {
+    const read = operatorModelSchema.safeParse(entry);
+    if (!read.success) {
+      skipped.push(`${entryLabel(entry, index)}: ${firstIssue(read.error)}`);
+      continue;
+    }
+    const key = read.data.id.toLowerCase();
+    // Skipped rather than last-wins, for the reason `assemble` throws on Studio's own: two
+    // spellings of one id is a document nobody can read, and collapsing them would apply settings
+    // the other entry argues against. Only the blast radius changes.
+    if (seen.has(key)) {
+      skipped.push(`${read.data.id}: appears twice`);
+      continue;
+    }
+    seen.add(key);
+    models.push(read.data as ReadDocument["models"][number]);
+  }
+
+  return assemble(
+    { measuredAgainst: parsed.data.measuredAgainst as RecordedBasis | undefined, models },
+    origin,
+    skipped,
+  );
 }

--- a/src/lib/agent/provider-registry.ts
+++ b/src/lib/agent/provider-registry.ts
@@ -31,13 +31,14 @@
  * `responses()` is deliberately not used: it is OpenAI's own API shape and a
  * self-hosted OpenAI-compatible endpoint does not serve it.
  *
- * Gemini deliberately does NOT take `LLM_API_URL`: `src/lib/llm/providers/gemini.ts`
- * ignores it, and `.env.example` documents the variable as needed for the Ollama
- * and custom kinds only. Honouring it here would mean a value left over from a
- * custom setup silently redirects Gemini traffic — carrying the configured key —
- * to that host on the agent path while the chat surface still talks to Google.
- * Same variables, same precedence means matching what the chat surface does with
- * them, not just where they come from.
+ * Gemini takes `LLM_API_URL` too, on both surfaces at once (B20): the chat
+ * provider passes it as this SDK family's origin-shaped `RequestOptions.baseUrl`
+ * and this adapter passes the versioned form `@ai-sdk/google` expects, both
+ * derived from the one variable by `src/lib/llm/utils/gemini-endpoint.ts`. Same
+ * variables, same precedence means matching what the chat surface does with them,
+ * not just where they come from — and the earlier arrangement, where only the
+ * OpenAI-compatible kinds read the variable, meant an operator behind an egress
+ * proxy configured Gemini, saw no error, and was routed to Google anyway.
  *
  * Not here: an Anthropic kind. Its package is ratified and installed, but the
  * settings surface has no `anthropic` kind, and adding one is a change to
@@ -49,6 +50,7 @@
 
 import type { LanguageModel } from "ai";
 import { type LLMConfig, type LLMProviderType, LLMConfigError } from "@/lib/llm/types";
+import { resolveGeminiSdkBaseUrl } from "@/lib/llm/utils/gemini-endpoint";
 
 /**
  * A constructed model instance.
@@ -139,8 +141,10 @@ async function createGeminiModel(config: LLMConfig, fetchImpl?: AgentFetch): Pro
     // is unreachable and no test pins it; it exists so the `string | undefined`
     // the type allows can never reach the SDK and re-open its env fallback.
     apiKey: config.apiKey ?? "",
-    // No baseURL: see the header. Leaving it undefined selects the SDK's own
-    // Google endpoint, and this provider has no base-URL env fallback to leak into.
+    // The versioned spelling this SDK expects; undefined when nothing is
+    // configured, which selects the SDK's own Google endpoint. That is safe here
+    // because this provider has no base-URL env fallback to leak into.
+    baseURL: resolveGeminiSdkBaseUrl(config.apiUrl),
     fetch: asSdkFetch(fetchImpl),
   }).chat(config.model);
 }

--- a/src/lib/agent/run-service.ts
+++ b/src/lib/agent/run-service.ts
@@ -94,6 +94,11 @@ export type AgentRunNarrativeEvent = Extract<
       // its own operation id, and this entry is the run's own account of being left
       // ungrounded.
       | "context-unavailable"
+      // The inventory the run did not read, because this process already held one (B56).
+      // Narrative for the same reason both entries above are: no catalog was read, no step
+      // was settled, and the run is recording where its ground came from — which is the one
+      // thing a reused inventory left no trace of.
+      | "context-reused"
       | "statement-drafted"
       | "report-composed"
       // A call the drive turned back, with what it asked for instead. It belongs here

--- a/src/lib/agent/run-store.ts
+++ b/src/lib/agent/run-store.ts
@@ -101,6 +101,7 @@ const EVENT_KINDS: ReadonlySet<string> = new Set(
     "run-started": true,
     "driver-resolved": true,
     "context-captured": true,
+    "context-reused": true,
     "context-unavailable": true,
     "statement-drafted": true,
     "tool-invoked": true,

--- a/src/lib/agent/table-profile.ts
+++ b/src/lib/agent/table-profile.ts
@@ -23,7 +23,10 @@
  *    the column NAME, and at `pattern` depth from the RATIO of values matching a
  *    shape — computed inside the database by a `count(CASE WHEN …)`, so the values
  *    that matched never leave it. Neither test establishes that a column holds
- *    personal data; both establish that it is worth a human looking.
+ *    personal data; both establish that it is worth a human looking. The shape tests
+ *    are PER-DIALECT predicates rather than one shared operator, because the shapes
+ *    worth suspecting are not all expressible in the intersection of the two
+ *    grammars (B26; see `PROFILE_SHAPES`).
  */
 
 import { quoteIdentifier } from "@/lib/sql/identifier";
@@ -41,9 +44,10 @@ export type AgentProfileDepth = "basic" | "distribution" | "pattern";
  * Columns one profile may cover.
  *
  * Bounded because the composed statement grows with it: at `pattern` depth each
- * column contributes four aggregates, so an unbounded table would compose a
- * statement whose cost nobody chose. A wider table is profiled in more than one
- * call, which the statement budget accounts for honestly.
+ * column contributes four aggregates — present, distinct and one per shape test — so
+ * an unbounded table would compose a statement whose cost nobody chose. A wider table
+ * is profiled in more than one call, which the statement budget accounts for
+ * honestly.
  */
 export const MAX_PROFILE_COLUMNS = 16;
 
@@ -89,18 +93,69 @@ const PII_NAME_WORDS: readonly string[] = Object.freeze([
 /** Declared types this module is willing to apply a text shape test to. */
 const TEXTUAL_TYPE = /char|text|string|clob|varying/i;
 
-/**
- * The one shape tested inside the database, so no matching value ever leaves it:
- * something, an `@`, something, a `.`, something.
- *
- * ONE shape, because `LIKE` is the only pattern operator both engines spell the
- * same way and `_` in it means "any character" rather than "any digit". A test for
- * a run of digits — a phone number, a national id — needs `~` on PostgreSQL and
- * `GLOB` on SQLite, so it is a dialect-specific predicate rather than a wider
- * pattern here, and it is deferred (`docs/BACKLOG.md` B26) instead of being
- * approximated by a length test that would match almost any text.
- */
+/** Dialects with a verified profile composition; enforced by `composeTableProfile`. */
+type ProfileDialect = "postgres" | "sqlite";
+
+/** Something, an `@`, something, a `.`, something. Both engines spell `LIKE` alike. */
 const EMAIL_SHAPE = "%_@_%._%";
+
+/**
+ * How many consecutive digits make a run worth suspecting.
+ *
+ * Nine, because that is the shortest of the identifiers `PII_NAME_WORDS` already
+ * names: an `ssn` is nine digits, and a `tckn`, a phone number or a `card` is longer.
+ * A shorter bound would start matching years, prices and quantities — the failure the
+ * earlier `LIKE '%_________%'` draft would have had for every text column.
+ */
+export const DIGIT_RUN_LENGTH = 9;
+
+/** SQLite has no quantifier, so the run is spelled out one class at a time. */
+const SQLITE_DIGIT_RUN = `*${"[0-9]".repeat(DIGIT_RUN_LENGTH)}*`;
+
+/** One value shape, and how each engine spells the test for it. */
+interface ProfileShape {
+  /** Alias prefix for this shape's count. Generated, never taken from a column name. */
+  readonly alias: string;
+  /** The app's own words for the shape, read back into a `suspected_pii` finding. */
+  readonly words: string;
+  /** The predicate, per dialect, over an already-quoted column reference. */
+  readonly predicate: Readonly<Record<ProfileDialect, (quotedColumn: string) => string>>;
+}
+
+/**
+ * The shapes tested inside the database, so no matching value ever leaves it.
+ *
+ * PER-DIALECT predicates rather than one shared `LIKE` (B26). `LIKE` is the only
+ * pattern operator both engines spell the same way, and `_` in it means "any
+ * character" rather than "any digit" — so a digit run cannot be expressed in the
+ * intersection at all, and an earlier draft's `LIKE '%_________%'` would have
+ * reported `suspected_pii` for essentially every text column. PostgreSQL spells the
+ * run `~ '[0-9]{9,}'` and SQLite spells it `GLOB '*[0-9]…*'`.
+ *
+ * Both spellings were run against live engines over the same four rows and returned
+ * the same counts — PostgreSQL 18 and SQLite 3.53 — so the two dialects agree about
+ * what a run is rather than merely both being accepted. The SQLite arm is executed
+ * end to end in `tests/unit/lib/agent/table-profile.test.ts`.
+ */
+const EMAIL_SHAPE_TEST: ProfileShape = Object.freeze({
+  alias: "shaped",
+  words: "an email address",
+  predicate: Object.freeze({
+    postgres: (quoted: string) => `${quoted} LIKE '${EMAIL_SHAPE}'`,
+    sqlite: (quoted: string) => `${quoted} LIKE '${EMAIL_SHAPE}'`,
+  }),
+});
+
+const DIGIT_RUN_SHAPE_TEST: ProfileShape = Object.freeze({
+  alias: "digits",
+  words: `a run of ${DIGIT_RUN_LENGTH} or more digits`,
+  predicate: Object.freeze({
+    postgres: (quoted: string) => `${quoted} ~ '[0-9]{${DIGIT_RUN_LENGTH},}'`,
+    sqlite: (quoted: string) => `${quoted} GLOB '${SQLITE_DIGIT_RUN}'`,
+  }),
+});
+
+const PROFILE_SHAPES: readonly ProfileShape[] = Object.freeze([EMAIL_SHAPE_TEST, DIGIT_RUN_SHAPE_TEST]);
 
 export type AgentProfileFindingCode =
   /** At least `HIGH_NULL_RATIO` of the rows have no value in this column. */
@@ -131,8 +186,10 @@ export interface AgentColumnProfile {
   readonly present: number;
   /** Distinct present values, at `distribution` depth and deeper. */
   readonly distinct?: number;
-  /** Rows whose value matches a personal-data shape, at `pattern` depth. */
+  /** Rows shaped like an email address, at `pattern` depth. */
   readonly shaped?: number;
+  /** Rows carrying a run of `DIGIT_RUN_LENGTH` or more digits, at `pattern` depth. */
+  readonly digitRun?: number;
 }
 
 export interface AgentTableProfile {
@@ -189,9 +246,9 @@ const isComparable = (column: ColumnSchema): boolean => !INCOMPARABLE_TYPE.test(
  * on a single table. Everything here is an aggregate over one scan, which is also
  * the shape an engine can plan best.
  *
- * `LIKE` is applied only to columns whose DECLARED type reads as textual: comparing
- * an integer column to a string pattern is an error on PostgreSQL, and casting
- * every column to text to avoid that would turn a bounded read into a full
+ * The shape tests are applied only to columns whose DECLARED type reads as textual:
+ * comparing an integer column to a string pattern is an error on PostgreSQL, and
+ * casting every column to text to avoid that would turn a bounded read into a full
  * conversion of the table.
  */
 export function composeTableProfile(
@@ -220,7 +277,10 @@ export function composeTableProfile(
     }
     if (selector.depth === "pattern" && isTextual(column)) {
       // Counted inside the database: the rows that matched are never returned.
-      parts.push(`count(CASE WHEN ${quoted} LIKE '${EMAIL_SHAPE}' THEN 1 END) AS ${alias("shaped", index)}`);
+      for (const shape of PROFILE_SHAPES) {
+        const test = shape.predicate[dialect](quoted);
+        parts.push(`count(CASE WHEN ${test} THEN 1 END) AS ${alias(shape.alias, index)}`);
+      }
     }
   });
 
@@ -257,12 +317,14 @@ export function readTableProfile(
 
   const profiled: AgentColumnProfile[] = columns.map((column, index) => {
     const distinct = count(row, alias("distinct", index));
-    const shaped = count(row, alias("shaped", index));
+    const shaped = count(row, alias(EMAIL_SHAPE_TEST.alias, index));
+    const digitRun = count(row, alias(DIGIT_RUN_SHAPE_TEST.alias, index));
     return {
       column: column.name,
       present: count(row, alias("present", index)) ?? 0,
       ...(distinct === undefined ? {} : { distinct }),
       ...(shaped === undefined ? {} : { shaped }),
+      ...(digitRun === undefined ? {} : { digitRun }),
     };
   });
 
@@ -274,6 +336,30 @@ const ratio = (part: number, whole: number): string => `${Math.round((part / who
 function namesPersonalData(column: string): boolean {
   const lowered = column.toLowerCase();
   return PII_NAME_WORDS.some((word) => lowered.includes(word));
+}
+
+/**
+ * The shapes that are the column's NORM rather than an accident, in the app's own
+ * words and carrying the ratio each was derived from.
+ *
+ * A shape the engine did not report is absent rather than zero, so a profile read at
+ * `basic` depth contributes no shape suspicion at all — which is exactly true.
+ */
+function matchedShapes(profile: AgentColumnProfile): readonly string[] {
+  if (profile.present < MIN_ROWS_FOR_RATIO_FINDINGS) return [];
+
+  const counted: readonly (readonly [number | undefined, string])[] = [
+    [profile.shaped, EMAIL_SHAPE_TEST.words],
+    [profile.digitRun, DIGIT_RUN_SHAPE_TEST.words],
+  ];
+
+  const matched: string[] = [];
+  for (const [matches, words] of counted) {
+    if (matches !== undefined && matches / profile.present >= PII_SHAPE_RATIO) {
+      matched.push(`${ratio(matches, profile.present)} of the values are shaped like ${words}`);
+    }
+  }
+  return matched;
 }
 
 /**
@@ -320,17 +406,15 @@ function deriveFindings(
       });
     }
 
-    const shapedEnough =
-      profile.shaped !== undefined &&
-      profile.present >= MIN_ROWS_FOR_RATIO_FINDINGS &&
-      profile.shaped / profile.present >= PII_SHAPE_RATIO;
-    if (declared !== undefined && (namesPersonalData(profile.column) || shapedEnough)) {
+    const shapes = matchedShapes(profile);
+    if (declared !== undefined && (namesPersonalData(profile.column) || shapes.length > 0)) {
       findings.push({
         code: "suspected_pii",
         column: profile.column,
-        detail: shapedEnough
-          ? `${ratio(profile.shaped ?? 0, profile.present)} of the values are shaped like an email address. No value was read out of the database to establish this.`
-          : "The column's name suggests personal data. Its values were not inspected to establish this.",
+        detail:
+          shapes.length > 0
+            ? `${shapes.join(", and ")}. No value was read out of the database to establish this.`
+            : "The column's name suggests personal data. Its values were not inspected to establish this.",
       });
     }
   });

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -47,7 +47,7 @@ import type { LLMProviderType } from "@/lib/llm/types";
 import type { PolicyDenyCode } from "@/lib/db/operations/policy";
 import type { AgentStatementViolation } from "@/lib/db/operations/statement-guard";
 import type { AgentChartSpec, DatabaseType, TableSchema } from "@/lib/types";
-import type { AgentContextRowBudget, AgentContextUnavailableCode } from "./context-snapshot";
+import type { AgentContextCharge, AgentContextRowBudget, AgentContextUnavailableCode } from "./context-snapshot";
 import type { AgentGoalShortfall, AgentGoalVerifierId } from "./goal-verifier";
 import type { AgentToolName } from "./tools";
 import type { AgentInventoryNoun } from "./inventory-noun";
@@ -577,6 +577,70 @@ interface AgentRunEventBase {
 }
 
 /**
+ * Every sentence the drive says to a run, named — and the ONE place a new one has to
+ * state itself (B51).
+ *
+ * Each notice is one-shot or count-bounded per DRIVE, and the flags that bound them are
+ * `let`s inside `runInvestigation` — which is also what RESUMES a run a dead process left
+ * running. So "once" meant once per drive, and a resumed drive could say again what the
+ * previous drive already said. The flags are now SEEDED from the deliveries the ledger
+ * already holds (`guidanceDelivered`), which is why every notice needs an id here: a
+ * delivery nothing records cannot bound anything.
+ *
+ * Two kinds of entry carry these ids, and which one a notice lands on follows from HOW it
+ * is delivered rather than from a second decision:
+ *
+ *  - a notice delivered as a `user` message, on a turn where nothing was refused, is a
+ *    `guidance-issued` entry — the drive said something and the model acts on it next
+ *    turn;
+ *  - a notice delivered as a TOOL RESULT, instead of running the call, is the `notice`
+ *    field of the `call-held` entry that already records the hold. A second entry for one
+ *    delivery would be the only place in this ledger where one thing writes twice, and the
+ *    rail would render both.
+ *
+ * The rail's own reading of these ids is `GUIDANCE_HEADLINE`; the wording lives in
+ * `models/notices.ts` and in `investigation.ts` for the two that name artifact ids.
+ */
+export type AgentGuidanceNotice =
+  /**
+   * A prose turn after a tool this run holds was called. Delivered as a `user` message,
+   * and the turn is taken again. Bounded by the model's own `reportReminderLimit`.
+   */
+  | "report-reminder"
+  /**
+   * A plan run whose prose named neither statement nor refusal. Delivered as a `user`
+   * message; bounded by the model's own `planStatementRetries`.
+   */
+  | "plan-statement"
+  /**
+   * A run within the turn or time reserve of a ceiling. Delivered as a `user` message
+   * riding the turn about to be taken; once per run.
+   */
+  | "report-reserve"
+  /**
+   * A run that stopped having read nothing, on a set holding both reading tools.
+   * Delivered as a `user` message; once per run, and only where the model's profile
+   * says the retry earned its turn.
+   */
+  | "unread-stop"
+  /**
+   * A `compose_report` on an answering workflow with a presentable read and no
+   * presentation. Delivered as a TOOL RESULT instead of running the call, so it rides
+   * the `call-held` entry; bounded by the model's own `presentReminderLimit`.
+   */
+  | "present-before-report"
+  /**
+   * A `compose_report` resting on no citation, or on nothing but empty readings.
+   * Delivered as a TOOL RESULT instead of running the call; once per run.
+   */
+  | "cite-what-you-read"
+  /**
+   * A `compose_report` from a run holding the two plans a comparison would use.
+   * Delivered as a TOOL RESULT instead of running the call; once per run.
+   */
+  | "compare-before-report";
+
+/**
  * The semantic events one run emits, in the vocabulary a user reads in the rail
  * and a resumed run replays. Deliberately coarse: one entry per thing that
  * HAPPENED, not per token or per SDK stream chunk.
@@ -662,6 +726,68 @@ export type AgentRunEvent =
        * claiming a vocabulary nobody recorded.
        */
       readonly noun?: AgentInventoryNoun;
+      /**
+       * What the reading COST this run, measured off the tracker around the capture
+       * (B13).
+       *
+       * The capture's catalog reads are charged against exactly the ceilings the rail
+       * shows and go through `executeAuditedOperation` rather than the run loop's
+       * `runStep`, which is the only writer of `tool-completed` — so a run that had
+       * spent three statements before its first model turn folded to a meter reading
+       * zero. This is what the fold adds instead of itemising reads it never saw.
+       *
+       * The tracker's own delta and not a count of the catalog kinds this dialect has:
+       * a denied read charges nothing while an acquisition failure charges a statement
+       * for a call that never ran, so a derived figure would state the reads the server
+       * INTENDED rather than the ones the run paid for.
+       *
+       * Optional, and the absence is the honest reading rather than a hedge: a ledger
+       * written before this field records a capture whose spend nobody measured, and a
+       * `{ statements: 0, elapsedMs: 0 }` there would state that the reading was free
+       * (#477). A reader folds an entry without one exactly as it always folded it.
+       */
+      readonly charged?: AgentContextCharge;
+    })
+  | (AgentRunEventBase & {
+      /**
+       * An inventory this run did not read, because the PROCESS already held one for
+       * its connection, and how old that reading was when this run took it (B56).
+       *
+       * `heldSnapshotForConnection` is consulted before any capture and has no expiry:
+       * newest reading wins, eviction is by use, nothing re-reads. Measured 2026-08-22,
+       * twice in one session — MongoDB's schema inference was changed, the schema tree
+       * showed the new dotted paths immediately, and two plan runs afterwards still
+       * grouped by the old field. Their ledgers carried NO context event at all, so the
+       * record could not distinguish "held, hours old" from "captured just now", and the
+       * only diagnosis available was restarting the process.
+       *
+       * Its own kind rather than a `context-captured`, for the reason
+       * `context-unavailable` is one: every reader that asks `kind === "context-captured"`
+       * treats the entry as this run's own reading — `reusableSnapshot` re-derives a
+       * snapshot from it and would hand a later drive an inventory this run never read,
+       * and the timeline would say "Schema captured" of a capture that did not happen.
+       *
+       * `ageMs` is what the entry exists for. The fingerprint says WHICH reading, and a
+       * user who has just added a collection needs to know it was taken before they did.
+       * It is the age at the moment of REUSE and not a timestamp difference a reader has
+       * to compute: the reading's own `capturedAtMs` belongs to whichever run captured it,
+       * and that run may not be in this ledger at all.
+       *
+       * No snapshot on the entry, deliberately. The inventory is not this run's reading,
+       * and recording it here would make `reusableSnapshot` reachable from a reuse — which
+       * is the reading that ages, so a resumed drive would keep re-deriving it for as long
+       * as the run lived.
+       */
+      readonly kind: "context-reused";
+      readonly fingerprint: string;
+      readonly tableCount: number;
+      /** How old the reading was when this run took it, in milliseconds. */
+      readonly ageMs: number;
+      /**
+       * What this engine calls the rows of that inventory, from the same source the
+       * capture entry takes it from (#414) and optional for the same reason.
+       */
+      readonly noun?: AgentInventoryNoun;
     })
   | (AgentRunEventBase & {
       /**
@@ -698,14 +824,23 @@ export type AgentRunEvent =
        * carries an engine's message.
        *
        * NOT recorded: the statements the capture composed, and no noun. The first
-       * belongs to the audit stream and to B13; the second describes rows, and there
-       * are none to describe.
+       * belongs to the audit stream — what those reads COST is a different question and
+       * `charged` answers it; the second describes rows, and there are none to describe.
        */
       readonly kind: "context-unavailable";
       readonly reasonCode: AgentContextUnavailableCode;
       readonly detail: string;
       /** Present only when the row budget is what refused it. */
       readonly rowBudget?: AgentContextRowBudget;
+      /**
+       * What the refused reading cost this run, measured off the tracker (B13).
+       *
+       * A refusal is not a free capture: the pipeline admitted the call, charged the
+       * statement and only then answered, and on the row-budget case the engine had
+       * already produced the rows. Same reading as the captured entry's, same reason for
+       * being optional there.
+       */
+      readonly charged?: AgentContextCharge;
     })
   | (AgentRunEventBase & {
       readonly kind: "statement-drafted";
@@ -750,6 +885,20 @@ export type AgentRunEvent =
       readonly tool: AgentToolName;
       readonly reason: string;
       readonly shortfall?: AgentGoalShortfall;
+      /**
+       * WHICH sentence the hold answered with, from the one vocabulary every delivery is
+       * named in (`AgentGuidanceNotice`, B51).
+       *
+       * `reason` is the prose the model was sent and names artifact ids in two of the
+       * three cases, so it cannot be matched against: a resumed drive reading it back to
+       * decide whether a notice had already been delivered would be pattern-matching a
+       * paragraph. This is the id that reading uses.
+       *
+       * Absent on the verdict-preview holds, which speak for a `shortfall` rather than for
+       * a notice, and on every entry written before the field existed — where the absence
+       * says "this delivery was not recorded under a name", not "no notice was sent".
+       */
+      readonly notice?: AgentGuidanceNotice;
     })
   | (AgentRunEventBase & {
       /**
@@ -834,7 +983,22 @@ export type AgentRunEvent =
        * badly and read as this server's own prose.
        */
       readonly kind: "guidance-issued";
-      readonly notice: "report-reminder" | "plan-statement" | "report-reserve" | "unread-stop";
+      readonly notice: AgentGuidanceNotice;
+      /**
+       * What the run had DONE when the sentence arrived (B51).
+       *
+       * The question `docs/llms/` exists to answer is "did this model do that by itself?",
+       * and after #416 and #417 a ledger could say a notice was delivered without saying
+       * where in the run it landed — a reminder on the second turn and one on the last are
+       * different facts about a model. Both figures are the drive's own counters at the
+       * moment of delivery.
+       *
+       * Optional, because a ledger written before they were recorded holds neither, and a
+       * zero would say the notice arrived before the run did anything.
+       */
+      readonly atTurn?: number;
+      /** Tool calls this run had made when it arrived. */
+      readonly toolCalls?: number;
     })
   | (AgentRunEventBase & {
       /**

--- a/src/lib/db-ui-config.ts
+++ b/src/lib/db-ui-config.ts
@@ -48,6 +48,9 @@ export interface DatabaseUIConfig {
   )[];
 }
 
+/** One addressing field, named by the same list that decides whether a save writes it. */
+export type ConnectionField = DatabaseUIConfig["connectionFields"][number];
+
 export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   postgres: {
     icon: PostgreSQLIcon,
@@ -129,7 +132,12 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     label: "Redis",
     defaultPort: "6379",
     showConnectionStringToggle: false,
-    connectionFields: ["host", "port", "password", "database"],
+    // `user` is the Redis 6 ACL user. It belongs here because `RedisProvider.connect()`
+    // authenticates with it (as ioredis's `username`) and docs/providers/redis.md has
+    // documented it as a connection field all along - this list was the one place that
+    // disagreed, and since it decides what a save WRITES, the value never reached the
+    // driver that #502 taught to send it.
+    connectionFields: ["host", "port", "user", "password", "database"],
   },
   oracle: {
     icon: OracleIcon,
@@ -302,4 +310,18 @@ export function getDBColor(type: DatabaseType): string {
 export function isFileBased(type: DatabaseType): boolean {
   const fields = DB_UI_CONFIG[type].connectionFields;
   return fields.length === 1 && fields[0] === "database";
+}
+
+/**
+ * Whether this engine takes a given addressing field at all.
+ *
+ * One list, two readers: `buildConnection` writes a field only when this says so, and the
+ * connection modal renders an input for it only when this says so. They used to disagree -
+ * the modal drew Username and Database for every networked engine while the write list
+ * discarded them - so libSQL asked for a user name it has none of, and Druid and the two
+ * search engines asked for a database they do not take. A box whose value is thrown away is
+ * the UI equivalent of reporting an absence as a measurement.
+ */
+export function takesConnectionField(type: DatabaseType, field: ConnectionField): boolean {
+  return DB_UI_CONFIG[type].connectionFields.includes(field);
 }

--- a/src/lib/db/base-provider.ts
+++ b/src/lib/db/base-provider.ts
@@ -61,30 +61,53 @@ const CREDENTIAL_PARAM_SUBSTRINGS = ["password", "token", "sslkey", "secret"];
  * Nothing here parses the input as a URL: a connection string is not always a valid one,
  * and a redaction that throws on the input it was handed is worse than none.
  *
- * What is NOT covered is an authority password containing a character RFC 3986 requires
- * to be percent-encoded there, because each one collides with a shape that carries no
- * secret and no regex separates them:
- * - `@` (`scheme://user:p@ss@host`) leaves the tail after the first `@` visible, because
- *   the authority's end cannot be located without it;
- * - `/`, `?` or `#` (`scheme://user:p/w@host/db`) is not masked at all. `/` is the
- *   instructive one: `scheme://host:5432/tenant@acme` has exactly the same shape, and
- *   masking it would hide the port behind a `***` asserting a credential the string never
- *   carried - a fabricated reading rather than a mask, which is the worse of the two. `?`
- *   and `#` end the authority for the same reason and are excluded with it.
+ * What is NOT covered is an authority password containing an unencoded `/`, `?` or `#`
+ * (`scheme://user:p/w@host/db`). Each of those ENDS the authority, so the `@` falls
+ * outside it and the parse below never sees a credential. `/` is the instructive one:
+ * `scheme://host:5432/tenant@acme` has exactly the same shape, and masking it would hide
+ * the port behind a `***` asserting a credential the string never carried - a fabricated
+ * reading rather than a mask, which is the worse of the two. `?` and `#` end the authority
+ * for the same reason and are excluded with it. An unencoded `@` IS covered, because the
+ * authority is parsed rather than pattern-matched (see `maskAuthorityPassword`).
  *
  * A scheme-relative string (`//user:pass@host/db`) is not covered either, and no driver
  * here accepts one.
  */
+/**
+ * Mask the password an authority carries, by PARSING it rather than by matching a pattern.
+ *
+ * The authority begins after `://` - anchoring there is what keeps this off a path: in
+ * `postgres://host/db:owner@example.com` the only `:`+text+`@` sits in the path, and a mask
+ * that matched it would replace a path segment while hiding no secret. It ENDS at the first
+ * `/`, `?` or `#`. Inside it the credential ends at the LAST `@`, not the first: `@` is a
+ * legal password character while a host name cannot hold one, so `scheme://user:p@ss@host`
+ * is masked whole where a single-`@` pattern left the tail visible.
+ */
+function maskAuthorityPassword(connectionString: string): string {
+  const schemeIndex = connectionString.indexOf("://");
+  if (schemeIndex === -1) return connectionString;
+
+  const authorityStart = schemeIndex + "://".length;
+  const delimiter = /[/?#]/.exec(connectionString.slice(authorityStart));
+  const authorityEnd = delimiter ? authorityStart + delimiter.index : connectionString.length;
+  const authority = connectionString.slice(authorityStart, authorityEnd);
+
+  const atIndex = authority.lastIndexOf("@");
+  if (atIndex === -1) return connectionString;
+
+  const colonIndex = authority.indexOf(":");
+  // No ':' before that '@' means the authority carries a user name and no password
+  // (`scheme://user@host`, `scheme://user@host:5432`), and a ':' immediately before it
+  // means the password is empty. Both stay verbatim for the reason the parameter half
+  // gives below: '***' over a value the string never carried asserts a secret.
+  if (colonIndex === -1 || colonIndex > atIndex || colonIndex + 1 === atIndex) return connectionString;
+
+  const masked = `${authority.slice(0, colonIndex + 1)}***${authority.slice(atIndex)}`;
+  return connectionString.slice(0, authorityStart) + masked + connectionString.slice(authorityEnd);
+}
+
 function redactConnectionString(connectionString: string): string {
-  // Anchoring the userinfo to `://` is what keeps this off a path: in
-  // `postgres://host/db:owner@example.com` the only `:`+text+`@` sits in the path, and a
-  // pattern that matched it would replace a path segment while hiding no secret. The
-  // password is bounded by '/' as well for the reason the docblock gives, and the userinfo
-  // before the ':' is bounded by it too, or the host would be swallowed.
-  const withAuthorityMasked = connectionString.replace(
-    /:\/\/([^:@/?#]*):([^@/?#]+)@/,
-    (_whole: string, userinfo: string) => `://${userinfo}:***@`,
-  );
+  const withAuthorityMasked = maskAuthorityPassword(connectionString);
 
   // Replace the VALUE of a credential-shaped parameter and keep its name, so the reader
   // can still see which knobs were set. Matching the name between a delimiter and '=' is

--- a/src/lib/db/compatibility.ts
+++ b/src/lib/db/compatibility.ts
@@ -115,7 +115,14 @@ const EXTERNAL: Readonly<Record<DatabaseType, boolean>> = Object.freeze({
   libredb: false,
 });
 
-/** The shipped ids that are databases a user already runs, in registry order. */
+/**
+ * The shipped ids that are databases a user already runs, in registry order.
+ *
+ * Also the DENOMINATOR the outward-facing catalog copy is counted against:
+ * `tests/unit/lib/catalog-copy-engine-count.test.ts` compares this length with every
+ * numeral qualifying "engines" in nine storefront files, which until #D47 were only ever
+ * corrected by somebody noticing.
+ */
 export const EXTERNAL_DATABASE_TYPES: readonly DatabaseType[] = Object.freeze(
   SHIPPED_DATABASE_TYPES.filter((type) => EXTERNAL[type]),
 );

--- a/src/lib/db/operations/descriptors.ts
+++ b/src/lib/db/operations/descriptors.ts
@@ -91,7 +91,7 @@ export const sqlExplainAnalyzeDescriptor: RegistrableOperationDescriptor = {
  *
  * A FOURTH descriptor, and that is a reversal of a product decision rather than an
  * oversight being corrected. Epic #325 pinned the canonical set at three, and
- * `docs/BACKLOG.md` B17 recorded profiling as deferred because of it; #330 T3
+ * the backlog recorded profiling as deferred because of it; #330 T3
  * instructs that profiling reach the database "as new descriptors in
  * `descriptors.ts` at R0/R1", which is the owner reopening that decision.
  *

--- a/src/lib/db/operations/statement-guard.ts
+++ b/src/lib/db/operations/statement-guard.ts
@@ -162,6 +162,15 @@ export interface AgentStatementOptions {
  * Whether a span is the statement's own text rather than trivia between tokens.
  * The same four kinds `statement-end.ts` treats as statement text — a literal, a
  * quoted name and a bracketed subscript are tokens a statement is made of.
+ *
+ * Only two of the four are reachable from this file's single caller, measured
+ * 2026-08-27 by deleting each disjunct in turn: `scanStatementShape` reads with
+ * `DEFAULT_SQL_GRAMMAR`, whose brackets are quoted names rather than subscripts,
+ * and a `dollar-string` span has already set `dialectAmbiguous`, which
+ * `inspectAgentStatement` answers before it looks at the tail. So no fixture can
+ * pin `dollar-string` or `subscript` here; the list is kept whole anyway because
+ * it is the shared reading of what a statement is made of, and a caller passing
+ * a named grammar would reach both.
  */
 function isStatementText(kind: SqlSpanKind): boolean {
   return kind === "string" || kind === "quoted-identifier" || kind === "dollar-string" || kind === "subscript";

--- a/src/lib/db/providers/embedded/libredb.ts
+++ b/src/lib/db/providers/embedded/libredb.ts
@@ -192,6 +192,17 @@ export class LibreDBProvider extends BaseDatabaseProvider {
       vacuumGlobalLabel: "Compact",
       vacuumGlobalTitle: "Compact",
       vacuumGlobalDesc: "Not supported for LibreDB in this version.",
+      // Stated verbatim in the agent's plan contract, and needed for the reason Redis
+      // needed one: a plan run on 2026-08-22, asked to list every entry under the
+      // `users` prefix, drafted `GET users:*`. `dispatchCommand` gives `get` exactly
+      // one meaning - `kv.get(parts[1])`, an exact-key lookup with no glob of any kind
+      // - so that command answers zero rows and NO error, which on a key-value store
+      // reads as "nothing stored there" rather than as a mistake (#B55). The cause is
+      // the one Redis has: the inventory's rows are named `users:*`, which reads as a
+      // wildcard this grammar does not have, so the sentence names all five verbs and
+      // says in words what `tablesAreDerivedGroupings` says in a flag.
+      statementLanguage:
+        "LibreDB's own command grammar - exactly one command on one line, in one of the five forms `get <key>`, `put <key> <value>`, `delete <key>`, `prefix <p>` or `range <start> <end>` - and NOT SQL and not a shell: every key is matched EXACTLY, with no glob and no wildcard, so `get users:*` looks up a key literally named `users:*` and answers nothing; the inventory's `prefix:*` rows are groupings this engine summarised, not keys, so reach every entry under one with `prefix users:` and a single entry by its real name",
       // `getSlowQueries()` answers `[]` unconditionally, so the monitoring Queries
       // panel is ALWAYS empty here - and it used to name a PostgreSQL extension (#U12).
       slowQueriesEmptyState: "LibreDB keeps no statistics about finished statements in this version.",

--- a/src/lib/db/providers/sql/duckdb/index.ts
+++ b/src/lib/db/providers/sql/duckdb/index.ts
@@ -365,18 +365,24 @@ export class DuckDBProvider extends SQLBaseProvider {
   }
 
   /**
-   * The slow-query empty state and the wording for `optimize`, which on this engine is
+   * The two empty states and the wording for `optimize`, which on this engine is
    * a checkpoint rather than anything an operator would call optimization.
    *
    * `getSlowQueries()` answers `[]` unconditionally, so the monitoring Queries panel is
    * ALWAYS empty here - and the default sentence tells the reader to install a
-   * PostgreSQL extension (#U12).
+   * PostgreSQL extension (#U12). `getActiveSessions()` is the same shape for the same
+   * reason: measured on DuckDB v1.5.5, `duckdb_connections()` answers
+   * `Catalog Error: Table Function with name duckdb_connections does not exist!`, so the
+   * default "No active sessions found." would read as "nothing is running right now" on a
+   * panel that can never show a row (#D48).
    */
   public override getLabels(): ProviderLabels {
     return {
       ...super.getLabels(),
       slowQueriesEmptyState:
         "DuckDB keeps no store of finished statements - it publishes no duckdb_queries() table function - so there is nothing to enable.",
+      sessionsEmptyState:
+        "DuckDB publishes no session list - there is no duckdb_connections() table function - so this panel can never show a row.",
       vacuumGlobalDesc:
         "Runs bare VACUUM over the whole database. DuckDB reclaims space at checkpoint time, so this is a no-op on a database that has just been checkpointed.",
     };

--- a/src/lib/db/providers/sql/search/index.ts
+++ b/src/lib/db/providers/sql/search/index.ts
@@ -354,23 +354,23 @@ function toQueryResult(result: SearchQueryResult, executionTime: number): QueryR
  * as JSON null while the listing still names the index). `TableStats.rowCount`,
  * `totalSize` and `totalSizeBytes` are required numbers, so for those three a closed
  * index has nowhere to read but zero. `tableSize` and `tableSizeBytes` are OPTIONAL,
- * and this mapper fills them with the same zero anyway - a fabricated measurement
- * rather than a forced one, which turns on `StorageTab`'s `tableSizeKnown` and draws
- * a `0 B` Data figure for an index that reported nothing (docs/BACKLOG.md D50). The
- * schema tree is the surface that keeps the distinction today: its `rowCount` and
- * `size` are optional, so it OMITS them instead.
+ * so they are OMITTED instead: a 0 there would be a fabricated measurement rather
+ * than a forced one. The cost is deliberate and cluster-wide - `StorageTab` gates its
+ * Data figure on `tables.every((t) => t.tableSizeBytes !== undefined)`, so ONE closed
+ * index takes that figure to N/A for every open index beside it - and that is what the
+ * optional field prescribes, because a partial sum reads as a measurement. The schema
+ * tree makes the same distinction with its own optional `rowCount` and `size`.
  */
 function toTableStats(index: SearchIndexInfo): TableStats {
-  const sizeBytes = index.sizeBytes ?? 0;
+  const { sizeBytes } = index;
 
   return {
     schemaName: SEARCH_SCHEMA_NAME,
     tableName: index.name,
     rowCount: index.docCount ?? 0,
-    tableSize: formatBytes(sizeBytes),
-    tableSizeBytes: sizeBytes,
-    totalSize: formatBytes(sizeBytes),
-    totalSizeBytes: sizeBytes,
+    ...(sizeBytes === null ? {} : { tableSize: formatBytes(sizeBytes), tableSizeBytes: sizeBytes }),
+    totalSize: formatBytes(sizeBytes ?? 0),
+    totalSizeBytes: sizeBytes ?? 0,
   };
 }
 

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -484,6 +484,22 @@ export interface ProviderLabels {
    * is dropped where this label is set instead of being re-worded from it.
    */
   slowQueriesEmptyState?: string;
+
+  /**
+   * Why the monitoring Sessions panel and the admin Operations session list are
+   * empty on this engine, in that engine's own terms.
+   *
+   * The counterpart of `slowQueriesEmptyState` for the other half of the same
+   * absence (#D48). Both panels default to "No active sessions found.", which a
+   * reader takes as "nothing is running right now" - true on PostgreSQL, and false
+   * on an engine that publishes no session list at all and can never show a row.
+   *
+   * A provider sets this when its `getActiveSessions()` can only ever answer `[]`.
+   * The failure branch beside it is a different fact: it renders a reason only when
+   * the READ failed (`activeSessions` absent from the payload, the reason under
+   * `errors`), and an absence is not an error.
+   */
+  sessionsEmptyState?: string;
 }
 
 /**

--- a/src/lib/export/result-export.ts
+++ b/src/lib/export/result-export.ts
@@ -43,6 +43,33 @@ export interface ResultExportFile {
 /** The table name used when the tab's own name cannot safely be one. */
 export const FALLBACK_TABLE_NAME = "table_name";
 
+/** What the file is called when the rows on screen are the tab's own. */
+const USER_EXPORT_STEM = "query_result_export";
+/** How much of a run id the file name carries, so a long id cannot dominate it. */
+const MAX_RUN_ID_CHARS = 64;
+/** Everything a file name may not carry, collapsed to a single separator. */
+const UNNAMEABLE = /[^A-Za-z0-9_]+/g;
+
+/**
+ * What an export is saved as.
+ *
+ * A run's rows are named after the RUN, not after the tab they were read in (B34):
+ * these files leave the product, and one carrying an agent's rows that is
+ * indistinguishable from one the user ran is a file nobody can attribute later. The
+ * id is reduced to characters a file name can hold — it reaches a path, so a `/` or a
+ * `..` in it is not a naming problem — and an id that survives that as nothing at all
+ * still leaves the attribution behind, because "an agent run produced this" is the
+ * part that matters.
+ */
+export function resultExportFileName(extension: string, runId?: string): string {
+  if (runId === undefined) return `${USER_EXPORT_STEM}.${extension}`;
+  const safe = runId
+    .replace(UNNAMEABLE, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_RUN_ID_CHARS);
+  return safe === "" ? `agent_run_export.${extension}` : `agent_run_${safe}_export.${extension}`;
+}
+
 /**
  * The prefix `use-tab-manager` puts on a generated tab name — `Query 1`, `Query: users`.
  *

--- a/src/lib/llm/providers/gemini.ts
+++ b/src/lib/llm/providers/gemini.ts
@@ -13,6 +13,7 @@ import {
   LLMSafetyError,
   LLMStreamError,
 } from "../types";
+import { resolveGeminiChatBaseUrl } from "../utils/gemini-endpoint";
 import { encodeText, streamFromAsyncIterable } from "../utils/streaming";
 
 // ============================================================================
@@ -41,10 +42,13 @@ export class GeminiProvider extends BaseLLMProvider {
       const prompt = messages.map((m) => m.content).join("\n\n");
 
       try {
-        const generativeModel = this.client.getGenerativeModel({
-          model,
-          systemInstruction,
-        });
+        const generativeModel = this.client.getGenerativeModel(
+          { model, systemInstruction },
+          // B20: `LLM_API_URL` reaches this SDK only here — the constructor takes
+          // the key and nothing else. An unset value leaves `baseUrl` undefined,
+          // which is what selects the SDK's own Google endpoint.
+          { baseUrl: resolveGeminiChatBaseUrl(this.config.apiUrl) },
+        );
 
         const result = await generativeModel.generateContentStream(prompt);
 

--- a/src/lib/llm/utils/gemini-endpoint.ts
+++ b/src/lib/llm/utils/gemini-endpoint.ts
@@ -1,0 +1,56 @@
+/**
+ * Gemini endpoint resolution (B20).
+ *
+ * `LLM_API_URL` is one variable and the two Gemini consumers spell the same
+ * endpoint differently, so it has to be read two ways. Measured in the installed
+ * builds rather than taken from the vendors' documentation:
+ *
+ *  - `@google/generative-ai` (the chat surface) takes `RequestOptions.baseUrl` as
+ *    an ORIGIN and appends the version itself —
+ *    `` `${baseUrl}/${apiVersion}/${model}:${task}` `` with `apiVersion` defaulting
+ *    to `v1beta` (`node_modules/@google/generative-ai/dist/index.js:333-335`),
+ *  - `@ai-sdk/google` (the agent adapter) takes a `baseURL` that already CARRIES
+ *    the version path, defaulting to
+ *    `https://generativelanguage.googleapis.com/v1beta`
+ *    (`node_modules/@ai-sdk/google/dist/index.js:7855`).
+ *
+ * The value the operator enters is the versioned one, because that is the form
+ * Google's own documentation and every proxy's configuration print, and because it
+ * matches what `LLM_API_URL` already means for the OpenAI-compatible kinds — a
+ * complete base URL ending in the API version. The version segment is optional:
+ * an operator who names a bare origin gets `v1beta` appended for the agent and the
+ * origin passed through for the chat surface, so both surfaces reach one host either
+ * way. Leaving the variable unset returns undefined on both paths, which selects
+ * each SDK's own Google default; `@ai-sdk/google`'s base URL has no environment
+ * fallback for an undefined value to re-open (same line 7855).
+ */
+
+/** The version segment both SDKs default to; the only one this repository composes. */
+export const GEMINI_DEFAULT_API_VERSION = "v1beta";
+
+/** Version segments Google serves, so a configured one is preserved rather than doubled. */
+const API_VERSION_SUFFIX = /\/v1(?:alpha|beta)?$/;
+
+function withoutTrailingSlashes(apiUrl: string | undefined): string | undefined {
+  const trimmed = apiUrl?.trim().replace(/\/+$/, "");
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * The `RequestOptions.baseUrl` for `@google/generative-ai`: an origin with any
+ * version segment removed, because that SDK appends the version itself.
+ */
+export function resolveGeminiChatBaseUrl(apiUrl: string | undefined): string | undefined {
+  const base = withoutTrailingSlashes(apiUrl)?.replace(API_VERSION_SUFFIX, "");
+  return base ? base : undefined;
+}
+
+/**
+ * The `baseURL` for `@ai-sdk/google`: the same endpoint WITH a version segment,
+ * appended only when the configured value does not already carry one.
+ */
+export function resolveGeminiSdkBaseUrl(apiUrl: string | undefined): string | undefined {
+  const base = withoutTrailingSlashes(apiUrl);
+  if (!base) return undefined;
+  return API_VERSION_SUFFIX.test(base) ? base : `${base}/${GEMINI_DEFAULT_API_VERSION}`;
+}

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -83,8 +83,11 @@ const NO_COLUMN_MODIFICATION: Partial<Record<DatabaseType, { label: string; reas
   // reach libSQL: SQLite gained `ALTER COLUMN ... SET/DROP NOT NULL` in 3.53.0 (measured
   // 2026-08-27 on 3.53.0 - it rewrites the stored schema and is enforced on insert),
   // while sqld 0.24.33 ships 3.47.0, so declining every modification is still right here.
-  // Whether the `sqlite` branch should emit it is docs/BACKLOG.md D43, not a decision to
-  // take in a comment: the provider runs on whichever SQLite its runtime bundles.
+  // The `sqlite` branch below declines it too, and deliberately: that provider runs on
+  // whichever SQLite its runtime bundles - `bun:sqlite` or `node:sqlite`, chosen at runtime
+  // with `LIBREDB_SQLITE_DRIVER` as an override - so emitting the statement would write a
+  // migration file that succeeds on one deployment and fails on another. A file handed to a
+  // human to run elsewhere makes that guess worse than the decline.
   libsql: {
     label: "libSQL",
     reason: "SQLite cannot retype a column; recreate the table and copy the rows.",

--- a/tests/components/ConnectionModal.mobile.test.tsx
+++ b/tests/components/ConnectionModal.mobile.test.tsx
@@ -191,6 +191,21 @@ mock.module("@/hooks/use-connection-form", () => ({
 }));
 
 // ── Mock @/lib/db-ui-config ─────────────────────────────────────────────────
+// See the same table in ConnectionModal.test.tsx: the engines that diverge from the
+// networked default are spelled out, because an "the input is absent" assertion is only as
+// true as this list.
+const MOCK_CONNECTION_FIELDS: Record<string, string[]> = {
+  sqlite: ["database"],
+  libredb: ["database"],
+  duckdb: ["database"],
+  libsql: ["host", "port", "password", "connectionString"],
+  druid: ["host", "port", "user", "password"],
+  elasticsearch: ["host", "port", "user", "password"],
+  opensearch: ["host", "port", "user", "password"],
+};
+const mockFields = (type: string): string[] =>
+  MOCK_CONNECTION_FIELDS[type] ?? ["host", "port", "user", "password", "database"];
+
 mock.module("@/lib/db-ui-config", () => ({
   getDBConfig: (type: string) => ({
     icon: () => null,
@@ -198,14 +213,15 @@ mock.module("@/lib/db-ui-config", () => ({
     label: type,
     defaultPort: type === "mysql" ? "3306" : type === "mongodb" ? "27017" : "5432",
     showConnectionStringToggle: type === "mongodb",
-    connectionFields: ["host", "port", "user", "password", "database"],
+    connectionFields: mockFields(type),
   }),
+  takesConnectionField: (type: string, field: string) => mockFields(type).includes(field),
   getDBIcon: () => () => null,
   getDBColor: () => "text-blue-400",
   // See the same note in ConnectionModal.test.tsx: `DB_UI_CONFIG` became an exported
   // binding in #425, so this mock's `{}` now reaches the real `isFileBased` unless the
   // function is mocked here too.
-  isFileBased: (type: string) => type === "sqlite" || type === "libredb",
+  isFileBased: (type: string) => mockFields(type).length === 1 && mockFields(type)[0] === "database",
   DB_UI_CONFIG: {},
 }));
 

--- a/tests/components/ConnectionModal.test.tsx
+++ b/tests/components/ConnectionModal.test.tsx
@@ -228,6 +228,23 @@ mock.module("@/hooks/use-connection-form", () => ({
 }));
 
 // ── Mock @/lib/db-ui-config ─────────────────────────────────────────────────
+// Mirrors the real table for the engines that diverge from the networked default. A mock
+// that gave every type the full field set is what let the modal draw a Username box for
+// libSQL and a Database box for Druid unnoticed: the assertion that the box is absent
+// passes or fails against THIS list, not against src/lib/db-ui-config.ts. The real table is
+// the authority and tests/unit/lib/db-ui-config.test.ts derives it from the providers.
+const MOCK_CONNECTION_FIELDS: Record<string, string[]> = {
+  sqlite: ["database"],
+  libredb: ["database"],
+  duckdb: ["database"],
+  libsql: ["host", "port", "password", "connectionString"],
+  druid: ["host", "port", "user", "password"],
+  elasticsearch: ["host", "port", "user", "password"],
+  opensearch: ["host", "port", "user", "password"],
+};
+const mockFields = (type: string): string[] =>
+  MOCK_CONNECTION_FIELDS[type] ?? ["host", "port", "user", "password", "database"];
+
 mock.module("@/lib/db-ui-config", () => ({
   getDBConfig: (type: string) => ({
     icon: () => null,
@@ -236,8 +253,9 @@ mock.module("@/lib/db-ui-config", () => ({
     defaultPort: type === "mysql" ? "3306" : type === "mongodb" ? "27017" : "5432",
     // Mirrors the real config: the URI-addressed providers offer the toggle.
     showConnectionStringToggle: type === "mongodb" || type === "couchbase",
-    connectionFields: ["host", "port", "user", "password", "database"],
+    connectionFields: mockFields(type),
   }),
+  takesConnectionField: (type: string, field: string) => mockFields(type).includes(field),
   getDBIcon: () => () => null,
   getDBColor: () => "text-blue-400",
   // `isFileBased` must be mocked now that `DB_UI_CONFIG` is an exported binding (#425 made
@@ -245,7 +263,7 @@ mock.module("@/lib/db-ui-config", () => ({
   // binding, and this mock replaces it with `{}`, so leaving the function to the real module
   // makes it throw on `DB_UI_CONFIG[type].connectionFields` for every render. Mirrors the
   // real rule: a file-based provider carries only a path.
-  isFileBased: (type: string) => type === "sqlite" || type === "libredb",
+  isFileBased: (type: string) => mockFields(type).length === 1 && mockFields(type)[0] === "database",
   DB_UI_CONFIG: {},
 }));
 
@@ -745,6 +763,54 @@ describe("ConnectionModal", () => {
     const uriInput = container.querySelector("#connectionString") as HTMLInputElement | null;
     expect(uriInput).not.toBeNull();
     expect(uriInput!.placeholder).toContain("couchbase://");
+  });
+
+  // ── an addressing input exists exactly where a value is written ──────────
+  //
+  // `connectionFields` decides what `buildConnection` saves. The modal used to draw
+  // Username and Database for every networked engine regardless, so four engines asked
+  // for a value that was then discarded on save - a box that collects nothing is the UI
+  // form of reporting an absence as a measurement.
+
+  test("libSQL renders neither a Username nor a Database box, because it takes neither", () => {
+    // libSQL authenticates with a token the server minted - it has no user names at all -
+    // and addresses the whole database by URL. Its `connectionFields` say so, and nothing
+    // carried either box's value before this.
+    mockFormOverrides = { type: "libsql" };
+    const props = createDefaultProps();
+    const { container } = render(React.createElement(ConnectionModal, props));
+
+    expect(container.querySelector("#user")).toBeNull();
+    expect(container.querySelector("#database")).toBeNull();
+    // Not a blanket removal: the engine is still addressed, and still takes a credential.
+    expect(container.querySelector("#host")).not.toBeNull();
+    expect(container.querySelector("#password")).not.toBeNull();
+  });
+
+  test.each(["druid", "elasticsearch", "opensearch"] as const)(
+    "%s renders a Username but no Database box, matching what it takes",
+    (type) => {
+      // These three authenticate with HTTP Basic - their transports build the header from
+      // `config.user` - and name the datasource or index in the statement instead of on
+      // the connection. So exactly one of the two boxes belongs.
+      mockFormOverrides = { type };
+      const props = createDefaultProps();
+      const { container } = render(React.createElement(ConnectionModal, props));
+
+      expect(container.querySelector("#user")).not.toBeNull();
+      expect(container.querySelector("#database")).toBeNull();
+    },
+  );
+
+  test("redis renders a Username box, because its provider authenticates with one", () => {
+    // The Redis 6 ACL user. #502 taught the provider to send it to ioredis as `username`,
+    // measured on both arms, and the box has to be here for a value to reach it.
+    mockFormOverrides = { type: "redis" };
+    const props = createDefaultProps();
+    const { container } = render(React.createElement(ConnectionModal, props));
+
+    expect(container.querySelector("#user")).not.toBeNull();
+    expect(container.querySelector("#database")).not.toBeNull();
   });
 
   test("non-Couchbase types keep the Database Name label", () => {

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -973,6 +973,119 @@ describe("Studio", () => {
     expect(mockCreateObjectURL).not.toHaveBeenCalled();
   });
 
+  // --- exportResults over an agent run's rows (B34) ---
+  //
+  // The panel hands the artifact to the export rather than the export reading the tab
+  // back, so what leaves the product is what was on screen — and the file says which
+  // run produced it.
+  const withCapturedDownloadName = async (run: () => void): Promise<string[]> => {
+    const names: string[] = [];
+    const originalClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
+      names.push(this.download);
+    };
+    try {
+      run();
+      // The revoke is scheduled a task later; drain it so nothing leaks into the next test.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    } finally {
+      HTMLAnchorElement.prototype.click = originalClick;
+    }
+    return names;
+  };
+
+  const hydratedArtifact = {
+    runId: "arun_42",
+    correlationId: "corr_1",
+    operationId: "sql.query.read",
+    surface: "results" as const,
+    result: {
+      rows: [{ id: 9, city: "Ankara" }],
+      fields: ["id", "city"],
+      rowCount: 1,
+      executionTime: 3,
+      columnTypes: { id: "bigint", city: "text" },
+    },
+    explainPlan: null,
+    chartSpec: null,
+  };
+
+  test("exportResults writes the run's rows, not the tab's, when it is given the artifact", async () => {
+    tabMgrOverride = {
+      currentTab: {
+        id: "tab-1",
+        name: "Users",
+        query: "SELECT 1",
+        result: testResult,
+        isExecuting: false,
+        type: "sql",
+      },
+    };
+    render(<Studio />);
+    const exportFn = capturedBottomPanelProps.onExportResults as (
+      format: string,
+      hydrated: typeof hydratedArtifact | null,
+    ) => void;
+
+    const names = await withCapturedDownloadName(() => act(() => exportFn("json", hydratedArtifact)));
+
+    const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
+    expect(JSON.parse(await blob.text())).toEqual([{ id: 9, city: "Ankara" }]);
+    // Named after the run, so the file is not indistinguishable from one the user ran.
+    expect(names).toEqual(["agent_run_arun_42_export.json"]);
+  });
+
+  test("a run's rows take the neutral table name, not the tab's", async () => {
+    tabMgrOverride = {
+      currentTab: {
+        id: "tab-1",
+        name: "Users",
+        query: "SELECT 1",
+        result: testResult,
+        isExecuting: false,
+        type: "sql",
+      },
+    };
+    render(<Studio />);
+    const exportFn = capturedBottomPanelProps.onExportResults as (
+      format: string,
+      hydrated: typeof hydratedArtifact | null,
+    ) => void;
+
+    await withCapturedDownloadName(() => act(() => exportFn("sql-ddl", hydratedArtifact)));
+
+    const blob = (mockCreateObjectURL.mock.calls[0] as unknown[])[0] as Blob;
+    const content = await blob.text();
+    // The rows came from a run, so naming the tab's table would attribute them to a
+    // table that never produced them. The declared types are the artifact's own.
+    expect(content).toContain("CREATE TABLE table_name (");
+    expect(content).toContain("bigint");
+  });
+
+  test("the tab's own export is unchanged and keeps its own file name", async () => {
+    tabMgrOverride = {
+      currentTab: {
+        id: "tab-1",
+        name: "Users",
+        query: "SELECT 1",
+        result: testResult,
+        isExecuting: false,
+        type: "sql",
+      },
+    };
+    render(<Studio />);
+    const exportFn = capturedBottomPanelProps.onExportResults as (
+      format: string,
+      hydrated: typeof hydratedArtifact | null,
+    ) => void;
+
+    const names = await withCapturedDownloadName(() => act(() => exportFn("csv", null)));
+
+    expect(names).toEqual(["query_result_export.csv"]);
+  });
+
   // --- CommandPalette callbacks ---
   test("CommandPalette onLoadSavedQuery loads query and switches to results", () => {
     render(<Studio />);

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -1436,6 +1436,40 @@ describe("OperationsTab", () => {
     expect(getByTestId("operations-sessions-empty").textContent).toBe("No active sessions found.");
   });
 
+  // #D48. The default sentence reads as "nothing is running right now", which is false
+  // on an engine whose session list does not exist. Both branches are pinned so the
+  // fallback cannot quietly become the only path again.
+  test("an engine declaring sessionsEmptyState replaces the empty-state copy", async () => {
+    const duckdb = "DuckDB publishes no session list - there is no duckdb_connections() table function.";
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze"] },
+      labels: { sessionsEmptyState: duckdb },
+    };
+    monitoringOverride = { data: { activeSessions: [], tables: defaultTables } };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+
+    expect(renderResult!.getByTestId("operations-sessions-empty").textContent).toBe(duckdb);
+  });
+
+  test("a refused read outranks the label, because a refusal is not an absence", async () => {
+    mockMetadata = {
+      capabilities: { supportsMaintenance: true, maintenanceOperations: ["analyze"] },
+      labels: { sessionsEmptyState: "DuckDB publishes no session list." },
+    };
+    monitoringOverride = {
+      data: { tables: defaultTables, errors: { activeSessions: "permission denied" } },
+    };
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OperationsTab />);
+    });
+
+    expect(renderResult!.getByTestId("operations-sessions-empty").textContent).toBe("permission denied");
+  });
+
   test("a refused tables read shows the engine's own sentence", async () => {
     monitoringOverride = {
       data: { activeSessions: defaultSessions, errors: { tables: "permission denied for relation pg_class" } },

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -391,6 +391,10 @@ describe("AgentRail", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     window.matchMedia = originalMatchMedia;
+    // The rail now stores the conversation a run belongs to (#B69), and it is read at
+    // MOUNT — so a key left behind by one test puts an amber notice over the next test's
+    // first render, before any start it makes.
+    localStorage.clear();
     cleanup();
   });
 
@@ -600,6 +604,115 @@ describe("AgentRail", () => {
     // The start happened, so the absent strip is a decision rather than an accident.
     expect(runCalls).toHaveLength(1);
     expect(view.queryByTestId("agent-thread")).toBeNull();
+  });
+
+  /*
+    The transition a reload used to be silent about (#B69).
+
+    The rail was honest about the RESULT — no thread, no strip — and said nothing about the
+    change: a user mid-conversation who reloaded was not told that what they were doing had
+    ended, and their next question was answered as a fresh one. The conversation id lives in
+    localStorage, the same per-browser store every other browser-local preference uses.
+  */
+  test("a conversation this browser was in is stated before the next question is asked", async () => {
+    localStorage.setItem("libredb_agent_thread", JSON.stringify({ threadId: "arun_a", steps: 3 }));
+    mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE]);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    const notice = await view.findByTestId("agent-thread-ended");
+    // The two facts a person can check against the strip they had been reading, and the
+    // consequence stated rather than left to be discovered from the next answer.
+    expect(notice.textContent).toContain("3 questions");
+    expect(notice.textContent).toContain("arun_a");
+    expect(notice.textContent).toContain("starts a new one");
+
+    // And it is about the ABSENCE of a live run, so opening one ends it.
+    fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(view.getByTestId("agent-start"));
+    });
+    await view.findByTestId("agent-run-id");
+    expect(view.queryByTestId("agent-thread-ended")).toBeNull();
+  });
+
+  test("one question reads as one question, not as a plural nobody wrote", async () => {
+    localStorage.setItem("libredb_agent_thread", JSON.stringify({ threadId: "arun_a", steps: 1 }));
+    mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE]);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    expect((await view.findByTestId("agent-thread-ended")).textContent).toContain("(1 question,");
+  });
+
+  test("a start records the conversation it opened, counting itself", async () => {
+    // Counting itself is the point: the server reports the steps BEFORE this run, so
+    // storing that number verbatim would have the notice say "one question" about a
+    // conversation whose strip the user had just read as two.
+    mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE], {
+      runId: "arun_b",
+      status: "queued",
+      mode: "planning",
+      thread: { threadId: "arun_a", steps: [{ runId: "arun_a", objective: "count by department" }], text: "Step 1" },
+    });
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "chart those" } });
+    await act(async () => {
+      fireEvent.click(view.getByTestId("agent-start"));
+    });
+    await view.findByTestId("agent-thread");
+
+    expect(JSON.parse(localStorage.getItem("libredb_agent_thread") ?? "null")).toEqual({
+      threadId: "arun_a",
+      steps: 2,
+    });
+  });
+
+  test("a start that belongs to no conversation forgets the one stored", async () => {
+    // Otherwise the next mount would announce that a conversation had been interrupted
+    // when the run after it had already been answered on its own.
+    localStorage.setItem("libredb_agent_thread", JSON.stringify({ threadId: "arun_a", steps: 3 }));
+    mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE]);
+    const view = render(<AgentRail {...DEFAULT_PROPS} />);
+
+    fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "why is checkout slow" } });
+    await act(async () => {
+      fireEvent.click(view.getByTestId("agent-start"));
+    });
+    await view.findByTestId("agent-run-id");
+
+    expect(localStorage.getItem("libredb_agent_thread")).toBeNull();
+  });
+
+  test("a store that refuses the write costs the notice, never the run", async () => {
+    // Safari private mode and a full quota both land here. The bookkeeping is a nudge; the
+    // run is the work, and the same policy is written into `star-prompt.ts`.
+    const realSetItem = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+    const fetchMock = mockAgentFetch([OPENED_LINE, STARTED_LINE, FINISHED_LINE], {
+      runId: "arun_b",
+      status: "queued",
+      mode: "planning",
+      thread: { threadId: "arun_a", steps: [{ runId: "arun_a", objective: "count by department" }], text: "Step 1" },
+    });
+
+    try {
+      const view = render(<AgentRail {...DEFAULT_PROPS} />);
+      fireEvent.change(view.getByTestId("agent-objective"), { target: { value: "chart those" } });
+      await act(async () => {
+        fireEvent.click(view.getByTestId("agent-start"));
+      });
+      await view.findByTestId("agent-run-id");
+      // The start happened, so the swallowed write is a decision rather than an accident.
+      expect(
+        (fetchMock.mock.calls as [RequestInfo | URL, RequestInit?][]).filter(
+          ([url]) => String(url) === "/api/agent/runs",
+        ),
+      ).toHaveLength(1);
+    } finally {
+      localStorage.setItem = realSetItem;
+    }
   });
 
   test("a follow-up start names the run it follows on the same connection", async () => {
@@ -2254,13 +2367,16 @@ describe("AgentRail", () => {
     });
 
     /**
-     * The ledger records less than the tracker charges, in known ways
-     * (`docs/BACKLOG.md` B13, and a ledger written before #512, whose failed statements
-     * carry no duration) — the largest being that the run's schema
-     * capture reaches `executeAuditedOperation` without going through `runStep`, so
-     * its two-to-three catalog reads are paid for and never itemized. A meter that
-     * did not say so would read as exact while sitting two statements low from the
-     * first turn.
+     * The ledger records less than the tracker charges, in known ways. The largest used
+     * to be the run's schema capture: it reaches `executeAuditedOperation` without going
+     * through `runStep`, so its two-to-three catalog reads were paid for and never
+     * itemized, and a meter that did not say so read as exact while sitting two statements
+     * low from the first turn. The capture now carries the charge it was billed and the
+     * fold adds it. What is still uncounted is a call that failed while acquiring its
+     * provider (charged, but it settles no step, so nothing here can see it), the
+     * difference between an engine's own elapsed time and the span measured around the
+     * whole call, and a ledger written before #512, whose failed statements carry no
+     * duration at all.
      */
     test("the meter says its figures are a floor, and names what the ledger leaves out", () => {
       const { getByTestId } = render(<AgentRail {...DEFAULT_PROPS} />);

--- a/tests/components/agent/use-agent-run.test.tsx
+++ b/tests/components/agent/use-agent-run.test.tsx
@@ -1,7 +1,9 @@
 import "../../setup-dom";
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
+import React from "react";
+import ReactDOMServer from "react-dom/server";
 import { useAgentRun } from "@/components/agent/use-agent-run";
 
 /**
@@ -25,5 +27,86 @@ describe("useAgentRun — the fold is memoised on the entries", () => {
 
     expect(result.current.timeline).toBe(first);
     cleanup();
+  });
+});
+
+/**
+ * What this browser remembers about the conversation it was in (#B69).
+ *
+ * A reload clears `runId`, so the next question starts a new thread. The hook holds the
+ * READING — the stored id, and nothing inferred from it — and the rail owns the sentence.
+ * Driven through the hook rather than against the helpers directly: the storage key is an
+ * implementation detail of this module, and a test that reached past it would pin the key
+ * rather than the behaviour.
+ */
+describe("useAgentRun — the conversation a reload interrupted", () => {
+  const KEY = "libredb_agent_thread";
+
+  afterEach(() => {
+    localStorage.clear();
+    cleanup();
+  });
+
+  test("reports the stored conversation, counting the run that stored it", () => {
+    localStorage.setItem(KEY, JSON.stringify({ threadId: "arun_a", steps: 3 }));
+
+    const { result } = renderHook(() => useAgentRun());
+
+    expect(result.current.interrupted).toEqual({ threadId: "arun_a", steps: 3 });
+  });
+
+  test("reports nothing when this browser has held no conversation", () => {
+    const { result } = renderHook(() => useAgentRun());
+
+    expect(result.current.interrupted).toBeNull();
+  });
+
+  test("reports nothing for a stored value this build cannot read", () => {
+    // Not a guess and not a throw: a value written by a build that shaped it differently
+    // has to read as absent, or a sentence about a conversation would stand over a
+    // half-read object. Both classes land here — unparseable, and parsed but off-shape.
+    localStorage.setItem(KEY, "{ not json");
+    const { result: unparseable } = renderHook(() => useAgentRun());
+    expect(unparseable.current.interrupted).toBeNull();
+    cleanup();
+
+    localStorage.setItem(KEY, JSON.stringify({ threadId: "arun_a" }));
+    const { result: offShape } = renderHook(() => useAgentRun());
+    expect(offShape.current.interrupted).toBeNull();
+  });
+
+  test("assumes nothing was interrupted during server rendering, where no localStorage exists", () => {
+    /*
+      There is no localStorage on the server, so `useSyncExternalStore` must take the
+      SERVER snapshot — a `getSnapshot` that ran there would dereference localStorage and
+      500 the page, which is why the reading is an external store rather than a mount
+      effect in the first place.
+
+      A conversation is stored first ON PURPOSE: the suite's DOM gives the server render a
+      working localStorage, so with nothing stored both snapshots answer null and the
+      assertion could not tell them apart.
+    */
+    localStorage.setItem(KEY, JSON.stringify({ threadId: "arun_a", steps: 3 }));
+    function Probe() {
+      return React.createElement("span", null, useAgentRun().interrupted === null ? "none" : "some");
+    }
+
+    expect(ReactDOMServer.renderToString(React.createElement(Probe))).toContain("none");
+  });
+
+  test("reports nothing where the store refuses to be read at all", () => {
+    // Safari private mode and a browser configured to block site data both land here. The
+    // notice is what is lost; the rail still opens runs, which is the whole of the policy.
+    const realGetItem = localStorage.getItem.bind(localStorage);
+    localStorage.getItem = () => {
+      throw new Error("SecurityError");
+    };
+
+    try {
+      const { result } = renderHook(() => useAgentRun());
+      expect(result.current.interrupted).toBeNull();
+    } finally {
+      localStorage.getItem = realGetItem;
+    }
   });
 });

--- a/tests/components/agent/use-agent-run.test.tsx
+++ b/tests/components/agent/use-agent-run.test.tsx
@@ -1,7 +1,7 @@
 import "../../setup-dom";
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 import { useAgentRun } from "@/components/agent/use-agent-run";
@@ -53,6 +53,40 @@ describe("useAgentRun — the conversation a reload interrupted", () => {
     const { result } = renderHook(() => useAgentRun());
 
     expect(result.current.interrupted).toEqual({ threadId: "arun_a", steps: 3 });
+  });
+
+  test("says nothing about a conversation while the run that continues it is being opened", async () => {
+    // The window between `setRunId(null)` and the server's answer. `start()` clears
+    // `runId` before it fetches (so the previous run's entries and verdict go), and
+    // `interrupted` was derived from `runId === null` alone - so for as long as the POST
+    // was in flight the rail rendered "The conversation this browser was in (N questions,
+    // <id>) ended when the page reloaded. Your next question starts a new one." about the
+    // conversation the user was in the act of continuing. Two false claims at once: no
+    // page reloaded, and that conversation had not ended.
+    //
+    // It also broke the invariant this property documents about itself - "null whenever
+    // `thread` is set: the two never describe the same conversation" - because `thread`
+    // keeps its previous value across the same window.
+    localStorage.setItem(KEY, JSON.stringify({ threadId: "arun_previous", steps: 2 }));
+
+    const originalFetch = globalThis.fetch;
+    // Never resolves: the assertion is about the in-flight window, so the window is held
+    // open rather than raced.
+    globalThis.fetch = (() => new Promise(() => {})) as unknown as typeof globalThis.fetch;
+
+    try {
+      const { result } = renderHook(() => useAgentRun());
+      expect(result.current.interrupted).toEqual({ threadId: "arun_previous", steps: 2 });
+
+      await act(async () => {
+        void result.current.start({ mode: "agent", objective: "count the rows", connectionId: "conn-1" });
+      });
+
+      expect(result.current.isBusy).toBe(true);
+      expect(result.current.interrupted).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("reports nothing when this browser has held no conversation", () => {

--- a/tests/components/monitoring/SessionsTab.test.tsx
+++ b/tests/components/monitoring/SessionsTab.test.tsx
@@ -6,7 +6,7 @@ import { mock, describe, test, expect, afterEach } from "bun:test";
 import React from "react";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { SessionsTab } from "@/components/monitoring/tabs/SessionsTab";
-import type { MonitoringData } from "@/lib/db/types";
+import type { MonitoringData, ProviderLabels } from "@/lib/db/types";
 
 mock.module("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => React.createElement("div", {}, children),
@@ -213,6 +213,63 @@ describe("a refused activeSessions read", () => {
 
     expect(queryByTestId("panel-unavailable")).toBeNull();
     expect(queryByText("No active sessions found.")).not.toBeNull();
+  });
+});
+
+// #D48. "No active sessions found." reads as "nothing is running right now", which is
+// false on an engine that publishes no session list and can never show a row. Both
+// branches are pinned so the fallback cannot quietly become the only path again.
+describe("an engine that publishes no session list says so in its own words", () => {
+  const DUCKDB = "DuckDB publishes no session list - there is no duckdb_connections() table function.";
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("prefers the provider's sessionsEmptyState over the default sentence", () => {
+    const data = { ...makeData(), activeSessions: [] } as MonitoringData;
+    const { queryByText } = render(
+      <SessionsTab
+        data={data}
+        loading={false}
+        onKillSession={mock(async () => true)}
+        labels={{ sessionsEmptyState: DUCKDB } as ProviderLabels}
+      />,
+    );
+
+    expect(queryByText(DUCKDB)).not.toBeNull();
+    expect(queryByText("No active sessions found.")).toBeNull();
+  });
+
+  test("keeps the default sentence for a provider that declares no label", () => {
+    const data = { ...makeData(), activeSessions: [] } as MonitoringData;
+    const { queryByText } = render(
+      <SessionsTab data={data} loading={false} onKillSession={mock(async () => true)} labels={{} as ProviderLabels} />,
+    );
+
+    expect(queryByText("No active sessions found.")).not.toBeNull();
+  });
+
+  test("a refused read still carries the failure reason, not the label", () => {
+    // The label explains an absence; the failure branch explains a refusal. They are
+    // different facts and the refusal wins where both could apply.
+    const { getByTestId, queryByText } = render(
+      <SessionsTab
+        data={
+          {
+            ...makeData(),
+            activeSessions: undefined,
+            errors: { activeSessions: "permission denied" },
+          } as unknown as MonitoringData
+        }
+        loading={false}
+        onKillSession={mock(async () => true)}
+        labels={{ sessionsEmptyState: DUCKDB } as ProviderLabels}
+      />,
+    );
+
+    expect(getByTestId("panel-unavailable-message").textContent).toBe("permission denied");
+    expect(queryByText(DUCKDB)).toBeNull();
   });
 });
 

--- a/tests/components/monitoring/StorageTab.test.tsx
+++ b/tests/components/monitoring/StorageTab.test.tsx
@@ -262,21 +262,25 @@ describe("StorageTab", () => {
   test("a measured zero total beside per-table bytes that answered draws no figure it cannot support", () => {
     // The scenario #517's entry stated, and the one the fixture above cannot show. `getTableStats()` is
     // a separate read from the overview, so a 0 total can arrive beside real per-table figures.
-    // Then `total - tables - indexes` is 0 - 734003200 - 209715200 = -943718400, and the tab's
-    // local byte cascade returns its input unchanged, so the remainder cell rendered
-    // "-943718400 B" - a negative byte count drawn as a measurement. The two Quick Stats shares
-    // were fabricated the other way: real "700.00 MB" and "200.00 MB" figures over a "0.0%"
-    // computed against a zero denominator.
+    // Then `total - tables - indexes` is 0 - 734003200 - 209715200 = -943718400, and the byte
+    // cascade this tab formatted with returned its input unchanged, so the remainder cell
+    // rendered "-943718400 B" - a negative byte count drawn as a measurement. The two Quick
+    // Stats shares were fabricated the other way: real "700 MB" and "200 MB" figures over a
+    // "0.0%" computed against a zero denominator.
     const zeroTotalWithTables = {
       ...makeMonitoringData(),
       overview: { ...makeMonitoringData().overview, databaseSize: "0 bytes", databaseSizeBytes: 0 },
     } as MonitoringData;
 
-    const { container, queryAllByText } = render(<StorageTab data={zeroTotalWithTables} loading={false} />);
+    const { container, getByTestId, queryAllByText } = render(
+      <StorageTab data={zeroTotalWithTables} loading={false} />,
+    );
 
-    // The honest numerators survive: this tab measured those bytes itself.
-    expect(queryAllByText("700.00 MB").length).toBeGreaterThan(0);
-    expect(queryAllByText("200.00 MB").length).toBeGreaterThan(0);
+    // The honest numerators survive: this tab measured those bytes itself. Read by testid
+    // because the fixture's own `totalSize` strings share the shared formatter's spelling -
+    // `orders` reports "700 MB" - so a text query would pass even with the card blanked.
+    expect(getByTestId("storage-breakdown-tables").textContent).toBe("700 MB");
+    expect(getByTestId("storage-breakdown-indexes").textContent).toBe("200 MB");
     // Nothing divided by zero bytes is published, in either direction.
     expect(container.textContent).not.toContain("-943718400");
     expect(container.textContent).not.toContain("0.0%");
@@ -300,7 +304,7 @@ describe("StorageTab", () => {
       errors: { overview: "overview refused", storage: "storage refused", tables: "tables refused" },
     } as unknown as MonitoringData;
 
-    const { container, queryAllByTestId, queryAllByText } = render(
+    const { container, getByTestId, queryAllByTestId } = render(
       <StorageTab data={answeredWithErrors} loading={false} />,
     );
 
@@ -309,7 +313,7 @@ describe("StorageTab", () => {
     expect(container.textContent).not.toContain("storage refused");
     expect(container.textContent).not.toContain("tables refused");
     // The measured breakdown is still drawn from the overview that answered.
-    expect(queryAllByText("700.00 MB").length).toBeGreaterThan(0);
+    expect(getByTestId("storage-breakdown-tables").textContent).toBe("700 MB");
     expect(barTransforms(container).slice(0, 3)).toEqual([
       "translateX(-65.8203125%)",
       "translateX(-90.234375%)",
@@ -343,7 +347,7 @@ describe("StorageTab", () => {
     const { queryByText, queryAllByText } = render(<StorageTab data={makeMonitoringData()} loading={false} />);
 
     // 120 MB + 80 MB from the two tables, on a 2 GB database.
-    expect(queryAllByText("200.00 MB").length).toBe(2); // Indexes card and breakdown row
+    expect(queryAllByText("200 MB").length).toBe(2); // Indexes card and breakdown row
     expect(queryAllByText("9.8%").length).toBe(1);
     expect(queryByText("1.12 GB")).not.toBeNull(); // the remainder, still positive
     expect(queryAllByText("2.00 GB").length).toBe(1); // the DB Size card, and nothing else
@@ -355,7 +359,7 @@ describe("StorageTab", () => {
     // draws beside the measured database size. With the guess gone, a provider may
     // report a table it has no byte figure for, and summing the rest as 0 publishes a
     // number no engine reported. The fixture keeps `orders` at 500 MB and strips
-    // `users`, so a regression to `?? 0` renders "500.00 MB" as the table total -
+    // `users`, so a regression to `?? 0` renders "500 MB" as the table total -
     // visible here rather than only against a server.
     const base = makeMonitoringData();
     const partial = {
@@ -370,7 +374,7 @@ describe("StorageTab", () => {
 
     const { queryAllByText } = render(<StorageTab data={partial} loading={false} />);
 
-    expect(queryAllByText("500.00 MB").length).toBe(0);
+    expect(queryAllByText("500 MB").length).toBe(0);
     // Tables card, the breakdown's Tables row, and the remainder that cannot be
     // computed without them - plus the % under the card is not drawn at all.
     expect(queryAllByText("N/A").length).toBe(3);
@@ -421,8 +425,9 @@ describe("StorageTab", () => {
   });
 
   test("a libSQL database gets the same remainder label as PostgreSQL, not another engine's", () => {
-    // Measured for #515: a real 64 KB libSQL database read "4.00 KB" under "Other (TOAST,
-    // FSM)". The number is right and the words belong to PostgreSQL - libSQL has neither
+    // Measured for #515: a real 64 KB libSQL database read 4 KB (then spelled "4.00 KB")
+    // under "Other (TOAST, FSM)". The number is right and the words belong to PostgreSQL -
+    // libSQL has neither
     // structure. The label must be identical on both engines because this tab is given no
     // provider labels to vary it by.
     const { container, getByTestId, queryAllByText } = render(
@@ -433,8 +438,8 @@ describe("StorageTab", () => {
     expect(getByTestId("storage-breakdown-other-label-compact").textContent).toBe("Other");
     expect(container.textContent).not.toMatch(/TOAST|FSM|free space map/i);
     // 65536 bytes less 49152 of data and 12288 of indexes; no other figure in this fixture
-    // formats to 4.00 KB, so the remainder is pinned as well as its label.
-    expect(queryAllByText("4.00 KB").length).toBe(1);
+    // formats to 4 KB, so the remainder is pinned as well as its label.
+    expect(queryAllByText("4 KB").length).toBe(1);
   });
 
   test("a table reported without an index size does not turn the totals into a measurement", () => {
@@ -456,7 +461,38 @@ describe("StorageTab", () => {
 
     // Indexes card, breakdown row and the now-uncomputable remainder.
     expect(queryAllByText("N/A").length).toBe(3);
-    expect(queryAllByText("200.00 MB").length).toBe(0);
+    expect(queryAllByText("200 MB").length).toBe(0);
+  });
+
+  // This tab formats five figures, and until now it did so with a private threshold cascade
+  // byte-identical to `TablesTab`'s: no guard and no rung above GB, so a negative rendered
+  // "-1 B", a non-finite "NaN B" and an exabyte "1073741824.00 GB". The negative was reachable
+  // here - a 0 total beside per-table bytes that answered - and is refused one layer up by
+  // `remainderKnown`; these arms pin what the formatter itself now does with each input.
+  test.each<[string, number, string]>([
+    ["a negative", -1, "N/A"],
+    ["a NaN", Number.NaN, "N/A"],
+    ["an Infinity", Number.POSITIVE_INFINITY, "N/A"],
+    ["a PB-scale figure", 1024 ** 5, "1 PB"],
+    ["an EB-scale figure", 1024 ** 6, "1 EB"],
+  ])("draws %s as the formatter's own answer, never as a gigabyte figure", (_label, bytes, expected) => {
+    // One table carrying the whole table total, so the Tables card's sum IS the input under
+    // test. The database total is left alone, which keeps `sizeKnown` true - so the figure
+    // below comes from the formatter and not from an absence gate.
+    const base = makeMonitoringData();
+    const [first] = base.tables ?? [];
+    const single = {
+      ...base,
+      tables: [{ ...first, tableSizeBytes: bytes }],
+    } as MonitoringData;
+
+    const { getByTestId } = render(<StorageTab data={single} loading={false} />);
+
+    expect(getByTestId("storage-stat-tables").textContent).toBe(expected);
+    expect(getByTestId("storage-breakdown-tables").textContent).toBe(expected);
+    // The Indexes figure is untouched by this input, which is what proves the card above is
+    // reading the formatter rather than a tab-wide refusal.
+    expect(getByTestId("storage-stat-indexes").textContent).toBe("120 MB");
   });
 });
 
@@ -565,15 +601,19 @@ describe("a refused table statistics read", () => {
     expect(queryAllByText("0 B").length).toBe(4);
     expect(queryAllByText("0.0%").length).toBe(2);
     // The remainder is the entire database, and that is the arithmetic, not a fabrication.
-    expect(queryAllByText("2.00 GB").length).toBe(2);
+    // The DB Size card renders the provider's own "2.00 GB" string; the remainder is this
+    // tab's own formatting of the same bytes, which spells the trailing zeros away.
+    expect(queryAllByText("2.00 GB").length).toBe(1);
+    expect(queryAllByText("2 GB").length).toBe(1);
   });
 
   test("a populated table list keeps its measured figures", () => {
     const { queryAllByText, queryByTestId } = render(<StorageTab data={makeMonitoringData()} loading={false} />);
 
     expect(queryByTestId("panel-unavailable")).toBeNull();
-    // 500 MB + 200 MB of table data, on the Tables card and the breakdown's Tables row.
-    expect(queryAllByText("700.00 MB").length).toBe(2);
+    // 500 MB + 200 MB of table data, on the Tables card and the breakdown's Tables row -
+    // plus the `orders` row, whose engine-reported `totalSize` string is "700 MB" too.
+    expect(queryAllByText("700 MB").length).toBe(3);
     expect(queryAllByText("N/A").length).toBe(0);
   });
 });

--- a/tests/components/monitoring/TablesTab.test.tsx
+++ b/tests/components/monitoring/TablesTab.test.tsx
@@ -468,7 +468,41 @@ describe("tables that carry no per-table bytes", () => {
       <TablesTab data={makeData()} loading={false} onRunMaintenance={mock(async () => true)} />,
     );
 
-    expect(getByTestId("tables-stat-size").textContent).toBe("820.00 MB");
+    expect(getByTestId("tables-stat-size").textContent).toBe("820 MB");
+  });
+
+  // The Size card is this tab's only formatted figure, so it is where the formatter's own
+  // refusals are visible. The cascade this tab used to carry drew all three of these as
+  // figures: "-1 B", "NaN B" and, for an exabyte, "1073741824.00 GB" - a magnitude spelled
+  // in the wrong unit because the ladder stopped at GB.
+  test.each<[string, number, string]>([
+    ["a negative total", -1, "N/A"],
+    ["a non-finite total", Number.NaN, "N/A"],
+    ["an infinite total", Number.POSITIVE_INFINITY, "N/A"],
+    ["a PB-scale total", 1024 ** 5, "1 PB"],
+    ["an EB-scale total", 1024 ** 6, "1 EB"],
+  ])("the Size card refuses %s rather than drawing it as a reading", (_label, bytes, expected) => {
+    // One table carrying the whole total, so the card's sum IS the input under test. A
+    // negative and a NaN are not reachable from a provider in this tree today; the point of
+    // the shared formatter is that they cannot be drawn as measurements if one ever sends one,
+    // and the PB and EB arms are reachable now (ClickHouse sums bytes over every active part).
+    const data = makeData();
+    const [first] = data.tables ?? [];
+    const single = {
+      ...data,
+      tables: [{ ...first, tableSizeBytes: bytes, totalSizeBytes: bytes }],
+    } as MonitoringData;
+
+    const { getByTestId, queryByText } = render(
+      <TablesTab data={single} loading={false} onRunMaintenance={mock(async () => true)} />,
+    );
+
+    expect(getByTestId("tables-stat-size").textContent).toBe(expected);
+    // And the "N/A" arms come from the FORMATTER, not from the card's own absence gate:
+    // `tableSizeBytes` is present on the row, so `sizeAbsent` is false and the "Total"
+    // caption below the figure is still drawn. Without this the two refusal arms would pass
+    // against a card that had simply given up.
+    expect(queryByText("Total")).not.toBeNull();
   });
 });
 

--- a/tests/components/schema-explorer/SchemaExplorer.test.tsx
+++ b/tests/components/schema-explorer/SchemaExplorer.test.tsx
@@ -113,6 +113,26 @@ describe("SchemaExplorer", () => {
     expect(view.queryByText("No structures found")).not.toBeNull();
   });
 
+  // D31: an empty tree after a FAILED read must not read as "this database has
+  // nothing in it". The engine's own message is what tells the two apart.
+  test("a failed read states the engine's error instead of claiming nothing was found", () => {
+    const props = createDefaultProps({ schema: emptySchema, schemaError: "'(' expected" });
+    const { container } = render(<SchemaExplorer {...props} />);
+    const view = within(container);
+
+    expect(view.queryByText("No structures found")).toBeNull();
+    expect(view.queryByTestId("schema-read-failed")).not.toBeNull();
+    expect(view.queryByText("'(' expected")).not.toBeNull();
+  });
+
+  test("a schema that loaded is rendered even when a previous read had failed", () => {
+    const props = createDefaultProps({ schemaError: "'(' expected" });
+    const { container } = render(<SchemaExplorer {...props} />);
+
+    expect(container.querySelector('[data-testid="schema-read-failed"]')).toBeNull();
+    expect(within(container).queryByPlaceholderText("Search tables or columns...")).not.toBeNull();
+  });
+
   // ── Renders table items ───────────────────────────────────────────────────
 
   test("renders table items from schema", () => {

--- a/tests/components/sidebar/Sidebar.test.tsx
+++ b/tests/components/sidebar/Sidebar.test.tsx
@@ -33,6 +33,7 @@ mock.module("@/components/schema-explorer", () => ({
       {
         "data-testid": "schema-explorer",
         "data-schema-count": String(schema?.length ?? 0),
+        "data-schema-error": String(props.schemaError ?? ""),
       },
       "SchemaExplorer Mock",
     );
@@ -156,6 +157,15 @@ describe("Sidebar", () => {
     const propsNoConn = createDefaultProps({ activeConnection: null });
     const result2 = render(<Sidebar {...propsNoConn} />);
     expect(result2.queryByTestId("schema-explorer")).toBeNull();
+  });
+
+  // D31: the explorer's empty state says WHY it is empty, so the reason has to reach
+  // it — the sidebar is the only path between the hook that read it and the tree.
+  test("the schema read's error reaches the explorer", () => {
+    const props = createDefaultProps({ schema: [], schemaError: "'(' expected" });
+    const { getByTestId } = render(<Sidebar {...props} />);
+
+    expect(getByTestId("schema-explorer").getAttribute("data-schema-error")).toBe("'(' expected");
   });
 
   test("ERD button only appears when activeConnection exists", () => {

--- a/tests/components/studio/BottomPanel.test.tsx
+++ b/tests/components/studio/BottomPanel.test.tsx
@@ -149,7 +149,8 @@ mock.module("@/lib/storage", () => ({
 // ---- Now import bun:test, testing-library, and the component ----
 
 import { describe, test, expect, afterEach, beforeAll } from "bun:test";
-import { render, fireEvent, cleanup, act } from "@testing-library/react";
+import { render, fireEvent, cleanup, act, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import { BottomPanel } from "@/components/studio/BottomPanel";
@@ -676,13 +677,57 @@ describe("BottomPanel", () => {
       expect(capturedResultsGridProps.result).toEqual(ARTIFACT_RESULT);
     });
 
-    test("a hydrated result is read-only: nothing offers to edit it or export it as the tab's own", () => {
+    test("a hydrated result is read-only: nothing offers to edit it or page it", () => {
       const props = hydratedProps({ editingEnabled: true });
-      const { queryByText } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
+      render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
 
       expect(capturedResultsGridProps.editingEnabled).toBe(false);
       expect(capturedResultsGridProps.onLoadMore).toBeUndefined();
-      expect(queryByText("Export")).toBeNull();
+    });
+
+    // B34: the menu used to be hidden here, because the export serialized the tab's
+    // own rows. It is now retargeted — the artifact travels with the format, so the
+    // file is the rows on screen and is named after the run that produced them.
+    test("the export menu is offered over a hydrated result and carries the artifact", async () => {
+      const onExportResults = mock(() => {});
+      const artifact = {
+        runId: "arun_1",
+        correlationId: "corr_9",
+        operationId: "sql.query.read",
+        surface: "results",
+        result: ARTIFACT_RESULT,
+        explainPlan: null,
+      };
+      const props = hydratedProps({ onExportResults, agentArtifact: artifact });
+      const { getByText, getByTestId } = render(
+        <BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />,
+      );
+
+      // The count is the artifact's rows, not the tab's — two, not one.
+      expect(getByTestId("export-row-count").textContent).toBe("2");
+      // The menu's items are portalled into the body, so they are queried there.
+      await userEvent.click(getByText("Export"));
+      const menu = within(document.body as HTMLElement);
+      // Said in the menu as well as in the name, because the name is the only part of
+      // a file that survives being renamed by whoever receives it. Read while the menu
+      // is still open: choosing a format closes it.
+      expect(menu.getByTestId("export-provenance").textContent).toContain("arun_1");
+      await userEvent.click(menu.getByText("Export as CSV"));
+
+      expect(onExportResults).toHaveBeenCalledWith("csv", artifact);
+    });
+
+    test("without an artifact the export menu carries none, and stays the tab's own", async () => {
+      const onExportResults = mock(() => {});
+      const props = hydratedProps({ agentArtifact: null, onExportResults });
+      const { getByText } = render(<BottomPanel {...(props as React.ComponentProps<typeof BottomPanel>)} />);
+
+      await userEvent.click(getByText("Export"));
+      const menu = within(document.body as HTMLElement);
+      await userEvent.click(menu.getByText("Export as JSON"));
+
+      expect(onExportResults).toHaveBeenCalledWith("json", null);
+      expect(menu.queryByTestId("export-provenance")).toBeNull();
     });
 
     test("dismissing it is a user action, and the tab's own result is what returns", () => {

--- a/tests/evals/investigation-arc.test.ts
+++ b/tests/evals/investigation-arc.test.ts
@@ -202,9 +202,16 @@ describe("a planning run is judged by what planning mode can produce", () => {
     expect(reading.statements).toHaveLength(3);
     // No capture, and no catalog re-read: the inventory was given for free. The one
     // statement it did send is the statistics read, which no hold carries.
+    //
+    // The reuse is NOT free of the ledger, though, and `context-reused` is where this
+    // test now says so. A held inventory has no expiry, so a run inheriting one could
+    // be reasoning over a schema read hours ago and the ledger could not tell that
+    // apart from a capture taken this second. The event carries the reading's age, so
+    // the saving is still recorded as a saving rather than as silence.
     expect(drive.kinds).toEqual([
       "run-started",
       "driver-resolved",
+      "context-reused",
       "closing-statement",
       "plan-statement-drafted",
       "run-finished",

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -17,6 +17,28 @@ const DEFAULT_PORTS: Record<string, string> = {
   couchbase: "8091",
 };
 
+// The engines whose addressing fields diverge from the networked default. Spelled out
+// rather than collapsed to "everything but the file-based ones": `connectionFields` is what
+// `buildConnection` writes from, so a mock that hands every type the full set cannot fail
+// when the real list is wrong - which is how Redis came to have its ACL user discarded by a
+// list that omitted `user` while the provider authenticated with it. The real table is the
+// authority; tests/unit/lib/db-ui-config.test.ts derives it from the provider sources.
+const MOCK_CONNECTION_FIELDS: Record<string, string[]> = {
+  sqlite: ["database"],
+  libredb: ["database"],
+  duckdb: ["database"],
+  libsql: ["host", "port", "password", "connectionString"],
+  // Named explicitly even though it matches the default: it is the one this table exists
+  // for, and `user` being present here is a statement about the real config, not a
+  // convenience.
+  redis: ["host", "port", "user", "password", "database"],
+  druid: ["host", "port", "user", "password"],
+  elasticsearch: ["host", "port", "user", "password"],
+  opensearch: ["host", "port", "user", "password"],
+};
+const mockFields = (type: string): string[] =>
+  MOCK_CONNECTION_FIELDS[type] ?? ["host", "port", "user", "password", "database"];
+
 mock.module("@/lib/db-ui-config", () => ({
   getDBConfig: (type: string) => ({
     label: type.charAt(0).toUpperCase() + type.slice(1),
@@ -29,9 +51,9 @@ mock.module("@/lib/db-ui-config", () => ({
     // else. A mock that gave every type the full network field set would hide what
     // the editor does to a SQLite or LibreDB connection, which is exactly where it
     // went wrong.
-    connectionFields:
-      type === "sqlite" || type === "libredb" ? ["database"] : ["host", "port", "user", "password", "database"],
+    connectionFields: mockFields(type),
   }),
+  takesConnectionField: (type: string, field: string) => mockFields(type).includes(field),
 }));
 
 import { useConnectionForm } from "@/hooks/use-connection-form";
@@ -1772,5 +1794,72 @@ describe("useConnectionForm", () => {
     expect(defaultProps.onConnect).toHaveBeenCalledTimes(1);
     // Form is reset after a successful connect
     expect(result.current.name).toBe("");
+  });
+
+  // ── an addressing field is written when, and only when, the engine takes it ───
+
+  test("a Redis ACL username reaches the saved connection", async () => {
+    // `RedisProvider.connect()` passes `config.user` to ioredis as `username`, and its
+    // docblock records the two-arm measurement behind it (#502): without it `ACL WHOAMI`
+    // answered `default`, so a restricted principal reported full health. That repair is
+    // only reachable if the write list names the field, and it did not - the value was
+    // discarded between the box the user typed it into and the driver that needed it.
+    //
+    // What this test pins is the MECHANISM: given a list that names `user`, the field
+    // survives the save. It cannot pin the list itself, because this file mocks
+    // `@/lib/db-ui-config` - that is what
+    // tests/unit/lib/db-ui-config.test.ts does, deriving each engine's fields from
+    // whether its provider source ever reads them.
+    mockGlobalFetch({
+      "/api/db/test-connection": { ok: true, json: { success: true, latency: 5 } },
+    });
+
+    const onConnect = mock(() => {});
+    const { result } = renderHook(() => useConnectionForm({ ...defaultProps, onConnect }));
+
+    act(() => {
+      result.current.setType("redis");
+      result.current.setUser("probe");
+      result.current.setPassword("probepw");
+    });
+
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+
+    const saved = (onConnect.mock.calls as unknown[][])[0][0] as DatabaseConnection;
+    expect(saved.user).toBe("probe");
+    expect(saved.password).toBe("probepw");
+  });
+
+  test("a user name and database typed for libSQL are not saved, because it takes neither", async () => {
+    // The modal renders no box for either now, so this is the write half of the same
+    // rule: were a value to arrive anyway - a stale form state, a future edit to the
+    // modal - nothing carries it onto a libSQL connection. The engine authenticates with
+    // a token the server minted and is addressed entirely by URL.
+    mockGlobalFetch({
+      "/api/db/test-connection": { ok: true, json: { success: true, latency: 5 } },
+    });
+
+    const onConnect = mock(() => {});
+    const { result } = renderHook(() => useConnectionForm({ ...defaultProps, onConnect }));
+
+    act(() => {
+      result.current.setType("libsql");
+      result.current.setUser("ignored");
+      result.current.setDatabase("also-ignored");
+      result.current.setHost("db.turso.io");
+    });
+
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+
+    const saved = (onConnect.mock.calls as unknown[][])[0][0] as DatabaseConnection;
+    expect(saved.user).toBeUndefined();
+    expect(saved.database).toBeUndefined();
+    // Non-vacuous: the connection WAS built, and the fields libSQL does take survived.
+    expect(saved.host).toBe("db.turso.io");
+    expect(saved.type).toBe("libsql");
   });
 });

--- a/tests/hooks/use-connection-manager.test.ts
+++ b/tests/hooks/use-connection-manager.test.ts
@@ -189,6 +189,64 @@ describe("useConnectionManager", () => {
     expect(mockToastError).toHaveBeenCalledWith("Schema Error", { description: "Connection refused" });
   });
 
+  // A failing read must not leave the PREVIOUS connection's tables on screen (D31).
+  // The assertion above is vacuous on its own — `schema` starts empty — so this one
+  // loads a schema first and then fails the next read, which is the measured sequence.
+  test("a failed read clears the schema loaded for the previous connection", async () => {
+    mockGlobalFetch({
+      "/api/db/schema/list": { ok: true, json: makeSchema() },
+      "/api/db/schema/relations": { ok: false, status: 500, json: {} },
+    });
+
+    const { result } = renderHook(() => useConnectionManager(true));
+
+    await act(async () => {
+      await result.current.fetchSchema(makeConnection());
+    });
+    expect(result.current.schema.map((t) => t.name)).toEqual(["users", "orders"]);
+    expect(result.current.schemaError).toBeNull();
+
+    restoreGlobalFetch();
+    mockGlobalFetch({
+      "/api/db/schema/list": { ok: false, status: 500, json: { error: "'(' expected" } },
+    });
+
+    await act(async () => {
+      await result.current.fetchSchema(makeConnection({ id: "conn-2", name: "Other DB" }));
+    });
+
+    expect(result.current.schema).toEqual([]);
+    // The engine's own words, so the empty tree can say why it is empty rather than
+    // reading as "this database has no tables".
+    expect(result.current.schemaError).toBe("'(' expected");
+  });
+
+  test("a read that succeeds after a failure drops the previous error", async () => {
+    mockGlobalFetch({
+      "/api/db/schema/list": { ok: false, status: 500, json: { error: "Prepare is not support in Databend" } },
+    });
+
+    const { result } = renderHook(() => useConnectionManager(true));
+
+    await act(async () => {
+      await result.current.fetchSchema(makeConnection());
+    });
+    expect(result.current.schemaError).toBe("Prepare is not support in Databend");
+
+    restoreGlobalFetch();
+    mockGlobalFetch({
+      "/api/db/schema/list": { ok: true, json: makeSchema() },
+      "/api/db/schema/relations": { ok: false, status: 500, json: {} },
+    });
+
+    await act(async () => {
+      await result.current.fetchSchema(makeConnection({ id: "conn-2" }));
+    });
+
+    expect(result.current.schemaError).toBeNull();
+    expect(result.current.schema.map((t) => t.name)).toEqual(["users", "orders"]);
+  });
+
   // ── Two-phase schema loading (list + relations) ───────────────────────────
   // The schema fetch was split so a slow/failing FK+index query can never block
   // (or wipe) the table list. These tests lock in that contract.

--- a/tests/integration/db/duckdb-provider.test.ts
+++ b/tests/integration/db/duckdb-provider.test.ts
@@ -186,6 +186,12 @@ describe("DuckDBProvider labels", () => {
     expect(labels.slowQueriesEmptyState).not.toContain("pg_stat_statements");
   });
 
+  test("the sessions panel says the list can never have a row, not that none is running", () => {
+    // #D48: the default "No active sessions found." reads as "nothing is running right
+    // now", and duckdb_connections() does not exist, so no row can ever appear.
+    expect(labels.sessionsEmptyState).toContain("duckdb_connections()");
+  });
+
   test("the global vacuum wording says what VACUUM actually does on this engine", () => {
     expect(labels.vacuumGlobalDesc).toContain("checkpoint");
   });

--- a/tests/integration/db/elasticsearch-provider.test.ts
+++ b/tests/integration/db/elasticsearch-provider.test.ts
@@ -262,6 +262,41 @@ const CAT_INDICES_CLOSED_BODY = JSON.stringify([
 ]);
 
 /**
+ * The same closed index BESIDE an open one, so the cluster-wide aggregate can be
+ * asserted rather than inferred: `StorageTab`'s `tableSizeKnown` is
+ * `tables.every((t) => t.tableSizeBytes !== undefined)`, so one index that
+ * published no size takes the Data figure away from every index that did.
+ */
+const CAT_INDICES_MIXED_BODY = JSON.stringify([
+  {
+    health: "yellow",
+    status: "open",
+    index: "probe_orders",
+    uuid: "ArZ2X__TSEqj8KjbAtIhvg",
+    pri: "1",
+    rep: "1",
+    "docs.count": "1",
+    "docs.deleted": "0",
+    "store.size": "5913",
+    "pri.store.size": "5913",
+    "dataset.size": "5913",
+  },
+  {
+    health: "yellow",
+    status: "close",
+    index: "probe_closed",
+    uuid: "Pjif3CuaTwW2pmgHmRr8iQ",
+    pri: "1",
+    rep: "1",
+    "docs.count": null,
+    "docs.deleted": null,
+    "store.size": null,
+    "pri.store.size": null,
+    "dataset.size": null,
+  },
+]);
+
+/**
  * An index the engine keeps for itself, CONSTRUCTED - and the one listing row here
  * that is not a capture, because it cannot be: this node runs with security
  * disabled, so it has created no `.security-*` index and `_cat` lists no system
@@ -2053,10 +2088,11 @@ describe("ElasticsearchProvider monitoring", () => {
     ]);
   });
 
-  test("getTableStats reads a closed index as zero, where the schema tree omits it", async () => {
-    // `TableStats` has no way to say "unknown" - both fields are required numbers - so a
-    // closed index reads as zero here, and the schema tree is the surface that keeps the
-    // distinction because its `rowCount` and `size` are optional.
+  test("getTableStats omits the optional size fields for a closed index, and zeroes only the required ones", async () => {
+    // A closed index reports neither a count nor a size. `TableStats.rowCount`, `totalSize`
+    // and `totalSizeBytes` are required numbers, so those three have nowhere to read but
+    // zero; `tableSize` and `tableSizeBytes` are OPTIONAL, and a 0 there is a fabricated
+    // measurement rather than a forced one, so they are absent.
     const provider = await connectProvider();
     overridePath("/_cat/indices?format=json&bytes=b", ok(CAT_INDICES_CLOSED_BODY));
 
@@ -2067,12 +2103,47 @@ describe("ElasticsearchProvider monitoring", () => {
         schemaName: "",
         tableName: "probe_closed",
         rowCount: 0,
-        tableSize: "0 B",
-        tableSizeBytes: 0,
         totalSize: "0 B",
         totalSizeBytes: 0,
       },
     ]);
+    // Absent, not zero: `toEqual` ignores an undefined value, so the key itself is the
+    // assertion.
+    expect("tableSize" in stats[0]).toBe(false);
+    expect("tableSizeBytes" in stats[0]).toBe(false);
+  });
+
+  test("getTableStats lets one closed index take the cluster's Data figure away from an open one", async () => {
+    // The visible consequence of the omission above, and why it needed a decision rather
+    // than a patch: `StorageTab` gates its Data figure on
+    // `tables.every((t) => t.tableSizeBytes !== undefined)`, so the open index's measured
+    // bytes stop being summed as soon as one index in the cluster published nothing. That
+    // is what the optional field prescribes - a partial sum reads as a measurement - and it
+    // is still a change a user sees, so the aggregate is asserted here, not inferred.
+    const provider = await connectProvider();
+    overridePath("/_cat/indices?format=json&bytes=b", ok(CAT_INDICES_MIXED_BODY));
+
+    const stats = await provider.getTableStats();
+
+    expect(stats).toEqual([
+      {
+        schemaName: "",
+        tableName: "probe_orders",
+        rowCount: 1,
+        tableSize: "5.77 KB",
+        tableSizeBytes: 5913,
+        totalSize: "5.77 KB",
+        totalSizeBytes: 5913,
+      },
+      {
+        schemaName: "",
+        tableName: "probe_closed",
+        rowCount: 0,
+        totalSize: "0 B",
+        totalSizeBytes: 0,
+      },
+    ]);
+    expect(stats.every((row) => row.tableSizeBytes !== undefined)).toBe(false);
   });
 
   test("getTableStats answers a named schema without a round trip", async () => {

--- a/tests/integration/db/libredb-provider.test.ts
+++ b/tests/integration/db/libredb-provider.test.ts
@@ -156,6 +156,32 @@ describe("LibreDBProvider — lifecycle & metadata", () => {
     expect(slowQueriesEmptyState).toContain("LibreDB keeps no statistics");
     expect(slowQueriesEmptyState).not.toContain("pg_stat_statements");
   });
+
+  // `statementLanguage` is the sentence the agent's plan contract states verbatim
+  // (`ProviderLabels.statementLanguage`), and this engine needs one for the reason
+  // Redis did: a plan run on 2026-08-22, asked to list every entry under the `users`
+  // prefix, drafted `GET users:*`. `dispatchCommand` gives `get` exactly one meaning
+  // - `kv.get(parts[1])`, an exact-key lookup with no glob - so that command answers
+  // zero rows and no error, which on a key-value store reads as "nothing stored
+  // there" (#B55). So the sentence names all five verbs AND says a key is exact,
+  // because the inventory's rows are named `users:*` and that reads as a wildcard
+  // the grammar does not have.
+  test("getLabels() declares the five verbs as the statement language and that a key is exact", () => {
+    const { statementLanguage } = new LibreDBProvider(makeConn(tmpFile)).getLabels();
+
+    expect(statementLanguage).toBeString();
+    // Every verb `dispatchCommand` matches; a verb left out is one a model must guess.
+    for (const verb of ["get", "put", "delete", "prefix", "range"]) {
+      expect(statementLanguage).toContain(verb);
+    }
+    // The two words that stop `users:*` being read as a pattern, and the runnable
+    // form for that objective - the one `generateTableQuery` already emits.
+    expect(statementLanguage).toContain("exact");
+    expect(statementLanguage).toContain("no wildcard");
+    expect(statementLanguage).toContain("prefix users:");
+    // Neither SQL nor a shell: the grammar is line-oriented and one command per line.
+    expect(statementLanguage).toContain("SQL");
+  });
 });
 
 describe("LibreDBProvider — getSchema", () => {

--- a/tests/integration/db/opensearch-provider.test.ts
+++ b/tests/integration/db/opensearch-provider.test.ts
@@ -307,6 +307,39 @@ const CAT_INDICES_BODY = JSON.stringify([
   },
 ]);
 
+/**
+ * The same listing with one OPEN index and one CLOSED one, so the cluster-wide
+ * aggregate has both inputs. Constructed from this product's measured closed-index
+ * shape (status word `close`, counts as JSON `null` - docs/providers/opensearch.md
+ * §6); the open row is the captured `probe_orders` verbatim.
+ */
+const CAT_INDICES_MIXED_BODY = JSON.stringify([
+  {
+    health: "yellow",
+    status: "open",
+    index: "probe_orders",
+    uuid: "e4QJ354KTqyCX763SC2eag",
+    pri: "1",
+    rep: "1",
+    "docs.count": "1",
+    "docs.deleted": "0",
+    "store.size": "4807",
+    "pri.store.size": "4807",
+  },
+  {
+    health: "yellow",
+    status: "close",
+    index: "probe_closed",
+    uuid: "Pjif3CuaTwW2pmgHmRr8iQ",
+    pri: "1",
+    rep: "1",
+    "docs.count": null,
+    "docs.deleted": null,
+    "store.size": null,
+    "pri.store.size": null,
+  },
+]);
+
 /** `GET /probe_orders/_mapping`. */
 const ORDERS_MAPPING_BODY = JSON.stringify({
   probe_orders: {
@@ -1000,6 +1033,44 @@ describe("OpenSearchProvider monitoring", () => {
     // provider made up.
     expect(stats.every((row) => row.schemaName === "")).toBe(true);
     expect(stats[1]).toMatchObject({ rowCount: 2, tableSizeBytes: 6070, totalSizeBytes: 6070 });
+  });
+
+  test("omits the optional size fields for a closed index, which takes the cluster's Data figure away", async () => {
+    // The closed row's shape is this product's own, documented in docs/providers/opensearch.md
+    // §6: the status word is `close` and `docs.count` / `pri.store.size` arrive as JSON null
+    // while the listing still names the index. `TableStats.rowCount`, `totalSize` and
+    // `totalSizeBytes` are required, so a closed index has nowhere to read but zero there;
+    // `tableSize` and `tableSizeBytes` are OPTIONAL and are omitted, because a 0 would be a
+    // fabricated measurement.
+    const provider = await connectProvider();
+    overridePath("/_cat/indices", ok(CAT_INDICES_MIXED_BODY));
+
+    const stats = await provider.getTableStats();
+
+    expect(stats).toEqual([
+      {
+        schemaName: "",
+        tableName: "probe_orders",
+        rowCount: 1,
+        tableSize: "4.69 KB",
+        tableSizeBytes: 4807,
+        totalSize: "4.69 KB",
+        totalSizeBytes: 4807,
+      },
+      {
+        schemaName: "",
+        tableName: "probe_closed",
+        rowCount: 0,
+        totalSize: "0 B",
+        totalSizeBytes: 0,
+      },
+    ]);
+    // The cluster-wide consequence, asserted rather than inferred: `StorageTab` gates its
+    // Data figure on `tables.every((t) => t.tableSizeBytes !== undefined)`, so the open
+    // index's measured 4807 bytes stop being drawn as a total the moment one index beside it
+    // published nothing. A partial sum would read as a measurement.
+    expect(stats.every((row) => row.tableSizeBytes !== undefined)).toBe(false);
+    expect("tableSizeBytes" in stats[1]).toBe(false);
   });
 
   test("reports the cluster as the one storage unit there is", async () => {

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -11,6 +11,7 @@ import {
   AGENT_CITATION_RULE,
   AGENT_REPORT_RESERVE_NOTICE,
   type AgentToolResources,
+  guidanceDelivered,
   PLAN_NO_REASONING_EFFORT,
   runInvestigation,
 } from "@/lib/agent/investigation";
@@ -1201,6 +1202,56 @@ describe("planning mode runs no statement of the user's", () => {
         expect.stringContaining("pg_stats") as unknown as string,
       ]);
       expect(result.status).toBe("succeeded");
+    });
+
+    /*
+      The reuse, on the ledger, with the age of the reading (B56).
+
+      `holdSnapshotForConnection` has no expiry: newest reading wins, eviction is by use,
+      nothing re-reads. Measured 2026-08-22 — MongoDB's schema inference was changed, the
+      schema tree showed the new dotted paths at once, and two plan runs afterwards still
+      grouped by the old field with ledgers carrying no context event at all. So the record
+      could not tell "held, hours old" from "captured just now", and the only diagnosis
+      available was restarting the process.
+
+      Two hours are expressed as two clock readings rather than as a wait: the age is
+      measured against the drive's own clock, which is the seam these runs are given.
+    */
+    test("it records the reading it reused, and how old that reading was when it took it", async () => {
+      const capturedAtMs = 1_000_000;
+      const reader = boot(freshDataDir(), { answer: catalog });
+      const readerRun = await startRun(reader, "agent");
+      const readerScript = scriptedModel(answersProse("understood"));
+      await runInvestigation(readerRun.runId, {
+        service: reader.service,
+        model: await modelOver(readerScript.fetch),
+        resources: { ...reader.resources, clock: () => capturedAtMs },
+      });
+      const capture = (await eventsOf(reader.store, readerRun.runId)).find(
+        (event) => event.kind === "context-captured",
+      );
+
+      const b = boot(freshDataDir(), { answer: catalog });
+      const run = await startRun(b, "planning");
+      const script = scriptedModel(answersProse("a plan"));
+      await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: { ...b.resources, clock: () => capturedAtMs + 7_200_000 },
+      });
+
+      const events = await eventsOf(b.store, run.runId);
+      const reused = events.find((event) => event.kind === "context-reused");
+      expect(reused).toBeDefined();
+      expect(reused?.ageMs).toBe(7_200_000);
+      // The reading it names is the one the earlier run recorded, which is what makes the
+      // entry provenance rather than a note that something was reused.
+      expect(reused?.fingerprint).toBe(capture?.fingerprint);
+      expect(reused?.tableCount).toBe(2);
+      // And it is NOT recorded as this run's own capture: no catalog was read here, and an
+      // entry saying otherwise would let a later drive re-derive an inventory this run
+      // never took.
+      expect(kindsOf(events)).not.toContain("context-captured");
     });
 
     /*
@@ -3303,6 +3354,88 @@ describe("a run that used its tools and then narrated is reminded once", () => {
     expect((await eventsOf(b.store, run.runId)).map((event) => event.kind)).toContain("report-composed");
   });
 
+  /*
+    Once per RUN and not once per drive (B51).
+
+    Every notice bound was a `let` inside `runInvestigation` — which is also what RESUMES a
+    run a dead process left running — so a resumed drive started with every flag false and
+    could deliver a notice the previous drive had already delivered. Nothing durable bounded
+    them, because a delivery wrote no ledger entry at all: `docs/llms/` is built by reading
+    run ledgers, and its whole claim is that each figure comes from an observed run, so an
+    unattributable rescue is worse than an unrecorded one.
+
+    Driven as two drives over one data directory, which is what a resume is in this suite.
+    The first drive dies where the loop cannot decide (a 401 leaves the run running), so
+    the second is a genuine resume with its own counters.
+  */
+  test("a resumed drive is not told to report again, because the delivery is on the ledger", async () => {
+    const dataDir = freshDataDir();
+    const first = boot(dataDir);
+    const run = await startRun(first);
+    const firstScript = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "read it" }),
+      // Prose after a tool call, which is what earns the reminder — and the turn is taken
+      // again, so the third scripted answer is what the reminded turn gets.
+      answersProse("Orders were read."),
+      () => endpointError(401, "invalid api key"),
+    );
+
+    await expect(
+      runInvestigation(run.runId, {
+        service: first.service,
+        model: await modelOver(firstScript.fetch),
+        resources: first.resources,
+      }),
+    ).rejects.toBeInstanceOf(LLMAuthError);
+    const delivered = guidanceDelivered(await eventsOf(first.store, run.runId));
+    expect(delivered["report-reminder"]).toBe(1);
+
+    // A second process over the same ledger. It calls a tool of its own, so `anyToolCalled`
+    // is true here too and the only thing standing between it and a second reminder is what
+    // the ledger says.
+    const second = boot(dataDir);
+    const secondScript = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM customers", rationale: "read it" }, "call_2"),
+      answersProse("Customers were read."),
+    );
+
+    const result = await runInvestigation(run.runId, {
+      service: second.service,
+      model: await modelOver(secondScript.fetch),
+      resources: second.resources,
+    });
+
+    // Two turns and not three: the run narrated and stopped, un-nudged.
+    expect(result.turns).toBe(2);
+    expect(guidanceDelivered(await eventsOf(second.store, run.runId))["report-reminder"]).toBe(1);
+    const sent = secondScript.turns.flatMap((turn) => JSON.stringify(turn.body.messages ?? []));
+    expect(sent.some((messages) => messages.includes("written your findings as prose"))).toBe(false);
+  });
+
+  test("a delivery records where in the run it landed, not only that it happened", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "read it" }),
+      answersProse("Orders were read."),
+      reportOn("Orders were read."),
+    );
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const issued = (await eventsOf(b.store, run.runId)).find((event) => event.kind === "guidance-issued");
+    expect(issued?.notice).toBe("report-reminder");
+    // The reminder rides the SECOND turn, after one tool call: a nudge on the second turn
+    // and one on the last are different facts about a model, and the ledger could say
+    // neither.
+    expect(issued?.atTurn).toBe(2);
+    expect(issued?.toolCalls).toBe(1);
+  });
+
   test("the reminder is sent once, so a model that narrates again still stops", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
@@ -3320,6 +3453,44 @@ describe("a run that used its tools and then narrated is reminded once", () => {
 
     expect(result.stopReason).toBe("model-stopped");
     expect(result.turns).toBe(3);
+  });
+});
+
+/*
+  The fold that makes "once" mean once (B51).
+
+  Driven directly as well as through a drive, because what it has to get right is a reading
+  of two DIFFERENT entry kinds: a notice sent as a `user` message writes `guidance-issued`,
+  and one sent instead of running a call is the `notice` on that call's hold.
+*/
+describe("guidanceDelivered", () => {
+  const at = (event: AgentRunEvent): AgentRunEvent => event;
+
+  test("counts both entry kinds, because a delivery lands on whichever records the call", () => {
+    const counts = guidanceDelivered([
+      at({ kind: "guidance-issued", atMs: 1, notice: "report-reminder" }),
+      at({ kind: "guidance-issued", atMs: 2, notice: "report-reminder", atTurn: 4, toolCalls: 2 }),
+      at({ kind: "call-held", atMs: 3, tool: "compose_report", reason: "cite it", notice: "cite-what-you-read" }),
+    ]);
+
+    expect(counts["report-reminder"]).toBe(2);
+    expect(counts["cite-what-you-read"]).toBe(1);
+    // Every id is answered, and a notice nobody delivered is a zero it measured: the
+    // record is total, so a new id cannot read as "never delivered" by being absent.
+    expect(counts["report-reserve"]).toBe(0);
+    expect(Object.values(counts).reduce((sum, count) => sum + count, 0)).toBe(3);
+  });
+
+  test("a hold carrying no notice counts towards nothing, which is what it says", () => {
+    // A verdict-preview hold speaks for a `shortfall` rather than for a named notice, and
+    // so does every hold written before the field existed. Counting it as one would bound
+    // a notice nobody sent.
+    const counts = guidanceDelivered([
+      at({ kind: "call-held", atMs: 1, tool: "compose_report", reason: "profile a table", shortfall: "no-report" }),
+      at({ kind: "context-captured", atMs: 2, fingerprint: "ctx_1", tableCount: 1 }),
+    ]);
+
+    expect(Object.values(counts).every((count) => count === 0)).toBe(true);
   });
 });
 
@@ -3656,6 +3827,58 @@ describe("the run reads its schema context through the catalog tool", () => {
     }
   });
 
+  /*
+    What the capture SPENT, on the entry (B13).
+
+    Its reads reach `executeAuditedOperation` through `captureContextSnapshot` and never
+    through `runStep`, the only writer of `tool-completed` — so the whole cost of
+    grounding a run was charged against the ceilings the rail displays and folded to
+    nothing: a drive with no reusable snapshot showed "0 statements" with three already
+    spent, before the model's first turn.
+  */
+  test("the capture records the statements the tracker charged it, and not a count of its plan", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b);
+    const script = scriptedModel(answersProse("understood"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const captured = (await eventsOf(b.store, run.runId)).find((event) => event.kind === "context-captured");
+    expect(captured?.charged?.statements).toBe(CONTEXT_READS);
+    // And the entry is the only place that figure survives: the run has ended, so
+    // `releaseExecutionRun` has dropped its accounting and the tracker now answers zero
+    // for it. Reading the meter from the tracker instead of the ledger is the alternative
+    // B13 records as not a drop-in, and this is why.
+    expect(b.resources.tracker.usage(run.runId).executedStatements).toBe(0);
+  });
+
+  test("a capture that was REFUSED records what it paid anyway", async () => {
+    // The engine refuses the third read, so two answered and one did not — and all three
+    // were admitted and charged before the refusal was known.
+    const b = boot(freshDataDir(), {
+      answer: async (sql: string) => {
+        if (sql.includes("pg_index")) throw new QueryError("permission denied for relation pg_index");
+        return queryResult();
+      },
+    });
+    const run = await startRun(b);
+    const script = scriptedModel(answersProse("understood"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const refused = (await eventsOf(b.store, run.runId)).find((event) => event.kind === "context-unavailable");
+    expect(refused?.reasonCode).toBe("CATALOG_READ_REFUSED");
+    expect(refused?.charged?.statements).toBe(CONTEXT_READS);
+  });
+
   test("the packed inventory reaches the model fenced, carrying the fingerprint a claim can cite", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
@@ -3934,6 +4157,39 @@ describe("a run that would report an answer it never presented", () => {
     // And the answer was recorded BEFORE the report, which is the ordering the
     // shortfall is about.
     expect(kinds.indexOf("answer-composed")).toBeLessThan(kinds.indexOf("report-composed"));
+  });
+
+  /*
+    The hold's own entry says WHICH notice it answered with (B51).
+
+    A held delivery has always written `call-held`, so this one was never invisible — what
+    it lacked was a name. `reason` is the prose the model was sent and names artifact ids in
+    two of the three cases, so a resumed drive reading it back to decide whether a notice
+    had already been delivered would be pattern-matching a paragraph.
+  */
+  test("the hold records which notice it answered with, in the vocabulary every delivery shares", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "agent", "data-analysis", true);
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT id FROM orders", rationale: "the question, in SQL" }),
+      reportOn("Orders were read."),
+      presentsRead(),
+      reportOn("Orders were read."),
+    );
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch),
+      resources: b.resources,
+    });
+
+    const events = await eventsOf(b.store, run.runId);
+    const held = events.find((event) => event.kind === "call-held");
+    expect(held?.tool).toBe("compose_report");
+    expect(held?.notice).toBe("present-before-report");
+    // And the same fold that bounds a `user`-message notice across a resume counts this
+    // one, which is the whole reason the id is on the hold rather than in a second entry.
+    expect(guidanceDelivered(events)["present-before-report"]).toBe(1);
   });
 
   test("the notice is sent once, so a model that ignores it still reports", async () => {

--- a/tests/isolated/agent-model-adapter.test.ts
+++ b/tests/isolated/agent-model-adapter.test.ts
@@ -237,16 +237,15 @@ describe("createAgentModel reads the existing LLM settings surface", () => {
     expect(recording.requests[0]?.headers["x-goog-api-key"]).toBe("gemini-key");
   });
 
-  test("Gemini ignores LLM_API_URL, exactly as the chat surface's provider does", async () => {
-    // .env.example documents LLM_API_URL for the Ollama and custom kinds, and
-    // src/lib/llm/providers/gemini.ts never reads it. Honouring it here would let
-    // a value left over from a custom setup redirect a keyed Gemini request.
+  test("Gemini reads LLM_API_URL, exactly as the chat surface's provider now does (B20)", async () => {
+    // Both Gemini consumers take the variable; src/lib/llm/utils/gemini-endpoint.ts
+    // is what turns one value into the two spellings the SDKs disagree about.
     process.env.LLM_API_KEY = "gemini-key";
-    process.env.LLM_API_URL = "https://left-over-proxy.example.com/v1";
+    process.env.LLM_API_URL = "https://gemini-proxy.example.com/v1beta";
 
     const request = await firstRequest({}, geminiCompletion("pong"));
 
-    expect(request.url).toStartWith("https://generativelanguage.googleapis.com/v1beta/");
+    expect(request.url).toStartWith("https://gemini-proxy.example.com/v1beta/");
     expect(request.headers["x-goog-api-key"]).toBe("gemini-key");
   });
 

--- a/tests/isolated/agent-provider-registry.test.ts
+++ b/tests/isolated/agent-provider-registry.test.ts
@@ -110,6 +110,32 @@ describe("each resolved adapter builds a model for its own endpoint", () => {
     expect(request.headers["x-goog-api-key"]).toBe("gemini-key");
   });
 
+  // B20: the adapter used to pass no baseURL at all, so an operator behind an
+  // egress proxy set LLM_API_URL, saw no error, and was routed to Google.
+  test("gemini reaches a configured endpoint, keeping the version segment it was given", async () => {
+    const request = await firstRequestThroughRegistry(
+      {
+        provider: "gemini",
+        apiKey: "gemini-key",
+        model: "gemini-2.5-flash",
+        apiUrl: "https://gemini-proxy.internal/v1beta",
+      },
+      geminiTextStream("pong"),
+    );
+
+    expect(request.url).toStartWith("https://gemini-proxy.internal/v1beta/");
+    expect(request.headers["x-goog-api-key"]).toBe("gemini-key");
+  });
+
+  test("gemini reaches a configured bare origin, the version segment composed for it", async () => {
+    const request = await firstRequestThroughRegistry(
+      { provider: "gemini", apiKey: "gemini-key", model: "gemini-2.5-flash", apiUrl: "https://gemini-proxy.internal" },
+      geminiTextStream("pong"),
+    );
+
+    expect(request.url).toStartWith("https://gemini-proxy.internal/v1beta/");
+  });
+
   test("openai reaches the configured OpenAI-compatible endpoint with a bearer key", async () => {
     const request = await firstRequestThroughRegistry(
       { provider: "openai", apiKey: "sk-configured", model: "gpt-4o-mini", apiUrl: "https://api.openai.com/v1" },

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, mock, spyOn, beforeEach } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { discoverRoutes } from "./helpers/discover-routes";
 
@@ -170,7 +170,8 @@ describe("guardRoute", () => {
 // no denial audit, sitting undetected next to routes that had already been fixed. Walking the
 // whole tree and requiring an explicit reason for every exemption is what makes a newly added
 // provider-reaching route red by default instead of invisible by default.
-const API_ROOT_DIR = join(import.meta.dir, "..", "..", "src", "app", "api");
+const SRC_ROOT_DIR = join(import.meta.dir, "..", "..", "src");
+const API_ROOT_DIR = join(SRC_ROOT_DIR, "app", "api");
 
 const ALL_ROUTES = discoverRoutes(API_ROOT_DIR);
 
@@ -324,6 +325,156 @@ describe("routes that reach a provider require a session", () => {
     }
 
     expect(violations).toEqual([]);
+  });
+
+  // ─── The residual the check above leaves: what the route's IMPORTS reach ────
+  //
+  // Reading a route's own source proves it names no provider entry point itself. It does not
+  // prove the module it delegates to names none either, so a route that obtained a provider
+  // through a NEW indirect helper would still pass. `@/lib/api/schema-route` is the one such
+  // helper that exists on the non-allowlisted side, and it is only covered above because
+  // somebody thought to name it.
+  //
+  // Resolving the import graph transitively was measured 2026-08-27 and rejected: it flags four
+  // of the fifteen allowlisted routes, all of them wrongly. The three `agent/runs/*` routes reach
+  // `@/lib/agent/runtime`, which does import `@/lib/db` - but for the in-process
+  // `ExecutionArtifactStore` the route reads, not for a provider; `agent/config` reaches
+  // `@/lib/llm/utils/config` to validate a model id. A module-level graph cannot tell an import
+  // used on this route's path from a sibling in the same file, so transitively it answers "reaches
+  // a provider" for every route that touches a shared module - a guard that is red for correct
+  // code teaches people to widen it.
+  //
+  // So the SET of indirect helpers is pinned instead. A new one cannot appear unnoticed: it has to
+  // be added here with a reason, and adding it is where the judgement gets made.
+  //
+  // Each reason also carries whether the helper names a provider module of its own, and both
+  // directions are enforced below - a helper that GROWS a provider import fails until its reason
+  // says so, and a stale marker on a helper that lost one fails too, so the marker cannot rot into
+  // a blanket exemption.
+  const PROVIDER_NAMING_HELPER = "names a provider module";
+
+  const ALLOWLISTED_ROUTE_HELPERS: Record<string, string> = {
+    "@/hooks/use-connection-payload": "shapes a connection record for the client; opens nothing",
+    "@/lib/agent/config": `reads the agent runtime's env config and ${PROVIDER_NAMING_HELPER} (@/lib/llm/utils/config) to validate the model id, which resolves config rather than calling a model`,
+    "@/lib/agent/model-tuning": "the per-model tuning table; data only",
+    "@/lib/agent/runtime": `the run loop, and it ${PROVIDER_NAMING_HELPER} - but the artifacts route imports only readAgentArtifact, which reads the in-process ExecutionArtifactStore`,
+    "@/lib/api/agent-run-access": "resolves a run id to its ledger behind guardRoute; reads no provider",
+    "@/lib/api/client-address": "parses the forwarded-for chain for the audit record",
+    "@/lib/api/errors": `maps a thrown error to a response and ${PROVIDER_NAMING_HELPER} (@/lib/db/errors, @/lib/llm/types) for the error CLASSES alone - nearly every route imports it, and treating it as an entry point would fire on all fifteen`,
+    "@/lib/api/rate-limit": "the in-process token buckets",
+    "@/lib/api/require-session": "guardRoute itself",
+    "@/lib/audit": "the in-process audit ring buffer",
+    "@/lib/auth": "session cookie minting and reading",
+    "@/lib/auth-compare": "constant-time credential comparison",
+    "@/lib/auth-errors": "the auth failure taxonomy",
+    "@/lib/local-auth": "the local email/password credential store",
+    "@/lib/logger": "structured logging",
+    "@/lib/oidc": "the OIDC discovery and PKCE exchange",
+    "@/lib/seed": "reads seed connection metadata from config; never connects",
+    "@/lib/storage/factory": "the app's own storage backend (STORAGE_PROVIDER), not a user database",
+    "@/lib/storage/types": "the storage backend's interfaces",
+  };
+
+  /**
+   * The `@/`-aliased modules this source imports at runtime, one level deep.
+   *
+   * A `from "@/…"` on a continuation line of a multi-line `import type` block reads as a runtime
+   * import here. That errs toward demanding a pin entry for a module that could reach nothing,
+   * which is the safe direction: the guard fails loudly rather than falling silent.
+   */
+  function aliasedImports(source: string): string[] {
+    const specifiers = new Set<string>();
+
+    for (const line of withoutComments(source).split("\n")) {
+      if (line.trimStart().startsWith("import type ")) {
+        continue;
+      }
+      const match = line.match(/from\s+"(@\/[^"]+)"/);
+      if (match !== null) {
+        specifiers.add(match[1]);
+      }
+    }
+
+    return [...specifiers];
+  }
+
+  /** Where `@/x` lives on disk, or null. Both shapes are in use: `@/lib/auth`, `@/lib/seed`. */
+  function resolveAliasedModule(specifier: string): string | null {
+    const relative = specifier.slice("@/".length);
+
+    for (const candidate of [`${relative}.ts`, join(relative, "index.ts")]) {
+      const path = join(SRC_ROOT_DIR, candidate);
+      if (existsSync(path)) {
+        return path;
+      }
+    }
+
+    return null;
+  }
+
+  function allowlistedRouteKeys(): string[] {
+    return Object.keys(ROUTES_WITHOUT_A_PROVIDER).filter((key) => !ALLOWLISTED_BUT_REACHES_A_PROVIDER.includes(key));
+  }
+
+  test("every module an allowlisted route imports is pinned", () => {
+    const unpinned: string[] = [];
+
+    for (const key of allowlistedRouteKeys()) {
+      const source = readFileSync(join(API_ROOT_DIR, key, "route.ts"), "utf8");
+      for (const specifier of aliasedImports(source)) {
+        if (!(specifier in ALLOWLISTED_ROUTE_HELPERS)) {
+          unpinned.push(
+            `"${key}" imports "${specifier}", which is not pinned: add it to ALLOWLISTED_ROUTE_HELPERS with a reason it reaches no provider on this route's path, or stop importing it`,
+          );
+        }
+      }
+    }
+
+    expect(unpinned).toEqual([]);
+  });
+
+  // A pin nobody imports any more is the same drift as a stale allowlist key: it keeps a reason
+  // alive for a path that no longer exists, and the next reader trusts it.
+  test("every pinned module is still imported by an allowlisted route", () => {
+    const imported = new Set(
+      allowlistedRouteKeys().flatMap((key) =>
+        aliasedImports(readFileSync(join(API_ROOT_DIR, key, "route.ts"), "utf8")),
+      ),
+    );
+
+    expect(Object.keys(ALLOWLISTED_ROUTE_HELPERS).filter((specifier) => !imported.has(specifier))).toEqual([]);
+  });
+
+  test("every pinned module resolves to a file", () => {
+    for (const specifier of Object.keys(ALLOWLISTED_ROUTE_HELPERS)) {
+      expect(resolveAliasedModule(specifier), specifier).not.toBeNull();
+    }
+  });
+
+  test("a pinned module's reason says whether the module names a provider module", () => {
+    const wrong: string[] = [];
+
+    for (const [specifier, reason] of Object.entries(ALLOWLISTED_ROUTE_HELPERS)) {
+      const path = resolveAliasedModule(specifier);
+      if (path === null) {
+        continue;
+      }
+      const source = withoutComments(readFileSync(path, "utf8"));
+      const named = source
+        .split("\n")
+        .filter((line) => !line.trimStart().startsWith("import type "))
+        .some((line) => PROVIDER_ENTRY_POINTS.some(({ pattern }) => pattern.test(line)));
+      const claimed = reason.includes(PROVIDER_NAMING_HELPER);
+
+      if (named && !claimed) {
+        wrong.push(`"${specifier}" now names a provider module; its reason has to say so and explain the path`);
+      }
+      if (!named && claimed) {
+        wrong.push(`"${specifier}" no longer names a provider module; drop the claim from its reason`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
   });
 
   for (const [route, load] of PROVIDER_ROUTES) {

--- a/tests/unit/backlog-structure.test.ts
+++ b/tests/unit/backlog-structure.test.ts
@@ -82,11 +82,19 @@ describe("the file was parsed at all", () => {
   // Every assertion below is a containment or an equality that an empty parse would satisfy
   // vacuously, so the parse is pinned first.
   test("the section headings were found", () => {
-    expect(sections.length).toBeGreaterThan(15);
+    expect(sections.length).toBe([...BACKLOG.matchAll(/^## /gm)].length);
+    expect(sections.length).toBeGreaterThan(1);
   });
 
   test("the entries were found", () => {
-    expect(sections.flatMap((section) => section.ids).length).toBeGreaterThan(100);
+    // Derived, not a floor. This used to assert "more than 100", which pinned the parse by
+    // pinning the backlog's SIZE - so the settlement that took the file from 129 entries to
+    // 90 failed a test whose subject is whether the regex matched. The count the parse found
+    // has to equal the count in the raw text, and that stays true at any size, including a
+    // file with one entry left.
+    const headings = [...BACKLOG.matchAll(/^### [A-Z]+\d+\./gm)].length;
+    expect(sections.flatMap((section) => section.ids).length).toBe(headings);
+    expect(headings).toBeGreaterThan(1);
   });
 
   test("the index block was found", () => {

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -960,6 +960,83 @@ describe("foldLedgerEntries", () => {
     expect(view.capture).toBeNull();
   });
 
+  /*
+    The inventory the run REUSED (B56).
+
+    `heldSnapshotForConnection` has no expiry, so a plan run can be grounded on a reading
+    taken before the user added the collection they are asking about — and such a run's
+    ledger used to carry no context entry at all, which reads as a run that needed no
+    grounding. The age is what the line exists to say.
+  */
+  test("a reused inventory says so, in the engine's own word, with the age of the reading", () => {
+    const view = foldLedgerEntries([
+      event({
+        kind: "event",
+        event: {
+          kind: "context-reused",
+          atMs: 3,
+          fingerprint: "abcdef1234",
+          tableCount: 17,
+          ageMs: 3 * 3_600_000 + 90_000,
+          noun: { singular: "key pattern", plural: "key patterns" },
+        },
+      }),
+    ]);
+
+    expect(view.items[0].headline).toBe("Schema reused");
+    expect(view.items[0].detail).toBe("17 key patterns, fingerprint abcdef12, read by an earlier run and 3 hours old");
+    // It IS provenance: the run reasoned over this inventory, so the surfaces that state
+    // where an answer came from read it exactly as they read a capture.
+    expect(view.capture).toEqual({
+      fingerprint: "abcdef1234",
+      tableCount: 17,
+      noun: { singular: "key pattern", plural: "key patterns" },
+    });
+    // And it charged nothing, which is the fact rather than an omission: the reuse is why
+    // no catalog read happened.
+    expect(view.budget.map((entry) => entry.used)).toEqual([0, 0, 0]);
+  });
+
+  test("a reused inventory with no noun on it is described in the default word", () => {
+    // A ledger written before the noun was recorded reads as it always read.
+    const view = foldLedgerEntries([
+      event({
+        kind: "event",
+        event: { kind: "context-reused", atMs: 3, fingerprint: "abcdef1234", tableCount: 1, ageMs: 0 },
+      }),
+    ]);
+
+    expect(view.items[0].detail).toBe("1 table, fingerprint abcdef12, read by an earlier run and under a minute old");
+  });
+
+  /*
+    The age, in the coarsest unit that is still true. Every step rounds DOWN, so the line
+    cannot claim a reading is older than it is — and under a minute is said in words,
+    because a reading taken in this same drive is not a stale one.
+  */
+  test.each([
+    [0, "under a minute old"],
+    [59_999, "under a minute old"],
+    [60_000, "1 minute old"],
+    [119_000, "1 minute old"],
+    [120_000, "2 minutes old"],
+    [3_599_999, "59 minutes old"],
+    [3_600_000, "1 hour old"],
+    [7_200_000, "2 hours old"],
+    [86_399_999, "23 hours old"],
+    [86_400_000, "1 day old"],
+    [172_800_000, "2 days old"],
+  ])("an age of %ims reads as %s", (ageMs, said) => {
+    const view = foldLedgerEntries([
+      event({
+        kind: "event",
+        event: { kind: "context-reused", atMs: 3, fingerprint: "abcdef1234", tableCount: 2, ageMs },
+      }),
+    ]);
+
+    expect(view.items[0].detail).toBe(`2 tables, fingerprint abcdef12, read by an earlier run and ${said}`);
+  });
+
   test("a refused capture with no budget in it shows the reason alone", () => {
     // The other refusal family — a provider that cannot describe itself — where there is
     // no bound to name. The entry states the reason and stops, rather than printing a
@@ -1500,6 +1577,79 @@ describe("foldLedgerEntries — the budget meter", () => {
     expect(view.budget.map((entry) => entry.used)).toEqual([0, 0, 0]);
   });
 
+  /**
+   * The schema capture's own spend (B13).
+   *
+   * Its catalog reads reach the execution layer through `captureContextSnapshot` and
+   * never through `runStep`, the only writer of `tool-completed`, so the meter of a run
+   * whose first three statements were catalog reads read "0 of 20" before its first
+   * model turn.
+   */
+  test("a capture contributes the statements and the span the tracker charged it", () => {
+    const view = foldLedgerEntries([
+      OPENED,
+      event({
+        kind: "event",
+        event: {
+          kind: "context-captured",
+          atMs: 5,
+          fingerprint: "ctx_1",
+          tableCount: 3,
+          charged: { statements: 3, elapsedMs: 41 },
+        },
+      }),
+      completed("s1", "corr_1", 12),
+    ]);
+
+    expect(gauge(view, "statements").used).toBe(4);
+    expect(gauge(view, "database-time").used).toBe(53);
+    // Nothing was repaired and nothing is missing a duration: the capture measured its
+    // own span, so the caveat about missing durations has nothing to say about this run.
+    expect(gauge(view, "repairs").used).toBe(0);
+    expect(view.statementsWithoutDuration).toBe(0);
+  });
+
+  test("a REFUSED capture contributes what it paid, because the read was charged before it was answered", () => {
+    const view = foldLedgerEntries([
+      OPENED,
+      event({
+        kind: "event",
+        event: {
+          kind: "context-unavailable",
+          atMs: 5,
+          reasonCode: "CATALOG_READ_REFUSED",
+          detail: "row budget: 536 rows > 200 allowed",
+          rowBudget: { projected: 536, allowed: 200 },
+          charged: { statements: 1, elapsedMs: 18 },
+        },
+      }),
+    ]);
+
+    expect(gauge(view, "statements").used).toBe(1);
+    expect(gauge(view, "database-time").used).toBe(18);
+  });
+
+  /*
+    A ledger written before the measurement existed. It contributes nothing rather than
+    a zero: a capture whose spend nobody measured is not a free capture, and the fold has
+    no figure to state (#477). Such a run reads exactly as it always read.
+  */
+  test("a capture carrying no charge contributes nothing rather than a fabricated zero", () => {
+    const view = foldLedgerEntries([
+      OPENED,
+      event({
+        kind: "event",
+        event: { kind: "context-captured", atMs: 5, fingerprint: "ctx_1", tableCount: 3 },
+      }),
+      event({
+        kind: "event",
+        event: { kind: "context-unavailable", atMs: 6, reasonCode: "CATALOG_READ_REFUSED", detail: "denied" },
+      }),
+    ]);
+
+    expect(view.budget.map((entry) => entry.used)).toEqual([0, 0, 0]);
+  });
+
   test("a completed read costs one statement and the database time it reported", () => {
     const view = foldLedgerEntries([completed("s1", "corr_1", 12), completed("s2", "corr_2", 30)]);
 
@@ -1713,7 +1863,8 @@ describe("foldLedgerEntries — the budget meter", () => {
    * provider, which `tools.ts` accounts as a spent statement even though nothing
    * ran. The fold charges neither, because the ledger cannot tell them apart and a
    * meter that guessed would be the one figure here that is not an enforced value.
-   * The second case is a known under-count, recorded as `docs/BACKLOG.md` B13.
+   * The second case is a known under-count, and a deliberate one: the ledger cannot
+   * tell it apart from an interruption, so the fold declines to guess.
    */
   /**
    * A ceiling is per drive (`docs/BACKLOG.md` B6) while the ledger spans every
@@ -2794,6 +2945,34 @@ describe("an answer reads as the app's decision, with the model's caption quoted
       expect(view.items[1]?.detail ?? "").not.toContain("finished looking at the tables");
     });
 
+    /*
+      A held delivery is ONE entry, and this is what keeps it that way (B51). The notice id
+      is a field on the hold rather than a second `guidance-issued` beside it, because two
+      entries for one delivery would render twice in the rail — and the entry the ledger
+      needs is the one that says the call was not run.
+    */
+    test("a held call names its notice on the ledger and still renders as one line", () => {
+      const view = foldLedgerEntries([
+        OPENED,
+        event({
+          kind: "event",
+          event: {
+            kind: "call-held",
+            atMs: 6_000,
+            tool: "compose_report",
+            reason: "Cite the reading you took.",
+            notice: "cite-what-you-read",
+          },
+        }),
+      ]);
+
+      expect(view.items).toHaveLength(2);
+      expect(view.items[1]?.headline).toBe("Held back compose_report");
+      // The prose the model was sent, which is what a reader needs; the id is for the fold
+      // that bounds the notice across a resume, not for the line.
+      expect(view.items[1]?.detail).toBe("Cite the reading you took.");
+    });
+
     test("a notice the drive issued is shown, so a reminded run does not read as an idle one", () => {
       const view = foldLedgerEntries([
         OPENED,
@@ -2804,24 +2983,33 @@ describe("an answer reads as the app's decision, with the model's caption quoted
       expect(`${view.items[1]?.headline} ${view.items[1]?.detail}`.length).toBeGreaterThan(0);
     });
 
-    test.each(["report-reminder", "plan-statement", "report-reserve", "unread-stop"] as const)(
-      "the %s notice reads as a sentence rather than as its own event name",
-      (notice) => {
-        /*
+    test.each([
+      "report-reminder",
+      "plan-statement",
+      "report-reserve",
+      "unread-stop",
+      // The three delivered as a tool result (B51). They reach a reader through the
+      // `call-held` entry, so these ids only render here for a ledger written by a build
+      // that recorded one this way — and a headline map with no word for an id it can be
+      // handed renders `undefined` at the top of a timeline item.
+      "present-before-report",
+      "cite-what-you-read",
+      "compare-before-report",
+    ] as const)("the %s notice reads as a sentence rather than as its own event name", (notice) => {
+      /*
           Every notice at once, because the headline map is DATA: a missing entry renders
           `undefined` at the top of a timeline item and the line still counts as covered the
           moment the module loads. Only rendering each one asks the question.
         */
-        const view = foldLedgerEntries([
-          OPENED,
-          event({ kind: "event", event: { kind: "guidance-issued", atMs: 6_000, notice } }),
-        ]);
+      const view = foldLedgerEntries([
+        OPENED,
+        event({ kind: "event", event: { kind: "guidance-issued", atMs: 6_000, notice } }),
+      ]);
 
-        const headline = view.items[1]?.headline ?? "";
-        expect(headline.length).toBeGreaterThan(0);
-        expect(headline).not.toContain(notice);
-      },
-    );
+      const headline = view.items[1]?.headline ?? "";
+      expect(headline.length).toBeGreaterThan(0);
+      expect(headline).not.toContain(notice);
+    });
   });
 
   test("the columns the chart names never reach the app's own sentence", () => {

--- a/tests/unit/db/base-provider.test.ts
+++ b/tests/unit/db/base-provider.test.ts
@@ -510,6 +510,34 @@ describe("BaseDatabaseProvider", () => {
       expect(info).toBe("postgres://host/db?sslmode=verify-full&password=***&sslkey=***&token=***");
     });
 
+    test("masks a bracketed IPv6 authority without disturbing the brackets", () => {
+      // The authority parse finds the credential at the LAST `@` and the password at the
+      // authority's FIRST `:`. An IPv6 host puts colons inside `[...]`, which is the shape
+      // that would break a naive first-`:`-to-first-`@` mask. It does not break this one,
+      // and these pin why: with a credential the mask lands before the brackets, and with
+      // no credential the colons inside them are left alone rather than read as a password
+      // boundary - there is no `@`, so nothing is masked.
+      expect(infoFor("postgres://user:pw@[::1]:5432/db")).toBe("postgres://user:***@[::1]:5432/db");
+      expect(infoFor("postgres://user:pw@[2001:db8::1]:5432/db")).toBe("postgres://user:***@[2001:db8::1]:5432/db");
+      expect(infoFor("postgres://[::1]:5432/db")).toBe("postgres://[::1]:5432/db");
+      expect(infoFor("redis://[2001:db8::1]:6379")).toBe("redis://[2001:db8::1]:6379");
+      // An `@` in the password, with an IPv6 host behind it: masked whole, as elsewhere.
+      expect(infoFor("postgres://user:p@ss@[::1]:5432/db")).toBe("postgres://user:***@[::1]:5432/db");
+      // User name and no password, and an empty password: both verbatim, as they are for a
+      // named host - '***' over a value the string never carried would assert a secret.
+      expect(infoFor("postgres://user@[::1]:5432/db")).toBe("postgres://user@[::1]:5432/db");
+      expect(infoFor("postgres://user:@[::1]:5432/db")).toBe("postgres://user:@[::1]:5432/db");
+    });
+
+    test("the known limit: a bracketed host in the userinfo position is mangled", () => {
+      // Recorded rather than fixed. `postgres://[::1]:5432@host/db` is not a URI any driver
+      // or connection form produces - an IPv6 host cannot be followed by `@host` - and the
+      // parse reads the bracket's first `:` as the password boundary. Bracket-awareness
+      // would be a branch with no real caller, so the boundary is written down instead of
+      // being left for someone to rediscover as a defect.
+      expect(infoFor("postgres://[::1]:5432@host/db")).toBe("postgres://[:***@host/db");
+    });
+
     test("masks a credential in the authority and in the query string together", () => {
       const info = infoFor("libsql://admin:s3cret@db-org.turso.io?authToken=jwt");
 

--- a/tests/unit/db/base-provider.test.ts
+++ b/tests/unit/db/base-provider.test.ts
@@ -578,13 +578,34 @@ describe("BaseDatabaseProvider", () => {
       expect(infoFor(given)).toBe(expected);
     });
 
-    test("leaves a password containing an unencoded '/' unmasked, which is the documented limit", () => {
-      // Pinned so the gap is visible rather than assumed closed. RFC 3986 wants that '/'
-      // percent-encoded, and `postgres://host:5432/tenant@acme` - a path holding an '@',
-      // pinned above - has the identical shape, so masking one masks the other. Hiding a
-      // port behind a `***` that asserts a credential the string never carried is the
-      // worse error of the two, so this case is left to the parse-based fix in D42.
-      expect(infoFor("postgres://user:p/w@db.example.com/mydb")).toBe("postgres://user:p/w@db.example.com/mydb");
+    test("masks a password containing an unencoded '@'", () => {
+      // The authority is parsed, and the credential ends at the LAST '@' inside it: '@' is
+      // a legal password character while a host name cannot hold one. A single-'@' pattern
+      // left everything after the first one in the clear.
+      expect(infoFor("postgres://user:p@ss@db.example.com/mydb")).toBe("postgres://user:***@db.example.com/mydb");
+      expect(infoFor("mongodb://admin:a@b@c@cluster0.example.com:27017/db")).toBe(
+        "mongodb://admin:***@cluster0.example.com:27017/db",
+      );
+    });
+
+    test("masks an authority that no delimiter follows", () => {
+      // Nothing bounds the authority on the right here, so its end is the end of the
+      // string; a parse that required a '/' would return this password verbatim.
+      expect(infoFor("postgres://user:s3cret@db.example.com")).toBe("postgres://user:***@db.example.com");
+    });
+
+    test.each([
+      // RFC 3986 wants each of these percent-encoded in userinfo, and each one ENDS the
+      // authority - so the '@' falls outside it and the parse sees no credential. Pinned
+      // so the gap is visible rather than assumed closed. '/' is why: the path-holding
+      // '@' pinned above (`postgres://host:5432/tenant@acme`) has the identical shape, and
+      // hiding a port behind a `***` that asserts a credential the string never carried is
+      // the worse error of the two.
+      ["postgres://user:p/w@db.example.com/mydb"],
+      ["postgres://user:p?w@db.example.com/mydb"],
+      ["postgres://user:p#w@db.example.com/mydb"],
+    ])("leaves %s unmasked, which is the documented limit", (given) => {
+      expect(infoFor(given)).toBe(given);
     });
 
     test("masks the authority of a string whose scheme carries its own prefix", () => {
@@ -599,6 +620,12 @@ describe("BaseDatabaseProvider", () => {
       // and hide nothing - and a mask that eats the '//' is how a scheme goes missing.
       expect(infoFor("postgres://user@db.example.com/mydb")).toBe("postgres://user@db.example.com/mydb");
       expect(infoFor("postgres://host/db:owner@example.com")).toBe("postgres://host/db:owner@example.com");
+      // The ':' here belongs to the PORT, which sits after the '@'. Masking from the
+      // authority's first ':' without checking that it precedes the '@' would replace the
+      // user name and the host with one '***'.
+      expect(infoFor("postgres://user@db.example.com:5432/mydb")).toBe("postgres://user@db.example.com:5432/mydb");
+      // An empty password stays empty, as it does in the parameter half.
+      expect(infoFor("postgres://user:@db.example.com/mydb")).toBe("postgres://user:@db.example.com/mydb");
     });
 
     test("masks a credential a fragment delimits", () => {

--- a/tests/unit/db/operations/statement-guard.test.ts
+++ b/tests/unit/db/operations/statement-guard.test.ts
@@ -67,6 +67,16 @@ describe("inspectAgentStatement — multi-statement input", () => {
     ["no whitespace after the terminator", "SELECT 1;SELECT 2"],
     ["transaction control between reads", "SELECT 1; COMMIT; SELECT 2"],
     ["a literal after the terminator", "SELECT 1; 'tail'"],
+    // A quoted name after the terminator is a token too, and it is the only
+    // other span kind this walk can reach: `scanStatementShape` reads with
+    // `DEFAULT_SQL_GRAMMAR`, whose brackets are quoted names rather than
+    // subscripts, and a dollar-quoted run is refused a step earlier as text the
+    // engines read differently. Measured 2026-08-27: without the
+    // `quoted-identifier` reading these two answer `null` - the guard's own
+    // one-statement rule bypassed by a quote.
+    ["a quoted name after the terminator", 'SELECT 1; "tail"'],
+    ["a backtick name after the terminator", "SELECT 1; `tail`"],
+    ["a bracketed name after the terminator", "SELECT 1; [tail]"],
     ["a leading terminator", "; SELECT 1"],
     ["a comment hiding the terminator's tail", "SELECT 1; -- x\nDROP TABLE t"],
   ])("denies %s", (_label, sql) => {

--- a/tests/unit/lib/agent/context-snapshot.test.ts
+++ b/tests/unit/lib/agent/context-snapshot.test.ts
@@ -487,6 +487,155 @@ describe("captureContextSnapshot — when no honest inventory can be built", () 
 });
 
 /**
+ * An environment failure on the COMPOSED path, which used to end the run (B48).
+ *
+ * `captureFromProvider` has converted an unreachable host and a refused execution
+ * profile into an unavailable capture since #414; PostgreSQL and SQLite propagated the
+ * same failure out of `captureContextSnapshot` and ended the run `internal`, or
+ * `engine-unsupported` on the profile error. The asymmetry was one catch block wide.
+ */
+describe("captureContextSnapshot — an environment failure on the composed path", () => {
+  test("a database that cannot be reached loses the grounding, not the run", async () => {
+    const h = harness("postgres");
+
+    const capture = await captureContextSnapshot({
+      ...h.context,
+      acquireProvider: async () => {
+        throw new ConnectionError("connect ECONNREFUSED 127.0.0.1:5432", "postgres");
+      },
+    });
+
+    expect(capture.kind).toBe("unavailable");
+    if (capture.kind !== "unavailable") throw new Error("unreachable");
+    expect(capture.reasonCode).toBe("CATALOG_READ_REFUSED");
+    // The same sentence the provider path answers with, because it is the same reading:
+    // one voice per environment, whichever route the dialect takes.
+    expect(capture.detail).toContain("could not reach this postgres database to ask it for its schema");
+    // The driver's own message stays out of the note a run reads as the server's voice.
+    expect(capture.detail).not.toContain("ECONNREFUSED");
+  });
+
+  test("a credential the profile layer will not grant loses the grounding, not the run", async () => {
+    const h = harness("sqlite");
+
+    const capture = await captureContextSnapshot({
+      ...h.context,
+      acquireProvider: async () => {
+        throw new ExecutionProfileError(
+          "agent credential for this connection could not be decrypted",
+          "AGENT_CREDENTIAL_UNRESOLVABLE",
+        );
+      },
+    });
+
+    expect(capture.kind).toBe("unavailable");
+    if (capture.kind !== "unavailable") throw new Error("unreachable");
+    expect(capture.reasonCode).toBe("CATALOG_READ_REFUSED");
+    expect(capture.detail).toContain("under the execution profile a grounding read takes");
+    expect(capture.detail).not.toContain("could not be decrypted");
+  });
+
+  test("anything that is not one of those two is this server's own bug, and propagates", async () => {
+    // The bound on the catch, asserted on this path as it is on the provider one: a
+    // `TypeError` is not a property of the user's database.
+    const h = harness("postgres");
+
+    await expect(
+      captureContextSnapshot({
+        ...h.context,
+        acquireProvider: async () => {
+          throw new TypeError("acquireProvider is not a function");
+        },
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+});
+
+/**
+ * What a capture SPENT, and where the meter used to read zero (B13).
+ *
+ * The capture's reads go through `executeAuditedOperation` and never through the run
+ * loop's `runStep`, which is the only writer of `tool-completed` — so the whole cost of
+ * grounding a run was charged against the ceilings the rail displays and folded to
+ * nothing. What is asserted here is that the figure is the TRACKER's, because that is
+ * what the budget is enforced from.
+ */
+describe("captureContextSnapshot — what the reading charged", () => {
+  test("carries the statements the tracker charged, which is one per composed catalog read", async () => {
+    const h = harness("postgres");
+
+    const capture = await captureContextSnapshot(h.context);
+
+    if (capture.kind !== "captured") throw new Error("expected a snapshot");
+    expect(capture.charged?.statements).toBe(3);
+    // The tracker's own figure and not a count of `plan.kinds`: a derived number would
+    // state the reads this module intended rather than the ones the run paid for.
+    expect(capture.charged?.statements).toBe(h.context.tracker.usage("run-1").executedStatements);
+  });
+
+  test("charges two on SQLite, because the dialect has two catalog reads and not three", async () => {
+    const h = harness("sqlite");
+
+    const capture = await captureContextSnapshot(h.context);
+
+    if (capture.kind !== "captured") throw new Error("expected a snapshot");
+    expect(capture.charged?.statements).toBe(2);
+  });
+
+  test("carries the span the tracker charged, not the engine's own elapsed time", async () => {
+    // An advancing clock, because the frozen one measures every execution as free and a
+    // zero there would be indistinguishable from the figure never having been taken.
+    let now = 1_000;
+    const h = harness("postgres");
+    const capture = await captureContextSnapshot({ ...h.context, clock: () => (now += 7) });
+
+    if (capture.kind !== "captured") throw new Error("expected a snapshot");
+    expect(capture.charged?.elapsedMs).toBeGreaterThan(0);
+    expect(capture.charged?.elapsedMs).toBe(h.context.tracker.usage("run-1").totalElapsedMs);
+    // The result's own `executionTime` is 3ms per read in this harness; the charge is the
+    // span around the whole call, so the two are deliberately not the same number.
+    expect(capture.charged?.elapsedMs).not.toBe(9);
+  });
+
+  test("is the DELTA around the reading, so a run that had already spent is not charged twice", async () => {
+    const h = harness("postgres");
+    // One statement this run spent before it was grounded at all.
+    h.context.tracker.beginExecution("run-1");
+    h.context.tracker.endExecution("run-1", { statements: 1, elapsedMs: 40 });
+
+    const capture = await captureContextSnapshot(h.context);
+
+    if (capture.kind !== "captured") throw new Error("expected a snapshot");
+    expect(capture.charged?.statements).toBe(3);
+    expect(h.context.tracker.usage("run-1").executedStatements).toBe(4);
+  });
+
+  test("a refused capture carries what it paid anyway: the read was charged before it was answered", async () => {
+    const h = harness("postgres", async (sql: string) => {
+      if (sql.includes("pg_index")) throw new QueryError("permission denied for relation pg_index");
+      return answerPostgres(sql);
+    });
+
+    const capture = await captureContextSnapshot(h.context);
+
+    if (capture.kind !== "unavailable") throw new Error("expected no snapshot");
+    // Three admitted executions: two that answered and the one the engine refused.
+    expect(capture.charged?.statements).toBe(3);
+  });
+
+  test("the provider path reports its own charge, whatever the reading came to", async () => {
+    // `mysql` composes no catalog, so this is the provider reading — and the harness's
+    // fake provider cannot describe itself, which is the refusal it answers with.
+    const h = harness("mysql");
+
+    const capture = await captureContextSnapshot(h.context);
+
+    if (capture.kind !== "unavailable") throw new Error("expected no snapshot");
+    expect(capture.charged?.statements).toBe(h.context.tracker.usage("run-1").executedStatements);
+  });
+});
+
+/**
  * The second reading (#414): the engine's own schema inspection, for the dialects no
  * catalog statement is composed for.
  *

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -342,17 +342,132 @@ describe("what a document from outside Studio is held to instead", () => {
   });
 
   test("the bounds still hold, so a tolerant schema is not an unchecked one", () => {
+    // Held per ENTRY rather than per document (B55/B57): the out-of-range entry is not applied,
+    // which is the rule, and it is named so the operator can find the number that broke it.
     const outOfRange = {
-      models: [{ id: "some-model:9b", measured: "m", settings: { turnTimeoutMs: 400_000 } }],
+      models: [
+        { id: "some-model:9b", measured: "m", settings: { turnTimeoutMs: 400_000 } },
+        { id: "other-model:9b", measured: "m", settings: { retryEmptyTurn: true } },
+      ],
     };
-    expect(() => parseOperatorTuning(document(outOfRange), "test")).toThrow(ModelTuningError);
+    const tuning = parseOperatorTuning(document(outOfRange), "test");
+    expect(tuning.models["some-model:9b"]).toBeUndefined();
+    expect(tuning.models["other-model:9b"]?.retryEmptyTurn).toBe(true);
+    expect(tuning.skippedEntries).toEqual([
+      "some-model:9b: settings.turnTimeoutMs: Too big: expected number to be <=179999",
+    ]);
   });
 
   test("wording is still refused, which is the one rule that does not relax", () => {
     // Tolerance is about settings Studio may not know yet. Prompt text is not a setting Studio
-    // might add later: it is the thing a mounted document must never be able to say.
-    const withWording = { models: [{ id: "some-model:9b", measured: "m", notices: { ...BASELINE_NOTICES } }] };
-    expect(() => parseOperatorTuning(document(withWording), "test")).toThrow(ModelTuningError);
+    // might add later: it is the thing a mounted document must never be able to say. Per-entry
+    // validation does not soften that — the entry carrying it is refused whole, so no wording it
+    // named can reach a run — it only stops the entry beside it paying for the attempt.
+    const withWording = {
+      models: [
+        // `settings` is stated, and that is deliberate: it is a REQUIRED key, so the entry this
+        // test used to carry — wording and nothing else — was refused for the missing settings and
+        // never reached the `notices` rule at all. The assertion below now names the fault.
+        { id: "some-model:9b", measured: "m", settings: { retryEmptyTurn: true }, notices: { ...BASELINE_NOTICES } },
+        { id: "other-model:9b", measured: "m", settings: { retryEmptyTurn: true } },
+      ],
+    };
+    const tuning = parseOperatorTuning(document(withWording), "test");
+    expect(tuning.models["some-model:9b"]).toBeUndefined();
+    expect(tuning.models["other-model:9b"]).toBeDefined();
+    expect(tuning.skippedEntries[0]).toContain("notices");
+    // And Studio's own document refuses the same entry whole, as it always did.
+    expect(() => parseTuning(document(withWording), "test")).toThrow(ModelTuningError);
+  });
+
+  /*
+    Per-ENTRY validation, which is where the all-or-nothing rule actually belongs (B57).
+
+    The argument for refusing whole was always about MERGING — half of one measurement beside half
+    of another is a configuration nobody has run — and that argument protects whole-ENTRY
+    replacement, not whole-document rejection. A document holding fifty models lost all fifty to a
+    typo in the thirty-seventh, and the day these are published as a catalog that failure lands on
+    everyone who mounted it for a fault in an entry nobody else is using.
+  */
+  test("one bad entry loses only that entry, and the rest apply", () => {
+    const mixed = {
+      models: [
+        { id: "first:9b", measured: "m", settings: { retryEmptyTurn: true } },
+        { id: "broken:9b", measured: "m", settings: { unreportedCallCeiling: "twelve" } },
+        { id: "third:9b", measured: "m", settings: { retryUnreadStop: true } },
+      ],
+    };
+    const tuning = parseOperatorTuning(document(mixed), "test");
+
+    expect(Object.keys(tuning.models)).toEqual(["first:9b", "third:9b"]);
+    expect(tuning.skippedEntries[0]).toContain("broken:9b: settings.unreportedCallCeiling");
+  });
+
+  test("an entry whose id is what is wrong is reported by its position, not by an invented name", () => {
+    // Reported by `id` everywhere there is one, because that is what the operator wrote and what
+    // they will search the file for. When the id is the fault there is nothing to search for, so
+    // the position is the only honest handle — naming a model nobody configured would be worse.
+    const noId = { models: [{ measured: "m", settings: { retryEmptyTurn: true } }, { ...ENTRY }] };
+    const tuning = parseOperatorTuning(document(noId), "test");
+
+    expect(tuning.models["some-model:9b"]).toBeDefined();
+    expect(tuning.skippedEntries[0]).toContain("#0: id");
+  });
+
+  test("an entry that is not an object at all is skipped by position too", () => {
+    // The array's element type is unread until the entry is validated, so a bare number reaches
+    // the labeller. It has no `id` to read, and reading one off a non-object must not throw.
+    const notAnObject = { models: [7, { ...ENTRY }] };
+    const tuning = parseOperatorTuning(document(notAnObject), "test");
+
+    expect(tuning.models["some-model:9b"]).toBeDefined();
+    expect(tuning.skippedEntries[0]).toContain("#0");
+  });
+
+  test("a duplicate id skips the second entry rather than refusing the document", () => {
+    // Still not last-wins: two spellings of one id is a document nobody can read, and collapsing
+    // them would apply settings the other entry argues against. What changes is the blast radius.
+    const twice = {
+      models: [
+        { id: "some-model:9b", measured: "first", settings: { retryEmptyTurn: true } },
+        { id: "SOME-MODEL:9B", measured: "second", settings: { retryEmptyTurn: false } },
+        { id: "other:9b", measured: "m", settings: { retryUnreadStop: true } },
+      ],
+    };
+    const tuning = parseOperatorTuning(document(twice), "test");
+
+    expect(tuning.models["some-model:9b"]?.measured).toBe("first");
+    expect(tuning.models["other:9b"]).toBeDefined();
+    expect(tuning.skippedEntries).toEqual(["SOME-MODEL:9B: appears twice"]);
+  });
+
+  test("a document whose ENVELOPE is wrong is still refused whole, because nothing in it survives", () => {
+    // Per-entry tolerance is about entries. A wrong `schemaVersion` means Studio cannot say what
+    // any entry in the file means, and `models` not being an array leaves no entries to walk.
+    expect(() => parseOperatorTuning(document({ schemaVersion: 99 }), "test")).toThrow(ModelTuningError);
+    expect(() => parseOperatorTuning(document({ models: "some-model:9b" }), "test")).toThrow(ModelTuningError);
+  });
+
+  test("Studio's own document is still refused whole on a bad entry and on a duplicate", () => {
+    // The asymmetry, again: a fault in the document this repository ships is a repo fault, caught
+    // by the test suite before anybody runs it, so there is nothing to keep working around.
+    const oneBad = { models: [{ ...ENTRY }, { ...ENTRY, id: "x:1b", settings: { ...COMPLETE, retryEmptyTurn: 3 } }] };
+    expect(() => parseTuning(document(oneBad), "test")).toThrow(ModelTuningError);
+    expect(() => parseTuning(document({ models: [ENTRY, ENTRY] }), "test")).toThrow(/appears twice/);
+  });
+
+  test("a document with no readable entry at all applies nothing and names every one it dropped", () => {
+    // The degenerate case stated rather than left to be discovered: the document parsed, so it is
+    // not "ignored"; it simply contributed no entry, and the list says which faults cost it.
+    const allBad = {
+      models: [
+        { id: "a:1b", measured: "m", settings: { retryEmptyTurn: 3 } },
+        { id: "b:1b", measured: "", settings: { retryEmptyTurn: true } },
+      ],
+    };
+    const tuning = parseOperatorTuning(document(allBad), "test");
+    expect(tuning.models).toEqual({});
+    expect(tuning.skippedEntries).toHaveLength(2);
   });
 
   test("the bundled document is still held to completeness, so the discipline is not lost", () => {
@@ -497,6 +612,31 @@ describe("a document an operator supplies", () => {
     const status = operatorTuningStatus();
     expect(status.state).toBe("applied");
     expect(status.state === "applied" && status.models).toBe(1);
+    expect(status.state === "applied" && status.skippedEntries).toEqual([]);
+  });
+
+  test("reports the entries it skipped by id, the way it reports ignored keys", () => {
+    /*
+      The reporting surface a per-entry refusal needs (B57), and it is the one `ignoredKeys`
+      already had for the same reason: the document was applied AROUND the fault, so without this
+      an operator's thirty-seventh entry would do nothing and say nothing — which is exactly the
+      quietness the strict schema existed to prevent.
+    */
+    process.env[ENV] = writeDocument(
+      document({
+        models: [
+          { id: "applied:9b", measured: "m", settings: { retryEmptyTurn: true } },
+          { id: "dropped:9b", measured: "m", settings: { retryEmptyTurn: "yes" } },
+        ],
+      }),
+    );
+    resetTuning();
+    const status = operatorTuningStatus();
+
+    expect(status.state).toBe("applied");
+    expect(status.state === "applied" && status.models).toBe(1);
+    expect(status.state === "applied" && status.skippedEntries?.[0]).toContain("dropped:9b: settings.retryEmptyTurn");
+    expect(activeTuning().models["applied:9b"]?.retryEmptyTurn).toBe(true);
   });
 
   test("reports a relative path as the absolute one it actually looked at", () => {

--- a/tests/unit/lib/agent/table-profile.test.ts
+++ b/tests/unit/lib/agent/table-profile.test.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { parseSqliteTableDdl } from "@/lib/agent/sqlite-ddl";
 import {
+  DIGIT_RUN_LENGTH,
   HIGH_NULL_RATIO,
   MIN_ROWS_FOR_RATIO_FINDINGS,
   composeTableProfile,
@@ -57,7 +58,7 @@ describe("the composed statement", () => {
     expect(pattern).toContain("LIKE");
   });
 
-  test("the shape test is applied only to columns whose declared type is textual", () => {
+  test("the shape tests are applied only to columns whose declared type is textual", () => {
     // Comparing an integer column to a string pattern is an error on PostgreSQL,
     // and casting every column to text would turn a bounded read into a full
     // conversion of the table.
@@ -65,6 +66,32 @@ describe("the composed statement", () => {
 
     expect(sql).toContain('count(CASE WHEN "email" LIKE');
     expect(sql).not.toContain('count(CASE WHEN "id" LIKE');
+    expect(sql).toContain('count(CASE WHEN "email" ~ ');
+    expect(sql).not.toContain('count(CASE WHEN "id" ~ ');
+  });
+
+  // B26: `LIKE` cannot express a run of digits — `_` means "any character", so a
+  // length test would match almost any text. Each engine spells it its own way, and
+  // both spellings were run against a live engine; see the live-execution test
+  // below and the module comment for the PostgreSQL 18 measurement.
+  test("the digit-run test is the dialect's own operator, not a shared LIKE", () => {
+    const postgres = composeTableProfile("postgres", { table: "t", depth: "pattern" }, COLUMNS);
+    const sqlite = composeTableProfile("sqlite", { table: "t", depth: "pattern" }, COLUMNS);
+
+    expect(postgres).toContain(`"email" ~ '[0-9]{${DIGIT_RUN_LENGTH},}'`);
+    expect(postgres).not.toContain("GLOB");
+    expect(sqlite).toContain(`"email" GLOB '*${"[0-9]".repeat(DIGIT_RUN_LENGTH)}*'`);
+    expect(sqlite).not.toContain(" ~ ");
+  });
+
+  test("both shape tests still project a count and nothing else on either dialect", () => {
+    for (const dialect of ["postgres", "sqlite"] as const) {
+      const sql = composeTableProfile(dialect, { table: "t", depth: "pattern" }, COLUMNS);
+      const projection = sql.slice("SELECT ".length, sql.indexOf(" FROM "));
+
+      for (const part of projection.split(", ")) expect(part.startsWith("count("), `${dialect}: ${part}`).toBe(true);
+      expect(inspectAgentStatement(sql), dialect).toBeNull();
+    }
   });
 
   test("an identifier carrying the closing quote is escaped, not interpolated", () => {
@@ -106,6 +133,7 @@ describe("reading the aggregate row back", () => {
 
     expect(profile?.columns[0]?.distinct).toBeUndefined();
     expect(profile?.columns[0]?.shaped).toBeUndefined();
+    expect(profile?.columns[0]?.digitRun).toBeUndefined();
   });
 
   test("a result with no row, or no row count, is unreadable rather than a profile of nothing", () => {
@@ -176,6 +204,44 @@ describe("the findings, derived from the numbers", () => {
     expect(codes(profile)).toEqual(["suspected_pii"]);
     // Still no value: the ratio was computed inside the database.
     expect(profile?.findings[0]?.detail).toContain("No value was read out of the database");
+  });
+
+  test("a column whose values are mostly digit runs is suspected, and the finding names that shape", () => {
+    const profile = readTableProfile(
+      "t",
+      "pattern",
+      [column("col_7")],
+      [{ row_count: 100, present_0: 100, distinct_0: 100, shaped_0: 0, digits_0: 96 }],
+    );
+
+    expect(codes(profile)).toEqual(["suspected_pii"]);
+    expect(profile?.findings[0]?.detail).toContain(`a run of ${DIGIT_RUN_LENGTH} or more digits`);
+    expect(profile?.findings[0]?.detail).not.toContain("email");
+    expect(profile?.findings[0]?.detail).toContain("No value was read out of the database");
+  });
+
+  test("a column matching both shapes reports one finding naming both", () => {
+    const profile = readTableProfile(
+      "t",
+      "pattern",
+      [column("col_7")],
+      [{ row_count: 100, present_0: 100, distinct_0: 100, shaped_0: 80, digits_0: 70 }],
+    );
+
+    expect(codes(profile)).toEqual(["suspected_pii"]);
+    expect(profile?.findings[0]?.detail).toContain("an email address");
+    expect(profile?.findings[0]?.detail).toContain(`a run of ${DIGIT_RUN_LENGTH} or more digits`);
+  });
+
+  test("a column with a few incidental digit runs is not suspected on that ground", () => {
+    const profile = readTableProfile(
+      "t",
+      "pattern",
+      [column("col_7")],
+      [{ row_count: 100, present_0: 100, distinct_0: 100, shaped_0: 1, digits_0: 3 }],
+    );
+
+    expect(codes(profile)).toEqual([]);
   });
 
   test("a column with a few incidental matches is not suspected", () => {
@@ -374,5 +440,76 @@ describe("a foreign key covered by a constraint-created index (docs/BACKLOG.md B
 
   test("the control: a key with no index at all is still reported", () => {
     expect(findUnindexedForeignKeys(inventory(SCHEMA, "bare")).map((f) => f.code)).toEqual(["fk_unindexed"]);
+  });
+});
+
+describe("the shape tests against a live engine", () => {
+  /**
+   * The composed `pattern` statement, executed by SQLite itself.
+   *
+   * The point is the GRAMMAR: `GLOB '*[0-9]…*'` is SQLite's spelling of a digit run
+   * and `~ '[0-9]{9,}'` is PostgreSQL's, so neither can be established by reading the
+   * composed string. This runs the SQLite arm end to end — compose, execute, read
+   * back, derive findings. The PostgreSQL arm was run the same way against a live
+   * PostgreSQL 18 and returned the same counts for the same rows; the measurement is
+   * recorded beside the predicate in `src/lib/agent/table-profile.ts`.
+   */
+  const COLUMNS_LIVE: ColumnSchema[] = [column("id", "integer"), column("contact"), column("note")];
+
+  const profileLive = (rows: readonly (readonly [number, string | null, string])[]) => {
+    const database = new Database(":memory:");
+    try {
+      database.run('CREATE TABLE "people" (id INTEGER, contact TEXT, note TEXT)');
+      for (const row of rows) database.run('INSERT INTO "people" VALUES (?, ?, ?)', row as never);
+
+      const sql = composeTableProfile("sqlite", { table: "people", depth: "pattern" }, COLUMNS_LIVE);
+      const aggregate = database.query(sql).get() as Record<string, unknown>;
+      return readTableProfile("people", "pattern", COLUMNS_LIVE, [aggregate]);
+    } finally {
+      database.close();
+    }
+  };
+
+  test("a column of national ids is counted as a digit run and suspected; a column of prose is not", () => {
+    // 24 rows, so the ratio findings apply at all (MIN_ROWS_FOR_RATIO_FINDINGS).
+    const rows = Array.from({ length: 24 }, (_, index) => {
+      const id = `1234567${String(index).padStart(2, "0")}`;
+      return [index, id, `note number ${index}`] as const;
+    });
+
+    const profile = profileLive(rows);
+
+    expect(profile?.rowCount).toBe(24);
+    // Nine consecutive digits in every `contact`, none in a `note` — SQLite agrees.
+    expect(profile?.columns[1]?.digitRun).toBe(24);
+    expect(profile?.columns[2]?.digitRun).toBe(0);
+    expect(profile?.columns[1]?.shaped).toBe(0);
+
+    const suspected = profile?.findings.filter((finding) => finding.code === "suspected_pii") ?? [];
+    expect(suspected.map((finding) => finding.column)).toEqual(["contact"]);
+    expect(suspected[0]?.detail).toContain(`a run of ${DIGIT_RUN_LENGTH} or more digits`);
+  });
+
+  test("a run one digit short of the bound does not match, so a year or a price is not a suspicion", () => {
+    // Eight digits, and a four-digit year in the note.
+    const rows = Array.from({ length: 24 }, (_, index) => [index, `1234567${index % 10}`, "sold in 2026"] as const);
+
+    const profile = profileLive(rows);
+
+    expect(profile?.columns[1]?.digitRun).toBe(0);
+    expect(profile?.columns[2]?.digitRun).toBe(0);
+    expect(profile?.findings.map((finding) => finding.code)).not.toContain("suspected_pii");
+  });
+
+  test("the email shape still matches on the live engine, beside the digit run", () => {
+    const rows = Array.from({ length: 24 }, (_, index) => [index, `user${index}@example.com`, "hello"] as const);
+
+    const profile = profileLive(rows);
+
+    expect(profile?.columns[1]?.shaped).toBe(24);
+    expect(profile?.columns[1]?.digitRun).toBe(0);
+    expect(profile?.findings.filter((finding) => finding.code === "suspected_pii")[0]?.detail).toContain(
+      "an email address",
+    );
   });
 });

--- a/tests/unit/lib/agent/types.test.ts
+++ b/tests/unit/lib/agent/types.test.ts
@@ -129,6 +129,23 @@ const EVENTS: Record<AgentRunEvent["kind"], AgentRunEvent> = {
     // And the word the engine used for those rows (#414), which is two strings and
     // therefore as inert as the rest of the entry.
     noun: { singular: "key pattern", plural: "key patterns" },
+    // What the reading cost this run, measured off the tracker (B13). In the fixture
+    // because it is what a run driven by this build records: the capture's catalog reads
+    // are charged against the ceilings the rail shows and write no `tool-completed`.
+    charged: { statements: 3, elapsedMs: 41 },
+  },
+  // The inventory the run did NOT read, because this process already held one (B56). Its
+  // own kind rather than the entry above, because every reader that finds a capture treats
+  // it as this run's own reading — and `ageMs` is the field the entry exists for: the hold
+  // has no expiry, so a plan run can be grounded on a reading taken before the user added
+  // the collection they are asking about.
+  "context-reused": {
+    kind: "context-reused",
+    atMs: 2,
+    fingerprint: SNAPSHOT.fingerprint,
+    tableCount: SNAPSHOT.tables.length,
+    ageMs: 3_600_000,
+    noun: { singular: "key pattern", plural: "key patterns" },
   },
   // The capture that was REFUSED (B54). Its own kind rather than the entry above
   // carrying an absence, and the fixture is the row-budget case because that is the
@@ -142,6 +159,9 @@ const EVENTS: Record<AgentRunEvent["kind"], AgentRunEvent> = {
     reasonCode: "CATALOG_READ_REFUSED",
     detail: "This run's schema inventory was refused.",
     rowBudget: { projected: 536, allowed: 200 },
+    // A refusal is not a free capture: the read was admitted and charged before it was
+    // answered, and on this shape the engine had already produced the rows (B13).
+    charged: { statements: 1, elapsedMs: 18 },
   },
   "statement-drafted": {
     kind: "statement-drafted",

--- a/tests/unit/lib/catalog-copy-engine-count.test.ts
+++ b/tests/unit/lib/catalog-copy-engine-count.test.ts
@@ -114,7 +114,21 @@ const SEGMENT_END_RE = /\.\s|\n\s*\n|\n\s*[-*]\s/;
  * measured while writing this test.
  */
 function withoutMarkup(text: string): string {
-  return text.replace(/<\/(?:li|p|ul|ol|h[1-6])>|<br\s*\/?>/gi, "\n\n").replace(/<[^>]*>/g, "");
+  const withBlockBreaks = text.replace(/<\/(?:li|p|ul|ol|h[1-6])>|<br\s*\/?>/gi, "\n\n");
+
+  // Stripped to a FIXED POINT rather than in one pass. A single `replace` can splice two
+  // surviving fragments into a fresh tag - `<<p>p>` becomes `<p>` - which is what CodeQL's
+  // `js/incomplete-multi-character-sanitization` rule reports, and it reported it here.
+  // Nothing this function returns is ever rendered: the output is searched for engine names
+  // and counted inside this test. But the rule is right about the behaviour, and a stripper
+  // that can reintroduce a tag is wrong for counting too, because it would leave a tag NAME
+  // in the text being searched. `[^<>]*` rather than `[^>]*` so the inner tag is the match.
+  let stripped = withBlockBreaks;
+  for (let previous = ""; previous !== stripped; ) {
+    previous = stripped;
+    stripped = stripped.replace(/<[^<>]*>/g, "");
+  }
+  return stripped;
 }
 
 function listSegment(text: string, offset: number): string {
@@ -183,6 +197,23 @@ describe("outward-facing catalog copy counts the engines the registry ships", ()
       (segment) => !ABRIDGED_RE.test(segment) && ENGINE_NAMES.filter(({ name }) => segment.includes(name)).length >= 2,
     );
     expect(counted.length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe("the markup stripper cannot reintroduce what it removes", () => {
+  test("a spliced tag is stripped, not left as a bare tag name", () => {
+    // One `replace` pass turns `<<p>p>` into `p>` - it removes the inner tag and leaves the
+    // outer fragments touching. For this gate that is a counting fault, not a rendering one:
+    // a tag NAME surviving into the text is a token the engine-name search then reads. The
+    // one-pass form is what CodeQL flagged as `js/incomplete-multi-character-sanitization`.
+    expect(withoutMarkup("<<p>p>PostgreSQL")).toBe("PostgreSQL");
+    expect(withoutMarkup("<<span>span>MySQL")).toBe("MySQL");
+  });
+
+  test("an ordinary tag is still stripped once", () => {
+    // Control: the fixed-point loop must not change the plain case it was already right about.
+    expect(withoutMarkup("<p>PostgreSQL</p>")).toBe("PostgreSQL\n\n");
+    expect(withoutMarkup("no markup at all")).toBe("no markup at all");
   });
 });
 

--- a/tests/unit/lib/catalog-copy-engine-count.test.ts
+++ b/tests/unit/lib/catalog-copy-engine-count.test.ts
@@ -1,0 +1,240 @@
+/**
+ * The accuracy gate for the engine COUNT in outward-facing catalog copy (#D47).
+ *
+ * Nine files outside `src/` name the engine set by hand, and until this test nothing
+ * counted them: `scripts/readme-check.mjs` locates the engine table in the three
+ * READMEs and `chart:check` pins a version across files, but a storefront listing was
+ * only ever corrected by somebody noticing. Measured on the DuckDB registration branch,
+ * every one of these nine was a full engine behind two weeks after libSQL shipped
+ * (#511), and DuckDB was the second engine in a row to walk into it.
+ *
+ * The rule is not "every file names every engine" - three of the nine deliberately
+ * abridge, because a numeral there goes stale the day the next engine lands (#445). It
+ * is:
+ *
+ * 1. a numeral qualifying the word "engines" must equal `EXTERNAL_DATABASE_TYPES.length`;
+ * 2. where that numeral introduces a LIST, the list must name every one of them, by the
+ *    `DB_UI_CONFIG` labels rather than by a copy of the names kept here.
+ *
+ * A numeral that qualifies a NARROWER noun ("the two search engines") is not a claim
+ * about the product's set and is left alone, and an explicitly abridged list ("and
+ * more", "among them", "from X ... to Y") is checked on its numeral only.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DB_UI_CONFIG } from "@/lib/db-ui-config";
+import { EXTERNAL_DATABASE_TYPES } from "@/lib/db/compatibility";
+
+const REPO_ROOT = join(import.meta.dir, "../../..");
+
+/**
+ * The nine files that publish the engine set outward. Each is copy somebody else's
+ * catalog renders, so nobody in this repo reads it again once it is submitted.
+ *
+ * `from`/`to` cut away editorial matter, and only `CATALOG_LISTING.md` has any: its
+ * accuracy-gate blockquote and its outstanding-corrections table exist to NAME stale
+ * numerals (including a quote of the count the LIVE listing still publishes), so a
+ * count check over the whole file would fail on the note that warns about the count.
+ * The same slice is used by `tests/unit/marketplace-copy.test.ts`.
+ */
+const COPY_FILES: ReadonlyArray<{ path: string; from?: string; to?: string }> = [
+  { path: "packaging/linux/nfpm.yaml" },
+  { path: "packaging/winget/LibreDB.Studio.locale.en-US.yaml.tmpl" },
+  { path: "packaging/chocolatey/libredb-studio.nuspec.tmpl" },
+  { path: "desktop/src-tauri/tauri.conf.json" },
+  { path: "deploy/caprover/libredb-studio.yml" },
+  { path: "deploy/railway/template.json" },
+  { path: "deploy/azure/listing/listing-fields.md" },
+  { path: "deploy/azure/listing/description.html" },
+  { path: "deploy/rancher/CATALOG_LISTING.md", from: "## Short description", to: "## Outstanding corrections" },
+];
+
+const NUMERAL_WORDS: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+  thirteen: 13,
+  fourteen: 14,
+  fifteen: 15,
+  sixteen: 16,
+  seventeen: 17,
+  eighteen: 18,
+  nineteen: 19,
+  twenty: 20,
+};
+
+/**
+ * Only "N engines" and "N database engines" count. Any other qualifier narrows the noun
+ * to a subset of the product - "the two search engines accept no mutation" is a true
+ * sentence about Elasticsearch and OpenSearch, not a stale total.
+ */
+const ENGINE_COUNT_RE = new RegExp(
+  `\\b(\\d{1,3}|${Object.keys(NUMERAL_WORDS).join("|")})\\s+(?:database\\s+)?engines\\b`,
+  "gi",
+);
+
+/** A list that says so is checked on its numeral only (#445). */
+const ABRIDGED_RE = /\band more\b|\bamong them\b|\bfrom\b[^.]*?\bto\b/i;
+
+/**
+ * The name each engine is searched for. Taken from the `DB_UI_CONFIG` label with a
+ * leading "Apache " dropped, because the copy is inconsistent about it in both
+ * directions - the label says "Trino" where the listings say "Apache Trino", and says
+ * "Apache Druid" where one listing says "Druid" - and because the bare product name is
+ * what survives every spelling a listing uses for a family ("MySQL/MariaDB/TiDB",
+ * "Microsoft SQL Server", "libSQL/Turso").
+ */
+const ENGINE_NAMES: ReadonlyArray<{ type: string; name: string }> = EXTERNAL_DATABASE_TYPES.map((type) => ({
+  type,
+  name: DB_UI_CONFIG[type].label.replace(/^Apache /, ""),
+}));
+
+/**
+ * Where the sentence (or the markdown bullet, or the `<li>`) holding a numeral ends.
+ * The list has to be bounded or the count would sweep up the engine names in the copy
+ * below it - every listing names a subset again when it describes inline editing or the
+ * explain-capable set.
+ */
+const SEGMENT_END_RE = /\.\s|\n\s*\n|\n\s*[-*]\s/;
+
+/**
+ * Markup out, block boundaries kept. The Azure description is HTML and puts a
+ * `</strong>` between the numeral and its list, which ended the segment on a tag rather
+ * than on the sentence and left the longest exhaustive list in the nine unchecked -
+ * measured while writing this test.
+ */
+function withoutMarkup(text: string): string {
+  return text.replace(/<\/(?:li|p|ul|ol|h[1-6])>|<br\s*\/?>/gi, "\n\n").replace(/<[^>]*>/g, "");
+}
+
+function listSegment(text: string, offset: number): string {
+  const rest = text.slice(offset);
+  const end = SEGMENT_END_RE.exec(rest);
+  return end ? rest.slice(0, end.index) : rest;
+}
+
+/** Every problem the copy in `text` publishes, named so the fix is obvious. */
+function engineCountProblems(text: string, label: string): string[] {
+  const expected = EXTERNAL_DATABASE_TYPES.length;
+  const problems: string[] = [];
+
+  for (const match of text.matchAll(ENGINE_COUNT_RE)) {
+    const written = match[1].toLowerCase();
+    const value = NUMERAL_WORDS[written] ?? Number(written);
+    if (value !== expected) {
+      problems.push(`${label}: "${match[0]}" publishes ${value}, and there are ${expected}`);
+      continue;
+    }
+
+    const segment = listSegment(text, (match.index ?? 0) + match[0].length);
+    const named = ENGINE_NAMES.filter(({ name }) => segment.includes(name));
+    // Two names is what separates a list from a sentence that happens to mention an
+    // engine; below that there is nothing to count.
+    if (named.length < 2 || ABRIDGED_RE.test(segment)) continue;
+
+    if (named.length !== expected) {
+      const missing = ENGINE_NAMES.filter(({ name }) => !segment.includes(name)).map(({ type }) => type);
+      problems.push(`${label}: the list after "${match[0]}" names ${named.length}, missing ${missing.join(", ")}`);
+    }
+  }
+
+  return problems;
+}
+
+function copyOf(entry: (typeof COPY_FILES)[number]): string {
+  const content = readFileSync(join(REPO_ROOT, entry.path), "utf8");
+  if (!entry.from) return withoutMarkup(content);
+  const from = content.indexOf(entry.from);
+  const to = entry.to ? content.indexOf(entry.to) : content.length;
+  expect(from).toBeGreaterThan(-1);
+  expect(to).toBeGreaterThan(from);
+  return withoutMarkup(content.slice(from, to));
+}
+
+describe("outward-facing catalog copy counts the engines the registry ships", () => {
+  test.each(COPY_FILES.map((entry) => [entry.path, entry] as const))("%s", (path, entry) => {
+    expect(engineCountProblems(copyOf(entry), path)).toEqual([]);
+  });
+
+  // The walk is only worth as much as the matches it finds: a regex that matched
+  // nothing would pass every file above. Both halves of the rule must fire on the real
+  // copy, not only on the fixtures below.
+  test("the walk actually finds numerals and lists to check", () => {
+    const segments = COPY_FILES.flatMap((entry) => {
+      const text = copyOf(entry);
+      return [...text.matchAll(ENGINE_COUNT_RE)].map((match) =>
+        listSegment(text, (match.index ?? 0) + match[0].length),
+      );
+    });
+
+    // Nine numerals and seven counted lists on this revision.
+    expect(segments.length).toBeGreaterThanOrEqual(8);
+    const counted = segments.filter(
+      (segment) => !ABRIDGED_RE.test(segment) && ENGINE_NAMES.filter(({ name }) => segment.includes(name)).length >= 2,
+    );
+    expect(counted.length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe("the gate fails the copy it exists to catch", () => {
+  const fullList = ENGINE_NAMES.map(({ name }) => name).join(", ");
+  const expected = EXTERNAL_DATABASE_TYPES.length;
+
+  test("a list naming one engine too few is refused", () => {
+    // The exact shape D47 measured nine times: the numeral was corrected and one name
+    // was not, or the other way round.
+    const short = ENGINE_NAMES.slice(0, -1)
+      .map(({ name }) => name)
+      .join(", ");
+    const problems = engineCountProblems(`SQL IDE for ${expected} engines - ${short} - with AI.`, "fixture");
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain(ENGINE_NAMES[ENGINE_NAMES.length - 1].type);
+  });
+
+  test("a stale numeral in front of a complete list is refused", () => {
+    const problems = engineCountProblems(`SQL IDE for ${expected - 1} engines - ${fullList} - with AI.`, "fixture");
+
+    expect(problems).toEqual([
+      `fixture: "${expected - 1} engines" publishes ${expected - 1}, and there are ${expected}`,
+    ]);
+  });
+
+  test("an English numeral is read as well as a digit", () => {
+    expect(engineCountProblems("Query fourteen engines from your browser.", "fixture")).toHaveLength(1);
+    expect(engineCountProblems(`Sixteen database engines in one IDE: ${fullList}`, "fixture")).toEqual([]);
+  });
+
+  test("a deliberately abridged list is checked on its numeral only", () => {
+    // winget's and chocolatey's summaries, and two Azure fields, name a few engines and
+    // stop - deliberately, so that no numeral goes stale (#445).
+    expect(
+      engineCountProblems(`SQL IDE for ${expected} engines: PostgreSQL, MySQL, Redis and more`, "fixture"),
+    ).toEqual([]);
+    expect(
+      engineCountProblems(`Connect to ${expected} engines, from PostgreSQL and MySQL to Apache Cassandra.`, "fixture"),
+    ).toEqual([]);
+  });
+
+  test("a numeral qualifying a narrower noun is not a claim about the set", () => {
+    // A real sentence from the Rancher listing's long description.
+    expect(engineCountProblems("the two search engines accept no mutation at all", "fixture")).toEqual([]);
+  });
+
+  test("copy that publishes no numeral at all is left alone", () => {
+    // The winget and chocolatey summaries name engines without counting them.
+    expect(engineCountProblems("Web-based SQL IDE for SQL, NoSQL, analytics and search engines.", "fixture")).toEqual(
+      [],
+    );
+  });
+});

--- a/tests/unit/lib/db-ui-config.test.ts
+++ b/tests/unit/lib/db-ui-config.test.ts
@@ -240,6 +240,17 @@ describe("db-ui-config", () => {
     providers split across files) says whether it ever reads the field. Comments and
     docblocks are stripped first, so a docblock that merely DISCUSSES `config.user` does not
     count as a read.
+
+    Two ways the `config.<field>` pattern can be wrong, and they are not symmetric:
+
+    - A FALSE POSITIVE - the token inside a SQL string literal, say - makes this test fail
+      loudly with a name in the message. Someone reads it and adds the exclusion. Safe.
+    - A FALSE NEGATIVE is the dangerous one: a provider reading the field some other way
+      (`const { user } = this.config`, or `this.config` bound to a local first) would be
+      seen as not reading it, and a list that omits the field would pass. Measured
+      2026-08-27 across every provider directory: there are no destructured reads of `user`
+      or `database` and `this.config` is never aliased to a bare variable, so the pattern
+      catches every real read today. If you add one of those shapes, widen this first.
   */
   describe("the write list names every addressing field its provider reads", () => {
     const FACTORY = readFileSync(path.join(ROOT, "src/lib/db/factory.ts"), "utf8");

--- a/tests/unit/lib/db-ui-config.test.ts
+++ b/tests/unit/lib/db-ui-config.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect } from "bun:test";
-import { getDBConfig, getDBIcon, getDBColor, isFileBased } from "@/lib/db-ui-config";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { getDBConfig, getDBIcon, getDBColor, isFileBased, takesConnectionField } from "@/lib/db-ui-config";
 import { SHOWCASE_DATABASE_ORDER, SHOWCASE_RANK, listShowcaseDatabases } from "@/lib/db-showcase";
 import type { DatabaseType } from "@/lib/types";
+
+const ROOT = path.resolve(import.meta.dir, "../../..");
 
 const ALL_TYPES: DatabaseType[] = [
   "postgres",
@@ -214,6 +218,108 @@ describe("db-ui-config", () => {
       expect(isFileBased("couchbase")).toBe(false);
       expect(isFileBased("clickhouse")).toBe(false);
       expect(isFileBased("druid")).toBe(false);
+    });
+  });
+
+  /*
+    `connectionFields` decides what a save WRITES: `buildConnection` in
+    `src/hooks/use-connection-form.ts` spreads `host`/`port`/`user`/`password`/`database`
+    only when this list names them. So an engine whose provider authenticates with a field
+    the list omits discards the value between the box the user typed it into and the driver
+    that needed it, and nothing fails - the connection simply acts as a principal the user
+    did not choose.
+
+    That is not hypothetical. #502 taught `RedisProvider.connect()` to pass `config.user` to
+    ioredis as `username`, measured on both arms against `redis:latest` (without it
+    `ACL WHOAMI` answered `default` and a restricted principal reported full health). The
+    repair was correct and unreachable: `redis` did not name `user` here, so the form threw
+    the value away before the provider could ever see it.
+
+    These tests derive the answer rather than restating the table: the factory says which
+    module implements each type-id, and the module (with its directory siblings, for the
+    providers split across files) says whether it ever reads the field. Comments and
+    docblocks are stripped first, so a docblock that merely DISCUSSES `config.user` does not
+    count as a read.
+  */
+  describe("the write list names every addressing field its provider reads", () => {
+    const FACTORY = readFileSync(path.join(ROOT, "src/lib/db/factory.ts"), "utf8");
+
+    /** `case "redis": ... await import("./providers/keyvalue/redis")` */
+    const moduleForType = (type: DatabaseType): string => {
+      const pattern = new RegExp(`case "${type}":[\\s\\S]{0,400}?await import\\("\\./providers/([^"]+)"\\)`);
+      const match = pattern.exec(FACTORY);
+      if (match === null) throw new Error(`factory.ts declares no module for ${type}`);
+      return match[1].replace(/\/index$/, "");
+    };
+
+    const providerSource = (type: DatabaseType): string => {
+      const base = path.join(ROOT, "src/lib/db/providers", moduleForType(type));
+      const files = existsSync(`${base}.ts`)
+        ? [`${base}.ts`]
+        : readdirSync(base, { recursive: true, encoding: "utf8" })
+            .map((entry) => path.join(base, entry))
+            .filter((entry) => entry.endsWith(".ts"));
+      const source = files.map((file) => readFileSync(file, "utf8")).join("\n");
+      return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+    };
+
+    test("the factory names a readable module for every type", () => {
+      // Every assertion below is vacuously true if the source comes back empty.
+      for (const type of ALL_TYPES) expect(providerSource(type).length).toBeGreaterThan(200);
+    });
+
+    test.each(["user", "database"] as const)("a provider that reads config.%s is given it", (field) => {
+      const diverging = ALL_TYPES.filter(
+        (type) =>
+          new RegExp(`config\\.${field}\\b`).test(providerSource(type)) !==
+          getDBConfig(type).connectionFields.includes(field),
+      );
+      expect(diverging).toEqual([]);
+    });
+
+    /*
+      The predicate the modal reads. It has to be exercised here rather than through
+      `ConnectionModal`, because both component test files mock `@/lib/db-ui-config` - so a
+      test driving the modal never runs this function at all, and the coverage gate is what
+      said so.
+    */
+    describe("takesConnectionField", () => {
+      test("answers for the engines whose field set is not the networked default", () => {
+        // libSQL: a token, not a user name; and the database IS the host.
+        expect(takesConnectionField("libsql", "user")).toBe(false);
+        expect(takesConnectionField("libsql", "database")).toBe(false);
+        expect(takesConnectionField("libsql", "host")).toBe(true);
+        expect(takesConnectionField("libsql", "password")).toBe(true);
+
+        // The three HTTP-Basic engines take a credential but name their datasource or
+        // index in the statement.
+        for (const type of ["druid", "elasticsearch", "opensearch"] as const) {
+          expect(takesConnectionField(type, "user")).toBe(true);
+          expect(takesConnectionField(type, "database")).toBe(false);
+        }
+
+        // Redis takes both, which is the fix this round made.
+        expect(takesConnectionField("redis", "user")).toBe(true);
+        expect(takesConnectionField("redis", "database")).toBe(true);
+      });
+
+      test("agrees with the list it reads, for every type and every field", () => {
+        // Derived rather than enumerated: the predicate must not develop an opinion of its
+        // own about any engine.
+        const FIELDS = ["host", "port", "user", "password", "database", "connectionString"] as const;
+        for (const type of ALL_TYPES) {
+          for (const field of FIELDS) {
+            expect(takesConnectionField(type, field)).toBe(getDBConfig(type).connectionFields.includes(field));
+          }
+        }
+      });
+    });
+
+    test("redis names the ACL user, because its provider authenticates with it", () => {
+      // Pinned by name as well as by the rule above: this is the one the rule was written
+      // for, and a rule can be weakened by a future edit without anyone noticing which
+      // case it existed to catch.
+      expect(getDBConfig("redis").connectionFields).toContain("user");
     });
   });
 });

--- a/tests/unit/lib/export/result-export.test.ts
+++ b/tests/unit/lib/export/result-export.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { buildResultExport, deriveTableName, FALLBACK_TABLE_NAME } from "@/lib/export/result-export";
+import {
+  buildResultExport,
+  deriveTableName,
+  FALLBACK_TABLE_NAME,
+  resultExportFileName,
+} from "@/lib/export/result-export";
 
 const source = (over: Partial<Parameters<typeof buildResultExport>[1]> = {}) => ({
   rows: [{ id: 1, name: "Ada" }],
@@ -980,5 +985,33 @@ describe("buildResultExport - Oracle date and timestamp literals", () => {
       source({ rows: [{ at: instant }], fields: ["at"], dialect: "postgres", columnTypes: { at: "DATE" } }),
     );
     expect(file.content).toContain(`VALUES ('2026-08-24T17:11:12.345Z');`);
+  });
+});
+
+describe("resultExportFileName", () => {
+  test("names a file the user's own query produced after the result", () => {
+    expect(resultExportFileName("csv")).toBe("query_result_export.csv");
+  });
+
+  // B34: a file carrying an agent run's rows must not be indistinguishable from one
+  // the user ran, so the run it came from is in the name.
+  test("names a run's own file after the run", () => {
+    expect(resultExportFileName("json", "arun_7f3c")).toBe("agent_run_arun_7f3c_export.json");
+  });
+
+  test("keeps a run id out of the path and off the extension", () => {
+    expect(resultExportFileName("csv", "../../etc/passwd")).toBe("agent_run_etc-passwd_export.csv");
+    expect(resultExportFileName("csv", "run.2026/08")).toBe("agent_run_run-2026-08_export.csv");
+  });
+
+  test("still says the file came from a run when the id contributes nothing nameable", () => {
+    // The attribution is the point; a run id made entirely of characters a file name
+    // cannot carry leaves the attribution and drops the id.
+    expect(resultExportFileName("csv", "///")).toBe("agent_run_export.csv");
+  });
+
+  test("caps how much of a run id reaches the name", () => {
+    const name = resultExportFileName("csv", "r".repeat(200));
+    expect(name).toBe(`agent_run_${"r".repeat(64)}_export.csv`);
   });
 });

--- a/tests/unit/llm/gemini-endpoint.test.ts
+++ b/tests/unit/llm/gemini-endpoint.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from "bun:test";
+import {
+  GEMINI_DEFAULT_API_VERSION,
+  resolveGeminiChatBaseUrl,
+  resolveGeminiSdkBaseUrl,
+} from "@/lib/llm/utils/gemini-endpoint";
+
+// One `LLM_API_URL` is read two ways because the two installed SDKs disagree about
+// whether the version segment belongs to the base URL. These tests pin the seam;
+// tests/unit/llm/gemini-provider.test.ts and tests/isolated/agent-model-adapter.test.ts
+// pin that each consumer actually reaches the resolved host.
+
+describe("resolveGeminiChatBaseUrl", () => {
+  test("returns undefined when nothing is configured, so the SDK keeps its Google default", () => {
+    expect(resolveGeminiChatBaseUrl(undefined)).toBeUndefined();
+  });
+
+  test("treats a blank or whitespace value as unconfigured", () => {
+    expect(resolveGeminiChatBaseUrl("")).toBeUndefined();
+    expect(resolveGeminiChatBaseUrl("   ")).toBeUndefined();
+  });
+
+  test("strips the version segment, because the SDK appends the version itself", () => {
+    expect(resolveGeminiChatBaseUrl("https://proxy.example.com/v1beta")).toBe("https://proxy.example.com");
+    expect(resolveGeminiChatBaseUrl("https://proxy.example.com/v1")).toBe("https://proxy.example.com");
+    expect(resolveGeminiChatBaseUrl("https://proxy.example.com/v1alpha")).toBe("https://proxy.example.com");
+  });
+
+  test("passes a bare origin through, trailing slashes and surrounding space removed", () => {
+    expect(resolveGeminiChatBaseUrl("  https://proxy.example.com//  ")).toBe("https://proxy.example.com");
+  });
+
+  test("keeps a path prefix a proxy mounts the API under", () => {
+    expect(resolveGeminiChatBaseUrl("https://gw.example.com/google/v1beta")).toBe("https://gw.example.com/google");
+  });
+
+  test("returns undefined when the version segment is all there was", () => {
+    expect(resolveGeminiChatBaseUrl("/v1beta")).toBeUndefined();
+  });
+});
+
+describe("resolveGeminiSdkBaseUrl", () => {
+  test("returns undefined when nothing is configured, so the SDK keeps its Google default", () => {
+    expect(resolveGeminiSdkBaseUrl(undefined)).toBeUndefined();
+    expect(resolveGeminiSdkBaseUrl("  ")).toBeUndefined();
+  });
+
+  test("keeps a configured version segment rather than doubling it", () => {
+    expect(resolveGeminiSdkBaseUrl("https://proxy.example.com/v1beta")).toBe("https://proxy.example.com/v1beta");
+    expect(resolveGeminiSdkBaseUrl("https://proxy.example.com/v1alpha/")).toBe("https://proxy.example.com/v1alpha");
+  });
+
+  test("appends the default version to a bare origin", () => {
+    expect(resolveGeminiSdkBaseUrl("https://proxy.example.com")).toBe(
+      `https://proxy.example.com/${GEMINI_DEFAULT_API_VERSION}`,
+    );
+  });
+
+  test("resolves the same host as the chat surface for either spelling", () => {
+    const versioned = resolveGeminiSdkBaseUrl("https://proxy.example.com/v1beta");
+    const bare = resolveGeminiSdkBaseUrl("https://proxy.example.com");
+    expect(bare).toBe(versioned);
+  });
+});

--- a/tests/unit/llm/gemini-provider.test.ts
+++ b/tests/unit/llm/gemini-provider.test.ts
@@ -14,6 +14,8 @@ import {
 // ============================================================================
 
 let mockGenerateContentStream: (prompt: string) => Promise<unknown>;
+let capturedModelParams: Record<string, unknown> | undefined;
+let capturedRequestOptions: Record<string, unknown> | undefined;
 
 // ============================================================================
 // Module Mocks (must be before await import)
@@ -22,7 +24,9 @@ let mockGenerateContentStream: (prompt: string) => Promise<unknown>;
 mock.module("@google/generative-ai", () => ({
   GoogleGenerativeAI: function () {
     return {
-      getGenerativeModel: function () {
+      getGenerativeModel: function (modelParams: Record<string, unknown>, requestOptions?: Record<string, unknown>) {
+        capturedModelParams = modelParams;
+        capturedRequestOptions = requestOptions;
         return {
           generateContentStream: async (prompt: string) => mockGenerateContentStream(prompt),
         };
@@ -81,6 +85,8 @@ function makeStreamOptions(overrides?: Partial<LLMStreamOptions>): LLMStreamOpti
 
 describe("GeminiProvider", () => {
   beforeEach(() => {
+    capturedModelParams = undefined;
+    capturedRequestOptions = undefined;
     mockGenerateContentStream = async () => ({
       stream: mockStreamChunks(["Hello", " World"]),
     });
@@ -133,6 +139,24 @@ describe("GeminiProvider", () => {
         }),
       );
       expect(stream).toBeInstanceOf(ReadableStream);
+    });
+
+    // B20: an operator behind an egress proxy or on a regional endpoint sets
+    // LLM_API_URL and this SDK's RequestOptions.baseUrl is where it has to land.
+    test("routes through config.apiUrl when one is configured", async () => {
+      const provider = new GeminiProvider(makeConfig({ apiUrl: "https://proxy.example.com/v1beta" }));
+      await provider.stream(makeStreamOptions());
+
+      // The origin, not the versioned URL: this SDK appends the version itself.
+      expect(capturedRequestOptions?.baseUrl).toBe("https://proxy.example.com");
+    });
+
+    test("leaves baseUrl unset when no apiUrl is configured, keeping the SDK's Google default", async () => {
+      const provider = new GeminiProvider(makeConfig());
+      await provider.stream(makeStreamOptions());
+
+      expect(capturedRequestOptions?.baseUrl).toBeUndefined();
+      expect(capturedModelParams?.model).toBe("gemini-2.0-flash");
     });
 
     test("handles empty stream", async () => {

--- a/tests/unit/sql/statement-end.test.ts
+++ b/tests/unit/sql/statement-end.test.ts
@@ -71,6 +71,7 @@ describe("readStatementEnd", () => {
       ["a comment marker in a quoted identifier", 'SELECT "a -- b"'],
       ["a comment marker in a backtick identifier", "SELECT `a -- b`"],
       ["a comment marker in a dollar-quoted body", "SELECT $$ ; -- $$"],
+      ["a comment marker in a TAGGED dollar-quoted body", "SELECT $tag$ ; -- $tag$"],
       ["a doubled quote inside a string", "SELECT 'it''s -- fine'"],
     ])("keeps %s inside the statement", (_label, sql) => {
       expect(split(sql)).toEqual([sql, ""]);
@@ -83,6 +84,24 @@ describe("readStatementEnd", () => {
 
     test("a semicolon that separates statements is not trailing trivia", () => {
       expect(split("SELECT 1; SELECT 2;")).toEqual(["SELECT 1; SELECT 2", ";"]);
+    });
+
+    // ── A dollar-quoted body is the statement's own text ───────────────────
+    //
+    // Same shape as the bracketed run below, and pinned the same way: only a
+    // fixture where the two readings DISAGREE decides it. With code after the
+    // body the end reaches the same index either way, so the body has to be the
+    // LAST token - either ending the input or with nothing but trivia after it.
+    // Read as trivia instead, the body would join the trailing run and the end
+    // would fall back to the last code character before it, so the
+    // insert-before-trivia rewrite would emit `SELECT $$body$$` as
+    // `SELECT LIMIT 500 $$body$$` - the corrupted-statement class, not a missed
+    // bound.
+    test("splits the trailing trivia off after a dollar-quoted body, not before it", () => {
+      expect(readStatementEnd("SELECT $$a$$")).toEqual({ end: 12, rewritable: true });
+      expect(split("SELECT $$a$$ -- daily")).toEqual(["SELECT $$a$$", " -- daily"]);
+      expect(split("SELECT $tag$a$tag$;")).toEqual(["SELECT $tag$a$tag$", ";"]);
+      expect(split("SELECT $$ ; -- $$ /* c */")).toEqual(["SELECT $$ ; -- $$", " /* c */"]);
     });
   });
 

--- a/tests/unit/ssh-tunnel.test.ts
+++ b/tests/unit/ssh-tunnel.test.ts
@@ -3,6 +3,14 @@ import { mock, describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { EventEmitter } from "events";
 
 // --- Mock ssh2 Client ---
+// CI rests on this mock's FIDELITY to ssh2, and nothing here measures it. The handshake
+// ordering, the `hostVerifier` contract and the refusal message below were derived by
+// reading ssh2's own source - `node_modules/ssh2/lib/protocol/kex.js` and
+// `lib/client.js` - so an ssh2 upgrade that changes any of them leaves this suite green
+// while the product regresses. The live arm exists but does not stand: the three arms
+// (no pin, correct pin, wrong pin) were driven once by hand on 2026-08-26 against a real
+// `openssh-server` on port 2226, recorded in `docs/providers/README.md`; there is no sshd
+// container fixture, so that is a one-time observation rather than a property the suite holds.
 class MockSSHClient extends EventEmitter {
   connectOptions: Record<string, unknown> | null = null;
   forwardOutCalls: Array<{ bindAddr: string; bindPort: number; host: string; port: number }> = [];


### PR DESCRIPTION
## What this is

A settlement pass over `docs/BACKLOG.md`, opened because the file had stopped shrinking. Measured over
the 30 commits that touched it: **106 entries on 2026-08-23, 129 on 2026-08-27 — 63 closed, 86 opened,
1.37 new entries per closed one.** Two producers, and only the second was a process fault:

- `feat` commits ship new surface with its own unfinished edges and close nothing (libSQL 0 closed / 5
  opened, DuckDB 0/3, agent-conversation 1/5, per-model settings 0/5), so growth tracked feature
  velocity;
- `fix` rounds ran ~5 closed / 7 opened, because "outside this PR's scope" was being treated as
  "deserves an id". A round whose method is measurement produces findings faster than fixes by
  construction, so a rule that auto-files every finding cannot converge. U25 is the proof: its fix was
  "delete two duplicated `formatBytes` copies, import the shared one, add a test", and the entry
  describing it was 20 lines that cost about as much to write.

**Result: 129 entries -> 89. Zero opened.**

| | count | |
| --- | --- | --- |
| removed as not-work | 19 | premise re-measured first; 3 were already resolved |
| closed because the work landed | 21 | each against its own "Done when" |
| opened | **0** | findings were fixed, or put to the owner as a question |

## The defect that was not on the list

Comparing, across all 17 type-ids, whether a provider reads `config.user` against whether
`connectionFields` names it gave exactly one divergence: **redis**.

#502 taught `RedisProvider.connect()` to send `config.user` to ioredis as `username`, measured on both
arms against a live server, and `docs/providers/redis.md` documented `user` as a connection field. But
`connectionFields` — which decides what `buildConnection` WRITES — omitted it, so a Redis 6 ACL user
typed into the form was discarded between the box and the driver and the connection authenticated as
`default`. #502's message said "the form collects the value"; on the write path it did not.

Both halves are now driven by one list, verified in real Chrome against a dev server:

| engine | host | port | user | password | database |
| --- | --- | --- | --- | --- | --- |
| postgres (control) | yes | yes | yes | yes | yes |
| libsql | yes | yes | **no** | yes | **no** |
| druid, elasticsearch, opensearch | yes | yes | yes | yes | **no** |
| redis | yes | yes | **yes (new)** | yes | yes |

Two arms: with the field named, `POST /api/db/test-connection` carries `"user": "probe"`; with `user`
removed from redis's list again, the box does not render and the key is absent from the body. U22 named
four engines; there were five — it had missed Redis, the one whose box was losing a credential rather
than merely collecting nothing.

A new test derives the rule from the factory's type-to-module map plus each provider's own source, so
the next provider to authenticate with a field its list omits fails a gate instead of shipping.

## Vacuous tests found along the way

Four tests passed while their subject was broken. Two were mine to find, two were the lanes':

- `tests/hooks/use-connection-form.test.ts` and `tests/components/ConnectionModal.test.tsx` both mock
  `@/lib/db-ui-config` with a `connectionFields` list that hands every networked engine the full field
  set — so no assertion in either file could ever fail on a wrong list. The first Redis test written
  here passed while the defect was live. Both mocks now mirror the real table.
- D31's "schema is empty after a failed read" — schema starts empty, so it never measured the clearing.
- B57's "wording is still refused" — the fixture carried no `settings` at all.

`tests/unit/backlog-structure.test.ts` had a third kind: it pinned the parse by pinning the backlog's
SIZE (`toBeGreaterThan(100)`), so a settlement taking the file to 89 would have failed it for the wrong
reason. It now compares the parsed count against the count in the raw text.

## User-visible change to flag

`U25` unifies three byte formatters onto the guarded shared one. It drops trailing zeros, so on the
Storage and Tables tabs **"700.00 MB" now reads "700 MB"**. Seven assertions moved with it. The gain is
that the two local cascades had no guard and stopped at GB: a negative rendered `-1 B`, a non-finite
`NaN B`, and an exabyte `1073741824.00 GB` — non-magnitudes drawn as figures, in the panels whose
subject is telling a reading from an absence.

## Left for you rather than decided here

- **C4** — the operator image has no SBOM. The premise measured out true; whether that gap is worth
  closing before a certification asks for it is a posture decision, so the entry stays and the question
  comes to you rather than being deleted as "nobody will act on it".
- **D31 was not verified in a browser.** Its scenario needs a connection that opens but whose schema
  read fails, which is a probe to manufacture. Covered at hook and component level only, and said so
  rather than implied.

## Not filed, fixed next instead

**21 citations across 72 sites name backlog entries that no longer exist** — `B17`, `D3`, `U12` and 18
others. All 21 predate this round (verified by diffing the cited set against the surviving set; this PR
introduced none, and repaired the two it would have). Nothing in CI measures whether a cited entry
resolves, which is why `B17` had been dangling unnoticed through 17 green checks. That is a separate PR
with its own guard — filing it as a backlog entry is the behaviour this PR exists to stop.

## Verification

Six gates locally, plus coverage and a real browser. Full tally in the thread below.
