### PR TITLE
chore(distribution): AppImageHub is live

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -877,7 +877,7 @@ channels:
   - id: appimagehub
     name: AppImageHub catalog (appimage.github.io)
     short_name: AppImageHub
-    status: pending
+    status: live
     category: os-desktop
     platforms: [linux]
     runtime: channel_supplied
@@ -893,8 +893,10 @@ channels:
       docs: desktop/README.md
     pin:
       strategy: none
-      note: One line in the catalog's data/LibreDB_Studio naming this repository - their worker reads
-        the releases API, takes the first AppImage asset matching x64 and re-reads it on every
+      note: Live since 2026-08-30 - AppImage/appimage.github.io#3861 merged and the listing serves at
+        https://appimage.github.io/LibreDB_Studio/, linking the releases page rather than a frozen
+        asset URL. One line in the catalog's data/LibreDB_Studio names this repository - their
+        worker reads the releases API, takes the first AppImage asset matching x64 and re-reads it on every
         catalog rebuild, so no release bumps anything here and there is no served version to pin.
         What the listing depends on instead is the x64 AppImage staying startable for someone other
         than its builder - the review CI runs it under firejail --appimage on ubuntu-22.04 and fails

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -34,9 +34,9 @@ channel count.
 
 ## Coverage snapshot
 
-**33 channels · 25 live · 7 pending · 1 deprecated**
+**33 channels · 26 live · 6 pending · 1 deprecated**
 
-Live channels by platform: **Linux 7 · macOS 3 · Windows 4 · Container 4 · Kubernetes 2 · Cloud 10**
+Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · Kubernetes 2 · Cloud 10**
 
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
@@ -44,7 +44,7 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 4 · Container 4 · K
 | Containers | 2 | 0 | 0 |
 | Kubernetes & operators | 2 | 1 | 0 |
 | Package managers | 5 | 0 | 1 |
-| OS / desktop packages | 2 | 1 | 0 |
+| OS / desktop packages | 3 | 0 | 0 |
 | PaaS catalogs (listed) | 8 | 4 | 0 |
 | Deploy recipes | 3 | 0 | 0 |
 | Cloud marketplaces | 1 | 1 | 0 |
@@ -71,8 +71,8 @@ Live channels by platform: **Linux 7 · macOS 3 · Windows 4 · Container 4 · K
 | [winget](https://github.com/microsoft/winget-pkgs/tree/master/manifests/l/LibreDB/Studio) | Package managers | Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | Flathub | Package managers | Linux | deprecated | — | [packaging/flatpak/README.md](../packaging/flatpak/README.md) |
 | [Desktop app (AppImage, .deb)](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [desktop/README.md](../desktop/README.md) |
+| [AppImageHub](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Manual, on demand | [desktop/README.md](../desktop/README.md) |
 | [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [AppImageHub](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | pending | Manual, on demand | [desktop/README.md](../desktop/README.md) |
 | [CapRover official](https://github.com/caprover/one-click-apps) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/caprover/README.md](../deploy/caprover/README.md) |
 | [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
 | [Dokploy template catalog](https://templates.dokploy.com) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |

--- a/src/lib/distribution/channels.generated.ts
+++ b/src/lib/distribution/channels.generated.ts
@@ -42,6 +42,7 @@ export const LIVE_CHANNELS: readonly ShowcaseChannel[] = [
   { id: "winget", label: "winget", group: "packages" },
   { id: "chocolatey", label: "Chocolatey", group: "packages" },
   { id: "flatpark", label: "FlatPark (Flatpak)", group: "packages" },
+  { id: "appimagehub", label: "AppImageHub", group: "packages" },
 ];
 
 export const LIVE_PLATFORMS: readonly ShowcasePlatform[] = [


### PR DESCRIPTION
[AppImage/appimage.github.io#3861](https://github.com/AppImage/appimage.github.io/pull/3861) merged on 2026-08-30 and the listing is serving at https://appimage.github.io/LibreDB_Studio/ — it links the releases page, so the catalog's worker resolves the newest release carrying an x64 AppImage instead of freezing on one asset URL.

- `distribution/channels.yaml`: `appimagehub` status `pending` → `live`, merge recorded in the pin note.
- Regenerated derived surfaces: `docs/CHANNELS.md` coverage matrix (33 channels · 26 live · 6 pending · 1 deprecated; Linux 7 → 8) and `src/lib/distribution/channels.generated.ts`, which is what the login page renders.

Gates: format, lint, typecheck, knip, build, `distribution-check --check --matrix`, `channels:showcase:check`, `readme-check` all pass. `bun run test` has 3 pre-existing local-only reds (dbstat under the newer local bun; a backlog-citation test reading gitignored `docs/superpowers/`) — identical on clean HEAD, invisible to CI.