### PR TITLE
fix(ci): the Docker Hub namespace is not the account that logs in

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -173,19 +173,27 @@ jobs:
           echo "Image name (lowercase): ${IMAGE_NAME_LOWER}"
 
       # Build the list of target images. GHCR is always included; Docker Hub
-      # (docker.io/<DOCKER_HUB_USERNAME>/<repo>) is added only when enabled.
+      # (docker.io/<DOCKER_HUB_ORGANIZATION>/<repo>) is added only when enabled.
+      #
+      # The namespace is NOT the login user. `libredb` was a Docker Hub user
+      # account until 2026-09-01 and one variable answered both questions; the
+      # conversion to an organization split them, because an organization cannot
+      # sign in. DOCKER_HUB_USERNAME is now the owner who logs in, and the image
+      # must still be published under the organization everyone pulls from.
+      # Using the login name here does not fail - it publishes to a real
+      # repository nobody reads while the mirror goes stale.
       - name: Compose registry image list
         id: images
         env:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
           REPO_NAME: ${{ steps.image.outputs.name }}
           DH_ENABLED: ${{ steps.dockerhub.outputs.enabled }}
-          DH_USERNAME: ${{ vars.DOCKER_HUB_USERNAME }}
+          DH_ORGANIZATION: ${{ vars.DOCKER_HUB_ORGANIZATION }}
         run: |
           IMAGES="$GHCR_IMAGE"
-          if [ "$DH_ENABLED" = "true" ] && [ -n "$DH_USERNAME" ]; then
+          if [ "$DH_ENABLED" = "true" ] && [ -n "$DH_ORGANIZATION" ]; then
             SHORT_NAME="${REPO_NAME##*/}"
-            IMAGES="$(printf '%s\ndocker.io/%s/%s' "$IMAGES" "$DH_USERNAME" "$SHORT_NAME")"
+            IMAGES="$(printf '%s\ndocker.io/%s/%s' "$IMAGES" "$DH_ORGANIZATION" "$SHORT_NAME")"
           fi
           {
             echo "list<<EOF"

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1202,7 +1202,7 @@ setups still publish the rest:
 |---|---|---|
 | `TAP_GITHUB_TOKEN` | Rendering and pushing the Homebrew formula to `libredb/homebrew-tap` (needs write access to that repo) | Tap update skipped; tarballs still attach to the release |
 | `SNAPCRAFT_STORE_CREDENTIALS` | The entire snap build/publish job (exported via `snapcraft export-login`) | Snap job skipped |
-| `DOCKER_HUB_TOKEN` (+ `DOCKER_HUB_USERNAME` variable) | The Docker Hub mirror push | GHCR-only publish |
+| `DOCKER_HUB_TOKEN` (+ `DOCKER_HUB_USERNAME` and `DOCKER_HUB_ORGANIZATION` variables) | The Docker Hub mirror push. Two variables, not one: `DOCKER_HUB_USERNAME` is the **owner who logs in** (an organization cannot sign in), `DOCKER_HUB_ORGANIZATION` is the **namespace the image is published under**. They were the same value while `libredb` was a user account; converting it to an organization on 2026-09-01 split them | GHCR-only publish |
 | `CHOCO_API_KEY` | The chocolatey job: `choco pack` + `choco push` to `https://push.chocolatey.org/` (API key of the `libredb` community account) | Chocolatey publish skipped; the win32 zip still attaches to the release |
 | — | Every row above whose channel is switchable also needs `update.ci_enabled: true` in [`distribution/channels.yaml`](../distribution/channels.yaml): the secret says CI *can* publish, the flag says it *should*. See [Turning a channel's automation off](#turning-a-channels-automation-off) | Channel skipped with a notice; the release publishes normally |
 | `WINGETCREATE_GITHUB_TOKEN` | The winget job: `wingetcreate update --submit` PRs to `microsoft/winget-pkgs`. Classic PAT with `public_repo` scope — wingetcreate does not support fine-grained PATs | winget submission skipped |

--- a/tests/unit/docker-hub-namespace.test.ts
+++ b/tests/unit/docker-hub-namespace.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the Docker Hub mirror's two identities.
+ *
+ * Why a test for YAML: `libredb` on Docker Hub was a user account until
+ * 2026-09-01, so one variable could answer two different questions - who logs
+ * in, and which namespace the image is published under. Converting it to an
+ * organization split those answers apart: an organization cannot sign in, so
+ * the login is now the owner user (`cevheri`), while the namespace must stay
+ * `libredb` or every `docker run` line in the README points at nothing.
+ *
+ * The failure this guards is silent in both directions. Using the login name as
+ * the namespace does not error - it publishes to `docker.io/<owner>/...`, a real
+ * repository nobody pulls, while the mirror everyone does pull goes stale.
+ * Using the namespace as the login fails the whole job, because buildx exports
+ * every tag in one push and one rejected mirror tag takes GHCR down with it.
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { parse as parseYaml } from "yaml";
+
+interface Step {
+  name?: string;
+  id?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, string | boolean>;
+}
+interface Job {
+  steps?: Step[];
+}
+
+const read = (file: string) =>
+  parseYaml(fs.readFileSync(path.join(__dirname, "../../.github/workflows", file), "utf8")) as {
+    jobs: Record<string, Job>;
+  };
+
+const dockerBuild = read("docker-build-push.yml");
+const releaseArtifacts = read("release-artifacts.yml");
+
+const allSteps = (wf: { jobs: Record<string, Job> }) => Object.values(wf.jobs).flatMap((j) => j.steps ?? []);
+
+const logins = [...allSteps(dockerBuild), ...allSteps(releaseArtifacts)].filter(
+  (s) => s.name === "Log in to Docker Hub",
+);
+const compose = allSteps(dockerBuild).find((s) => s.id === "images");
+
+describe("the Docker Hub mirror's login identity", () => {
+  test("both workflows log in, so neither is left anonymous", () => {
+    // A floor, not an exact count: the assertion below is vacuous over an empty
+    // list, and a renamed step would empty it without failing anything else.
+    expect(logins.length).toBe(2);
+  });
+
+  test("every login uses the owner user, never the organization", () => {
+    for (const login of logins) {
+      expect(login.with?.username).toBe("${{ vars.DOCKER_HUB_USERNAME }}");
+      expect(login.with?.username).not.toBe("${{ vars.DOCKER_HUB_ORGANIZATION }}");
+    }
+  });
+});
+
+describe("the Docker Hub mirror's namespace", () => {
+  test("the image list is built from the organization, not the login user", () => {
+    expect(compose?.env?.DH_ORGANIZATION).toBe("${{ vars.DOCKER_HUB_ORGANIZATION }}");
+    expect(compose?.env?.DH_USERNAME).toBeUndefined();
+  });
+
+  test("the pushed image name interpolates the organization", () => {
+    expect(compose?.run).toContain("$DH_ORGANIZATION");
+    expect(compose?.run).not.toContain("$DH_USERNAME");
+  });
+
+  test("an unset organization leaves the mirror off rather than guessing a namespace", () => {
+    // Falling back to the login user would publish to the wrong repository
+    // silently, which is the failure this whole file exists to prevent.
+    expect(compose?.run).toContain('[ -n "$DH_ORGANIZATION" ]');
+  });
+});


### PR DESCRIPTION
## What happened

`libredb` on Docker Hub was a **user** account. The Docker-Sponsored Open Source application requires an **organization**, so it was converted on 2026-09-01. An organization cannot sign in — so the single `DOCKER_HUB_USERNAME` variable, which until now answered both "who authenticates" and "which namespace do we publish under", had to become two:

| Variable | Answers | Value |
| --- | --- | --- |
| `DOCKER_HUB_USERNAME` | who logs in — the org owner | `cevheri` |
| `DOCKER_HUB_ORGANIZATION` | the namespace the image is published under | `libredb` |

Both are already set on the repository. This PR makes the workflow read the second one for the image name.

## Why this is not cosmetic

The variables were changed before the workflow was. In that window, a push to `main` would have published to `docker.io/cevheri/libredb-studio` — and **that does not error**. It creates a real repository nobody pulls, while `docker.io/libredb/libredb-studio` (the image behind every `docker run` line in the README, and the 75,137 pulls the DSOS application cites) quietly stops receiving releases. Nothing turns red; the mirror just goes stale, and DSOS's own "actively developed on Docker Hub in the past 6 months" criterion erodes on its own.

The opposite mistake is loud but costs more than it looks: buildx exports every tag in one push, so a rejected Docker Hub login fails the whole job **including the canonical GHCR publish**. `tests/unit/docker-hub-namespace.test.ts` pins both directions — the login must not use the organization, the image list must not use the login user, and an unset organization must leave the mirror off rather than guess a namespace.

## Verification — end to end, on a safe tag

Not by dispatching a version: Docker Hub tag immutability is enabled on this repo scoped to semver (`^\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$`), so re-pushing a released version would be denied and would take GHCR down with it. Instead this branch is a `fix/**` branch, which publishes the **mutable `dev` tag** — a full credential test that cannot touch a published release.

Run [33454450035](https://github.com/libredb/libredb-studio/actions/runs/33454450035) — `Docker Build and Push`, success. Then measured from Docker Hub rather than inferred from the green tick:

- `libredb/libredb-studio:dev` — `tag_last_pushed: 2026-09-01T00:24:09Z`, from this run
- `cevheri/libredb-studio` — **404**, nothing leaked into the login user's namespace
- `/v2/orgs/libredb/` — `type: Organization`, the conversion is live

Gates: `format` · `lint` · `typecheck` · `knip` · `build` clean; the three workflow-shape suites (`release-sbom`, `release-provenance`, `docker-hub-namespace`) 55 pass.

`docs/DISTRIBUTION.md` updated so the credentials table explains why there are two variables rather than leaving the next reader to collapse them back into one.