### PR TITLE
fix(redis): read the active session's user from CLIENT LIST's user field

### DIFF
--- a/docs/providers/redis.md
+++ b/docs/providers/redis.md
@@ -86,20 +86,18 @@ though `CLIENT LIST` itself answers correctly - the session list is right while 
 is not.
 
 **Every `CLIENT LIST` field is optional, and the absent ones surface as defaults.**
-`getActiveSessions()` ([`redis.ts:623`](../../src/lib/db/providers/keyvalue/redis.ts)) splits each
+`getActiveSessions()` ([`redis.ts:640`](../../src/lib/db/providers/keyvalue/redis.ts)) splits each
 line into `key=value` pairs and substitutes a default for anything missing: the session's user is
-`name` falling back to `default`, its pid `id` falling back to `0`, its state `flags` falling back
+`user` falling back to `default`, its pid `id` falling back to `0`, its state `flags` falling back
 to `N`, its command `cmd` falling back to `idle`. A relative that omits a field therefore produces a
-plausible-looking row rather than an error. Note that the user column reads `name`, not the `user`
-field Redis also publishes, and `name=` is empty until a client calls `CLIENT SETNAME` — so
-`default` is what every engine here shows, Redis included, rather than a relative's quirk.
+plausible-looking row rather than an error.
 
 Three relatives diverge, all measured on the versions above:
 
-- **Dragonfly fills `name` with the connection id**, so the user column shows a number (`8`) rather
-  than falling back to `default` — the fallback is never reached. Its line also carries no `cmd=`
-  and no `flags=` at all, so the query column reads `idle` and the state column `N` for every
-  session, whatever that session is doing.
+- **Dragonfly publishes no `user=` field at all**, so the user column reads `default` regardless of
+  which ACL user the connection authenticated as — the fallback is always the answer there, not the
+  exception. Its line also carries no `cmd=` and no `flags=` at all, so the query column reads
+  `idle` and the state column `N` for every session, whatever that session is doing.
 - **KeyDB reports a command without its subcommand** (`cmd=client` where Redis and Valkey both send
   `cmd=client|list`), which the query column shows verbatim.
 - **Garnet answers `CLIENT LIST` in full** - the session row is complete and correct - so the

--- a/src/lib/db/providers/keyvalue/redis.ts
+++ b/src/lib/db/providers/keyvalue/redis.ts
@@ -654,7 +654,7 @@ export class RedisProvider extends BaseDatabaseProvider {
 
         sessions.push({
           pid: fields.id || "0",
-          user: fields.name || "default",
+          user: fields.user || "default",
           database: fields.db || "0",
           state: fields.flags || "N",
           query: fields.cmd || "idle",

--- a/tests/integration/db/redis-provider.test.ts
+++ b/tests/integration/db/redis-provider.test.ts
@@ -33,8 +33,11 @@ const MOCK_INFO_STRING = [
   "",
 ].join("\n");
 
+// `name=` is the connection name (empty until a client calls CLIENT SETNAME) and is
+// deliberately left blank here, distinct from `user=` (the authenticated ACL user) - the
+// two used to be conflated in getActiveSessions(), which read `name` for the user column.
 const MOCK_CLIENT_LIST =
-  "id=1 addr=127.0.0.1:6379 name=app1 db=0 flags=N cmd=get idle=5\nid=2 addr=127.0.0.1:6380 name=app2 db=0 flags=N cmd=set idle=10";
+  "id=1 addr=127.0.0.1:6379 name= db=0 flags=N cmd=get idle=5 user=studio\nid=2 addr=127.0.0.1:6380 name= db=0 flags=N cmd=set idle=10 user=default";
 
 // SLOWLOG GET entries: [id, timestamp, duration-in-microseconds, args, clientAddr, clientName]
 // The second entry carries a non-array args payload to exercise the String() fallback.
@@ -967,6 +970,12 @@ describe("RedisProvider", () => {
       expect(sessions).toBeArray();
       expect(sessions.length).toBe(2);
       expect(sessions[0].user).toBeDefined();
+    });
+
+    test("reads the user column from CLIENT LIST's user field, not its name field", async () => {
+      const sessions = await provider.getActiveSessions();
+      expect(sessions[0].user).toBe("studio");
+      expect(sessions[1].user).toBe("default");
     });
   });
 


### PR DESCRIPTION
getActiveSessions() read the name field from CLIENT LIST for the session's user column. That field stays empty until a client calls CLIENT SETNAME, so the column read default for every session regardless of which ACL user actually connected. CLIENT LIST reports the ACL user separately in its own user field, which this fixes it to read instead.

Verified against live containers rather than assumed:

- Valkey 9.1.1, Redis, KeyDB and Garnet all publish user, and it reflects the connected ACL user correctly.
- Dragonfly publishes no user field at all, so its session list keeps reading default, same as before, just for the right reason now.

docs/providers/redis.md documented the old (buggy) behavior as measured fact per engine. Updated that section to match, including the Dragonfly line, since the previous text described name filling with a connection id there.

Test plan:
- tests/integration/db/redis-provider.test.ts updated with a realistic CLIENT LIST mock (separate name and user fields) and a new test asserting the session's user comes from user, not name.
- bun run test (full suite) passes.
- bun run typecheck passes.