### PR TITLE
docs(readme): the first supporter, and the attribution the site already promised

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,21 @@ _Be the first to sponsor libredb-studio!_
 
 ---
 
+## Supporters
+
+Distinct from the sponsors above: these are open-source programmes that cover a
+running cost of the project. A place here cannot be bought, and nothing here is
+an endorsement of libredb-studio by the company named. The full list, what each
+one covers and what attribution is owed in return are at
+[libredb.org/supporters](https://libredb.org/supporters/).
+
+- **[Tailscale](https://tailscale.com/opensource)** — the Community on GitHub
+  plan behind the private network maintainers use to reach the database probe
+  hosts, so testing against real engines does not mean exposing database ports
+  to the internet. Since 2026-09-01.
+
+---
+
 ## Contributing
 
 We welcome contributions from the community! Whether it's a bug fix, a new feature, or documentation improvements:


### PR DESCRIPTION
## What

Adds a `## Supporters` section to the README with its first entry: Tailscale, which granted the Community on GitHub plan to the `libredb` organization on 2026-09-01 (support ticket TSS-100364, confirmed in the admin console: plan "GitHub Community plan", next invoice 2027-09-01, $0.00).

## Why this is a debt, not a marketing addition

`libredb.org/supporters` publishes what a supporter is promised, and one of the four promises is stated in these words:

> **The same entry in the repository** — the README carries it too, so the attribution survives someone reading the project on GitHub and never opening this site.

That page is cited on the application forms so a reviewer can hold the page against the form. Until now the promise had never come due, because no programme had accepted the project. One has, so the README owes the entry the same day the site got it.

## Why not inside `## Sponsors`

That block sits between `<!-- sponsors-start -->` / `<!-- sponsors-end -->`, which `.github/workflows/update-sponsors.yml` rewrites from GitHub Sponsors. An entry placed there would be erased by the next bot run, and it would conflate individual donations with a programme covering a specific running cost. The new section says which of the two it is.

## Verification

- `bun run readme:check` — OK, 16 engines and the install commands still match `README_zh.md` / `README_ja.md`. The guard covers engine names and install commands, so an English-only section is legal abridgement and needs no translation.
- `format` · `lint` · `typecheck` · `knip` · `build` — all clean.
- `bun run test` — 10474 pass, 1 fail. The failure is `backlog-structure.test.ts > every cited entry exists`, and it is **local-only and pre-existing**: all five dangling citations are inside `docs/superpowers/`, which is gitignored and therefore invisible to CI. Reproduced on a clean `origin/main` tree with this change stashed, so it is not from this PR.

Documentation only. No executable lines added, so the coverage gate is unaffected.