### PR TITLE
docs(readme): let the coverage badge report the number instead of asserting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
   <a href="https://github.com/libredb/libredb-studio"><img src="https://img.shields.io/github/stars/libredb/libredb-studio?style=social" alt="GitHub stars"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://sonarcloud.io/project/overview?id=libredb_libredb-studio"><img src="https://sonarcloud.io/api/project_badges/measure?project=libredb_libredb-studio&metric=alert_status" alt="Quality Gate"></a>
-  <a href="#testing"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen" alt="Coverage 100%"></a>
+  <a href="https://codecov.io/github/libredb/libredb-studio"><img src="https://codecov.io/github/libredb/libredb-studio/graph/badge.svg?token=VA6CO9R7IH" alt="Coverage"></a>
   <a href="https://deepwiki.com/libredb/libredb-studio"><img src="https://img.shields.io/badge/Docs-DeepWiki-blue?logo=gitbook" alt="DeepWiki Docs"></a>
   <a href="https://artifacthub.io/packages/helm/libredb-studio/libredb-studio"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/libredb-studio" alt="Artifact Hub"></a>
 </p>

--- a/README_ja.md
+++ b/README_ja.md
@@ -36,7 +36,7 @@
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://sonarcloud.io/project/overview?id=libredb_libredb-studio"><img src="https://sonarcloud.io/api/project_badges/measure?project=libredb_libredb-studio&metric=alert_status" alt="Quality Gate"></a>
-  <a href="#テストと品質"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen" alt="Coverage 100%"></a>
+  <a href="https://codecov.io/github/libredb/libredb-studio"><img src="https://codecov.io/github/libredb/libredb-studio/graph/badge.svg?token=VA6CO9R7IH" alt="Coverage"></a>
   <a href="https://artifacthub.io/packages/helm/libredb-studio/libredb-studio"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/libredb-studio" alt="Artifact Hub"></a>
 </p>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -38,7 +38,7 @@
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://sonarcloud.io/project/overview?id=libredb_libredb-studio"><img src="https://sonarcloud.io/api/project_badges/measure?project=libredb_libredb-studio&metric=alert_status" alt="Quality Gate"></a>
-  <a href="#测试与质量"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen" alt="Coverage 100%"></a>
+  <a href="https://codecov.io/github/libredb/libredb-studio"><img src="https://codecov.io/github/libredb/libredb-studio/graph/badge.svg?token=VA6CO9R7IH" alt="Coverage"></a>
   <a href="https://artifacthub.io/packages/helm/libredb-studio/libredb-studio"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/libredb-studio" alt="Artifact Hub"></a>
 </p>
 


### PR DESCRIPTION
Follow-up to #532, held back until `main` actually carried a Codecov report so the badge would never render `unknown` on the front page.

## What was there

All three READMEs carried a hand-written shields.io image:

```
https://img.shields.io/badge/coverage-100%25-brightgreen
```

The `100` in that URL is a literal. The badge was green because someone typed it, not because anything measured it — so the single state it could never display is the one a reader would consult it for: coverage having fallen. The `alt` text hardcoded `100%` too, which repeated the claim to screen readers.

## What it is now

The live Codecov badge for the merged lcov that #532 started publishing. `main` now has a report — 385 files, 45,424 lines, 100.00% — and the badge renders `100%` today rather than the `unknown` it returned while `main` had none.

The link target moves from the in-page testing anchor to the Codecov dashboard, which is where someone who clicked a coverage badge meant to go.

## Verification

- `bun run readme:check` — `OK: 16 engines and the install commands match README.md in README_zh.md, README_ja.md`
- `bun run format` — clean
- `bun run knip` — clean (the two pre-existing configuration hints)
- Badge fetched directly: `200 image/svg+xml`, rendering `100%`
- Codecov API for `main`: `{"lines": 45424, "hits": 45424, "coverage": 100.0}`

Three lines changed, one per README. No TypeScript is touched, so `lint`, `typecheck` and `build` are unaffected.