### PR TITLE
feat(agent): five models reach 30/30, and four refusals that named no remedy

### DIFF
--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,10 +8,10 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Twenty-two models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
-Operate, Analyze and Plan — five consecutive times: 660 runs, 660 passes.
+**Twenty-seven models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+Operate, Analyze and Plan — five consecutive times: 810 runs, 810 passes.
 
-Sixteen of the twenty-two cleared them at the 90-second per-turn limit the product ships. Six carry a
+Twenty-one of the twenty-seven cleared them at the 90-second per-turn limit the product ships. Six carry a
 150-second limit of their own — `qwen3.5:9b`, `gemma4:12b`, `nemotron-3.5-lightning:30b`,
 `nemotron-3-nano:30b`, `muse-glimmer:latest` and `qwen3.6:27b` — because one turn of theirs does
 not fit inside 90 while every other surface does. The limit stays 90 for every other model, and
@@ -19,6 +19,7 @@ each page says what its model needed.
 
 | Model | Served through | Disk | Median run | Slowest run |
 | --- | --- | --- | --- | --- |
+| [`qwen2.5:7b`](qwen/qwen2.5.md) | Ollama | 4.7 GB | 6s | 21s |
 | [`gemini-3.5-flash-lite`](gemini/gemini-3.5.md) | Gemini API | — | 10s | 21s |
 | [`gemma4:12b`](gemma/gemma4.md) | Ollama | 7.6 GB | 11s | 63s |
 | [`granite4.1:8b`](granite/granite4.1.md) | Ollama | 5.3 GB | 11s | 22s |
@@ -27,12 +28,16 @@ each page says what its model needed.
 | [`ministral-3:8b`](mistral/ministral-3.md) | Ollama | 6.0 GB | 13s | 26s |
 | [`ministral-3:14b`](mistral/ministral-3.md) | Ollama | 9.1 GB | 16s | 56s |
 | [`qwen2.5:14b`](qwen/qwen2.5.md) | Ollama | 9.0 GB | 18s | 65s |
+| [`qwen2.5-coder:14b`](qwen/qwen2.5-coder.md) | Ollama | 9.0 GB | 20s | 37s |
+| [`qwen2.5:32b`](qwen/qwen2.5.md) | Ollama | 19 GB | 20s | 36s |
+| [`cogito:32b`](cogito/cogito.md) | Ollama | 19 GB | 23s | 39s |
 | [`granite4.1:30b`](granite/granite4.1.md) | Ollama | 17 GB | 26s | 52s |
 | [`nemotron3:33b`](nvidia/nemotron3.md) | Ollama | 27 GB | 21s | 119s |
 | [`nemotron-3.5-lightning:30b`](nvidia/nemotron-3.5-lightning.md) | Ollama | 25 GB | 29s | 145s |
 | [`ornith:9b`](ornith/ornith.md) | Ollama | 5.5 GB | 31s | 118s |
 | [`qwen3.5:9b`](qwen/qwen3.5.md) | Ollama | 5.8 GB | 33s | 98s |
 | [`gemma4:26b`](gemma/gemma4.md) | Ollama | 16 GB | 36s | 92s |
+| [`ornith:35b`](ornith/ornith.md) | Ollama | 21 GB | 36s | 150s |
 | [`qwen3:8b`](qwen/qwen3.md) | Ollama | 5.2 GB | 36s | 108s |
 | [`qwen3:14b`](qwen/qwen3.md) | Ollama | 9.3 GB | 41s | 303s |
 | [`granite4.2:8b`](granite/granite4.2.md) | Ollama | 5.3 GB | 46s | 116s |
@@ -44,8 +49,8 @@ each page says what its model needed.
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these twenty-two — the fastest reaches the same verdicts as the slowest in
-a twelfth of the time.
+for is choosing between these twenty-seven — the fastest reaches the same verdicts as the slowest in
+a nineteenth of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a
 size is chosen and because the interesting fact is usually the difference between two sizes of

--- a/docs/llms/cogito/cogito.md
+++ b/docs/llms/cogito/cogito.md
@@ -1,10 +1,11 @@
 # cogito
 
-`ollama pull cogito:<size>` · sizes supported: 14b
+`ollama pull cogito:<size>` · sizes supported: 14b, 32b
 
-The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
-The fastest six-surface sweep on record here — all thirty runs finished in ten minutes — and the
-only family measured at three sizes where the middle one is the only one that clears.
+Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+The 14b is the fastest six-surface sweep on record here — all thirty runs finished in ten minutes.
+The 32b spent weeks recorded as unsupported for one cell it could not close, and the cell turned
+out to be the server's.
 
 ## What it does, and how long it takes
 
@@ -13,12 +14,16 @@ Seconds are the median of the runs that passed, per surface.
 | Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | **14b** | 9.0 GB | 4s | 13s | 18s | 13s | 8s | 6s | **11s** | 20s |
+| **32b** | 19 GB | 21s | 23s | 32s | 31s | 23s | 4s | **23s** | 39s |
 
 Every cell is 5/5, so the table says how long rather than whether.
 
-Its 20-second slowest run is the shortest on this list, and that is the figure worth choosing on
-rather than the median: several models match 11 seconds in the middle and then have a tail three
+The 14b's 20-second slowest run is the shortest on this list, and that is the figure worth choosing
+on rather than the median: several models match 11 seconds in the middle and then have a tail three
 or five times longer. Nothing this model did on thirty runs took twice its median.
+
+The 32b holds the same shape at twice the weight — a 39-second slowest run against a 23-second
+median — and buys nothing for it. Both sizes are supported; the 14b is the one to reach for.
 
 ## What it needs that the defaults do not give it
 
@@ -26,22 +31,36 @@ or five times longer. Nothing this model did on thirty runs took twice its media
 
 Nothing. Measured at the defaults — temperature 0, top_p 1, a ceiling of twelve unreported calls — and it clears every surface on them.
 
-## The other two sizes are not supported, in opposite directions
+### `cogito:32b`
+
+**One plan ask, and this one is load-bearing.** One of its five passing plan runs wrote its
+statement only after being asked for it; the other four fenced one unprompted. Remove the ask and
+the cell is 4/5 and this size is not supported.
+
+## What the 32b's plan cell was, and what it turned out to be
+
+This page recorded the 32b as unsupported, in these words: *five surfaces read 5/5 on the first
+attempt; planning read 0/5, then 1/5, then 0/5 three more times across five configurations.* The
+loss was always `no-statement` — the model discusses the plan and never writes the runnable
+statement the surface is scored on — and five configurations of sampling, reasoning suppression and
+turn budget moved none of it.
+
+The server had a notice written for exactly that loss and did not send it. The notice was offered
+only to a model whose profile asked for it, and a model nobody has measured has no profile, so the
+one model that most needed the ask was the one guaranteed not to get it. Asking whoever produced
+neither statement nor refusal closed the cell on the next attempt: 5/5 at the defaults, one of the
+five a run that was asked.
+
+Nothing about the model changed. What is recorded here is a measurement that was reading the
+server, and this size now clears all six.
+
+## The smallest size is not supported
 
 **`cogito:8b` never files a report.** Its investigation cell read 0/5 twice, ten runs, every one
 the same: `no-report`, stopped by the turn limit. It works the database and runs out of turns
 still working. The refusal wording added alongside these measurements did not move it — the second
 0/5 is the read taken after that change — so it is recorded as measured and unfixed rather than
 untried.
-
-**`cogito:32b` fails one cell and only one.** Five surfaces read 5/5 on the first attempt;
-planning read 0/5, then 1/5, then 0/5 three more times across five configurations. The loss is
-always `no-statement` with the model stopping on its own — it discusses the plan and never writes
-the runnable statement the surface is scored on. Five sixths is not the claim this product makes,
-so 25 of 30 is not listed as supported.
-
-Both are the same finding from either side: on this family the 14b is the size that works, and
-neither the smaller nor the larger sibling is a safe substitute for it.
 
 ---
 

--- a/docs/llms/ornith/ornith.md
+++ b/docs/llms/ornith/ornith.md
@@ -1,9 +1,10 @@
 # ornith
 
-`ollama pull ornith:<size>` · sizes supported: 9b
+`ollama pull ornith:<size>` · sizes supported: 9b, 35b
 
 Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
-runs. One size, and it clears every surface with no setting of its own beyond a single extra plan turn.
+runs. The 9b clears every surface with no setting of its own beyond a single extra plan turn. The
+35b is the slowest supported model on this list and needs both reasoning suppressions to get there.
 
 ## What it does, and how long it takes
 
@@ -12,14 +13,40 @@ Seconds are the median of the runs that passed, per surface.
 | Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | ornith:9b | 5.5 GB | 20s | 36s | 51s | 21s | 16s | 31s | **31s** | 1:58 |
+| ornith:35b | 21 GB | 1:37 | 55s | 50s | 16s | 28s | 37s | **36s** | 2:30 |
 
 Every cell is 5/5, so the table says how long rather than whether.
+
+The 35b is the slowest model this list supports, and its investigation cell is where the time
+goes: a minute and a half against the 9b's twenty seconds for the same question and the same
+answer. Four times the weight buys nothing measurable here, and the 9b is the size to reach for.
 
 ## What it needs that the defaults do not give it
 
 ### `ornith:9b`
 
 **one extra plan turn.** Its plans describe the schema correctly and completely and stop one sentence short of the runnable statement the surface is scored on.
+
+### `ornith:35b`
+
+**Both reasoning suppressions, and one extra plan turn.** Its plan cell read 0/5 twice at the
+defaults, and the loss was the clock rather than the plan — it spends the turn thinking and the
+deliverable never arrives. Quiet, it answers in 37 seconds. The plan-turn switch alone did not
+close the cell; the pair did.
+
+The extra plan turn is load-bearing here too: one of its five passing plan runs wrote a statement
+only after being asked for one.
+
+## Why the 35b was measured twice
+
+The sweep locks a cell against whatever settings were in force when it closed, and it moves
+settings between cells. This model closed plan and investigate with both suppressions on and its
+other four surfaces at the defaults — but a bundled profile carries ONE set for all six, so
+shipping the pair would have put four surfaces out under settings no run of theirs had used.
+
+They were read again with the pair on rather than described as something they had not been
+measured as: assess, operate and analyze read 5/5, and optimize read 4/5 and then 5/5 on a
+re-roll. The figures in the table above are from those runs.
 
 
 ---

--- a/docs/llms/qwen/qwen2.5-coder.md
+++ b/docs/llms/qwen/qwen2.5-coder.md
@@ -1,0 +1,49 @@
+# qwen2.5-coder
+
+`ollama pull qwen2.5-coder:<size>` · sizes supported: 14b
+
+The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+The only code-specialised model on this list, and it arrived by being tried after the reasoning
+that excluded its whole class turned out to be wrong.
+
+## What it does, and how long it takes
+
+Seconds are the median of the runs that passed, per surface.
+
+| Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **14b** | 9.0 GB | 29s | 34s | 21s | 17s | 10s | 1s | **20s** | 37s |
+
+Every cell is 5/5, and every cell closed on its first attempt.
+
+Its one-second plan turn is the fastest on this list, and the shape of the whole model is in that
+figure beside the 29 seconds it spends investigating: asked to write a statement it answers at once,
+asked to go and read a database it takes longer than its general-purpose sibling of the same size.
+
+## What it needs that the defaults do not give it
+
+### `qwen2.5-coder:14b`
+
+**One plan ask**, which no run of its five spent. It was driven with no entry of its own, so the
+server offered the ask on every plan run and its plans fenced a statement without being asked. The
+number records the configuration the thirty runs were taken under; nothing here needed it.
+
+## Why a code model was not expected to clear this
+
+The agent surfaces are not code generation. A run reads a database through tools, holds what came
+back, and files a report whose claims cite the readings — the SQL it writes along the way is a
+means, and a model that writes beautiful SQL and never calls a tool answers nothing here. On that
+reasoning the coder families were set aside as a class and none was measured.
+
+The reasoning was sound and the conclusion was wrong. This model matches [`qwen2.5:14b`](qwen2.5.md)
+— same generation, same size, same 9 GB — cell for cell, and beats it on assessment by two thirds
+of a minute. What the surfaces ask for is instruction-following against a tool schema, and a model
+tuned to emit exactly-shaped code turns out to be good at exactly-shaped tool calls.
+
+One size is measured, so this is one data point and not a claim about coder models generally. It is
+recorded because it is the one that falsified the exclusion.
+
+---
+
+Method, and where these numbers stop being safe to generalise from:
+[`methodology.md`](../methodology.md).

--- a/docs/llms/qwen/qwen2.5.md
+++ b/docs/llms/qwen/qwen2.5.md
@@ -1,9 +1,10 @@
 # qwen2.5
 
-`ollama pull qwen2.5:<size>` · sizes supported: 14b
+`ollama pull qwen2.5:<size>` · sizes supported: 7b, 14b, 32b
 
-The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
-The oldest model generation on this list, and it needs nothing that the newest ones do not.
+Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+The oldest model generation on this list, and the only family measured at three sizes where all
+three clear — including the smallest model on the whole list, which is also the fastest.
 
 ## What it does, and how long it takes
 
@@ -11,19 +12,42 @@ Seconds are the median of the runs that passed, per surface.
 
 | Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **7b** | 4.7 GB | 6s | 10s | 5s | 9s | 5s | 2s | **6s** | 21s |
 | **14b** | 9.0 GB | 17s | 35s | 1:03 | 18s | 13s | 1s | **18s** | 1:05 |
+| **32b** | 19 GB | 19s | 28s | 29s | 28s | 16s | 3s | **20s** | 36s |
 
 Every cell is 5/5, so the table says how long rather than whether.
 
-Assessment is where its minute goes: a passing assess run profiles a table and takes a full minute,
-where its other five surfaces are done inside 35 seconds and its plan turn inside two. The 1:05
-slowest run is an assess run, so the tail is that one cell rather than a general unsteadiness.
+**The 7b is the fastest model measured here and the second smallest.** Its median run is six
+seconds, its slowest of thirty is 21, and no surface of its six takes ten. Nothing else on this
+list combines those two figures; the models that match its median have tails five and ten times
+longer. If the question is which local model to put in front of a user who is waiting, this is
+the answer, and it takes 4.7 GB of disk to hold.
+
+Assessment is where the 14b's minute goes: a passing assess run profiles a table and takes a full
+minute, where its other five surfaces are done inside 35 seconds and its plan turn inside two. The
+1:05 slowest run is an assess run, so the tail is that one cell rather than a general unsteadiness.
+The 32b does not repeat it — its assess cell is 29 seconds and its slowest run of thirty is 36 —
+which is the one place in this family where the larger model is the steadier one.
 
 ## What it needs that the defaults do not give it
+
+### `qwen2.5:7b`
+
+**One plan ask**, which no run of its five spent. It was driven with no entry of its own, so the
+server offered the ask every plan run and its plans fenced a statement without being asked. The
+number is recorded because it is the configuration the thirty runs were taken under, not because
+a run needed it.
 
 ### `qwen2.5:14b`
 
 Nothing. Measured at the defaults — temperature 0, top_p 1, a ceiling of twelve unreported calls — and it clears every surface on them.
+
+### `qwen2.5:32b`
+
+**One plan ask, and this one is load-bearing.** One of its five passing plan runs wrote its
+statement only after being asked for it; the other four fenced one unprompted. Remove the ask and
+the cell is 4/5 and this size is not supported.
 
 ## Why an older generation is on this list
 
@@ -34,7 +58,12 @@ same 9 GB as `qwen3:14b`, arrived on the defaults. It is a useful correction to 
 drove most of the measuring — that the newer or the larger model is the one to reach for. Neither
 held here.
 
-`qwen2.5:7b` and `qwen2.5:32b` have not been measured. They are absent rather than rejected.
+The two sizes added since say the same thing twice more. The 7b is a generation old, a third the
+weight of the 14b, and it is the fastest model on this list at every one of the six surfaces. The
+32b is twice the 14b's weight and matches it rather than beating it. Within this family, size buys
+steadiness on one cell and nothing else.
+
+[`qwen2.5-coder:14b`](qwen2.5-coder.md) is measured separately, and clears all six as well.
 
 ---
 

--- a/e2e/agent-models.spec.ts
+++ b/e2e/agent-models.spec.ts
@@ -1,5 +1,5 @@
 /**
- * The ten supported models, driven through the APPLICATION rather than through its API.
+ * The supported models, driven through the APPLICATION rather than through its API.
  *
  * Every figure in `docs/llms/` came from runs opened over HTTP: real runs against a real database
  * with a real model, but never once through the rail a user actually clicks. That gap is the

--- a/scripts/agent-model-e2e.sh
+++ b/scripts/agent-model-e2e.sh
@@ -19,7 +19,7 @@ MODELS=("$@")
 if [ ${#MODELS[@]} -eq 0 ]; then
   # Fastest first, so the run reports something early, and the hosted model last because it needs
   # its own environment file swapped in rather than a line rewritten.
-  MODELS=(granite4.1:8b granite4.2:8b granite4.1:30b ornith:9b qwen3.5:9b qwen3:8b gemma4:12b gemma4:26b qwen3:14b nemotron3:33b nemotron-3.5-lightning:30b nemotron-3-nano:30b qwen3.6:27b qwen3.8:latest muse-glimmer:latest qwen3:4b gemini-3.5-flash-lite)
+  MODELS=(qwen2.5:7b cogito:14b ministral-3:8b granite4.1:8b ministral-3:14b qwen2.5:14b qwen3.5:4b qwen2.5-coder:14b qwen2.5:32b cogito:32b granite4.2:8b granite4.1:30b ornith:9b ornith:35b qwen3.5:9b qwen3:8b gemma4:12b gemma4:26b qwen3:14b nemotron3:33b nemotron-3.5-lightning:30b nemotron-3-nano:30b qwen3.6:27b qwen3.8:latest muse-glimmer:latest qwen3:4b gemini-3.5-flash-lite)
 fi
 
 # Watchable by default: the browser opens on screen and every click is visible, and a video of

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -74,6 +74,9 @@ type PlanStatementEvent = Extract<AgentRunEvent, { kind: "plan-statement-drafted
 const GUIDANCE_HEADLINE: Record<Extract<AgentRunEvent, { kind: "guidance-issued" }>["notice"], string> = {
   "report-reminder": "Asked to file its report",
   "plan-statement": "Asked for a runnable statement",
+  // Named for what the reader can see happened rather than for the limit that did it: the turn
+  // produced nothing and the run kept going.
+  "turn-cut-off": "A turn ran long and was cut; asked again",
   "report-reserve": "Told this is its last turn",
   "unread-stop": "Asked to read the database itself",
   /*

--- a/src/lib/agent/execution-policy.ts
+++ b/src/lib/agent/execution-policy.ts
@@ -361,8 +361,13 @@ export const AGENT_WORKFLOW_BUDGETS: Readonly<Record<AgentRunWorkflowType, Agent
  * showed what that costs: an unanswered call ended a run at exactly 300.0s — the whole
  * investigation deadline of the day — with a two-event ledger, having spent a budget
  * meant to cover a whole investigation, and a user watched it do so with no feedback.
- * Turns on this workload land in seconds, so a ceiling this far above them is only ever
- * reached by a call that is not coming back. It is deliberately NOT per workflow: the
+ * Most turns on this workload land in seconds, and this ceiling was written on the assumption
+ * that anything reaching it was a call that would never come back. A local model falsifies that:
+ * measured on `qwen3.6:35b`, query-optimization, nine losses were cut near 100s of a 450s deadline
+ * with 34 of 36 turns unspent, while the same cell's longest PASSING run took 183s. So the ceiling
+ * is a bound on ONE CALL and the drive treats it as one — a cut turn is asked again rather than
+ * ending the run — which is what makes the sentence below true rather than aspirational. It is
+ * deliberately NOT per workflow: the
  * decision table varies what a RUN may spend, and how long one request may hang before
  * it is written off is a property of the transport, not of the question being asked.
  *

--- a/src/lib/agent/execution-policy.ts
+++ b/src/lib/agent/execution-policy.ts
@@ -411,6 +411,20 @@ export const AGENT_REPORT_RESERVE_TURNS = 2;
 export const AGENT_REPORT_RESERVE_MS = 20_000;
 
 /**
+ * How many times one turn may be re-asked when its STREAM broke, rather than the model.
+ *
+ * Two, matching the chat surface: `base-provider.ts` retries a retryable `LLMStreamError` three
+ * times against these same endpoints, and an agent turn is far more expensive than a chat one, so
+ * this is the same judgement spent more carefully.
+ *
+ * It bounds a fault in the connection, never one in the model. `isRetryableError` refuses auth,
+ * safety and config errors, so a misconfigured server still fails on its first turn; what this
+ * covers is the broken frame measured on `gpt-oss:20b`, where runs died a median of 17 seconds
+ * into a 630-second budget having already called four tools.
+ */
+export const AGENT_TRANSPORT_TURN_RETRIES = 2;
+
+/**
  * How many statements that FAILED AT THE DATABASE a run may try to repair.
  *
  * Policy denials and approval requirements deliberately do not consume one — they

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -68,6 +68,7 @@ import {
   suppressesAgentReasoning,
   suppressesPlanReasoning,
   turnTimeoutMsFor,
+  planStatementAsksFor,
   planStatementRetriesFor,
   reportReminderLimitFor,
   samplingFor,
@@ -3129,19 +3130,45 @@ export async function runInvestigation(
     /**
      * Gives a PLAN run one more turn when its prose named neither statement nor refusal.
      *
-     * Bounded by the model's own `planStatementRetries`, which is 0 for every model but the one
-     * whose ledgers earned it. The other bounds are the same three `remindToReport` applies and
-     * load-bearing for the same reasons: an agent run has no plan deliverable to miss, an
-     * operations plan is prose by decision (`verifyPlanningGoal` exempts it), and a run with no
-     * turn left cannot act on what it is told.
+     * The other bounds are the same three `remindToReport` applies and load-bearing for the same
+     * reasons: an agent run has no plan deliverable to miss, an operations plan is prose by
+     * decision (`verifyPlanningGoal` exempts it), and a run with no turn left cannot act on what
+     * it is told.
      *
      * The reading is `readPlanStatement`, the same reader `recordPlanStatement` and the verifier
      * use, so this cannot ask for a statement the run already wrote — a disagreement between the
      * notice and the verdict would spend a turn telling a passing run it had failed.
+     *
+     * THE FIRST ASK IS THE SERVER'S OWN, NOT A PER-MODEL FAVOUR.
+     *
+     * It was gated behind `planStatementRetries`, which defaults to 0, so a model with no row in
+     * `measured-profiles.json` was told nothing at all: the server read the closing prose, learned
+     * it held neither a fenced statement nor the refusal marker, held the sentence written for
+     * exactly that shape — and returned false on the line above, because of who the model was
+     * rather than what the run did.
+     *
+     * The order was the whole defect. The reader below decides whether the run FELL SHORT, and it
+     * is the same reader, with the same dialect, that `verifyPlanningGoal` is about to score
+     * `no-statement` on. So this branch is reachable only on a run already earning that verdict,
+     * and a run that clears the bar returns non-absent and is never touched. The turn provably
+     * cannot cost a pass, which is the standard the unread-stop retry is already granted under.
+     *
+     * Measured: `cogito:32b` and `qwen2.5:32b` each lost their plan cell 4/5 with every single
+     * loss `no-statement` / `model-stopped`, prose describing the schema correctly and no
+     * statement. `ornith:9b` and `qwen3:14b` lost the same cell the same way and BOTH were won by
+     * this very sentence, filed as a number in a document. The mechanism was discovered three
+     * times; the third and fourth models got nothing.
+     *
+     * `Math.max` rather than a raised default: the two models measured with this mechanism live
+     * keep exactly one ask and see byte-identical drives, and a profile may still RAISE the bound.
+     * It may no longer silence a sentence the server is holding for a run it has already failed.
      */
     const askForPlanStatement = async (assistant: readonly ModelMessage[]): Promise<boolean> => {
       if (record.mode === "agent" || record.workflowType === "operations") return false;
-      if (planStatementAsks >= planStatementRetriesFor(model.modelId)) return false;
+      if (planStatementAsks >= planStatementAsksFor(model.modelId)) return false;
+      // Grounded runs only. A run shown no inventory has nothing to write a statement FROM,
+      // and asking it for one is the impossible ask this file records having paid for before.
+      if (planningInventory === null || planningInventory.length === 0) return false;
       if (turns >= maxTurns || resources.deadline.remainingMs() <= 0) return false;
       if (text.length === 0 || readPlanStatement(text, context.connection.type).kind !== "absent") return false;
       planStatementAsks += 1;

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -71,7 +71,6 @@ import {
   suppressesPlanReasoning,
   turnTimeoutMsFor,
   planStatementAsksFor,
-  planStatementRetriesFor,
   reportReminderLimitFor,
   samplingFor,
 } from "./models";
@@ -364,8 +363,11 @@ function planningEngine(context: AgentToolContext): PlanningEngine {
  * only for SQL would push a model whose inventory cannot answer into inventing a table name
  * to satisfy it, which is the failure `verifyPlanningGoal` accepts refusals to avoid.
  *
- * Offered only where a profile asks for it (`planStatementRetriesFor`, 0 for every model but
- * one), so introducing it changed no other model's run.
+ * Offered to whoever needs it, because the ask is the server's own: `planStatementAsksFor` reads a
+ * measured profile's number when there is one and answers 1 when there is not, so a model nobody
+ * has measured is asked once rather than being refused a turn on the strength of its absence. A
+ * profile that states 0 is a measurement — that model was watched declining the ask — and it still
+ * decides for the model it was written about.
  */
 /**
  * What an answer-presenting run is told once when it would report without presenting.
@@ -2640,7 +2642,9 @@ export async function runInvestigation(
     /** Whether this drive has already re-asked an empty turn; see `retryEmptyTurn`. */
     let emptyTurnRetried = false;
     /**
-     * Whether this drive has already given back a turn the per-call ceiling cut; once per run.
+     * Whether this drive has already given back a turn the per-call ceiling cut; once per DRIVE,
+     * which is what this local declares — a resumed run opens a new drive and is granted one
+     * again, deliberately, because a resume is a second decision to spend on this run.
      *
      * The ceiling is documented as bounding one call and it ended the run. Measured on
      * `qwen3.6:35b`, query-optimization: nine losses, all `model-timeout` with `no-report`, all
@@ -3326,17 +3330,17 @@ export async function runInvestigation(
       try {
         turn = await takeTurn(
           model,
-        // The engine is the fence tag a plan run is told to write, so the prompt reads
-        // it from the connection this drive was given rather than from the record: the
-        // resources are what a statement would actually be run against.
-        systemPrompt(record, grounding, engine),
-        messages,
-        // Narrowed once the run has been told to finish; see `AGENT_NARROWED_EXTRA_TOOLS`.
-        narrowed && !prompted ? narrowedTools(ledger, narrowedAtEvent) : tools,
-        turnBudgetMs,
-        // Constraint measured and REVERTED; see the commit that removes it. Left unset here
-        // rather than deleted from `takeTurn`, because the seam is correct and the cost was in
-        // the model, not the wiring.
+          // The engine is the fence tag a plan run is told to write, so the prompt reads
+          // it from the connection this drive was given rather than from the record: the
+          // resources are what a statement would actually be run against.
+          systemPrompt(record, grounding, engine),
+          messages,
+          // Narrowed once the run has been told to finish; see `AGENT_NARROWED_EXTRA_TOOLS`.
+          narrowed && !prompted ? narrowedTools(ledger, narrowedAtEvent) : tools,
+          turnBudgetMs,
+          // Constraint measured and REVERTED; see the commit that removes it. Left unset here
+          // rather than deleted from `takeTurn`, because the seam is correct and the cost was in
+          // the model, not the wiring.
           undefined,
           record.workflowType,
           record.mode,

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -2456,6 +2456,7 @@ export function guidanceDelivered(events: readonly AgentRunEvent[]): Readonly<Re
   const counts: Record<AgentGuidanceNotice, number> = {
     "report-reminder": 0,
     "plan-statement": 0,
+    "turn-cut-off": 0,
     "report-reserve": 0,
     "unread-stop": 0,
     "present-before-report": 0,
@@ -2635,6 +2636,20 @@ export async function runInvestigation(
     let narrowedAtEvent = Number.POSITIVE_INFINITY;
     /** Whether this drive has already re-asked an empty turn; see `retryEmptyTurn`. */
     let emptyTurnRetried = false;
+    /**
+     * Whether this drive has already given back a turn the per-call ceiling cut; once per run.
+     *
+     * The ceiling is documented as bounding one call and it ended the run. Measured on
+     * `qwen3.6:35b`, query-optimization: nine losses, all `model-timeout` with `no-report`, all
+     * ending near 100s of a 450s deadline with 34 of 36 turns unspent — while the same cell's
+     * longest PASSING run took 183s. Those calls were coming back; the loop stopped waiting and
+     * threw away the run instead of the call.
+     *
+     * Every other failed turn in this loop has a recovery path and this one had none. Granted only
+     * where the run has already lost anyway — it filed no report, so it has earned `no-report` and
+     * the turn cannot cost a pass — and once, so a genuinely hung endpoint still fails fast.
+     */
+    let turnCutOffRetried = false;
     /*
     Every notice this run has already been delivered, read once (B51). The counters it
     seeds are declared in two places — this one and the block before the turn loop — and
@@ -3309,7 +3324,29 @@ export async function runInvestigation(
         record.mode,
       );
       text = turn.text;
-      if (turn.aborted) return conclude("failed", turnBudgetMs < remainingMs ? "model-timeout" : "deadline-exceeded");
+      if (turn.aborted) {
+        /*
+          See the note above `turnCutOffRetried`. `turnBudgetMs < remainingMs` is not only the word
+          this ending gets — it is a FACT about the run: the run's own clock is untouched, so what
+          ended is one call, which is exactly what this ceiling says it bounds.
+        */
+        const cutByTurnCeiling = turnBudgetMs < remainingMs;
+        if (
+          cutByTurnCeiling &&
+          !turnCutOffRetried &&
+          record.mode === "agent" &&
+          turns < maxTurns &&
+          resources.deadline.remainingMs() > AGENT_REPORT_RESERVE_MS
+        ) {
+          turnCutOffRetried = true;
+          // No assistant message is pushed: `takeTurn` returns none on abort, and a cut-off
+          // partial must not enter the transcript as a completed turn.
+          messages.push({ role: "user", content: notice(BASELINE_NOTICES.turnCutOff) });
+          await issueGuidance("turn-cut-off");
+          return null;
+        }
+        return conclude("failed", cutByTurnCeiling ? "model-timeout" : "deadline-exceeded");
+      }
       /*
         On the prompted path the call arrives as a JSON object inside ordinary text, so it is
         read out here and from here on the turn is indistinguishable from a native one.

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -44,6 +44,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { logger } from "@/lib/logger";
+import { isRetryableError } from "@/lib/llm/types";
 import { type ModelMessage, Output, type ToolSet, streamText, tool } from "ai";
 import { z } from "zod";
 import {
@@ -89,6 +91,7 @@ import { packSchemaStatistics, readSchemaStatistics } from "./schema-stats";
 import {
   AGENT_MODEL_TURN_TIMEOUT_MS,
   AGENT_REPORT_RESERVE_MS,
+  AGENT_TRANSPORT_TURN_RETRIES,
   AGENT_REPORT_RESERVE_TURNS,
   AGENT_WORKFLOW_BUDGETS,
 } from "./execution-policy";
@@ -2650,6 +2653,19 @@ export async function runInvestigation(
      * the turn cannot cost a pass — and once, so a genuinely hung endpoint still fails fast.
      */
     let turnCutOffRetried = false;
+    /**
+     * Turns re-asked because the STREAM broke rather than the model.
+     *
+     * `isRetryableError` is this repository's own reading of an `LLMStreamError`, and
+     * `base-provider.ts` already acts on it three times over on the chat surface against the same
+     * endpoints. This loop held that judgement and spent runs anyway: measured on `gpt-oss:20b`,
+     * database-assessment, runs died on a broken frame a median of 17s into a 630s budget having
+     * called a median of four tools — indistinguishable, up to the break, from the runs that
+     * answered.
+     *
+     * Bounded, so a provider that is genuinely down still ends the run rather than looping.
+     */
+    let transportRetries = 0;
     /*
     Every notice this run has already been delivered, read once (B51). The counters it
     seeds are declared in two places — this one and the block before the turn loop — and
@@ -3306,8 +3322,10 @@ export async function runInvestigation(
       // Built after the context, because in planning mode the rules depend on whether
       // there WAS one: a run told to plan against an inventory it was not given is the
       // same defect as a run given one and never told to use it (#350).
-      const turn = await takeTurn(
-        model,
+      let turn: ModelTurn;
+      try {
+        turn = await takeTurn(
+          model,
         // The engine is the fence tag a plan run is told to write, so the prompt reads
         // it from the connection this drive was given rather than from the record: the
         // resources are what a statement would actually be run against.
@@ -3319,10 +3337,39 @@ export async function runInvestigation(
         // Constraint measured and REVERTED; see the commit that removes it. Left unset here
         // rather than deleted from `takeTurn`, because the seam is correct and the cost was in
         // the model, not the wiring.
-        undefined,
-        record.workflowType,
-        record.mode,
-      );
+          undefined,
+          record.workflowType,
+          record.mode,
+        );
+      } catch (error) {
+        /*
+          A turn that broke in TRANSPORT is not a turn the model failed, and this loop's other
+          re-asks all cover the model.
+
+          Re-asked rather than ended because nothing was written: `takeTurn` copies the transcript
+          (`messages: [...messages]`) and never mutates the caller's array, and every ledger write
+          for a call happens downstream in `handleCall`. So the re-ask sends byte-identical bytes —
+          no second result for a `tool_call_id`, none of the wedging hazards the comments around
+          `toolResultMessage` guard.
+
+          Bounded by the run's own clock and by a small count, so a provider that is genuinely down
+          still ends the run — with its own error, finally meaning it.
+        */
+        if (
+          !isRetryableError(error) ||
+          transportRetries >= AGENT_TRANSPORT_TURN_RETRIES ||
+          resources.deadline.remainingMs() <= 0
+        ) {
+          throw error;
+        }
+        transportRetries += 1;
+        logger.warn(`agent run ${runId} re-asking a turn whose stream failed`, {
+          runId,
+          attempt: transportRetries,
+          modelId: model.modelId,
+        });
+        return null;
+      }
       text = turn.text;
       if (turn.aborted) {
         /*

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -39,6 +39,30 @@
       }
     },
     {
+      "id": "cogito:32b",
+      "measured": "6/6 modes locked, 30/30 runs passed, every cell on its first attempt. Investigate 21s · Optimize 23s · Assess 32s · Operate 31s · Analyze 23s · Plan 4s (medians of the passing runs), slowest run 39s. This size was recorded here at 25/30 with its plan cell at 0/5 across five configurations, always losing `no-statement`. No setting reached it because the notice that would have was offered only to models whose profile asked for it, and this one had no profile. The cell reads 5/5 now, and one of those five runs is a run that was asked.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 1,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      },
+      "rationale": {
+        "planStatementRetries": [
+          "One plan run in five was asked, and wrote its statement only then. The other four fenced one unprompted.",
+          "So this number is load-bearing rather than nominal: at 0 the cell is 4/5 and the model is not supported. It was measured with the ask because it was driven with no entry of its own, and it is recorded with the ask for the same reason it passed."
+        ]
+      }
+    },
+    {
       "id": "gemini-3.5-flash-lite",
       "measured": "6/6 modes locked, 30/30 runs passed at these settings. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 5/5.",
       "settings": {
@@ -342,6 +366,39 @@
       }
     },
     {
+      "id": "ornith:35b",
+      "measured": "6/6 modes locked, 30/30 runs passed with the two suppressions below. Investigate 97s · Optimize 55s · Assess 50s · Operate 16s · Analyze 28s · Plan 37s (medians of the passing runs), slowest run 150s. Its plan cell read 0/5 twice at the defaults and locked on the third attempt once both suppressions were on. The other four surfaces had cleared at the defaults, and were read AGAIN under the same pair rather than shipped under a configuration no run had used: assess, operate and analyze read 5/5 on that pass, and optimize read 4/5 and then 5/5 on the re-roll. The slowest model here that still clears every surface.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 1,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": true,
+        "refusalExamples": false,
+        "suppressAgentReasoning": true
+      },
+      "rationale": {
+        "planStatementRetries": [
+          "One plan run in five was asked, and wrote its statement only then. The other four fenced one unprompted.",
+          "So the number is load-bearing rather than nominal: at 0 the cell is 4/5 and this size is not supported. It was measured with the ask because it was driven with no entry of its own, and it is recorded with the ask for the same reason it passed."
+        ],
+        "suppressPlanReasoning": [
+          "Its plan cell read 0/5 twice at the defaults, and the loss was the clock rather than the plan: the model spends the turn thinking and the deliverable never arrives.",
+          "Quiet, it answers in 37 seconds. This is the setting that opened the cell, and it reaches plan turns only."
+        ],
+        "suppressAgentReasoning": [
+          "The plan-turn switch alone did not close the cell; the pair did, on the third attempt.",
+          "So it ships on both, and the four surfaces that had cleared at the defaults were measured again with it on rather than inheriting a setting they were never run under. Investigate is the cost: 97 seconds, the slowest of any supported model."
+        ]
+      }
+    },
+    {
       "id": "ornith:9b",
       "measured": "2/6 modes locked, 25/30 runs passed on an EARLIER ROUND. Investigate 4/5 · Optimize 3/5 · Assess 4/5 · Operate 5/5 · Analyze 5/5 · Plan 4/5. The plan cell is what the extra turn below was added for. What moved the other four is not recorded here and is not claimed: what is known is that the model now locks 6/6 and passes 30/30, every surface 5/5.",
       "settings": {
@@ -366,6 +423,30 @@
       }
     },
     {
+      "id": "qwen2.5-coder:14b",
+      "measured": "6/6 modes locked, 30/30 runs passed, every cell on its first attempt. Investigate 29s · Optimize 34s · Assess 21s · Operate 17s · Analyze 10s · Plan 1s (medians of the passing runs), slowest run 37s. A code-specialised model clearing all six surfaces is the finding worth recording: the surfaces are not code generation — they are reading a database and citing what was read — and a family set aside on that reasoning matches its general-purpose sibling of the same size, cell for cell.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 1,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      },
+      "rationale": {
+        "planStatementRetries": [
+          "Recorded as one because that is the configuration the thirty runs were taken under: driven with no entry of its own, the resolver answers one and every plan run had the ask available.",
+          "No run of its five spent it — its plans fence a statement unprompted — so the turn costs this model nothing and is recorded rather than removed. Writing 0 would describe a configuration nothing was measured in."
+        ]
+      }
+    },
+    {
       "id": "qwen2.5:14b",
       "measured": "6/6 modes locked, 30/30 runs passed at the compiled defaults, every cell on its first attempt. Investigate 17s · Optimize 35s · Assess 1:03 · Operate 18s · Analyze 13s · Plan 1s (medians of the passing runs). An older Qwen generation than anything else on the roster and it needs nothing, which is worth recording: the newer qwen3 line is represented at four sizes and this one arrived on the defaults alongside them.",
       "settings": {
@@ -381,6 +462,54 @@
         "retryUnreadStop": false,
         "suppressPlanReasoning": false,
         "refusalExamples": false
+      }
+    },
+    {
+      "id": "qwen2.5:32b",
+      "measured": "6/6 modes locked, 30/30 runs passed, every cell on its first attempt. Investigate 19s · Optimize 28s · Assess 29s · Operate 28s · Analyze 16s · Plan 3s (medians of the passing runs), slowest run 36s. It stood at 29/30 for days on the same plan cell and the same `no-statement` loss as `cogito:32b`, and opened for the same reason. One of its five passing plan runs is a run that was asked.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 1,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      },
+      "rationale": {
+        "planStatementRetries": [
+          "One plan run in five was asked, and wrote its statement only then. The other four fenced one unprompted.",
+          "So this number is load-bearing rather than nominal: at 0 the cell is 4/5 and the model is not supported. It was measured with the ask because it was driven with no entry of its own, and it is recorded with the ask for the same reason it passed."
+        ]
+      }
+    },
+    {
+      "id": "qwen2.5:7b",
+      "measured": "6/6 modes locked, 30/30 runs passed, every cell on its first attempt. Investigate 6s · Optimize 10s · Assess 5s · Operate 9s · Analyze 5s · Plan 2s (medians of the passing runs) — the fastest model measured here, and nothing it did on thirty runs took longer than 21s. Its optimize cell had been the one that would not close, losing while `recommend_change` refused calls without ever saying what shape one takes; it locked on the first attempt once the tool stated its own.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 1,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": false,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      },
+      "rationale": {
+        "planStatementRetries": [
+          "Recorded as one because that is the configuration the thirty runs were taken under: driven with no entry of its own, the resolver answers one and every plan run had the ask available.",
+          "No run of its five spent it — its plans fence a statement unprompted — so the turn costs this model nothing and is recorded rather than removed. Writing 0 would describe a configuration nothing was measured in."
+        ]
       }
     },
     {
@@ -492,7 +621,7 @@
     },
     {
       "id": "qwen3:14b",
-      "measured": "5/6 modes locked, 29/30 runs passed. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 4/5. The single loss is no-statement on plan: the run described all eight tables, both join tables and the key each relation travels on, then stopped without a fenced statement or the NO STATEMENT refusal that plan mode scores. Its other four plan runs fenced a statement, so it gets one extra turn to be asked for the deliverable — a planning run costs 15 seconds, and no other model is offered it.",
+      "measured": "5/6 modes locked, 29/30 runs passed. Investigate 5/5 · Optimize 5/5 · Assess 5/5 · Operate 5/5 · Analyze 5/5 · Plan 4/5. The single loss is no-statement on plan: the run described all eight tables, both join tables and the key each relation travels on, then stopped without a fenced statement or the NO STATEMENT refusal that plan mode scores. Its other four plan runs fenced a statement, so it gets one extra turn to be asked for the deliverable — a planning run costs 15 seconds. It is no longer the only model offered the turn: five models measured since state the same number, and a model with no profile is asked once, because absence is not a measurement.",
       "settings": {
         "sampling": {
           "temperature": 0,

--- a/src/lib/agent/models/index.ts
+++ b/src/lib/agent/models/index.ts
@@ -111,6 +111,33 @@ export function planStatementRetriesFor(modelId: string): number {
 }
 
 /**
+ * The same question, asked for a model NOBODY HAS MEASURED: one ask rather than none.
+ *
+ * The distinction the drive needs and `planStatementRetriesFor` cannot make. That resolver folds
+ * "this profile states 0" and "there is no profile" onto the same number, which is right for a
+ * setting and wrong for a decision: a stated 0 is a measurement, and an absent profile is the
+ * absence of one.
+ *
+ * The gate it feeds fires only where `readPlanStatement` scores the closing prose `absent` — the
+ * same reader, with the same dialect, that `verifyPlanningGoal` is about to score `no-statement`
+ * on. So the ask is reachable only on a run already earning that verdict and provably cannot cost
+ * a pass; what it costs an unmeasured model is one turn on a run it had already lost.
+ *
+ * Measured. `cogito:32b` and `qwen2.5:32b` each hold five surfaces and lose plan 4/5, every loss
+ * `no-statement` with the model stopping on its own after prose that describes the schema
+ * correctly and names no statement. Neither has a row in `measured-profiles.json`, so both were
+ * told nothing. `ornith:9b` and `qwen3:14b` lost that cell in exactly that shape and BOTH were won
+ * by this one sentence — recorded as a number against their names rather than as a rule. The
+ * mechanism has now been found four times.
+ *
+ * A measured model is untouched, including the twenty whose profiles state 0: their plan cells
+ * locked without the ask, and a number somebody measured is not this function's to overrule.
+ */
+export function planStatementAsksFor(modelId: string): number {
+  return resolve(modelId, "planStatementRetries") ?? 1;
+}
+
+/**
  * Whether an empty turn is asked again before this model's run is ended.
  *
  * False everywhere but the model measured returning nothing with its readings already taken,

--- a/src/lib/agent/models/notices.ts
+++ b/src/lib/agent/models/notices.ts
@@ -36,6 +36,12 @@ export const BASELINE_NOTICES: AgentNotices = Object.freeze({
     "Call compose_report now with what you established.",
     CITATION_RULE,
   ].join(" "),
+  turnCutOff: [
+    "Your last turn was cut off at this server's per-call limit and nothing from it was kept: whatever you were working out has not reached this run, and this run cannot see it.",
+    "The run itself is not over. It has most of its time and nearly all of its steps left, and it ends only when you file something.",
+    "Do not work that turn out again — a turn cut for taking too long will be cut again. Act in ONE short move now: if you already know what you would say, call compose_report with what this conversation established; otherwise make one tool call and nothing else.",
+    CITATION_RULE,
+  ].join(" "),
   planStatement: [
     "Your plan describes the database but names no statement, and a plan is scored on what the user can run: it must end either with a fenced code block holding one statement for this engine, or with an explicit refusal.",
     `Write the statement in a fenced block now, or begin a line with ${PLAN_NO_STATEMENT_MARKER} and say what the database does not support.`,

--- a/src/lib/agent/models/profile.ts
+++ b/src/lib/agent/models/profile.ts
@@ -235,6 +235,14 @@ export interface AgentNotices {
   readonly reportReminder: string;
   /** A PLAN run whose prose carried neither a runnable statement nor an explicit refusal. */
   readonly planStatement: string;
+  /**
+   * A turn the per-call ceiling cut off, on a run whose own deadline still has room.
+   *
+   * The one stop shape in the drive that had no recovery path. Measured on `qwen3.6:35b`: nine
+   * losses, every one cut at the ceiling with 333 to 353 seconds of a 450-second deadline and 34
+   * of 36 turns unspent, while the same cell's longest PASSING run took 183 seconds.
+   */
+  readonly turnCutOff: string;
   /** An answer-presenting run about to report a result it read but never presented. */
   readonly presentBeforeReport: string;
   /** A run that stopped without calling anything, having asked for what it could have read. */

--- a/src/lib/agent/models/profile.ts
+++ b/src/lib/agent/models/profile.ts
@@ -51,10 +51,14 @@ export interface AgentModelProfile {
   /**
    * How many extra turns a PLAN run gets when its prose named no statement and no refusal.
    *
-   * Zero by default, because a run that answered its objective is not obviously owed another
-   * turn, and 24 models clear this bar unaided. `qwen3:14b` is the measured case: its losing
-   * plan describes all eight tables and every relation and then stops without the fenced
-   * statement or the explicit refusal that plan mode scores.
+   * Stated by every measured profile, and the number a profile states is what that model gets:
+   * 0 where the model was watched declining the ask, 1 where the extra turn is what closed the
+   * cell. `qwen3:14b` is the measured case for 1 — its losing plan describes all eight tables and
+   * every relation and then stops without the fenced statement or the explicit refusal that plan
+   * mode scores.
+   *
+   * A model with no profile is a different question, and it is answered in `planStatementAsksFor`
+   * rather than here: absence is not a measurement, so an unmeasured model is asked once.
    */
   readonly planStatementRetries?: number;
 
@@ -271,7 +275,12 @@ export const DEFAULT_REPORT_REMINDER_LIMIT = 1;
  * No extra turn, which is what every locked plan cell was measured against.
  *
  * A plan run that produced prose has answered or it has not, and the verifier reads that for
- * itself. Offering another turn to every model would change 24 models' runs to reach one.
+ * itself. This is the number a MEASURED profile falls back to when it states none, and every
+ * profile that ships states one, so in practice it changes no measured model's run.
+ *
+ * It is not what an unmeasured model gets. That is `planStatementAsksFor`, which answers 1: a
+ * model nobody has watched has not been watched declining the ask either, and refusing it a turn
+ * on the strength of a missing measurement is the server deciding by silence.
  */
 export const DEFAULT_PLAN_STATEMENT_RETRIES = 0;
 

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1156,7 +1156,43 @@ function isShapeFailure(problems: string): boolean {
   return /claims(\.\d+)?: expected (object|array)/.test(problems) || /claims: expected array/.test(problems);
 }
 
-function invalidEvidenceInput(problems: string, example?: string): AgentToolOutcome & { kind: "unavailable" } {
+/**
+ * `recommend_change`'s own call shape — the one evidence-bearing tool that never stated it.
+ *
+ * `compose_report` has `AGENT_CLAIM_SHAPE` and `present_answer` has `AGENT_ANSWER_SHAPE`, both
+ * ungated. This tool had neither: `isShapeFailure` tests for a `claims` path and this call has no
+ * `claims` field, so that branch could never fire for it, and the only place its shape could reach
+ * a model was `exampleRecommendCall` behind the `refusalExamples` lever.
+ *
+ * Measured on `qwen2.5:7b`, query-optimization, 25 runs: the 9 that passed recorded a `statement`,
+ * the 16 that lost recorded none — and nothing else separated them. What the losing runs sent was
+ * `{"change","evidence","rationale"}`, three keys and never a fourth, while the SAME TURN wrote
+ * the value the missing field wants as prose: "Here is the SQL statement for creating the index:
+ * ```sql CREATE INDEX idx_employee_name ON employee(first_name, last_name); ```". The passing runs
+ * carry that exact string in `statement`. The model did not know the field existed.
+ *
+ * What it read instead was `statement: expected string` followed by a paragraph about `evidence` —
+ * the one field it had got right on all 134 attempts.
+ */
+const AGENT_RECOMMENDATION_SHAPE =
+  'The call is ONE object: {"change": "index", "statement": "<the CREATE INDEX or the rewritten SELECT, as SQL text>", "rationale": "<why it answers the objective>", "evidence": [ ... ]} — "statement" is that SQL itself, as a plain string in this call; SQL written only in your reply is not part of it.';
+
+/**
+ * Whether a `recommend_change` call failed on one of its OWN top-level fields.
+ *
+ * Whole-path tokens only, the same restraint `isShapeFailure` shows: a fault inside an evidence
+ * item (`evidence.0.source`) is a one-word correction, and answering it with the whole wrapper
+ * would bury the word that has to change.
+ */
+function isRecommendationShapeFailure(problems: string): boolean {
+  return /(^|[\s,])(change|statement|rationale|evidence): /.test(problems);
+}
+
+function invalidEvidenceInput(
+  problems: string,
+  example?: string,
+  shape?: string,
+): AgentToolOutcome & { kind: "unavailable" } {
   return {
     kind: "unavailable",
     reasonCode: "INVALID_TOOL_INPUT",
@@ -1185,6 +1221,9 @@ function invalidEvidenceInput(problems: string, example?: string): AgentToolOutc
       // Before the evidence contract, because a run that sent prose where an object goes has
       // not reached the evidence yet — and the contract answers a question it did not ask.
       ...(isShapeFailure(problems) ? [AGENT_CLAIM_SHAPE] : []),
+      // The caller's own shape, on the same rule and in the same position: only
+      // `recommendChangeTool` passes one, so no other tool's refusal changes a character.
+      ...(shape === undefined ? [] : [shape]),
       AGENT_EVIDENCE_CONTRACT,
       ...(example === undefined ? [] : [`A call this run could make right now: ${example}`]),
     ].join(" "),
@@ -3078,6 +3117,11 @@ export function recommendChangeTool(
     return invalidEvidenceInput(
       parsed.problems,
       offersRefusalExamples(context.modelId) ? exampleRecommendCall(run.events) : undefined,
+      // The only site that passes a shape, and the reason this parameter exists: see
+      // `AGENT_RECOMMENDATION_SHAPE`. The worked call above stays behind the lever it was
+      // measured on; the one line stating the contract goes to every model, as it does for
+      // this tool's two evidence-bearing siblings.
+      isRecommendationShapeFailure(parsed.problems) ? AGENT_RECOMMENDATION_SHAPE : undefined,
     );
   }
   if (!matchesCard(parsed.value.change, parsed.value.statement)) {

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -631,6 +631,16 @@ export type AgentGuidanceNotice =
    */
   | "plan-statement"
   /**
+   * A turn the per-call ceiling cut off, on a run whose own clock still has room. Delivered as a
+   * `user` message and the turn is taken again; once per run.
+   *
+   * The ceiling is documented as bounding one call and it ended the run instead. Measured on
+   * `qwen3.6:35b`, query-optimization: nine losses, all `model-timeout` with `no-report`, all
+   * near 100s of a 450s deadline with 34 of 36 turns unspent, while the same cell's longest
+   * PASSING run took 183s.
+   */
+  | "turn-cut-off"
+  /**
    * A run within the turn or time reserve of a ceiling. Delivered as a `user` message
    * riding the turn about to be taken; once per run.
    */

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -627,12 +627,14 @@ export type AgentGuidanceNotice =
   | "report-reminder"
   /**
    * A plan run whose prose named neither statement nor refusal. Delivered as a `user`
-   * message; bounded by the model's own `planStatementRetries`.
+   * message; bounded by the model's own `planStatementRetries` where it has a profile, and by
+   * one ask where it has none — absence is not a measurement, so an unmeasured model is asked.
    */
   | "plan-statement"
   /**
    * A turn the per-call ceiling cut off, on a run whose own clock still has room. Delivered as a
-   * `user` message and the turn is taken again; once per run.
+   * `user` message and the turn is taken again; once per drive, so a resumed run is granted one
+   * again.
    *
    * The ceiling is documented as bounding one call and it ended the run instead. Measured on
    * `qwen3.6:35b`, query-optimization: nine losses, all `model-timeout` with `no-report`, all

--- a/tests/evals/investigation-arc.test.ts
+++ b/tests/evals/investigation-arc.test.ts
@@ -150,12 +150,19 @@ describe("a planning run is judged by what planning mode can produce", () => {
     // user can run. Every field on this ledger called it answered until `no-statement`.
     const run = await open("postgres", { mode: "planning" });
 
-    const drive = await run.drive([answersProse("First I would ", "read the employees table.")]);
+    const drive = await run.drive([
+      answersProse("First I would ", "read the employees table."),
+      answersProse("I would still read the employees table."),
+    ]);
 
+    // `guidance-issued` is new and is the fix: a grounded plan run that named neither a statement
+    // nor a refusal is now told so while it still holds a turn, instead of being failed in
+    // silence. The verdict below is unchanged — prose twice is still `no-statement`.
     expect(drive.kinds).toEqual([
       "run-started",
       "driver-resolved",
       "context-captured",
+      "guidance-issued",
       "closing-statement",
       "run-finished",
     ]);
@@ -264,7 +271,10 @@ describe("a planning run is judged by what planning mode can produce", () => {
     // restarted process, a second replica, or a user who has never run agent mode.
     const run = await open("postgres", { mode: "planning" });
 
-    const drive = await run.drive([answersProse("I would begin with the engineering table.")]);
+    const drive = await run.drive([
+      answersProse("I would begin with the engineering table."),
+      answersProse("I would begin with the engineering table."),
+    ]);
 
     expect(drive.kinds).toContain("context-captured");
     expect(drive.modelStatements).toEqual([]);
@@ -297,7 +307,10 @@ describe("the planning-grounded case can fail on the defect it was written for",
   test("opening the case grounds its run, without the case sending anything itself", async () => {
     const run = await openCase();
 
-    const drive = await run.drive([answersProse("I would start with the engineering table.")]);
+    const drive = await run.drive([
+      answersProse("I would start with the engineering table."),
+      answersProse("I would start with the engineering table."),
+    ]);
 
     // The warm-up read the catalog, so the case's own run re-read none of it: it
     // sent nothing of the model's, and only the statistics read the hold cannot

--- a/tests/evals/plan-grounding.test.ts
+++ b/tests/evals/plan-grounding.test.ts
@@ -73,7 +73,12 @@ async function openPlan(engine: EvalEngine): Promise<EvalRun> {
   return run;
 }
 
-const PLAN = [answersProse("I would read the engineering table and count its rows.")];
+// Two turns of the same prose: a grounded plan run that names no statement is now asked for
+// one, and a model with nothing to add says the same thing again. The verdict is unchanged.
+const PLAN = [
+  answersProse("I would read the engineering table and count its rows."),
+  answersProse("I would read the engineering table and count its rows."),
+];
 
 describe("a plan run on a cold process grounds itself in the database it is about", () => {
   for (const engine of ["postgres", "sqlite"] as const) {
@@ -314,13 +319,25 @@ describe("a plan that names no statement is asked for one, where its model was m
     expect(drive.status).toBe("succeeded");
   });
 
-  test("a model nobody measured keeps the one turn it had", async () => {
-    // The whole point of the per-model file: introducing this mechanism changed no run of any
-    // model but the one whose ledgers earned it. Same prose, same engine, one turn.
-    const { drive, sent } = await drivePlan("gpt-4o-mini", [answersProse(PROSE)]);
+  test("a model nobody measured is asked too, because the ask is the server's own", async () => {
+    /*
+      This test asserted the opposite, and its reason was the per-model file's whole discipline:
+      introducing a mechanism must change no run of any model but the one whose ledgers earned it.
+      That restraint is right for a SETTING and wrong for this one. The ask fires only where
+      `readPlanStatement` scores the closing prose `absent` — the same reader, with the same
+      dialect, that `verifyPlanningGoal` is about to score `no-statement` on — so it is reachable
+      only on a run already earning that verdict, and a run that clears the bar is never touched.
+      What the old bound protected was not a passing run; it was silence on a losing one.
 
-    expect(sent.length).toBe(1);
-    expect(drive.kinds).not.toContain("plan-statement-drafted");
+      `cogito:32b` and `qwen2.5:32b` are the measured cost: five surfaces each, plan 4/5, every
+      loss `no-statement` with the model stopping on its own after prose that named the schema
+      correctly. Neither has a row in the document, so neither was ever sent the sentence that
+      won this cell for `ornith:9b` and `qwen3:14b`.
+    */
+    const { sent } = await drivePlan("gpt-4o-mini", [answersProse(PROSE), answersProse(FENCED)]);
+
+    expect(sent.length).toBe(2);
+    expect(sent[1] ?? "").toContain("names no statement");
   });
 
   test("qwen3:14b that refused instead of drafting is not asked again", async () => {

--- a/tests/evals/plan-grounding.test.ts
+++ b/tests/evals/plan-grounding.test.ts
@@ -277,15 +277,17 @@ describe("a refused capture records why it was refused", () => {
   });
 });
 
-describe("a plan that names no statement is asked for one, where its model was measured needing it", () => {
+describe("a plan that names no statement is asked for one, whoever the model is", () => {
   /*
     `qwen3:14b`, plan, 4 of 5. Its losing run answered the objective completely — all eight
     tables, both join tables, the key every relation travels on — and never wrote the
     deliverable, so the verdict was `no-statement`. Planning had no notice for that: the prose
     arrived, `conclude` filed it as the closing statement, and the run was over.
 
-    The turn is offered per model (`planStatementRetries`, 0 everywhere else), so this is
-    driven through `modelOver`'s model name rather than the fixture default.
+    Who gets the turn is what these cases pin. A measured profile's number decides for the model
+    it was written about — 0 means that model was watched declining the ask — and a model with no
+    profile is asked once, because absence is not a measurement. So the drive is run through
+    `modelOver`'s model name rather than the fixture default, and both sides are asserted.
   */
   const PROSE = "The department table holds dept_no and dept_name, and dept_emp joins it to employee.";
   const FENCED = "Here is the plan.\n\n```sql\nSELECT dept_no, COUNT(*) FROM dept_emp GROUP BY dept_no;\n```";

--- a/tests/evals/report-citation.test.ts
+++ b/tests/evals/report-citation.test.ts
@@ -110,14 +110,15 @@ describe("a run can cite using only what it was shown", () => {
   test("a planning run is offered no citation, because it can produce none", async () => {
     const offered: unknown[][] = [];
     const run = await open({ mode: "planning" });
-    await run.drive([
-      (turn) => {
-        offered.push(offeredCitationsIn(turn));
-        return answersProse("First, read the plan of the report query.")(turn);
-      },
-    ]);
+    const prose = (turn: Parameters<typeof offeredCitationsIn>[0]) => {
+      offered.push(offeredCitationsIn(turn));
+      return answersProse("First, read the plan of the report query.")(turn);
+    };
+    // Two turns, because a grounded plan run that named no statement is now asked for one — and
+    // the offer is checked on BOTH, which is stronger than checking the first alone.
+    await run.drive([prose, prose]);
 
-    expect(offered).toEqual([[]]);
+    expect(offered).toEqual([[], []]);
   });
 
   test("the placeholder in the rules is not mistaken for a real id", async () => {

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -3021,6 +3021,77 @@ describe("the run loop is bounded", () => {
     expect(finished).toMatchObject({ status: "failed", stopReason: "model-timeout" });
   });
 
+  describe("a turn the ceiling cut is given back, because the RUN still has its time", () => {
+    /*
+      `AGENT_MODEL_TURN_TIMEOUT_MS` says what it bounds in as many words — "It bounds ONE call,
+      never the run" — and this branch ended the run anyway. It computed the distinction,
+      `turnBudgetMs < remainingMs`, and spent it on choosing a WORD while taking the same action
+      either way: the branch that PROVES the run still has time was the branch that threw it away.
+
+      Measured on `qwen3.6:35b`, query-optimization: nine losses, every one `model-timeout` with
+      `no-report`, every one ending between 96.9s and 117.2s of a 450000ms deadline — 333 to 353
+      seconds unspent, on turn 2 or 3 of 36. The same cell's longest PASSING run took 183.1s,
+      longer than the total spend of any loss. The premise that licensed the ending ("a ceiling
+      this far above them is only ever reached by a call that is not coming back") holds for a
+      hosted API and is false on a local model: this cell's passing turns run 56.5s and 63.1s.
+
+      It was also the only stop shape in the drive with no recovery path. An empty turn is
+      re-asked, an unread stop is answered with the instruments, the call ceiling is narrowed and
+      reminded, a premature report is held with the next call named — and three of that cell's
+      seven passes are runs one of those paths rescued. This one got silence.
+    */
+    test("the run keeps going, is told what happened, and can still file", async () => {
+      const b = boot(freshDataDir());
+      const run = await startRun(b);
+      /*
+        A read, then a call that never comes back, then a report. The middle turn is the one the
+        ceiling cuts, and the run holds a reading at that moment — which is the losing arc:
+        `qwen3.6:35b` was cut having already called tools, with its report never filed.
+
+        The deadline is five minutes and the ceiling is 200ms, so the run's own clock is untouched
+        when the call is cut, and `turnBudgetMs < remainingMs` is true.
+      */
+      const script = scriptedModel(
+        callsTool("run_read_query", { sql: "SELECT id FROM orders" }),
+        unansweredCall,
+        reportOn(),
+      );
+
+      const result = await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+        turnTimeoutMs: 200,
+      });
+
+      expect(result.status).toBe("succeeded");
+      const events = await eventsOf(b.store, run.runId);
+      expect(events.filter((event) => event.kind === "guidance-issued").map((event) => event.notice)).toContain(
+        "turn-cut-off",
+      );
+      // The THIRD turn: the read was turn 1, the cut call turn 2, and the notice rides turn 3.
+      expect(script.turns[2]?.transcript).toContain("cut off at this server's per-call limit");
+    });
+
+    test("once only, so an endpoint that is genuinely gone still fails fast", async () => {
+      // The bound. A second cut ends the run, with the reason it always had.
+      const b = boot(freshDataDir());
+      const run = await startRun(b);
+      const script = scriptedModel(unansweredCall, unansweredCall);
+
+      const result = await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+        turnTimeoutMs: 200,
+      });
+
+      expect(result.status).toBe("failed");
+      expect(result.stopReason).toBe("model-timeout");
+      expect(script.turns).toHaveLength(2);
+    });
+  });
+
   test("a run that runs out of time is still reported as out of time, not as a slow call", async () => {
     // The turn ceiling must not relabel the run deadline: when less time remains than
     // a turn is allowed, the shorter bound is the run's own, and the reason follows it.

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -743,7 +743,10 @@ describe("planning mode runs no statement of the user's", () => {
   test("the model is handed no tools, only the server's catalog reads are sent, and the prose is returned", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("First ", "look at the index."), answersProse("First ", "look at the index."));
+    const script = scriptedModel(
+      answersProse("First ", "look at the index."),
+      answersProse("First ", "look at the index."),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -777,7 +780,10 @@ describe("planning mode runs no statement of the user's", () => {
   test("an operations plan reads its own inventory, is told what it holds, and is told of no tool", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning", "operations");
-    const script = scriptedModel(answersProse("I would read the wait events."), answersProse("I would read the wait events."));
+    const script = scriptedModel(
+      answersProse("I would read the wait events."),
+      answersProse("I would read the wait events."),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -875,7 +881,10 @@ describe("planning mode runs no statement of the user's", () => {
     const catalogReadsSoFar = b.queryReadOnly.mock.calls.length;
 
     const laterRun = await startRun(b, "planning", "investigation");
-    const laterScript = scriptedModel(answersProse("```postgres\nSELECT id FROM orders\n```"), answersProse("```postgres\nSELECT id FROM orders\n```"));
+    const laterScript = scriptedModel(
+      answersProse("```postgres\nSELECT id FROM orders\n```"),
+      answersProse("```postgres\nSELECT id FROM orders\n```"),
+    );
     await runInvestigation(laterRun.runId, {
       service: b.service,
       model: await modelOver(laterScript.fetch),
@@ -981,7 +990,10 @@ describe("planning mode runs no statement of the user's", () => {
   test("the plan reaches the ledger, not just the caller", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("Start with ", "the salary index."), answersProse("Start with ", "the salary index."));
+    const script = scriptedModel(
+      answersProse("Start with ", "the salary index."),
+      answersProse("Start with ", "the salary index."),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -1057,7 +1069,11 @@ describe("planning mode runs no statement of the user's", () => {
   test("a tool the run was never offered is refused without reaching the database", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"), answersProse("understood"));
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT 1" }),
+      answersProse("understood"),
+      answersProse("understood"),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -1950,7 +1966,10 @@ describe("planning mode runs no statement of the user's", () => {
         const b = boot(freshDataDir());
         const run = await startRun(b, "planning");
         // Two turns of prose, neither naming a statement — the losing shape, twice.
-        const script = scriptedModel(answersProse("The database holds orders and customers."), answersProse("Still prose."));
+        const script = scriptedModel(
+          answersProse("The database holds orders and customers."),
+          answersProse("Still prose."),
+        );
 
         await runInvestigation(run.runId, {
           service: b.service,
@@ -2762,7 +2781,10 @@ describe("a run survives the process driving it dying", () => {
     await first.service.cancel(run.runId, ACTOR);
 
     const second = boot(dataDir);
-    const resumed = scriptedModel(answersProse("I would look at the index."), answersProse("I would look at the index."));
+    const resumed = scriptedModel(
+      answersProse("I would look at the index."),
+      answersProse("I would look at the index."),
+    );
     const result = await runInvestigation(run.runId, {
       service: second.service,
       model: await modelOver(resumed.fetch),
@@ -3285,7 +3307,10 @@ describe("a run reserves its last turns for its report", () => {
     // inside its reserve before its first turn.
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("I would start with the orders table."), answersProse("I would start with the orders table."));
+    const script = scriptedModel(
+      answersProse("I would start with the orders table."),
+      answersProse("I would start with the orders table."),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -3506,7 +3531,11 @@ describe("a run that used its tools and then narrated is reminded once", () => {
     // for reaching outside its set is not evidence that it used one.
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"), answersProse("understood"));
+    const script = scriptedModel(
+      callsTool("run_read_query", { sql: "SELECT 1" }),
+      answersProse("understood"),
+      answersProse("understood"),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -4225,7 +4254,10 @@ describe("the run reads its schema context through the catalog tool", () => {
   test("a planning run on a cold process captures its own context, and still sends no statement of the user's", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("I would start with the index."), answersProse("I would start with the index."));
+    const script = scriptedModel(
+      answersProse("I would start with the index."),
+      answersProse("I would start with the index."),
+    );
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -4896,7 +4928,10 @@ describe("a run that will not record what it read is narrowed to what would fini
   test("a run that took no readings is not narrowed, because it has nothing to report yet", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("I will not be reading anything today."), answersProse("I will not be reading anything today."));
+    const script = scriptedModel(
+      answersProse("I will not be reading anything today."),
+      answersProse("I will not be reading anything today."),
+    );
 
     const result = await runInvestigation(run.runId, {
       service: b.service,

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -534,7 +534,7 @@ describe("a fresh run drives the investigation arc", () => {
   test("the model is offered exactly the four read-class tools", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("nothing to do"));
+    const script = scriptedModel(answersProse("nothing to do"), answersProse("nothing to do"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -556,7 +556,7 @@ describe("a fresh run drives the investigation arc", () => {
   test("the objective and the untrusted-content rule are both stated to the model", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("ok"));
+    const script = scriptedModel(answersProse("ok"), answersProse("ok"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -604,7 +604,7 @@ describe("the model is told what a citation IS, not only that it must cite (#350
   test("the run's rules carry both arms of the evidence contract", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("ok"));
+    const script = scriptedModel(answersProse("ok"), answersProse("ok"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -622,7 +622,7 @@ describe("the model is told what a citation IS, not only that it must cite (#350
   test("the snapshot's own fingerprint is offered as a citation when it is captured", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("ok"));
+    const script = scriptedModel(answersProse("ok"), answersProse("ok"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -679,7 +679,7 @@ describe("the model is told what a citation IS, not only that it must cite (#350
     ).rejects.toThrow();
 
     const second = boot(dataDir);
-    const resumed = scriptedModel(answersProse("ok"));
+    const resumed = scriptedModel(answersProse("ok"), answersProse("ok"));
     await runInvestigation(run.runId, {
       service: second.service,
       model: await modelOver(resumed.fetch),
@@ -701,7 +701,7 @@ describe("the model is told what a citation IS, not only that it must cite (#350
   test("planning mode is not told to cite anything, because it has nothing to cite", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("a plan"));
+    const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -743,7 +743,7 @@ describe("planning mode runs no statement of the user's", () => {
   test("the model is handed no tools, only the server's catalog reads are sent, and the prose is returned", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("First ", "look at the index."));
+    const script = scriptedModel(answersProse("First ", "look at the index."), answersProse("First ", "look at the index."));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -777,7 +777,7 @@ describe("planning mode runs no statement of the user's", () => {
   test("an operations plan reads its own inventory, is told what it holds, and is told of no tool", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning", "operations");
-    const script = scriptedModel(answersProse("I would read the wait events."));
+    const script = scriptedModel(answersProse("I would read the wait events."), answersProse("I would read the wait events."));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -866,7 +866,7 @@ describe("planning mode runs no statement of the user's", () => {
     };
     const b = boot(freshDataDir(), { answer: catalog });
     const operationsRun = await startRun(b, "agent", "operations");
-    const operationsScript = scriptedModel(answersProse("nothing to add"));
+    const operationsScript = scriptedModel(answersProse("nothing to add"), answersProse("nothing to add"));
     await runInvestigation(operationsRun.runId, {
       service: b.service,
       model: await modelOver(operationsScript.fetch),
@@ -875,7 +875,7 @@ describe("planning mode runs no statement of the user's", () => {
     const catalogReadsSoFar = b.queryReadOnly.mock.calls.length;
 
     const laterRun = await startRun(b, "planning", "investigation");
-    const laterScript = scriptedModel(answersProse("```postgres\nSELECT id FROM orders\n```"));
+    const laterScript = scriptedModel(answersProse("```postgres\nSELECT id FROM orders\n```"), answersProse("```postgres\nSELECT id FROM orders\n```"));
     await runInvestigation(laterRun.runId, {
       service: b.service,
       model: await modelOver(laterScript.fetch),
@@ -936,7 +936,7 @@ describe("planning mode runs no statement of the user's", () => {
     for (const mode of ["agent", "planning"] as const) {
       const b = boot(freshDataDir(), { answer: wide });
       const run = await startRun(b, mode, "operations");
-      const script = scriptedModel(answersProse("understood"));
+      const script = scriptedModel(answersProse("understood"), answersProse("understood"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -957,7 +957,7 @@ describe("planning mode runs no statement of the user's", () => {
     for (const mode of ["agent", "planning"] as const) {
       const b = boot(freshDataDir());
       const run = await startRun(b, mode, "operations");
-      const script = scriptedModel(answersProse("understood"));
+      const script = scriptedModel(answersProse("understood"), answersProse("understood"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -981,7 +981,7 @@ describe("planning mode runs no statement of the user's", () => {
   test("the plan reaches the ledger, not just the caller", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("Start with ", "the salary index."));
+    const script = scriptedModel(answersProse("Start with ", "the salary index."), answersProse("Start with ", "the salary index."));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -1000,7 +1000,7 @@ describe("planning mode runs no statement of the user's", () => {
   test("the ledger records how the loop ended, not only that it did", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("a plan"));
+    const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -1015,7 +1015,7 @@ describe("planning mode runs no statement of the user's", () => {
   test("a run that says nothing writes no empty closing statement", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse(""));
+    const script = scriptedModel(answersProse(""), answersProse(""));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -1057,7 +1057,7 @@ describe("planning mode runs no statement of the user's", () => {
   test("a tool the run was never offered is refused without reaching the database", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"));
+    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"), answersProse("understood"));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -1145,7 +1145,7 @@ describe("planning mode runs no statement of the user's", () => {
     /** One agent run, which is what puts this connection's inventory in the process. */
     const readTheCatalogOnce = async (b: Boot): Promise<void> => {
       const run = await startRun(b, "agent");
-      const script = scriptedModel(answersProse("understood"));
+      const script = scriptedModel(answersProse("understood"), answersProse("understood"));
       await runInvestigation(run.runId, {
         service: b.service,
         model: await modelOver(script.fetch),
@@ -1159,7 +1159,7 @@ describe("planning mode runs no statement of the user's", () => {
 
       const b = boot(freshDataDir(), { answer: catalog });
       const run = await startRun(b, "planning");
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
       const result = await runInvestigation(run.runId, {
         service: b.service,
@@ -1207,7 +1207,7 @@ describe("planning mode runs no statement of the user's", () => {
       const capturedAtMs = 1_000_000;
       const reader = boot(freshDataDir(), { answer: catalog });
       const readerRun = await startRun(reader, "agent");
-      const readerScript = scriptedModel(answersProse("understood"));
+      const readerScript = scriptedModel(answersProse("understood"), answersProse("understood"));
       await runInvestigation(readerRun.runId, {
         service: reader.service,
         model: await modelOver(readerScript.fetch),
@@ -1219,7 +1219,7 @@ describe("planning mode runs no statement of the user's", () => {
 
       const b = boot(freshDataDir(), { answer: catalog });
       const run = await startRun(b, "planning");
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
       await runInvestigation(run.runId, {
         service: b.service,
         model: await modelOver(script.fetch),
@@ -1251,7 +1251,7 @@ describe("planning mode runs no statement of the user's", () => {
 
       const b = boot(freshDataDir(), { answer: catalog });
       const run = await startRun(b, "planning");
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -1292,7 +1292,7 @@ describe("planning mode runs no statement of the user's", () => {
     test("a run on an engine this server cannot ground is told so rather than left to invent a schema", async () => {
       const b = boot(freshDataDir(), { answer: catalog });
       const run = await startRun(b, "planning");
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -1352,7 +1352,7 @@ describe("planning mode runs no statement of the user's", () => {
       ): Promise<{ readonly rules: string; readonly transcript: string }> => {
         const b = boot(freshDataDir(), { describesSchema: async () => PROVIDER_INVENTORY });
         const run = await startRun(b, "planning");
-        const script = scriptedModel(answersProse("a plan"));
+        const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
         await runInvestigation(run.runId, {
           service: b.service,
@@ -1563,7 +1563,7 @@ describe("planning mode runs no statement of the user's", () => {
       test("a composed reading keeps its own two sentences", async () => {
         const first = boot(freshDataDir(), { answer: catalog });
         const firstRun = await startRun(first, "planning");
-        const firstScript = scriptedModel(answersProse("a plan"));
+        const firstScript = scriptedModel(answersProse("a plan"), answersProse("a plan"));
         await runInvestigation(firstRun.runId, {
           service: first.service,
           model: await modelOver(firstScript.fetch),
@@ -1575,7 +1575,7 @@ describe("planning mode runs no statement of the user's", () => {
         // The same connection, a second process: the reading is now the hold's.
         const second = boot(freshDataDir(), { answer: catalog });
         const secondRun = await startRun(second, "planning");
-        const secondScript = scriptedModel(answersProse("a plan"));
+        const secondScript = scriptedModel(answersProse("a plan"), answersProse("a plan"));
         await runInvestigation(secondRun.runId, {
           service: second.service,
           model: await modelOver(secondScript.fetch),
@@ -1622,7 +1622,7 @@ describe("planning mode runs no statement of the user's", () => {
       }> => {
         const b = boot(freshDataDir(), { describesSchema: async () => KEY_PREFIXES });
         const run = await startRun(b, "planning", workflowType);
-        const script = scriptedModel(answersProse("a plan"));
+        const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
         await runInvestigation(run.runId, {
           service: b.service,
@@ -1720,7 +1720,7 @@ describe("planning mode runs no statement of the user's", () => {
       test("an engine that declares neither the noun nor the grouping is untouched", async () => {
         const b = boot(freshDataDir(), { answer: catalog });
         const run = await startRun(b, "planning");
-        const script = scriptedModel(answersProse("a plan"));
+        const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
         await runInvestigation(run.runId, {
           service: b.service,
           model: await modelOver(script.fetch),
@@ -1768,7 +1768,7 @@ describe("planning mode runs no statement of the user's", () => {
         connectionId: "conn_2",
         objective: OBJECTIVE,
       });
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
       await runInvestigation(run.runId, {
         service: other.service,
@@ -1855,7 +1855,7 @@ describe("planning mode runs no statement of the user's", () => {
     const firstTurnOf = async (mode: "agent" | "planning"): Promise<string> => {
       const b = boot(freshDataDir(), { answer: wideCatalog });
       const run = await startRun(b, mode);
-      const script = scriptedModel(answersProse("understood"));
+      const script = scriptedModel(answersProse("understood"), answersProse("understood"));
       await runInvestigation(run.runId, {
         service: b.service,
         model: await modelOver(script.fetch),
@@ -1915,7 +1915,7 @@ describe("planning mode runs no statement of the user's", () => {
     const planRulesFor = async (workflowType: AgentRunWorkflowType): Promise<string> => {
       const b = boot(freshDataDir());
       const run = await startRun(b, "planning", workflowType);
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
       await runInvestigation(run.runId, {
         service: b.service,
         model: await modelOver(script.fetch),
@@ -1923,6 +1923,72 @@ describe("planning mode runs no statement of the user's", () => {
       });
       return rulesOfTurn(script.turns[0] as Turn);
     };
+
+    describe("a run that named neither statement nor refusal is ASKED, whoever it is", () => {
+      /*
+        The ask existed and was unreachable for anyone nobody had measured.
+
+        `askForPlanStatement` tested the model's `planStatementRetries` — 0 unless a profile says
+        otherwise — BEFORE it tested whether the run had fallen short. So the server read the
+        closing prose, learned through `readPlanStatement` that it held neither a fenced statement
+        nor the `NO STATEMENT:` marker, held the sentence written for exactly that shape, and
+        returned false on the line above: because of who the model was, not what the run did.
+
+        The order was the whole defect. The reader below is the same reader, with the same dialect,
+        that `verifyPlanningGoal` is about to score `no-statement` on, so the branch is reachable
+        only on a run already earning that verdict; a run that clears the bar returns non-absent
+        and is never touched. The turn provably cannot cost a pass.
+
+        Measured. `cogito:32b` and `qwen2.5:32b` each hold five surfaces and lose plan 4/5, every
+        loss `no-statement` with the model stopping on its own after prose that describes the
+        schema correctly and names no statement — and neither has a row in the document, so
+        neither was ever told. `ornith:9b` and `qwen3:14b` lost that cell in that exact shape and
+        BOTH were won by this one sentence, recorded as a number against their names rather than
+        as a rule.
+      */
+      test("a model with no measured profile is sent the sentence, and given the turn to act on it", async () => {
+        const b = boot(freshDataDir());
+        const run = await startRun(b, "planning");
+        // Two turns of prose, neither naming a statement — the losing shape, twice.
+        const script = scriptedModel(answersProse("The database holds orders and customers."), answersProse("Still prose."));
+
+        await runInvestigation(run.runId, {
+          service: b.service,
+          // A model nobody has measured, which is the case the ask could not reach.
+          model: await modelOver(script.fetch, undefined, "some-model-nobody-measured:9b"),
+          resources: b.resources,
+        });
+
+        const events = await eventsOf(b.store, run.runId);
+        expect(events.filter((event) => event.kind === "guidance-issued").map((event) => event.notice)).toContain(
+          "plan-statement",
+        );
+        // The sentence itself reached the model, on a turn it could still act on.
+        expect(script.turns[1]?.transcript).toContain("names no statement");
+      });
+
+      test("a run whose prose already holds a refusal is not asked", async () => {
+        // The guard, and the reason the reader runs where it does: a run that ended correctly
+        // must not be told it failed. `NO STATEMENT:` IS a correct ending.
+        const b = boot(freshDataDir());
+        const run = await startRun(b, "planning");
+        const script = scriptedModel(
+          answersProse("NO STATEMENT: the inventory cannot derive the columns this question needs."),
+          answersProse("unused"),
+        );
+
+        await runInvestigation(run.runId, {
+          service: b.service,
+          model: await modelOver(script.fetch, undefined, "some-model-nobody-measured:9b"),
+          resources: b.resources,
+        });
+
+        const events = await eventsOf(b.store, run.runId);
+        expect(events.filter((event) => event.kind === "guidance-issued").map((event) => event.notice)).not.toContain(
+          "plan-statement",
+        );
+      });
+    });
 
     test("a grounded plan is asked for one runnable statement, fenced and tagged with this engine", async () => {
       const rules = await planRulesFor("investigation");
@@ -1973,7 +2039,7 @@ describe("planning mode runs no statement of the user's", () => {
     test("an ungrounded plan is told to refuse with NO STATEMENT: rather than invent one", async () => {
       const b = boot(freshDataDir());
       const run = await startRun(b, "planning");
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -2071,7 +2137,7 @@ describe("planning mode runs no statement of the user's", () => {
     test("an operations plan on an engine this server cannot ground is told it has seen nothing", async () => {
       const b = boot(freshDataDir());
       const run = await startRun(b, "planning", "operations");
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -2119,7 +2185,7 @@ describe("planning mode runs no statement of the user's", () => {
     test("an ungrounded operations plan may still write the engine's own reporting reading as a statement", async () => {
       const b = boot(freshDataDir());
       const run = await startRun(b, "planning", "operations");
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -2164,7 +2230,7 @@ describe("planning mode runs no statement of the user's", () => {
         },
       });
       const run = await startRun(b, "planning", "operations");
-      const script = scriptedModel(answersProse("a plan"));
+      const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -2268,7 +2334,7 @@ describe("planning mode runs no statement of the user's", () => {
       ): Promise<{ readonly rules: string; readonly transcript: string }> => {
         const b = boot(freshDataDir(), options);
         const run = await startRun(b, "planning", "operations");
-        const script = scriptedModel(answersProse("a plan"));
+        const script = scriptedModel(answersProse("a plan"), answersProse("a plan"));
 
         await runInvestigation(run.runId, {
           service: b.service,
@@ -2415,7 +2481,10 @@ describe("planning mode runs no statement of the user's", () => {
     ): Promise<readonly AgentRunEvent[]> => {
       const b = boot(freshDataDir(), { answer: catalog });
       const run = await startRun(b, "planning", options.workflowType);
-      const script = scriptedModel(answersProse(closing));
+      // Two turns of the same prose: the drive now asks a grounded plan run that named no
+      // statement to write one, and a model with nothing new to say repeats itself. The
+      // verdict, the ledger and every assertion below are unchanged by the extra turn.
+      const script = scriptedModel(answersProse(closing), answersProse(closing));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -2693,7 +2762,7 @@ describe("a run survives the process driving it dying", () => {
     await first.service.cancel(run.runId, ACTOR);
 
     const second = boot(dataDir);
-    const resumed = scriptedModel(answersProse("I would look at the index."));
+    const resumed = scriptedModel(answersProse("I would look at the index."), answersProse("I would look at the index."));
     const result = await runInvestigation(run.runId, {
       service: second.service,
       model: await modelOver(resumed.fetch),
@@ -3085,7 +3154,7 @@ describe("a run reserves its last turns for its report", () => {
     // inside its reserve before its first turn.
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("I would start with the orders table."));
+    const script = scriptedModel(answersProse("I would start with the orders table."), answersProse("I would start with the orders table."));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -3157,7 +3226,7 @@ describe("a run reserves its last turns for its report", () => {
 
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("nothing to add"));
+    const script = scriptedModel(answersProse("nothing to add"), answersProse("nothing to add"));
     await runInvestigation(run.runId, {
       service: b.service,
       model: await modelOver(script.fetch),
@@ -3306,7 +3375,7 @@ describe("a run that used its tools and then narrated is reminded once", () => {
     // for reaching outside its set is not evidence that it used one.
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"));
+    const script = scriptedModel(callsTool("run_read_query", { sql: "SELECT 1" }), answersProse("understood"), answersProse("understood"));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -3700,7 +3769,7 @@ describe("prior progress is described from the ledger alone", () => {
     });
 
     const second = boot(dataDir);
-    const resumed = scriptedModel(answersProse("continuing"));
+    const resumed = scriptedModel(answersProse("continuing"), answersProse("continuing"));
     await runInvestigation(run.runId, {
       service: second.service,
       model: await modelOver(resumed.fetch),
@@ -3727,7 +3796,7 @@ describe("prior progress is described from the ledger alone", () => {
     });
 
     const second = boot(dataDir);
-    const resumed = scriptedModel(answersProse("continuing"));
+    const resumed = scriptedModel(answersProse("continuing"), answersProse("continuing"));
     await runInvestigation(run.runId, {
       service: second.service,
       model: await modelOver(resumed.fetch),
@@ -3793,7 +3862,7 @@ describe("prior progress is described from the ledger alone", () => {
     }
 
     const second = boot(dataDir);
-    const resumed = scriptedModel(answersProse("continuing"));
+    const resumed = scriptedModel(answersProse("continuing"), answersProse("continuing"));
     await runInvestigation(run.runId, {
       service: second.service,
       model: await modelOver(resumed.fetch),
@@ -3823,7 +3892,7 @@ describe("the run reads its schema context through the catalog tool", () => {
   test("captures the inventory before the first turn, through the audited tool path", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("understood"));
+    const script = scriptedModel(answersProse("understood"), answersProse("understood"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -3868,7 +3937,7 @@ describe("the run reads its schema context through the catalog tool", () => {
   test("the capture records the statements the tracker charged it, and not a count of its plan", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("understood"));
+    const script = scriptedModel(answersProse("understood"), answersProse("understood"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -3895,7 +3964,7 @@ describe("the run reads its schema context through the catalog tool", () => {
       },
     });
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("understood"));
+    const script = scriptedModel(answersProse("understood"), answersProse("understood"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -3911,7 +3980,7 @@ describe("the run reads its schema context through the catalog tool", () => {
   test("the packed inventory reaches the model fenced, carrying the fingerprint a claim can cite", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("understood"));
+    const script = scriptedModel(answersProse("understood"), answersProse("understood"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -3970,7 +4039,7 @@ describe("the run reads its schema context through the catalog tool", () => {
     ).rejects.toThrow();
 
     const second = boot(dataDir);
-    const resumed = scriptedModel(answersProse("continuing"));
+    const resumed = scriptedModel(answersProse("continuing"), answersProse("continuing"));
     await runInvestigation(run.runId, {
       service: second.service,
       model: await modelOver(resumed.fetch),
@@ -3996,7 +4065,7 @@ describe("the run reads its schema context through the catalog tool", () => {
     await first.service.recordEvent(run.runId, { kind: "context-captured", fingerprint: "ctx_old", tableCount: 2 });
 
     const second = boot(dataDir);
-    const resumed = scriptedModel(answersProse("continuing"));
+    const resumed = scriptedModel(answersProse("continuing"), answersProse("continuing"));
     await runInvestigation(run.runId, {
       service: second.service,
       model: await modelOver(resumed.fetch),
@@ -4025,7 +4094,7 @@ describe("the run reads its schema context through the catalog tool", () => {
   test("a planning run on a cold process captures its own context, and still sends no statement of the user's", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("I would start with the index."));
+    const script = scriptedModel(answersProse("I would start with the index."), answersProse("I would start with the index."));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -4059,7 +4128,7 @@ describe("the run reads its schema context through the catalog tool", () => {
       },
     });
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("I will inspect it myself."));
+    const script = scriptedModel(answersProse("I will inspect it myself."), answersProse("I will inspect it myself."));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -4091,7 +4160,7 @@ describe("a run opened with auto-execute is told what the gate needs", () => {
   test("the rule names the plan the gate reads, and the bound the editor does not have", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "agent", "data-analysis", true);
-    const script = scriptedModel(answersProse("ok"));
+    const script = scriptedModel(answersProse("ok"), answersProse("ok"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -4108,7 +4177,7 @@ describe("a run opened with auto-execute is told what the gate needs", () => {
   test("a run opened without it is told nothing: a rule about what cannot happen is noise", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "agent", "data-analysis");
-    const script = scriptedModel(answersProse("ok"));
+    const script = scriptedModel(answersProse("ok"), answersProse("ok"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -4130,7 +4199,7 @@ describe("a run opened with auto-execute is told what the gate needs", () => {
     for (const workflowType of ["investigation", "query-optimization", "database-assessment", "operations"] as const) {
       const b = boot(freshDataDir());
       const run = await startRun(b, "agent", workflowType, true);
-      const script = scriptedModel(answersProse("ok"));
+      const script = scriptedModel(answersProse("ok"), answersProse("ok"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -4696,7 +4765,7 @@ describe("a run that will not record what it read is narrowed to what would fini
   test("a run that took no readings is not narrowed, because it has nothing to report yet", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b);
-    const script = scriptedModel(answersProse("I will not be reading anything today."));
+    const script = scriptedModel(answersProse("I will not be reading anything today."), answersProse("I will not be reading anything today."));
 
     const result = await runInvestigation(run.runId, {
       service: b.service,
@@ -5081,7 +5150,7 @@ describe("a model that thinks instead of answering is told not to", () => {
       */
       const b = boot(freshDataDir());
       const run = await startRun(b, "planning");
-      const script = scriptedModel(answersProse("```sqlite\nSELECT 1\n```"));
+      const script = scriptedModel(answersProse("```sqlite\nSELECT 1\n```"), answersProse("```sqlite\nSELECT 1\n```"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -5098,7 +5167,7 @@ describe("a model that thinks instead of answering is told not to", () => {
     // cells it had already won.
     const b = boot(freshDataDir());
     const run = await startRun(b, "planning");
-    const script = scriptedModel(answersProse("```sqlite\nSELECT 1\n```"));
+    const script = scriptedModel(answersProse("```sqlite\nSELECT 1\n```"), answersProse("```sqlite\nSELECT 1\n```"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -5124,7 +5193,7 @@ describe("a model that thinks instead of answering is told not to", () => {
       */
       const b = boot(freshDataDir());
       const run = await startRun(b, "agent", undefined, undefined, protocol);
-      const script = scriptedModel(answersProse("nothing to add"));
+      const script = scriptedModel(answersProse("nothing to add"), answersProse("nothing to add"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -5160,7 +5229,7 @@ describe("a model that thinks instead of CALLING is told not to, on its agent tu
       // indistinguishable from a planning turn at the gate.
       const b = boot(freshDataDir());
       const run = await startRun(b, "agent", undefined, undefined, protocol);
-      const script = scriptedModel(answersProse("nothing to add"));
+      const script = scriptedModel(answersProse("nothing to add"), answersProse("nothing to add"));
 
       await runInvestigation(run.runId, {
         service: b.service,
@@ -5177,7 +5246,7 @@ describe("a model that thinks instead of CALLING is told not to, on its agent tu
     // plan one and must not acquire the agent one by association.
     const b = boot(freshDataDir());
     const run = await startRun(b, "agent");
-    const script = scriptedModel(answersProse("nothing to add"));
+    const script = scriptedModel(answersProse("nothing to add"), answersProse("nothing to add"));
 
     await runInvestigation(run.runId, {
       service: b.service,
@@ -5191,7 +5260,7 @@ describe("a model that thinks instead of CALLING is told not to, on its agent tu
   test("a model nobody measured is left thinking on both", async () => {
     const b = boot(freshDataDir());
     const run = await startRun(b, "agent");
-    const script = scriptedModel(answersProse("nothing to add"));
+    const script = scriptedModel(answersProse("nothing to add"), answersProse("nothing to add"));
 
     await runInvestigation(run.runId, {
       service: b.service,

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -30,7 +30,7 @@ import { createCanonicalOperationRegistry } from "@/lib/db/operations/descriptor
 import { createTargetScope } from "@/lib/db/operations/policy";
 import type { DatabaseProvider, ProviderCapabilities, ProviderLabels } from "@/lib/db/types";
 import { KEY_PATTERN_LABELS, SEARCH_INDEX_LABELS, TABLE_LABELS } from "../fixtures/provider-labels";
-import { LLMAuthError } from "@/lib/llm/types";
+import { LLMAuthError, LLMStreamError } from "@/lib/llm/types";
 import type { ColumnSchema, DatabaseConnection, DatabaseType, QueryResult, TableSchema } from "@/lib/types";
 import {
   type Turn,
@@ -3019,6 +3019,66 @@ describe("the run loop is bounded", () => {
 
     const finished = (await eventsOf(b.store, run.runId)).find((event) => event.kind === "run-finished");
     expect(finished).toMatchObject({ status: "failed", stopReason: "model-timeout" });
+  });
+
+  describe("a turn whose STREAM broke is re-asked, because the model did not fail", () => {
+    /*
+      `isRetryableError` is this repository's own reading of an `LLMStreamError`, and
+      `base-provider.ts` already acts on it three times over on the chat surface against these
+      same endpoints. This loop held that judgement and spent runs anyway.
+
+      Measured on `gpt-oss:20b`, database-assessment: runs died on a broken frame a median of 17
+      seconds into a 630-second budget, having called a median of four tools — indistinguishable,
+      up to the break, from the runs that answered. Nothing about the model had failed.
+
+      Re-asked rather than ended because nothing was written: `takeTurn` copies the transcript and
+      never mutates the caller's array, and every ledger write for a call happens downstream in
+      `handleCall`, so the re-ask sends byte-identical bytes.
+    */
+    test("a broken frame costs the turn, not the run", async () => {
+      const b = boot(freshDataDir());
+      const run = await startRun(b);
+      /*
+        A read, then a broken frame, then a report — the measured arc: gpt-oss:20b was cut having
+        already called a median of four tools, holding readings it never filed.
+      */
+      const script = scriptedModel(
+        callsTool("run_read_query", { sql: "SELECT id FROM orders" }),
+        () => {
+          throw new LLMStreamError("terminated", "openai");
+        },
+        reportOn(),
+      );
+
+      const result = await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+      });
+
+      // Three turns asked: the read, the frame that broke, and the re-ask that filed.
+      expect(script.turns).toHaveLength(3);
+      expect(result.status).not.toBe("failed");
+    });
+
+    test("an auth failure is not re-asked, because it is not the connection", async () => {
+      // The bound `isRetryableError` draws: a misconfigured server still fails on its first turn.
+      const b = boot(freshDataDir());
+      const run = await startRun(b);
+      const script = scriptedModel(() => {
+        throw new LLMAuthError("no key", "openai");
+      }, reportOn());
+
+      await expect(
+        runInvestigation(run.runId, {
+          service: b.service,
+          model: await modelOver(script.fetch),
+          resources: b.resources,
+        }),
+      ).rejects.toThrow();
+      // One turn only: the second scripted entry is never reached.
+      expect(script.turns).toHaveLength(1);
+    });
   });
 
   describe("a turn the ceiling cut is given back, because the RUN still has its time", () => {

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -97,8 +97,11 @@ mock.module("@/lib/llm/types", () => ({
     stream is retryable, which is the case this file's subjects never reach but its importers hold.
   */
   isRetryableError: (error: unknown): boolean =>
-    !(error instanceof MockLLMAuthError || error instanceof MockLLMSafetyError || error instanceof MockLLMConfigError) &&
-    error instanceof MockLLMError,
+    !(
+      error instanceof MockLLMAuthError ||
+      error instanceof MockLLMSafetyError ||
+      error instanceof MockLLMConfigError
+    ) && error instanceof MockLLMError,
 }));
 
 const { guardRoute } = await import("@/lib/api/require-session");

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -85,6 +85,20 @@ mock.module("@/lib/llm/types", () => ({
   LLMRateLimitError: MockLLMRateLimitError,
   LLMSafetyError: MockLLMSafetyError,
   LLMStreamError: MockLLMStreamError,
+  /*
+    Mirrors the real predicate over the classes mocked above, and it is here because a module mock
+    is WHOLE: `mock.module` replaces the module, so an export this object omits does not fall
+    through to the real one — it stops existing, and every importer of it fails to load. The agent
+    drive imports this one, so leaving it out turned two 401 assertions in this file into
+    `SyntaxError: Export named 'isRetryableError' not found`, and only under `test:coverage`, where
+    each file runs in its own process and nothing else has loaded the real module first.
+
+    Auth and safety are refused, so a misconfigured server still fails on its first turn; a broken
+    stream is retryable, which is the case this file's subjects never reach but its importers hold.
+  */
+  isRetryableError: (error: unknown): boolean =>
+    !(error instanceof MockLLMAuthError || error instanceof MockLLMSafetyError || error instanceof MockLLMConfigError) &&
+    error instanceof MockLLMError,
 }));
 
 const { guardRoute } = await import("@/lib/api/require-session");

--- a/tests/unit/components/agent-timeline.test.ts
+++ b/tests/unit/components/agent-timeline.test.ts
@@ -2986,6 +2986,7 @@ describe("an answer reads as the app's decision, with the model's caption quoted
     test.each([
       "report-reminder",
       "plan-statement",
+      "turn-cut-off",
       "report-reserve",
       "unread-stop",
       // The three delivered as a tool result (B51). They reach a reader through the

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -344,6 +344,77 @@ const RESOLVED: ResolvedRow[] = [
     refusalExamples: false,
     turnTimeoutMs: undefined,
   },
+  // The five measured after the run-loop fixes, and the only five rows here that state
+  // `planStatementRetries: 1` without a plan cell that lost. They were driven with no entry of
+  // their own, so the drive answered its own 1 and every plan run of the thirty had the ask
+  // available; three of them spent it. The number records what they ran under. Writing the 0
+  // their sweeps call "the default" would remove the ask from a model that passed with it.
+  {
+    // Twenty-five weeks recorded as unsupported for one cell, and the cell was the server's:
+    // planning read 0/5 across five configurations because the notice for `no-statement` was
+    // offered only to a model whose profile asked for it, and this one had no profile.
+    id: "cogito:32b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 1,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  {
+    // The only code-specialised model here. The class was excluded by reasoning about what the
+    // surfaces ask for, and this row is the measurement that falsified it.
+    id: "qwen2.5-coder:14b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 1,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  {
+    // Held at 29/30 for days on the same plan cell and the same loss as `cogito:32b`, and opened
+    // by the same change.
+    id: "qwen2.5:32b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 1,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  {
+    // The fastest model in the table: a six-second median and a 21-second slowest run of thirty.
+    // Its optimize cell was the one that would not close while `recommend_change` refused calls
+    // without stating what shape one takes.
+    id: "qwen2.5:7b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 1,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  {
+    // The only one of the five that is not a defaults model, and the slowest supported model here.
+    // Both suppressions, because the plan-turn switch alone left its plan cell at 0/5 and the pair
+    // closed it — and the four surfaces that had already cleared at the defaults were measured
+    // again under the pair rather than inheriting settings no run of theirs had used.
+    id: "ornith:35b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 1,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    refusalExamples: false,
+    suppressesPlanReasoning: true,
+    suppressesAgentReasoning: true,
+    turnTimeoutMs: undefined,
+  },
   // Not a model anybody has run: the defaults, which is the honest treatment of one nobody
   // has measured.
   {
@@ -409,7 +480,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
   test("the table covers every registered model, so a new one cannot arrive unpinned", () => {
     const pinned = new Set(RESOLVED.map((row) => row.id));
     for (const id of Object.keys(modelProfiles())) expect(pinned.has(id)).toBe(true);
-    expect(Object.keys(modelProfiles())).toHaveLength(22);
+    expect(Object.keys(modelProfiles())).toHaveLength(27);
   });
 });
 
@@ -449,42 +520,33 @@ describe("what each model records about the runs that earned its settings", () =
     lock 6/6 at 30/30 with them.
   */
   const MEASURED_DIGESTS: Readonly<Record<string, string>> = {
+    "cogito:14b": "2c2fcded189b2123048e5c789844d3d8e392d7e19951e428695afa852eddd473",
+    "cogito:32b": "5564b00061b8615b9d25778ac1d69924e43c24e85dbe7d33c2ea98c99a1c1306",
     "gemini-3.5-flash-lite": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
+    "gemma4:12b": "9a49a9323c21ffe507698ca2ca852cc1b59647a206e73c448afeea7f1a0a674b",
     "gemma4:26b": "d8124e9d5b0929364129274fd4f80dea2640773147fdfd834cf2c68a5a08dd76",
     "granite4.1:30b": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
     "granite4.1:8b": "a3eea21447a81fbe058e3c18a0f7194c357e5d5f22db9acfe13e6139d9198874",
+    "granite4.2:8b": "c9e47190c44d1fda45bf035831dcb17ba21621e98a455259a438710775600ae0",
+    "ministral-3:14b": "23ef778193d6d714d7f3bb95523172d1e0f68520f0f9b2d20806b129a84a33c1",
+    "ministral-3:8b": "282d7f01c554b5bed006533190e2392330256b67f46ffee8a1462d5b254424ab",
+    "muse-glimmer:latest": "32bf1643caa8ed550066a64c4a231585a3ddbd30286646bef45f5531198d06cb",
+    "nemotron-3-nano:30b": "20cca3398ec9a7ff927f014a212784f38d6b36e74be49fe2b74fb223a7d56eec",
+    "nemotron-3.5-lightning:30b": "9a581f6838f604eaa3bf9fb0e2636635bd878f50d03b135205eac3e2ab7b0678",
+    "nemotron3:33b": "c1693800c32d336e610590e909300df682479247a910a291c9913ba278f26a8d",
+    "ornith:35b": "7ed7fad29552be880f2eefaaad3aa5258898820a1b617059da9f8055f1ce1d8b",
     "ornith:9b": "4e14e79cb5fd6572748df90786778ce72280c2bae79a27b5f8636d4eac1dbee7",
+    "qwen2.5-coder:14b": "d0e6f9ae86ee128fe709c66efcf75d89d8fa7ecaea9cf96692d23f9c514da231",
+    "qwen2.5:14b": "51ea773ff735a6f9d7f7f930b97c40ec70b5dc531dea65fa1594935a2471e991",
+    "qwen2.5:32b": "71885a95b0d717ca4f6814cfa4575bfa5f3cc20b7086c4de44f79835be3bcb1a",
+    "qwen2.5:7b": "09631668500b307a79ca06e1a7de2dfdffc1632f4bd5bb4a460abab6caf09857",
+    "qwen3.5:4b": "204b6f6beb8710155508938a2271cbf34013235fa612b40ecebf98ff5dcff061",
     "qwen3.5:9b": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
+    "qwen3.6:27b": "d0ebde3fdf25b9c56ab7bcad4adc3b54510a413285e51edcb46aec261e661157",
     "qwen3.8:latest": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
-    "qwen3:14b": "b1a344db5ee6b5f78780925657fee571eae510a7b8507bcb8badabaf01718aa3",
+    "qwen3:14b": "96e0d729224168eff3eddc16ed1bd588dd28cd133441c85790670ffd3e36dddd",
     "qwen3:4b": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
     "qwen3:8b": "3dd169b2c0718d77a0db8732d575bb4c863d78ed8343020c103c0f38e9cf016b",
-    // The eleventh model, whose record is new rather than moved; see its entry for the runs.
-    "nemotron3:33b": "c1693800c32d336e610590e909300df682479247a910a291c9913ba278f26a8d",
-    // The thirteenth. Its record is the only one that states a COST as well as a result: the plan
-    // turn's median doubled when the limit rose, and that sentence is load-bearing.
-    "nemotron-3.5-lightning:30b": "9a581f6838f604eaa3bf9fb0e2636635bd878f50d03b135205eac3e2ab7b0678",
-    // The fourteenth. Its record says its cells were read in ONE pass under the settings it
-    // ships with, which is the claim three settings on one model has to earn.
-    "muse-glimmer:latest": "32bf1643caa8ed550066a64c4a231585a3ddbd30286646bef45f5531198d06cb",
-    // The fifteenth. Its record states the outlier as well as the result: assess read 4/5 once
-    // and 5/5 on a second read of the same cell at the same setting.
-    "qwen3.6:27b": "d0ebde3fdf25b9c56ab7bcad4adc3b54510a413285e51edcb46aec261e661157",
-    // The fourth closed here, and the one the new switch was written for. Its record states the
-    // refuted hypothesis too: the tool count does not separate its passing runs from its loss.
-    "gemma4:12b": "9a49a9323c21ffe507698ca2ca852cc1b59647a206e73c448afeea7f1a0a674b",
-    "nemotron-3-nano:30b": "20cca3398ec9a7ff927f014a212784f38d6b36e74be49fe2b74fb223a7d56eec",
-    "qwen3.5:4b": "204b6f6beb8710155508938a2271cbf34013235fa612b40ecebf98ff5dcff061",
-    "granite4.2:8b": "c9e47190c44d1fda45bf035831dcb17ba21621e98a455259a438710775600ae0",
-    // The four this branch adds, and the only group whose records are identical in shape: every
-    // one locked all six surfaces on its FIRST attempt with no lever spent, so every one states
-    // the compiled defaults and nothing else. That is a measurement rather than an omission —
-    // and it is how every 30/30 model on this roster arrived, which is why the four are here
-    // and the models that absorbed a hundred lever attempts between them are not.
-    "ministral-3:8b": "282d7f01c554b5bed006533190e2392330256b67f46ffee8a1462d5b254424ab",
-    "ministral-3:14b": "23ef778193d6d714d7f3bb95523172d1e0f68520f0f9b2d20806b129a84a33c1",
-    "cogito:14b": "2c2fcded189b2123048e5c789844d3d8e392d7e19951e428695afa852eddd473",
-    "qwen2.5:14b": "51ea773ff735a6f9d7f7f930b97c40ec70b5dc531dea65fa1594935a2471e991",
   };
 
   test("every model's record survives the move, character for character", () => {

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -93,7 +93,7 @@ afterEach(() => {
 describe("the document Studio ships with", () => {
   test("passes its own contract", () => {
     const tuning = parseTuning(bundled, "test");
-    expect(Object.keys(tuning.models)).toHaveLength(22);
+    expect(Object.keys(tuning.models)).toHaveLength(27);
   });
 
   test("argues for every value it changed", () => {
@@ -563,7 +563,7 @@ describe("a document an operator supplies", () => {
     process.env[ENV] = writeDocument("{ not json");
     resetTuning();
     expect(ceilingFor("gemma4:26b")).toBe(10);
-    expect(Object.keys(activeTuning().models)).toHaveLength(22);
+    expect(Object.keys(activeTuning().models)).toHaveLength(27);
   });
 
   test("reports that it ignored a document, naming the file and the reason", () => {
@@ -717,13 +717,13 @@ describe("a document an operator supplies", () => {
   test("is ignored when it breaks the contract, not partially applied", () => {
     process.env[ENV] = writeDocument(document({ schemaVersion: 99 }));
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(22);
+    expect(Object.keys(activeTuning().models)).toHaveLength(27);
   });
 
   test("is ignored when the file is not there at all", () => {
     process.env[ENV] = "/nonexistent/models.json";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(22);
+    expect(Object.keys(activeTuning().models)).toHaveLength(27);
   });
 
   test("an unset or blank variable is simply no operator document", () => {
@@ -731,7 +731,7 @@ describe("a document an operator supplies", () => {
     // reading it as a path would warn on every boot of an install that configured nothing.
     process.env[ENV] = "   ";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(22);
+    expect(Object.keys(activeTuning().models)).toHaveLength(27);
   });
 
   test("is read once, so a run cannot see the table change under it", () => {

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -1304,6 +1304,79 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
       expect(outcome.modelText).toContain("<table>");
     });
 
+    describe("recommend_change states its OWN call shape, which it never did", () => {
+      /*
+        Measured on `qwen2.5:7b`, query-optimization, 25 runs read from their ledgers: the 9 that
+        passed recorded a `statement`, the 16 that lost recorded none, and nothing else separated
+        them — the two sides are step-for-step identical up to that point.
+
+        What the losing runs sent was three keys, `{"change","evidence","rationale"}`, never a
+        fourth. In the SAME turn they wrote the value the missing field wants as prose: "Here is
+        the SQL statement for creating the index: ```sql CREATE INDEX idx_employee_name ON
+        employee(first_name, last_name); ```" — and eight of the nine passing runs carry that
+        string, character for character, in `statement`. The model was not failing to write the
+        SQL. It did not know the field existed.
+
+        It could not have learned it here. `compose_report` is answered with `AGENT_CLAIM_SHAPE`
+        and `present_answer` with `AGENT_ANSWER_SHAPE`, both ungated; this tool had neither, and
+        `isShapeFailure` tests for a `claims` path that this call does not have, so that branch
+        could never fire for it. Its shape existed only inside `exampleRecommendCall`, behind the
+        `refusalExamples` lever — which `qwen2.5:7b` does not carry, having no profile row at all.
+      */
+      test("a call missing `statement` is shown the object it should have been", () => {
+        const h = harness();
+
+        const outcome = recommendChangeTool(
+          h.context,
+          { runId: h.context.runId, events: [artifactEvent] },
+          { change: "index", rationale: "the read scans", evidence: [{ source: "artifact", correlationId: "corr-real" }] },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.reasonCode).toBe("INVALID_TOOL_INPUT");
+        // The failing path, as it already did.
+        expect(outcome.modelText).toContain("statement: expected string");
+        // And now the field it never knew about, named in the object it belongs to.
+        expect(outcome.modelText).toContain('"statement"');
+        expect(outcome.modelText).toContain("SQL written only in your reply is not part of it");
+      });
+
+      test("the shape stays out of the ledger line, which counts paths", () => {
+        const h = harness();
+
+        const outcome = recommendChangeTool(
+          h.context,
+          { runId: h.context.runId, events: [artifactEvent] },
+          { change: "index", rationale: "the read scans", evidence: [{ source: "artifact", correlationId: "corr-real" }] },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.detail).toContain("statement");
+        expect(outcome.detail).not.toContain("SQL written only in your reply");
+      });
+
+      test("a fault INSIDE an evidence item is not buried under the wrapper", () => {
+        // The guard on the sentence, and the same restraint `isShapeFailure` shows: a model that
+        // built the call correctly and mistyped one field inside a citation needs that field
+        // named, not the whole object it already got right.
+        const h = harness();
+
+        const outcome = recommendChangeTool(
+          h.context,
+          { runId: h.context.runId, events: [artifactEvent] },
+          {
+            change: "index",
+            statement: "CREATE INDEX i ON orders (id)",
+            rationale: "the read scans",
+            evidence: [{ source: "artifact", correlationId: 7 }],
+          },
+        );
+
+        if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
+        expect(outcome.modelText).not.toContain("SQL written only in your reply");
+      });
+    });
+
     test("recommend_change tells a wrong-shaped citation what the shape is", () => {
       const h = harness();
 

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -1329,7 +1329,11 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
         const outcome = recommendChangeTool(
           h.context,
           { runId: h.context.runId, events: [artifactEvent] },
-          { change: "index", rationale: "the read scans", evidence: [{ source: "artifact", correlationId: "corr-real" }] },
+          {
+            change: "index",
+            rationale: "the read scans",
+            evidence: [{ source: "artifact", correlationId: "corr-real" }],
+          },
         );
 
         if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);
@@ -1347,7 +1351,11 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
         const outcome = recommendChangeTool(
           h.context,
           { runId: h.context.runId, events: [artifactEvent] },
-          { change: "index", rationale: "the read scans", evidence: [{ source: "artifact", correlationId: "corr-real" }] },
+          {
+            change: "index",
+            rationale: "the read scans",
+            evidence: [{ source: "artifact", correlationId: "corr-real" }],
+          },
         );
 
         if (outcome.kind !== "unavailable") throw new Error(`expected unavailable, got ${outcome.kind}`);


### PR DESCRIPTION
Twenty-two supported models becomes twenty-seven: 810 runs, 810 passes. Four of the five additions
were driven by fixes in this branch, and each fix is the same shape — the server held the answer
and refused without saying it.

## The four fixes

| Commit | What it changes |
| --- | --- |
| `8676c7d6` | `recommend_change` states its own call shape. It demanded a `statement` field and, when one did not arrive, refused without ever saying that the SQL belongs in the call rather than in the reply. |
| `af5a1d1e` | A plan run that named neither statement nor refusal is asked for one, whoever the model is. The ask was gated on a measured profile, so a model nobody had measured could not get it — which is exactly the model that needs it. |
| `8d62ac39` | The per-call turn ceiling ends the CALL, not the RUN. Measured on `qwen3.6:35b`: nine losses cut near 100s of a 450s deadline with 34 of 36 turns unspent, while the same cell's longest passing run took 183s. |
| `0cccd64f` | A turn whose stream broke is re-asked. `isRetryableError` is this repository's own reading of an `LLMStreamError` and `base-provider.ts` acts on it three times over on the chat surface; the agent loop consulted it nowhere. |

## The five models

| Model | Disk | Median | Slowest | Settings |
| --- | --- | --- | --- | --- |
| `qwen2.5:7b` | 4.7 GB | **6s** | 21s | one plan ask, unspent |
| `qwen2.5-coder:14b` | 9.0 GB | 20s | 37s | one plan ask, unspent |
| `qwen2.5:32b` | 19 GB | 20s | 36s | one plan ask, **spent** |
| `cogito:32b` | 19 GB | 23s | 39s | one plan ask, **spent** |
| `ornith:35b` | 21 GB | 36s | 150s | both reasoning suppressions, one plan ask, **spent** |

`qwen2.5:7b` is now the fastest model on the list — a six-second median, and nothing it did on
thirty runs took longer than 21 seconds.

**Three of these were recorded here as unsupported.** `docs/llms/cogito/cogito.md` said of the 32b:
*"planning read 0/5, then 1/5, then 0/5 three more times across five configurations"*, always
`no-statement`. `qwen2.5:32b` lost the same cell the same way and stood at 29/30 for days. Nothing
about either model changed; the measurement was reading the server.

**`qwen2.5-coder:14b` falsifies a class exclusion.** The coder families were set aside untested, on
the reasoning that the agent surfaces are not code generation. They are not — but what they ask for
is instruction-following against a tool schema, and this model matches `qwen2.5:14b` cell for cell.

## The line worth reviewing

`planStatementRetries` is **1** on all five. Every sweep ran with `tuning=bundled` and no entry, so
the resolver answered its own 1 and each plan run had the ask available; the ledger shows three of
the five spent it. Recording the 0 their sweeps call "the default" would have removed the ask at
the moment the profile landed and dropped three locked cells out of 5/5 — a profile that regresses
the model it was written to describe.

`ornith:35b` was measured twice for the same reason. Its lock carried both suppressions on plan and
investigate and the defaults on the other four, because the sweep moves settings between cells; a
bundled profile carries one set for all six. The four were read again with the pair on rather than
shipped under a configuration no run of theirs had used.

## What the fixes left behind, fixed in `fabb1791`

- `bun run format` failed on three files this branch touched — the required Lint, Typecheck and
  Build job would have gone red.
- `turn-cut-off` was added to `GUIDANCE_HEADLINE` and not to the exhaustive `test.each` beside it.
  The map is an object literal, so the line counts as covered when the module loads and 100%
  coverage stays green while no test renders it.
- `tests/security/route-auth.test.ts` mocks `@/lib/llm/types` and omitted `isRetryableError`, which
  the drive began importing in `0cccd64f`. A module mock is whole, so the export stopped existing:
  green under `bun run test`, `SyntaxError` under `test:coverage` where each file runs alone.
- Five files still argued for the behaviour the four commits replaced, `investigation.ts` and
  `plan-grounding.test.ts` each contradicting themselves two hundred lines apart.

## Gates

`format` · `lint` · `typecheck` · `knip` · `test` (38 groups, 0 fail) · `build` — all green.
Coverage: **45547/45547 lines, 100.00%**.
