### PR TITLE
docs: state elkjs's EPL-2.0 license alongside the MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,8 +984,8 @@ We welcome contributions from the community! Whether it's a bug fix, a new featu
 
 ## License
 
-Distributed under the MIT License. See `LICENSE` for more information. One direct dependency ships
-under different terms — see [`docs/THIRD_PARTY_LICENSES.md`](docs/THIRD_PARTY_LICENSES.md).
+Distributed under the MIT License. See `LICENSE` for more information. One direct dependency,
+`elkjs`, is under the reciprocal EPL-2.0; see [`docs/THIRD_PARTY_LICENSES.md`](docs/THIRD_PARTY_LICENSES.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -984,7 +984,8 @@ We welcome contributions from the community! Whether it's a bug fix, a new featu
 
 ## License
 
-Distributed under the MIT License. See `LICENSE` for more information.
+Distributed under the MIT License. See `LICENSE` for more information. One direct dependency ships
+under different terms — see [`docs/THIRD_PARTY_LICENSES.md`](docs/THIRD_PARTY_LICENSES.md).
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -37,7 +37,7 @@ None of it is a GitHub issue.
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3
 - [Chart configuration surface](#chart-configuration-surface) — N1, N3 · 2
 - [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H8 · 2
-- [Security Phase 2 deferrals](#security-phase-2-deferrals) — C3–C10 · 8
+- [Security Phase 2 deferrals](#security-phase-2-deferrals) — C3–C10 · 7
 - [Security Phase 3 deferrals](#security-phase-3-deferrals) — K4
 - [Agent M1 deferrals (#328)](#agent-m1-deferrals-328) — A1–A5 · 4
 - [Agent M2 deferrals (#329)](#agent-m2-deferrals-329) — B2–B76 · 22
@@ -1256,23 +1256,6 @@ a CC BY-SA database with no note connecting them.
 **Done when:** a generated `NOTICE` (or `THIRD_PARTY_LICENSES`) ships at the root of the image and the
 tarballs, names the sample database's separate terms explicitly, and is regenerated from the lockfile
 rather than hand-maintained.
-
-### C9. `elkjs` is EPL-2.0 and a direct production dependency
-
-Every other direct production dependency is permissive. `elkjs@^0.12.0` is EPL-2.0 — a file-level
-reciprocal license with a patent-retaliation clause — and it is ours by choice rather than transitive:
-the schema diagram's layout worker imports it at
-`src/components/schema-diagram/elk.worker.ts`.
-
-It is used unmodified, which is the case EPL-2.0 is comfortable with, so nothing is wrong today. But
-the distributed bundle is MIT-plus-EPL rather than MIT, and that is a question an acquirer's counsel
-asks rather than overlooks.
-
-Recorded rather than acted on because the alternatives are worse: ELK is the only layout engine in the
-ecosystem that produces the layered orthogonal routing the ER diagram depends on.
-
-**Done when:** the mixed terms are stated openly (alongside C8, the natural place), or a permissive
-layout engine proves it can match the output.
 
 ### C10. The last DOMPurify advisories are held open by Monaco's pin
 

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -5,12 +5,12 @@ production dependency carries different terms:
 
 | Package | License | Used at |
 | --- | --- | --- |
-| [`elkjs`](https://github.com/kieler/elkjs) `^0.12.0` | [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/) | `src/components/schema-diagram/elk.worker.ts`, unmodified, for the schema diagram's layered orthogonal layout |
+| [`elkjs`](https://github.com/kieler/elkjs) | [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/) (offered as `EPL-2.0 OR GPL-3.0-or-later`; this project takes it under EPL-2.0) | `src/components/schema-diagram/elk.worker.ts`, unmodified, for the schema diagram's layered orthogonal layout |
 
-EPL-2.0 is a file-level reciprocal license with a patent-retaliation clause. `elkjs` is used
-unmodified, which is the case the license is comfortable with, so nothing beyond disclosure is
-required — but the distributed bundle is MIT-plus-EPL-2.0 rather than pure MIT, and that is worth
-stating openly rather than leaving implicit.
+EPL-2.0 is a file-level reciprocal license with a patent-retaliation clause. elkjs is used
+unmodified. Its license text ships with the package at `node_modules/elkjs/LICENSE.md`; the source
+is at the repository linked above. The distributed bundle is therefore MIT plus EPL-2.0, not pure
+MIT.
 
 See `docs/BACKLOG.md` entry C8 for the broader, not-yet-generated NOTICE this file is a manual
 precursor to.

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,16 @@
+# Third-Party Licenses
+
+LibreDB Studio itself is distributed under the MIT License (see [`LICENSE`](../LICENSE)). One direct
+production dependency carries different terms:
+
+| Package | License | Used at |
+| --- | --- | --- |
+| [`elkjs`](https://github.com/kieler/elkjs) `^0.12.0` | [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/) | `src/components/schema-diagram/elk.worker.ts`, unmodified, for the schema diagram's layered orthogonal layout |
+
+EPL-2.0 is a file-level reciprocal license with a patent-retaliation clause. `elkjs` is used
+unmodified, which is the case the license is comfortable with, so nothing beyond disclosure is
+required — but the distributed bundle is MIT-plus-EPL-2.0 rather than pure MIT, and that is worth
+stating openly rather than leaving implicit.
+
+See `docs/BACKLOG.md` entry C8 for the broader, not-yet-generated NOTICE this file is a manual
+precursor to.


### PR DESCRIPTION
## What

Every other direct production dependency in this repo is permissively licensed. `elkjs@^0.12.0` (used unmodified by the schema diagram's layout worker at `src/components/schema-diagram/elk.worker.ts`) is EPL-2.0 — a file-level reciprocal license with a patent-retaliation clause. Nothing is wrong legally, but nothing in the repo stated that the distributed bundle is MIT-plus-EPL-2.0 rather than pure MIT.

## Where I put it

Added `docs/THIRD_PARTY_LICENSES.md` (a short factual table: package, license, where it's used) and linked it from `README.md`'s existing License section, right next to the "Distributed under the MIT License" line — the place a reader of the license would actually land. Chose the new-file option over adding to `SECURITY.md` since `SECURITY.md` doesn't currently have a dedicated license section, and the filename matches what `docs/BACKLOG.md` entry C8 already names as the eventual generated NOTICE file — this is a manual precursor to that, not a competing convention.

Docs only, no executable lines touched, so the coverage gate doesn't apply per the issue text. `package.json` and `elkjs` itself are untouched, per the issue's explicit "out of scope."

## Verified

`bun run readme:check` still passes (the localized `README_zh.md`/`README_ja.md` license blurbs are untouched — that check only guards the engine table and install commands, and translating legal text without being a fluent speaker felt like the wrong call). `bun run typecheck` and `bun run knip` both clean.

Fixes #544