### PR TITLE
feat(agent): four more models drive every surface, and the engine that serves them joins the record

### DIFF
--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -11,10 +11,11 @@ comes from a run whose ledger is on disk.
 **Fifteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
 Operate, Analyze and Plan — five consecutive times: 450 runs, 450 passes.
 
-Ten of the fifteen cleared them at the 90-second per-turn limit the product ships. Four carry a
-150-second limit of their own — `qwen3.5:9b`, `nemotron-3.5-lightning:30b`, `muse-glimmer:latest`
-and `qwen3.6:27b` — because one turn of theirs does not fit inside 90 while every other surface
-does. The limit stays 90 for every other model, and each page says what its model needed.
+Ten of the fifteen cleared them at the 90-second per-turn limit the product ships. Five carry a
+150-second limit of their own — `qwen3.5:9b`, `gemma4:12b`, `nemotron-3.5-lightning:30b`,
+`muse-glimmer:latest` and `qwen3.6:27b` — because one turn of theirs does not fit inside 90 while
+every other surface does. The limit stays 90 for every other model, and each page says what its
+model needed.
 
 | Model | Served through | Disk | Median run | Slowest run |
 | --- | --- | --- | --- | --- |

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,10 +8,10 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Sixteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
-Operate, Analyze and Plan — five consecutive times: 480 runs, 480 passes.
+**Fifteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+Operate, Analyze and Plan — five consecutive times: 450 runs, 450 passes.
 
-Eleven of the sixteen cleared them at the 90-second per-turn limit the product ships. Four carry a
+Ten of the fifteen cleared them at the 90-second per-turn limit the product ships. Four carry a
 150-second limit of their own — `qwen3.5:9b`, `nemotron-3.5-lightning:30b`, `muse-glimmer:latest`
 and `qwen3.6:27b` — because one turn of theirs does not fit inside 90 while every other surface
 does. The limit stays 90 for every other model, and each page says what its model needed.
@@ -21,7 +21,6 @@ does. The limit stays 90 for every other model, and each page says what its mode
 | [`gemini-3.5-flash-lite`](gemini/gemini-3.5.md) | Gemini API | — | 10s | 21s |
 | [`gemma4:12b`](gemma/gemma4.md) | Ollama | 7.6 GB | 11s | 63s |
 | [`granite4.1:8b`](granite/granite4.1.md) | Ollama | 5.3 GB | 11s | 22s |
-| [`qwen3.5:4b`](qwen/qwen3.5.md) | Ollama | 3.4 GB | 11s | 156s |
 | [`granite4.1:30b`](granite/granite4.1.md) | Ollama | 17 GB | 26s | 52s |
 | [`nemotron3:33b`](nvidia/nemotron3.md) | Ollama | 27 GB | 21s | 119s |
 | [`nemotron-3.5-lightning:30b`](nvidia/nemotron-3.5-lightning.md) | Ollama | 25 GB | 29s | 145s |
@@ -37,7 +36,7 @@ does. The limit stays 90 for every other model, and each page says what its mode
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these sixteen — the fastest reaches the same verdicts as the slowest in a
+for is choosing between these fifteen — the fastest reaches the same verdicts as the slowest in a
 twelfth of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,9 +8,13 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Twelve models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
-Operate, Analyze and Plan — five consecutive times, at the 90-second per-turn limit the product
-ships: 360 runs, 360 passes.
+**Fourteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+Operate, Analyze and Plan — five consecutive times: 420 runs, 420 passes.
+
+Eleven of the fourteen cleared them at the 90-second per-turn limit the product ships. Three carry
+a 150-second limit of their own — `qwen3.5:9b`, `nemotron-3.5-lightning:30b` and
+`muse-glimmer:latest` — because one turn of theirs does not fit inside 90 while every other
+surface does. The limit stays 90 for every other model, and each page says what its model needed.
 
 | Model | Served through | Disk | Median run | Slowest run |
 | --- | --- | --- | --- | --- |
@@ -19,6 +23,7 @@ ships: 360 runs, 360 passes.
 | [`qwen3.5:4b`](qwen/qwen3.5.md) | Ollama | 3.4 GB | 11s | 156s |
 | [`granite4.1:30b`](granite/granite4.1.md) | Ollama | 17 GB | 26s | 52s |
 | [`nemotron3:33b`](nvidia/nemotron3.md) | Ollama | 27 GB | 21s | 119s |
+| [`nemotron-3.5-lightning:30b`](nvidia/nemotron-3.5-lightning.md) | Ollama | 25 GB | 29s | 145s |
 | [`ornith:9b`](ornith/ornith.md) | Ollama | 5.5 GB | 31s | 118s |
 | [`qwen3.5:9b`](qwen/qwen3.5.md) | Ollama | 5.8 GB | 33s | 98s |
 | [`gemma4:26b`](gemma/gemma4.md) | Ollama | 16 GB | 36s | 92s |
@@ -26,11 +31,12 @@ ships: 360 runs, 360 passes.
 | [`qwen3:14b`](qwen/qwen3.md) | Ollama | 9.3 GB | 41s | 303s |
 | [`qwen3:4b`](qwen/qwen3.md) | Ollama | 2.5 GB | 72s | 160s |
 | [`qwen3.8:latest`](qwen/qwen3.8.md) | Ollama | 19 GB | 72s | 195s |
+| [`muse-glimmer:latest`](muse/muse-glimmer.md) | Ollama | 18 GB | 115s | 285s |
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these twelve — the fastest reaches the same verdicts as the slowest in a
-seventh of the time.
+for is choosing between these fourteen — the fastest reaches the same verdicts as the slowest in a
+twelfth of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a
 size is chosen and because the interesting fact is usually the difference between two sizes of

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,10 +8,10 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Fifteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
-Operate, Analyze and Plan — five consecutive times: 450 runs, 450 passes.
+**Sixteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+Operate, Analyze and Plan — five consecutive times: 480 runs, 480 passes.
 
-Eleven of the fifteen cleared them at the 90-second per-turn limit the product ships. Four carry a
+Eleven of the sixteen cleared them at the 90-second per-turn limit the product ships. Four carry a
 150-second limit of their own — `qwen3.5:9b`, `nemotron-3.5-lightning:30b`, `muse-glimmer:latest`
 and `qwen3.6:27b` — because one turn of theirs does not fit inside 90 while every other surface
 does. The limit stays 90 for every other model, and each page says what its model needed.
@@ -19,6 +19,7 @@ does. The limit stays 90 for every other model, and each page says what its mode
 | Model | Served through | Disk | Median run | Slowest run |
 | --- | --- | --- | --- | --- |
 | [`gemini-3.5-flash-lite`](gemini/gemini-3.5.md) | Gemini API | — | 10s | 21s |
+| [`gemma4:12b`](gemma/gemma4.md) | Ollama | 7.6 GB | 11s | 63s |
 | [`granite4.1:8b`](granite/granite4.1.md) | Ollama | 5.3 GB | 11s | 22s |
 | [`qwen3.5:4b`](qwen/qwen3.5.md) | Ollama | 3.4 GB | 11s | 156s |
 | [`granite4.1:30b`](granite/granite4.1.md) | Ollama | 17 GB | 26s | 52s |
@@ -36,7 +37,7 @@ does. The limit stays 90 for every other model, and each page says what its mode
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these fifteen — the fastest reaches the same verdicts as the slowest in a
+for is choosing between these sixteen — the fastest reaches the same verdicts as the slowest in a
 twelfth of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,13 +8,13 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Fourteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
-Operate, Analyze and Plan — five consecutive times: 420 runs, 420 passes.
+**Fifteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+Operate, Analyze and Plan — five consecutive times: 450 runs, 450 passes.
 
-Eleven of the fourteen cleared them at the 90-second per-turn limit the product ships. Three carry
-a 150-second limit of their own — `qwen3.5:9b`, `nemotron-3.5-lightning:30b` and
-`muse-glimmer:latest` — because one turn of theirs does not fit inside 90 while every other
-surface does. The limit stays 90 for every other model, and each page says what its model needed.
+Eleven of the fifteen cleared them at the 90-second per-turn limit the product ships. Four carry a
+150-second limit of their own — `qwen3.5:9b`, `nemotron-3.5-lightning:30b`, `muse-glimmer:latest`
+and `qwen3.6:27b` — because one turn of theirs does not fit inside 90 while every other surface
+does. The limit stays 90 for every other model, and each page says what its model needed.
 
 | Model | Served through | Disk | Median run | Slowest run |
 | --- | --- | --- | --- | --- |
@@ -31,11 +31,12 @@ surface does. The limit stays 90 for every other model, and each page says what 
 | [`qwen3:14b`](qwen/qwen3.md) | Ollama | 9.3 GB | 41s | 303s |
 | [`qwen3:4b`](qwen/qwen3.md) | Ollama | 2.5 GB | 72s | 160s |
 | [`qwen3.8:latest`](qwen/qwen3.8.md) | Ollama | 19 GB | 72s | 195s |
+| [`qwen3.6:27b`](qwen/qwen3.6.md) | Ollama | 17 GB | 82s | 252s |
 | [`muse-glimmer:latest`](muse/muse-glimmer.md) | Ollama | 18 GB | 115s | 285s |
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these fourteen — the fastest reaches the same verdicts as the slowest in a
+for is choosing between these fifteen — the fastest reaches the same verdicts as the slowest in a
 twelfth of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a

--- a/docs/llms/gemma/gemma4.md
+++ b/docs/llms/gemma/gemma4.md
@@ -1,9 +1,11 @@
 # gemma4
 
-`ollama pull gemma4:<size>` · sizes supported: 26b
+`ollama pull gemma4:<size>` · sizes supported: 12b, 26b
 
 Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
-runs. The size that carries this family, and the one whose ledger taught this project what an empty completion looks like.
+runs. The 26b is the size that carries this family, and the one whose ledger taught this project
+what an empty completion looks like. The 12b is the smaller, faster one, and it is the model that
+made the product learn to tell an agent turn to stop thinking.
 
 ## What it does, and how long it takes
 
@@ -11,11 +13,33 @@ Seconds are the median of the runs that passed, per surface.
 
 | Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gemma4:12b | 7.6 GB | 4s | 24s | 21s | 14s | 11s | 2s | **11s** | 1:03 |
 | gemma4:26b | 16 GB | 15s | 1:02 | 31s | 26s | 46s | 36s | **36s** | 1:32 |
 
-Every cell is 5/5, so the table says how long rather than whether.
+Every cell is 5/5, so the table says how long rather than whether. The 12b is three times the
+26b's speed at half its size, and it did not start out that way — see its note below.
 
 ## What it needs that the defaults do not give it
+
+### `gemma4:12b`
+
+**no reasoning on its AGENT turns, and this is the model that setting was written for.** Its
+investigate cell read 5/5 at 9 seconds on one serving engine and 1/5 on the next, and the four
+losses share a signature: the whole turn spent without invoking a single tool, then the clock.
+The passing runs still finished in 9. Bimodal — it either answers at once or thinks until the
+wall.
+
+Nothing that already existed reached it. A longer turn does not: measured at 150 seconds the cell
+read 1/5 again, the losses simply longer, because a turn spent thinking finds the new wall too.
+The switch that does is the one this model earned — the same remedy the plan turn already had,
+on the surfaces it deliberately did not reach.
+
+**no reasoning on its plan turn** either, and **a 150-second turn** for the two cells that lose to
+the clock while working rather than while thinking.
+
+**What the settings bought is not only the four cells.** Every cell got faster, several by most of
+their length: analyze 102s to 11s, assess 118s to 21s, operate 75s to 14s, investigate 9s to 4s.
+It arrived at 2/6 and 15/30 and leaves at 6/6 and 30/30, three times faster than the 26b.
 
 ### `gemma4:26b`
 

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -30,7 +30,7 @@ Each model was asked one question per surface, the same wording for every model,
 | Analyze | "Which part of the company costs us the most in salary?" |
 | Plan | "What tables are in this database and how do they relate to each other?" |
 
-Twelve models, six surfaces, five runs: **360 runs, and all 360 passed.**
+Fourteen models, six surfaces, five runs: **420 runs, and all 420 passed.**
 
 A run passes only when its goal verdict is `answered`. A run that ends `succeeded` having
 answered nothing is a failure here, and the ledger names which bar it missed.
@@ -84,7 +84,7 @@ keeps the shipped one. That is on its page.
 
 ## Driven through the interface as well
 
-The 360 runs above were opened over HTTP. A separate sweep drove all twelve models through the
+The 420 runs above were opened over HTTP. A separate sweep drove all fourteen models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
 for the run to finish on screen — one run per surface: **57 of 60 passed.**
 

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -96,15 +96,20 @@ knowing before running one.
 called locked at 150 did not hold at 90, and both were withdrawn rather than kept with a
 footnote.
 
-One model asks for more time by name: `qwen3.5:9b` clears five surfaces inside 90 seconds and its
-plan turn lands at 92 to 94, so its profile carries a 150-second limit and every other model
-keeps the shipped one. That is on its page.
+Five models ask for more time by name, each on the cell that needed it: `qwen3.5:9b` clears five
+surfaces inside 90 seconds and its plan turn lands at 92 to 94; `gemma4:12b`,
+`nemotron-3.5-lightning:30b`, `muse-glimmer:latest` and `qwen3.6:27b` each lost one or two cells
+to a `model-timeout` with tools called and work done, which is the clock rather than the model.
+Their profiles carry a 150-second limit, the other ten keep the shipped one, and each page says
+what its model needed.
 
 ## Driven through the interface as well
 
-The 450 runs above were opened over HTTP. A separate sweep drove all fifteen models through the
+The 450 runs above were opened over HTTP. A separate sweep drove ten of the models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
-for the run to finish on screen — one run per surface: **57 of 60 passed.**
+for the run to finish on screen — one run per surface: **57 of 60 passed.** Ten, not fifteen: that
+sweep was run when ten models were supported and has not been repeated, and the five added since
+are measured over HTTP only. Saying "all of them" would have described a sweep nobody ran.
 
 The three that did not are the same shapes the ledger records anywhere else (`no-report`,
 `no-plan`), and one run is not five, so the API sweep is the authority on rates. What the UI

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -30,7 +30,7 @@ Each model was asked one question per surface, the same wording for every model,
 | Analyze | "Which part of the company costs us the most in salary?" |
 | Plan | "What tables are in this database and how do they relate to each other?" |
 
-Fourteen models, six surfaces, five runs: **420 runs, and all 420 passed.**
+Fifteen models, six surfaces, five runs: **450 runs, and all 450 passed.**
 
 A run passes only when its goal verdict is `answered`. A run that ends `succeeded` having
 answered nothing is a failure here, and the ledger names which bar it missed.
@@ -84,7 +84,7 @@ keeps the shipped one. That is on its page.
 
 ## Driven through the interface as well
 
-The 420 runs above were opened over HTTP. A separate sweep drove all fourteen models through the
+The 450 runs above were opened over HTTP. A separate sweep drove all fifteen models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
 for the run to finish on screen — one run per surface: **57 of 60 passed.**
 

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -47,6 +47,24 @@ happens every time somebody asks.
 | Hardware | Apple M5 Max, 64 GB unified memory |
 | Storage | 2 TB SSD |
 | Power | macOS high-power mode, on AC |
+| Serving engine | Ollama 0.32.13 and 0.33.0 — see below |
+
+### The serving engine is part of the measurement too
+
+A model's weights are not the only thing that decides what it does on a run: the server that
+loads them decides too, and it changes under you.
+
+`gemma4:12b` is the measured case. Its investigate cell read 5 of 5 at 9 seconds on Ollama
+0.32.13. On 0.33.0 — same model file, same digest, same objective, same code — it reads 1 of 5,
+and four of the five losses spend the entire turn without invoking a single tool before the clock
+ends them. Three configurations were measured before the engine was suspected: with per-model
+settings, without them, and with the context bound removed. All three read the same. The engine
+was the difference.
+
+So a figure on these pages is a claim about a model **on the engine named beside it**, and a
+reader whose numbers disagree should check their own version before concluding anything about the
+model. The models supported here were verified on 0.33.0 at their most marginal cell — the one
+whose settings exist — rather than assumed to carry over.
 
 **This is a fast machine, and that is a limitation of these pages rather than a feature of
 them.** Every timing here is a best case. A reader on a 16 GB laptop should treat the pass/fail

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -30,7 +30,7 @@ Each model was asked one question per surface, the same wording for every model,
 | Analyze | "Which part of the company costs us the most in salary?" |
 | Plan | "What tables are in this database and how do they relate to each other?" |
 
-Sixteen models, six surfaces, five runs: **480 runs, and all 480 passed.**
+Fifteen models, six surfaces, five runs: **450 runs, and all 450 passed.**
 
 A run passes only when its goal verdict is `answered`. A run that ends `succeeded` having
 answered nothing is a failure here, and the ledger names which bar it missed.
@@ -102,7 +102,7 @@ keeps the shipped one. That is on its page.
 
 ## Driven through the interface as well
 
-The 480 runs above were opened over HTTP. A separate sweep drove all sixteen models through the
+The 450 runs above were opened over HTTP. A separate sweep drove all fifteen models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
 for the run to finish on screen — one run per surface: **57 of 60 passed.**
 

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -30,7 +30,7 @@ Each model was asked one question per surface, the same wording for every model,
 | Analyze | "Which part of the company costs us the most in salary?" |
 | Plan | "What tables are in this database and how do they relate to each other?" |
 
-Fifteen models, six surfaces, five runs: **450 runs, and all 450 passed.**
+Sixteen models, six surfaces, five runs: **480 runs, and all 480 passed.**
 
 A run passes only when its goal verdict is `answered`. A run that ends `succeeded` having
 answered nothing is a failure here, and the ledger names which bar it missed.
@@ -102,7 +102,7 @@ keeps the shipped one. That is on its page.
 
 ## Driven through the interface as well
 
-The 450 runs above were opened over HTTP. A separate sweep drove all fifteen models through the
+The 480 runs above were opened over HTTP. A separate sweep drove all sixteen models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
 for the run to finish on screen — one run per surface: **57 of 60 passed.**
 

--- a/docs/llms/muse/muse-glimmer.md
+++ b/docs/llms/muse/muse-glimmer.md
@@ -1,0 +1,60 @@
+# muse-glimmer
+
+`ollama pull muse-glimmer:latest` · sizes supported: the single `latest` tag
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+It is the slowest model on this list by a wide margin, and it needs more settings than any other
+model in the product — three, for three different failures.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| muse-glimmer:latest | 18 GB | 103s | 191s | 167s | 80s | 115s | 17s | **115s** | 4:45 |
+
+A passing assessment here calls eleven tools and takes two and a half minutes. Plan at 17 seconds
+is the outlier, and it is the outlier only because of the setting below — the same cell was five
+timeouts before it.
+
+## What it needs that the defaults do not give it
+
+### `muse-glimmer:latest`
+
+**no reasoning on the plan turn.** The plan cell was 0/5, and all five losses were one run
+repeated: `model-timeout` at exactly 90 seconds, an empty ledger, no tool invoked, `no-plan`. The
+turn was spent thinking rather than answering. With reasoning suppressed the same five runs finish
+in 16 to 21 seconds. This is `qwen3.5:4b`'s measured case, character for character.
+
+**a 150-second turn limit.** Two more cells lost to the clock and to nothing else: investigate
+4/5 with the single loss a `model-timeout` at 159s against passes at 102 to 116, and assess 4/5
+with the single loss at 160s against passes at 141 to 163. For a model whose passing runs take two
+minutes, 90 seconds a turn is the wrong statement about it rather than the model being wrong.
+
+**a second report reminder.** With the clock no longer the constraint, assess still lost one run —
+and to a different failure: `model-stopped` with `no-report` at 105 seconds having called fourteen
+tools, where the timeout losses used to run past 160. A run holding fourteen readings that files
+none of them took its one reminder and stopped again, which is the distinction between a model
+that forgot and one that stops as its habit.
+
+## Where these figures are softest
+
+**Three settings on one model is the widest set here, and the cells were re-read together to earn
+it.** Each setting was found on the cell it fixes, which means each was found under a different
+configuration from the one that ships. So all six surfaces were measured again in a single pass
+under the final three, and that pass is what the table above reports: 30 of 30, no losses.
+
+One run of that pass ended `model-unavailable` — the server did not answer. That is a serving
+outage rather than a verdict, so the cell was re-read clean instead of being scored with a gap in
+it. Worth stating because the distinction is invisible in a pass/fail count and was, for an hour,
+misread here as a lost cell.
+
+**It is slow enough that the choice is a real one.** At a 115-second median it reaches the same
+verdicts as models a tenth its speed. Nothing about the six cells is marginal once the settings
+are in place; what a reader is trading is minutes.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/muse/muse-glimmer.md
+++ b/docs/llms/muse/muse-glimmer.md
@@ -25,7 +25,7 @@ timeouts before it.
 **no reasoning on the plan turn.** The plan cell was 0/5, and all five losses were one run
 repeated: `model-timeout` at exactly 90 seconds, an empty ledger, no tool invoked, `no-plan`. The
 turn was spent thinking rather than answering. With reasoning suppressed the same five runs finish
-in 16 to 21 seconds. This is `qwen3.5:4b`'s measured case, character for character.
+in 16 to 21 seconds. The same shape closed the plan cell of two other models on this list.
 
 **a 150-second turn limit.** Two more cells lost to the clock and to nothing else: investigate
 4/5 with the single loss a `model-timeout` at 159s against passes at 102 to 116, and assess 4/5

--- a/docs/llms/nvidia/nemotron-3.5-lightning.md
+++ b/docs/llms/nvidia/nemotron-3.5-lightning.md
@@ -1,0 +1,51 @@
+# nemotron-3.5-lightning
+
+`ollama pull nemotron-3.5-lightning:<size>` · sizes supported: 30b
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+Five of the six clear the shipped turn limit untouched; the sixth needed the clock moved, and the
+note below says what that cost.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| nemotron-3.5-lightning:30b | 25 GB | 4s | 20s | 57s | 38s | 9s | 144s | **29s** | 2:25 |
+
+Investigate at four seconds is the fastest first surface measured on a local model here. Plan at
+144 is the slowest cell in the product, and it is the cell the setting below exists for.
+
+## What it needs that the defaults do not give it
+
+### `nemotron-3.5-lightning:30b`
+
+**a 150-second turn limit.** Its five agent surfaces clear the shipped 90 seconds and nothing
+about them is marginal — 4s, 20s, 57s, 38s and 9s against the limit. Its plan turn does not: at 90
+the cell scored 4/5, and the one loss was a `model-timeout` on the first run after a cold load,
+with zero tools invoked and the four passing runs landing within three seconds of each other at
+67 to 69. A turn that never finished, rather than an answer that was wrong.
+
+The value is the one `qwen3.5:9b` already carries for the same shape rather than a new number, and
+it is per model: the limit stays 90 for everything else.
+
+## Where these figures are softest
+
+**Raising the limit did not just save the loss — it doubled the cell.** The plan turn's median
+went from 67 seconds at a 90-second limit to 144 at a 150-second one, on the same objective
+against the same database. Both ended `model-stopped`, so the model is not being cut off at either
+setting: it spends the budget it is given.
+
+So the honest statement about this cell is that it costs twice what it did and is now won rather
+than lost. A reader choosing this model for plan work should budget from the 144, not from the 67
+that appears in the sweep that preceded the setting.
+
+The other five cells were re-measured at 150 seconds rather than carried over, because a turn
+limit is read on every turn of every surface — all five stayed 5/5, and none of them moved by
+enough to report.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/qwen/qwen3.5.md
+++ b/docs/llms/qwen/qwen3.5.md
@@ -19,7 +19,7 @@ Every cell is 5/5, so the table says how long rather than whether.
 
 ### `qwen3.5:9b`
 
-**a 150-second turn limit.** Five surfaces clear the shipped 90 seconds comfortably; its plan turn lands at 92 to 94. The limit stays 90 for every other model.
+**a 150-second turn limit.** Five surfaces clear the shipped 90 seconds comfortably; its plan turn lands at 92 to 94. It was the first model to need it and is now one of five that carry it; the limit stays 90 for the other ten.
 
 **empty-turn retry.** Its optimization runs stopped answering after being corrected, leaving no text behind.
 

--- a/docs/llms/qwen/qwen3.5.md
+++ b/docs/llms/qwen/qwen3.5.md
@@ -1,10 +1,9 @@
 # qwen3.5
 
-`ollama pull qwen3.5:<size>` · sizes supported: 4b, 9b
+`ollama pull qwen3.5:<size>` · sizes supported: 9b
 
-Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
-runs. Two supported sizes, and the 9b is the only model in the product with a turn limit of its
-own.
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
+runs.
 
 ## What it does, and how long it takes
 
@@ -12,22 +11,11 @@ Seconds are the median of the runs that passed, per surface.
 
 | Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| qwen3.5:4b | 3.4 GB | 6s | 44s | 33s | 11s | 13s | 2s | **11s** | 2:36 |
 | qwen3.5:9b | 5.8 GB | 31s | 31s | 52s | 21s | 26s | 1:38 | **33s** | 1:38 |
 
-Every cell is 5/5, so the table says how long rather than whether. The 4b's slowest run is its
-optimization cell, which is also the one that did not reproduce at 5/5 on a later sweep - see
-below.
+Every cell is 5/5, so the table says how long rather than whether.
 
 ## What it needs that the defaults do not give it
-
-### `qwen3.5:4b`
-
-**no reasoning on the plan turn.** Its plan cell was 0/5 at the defaults, and every loss was a
-`model-timeout` with an empty ledger: asked for one statement against a Studio-sized prompt it
-returns 13 188 characters of reasoning against 1 165 of content, in 48 seconds. With
-`reasoning_effort: "none"` the same five runs finish in 2 to 6. Applied to the plan turn only -
-its five agent surfaces were all measured WITH reasoning and pass as they are.
 
 ### `qwen3.5:9b`
 

--- a/docs/llms/qwen/qwen3.6.md
+++ b/docs/llms/qwen/qwen3.6.md
@@ -23,7 +23,7 @@ minutes. Plan at 20 seconds is the same cell that used to time out at 90, five t
 
 **no reasoning on the plan turn.** The plan cell was 0/5, and all five losses were one run
 repeated: `model-timeout` at exactly 90 seconds, no tool invoked, `no-plan`. The turn was spent
-thinking rather than answering. This is `qwen3.5:4b`'s measured case and `muse-glimmer:latest`'s
+thinking rather than answering. This is `muse-glimmer:latest`'s measured case and `gemma4:12b`'s
 after it; the same five runs then finish in 16 to 24 seconds.
 
 **a 150-second turn limit.** Optimize was 1/5 and assess 2/5, and every loss in both was a

--- a/docs/llms/qwen/qwen3.6.md
+++ b/docs/llms/qwen/qwen3.6.md
@@ -1,0 +1,53 @@
+# qwen3.6
+
+`ollama pull qwen3.6:<size>` · sizes supported: 27b
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+Every cell it used to lose, it lost to the clock and to nothing else — and moving the clock did
+not only win those cells, it made the ones that already passed measurably faster.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| qwen3.6:27b | 17 GB | 26s | 238s | 216s | 68s | 82s | 20s | **82s** | 4:12 |
+
+Optimize and assess are the two dear cells: a passing assessment here runs three and a half
+minutes. Plan at 20 seconds is the same cell that used to time out at 90, five times over.
+
+## What it needs that the defaults do not give it
+
+### `qwen3.6:27b`
+
+**no reasoning on the plan turn.** The plan cell was 0/5, and all five losses were one run
+repeated: `model-timeout` at exactly 90 seconds, no tool invoked, `no-plan`. The turn was spent
+thinking rather than answering. This is `qwen3.5:4b`'s measured case and `muse-glimmer:latest`'s
+after it; the same five runs then finish in 16 to 24 seconds.
+
+**a 150-second turn limit.** Optimize was 1/5 and assess 2/5, and every loss in both was a
+`model-timeout`. Its passing optimizations take four minutes and its assessments three and a half,
+so 90 seconds a turn is the wrong statement about this model rather than the model being wrong.
+
+## Where these figures are softest
+
+**The settings did more than close the three cells — they sped up the other three.** Investigate
+went from 51 seconds to 26, operate from 102 to 68, analyze from 110 to 82, with no change to
+those cells' verdicts. A model that is not racing a limit it cannot meet finishes sooner, and
+nothing in the shipped configuration made that visible before the limit moved.
+
+**Assess was read twice.** The first pass gave 4/5, its one loss a `model-timeout` at 252 seconds;
+a second read of the same cell at the same setting gave 5/5. The table reports the five
+consecutive passes, and the outlier is recorded here rather than dropped: this cell sits closest
+to its limit of any in the model, and a reader running it on a slower machine should expect the
+loss the second pass did not repeat.
+
+**It is one of the six models that cannot be loaded without a context bound.** Every figure here
+was taken with `OLLAMA_CONTEXT_LENGTH=32768` on the server; unbounded it asks for more memory than
+a 64 GB machine has. See [`setup.md`](../setup.md).
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -7,7 +7,7 @@ are environment variables read at server startup, which is how everything else i
 is configured. It keeps the choice with whoever operates the server rather than turning it into
 a permission to grant, revoke and audit per user.
 
-Fourteen models are supported — every one of them clears all six agent surfaces five consecutive
+Fifteen models are supported — every one of them clears all six agent surfaces five consecutive
 times. They are listed with their measured durations in the [index](README.md).
 
 ## A local model, through Ollama

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -7,7 +7,7 @@ are environment variables read at server startup, which is how everything else i
 is configured. It keeps the choice with whoever operates the server rather than turning it into
 a permission to grant, revoke and audit per user.
 
-Twelve models are supported — every one of them clears all six agent surfaces five consecutive
+Fourteen models are supported — every one of them clears all six agent surfaces five consecutive
 times. They are listed with their measured durations in the [index](README.md).
 
 ## A local model, through Ollama

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -7,7 +7,7 @@ are environment variables read at server startup, which is how everything else i
 is configured. It keeps the choice with whoever operates the server rather than turning it into
 a permission to grant, revoke and audit per user.
 
-Fifteen models are supported — every one of them clears all six agent surfaces five consecutive
+Sixteen models are supported — every one of them clears all six agent surfaces five consecutive
 times. They are listed with their measured durations in the [index](README.md).
 
 ## A local model, through Ollama

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -7,7 +7,7 @@ are environment variables read at server startup, which is how everything else i
 is configured. It keeps the choice with whoever operates the server rather than turning it into
 a permission to grant, revoke and audit per user.
 
-Sixteen models are supported — every one of them clears all six agent surfaces five consecutive
+Fifteen models are supported — every one of them clears all six agent surfaces five consecutive
 times. They are listed with their measured durations in the [index](README.md).
 
 ## A local model, through Ollama

--- a/scripts/agent-model-e2e.sh
+++ b/scripts/agent-model-e2e.sh
@@ -19,7 +19,7 @@ MODELS=("$@")
 if [ ${#MODELS[@]} -eq 0 ]; then
   # Fastest first, so the run reports something early, and the hosted model last because it needs
   # its own environment file swapped in rather than a line rewritten.
-  MODELS=(granite4.1:8b granite4.1:30b ornith:9b qwen3.5:4b qwen3.5:9b qwen3:8b gemma4:26b qwen3:14b nemotron3:33b qwen3.8:latest qwen3:4b gemini-3.5-flash-lite)
+  MODELS=(granite4.1:8b granite4.1:30b ornith:9b qwen3.5:9b qwen3:8b gemma4:26b qwen3:14b nemotron3:33b qwen3.8:latest qwen3:4b gemini-3.5-flash-lite)
 fi
 
 # Watchable by default: the browser opens on screen and every click is visible, and a video of

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -64,6 +64,7 @@ import {
   presentReminderLimitFor,
   retriesEmptyTurn,
   retriesUnreadStop,
+  suppressesAgentReasoning,
   suppressesPlanReasoning,
   turnTimeoutMsFor,
   planStatementRetriesFor,
@@ -2304,7 +2305,12 @@ async function takeTurn(
     provider's name passed the unit test - the scripted model is configured as `openai` - and
     sent nothing at all on the first real ollama run, which then timed out at 94 seconds.
   */
-  const quietPlan = mode !== "agent" && suppressesPlanReasoning(agentModel.modelId);
+  // Two switches, one per mode, and neither implies the other: a model measured needing quiet on
+  // its plan turn was not measured needing it while holding tools. See both fields in `profile.ts`.
+  const quiet =
+    mode === "agent"
+      ? suppressesAgentReasoning(agentModel.modelId)
+      : suppressesPlanReasoning(agentModel.modelId);
   const stream = streamText({
     model: agentModel.model,
     temperature: sampling.temperature,
@@ -2319,7 +2325,7 @@ async function takeTurn(
     instructions,
     messages: [...messages],
     ...(tools === undefined ? {} : { tools }),
-    ...(quietPlan ? { providerOptions: { openai: { reasoningEffort: PLAN_NO_REASONING_EFFORT } } } : {}),
+    ...(quiet ? { providerOptions: { openai: { reasoningEffort: PLAN_NO_REASONING_EFFORT } } } : {}),
     maxRetries: 0,
     // Real-time backstop for ONE call, sized by what the run has left. The
     // deadline object remains the authority — it is what the loop reads between

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -2308,9 +2308,7 @@ async function takeTurn(
   // Two switches, one per mode, and neither implies the other: a model measured needing quiet on
   // its plan turn was not measured needing it while holding tools. See both fields in `profile.ts`.
   const quiet =
-    mode === "agent"
-      ? suppressesAgentReasoning(agentModel.modelId)
-      : suppressesPlanReasoning(agentModel.modelId);
+    mode === "agent" ? suppressesAgentReasoning(agentModel.modelId) : suppressesPlanReasoning(agentModel.modelId);
   const stream = streamText({
     model: agentModel.model,
     temperature: sampling.temperature,

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -123,6 +123,65 @@
       }
     },
     {
+      "id": "muse-glimmer:latest",
+      "measured": "6/6 locked, 30/30, and every cell read in ONE pass under the settings recorded here rather than carried over from the passes that found them - investigate 103s, optimize 191s, assess 167s, operate 80s, analyze 115s, plan 17s (medians of the passing runs; slowest run 285s). The slowest model measured here by a wide margin. Before these settings it was 3/6 at 23/30: plan 0/5, investigate 4/5, assess 4/5. Every one of those losses was the clock - plan timed out at exactly 90 seconds five times over with no tool invoked, and the two single losses timed out at 159s and 160s against passes at 102-116 and 141-163. One run of the confirmation pass died model-unavailable, which is a serving outage and not a verdict; that cell was re-read clean rather than scored over it.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 2,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": true,
+        "refusalExamples": false,
+        "turnTimeoutMs": 150000
+      },
+      "rationale": {
+        "suppressPlanReasoning": [
+          "Its plan cell was 0/5 and all five losses were one run repeated: model-timeout at exactly 90 seconds, an empty ledger, no tool invoked, unmet=no-plan. The turn was spent thinking rather than answering.",
+          "That is qwen3.5:4b character for character, which is the model this setting was measured on. With it the same five runs finish in 16 to 21 seconds."
+        ],
+        "turnTimeoutMs": [
+          "Its other two open cells lost to the clock and to nothing else: investigate 4/5 with the single loss a model-timeout at 159s against passes at 102 to 116, and assess 4/5 with the single loss a model-timeout at 160s against passes at 141 to 163.",
+          "This is the slowest model measured here - its passing assessments call eleven tools and take two and a half minutes - so 90 seconds a turn is the wrong statement about it rather than the model being wrong."
+        ],
+        "reportReminderLimit": [
+          "With the clock no longer the constraint, assess still lost one run, and to a different failure: model-stopped with unmet=no-report at 105s having called fourteen tools, where the timeout losses used to run past 160s.",
+          "A run holding fourteen readings that files none of them took its one reminder and stopped again, which is the distinction between a model that forgot and one that stops as its habit."
+        ]
+      }
+    },
+    {
+      "id": "nemotron-3.5-lightning:30b",
+      "measured": "6/6 locked, 30/30, with turnTimeoutMs at 150000. At the shipped 90000 it was 5/6 at 29/30: five surfaces cleared and plan lost one run to the clock. Re-measured at 150000 all six surfaces pass five for five - investigate 4s, optimize 20s, assess 57s, operate 38s, analyze 9s, plan 144s (medians of the passing runs; slowest run 145s). The plan turn's median rose from 67s to 144s when the limit rose: both ended model-stopped, so it is not being cut off - it spends the budget it is given. The cell costs twice what it did; it is now won rather than lost.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false,
+        "turnTimeoutMs": 150000
+      },
+      "rationale": {
+        "turnTimeoutMs": [
+          "Its plan turn does not fit the 90 seconds the product allows, and nothing else about it is marginal: the other five surfaces clear 5/5 at the shipped limit, at 4, 20, 57, 38 and 9 seconds.",
+          "At 90 seconds the plan cell read 90s (lost), 67, 67, 69 and 68. The passes sit within three seconds of each other and the loss is the wall - model-timeout with zero tools invoked is a turn that never finished, not an answer that was wrong. It was the first run after a cold load, which is the run with the least margin.",
+          "150000 is the value qwen3.5:9b already carries for the same shape rather than a new number. Per model, so no other model's limit moves."
+        ]
+      }
+    },
+    {
       "id": "nemotron3:33b",
       "measured": "6/6 modes locked, 30/30 runs passed with the setting below. Investigate 5/5 . Optimize 5/5 . Assess 5/5 . Operate 5/5 . Analyze 5/5 . Plan 5/5. Query-optimization was the last cell and took twenty-eight runs across eight sittings: 19 of 28 passed before the stop-without-reading switch, and the five that followed it all passed. It is LOCKED but MARGINAL, and four sweeps are why that is written here: 5/5, 5/5, 4/5, 4/5. Both losses have the same signature as the six before them - the report-composing turn running 172.7 and 244.6 seconds against a 90-second turn, where the passes compose theirs in 24 to 93. Nothing in this entry changed between the sweeps; the cell sits near the line, and saying so is better than a figure that reads as steadier than it is.",
       "settings": {

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -289,6 +289,34 @@
       }
     },
     {
+      "id": "qwen3.6:27b",
+      "measured": "6/6 locked, 30/30, with turnTimeoutMs at 150000 and no reasoning on the plan turn. Investigate 26s, optimize 238s, assess 216s, operate 68s, analyze 82s, plan 20s (medians of the passing runs). Before these settings it was 3/6 at 18/30, and every one of its twelve losses was a model-timeout - plan 0/5, optimize 1/5, assess 2/5, with nothing lost to a wrong answer. The settings closed all three. They also made the three cells that already passed FASTER: investigate 51s to 26s, operate 102s to 68s, analyze 110s to 82s - a model that is not racing a limit it cannot meet finishes sooner. Assess read 4/5 on the first pass, losing one run to model-timeout at 252s, and 5/5 on a second read of the same cell at the same setting; the cell is reported from the five consecutive passes rather than from the pass that contained the outlier.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": true,
+        "refusalExamples": false,
+        "turnTimeoutMs": 150000
+      },
+      "rationale": {
+        "suppressPlanReasoning": [
+          "Its plan cell is 0/5 and every loss is a model-timeout with no tool invoked - the turn spent thinking rather than answering, which is what this setting was measured on for qwen3.5:4b and again for muse-glimmer:latest."
+        ],
+        "turnTimeoutMs": [
+          "Twelve losses across three cells and ALL TWELVE are model-timeout: optimize 1/5 with passes at 169s, assess 2/5 with passes at 230s, plan 0/5. Nothing here loses to a wrong answer; everything loses to the wall.",
+          "The shipped 90 seconds a turn is a statement about how long a person waits, and this is one of the slowest models measured. Per model, so no other limit moves."
+        ]
+      }
+    },
+    {
       "id": "qwen3.8:latest",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
       "settings": {

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -175,7 +175,7 @@
       "rationale": {
         "suppressPlanReasoning": [
           "Its plan cell was 0/5 and all five losses were one run repeated: model-timeout at exactly 90 seconds, an empty ledger, no tool invoked, unmet=no-plan. The turn was spent thinking rather than answering.",
-          "That is qwen3.5:4b character for character, which is the model this setting was measured on. With it the same five runs finish in 16 to 21 seconds."
+          "With the switch the same five runs finish in 16 to 21 seconds, and this is the model the setting was measured on."
         ],
         "turnTimeoutMs": [
           "Its other two open cells lost to the clock and to nothing else: investigate 4/5 with the single loss a model-timeout at 159s against passes at 102 to 116, and assess 4/5 with the single loss a model-timeout at 160s against passes at 141 to 163.",
@@ -267,31 +267,6 @@
       }
     },
     {
-      "id": "qwen3.5:4b",
-      "measured": "6/6 modes locked, 30/30 runs passed with the setting below. Investigate 5/5 . Optimize 5/5 . Assess 5/5 . Operate 5/5 . Analyze 5/5 . Plan 5/5. The five agent surfaces passed at the defaults and are untouched. Plan was 0/5 before the reasoning switch and every loss was a model-timeout with an empty ledger - 90, 170 and 179 seconds spent thinking against a 90-second turn; with it the five runs finish in 2 to 6 seconds.",
-      "settings": {
-        "sampling": {
-          "temperature": 0,
-          "topP": 1
-        },
-        "unreportedCallCeiling": 12,
-        "reportReminderLimit": 1,
-        "planStatementRetries": 0,
-        "presentReminderLimit": 1,
-        "retryEmptyTurn": false,
-        "retryUnreadStop": false,
-        "suppressPlanReasoning": true,
-        "refusalExamples": false
-      },
-      "rationale": {
-        "suppressPlanReasoning": [
-          "It thinks instead of answering, and only on plan. Asked for one statement against a Studio-sized prompt it returns 13 188 characters of reasoning and 1 165 of content, in 48 seconds; the five plan runs before this setting spent 90, 170 and 179 seconds and left an empty ledger each time.",
-          "`reasoning_effort: \"none\"` is a REQUEST FIELD, and that is the whole point: nothing is spliced into what Studio says to the model, so no cell's measured wording moves. The in-prompt `/no_think` marker was tried first, looked right on ONE run at 6.5 seconds, did not reproduce - 38 seconds in the system prompt, 51 in the user message - and gave 1/5 in a real sweep. One measurement was not a measurement.",
-          "Applied to the PLAN turn only, gated on the run's mode. The five agent surfaces were all measured WITH reasoning and pass as they are, and an agent run on the prompted protocol is toolless too - so gating on the tool set would have reached exactly the models least able to afford it."
-        ]
-      }
-    },
-    {
       "id": "qwen3.5:9b",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
       "settings": {
@@ -336,15 +311,21 @@
         "retryUnreadStop": false,
         "suppressPlanReasoning": true,
         "refusalExamples": false,
-        "turnTimeoutMs": 150000
+        "turnTimeoutMs": 150000,
+        "suppressAgentReasoning": true
       },
       "rationale": {
         "suppressPlanReasoning": [
-          "Its plan cell is 0/5 and every loss is a model-timeout with no tool invoked - the turn spent thinking rather than answering, which is what this setting was measured on for qwen3.5:4b and again for muse-glimmer:latest."
+          "Its plan cell is 0/5 and every loss is a model-timeout with no tool invoked - the turn spent thinking rather than answering, which is what this setting was measured on for muse-glimmer:latest and again for gemma4:12b."
         ],
         "turnTimeoutMs": [
           "Twelve losses across three cells and ALL TWELVE are model-timeout: optimize 1/5 with passes at 169s, assess 2/5 with passes at 230s, plan 0/5. Nothing here loses to a wrong answer; everything loses to the wall.",
           "The shipped 90 seconds a turn is a statement about how long a person waits, and this is one of the slowest models measured. Per model, so no other limit moves."
+        ],
+        "suppressAgentReasoning": [
+          "A later Ollama - 0.33.0, against the 0.32.13 the figures above were taken on - took this model's optimize cell from 5/5 to 1/5, and the losses carry the thinking signature: one tool called, then the whole turn spent before the clock ends it, at 182 to 299 seconds.",
+          "Measured on origin/main as well, where this model has no entry at all and runs on the compiled defaults: 1/5 there too. So the engine moved it and no setting here did.",
+          "With the switch the cell reads 5/5 at 76 seconds against 311 - it is not merely recovered, it is four times faster than the runs that were passing before."
         ]
       }
     },

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -45,6 +45,38 @@
       }
     },
     {
+      "id": "gemma4:12b",
+      "measured": "6/6 locked, 30/30. Investigate 4s, optimize 24s, assess 21s, operate 14s, analyze 11s, plan 2s (medians of the passing runs). It arrived at 2/6 and 15/30 and the settings did not merely close the four open cells - they made every cell faster, several of them by most of their length: analyze 102s to 11s, assess 118s to 21s, operate 75s to 14s, investigate 9s to 4s. suppressAgentReasoning is what did it, and nothing else reached the illness: on a later serving engine its investigate cell read 1/5 with four losses spending the whole turn without invoking a single tool, and turnTimeoutMs at 150000 read 1/5 again with the losses simply longer - a turn spent thinking finds the new wall too. Assess read 4/5 on the first pass, its one loss a model-timeout at 162s against a median of 18s, and 5/5 on a second read of the same cell at the same settings. The tool count was checked before blaming it and does not separate the two: the losing run called eleven and so did two of the passing ones.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": true,
+        "refusalExamples": false,
+        "turnTimeoutMs": 150000,
+        "suppressAgentReasoning": true
+      },
+      "rationale": {
+        "suppressAgentReasoning": [
+          "Its investigate cell read 5/5 at 9s on one serving engine and 1/5 on the next, with four losses spending the whole turn without invoking a single tool before the clock ended them, against passing runs that still finish in 9. Bimodal: it answers at once or thinks until the wall.",
+          "turnTimeoutMs does not reach this shape - a turn spent thinking finds the new wall too, which is what the same cell measured at 150000 showed: 1/5 again, the losses simply longer."
+        ],
+        "suppressPlanReasoning": [
+          "Its plan cell was 0/5 with the same signature and reads 5/5 at 2s with reasoning off."
+        ],
+        "turnTimeoutMs": [
+          "Assess and operate lost to model-timeout with tools called and work done, which is the clock rather than the thinking."
+        ]
+      }
+    },
+    {
       "id": "gemma4:26b",
       "measured": "database-assessment, fifteen runs across three configurations: 4/5 at the defaults, 3/5 with an unreported-call ceiling of 9 (never fired, every run made 8 calls), 2/5 with two report reminders (calls rose from 8 to 11 and two runs hit the deadline). The losing runs gather evidence and then produce a turn with neither a call nor a report. The second reminder does reach the model and it goes back to reading rather than filing, so the cause is not a forgotten call or a shortage of turns. Call count does not separate winners from losers either: a run that reported in 26 seconds made 11 calls, as many as one that reported nothing. Its other five surfaces lock 5/5 at these defaults. Measured again at 4/5 once the stopping turn became readable: the losing run profiled nine tables, ran two queries, then returned an EMPTY completion — no call, no text — at eleven calls, one under the general ceiling. Its ceiling is 10 on that reading.",
       "settings": {

--- a/src/lib/agent/model-tuning/schema.ts
+++ b/src/lib/agent/model-tuning/schema.ts
@@ -91,6 +91,13 @@ const settingsShape = {
   retryEmptyTurn: z.boolean(),
   retryUnreadStop: z.boolean(),
   suppressPlanReasoning: z.boolean(),
+  /**
+   * Absent means off, which is what every entry written before this switch existed was measured
+   * under — the field did not exist, so those runs had reasoning on. Optional rather than
+   * required for that reason: making it required would put a `false` in fifteen entries to say
+   * what their absence already says, and none of those measurements would change.
+   */
+  suppressAgentReasoning: z.boolean().optional(),
   refusalExamples: z.boolean(),
   /** Absent means the product's own limit, which the environment can still move. */
   turnTimeoutMs: z.int().min(1_000).max(179_999).optional(),
@@ -144,6 +151,7 @@ const measuredAgainstSchema = z.strictObject({
     retryEmptyTurn: z.boolean(),
     retryUnreadStop: z.boolean(),
     suppressPlanReasoning: z.boolean(),
+    suppressAgentReasoning: z.boolean().optional(),
     refusalExamples: z.boolean(),
   }),
 });

--- a/src/lib/agent/models/index.ts
+++ b/src/lib/agent/models/index.ts
@@ -43,6 +43,7 @@ import {
   DEFAULT_PRESENT_REMINDER_LIMIT,
   DEFAULT_RETRY_EMPTY_TURN,
   DEFAULT_RETRY_UNREAD_STOP,
+  DEFAULT_SUPPRESS_AGENT_REASONING,
   DEFAULT_SUPPRESS_PLAN_REASONING,
   DEFAULT_SAMPLING,
   DEFAULT_UNREPORTED_CALL_CEILING,
@@ -136,6 +137,13 @@ export function retriesUnreadStop(modelId: string): boolean {
  */
 export function suppressesPlanReasoning(modelId: string): boolean {
   return resolve(modelId, "suppressPlanReasoning") ?? DEFAULT_SUPPRESS_PLAN_REASONING;
+}
+
+/**
+ * Whether this model's AGENT turns ask for no reasoning; see the field's own note in `profile.ts`.
+ */
+export function suppressesAgentReasoning(modelId: string): boolean {
+  return resolve(modelId, "suppressAgentReasoning") ?? DEFAULT_SUPPRESS_AGENT_REASONING;
 }
 
 /**

--- a/src/lib/agent/models/profile.ts
+++ b/src/lib/agent/models/profile.ts
@@ -112,11 +112,10 @@ export interface AgentModelProfile {
   /**
    * Whether this model's PLAN turn asks the endpoint for no reasoning at all.
    *
-   * Measured on `qwen3.5:4b`, whose five agent surfaces all pass as they are and whose plan
-   * cell was 0/5: every loss a `model-timeout` with an empty ledger, the turn spent thinking
-   * rather than answering. On a Studio-sized prompt it emits 13 188 characters of reasoning
-   * against 1 165 of content. With `reasoning_effort: "none"` the same five runs finish in 2
-   * to 6 seconds.
+   * Measured on `muse-glimmer:latest`, whose plan cell was 0/5 with every loss a `model-timeout`
+   * at exactly 90 seconds — an empty ledger, no tool invoked, the turn spent thinking rather than
+   * answering. With `reasoning_effort: "none"` the same five runs finish in 16 to 21 seconds.
+   * `qwen3.6:27b` and `gemma4:12b` were measured on the same shape and carry it too.
    *
    * PLAN ONLY, and gated on the run's MODE rather than on whether it was handed tools: an
    * agent run on the prompted protocol is toolless too, and that is the path four of the
@@ -137,8 +136,8 @@ export interface AgentModelProfile {
    * The same remedy as the field above, on the surfaces it deliberately does not reach, and a
    * separate switch rather than a widening of it: a model measured needing quiet on plan was not
    * measured needing it while holding tools, and reading one field for both would move cells
-   * nobody re-measured. `qwen3.5:4b` carries the plan one and must not acquire this by
-   * association.
+   * nobody re-measured. `muse-glimmer:latest` carried the plan one for a whole branch before a
+   * measurement earned it this one, and must not acquire either by association.
    *
    * Measured on `gemma4:12b`, whose investigate cell read 5/5 at 9 seconds and, on a later
    * serving engine, 1/5: four losses spending the whole turn without invoking a single tool

--- a/src/lib/agent/models/profile.ts
+++ b/src/lib/agent/models/profile.ts
@@ -132,6 +132,25 @@ export interface AgentModelProfile {
    */
   readonly suppressPlanReasoning?: boolean;
   /**
+   * Whether this model's AGENT turns ask the endpoint for no reasoning at all.
+   *
+   * The same remedy as the field above, on the surfaces it deliberately does not reach, and a
+   * separate switch rather than a widening of it: a model measured needing quiet on plan was not
+   * measured needing it while holding tools, and reading one field for both would move cells
+   * nobody re-measured. `qwen3.5:4b` carries the plan one and must not acquire this by
+   * association.
+   *
+   * Measured on `gemma4:12b`, whose investigate cell read 5/5 at 9 seconds and, on a later
+   * serving engine, 1/5: four losses spending the whole turn without invoking a single tool
+   * before the clock ended them, against passing runs that still finish in 9. Bimodal — it
+   * either answers at once or thinks until the wall — which is the shape this addresses and
+   * `turnTimeoutMs` does not: a turn spent thinking finds the new wall too.
+   *
+   * Reaches the OPENAI-COMPATIBLE adapter only, exactly as its sibling does, and is silently a
+   * no-op on `gemini`.
+   */
+  readonly suppressAgentReasoning?: boolean;
+  /**
    * How many times a report may be held to ask for the answer that belongs beside it.
    *
    * One is enough for a model that forgot. One evaluated model did not forget: held once
@@ -254,6 +273,14 @@ export const DEFAULT_RETRY_UNREAD_STOP = false;
  * won, so the switch stays per-model and per-mode.
  */
 export const DEFAULT_SUPPRESS_PLAN_REASONING = false;
+
+/**
+ * Off, for the same reason and with the same blast radius as its sibling above.
+ *
+ * Separate from it rather than one field read twice: a model measured needing quiet on plan was
+ * not measured needing it while holding tools, and the two populations are not the same one.
+ */
+export const DEFAULT_SUPPRESS_AGENT_REASONING = false;
 
 /**
  * One, which is what every locked answer-presenting cell was measured against.

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -5029,7 +5029,7 @@ describe("a run is told to report only when it holds something to report from", 
 
 describe("a model that thinks instead of answering is told not to", () => {
   /*
-    `qwen3.5:4b` locks five surfaces at the defaults and lost the sixth to its own reasoning:
+    `muse-glimmer:latest` locks five surfaces with the settings it carries and lost the sixth to its own reasoning:
     asked for one statement it returns 13 188 characters of thinking against 1 165 of content,
     and the five plan runs spent 90, 170 and 179 seconds against a 90-second turn, each leaving
     an empty ledger.
@@ -5056,7 +5056,7 @@ describe("a model that thinks instead of answering is told not to", () => {
 
       await runInvestigation(run.runId, {
         service: b.service,
-        model: await modelOver(script.fetch, "https://api.openai.com/v1", "qwen3.5:4b", provider),
+        model: await modelOver(script.fetch, "https://api.openai.com/v1", "muse-glimmer:latest", provider),
         resources: b.resources,
       });
 
@@ -5099,7 +5099,7 @@ describe("a model that thinks instead of answering is told not to", () => {
 
       await runInvestigation(run.runId, {
         service: b.service,
-        model: await modelOver(script.fetch, "https://api.openai.com/v1", "qwen3.5:4b"),
+        model: await modelOver(script.fetch, "https://api.openai.com/v1", "muse-glimmer:latest"),
         resources: b.resources,
       });
 
@@ -5144,7 +5144,7 @@ describe("a model that thinks instead of CALLING is told not to, on its agent tu
   );
 
   test("a model measured needing quiet only on PLAN keeps its agent turns thinking", async () => {
-    // The two switches are separate, and this is the test that says so: `qwen3.5:4b` carries the
+    // The two switches are separate, and this is the test that says so: a model may carry the
     // plan one and must not acquire the agent one by association.
     const b = boot(freshDataDir());
     const run = await startRun(b, "agent");
@@ -5152,7 +5152,7 @@ describe("a model that thinks instead of CALLING is told not to, on its agent tu
 
     await runInvestigation(run.runId, {
       service: b.service,
-      model: await modelOver(script.fetch, "https://api.openai.com/v1", "qwen3.5:4b"),
+      model: await modelOver(script.fetch, "https://api.openai.com/v1", "muse-glimmer:latest"),
       resources: b.resources,
     });
 

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -5107,3 +5107,69 @@ describe("a model that thinks instead of answering is told not to", () => {
     },
   );
 });
+
+describe("a model that thinks instead of CALLING is told not to, on its agent turns too", () => {
+  /*
+    `gemma4:12b` is the measured case, and it is a different one from the plan-only setting
+    above. Its investigate cell read 5/5 at 9 seconds; on a later serving engine it reads 1/5,
+    and four of the five losses spend the WHOLE turn without invoking a single tool before the
+    clock ends them — 90 seconds, empty ledger, `no-report`. The passing runs still finish in 9.
+    Bimodal: it either answers at once or thinks until the wall.
+
+    That is the same illness `suppressPlanReasoning` was measured on and the same remedy, on a
+    surface that setting deliberately does not reach. So it is a SECOND switch rather than a
+    widening of the first: a model measured needing quiet on plan was not measured needing it
+    while holding tools, and reading one field for both would move cells nobody re-measured.
+
+    Off by default, like its sibling, and for the reason its sibling records: a drive-wide change
+    here is how this repository has twice handed back cells it had already won.
+  */
+  test.each(["native", "prompted"] as const)(
+    "the field reaches an agent turn of a model measured needing it, on the %s protocol",
+    async (protocol) => {
+      // Both protocols, because a prompted agent turn is handed no tools and would otherwise be
+      // indistinguishable from a planning turn at the gate.
+      const b = boot(freshDataDir());
+      const run = await startRun(b, "agent", undefined, undefined, protocol);
+      const script = scriptedModel(answersProse("nothing to add"));
+
+      await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch, "https://api.openai.com/v1", "gemma4:12b"),
+        resources: b.resources,
+      });
+
+      expect(script.turns[0]?.body?.reasoning_effort).toBe(PLAN_NO_REASONING_EFFORT);
+    },
+  );
+
+  test("a model measured needing quiet only on PLAN keeps its agent turns thinking", async () => {
+    // The two switches are separate, and this is the test that says so: `qwen3.5:4b` carries the
+    // plan one and must not acquire the agent one by association.
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "agent");
+    const script = scriptedModel(answersProse("nothing to add"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch, "https://api.openai.com/v1", "qwen3.5:4b"),
+      resources: b.resources,
+    });
+
+    expect(script.turns[0]?.body?.reasoning_effort).toBeUndefined();
+  });
+
+  test("a model nobody measured is left thinking on both", async () => {
+    const b = boot(freshDataDir());
+    const run = await startRun(b, "agent");
+    const script = scriptedModel(answersProse("nothing to add"));
+
+    await runInvestigation(run.runId, {
+      service: b.service,
+      model: await modelOver(script.fetch, "https://api.openai.com/v1", "gemma4:26b"),
+      resources: b.resources,
+    });
+
+    expect(script.turns[0]?.body?.reasoning_effort).toBeUndefined();
+  });
+});

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -158,6 +158,31 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: undefined,
   },
   {
+    // The thirteenth model. Its only setting is the clock, and everything else is the compiled
+    // default: it was measured needing one thing, and a setting it did not earn is a guess.
+    id: "nemotron-3.5-lightning:30b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: 150_000,
+  },
+  {
+    // The fourteenth, and the widest set any model carries: three settings for three DIFFERENT
+    // failures, each measured on the cell it was added for.
+    id: "muse-glimmer:latest",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 2,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    suppressesPlanReasoning: true,
+    turnTimeoutMs: 150_000,
+  },
+  {
     id: "nemotron3:33b",
     unreportedCallCeiling: 12,
     reportReminderLimit: 1,
@@ -255,7 +280,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
   test("the table covers every registered model, so a new one cannot arrive unpinned", () => {
     const pinned = new Set(RESOLVED.map((row) => row.id));
     for (const id of Object.keys(modelProfiles())) expect(pinned.has(id)).toBe(true);
-    expect(Object.keys(modelProfiles())).toHaveLength(12);
+    expect(Object.keys(modelProfiles())).toHaveLength(14);
   });
 });
 
@@ -309,6 +334,12 @@ describe("what each model records about the runs that earned its settings", () =
     "nemotron3:33b": "c1693800c32d336e610590e909300df682479247a910a291c9913ba278f26a8d",
     // The twelfth model, whose record is new too; the plan cell is what its setting bought.
     "qwen3.5:4b": "5e873a71f788b8e5cd361dca67faf1397630fd4da43ac8bf6e570453d02aa811",
+    // The thirteenth. Its record is the only one that states a COST as well as a result: the plan
+    // turn's median doubled when the limit rose, and that sentence is load-bearing.
+    "nemotron-3.5-lightning:30b": "9a581f6838f604eaa3bf9fb0e2636635bd878f50d03b135205eac3e2ab7b0678",
+    // The fourteenth. Its record says its cells were read in ONE pass under the settings it
+    // ships with, which is the claim three settings on one model has to earn.
+    "muse-glimmer:latest": "32bf1643caa8ed550066a64c4a231585a3ddbd30286646bef45f5531198d06cb",
   };
 
   test("every model's record survives the move, character for character", () => {

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -145,8 +145,9 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: 150_000,
   },
   {
-    // The fifteenth. Two settings, both for the clock: twelve losses across three cells and every
-    // one of them a model-timeout.
+    // Three settings, and the third was added a day after the other two: a serving-engine upgrade
+    // took its optimize cell from 5/5 to 1/5, and the quiet agent turn took it back at 76 seconds
+    // against 311.
     id: "qwen3.6:27b",
     unreportedCallCeiling: 12,
     reportReminderLimit: 1,
@@ -155,6 +156,7 @@ const RESOLVED: ResolvedRow[] = [
     retriesEmptyTurn: false,
     refusalExamples: false,
     suppressesPlanReasoning: true,
+    suppressesAgentReasoning: true,
     turnTimeoutMs: 150_000,
   },
   {
@@ -222,18 +224,6 @@ const RESOLVED: ResolvedRow[] = [
     // The one value this model does not share with the defaults, and the reason it has an entry.
     retriesUnreadStop: true,
     refusalExamples: true,
-    turnTimeoutMs: undefined,
-  },
-  {
-    id: "qwen3.5:4b",
-    unreportedCallCeiling: 12,
-    reportReminderLimit: 1,
-    planStatementRetries: 0,
-    presentReminderLimit: 1,
-    retriesEmptyTurn: false,
-    // The one value this model does not share with the defaults, and the reason it has an entry.
-    suppressesPlanReasoning: true,
-    refusalExamples: false,
     turnTimeoutMs: undefined,
   },
   {
@@ -311,7 +301,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
   test("the table covers every registered model, so a new one cannot arrive unpinned", () => {
     const pinned = new Set(RESOLVED.map((row) => row.id));
     for (const id of Object.keys(modelProfiles())) expect(pinned.has(id)).toBe(true);
-    expect(Object.keys(modelProfiles())).toHaveLength(16);
+    expect(Object.keys(modelProfiles())).toHaveLength(15);
   });
 });
 
@@ -363,8 +353,6 @@ describe("what each model records about the runs that earned its settings", () =
     "qwen3:8b": "3dd169b2c0718d77a0db8732d575bb4c863d78ed8343020c103c0f38e9cf016b",
     // The eleventh model, whose record is new rather than moved; see its entry for the runs.
     "nemotron3:33b": "c1693800c32d336e610590e909300df682479247a910a291c9913ba278f26a8d",
-    // The twelfth model, whose record is new too; the plan cell is what its setting bought.
-    "qwen3.5:4b": "5e873a71f788b8e5cd361dca67faf1397630fd4da43ac8bf6e570453d02aa811",
     // The thirteenth. Its record is the only one that states a COST as well as a result: the plan
     // turn's median doubled when the limit rose, and that sentence is load-bearing.
     "nemotron-3.5-lightning:30b": "9a581f6838f604eaa3bf9fb0e2636635bd878f50d03b135205eac3e2ab7b0678",

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -31,6 +31,7 @@ import {
   retriesEmptyTurn,
   retriesUnreadStop,
   samplingFor,
+  suppressesAgentReasoning,
   suppressesPlanReasoning,
   turnTimeoutMsFor,
 } from "@/lib/agent/models";
@@ -59,6 +60,8 @@ interface ResolvedRow {
   readonly retriesUnreadStop?: boolean;
   /** Optional, and PLAN-only; see the field's own note in `profile.ts`. */
   readonly suppressesPlanReasoning?: boolean;
+  /** Optional, and AGENT-only; its sibling above does not imply it. */
+  readonly suppressesAgentReasoning?: boolean;
   readonly refusalExamples: boolean;
   readonly turnTimeoutMs: number | undefined;
   /** Only the surfaces that differ from `PINNED`; every other surface resolves to it. */
@@ -76,6 +79,20 @@ const RESOLVED: ResolvedRow[] = [
     retriesEmptyTurn: true,
     refusalExamples: false,
     turnTimeoutMs: undefined,
+  },
+  {
+    // The sixteenth entry and the fourth model closed on this branch. The only one carrying
+    // suppressAgentReasoning, which was written for it: nothing else reached its illness.
+    id: "gemma4:12b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    suppressesPlanReasoning: true,
+    suppressesAgentReasoning: true,
+    turnTimeoutMs: 150_000,
   },
   {
     id: "gemma4:26b",
@@ -277,6 +294,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
     expect(retriesEmptyTurn(row.id)).toBe(row.retriesEmptyTurn);
     expect(retriesUnreadStop(row.id)).toBe(row.retriesUnreadStop ?? false);
     expect(suppressesPlanReasoning(row.id)).toBe(row.suppressesPlanReasoning ?? false);
+    expect(suppressesAgentReasoning(row.id)).toBe(row.suppressesAgentReasoning ?? false);
     expect(offersRefusalExamples(row.id)).toBe(row.refusalExamples);
     expect(turnTimeoutMsFor(row.id)).toBe(row.turnTimeoutMs);
   });
@@ -293,7 +311,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
   test("the table covers every registered model, so a new one cannot arrive unpinned", () => {
     const pinned = new Set(RESOLVED.map((row) => row.id));
     for (const id of Object.keys(modelProfiles())) expect(pinned.has(id)).toBe(true);
-    expect(Object.keys(modelProfiles())).toHaveLength(15);
+    expect(Object.keys(modelProfiles())).toHaveLength(16);
   });
 });
 
@@ -356,6 +374,9 @@ describe("what each model records about the runs that earned its settings", () =
     // The fifteenth. Its record states the outlier as well as the result: assess read 4/5 once
     // and 5/5 on a second read of the same cell at the same setting.
     "qwen3.6:27b": "d0ebde3fdf25b9c56ab7bcad4adc3b54510a413285e51edcb46aec261e661157",
+    // The fourth closed here, and the one the new switch was written for. Its record states the
+    // refuted hypothesis too: the tool count does not separate its passing runs from its loss.
+    "gemma4:12b": "9a49a9323c21ffe507698ca2ca852cc1b59647a206e73c448afeea7f1a0a674b",
   };
 
   test("every model's record survives the move, character for character", () => {

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -128,6 +128,19 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: 150_000,
   },
   {
+    // The fifteenth. Two settings, both for the clock: twelve losses across three cells and every
+    // one of them a model-timeout.
+    id: "qwen3.6:27b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    suppressesPlanReasoning: true,
+    turnTimeoutMs: 150_000,
+  },
+  {
     id: "qwen3.8:latest",
     unreportedCallCeiling: 12,
     reportReminderLimit: 1,
@@ -280,7 +293,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
   test("the table covers every registered model, so a new one cannot arrive unpinned", () => {
     const pinned = new Set(RESOLVED.map((row) => row.id));
     for (const id of Object.keys(modelProfiles())) expect(pinned.has(id)).toBe(true);
-    expect(Object.keys(modelProfiles())).toHaveLength(14);
+    expect(Object.keys(modelProfiles())).toHaveLength(15);
   });
 });
 
@@ -340,6 +353,9 @@ describe("what each model records about the runs that earned its settings", () =
     // The fourteenth. Its record says its cells were read in ONE pass under the settings it
     // ships with, which is the claim three settings on one model has to earn.
     "muse-glimmer:latest": "32bf1643caa8ed550066a64c4a231585a3ddbd30286646bef45f5531198d06cb",
+    // The fifteenth. Its record states the outlier as well as the result: assess read 4/5 once
+    // and 5/5 on a second read of the same cell at the same setting.
+    "qwen3.6:27b": "d0ebde3fdf25b9c56ab7bcad4adc3b54510a413285e51edcb46aec261e661157",
   };
 
   test("every model's record survives the move, character for character", () => {

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -90,7 +90,7 @@ afterEach(() => {
 describe("the document Studio ships with", () => {
   test("passes its own contract", () => {
     const tuning = parseTuning(bundled, "test");
-    expect(Object.keys(tuning.models)).toHaveLength(15);
+    expect(Object.keys(tuning.models)).toHaveLength(16);
   });
 
   test("argues for every value it changed", () => {
@@ -559,7 +559,7 @@ describe("a document an operator supplies", () => {
     process.env[ENV] = writeDocument("{ not json");
     resetTuning();
     expect(ceilingFor("gemma4:26b")).toBe(10);
-    expect(Object.keys(activeTuning().models)).toHaveLength(15);
+    expect(Object.keys(activeTuning().models)).toHaveLength(16);
   });
 
   test("reports that it ignored a document, naming the file and the reason", () => {
@@ -713,13 +713,13 @@ describe("a document an operator supplies", () => {
   test("is ignored when it breaks the contract, not partially applied", () => {
     process.env[ENV] = writeDocument(document({ schemaVersion: 99 }));
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(15);
+    expect(Object.keys(activeTuning().models)).toHaveLength(16);
   });
 
   test("is ignored when the file is not there at all", () => {
     process.env[ENV] = "/nonexistent/models.json";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(15);
+    expect(Object.keys(activeTuning().models)).toHaveLength(16);
   });
 
   test("an unset or blank variable is simply no operator document", () => {
@@ -727,7 +727,7 @@ describe("a document an operator supplies", () => {
     // reading it as a path would warn on every boot of an install that configured nothing.
     process.env[ENV] = "   ";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(15);
+    expect(Object.keys(activeTuning().models)).toHaveLength(16);
   });
 
   test("is read once, so a run cannot see the table change under it", () => {

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -90,7 +90,7 @@ afterEach(() => {
 describe("the document Studio ships with", () => {
   test("passes its own contract", () => {
     const tuning = parseTuning(bundled, "test");
-    expect(Object.keys(tuning.models)).toHaveLength(16);
+    expect(Object.keys(tuning.models)).toHaveLength(15);
   });
 
   test("argues for every value it changed", () => {
@@ -559,7 +559,7 @@ describe("a document an operator supplies", () => {
     process.env[ENV] = writeDocument("{ not json");
     resetTuning();
     expect(ceilingFor("gemma4:26b")).toBe(10);
-    expect(Object.keys(activeTuning().models)).toHaveLength(16);
+    expect(Object.keys(activeTuning().models)).toHaveLength(15);
   });
 
   test("reports that it ignored a document, naming the file and the reason", () => {
@@ -713,13 +713,13 @@ describe("a document an operator supplies", () => {
   test("is ignored when it breaks the contract, not partially applied", () => {
     process.env[ENV] = writeDocument(document({ schemaVersion: 99 }));
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(16);
+    expect(Object.keys(activeTuning().models)).toHaveLength(15);
   });
 
   test("is ignored when the file is not there at all", () => {
     process.env[ENV] = "/nonexistent/models.json";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(16);
+    expect(Object.keys(activeTuning().models)).toHaveLength(15);
   });
 
   test("an unset or blank variable is simply no operator document", () => {
@@ -727,7 +727,7 @@ describe("a document an operator supplies", () => {
     // reading it as a path would warn on every boot of an install that configured nothing.
     process.env[ENV] = "   ";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(16);
+    expect(Object.keys(activeTuning().models)).toHaveLength(15);
   });
 
   test("is read once, so a run cannot see the table change under it", () => {

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -90,7 +90,7 @@ afterEach(() => {
 describe("the document Studio ships with", () => {
   test("passes its own contract", () => {
     const tuning = parseTuning(bundled, "test");
-    expect(Object.keys(tuning.models)).toHaveLength(14);
+    expect(Object.keys(tuning.models)).toHaveLength(15);
   });
 
   test("argues for every value it changed", () => {
@@ -559,7 +559,7 @@ describe("a document an operator supplies", () => {
     process.env[ENV] = writeDocument("{ not json");
     resetTuning();
     expect(ceilingFor("gemma4:26b")).toBe(10);
-    expect(Object.keys(activeTuning().models)).toHaveLength(14);
+    expect(Object.keys(activeTuning().models)).toHaveLength(15);
   });
 
   test("reports that it ignored a document, naming the file and the reason", () => {
@@ -713,13 +713,13 @@ describe("a document an operator supplies", () => {
   test("is ignored when it breaks the contract, not partially applied", () => {
     process.env[ENV] = writeDocument(document({ schemaVersion: 99 }));
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(14);
+    expect(Object.keys(activeTuning().models)).toHaveLength(15);
   });
 
   test("is ignored when the file is not there at all", () => {
     process.env[ENV] = "/nonexistent/models.json";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(14);
+    expect(Object.keys(activeTuning().models)).toHaveLength(15);
   });
 
   test("an unset or blank variable is simply no operator document", () => {
@@ -727,7 +727,7 @@ describe("a document an operator supplies", () => {
     // reading it as a path would warn on every boot of an install that configured nothing.
     process.env[ENV] = "   ";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(14);
+    expect(Object.keys(activeTuning().models)).toHaveLength(15);
   });
 
   test("is read once, so a run cannot see the table change under it", () => {

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -90,7 +90,7 @@ afterEach(() => {
 describe("the document Studio ships with", () => {
   test("passes its own contract", () => {
     const tuning = parseTuning(bundled, "test");
-    expect(Object.keys(tuning.models)).toHaveLength(12);
+    expect(Object.keys(tuning.models)).toHaveLength(14);
   });
 
   test("argues for every value it changed", () => {
@@ -559,7 +559,7 @@ describe("a document an operator supplies", () => {
     process.env[ENV] = writeDocument("{ not json");
     resetTuning();
     expect(ceilingFor("gemma4:26b")).toBe(10);
-    expect(Object.keys(activeTuning().models)).toHaveLength(12);
+    expect(Object.keys(activeTuning().models)).toHaveLength(14);
   });
 
   test("reports that it ignored a document, naming the file and the reason", () => {
@@ -713,13 +713,13 @@ describe("a document an operator supplies", () => {
   test("is ignored when it breaks the contract, not partially applied", () => {
     process.env[ENV] = writeDocument(document({ schemaVersion: 99 }));
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(12);
+    expect(Object.keys(activeTuning().models)).toHaveLength(14);
   });
 
   test("is ignored when the file is not there at all", () => {
     process.env[ENV] = "/nonexistent/models.json";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(12);
+    expect(Object.keys(activeTuning().models)).toHaveLength(14);
   });
 
   test("an unset or blank variable is simply no operator document", () => {
@@ -727,7 +727,7 @@ describe("a document an operator supplies", () => {
     // reading it as a path would warn on every boot of an install that configured nothing.
     process.env[ENV] = "   ";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(12);
+    expect(Object.keys(activeTuning().models)).toHaveLength(14);
   });
 
   test("is read once, so a run cannot see the table change under it", () => {


### PR DESCRIPTION
Four models clear all six agent surfaces five consecutive times each, one that was shipped comes
out, and both halves belong in one PR because of the third thing that happened between them:
Ollama moved from 0.32.13 to 0.33.0 under this work and did not move every model the same way.
Fifteen models, 450 runs, 450 passes.

## The four models

**`nemotron-3.5-lightning:30b` — 30/30, one setting.** Its five agent surfaces clear the shipped
90-second turn untouched (4s, 20s, 57s, 38s, 9s); its plan turn scored 4/5 there, losing the first
run after a cold load to a `model-timeout` with zero tools invoked while the four passes landed
within three seconds of each other at 67 to 69. It carries `turnTimeoutMs: 150000`, and the entry
records what that cost as well as what it bought: the plan turn's median rose from 67 seconds to
144, both ending model-stopped. The model spends the budget it is given, so the cell now costs
twice what it did and is won rather than lost. A reader choosing it for plan work should budget
from the 144.

**`muse-glimmer:latest` — 30/30 with three settings, the widest set any model here carries,**
because it lost three cells to three different failures: plan 0/5, every loss a timeout at exactly
90 seconds with an empty ledger and no tool invoked — reasoning suppressed on the plan turn, and
the same five runs then finish in 16 to 21s; investigate 4/5 and assess 4/5, both single timeouts
at 159s and 160s against passes at 102–116 and 141–163 — a 150-second turn, since its passing
assessments call eleven tools and take two and a half minutes; and assess still losing one run
once the clock was not the constraint, to model-stopped with `no-report` at 105s having called
fourteen tools — a second report reminder, which is the distinction between a model that forgot
and one that stops as its habit. Each setting was found on the cell it fixes and therefore under a
different configuration from the one that ships, so all six surfaces were re-read in a single pass
under the final three, and that pass is what the numbers report.

**`qwen3.6:27b` — 30/30, and its settings made the cells that already passed faster.** It arrived
at 3/6 and 18/30 with every one of its twelve losses a `model-timeout` — plan 0/5, optimize 1/5,
assess 2/5, nothing lost to a wrong answer. No reasoning on the plan turn and a 150-second turn
close all three. The part worth reading twice is what happened to the three cells that were
already passing: investigate 51s to 26s, operate 102s to 68s, analyze 110s to 82s, with no change
to their verdicts. A model that is not racing a limit it cannot meet finishes sooner, and nothing
in the shipped configuration made that visible until the limit moved.

**`gemma4:12b` — 2/6 and 15/30 to 6/6 and 30/30, on a switch the product did not have.** It
carries three settings and the new one is what did it; the other two are the clock (assess and
operate lost to `model-timeout` with tools called and work done) and its plan turn, which was 0/5
with the thinking signature and reads 5/5 at 2 s with reasoning off. It is three times faster than
the 26b at half the size, and the settings did not merely close the four open cells — every cell
got faster, several by most of their length: analyze 102s to 11s, assess 118s to 21s, operate 75s
to 14s, investigate 9s to 4s.

## What was wrong

**The product could tell a model to spend nothing on reasoning during a PLAN turn and had no way
to say it during an AGENT turn.** `gemma4:12b` is the model that needed the second sentence: its
investigate cell read 5/5 at 9 seconds on one serving engine and 1/5 on the next, with four losses
spending the entire turn without invoking a single tool before the clock ended them, against
passing runs that still finished in 9. Bimodal — it answers at once or thinks until the wall.
Nothing that already existed reached it, and that was measured rather than assumed:
`turnTimeoutMs: 150000` read 1/5 again with the losses simply longer, because a turn spent
thinking finds the new wall too. `suppressAgentReasoning` is a SECOND field rather than a widening
of the first, and the tests pin why — a model carrying only the plan switch won its five agent
cells while thinking, so one field read for both modes would have moved five cells nobody
re-measured.

**The method recorded the machine, the database and the code revision, and said nothing about the
server that loads the weights.** Same model file, same digest, same objective, same code, one
engine version apart: 5 of 5 at 9 seconds, then 1 of 5. Three configurations were measured before
the engine was suspected, because the obvious suspects were ours — with the per-model settings
under test, without them, and with the context bound removed. All three read the same. The upgrade
is not simply a regression, which is why the note is about versions rather than advice to stay on
one: the two models measured on 0.32.13 were re-verified on 0.33.0 at their most marginal cell,
and both hold, faster than before — `nemotron-3.5-lightning:30b`'s plan 5/5 at 93s against 144s,
`muse-glimmer:latest`'s assess 5/5 at 137s against 167s. The same upgrade that broke one model
improved two. A figure on these pages is a claim about a model on the engine named beside it.

**A shipped model reads 1/5 on a cell and no fix reaches it, so it is withdrawn.**
`qwen3.5:4b`'s plan losses stop in two seconds having written nothing at all. Three fixes were
measured and none of them reached it: the plan-statement retry read 1/5 unchanged, turning its
reasoning-off switch back on read 0/5 with every loss timing out at exactly 90 seconds, and paying
for that with a 150-second turn read 0/4 timing out at 150. It loses at both ends of the one
switch that governs the cell — silent in two seconds, or thinking past any limit it is given — so
it is withdrawn rather than shipped with a figure the docs cannot stand behind. It leaves the
profile document, the pinned resolution table, the README, its own page, the e2e sweep list and
the prose that cited it as a measured case; `muse-glimmer:latest` and `gemma4:12b` carry that
citation now, having been measured on the same shape.

**Neither broken cell is this branch's doing, and that was measured rather than argued.** Both
read the same on a clean `origin/main` worktree carrying none of these commits, and `qwen3.6:27b`
is not in that document at all — it ran there on the compiled defaults and lost anyway.

## Three claims this repo made about itself, corrected

- **`docs/llms/README.md` said every supported model cleared its six surfaces "at the 90-second
  per-turn limit the product ships".** One of them already did not: `qwen3.5:9b` has carried
  `turnTimeoutMs: 150000` since it was measured. Five models carry it now, and the README and
  `methodology.md` name them rather than asserting a limit that five of their own rows contradict.
- **`methodology.md` said the UI sweep drove "all twelve models" through the product's own rail,
  and reported 57 of 60.** Sixty runs at one per surface is ten models, which is what that sweep
  covered when it ran in #465; the models added since have been driven over HTTP only. It says
  ten now, and says so explicitly, because "all of them" described a sweep nobody ran.
- **`gemma4:12b`'s assess loss looked like the call ceiling, and the ledger refutes it.** The
  losing run made eleven calls, one under the general ceiling of 12 — which is `gemma4:26b`'s
  measured case exactly. Two of the passing runs also made eleven. Lowering the ceiling would have
  cut runs that pass, and the record now says so where the next reader will look.

## New entries, all measured

| Model | Runs | Settings it needed |
| --- | --- | --- |
| `nemotron-3.5-lightning:30b` | 30/30 | `turnTimeoutMs: 150000` |
| `muse-glimmer:latest` | 30/30 | `turnTimeoutMs: 150000`, `suppressPlanReasoning`, `reportReminderLimit: 2` |
| `qwen3.6:27b` | 30/30 | `turnTimeoutMs: 150000`, `suppressPlanReasoning`, `suppressAgentReasoning` |
| `gemma4:12b` | 30/30 | `turnTimeoutMs: 150000`, `suppressPlanReasoning`, `suppressAgentReasoning` |

Each is pinned by digest in `tests/unit/lib/agent/model-resolution-table.test.ts`, so no entry can
drift unnoticed, and each has a page under `docs/llms/`.

## What this does not close

`nemotron3:33b` is untouched here, and `B66` stays open on the work list. The sweep it asks for
has been run and is recorded on the model's page rather than in the entry: a 150-second turn read
3/5 again, but one of those runs composed its report at 114 s — a run the shipped 90-second limit
would have killed. So the limit is part of the answer and not all of it, and what the cell
actually shows is a report turn whose length varies by a factor of twenty on identical input.
Settling the entry against that record is somebody's next PR, not this one's business.
