### PR TITLE
feat(distribution): Google Cloud Marketplace is live, Azure is in review, and the inventory knew neither

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -419,6 +419,7 @@ channels:
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/56
       first_pr: https://github.com/caprover/one-click-apps/pull/1303
+      last_bump_pr: https://github.com/caprover/one-click-apps/pull/1315
       upstream_repo: https://github.com/caprover/one-click-apps
       docs: deploy/caprover/README.md
     pin:
@@ -447,6 +448,7 @@ channels:
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/171
       first_pr: https://github.com/Dokploy/templates/pull/931
+      last_bump_pr: https://github.com/Dokploy/templates/pull/1039
       catalog: https://templates.dokploy.com
       upstream_repo: https://github.com/Dokploy/templates
       docs: deploy/dokploy/README.md
@@ -454,7 +456,9 @@ channels:
       strategy: remote_file
       url: https://raw.githubusercontent.com/Dokploy/templates/main/blueprints/libredb-studio/docker-compose.yml
       extract: 'libredb-studio:(\d+\.\d+\.\d+)'
-      note: Bump from 0.9.27 to the current release is tracked in issue 175.
+      note: The blueprint serves 0.9.59, bumped there by Dokploy/templates#1039 (merged 2026-08-03).
+        Every bump is an upstream pull request a maintainer has to merge, so this pin drifts behind
+        the release by design and the drift row is the reminder to open the next one.
 
   - id: cosmos
     name: Cosmos servapp marketplace
@@ -743,6 +747,54 @@ channels:
     pin:
       strategy: none
 
+  - id: gcp-marketplace
+    name: Google Cloud Marketplace
+    short_name: Google Cloud Marketplace
+    status: live
+    category: cloud-marketplaces
+    platforms: [kubernetes, cloud]
+    runtime: channel_supplied
+    tier: 4
+    kind: marketplace
+    update:
+      # Producer Portal, not a pull request: the listing, its version and its
+      # Terraform module are submitted through Google's console and each change
+      # goes through Google's own review, so nothing here can be CI-driven.
+      method: manual_ui
+      sla: on_demand
+    links:
+      catalog: https://console.cloud.google.com/marketplace/product/libredb-public/libredb-studio
+      docs: docs/DISTRIBUTION.md
+    pin:
+      # The listed version is held in Google's Producer Portal and the artifacts
+      # live in a private Artifact Registry, so there is no public file to read a
+      # version out of. It is checked by hand against the portal.
+      strategy: none
+
+  - id: azure-marketplace
+    name: Microsoft Azure Marketplace
+    short_name: Azure Marketplace
+    status: pending
+    category: cloud-marketplaces
+    platforms: [cloud]
+    runtime: channel_supplied
+    tier: 4
+    kind: marketplace
+    update:
+      method: manual_ui
+      sla: on_demand
+    links:
+      docs: deploy/azure/README.md
+    pin:
+      strategy: none
+      note: The offer is submitted and in Microsoft's certification review, so nothing is listed
+        yet. It is recorded here rather than left out because the submission exists and its whole
+        descriptor does too - deploy/azure/ holds the solution template, the ARM assets and the
+        Partner Center listing texts - which is the same reason the four open catalog submissions
+        carry an entry. On publication, flip to live and add the offer's public listing URL as
+        links.catalog; there is no pin to add, because the listed version lives in Partner Center
+        the way Google's lives in the Producer Portal.
+
   - id: winget
     name: winget community repository (LibreDB.Studio)
     short_name: winget
@@ -805,9 +857,10 @@ channels:
       extract: '<d:Version>(\d+\.\d+\.\d+)</d:Version>'
       note: Listed since 0.9.59 (choco install libredb-studio), approved 2026-08-24. The community
         feed publishes no floating "latest" document, so the pin filters the OData package list to
-        IsLatestVersion - one document, one match, whatever the published version count. It reads
-        0.9.59 until the next release publishes through the now-enabled job, which is real lag and
-        not a broken pin. The feed lists APPROVED versions only, so a drift row here means the
+        IsLatestVersion - one document, one match, whatever the published version count. It sat at
+        0.9.59 while the job was disabled and has moved with every release since; it reads 0.13.6
+        today, one behind, which is moderation lag and not a broken pin. The feed lists APPROVED
+        versions only, so a drift row here means the
         version is waiting on human moderation rather than that the push failed; the release run's
         job summary reports the push outcome and that version's PackageStatus. Trusted status is
         what removes the wait - docs/BACKLOG.md REL3.

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -34,9 +34,9 @@ channel count.
 
 ## Coverage snapshot
 
-**33 channels · 26 live · 6 pending · 1 deprecated**
+**35 channels · 27 live · 7 pending · 1 deprecated**
 
-Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · Kubernetes 2 · Cloud 10**
+Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · Kubernetes 3 · Cloud 11**
 
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
@@ -47,7 +47,7 @@ Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · K
 | OS / desktop packages | 3 | 0 | 0 |
 | PaaS catalogs (listed) | 8 | 4 | 0 |
 | Deploy recipes | 3 | 0 | 0 |
-| Cloud marketplaces | 1 | 1 | 0 |
+| Cloud marketplaces | 2 | 2 | 0 |
 
 <!-- END:CHANNEL-SCORECARD -->
 
@@ -89,6 +89,8 @@ Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · K
 | [Koyeb deploy button](https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb) | Deploy recipes | Cloud | live | Manual, on demand | [deploy/koyeb/README.md](../deploy/koyeb/README.md) |
 | [Render Blueprint](https://github.com/libredb/libredb-studio/blob/main/render.yaml) | Deploy recipes | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/libredb-studio) | Cloud marketplaces | Cloud | live | Manual, on demand | [deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
+| [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/libredb-public/libredb-studio) | Cloud marketplaces | Kubernetes, Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| Azure Marketplace | Cloud marketplaces | Cloud | pending | Manual, on demand | [deploy/azure/README.md](../deploy/azure/README.md) |
 | [Koyeb One-Click Apps catalog](https://www.koyeb.com/deploy) | Cloud marketplaces | Cloud | pending | Manual, on demand | [deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
 
 <!-- END:CHANNEL-TABLE -->
@@ -99,5 +101,10 @@ hand. To propose a new channel, add an entry with a `category` and a `platforms`
 list, then run `bun run distribution:matrix`. Freshness is enforced on pull
 requests with `bun run distribution:matrix --check`.
 
-Planned and deliberately not counted here until a listing exists: GCP, Azure, AWS
-and Alibaba cloud marketplaces, and Coolify, Portainer and Dokku deploy support.
+Not counted here, and why. **AWS Marketplace** has a registered seller account
+but no submitted product, so there is nothing to track yet. **Alibaba Cloud** is
+not being pursued. **Coolify** declined the submission: its maintainers accept
+service templates only from projects above 1000 GitHub stars. **Dokku** has no
+application catalog to apply to. A row appears above the moment a submission
+exists — `pending` while it is open or under review, `live` once the product can
+be installed from that channel.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -738,8 +738,8 @@ resolves from the community repository and every release packs and pushes automa
 > while an account's first submission is unapproved, which failed the 0.9.60 and 0.9.61 release
 > runs even though both releases published correctly. The 2026-08-24 approval set
 > `ci_enabled: true` and `status: live` in a single edit — exactly what winget got once its
-> listing merged. The community feed serves 0.9.59 until the next release publishes through the
-> re-enabled job; do not re-dispatch `release-artifacts` for an already-published version to
+> listing merged. The community feed has moved with every release since and serves 0.13.6 today,
+> one behind, which is moderation lag; do not re-dispatch `release-artifacts` for an already-published version to
 > backfill the feed, because its asset steps would fight the immutable release — push a back
 > version by hand (the same choco container the job uses for Chocolatey; the [manual manifest
 > recipe](#windows-first-listing-checklist) for winget).
@@ -966,8 +966,10 @@ They are documented here rather than under `deploy/<provider>/` because neither 
 this repo: the Sealos template lives upstream in
 [`labring-actions/templates`](https://github.com/labring-actions/templates) and the Unraid template
 in [`libredb/unraid-templates`](https://github.com/libredb/unraid-templates), and neither has a
-`deploy/<provider>/` folder here at all. Every other catalog channel does have one and keeps its
-notes in `deploy/<provider>/README.md` instead - CapRover and Railway alongside the source
+`deploy/<provider>/` folder here at all. They are two of the eight catalog channels with no such
+folder - the others are TrueNAS SCALE, the four open submissions (CasaOS, Umbrel, Easypanel,
+Portainer) and Google Cloud Marketplace, whose artefacts live in Google's Producer Portal. The
+catalog channels that DO keep a folder keep their notes in `deploy/<provider>/README.md` - CapRover and Railway alongside the source
 descriptor itself, Dokploy, Kubero and Cosmos as notes only, since those three descriptors are also
 authored upstream. The full channel list is [`docs/CHANNELS.md`](CHANNELS.md).
 
@@ -1022,6 +1024,32 @@ provisions compute, networking, storage and ingress, so there is nothing to inst
 - Bumps go in as a template PR to `labring-actions/templates`. That repo's default branch is
   **`kb-0.9`**, not `main` or `master`, which is what both the drift-check pin URL and any bump PR
   must target.
+
+## Google Cloud Marketplace
+
+Publicly listed since **2026-09-04** as a free **Terraform Kubernetes app**: a customer finds
+LibreDB Studio in the Marketplace catalog inside the Google Cloud console and deploys it into their
+own GKE cluster. Deploying requires the **Kubernetes Engine Admin** role on the target project.
+
+It is the one channel in the inventory with **no public artefact to read a version from**, and that
+shapes everything below. The listing, its version and its Terraform module are all held in Google's
+Producer Portal; the Helm chart and the container image are served from a private Artifact Registry
+under the `libredb-public` project. So `pin.strategy` is `none` in
+[`distribution/channels.yaml`](../distribution/channels.yaml) and the listed version is checked by
+hand against the portal — the drift table cannot do it, and a pin that guessed would be worse than
+no pin.
+
+**The Marketplace version is its own number.** Google requires the chart and the image tags of a
+Terraform Kubernetes app to share a MAJOR.MINOR, which the repo's chart version (`0.1.x`) and the
+application version (`0.13.x`) do not. The published copy is therefore packaged with a version of
+its own — `helm package --version <n> --app-version <n>` at submission time, leaving the repo's
+chart untouched. The listing currently reads **0.10**, so a Marketplace version is not comparable
+with a release tag and must not be read as one.
+
+**Every change is a portal submission, not a pull request.** `update.method` is `manual_ui` and
+`update.sla` is `on_demand` because each new version goes through Google's own review before it
+reaches customers; nothing here can be driven from release CI, and no upstream repository accepts a
+bump PR for it.
 
 ## Building a standalone payload locally
 
@@ -1338,7 +1366,7 @@ pin or editing a channel entry is always a human commit.
 | 1 | Packaged formats owned by this repo, CI-published | Helm, Homebrew tap, Snap, .deb/.rpm, desktop AppImage |
 | 2 | LibreDB-owned copies and listings, bumped by hand | Railway, Koyeb button, Fly.io config, Render Blueprint, Unraid CA template |
 | 3 | Upstream community catalogs, bumped via PR | CapRover official, Dokploy, Cosmos, Kubero, Sealos, TrueNAS SCALE |
-| 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DO, winget, Chocolatey, Flathub |
+| 4 | Partner or curated catalogs (not self-serve) | Rancher partner charts, Koyeb catalog, DigitalOcean, Google Cloud Marketplace, winget, Chocolatey, Flathub |
 
 **Categories** (`category` on every channel) are the business-facing buckets rendered in
 [`docs/CHANNELS.md`](CHANNELS.md): `registries-releases`, `containers`,
@@ -1375,7 +1403,7 @@ channel's users or an invisible build detail (issue #326):
 | Value | Meaning | Channels |
 |---|---|---|
 | `user_supplied` | The user's own `node` executes the payload, so the floor is theirs to meet. A release that raises it is user-visible here and nowhere else. | `npm`, `github-release` |
-| `channel_supplied` | The channel provides the runtime — bundled inside the artefact (container image, snap, deb/rpm, Windows zip, Flatpak, the Tauri sidecar), inherited from an image a template deploys, or installed as a declared package dependency (Homebrew's `node@24`). Raising the floor is transparent. | the other 25 |
+| `channel_supplied` | The channel provides the runtime — bundled inside the artefact (container image, snap, deb/rpm, Windows zip, Flatpak, the Tauri sidecar), inherited from an image a template deploys, or installed as a declared package dependency (Homebrew's `node@24`). Raising the floor is transparent. | every other channel |
 
 It is deliberately not derived from `kind`: `os-package` covers deb/rpm, which ship a private Node
 (`packaging/linux/fetch-node.sh` installs `bin/node` into the payload), while `package-registry`
@@ -1508,10 +1536,16 @@ its in-repo descriptor unmeasured by any gate
 ([#268](https://github.com/libredb/libredb-studio/issues/268)); it fell 45 patch versions behind the
 catalog before anyone noticed. **Dokploy**, **Kubero** and **Cosmos** keep only a README there -
 their descriptors are authored in the upstream catalog repo, so all three are pinned `remote_file`
-and a bump is an upstream PR with nothing to change here. Two catalog channels keep **no**
-descriptor here at all — the Sealos template is authored in `labring-actions/templates` and the
-Unraid CA template in `libredb/unraid-templates` — so both are pinned with `remote_file` against
-those repos and documented under [App catalogs](#app-catalogs-unraid-sealos). Neither Fly.io nor
+and a bump is an upstream PR with nothing to change here. **Eight catalog channels keep no
+descriptor here at all.** Two of them are pinned `remote_file` against the repository that does
+hold it — the Sealos template in `labring-actions/templates`, the Unraid CA template in
+`libredb/unraid-templates` — and both are documented under
+[App catalogs](#app-catalogs-unraid-sealos); TrueNAS SCALE is pinned the same way against
+`truenas/apps`. The four open submissions (CasaOS, Umbrel, Easypanel, Portainer) have nothing to
+pin until their upstream PR merges, and each entry's note names the pin to add on that day.
+[Google Cloud Marketplace](#google-cloud-marketplace) is the one with nothing to pin even in
+principle: its artefacts are held in Google's Producer Portal and a private Artifact Registry.
+Neither Fly.io nor
 Render has a marketplace or template gallery to publish into, which is why the repo file itself is the
 deliverable (`pin.strategy: local_file` for the version-pinned `fly.toml`; `none` for
 `render.yaml`, which builds from the repo Dockerfile and tracks whatever `main` builds).

--- a/src/lib/distribution/channels.generated.ts
+++ b/src/lib/distribution/channels.generated.ts
@@ -39,6 +39,7 @@ export const LIVE_CHANNELS: readonly ShowcaseChannel[] = [
   { id: "truenas-scale", label: "TrueNAS SCALE apps", group: "paas" },
   { id: "rancher-partner", label: "Rancher Partner Charts", group: "kubernetes" },
   { id: "digitalocean", label: "DigitalOcean Marketplace", group: "paas" },
+  { id: "gcp-marketplace", label: "Google Cloud Marketplace", group: "paas" },
   { id: "winget", label: "winget", group: "packages" },
   { id: "chocolatey", label: "Chocolatey", group: "packages" },
   { id: "flatpark", label: "FlatPark (Flatpak)", group: "packages" },


### PR DESCRIPTION
Two cloud marketplaces the inventory did not know about, and the counts that had rotted around
them. The inventory reads **35 channels · 27 live · 7 pending · 1 deprecated**.

## The two channels

**Google Cloud Marketplace — `live`.** Publicly listed on **2026-09-04** as a free Terraform
Kubernetes app. The repository said the opposite in two places at once: no entry in
`distribution/channels.yaml`, and `docs/CHANNELS.md` closing with *"Planned and deliberately not
counted here until a listing exists: GCP, …"*. A reader asking the coverage question that page
exists to answer got a wrong answer.

**Azure Marketplace — `pending`.** The same omission one stage earlier. `deploy/azure/` holds the
solution template, the ARM assets and the Partner Center listing texts; the offer is submitted and
in certification; no row tracked any of it, while five other open submissions had one.

## Why GCP carries no pin and no CI

Each is a property of the channel, not an omission:

| | |
| --- | --- |
| `update.method: manual_ui` | The listing, its version and its Terraform module are submitted through Google's Producer Portal, and every change goes through Google's own review. No upstream repository accepts a bump PR for it. |
| `pin.strategy: none` | The chart and the image are served from a private Artifact Registry. There is no public file to read a version out of, and a pin that guessed would be worse than none. |

`docs/DISTRIBUTION.md` gains the section the channel's own `docs` link points at, including the one
fact most likely to be misread: **the listed version reads `0.10` while the release is `0.13.7`.**
Google requires the chart and image tags of a Terraform Kubernetes app to share a MAJOR.MINOR, which
`0.1.x` and `0.13.x` do not, so the published copy is packaged with a version of its own. It is not
a release tag and must not be compared with one.

## Two counts that were wrong about this repository's own contents

`docs/DISTRIBUTION.md` said *"Two catalog channels keep no descriptor here at all"* and, in a second
passage, that *"every other catalog channel does have one"*. Counted: **eight** have no
`deploy/<provider>/` folder — Unraid CA, Sealos, TrueNAS SCALE, the four open submissions, and now
GCP. Both passages now name the set and say what each subgroup pins instead.

## Three stale facts, each measured against the live source

| Where | Said | Measured |
| --- | --- | --- |
| `channels.yaml` + `DISTRIBUTION.md` | Chocolatey serves `0.9.59` | OData feed serves **`0.13.6`** — one behind, moderation lag |
| `channels.yaml` dokploy pin note | bump tracked "in issue 175" | issue closed 2026-07-31; `Dokploy/templates#1039` merged 2026-08-03 → blueprint at `0.9.59` |
| `DISTRIBUTION.md:1378` | "the other 25" | rewritten as "every other channel", which cannot go stale again |

## `links.last_bump_pr` gets its first two values

`docs/DISTRIBUTION.md` has required this field since a bump merges, and the drift table renders a
column for it — yet **none of the thirty-three entries carried one**, so the column read `-` for
every row while at least two bumps had merged: `caprover/one-click-apps#1315` and
`Dokploy/templates#1039`.

## Also

`docs/CHANNELS.md`'s closing paragraph is rewritten rather than trimmed: it listed **Portainer** as
"planned" while Portainer had been a `pending` row four lines above it, and filed **Coolify** and
**Dokku** under "planned" when neither is — Coolify declined the submission over a 1000-star
threshold its maintainers confirmed, and Dokku has no application catalog to apply to.

`docs/CHANNELS.md` and `src/lib/distribution/channels.generated.ts` are **regenerated, not edited**
(`bun run distribution:matrix`, `bun run channels:showcase`), whose freshness both gate on CI.

## Verification

Every channel status in this diff was checked against its upstream PR state and its live catalog,
not inferred from a tracking issue — a tracking issue closed COMPLETED while its upstream PR is
still open is the specific trap here, and three of the `pending` rows are exactly that shape.

`format` · `lint` · `typecheck` · `knip` · `test` (38 groups, 0 fail) · `build` — all green.
`distribution:check` · `distribution:matrix --check` · `channels:showcase:check` — all exit 0.
Coverage: **45548/45548 lines, 100.00%**.

## Deliberately not in this PR

The version bumps the drift table reports for `fly.toml` (0.9.59) and the three Railway files
(0.9.22). Those change what a user deploys, and the Railway one has an out-of-repo consequence its
own `PUBLISH.md` describes — a different change with a different risk, and mixing it with an
inventory correction would make both harder to review.
