### PR TITLE
fix(schema-diff): stop wrapping non-transactional dialects in BEGIN;/COMMIT;

### DIFF
--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -800,7 +800,11 @@ The integration points, all of which need an entry. This is the list the Strateg
       PostgreSQL-shaped, so check before assuming it fits
 - [ ] `src/lib/schema-diff/migration-generator.ts` — same shape, same hazard: the modified-column
       chain's trailing `else` is PostgreSQL DDL, so an unlisted id silently inherits it (#269). Give the
-      dialect a branch, or list it in `NO_COLUMN_MODIFICATION` to emit an honest comment instead
+      dialect a branch, or list it in `NO_COLUMN_MODIFICATION` to emit an honest comment instead. A new
+      id also needs a decision in `NO_TRANSACTION_WRAPPER` (#284): does `BEGIN;`/`COMMIT;` wrap this
+      engine's DDL at all, or does it belong in the set that gets no wrapper? An id absent from that
+      set inherits the PostgreSQL-shaped wrapper by default, which is silently wrong for a non-SQL or
+      non-transactional engine the same way the modified-column `else` used to be
 - [ ] `src/lib/sql/grammar.ts` — **two decisions, neither of which the compiler can force.** First,
       whether your engine's query text is SQL at all (`NON_SQL_DIALECTS`): an id absent from that set is
       declared to write SQL, and the confirmation gate then applies a SQL span reader to it — which for
@@ -859,7 +863,9 @@ connection-form test), so the compiler and those tests refuse to pass until each
 `tests/unit/lib/query-generators.test.ts`, `tests/unit/seed/types.test.ts`,
 `tests/hooks/use-connection-form.test.ts`,
 `tests/unit/schema-diff/migration-generator.test.ts` (`MODIFIED_COLUMN_COVERAGE` — classify the new id
-as having its own dialect branch or as unable to express a column modification),
+as having its own dialect branch or as unable to express a column modification; and
+`TRANSACTION_WRAPPER_COVERAGE` — classify it as `"wrapped"` or `"unwrapped"`, matching whatever you
+chose in `NO_TRANSACTION_WRAPPER`),
 `tests/unit/sql/grammar.test.ts` (`GRAMMAR_COVERAGE` and `SQL_TEXT_COVERAGE` — record whether the id
 has an established grammar or reads at the default, and whether its query text is SQL).
 

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -1046,9 +1046,10 @@ database-wide statistics. Transaction and cancel routes do not apply — see
     (a bare `x String EPHEMERAL` has no expression, so it reaches the diff as no default at all and the
     generator never sees it); and `REMOVE DEFAULT`
     against a column that has none is itself an error (code `36`), so it is emitted only for a default
-    that existed. Still approximate: the generator wraps its output in `BEGIN` / `COMMIT`, which this
-    server has no transaction model for, so drop those two lines before running a generated migration
-    here.
+    that existed. Since [#284](https://github.com/libredb/libredb-studio/issues/284) the generator no
+    longer wraps ClickHouse's output in `BEGIN` / `COMMIT` at all — this server has no transaction model
+    for it (ClickHouse's own transaction support is experimental and setting-gated, not a safe default),
+    so a generated migration here is the bare DDL with nothing to strip.
 - **No native protocol.** Port `9000` and everything that needs it — the native wire format, some
   server-side settings only exposed there — is out of scope; see
   [§3.1](#31-http-transport-only--no-native-dependency).

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -9,8 +9,8 @@
  *   the limitation in a comment where an engine has no such statement (#269); the
  *   `ADD` / `DROP` keyword, which CQL spells without `COLUMN`; `CREATE TABLE`,
  *   which is refused outright for Cassandra (see CASSANDRA_NO_CREATE_TABLE); the
- *   transaction wrapper (see NO_TRANSACTION_WRAPPER), which twelve of the sixteen
- *   type ids do without, each for its own named reason; and the foreign-key
+ *   transaction wrapper (see NO_TRANSACTION_WRAPPER), which twelve of the
+ *   seventeen type ids do without, each for its own named reason; and the foreign-key
  *   statements, which CQL has no grammar for at all and which SQLite's grammar
  *   takes only inside `CREATE TABLE` (see FOREIGN_KEY_ONLY_IN_CREATE_TABLE).
  * - Not yet: MSSQL and Oracle's own transaction-wrapper forms (`BEGIN;` is not
@@ -189,14 +189,28 @@ const NO_COLUMN_MODIFICATION: Partial<Record<DatabaseType, { label: string; reas
  * `mongodb` and `redis` write no SQL text at all (`NON_SQL_DIALECTS` in `grammar.ts`), and
  * wrapping non-SQL command text in SQL statements is wrong regardless of Mongo's own
  * driver-level transaction API; `libredb` "speaks a JSON command grammar, not SQL DDL"
- * (`NO_COLUMN_MODIFICATION`'s own words); `couchbase` and `druid` never receive column DDL
- * from this generator in the first place (`NO_COLUMN_MODIFICATION`, and both providers
- * report `supportsCreateTable: false`), so a wrapper would bracket nothing but comments;
- * `elasticsearch` and `opensearch` are SQL-read-only (`NO_COLUMN_MODIFICATION`) for the
- * same reason; `trino`'s transactional semantics are the CONNECTOR's answer, not a
+ * (`NO_COLUMN_MODIFICATION`'s own words); `couchbase` HAS distributed ACID transactions,
+ * but spells one `BEGIN TRANSACTION` and answers with a `txid` that every following
+ * statement has to carry as a request parameter (`docs/providers/couchbase.md` §13) - a
+ * shape a flat migration file cannot express at all, so `BEGIN;` is both the wrong
+ * keyword and the wrong mechanism; `druid` has no transaction concept to translate the
+ * wrapper into ("Druid SQL has no ALTER TABLE", `NO_COLUMN_MODIFICATION`; a datasource is
+ * rewritten by an MSQ task, not by a bracketed statement list); `elasticsearch` and
+ * `opensearch` do not have `BEGIN` in their grammar at all - the parse error quoted in
+ * `NO_COLUMN_MODIFICATION` lists every statement Elasticsearch SQL accepts and `BEGIN` is
+ * not among them, and OpenSearch 3.8.0 was measured separately
+ * (`docs/providers/opensearch.md` §9); `trino`'s transactional semantics are the CONNECTOR's answer, not a
  * property of Trino itself (`NO_COLUMN_MODIFICATION`), so no portable `BEGIN;`/`COMMIT;`
  * exists; and `clickhouse`'s transaction support is experimental and setting-gated rather
  * than a safe default — this set is what removes it from the wrapper it used to inherit.
+ *
+ * What none of these nine reasons is: "this generator emits nothing for that id anyway".
+ * It has no capability gate - `supportsCreateTable` is read by the schema explorer, not
+ * here - so its added-table branch emits a real `CREATE TABLE` for every id except
+ * `cassandra` (see CASSANDRA_NO_CREATE_TABLE). The wrapper this set removes was bracketing
+ * runnable DDL for these ids, not just comments, which is what makes removing it a fix.
+ * `tests/unit/schema-diff/migration-generator.test.ts` drives the coverage table over an
+ * added-table diff as well as a modified-table one so that stays measured.
  *
  * `mssql` and `oracle` are deliberately ABSENT from this set — they still get the
  * PostgreSQL-shaped wrapper, UNCHANGED, because their real forms (`BEGIN TRANSACTION;`

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -9,26 +9,41 @@
  *   the limitation in a comment where an engine has no such statement (#269); the
  *   `ADD` / `DROP` keyword, which CQL spells without `COLUMN`; `CREATE TABLE`,
  *   which is refused outright for Cassandra (see CASSANDRA_NO_CREATE_TABLE); the
- *   transaction wrapper, which Cassandra and SQLite's two type ids each do
- *   without; and the foreign-key statements, which CQL has no grammar for at all
- *   and which SQLite's grammar takes only inside `CREATE TABLE` (see
- *   FOREIGN_KEY_ONLY_IN_CREATE_TABLE).
- * - Not yet: the transaction wrapper for everyone ELSE (`BEGIN;` / `COMMIT;` is
- *   only valid for PostgreSQL and MySQL — MSSQL spells it `BEGIN TRANSACTION`,
- *   Oracle opens a PL/SQL block and auto-commits DDL anyway, and five remaining
- *   type ids have no transactional DDL at all), the rest of `ADD COLUMN` and
- *   `DROP COLUMN`, and the index/FK fallbacks that emit `DROP INDEX IF EXISTS`.
+ *   transaction wrapper (see NO_TRANSACTION_WRAPPER), which twelve of the sixteen
+ *   type ids do without, each for its own named reason; and the foreign-key
+ *   statements, which CQL has no grammar for at all and which SQLite's grammar
+ *   takes only inside `CREATE TABLE` (see FOREIGN_KEY_ONLY_IN_CREATE_TABLE).
+ * - Not yet: MSSQL and Oracle's own transaction-wrapper forms (`BEGIN;` is not
+ *   `BEGIN TRANSACTION;`, and Oracle DDL auto-commits regardless of what wraps
+ *   it) — both still get today's PostgreSQL-shaped `BEGIN;`/`COMMIT;`, because
+ *   settling their real forms wants checking against a live server first, the
+ *   way #264 and #265 did, and that measurement is the tracked follow-up to this
+ *   fix rather than part of it.
  *
- * Cassandra is ahead of the others here for a reason worth stating: it is the one
- * dialect whose OTHER statements were each measured against a live server, so the
- * wrapper and the FK lines would have been the only unrunnable lines in an
- * otherwise runnable migration. Elsewhere they are one problem among several, and
- * the emitted forms still want checking against a live server first.
+ *   Two more MSSQL/Oracle questions surfaced while checking the rest of this
+ *   docstring's claims, and both belong in that same follow-up rather than
+ *   being guessed at here: the `ADD COLUMN` keyword — the modified-column path
+ *   a few lines below already spells Oracle's own ALTER as `MODIFY (...)`,
+ *   with no `COLUMN` keyword in its grammar at all, and MSSQL's documented
+ *   `ADD` clause has none either, yet the generic added-column branch hands
+ *   both the same literal `ADD COLUMN` every other engine gets; and whether
+ *   `DROP TABLE`/`DROP INDEX`/`DROP CONSTRAINT ... IF EXISTS` are valid there
+ *   at all — Oracle had no conditional DDL clause before 23ai. Both are
+ *   internal inconsistencies or open questions this pass surfaced rather than
+ *   fresh guesses, but neither is fixed here.
  *
- * So the output is correct for PostgreSQL, largely correct for MySQL and SQLite,
- * and can be unrunnable elsewhere. Tracked rather than fixed here because the
- * emitted forms want checking against a live MSSQL and Oracle before they are
- * settled, the way #264 and #265 did.
+ *   For every OTHER dialect, `ADD`/`DROP COLUMN` and the index/FK `IF EXISTS`
+ *   fallbacks were checked against the same questions and found to already
+ *   agree with each one's documented grammar via the existing
+ *   Cassandra/SQLite/libSQL/DuckDB/MySQL branches, so nothing there needed
+ *   changing in this pass.
+ *
+ * Cassandra is ahead of MSSQL and Oracle here for a reason worth stating (see
+ * NO_TRANSACTION_WRAPPER for the measurement): it is a dialect whose OTHER
+ * statements were each measured against a live server too, so its wrapper and FK
+ * lines would have been the only unrunnable lines in an otherwise runnable
+ * migration. For MSSQL and Oracle they are one problem among several, and the
+ * emitted forms still want checking against a live server first.
  */
 import type { DatabaseType } from "@/lib/types";
 // The shared quoter, which also escapes an embedded closing quote character — this
@@ -153,6 +168,56 @@ const NO_COLUMN_MODIFICATION: Partial<Record<DatabaseType, { label: string; reas
     reason: "The embedded engine speaks a JSON command grammar, not SQL DDL.",
   },
 };
+
+/**
+ * Canonical type ids whose migration text carries no transaction wrapper, because no
+ * `BEGIN;` this generator could emit would be both valid and meaningful for them (#284).
+ *
+ * `sqlite` runs its own transaction, and `libsql` is SQLite - the same reasoning, with
+ * one addition of its own: this provider closes its Hrana stream in the same request as
+ * each statement, so a BEGIN it emitted could not be continued by the app that generated
+ * the file. `cassandra` has no transaction at all - measured on 5.0.9, `BEGIN;` is "line
+ * 1:5 mismatched input ';' expecting K_BATCH" and `COMMIT;` is "no viable alternative at
+ * input 'COMMIT'". The only grouping CQL has is `BEGIN BATCH ... APPLY BATCH`, which is
+ * not a transaction and takes no DDL, so there is nothing to translate the wrapper INTO -
+ * it can only be left out. Unlike the other two, Cassandra's OTHER statements in this
+ * generator were each measured against a live server too, so the wrapper would have been
+ * the only unrunnable line in an otherwise runnable migration.
+ *
+ * The other nine are new, and each reuses a fact this module (or `src/lib/sql/grammar.ts`)
+ * already established for a different fallback rather than asserting a fresh one:
+ * `mongodb` and `redis` write no SQL text at all (`NON_SQL_DIALECTS` in `grammar.ts`), and
+ * wrapping non-SQL command text in SQL statements is wrong regardless of Mongo's own
+ * driver-level transaction API; `libredb` "speaks a JSON command grammar, not SQL DDL"
+ * (`NO_COLUMN_MODIFICATION`'s own words); `couchbase` and `druid` never receive column DDL
+ * from this generator in the first place (`NO_COLUMN_MODIFICATION`, and both providers
+ * report `supportsCreateTable: false`), so a wrapper would bracket nothing but comments;
+ * `elasticsearch` and `opensearch` are SQL-read-only (`NO_COLUMN_MODIFICATION`) for the
+ * same reason; `trino`'s transactional semantics are the CONNECTOR's answer, not a
+ * property of Trino itself (`NO_COLUMN_MODIFICATION`), so no portable `BEGIN;`/`COMMIT;`
+ * exists; and `clickhouse`'s transaction support is experimental and setting-gated rather
+ * than a safe default — this set is what removes it from the wrapper it used to inherit.
+ *
+ * `mssql` and `oracle` are deliberately ABSENT from this set — they still get the
+ * PostgreSQL-shaped wrapper, UNCHANGED, because their real forms (`BEGIN TRANSACTION;`
+ * for MSSQL; whether Oracle needs a wrapper at all, given DDL there auto-commits) want
+ * checking against a live server first, the way #264 and #265 were, and remain tracked
+ * in the module docstring above as the follow-up this PR does not attempt.
+ */
+const NO_TRANSACTION_WRAPPER: ReadonlySet<DatabaseType> = new Set<DatabaseType>([
+  "sqlite",
+  "libsql",
+  "cassandra",
+  "mongodb",
+  "redis",
+  "libredb",
+  "couchbase",
+  "druid",
+  "clickhouse",
+  "elasticsearch",
+  "opensearch",
+  "trino",
+]);
 
 function generateColumnDef(col: ColumnDiff, dialect: DatabaseType): string {
   const type = col.targetType || col.sourceType || "TEXT";
@@ -526,20 +591,8 @@ export function generateMigrationSQL(diff: SchemaDiff, dialect: DatabaseType): s
 
   // ONE definition, read twice: the opening and the closing halves of this wrapper used
   // to be two independent conditions, which is a shape that can diverge into a `BEGIN;`
-  // with no `COMMIT;`.
-  //
-  // SQLite runs its own transaction, and libSQL is SQLite - the same reasoning, with
-  // one addition of its own: this provider closes its Hrana stream in the same request
-  // as each statement, so a BEGIN it emitted could not be continued by the app that
-  // generated the file. Cassandra has no transaction at all. Measured on
-  // 5.0.9: `BEGIN;` is "line 1:5 mismatched input ';' expecting K_BATCH" and `COMMIT;`
-  // is "no viable alternative at input 'COMMIT'". The only grouping CQL has is
-  // `BEGIN BATCH ... APPLY BATCH`, which is not a transaction and takes no DDL, so
-  // there is nothing to translate the wrapper INTO - it can only be left out. The
-  // wrapper is still wrong for the other engines named in the module docstring; that
-  // stays tracked there, and unlike them Cassandra emits DDL this generator was taught
-  // to spell correctly, so the wrapper would be the only unrunnable line in it.
-  const wrapsInTransaction = dialect !== "sqlite" && dialect !== "libsql" && dialect !== "cassandra";
+  // with no `COMMIT;`. See NO_TRANSACTION_WRAPPER for why each excluded id is excluded.
+  const wrapsInTransaction = !NO_TRANSACTION_WRAPPER.has(dialect);
 
   if (wrapsInTransaction) {
     sections.push("BEGIN;");

--- a/tests/unit/schema-diff/migration-generator.test.ts
+++ b/tests/unit/schema-diff/migration-generator.test.ts
@@ -1181,6 +1181,65 @@ describe("generateMigrationSQL: dialects that cannot modify a column", () => {
   }
 });
 
+/**
+ * Exhaustive by construction, same spirit as `MODIFIED_COLUMN_COVERAGE` above: a new
+ * `DatabaseType` fails typecheck here until it is classified, so it cannot silently
+ * inherit the wrapper meant for PostgreSQL and MySQL (#284).
+ *
+ * `"wrapped"` — the dialect's DDL is bracketed in `BEGIN;` / `COMMIT;`.
+ * `"unwrapped"` — no wrapper reaches the migration text. mssql and oracle are
+ * deliberately absent from this table's classification of "unwrapped" — they still
+ * read `"wrapped"` here, UNCHANGED from today's behaviour, because the module
+ * docstring and the issue itself say their real wrapper forms (`BEGIN TRANSACTION;`
+ * for MSSQL; whether Oracle needs one at all, given DDL there auto-commits) want
+ * checking against a live server before they are settled, the way #264/#265 were -
+ * and this PR does not have one available. Tracked as the named follow-up rather than
+ * guessed here.
+ */
+const TRANSACTION_WRAPPER_COVERAGE: Record<DatabaseType, "wrapped" | "unwrapped"> = {
+  postgres: "wrapped",
+  mysql: "wrapped",
+  // Measured live via @duckdb/node-api 1.5.5-r.4 (DuckDB v1.5.5, in-process, no server
+  // needed): `BEGIN;` / `BEGIN TRANSACTION;` both open a real transaction around DDL,
+  // and a `CREATE TABLE` issued inside one is undone by `ROLLBACK;` — pinned further in
+  // the "generateMigrationSQL: duckdb" describe block above.
+  duckdb: "wrapped",
+  // UNCHANGED — see this table's own doc comment above.
+  mssql: "wrapped",
+  oracle: "wrapped",
+  sqlite: "unwrapped", // runs its own transaction (module docstring)
+  libsql: "unwrapped", // SQLite fork, same reasoning, plus its own Hrana-stream note (module docstring)
+  cassandra: "unwrapped", // CQL has no BEGIN/COMMIT — measured on 5.0.9 (module docstring)
+  // The remaining nine already have their non-SQL or no-DDL status established
+  // elsewhere in this same module (`NO_COLUMN_MODIFICATION`) or in `src/lib/sql/grammar.ts`
+  // (`NON_SQL_DIALECTS`) — this table applies that same established fact to the wrapper
+  // fallback rather than asserting it fresh, so none of these nine need a new live probe.
+  mongodb: "unwrapped", // not SQL text at all (`NON_SQL_DIALECTS`); wrapping non-SQL in SQL statements is wrong regardless of Mongo's own transaction API
+  redis: "unwrapped", // same: command-line grammar, not SQL (`NON_SQL_DIALECTS`)
+  libredb: "unwrapped", // "a JSON command grammar, not SQL DDL" (NO_COLUMN_MODIFICATION's own words)
+  couchbase: "unwrapped", // this generator never emits column DDL for it (NO_COLUMN_MODIFICATION, supportsCreateTable: false) — a wrapper would bracket only comments
+  druid: "unwrapped", // "Druid SQL has no ALTER TABLE" and no transaction concept (NO_COLUMN_MODIFICATION)
+  clickhouse: "unwrapped", // ClickHouse's transaction support is experimental and setting-gated, not a safe default; today's code wraps it anyway, which this fixes
+  elasticsearch: "unwrapped", // "Elasticsearch SQL reads only" (NO_COLUMN_MODIFICATION) — no DDL is ever emitted for it
+  opensearch: "unwrapped", // same (NO_COLUMN_MODIFICATION)
+  trino: "unwrapped", // connector-dependent at best; no portable BEGIN/COMMIT (NO_COLUMN_MODIFICATION)
+};
+
+describe("generateMigrationSQL: transaction wrapper by dialect", () => {
+  for (const [dialect, expected] of Object.entries(TRANSACTION_WRAPPER_COVERAGE)) {
+    test(`${dialect}: ${expected === "wrapped" ? "wraps DDL in BEGIN;/COMMIT;" : "emits no transaction wrapper"}`, () => {
+      const sql = generateMigrationSQL(makeModifiedTableDiff(), dialect as DatabaseType);
+      if (expected === "wrapped") {
+        expect(sql).toContain("BEGIN;");
+        expect(sql).toContain("COMMIT;");
+      } else {
+        expect(sql).not.toContain("BEGIN;");
+        expect(sql).not.toContain("COMMIT;");
+      }
+    });
+  }
+});
+
 // ============================================================================
 // Multi-table diff
 // ============================================================================

--- a/tests/unit/schema-diff/migration-generator.test.ts
+++ b/tests/unit/schema-diff/migration-generator.test.ts
@@ -1210,33 +1210,59 @@ const TRANSACTION_WRAPPER_COVERAGE: Record<DatabaseType, "wrapped" | "unwrapped"
   sqlite: "unwrapped", // runs its own transaction (module docstring)
   libsql: "unwrapped", // SQLite fork, same reasoning, plus its own Hrana-stream note (module docstring)
   cassandra: "unwrapped", // CQL has no BEGIN/COMMIT — measured on 5.0.9 (module docstring)
-  // The remaining nine already have their non-SQL or no-DDL status established
-  // elsewhere in this same module (`NO_COLUMN_MODIFICATION`) or in `src/lib/sql/grammar.ts`
-  // (`NON_SQL_DIALECTS`) — this table applies that same established fact to the wrapper
-  // fallback rather than asserting it fresh, so none of these nine need a new live probe.
+  // The remaining nine each have a recorded reason for having no `BEGIN;` to emit, in this
+  // same module (`NO_COLUMN_MODIFICATION`), in `src/lib/sql/grammar.ts` (`NON_SQL_DIALECTS`)
+  // or in the provider doc named on the line — this table applies those established facts to
+  // the wrapper fallback rather than asserting fresh ones, so none of the nine needs a new
+  // live probe. What none of them means is "the wrapper bracketed nothing": see the
+  // added-table fixture below.
   mongodb: "unwrapped", // not SQL text at all (`NON_SQL_DIALECTS`); wrapping non-SQL in SQL statements is wrong regardless of Mongo's own transaction API
   redis: "unwrapped", // same: command-line grammar, not SQL (`NON_SQL_DIALECTS`)
   libredb: "unwrapped", // "a JSON command grammar, not SQL DDL" (NO_COLUMN_MODIFICATION's own words)
-  couchbase: "unwrapped", // this generator never emits column DDL for it (NO_COLUMN_MODIFICATION, supportsCreateTable: false) — a wrapper would bracket only comments
-  druid: "unwrapped", // "Druid SQL has no ALTER TABLE" and no transaction concept (NO_COLUMN_MODIFICATION)
+  couchbase: "unwrapped", // has transactions, but spells them `BEGIN TRANSACTION` + a txid every later statement must carry — not something a flat file expresses (docs/providers/couchbase.md §13)
+  druid: "unwrapped", // "Druid SQL has no ALTER TABLE" and no transaction concept at all (NO_COLUMN_MODIFICATION)
   clickhouse: "unwrapped", // ClickHouse's transaction support is experimental and setting-gated, not a safe default; today's code wraps it anyway, which this fixes
-  elasticsearch: "unwrapped", // "Elasticsearch SQL reads only" (NO_COLUMN_MODIFICATION) — no DDL is ever emitted for it
-  opensearch: "unwrapped", // same (NO_COLUMN_MODIFICATION)
+  elasticsearch: "unwrapped", // `BEGIN` is not in the grammar (NO_COLUMN_MODIFICATION's measured statement list; docs/providers/elasticsearch.md §9)
+  opensearch: "unwrapped", // same, measured separately on OpenSearch 3.8.0 (docs/providers/opensearch.md §9)
   trino: "unwrapped", // connector-dependent at best; no portable BEGIN/COMMIT (NO_COLUMN_MODIFICATION)
 };
 
+/**
+ * Two fixtures, because one of them alone cannot see the thing that matters here.
+ *
+ * `generateMigrationSQL` reads NO provider capability — not `supportsCreateTable`, not
+ * anything else — so its added-table branch emits a real `CREATE TABLE` for every id
+ * except `cassandra`, which is the one the generator refuses outright
+ * (`CASSANDRA_NO_CREATE_TABLE`). A modified-table diff on an id in
+ * `NO_COLUMN_MODIFICATION` really does reduce to comments, so a table driven only by
+ * that fixture would let "this dialect never gets DDL, so the wrapper bracketed nothing"
+ * stand unchallenged. It is false: the wrapper this set removes was bracketing runnable
+ * DDL for those ids too, which is why removing it is a fix rather than a tidy-up.
+ */
+const WRAPPER_FIXTURES = [
+  { label: "a modified table", makeDiff: makeModifiedTableDiff, emitsCreateTable: false },
+  { label: "an added table", makeDiff: makeAddedTableDiff, emitsCreateTable: true },
+] as const;
+
 describe("generateMigrationSQL: transaction wrapper by dialect", () => {
   for (const [dialect, expected] of Object.entries(TRANSACTION_WRAPPER_COVERAGE)) {
-    test(`${dialect}: ${expected === "wrapped" ? "wraps DDL in BEGIN;/COMMIT;" : "emits no transaction wrapper"}`, () => {
-      const sql = generateMigrationSQL(makeModifiedTableDiff(), dialect as DatabaseType);
-      if (expected === "wrapped") {
-        expect(sql).toContain("BEGIN;");
-        expect(sql).toContain("COMMIT;");
-      } else {
-        expect(sql).not.toContain("BEGIN;");
-        expect(sql).not.toContain("COMMIT;");
-      }
-    });
+    for (const fixture of WRAPPER_FIXTURES) {
+      test(`${dialect}: ${expected === "wrapped" ? "wraps DDL in BEGIN;/COMMIT;" : "emits no transaction wrapper"} for ${fixture.label}`, () => {
+        const sql = generateMigrationSQL(fixture.makeDiff(), dialect as DatabaseType);
+        // Non-vacuity guard: on the added-table fixture the wrapper assertion below is
+        // about text that brackets a real statement, not an empty run of comments.
+        if (fixture.emitsCreateTable && dialect !== "cassandra") {
+          expect(sql).toMatch(/^CREATE TABLE /m);
+        }
+        if (expected === "wrapped") {
+          expect(sql).toContain("BEGIN;");
+          expect(sql).toContain("COMMIT;");
+        } else {
+          expect(sql).not.toContain("BEGIN;");
+          expect(sql).not.toContain("COMMIT;");
+        }
+      });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Partial fix for #284 — the transaction-wrapper portion specifically.

`generateMigrationSQL()` wrapped every dialect except `sqlite`/`libsql`/`cassandra` in PostgreSQL-shaped `BEGIN;`/`COMMIT;`. Nine of those wrapped dialects can't actually run that text:

- `mongodb`, `redis` — not SQL text at all (`NON_SQL_DIALECTS` in `src/lib/sql/grammar.ts` already establishes this)
- `libredb` — "a JSON command grammar, not SQL DDL" (`NO_COLUMN_MODIFICATION`'s own words, reused here)
- `couchbase` — has distributed ACID transactions, but spells one `BEGIN TRANSACTION` and answers with a `txid` every following statement must carry as a request parameter (`docs/providers/couchbase.md` §13); a flat migration file cannot express that, so `BEGIN;` is both the wrong keyword and the wrong mechanism
- `druid` — no transaction concept to translate the wrapper into (`NO_COLUMN_MODIFICATION`: "Druid SQL has no ALTER TABLE"; a datasource is rewritten by an MSQ task)
- `elasticsearch`, `opensearch` — `BEGIN` is not in either grammar: the parse error quoted in `NO_COLUMN_MODIFICATION` lists every statement Elasticsearch SQL accepts and `BEGIN` is not among them, and OpenSearch 3.8.0 was measured separately (`docs/providers/opensearch.md` §9)
- `trino` — transactional semantics are the connector's answer, not Trino's (`NO_COLUMN_MODIFICATION`)
- `clickhouse` — transaction support is experimental and setting-gated, not a safe default; today's code wraps it anyway

This extends the existing 3-dialect exclusion into a `NO_TRANSACTION_WRAPPER` set covering all twelve, in the same `Record`/`Set`-driven exhaustive-classification style as this file's existing `NO_COLUMN_MODIFICATION` and `FOREIGN_KEY_ONLY_IN_CREATE_TABLE`, per [@cevheri's comment on #284](https://github.com/libredb/libredb-studio/issues/284#issuecomment-3459373570) ("extend that mechanism rather than adding prose guards").

## What's deliberately NOT in this PR

Per the same comment's explicit caution — *"Check the emitted forms against a live MSSQL and Oracle before settling them... the live run overruled the documented reading more than once"* — and since I don't have a Docker daemon running to bring up the `mssql`/`oracle` services from `database-compose.yml` right now:

- **`mssql` and `oracle` are unchanged.** Both still get today's `BEGIN;`/`COMMIT;`. Their real forms (`BEGIN TRANSACTION;` for MSSQL; whether Oracle needs a wrapper at all, since DDL there auto-commits) are flagged in the module docstring as a tracked follow-up.
- **A related discovery, also deferred**: auditing the rest of #284's scope (`ADD`/`DROP COLUMN`, the `IF EXISTS` fallbacks) against each dialect's documented grammar, I found `ADD COLUMN`'s literal `COLUMN` keyword is inconsistent with this same file's own Oracle `MODIFY (...)` branch (no `COLUMN` keyword in Oracle's grammar) and MSSQL's documented `ADD` clause (same). Noted in the docstring rather than fixed, since it wants the same live check. Everything else in that scope (`DROP COLUMN`, `DROP TABLE`/`INDEX`/`CONSTRAINT ... IF EXISTS`) already agrees with each dialect's documented grammar via the existing Cassandra/SQLite/libSQL/DuckDB/MySQL branches — no change needed there.

## duckdb — live-verified, no change needed

`duckdb` was already in the "wrapped" bucket and stays there — verified with a real embedded DuckDB (no Docker needed, it runs in-process via `@duckdb/node-api`): `BEGIN;`/`BEGIN TRANSACTION;` both open a real transaction around DDL, and a `CREATE TABLE` issued inside one is genuinely undone by `ROLLBACK;`. This matches the file's own existing pinned test ("the migration is still wrapped in a transaction, because DuckDB DDL is transactional").

---

## Test plan

- [x] TDD: wrote the failing `TRANSACTION_WRAPPER_COVERAGE` exhaustive test first (mirrors `MODIFIED_COLUMN_COVERAGE`'s pattern — a `Record<DatabaseType, ...>` that fails typecheck until a new type id is classified), confirmed it failed for exactly the 9 dialects this PR fixes, then implemented
- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run knip`
- [x] `bun run test tests/unit/schema-diff/migration-generator.test.ts` — 104 pass
- [x] `bun run test` (full suite) — only pre-existing environment-dependent failures (Helm chart tests needing the `helm` binary, DB-provider integration tests needing live servers), none in schema-diff
- [x] `bun run build`
- [x] `bun run test:coverage && bun run coverage:check` — 100.00% (45421/45421 lines)

---

## Docs synced

- `docs/ADDING_A_PROVIDER.md` — new-provider checklist now names `NO_TRANSACTION_WRAPPER` alongside `NO_COLUMN_MODIFICATION`, and the exhaustive-test-map list now includes `TRANSACTION_WRAPPER_COVERAGE`
- `docs/providers/clickhouse.md` — its "Known limitations" section used to say the generator wraps ClickHouse's output in `BEGIN`/`COMMIT` and told the reader to strip those two lines before running a migration; updated to reflect that the generator no longer emits them

Fixes the transaction-wrapper portion of #284. MSSQL/Oracle's own wrapper forms remain open, tracked in the module docstring as the follow-up.

---

## Maintainer follow-up commit (dde09f9d)

Pushed onto this branch during review. It does not change the set this PR introduces; it corrects two
things the PR said about it.

1. **The `couchbase`/`druid` premise was wrong, though the conclusion was right.** The original wording
   was "never receive column DDL from this generator to begin with ... so the wrapper only ever bracketed
   comments", citing `supportsCreateTable: false`. That flag is read by `SchemaExplorer.tsx`, not here —
   `generateMigrationSQL` consults no provider capability at all, and its added-table branch emits a real
   `CREATE TABLE` for every id except `cassandra` (`CASSANDRA_NO_CREATE_TABLE`). So the wrapper was
   bracketing runnable DDL for those ids too, which is what makes removing it a fix rather than a tidy-up.
   The four ids that leaned on that premise now carry the reason they actually have (see the bullets
   above), and the module docstring says explicitly that this generator has no capability gate.

2. **`TRANSACTION_WRAPPER_COVERAGE` could not have caught it**, because it drove only
   `makeModifiedTableDiff()` — the single fixture for which the discarded premise is true. It now runs over
   `makeAddedTableDiff()` as well, and the added-table arm asserts the emitted text really does carry a
   `CREATE TABLE` that the absent wrapper would otherwise have bracketed. Non-vacuity checked against the
   pre-PR generator: 18 arms fail there, both fixtures for each of the nine ids.

3. **Count fix**: "twelve of the sixteen type ids" is seventeen — `DatabaseType` gained `duckdb` in #516,
   and the table's own 12 unwrapped + 5 wrapped already added up to it.

Gates re-run on the merged branch: `format`, `lint` (0 errors), `typecheck`, `knip`, `bun run test`
(10461 pass; the one local failure is an untracked, gitignored `docs/superpowers/` artifact citing
backlog ids deleted in #518/#519 — not reproducible in CI), `build`, and
`test:coverage` + `coverage:check` — 100.00% (45421/45421).

"added some new commits"