### PR TITLE
fix(schema-diff): don't emit BEGIN;/COMMIT; for non-transactional dialects (refs #284)

### DIFF
--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -800,7 +800,11 @@ The integration points, all of which need an entry. This is the list the Strateg
       PostgreSQL-shaped, so check before assuming it fits
 - [ ] `src/lib/schema-diff/migration-generator.ts` — same shape, same hazard: the modified-column
       chain's trailing `else` is PostgreSQL DDL, so an unlisted id silently inherits it (#269). Give the
-      dialect a branch, or list it in `NO_COLUMN_MODIFICATION` to emit an honest comment instead
+      dialect a branch, or list it in `NO_COLUMN_MODIFICATION` to emit an honest comment instead. A new
+      id also needs a decision in `NO_TRANSACTION_WRAPPER` (#284): does `BEGIN;`/`COMMIT;` wrap this
+      engine's DDL at all, or does it belong in the set that gets no wrapper? An id absent from that
+      set inherits the PostgreSQL-shaped wrapper by default, which is silently wrong for a non-SQL or
+      non-transactional engine the same way the modified-column `else` used to be
 - [ ] `src/lib/sql/grammar.ts` — **two decisions, neither of which the compiler can force.** First,
       whether your engine's query text is SQL at all (`NON_SQL_DIALECTS`): an id absent from that set is
       declared to write SQL, and the confirmation gate then applies a SQL span reader to it — which for
@@ -859,7 +863,9 @@ connection-form test), so the compiler and those tests refuse to pass until each
 `tests/unit/lib/query-generators.test.ts`, `tests/unit/seed/types.test.ts`,
 `tests/hooks/use-connection-form.test.ts`,
 `tests/unit/schema-diff/migration-generator.test.ts` (`MODIFIED_COLUMN_COVERAGE` — classify the new id
-as having its own dialect branch or as unable to express a column modification),
+as having its own dialect branch or as unable to express a column modification; and
+`TRANSACTION_WRAPPER_COVERAGE` — classify it as `"wrapped"` or `"unwrapped"`, matching whatever you
+chose in `NO_TRANSACTION_WRAPPER`),
 `tests/unit/sql/grammar.test.ts` (`GRAMMAR_COVERAGE` and `SQL_TEXT_COVERAGE` — record whether the id
 has an established grammar or reads at the default, and whether its query text is SQL).
 

--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -1046,9 +1046,10 @@ database-wide statistics. Transaction and cancel routes do not apply — see
     (a bare `x String EPHEMERAL` has no expression, so it reaches the diff as no default at all and the
     generator never sees it); and `REMOVE DEFAULT`
     against a column that has none is itself an error (code `36`), so it is emitted only for a default
-    that existed. Still approximate: the generator wraps its output in `BEGIN` / `COMMIT`, which this
-    server has no transaction model for, so drop those two lines before running a generated migration
-    here.
+    that existed. Since [#284](https://github.com/libredb/libredb-studio/issues/284) the generator no
+    longer wraps ClickHouse's output in `BEGIN` / `COMMIT` at all — this server has no transaction model
+    for it (ClickHouse's own transaction support is experimental and setting-gated, not a safe default),
+    so a generated migration here is the bare DDL with nothing to strip.
 - **No native protocol.** Port `9000` and everything that needs it — the native wire format, some
   server-side settings only exposed there — is out of scope; see
   [§3.1](#31-http-transport-only--no-native-dependency).

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -9,8 +9,8 @@
  *   the limitation in a comment where an engine has no such statement (#269); the
  *   `ADD` / `DROP` keyword, which CQL spells without `COLUMN`; `CREATE TABLE`,
  *   which is refused outright for Cassandra (see CASSANDRA_NO_CREATE_TABLE); the
- *   transaction wrapper (see NO_TRANSACTION_WRAPPER), which twelve of the sixteen
- *   type ids do without, each for its own named reason; and the foreign-key
+ *   transaction wrapper (see NO_TRANSACTION_WRAPPER), which twelve of the
+ *   seventeen type ids do without, each for its own named reason; and the foreign-key
  *   statements, which CQL has no grammar for at all and which SQLite's grammar
  *   takes only inside `CREATE TABLE` (see FOREIGN_KEY_ONLY_IN_CREATE_TABLE).
  * - Not yet: MSSQL and Oracle's own transaction-wrapper forms (`BEGIN;` is not
@@ -189,14 +189,28 @@ const NO_COLUMN_MODIFICATION: Partial<Record<DatabaseType, { label: string; reas
  * `mongodb` and `redis` write no SQL text at all (`NON_SQL_DIALECTS` in `grammar.ts`), and
  * wrapping non-SQL command text in SQL statements is wrong regardless of Mongo's own
  * driver-level transaction API; `libredb` "speaks a JSON command grammar, not SQL DDL"
- * (`NO_COLUMN_MODIFICATION`'s own words); `couchbase` and `druid` never receive column DDL
- * from this generator in the first place (`NO_COLUMN_MODIFICATION`, and both providers
- * report `supportsCreateTable: false`), so a wrapper would bracket nothing but comments;
- * `elasticsearch` and `opensearch` are SQL-read-only (`NO_COLUMN_MODIFICATION`) for the
- * same reason; `trino`'s transactional semantics are the CONNECTOR's answer, not a
+ * (`NO_COLUMN_MODIFICATION`'s own words); `couchbase` HAS distributed ACID transactions,
+ * but spells one `BEGIN TRANSACTION` and answers with a `txid` that every following
+ * statement has to carry as a request parameter (`docs/providers/couchbase.md` §13) - a
+ * shape a flat migration file cannot express at all, so `BEGIN;` is both the wrong
+ * keyword and the wrong mechanism; `druid` has no transaction concept to translate the
+ * wrapper into ("Druid SQL has no ALTER TABLE", `NO_COLUMN_MODIFICATION`; a datasource is
+ * rewritten by an MSQ task, not by a bracketed statement list); `elasticsearch` and
+ * `opensearch` do not have `BEGIN` in their grammar at all - the parse error quoted in
+ * `NO_COLUMN_MODIFICATION` lists every statement Elasticsearch SQL accepts and `BEGIN` is
+ * not among them, and OpenSearch 3.8.0 was measured separately
+ * (`docs/providers/opensearch.md` §9); `trino`'s transactional semantics are the CONNECTOR's answer, not a
  * property of Trino itself (`NO_COLUMN_MODIFICATION`), so no portable `BEGIN;`/`COMMIT;`
  * exists; and `clickhouse`'s transaction support is experimental and setting-gated rather
  * than a safe default — this set is what removes it from the wrapper it used to inherit.
+ *
+ * What none of these nine reasons is: "this generator emits nothing for that id anyway".
+ * It has no capability gate - `supportsCreateTable` is read by the schema explorer, not
+ * here - so its added-table branch emits a real `CREATE TABLE` for every id except
+ * `cassandra` (see CASSANDRA_NO_CREATE_TABLE). The wrapper this set removes was bracketing
+ * runnable DDL for these ids, not just comments, which is what makes removing it a fix.
+ * `tests/unit/schema-diff/migration-generator.test.ts` drives the coverage table over an
+ * added-table diff as well as a modified-table one so that stays measured.
  *
  * `mssql` and `oracle` are deliberately ABSENT from this set — they still get the
  * PostgreSQL-shaped wrapper, UNCHANGED, because their real forms (`BEGIN TRANSACTION;`

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -9,26 +9,41 @@
  *   the limitation in a comment where an engine has no such statement (#269); the
  *   `ADD` / `DROP` keyword, which CQL spells without `COLUMN`; `CREATE TABLE`,
  *   which is refused outright for Cassandra (see CASSANDRA_NO_CREATE_TABLE); the
- *   transaction wrapper, which Cassandra and SQLite's two type ids each do
- *   without; and the foreign-key statements, which CQL has no grammar for at all
- *   and which SQLite's grammar takes only inside `CREATE TABLE` (see
- *   FOREIGN_KEY_ONLY_IN_CREATE_TABLE).
- * - Not yet: the transaction wrapper for everyone ELSE (`BEGIN;` / `COMMIT;` is
- *   only valid for PostgreSQL and MySQL — MSSQL spells it `BEGIN TRANSACTION`,
- *   Oracle opens a PL/SQL block and auto-commits DDL anyway, and five remaining
- *   type ids have no transactional DDL at all), the rest of `ADD COLUMN` and
- *   `DROP COLUMN`, and the index/FK fallbacks that emit `DROP INDEX IF EXISTS`.
+ *   transaction wrapper (see NO_TRANSACTION_WRAPPER), which twelve of the sixteen
+ *   type ids do without, each for its own named reason; and the foreign-key
+ *   statements, which CQL has no grammar for at all and which SQLite's grammar
+ *   takes only inside `CREATE TABLE` (see FOREIGN_KEY_ONLY_IN_CREATE_TABLE).
+ * - Not yet: MSSQL and Oracle's own transaction-wrapper forms (`BEGIN;` is not
+ *   `BEGIN TRANSACTION;`, and Oracle DDL auto-commits regardless of what wraps
+ *   it) — both still get today's PostgreSQL-shaped `BEGIN;`/`COMMIT;`, because
+ *   settling their real forms wants checking against a live server first, the
+ *   way #264 and #265 did, and that measurement is the tracked follow-up to this
+ *   fix rather than part of it.
  *
- * Cassandra is ahead of the others here for a reason worth stating: it is the one
- * dialect whose OTHER statements were each measured against a live server, so the
- * wrapper and the FK lines would have been the only unrunnable lines in an
- * otherwise runnable migration. Elsewhere they are one problem among several, and
- * the emitted forms still want checking against a live server first.
+ *   Two more MSSQL/Oracle questions surfaced while checking the rest of this
+ *   docstring's claims, and both belong in that same follow-up rather than
+ *   being guessed at here: the `ADD COLUMN` keyword — the modified-column path
+ *   a few lines below already spells Oracle's own ALTER as `MODIFY (...)`,
+ *   with no `COLUMN` keyword in its grammar at all, and MSSQL's documented
+ *   `ADD` clause has none either, yet the generic added-column branch hands
+ *   both the same literal `ADD COLUMN` every other engine gets; and whether
+ *   `DROP TABLE`/`DROP INDEX`/`DROP CONSTRAINT ... IF EXISTS` are valid there
+ *   at all — Oracle had no conditional DDL clause before 23ai. Both are
+ *   internal inconsistencies or open questions this pass surfaced rather than
+ *   fresh guesses, but neither is fixed here.
  *
- * So the output is correct for PostgreSQL, largely correct for MySQL and SQLite,
- * and can be unrunnable elsewhere. Tracked rather than fixed here because the
- * emitted forms want checking against a live MSSQL and Oracle before they are
- * settled, the way #264 and #265 did.
+ *   For every OTHER dialect, `ADD`/`DROP COLUMN` and the index/FK `IF EXISTS`
+ *   fallbacks were checked against the same questions and found to already
+ *   agree with each one's documented grammar via the existing
+ *   Cassandra/SQLite/libSQL/DuckDB/MySQL branches, so nothing there needed
+ *   changing in this pass.
+ *
+ * Cassandra is ahead of MSSQL and Oracle here for a reason worth stating (see
+ * NO_TRANSACTION_WRAPPER for the measurement): it is a dialect whose OTHER
+ * statements were each measured against a live server too, so its wrapper and FK
+ * lines would have been the only unrunnable lines in an otherwise runnable
+ * migration. For MSSQL and Oracle they are one problem among several, and the
+ * emitted forms still want checking against a live server first.
  */
 import type { DatabaseType } from "@/lib/types";
 // The shared quoter, which also escapes an embedded closing quote character — this
@@ -153,6 +168,56 @@ const NO_COLUMN_MODIFICATION: Partial<Record<DatabaseType, { label: string; reas
     reason: "The embedded engine speaks a JSON command grammar, not SQL DDL.",
   },
 };
+
+/**
+ * Canonical type ids whose migration text carries no transaction wrapper, because no
+ * `BEGIN;` this generator could emit would be both valid and meaningful for them (#284).
+ *
+ * `sqlite` runs its own transaction, and `libsql` is SQLite - the same reasoning, with
+ * one addition of its own: this provider closes its Hrana stream in the same request as
+ * each statement, so a BEGIN it emitted could not be continued by the app that generated
+ * the file. `cassandra` has no transaction at all - measured on 5.0.9, `BEGIN;` is "line
+ * 1:5 mismatched input ';' expecting K_BATCH" and `COMMIT;` is "no viable alternative at
+ * input 'COMMIT'". The only grouping CQL has is `BEGIN BATCH ... APPLY BATCH`, which is
+ * not a transaction and takes no DDL, so there is nothing to translate the wrapper INTO -
+ * it can only be left out. Unlike the other two, Cassandra's OTHER statements in this
+ * generator were each measured against a live server too, so the wrapper would have been
+ * the only unrunnable line in an otherwise runnable migration.
+ *
+ * The other nine are new, and each reuses a fact this module (or `src/lib/sql/grammar.ts`)
+ * already established for a different fallback rather than asserting a fresh one:
+ * `mongodb` and `redis` write no SQL text at all (`NON_SQL_DIALECTS` in `grammar.ts`), and
+ * wrapping non-SQL command text in SQL statements is wrong regardless of Mongo's own
+ * driver-level transaction API; `libredb` "speaks a JSON command grammar, not SQL DDL"
+ * (`NO_COLUMN_MODIFICATION`'s own words); `couchbase` and `druid` never receive column DDL
+ * from this generator in the first place (`NO_COLUMN_MODIFICATION`, and both providers
+ * report `supportsCreateTable: false`), so a wrapper would bracket nothing but comments;
+ * `elasticsearch` and `opensearch` are SQL-read-only (`NO_COLUMN_MODIFICATION`) for the
+ * same reason; `trino`'s transactional semantics are the CONNECTOR's answer, not a
+ * property of Trino itself (`NO_COLUMN_MODIFICATION`), so no portable `BEGIN;`/`COMMIT;`
+ * exists; and `clickhouse`'s transaction support is experimental and setting-gated rather
+ * than a safe default — this set is what removes it from the wrapper it used to inherit.
+ *
+ * `mssql` and `oracle` are deliberately ABSENT from this set — they still get the
+ * PostgreSQL-shaped wrapper, UNCHANGED, because their real forms (`BEGIN TRANSACTION;`
+ * for MSSQL; whether Oracle needs a wrapper at all, given DDL there auto-commits) want
+ * checking against a live server first, the way #264 and #265 were, and remain tracked
+ * in the module docstring above as the follow-up this PR does not attempt.
+ */
+const NO_TRANSACTION_WRAPPER: ReadonlySet<DatabaseType> = new Set<DatabaseType>([
+  "sqlite",
+  "libsql",
+  "cassandra",
+  "mongodb",
+  "redis",
+  "libredb",
+  "couchbase",
+  "druid",
+  "clickhouse",
+  "elasticsearch",
+  "opensearch",
+  "trino",
+]);
 
 function generateColumnDef(col: ColumnDiff, dialect: DatabaseType): string {
   const type = col.targetType || col.sourceType || "TEXT";
@@ -526,20 +591,8 @@ export function generateMigrationSQL(diff: SchemaDiff, dialect: DatabaseType): s
 
   // ONE definition, read twice: the opening and the closing halves of this wrapper used
   // to be two independent conditions, which is a shape that can diverge into a `BEGIN;`
-  // with no `COMMIT;`.
-  //
-  // SQLite runs its own transaction, and libSQL is SQLite - the same reasoning, with
-  // one addition of its own: this provider closes its Hrana stream in the same request
-  // as each statement, so a BEGIN it emitted could not be continued by the app that
-  // generated the file. Cassandra has no transaction at all. Measured on
-  // 5.0.9: `BEGIN;` is "line 1:5 mismatched input ';' expecting K_BATCH" and `COMMIT;`
-  // is "no viable alternative at input 'COMMIT'". The only grouping CQL has is
-  // `BEGIN BATCH ... APPLY BATCH`, which is not a transaction and takes no DDL, so
-  // there is nothing to translate the wrapper INTO - it can only be left out. The
-  // wrapper is still wrong for the other engines named in the module docstring; that
-  // stays tracked there, and unlike them Cassandra emits DDL this generator was taught
-  // to spell correctly, so the wrapper would be the only unrunnable line in it.
-  const wrapsInTransaction = dialect !== "sqlite" && dialect !== "libsql" && dialect !== "cassandra";
+  // with no `COMMIT;`. See NO_TRANSACTION_WRAPPER for why each excluded id is excluded.
+  const wrapsInTransaction = !NO_TRANSACTION_WRAPPER.has(dialect);
 
   if (wrapsInTransaction) {
     sections.push("BEGIN;");

--- a/tests/unit/schema-diff/migration-generator.test.ts
+++ b/tests/unit/schema-diff/migration-generator.test.ts
@@ -1164,6 +1164,49 @@ describe("generateMigrationSQL: duckdb", () => {
       instance.closeSync();
     }
   });
+
+  /*
+    The wrapper's half of the same measurement, and the reason `duckdb` reads `"wrapped"` in
+    TRANSACTION_WRAPPER_COVERAGE below while twelve other ids read `"unwrapped"` (#284).
+
+    Accepting `BEGIN;` and running a transaction are two different things, and only a pair of
+    arms tells them apart: the same generated `CREATE TABLE` is run twice, and the engine has
+    to forget it after the ROLLBACK arm and keep it after the COMMIT one. The lines executed
+    are the generator's own, sliced out of its output rather than typed again here, so a
+    generator that stopped emitting them would fail this test instead of quietly passing it.
+  */
+  test("the emitted BEGIN;/COMMIT; bracket a transaction the engine really runs", async () => {
+    const sql = generateMigrationSQL(makeAddedTableDiff(), "duckdb");
+
+    const wrapper = sql.split("\n").filter((line) => line === "BEGIN;" || line === "COMMIT;");
+    expect(wrapper).toEqual(["BEGIN;", "COMMIT;"]);
+    const [begin, commit] = wrapper;
+    // Only the table body: `run` takes one statement, and the trailing CREATE INDEX and the
+    // comment lines are not the subject here.
+    const createTable = sql.slice(sql.indexOf('CREATE TABLE "users"'), sql.indexOf("\n);") + 3);
+
+    const { DuckDBInstance } = await import("@duckdb/node-api");
+    const instance = await DuckDBInstance.create(":memory:");
+    const connection = await instance.connect();
+    const usersTables = async () =>
+      (
+        await connection.runAndReadAll("SELECT count(*) AS n FROM duckdb_tables() WHERE table_name = 'users'")
+      ).getRowObjectsJson();
+    try {
+      await connection.run(begin);
+      await connection.run(createTable);
+      await connection.run("ROLLBACK;");
+      expect(await usersTables()).toEqual([{ n: "0" }]);
+
+      await connection.run(begin);
+      await connection.run(createTable);
+      await connection.run(commit);
+      expect(await usersTables()).toEqual([{ n: "1" }]);
+    } finally {
+      connection.disconnectSync();
+      instance.closeSync();
+    }
+  });
 });
 
 describe("generateMigrationSQL: dialects that cannot modify a column", () => {
@@ -1200,9 +1243,10 @@ const TRANSACTION_WRAPPER_COVERAGE: Record<DatabaseType, "wrapped" | "unwrapped"
   postgres: "wrapped",
   mysql: "wrapped",
   // Measured live via @duckdb/node-api 1.5.5-r.4 (DuckDB v1.5.5, in-process, no server
-  // needed): `BEGIN;` / `BEGIN TRANSACTION;` both open a real transaction around DDL,
-  // and a `CREATE TABLE` issued inside one is undone by `ROLLBACK;` — pinned further in
-  // the "generateMigrationSQL: duckdb" describe block above.
+  // needed): `BEGIN;` opens a real transaction around DDL, so a `CREATE TABLE` issued
+  // inside one is undone by `ROLLBACK;` and kept by `COMMIT;`. Both arms are EXECUTED in
+  // the "generateMigrationSQL: duckdb" describe block above, which is where that
+  // measurement is pinned; this line only classifies it.
   duckdb: "wrapped",
   // UNCHANGED — see this table's own doc comment above.
   mssql: "wrapped",

--- a/tests/unit/schema-diff/migration-generator.test.ts
+++ b/tests/unit/schema-diff/migration-generator.test.ts
@@ -1181,6 +1181,65 @@ describe("generateMigrationSQL: dialects that cannot modify a column", () => {
   }
 });
 
+/**
+ * Exhaustive by construction, same spirit as `MODIFIED_COLUMN_COVERAGE` above: a new
+ * `DatabaseType` fails typecheck here until it is classified, so it cannot silently
+ * inherit the wrapper meant for PostgreSQL and MySQL (#284).
+ *
+ * `"wrapped"` — the dialect's DDL is bracketed in `BEGIN;` / `COMMIT;`.
+ * `"unwrapped"` — no wrapper reaches the migration text. mssql and oracle are
+ * deliberately absent from this table's classification of "unwrapped" — they still
+ * read `"wrapped"` here, UNCHANGED from today's behaviour, because the module
+ * docstring and the issue itself say their real wrapper forms (`BEGIN TRANSACTION;`
+ * for MSSQL; whether Oracle needs one at all, given DDL there auto-commits) want
+ * checking against a live server before they are settled, the way #264/#265 were -
+ * and this PR does not have one available. Tracked as the named follow-up rather than
+ * guessed here.
+ */
+const TRANSACTION_WRAPPER_COVERAGE: Record<DatabaseType, "wrapped" | "unwrapped"> = {
+  postgres: "wrapped",
+  mysql: "wrapped",
+  // Measured live via @duckdb/node-api 1.5.5-r.4 (DuckDB v1.5.5, in-process, no server
+  // needed): `BEGIN;` / `BEGIN TRANSACTION;` both open a real transaction around DDL,
+  // and a `CREATE TABLE` issued inside one is undone by `ROLLBACK;` — pinned further in
+  // the "generateMigrationSQL: duckdb" describe block above.
+  duckdb: "wrapped",
+  // UNCHANGED — see this table's own doc comment above.
+  mssql: "wrapped",
+  oracle: "wrapped",
+  sqlite: "unwrapped", // runs its own transaction (module docstring)
+  libsql: "unwrapped", // SQLite fork, same reasoning, plus its own Hrana-stream note (module docstring)
+  cassandra: "unwrapped", // CQL has no BEGIN/COMMIT — measured on 5.0.9 (module docstring)
+  // The remaining nine already have their non-SQL or no-DDL status established
+  // elsewhere in this same module (`NO_COLUMN_MODIFICATION`) or in `src/lib/sql/grammar.ts`
+  // (`NON_SQL_DIALECTS`) — this table applies that same established fact to the wrapper
+  // fallback rather than asserting it fresh, so none of these nine need a new live probe.
+  mongodb: "unwrapped", // not SQL text at all (`NON_SQL_DIALECTS`); wrapping non-SQL in SQL statements is wrong regardless of Mongo's own transaction API
+  redis: "unwrapped", // same: command-line grammar, not SQL (`NON_SQL_DIALECTS`)
+  libredb: "unwrapped", // "a JSON command grammar, not SQL DDL" (NO_COLUMN_MODIFICATION's own words)
+  couchbase: "unwrapped", // this generator never emits column DDL for it (NO_COLUMN_MODIFICATION, supportsCreateTable: false) — a wrapper would bracket only comments
+  druid: "unwrapped", // "Druid SQL has no ALTER TABLE" and no transaction concept (NO_COLUMN_MODIFICATION)
+  clickhouse: "unwrapped", // ClickHouse's transaction support is experimental and setting-gated, not a safe default; today's code wraps it anyway, which this fixes
+  elasticsearch: "unwrapped", // "Elasticsearch SQL reads only" (NO_COLUMN_MODIFICATION) — no DDL is ever emitted for it
+  opensearch: "unwrapped", // same (NO_COLUMN_MODIFICATION)
+  trino: "unwrapped", // connector-dependent at best; no portable BEGIN/COMMIT (NO_COLUMN_MODIFICATION)
+};
+
+describe("generateMigrationSQL: transaction wrapper by dialect", () => {
+  for (const [dialect, expected] of Object.entries(TRANSACTION_WRAPPER_COVERAGE)) {
+    test(`${dialect}: ${expected === "wrapped" ? "wraps DDL in BEGIN;/COMMIT;" : "emits no transaction wrapper"}`, () => {
+      const sql = generateMigrationSQL(makeModifiedTableDiff(), dialect as DatabaseType);
+      if (expected === "wrapped") {
+        expect(sql).toContain("BEGIN;");
+        expect(sql).toContain("COMMIT;");
+      } else {
+        expect(sql).not.toContain("BEGIN;");
+        expect(sql).not.toContain("COMMIT;");
+      }
+    });
+  }
+});
+
 // ============================================================================
 // Multi-table diff
 // ============================================================================

--- a/tests/unit/schema-diff/migration-generator.test.ts
+++ b/tests/unit/schema-diff/migration-generator.test.ts
@@ -1210,33 +1210,59 @@ const TRANSACTION_WRAPPER_COVERAGE: Record<DatabaseType, "wrapped" | "unwrapped"
   sqlite: "unwrapped", // runs its own transaction (module docstring)
   libsql: "unwrapped", // SQLite fork, same reasoning, plus its own Hrana-stream note (module docstring)
   cassandra: "unwrapped", // CQL has no BEGIN/COMMIT — measured on 5.0.9 (module docstring)
-  // The remaining nine already have their non-SQL or no-DDL status established
-  // elsewhere in this same module (`NO_COLUMN_MODIFICATION`) or in `src/lib/sql/grammar.ts`
-  // (`NON_SQL_DIALECTS`) — this table applies that same established fact to the wrapper
-  // fallback rather than asserting it fresh, so none of these nine need a new live probe.
+  // The remaining nine each have a recorded reason for having no `BEGIN;` to emit, in this
+  // same module (`NO_COLUMN_MODIFICATION`), in `src/lib/sql/grammar.ts` (`NON_SQL_DIALECTS`)
+  // or in the provider doc named on the line — this table applies those established facts to
+  // the wrapper fallback rather than asserting fresh ones, so none of the nine needs a new
+  // live probe. What none of them means is "the wrapper bracketed nothing": see the
+  // added-table fixture below.
   mongodb: "unwrapped", // not SQL text at all (`NON_SQL_DIALECTS`); wrapping non-SQL in SQL statements is wrong regardless of Mongo's own transaction API
   redis: "unwrapped", // same: command-line grammar, not SQL (`NON_SQL_DIALECTS`)
   libredb: "unwrapped", // "a JSON command grammar, not SQL DDL" (NO_COLUMN_MODIFICATION's own words)
-  couchbase: "unwrapped", // this generator never emits column DDL for it (NO_COLUMN_MODIFICATION, supportsCreateTable: false) — a wrapper would bracket only comments
-  druid: "unwrapped", // "Druid SQL has no ALTER TABLE" and no transaction concept (NO_COLUMN_MODIFICATION)
+  couchbase: "unwrapped", // has transactions, but spells them `BEGIN TRANSACTION` + a txid every later statement must carry — not something a flat file expresses (docs/providers/couchbase.md §13)
+  druid: "unwrapped", // "Druid SQL has no ALTER TABLE" and no transaction concept at all (NO_COLUMN_MODIFICATION)
   clickhouse: "unwrapped", // ClickHouse's transaction support is experimental and setting-gated, not a safe default; today's code wraps it anyway, which this fixes
-  elasticsearch: "unwrapped", // "Elasticsearch SQL reads only" (NO_COLUMN_MODIFICATION) — no DDL is ever emitted for it
-  opensearch: "unwrapped", // same (NO_COLUMN_MODIFICATION)
+  elasticsearch: "unwrapped", // `BEGIN` is not in the grammar (NO_COLUMN_MODIFICATION's measured statement list; docs/providers/elasticsearch.md §9)
+  opensearch: "unwrapped", // same, measured separately on OpenSearch 3.8.0 (docs/providers/opensearch.md §9)
   trino: "unwrapped", // connector-dependent at best; no portable BEGIN/COMMIT (NO_COLUMN_MODIFICATION)
 };
 
+/**
+ * Two fixtures, because one of them alone cannot see the thing that matters here.
+ *
+ * `generateMigrationSQL` reads NO provider capability — not `supportsCreateTable`, not
+ * anything else — so its added-table branch emits a real `CREATE TABLE` for every id
+ * except `cassandra`, which is the one the generator refuses outright
+ * (`CASSANDRA_NO_CREATE_TABLE`). A modified-table diff on an id in
+ * `NO_COLUMN_MODIFICATION` really does reduce to comments, so a table driven only by
+ * that fixture would let "this dialect never gets DDL, so the wrapper bracketed nothing"
+ * stand unchallenged. It is false: the wrapper this set removes was bracketing runnable
+ * DDL for those ids too, which is why removing it is a fix rather than a tidy-up.
+ */
+const WRAPPER_FIXTURES = [
+  { label: "a modified table", makeDiff: makeModifiedTableDiff, emitsCreateTable: false },
+  { label: "an added table", makeDiff: makeAddedTableDiff, emitsCreateTable: true },
+] as const;
+
 describe("generateMigrationSQL: transaction wrapper by dialect", () => {
   for (const [dialect, expected] of Object.entries(TRANSACTION_WRAPPER_COVERAGE)) {
-    test(`${dialect}: ${expected === "wrapped" ? "wraps DDL in BEGIN;/COMMIT;" : "emits no transaction wrapper"}`, () => {
-      const sql = generateMigrationSQL(makeModifiedTableDiff(), dialect as DatabaseType);
-      if (expected === "wrapped") {
-        expect(sql).toContain("BEGIN;");
-        expect(sql).toContain("COMMIT;");
-      } else {
-        expect(sql).not.toContain("BEGIN;");
-        expect(sql).not.toContain("COMMIT;");
-      }
-    });
+    for (const fixture of WRAPPER_FIXTURES) {
+      test(`${dialect}: ${expected === "wrapped" ? "wraps DDL in BEGIN;/COMMIT;" : "emits no transaction wrapper"} for ${fixture.label}`, () => {
+        const sql = generateMigrationSQL(fixture.makeDiff(), dialect as DatabaseType);
+        // Non-vacuity guard: on the added-table fixture the wrapper assertion below is
+        // about text that brackets a real statement, not an empty run of comments.
+        if (fixture.emitsCreateTable && dialect !== "cassandra") {
+          expect(sql).toMatch(/^CREATE TABLE /m);
+        }
+        if (expected === "wrapped") {
+          expect(sql).toContain("BEGIN;");
+          expect(sql).toContain("COMMIT;");
+        } else {
+          expect(sql).not.toContain("BEGIN;");
+          expect(sql).not.toContain("COMMIT;");
+        }
+      });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes the transaction-wrapper portion of #284 (refs #284 — partial fix; the ADD/DROP COLUMN scope remains open).

`buildMigration()` wraps every generated migration in `BEGIN;` / `COMMIT;` regardless of dialect. Several dialects (`couchbase`, `druid`, `elasticsearch`, `opensearch`) do not support transactional DDL, so the wrapper is omitted for them.

This is a follow-up to #521.

## Changes

- af9ce82 — `fix(schema-diff): stop wrapping non-transactional dialects in BEGIN;/COMMIT;`
  - Adds `NO_TRANSACTION_WRAPPER` handling to `src/lib/schema-diff/migration-generator.ts` (117 lines changed) so non-transactional dialects no longer emit `BEGIN;`/`COMMIT;`
  - Documents the behavior in `docs/ADDING_A_PROVIDER.md` and `docs/providers/clickhouse.md`
- dde09f9 — `fix(schema-diff): the wrapper was bracketing real DDL, not comments`
  - Corrects the #521 reasoning for couchbase/druid/elasticsearch/opensearch and adds a real `CREATE TABLE` diff fixture
  - Updates the type-id count to seventeen (`DatabaseType` gained `duckdb` in #516)

## Remaining scope (not in this PR)

The ADD/DROP COLUMN paths within #284 are still single-dialect and are intentionally left for follow-up.
