### PR TITLE
ci(coverage): publish the merged lcov to Codecov as a report, never as a second gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,27 @@ jobs:
           name: coverage
           path: coverage/lcov.info
 
+      # Codecov publishes the same merged lcov for PR annotations and the README
+      # badge. It is NOT the coverage gate: `coverage:check` above is, and it runs
+      # first. Two consequences are deliberate here:
+      #   - always(), so a run that trips the gate still ships the report that
+      #     shows which lines regressed, matching the artifact step above.
+      #   - fail_ci_if_error stays false. This job is a required check, and a
+      #     Codecov outage - or a fork PR, which gets no secrets and so no token -
+      #     must not be able to block a merge. Codecov's own PR statuses are
+      #     informational for the same reason (see codecov.yml).
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          # The merged lcov is the only report worth sending; without this the
+          # action walks the tree and uploads the per-file intermediates that
+          # `merge-lcov.mjs` already folded in.
+          disable_search: true
+          fail_ci_if_error: false
+
   e2e:
     name: E2E Tests
     needs: [lint-and-build]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+# Codecov is a reporting surface here, not a gate.
+#
+# The authoritative coverage rule is `bun run coverage:check`
+# (scripts/check-coverage.mjs) in the "Unit & Integration Tests" job: the merged
+# lcov must be at 100% lines, and that job is a required check. A second gate
+# that can disagree with it would be worse than none - Codecov computes its own
+# base via carry-forward and can report a delta on a run where the required gate
+# is green, which would block merges for a reason no local command reproduces.
+#
+# So every status below is informational: Codecov annotates the diff and renders
+# the badge, and never fails a pull request.
+#
+# There is deliberately no `ignore:` list. Path filtering happens upstream, in
+# scripts/merge-lcov.mjs, which keeps only `src/` records and drops
+# `src/components/ui/` (mirroring sonar.exclusions) before the report is written.
+# Restating that here would be configuration that cannot have an effect, and the
+# next person would have to prove that rather than read it.
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
Wires the Codecov upload into the `Unit & Integration Tests` job, next to the coverage artifact it already publishes.

## Why it is not a gate

`bun run coverage:check` over `coverage/lcov.info` is the coverage rule, and that job is a required check. Codecov is a reporting surface on top of it, so it is configured without the authority to fail anything:

- **`if: always()`** — a run that trips the 100% gate still ships the report showing which lines regressed. That is exactly when the report is worth having, and it matches the reasoning already written on the artifact step beside it.
- **`fail_ci_if_error: false`** — the job is a required check. A Codecov outage, or a fork PR (no secrets, therefore no token), must not be able to block a merge.
- **`informational: true` on both project and patch statuses** — Codecov computes its own base by carry-forward and can report a delta on a run where the required gate is green. A second, weaker gate that can disagree with the first is worse than having no second gate: it blocks merges for a reason no local command reproduces.

## Two deviations from Codecov's onboarding snippet

- The page still shows `codecov/codecov-action@v5`. The current major is **v7.0.0** (2026-06-07; v5.5.5 is a later maintenance release on the old line). It is pinned by SHA, like every other `uses:` in this workflow.
- The page's example is `npx jest --coverage`. This repo produces one merged lcov through `run-core.sh` and `merge-lcov.mjs`, so the step passes `files: coverage/lcov.info` with `disable_search: true` — without that, the action walks the tree and re-uploads the per-file intermediates the merge already folded in.

## No `ignore:` list in codecov.yml

Deliberate. Path filtering happens upstream in `merge-lcov.mjs`, which keeps only `src/` records and drops `src/components/ui/`. Restating that in `codecov.yml` would be configuration that cannot have an effect, and the next person would have to prove that rather than read it.

## Verification

- `bun run format` — clean
- `bun run knip` — clean (only the two pre-existing configuration hints)
- `bun test tests/unit/security-scan-workflow.test.ts tests/unit/helm-pin-matrix.test.ts tests/unit/release-provenance.test.ts` — 90 pass, 0 fail (the suites that read workflow YAML)
- Both YAML files parse

`lint`, `typecheck` and `build` are unaffected: the change is two YAML files and touches no TypeScript.

Requires the `CODECOV_TOKEN` repository secret, which is configured. The badge fills on the first run after this merges to `main`.