### PR TITLE
feat(agent): four models reach 30/30 with nothing configured, and three refusals that named no remedy

### DIFF
--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,10 +8,10 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Eighteen models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
-Operate, Analyze and Plan — five consecutive times: 540 runs, 540 passes.
+**Twenty-two models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+Operate, Analyze and Plan — five consecutive times: 660 runs, 660 passes.
 
-Twelve of the eighteen cleared them at the 90-second per-turn limit the product ships. Six carry a
+Sixteen of the twenty-two cleared them at the 90-second per-turn limit the product ships. Six carry a
 150-second limit of their own — `qwen3.5:9b`, `gemma4:12b`, `nemotron-3.5-lightning:30b`,
 `nemotron-3-nano:30b`, `muse-glimmer:latest` and `qwen3.6:27b` — because one turn of theirs does
 not fit inside 90 while every other surface does. The limit stays 90 for every other model, and
@@ -23,6 +23,10 @@ each page says what its model needed.
 | [`gemma4:12b`](gemma/gemma4.md) | Ollama | 7.6 GB | 11s | 63s |
 | [`granite4.1:8b`](granite/granite4.1.md) | Ollama | 5.3 GB | 11s | 22s |
 | [`qwen3.5:4b`](qwen/qwen3.5.md) | Ollama | 3.4 GB | 11s | 167s |
+| [`cogito:14b`](cogito/cogito.md) | Ollama | 9.0 GB | 11s | 20s |
+| [`ministral-3:8b`](mistral/ministral-3.md) | Ollama | 6.0 GB | 13s | 26s |
+| [`ministral-3:14b`](mistral/ministral-3.md) | Ollama | 9.1 GB | 16s | 56s |
+| [`qwen2.5:14b`](qwen/qwen2.5.md) | Ollama | 9.0 GB | 18s | 65s |
 | [`granite4.1:30b`](granite/granite4.1.md) | Ollama | 17 GB | 26s | 52s |
 | [`nemotron3:33b`](nvidia/nemotron3.md) | Ollama | 27 GB | 21s | 119s |
 | [`nemotron-3.5-lightning:30b`](nvidia/nemotron-3.5-lightning.md) | Ollama | 25 GB | 29s | 145s |
@@ -40,8 +44,8 @@ each page says what its model needed.
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these eighteen — the fastest reaches the same verdicts as the slowest in a
-twelfth of the time.
+for is choosing between these twenty-two — the fastest reaches the same verdicts as the slowest in
+a twelfth of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a
 size is chosen and because the interesting fact is usually the difference between two sizes of
@@ -77,7 +81,7 @@ pass says nothing at all about the fifth.
 | --- | --- | --- |
 | the fastest local model | [`granite4.1:8b`](granite/granite4.1.md) | 11s median, 5.3 GB, and it clears everything |
 | the smallest download | [`qwen3:4b`](qwen/qwen3.md) | 2.5 GB — and not the fastest: size buys memory, not speed |
-| the steadiest | [`granite4.1:30b`](granite/granite4.1.md) | its slowest run is under twice its median, where most models have a longer tail |
+| the steadiest | [`cogito:14b`](cogito/cogito.md) | 20s is the shortest slowest-run on the roster, and under twice its own median |
 | no local hardware at all | [`gemini-3.5-flash-lite`](gemini/gemini-3.5.md) | the one hosted model, 10s median, and it needs a key |
 
 ## What is not here

--- a/docs/llms/cogito/cogito.md
+++ b/docs/llms/cogito/cogito.md
@@ -1,0 +1,49 @@
+# cogito
+
+`ollama pull cogito:<size>` · sizes supported: 14b
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+The fastest six-surface sweep on record here — all thirty runs finished in ten minutes — and the
+only family measured at three sizes where the middle one is the only one that clears.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **14b** | 9.0 GB | 4s | 13s | 18s | 13s | 8s | 6s | **11s** | 20s |
+
+Every cell is 5/5, so the table says how long rather than whether.
+
+Its 20-second slowest run is the shortest on this list, and that is the figure worth choosing on
+rather than the median: several models match 11 seconds in the middle and then have a tail three
+or five times longer. Nothing this model did on thirty runs took twice its median.
+
+## What it needs that the defaults do not give it
+
+### `cogito:14b`
+
+Nothing. Measured at the defaults — temperature 0, top_p 1, a ceiling of twelve unreported calls — and it clears every surface on them.
+
+## The other two sizes are not supported, in opposite directions
+
+**`cogito:8b` never files a report.** Its investigation cell read 0/5 twice, ten runs, every one
+the same: `no-report`, stopped by the turn limit. It works the database and runs out of turns
+still working. The refusal wording added alongside these measurements did not move it — the second
+0/5 is the read taken after that change — so it is recorded as measured and unfixed rather than
+untried.
+
+**`cogito:32b` fails one cell and only one.** Five surfaces read 5/5 on the first attempt;
+planning read 0/5, then 1/5, then 0/5 three more times across five configurations. The loss is
+always `no-statement` with the model stopping on its own — it discusses the plan and never writes
+the runnable statement the surface is scored on. Five sixths is not the claim this product makes,
+so 25 of 30 is not listed as supported.
+
+Both are the same finding from either side: on this family the 14b is the size that works, and
+neither the smaller nor the larger sibling is a safe substitute for it.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/gemini/gemini-3.5.md
+++ b/docs/llms/gemini/gemini-3.5.md
@@ -1,7 +1,7 @@
 # gemini-3.5
 
 Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
-runs. The one hosted model of the ten, measured exactly as the nine local ones were.
+runs. The one hosted model on this list, measured exactly as the twenty-one local ones were.
 
 ## What it does, and how long it takes
 

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -30,7 +30,7 @@ Each model was asked one question per surface, the same wording for every model,
 | Analyze | "Which part of the company costs us the most in salary?" |
 | Plan | "What tables are in this database and how do they relate to each other?" |
 
-Fifteen models, six surfaces, five runs: **450 runs, and all 450 passed.**
+Twenty-two models, six surfaces, five runs: **660 runs, and all 660 passed.**
 
 A run passes only when its goal verdict is `answered`. A run that ends `succeeded` having
 answered nothing is a failure here, and the ledger names which bar it missed.
@@ -96,20 +96,20 @@ knowing before running one.
 called locked at 150 did not hold at 90, and both were withdrawn rather than kept with a
 footnote.
 
-Five models ask for more time by name, each on the cell that needed it: `qwen3.5:9b` clears five
+Six models ask for more time by name, each on the cell that needed it: `qwen3.5:9b` clears five
 surfaces inside 90 seconds and its plan turn lands at 92 to 94; `gemma4:12b`,
-`nemotron-3.5-lightning:30b`, `muse-glimmer:latest` and `qwen3.6:27b` each lost one or two cells
-to a `model-timeout` with tools called and work done, which is the clock rather than the model.
-Their profiles carry a 150-second limit, the other ten keep the shipped one, and each page says
-what its model needed.
+`nemotron-3.5-lightning:30b`, `nemotron-3-nano:30b`, `muse-glimmer:latest` and `qwen3.6:27b` each
+lost one or two cells to a `model-timeout` with tools called and work done, which is the clock
+rather than the model. Their profiles carry a 150-second limit, the other sixteen keep the shipped
+one, and each page says what its model needed.
 
 ## Driven through the interface as well
 
-The 450 runs above were opened over HTTP. A separate sweep drove ten of the models through the
+The 660 runs above were opened over HTTP. A separate sweep drove ten of the models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
-for the run to finish on screen — one run per surface: **57 of 60 passed.** Ten, not fifteen: that
-sweep was run when ten models were supported and has not been repeated, and the five added since
-are measured over HTTP only. Saying "all of them" would have described a sweep nobody ran.
+for the run to finish on screen — one run per surface: **57 of 60 passed.** Ten, not twenty-two:
+that sweep was run when ten models were supported and has not been repeated, and the twelve added
+since are measured over HTTP only. Saying "all of them" would have described a sweep nobody ran.
 
 The three that did not are the same shapes the ledger records anywhere else (`no-report`,
 `no-plan`), and one run is not five, so the API sweep is the authority on rates. What the UI

--- a/docs/llms/mistral/ministral-3.md
+++ b/docs/llms/mistral/ministral-3.md
@@ -1,0 +1,47 @@
+# ministral-3
+
+`ollama pull ministral-3:<size>` · sizes supported: 8b, 14b
+
+Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
+runs. Mistral's first entry on this list, and both supported sizes cleared every surface on their
+first attempt with nothing configured.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **8b** | 6.0 GB | 16s | 22s | 4s | 14s | 13s | 5s | **13s** | 26s |
+| **14b** | 9.1 GB | 19s | 27s | 34s | 13s | 15s | 8s | **16s** | 56s |
+
+Every cell is 5/5, so the table says how long rather than whether.
+
+The 8b is the faster of the two everywhere except operate, and the gap is widest on assess — 4
+seconds against 34. Between two sizes that both clear everything, the smaller one is the one to
+take; the 14b is here because a family that clears six surfaces at one size is worth measuring at
+the next, not because it does anything the 8b cannot.
+
+## What it needs that the defaults do not give it
+
+### `ministral-3:8b`
+
+Nothing. Measured at the defaults — temperature 0, top_p 1, a ceiling of twelve unreported calls — and it clears every surface on them.
+
+### `ministral-3:14b`
+
+Nothing. Measured at the defaults, and it clears every surface on them.
+
+## The 3b is not supported
+
+`ministral-3:3b` locks three of the six — analyze, assess and plan — and does not lock investigate,
+operate or optimize. It is not that it cannot answer them: across nine attempts at those three
+cells it passed 20 of 45 runs, reading 4/5 on investigation once. The losses are one shape,
+`no-report`: it reads the database, and then finishes the run without filing what it read. Five
+consecutive is the bar precisely because a model that answers four times in five is not one to put
+in front of a user, so the 3b is measured, recorded here, and not listed as supported.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/qwen/qwen2.5.md
+++ b/docs/llms/qwen/qwen2.5.md
@@ -1,0 +1,42 @@
+# qwen2.5
+
+`ollama pull qwen2.5:<size>` · sizes supported: 14b
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+The oldest model generation on this list, and it needs nothing that the newest ones do not.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **14b** | 9.0 GB | 17s | 35s | 1:03 | 18s | 13s | 1s | **18s** | 1:05 |
+
+Every cell is 5/5, so the table says how long rather than whether.
+
+Assessment is where its minute goes: a passing assess run profiles a table and takes a full minute,
+where its other five surfaces are done inside 35 seconds and its plan turn inside two. The 1:05
+slowest run is an assess run, so the tail is that one cell rather than a general unsteadiness.
+
+## What it needs that the defaults do not give it
+
+### `qwen2.5:14b`
+
+Nothing. Measured at the defaults — temperature 0, top_p 1, a ceiling of twelve unreported calls — and it clears every surface on them.
+
+## Why an older generation is on this list
+
+[`qwen3`](qwen3.md) is represented here at three sizes and [`qwen3.5`](qwen3.5.md) at two, and both
+of those needed settings written for them: `qwen3:8b` is the only sampled cell in the product,
+`qwen3:14b` and `qwen3.5:4b` each needed a plan-turn setting. This one, a generation older and the
+same 9 GB as `qwen3:14b`, arrived on the defaults. It is a useful correction to the assumption that
+drove most of the measuring — that the newer or the larger model is the one to reach for. Neither
+held here.
+
+`qwen2.5:7b` and `qwen2.5:32b` have not been measured. They are absent rather than rejected.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/qwen/qwen3.5.md
+++ b/docs/llms/qwen/qwen3.5.md
@@ -42,7 +42,7 @@ size on data-analysis, expect it to need a second attempt more often than the ta
 
 ### `qwen3.5:9b`
 
-**a 150-second turn limit.** Five surfaces clear the shipped 90 seconds comfortably; its plan turn lands at 92 to 94. It was the first model to need it and is now one of five that carry it; the limit stays 90 for the other ten.
+**a 150-second turn limit.** Five surfaces clear the shipped 90 seconds comfortably; its plan turn lands at 92 to 94. It was the first model to need it and is now one of six that carry it; the limit stays 90 for the other sixteen.
 
 **empty-turn retry.** Its optimization runs stopped answering after being corrected, leaving no text behind.
 

--- a/docs/llms/qwen/qwen3.8.md
+++ b/docs/llms/qwen/qwen3.8.md
@@ -3,7 +3,7 @@
 `ollama pull qwen3.8:<size>` · sizes supported: latest
 
 Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
-runs. The slowest of the ten, and it reaches the same verdicts as models six times faster.
+runs. Among the slowest on this list, and it reaches the same verdicts as models six times faster.
 
 ## What it does, and how long it takes
 

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -7,12 +7,12 @@ are environment variables read at server startup, which is how everything else i
 is configured. It keeps the choice with whoever operates the server rather than turning it into
 a permission to grant, revoke and audit per user.
 
-Fifteen models are supported — every one of them clears all six agent surfaces five consecutive
+Twenty-two models are supported — every one of them clears all six agent surfaces five consecutive
 times. They are listed with their measured durations in the [index](README.md).
 
 ## A local model, through Ollama
 
-Nine of the ten run locally, with no key and no traffic leaving the machine.
+Twenty-one of the twenty-two run locally, with no key and no traffic leaving the machine.
 
 ```bash
 # macOS
@@ -38,7 +38,7 @@ where is in [`../AGENT_DATA_FLOW.md`](../AGENT_DATA_FLOW.md).
 
 ## A hosted model
 
-One of the ten is hosted, and it is configured the same way with one line more:
+One of the twenty-two is hosted, and it is configured the same way with one line more:
 
 ```bash
 LLM_PROVIDER=gemini

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -21,6 +21,24 @@
   },
   "models": [
     {
+      "id": "cogito:14b",
+      "measured": "6/6 modes locked, 30/30 runs passed at the compiled defaults, every cell on its first attempt and the whole model in ten minutes. Investigate 4s · Optimize 13s · Assess 18s · Operate 13s · Analyze 8s · Plan 6s (medians of the passing runs) — the fastest six-surface sweep on record here. Its 8b sibling reads 0/5 on investigation and is not supported: it loops on one refusal until the turns run out, which the fix in this branch did not rescue. The family is supported at 14b and not below it.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      }
+    },
+    {
       "id": "gemini-3.5-flash-lite",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
       "settings": {
@@ -175,6 +193,42 @@
       "rationale": {}
     },
     {
+      "id": "ministral-3:14b",
+      "measured": "6/6 modes locked, 30/30 runs passed at the compiled defaults, every cell on its first attempt. Investigate 19s · Optimize 27s · Assess 34s · Operate 13s · Analyze 15s · Plan 8s (medians of the passing runs). Measured because its 8b sibling had just locked everything, on the one rule with evidence behind it — the larger member of a family that has already won — and it is the only prediction this work has made that then held.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      }
+    },
+    {
+      "id": "ministral-3:8b",
+      "measured": "6/6 modes locked, 30/30 runs passed at the compiled defaults, and every cell closed on its FIRST attempt with no setting carried over. Investigate 16s · Optimize 22s · Assess 4s · Operate 14s · Analyze 13s · Plan 5s (medians of the passing runs); the whole model took twelve minutes to measure. Mistral's first entry here, and the vendor breadth is the point: the roster before it came from six vendors and none of them was Mistral.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      }
+    },
+    {
       "id": "muse-glimmer:latest",
       "measured": "6/6 locked, 30/30, and every cell read in ONE pass under the settings recorded here rather than carried over from the passes that found them - investigate 103s, optimize 191s, assess 167s, operate 80s, analyze 115s, plan 17s (medians of the passing runs; slowest run 285s). The slowest model measured here by a wide margin. Before these settings it was 3/6 at 23/30: plan 0/5, investigate 4/5, assess 4/5. Every one of those losses was the clock - plan timed out at exactly 90 seconds five times over with no tool invoked, and the two single losses timed out at 159s and 160s against passes at 102-116 and 141-163. One run of the confirmation pass died model-unavailable, which is a serving outage and not a verdict; that cell was re-read clean rather than scored over it.",
       "settings": {
@@ -309,6 +363,24 @@
           "Its last open cell, and the loss is `no-statement` twice over.",
           "The closing prose is not a bad plan — it names all eight tables, their columns and their keys, correctly. What it never writes is a runnable statement or the explicit `NO STATEMENT:` refusal, and plan mode's bar is one of those two. `qwen3:14b` lost the same cell the same way and the extra turn won it."
         ]
+      }
+    },
+    {
+      "id": "qwen2.5:14b",
+      "measured": "6/6 modes locked, 30/30 runs passed at the compiled defaults, every cell on its first attempt. Investigate 17s · Optimize 35s · Assess 1:03 · Operate 18s · Analyze 13s · Plan 1s (medians of the passing runs). An older Qwen generation than anything else on the roster and it needs nothing, which is worth recording: the newer qwen3 line is represented at four sizes and this one arrived on the defaults alongside them.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
       }
     },
     {

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -669,6 +669,35 @@ export const AGENT_ANSWER_CONTRACT = [
   "When the objective asks for a chart and the result can carry one, chart it: the user named the shape of the answer they wanted.",
 ].join(" ");
 
+/**
+ * The one-line skeleton of the `present_answer` CALL, for failures in the wrapper rather than
+ * in the presentation inside it.
+ *
+ * `AGENT_ANSWER_CONTRACT` above describes `presentation` in full — chart types, y columns, when
+ * a table is the right answer — and never says what the call itself looks like. Measured across
+ * every data-analysis and query-optimization loss on record (423 runs): `present_answer` is 1023
+ * of 1887 `INVALID_TOOL_INPUT` refusals, more than `compose_report` and `recommend_change`
+ * together, and its three commonest details are all the wrapper: `artifact: expected string`
+ * (409), `the arguments object: remove presentation` (184), `evidence: expected array` (154). A
+ * model that misplaced the id was answered with a careful explanation of the half it got right.
+ *
+ * Ungated, on the same split `AGENT_CLAIM_SHAPE` makes: one line stating the contract goes to
+ * every model, while `exampleAnswerCall` — a whole call rebuilt from this run's ledger — stays
+ * behind `refusalExamples`.
+ */
+const AGENT_ANSWER_SHAPE =
+  'The call is ONE object: {"artifact": "<the id a completed step reported>", "presentation": { ... }} — "artifact" is that id as a plain string, and nothing else belongs beside these two fields.';
+
+/**
+ * Whether the arguments failed in the WRAPPER rather than inside `presentation`.
+ *
+ * A wrong chart type is a fault in the object the contract already explains at length, and
+ * answering it with the wrapper's shape would bury the one word that has to change.
+ */
+function isAnswerShapeFailure(problems: string): boolean {
+  return /\bartifact:|arguments object:|^presentation: |\bpresentation: expected/.test(problems);
+}
+
 const recommendationSchema = z.strictObject({
   change: z.enum(["index", "rewrite"]),
   statement: z.string().min(1),
@@ -1097,6 +1126,36 @@ function unavailable(
  * `UNVERIFIABLE_EVIDENCE` carries the contract in `UNAVAILABLE_TEXT` itself, because
  * only these same two tools can produce it.
  */
+/**
+ * The one-line skeleton of a CLAIM, for the failures where the model sent the wrong kind of
+ * thing rather than a wrong value inside the right one.
+ *
+ * `AGENT_EVIDENCE_CONTRACT` describes an evidence object in full and never says that a claim
+ * is an object at all — so a model sending `claims: ["some prose"]` is answered with a
+ * careful explanation of the part it did not get wrong. Measured: `claims.N: expected object`
+ * is the single most repeated refusal detail in the corpus (66 occurrences), inside the
+ * largest refusal there is — `INVALID_TOOL_INPUT` runs at 4.3 per run on data-analysis and
+ * 3.2 on investigation, against 0.1 on operations.
+ *
+ * Ungated, unlike `exampleReportCall`, and the split is the one the column advice already
+ * makes: this is ONE line stating the contract, the same for every run, while the worked call
+ * is rebuilt from a run's own ledger and stays behind `refusalExamples`.
+ */
+const AGENT_CLAIM_SHAPE =
+  'Each claim is ONE object: {"claim": "<the sentence>", "evidence": [ ... ]} — a bare string is not a claim.';
+
+/**
+ * Whether the arguments failed STRUCTURALLY — the wrong kind of thing in a position — rather
+ * than on a value inside a well-formed one.
+ *
+ * The distinction decides whether the skeleton helps or buries: a model that built the object
+ * correctly and typed `locator: 3` needs the one word `locator`, and answering it with the
+ * whole shape hides that word in a sentence it has already satisfied.
+ */
+function isShapeFailure(problems: string): boolean {
+  return /claims(\.\d+)?: expected (object|array)/.test(problems) || /claims: expected array/.test(problems);
+}
+
 function invalidEvidenceInput(problems: string, example?: string): AgentToolOutcome & { kind: "unavailable" } {
   return {
     kind: "unavailable",
@@ -1123,6 +1182,9 @@ function invalidEvidenceInput(problems: string, example?: string): AgentToolOutc
     */
     modelText: [
       `${UNAVAILABLE_TEXT.INVALID_TOOL_INPUT} (${problems})`,
+      // Before the evidence contract, because a run that sent prose where an object goes has
+      // not reached the evidence yet — and the contract answers a question it did not ask.
+      ...(isShapeFailure(problems) ? [AGENT_CLAIM_SHAPE] : []),
       AGENT_EVIDENCE_CONTRACT,
       ...(example === undefined ? [] : [`A call this run could make right now: ${example}`]),
     ].join(" "),
@@ -3032,8 +3094,12 @@ export function recommendChangeTool(
   }
   if (!parsed.value.evidence.every((reference) => verifiedAgainst(run.events, reference))) {
     // Both evidence-bearing tools name what is citable, because a model that guessed an id
-    // here will guess the same one at `compose_report` a turn later.
-    return unavailable("UNVERIFIABLE_EVIDENCE", citableEvidence(run.events));
+    // here will guess the same one at `compose_report` a turn later — and both now name
+    // WHICH citation failed, for the same reason.
+    return unavailable(
+      "UNVERIFIABLE_EVIDENCE",
+      unverifiableCitation(run.events, [{ evidence: parsed.value.evidence }]),
+    );
   }
 
   return {
@@ -3164,6 +3230,67 @@ function citableEvidence(events: readonly AgentRunEvent[]): string | undefined {
 function verifiedAgainst(events: readonly AgentRunEvent[], reference: AgentEvidenceReference): boolean {
   if (reference.source === "artifact") return producedArtifact(events, reference.correlationId) !== null;
   return events.some((event) => event.kind === "context-captured" && event.fingerprint === reference.fingerprint);
+}
+
+/**
+ * The id is one this run produced — under the OTHER source. Says which, in the words of
+ * the object that would have worked.
+ *
+ * Measured on `cogito:8b`: five database-investigation runs, all five `turn-limit` with
+ * `no-report`, each holding the same `compose_report` call sent about forty times. Its two
+ * claims were correct and its two citations carried the SAME id, one filed as a
+ * `context-snapshot` and one as an `artifact`. The refusal said "at least one evidence
+ * reference does not match" and then offered the id the model was already using, so nothing
+ * in the answer distinguished the good citation from the bad one and the model resent it
+ * until the turns ran out.
+ *
+ * Deliberately narrow: it fires only when the id names something this run REALLY holds
+ * under the other source. An invented id gets the offer of what is citable and no sentence
+ * about where it belongs, because there is nowhere it belongs.
+ */
+function misfiledSource(events: readonly AgentRunEvent[], reference: AgentEvidenceReference): string | undefined {
+  if (reference.source === "artifact") {
+    const snapshot = events.find(
+      (event) => event.kind === "context-captured" && event.fingerprint === reference.correlationId,
+    );
+    if (snapshot === undefined) return undefined;
+    return `that id is this run's schema snapshot and belongs under a different source: {"source": "context-snapshot", "fingerprint": "${reference.correlationId}"}`;
+  }
+  if (producedArtifact(events, reference.fingerprint) === null) return undefined;
+  return `that id is a result this run read and belongs under a different source: {"source": "artifact", "correlationId": "${reference.fingerprint}"}`;
+}
+
+/**
+ * WHICH citation failed, and what to do about it — the two halves a run stuck here needs.
+ *
+ * `citableEvidence` alone answers neither: it names what the run holds, which a model that
+ * has already cited one of those ids reads as agreement. The path is what makes the answer
+ * actionable when a report carries several claims, and `misfiledSource` is what ends the
+ * loop when the id was right all along.
+ */
+function unverifiableCitation(
+  events: readonly AgentRunEvent[],
+  claims: readonly { readonly evidence: readonly AgentEvidenceReference[] }[],
+): string | undefined {
+  for (const [claimIndex, claim] of claims.entries()) {
+    for (const [evidenceIndex, reference] of claim.evidence.entries()) {
+      if (verifiedAgainst(events, reference)) continue;
+      // One path per refusal, the FIRST that failed: a model fixes one citation per turn,
+      // and a list of every fault reads as a wall rather than a next step. Always spelled
+      // as a path, even for a single claim — it is the field name the model has to look at,
+      // and "the citation" would leave a two-claim report guessing again.
+      const path = `claims.${claimIndex}.evidence.${evidenceIndex}`;
+      const misfiled = misfiledSource(events, reference);
+      const offer = citableEvidence(events);
+      return [
+        `${path} does not match anything this run produced`,
+        misfiled ?? (offer === undefined ? undefined : offer),
+      ]
+        .filter((part) => part !== undefined)
+        .join(" — ");
+    }
+  }
+  return citableEvidence(events);
 }
 
 /**
@@ -3474,6 +3601,9 @@ export function presentAnswerTool(
       detail: parsed.problems,
       modelText: [
         `${UNAVAILABLE_TEXT.INVALID_TOOL_INPUT} (${parsed.problems})`,
+        // Before the contract, because a run that misplaced the id has not reached the
+        // presentation yet — and the contract answers a question it did not ask.
+        ...(isAnswerShapeFailure(parsed.problems) ? [AGENT_ANSWER_SHAPE] : []),
         AGENT_ANSWER_CONTRACT,
         ...(example === undefined ? [] : [`A call this run could make right now: ${example}`]),
       ].join(" "),
@@ -3576,7 +3706,9 @@ export function composeReportTool(
     // shared with `recommend_change`: two would be two things to keep equal, and the
     // one that drifted would be the one letting an uncited claim through.
     if (!claim.evidence.every((reference) => verifiedAgainst(run.events, reference))) {
-      return unavailable("UNVERIFIABLE_EVIDENCE", citableEvidence(run.events));
+      // Asked of the WHOLE claim list rather than this one claim, so the path it names is
+      // the one the model sent — a per-claim reader would say `claims.0` for every claim.
+      return unavailable("UNVERIFIABLE_EVIDENCE", unverifiableCitation(run.events, parsed.value.claims));
     }
     claims.push({
       claim: claim.claim,

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -290,6 +290,60 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: undefined,
     samplingOverrides: { "query-optimization": { temperature: 0.8, topP: 0.9 } },
   },
+  // The nineteenth, and Mistral's first entry: the roster before it came from six vendors and
+  // none of them was Mistral. All four rows this branch adds are identical because all four
+  // locked every surface on the FIRST attempt with no lever spent. Pinning a row of defaults is
+  // not redundant — it asserts that a later change to the defaults cannot silently move a model
+  // that was measured under the old ones.
+  {
+    id: "ministral-3:8b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  // The twentieth. Measured because its 8b sibling had just locked everything, on the one
+  // rule with evidence behind it — the larger member of a family that has already won —
+  // and it is the only prediction this work has made that then held.
+  {
+    id: "ministral-3:14b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  // The twenty-first, and the fastest six-surface sweep on record here: all thirty runs in
+  // ten minutes. Its 8b sibling reads 0/5 on investigation and its 32b loses planning, so
+  // this is the one size of the family that is supported.
+  {
+    id: "cogito:14b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  // The twenty-second, and the oldest model generation on the roster. Three newer Qwen
+  // entries each needed a setting written for them; this one arrived on the defaults,
+  // which is the counter-example to choosing by generation.
+  {
+    id: "qwen2.5:14b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
   // Not a model anybody has run: the defaults, which is the honest treatment of one nobody
   // has measured.
   {
@@ -355,7 +409,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
   test("the table covers every registered model, so a new one cannot arrive unpinned", () => {
     const pinned = new Set(RESOLVED.map((row) => row.id));
     for (const id of Object.keys(modelProfiles())) expect(pinned.has(id)).toBe(true);
-    expect(Object.keys(modelProfiles())).toHaveLength(18);
+    expect(Object.keys(modelProfiles())).toHaveLength(22);
   });
 });
 
@@ -422,6 +476,15 @@ describe("what each model records about the runs that earned its settings", () =
     "nemotron-3-nano:30b": "20cca3398ec9a7ff927f014a212784f38d6b36e74be49fe2b74fb223a7d56eec",
     "qwen3.5:4b": "204b6f6beb8710155508938a2271cbf34013235fa612b40ecebf98ff5dcff061",
     "granite4.2:8b": "c9e47190c44d1fda45bf035831dcb17ba21621e98a455259a438710775600ae0",
+    // The four this branch adds, and the only group whose records are identical in shape: every
+    // one locked all six surfaces on its FIRST attempt with no lever spent, so every one states
+    // the compiled defaults and nothing else. That is a measurement rather than an omission —
+    // and it is how every 30/30 model on this roster arrived, which is why the four are here
+    // and the models that absorbed a hundred lever attempts between them are not.
+    "ministral-3:8b": "282d7f01c554b5bed006533190e2392330256b67f46ffee8a1462d5b254424ab",
+    "ministral-3:14b": "23ef778193d6d714d7f3bb95523172d1e0f68520f0f9b2d20806b129a84a33c1",
+    "cogito:14b": "2c2fcded189b2123048e5c789844d3d8e392d7e19951e428695afa852eddd473",
+    "qwen2.5:14b": "51ea773ff735a6f9d7f7f930b97c40ec70b5dc531dea65fa1594935a2471e991",
   };
 
   test("every model's record survives the move, character for character", () => {

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -93,7 +93,7 @@ afterEach(() => {
 describe("the document Studio ships with", () => {
   test("passes its own contract", () => {
     const tuning = parseTuning(bundled, "test");
-    expect(Object.keys(tuning.models)).toHaveLength(18);
+    expect(Object.keys(tuning.models)).toHaveLength(22);
   });
 
   test("argues for every value it changed", () => {
@@ -563,7 +563,7 @@ describe("a document an operator supplies", () => {
     process.env[ENV] = writeDocument("{ not json");
     resetTuning();
     expect(ceilingFor("gemma4:26b")).toBe(10);
-    expect(Object.keys(activeTuning().models)).toHaveLength(18);
+    expect(Object.keys(activeTuning().models)).toHaveLength(22);
   });
 
   test("reports that it ignored a document, naming the file and the reason", () => {
@@ -717,13 +717,13 @@ describe("a document an operator supplies", () => {
   test("is ignored when it breaks the contract, not partially applied", () => {
     process.env[ENV] = writeDocument(document({ schemaVersion: 99 }));
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(18);
+    expect(Object.keys(activeTuning().models)).toHaveLength(22);
   });
 
   test("is ignored when the file is not there at all", () => {
     process.env[ENV] = "/nonexistent/models.json";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(18);
+    expect(Object.keys(activeTuning().models)).toHaveLength(22);
   });
 
   test("an unset or blank variable is simply no operator document", () => {
@@ -731,7 +731,7 @@ describe("a document an operator supplies", () => {
     // reading it as a path would warn on every boot of an install that configured nothing.
     process.env[ENV] = "   ";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(18);
+    expect(Object.keys(activeTuning().models)).toHaveLength(22);
   });
 
   test("is read once, so a run cannot see the table change under it", () => {

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -796,6 +796,313 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
       expect(bothArms(outcome.modelText)).toEqual(["artifact", "context-snapshot"]);
     });
 
+    describe("present_answer is shown ITS shape too, and it is the biggest refusal there is", () => {
+      /*
+        Counted across every data-analysis and query-optimization LOSS on record — 423 runs, the
+        two surfaces that block every model still short of 30/30:
+
+          INVALID_TOOL_INPUT   1887      present_answer 1023 · compose_report 621 · recommend 389
+          UNVERIFIABLE_EVIDENCE 306
+
+        `present_answer` alone is more than half. Its details, normalised:
+
+          409  artifact: expected string
+          184  the arguments object: remove presentation
+          154  evidence: expected array
+
+        All three are the OUTER call, and `AGENT_ANSWER_CONTRACT` describes only the INNER
+        `presentation` object — chart types, y columns, when a table is the right answer, in
+        detail — while never saying that the call itself is `{artifact, presentation}` and that
+        `artifact` is a plain string id. A model that put the id in the wrong shape reads a
+        careful explanation of the part it got right, exactly as `compose_report` did before its
+        claim skeleton was added.
+
+        Same fix, same split: one line stating the call's shape, ungated, on structural failures
+        only; `exampleAnswerCall` stays behind `refusalExamples` because it rebuilds a whole call
+        from this run's ledger.
+      */
+      const artifactEvent2: AgentRunEvent = {
+        kind: "tool-completed",
+        atMs: 1,
+        stepId: "step_1",
+        artifact: {
+          correlationId: "corr-real",
+          operationId: "sql.query.read",
+          connectionId: "conn-1",
+          createdAtMs: 1,
+          summary: { rowCount: 2, columns: ["dept", "total"], truncated: false },
+        },
+      } as unknown as AgentRunEvent;
+
+      test("an artifact sent as something other than a string is shown the call's shape", () => {
+        const h = harness();
+
+        const outcome = presentAnswerTool(
+          h.context,
+          { runId: h.context.runId, autoExecute: false, events: [artifactEvent2] },
+          { artifact: { id: "corr-real" }, presentation: { kind: "table" } },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
+        // The path, as it already did — asserted WITH its issue text. The bare word "artifact"
+        // is in `AGENT_EVIDENCE_CONTRACT`, which is appended to refusals on this path, so a
+        // `toContain("artifact")` would pass even if the path were never named.
+        expect(outcome.modelText).toContain("artifact: expected string");
+        // And now the shape of the call it belongs to.
+        expect(outcome.modelText).toContain('"presentation"');
+        expect(outcome.modelText).toContain("plain string");
+      });
+
+      test("the skeleton stays out of the ledger line", () => {
+        const h = harness();
+
+        const outcome = presentAnswerTool(
+          h.context,
+          { runId: h.context.runId, autoExecute: false, events: [artifactEvent2] },
+          { artifact: ["corr-real"], presentation: { kind: "table" } },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.detail).toContain("artifact");
+        expect(outcome.detail).not.toContain("plain string");
+      });
+
+      test("a chart spec that is merely wrong is NOT shown the call skeleton", () => {
+        // The guard: the outer call was built correctly and the fault is inside `presentation`,
+        // which the contract already explains at length. Repeating the wrapper there would bury
+        // the part that has to change.
+        const h = harness();
+
+        const outcome = presentAnswerTool(
+          h.context,
+          { runId: h.context.runId, autoExecute: false, events: [artifactEvent2] },
+          {
+            artifact: "corr-real",
+            presentation: { kind: "chart", spec: { type: "sunburst", x: "dept", y: ["total"] } },
+          },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.modelText).not.toContain("plain string");
+      });
+    });
+
+    describe("a STRUCTURAL shape failure is shown the shape, whatever model sent it", () => {
+      /*
+        The largest refusal in the measured corpus, and it was invisible until the surfaces were
+        counted side by side. `INVALID_TOOL_INPUT` per run:
+
+          analyze 4.3   investigate 3.2   optimize 1.5   assess 1.1   operate 0.1   plan 0.0
+
+        973 of them across 225 data-analysis runs. It is not one surface's protocol problem — it
+        is `compose_report`'s claim shape, and it lands hardest on the two surfaces with the worst
+        scores. The two dominant details are structural rather than typographic: `claims.0:
+        expected object` (66) and `claims.0.evidence.0.locator: expected string` (43) — a model
+        sending prose where an object goes.
+
+        The paths were already named. What was gated was the SHAPE: `exampleReportCall` rebuilds a
+        whole call from the run's ledger and sits behind `refusalExamples`, which two of twenty-two
+        shipped models carry. Everyone else reads "expected object" and has to guess the object.
+
+        So this splits the two, on the rule the column advice was split on: a one-line skeleton is
+        a statement of the contract and goes to every model, while the rebuilt call — long, and
+        carrying this run's real ids — stays behind the lever it was measured on.
+      */
+      const snapshotEvent: AgentRunEvent = {
+        kind: "context-captured",
+        atMs: 1,
+        fingerprint: "ctx_1",
+        tableCount: 1,
+      } as unknown as AgentRunEvent;
+
+      test("a claim sent as prose is shown the object it should have been", () => {
+        const h = harness();
+
+        const outcome = composeReportTool(
+          h.context,
+          { runId: h.context.runId, events: [snapshotEvent, artifactEvent] },
+          { claims: ["Engineering is the largest department."] },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
+        // The path, as before — with its issue text, so the assertion cannot be satisfied by a
+        // path-shaped string appearing anywhere else in the refusal.
+        expect(outcome.modelText).toContain("claims.0: expected object");
+        // And now the shape, to a model carrying no lever at all. Both fields of the skeleton
+        // and nothing that `AGENT_EVIDENCE_CONTRACT` also carries: a `"source"` assertion here
+        // would be green on the appended contract alone, which is the defect the previous
+        // review named in this file.
+        expect(outcome.modelText).toContain('{"claim"');
+        expect(outcome.modelText).toContain('"evidence"');
+      });
+
+      test("the skeleton stays out of the LEDGER line, which counts paths", () => {
+        // `detail` is what a reader tallies refusals by. A skeleton repeated into every entry
+        // would make the same failure look like many different ones.
+        const h = harness();
+
+        const outcome = composeReportTool(
+          h.context,
+          { runId: h.context.runId, events: [snapshotEvent] },
+          { claims: ["Prose again."] },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.detail).toContain("claims.0");
+        expect(outcome.detail).not.toContain('"evidence"');
+      });
+
+      test("a merely mistyped field is NOT shown the skeleton, because the shape was right", () => {
+        // The guard on the sentence. `locator` wanting a string is a typo inside an object the
+        // model already built correctly; answering it with the whole skeleton would bury the one
+        // word that has to change.
+        const h = harness();
+
+        const outcome = composeReportTool(
+          h.context,
+          { runId: h.context.runId, events: [snapshotEvent, artifactEvent] },
+          {
+            claims: [
+              {
+                claim: "Engineering is largest.",
+                evidence: [{ source: "artifact", correlationId: "corr-real", locator: 3 }],
+              },
+            ],
+          },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        // The FULL path, not the bare word. `AGENT_EVIDENCE_CONTRACT` is appended to every
+        // refusal on this path and its last sentence contains "locator", so `toContain("locator")`
+        // passes whether or not the issue was named at all — green on a total regression. The
+        // previous review caught exactly that shape in another test on this file.
+        expect(outcome.modelText).toContain("claims.0.evidence.0.locator: expected string");
+        expect(outcome.modelText).not.toContain('"claim":');
+      });
+    });
+
+    describe("an unverifiable citation is named, and a misfiled id is told where it belongs", () => {
+      /*
+        Measured on `cogito:8b`, database-investigation, five runs at one sitting: all five
+        ended `turn-limit` with `no-report`, and each holds the SAME call sent about forty
+        times. The model was not confused about the database — its two claims are correct —
+        it was sending this:
+
+          claims[0].evidence[0]  {source: "context-snapshot", fingerprint: "ctx_f2b7…"}   ✓
+          claims[1].evidence[0]  {source: "artifact",         correlationId: "ctx_f2b7…"}  ✗
+
+        One right, one wrong, and the same id in both. What came back was "At least one
+        evidence reference does not match anything this run produced" plus "this run produced
+        the schema snapshot ctx_f2b7…" — which names the id the model was ALREADY using and
+        never says which of the two citations is the bad one. There is nothing in that answer
+        to act on, so it resent the identical call until the turns ran out.
+
+        Both halves are here: WHICH reference failed, and — when the id names something this
+        run really did produce, under the other source — the source it belongs under. The
+        second half is the whole of this model's failure and needs no example to carry it.
+      */
+      const snapshotEvent: AgentRunEvent = {
+        kind: "context-captured",
+        atMs: 1,
+        fingerprint: "ctx_1",
+        tableCount: 1,
+      } as unknown as AgentRunEvent;
+
+      test("compose_report names the failing claim and evidence position", () => {
+        const h = harness();
+
+        const outcome = composeReportTool(
+          h.context,
+          { runId: h.context.runId, events: [snapshotEvent, artifactEvent] },
+          {
+            claims: [
+              { claim: "First.", evidence: [{ source: "context-snapshot", fingerprint: "ctx_1" }] },
+              { claim: "Second.", evidence: [{ source: "artifact", correlationId: "nothing-like-this" }] },
+            ],
+          },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.reasonCode).toBe("UNVERIFIABLE_EVIDENCE");
+        // The SECOND claim, not "at least one".
+        expect(outcome.detail).toContain("claims.1.evidence.0");
+        // And the first is not blamed, because it verified.
+        expect(outcome.detail).not.toContain("claims.0.evidence.0");
+      });
+
+      test("a snapshot cited as an artifact is told which source it belongs under", () => {
+        const h = harness();
+
+        const outcome = composeReportTool(
+          h.context,
+          { runId: h.context.runId, events: [snapshotEvent] },
+          {
+            claims: [
+              { claim: "The database has one table.", evidence: [{ source: "artifact", correlationId: "ctx_1" }] },
+            ],
+          },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.reasonCode).toBe("UNVERIFIABLE_EVIDENCE");
+        // The remedy, in the words of the object the model has to send.
+        expect(outcome.detail).toContain("context-snapshot");
+        expect(outcome.detail).toContain("fingerprint");
+        expect(outcome.detail).toContain("ctx_1");
+        // And it reaches the MODEL, not only the ledger — the ledger half is what a reader
+        // diagnoses with afterwards, and the model half is what ends the loop. Asserted on the
+        // REMEDY, not on the source name: `AGENT_EVIDENCE_CONTRACT` names both sources and is
+        // appended here, so `toContain("context-snapshot")` would pass with the remedy removed.
+        expect(outcome.modelText).toContain("belongs under a different source");
+        expect(outcome.modelText).toContain("ctx_1");
+      });
+
+      test("an artifact cited as a snapshot is told the same thing, the other way round", () => {
+        // The mirror, because the two sources are symmetrical and a fix that only knew one
+        // direction would leave the other model looping.
+        const h = harness();
+
+        const outcome = composeReportTool(
+          h.context,
+          { runId: h.context.runId, events: [snapshotEvent, artifactEvent] },
+          {
+            claims: [
+              {
+                claim: "Engineering is largest.",
+                evidence: [{ source: "context-snapshot", fingerprint: "corr-real" }],
+              },
+            ],
+          },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.detail).toContain("artifact");
+        expect(outcome.detail).toContain("correlationId");
+        expect(outcome.detail).toContain("corr-real");
+      });
+
+      test("an id the run never produced is still just named, with no invented remedy", () => {
+        // The guard on the sentence above: it may only fire when the id really does name
+        // something this run holds. A model that invented an id is told what IS citable, as
+        // before, and nothing is claimed about where its invention belongs.
+        const h = harness();
+
+        const outcome = composeReportTool(
+          h.context,
+          { runId: h.context.runId, events: [snapshotEvent] },
+          { claims: [{ claim: "Invented.", evidence: [{ source: "artifact", correlationId: "no-such-id" }] }] },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.detail).toContain("claims.0.evidence.0");
+        expect(outcome.detail).not.toContain("belongs under");
+        // Still offers what this run has, which is the behaviour that was already there.
+        expect(outcome.detail).toContain("ctx_1");
+      });
+    });
+
     test("and it hands over a call this run could make, built from its own ledger", () => {
       /*
         Naming the failing field was the previous step, and it was measured as not enough:


### PR DESCRIPTION
Twenty-two models now drive every agent surface. The four added here were measured **against this branch** — six surfaces, five consecutive passing runs each, through the API the UI uses and against the document this repository ships rather than an operator file.

| Model | Pla | Inv | Ass | Ope | Ana | Opt | Settings |
|---|---|---|---|---|---|---|---|
| `ministral-3:8b` | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | none |
| `ministral-3:14b` | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | none |
| `cogito:14b` | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | none |
| `qwen2.5:14b` | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | none |

**All twenty-four cells locked on the FIRST attempt with no lever spent.** That is the whole reason these four are the ones being added: in the same window, four models already sitting at 4/6 absorbed roughly fourteen lever attempts between them and locked nothing. Every model that has reached 30/30 arrived this way — the eighteen already shipped carry 0–2 settings between them.

Each entry states the compiled defaults and nothing else. An absent entry records no measurement, and a model nobody can see was measured is a model nobody can trust.

Mistral and Deep Cogito are new vendors on this list. `qwen2.5:14b` is the oldest model generation on it and needs nothing, where `qwen3:8b`, `qwen3:14b` and `qwen3.5:4b` each needed a setting written for them — a useful counter-example to choosing by generation or by size.

## Three refusals that named no remedy

Read out of run ledgers, and measured: 423 analyze and optimize losses carry **1887 `INVALID_TOOL_INPUT` events** between them, 4.5 per losing run. Split by tool: `present_answer` 1023, `compose_report` 621, `recommend_change` 389. The same shape as the five in #528 — the server knew what would have worked and refused without saying it.

**1. An id filed under the wrong source was refused as unknown.** A run holding a schema snapshot cited it as `{"source": "artifact"}`, and the refusal said the id was not citable — while the run held it under the other source the whole time. It now names where the id belongs and hands back the reference to use, in both directions.

**2. An unverifiable citation named neither the path nor a way forward.** It now names the exact position (`claims.1.evidence.0`) plus either the misfiled hint above or the ids that ARE citable.

**3. `claims: expected object` and `artifact: expected string` are the two dominant details** — 66 and 409 occurrences. Both now carry a one-line shape skeleton, ungated. The rebuilt worked example stays behind `refusalExamples`, which two of twenty-two models carry: a skeleton is a statement of the contract and goes to every model, while a whole call rebuilt from this run's ledger is long enough to crowd a small model's turn and stays behind the lever it was measured on. This is the same split the column advice took in #528.

## Docs, including drift this branch did not cause

Four models registered means four models documented, and the counts several pages still carried were already wrong before this branch:

- `docs/llms/README.md` — eighteen → twenty-two, 540 → 660 runs, twelve/six → sixteen/six on the turn limit, four table rows
- `docs/llms/methodology.md` — said **fifteen models and 450 runs**, and enumerated **five** models carrying a 150-second limit where the shipped document has **six** (`nemotron-3-nano:30b` was missing, the same omission finding 3 of the #528 review named)
- `docs/llms/setup.md` — said fifteen supported and "nine of the ten run locally"
- `docs/llms/gemini/gemini-3.5.md`, `qwen/qwen3.8.md`, `qwen/qwen3.5.md` — "of the ten", "the slowest of the ten", "one of five that carry it"
- New: `docs/llms/mistral/ministral-3.md`, `docs/llms/cogito/cogito.md`, `docs/llms/qwen/qwen2.5.md`

The 150-second enumeration is now derived from the set of profiles that actually carry `turnTimeoutMs`, which is six.

## Measured and NOT supported, recorded rather than omitted

- **`cogito:8b`** — investigation 0/5 twice, ten runs, every one `no-report` at the turn limit. The second reading is *after* the refusal fix in this branch, so it is recorded as unfixed rather than untried.
- **`cogito:32b`** — five surfaces 5/5 on the first attempt; planning 0/5 across five configurations, always `no-statement` with the model stopping on its own. 25 of 30 is not the claim this product makes.
- **`ministral-3:3b`** — three of six. Across nine attempts at the three open cells it passed 20 of 45 runs, all losses `no-report`.

Both cogito results are the same finding from either side: on that family the 14b is the size that works, and neither sibling substitutes.

## Verification

Every required CI step run locally on this branch, on the pinned `bun@1.4.0`:

`chart:check` (strict) · `channels:showcase:check` · `readme:check` · `security:check` · `format` · `lint` (0 errors) · `typecheck` · `knip` · `build` · `build:lib` · `attw` — all clean.
Full suite **10499 pass, 0 fail**. `test:coverage` + `coverage:check` at **100%**.

Not run locally: the Windows launcher Go gate (no Go toolchain on this machine). This branch touches no file under `packaging/`.
