### PR TITLE
fix(oracle): Thick mode never loaded in a build, plus the Linux client recipe (#538)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,12 +172,21 @@ STORAGE_PROVIDER=local
 # ===========================================
 # The Oracle DB provider runs in Thin mode (pure JS, no Instant Client) by
 # default, which only supports Oracle Database 12.1+. Set this to an installed
-# Oracle Instant Client "lib" directory to opt into Thick mode for older
-# servers (11.2 and earlier). Leave unset unless you hit driver error NJS-138.
+# Oracle Instant Client directory to opt into Thick mode - for servers older
+# than 12.1 (driver error NJS-138), and for a 12.1+ server that requires
+# something Thin mode does not implement (NJS-533 native network encryption,
+# NJS-116 10G-only password verifier, NJS-089 Kerberos / LDAP naming / an
+# sso-only wallet).
 # Version matters: use Instant Client 19c for an Oracle 11.2 (11g) server -
-# 21c/23ai cannot reach 11.2. The published image is Thin-only and does not
-# bundle the client; see docs/providers/oracle.md section 4.4 to build an
-# image with it. A wrong path fails fast with a clear config error.
+# 21c/23ai cannot reach 11.2.
+# ON LINUX THIS VARIABLE IS NOT ENOUGH BY ITSELF. libclntsh has no RUNPATH, so
+# the same directory must also be on the system library search path: add it to
+# a file under /etc/ld.so.conf.d/ and run ldconfig, or export LD_LIBRARY_PATH
+# before Node starts. Without that step the driver fails with DPI-1047 however
+# correct the path is. On Debian 13 libaio.so.1 must resolve too.
+# The published image is Thin-only and does not bundle the client; see
+# docs/providers/oracle.md section 4.4 for the full recipe. Every load failure
+# fails fast with a config error that says which of these it is.
 # ORACLE_CLIENT_LIB_DIR=/opt/oracle/instantclient_19_28
 
 # ===========================================

--- a/.env.example
+++ b/.env.example
@@ -174,9 +174,12 @@ STORAGE_PROVIDER=local
 # default, which only supports Oracle Database 12.1+. Set this to an installed
 # Oracle Instant Client directory to opt into Thick mode - for servers older
 # than 12.1 (driver error NJS-138), and for a 12.1+ server that requires
-# something Thin mode does not implement (NJS-533 native network encryption,
-# NJS-116 10G-only password verifier, NJS-089 Kerberos / LDAP naming / an
-# sso-only wallet).
+# something Thin mode does not implement: NJS-533 native network encryption,
+# NJS-116 10G-only password verifier, NJS-529 an sso-only wallet (converting
+# it to ewallet.pem avoids Thick mode), or Kerberos / RADIUS / OS
+# authentication and LDAP naming, which Thin mode does not implement at all
+# and which surface as a server logon error or a connect-string failure
+# rather than as one driver code.
 # Version matters: use Instant Client 19c for an Oracle 11.2 (11g) server -
 # 21c/23ai cannot reach 11.2.
 # ON LINUX THIS VARIABLE IS NOT ENOUGH BY ITSELF. libclntsh has no RUNPATH, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ A clean local pass is still not a guarantee: the same job also runs `build:lib` 
 
 ## Architecture
 
-- **DB drivers:** `pg`, `mysql2`, `cassandra-driver`, `oracledb`, `mssql`, `mongodb`, `ioredis` — all external in both build configs. Two traps: SQLite is **`bun:sqlite`/`node:sqlite`** for the DB provider (runtime-selected, `LIBREDB_SQLITE_DRIVER` overrides) but `better-sqlite3` for the storage layer; `@duckdb/node-api` is a native N-API addon (~68 MB of bindings per libc variant), external too.
+- **DB drivers:** the two build configs do NOT externalize the same set, so read [`next.config.ts`](next.config.ts) and [`tsup.config.ts`](tsup.config.ts) rather than any prose list. `pg`, `mysql2`, `cassandra-driver`, `mongodb` and `oracledb` are external in both; `mssql` and `ioredis` are external in the library build only and Turbopack bundles them into the server chunk. That is not always harmless: `oracledb` was in exactly that position until #538, and bundling rewrote its `__dirname` to `/ROOT/...`, so Thick mode could never load its native addon. Two traps: SQLite is **`bun:sqlite`/`node:sqlite`** for the DB provider (runtime-selected, `LIBREDB_SQLITE_DRIVER` overrides) but `better-sqlite3` for the storage layer; `@duckdb/node-api` is a native N-API addon (~68 MB of bindings per libc variant), external too.
 - **Layout:** tree + data flow in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Key dirs: `src/lib/db` (providers), `src/lib/llm`, `src/lib/storage`, `src/workspace` + `src/exports` (the npm-package library surface), `src/proxy.ts` (RBAC middleware).
 
 ### Rules & patterns

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,27 @@ COPY --from=builder /usr/src/app/node_modules/@libredb/libredb ./node_modules/@l
 COPY --from=builder /usr/src/app/node_modules/@duckdb ./node_modules/@duckdb
 COPY --from=builder /usr/src/app/node_modules/detect-libc ./node_modules/detect-libc
 
+# Copy the Oracle driver (#538). It is pure JavaScript in its default Thin mode,
+# which is why it was never copied before, but Thick mode
+# (ORACLE_CLIENT_LIB_DIR) makes node-oracledb load a native addon and that addon
+# is missed by BOTH build stages, for two separate reasons.
+# 1. Bundling: node-oracledb resolves the addon relative to its own __dirname,
+#    and Turbopack rewrote that to the literal string /ROOT/node_modules/
+#    oracledb/lib, so initOracleClient() died with NJS-045 before it ever looked
+#    at the Instant Client. That is why the package is now in
+#    serverExternalPackages (next.config.ts); this COPY is what makes "external"
+#    resolvable at runtime.
+# 2. Tracing: even externalized, Next's output file tracing copies index.js,
+#    lib/ and package.json but not build/Release/*.node, because the addon is
+#    reached through a computed require(path) rather than a literal specifier -
+#    the same blind spot as @libredb/libredb and the @duckdb scope.
+# The whole package directory, never one file: build/ holds a binary per
+# platform and arch (~3 MB total), and naming one would break the ARM64 leg.
+# This image stays Thin-only - no Instant Client, no libaio - so the addon sits
+# unused until an operator layers a client on top; see docs/providers/oracle.md.
+# Keep in sync with scripts/build-standalone-payload.sh.
+COPY --from=builder /usr/src/app/node_modules/oracledb ./node_modules/oracledb
+
 # Vendored sample database templates (the SQLite employees sample). Read at
 # runtime via fs relative to process.cwd() (/app), so output file tracing
 # never sees them — copy explicitly (keep scripts/build-standalone-payload.sh

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -274,7 +274,7 @@ the same string to `tls.createSecureContext()` as `cert`, `key` **and** `ca`.
 
 | Env var | Required | Effect |
 |---------|----------|--------|
-| `ORACLE_CLIENT_LIB_DIR` | No (default: unset, Thin mode) | Absolute path to an installed Oracle Instant Client `lib` directory. When set, the constructor calls `oracledb.initOracleClient({ libDir })` and the driver runs in Thick mode instead of Thin. |
+| `ORACLE_CLIENT_LIB_DIR` | No (default: unset, Thin mode) | Absolute path to an installed Oracle Instant Client directory. When set, the constructor calls `oracledb.initOracleClient({ libDir })` and the driver runs in Thick mode instead of Thin. **On Linux this variable alone is not enough** — see [below](#on-linux-the-variable-alone-is-not-enough). |
 
 ```bash
 # Only needed against a pre-12.1 Oracle server (see the Thin-mode caveat above).
@@ -288,8 +288,52 @@ process-level env var rather than a per-connection config field: every `OraclePr
 process shares one driver mode. The constructor guards the call with a module-level flag so it runs
 at most once regardless of how many `OracleProvider` instances (i.e. connections) are created. The
 Oracle Instant Client itself must already be installed at the given path — this provider does not
-download or bundle it. If the path is wrong (no client library there), the constructor fails fast
-with a `DatabaseConfigError` naming `ORACLE_CLIENT_LIB_DIR`, not a cryptic driver error.
+download or bundle it. If the client cannot be loaded, the constructor fails fast with a
+`DatabaseConfigError` that names `ORACLE_CLIENT_LIB_DIR` and says which of the three failures it is
+(`describeOracleClientLoadFailure()` in [errors.ts](../../src/lib/db/errors.ts) decides the wording;
+[§11](#11-error-handling) lists the codes).
+
+#### On Linux the variable alone is not enough
+
+Setting `ORACLE_CLIENT_LIB_DIR` makes the driver call `initOracleClient({ libDir })`, and on Linux
+that call **cannot** load Instant Client on its own. `libclntsh.so.19.1` is built with no RUNPATH, so
+the dynamic loader has no way to find the libraries it depends on (`libnnz19.so`,
+`libclntshcore.so.19.1`) even though they sit right next to it. The call fails with:
+
+```
+DPI-1047: Cannot locate a 64-bit Oracle Client library: "libnnz19.so: cannot open shared object file"
+```
+
+node-oracledb's own documentation is explicit about this: *"Never set libDir on Linux and related
+platforms. Instead you must configure the system library search path to include the directory before
+starting Node.js."* This provider still passes `libDir` on every platform (it is the documented
+mechanism on Windows and macOS, and it is harmless on Linux once the directory is on the loader
+path), so on Linux you need **both**:
+
+1. `ORACLE_CLIENT_LIB_DIR=<dir>`, and
+2. `<dir>` on the system library search path — either a file under `/etc/ld.so.conf.d/` followed by
+   `ldconfig`, or `LD_LIBRARY_PATH=<dir>` exported **before** Node starts (the loader reads it at
+   process start; setting it from inside the app is too late).
+
+Measured with Instant Client 19.28 against Oracle Free 23ai: with either of those two in place,
+`initOracleClient({ libDir })` succeeds (`oracledb.thin === false`, client 19.28.0.0.0) and
+`v$session_connect_info.client_driver` reports `node-oracledb : 6.10.0 thk`. Without them, only
+`DPI-1047`.
+
+There is a second Linux prerequisite on Debian 13 (the runtime base): the client links against
+`libaio.so.1`, but trixie's `libaio1t64` package installs only `libaio.so.1t64`, so
+`ldd libclntsh.so.19.1` reports `libaio.so.1 => not found`. A symlink fixes it, and the recipe below
+creates one.
+
+> **Before this fix, Thick mode could not be entered at all in a real build.** Measured on the
+> published images 0.13.4 and 0.13.7: with `ORACLE_CLIENT_LIB_DIR` set, `POST /api/db/test-connection`
+> returned HTTP 400 `CONFIG_ERROR` quoting `NJS-045` and paths under `/ROOT/node_modules/oracledb`.
+> The driver was bundled into the server chunk, which rewrote its `__dirname`, so it looked for its
+> own native addon at a path that does not exist and never got as far as reading the Instant Client.
+> The recipes in this section could not have worked on those images. `oracledb` is now in
+> `serverExternalPackages` ([next.config.ts](../../next.config.ts)) and the package is copied
+> explicitly by the Dockerfile runner stage and `scripts/build-standalone-payload.sh`, the same way
+> the other native drivers are.
 
 #### Pick the right Instant Client version
 
@@ -302,13 +346,36 @@ by [Oracle client/server interoperability](https://docs.oracle.com/en/database/o
 | **Oracle 11.2** (11g) | **19c** — the newest client that still reaches 11.2 (11.2.0.3 / 11.2.0.4). **21c and 23ai cannot connect to 11.2.** |
 | Oracle 12.1+ | Any current Instant Client (19c / 21c / 23ai). Thin mode already covers these, so Thick is rarely needed. |
 
-#### Connecting to a pre-12.1 server (build your own image)
+#### A 12.1+ server can still force Thick mode
+
+The server version is not the only reason to leave Thin mode, and "my DBA says I need Thick mode on
+12.2" is a real and common case (#538). Thin mode covers 12.1 and later *as a version*, but it
+refuses a connection when the server demands something it does not implement:
+
+| What the server requires | Driver error |
+|--------------------------|--------------|
+| Oracle Native Network Encryption or data integrity checksumming | `NJS-533` |
+| An account whose only password verifier is the 10G one | `NJS-116` |
+| Kerberos, RADIUS, operating-system or other external authentication | `NJS-089` |
+| LDAP (directory) naming for the connect identifier | `NJS-089` |
+| A wallet available only as `cwallet.sso` | `NJS-089` |
+
+Each of those maps to a non-retryable `DatabaseConfigError` naming `ORACLE_CLIENT_LIB_DIR`
+([§11](#11-error-handling)) rather than to a retryable connection failure.
+
+`NJS-116` has a Thin-mode way out that needs no Instant Client at all: the account simply has no 12C
+verifier, and a DBA resetting its password writes one (given a server
+`SQLNET.ALLOWED_LOGON_VERSION_SERVER` that permits it). The provider's error message says so. The
+other rows have no Thin-mode alternative.
+
+#### Building an image with Instant Client (works for both cases above)
 
 The published image (`ghcr.io/libredb/libredb-studio`) ships **Thin only** — it does not bundle the
 Oracle Instant Client, because the native client is ~100 MB and only a minority of deployments need
-it. To reach an 11g server, build a derived image that layers Instant Client 19c on top and sets the
-env var. The runtime base is Debian 13 (`node:*-trixie-slim`), so install `libaio1t64` (trixie's
-renamed `libaio1`) and unpack the Basic package:
+it. What the image does carry (since #538) is the driver's own Thick-mode addon, so layering a client
+on top is all that is left to do. The runtime base is Debian 13 (`node:*-trixie-slim`), so the recipe
+installs `libaio1t64` (trixie's renamed `libaio1`), symlinks the SONAME the client actually asks for,
+unpacks the Basic package, and puts the directory on the loader path:
 
 ```dockerfile
 FROM ghcr.io/libredb/libredb-studio:latest
@@ -322,15 +389,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends libaio1t64 unzi
     && curl -fsSLO https://download.oracle.com/otn_software/linux/instantclient/1928000/instantclient-basic-linux.x64-19.28.0.0.0dbru.zip \
     && unzip -q instantclient-basic-linux.x64-*.zip \
     && rm instantclient-basic-linux.x64-*.zip \
+    # Debian 13 ships libaio.so.1t64; the client links against libaio.so.1.
+    && ln -sf libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1 \
+    # Required, not optional: libclntsh has no RUNPATH, so without this the
+    # driver fails with DPI-1047 no matter what ORACLE_CLIENT_LIB_DIR says.
+    && echo /opt/oracle/instantclient_19_28 > /etc/ld.so.conf.d/oracle-instantclient.conf \
+    && ldconfig \
     && rm -rf /var/lib/apt/lists/*
 ENV ORACLE_CLIENT_LIB_DIR=/opt/oracle/instantclient_19_28
 USER nextjs
 ```
 
-Instead of rebuilding, you can also mount an Instant Client directory from the host into the stock
-image and point `ORACLE_CLIENT_LIB_DIR` at the mount — whichever your deployment prefers. A
-first-class, separately-published Thick-mode image variant is a possible future addition; until then
-the derived image above is the supported path.
+Instead of rebuilding, you can mount an Instant Client directory from the host into the stock image
+and point `ORACLE_CLIENT_LIB_DIR` at the mount — but then the loader-path step has to be done on the
+container too, and `ldconfig` is not available to you at that point, so set `LD_LIBRARY_PATH` to the
+same directory in the container's environment (`docker run -e`, or `env:` in the pod spec). The
+`libaio.so.1` symlink is needed either way; on the stock image that means the mount has to supply it
+or the container has to run as root long enough to create it, which is why the derived image above is
+the supported path. A first-class, separately-published Thick-mode image variant is a possible future
+addition.
 
 ---
 
@@ -996,6 +1073,11 @@ DBA can act on.
 | `ORA-12541` / `ORA-12154` / `TNS:` | `ConnectionError` |
 | `ORA-00942` (table or view does not exist) | `QueryError` |
 | `NJS-138` (server predates Oracle 12.1, Thin-mode incompatible) | `DatabaseConfigError`, **not retryable** — see [§4.4](#44-thick-mode-opt-in-oracle_client_lib_dir) |
+| `NJS-116` (account has only a 10G password verifier) | `DatabaseConfigError`, **not retryable**. Checked *before* the generic *password* branch, which would otherwise report it as an authentication failure. The message also names the DBA-side fix (a password reset writes a 12C verifier) |
+| `NJS-533` (server requires Native Network Encryption or checksumming) | `DatabaseConfigError`, **not retryable** |
+| `NJS-089` (a feature Thin mode does not implement: Kerberos, LDAP naming, `cwallet.sso`, …), or any message containing *not supported by node-oracledb in Thin mode* | `DatabaseConfigError`, **not retryable** |
+| `NJS-045` from `initOracleClient()` (no Thick-mode addon in this build) | `DatabaseConfigError` from the constructor, worded as a **packaging defect** naming the platform and arch, not as a bad path |
+| `DPI-1047` from `initOracleClient()` (client libraries not loadable) | `DatabaseConfigError` from the constructor, pointing at the loader path (`/etc/ld.so.conf.d/` + `ldconfig`, or `LD_LIBRARY_PATH`) and `libaio.so.1` |
 | Driver message contains *timeout* / *timed out* | `TimeoutError` |
 | `connection.break()`-interrupted query | maps via the generic path (the driver's `ORA-01013` / "user requested cancel"); other `ORA-*` codes fall through to `QueryError`/`DatabaseError` with the original message |
 
@@ -1121,10 +1203,19 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
   declares the members this provider actually uses instead of the blanket `any` it used to; that
   declaration is checked against the driver only by the live probes and the integration mock, so a
   driver upgrade that changes a shape will not be caught by `tsc` alone.
-- **`NJS-138` (pre-12.1 server) is a non-retryable configuration error, not a transient one.**
-  `mapDatabaseError()` maps it to `DatabaseConfigError` instead of the generic retryable
-  `ConnectionError` every other `connect()` failure produces — see [§4.4](#44-thick-mode-opt-in-oracle_client_lib_dir)
-  and [§11](#11-error-handling). The error message points the operator at `ORACLE_CLIENT_LIB_DIR`.
+- **Every Thin-mode refusal is a non-retryable configuration error, not a transient one.**
+  `mapDatabaseError()` maps `NJS-138`, `NJS-116`, `NJS-533` and `NJS-089` (plus any message saying
+  *not supported by node-oracledb in Thin mode*) to `DatabaseConfigError` instead of the generic
+  retryable `ConnectionError` every other `connect()` failure produces — see
+  [§4.4](#44-thick-mode-opt-in-oracle_client_lib_dir) and [§11](#11-error-handling). Each message
+  points the operator at `ORACLE_CLIENT_LIB_DIR`. Only `NJS-138` was recognised before #538; the
+  others reached the user as "try again later" for a condition that never clears.
+- **Thick mode needs the operator to configure the loader, and the stock image ships no client.**
+  On Linux `ORACLE_CLIENT_LIB_DIR` alone produces `DPI-1047`: the directory must also be on the
+  system library search path, and `libaio.so.1` must resolve on Debian 13. That is a documented
+  two-step recipe ([§4.4](#44-thick-mode-opt-in-oracle_client_lib_dir)), not something the provider
+  can do for the operator — the loader reads `LD_LIBRARY_PATH` before Node starts, and `ldconfig`
+  needs root. *Future:* a separately-published image variant with Instant Client already layered in.
 - **`EXPLAIN` is intentionally disabled for Oracle until a dialect wrapper exists.**
   `getCapabilities().supportsExplain` is `false`, so the UI hides the *Explain* action. The UI's
   EXPLAIN builder only handles Postgres/MySQL; before the flag was flipped, the *Explain* action

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -352,21 +352,36 @@ The server version is not the only reason to leave Thin mode, and "my DBA says I
 12.2" is a real and common case (#538). Thin mode covers 12.1 and later *as a version*, but it
 refuses a connection when the server demands something it does not implement:
 
-| What the server requires | Driver error |
-|--------------------------|--------------|
+The codes below are read out of node-oracledb 6.10.0's own source (`lib/thin/`, `lib/errors.js`),
+not inferred from the symptom, because the driver does **not** report every one of these as a Thin
+mode refusal and some are not the driver's error at all:
+
+| What the server or connection requires | What you actually see |
+|----------------------------------------|-----------------------|
 | Oracle Native Network Encryption or data integrity checksumming | `NJS-533` |
 | An account whose only password verifier is the 10G one | `NJS-116` |
-| Kerberos, RADIUS, operating-system or other external authentication | `NJS-089` |
-| LDAP (directory) naming for the connect identifier | `NJS-089` |
-| A wallet available only as `cwallet.sso` | `NJS-089` |
+| A wallet available only as `cwallet.sso` | `NJS-529` — *Invalid wallet content format. Supported format is PEM* |
+| Kerberos, RADIUS, operating-system or other external authentication | **No single driver code.** Thin mode implements `externalAuth` for token-based authentication (`lib/thin/protocol/messages/auth.js`) but has no Kerberos, RADIUS or OS-auth implementation, and raises nothing of its own for them — the *server* refuses the logon, so what arrives is an `ORA-` logon error. Thick mode only. |
+| LDAP (directory) naming for the connect identifier | **Not a Thin-mode refusal.** There is no LDAP code anywhere under `lib/thin`, so an `ldap://` identifier fails during connect-string resolution instead, typically `NJS-516` (*no configuration directory set or available to search for tnsnames.ora*) or a connect-string parse error. Thick mode only. |
 
-Each of those maps to a non-retryable `DatabaseConfigError` naming `ORACLE_CLIENT_LIB_DIR`
-([§11](#11-error-handling)) rather than to a retryable connection failure.
+The three rows that *are* driver codes map to a non-retryable `DatabaseConfigError` naming
+`ORACLE_CLIENT_LIB_DIR` ([§11](#11-error-handling)) rather than to a retryable connection failure.
+The last two rows do not, and cannot: nothing in their text identifies the cause.
 
-`NJS-116` has a Thin-mode way out that needs no Instant Client at all: the account simply has no 12C
-verifier, and a DBA resetting its password writes one (given a server
-`SQLNET.ALLOWED_LOGON_VERSION_SERVER` that permits it). The provider's error message says so. The
-other rows have no Thin-mode alternative.
+Two of them have a way out that needs no Instant Client, and the provider's error message says so in
+both cases:
+
+- **`NJS-116`** — the account simply has no 12C verifier. A DBA resetting its password writes one
+  (given a server `SQLNET.ALLOWED_LOGON_VERSION_SERVER` that permits it).
+- **`NJS-529`** — Thin mode reads only PEM. Converting the wallet to `ewallet.pem`
+  (`orapki wallet pkcs12_to_pem`, or openssl against the PKCS#12) is enough; Thick mode reads the
+  `cwallet.sso` as it stands.
+
+`NJS-089` is **not** in the table on purpose. In Thin mode the driver raises it for client-side
+features it has not implemented — heterogeneous pooling (`lib/thin/pool.js`), some database object
+types (`lib/thin/dbObject.js`), Advanced Queuing (`lib/thin/protocol/messages/aqArray.js`,
+`aqBase.js`) and a few protocol features — none of which is something a server can demand at
+connect time. It is still mapped ([§11](#11-error-handling)), because the remedy is the same.
 
 #### Building an image with Instant Client (works for both cases above)
 
@@ -384,7 +399,10 @@ USER root
 # Instant Client 19c — reaches Oracle 11.2; 21c/23ai do not. Pin to a specific
 # 19.x build; check https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html
 # for the current file name and update the version folder in ORACLE_CLIENT_LIB_DIR to match.
-RUN apt-get update && apt-get install -y --no-install-recommends libaio1t64 unzip curl \
+# ca-certificates is not optional: the base image does not have it (and has no
+# curl either), and --no-install-recommends will not pull it in, so without it
+# the download below fails with curl (77) setting the certificate file.
+RUN apt-get update && apt-get install -y --no-install-recommends libaio1t64 unzip curl ca-certificates \
     && mkdir -p /opt/oracle && cd /opt/oracle \
     && curl -fsSLO https://download.oracle.com/otn_software/linux/instantclient/1928000/instantclient-basic-linux.x64-19.28.0.0.0dbru.zip \
     && unzip -q instantclient-basic-linux.x64-*.zip \
@@ -1075,7 +1093,9 @@ DBA can act on.
 | `NJS-138` (server predates Oracle 12.1, Thin-mode incompatible) | `DatabaseConfigError`, **not retryable** — see [§4.4](#44-thick-mode-opt-in-oracle_client_lib_dir) |
 | `NJS-116` (account has only a 10G password verifier) | `DatabaseConfigError`, **not retryable**. Checked *before* the generic *password* branch, which would otherwise report it as an authentication failure. The message also names the DBA-side fix (a password reset writes a 12C verifier) |
 | `NJS-533` (server requires Native Network Encryption or checksumming) | `DatabaseConfigError`, **not retryable** |
-| `NJS-089` (a feature Thin mode does not implement: Kerberos, LDAP naming, `cwallet.sso`, …), or any message containing *not supported by node-oracledb in Thin mode* | `DatabaseConfigError`, **not retryable** |
+| `NJS-529` (wallet is not PEM, typically an sso-only `cwallet.sso`) | `DatabaseConfigError`, **not retryable**. Caught by code, not by substring: the driver's text says nothing about Thin mode. The message names both ways out — convert the wallet to `ewallet.pem`, or use Thick mode |
+| `NJS-089` (a **client-side** feature Thin mode does not implement: heterogeneous pooling, some database object types, Advanced Queuing) | `DatabaseConfigError`, **not retryable** |
+| Any other message containing *not supported by node-oracledb in Thin mode* | `DatabaseConfigError`, **not retryable** |
 | `NJS-045` from `initOracleClient()` (no Thick-mode addon in this build) | `DatabaseConfigError` from the constructor, worded as a **packaging defect** naming the platform and arch, not as a bad path |
 | `DPI-1047` from `initOracleClient()` (client libraries not loadable) | `DatabaseConfigError` from the constructor, pointing at the loader path (`/etc/ld.so.conf.d/` + `ldconfig`, or `LD_LIBRARY_PATH`) and `libaio.so.1` |
 | Driver message contains *timeout* / *timed out* | `TimeoutError` |
@@ -1204,7 +1224,7 @@ Over the API: `POST /api/db/query`, `POST /api/db/transaction`, `POST /api/db/ca
   declaration is checked against the driver only by the live probes and the integration mock, so a
   driver upgrade that changes a shape will not be caught by `tsc` alone.
 - **Every Thin-mode refusal is a non-retryable configuration error, not a transient one.**
-  `mapDatabaseError()` maps `NJS-138`, `NJS-116`, `NJS-533` and `NJS-089` (plus any message saying
+  `mapDatabaseError()` maps `NJS-138`, `NJS-116`, `NJS-533`, `NJS-529` and `NJS-089` (plus any message saying
   *not supported by node-oracledb in Thin mode*) to `DatabaseConfigError` instead of the generic
   retryable `ConnectionError` every other `connect()` failure produces — see
   [§4.4](#44-thick-mode-opt-in-oracle_client_lib_dir) and [§11](#11-error-handling). Each message

--- a/next.config.ts
+++ b/next.config.ts
@@ -215,6 +215,18 @@ const nextConfig: NextConfig = {
   // `@duckdb/node-bindings` is listed next to `@duckdb/node-api` on purpose: it is
   // the loader that does a bare top-level `require('@duckdb/node-bindings-<platform>-
   // <arch>/duckdb.node')`, so it is the module that must never be bundled.
+  // `oracledb` is external for a reason that only shows up in Thick mode (#538).
+  // The driver is pure JS in its default Thin mode, so bundling it looked free.
+  // It is not: node-oracledb locates its native addon relative to its own
+  // `__dirname`, and Turbopack rewrites that to the literal string
+  // `/ROOT/node_modules/oracledb/lib`. `initOracleClient()` then looked for
+  // `/ROOT/node_modules/oracledb/build/Release/oracledb-<ver>-<platform>.node`,
+  // found nothing, and threw NJS-045 before the Instant Client was consulted -
+  // measured through /api/db/test-connection on the published 0.13.4 and 0.13.7
+  // images. Externalizing removes every `/ROOT/node_modules/oracledb` reference
+  // from `.next/server/chunks`. The addon itself is still a file-tracing blind
+  // spot; the Dockerfile runner stage and scripts/build-standalone-payload.sh
+  // copy the package for that.
   serverExternalPackages: [
     "pg",
     "mysql2",
@@ -222,6 +234,7 @@ const nextConfig: NextConfig = {
     "better-sqlite3",
     "ssh2",
     "cassandra-driver",
+    "oracledb",
     "@duckdb/node-api",
     "@duckdb/node-bindings",
   ],

--- a/scripts/build-standalone-payload.sh
+++ b/scripts/build-standalone-payload.sh
@@ -18,6 +18,10 @@
 #                                      duckdb.node + libduckdb.so
 #   - node_modules/detect-libc      -> what the DuckDB binding loader uses to
 #                                      pick between a glibc and a musl package
+#   - node_modules/oracledb         -> the Oracle driver, whole: Thick mode
+#                                      (ORACLE_CLIENT_LIB_DIR) loads a native
+#                                      addon from build/Release, which file
+#                                      tracing never sees (#538)
 #   - seed-assets/                  -> vendored sample DB templates (fs-read
 #                                      at runtime, not seen by file tracing)
 #   - data/                         -> default SQLite storage directory
@@ -222,6 +226,30 @@ rm -rf "${PAYLOAD_DIR:?}/node_modules/@duckdb"
 cp -R node_modules/@duckdb "$PAYLOAD_DIR/node_modules/@duckdb"
 rm -rf "${PAYLOAD_DIR:?}/node_modules/detect-libc"
 cp -R node_modules/detect-libc "$PAYLOAD_DIR/node_modules/detect-libc"
+
+# The Oracle driver (#538). Thin mode is pure JavaScript, so this package looked
+# like an ordinary traced dependency for a long time. Thick mode is not: setting
+# ORACLE_CLIENT_LIB_DIR makes node-oracledb load build/Release/oracledb-<ver>-
+# <platform>-<arch>.node, reached through a computed require(path) that output
+# file tracing cannot follow, so the standalone tree got the JavaScript and none
+# of the binaries. Copy the whole package: build/ carries one binary per
+# platform and arch (~3 MB), which is what keeps this arch-agnostic.
+if [ ! -d node_modules/oracledb ]; then
+  echo "node_modules/oracledb not found - run 'bun install --frozen-lockfile' first" >&2
+  exit 1
+fi
+rm -rf "${PAYLOAD_DIR:?}/node_modules/oracledb"
+cp -R node_modules/oracledb "$PAYLOAD_DIR/node_modules/oracledb"
+# Unlike the two probes above, this one cannot `require` its way to proof: the
+# addon only loads under initOracleClient(), which needs an Oracle Instant
+# Client that no build runner has. What IS checkable is the failure the copy
+# exists to prevent - the addon for THIS target missing from the payload.
+if ! ls "$PAYLOAD_DIR"/node_modules/oracledb/build/Release/oracledb-*-"${OS}"-"${ARCH}".node >/dev/null 2>&1; then
+  echo "node_modules/oracledb has no Thick-mode addon for ${OS}-${ARCH} in build/Release." >&2
+  echo "The published package ships one per platform, so this normally means an incomplete" >&2
+  echo "node_modules - reinstall with 'bun install --frozen-lockfile'." >&2
+  exit 1
+fi
 
 # Vendored sample database templates (seed-assets/): read at runtime relative
 # to the payload root, so output file tracing never includes them — copy

--- a/src/lib/db/errors.ts
+++ b/src/lib/db/errors.ts
@@ -286,8 +286,28 @@ export function describeOracleThinModeRefusal(message: string): string | null {
       "which Thin mode does not implement"
     );
   }
-  if (message.includes("njs-089") || message.includes("not supported by node-oracledb in thin mode")) {
-    return "the server requires a feature Thin mode does not implement";
+  if (message.includes("njs-529")) {
+    // ERR_WALLET_TYPE_NOT_SUPPORTED in the driver's lib/errors.js. Its text says
+    // nothing about Thin mode, so the generic substring below never catches it,
+    // and it is the one refusal here with a way out that costs nothing: Thin
+    // mode reads PEM, so converting the wallet is enough.
+    return (
+      "Thin mode reads only a PEM wallet, and this one is not PEM (typically an sso-only " +
+      "cwallet.sso). Converting it to ewallet.pem avoids Thick mode entirely " +
+      "(orapki wallet pkcs12_to_pem, or openssl against the PKCS#12); otherwise use Thick mode, " +
+      "which reads the sso wallet as it stands"
+    );
+  }
+  if (message.includes("njs-089")) {
+    // Measured against node-oracledb 6.10.0's own source rather than assumed:
+    // NJS-089 is raised for CLIENT-side features (heterogeneous pooling in
+    // lib/thin/pool.js, some database object types in lib/thin/dbObject.js,
+    // Advanced Queuing in aqArray.js and aqBase.js, a few protocol features in
+    // withData.js). It is not the code for Kerberos, LDAP naming or a wallet.
+    return "this uses a client-side feature Thin mode does not implement";
+  }
+  if (message.includes("not supported by node-oracledb in thin mode")) {
+    return "the driver reports a feature Thin mode does not implement";
   }
   return null;
 }

--- a/src/lib/db/errors.ts
+++ b/src/lib/db/errors.ts
@@ -243,6 +243,103 @@ export function isRetryableError(error: unknown): boolean {
   return true;
 }
 
+// ============================================================================
+// Oracle Thick-mode diagnostics (#538)
+// ============================================================================
+
+/**
+ * The one remedy every Thin-mode refusal shares, written once. Both the reason
+ * strings below and the constructor's load failures point at the same place, and
+ * two prose copies of one instruction drift.
+ */
+const ORACLE_THICK_MODE_REMEDY =
+  "Thick mode is the remedy: set ORACLE_CLIENT_LIB_DIR to an installed Oracle Instant Client " +
+  "directory (on Linux the directory must also be on the loader path). See " +
+  "docs/providers/oracle.md section 4.4.";
+
+/**
+ * Why node-oracledb's Thin mode refused this connection, or `null` if the error
+ * is not a Thin-mode refusal at all.
+ *
+ * These are the messages a DBA turns into "you must use Thick mode", and until
+ * #538 only `NJS-138` was recognised. The rest fell through to the generic
+ * retryable `ConnectionError`, which tells the operator to try again for a
+ * condition that will never clear on its own - the exact defect #228 fixed for
+ * `NJS-138`.
+ *
+ * `message` is expected already lower-cased (mapDatabaseError does that once).
+ */
+export function describeOracleThinModeRefusal(message: string): string | null {
+  if (message.includes("njs-138")) {
+    return "Oracle server version predates 12.1, which Thin mode does not support";
+  }
+  if (message.includes("njs-116")) {
+    return (
+      "the account's password verifier is 10G-only, and Thin mode can only use a 12C verifier. " +
+      "A DBA can fix this without Thick mode by resetting the account's password, which writes " +
+      "a 12C verifier (given a suitable SQLNET.ALLOWED_LOGON_VERSION_SERVER)"
+    );
+  }
+  if (message.includes("njs-533")) {
+    return (
+      "the server requires Oracle Native Network Encryption or data integrity checksumming, " +
+      "which Thin mode does not implement"
+    );
+  }
+  if (message.includes("njs-089") || message.includes("not supported by node-oracledb in thin mode")) {
+    return "the server requires a feature Thin mode does not implement";
+  }
+  return null;
+}
+
+/**
+ * What to tell the operator when `initOracleClient({ libDir })` throws.
+ *
+ * The old message said one thing for every failure - "verify the path points at
+ * an installed Instant Client 'lib' directory" - and for the two failures that
+ * actually happen that advice is wrong in both directions:
+ *
+ * - `NJS-045` is not about the path at all. It means this build has no
+ *   node-oracledb Thick-mode addon to load, which is a defect of how the app was
+ *   packaged, not of anything the operator configured. The operator can stare at
+ *   a perfectly good Instant Client directory forever.
+ * - `DPI-1047` means the addon loaded and then could not pull in the client
+ *   libraries. On Linux that is almost never a wrong path: `libclntsh.so` has no
+ *   RUNPATH, so its siblings (`libnnz*.so`, `libclntshcore.so`) are found only
+ *   through the system library search path, and node-oracledb's own
+ *   documentation says never to rely on `libDir` there.
+ *
+ * Exported so the mapping is testable without constructing a provider.
+ */
+export function describeOracleClientLoadFailure(libDir: string, detail: string): string {
+  const lower = detail.toLowerCase();
+  if (lower.includes("njs-045")) {
+    return (
+      `This build has no node-oracledb Thick mode binary for ${process.platform}-${process.arch}, ` +
+      `so ORACLE_CLIENT_LIB_DIR=${libDir} could not be used: ${detail}. ` +
+      "This is a packaging defect of the build, not a problem with the path - the driver's native " +
+      "addon is missing or was resolved from a rewritten directory. Report it with the platform and " +
+      "architecture above; see docs/providers/oracle.md section 4.4."
+    );
+  }
+  if (lower.includes("dpi-1047")) {
+    return (
+      `The Oracle Client libraries in ORACLE_CLIENT_LIB_DIR=${libDir} could not be loaded: ${detail}. ` +
+      "On Linux the directory must ALSO be on the system library search path - add it to a file under " +
+      "/etc/ld.so.conf.d/ and run ldconfig, or set LD_LIBRARY_PATH before Node starts - because " +
+      "libclntsh has no RUNPATH and cannot find its own siblings otherwise. On Debian 13 also check " +
+      "that libaio.so.1 resolves (the distribution ships libaio.so.1t64 and the client asks for " +
+      "libaio.so.1). See docs/providers/oracle.md section 4.4."
+    );
+  }
+  return (
+    `Failed to load the Oracle Instant Client from ORACLE_CLIENT_LIB_DIR=${libDir}: ${detail}. ` +
+    "Verify the path points at an installed Oracle Instant Client directory " +
+    "(Instant Client 19c is required to reach Oracle 11.2 servers); see " +
+    "docs/providers/oracle.md section 4.4."
+  );
+}
+
 /**
  * Map native database errors to our error types
  */
@@ -265,6 +362,16 @@ export function mapDatabaseError(error: unknown, provider: DatabaseType, query?:
     message.includes("getaddrinfo")
   ) {
     return new ConnectionError(`Failed to connect to ${provider} database: ${error.message}`, provider);
+  }
+
+  // Oracle Thin-mode refusals. This runs BEFORE the authentication branch on
+  // purpose: NJS-116's own text is "password verifier type 0x... is not
+  // supported by node-oracledb in Thin mode", so the generic `password` match
+  // below would otherwise turn a configuration problem into "wrong credentials"
+  // and send the operator to reset something that is not broken.
+  const thinModeRefusal = describeOracleThinModeRefusal(message);
+  if (thinModeRefusal) {
+    return new DatabaseConfigError(`${thinModeRefusal}: ${error.message}. ${ORACLE_THICK_MODE_REMEDY}`, provider);
   }
 
   // Authentication errors
@@ -302,13 +409,8 @@ export function mapDatabaseError(error: unknown, provider: DatabaseType, query?:
   if (message.includes("ora-00942")) {
     return new QueryError(`Table or view does not exist: ${error.message}`, provider, query);
   }
-  if (message.includes("njs-138")) {
-    return new DatabaseConfigError(
-      `Oracle server version predates 12.1, which Thin mode does not support: ${error.message}. ` +
-        "Set ORACLE_CLIENT_LIB_DIR to an installed Oracle Instant Client directory to enable Thick mode for older servers.",
-      provider,
-    );
-  }
+  // NJS-138 and its siblings are handled above, before the authentication
+  // branch - see describeOracleThinModeRefusal().
 
   // MSSQL errors
   if (message.includes("login failed")) {

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -28,7 +28,13 @@ import {
   type PreparedQuery,
   type QueryPrepareOptions,
 } from "../../types";
-import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
+import {
+  DatabaseConfigError,
+  ConnectionError,
+  QueryError,
+  mapDatabaseError,
+  describeOracleClientLoadFailure,
+} from "../../errors";
 import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
 import { resolveSqlGrammar } from "@/lib/sql/grammar";
@@ -366,16 +372,13 @@ export class OracleProvider extends SQLBaseProvider {
       try {
         oracledb.initOracleClient({ libDir });
       } catch (error) {
-        // A bad ORACLE_CLIENT_LIB_DIR (e.g. no Instant Client at that path) makes
-        // node-oracledb throw a raw driver error (DPI-1047). Surface it as a
-        // non-retryable configuration error that names the offending env var, so it
-        // is actionable rather than looking like a transient failure.
-        throw new DatabaseConfigError(
-          `Failed to load the Oracle Instant Client from ORACLE_CLIENT_LIB_DIR=${libDir}: ${String(error)}. ` +
-            "Verify the path points at an installed Oracle Instant Client 'lib' directory " +
-            "(Instant Client 19c is required to reach Oracle 11.2 servers).",
-          "oracle",
-        );
+        // node-oracledb throws a raw driver error here, and the two that
+        // actually happen mean opposite things: NJS-045 is a missing Thick-mode
+        // addon in THIS build (nothing the operator configured), DPI-1047 is the
+        // client libraries failing to load from a directory that is very likely
+        // correct but not on the loader path. Surface either as a non-retryable
+        // configuration error carrying the diagnosis, not one generic sentence.
+        throw new DatabaseConfigError(describeOracleClientLoadFailure(libDir, String(error)), "oracle");
       }
       thickClientInitialized = true;
     }

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -2388,6 +2388,29 @@ describe("OracleProvider", () => {
       expect((caught as Error).message).toContain("ORACLE_CLIENT_LIB_DIR");
       expect((caught as Error).message).toContain("/nonexistent/instantclient");
       expect((caught as Error).message).toContain("DPI-1047");
+      // The old message said "verify the path" for every failure. DPI-1047 on
+      // Linux is usually not a path problem at all: libclntsh has no RUNPATH,
+      // so the directory has to be on the loader path too (#538).
+      expect((caught as Error).message).toContain("ldconfig");
+    });
+
+    test("reports a missing Thick-mode binary (NJS-045) as a packaging defect, not a bad path", () => {
+      process.env.ORACLE_CLIENT_LIB_DIR = "/opt/oracle/instantclient_19_28";
+      mockInitOracleClientFn.mockImplementationOnce(() => {
+        throw new Error("NJS-045: cannot load a node-oracledb Thick mode binary for Node.js");
+      });
+
+      let caught: unknown;
+      try {
+        new OracleProvider(baseConfig);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(DatabaseConfigError);
+      expect((caught as Error).message).toContain("NJS-045");
+      expect((caught as Error).message).toContain(`${process.platform}-${process.arch}`);
+      expect((caught as Error).message).toContain("packaging");
     });
 
     test("calls initOracleClient with libDir at most once, even across multiple providers", () => {

--- a/tests/unit/db/errors.test.ts
+++ b/tests/unit/db/errors.test.ts
@@ -396,6 +396,17 @@ describe("mapDatabaseError", () => {
     expect(result.message).toContain("ORACLE_CLIENT_LIB_DIR");
   });
 
+  test("Oracle NJS-529 (sso-only wallet) maps to non-retryable DatabaseConfigError", () => {
+    // The driver's own text (ERR_WALLET_TYPE_NOT_SUPPORTED) says nothing about
+    // Thin mode, so the generic substring branch never sees it.
+    const err = new Error("NJS-529: Invalid wallet content format. Supported format is PEM");
+    const result = mapDatabaseError(err, "oracle");
+    expect(result).toBeInstanceOf(DatabaseConfigError);
+    expect(isRetryableError(result)).toBe(false);
+    expect(result.message).toContain("PEM");
+    expect(result.message).toContain("ORACLE_CLIENT_LIB_DIR");
+  });
+
   test('a bare "not supported by node-oracledb in Thin mode" with no NJS code still maps to DatabaseConfigError', () => {
     const err = new Error("LDAP naming is not supported by node-oracledb in Thin mode");
     const result = mapDatabaseError(err, "oracle");
@@ -475,6 +486,14 @@ describe("describeOracleThinModeRefusal", () => {
 
   test("names native network encryption for NJS-533", () => {
     expect(describeOracleThinModeRefusal("njs-533: ...")).toContain("Native Network Encryption");
+  });
+
+  test("names both ways out of an sso-only wallet for NJS-529", () => {
+    const reason = describeOracleThinModeRefusal("njs-529: invalid wallet content format");
+    // Thin mode reads PEM only, so converting the wallet is a real alternative
+    // to installing an Instant Client.
+    expect(reason).toContain("PEM");
+    expect(reason).toContain("ewallet.pem");
   });
 });
 

--- a/tests/unit/db/errors.test.ts
+++ b/tests/unit/db/errors.test.ts
@@ -15,6 +15,8 @@ import {
   isAuthenticationError,
   isRetryableError,
   mapDatabaseError,
+  describeOracleThinModeRefusal,
+  describeOracleClientLoadFailure,
 } from "@/lib/db/errors";
 import { ApiErrorCode } from "@/lib/api/error-codes";
 
@@ -359,6 +361,48 @@ describe("mapDatabaseError", () => {
     expect(result.message).toContain("ORACLE_CLIENT_LIB_DIR");
   });
 
+  // NJS-138 was the first Thin-mode refusal to get this treatment (#228). The
+  // rest fell through to the generic retryable ConnectionError until #538,
+  // which is the same defect class: a DBA-visible "you must use Thick mode"
+  // arriving as "try again later".
+  test("Oracle NJS-116 (10G-only password verifier) maps to non-retryable DatabaseConfigError", () => {
+    const err = new Error("NJS-116: password verifier type 0x939 is not supported by node-oracledb in Thin mode");
+    const result = mapDatabaseError(err, "oracle");
+    // The driver's own text contains "password", so the generic authentication
+    // branch would swallow this one if the Oracle check did not run first.
+    expect(result).toBeInstanceOf(DatabaseConfigError);
+    expect(isRetryableError(result)).toBe(false);
+    expect(result.message).toContain("ORACLE_CLIENT_LIB_DIR");
+    // The DBA-side way out, which needs no Instant Client at all.
+    expect(result.message).toContain("12C");
+  });
+
+  test("Oracle NJS-533 (native network encryption) maps to non-retryable DatabaseConfigError", () => {
+    const err = new Error(
+      "NJS-533: Advanced Networking Option service negotiation failed. Native Network Encryption " +
+        "and DataIntegrity are only supported in node-oracledb thick mode",
+    );
+    const result = mapDatabaseError(err, "oracle");
+    expect(result).toBeInstanceOf(DatabaseConfigError);
+    expect(isRetryableError(result)).toBe(false);
+    expect(result.message).toContain("ORACLE_CLIENT_LIB_DIR");
+  });
+
+  test("Oracle NJS-089 (unimplemented Thin-mode feature) maps to non-retryable DatabaseConfigError", () => {
+    const err = new Error("NJS-089: Kerberos authentication is not supported by node-oracledb in Thin mode");
+    const result = mapDatabaseError(err, "oracle");
+    expect(result).toBeInstanceOf(DatabaseConfigError);
+    expect(isRetryableError(result)).toBe(false);
+    expect(result.message).toContain("ORACLE_CLIENT_LIB_DIR");
+  });
+
+  test('a bare "not supported by node-oracledb in Thin mode" with no NJS code still maps to DatabaseConfigError', () => {
+    const err = new Error("LDAP naming is not supported by node-oracledb in Thin mode");
+    const result = mapDatabaseError(err, "oracle");
+    expect(result).toBeInstanceOf(DatabaseConfigError);
+    expect(isRetryableError(result)).toBe(false);
+  });
+
   test('MSSQL "login failed" maps to AuthenticationError', () => {
     const err = new Error('Login failed for user "sa"');
     const result = mapDatabaseError(err, "mssql");
@@ -409,5 +453,63 @@ describe("mapDatabaseError", () => {
     const result = mapDatabaseError(error, "mysql");
     expect(result).toBeInstanceOf(QueryCancelledError);
     expect(result.message).toBe("Query was cancelled");
+  });
+});
+
+// ============================================================================
+// Oracle Thick-mode diagnostics (#538)
+// ============================================================================
+
+describe("describeOracleThinModeRefusal", () => {
+  test("returns null for an error that has nothing to do with Thin mode", () => {
+    expect(describeOracleThinModeRefusal("ora-00942: table or view does not exist")).toBeNull();
+  });
+
+  test("names the pre-12.1 server for NJS-138", () => {
+    expect(describeOracleThinModeRefusal("njs-138: ...")).toContain("12.1");
+  });
+
+  test("names the verifier for NJS-116", () => {
+    expect(describeOracleThinModeRefusal("njs-116: password verifier type 0x939")).toContain("verifier");
+  });
+
+  test("names native network encryption for NJS-533", () => {
+    expect(describeOracleThinModeRefusal("njs-533: ...")).toContain("Native Network Encryption");
+  });
+});
+
+describe("describeOracleClientLoadFailure", () => {
+  test("NJS-045 is reported as a packaging defect of the build, naming platform and arch", () => {
+    const message = describeOracleClientLoadFailure(
+      "/opt/oracle/instantclient_19_28",
+      "Error: NJS-045: cannot load a node-oracledb Thick mode binary for Node.js",
+    );
+
+    expect(message).toContain("NJS-045");
+    expect(message).toContain(`${process.platform}-${process.arch}`);
+    // The operator must not go hunting for a path problem that is not one.
+    expect(message).toContain("packaging");
+  });
+
+  test("DPI-1047 points at the loader path, libaio and the recipe", () => {
+    const message = describeOracleClientLoadFailure(
+      "/opt/oracle/instantclient_19_28",
+      'Error: DPI-1047: Cannot locate a 64-bit Oracle Client library: "libnnz19.so: cannot open shared object file"',
+    );
+
+    expect(message).toContain("/opt/oracle/instantclient_19_28");
+    expect(message).toContain("ldconfig");
+    expect(message).toContain("LD_LIBRARY_PATH");
+    expect(message).toContain("libaio.so.1");
+    expect(message).toContain("docs/providers/oracle.md");
+  });
+
+  test("any other failure keeps a generic message that still names the variable", () => {
+    const message = describeOracleClientLoadFailure("/tmp/ic", "Error: something else entirely");
+
+    expect(message).toContain("ORACLE_CLIENT_LIB_DIR");
+    expect(message).toContain("/tmp/ic");
+    expect(message).toContain("something else entirely");
+    expect(message).not.toContain("NJS-045");
   });
 });

--- a/tests/unit/packaging-oracledb-thick.test.ts
+++ b/tests/unit/packaging-oracledb-thick.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit test for the Oracle Thick-mode packaging wiring (#538).
+ *
+ * `oracledb` runs in pure-JS Thin mode by default, so for most of this
+ * project's life the driver needed no packaging at all. `ORACLE_CLIENT_LIB_DIR`
+ * changed that: `initOracleClient()` makes node-oracledb load its own native
+ * addon, and that addon is invisible to both build stages.
+ *
+ * Two independent blind spots, both measured on the published images:
+ *
+ * 1. Turbopack bundled the driver into the server chunk and rewrote its
+ *    `__dirname` to the literal `/ROOT/node_modules/oracledb/lib`, so the addon
+ *    was looked for under `/ROOT/...` and `initOracleClient()` died with
+ *    `NJS-045` before the Instant Client was ever consulted. `oracledb` has to
+ *    be in `serverExternalPackages` for the path to be a real one.
+ * 2. Once external, Next's output file tracing copies the package's JavaScript
+ *    but NOT `build/Release/*.node`, because the driver reaches the addon
+ *    through a computed `require(path)`. Every packaging site must copy the
+ *    package explicitly, the way better-sqlite3, `@libredb/libredb` and the
+ *    `@duckdb` scope already are.
+ *
+ * The copy is the WHOLE package directory on purpose: `build/Release` holds a
+ * binary per platform/arch, so naming one would break the ARM64 image leg.
+ *
+ * Asserted as text because a real image build and a real Instant Client are
+ * both out of reach in a unit test; the runtime proofs are the payload
+ * `--smoke` probe and a live Thick-mode connection.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(join(ROOT, relativePath), "utf8");
+}
+
+describe("Oracle Thick-mode packaging", () => {
+  test("Next.js externalizes the driver so its __dirname stays real", () => {
+    const nextConfig = readRepoFile("next.config.ts");
+    const externals = /serverExternalPackages:\s*\[([^\]]*)\]/.exec(nextConfig)?.[1];
+
+    expect(externals).toContain('"oracledb"');
+  });
+
+  test("tsup leaves the driver out of the published bundles", () => {
+    expect(readRepoFile("tsup.config.ts")).toContain('"oracledb"');
+  });
+
+  test("the Dockerfile runner copies the whole driver package, arch-agnostically", () => {
+    const dockerfile = readRepoFile("Dockerfile");
+
+    expect(dockerfile).toContain("/usr/src/app/node_modules/oracledb ./node_modules/oracledb");
+    // build/Release carries one binary per platform/arch. Naming any of them
+    // here would break the ARM64 leg.
+    expect(dockerfile).not.toContain("oracledb-6");
+    expect(dockerfile).not.toContain("build/Release/oracledb");
+  });
+
+  test("the standalone payload copies the driver and probes its binary", () => {
+    const script = readRepoFile("scripts/build-standalone-payload.sh");
+
+    // The header manifest claims to mirror the Dockerfile runner stage exactly.
+    expect(script).toContain("node_modules/oracledb");
+    expect(script).toContain('cp -R node_modules/oracledb "$PAYLOAD_DIR/node_modules/oracledb"');
+    // Instant Client is not installed on a build runner, so Thick mode cannot
+    // actually be entered here. What CAN be checked is the file tracing drops:
+    // the addon for the target platform must exist in the copied package.
+    expect(script).toContain("build/Release");
+  });
+
+  test("the docs recipe carries the three Linux loader steps", () => {
+    const doc = readRepoFile("docs/providers/oracle.md");
+
+    // `initOracleClient({ libDir })` alone cannot load Instant Client on Linux:
+    // libclntsh.so has no RUNPATH, so its siblings are found only through the
+    // system library search path.
+    expect(doc).toContain("ldconfig");
+    expect(doc).toContain("/etc/ld.so.conf.d/");
+    // Debian 13 ships libaio.so.1t64 only; the SONAME the client needs is
+    // libaio.so.1.
+    expect(doc).toContain("libaio.so.1");
+  });
+});

--- a/tests/unit/packaging-oracledb-thick.test.ts
+++ b/tests/unit/packaging-oracledb-thick.test.ts
@@ -81,5 +81,10 @@ describe("Oracle Thick-mode packaging", () => {
     // Debian 13 ships libaio.so.1t64 only; the SONAME the client needs is
     // libaio.so.1.
     expect(doc).toContain("libaio.so.1");
+    // Measured by building the recipe verbatim: neither the published image nor
+    // node:26-trixie-slim has ca-certificates installed (dpkg reports `un`), and
+    // --no-install-recommends does not pull it in with curl, so the Instant
+    // Client download dies with curl (77) before anything else can be tested.
+    expect(doc).toContain("ca-certificates");
   });
 });


### PR DESCRIPTION
Thick mode has never worked in a build, for four independent reasons, all measured on the published 0.13.4 and 0.13.7 images. Turbopack bundled `oracledb` into the server chunk and rewrote its `__dirname` to the literal `/ROOT/node_modules/oracledb/lib`, so `initOracleClient()` threw NJS-045 before the Instant Client was consulted and every recipe in the docs was unreachable. Even externalized, Next's file tracing copies the driver's JavaScript but not `build/Release/*.node`, since the addon is reached through a computed `require(path)`. On Linux `initOracleClient({ libDir })` cannot load Instant Client on its own either: `libclntsh.so.19.1` has no RUNPATH, so it fails with DPI-1047 unless the directory is also on the system library search path. And on Debian 13 the client asks for `libaio.so.1` while the distribution ships only `libaio.so.1t64`. Separately, `mapDatabaseError` recognised only NJS-138, so the other Thin-mode refusals a DBA turns into "you must use Thick mode" arrived as a retryable ConnectionError, which is the defect #228 fixed for NJS-138.

Changed: `next.config.ts` adds `oracledb` to `serverExternalPackages`; the `Dockerfile` runner stage and `scripts/build-standalone-payload.sh` copy the whole package with a target-addon probe, arch-agnostically, so the ARM64 leg keeps working; `src/lib/db/errors.ts` gains `describeOracleThinModeRefusal` (NJS-116, NJS-533, NJS-089 and the generic Thin-mode substring join NJS-138 as non-retryable `DatabaseConfigError`, checked before the generic password branch because NJS-116's own text contains "password") and `describeOracleClientLoadFailure` (NJS-045 reads as a packaging defect naming platform and arch, DPI-1047 points at the loader path, `libaio.so.1` and section 4.4); `src/lib/db/providers/sql/oracle.ts` uses it; `docs/providers/oracle.md` rewrites section 4.4 with a recipe that works, adds the 12.2 case and its driver codes, and extends sections 11 and 14; `.env.example` and `CLAUDE.md` are corrected. New guard `tests/unit/packaging-oracledb-thick.test.ts`, plus tests in `tests/unit/db/errors.test.ts` and the Thick-mode block of `tests/integration/db/oracle-provider.test.ts`. The published image stays Thin only, no Instant Client and no libaio.

Verified locally: `format`, `lint`, `typecheck`, `knip`, `chart:check`, `channels:showcase:check`, `readme:check`, `security:check`, `test:ci` (all 34 groups), `test:coverage` plus `coverage:check` at 45569/45569 lines (100.00%), `build`, `build:lib` and `attw` all pass. After `DOCKER_BUILD=true bun run build`, `grep -l "/ROOT/node_modules/oracledb" .next/server/chunks/*.js | wc -l` is 0 (was 1), and `.next/standalone/node_modules/oracledb/package.json` exists while `build/Release` is absent from the traced tree, which is what the explicit COPY is for. The live Thick-mode run against a real Instant Client is not part of this PR.

Fixes #538
