### PR TITLE
test: match .gitattributes rules as whole lines in the drift guard

### DIFF
--- a/tests/unit/gitattributes.test.ts
+++ b/tests/unit/gitattributes.test.ts
@@ -3,6 +3,10 @@
  * including Windows clones with core.autocrlf=true (which made the byte-for-byte
  * channels:showcase:check fail on a clean tree, see #550). Guards the rule that
  * fixes it and the older #114 executable-source rules that must survive.
+ *
+ * Each rule is matched as a whole line rather than as a substring, so that a
+ * commented-out rule (`# * text=auto eol=lf`) fails the guard instead of
+ * silently satisfying it.
  */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -10,14 +14,21 @@ import { dirname, join } from "node:path";
 
 const gitattributes = readFileSync(join(dirname(import.meta.dir), "..", ".gitattributes"), "utf8");
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// A rule counts only when it sits on its own line, uncommented and in full.
+const expectRule = (rule: string): void => {
+  expect(gitattributes).toMatch(new RegExp(`^${escapeRegExp(rule)}$`, "m"));
+};
+
 describe(".gitattributes line-ending policy (#554)", () => {
   test("normalizes every text file to LF on checkout", () => {
-    expect(gitattributes).toContain("* text=auto eol=lf");
+    expectRule("* text=auto eol=lf");
   });
 
   test("keeps the explicit #114 executable-source rules", () => {
     for (const pattern of ["*.go", "*.sh", "*.mjs", "*.tmpl"]) {
-      expect(gitattributes).toContain(`${pattern} text eol=lf`);
+      expectRule(`${pattern} text eol=lf`);
     }
   });
 });


### PR DESCRIPTION
## Description
Follow-up to #555, implementing @cevheri's review suggestion. The drift guard used `toContain(...)`, which also matches a commented-out rule (`# * text=auto eol=lf`), so it wasn't really guarding the line. This anchors each rule to a whole line with a multiline regex, so a commented-out or altered rule fails the check.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Related Issue
Follow-up to #555 (suggestion: https://github.com/libredb/libredb-studio/pull/555#issuecomment-5543974569). Does not close an issue on its own.

## Changes Made
- `tests/unit/gitattributes.test.ts`: replace the two `toContain` assertions with a whole-line match (`^rule$` with the `m` flag; literals are regex-escaped). The same anchoring is applied to the four `#114` patterns.

## Testing
- [x] I have tested this locally
- [x] I have added/updated tests

- `bun test tests/unit/gitattributes.test.ts` on this branch: 2 pass / 0 fail.
- Confirmed the guard now fails when the rule is commented out as `# * text=auto eol=lf` (the old `toContain` passed in that case), then restored the file.
- `eslint` clean on the changed file.

## Screenshots (if applicable)
n/a (test-only change).

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the guard is effective
- [x] Test-only change; no runtime code is touched

## Additional Notes
Implements the maintainer's own optional follow-up from #555. AI-assisted (agent drafted the change; verified manually with the comment-out check above).
