### PR TITLE
fix(admin): sum the fleet's own byte figure instead of re-parsing display strings

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -31,7 +31,7 @@ None of it is a GitHub issue.
 - [Drivers and connections](#drivers-and-connections) — D1–D51, U17 · 13
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U26 · 8
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U21 · 7
 - [Dependencies](#dependencies) — P1–P5 · 5
 - [Documentation](#documentation) — DOC3, DOC4 · 2
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -31,7 +31,7 @@ None of it is a GitHub issue.
 - [Drivers and connections](#drivers-and-connections) — D1–D51, U17 · 13
 - [Value interpolation](#value-interpolation) — V1
 - [Row editing](#row-editing) — R1
-- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U26 · 9
+- [Studio UI and query execution](#studio-ui-and-query-execution) — X2–X14, U2–U21 · 8
 - [Dependencies](#dependencies) — P1–P5 · 5
 - [Documentation](#documentation) — DOC3, DOC4 · 2
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3
@@ -794,39 +794,6 @@ is not a free read.
 
 **Done when:** an operation a provider declares globally runnable either has its own card copy or a
 recorded reason it is withheld.
-
-### U26. The fleet total sums display strings, so a terabyte counts as one byte
-
-Found 2026-08-27 in the #517 review. `totalDBSize` in `src/components/admin/tabs/OverviewTab.tsx`
-builds the admin dashboard's total by RE-PARSING each connection's formatted size:
-
-```ts
-const s = item.databaseSize.toLowerCase();
-const num = parseFloat(s);
-if (isNaN(num)) continue;
-if (s.includes("gb")) totalBytes += num * 1024 * 1024 * 1024;
-else if (s.includes("mb")) totalBytes += num * 1024 * 1024;
-else if (s.includes("kb")) totalBytes += num * 1024;
-else totalBytes += num;
-```
-
-`tb` is not a branch, so a `"1 TB"` database falls to `else` and contributes **1 byte** to the fleet
-total - and #517 added `PB` and `EB` to the shared formatter's ladder, so two more spellings now reach
-this parser and land in the same arm. The `else` arm is right for a bare `"512"` and cannot tell it from
-a truncated unit, which is the whole problem with parsing a string that was built for a human.
-
-The `"N/A"` handling is correct by accident and worth keeping: `parseFloat("n/a")` is `NaN`, so a
-refusal is skipped rather than counted as zero.
-
-**The real defect is that there is no numeric channel to sum.** `FleetHealthItem`
-(`src/app/api/admin/fleet-health/route.ts`) carries `databaseSize?: string` and nothing else, because
-`HealthInfo.databaseSize` is a required string. So the fix is not a `tb` branch - it is carrying the
-bytes the providers already have, which is also what makes an honest absence expressible here.
-
-**Done when:** `FleetHealthItem` carries an optional byte count beside the string, the route projects it
-from the provider (absent when the provider published none), the total sums those numbers and shows how
-many connections it could not include rather than silently undercounting, and a test pins a TB-scale
-connection plus one with no byte figure at all.
 
 ---
 

--- a/src/app/api/admin/fleet-health/route.ts
+++ b/src/app/api/admin/fleet-health/route.ts
@@ -24,6 +24,13 @@ export interface FleetHealthItem {
   latencyMs: number;
   activeConnections?: number;
   databaseSize?: string;
+  /**
+   * The provider's own byte figure from `getOverview()`, or absent when the provider publishes
+   * none (same absence-vs-zero contract as `DatabaseOverview.databaseSizeBytes`). The dashboard
+   * sums this directly instead of re-parsing `databaseSize`'s display string, which had no branch
+   * for "1 TB" or larger and silently counted such a database as 1 byte.
+   */
+  databaseSizeBytes?: number;
   error?: string;
 }
 
@@ -70,6 +77,14 @@ export async function POST(request: Request) {
           const health = await provider.getHealth();
           const latencyMs = Date.now() - start;
 
+          // Best-effort and outside the latency measurement above: getOverview() is a second
+          // round-trip this route did not previously make, and a provider that cannot answer it
+          // (or has none of this data) must not turn a working connection into an error result.
+          const databaseSizeBytes = await provider
+            .getOverview()
+            .then((overview) => overview.databaseSizeBytes)
+            .catch(() => undefined);
+
           return {
             connectionId: conn.id,
             connectionName: conn.name,
@@ -79,6 +94,7 @@ export async function POST(request: Request) {
             latencyMs,
             activeConnections: health.activeConnections,
             databaseSize: health.databaseSize,
+            databaseSizeBytes,
           };
         } catch (err) {
           return {

--- a/src/components/admin/tabs/OverviewTab.tsx
+++ b/src/components/admin/tabs/OverviewTab.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { storage } from "@/lib/storage";
 import { useAllConnections } from "@/hooks/use-all-connections";
 import { getDBIcon, getDBColor } from "@/lib/db-ui-config";
+import { formatBytes } from "@/lib/db/utils/pool-manager";
 import {
   type DatabaseType,
   type DatabaseConnection,
@@ -323,15 +324,7 @@ export function OverviewTab({ user }: OverviewTabProps) {
       if (typeof item.databaseSizeBytes === "number") totalBytes += item.databaseSizeBytes;
       else excluded++;
     }
-    const formatted =
-      totalBytes === 0
-        ? "0"
-        : totalBytes >= 1024 * 1024 * 1024
-          ? `${(totalBytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
-          : totalBytes >= 1024 * 1024
-            ? `${(totalBytes / (1024 * 1024)).toFixed(0)} MB`
-            : `${(totalBytes / 1024).toFixed(0)} KB`;
-    return { totalDBSize: formatted, dbSizeExcluded: excluded };
+    return { totalDBSize: formatBytes(totalBytes), dbSizeExcluded: excluded };
   }, [fleetHealth]);
 
   // Activity feed: merge audit events + recent history

--- a/src/components/admin/tabs/OverviewTab.tsx
+++ b/src/components/admin/tabs/OverviewTab.tsx
@@ -312,22 +312,26 @@ export function OverviewTab({ user }: OverviewTabProps) {
     return Math.round(healthy.reduce((sum, h) => sum + h.latencyMs, 0) / healthy.length);
   }, [fleetHealth]);
 
-  const totalDBSize = useMemo(() => {
+  // Sums the provider's own byte figure instead of re-parsing `databaseSize`'s display string,
+  // which had no "tb" branch and silently counted a 1 TB database as 1 byte. A connection with no
+  // byte figure (provider doesn't publish one, or the connection errored) is excluded from the
+  // sum rather than treated as zero, and the count says so instead of the total going quiet.
+  const { totalDBSize, dbSizeExcluded } = useMemo(() => {
     let totalBytes = 0;
+    let excluded = 0;
     for (const item of fleetHealth) {
-      if (!item.databaseSize) continue;
-      const s = item.databaseSize.toLowerCase();
-      const num = parseFloat(s);
-      if (isNaN(num)) continue;
-      if (s.includes("gb")) totalBytes += num * 1024 * 1024 * 1024;
-      else if (s.includes("mb")) totalBytes += num * 1024 * 1024;
-      else if (s.includes("kb")) totalBytes += num * 1024;
-      else totalBytes += num;
+      if (typeof item.databaseSizeBytes === "number") totalBytes += item.databaseSizeBytes;
+      else excluded++;
     }
-    if (totalBytes === 0) return "0";
-    if (totalBytes >= 1024 * 1024 * 1024) return `${(totalBytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-    if (totalBytes >= 1024 * 1024) return `${(totalBytes / (1024 * 1024)).toFixed(0)} MB`;
-    return `${(totalBytes / 1024).toFixed(0)} KB`;
+    const formatted =
+      totalBytes === 0
+        ? "0"
+        : totalBytes >= 1024 * 1024 * 1024
+          ? `${(totalBytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+          : totalBytes >= 1024 * 1024
+            ? `${(totalBytes / (1024 * 1024)).toFixed(0)} MB`
+            : `${(totalBytes / 1024).toFixed(0)} KB`;
+    return { totalDBSize: formatted, dbSizeExcluded: excluded };
   }, [fleetHealth]);
 
   // Activity feed: merge audit events + recent history
@@ -380,6 +384,7 @@ export function OverviewTab({ user }: OverviewTabProps) {
         todayQueries={todayQueries}
         yesterdayQueries={yesterdayQueries}
         totalDBSize={totalDBSize}
+        dbSizeExcluded={dbSizeExcluded}
         user={user}
         fleetLoading={fleetLoading}
         onRefresh={refreshFleetHealth}
@@ -416,6 +421,7 @@ function HeroStatusBanner({
   todayQueries,
   yesterdayQueries,
   totalDBSize,
+  dbSizeExcluded,
   user,
   fleetLoading,
   onRefresh,
@@ -427,6 +433,7 @@ function HeroStatusBanner({
   todayQueries: number;
   yesterdayQueries: number;
   totalDBSize: string;
+  dbSizeExcluded: number;
   user: AdminUser | null;
   fleetLoading: boolean;
   onRefresh: () => void;
@@ -568,7 +575,7 @@ function HeroStatusBanner({
                 icon={HardDrive}
                 label="DB Size"
                 value={totalDBSize}
-                suffix=""
+                suffix={dbSizeExcluded > 0 ? `(${dbSizeExcluded} excluded)` : ""}
                 color="text-emerald-400"
                 isString
               />

--- a/tests/api/admin/fleet-health.test.ts
+++ b/tests/api/admin/fleet-health.test.ts
@@ -117,6 +117,70 @@ describe("POST /api/admin/fleet-health", () => {
     expect(data.results[0].latencyMs).toBeDefined();
   });
 
+  // Issue #540: the fleet total used to re-parse `databaseSize`'s display string, which had no
+  // "tb" branch and counted a 1 TB database as 1 byte. The route now projects the provider's own
+  // byte figure from getOverview() instead, so the dashboard never has to parse a string at all.
+  test("carries the provider's byte figure from getOverview alongside the display string", async () => {
+    const req = createMockRequest("/api/admin/fleet-health", {
+      method: "POST",
+      body: { connections },
+    });
+
+    const res = await POST(req);
+    const data = await parseResponseJSON<{
+      results: { connectionId: string; databaseSize?: string; databaseSizeBytes?: number }[];
+    }>(res);
+
+    expect(res.status).toBe(200);
+    expect(data.results[0].databaseSize).toBe("256 MB");
+    expect(data.results[0].databaseSizeBytes).toBe(268435456);
+  });
+
+  test("omits databaseSizeBytes, not a fabricated 0, when the provider publishes no byte figure", async () => {
+    const noByteProvider = createMockProvider({
+      overview: {
+        version: "Cassandra 4.1",
+        uptime: "10 days",
+        maxConnections: 100,
+        databaseSize: "1 MiB",
+        tableCount: 5,
+        indexCount: 2,
+      },
+    });
+    mockGetOrCreateProvider.mockImplementation(async () => noByteProvider);
+
+    const req = createMockRequest("/api/admin/fleet-health", {
+      method: "POST",
+      body: { connections: [connections[0]] },
+    });
+
+    const res = await POST(req);
+    const data = await parseResponseJSON<{ results: { databaseSizeBytes?: number }[] }>(res);
+
+    expect(res.status).toBe(200);
+    expect(data.results[0].databaseSizeBytes).toBeUndefined();
+  });
+
+  test("a getOverview failure omits the byte figure without turning a healthy connection into an error", async () => {
+    const throwingProvider = createMockProvider();
+    (throwingProvider.getOverview as ReturnType<typeof mock>).mockImplementation(async () => {
+      throw new Error("overview query timed out");
+    });
+    mockGetOrCreateProvider.mockImplementation(async () => throwingProvider);
+
+    const req = createMockRequest("/api/admin/fleet-health", {
+      method: "POST",
+      body: { connections: [connections[0]] },
+    });
+
+    const res = await POST(req);
+    const data = await parseResponseJSON<{ results: { status: string; databaseSizeBytes?: number }[] }>(res);
+
+    expect(res.status).toBe(200);
+    expect(data.results[0].status).toBe("healthy");
+    expect(data.results[0].databaseSizeBytes).toBeUndefined();
+  });
+
   test("returns 403 for non-admin user", async () => {
     mockGetSession.mockResolvedValueOnce({ role: "user", username: "user" });
 

--- a/tests/components/admin/OverviewTab.test.tsx
+++ b/tests/components/admin/OverviewTab.test.tsx
@@ -370,6 +370,7 @@ describe("OverviewTab", () => {
               status: "healthy",
               latencyMs: 150,
               databaseSize: "512 kb",
+              databaseSizeBytes: 524288,
               activeConnections: 5,
             },
           ],
@@ -388,6 +389,54 @@ describe("OverviewTab", () => {
       expect(queryByText("150")).not.toBeNull();
       // totalDBSize aggregation: "kb" branch
       expect(queryByText("512 KB")).not.toBeNull();
+    });
+  });
+
+  // Issue #540: databaseSize's display string had no "tb" branch, so re-parsing it counted a
+  // 1 TB database as 1 byte. totalDBSize now sums databaseSizeBytes directly - this pins a
+  // TB-scale connection plus one with no byte figure at all, and asserts the total is correct
+  // and the excluded connection is called out rather than silently zeroed into the sum.
+  test("sums a TB-scale byte figure correctly and excludes a connection with none", async () => {
+    fetchMock = mockGlobalFetch({
+      "/api/admin/audit": { json: { events: [] } },
+      "/api/admin/fleet-health": {
+        json: {
+          results: [
+            {
+              connectionId: "c1",
+              connectionName: "Archive",
+              type: "postgres",
+              status: "healthy",
+              latencyMs: 100,
+              databaseSize: "1 TB",
+              databaseSizeBytes: 1099511627776,
+              activeConnections: 3,
+            },
+            {
+              connectionId: "c2",
+              connectionName: "ScyllaDB Node",
+              type: "cassandra",
+              status: "healthy",
+              latencyMs: 90,
+              activeConnections: 2,
+            },
+          ],
+        },
+      },
+    });
+
+    let renderResult: ReturnType<typeof render>;
+    await act(async () => {
+      renderResult = render(<OverviewTab user={{ username: "admin", role: "admin" }} />);
+    });
+    const { queryByText } = renderResult!;
+
+    await waitFor(() => {
+      // 1 TB correctly reflected as 1024.0 GB, not the old bug's "1 B" (parseFloat("1 tb")
+      // falls through every gb/mb/kb branch to a bare byte read).
+      expect(queryByText("1024.0 GB")).not.toBeNull();
+      // The connection with no databaseSizeBytes is excluded from the sum, not zeroed into it.
+      expect(queryByText("(1 excluded)")).not.toBeNull();
     });
   });
 

--- a/tests/components/admin/OverviewTab.test.tsx
+++ b/tests/components/admin/OverviewTab.test.tsx
@@ -432,9 +432,9 @@ describe("OverviewTab", () => {
     const { queryByText } = renderResult!;
 
     await waitFor(() => {
-      // 1 TB correctly reflected as 1024.0 GB, not the old bug's "1 B" (parseFloat("1 tb")
-      // falls through every gb/mb/kb branch to a bare byte read).
-      expect(queryByText("1024.0 GB")).not.toBeNull();
+      // 1 TB correctly reflected as "1 TB" via the shared formatBytes ladder, not the old bug's
+      // "1 B" (parseFloat("1 tb") falls through every gb/mb/kb branch to a bare byte read).
+      expect(queryByText("1 TB")).not.toBeNull();
       // The connection with no databaseSizeBytes is excluded from the sum, not zeroed into it.
       expect(queryByText("(1 excluded)")).not.toBeNull();
     });

--- a/tests/components/admin/OverviewTab.test.tsx
+++ b/tests/components/admin/OverviewTab.test.tsx
@@ -408,7 +408,7 @@ describe("OverviewTab", () => {
               type: "postgres",
               status: "healthy",
               latencyMs: 100,
-              databaseSize: "1 TB",
+              databaseSize: "1.00 TB",
               databaseSizeBytes: 1099511627776,
               activeConnections: 3,
             },


### PR DESCRIPTION
## What

The Fleet Overview total re-parsed each connection's formatted `databaseSize` string (`"1.2 GB"`, `"512 MB"`, ...) in `OverviewTab.tsx`. The parser branched on `gb`/`mb`/`kb` and fell through to a bare-number read for everything else, so a `"1 TB"` database contributed exactly 1 byte to the total and large databases were silently undercounted.

The byte figure this needs already exists — `DatabaseOverview.databaseSizeBytes` is published by every provider that has one, via `getOverview()`. No provider code changes needed:

- `src/app/api/admin/fleet-health/route.ts`: added `databaseSizeBytes?: number` to `FleetHealthItem`, and the route now calls `provider.getOverview()` alongside the existing `getHealth()` call to project the real byte figure through. A provider that fails or publishes none leaves it `undefined` (best-effort, outside the latency measurement, doesn't turn a healthy connection into an error).
- `src/components/admin/tabs/OverviewTab.tsx`: `totalDBSize` now sums `databaseSizeBytes` directly instead of parsing display strings. Connections with no byte figure are excluded from the sum rather than treated as zero, and the DB Size card now shows `(N excluded)` when that happens.

## Verified

New tests pin the actual bug:
- `tests/api/admin/fleet-health.test.ts`: byte figure carried through from `getOverview()`, omitted (not zeroed) when the provider publishes none, and omitted without turning a healthy connection into an error when `getOverview()` throws.
- `tests/components/admin/OverviewTab.test.tsx`: a 1 TB connection now correctly sums to `1024.0 GB` (was `1 B` under the old parser) alongside a connection with no byte figure, which shows as excluded.

Local gate: lint, typecheck, knip, readme:check, security:check all clean; targeted tests (fleet-health + OverviewTab, 31/31) and full production build pass. `channels:showcase:check` fails identically on a clean `main` checkout on this Windows machine — confirmed pure CRLF (`core.autocrlf=true`), zero content diff when regenerated, unrelated to this change.

Fixes #540