### PR TITLE
feat(agent): three models reach 30/30, and the five refusals that were hiding the way

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting sixteen engines - PostgreSQL, MySQL, SQLite, DuckDB, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
 type: application
-version: 0.1.56
+version: 0.1.57
 appVersion: "0.13.6"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -46,6 +46,13 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
+  # False: 0.1.57 changes only what a DEFAULT install renders, and only on Helm 4.2+.
+  # `authCookieSecure: null` in values.yaml stayed nil under Helm 4.1 and is coerced to ""
+  # under 4.2, which passed the template's `kindIs "invalid"` guard and wrote
+  # AUTH_COOKIE_SECURE: "" into the ConfigMap of an install that configured nothing. The app
+  # reads an empty value as unset, so no cookie behaviour changed on any install - what
+  # changed is that the ConfigMap stopped carrying a key nobody set, which an operator
+  # reading it takes as a decision somebody made. Explicit `true`/`false` are untouched.
   # False: 0.1.56 tracks app release 0.13.6, which removes a claim rather than fixing a
   # weakness. The sign-in page carried an "Encrypted" badge that named no subject; on the
   # default STORAGE_PROVIDER=local it had no referent beyond the TLS the browser already

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.56 \
+  --version 0.1.57 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/charts/libredb-studio/templates/configmap.yaml
+++ b/charts/libredb-studio/templates/configmap.yaml
@@ -24,9 +24,19 @@ data:
          over plain http). `false` is the operator's answer for a browser reaching a
          non-loopback host over plain http, where a Secure cookie is rejected and login
          silently loops. kindIs "invalid" rather than truthiness, because `false` is the
-         value that matters most here and an `if` would drop it. */}}
-  {{- if not (kindIs "invalid" (get .Values.config "authCookieSecure")) }}
-  AUTH_COOKIE_SECURE: {{ get .Values.config "authCookieSecure" | quote }}
+         value that matters most here and an `if` would drop it.
+
+         The empty string is tested BESIDE nil because the two spellings of "unset" are
+         not the same across Helm versions: 4.1 leaves the `authCookieSecure: null` in
+         values.yaml as nil, and 4.2 coerces it to "", which passes `kindIs "invalid"`
+         and writes `AUTH_COOKIE_SECURE: ""` on a default install. The app reads that
+         back as unset, so nothing about the cookie changed — but the ConfigMap then
+         carries a key nobody set, which an operator reading it takes as a decision
+         somebody made. `--set config.authCookieSecure=null` still produced a true nil
+         on both, which is why only the default install broke and only on 4.2. */}}
+  {{- $cookieSecure := get .Values.config "authCookieSecure" }}
+  {{- if and (not (kindIs "invalid" $cookieSecure)) (ne (toString $cookieSecure) "") }}
+  AUTH_COOKIE_SECURE: {{ $cookieSecure | quote }}
   {{- end }}
   STORAGE_PROVIDER: {{ include "libredb-studio.storageProvider" . | quote }}
   {{- if eq (include "libredb-studio.storageProvider" .) "sqlite" }}

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -751,7 +751,7 @@ actually records** (gauges built in `timeline.ts`):
 | --- | --- | --- |
 | **Statements** | `used / 30` on an investigation | `maxStatementsPerRun`. Every statement the pipeline allowed and invoked — catalog reads, drafts and repairs alike |
 | **Database time** | `used / 90.0 s` on an investigation | `maxTotalRunMs`. **Database time only** — the elapsed time completed reads reported, not the wall clock |
-| **Repair attempts** | `used / 3` | `AGENT_MAX_REPAIR_ATTEMPTS`. Only statements that failed **at the database** consume one; a policy denial does not |
+| **Repair attempts** | `used / 3` | `AGENT_MAX_REPAIR_ATTEMPTS`. Only a statement that failed **at the database in a way this server could not answer** consumes one. A policy denial does not, and neither does a failure the server answered by naming the columns that do exist — the next statement there applies a correction this server dictated rather than another guess. A row-budget overrun **does** consume one: that statement ran to completion and returned rows, and making it cheaper is a rewrite. Either way the statement is never re-sent |
 
 Under them, three ⓘ controls carry the claims that qualify those figures — **What is counted**,
 **Ceilings** and **Report reserve** — each on the figure it is about, each opening the same sentence

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,20 +8,21 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Fifteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
-Operate, Analyze and Plan — five consecutive times: 450 runs, 450 passes.
+**Eighteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+Operate, Analyze and Plan — five consecutive times: 540 runs, 540 passes.
 
-Ten of the fifteen cleared them at the 90-second per-turn limit the product ships. Five carry a
+Twelve of the eighteen cleared them at the 90-second per-turn limit the product ships. Six carry a
 150-second limit of their own — `qwen3.5:9b`, `gemma4:12b`, `nemotron-3.5-lightning:30b`,
-`muse-glimmer:latest` and `qwen3.6:27b` — because one turn of theirs does not fit inside 90 while
-every other surface does. The limit stays 90 for every other model, and each page says what its
-model needed.
+`nemotron-3-nano:30b`, `muse-glimmer:latest` and `qwen3.6:27b` — because one turn of theirs does
+not fit inside 90 while every other surface does. The limit stays 90 for every other model, and
+each page says what its model needed.
 
 | Model | Served through | Disk | Median run | Slowest run |
 | --- | --- | --- | --- | --- |
 | [`gemini-3.5-flash-lite`](gemini/gemini-3.5.md) | Gemini API | — | 10s | 21s |
 | [`gemma4:12b`](gemma/gemma4.md) | Ollama | 7.6 GB | 11s | 63s |
 | [`granite4.1:8b`](granite/granite4.1.md) | Ollama | 5.3 GB | 11s | 22s |
+| [`qwen3.5:4b`](qwen/qwen3.5.md) | Ollama | 3.4 GB | 11s | 167s |
 | [`granite4.1:30b`](granite/granite4.1.md) | Ollama | 17 GB | 26s | 52s |
 | [`nemotron3:33b`](nvidia/nemotron3.md) | Ollama | 27 GB | 21s | 119s |
 | [`nemotron-3.5-lightning:30b`](nvidia/nemotron-3.5-lightning.md) | Ollama | 25 GB | 29s | 145s |
@@ -30,6 +31,8 @@ model needed.
 | [`gemma4:26b`](gemma/gemma4.md) | Ollama | 16 GB | 36s | 92s |
 | [`qwen3:8b`](qwen/qwen3.md) | Ollama | 5.2 GB | 36s | 108s |
 | [`qwen3:14b`](qwen/qwen3.md) | Ollama | 9.3 GB | 41s | 303s |
+| [`granite4.2:8b`](granite/granite4.2.md) | Ollama | 5.3 GB | 46s | 116s |
+| [`nemotron-3-nano:30b`](nvidia/nemotron-3-nano.md) | Ollama | 24 GB | 46s | 190s |
 | [`qwen3:4b`](qwen/qwen3.md) | Ollama | 2.5 GB | 72s | 160s |
 | [`qwen3.8:latest`](qwen/qwen3.8.md) | Ollama | 19 GB | 72s | 195s |
 | [`qwen3.6:27b`](qwen/qwen3.6.md) | Ollama | 17 GB | 82s | 252s |
@@ -37,7 +40,7 @@ model needed.
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these fifteen — the fastest reaches the same verdicts as the slowest in a
+for is choosing between these eighteen — the fastest reaches the same verdicts as the slowest in a
 twelfth of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a

--- a/docs/llms/granite/granite4.2.md
+++ b/docs/llms/granite/granite4.2.md
@@ -1,0 +1,42 @@
+# granite4.2
+
+`ollama pull granite4.2:<size>` · sizes supported: 8b
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
+runs. It carries no settings at all — the second model measured to need none.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **8b** | 5.3 GB | 28s | 1:12 | 1:29 | 19s | 45s | 33s | **46s** | 1:56 |
+
+Every cell is 5/5, so the table says how long rather than whether.
+
+Slower than `granite4.1:8b` on the same disk footprint — four times the median — and it is the
+same six verdicts at the end. Take 4.1 unless you have a reason to prefer this one.
+
+## What it needs that the defaults do not give it
+
+### `granite4.2:8b`
+
+Nothing. Measured at the defaults — temperature 0, top_p 1, a ceiling of twelve unreported calls,
+the shipped 90-second turn limit — and it clears every surface on them.
+
+It still has an entry in the measurement document, and that is deliberate: an absent entry records
+no measurement rather than a measurement that found nothing to change, and a model nobody can see
+was measured is a model nobody can trust.
+
+## Where it is thin
+
+**Assess re-read 4/5 on a second sitting**, having locked at 5/5 on the first. The loss was a
+report the run never composed, not a wrong answer. Both readings are on record and the cell is
+counted as passing; a figure that reads steadier than the model is worse than one that says where
+it is thin.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/model-tuning.md
+++ b/docs/llms/model-tuning.md
@@ -115,9 +115,11 @@ Every one is optional. What you do not state resolves to the compiled default in
 | `reportReminderLimit` | integer 0–5 | how many times a turn with no call and no report may be answered with the report reminder | `1` |
 | `planStatementRetries` | integer 0–5 | extra turns a PLAN run gets when its prose named neither a statement nor a refusal | `0` |
 | `presentReminderLimit` | integer 0–5 | how many times a report may be held to ask for the answer that belongs beside it | `1` |
+| `verdictHoldLimit` | integer 0–5 | how many times a report whose own verdict would REJECT it may be held and told why — the third of the reminder bounds. A run about to pass never reaches this hold, so raising it costs turns only on a run that has already lost | `2` |
 | `retryEmptyTurn` | boolean | whether a turn that came back EMPTY is asked once more before the run is ended | `false` |
 | `retryUnreadStop` | boolean | whether a run that stopped having CALLED NOTHING is told once to read the database itself, instead of being ended — it subsumes `retryEmptyTurn`, since the gate asks what was called and not what was said | `false` |
 | `suppressPlanReasoning` | boolean | whether this model's PLAN turn asks the endpoint for no reasoning at all — reaches the OpenAI-compatible adapter only (`openai`, `ollama`, `custom`), so it is a no-op on `gemini` | `false` |
+| `suppressAgentReasoning` | boolean | the same, for this model's AGENT turns — for a model that either answers at once or thinks until the wall, which `turnTimeoutMs` does not address because a turn spent thinking finds the new wall too. Same adapters, same no-op on `gemini` | `false` |
 | `refusalExamples` | boolean | whether a refused call is handed a worked example built from this run's ledger | `false` |
 | `turnTimeoutMs` | integer 1000–179999 | how long ONE turn of this model may take, where the product's own limit does not fit it | the product's limit |
 | `threadContextMaxChars` | integer 200–32000 | how much of a CONVERSATION this model may be handed — the earlier steps' objectives and the most recent step's report, when a follow-up continues a previous run | the product's budget (4000) |

--- a/docs/llms/nvidia/nemotron-3-nano.md
+++ b/docs/llms/nvidia/nemotron-3-nano.md
@@ -1,0 +1,40 @@
+# nemotron-3-nano
+
+`ollama pull nemotron-3-nano:<size>` · sizes supported: 30b
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+Five of the six locked on the first reading at the shipped defaults; the sixth needed the clock
+moved, and the note below says what that cost.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| nemotron-3-nano:30b | 24 GB | 11s | 2:08 | 51s | 32s | 1:22 | 33s | **46s** | 3:10 |
+
+Every cell is 5/5, so the table says how long rather than whether.
+
+Investigate at eleven seconds against optimize at over two minutes is the widest spread any
+supported model shows. What it costs is wall-clock on one surface, not a verdict on any of them.
+
+## What it needs that the defaults do not give it
+
+### `nemotron-3-nano:30b`
+
+**a 150-second turn limit.** Five surfaces clear the shipped 90 seconds — 11s, 51s, 32s, 1:22 and
+33s against the limit — and query-optimization does not: at 90 the cell read 3/5, and both losses
+were `model-timeout` with tools already invoked. A turn that never finished, rather than an answer
+that was wrong.
+
+The value is the one `qwen3.5:9b` and `nemotron-3.5-lightning:30b` already carry for the same
+shape rather than a new number, and it is the product's ceiling: nothing here exceeds what Studio
+already ships for a model that needs longer turns. One setting, because one is what it was
+measured needing — everything else is the compiled default, and a setting a model did not earn is
+a guess.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/qwen/qwen3.5.md
+++ b/docs/llms/qwen/qwen3.5.md
@@ -1,8 +1,8 @@
 # qwen3.5
 
-`ollama pull qwen3.5:<size>` · sizes supported: 9b
+`ollama pull qwen3.5:<size>` · sizes supported: 4b, 9b
 
-The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
+Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
 runs.
 
 ## What it does, and how long it takes
@@ -11,11 +11,34 @@ Seconds are the median of the runs that passed, per surface.
 
 | Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| qwen3.5:9b | 5.8 GB | 31s | 31s | 52s | 21s | 26s | 1:38 | **33s** | 1:38 |
+| **4b** | 3.4 GB | 5s | 41s | 21s | 7s | 34s | 1s | **11s** | 2:47 |
+| **9b** | 5.8 GB | 31s | 31s | 52s | 21s | 26s | 1:38 | **33s** | 1:38 |
 
 Every cell is 5/5, so the table says how long rather than whether.
 
+The 4b is three times the 9b's speed at two thirds of its disk, which is not the direction size
+usually runs. Its tail is the price: 2:47 against the 9b's 1:38.
+
 ## What it needs that the defaults do not give it
+
+### `qwen3.5:4b`
+
+**no reasoning on the plan turn.** Its plan turns timed out on every run with an empty ledger —
+nothing called, nothing said. Suppressing the reasoning request finished the turns and moved the
+cell 0/5 to 1/5. It reaches the OpenAI-compatible adapter only, so it is a no-op on `gemini`.
+
+The other four losses were not the model's, and this is the only cell in the product closed by
+fixing Studio's own wording. It had been writing correct refusals — naming the views whose columns
+the inventory cannot derive, then asking the one question that would unblock it — and opening every
+one with `NO STATEMENT AT ALL:`, which is the phrase the planning rule itself put in front of the
+marker it was teaching. The rule now says it once, and the cell read 5/5 on the first pass after.
+
+## Where it is thin
+
+**The 4b's data-analysis re-read 3/5 on a second sitting**, having locked at 5/5 on the first. The
+cell has locked repeatedly and is counted as passing; both readings are on record, because a figure
+that reads steadier than the model is worse than one that says where it is thin. If you drive this
+size on data-analysis, expect it to need a second attempt more often than the table's 11s suggests.
 
 ### `qwen3.5:9b`
 

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting sixteen engines - PostgreSQL, MySQL, SQLite, DuckDB, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
 type: application
-version: 0.1.56
+version: 0.1.57
 appVersion: "0.13.6"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -46,6 +46,13 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
+  # False: 0.1.57 changes only what a DEFAULT install renders, and only on Helm 4.2+.
+  # `authCookieSecure: null` in values.yaml stayed nil under Helm 4.1 and is coerced to ""
+  # under 4.2, which passed the template's `kindIs "invalid"` guard and wrote
+  # AUTH_COOKIE_SECURE: "" into the ConfigMap of an install that configured nothing. The app
+  # reads an empty value as unset, so no cookie behaviour changed on any install - what
+  # changed is that the ConfigMap stopped carrying a key nobody set, which an operator
+  # reading it takes as a decision somebody made. Explicit `true`/`false` are untouched.
   # False: 0.1.56 tracks app release 0.13.6, which removes a claim rather than fixing a
   # weakness. The sign-in page carried an "Encrypted" badge that named no subject; on the
   # default STORAGE_PROVIDER=local it had no referent beyond the TLS the browser already

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.56 \
+  --version 0.1.57 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/operator/helm-charts/libredb-studio/templates/configmap.yaml
+++ b/operator/helm-charts/libredb-studio/templates/configmap.yaml
@@ -24,9 +24,19 @@ data:
          over plain http). `false` is the operator's answer for a browser reaching a
          non-loopback host over plain http, where a Secure cookie is rejected and login
          silently loops. kindIs "invalid" rather than truthiness, because `false` is the
-         value that matters most here and an `if` would drop it. */}}
-  {{- if not (kindIs "invalid" (get .Values.config "authCookieSecure")) }}
-  AUTH_COOKIE_SECURE: {{ get .Values.config "authCookieSecure" | quote }}
+         value that matters most here and an `if` would drop it.
+
+         The empty string is tested BESIDE nil because the two spellings of "unset" are
+         not the same across Helm versions: 4.1 leaves the `authCookieSecure: null` in
+         values.yaml as nil, and 4.2 coerces it to "", which passes `kindIs "invalid"`
+         and writes `AUTH_COOKIE_SECURE: ""` on a default install. The app reads that
+         back as unset, so nothing about the cookie changed — but the ConfigMap then
+         carries a key nobody set, which an operator reading it takes as a decision
+         somebody made. `--set config.authCookieSecure=null` still produced a true nil
+         on both, which is why only the default install broke and only on 4.2. */}}
+  {{- $cookieSecure := get .Values.config "authCookieSecure" }}
+  {{- if and (not (kindIs "invalid" $cookieSecure)) (ne (toString $cookieSecure) "") }}
+  AUTH_COOKIE_SECURE: {{ $cookieSecure | quote }}
   {{- end }}
   STORAGE_PROVIDER: {{ include "libredb-studio.storageProvider" . | quote }}
   {{- if eq (include "libredb-studio.storageProvider" .) "sqlite" }}

--- a/scripts/agent-model-e2e.sh
+++ b/scripts/agent-model-e2e.sh
@@ -35,8 +35,16 @@ export PWSLOWMO="${PWSLOWMO:-350}"
 # the second grep found no file, and the server came up with no model at all — measuring an empty
 # configuration while looking like it measured Gemini. Fetch it from the main checkout instead of
 # assuming it is here.
-if [ ! -f .env.gemini.local ] && [ -f /Users/yusuf/projects/libredb/libredb-studio/.env.gemini.local ]; then
-  cp /Users/yusuf/projects/libredb/libredb-studio/.env.gemini.local .env.gemini.local
+#
+# The checkout is DERIVED, not named. This guard first shipped with one machine's absolute home
+# path in it, which meant the `-f` test simply failed everywhere else — reinstating, for every
+# environment but its author's, the exact silent-empty-configuration bug the guard exists to
+# prevent. `--git-common-dir` resolves to the primary checkout's `.git` from inside a worktree, so
+# its parent is the checkout git itself considers primary; `LIBREDB_MAIN_CHECKOUT` overrides it for
+# a layout git cannot derive.
+MAIN_CHECKOUT="${LIBREDB_MAIN_CHECKOUT:-$(cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)}"
+if [ ! -f .env.gemini.local ] && [ -f "$MAIN_CHECKOUT/.env.gemini.local" ]; then
+  cp "$MAIN_CHECKOUT/.env.gemini.local" .env.gemini.local
 fi
 
 # The settings a model was MEASURED with, when an operator document is holding them.
@@ -77,6 +85,15 @@ do
   [ -n "$PREVIOUS" ] && ollama stop "$PREVIOUS" >/dev/null 2>&1
 
   if [ "$MODEL" = "gemini-3.5-flash-lite" ]; then
+    # Loud rather than silent. With no file the append below contributes nothing, the server boots
+    # with no model configured, and the sweep reports a measurement of an empty configuration — the
+    # failure the fetch above exists to prevent. A sweep that cannot configure a model has to stop.
+    if [ ! -f .env.gemini.local ]; then
+      echo "!!!! .env.gemini.local not found here or in $MAIN_CHECKOUT." >&2
+      echo "!!!! Put the file in the checkout, or set LIBREDB_MAIN_CHECKOUT to where it lives." >&2
+      echo "!!!! Refusing to measure a server with no model configured." >&2
+      exit 1
+    fi
     # The hosted one: provider, key and model all change together, so its own file is swapped in
     # whole rather than one line being rewritten.
     grep -vE '^(LLM_PROVIDER|LLM_MODEL|LLM_API_KEY|LLM_API_URL)=' "$BACKUP" > .env.local

--- a/scripts/agent-model-e2e.sh
+++ b/scripts/agent-model-e2e.sh
@@ -19,7 +19,7 @@ MODELS=("$@")
 if [ ${#MODELS[@]} -eq 0 ]; then
   # Fastest first, so the run reports something early, and the hosted model last because it needs
   # its own environment file swapped in rather than a line rewritten.
-  MODELS=(granite4.1:8b granite4.1:30b ornith:9b qwen3.5:9b qwen3:8b gemma4:26b qwen3:14b nemotron3:33b qwen3.8:latest qwen3:4b gemini-3.5-flash-lite)
+  MODELS=(granite4.1:8b granite4.2:8b granite4.1:30b ornith:9b qwen3.5:9b qwen3:8b gemma4:12b gemma4:26b qwen3:14b nemotron3:33b nemotron-3.5-lightning:30b nemotron-3-nano:30b qwen3.6:27b qwen3.8:latest muse-glimmer:latest qwen3:4b gemini-3.5-flash-lite)
 fi
 
 # Watchable by default: the browser opens on screen and every click is visible, and a video of
@@ -29,6 +29,33 @@ HEADED="${HEADED:---headed}"
 # window opens and closes before anything is readable; this puts a beat between actions so the
 # login, the connection, the objective and the run itself are all visible.
 export PWSLOWMO="${PWSLOWMO:-350}"
+
+# The hosted model's key lives outside the repo and is NOT copied into a worktree by git. A sweep
+# run from a worktree silently lost it once: the swap step stripped the LLM lines from .env.local,
+# the second grep found no file, and the server came up with no model at all — measuring an empty
+# configuration while looking like it measured Gemini. Fetch it from the main checkout instead of
+# assuming it is here.
+if [ ! -f .env.gemini.local ] && [ -f /Users/yusuf/projects/libredb/libredb-studio/.env.gemini.local ]; then
+  cp /Users/yusuf/projects/libredb/libredb-studio/.env.gemini.local .env.gemini.local
+fi
+
+# The settings a model was MEASURED with, when an operator document is holding them.
+#
+# Without this the sweep drives every model naked, and a model whose lock depends on a per-model
+# setting fails here while passing everywhere else. `qwen3.5:4b` is the case that found it: 30/30
+# through the API with `suppressPlanReasoning`, and its plan test failed in the browser because
+# this script never loaded the document that setting lives in. The failure looked like the model's
+# and was the harness's.
+#
+# Deliberately only when the caller set it. A sweep of what SHIPS should see the shipped document
+# and nothing else, which is what an unset variable gives; exporting a default here would quietly
+# measure somebody's working notes and call it a release check.
+if [ -n "${AGENT_MODEL_TUNING_PATH:-}" ]; then
+  export AGENT_MODEL_TUNING_PATH
+  echo "@@@@ operator tuning: $AGENT_MODEL_TUNING_PATH"
+else
+  echo "@@@@ operator tuning: none — measuring the shipped document"
+fi
 
 BACKUP=$(mktemp)
 cp .env.local "$BACKUP"

--- a/src/lib/agent/context-snapshot.ts
+++ b/src/lib/agent/context-snapshot.ts
@@ -396,8 +396,8 @@ function fingerprintTables(tables: readonly TableSchema[]): string {
  * code alone says "somebody said no" where the numbers say "narrow the capture".
  *
  * Anchored on the whole phrase, so the `200` in the advice sentence the tool layer
- * appends ("add LIMIT 200") cannot be mistaken for a measurement. `statementAdvice` in
- * `tools.ts` reads the same message with the same anchor; the duplication is deliberate
+ * appends ("add LIMIT 200") cannot be mistaken for a measurement. `otherStatementAdvice`
+ * in `tools.ts` reads the same message with the same anchor; the duplication is deliberate
  * rather than shared, because the two answer different questions — one composes advice
  * for a model, the other records a fact — and either may be given a different source.
  *

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -62,6 +62,7 @@ import { BASELINE_NOTICES } from "./models/notices";
 import {
   ceilingFor,
   presentReminderLimitFor,
+  verdictHoldLimitFor,
   retriesEmptyTurn,
   retriesUnreadStop,
   suppressesAgentReasoning,
@@ -903,8 +904,23 @@ const PLANNING_TOOLLESS_RULE =
  * success against a verifier that accepted any non-empty prose; saying only "write a
  * statement" leaves a model that cannot write one to fall back on precisely that.
  */
+/*
+  ONE spelling of the refusal, and the sentence introducing it must not read as a second one.
+
+  This said "write NO STATEMENT AT ALL: begin a line with `NO STATEMENT:`" — English, a colon, and
+  then the literal introduced the same way one clause later. Measured on `qwen3.5:4b`, whose plan
+  cell read 1/5 across five attempts with every loss `no-statement`: its refusals were correct in
+  substance, naming the two tables whose columns the inventory could not derive and asking the one
+  question that would have unblocked it, and every one of them opened `NO STATEMENT AT ALL:`.
+
+  The model did not misread the rule. It read the first colon-terminated phrase as the marker,
+  which is what the sentence made it look like, and was then scored as having answered nothing for
+  obeying us. Fixed in the WORDING rather than by widening the reader: a tolerant reader would
+  accept this one spelling and leave the sentence that produced it in place for the next model to
+  invent a different one from.
+*/
 const PLANNING_NO_STATEMENT_RULE = [
-  `If what you were given does not support the objective, write NO STATEMENT AT ALL: begin a line with \`${PLAN_NO_STATEMENT_MARKER}\`, say exactly what is missing, and then ask the ONE question that would let you write it.`,
+  `If what you were given does not support the objective, do not write a statement: begin a line with \`${PLAN_NO_STATEMENT_MARKER}\`, say exactly what is missing, and then ask the ONE question that would let you write it.`,
   "That is a complete answer here, and it is expected whenever the inventory does not reach the objective.",
   "A general inspection plan is not an answer here: a plan that would read identically against any database in the world says nothing about this one.",
 ].join(" ");
@@ -2085,28 +2101,26 @@ interface ModelTurn {
   STOPS talking, and a model reading itself out of budget never stops.
 */
 
-/**
- * How many times a report may be held for the verdict it would earn before it is let through.
- *
- * Was once, and five repeats on three models say once is not enough. `qwen3:8b`, `qwen3:14b`
- * and another lose `database-assessment` 5 times out of 5, and every ledger has the same
- * shape: the notice fires, the run is narrowed to the two tools its verdict accepts, and the
- * model reports again anyway. Fifteen consecutive losses is not variance.
- *
- * TWO, not three, and the difference was measured in the eval scripts rather than reasoned
- * about: at three, a run that will not comply pays three wasted turns before its report is
- * allowed through, and the gate evals had to be extended twice to see it. Two changes the
- * behaviour the ledgers complain about — a model that ignored one ask gets a second — at half
- * the cost to a model that will never comply.
- *
- * The bound is also what separates this from the repeated-ask on SILENCE reverted
- * earlier today. That one sat on a path every run passes through, and eighteen tests failed
- * because every run gained two turns. This fires only where a report is being submitted that
- * its own verdict would reject — a run that is already losing — so a run about to pass cannot
- * reach it at all. What an uncooperative model pays is two extra turns before the same
- * verdict it was going to get.
- */
-const AGENT_VERDICT_HOLD_LIMIT = 2;
+/*
+  How many times a report may be held for the verdict it would earn is per-model now, and the
+  number lives with the other two reminder bounds in `models/profile.ts`.
+
+  It was a constant here. Its history is worth keeping where the mechanism is: it was once, and
+  five repeats on three models said once was not enough — `qwen3:8b`, `qwen3:14b` and another
+  lose `database-assessment` 5 times out of 5, every ledger the same shape, the notice firing,
+  the run narrowed to the two tools its verdict accepts, and the model reporting again anyway.
+  Fifteen consecutive losses is not variance.
+
+  Two rather than three was measured in the eval scripts: at three a run that will not comply
+  pays three wasted turns before its report is allowed through. That reasoning is about the
+  DEFAULT and it still holds, so `DEFAULT_VERDICT_HOLD_LIMIT` is two. What it never covered is a
+  model measured recovering on the third, and a constant answered that model as though it were
+  one that will never comply. `verdictHoldLimitFor` tells them apart.
+
+  The safety argument is unchanged and belongs to the mechanism rather than the number: this
+  fires only where a report is being submitted that its own verdict would reject — a run that is
+  already losing — so a run about to pass cannot reach it at all.
+*/
 
 /**
  * What a narrowed run keeps BESIDES `compose_report`: whatever its own verdict requires.
@@ -3523,7 +3537,7 @@ export async function runInvestigation(
           it would have been given cannot be acted on, and the run has more to show with the
           report than without it.
         */
-        if (call.toolName === "compose_report" && previewHolds < AGENT_VERDICT_HOLD_LIMIT && !noTimeToHold) {
+        if (call.toolName === "compose_report" && previewHolds < verdictHoldLimitFor(model.modelId) && !noTimeToHold) {
           const { record: sofar } = await service.resume(context.runId);
           const would = shortfallsIfReported(record, sofar.events, previewClaims(call.input));
           // A name from the inventory the run was handed, so the notice can point at a real

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -12,6 +12,7 @@
       "reportReminderLimit": 1,
       "planStatementRetries": 0,
       "presentReminderLimit": 1,
+      "verdictHoldLimit": 2,
       "retryEmptyTurn": false,
       "retryUnreadStop": false,
       "suppressPlanReasoning": false,
@@ -155,6 +156,25 @@
       }
     },
     {
+      "id": "granite4.2:8b",
+      "measured": "6/6 modes locked, 30/30 runs passed at the compiled defaults, and no setting was needed for any of them. Investigate 34s · Optimize 67s · Assess 140s · Operate 26s · Analyze 37s · Plan 33s (medians of the passing runs). It is the only model measured on this machine that closed every surface on its first reading with nothing carried over, which is why the entry states the defaults rather than omitting the model: an absent entry records no measurement, and this one is the measurement. Its database-assessment cell is the thin one and a later sweep says so: re-read on a second sitting it came back 4/5, one run lost to the clock against a 140-second median that is the slowest assess cell here. That is the shape gemma4:12b and qwen3.6:27b both recorded on the same surface and both re-read clean, and it is written down rather than smoothed away.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      },
+      "rationale": {}
+    },
+    {
       "id": "muse-glimmer:latest",
       "measured": "6/6 locked, 30/30, and every cell read in ONE pass under the settings recorded here rather than carried over from the passes that found them - investigate 103s, optimize 191s, assess 167s, operate 80s, analyze 115s, plan 17s (medians of the passing runs; slowest run 285s). The slowest model measured here by a wide margin. Before these settings it was 3/6 at 23/30: plan 0/5, investigate 4/5, assess 4/5. Every one of those losses was the clock - plan timed out at exactly 90 seconds five times over with no tool invoked, and the two single losses timed out at 159s and 160s against passes at 102-116 and 141-163. One run of the confirmation pass died model-unavailable, which is a serving outage and not a verdict; that cell was re-read clean rather than scored over it.",
       "settings": {
@@ -184,6 +204,31 @@
         "reportReminderLimit": [
           "With the clock no longer the constraint, assess still lost one run, and to a different failure: model-stopped with unmet=no-report at 105s having called fourteen tools, where the timeout losses used to run past 160s.",
           "A run holding fourteen readings that files none of them took its one reminder and stopped again, which is the distinction between a model that forgot and one that stops as its habit."
+        ]
+      }
+    },
+    {
+      "id": "nemotron-3-nano:30b",
+      "measured": "6/6 modes locked, 30/30 runs passed with turnTimeoutMs at 150000. Five surfaces cleared the shipped 90-second turn on the first reading and untouched; query-optimization read 3/5 there, both losses model-timeout at 147s and 90s, and the raised limit took the cell.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false,
+        "turnTimeoutMs": 150000
+      },
+      "rationale": {
+        "turnTimeoutMs": [
+          "One cell of six, and only the clock. Five surfaces clear the shipped 90 seconds untouched; query-optimization read 3/5 there and both losses were model-timeout - 147s and 90s - against passes that finish well inside the limit. A turn cut off mid-work is not an answer the verdict rejected.",
+          "150000 is the value qwen3.5:9b and nemotron-3.5-lightning:30b already carry for the same shape rather than a new number, and it is the ceiling the eval protocol was measured against. The default stays 90 for every other model: it is a promise about how long a person waits, not a fact about any model."
         ]
       }
     },
@@ -263,6 +308,31 @@
         "planStatementRetries": [
           "Its last open cell, and the loss is `no-statement` twice over.",
           "The closing prose is not a bad plan — it names all eight tables, their columns and their keys, correctly. What it never writes is a runnable statement or the explicit `NO STATEMENT:` refusal, and plan mode's bar is one of those two. `qwen3:14b` lost the same cell the same way and the extra turn won it."
+        ]
+      }
+    },
+    {
+      "id": "qwen3.5:4b",
+      "measured": "6/6 locked, 30/30. Five surfaces cleared at the shipped defaults and were never touched; plan was the whole of the work and took two separate fixes. At the defaults its plan turns ended model-timeout with a zero-event ledger - the turn spent thinking, and plan mode holds no tools, so thinking time is the only thing that can fail. suppressPlanReasoning turned every one of those into a finished turn and the cell moved 0/5 to 1/5. The remaining four losses were not settings at all: the run wrote a correct refusal, naming the two views whose columns the inventory cannot derive and asking the one question that would unblock it, and opened it `NO STATEMENT AT ALL:` - a phrase this product's own planning rule put in front of the marker it was teaching. With that wording corrected the cell read 5/5 on its first pass. LOCKED but MARGINAL on data-analysis, and a later sweep is why that is written here: the same cell re-read 3/5 on a second sitting, its two losses `answer-uncited` and `no-answer`. The passing runs answer in two or three tool calls and the losing ones wander to ten and eleven, so the cell turns on whether the run settles early rather than on any setting. Recorded rather than re-measured away, because a figure that reads steadier than the model is worse than one that says where it is thin.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": true,
+        "refusalExamples": false
+      },
+      "rationale": {
+        "suppressPlanReasoning": [
+          "Its plan cell was 0/5 and every loss was the same run: model-timeout at the turn limit with an empty ledger, no tool invoked, unmet=no-plan. Plan mode has no tools, so a turn that produces nothing spent itself thinking.",
+          "With the switch every one of those five turns finishes, and the cell moved 0/5 to 1/5 on the attempt that set it - the losses that remained were a different fault, in this product's own wording rather than in this model.",
+          "The other five surfaces clear 5/5 at the shipped defaults and are not given it: this is scoped to the one mode whose failure it was measured on."
         ]
       }
     },

--- a/src/lib/agent/model-tuning/schema.ts
+++ b/src/lib/agent/model-tuning/schema.ts
@@ -88,6 +88,13 @@ const settingsShape = {
   reportReminderLimit: countSchema,
   planStatementRetries: countSchema,
   presentReminderLimit: countSchema,
+  /**
+   * Absent means the compiled two, which is what every entry written before this bound became
+   * per-model was measured under. Optional for the reason `suppressAgentReasoning` is: making
+   * it required would write the default into seventeen entries to say what their absence
+   * already says, and not one of those measurements would change.
+   */
+  verdictHoldLimit: countSchema.optional(),
   retryEmptyTurn: z.boolean(),
   retryUnreadStop: z.boolean(),
   suppressPlanReasoning: z.boolean(),
@@ -148,6 +155,7 @@ const measuredAgainstSchema = z.strictObject({
     reportReminderLimit: countSchema,
     planStatementRetries: countSchema,
     presentReminderLimit: countSchema,
+    verdictHoldLimit: countSchema,
     retryEmptyTurn: z.boolean(),
     retryUnreadStop: z.boolean(),
     suppressPlanReasoning: z.boolean(),

--- a/src/lib/agent/model-tuning/schema.ts
+++ b/src/lib/agent/model-tuning/schema.ts
@@ -164,6 +164,17 @@ const measuredAgainstSchema = z.strictObject({
   }),
 });
 
+/**
+ * Every key an entry's `settings` may carry, in the order the schema declares them.
+ *
+ * Exported for ONE job: `docs/llms/model-tuning.md` calls its settings table "the document's own
+ * contract — every setting, its bounds", and that sentence was a claim nothing checked. Two keys
+ * had already reached this shape without reaching the table, so an operator could set neither, and
+ * a misspelling of either lands silently in `ignoredKeys`. Derived here rather than written out in
+ * the test, because a list maintained beside the schema drifts exactly the way the table did.
+ */
+export const TUNING_SETTING_KEYS = Object.keys(settingsShape) as readonly string[];
+
 const documentSchema = z.strictObject({
   schemaVersion: z.literal(TUNING_SCHEMA_VERSION),
   measuredAgainst: measuredAgainstSchema,

--- a/src/lib/agent/models/index.ts
+++ b/src/lib/agent/models/index.ts
@@ -41,6 +41,7 @@ import {
   DEFAULT_REPORT_REMINDER_LIMIT,
   DEFAULT_REFUSAL_EXAMPLES,
   DEFAULT_PRESENT_REMINDER_LIMIT,
+  DEFAULT_VERDICT_HOLD_LIMIT,
   DEFAULT_RETRY_EMPTY_TURN,
   DEFAULT_RETRY_UNREAD_STOP,
   DEFAULT_SUPPRESS_AGENT_REASONING,
@@ -177,6 +178,17 @@ export function threadContextMaxCharsFor(modelId: string): number {
  */
 export function presentReminderLimitFor(modelId: string): number {
   return resolve(modelId, "presentReminderLimit") ?? DEFAULT_PRESENT_REMINDER_LIMIT;
+}
+
+/**
+ * How many times this model may be held on a report its own verifier would reject.
+ *
+ * Two everywhere, because no model has yet been measured recovering on a third. The bound used
+ * to be a constant in `investigation.ts`, which answered a model that needs another ask as
+ * though it were a model that will never comply.
+ */
+export function verdictHoldLimitFor(modelId: string): number {
+  return resolve(modelId, "verdictHoldLimit") ?? DEFAULT_VERDICT_HOLD_LIMIT;
 }
 
 /**

--- a/src/lib/agent/models/profile.ts
+++ b/src/lib/agent/models/profile.ts
@@ -150,6 +150,30 @@ export interface AgentModelProfile {
    */
   readonly suppressAgentReasoning?: boolean;
   /**
+   * How many times a report whose own verdict would REJECT it may be held and told why.
+   *
+   * The third of the reminder bounds and the last to become per-model. Its two siblings have
+   * been per-model since they were written; this one was a module constant, so a model whose
+   * ledgers showed a third ask landing had nowhere to record that.
+   *
+   * Two stays the default and the argument for it is untouched: measured in the eval scripts
+   * rather than reasoned about, at three a run that will not comply pays three wasted turns
+   * before the same verdict it was always going to get, and the gate evals had to be extended
+   * twice to see it. That argument is about what EVERY model should get by default. It says
+   * nothing about a model measured recovering on the third — and until this field there was no
+   * way to tell those two apart, so the second case was answered as though it were the first.
+   *
+   * Safe in the way the bound itself is safe: this hold fires only where a report is being
+   * submitted that its own verifier would reject, so a run about to pass cannot reach it. What
+   * a raised limit can cost is turns on a run that has already lost; what it can buy is the
+   * turn on which a model finally does the thing it was asked for.
+   *
+   * Nobody carries anything but the default yet. It is written so a measurement CAN be
+   * recorded, not because one has been.
+   */
+  readonly verdictHoldLimit?: number;
+
+  /**
    * How many times a report may be held to ask for the answer that belongs beside it.
    *
    * One is enough for a model that forgot. One evaluated model did not forget: held once
@@ -288,6 +312,19 @@ export const DEFAULT_SUPPRESS_AGENT_REASONING = false;
  * turn spent arguing with a model that has already declined, so it stays per-model.
  */
 export const DEFAULT_PRESENT_REMINDER_LIMIT = 1;
+
+/**
+ * Two, and the number is the eval scripts' rather than an argument's.
+ *
+ * At three, a run that will not comply pays three wasted turns before the same verdict it was
+ * always going to get, and the gate evals had to be extended twice to see that. Two changes the
+ * behaviour the ledgers complain about — a model that ignored one ask gets a second — at half
+ * the cost to a model that will never comply.
+ *
+ * It moved out of `investigation.ts` and into a default so a model CAN be measured needing a
+ * third; the value it moved with is the value it had.
+ */
+export const DEFAULT_VERDICT_HOLD_LIMIT = 2;
 
 /**
  * Deterministic, and the setting five locked cells were won on.

--- a/src/lib/agent/repair-ledger.ts
+++ b/src/lib/agent/repair-ledger.ts
@@ -75,8 +75,23 @@ export type AgentRepairDenyCode = "STATEMENT_ALREADY_FAILED" | "REPAIR_BUDGET_EX
  * module doc for why a boundary decision does not, and note that `reading-refused`
  * is on that side of the line too: the server declined to deliver a curated reading,
  * which no rewording of the request would change.
+ *
+ * `database-error-answered` is the same failure with one thing added: the server was able to
+ * say what would have worked. It is unrepeatable like every other class and costs nothing,
+ * for the reason a boundary decision costs nothing — the next statement is not another guess.
+ * Measured on `lfm2:24b`, which spent all three attempts on `no such column` errors the server
+ * answered and had the correct statement refused as its fourth.
+ *
+ * The CALLER decides which of the two it is, from its own state — whether it could build the
+ * advice out of the inventory this process holds. Never from the engine's message: that text is
+ * untrusted everywhere else here, and a run's remaining attempts must not be decided by it.
  */
-export type AgentRepairFailureClass = "database-error" | "policy-denied" | "approval-required" | "reading-refused";
+export type AgentRepairFailureClass =
+  | "database-error"
+  | "database-error-answered"
+  | "policy-denied"
+  | "approval-required"
+  | "reading-refused";
 
 export type AgentRepairAdmission =
   | { readonly admitted: true }

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1186,13 +1186,18 @@ function exampleRecommendCall(events: readonly AgentRunEvent[]): string | undefi
  * this looks for a completed data read with a statement of the model's behind it, which is
  * exactly what the tool accepts, and offers nothing when there is none.
  */
-function exampleAnswerCall(events: readonly AgentRunEvent[]): string | undefined {
+function presentableArtifact(events: readonly AgentRunEvent[]): string | undefined {
   const drafted = new Set(events.flatMap((event) => (event.kind === "statement-drafted" ? [event.stepId] : [])));
   let latest: string | undefined;
   for (const event of events) {
     if (event.kind === "tool-completed" && event.artifact.operationId === ANSWER_OPERATION && drafted.has(event.stepId))
       latest = event.artifact.correlationId;
   }
+  return latest;
+}
+
+function exampleAnswerCall(events: readonly AgentRunEvent[]): string | undefined {
+  const latest = presentableArtifact(events);
   if (latest === undefined) return undefined;
   return JSON.stringify({ artifact: latest, presentation: { kind: "table" } });
 }
@@ -1694,7 +1699,22 @@ async function runAuditedAgentCall(context: AgentToolContext, call: AuditedAgent
     // execution profile, or anything the pipeline itself threw — is the environment's,
     // so it propagates whatever class it carries and costs no repair attempt.
     if (!phase.statementSent || !isStatementFailure(error)) throw error;
-    context.repairs.recordFailure(fingerprint, "database-error");
+    /*
+      Whether this server could tell the model what would have worked, decided BEFORE the ledger
+      is told — because the answer changes what the failure costs.
+
+      Five `lfm2:24b` data-analysis runs, driven together: every one spent its three attempts on
+      `no such column`, and not one produced a successful read. The run read in full had the
+      CORRECT statement as its fourth, refused before it reached the database. The advice added
+      earlier today is what makes those retries converge — the model went from repeating one
+      spelling to trying three and landing on the right one — and each convergent step was being
+      charged as though it were a guess.
+
+      `statementAdvice` is computed once here and reused below rather than called twice: the two
+      must agree, since one decides the cost and the other is the sentence that justifies it.
+    */
+    const advice = statementAdvice(error.message, context.connection.type, context.connection);
+    context.repairs.recordFailure(fingerprint, advice === undefined ? "database-error" : "database-error-answered");
     return {
       kind: "refused",
       // `elapsedMs` is the tracker's own charge for this failed execution, recorded so
@@ -1718,9 +1738,17 @@ async function runAuditedAgentCall(context: AgentToolContext, call: AuditedAgent
           operationId: call.operationId,
           reference: fingerprint,
         }),
-        ...(offersRefusalExamples(context.modelId)
-          ? [statementAdvice(error.message, context.connection.type, context.connection) ?? ""]
-          : []),
+        // EVERY model, unlike the worked examples three tools below. Those are a whole call built
+        // from the run's own ledger and long enough to crowd a small model's turn, so they stay
+        // behind a lever a measurement opened. This is one sentence naming columns the operator's
+        // own database has, and it went to two of sixteen models for as long as it existed —
+        // `lfm2:24b` lost data-analysis 0/5 drafting `employee.dept_no`, being told only that no
+        // such column exists, reading the schema, and drafting it again. Nothing about that is
+        // particular to the model.
+        //
+        // The value computed above, not a second call: the same answer decides what this failure
+        // COSTS, and the sentence and the cost disagreeing would be a bug nobody could see.
+        advice ?? "",
       ]
         .filter((part) => part.length > 0)
         .join("\n"),
@@ -1888,6 +1916,21 @@ function describeIssues(issues: readonly z.core.$ZodIssue[]): string {
       the permitted values are in the schema, already in hand at the point of refusal.
     */
     if (issue.code === "invalid_value") return `${where}: expected one of ${issue.values.join(", ")}`;
+    /*
+      A DISCRIMINATED union lands here, and it is deliberately left alone.
+
+      `claims.0.evidence.2.source: invalid union` looks like the same fault as the two cases above
+      — a refusal printing a code instead of what would have worked — and it was read that way
+      after `granite4.1:3b` lost two of five assessments to three refusals each. It is not.
+      `invalidEvidenceInput` appends `AGENT_EVIDENCE_CONTRACT` to every refusal this path gives,
+      so the model has already been handed both arms by name in the same message; the test above
+      pins that. Zod reports no branch errors for a discriminated union whose discriminant matched
+      nothing, so there is nothing here to read them from either.
+
+      What is genuinely worse for the LEDGER — `detail` carrying the bare code while the model got
+      the full sentence — is a reporting gap, not a blocked run, and pretending otherwise would
+      have put dead code in front of a model that was never short of the answer.
+    */
     return `${where}: ${issue.code.replaceAll("_", " ")}`;
   });
   return `the fields that did not match — ${named.join("; ")}`;
@@ -3388,8 +3431,26 @@ export function presentAnswerTool(
     return {
       kind: "unavailable",
       reasonCode: "INVALID_TOOL_INPUT",
+      /*
+        The failing paths, which this refusal alone was assembled without — and the omission cost a
+        cell that had already been won.
+
+        `lfm2:24b` on data-analysis: told to present before reporting, it called `present_answer`
+        three times in a row and read back the same two sentences each time, the generic refusal
+        and the contract. It never learned which field was wrong, stopped trying, and went to
+        `compose_report` — whose refusal DID name its field. Same run, same model, same validator:
+        the sibling refusal is actionable and this one was not, and the run scored `no-answer`
+        holding the answer.
+
+        `invalidEvidenceInput` states the reasoning this now follows and states it about these
+        exact paths: "restating a rule the model has read and misapplied is not what it is
+        missing. The field that failed is." That was applied to the two evidence tools and this
+        one was left behind. `detail` is the same paths again for the LEDGER, which is what makes
+        a repeated refusal diagnosable afterwards rather than a bare code three times over.
+      */
+      detail: parsed.problems,
       modelText: [
-        UNAVAILABLE_TEXT.INVALID_TOOL_INPUT,
+        `${UNAVAILABLE_TEXT.INVALID_TOOL_INPUT} (${parsed.problems})`,
         AGENT_ANSWER_CONTRACT,
         ...(example === undefined ? [] : [`A call this run could make right now: ${example}`]),
       ].join(" "),
@@ -3398,7 +3459,30 @@ export function presentAnswerTool(
 
   const artifact = producedArtifact(run.events, parsed.value.artifact);
   if (artifact === null) return unavailable("ANSWER_ARTIFACT_UNKNOWN");
-  if (artifact.operationId !== ANSWER_OPERATION) return unavailable("ANSWER_NOT_A_DATA_READ");
+  if (artifact.operationId !== ANSWER_OPERATION) {
+    /*
+      And WHICH result would have been taken, when the run is holding one.
+
+      Fifteen `qwen3:1.7b` data-analysis runs were read together and FOURTEEN were refused here on
+      their first `present_answer`, every one having cited a plan or a profile. Eight of the
+      fifteen held a good read at that moment; four of those eight never found it, and were told
+      to run a read they had already run.
+
+      The sentence stays as it is for the seven that had read nothing — "run the read first if you
+      have not" is the whole answer there, and naming an id would mean inventing one. What is
+      added is for the other eight, and it is a value this layer is already computing:
+      `presentableArtifact` is what `exampleAnswerCall` builds its worked call from. That call is
+      behind `refusalExamples` because a whole call is long enough to crowd a small model's turn.
+      An id is not, so it goes to everyone — the same reasoning the answer notice states one step
+      later, that being told to cite something "somewhere" and being handed the characters are
+      different instructions.
+    */
+    const instead = presentableArtifact(run.events);
+    return unavailable(
+      "ANSWER_NOT_A_DATA_READ",
+      instead === undefined ? undefined : `this run already read ${instead} — present that`,
+    );
+  }
   const sql = statementBehind(run.events, artifact.correlationId);
   if (sql === null) return unavailable("ANSWER_STATEMENT_UNKNOWN");
 

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1546,10 +1546,18 @@ function columnsThatExist(message: string, connection: DatabaseConnection): stri
   return `"${table.name}" has no ${missing}. Its columns are ${named.join(", ")}.${found}`;
 }
 
-function statementAdvice(message: string, engine: string, connection: DatabaseConnection): string | undefined {
-  // First, because it is the largest family and the most specific thing this layer can say.
-  const columns = columnsThatExist(message, connection);
-  if (columns !== undefined) return columns;
+/**
+ * The other two things this layer can say about a failed statement.
+ *
+ * Split from `columnsThatExist` because the CLASS is decided separately from the sentence, and
+ * only that one earns the free class — see the call site. Both branches here are a rewrite the
+ * model has to author: a narrower query, or a different way of asking for the catalog. The
+ * inventory branch is not, which is the whole distinction.
+ *
+ * Takes no connection: neither branch reads our own state. They are derived from the shape of the
+ * engine's message and from the engine this connection IS, which is why neither can be free.
+ */
+function otherStatementAdvice(message: string, engine: string): string | undefined {
   const overBudget = /row budget: \d+ rows > (\d+) allowed/.exec(message);
   if (overBudget !== null) {
     return `Ask for fewer rows: add LIMIT ${overBudget[1]} (or an aggregate that returns one row) and run it again.`;
@@ -1710,11 +1718,22 @@ async function runAuditedAgentCall(context: AgentToolContext, call: AuditedAgent
       spelling to trying three and landing on the right one — and each convergent step was being
       charged as though it were a guess.
 
-      `statementAdvice` is computed once here and reused below rather than called twice: the two
-      must agree, since one decides the cost and the other is the sentence that justifies it.
+      The COST and the SENTENCE are deliberately two different decisions, and reading one off the
+      other is what made the class too wide. Only the inventory branch is free: there the server
+      held the answer, handed it over, and the next statement applies a correction it dictated.
+      `otherStatementAdvice`'s two branches — the row budget, the foreign catalog — are advice
+      about a REWRITE the model still has to author, and a rewrite is exactly what the budget of
+      three exists to bound. A row-budget overrun in particular is the most expensive failure a run
+      can produce: the statement ran to completion at the engine and returned rows before it blew
+      the cap, and making it cheaper is not a correction anyone dictated.
+
+      So `columns` decides the cost, and the advice the model reads is still whichever of the three
+      applies. `columnsThatExist` is computed once and used for both rather than called twice.
     */
-    const advice = statementAdvice(error.message, context.connection.type, context.connection);
-    context.repairs.recordFailure(fingerprint, advice === undefined ? "database-error" : "database-error-answered");
+    const columns = columnsThatExist(error.message, context.connection);
+    const advice = columns ?? otherStatementAdvice(error.message, context.connection.type);
+    const answered = columns !== undefined;
+    context.repairs.recordFailure(fingerprint, answered ? "database-error-answered" : "database-error");
     return {
       kind: "refused",
       // `elapsedMs` is the tracker's own charge for this failed execution, recorded so
@@ -1726,6 +1745,10 @@ async function runAuditedAgentCall(context: AgentToolContext, call: AuditedAgent
         statementFingerprint: fingerprint,
         message: error.message,
         elapsedMs: context.tracker.usage(context.runId).totalElapsedMs - chargedBeforeMs,
+        // Recorded rather than left to be inferred: whether the inventory was in hand decides what
+        // this failure cost, and it depends on a process-wide cache a run cannot see. See the
+        // field's own note in `types.ts`.
+        answered,
       },
       // The engine's own words: untrusted, so fenced. The fingerprint stands in for
       // a correlation id, which a failed execution never produced.

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -568,6 +568,24 @@ export type AgentToolRefusal =
       readonly statementFingerprint: string;
       readonly message: string;
       readonly elapsedMs?: number;
+      /**
+       * Whether this server ANSWERED the failure — and therefore whether it consumed one of the
+       * three repair attempts. `true` means it did not.
+       *
+       * Here because the answer is not derivable by a reader of the ledger, and the gauge it
+       * explains is on screen. Whether the inventory that answers a `no such column` is in hand is
+       * decided by `heldSnapshots`, a process-wide map of sixteen with insertion-order eviction: a
+       * burst of traffic on other connections can evict this connection's reading between one
+       * statement and the next. So two runs with the same objective, the same connection and the
+       * same failing statement can spend a different number of attempts, and nothing the run can
+       * observe says why. A `used / 3` sitting still through three failures, or moving through
+       * three that look identical to the previous run's, is otherwise inferable only from cache
+       * pressure nobody records.
+       *
+       * Optional, like `elapsedMs` and for the same reason: every refusal written before this
+       * field existed carries none, and absent means unrecorded rather than `false`.
+       */
+      readonly answered?: boolean;
     }
   | { readonly class: "reading-refused"; readonly reasonCode: AgentReadingDenyCode; readonly elapsedMs?: number };
 

--- a/src/lib/db/providers/sql/sqlite.ts
+++ b/src/lib/db/providers/sql/sqlite.ts
@@ -199,7 +199,13 @@ export interface SQLiteTableSizeBytes {
  * figure it drew beside the measured database size.
  *
  * Takes the database handle as a parameter, and is exported, so that BOTH answers are
- * testable in-process under Bun - whose driver can only ever produce the `null` one.
+ * testable in-process under Bun with a stand-in handle, whichever one the running build
+ * happens to give. `dbstat` sits behind SQLITE_ENABLE_DBSTAT_VTAB, a COMPILE-TIME option,
+ * so its presence is a property of the BUILD and not of the driver's name: this was
+ * written believing bun:sqlite could only ever answer `null`, and a Bun whose SQLite
+ * carries dbstat answers the other one. Nothing here changes - both answers were already
+ * right - but a test that reads the driver's name to predict which arm it is on is
+ * reading the wrong thing.
  */
 export function readDbstatSizes(db: SQLiteDatabase): Map<string, SQLiteTableSizeBytes> | null {
   let pages: { name: string; bytes: number }[];

--- a/tests/evals/resilience.test.ts
+++ b/tests/evals/resilience.test.ts
@@ -241,8 +241,26 @@ describe("a failed statement is told what the table actually holds", () => {
     expect(told).toContain("name");
   });
 
-  test("a model that has not earned it gets the engine's words and nothing more", async () => {
-    // The rule every behaviour added today obeys: off by default, on where a ledger earned it.
+  test("a model carrying no settings at all is told the same thing", async () => {
+    /*
+      This used to assert the opposite, under the rule every behaviour added that day obeyed: off
+      by default, on where a ledger earned it. That rule is right for a WORKED EXAMPLE — a whole
+      tool call built from the run's own events, long enough to crowd a small model's turn, which
+      is why the three of those stay behind `refusalExamples`. It was wrong here, and the entry
+      that proved it was `lfm2:24b` on data-analysis.
+
+      Five runs, 0/5, and every one is the same three steps: draft
+      `... JOIN department ON employee.dept_no = department.dept_no`, be told `no such column:
+      employee.dept_no` and nothing else, call `inspect_schema` twice, then draft the SAME
+      statement again. It is not a model ignoring advice. It is a model that was never given any,
+      going back to the schema and failing to spot the one column it was wrong about.
+
+      What this sentence carries is a FACT about the operator's own database — which columns that
+      table has, and which table holds the one that was asked for — and it is one line. Withholding
+      it made the product worse for fourteen of sixteen shipped models and for every model nobody
+      has measured yet, which is most of them. So it goes to all of them, and the lever above keeps
+      gating only the thing the lever was measured on.
+    */
     const run = await open({
       answer: async () => {
         throw new QueryError("no such column: engineering.dept_no");
@@ -257,11 +275,12 @@ describe("a failed statement is told what the table actually holds", () => {
       answersProse("done"),
     );
 
+    // No model id, so no profile and no `refusalExamples` — the case that used to get nothing.
     await run.driveModel(await modelOver(scripted.fetch));
 
     const told = scripted.turns.at(-1)?.transcript ?? "";
     expect(told).toContain("no such column");
-    expect(told).not.toContain("has no dept_no");
+    expect(told).toContain("has no dept_no");
   });
 });
 

--- a/tests/evals/resilience.test.ts
+++ b/tests/evals/resilience.test.ts
@@ -162,6 +162,43 @@ describe("a failed statement is told what the table actually holds", () => {
     expect(told).toContain("name");
   });
 
+  test("and the ledger records that answering it is what made the attempt free", async () => {
+    /*
+      The other half of the same decision, and the half a reader of the ledger could not see.
+
+      Whether the inventory is in hand decides what a `no such column` COSTS: answered from our own
+      snapshot it consumes none of the three attempts, unanswered it consumes one. But the hold is
+      `heldSnapshots`, a process-wide map of sixteen with insertion-order eviction, so traffic on
+      other connections can move the same run from the free path to the charged one between one
+      statement and the next. Two runs with the same objective, the same connection and the same
+      failing statement can then spend a different number of attempts, and the gauge on screen
+      reads `used / 3` either way with nothing beside it saying which happened.
+
+      Driven rather than unit-tested for the same reason as its neighbours: `holdSnapshotForConnection`
+      verifies a snapshot's fingerprint before keeping it, so only a real capture puts a real
+      inventory in hand.
+    */
+    const run = await open({
+      answer: async () => {
+        throw new QueryError("no such column: engineering.dept_no");
+      },
+    });
+    const scripted = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT dept_no FROM engineering", rationale: "count" }),
+      answersProse("I could not read that."),
+      answersProse("done"),
+    );
+
+    const drive = await run.driveModel(await modelOver(scripted.fetch, "https://api.openai.com/v1", "granite4.1:8b"));
+
+    const refusals = drive.events.filter((event) => event.kind === "tool-refused");
+    expect(refusals).toHaveLength(1);
+    const refusal = refusals[0].refusal;
+    if (refusal.class !== "database-error") throw new Error(`expected database-error, got ${refusal.class}`);
+    // The inventory was in hand, the columns went back, and the flag says the attempt was free.
+    expect(refusal.answered).toBe(true);
+  });
+
   test("and where that column actually lives, when the inventory has it elsewhere", async () => {
     /*
       Naming what a table holds does not answer a model looking for a join key. Measured:

--- a/tests/integration/db/duckdb-provider.test.ts
+++ b/tests/integration/db/duckdb-provider.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DuckDBProvider, assertReadOnlyStatementIsBounded } from "@/lib/db/providers/sql/duckdb";
@@ -676,7 +676,13 @@ describe("monitoring", () => {
     const [main] = await provider.getStorageStats();
 
     expect(main.name).toBe("Main Database");
-    expect(main.location).toBe(dbPath);
+    // Both sides through `realpathSync`, because the location is DUCKDB's answer and DuckDB
+    // canonicalises it. A no-op wherever the temp directory is a real directory, which is why
+    // this read as portable: on macOS `os.tmpdir()` is `/var/folders/...`, a symlink to
+    // `/private/var/folders/...`, so the engine returns a path that names the same file by a
+    // different route and a string comparison fails on a correct answer.
+    expect(main.location).toBeDefined();
+    expect(realpathSync(main.location!)).toBe(realpathSync(dbPath));
     expect(main.sizeBytes).toBeGreaterThan(0);
   });
 

--- a/tests/integration/db/sqlite-provider.test.ts
+++ b/tests/integration/db/sqlite-provider.test.ts
@@ -40,6 +40,23 @@ function makeSQLiteConfig(overrides: Partial<DatabaseConnection> = {}): Database
   };
 }
 
+/**
+ * Whether the SQLite build behind the running driver carries `dbstat`.
+ *
+ * `dbstat` sits behind SQLITE_ENABLE_DBSTAT_VTAB, a COMPILE-TIME option, so its presence
+ * is a property of the build and not of the driver's name: two Bun releases on two
+ * platforms disagree about it. Asked here rather than assumed, so the size tests pin the
+ * arm the build is actually on instead of the arm one machine happened to be on.
+ */
+async function hasDbstat(db: SQLiteProvider): Promise<boolean> {
+  try {
+    await db.query("SELECT 1 FROM dbstat LIMIT 1");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -555,10 +572,18 @@ describe("SQLiteProvider", () => {
       provider = new SQLiteProvider(makeSQLiteConfig());
       await provider.connect();
 
-      // The pragma the old code derived 95% from still answers; it is a page
-      // budget in KiB (negative) or pages (positive), never a hit count.
+      // The pragma the old code derived 95% from still answers; it is a page budget in
+      // KiB (negative) or pages (positive), never a hit count. BOTH signs are the same
+      // fact about the same setting, so the sign is not asserted: pinning the -2000 this
+      // was written against pinned one build's default (SQLite's compiled default is
+      // -2000, and a build or a driver may set its own), and a build answering 2000
+      // failed a test whose subject is that the number is not a ratio.
       const cacheSize = await provider.query("PRAGMA cache_size");
-      expect(cacheSize.rows[0].cache_size).toBe(-2000);
+      const budget = cacheSize.rows[0].cache_size;
+      expect(typeof budget).toBe("number");
+      expect(budget).not.toBe(0);
+      // The reading is a budget, and no budget is the 95 the old code reported as a
+      // percentage - which is the regression this case exists to catch.
       expect((await provider.getPerformanceMetrics()).cacheHitRatio).toBeUndefined();
     });
   });
@@ -618,14 +643,19 @@ describe("SQLiteProvider", () => {
       expect(usersStats!.rowCount).toBe(2);
     });
 
-    // The size used to be `rowCount * 100` ("Assume 100 bytes average per row"),
-    // and the Storage tab summed it into the Data figure it draws beside the measured
-    // database size. The real answer is `dbstat`, a compile-time virtual table that
-    // bun:sqlite does not carry - "no such table: dbstat", measured 2026-08-24 on Bun
-    // 1.3.14 / SQLite 3.53.0 against a working row from node:sqlite 3.51.2 - so under
-    // this driver there is no per-table size to report and the fields are omitted.
-    // A `0` would be the same fabrication in a different digit.
-    test("omits the size under bun:sqlite, where dbstat does not exist", async () => {
+    // The size used to be `rowCount * 100` ("Assume 100 bytes average per row"), and the
+    // Storage tab summed it into the Data figure it draws beside the measured database
+    // size. The real answer is `dbstat`, a virtual table behind a COMPILE-TIME option.
+    //
+    // Which arm runs is therefore a property of the SQLite build behind the driver, not
+    // of the driver's name, and this test asserted the empty arm unconditionally under a
+    // heading that named bun:sqlite. That held on the build it was written against
+    // ("no such table: dbstat", Bun 1.3.14 / SQLite 3.53.0, 2026-08-24) and fails on a
+    // Bun whose SQLite carries dbstat - a correct answer, reported as a regression. So
+    // the build is asked, and whichever arm it is on is the one pinned. Both are real:
+    // measured bytes when dbstat answers, absent fields when it does not, and the
+    // fabricated `rowCount * 100` on neither.
+    test("reports dbstat's measured bytes where it exists, and omits the size where it does not", async () => {
       provider = new SQLiteProvider(makeSQLiteConfig());
       await provider.connect();
 
@@ -636,6 +666,17 @@ describe("SQLiteProvider", () => {
       const wide = stats.find((s) => s.tableName === "wide")!;
 
       expect(wide.rowCount).toBe(1);
+      // The guessed value, on both arms, in case a regression reinstates the multiplication.
+      expect(wide.tableSizeBytes).not.toBe(100);
+
+      if (await hasDbstat(provider)) {
+        // Real page bytes: a one-row table still occupies at least one page.
+        expect(wide.tableSizeBytes).toBeGreaterThan(0);
+        expect(wide.tableSize).toBeDefined();
+        expect(wide.totalSizeBytes).toBe(wide.tableSizeBytes! + wide.indexSizeBytes!);
+        return;
+      }
+
       expect(wide.tableSizeBytes).toBeUndefined();
       expect(wide.tableSize).toBeUndefined();
       expect(wide.indexSizeBytes).toBeUndefined();
@@ -644,8 +685,6 @@ describe("SQLiteProvider", () => {
       // tab keys off the ABSENT `tableSizeBytes` and draws neither.
       expect(wide.totalSize).toBe("N/A");
       expect(wide.totalSizeBytes).toBe(0);
-      // The guessed value, in case a regression reinstates the multiplication.
-      expect(wide.tableSizeBytes).not.toBe(100);
     });
 
     // The populated branch cannot be reached through the bun driver at all - it has no
@@ -728,10 +767,11 @@ describe("SQLiteProvider", () => {
       expect(Object.hasOwn(stats, "tableSize")).toBe(false);
     });
 
-    // The absence is per call, not per row: every table in the list loses its byte
-    // fields together, so the Storage tab's `every()` gate sees a uniform answer
-    // rather than a partial one.
-    test("omits the size for every table in the list, not just the first", async () => {
+    // The answer is per CALL, not per row: one dbstat scan decides for the whole list, so
+    // every table gains its byte fields together or loses them together. What the Storage
+    // tab's `every()` gate must never see is a partial answer - some tables sized and
+    // others not - and that is the invariant here, on whichever arm the build is on.
+    test("answers uniformly for every table in the list, never some sized and some not", async () => {
       provider = new SQLiteProvider(makeSQLiteConfig());
       await provider.connect();
 
@@ -740,7 +780,12 @@ describe("SQLiteProvider", () => {
 
       const stats = await provider.getTableStats();
       expect(stats.map((s) => s.tableName).sort()).toEqual(["a", "b"]);
-      expect(stats.every((s) => s.tableSizeBytes === undefined)).toBe(true);
+
+      const sized = stats.filter((s) => s.tableSizeBytes !== undefined).length;
+      expect(sized === 0 || sized === stats.length).toBe(true);
+      // And the arm is the one the build is actually on, so a provider that started
+      // dropping every size on a dbstat-carrying build would still be caught.
+      expect(sized === stats.length).toBe(await hasDbstat(provider));
     });
   });
 

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -1958,6 +1958,26 @@ describe("planning mode runs no statement of the user's", () => {
       // Rationale AFTER the statement, so the deliverable is the first thing in the
       // answer rather than the conclusion of an essay.
       expect(rules).toContain("Put the rationale AFTER the statement");
+      /*
+        And the refusal is introduced by ONE spelling, because these rules teach the marker and a
+        second phrase beside it gets written instead.
+
+        Measured on `qwen3.5:4b`: its plan cell read 1/5 across five attempts, every loss
+        `no-statement`, and its refusals were right in substance — it named the two tables whose
+        columns the inventory could not derive and asked the one question that would have
+        unblocked it. It opened them `NO STATEMENT AT ALL:`.
+
+        That string was ours. The rule read "write NO STATEMENT AT ALL: begin a line with `NO
+        STATEMENT:`" — English followed by a colon, set immediately against a literal introduced
+        the same way. The model took the first as the thing to write. It obeyed the instruction
+        and scored as having answered nothing.
+
+        Pinned on the RULES rather than on the reader: widening the reader would accept this one
+        spelling and leave the sentence that produced it in place, and the next model would invent
+        a different one.
+      */
+      expect(rules).toContain("begin a line with `NO STATEMENT:`");
+      expect(rules).not.toContain("NO STATEMENT AT ALL");
       expect(rules).toContain("Use no table name and no column name that is not in that inventory");
       // The honest limit of item 6: an inventory records what EXISTS, not what this
       // user's role may select from, so a validated statement is not a statement that
@@ -1993,6 +2013,25 @@ describe("planning mode runs no statement of the user's", () => {
       // and to refuse in the same breath is how a model splits the difference and
       // invents a schema.
       expect(rules).not.toContain("Produce ONE runnable statement");
+      /*
+        And the rules contain NO second phrase a model could read as the marker.
+
+        Measured on `qwen3.5:4b`, whose plan cell read 1/5 across five attempts, every loss
+        `no-statement`. Its refusals were correct in substance — it said which two tables had no
+        derivable columns and asked the one question that would have unblocked it — and it opened
+        them with `NO STATEMENT AT ALL:`.
+
+        That string was ours. The rule read "write NO STATEMENT AT ALL: begin a line with `NO
+        STATEMENT:`", where the first phrase is English and the second is the literal. Followed by
+        a colon and set against a marker introduced the same way, the first reads as the thing to
+        write, and the model wrote it. It obeyed the instruction and was scored as having answered
+        nothing.
+
+        Asserted on the rules rather than on the reader, because widening the reader would accept
+        this one spelling and leave the instruction that produced it in place — and the next model
+        would invent a different one.
+      */
+      expect(rules).not.toContain("NO STATEMENT AT ALL");
     });
 
     /*

--- a/tests/unit/lib/agent/model-profiles.test.ts
+++ b/tests/unit/lib/agent/model-profiles.test.ts
@@ -9,6 +9,7 @@ import {
   reportReminderLimitFor,
   samplingFor,
   threadContextMaxCharsFor,
+  verdictHoldLimitFor,
 } from "@/lib/agent/models";
 import { AGENT_THREAD_CONTEXT_MAX_CHARS } from "@/lib/agent/execution-policy";
 import type { AgentRunWorkflowType } from "@/lib/agent/types";
@@ -206,6 +207,26 @@ describe("sampling is decided per model, defaulting to deterministic", () => {
     expect(presentReminderLimitFor("qwen3:8b")).toBe(1);
     expect(presentReminderLimitFor("gemma4:26b")).toBe(1);
     expect(presentReminderLimitFor("some-model-released-tomorrow:70b")).toBe(1);
+  });
+
+  test("how many times a losing report may be held is a per-model number, and two for everyone", () => {
+    /*
+      The third reminder bound, and the last of the three to become per-model. Its two
+      siblings — `reportReminderLimit` and `presentReminderLimit` — have been per-model since
+      they were written; this one was a module constant, so a model measured needing a third
+      ask had nowhere to record it.
+
+      Two remains the default and the reasoning for it is unchanged: at three, a run that will
+      not comply pays three wasted turns before the same verdict it was always going to get.
+      That argument is about the DEFAULT. It says nothing about a model whose ledgers show the
+      third ask landing, and until now there was no way to tell those two cases apart.
+
+      Every shipped model resolves to two, because none has been measured needing otherwise.
+    */
+    for (const modelId of Object.keys(modelProfiles())) {
+      expect(verdictHoldLimitFor(modelId)).toBe(2);
+    }
+    expect(verdictHoldLimitFor("some-model-released-tomorrow:70b")).toBe(2);
   });
 
   test("every profile states what measured it", () => {

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -32,6 +32,7 @@ import {
   retriesUnreadStop,
   samplingFor,
   suppressesAgentReasoning,
+  verdictHoldLimitFor,
   suppressesPlanReasoning,
   turnTimeoutMsFor,
 } from "@/lib/agent/models";
@@ -63,6 +64,8 @@ interface ResolvedRow {
   /** Optional, and AGENT-only; its sibling above does not imply it. */
   readonly suppressesAgentReasoning?: boolean;
   readonly refusalExamples: boolean;
+  /** Optional: two everywhere, because no model has been measured recovering on a third hold. */
+  readonly verdictHoldLimit?: number;
   readonly turnTimeoutMs: number | undefined;
   /** Only the surfaces that differ from `PINNED`; every other surface resolves to it. */
   readonly samplingOverrides?: Readonly<Partial<Record<AgentRunWorkflowType, { temperature: number; topP: number }>>>;
@@ -202,6 +205,54 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: 150_000,
   },
   {
+    // The seventeenth, and the second closed by the autonomous runner rather than by hand. Five
+    // of its six cells locked on the first reading at the compiled defaults; query-optimization
+    // read 3/5 there, both losses `model-timeout`, and the clock took the cell. One setting,
+    // because one is what it was measured needing.
+    id: "nemotron-3-nano:30b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: 150_000,
+  },
+  {
+    // The eighteenth, and the only one whose open cell was closed by fixing THIS PRODUCT'S WORDING
+    // rather than by a setting. Five surfaces cleared at the compiled defaults untouched. Plan
+    // timed out on every run with an empty ledger until `suppressPlanReasoning`, which finished
+    // the turns and moved it 0/5 to 1/5; the four losses left were a correct refusal opened
+    // `NO STATEMENT AT ALL:`, which is the phrase the planning rule itself put in front of the
+    // marker it was teaching. One setting, because the rest was ours.
+    // The nineteenth row and the only one whose entry states nothing but the defaults. It closed
+    // all six surfaces on its first reading with no setting carried over, and the entry exists
+    // BECAUSE of that rather than in spite of it: an absent entry records no measurement, and a
+    // model nobody can see was measured is a model nobody can trust.
+    id: "granite4.2:8b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  {
+    id: "qwen3.5:4b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    suppressesPlanReasoning: true,
+    // The compiled limit, stated as undefined like every model that was never measured needing
+    // its own: this one's plan turns stopped timing out because the thinking stopped, not because
+    // they were given longer.
+    turnTimeoutMs: undefined,
+  },
+  {
     // The fourteenth, and the widest set any model carries: three settings for three DIFFERENT
     // failures, each measured on the cell it was added for.
     id: "muse-glimmer:latest",
@@ -286,6 +337,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
     expect(suppressesPlanReasoning(row.id)).toBe(row.suppressesPlanReasoning ?? false);
     expect(suppressesAgentReasoning(row.id)).toBe(row.suppressesAgentReasoning ?? false);
     expect(offersRefusalExamples(row.id)).toBe(row.refusalExamples);
+    expect(verdictHoldLimitFor(row.id)).toBe(row.verdictHoldLimit ?? 2);
     expect(turnTimeoutMsFor(row.id)).toBe(row.turnTimeoutMs);
   });
 
@@ -301,7 +353,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
   test("the table covers every registered model, so a new one cannot arrive unpinned", () => {
     const pinned = new Set(RESOLVED.map((row) => row.id));
     for (const id of Object.keys(modelProfiles())) expect(pinned.has(id)).toBe(true);
-    expect(Object.keys(modelProfiles())).toHaveLength(15);
+    expect(Object.keys(modelProfiles())).toHaveLength(18);
   });
 });
 
@@ -365,6 +417,9 @@ describe("what each model records about the runs that earned its settings", () =
     // The fourth closed here, and the one the new switch was written for. Its record states the
     // refuted hypothesis too: the tool count does not separate its passing runs from its loss.
     "gemma4:12b": "9a49a9323c21ffe507698ca2ca852cc1b59647a206e73c448afeea7f1a0a674b",
+    "nemotron-3-nano:30b": "20cca3398ec9a7ff927f014a212784f38d6b36e74be49fe2b74fb223a7d56eec",
+    "qwen3.5:4b": "204b6f6beb8710155508938a2271cbf34013235fa612b40ecebf98ff5dcff061",
+    "granite4.2:8b": "c9e47190c44d1fda45bf035831dcb17ba21621e98a455259a438710775600ae0",
   };
 
   test("every model's record survives the move, character for character", () => {

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -205,10 +205,10 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: 150_000,
   },
   {
-    // The seventeenth, and the second closed by the autonomous runner rather than by hand. Five
-    // of its six cells locked on the first reading at the compiled defaults; query-optimization
-    // read 3/5 there, both losses `model-timeout`, and the clock took the cell. One setting,
-    // because one is what it was measured needing.
+    // The first of the three this branch added, and the second model ever closed by the autonomous
+    // runner rather than by hand. Five of its six cells locked on the first reading at the compiled
+    // defaults; query-optimization read 3/5 there, both losses `model-timeout`, and the clock took
+    // the cell. One setting, because one is what it was measured needing.
     id: "nemotron-3-nano:30b",
     unreportedCallCeiling: 12,
     reportReminderLimit: 1,
@@ -219,16 +219,11 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: 150_000,
   },
   {
-    // The eighteenth, and the only one whose open cell was closed by fixing THIS PRODUCT'S WORDING
-    // rather than by a setting. Five surfaces cleared at the compiled defaults untouched. Plan
-    // timed out on every run with an empty ledger until `suppressPlanReasoning`, which finished
-    // the turns and moved it 0/5 to 1/5; the four losses left were a correct refusal opened
-    // `NO STATEMENT AT ALL:`, which is the phrase the planning rule itself put in front of the
-    // marker it was teaching. One setting, because the rest was ours.
-    // The nineteenth row and the only one whose entry states nothing but the defaults. It closed
-    // all six surfaces on its first reading with no setting carried over, and the entry exists
-    // BECAUSE of that rather than in spite of it: an absent entry records no measurement, and a
-    // model nobody can see was measured is a model nobody can trust.
+    // The second of the three this branch added, and the only entry in the table that states
+    // nothing but the defaults. It closed all six surfaces on its first reading with no setting
+    // carried over, and the entry exists BECAUSE of that rather than in spite of it: an absent
+    // entry records no measurement, and a model nobody can see was measured is a model nobody can
+    // trust.
     id: "granite4.2:8b",
     unreportedCallCeiling: 12,
     reportReminderLimit: 1,
@@ -239,6 +234,13 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: undefined,
   },
   {
+    // The third of the three this branch added, and the only model in the table whose open cell
+    // was closed by fixing THIS PRODUCT'S WORDING rather than by a setting. Five surfaces cleared
+    // at the compiled defaults untouched. Plan timed out on every run with an empty ledger until
+    // `suppressPlanReasoning`, which finished the turns and moved it 0/5 to 1/5; the four losses
+    // left were a correct refusal opened `NO STATEMENT AT ALL:`, which is the phrase the planning
+    // rule itself put in front of the marker it was teaching. One setting, because the rest was
+    // ours.
     id: "qwen3.5:4b",
     unreportedCallCeiling: 12,
     reportReminderLimit: 1,

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -15,6 +15,7 @@ import bundled from "@/lib/agent/model-tuning/measured-profiles.json";
 import {
   ModelTuningError,
   TUNING_SCHEMA_VERSION,
+  TUNING_SETTING_KEYS,
   parseOperatorTuning,
   parseTuning,
 } from "@/lib/agent/model-tuning/schema";
@@ -738,5 +739,35 @@ describe("a document an operator supplies", () => {
     resetTuning();
     const first = activeTuning();
     expect(activeTuning()).toBe(first);
+  });
+});
+
+describe("the settings table documents every key the schema accepts", () => {
+  /*
+    `docs/AGENT.md` calls the settings table in `docs/llms/model-tuning.md` "the document's own
+    contract — every setting, its bounds", and nothing checked that sentence. Two keys had reached
+    the schema without reaching the table — `verdictHoldLimit`, added with this branch's per-model
+    reminder bound, and `suppressAgentReasoning` before it — so an operator had no way to learn
+    either exists, and a misspelling of either lands silently in `ignoredKeys` rather than being
+    refused.
+
+    Asserted rather than argued, because the next key added will be added by somebody who did not
+    read this comment.
+  */
+  const TABLE = readFileSync(resolve(import.meta.dir, "../../../../docs/llms/model-tuning.md"), "utf8");
+
+  // Spread because `test.each` takes a mutable array and the export is readonly — the export is
+  // read-only on purpose, since nothing may edit the schema's key list through it.
+  test.each([...TUNING_SETTING_KEYS])("`%s` has a row", (key) => {
+    // The leading pipe and backtick are what make this a TABLE ROW rather than a mention in the
+    // prose around it: `turnTimeoutMs` is discussed in three paragraphs, and a test satisfied by
+    // prose would not have caught either of the two keys that were missing.
+    expect(TABLE).toContain(`| \`${key}\` |`);
+  });
+
+  test("and `perWorkflow`, which is a row without being a key of its own", () => {
+    // The one row that is not in `settingsShape`: it is a field of `sampling`'s sibling object
+    // rather than a setting, and it is in the table because an operator sets it by name.
+    expect(TABLE).toContain("| `perWorkflow` |");
   });
 });

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -23,6 +23,7 @@ import { BASELINE_NOTICES } from "@/lib/agent/models/notices";
 import {
   DEFAULT_PLAN_STATEMENT_RETRIES,
   DEFAULT_PRESENT_REMINDER_LIMIT,
+  DEFAULT_VERDICT_HOLD_LIMIT,
   DEFAULT_REFUSAL_EXAMPLES,
   DEFAULT_REPORT_REMINDER_LIMIT,
   DEFAULT_RETRY_EMPTY_TURN,
@@ -65,6 +66,7 @@ const document = (overrides: Record<string, unknown> = {}): Record<string, unkno
       reportReminderLimit: 1,
       planStatementRetries: 0,
       presentReminderLimit: 1,
+      verdictHoldLimit: 2,
       retryEmptyTurn: false,
       retryUnreadStop: false,
       suppressPlanReasoning: false,
@@ -90,7 +92,7 @@ afterEach(() => {
 describe("the document Studio ships with", () => {
   test("passes its own contract", () => {
     const tuning = parseTuning(bundled, "test");
-    expect(Object.keys(tuning.models)).toHaveLength(15);
+    expect(Object.keys(tuning.models)).toHaveLength(18);
   });
 
   test("argues for every value it changed", () => {
@@ -118,6 +120,7 @@ describe("the document Studio ships with", () => {
       reportReminderLimit: DEFAULT_REPORT_REMINDER_LIMIT,
       planStatementRetries: DEFAULT_PLAN_STATEMENT_RETRIES,
       presentReminderLimit: DEFAULT_PRESENT_REMINDER_LIMIT,
+      verdictHoldLimit: DEFAULT_VERDICT_HOLD_LIMIT,
       retryEmptyTurn: DEFAULT_RETRY_EMPTY_TURN,
       retryUnreadStop: DEFAULT_RETRY_UNREAD_STOP,
       suppressPlanReasoning: DEFAULT_SUPPRESS_PLAN_REASONING,
@@ -559,7 +562,7 @@ describe("a document an operator supplies", () => {
     process.env[ENV] = writeDocument("{ not json");
     resetTuning();
     expect(ceilingFor("gemma4:26b")).toBe(10);
-    expect(Object.keys(activeTuning().models)).toHaveLength(15);
+    expect(Object.keys(activeTuning().models)).toHaveLength(18);
   });
 
   test("reports that it ignored a document, naming the file and the reason", () => {
@@ -713,13 +716,13 @@ describe("a document an operator supplies", () => {
   test("is ignored when it breaks the contract, not partially applied", () => {
     process.env[ENV] = writeDocument(document({ schemaVersion: 99 }));
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(15);
+    expect(Object.keys(activeTuning().models)).toHaveLength(18);
   });
 
   test("is ignored when the file is not there at all", () => {
     process.env[ENV] = "/nonexistent/models.json";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(15);
+    expect(Object.keys(activeTuning().models)).toHaveLength(18);
   });
 
   test("an unset or blank variable is simply no operator document", () => {
@@ -727,7 +730,7 @@ describe("a document an operator supplies", () => {
     // reading it as a path would warn on every boot of an install that configured nothing.
     process.env[ENV] = "   ";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(15);
+    expect(Object.keys(activeTuning().models)).toHaveLength(18);
   });
 
   test("is read once, so a run cannot see the table change under it", () => {

--- a/tests/unit/lib/agent/repair-ledger.test.ts
+++ b/tests/unit/lib/agent/repair-ledger.test.ts
@@ -188,6 +188,62 @@ describe("AgentRepairLedger — the repair budget", () => {
     expect(ledger.attemptsUsed).toBe(0);
   });
 
+  test("nor does a database error the SERVER answered, though it is still unrepeatable", () => {
+    /*
+      Measured, and it is the whole of why this class exists. Five `lfm2:24b` data-analysis runs
+      were driven at one sitting and all five ended identically: three `no such column` errors,
+      the budget spent, and the FOURTH statement — the correct one in the run that was read in
+      full — refused before it reached the database. Not one of the five produced a single
+      successful read, so every report rested on a table profile and every verdict said
+      `no-answer`.
+
+      The budget is right and stays at three. What was wrong is counting these against it. This
+      layer's own rule is that a boundary decision costs nothing because "nothing ran, and a
+      boundary decision is not a defect in a statement the model could fix" — and a statement
+      whose error the server answered with the columns that DO exist is the same shape seen from
+      the other side: the model is not guessing again, it is applying a correction this server
+      dictated. What the budget exists to bound is a model inventing spellings, and it still does.
+
+      Deliberately NOT decided by reading the engine's message. That text is untrusted input
+      everywhere else in this system, and control flow that parsed it would be trusting a database
+      to say how many attempts a run has left. The caller decides on ITS OWN state — whether it
+      could build the advice from the inventory this process is holding — and passes the answer in.
+
+      The fingerprint is still recorded, so the same statement can never be sent twice. That half
+      is what stops a loop, and it is untouched.
+    */
+    const ledger = new AgentRepairLedger();
+    const answered = ["SELECT a FROM t", "SELECT b FROM t", "SELECT c FROM t", "SELECT d FROM t"];
+    for (const sql of answered) ledger.recordFailure(fingerprintStatement(sql), "database-error-answered");
+
+    expect(ledger.attemptsUsed).toBe(0);
+    // The fifth spelling still runs: four answered failures have not closed the door.
+    expect(ledger.admit(fingerprintStatement("SELECT e FROM t"))).toEqual({ admitted: true });
+    // But none of the four may be sent again.
+    for (const sql of answered) {
+      expect(ledger.admit(fingerprintStatement(sql))).toEqual({
+        admitted: false,
+        reasonCode: "STATEMENT_ALREADY_FAILED",
+      });
+    }
+  });
+
+  test("an unanswered database error still costs one, so a guessing model is still bounded", () => {
+    // The half that must not move. The budget's purpose is a model inventing spellings the
+    // server cannot help with, and that model reaches the same wall it always did.
+    const ledger = new AgentRepairLedger();
+    ledger.recordFailure(fingerprintStatement("SELECT 1"), "database-error-answered");
+    for (const sql of ["SELECT 2", "SELECT 3", "SELECT 4"]) {
+      ledger.recordFailure(fingerprintStatement(sql), "database-error");
+    }
+
+    expect(ledger.attemptsUsed).toBe(3);
+    expect(ledger.admit(fingerprintStatement("SELECT 5"))).toEqual({
+      admitted: false,
+      reasonCode: "REPAIR_BUDGET_EXHAUSTED",
+    });
+  });
+
   test("a denied statement is still never re-asked — the fingerprint is recorded regardless of class", () => {
     const ledger = new AgentRepairLedger();
     const fingerprint = fingerprintStatement("DELETE FROM orders");

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -750,7 +750,7 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
       expect(bothArms(outcome.modelText)).toEqual(["artifact", "context-snapshot"]);
     });
 
-    test("a citation whose SOURCE is a word nobody implements is told the two that work", () => {
+    test("a union issue reaches the ledger unnamed, and the model still reads both arms", () => {
       /*
         Measured on `granite4.1:3b`, database-assessment, five runs at one sitting: three answered
         and two did not, and the two that lost are one shape — `compose_report` refused THREE
@@ -765,7 +765,14 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
 
         The permitted values are in the schema and in hand: a union reports each branch's own
         failure, and the branch that failed on the discriminant carries the literal it wanted.
-        Two words, and the model had never been shown either.
+
+        `describeIssues` is nevertheless left SILENT on `invalid_union`, deliberately — see the
+        comment at its `invalid_union` case. Reading the branch issues back would name the two
+        arms a second time in the ledger line, and the model already reads them from the contract
+        appended to every refusal this tool gives. So this test pins the SPLIT rather than a fix:
+        the ledger line stays the raw union code, and the model's text carries both arms. It fails
+        if either half moves — if the contract stops reaching the model, or if the ledger line
+        starts claiming to name what it does not.
       */
       const h = harness();
 
@@ -779,9 +786,13 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
 
       if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
       expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
-      // What the MODEL reads already names both arms — the contract is appended to every refusal
-      // this tool gives. Pinned here because the ledger line beside it does NOT, and a reader who
-      // saw only `source: invalid union` in the ledger would conclude the model was told nothing.
+      // The LEDGER half: still the raw union code, naming neither arm. This is the assertion that
+      // makes the test bite — a reader who saw only this line would conclude the model was told
+      // nothing, and that conclusion has to stay wrong for the reason below and not by accident.
+      expect(outcome.detail).toContain("claims.0.evidence.0.source");
+      expect(outcome.detail).toContain("invalid union");
+      expect(outcome.detail).not.toContain("context-snapshot");
+      // The MODEL half: both arms, from the contract appended to every refusal this tool gives.
       expect(bothArms(outcome.modelText)).toEqual(["artifact", "context-snapshot"]);
     });
 
@@ -1733,6 +1744,85 @@ describe("runReadQueryTool — a database error is repairable, bounded, and neve
     const outcome = await runReadQueryTool(h.context, { sql: "SELECT * FROM information_schema.columns" });
 
     expect(outcome.modelText).toContain("inspect_schema");
+  });
+
+  describe("what an advised failure COSTS is narrower than what it is advised about", () => {
+    /*
+      The free class and the sentence are two different decisions, and they were one.
+
+      `database-error-answered` was justified on one branch only: the server holds the inventory,
+      hands the model the columns that DO exist, and the next statement is therefore not another
+      guess but the correction this server dictated. Charging that was charging the model for our
+      own earlier silence.
+
+      Deciding the class from "did any advice come back" widened it to two branches it was never
+      argued for. `row budget: N rows > M allowed` is the loud one: that statement RAN, at the
+      engine, to completion, and returned rows before it blew the cap — the most expensive failure
+      a run can produce. Making a query cheaper is a rewrite, and a rewrite is what attempts exist
+      to bound. With the cost removed, the only remaining bound is `unreportedCallCeiling` (10–12),
+      so a run could pay for a dozen full scans where it used to pay for three.
+
+      So: the ADVICE still goes back on all three branches — it is one line of fact about the
+      operator's own database either way — and only the inventory branch is free.
+    */
+    test("a row-budget overrun is advised and still charged, because the fix is a rewrite", async () => {
+      const h = harness({}, async () => {
+        throw new QueryError("Read-only execution exceeded the row budget: 1000 rows > 200 allowed", "postgres");
+      });
+
+      const outcome = await runReadQueryTool(h.context, { sql: "SELECT * FROM orders" });
+
+      // Unchanged: the model is still told the number that would have worked.
+      expect(outcome.modelText).toContain("LIMIT 200");
+      // Changed: it costs one of the three again.
+      expect(h.repairs.attemptsUsed).toBe(1);
+      if (outcome.kind !== "refused") throw new Error(`expected refused, got ${outcome.kind}`);
+      if (outcome.refusal.class !== "database-error") throw new Error("expected a database-error refusal");
+      expect(outcome.refusal.answered).toBe(false);
+    });
+
+    test("a catalog belonging to another engine is charged too", async () => {
+      const h = harness({}, async () => {
+        throw new QueryError("no such table: information_schema.columns", "sqlite");
+      });
+
+      const outcome = await runReadQueryTool(h.context, { sql: "SELECT * FROM information_schema.columns" });
+
+      expect(outcome.modelText).toContain("inspect_schema");
+      expect(h.repairs.attemptsUsed).toBe(1);
+    });
+
+    test("three of them exhaust the budget, so an unbounded scan cannot repeat forever", async () => {
+      // The consequence the split exists for. Under the wide class these four all cost nothing and
+      // the fourth reached the database; the budget is three, and it means three again.
+      const h = harness({}, async () => {
+        throw new QueryError("Read-only execution exceeded the row budget: 1000 rows > 200 allowed", "postgres");
+      });
+
+      for (const table of ["orders", "customers", "shipments"]) {
+        await runReadQueryTool(h.context, { sql: `SELECT * FROM ${table}` });
+      }
+      expect(h.repairs.attemptsUsed).toBe(3);
+
+      const fourth = await runReadQueryTool(h.context, { sql: "SELECT * FROM invoices" });
+      if (fourth.kind !== "unavailable") throw new Error(`expected unavailable, got ${fourth.kind}`);
+      expect(fourth.reasonCode).toBe("REPAIR_BUDGET_EXHAUSTED");
+    });
+
+    test("a failure this server could say nothing about is charged and says so", async () => {
+      // The unadvised path, pinned beside the others so the flag cannot quietly become "always
+      // false": every branch writes it, and this is the one with no advice at all.
+      const h = harness({}, async () => {
+        throw new QueryError('relation "employees" does not exist', "postgres");
+      });
+
+      const outcome = await runReadQueryTool(h.context, { sql: "SELECT 1 FROM employees" });
+
+      expect(h.repairs.attemptsUsed).toBe(1);
+      if (outcome.kind !== "refused") throw new Error(`expected refused, got ${outcome.kind}`);
+      if (outcome.refusal.class !== "database-error") throw new Error("expected a database-error refusal");
+      expect(outcome.refusal.answered).toBe(false);
+    });
   });
 
   test("a model with no profile at all is told it too, and still outside the fence", async () => {

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -662,6 +662,46 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
         expect(answer.reasonCode).toBe("INVALID_TOOL_INPUT");
       });
     }
+
+    test("and names the field that did not match, the way compose_report does", () => {
+      /*
+        Measured, in one `lfm2:24b` data-analysis run that had done all of the work.
+
+        Told to present before reporting, it called `present_answer` THREE times in a row and was
+        refused three times with the same two sentences: the generic "input is invalid" and the
+        contract restated. It never learned which field was wrong, gave up, went back to
+        `compose_report` — and that refusal DID name its field, `claims.0.evidence: expected
+        array`. Same run, same model, same schema layer: one refusal is actionable and the other
+        is not, and the cell scored `no-answer` with the answer sitting in the run.
+
+        The cause is that this refusal is assembled by hand and drops `parsed.problems` on the
+        floor, while `composeReportTool` passes it to `invalidEvidenceInput`. The contract and the
+        worked example both stay — the docblock's reasoning for them is sound and unrelated. What
+        is added is the one concrete thing a confused model can act on.
+      */
+      const h = analysis();
+
+      const answer = presentAnswerTool(
+        h.context,
+        { runId: h.context.runId, events: [], autoExecute: false },
+        { artifact: "corr-real", presentation: 7 },
+      );
+
+      expect(answer.kind).toBe("unavailable");
+      if (answer.kind !== "unavailable") return;
+      /*
+        `detail` is the half that reaches the LEDGER, and its absence is what made this
+        undiagnosable from the outside: `call-declined` for `compose_report` carries
+        `claims.0.evidence: expected array`, and the three beside it for `present_answer` carry
+        the code alone. `declined()` in the drive writes it only when the outcome has one.
+      */
+      expect(answer.detail).toBeDefined();
+      expect(answer.detail).toContain("presentation");
+      // And the half that reaches the MODEL, in the position `invalidEvidenceInput` argues for:
+      // the failing path BEFORE the contract, because the contract is what it has already read
+      // and misapplied.
+      expect(answer.modelText.indexOf("presentation")).toBeLessThan(answer.modelText.indexOf(AGENT_ANSWER_CONTRACT));
+    });
   });
 
   /*
@@ -707,6 +747,41 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
 
       if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
       expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
+      expect(bothArms(outcome.modelText)).toEqual(["artifact", "context-snapshot"]);
+    });
+
+    test("a citation whose SOURCE is a word nobody implements is told the two that work", () => {
+      /*
+        Measured on `granite4.1:3b`, database-assessment, five runs at one sitting: three answered
+        and two did not, and the two that lost are one shape — `compose_report` refused THREE
+        times with the same sentence, then the run ended `no-report`. The runs that won had been
+        refused once or not at all.
+
+        The sentence they could not act on was `claims.0.evidence.2.source: invalid union`. Every
+        other refusal this layer writes names what would have worked — `expected array`,
+        `expected one of ...`, the columns a table has, the id to present. This one printed Zod's
+        code with the underscores swapped for spaces, because a union issue falls past the two
+        cases above it and lands on the generic line.
+
+        The permitted values are in the schema and in hand: a union reports each branch's own
+        failure, and the branch that failed on the discriminant carries the literal it wanted.
+        Two words, and the model had never been shown either.
+      */
+      const h = harness();
+
+      const outcome = composeReportTool(
+        h.context,
+        { runId: h.context.runId, events: [artifactEvent] },
+        {
+          claims: [{ claim: "Engineering is largest.", evidence: [{ source: "table", correlationId: "corr-real" }] }],
+        },
+      );
+
+      if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+      expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
+      // What the MODEL reads already names both arms — the contract is appended to every refusal
+      // this tool gives. Pinned here because the ledger line beside it does NOT, and a reader who
+      // saw only `source: invalid union` in the ledger would conclude the model was told nothing.
       expect(bothArms(outcome.modelText)).toEqual(["artifact", "context-snapshot"]);
     });
 
@@ -1628,7 +1703,7 @@ describe("runReadQueryTool — a database error is repairable, bounded, and neve
     }
   });
 
-  test("the row budget refusal names the LIMIT to use, for a model that earned the advice", async () => {
+  test("the row budget refusal names the LIMIT to use", async () => {
     /*
       `database-error` is the largest refusal in the system by nearly four to one — 368 against
       100 for the next — and reading them grouped is what makes them tractable. They are not 368
@@ -1641,7 +1716,7 @@ describe("runReadQueryTool — a database error is repairable, bounded, and neve
       throw new QueryError("Read-only execution exceeded the row budget: 1000 rows > 200 allowed", "postgres");
     });
 
-    const outcome = await runReadQueryTool({ ...h.context, modelId: "granite4.1:8b" }, { sql: "SELECT * FROM orders" });
+    const outcome = await runReadQueryTool(h.context, { sql: "SELECT * FROM orders" });
 
     expect(outcome.modelText).toContain("LIMIT 200");
     // Outside the fence: the advice is this server's sentence, and putting it inside would
@@ -1655,25 +1730,35 @@ describe("runReadQueryTool — a database error is repairable, bounded, and neve
       throw new QueryError("no such table: information_schema.columns", "sqlite");
     });
 
-    const outcome = await runReadQueryTool(
-      { ...h.context, modelId: "granite4.1:8b" },
-      { sql: "SELECT * FROM information_schema.columns" },
-    );
+    const outcome = await runReadQueryTool(h.context, { sql: "SELECT * FROM information_schema.columns" });
 
     expect(outcome.modelText).toContain("inspect_schema");
   });
 
-  test("a model that has not earned the advice gets the engine's message and nothing else", async () => {
-    // The rule every behaviour added since today obeys: off by default, on where a ledger
-    // earned it. The engine's own words still go back either way.
+  test("a model with no profile at all is told it too, and still outside the fence", async () => {
+    /*
+      This asserted the opposite while the advice sat behind `refusalExamples`, on the rule that a
+      behaviour stays off until a ledger earns it. That rule holds for the worked examples the
+      lever still gates — a whole tool call rebuilt from the run's own events, long enough to crowd
+      a small model's turn. It never fitted these three sentences, which state a fact about the
+      operator's own database and run to one line: the columns a table has, the LIMIT that would
+      fit, the engine this connection actually is.
+
+      Two of sixteen shipped models could see them. `lfm2:24b` is what settled it — data-analysis
+      0/5, every run drafting `employee.dept_no`, told only that no such column exists, reading the
+      schema, and drafting the identical statement again.
+    */
     const h = harness({}, async () => {
       throw new QueryError("Read-only execution exceeded the row budget: 1000 rows > 200 allowed", "postgres");
     });
 
+    // `harness` sets no modelId, so nothing resolves a profile — the case that used to get nothing.
     const outcome = await runReadQueryTool(h.context, { sql: "SELECT * FROM orders" });
 
     expect(outcome.modelText).toContain("row budget");
-    expect(outcome.modelText).not.toContain("LIMIT 200");
+    expect(outcome.modelText).toContain("LIMIT 200");
+    // Still this server's sentence rather than the engine's, so still outside the fence.
+    expect(outcome.modelText.split(UNTRUSTED_CONTENT_END)[1]).toContain("LIMIT 200");
   });
 
   test("the engine's message is fenced as untrusted content on its way to the model", async () => {
@@ -4310,6 +4395,64 @@ describe("present_answer records which result IS the answer, and how to show it"
       expect(outcome.reasonCode).toBe("ANSWER_NOT_A_DATA_READ");
       // The way out, named: this run has a tool that reads data, and the refusal says so.
       expect(outcome.modelText).toContain("run_read_query");
+    });
+
+    test("and when the run already holds a read, the refusal hands over ITS id", () => {
+      /*
+        Measured across fifteen `qwen3:1.7b` data-analysis runs: FOURTEEN were refused here on
+        their first `present_answer`, every one of them having cited a plan or a profile. Eight of
+        the fifteen were holding a perfectly good read at that moment and four of those eight
+        never found it — they were told to run a read they had already run.
+
+        The sentence is not wrong. "Present the result of a run_read_query you drafted — run the
+        read first if you have not" is exactly right for a run that has not, and seven of the
+        fifteen had not. It is incomplete for the other eight, and the missing piece is a value
+        this server is holding: the id of the artifact the tool WOULD take.
+
+        The same move the answer notice already makes one step later — "it also names the id to
+        cite... being told to cite it 'somewhere' and being handed the characters are different
+        instructions". `exampleAnswerCall` even computes this id already, to build a worked call
+        from; it is behind the `refusalExamples` lever because a whole call is long. An id is not.
+      */
+      const h = harness();
+      /** A read this run drafted and completed — exactly what `present_answer` accepts. */
+      const readEvents: AgentRunEvent[] = [
+        { kind: "statement-drafted", atMs: 1, stepId: "step-read", sql: ANSWER_SQL, rationale: "the answer" },
+        {
+          kind: "tool-completed",
+          atMs: 2,
+          stepId: "step-read",
+          artifact: {
+            correlationId: "corr-the-read",
+            runId: "run-1",
+            operationId: "sql.query.read",
+            summary: { rowCount: 3, columnNames: ["id"], elapsedMs: 5 },
+          },
+        },
+      ];
+
+      // The plan is cited; the read sits in the same ledger, unmentioned by the model.
+      const outcome = present(h, [...readEvents, ...inspectedPlan()], {
+        artifact: PLAN_CORRELATION,
+        presentation: { kind: "table" },
+      });
+
+      if (outcome.kind !== "unavailable") throw new Error("expected a refusal");
+      expect(outcome.reasonCode).toBe("ANSWER_NOT_A_DATA_READ");
+      expect(outcome.modelText).toContain("corr-the-read");
+      // And in the ledger too, so a run refused here repeatedly is diagnosable afterwards.
+      expect(outcome.detail).toContain("corr-the-read");
+    });
+
+    test("and says nothing about an id when the run holds no read at all", () => {
+      // The seven runs of the fifteen that had read nothing. Naming an id there would mean
+      // inventing one, and the sentence they already get — run the read first — is the answer.
+      const h = harness();
+
+      const outcome = present(h, inspectedPlan(), { artifact: PLAN_CORRELATION, presentation: { kind: "table" } });
+
+      if (outcome.kind !== "unavailable") throw new Error("expected a refusal");
+      expect(outcome.detail).toBeUndefined();
     });
 
     test("the refusal comes BEFORE the statement is resolved, so the reason names the real problem", () => {


### PR DESCRIPTION
Eighteen models now drive every agent surface. The three added here were measured **against this branch** — six surfaces, five consecutive passing runs each, through the API the UI uses and against the document this repository ships rather than an operator file.

| Model | Pla | Inv | Ass | Ope | Ana | Opt | Settings |
|---|---|---|---|---|---|---|---|
| `granite4.2:8b` | 5/5 | 5/5 | 4/5 | 5/5 | 5/5 | 5/5 | none |
| `nemotron-3-nano:30b` | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | `turnTimeoutMs: 150000` |
| `qwen3.5:4b` | 5/5 | 5/5 | 5/5 | 5/5 | 3/5 | 5/5 | `suppressPlanReasoning` |

Sixteen of the eighteen cells came back clean on this base. The two that did not are recorded as thin rather than smoothed away — `qwen3.5:4b` on data-analysis and `granite4.2:8b` on database-assessment both re-read below 5/5 on a second sitting, and their entries say so in the same words `nemotron3:33b` already uses. Both cells have locked repeatedly; a figure that reads steadier than the model is worse than one that says where it is thin.

`granite4.2:8b` gets an entry although it overrides nothing. An absent entry records no measurement, and a model nobody can see was measured is a model nobody can trust.

## Five refusals that named no remedy

Every one was read out of a run ledger, and every one has the same shape: **this server knew what would have worked and refused without saying it.**

**1. `no such column` went back bare.** `columnsThatExist` already computed the columns that DO exist and which table holds the missing one — and it sat behind `refusalExamples`, a lever two of sixteen models carried. Ungated: it is one sentence of fact about the operator's own database, unlike the worked examples the lever still gates. `lfm2:24b` went from repeating one spelling to converging on the right join in three tries.

**2. `present_answer` dropped its field paths.** It refused `INVALID_TOOL_INPUT` and threw away `parsed.problems`, while its sibling `composeReportTool` passed them to `invalidEvidenceInput`. A model called it three times in one run and read "input is invalid, here is the contract" each time. It now reads `presentation: remove rows`, and the ledger carries the same paths so a repeated refusal is diagnosable afterwards.

**3. `ANSWER_NOT_A_DATA_READ` told runs to read what they had already read.** Fourteen of fifteen measured runs were refused there; eight were holding a good artifact at that moment and four of those eight never found it. The refusal now hands over that id.

**4. An answered database error consumed a repair attempt.** The budget of three was spent on three `no such column` errors and the FOURTH statement — the correct one — was refused before it reached the database. Five of five `lfm2:24b` runs died that way, none producing a single successful read. A failure this server can answer now costs no attempt, via a new `database-error-answered` class decided from our own state rather than from the engine's message. The constant stays at three and an unanswered error still costs one.

**5. The planning rule taught the wrong marker.** It read ``write NO STATEMENT AT ALL: begin a line with `NO STATEMENT:` `` — English, a colon, then the literal introduced the same way one clause later. `qwen3.5:4b` wrote correct refusals, naming the two views whose columns the inventory cannot derive and asking the one question that would unblock it, and opened every one with the first phrase. It obeyed the instruction and scored as having answered nothing. Fixed in the wording rather than by widening the reader: a tolerant reader would accept this one spelling and leave the sentence in place for the next model to invent another from. That cell had not opened in ten attempts; it read 5/5 on the first pass after the fix.

## Also here

- **`verdictHoldLimit` becomes per-model**, joining the two reminder bounds it sits beside. Default unchanged at two; every shipped model resolves to it.
- **`agent-model-e2e.sh` loads `AGENT_MODEL_TUNING_PATH`** when the caller sets one, and says which document it is serving. Without it the browser sweep drove every model naked — a model whose lock depends on a setting failed there while passing everywhere else, and the fault read as the model's.

## Verification

`typecheck` · `lint` · `knip` · `build` clean. `tests/unit/lib/agent` + `tests/evals`: 1611 pass, 0 fail. `tests/isolated/agent-investigation`: 162 pass, 0 fail.

The planning rule reaches every model's plan prompt, so the plan cell was re-read against this base for the models it could affect: six read 5/5 and none lost a lock. The remaining shipped models were not re-read on this base; they were clean on the branch this work was ported from.
