### PR TITLE
fix(libsql): omit unknown overview size bytes

### DIFF
--- a/docs/providers/libsql.md
+++ b/docs/providers/libsql.md
@@ -351,6 +351,7 @@ Measured through the provider against both deployments (fixture: 2 tables, 3 and
 |---|---|
 | Version | `sqld 0.24.33 (f8fb14f3 2026-08-11) (SQLite 3.47.0)` / `SQLite 3.47.0` on Turso Cloud |
 | Database size | `64 KB` (65536 bytes), from `page_count × page_size` |
+| Database size unavailable | `databaseSize` is `"N/A"`; `databaseSizeBytes` is omitted, not zeroed |
 | Tables / indexes | 2 / 1 |
 | Uptime | `N/A` — libSQL publishes none |
 | Max connections | `0` — no limit published |

--- a/src/lib/db/providers/sql/libsql/introspect.ts
+++ b/src/lib/db/providers/sql/libsql/introspect.ts
@@ -396,7 +396,7 @@ export async function readOverview(transport: LibSQLTransport): Promise<Database
     // provider counting itself.
     maxConnections: 0,
     databaseSize: sizeBytes === undefined ? "N/A" : formatBytes(sizeBytes),
-    databaseSizeBytes: sizeBytes ?? 0,
+    ...(sizeBytes === undefined ? {} : { databaseSizeBytes: sizeBytes }),
     tableCount: readNumber(firstRow(outcomes[2])?.table_count) ?? 0,
     indexCount: readNumber(firstRow(outcomes[3])?.index_count) ?? 0,
   };

--- a/tests/unit/db/libsql/introspect.test.ts
+++ b/tests/unit/db/libsql/introspect.test.ts
@@ -323,7 +323,7 @@ describe("readOverview", () => {
     const overview = await readOverview(twoTableTransport([[/page_count/, REFUSED]]));
 
     expect(overview.databaseSize).toBe("N/A");
-    expect(overview.databaseSizeBytes).toBe(0);
+    expect(overview.databaseSizeBytes).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Summary
- Fixes libSQL overview reporting so unknown database size keeps `databaseSize` as `"N/A"` and omits `databaseSizeBytes` instead of reporting `0`.

Changes
- Include `databaseSizeBytes` from libSQL overview only when page counters are readable.
- Update the existing absence test to expect the optional byte field to be undefined.
- Document the libSQL unavailable-size behavior in the provider monitoring table.

Testing
- `git diff --check`
- `npm exec --yes --package bun@1.4.0 -- bun test tests/unit/db/libsql/introspect.test.ts` — 26 pass, 0 fail
- `npm exec --yes --package bun@1.4.0 -- bun test tests/unit/db/libsql tests/integration/db/libsql-provider.test.ts` — 134 pass, 0 fail
- `npm exec --yes --package bun@1.4.0 -- bun run format` — checked 983 files, no fixes applied
- `npm exec --yes --package bun@1.4.0 -- bun run lint` — exit code 0, existing warnings only
- `npm exec --yes --package bun@1.4.0 -- bun run typecheck` — exit code 0
- `npm exec --yes --package bun@1.4.0 -- bun run test` — blocked by environment: Helm is not installed, so Helm chart tests fail with `Executable not found in $PATH: "helm"`; review evidence recorded 10108 pass, 355 fail, 6 errors before that tooling limitation stopped the full gate.

Related Issue
- Closes #568
