### PR TITLE
fix(mssql,oracle): omit unknown overview size bytes

### DIFF
--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -447,7 +447,7 @@ in parallel. Each sub-query is independently privilege-guarded (DMVs need `VIEW 
 | Method | Primary source | Notes |
 |--------|----------------|-------|
 | `getHealth()` | `dm_exec_sessions`, `database_files`, `dm_os_performance_counters`, `dm_exec_query_stats` | connections (**omitted**, never `0`, when the DMV is denied — [§7.2](#72-when-the-connection-count-is-not-measurable)), size, buffer-cache-hit % (`N/A`, never `0%`, when unreadable — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)), top-5 slow queries, 10 sessions; each block guarded → absent/`N/A`/`[]` |
-| `getOverview()` | `@@VERSION`, `dm_os_sys_info`, `dm_exec_sessions`, `sys.configurations`, `database_files`, `sys.tables`/`indexes` | `user connections = 0` → reported as 32767 (unlimited) |
+| `getOverview()` | `@@VERSION`, `dm_os_sys_info`, `dm_exec_sessions`, `sys.configurations`, `database_files`, `sys.tables`/`indexes` | `user connections = 0` → reported as 32767 (unlimited); `databaseSizeBytes` is **omitted** and `databaseSize` stays `N/A`, never a `0`, when the size statement fails — [§7.3](#73-when-the-database-size-is-not-measurable) |
 | `getPerformanceMetrics()` | `dm_os_performance_counters` | **only** the cache-hit ratio, and it is **omitted** when the DMV cannot be read (no QPS/deadlocks/buffer-pool) — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable) |
 | `getSlowQueries()` | `dm_exec_query_stats` ⋈ `dm_exec_sql_text` | `sharedBlksHit`=logical reads, `sharedBlksRead`=physical reads; `[]` on failure |
 | `getActiveSessions()` | `dm_exec_sessions` ⋈ `dm_exec_requests` ⋈ `dm_exec_sql_text` | **`blocked` is real** (`blocking_session_id > 0`); wait types; `[]` on failure |
@@ -609,6 +609,58 @@ less likely of the two shapes there.
 A count that really is `0` - an instance with no user sessions - is a reading and is reported as `0`,
 in `getOverview()` as in `getHealth()`.
 The absence is spelled `measuredNumber(...)` plus a conditional spread, never `|| undefined`.
+
+### 7.3 When the database size is not measurable
+
+`getOverview()` sizes the database with one statement over a **database-scoped catalog view**:
+
+```sql
+SELECT SUM(CAST(size AS BIGINT)) * 8 * 1024 AS size_bytes FROM sys.database_files
+```
+
+That is a different story from [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable) and
+[§7.2](#72-when-the-connection-count-is-not-measurable), and the difference is the point.
+`sys.database_files` is a catalog view scoped to the connected database
+([sys.database_files](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-database-files-transact-sql)),
+not one of the server-scoped DMVs those sections turn on, so the `Msg 300` refusal measured there is
+**not** what fails here - and **no failure of this statement has been measured on a live instance at
+all**. That is precisely why the guard names no cause: the client-side `requestTimeout` of
+[§3.5](#35-a-query-timeout-is-wired-driver-enforced) firing as a `TimeoutError` on a busy instance, a
+pool fault between this statement and the one before it, and a deployment whose T-SQL surface does
+not carry the view all arrive at the same `catch` in the same shape. A `catch` cannot tell them
+apart. It knows only that no figure arrived.
+
+So the figure is **omitted**, not zeroed. `DatabaseOverview.databaseSizeBytes` is optional exactly so
+this can be said - *"absence and zero are different facts"*, its docblock in
+[`src/lib/db/types.ts`](../../src/lib/db/types.ts) - and until #565 this method could not say it: the
+local was initialised to `0` and the `catch` was empty, so a statement that never answered published
+a measured-looking zero, indistinguishable from an empty database.
+
+The monitoring **Storage** tab
+([`src/components/monitoring/tabs/StorageTab.tsx`](../../src/components/monitoring/tabs/StorageTab.tsx))
+is what the difference buys: it keys its entire breakdown off `databaseSizeBytes !== undefined`, so
+on the absence it renders *"No storage size information available."* On the fabricated `0` it drew
+the breakdown instead - and drew it against a total that contradicted its own rows. The Tables and
+Indexes figures come from `getTableStats()`, a **separate** read that does not share the size
+statement's failure, so real per-table bytes sat under a database reported as `0 B`: every share is
+gated on `totalSize > 0`, so all three bars stayed empty, and `0 - tables - indexes` went negative,
+which the remainder row refuses as `N/A`. What the tab presented as a measurement was therefore a
+breakdown whose every element either disagreed with the total or declined to answer.
+
+**`databaseSize`, the formatted string, moves with the figure.** It is initialised to `"N/A"` and
+only `formatBytes()` replaces it, so an unanswered statement now leaves `"N/A"` where it used to
+leave `"0 bytes"`. That is not cosmetic: both the monitoring Overview card and the Storage tab's own
+header render this string as the headline size (`overview?.databaseSize || "N/A"`), so the old
+initialiser printed a confident `0 bytes` directly above *"No storage size information available."*
+`getHealth()` in this same file initialises its own `databaseSize` to `"N/A"`, so `getOverview()`
+was the odd one out; #569 (libSQL) and #517 (the search provider) merged the same
+pairing.
+
+A database that really measures `0` is a **reading** and is kept. `SUM(...)` over no row answers
+`NULL`, `Number(... || 0)` folds that to `0`, and the tab formats the `0 B` it was given. The absence
+is spelled `=== undefined` plus a conditional spread, never a falsy test: a falsy test would erase
+the very measurement it was meant to publish, which is the mistake §7.2 records for the connection
+count.
 
 ---
 

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -855,7 +855,7 @@ sub-query is independently privilege-guarded ([§3.6](#36-privilege-resilient-mo
 | Method | Primary source | Notes / degradation |
 |--------|----------------|---------------------|
 | `getHealth()` | `V$SESSION`, `USER_SEGMENTS`, `V$SYSSTAT`, `V$SQL` | each block guarded → absent/`N/A`/`[]` if no privilege; `activeConnections` is **omitted**, never `0` ([§7.2](#72-when-the-connection-count-is-not-measurable)); `cacheHitRatio` is `N/A`, never `0%` ([§7.1](#71-when-the-cache-hit-ratio-is-not-measurable)) |
-| `getOverview()` | `V$VERSION`, `V$INSTANCE`, `V$SESSION`, `V$PARAMETER`, `USER_SEGMENTS`, `USER_TABLES`/`USER_INDEXES` | each guarded; `activeConnections` is **omitted**, never `0` ([§7.2](#72-when-the-connection-count-is-not-measurable)), while `maxConnections` stays `0` because `0` there means "no limit published" |
+| `getOverview()` | `V$VERSION`, `V$INSTANCE`, `V$SESSION`, `V$PARAMETER`, `USER_SEGMENTS`, `USER_TABLES`/`USER_INDEXES` | each guarded; `activeConnections` is **omitted**, never `0` ([§7.2](#72-when-the-connection-count-is-not-measurable)), while `maxConnections` stays `0` because `0` there means "no limit published"; `databaseSizeBytes` is **omitted** and `databaseSize` stays `N/A`, never a `0`, when `USER_SEGMENTS` does not answer ([§7.3](#73-when-the-database-size-is-not-measurable)) |
 | `getPerformanceMetrics()` | `V$SYSSTAT` | **only** `cacheHitRatio`, and it is **omitted** when `V$SYSSTAT` cannot be read (no QPS/deadlocks/buffer-pool) — [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable) |
 | `getSlowQueries()` | `V$SQL` (top-N by `ELAPSED_TIME`) | `sharedBlksHit`=`BUFFER_GETS`, `sharedBlksRead`=`DISK_READS`; `[]` on failure |
 | `getActiveSessions()` | `V$SESSION` ⋈ `V$SQL` | `pid` = `"SID,SERIAL#"`; wait class/event; `[]` on failure |
@@ -952,6 +952,59 @@ reported as `0`. The absence is spelled `measuredNumber(...)` plus a conditional
 (`V$PARAMETER` `sessions`), and there `0` MEANS "no limit published" - the same fact as absence - so
 a refused `V$PARAMETER` leaves `0` and the card says "no limit published". The count is read first in
 that shared block precisely so a refused ceiling cannot carry a measured count away with it.
+
+### 7.3 When the database size is not measurable
+
+`getOverview()` sizes the schema with one statement over a **data dictionary view of the connected
+user's own segments**:
+
+```sql
+SELECT SUM(BYTES) AS TOTAL FROM USER_SEGMENTS
+```
+
+That is a different story from [§7.1](#71-when-the-cache-hit-ratio-is-not-measurable) and
+[§7.2](#72-when-the-connection-count-is-not-measurable), and the difference is the point. `USER_*`
+views describe objects the current user owns, so this statement needs none of the `V_$` access those
+sections turn on - the `ORA-00942` measured there against a `CREATE SESSION`-only user is **not**
+what fails here, and **no failure of this statement has been measured on a live instance at all**.
+That is precisely why the guard names no cause: a dictionary the DBA has locked down, a connection
+lost between this statement and the one before it, and an overrunning query that nothing here cuts
+short - this provider wires no server-side query timeout at all
+([§4.2](#42-connection-pooling)) - all arrive at the same `catch` in the same shape. A `catch` cannot
+tell them apart. It knows only that no figure arrived.
+
+So the figure is **omitted**, not zeroed. `DatabaseOverview.databaseSizeBytes` is optional exactly so
+this can be said - *"absence and zero are different facts"*, its docblock in
+[`src/lib/db/types.ts`](../../src/lib/db/types.ts) - and until #565 this method could not say it: the
+local was initialised to `0` and the `catch` was empty, so a statement that never answered published
+a measured-looking zero, indistinguishable from a schema that owns nothing.
+
+The monitoring **Storage** tab
+([`src/components/monitoring/tabs/StorageTab.tsx`](../../src/components/monitoring/tabs/StorageTab.tsx))
+is what the difference buys: it keys its entire breakdown off `databaseSizeBytes !== undefined`, so
+on the absence it renders *"No storage size information available."* On the fabricated `0` it drew
+the breakdown instead - and drew it against a total that contradicted its own rows. The Tables and
+Indexes figures come from `getTableStats()`, a **separate** read that does not share the size
+statement's failure, so real per-table bytes sat under a schema reported as `0 B`: every share is
+gated on `totalSize > 0`, so all three bars stayed empty, and `0 - tables - indexes` went negative,
+which the remainder row refuses as `N/A`. What the tab presented as a measurement was therefore a
+breakdown whose every element either disagreed with the total or declined to answer.
+
+**`databaseSize`, the formatted string, moves with the figure.** It is initialised to `"N/A"` and
+only `formatBytes()` replaces it, so an unanswered statement now leaves `"N/A"` where it used to
+leave `"0 bytes"`. That is not cosmetic: both the monitoring Overview card and the Storage tab's own
+header render this string as the headline size (`overview?.databaseSize || "N/A"`), so the old
+initialiser printed a confident `0 bytes` directly above *"No storage size information available."*
+`getHealth()` in this same file initialises its own `databaseSize` to `"N/A"`, so `getOverview()`
+was the odd one out; #569 (libSQL) and #517 (the search provider) merged the same
+pairing.
+
+A schema that really measures `0` is a **reading** and is kept, and here that case is ordinary rather
+than hypothetical: a freshly created user owns no segment, `SUM(BYTES)` over no row answers one row
+of `NULL`, `Number(... || 0)` folds that to `0`, and the tab formats the `0 B` it was given. The
+absence is therefore spelled `=== undefined` plus a conditional spread, never a falsy test - a falsy
+test would erase exactly that measurement, which is the mistake §7.2 records for the connection
+count.
 
 ---
 

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -1107,8 +1107,25 @@ export class MSSQLProvider extends SQLBaseProvider {
       // maxConnections stays a required number: 0 MEANS "no limit published" here,
       // so unlike the count above, 0 and absence are the SAME fact for the ceiling.
       let maxConnections = 0;
-      let databaseSize = "0 bytes";
-      let databaseSizeBytes = 0;
+      // Left UNDEFINED and spread conditionally too, for the reason the count above is:
+      // `DatabaseOverview.databaseSizeBytes` is optional because absence and zero are
+      // different facts, and a `sys.database_files` read that does not answer says
+      // nothing about the database's size. Unlike the count above this is NOT a
+      // permission story - that view is database-scoped, so §7.2's server-level
+      // refusal does not gate it, and no failure of this statement has been measured
+      // on a live instance; whatever reaches the catch, the catch cannot name it.
+      // StorageTab.tsx keys its whole breakdown off `databaseSizeBytes !== undefined`,
+      // so the old `0` initialiser drew that breakdown over a database it never
+      // measured, instead of "No storage size information available." - and drew it
+      // against per-table bytes from getTableStats(), a separate read that does not
+      // share this statement's failure, so the rows contradicted the total they were
+      // shares of. `databaseSize` moves with the figure for the same reason: both
+      // monitoring tabs render that string as the headline size, so a leftover
+      // "0 bytes" printed a confident zero beside that message. "N/A" while the bytes
+      // are unknown is the shape merged for libSQL (#569) and the search provider
+      // (#517). See docs/providers/mssql.md section 7.3.
+      let databaseSize = "N/A";
+      let databaseSizeBytes: number | undefined;
       let tableCount = 0;
       let indexCount = 0;
 
@@ -1162,10 +1179,14 @@ export class MSSQLProvider extends SQLBaseProvider {
       // Database size
       try {
         const sizeRes = await this.pool!.request().query(OVERVIEW_DATABASE_SIZE_SQL);
+        // `|| 0`, not measuredNumber: SUM over no row answers NULL and that is a
+        // measured zero here, so unlike the count above this reading keeps its falsy
+        // fold. Only the catch below leaves the figure absent.
         databaseSizeBytes = Number(sizeRes.recordset[0]?.size_bytes || 0);
         databaseSize = formatBytes(databaseSizeBytes);
       } catch {
-        /* ignore */
+        /* The size stays absent, never 0, and `databaseSize` keeps the "N/A" it was
+           initialised with. */
       }
 
       // Table/index counts
@@ -1184,7 +1205,7 @@ export class MSSQLProvider extends SQLBaseProvider {
         ...(activeConnections === undefined ? {} : { activeConnections }),
         maxConnections,
         databaseSize,
-        databaseSizeBytes,
+        ...(databaseSizeBytes === undefined ? {} : { databaseSizeBytes }),
         tableCount,
         indexCount,
       };

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -1177,8 +1177,25 @@ export class OracleProvider extends SQLBaseProvider {
       // NOT made optional alongside it: `maxConnections` is a published ceiling where
       // 0 MEANS "no limit published", so 0 and absence are the SAME fact there.
       let maxConnections = 0;
-      let databaseSize = "0 bytes";
-      let databaseSizeBytes = 0;
+      // Left UNDEFINED and spread conditionally too, for the reason the count above is:
+      // `DatabaseOverview.databaseSizeBytes` is optional because absence and zero are
+      // different facts, and a USER_SEGMENTS read that does not answer says nothing
+      // about how much the schema holds. Unlike the count above this is NOT a
+      // privilege story - USER_* views describe the caller's own objects, so §7.2's
+      // V_$ refusal does not gate it, and no failure of this statement has been
+      // measured on a live instance; whatever reaches the catch, the catch cannot
+      // name it. StorageTab.tsx keys its whole breakdown off
+      // `databaseSizeBytes !== undefined`, so the old `0` initialiser drew that
+      // breakdown over a schema it never measured, instead of "No storage size
+      // information available." - and drew it against per-table bytes from
+      // getTableStats(), a separate read that does not share this statement's failure,
+      // so the rows contradicted the total they were shares of. `databaseSize` moves
+      // with the figure for the same reason: both monitoring tabs render that string
+      // as the headline size, so a leftover "0 bytes" printed a confident zero beside
+      // that message. "N/A" while the bytes are unknown is the shape merged for libSQL
+      // (#569) and the search provider (#517). See docs/providers/oracle.md section 7.3.
+      let databaseSize = "N/A";
+      let databaseSizeBytes: number | undefined;
       let tableCount = 0;
       let indexCount = 0;
 
@@ -1237,10 +1254,15 @@ export class OracleProvider extends SQLBaseProvider {
         const sizeRes = await conn.execute(`SELECT SUM(BYTES) AS TOTAL FROM USER_SEGMENTS`, [], {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
         });
+        // `|| 0`, not measuredNumber: a schema that owns no segment answers one row
+        // whose SUM is NULL, and that is a measured zero rather than an unknown - so
+        // unlike the count above this reading keeps its falsy fold, and only the catch
+        // below leaves the figure absent.
         databaseSizeBytes = Number(((sizeRes.rows || []) as Record<string, unknown>[])[0]?.TOTAL || 0);
         databaseSize = formatBytes(databaseSizeBytes);
       } catch {
-        /* ignore */
+        /* The size stays absent, never 0, and `databaseSize` keeps the "N/A" it was
+           initialised with. */
       }
 
       // Table and index counts
@@ -1260,7 +1282,7 @@ export class OracleProvider extends SQLBaseProvider {
         ...(activeConnections === undefined ? {} : { activeConnections }),
         maxConnections,
         databaseSize,
-        databaseSizeBytes,
+        ...(databaseSizeBytes === undefined ? {} : { databaseSizeBytes }),
         tableCount,
         indexCount,
       };

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -1523,6 +1523,63 @@ describe("MSSQLProvider", () => {
       expect(overview.maxConnections).toBe(32767);
     });
 
+    test("a refused size read leaves overview databaseSizeBytes absent, never a measured 0", async () => {
+      // The same defect as the connections pair above, one field over, and it survived
+      // #515 because that round only moved the count: `let databaseSizeBytes = 0` plus an
+      // empty catch turned any failure of the size statement into a reading.
+      // Deliberately NOT given a permission-refusal shape like §7.2's. `sys.database_files`
+      // is a database-scoped catalog view, not one of the server-scoped DMVs that section
+      // measured a `Msg 300` against, and no failure of this statement has been measured on
+      // a live instance - the request timeout of §3.5 firing, a pool fault mid-overview and
+      // a deployment without the view all arrive here identically. That is the whole point:
+      // the `catch` cannot tell one cause from another, so it must not publish a figure for
+      // any of them. The error below therefore asserts nothing beyond "the statement threw".
+      mockQueryFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("SYS.DATABASE_FILES")) {
+          throw new Error("Timeout: Request failed to complete in 15000ms");
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      // Absent, so StorageTab.tsx's `sizeKnown` is false and the tab says "No storage
+      // size information available" instead of drawing a breakdown over a database it
+      // never measured, against per-table bytes that a separate read did answer for.
+      expect("databaseSizeBytes" in overview).toBe(false);
+      // The formatted string travels with the figure, as it does in the merged libSQL
+      // (#569) and search (#517) shapes: "0 bytes" beside an absent byte count would
+      // print a confident zero as the headline size on that same tab.
+      expect(overview.databaseSize).toBe("N/A");
+      // Only the refused statement goes absent; every other reading survives.
+      expect(overview.activeConnections).toBe(5);
+      expect(overview.tableCount).toBe(5);
+    });
+
+    test("a database that measures zero bytes keeps its measured zero size", async () => {
+      // The anti-vacuity twin of the test above: absence must never be spelled with a
+      // falsy test. `SUM(CAST(size AS BIGINT))` returns NULL when the aggregate has no
+      // row to sum, and `Number(... || 0)` reads that as 0 - a measurement, not a
+      // refusal - so the key stays present and the Storage tab formats the zero it was
+      // given rather than claiming it knows nothing.
+      mockQueryFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("SYS.DATABASE_FILES")) {
+          return { recordset: [{ size_bytes: null }], rowsAffected: [1] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(true);
+      expect(overview.databaseSizeBytes).toBe(0);
+      expect(overview.databaseSize).toBe("0 B");
+    });
+
     test("Azure SQL detection from hostname", () => {
       const azureProvider = new MSSQLProvider({
         ...baseConfig,

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -1884,7 +1884,14 @@ describe("OracleProvider", () => {
       // are the same fact for the ceiling and different facts for the count.
       expect("activeConnections" in overview).toBe(false);
       expect(overview.maxConnections).toBe(0);
-      expect(overview.databaseSizeBytes).toBe(0);
+      // Same correction, one field over. This read `toBe(0)` until #565 and pinned the
+      // fabrication too: `DatabaseOverview.databaseSizeBytes` is optional for the same
+      // reason the count above is, and `USER_SEGMENTS` refusing tells us nothing about
+      // the schema's size. The string travels with it, as in the merged libSQL (#569)
+      // and search (#517) shapes - "N/A" beside an absent figure, never "0 bytes"
+      // beside "No storage size information available."
+      expect("databaseSizeBytes" in overview).toBe(false);
+      expect(overview.databaseSize).toBe("N/A");
       expect(overview.tableCount).toBe(0);
       expect(overview.indexCount).toBe(0);
     });
@@ -1953,6 +1960,33 @@ describe("OracleProvider", () => {
 
       expect(overview.activeConnections).toBe(8);
       expect(overview.maxConnections).toBe(0);
+    });
+
+    test("a schema that owns no segment keeps its measured zero size", async () => {
+      // The anti-vacuity twin of the absence pinned above, and why the guard is spelled
+      // `=== undefined` rather than a falsy test. `SUM(BYTES) FROM USER_SEGMENTS` over a
+      // schema that owns no segment is not a refusal: Oracle answers one row whose
+      // aggregate is NULL, and `Number(... || 0)` reads that as the measured 0 it is - a
+      // schema that really does hold nothing. A falsy test would erase exactly this
+      // reading, and StorageTab.tsx would say "No storage size information available"
+      // about a schema Oracle had just measured.
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_SEGMENTS") && upper.includes("SUM(BYTES)")) {
+          return { rows: [{ TOTAL: null }], metaData: [{ name: "TOTAL" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(true);
+      expect(overview.databaseSizeBytes).toBe(0);
+      expect(overview.databaseSize).toBe("0 B");
+      // Only the size reading is at stake; every other read still answers.
+      expect(overview.activeConnections).toBe(8);
+      expect(overview.tableCount).toBe(10);
     });
   });
 


### PR DESCRIPTION
## Description

`getOverview()` in both providers initialised `databaseSizeBytes` to `0` beside a `databaseSize` of `"0 bytes"`, ran the size statement inside a `try` whose `catch` was empty, and returned the field unconditionally — so a statement that never answered published a measured-looking zero. `DatabaseOverview.databaseSizeBytes` is optional precisely so that cannot happen (`src/lib/db/types.ts`: *"absence and zero are different facts"*), and both files already get this right for `activeConnections`, spread conditionally **two lines above** the defect in the same return.

What the fabrication bought on screen: `StorageTab.tsx` keys its whole breakdown off `databaseSizeBytes !== undefined`, so the `0` drew that breakdown instead of *"No storage size information available."* — and drew it against per-table bytes from `getTableStats()`, a separate read that does not share the size statement's failure. Every share is gated on `totalSize > 0`, so all three bars stayed empty and `0 - tables - indexes` went negative, which the remainder row refuses as `N/A`. The tab presented, as a measurement, a breakdown whose every element either disagreed with the total or declined to answer.

@cevheri — I took your correction from the issue: the `databaseSize` string moves with the bytes. It is now initialised to `"N/A"` rather than `"0 bytes"`, which is the pairing merged in #569 (libSQL) and #517 (the search provider), and what `getHealth()` in both of these same files already does.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Related Issue

Closes #565

## Changes Made

- **`src/lib/db/providers/sql/mssql.ts`, `src/lib/db/providers/sql/oracle.ts`** — `let databaseSizeBytes: number | undefined` and `...(databaseSizeBytes === undefined ? {} : { databaseSizeBytes })` in the return, mirroring the `activeConnections` line above it; `let databaseSize = "N/A"`.
- **A measured `0` still reports `0`.** The `Number(... || 0)` fold *inside* the `try` is deliberately unchanged, and `measuredNumber` is deliberately **not** used here: an Oracle `SUM(BYTES)` over a schema that owns no segment answers `NULL`, and that is a measurement, not an unknown. Only the `catch` path leaves the field absent. Both arms are pinned by tests.
- **`tests/integration/db/oracle-provider.test.ts`** — "degrades to defaults when every statistics query fails" asserted `expect(overview.databaseSizeBytes).toBe(0)`, i.e. the suite pinned the fabrication; it now asserts the key is absent and the string is `"N/A"`. New case: "a schema that owns no segment keeps its measured zero size".
- **`tests/integration/db/mssql-provider.test.ts`** — the mirror pair, next to the existing `activeConnections` pair.
- **`docs/providers/mssql.md`, `docs/providers/oracle.md`** — a new **7.3 When the database size is not measurable** beside 7.1 and 7.2, plus the `getOverview()` row in the §8 table. Provider triad moves together.

### Two things I deliberately did not do

- **`maxConnections` is untouched.** Its docblock says `0` there *means* "no limit published", so `0` and absence are the same fact for the ceiling and different facts for the size.
- **Neither 7.3 section names a cause for the failure**, and both say so explicitly. `sys.database_files` is database-scoped and `USER_SEGMENTS` describes the caller's own objects, so neither is gated by the server-level / `V_$` grants that §7.1 and §7.2 measured refusals against — and I have **not** measured a failure of either statement on a live instance. That is the argument for the guard rather than a gap in it: a request timeout, a pool fault mid-overview and a missing view all reach the same `catch` in the same shape, so it must not publish a figure for any of them.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass — with one environment caveat, below

I wrote the failing tests first. Before the fix:

```
$ bun test tests/integration/db/mssql-provider.test.ts tests/integration/db/oracle-provider.test.ts
      expect("databaseSizeBytes" in overview).toBe(false);
                                             ^
error: expect(received).toBe(expected)
Expected: false
Received: true
(fail) MSSQLProvider > getOverview() > a refused size read leaves overview databaseSizeBytes absent, never a measured 0
(fail) OracleProvider > getOverview() > degrades to defaults when every statistics query fails

 255 pass
 2 fail
Ran 257 tests across 2 files.
```

After the fix:

```
$ bun test tests/integration/db/mssql-provider.test.ts tests/integration/db/oracle-provider.test.ts
 257 pass
 0 fail
 663 expect() calls
Ran 257 tests across 2 files. [503.00ms]
```

The whole provider suite, run on this branch and on `main` for comparison. Same three pre-existing failures either way — all of them in `duckdb-provider.test.ts`, where the native addon does not open on my machine (`openDuckDBClient` at `src/lib/db/providers/sql/duckdb/client.ts:180`) — and my three new tests are the only difference:

```
$ bun test tests/integration/db            # this branch
 1519 pass
 3 fail
Ran 1522 tests across 17 files. [4.95s]

$ git stash && bun test tests/integration/db      # main, unmodified
 1516 pass
 3 fail
Ran 1519 tests across 17 files. [4.67s]
```

`tests/api` gives `423 pass / 6 fail` on both, and the two logs are byte-identical apart from timestamps — so the failure set is provably unchanged. The consumer components are green:

```
$ bun test tests/components/monitoring/StorageTab.test.tsx \
           tests/components/monitoring/OverviewTab.test.tsx \
           tests/components/admin/OverviewTab.test.tsx
 73 pass
 0 fail
Ran 73 tests across 3 files. [13.76s]
```

Coverage of the two changed files, measured from their own suites (lcov, `DA:` lines):

```
src/lib/db/providers/sql/mssql.ts    DA lines: 642   uncovered: 0
src/lib/db/providers/sql/oracle.ts   DA lines: 745   uncovered: 0
```

The rest of the local gate:

```
$ bun run format      # Checked 984 files in 811ms. No fixes applied.
$ bun run lint        # 0 errors, 132 warnings — 371 warning lines, byte-identical to main
$ bun run typecheck   # tsc --noEmit, clean
$ bun run knip        # clean (2 pre-existing config hints)
$ bun run readme:check              # OK: 16 engines and the install commands match
$ bun run chart:check               # OK: chart 0.1.58 / appVersion 0.13.7 in sync
$ bun run channels:showcase:check   # up to date
$ bun run security:check            # OK: 18 controls documented, 19 security tests accounted for
$ bun run build                     # exit 0
```

**The caveat, stated plainly:** I could not get a clean full `bun run test` on this machine (Windows), and I am not going to claim one. `helm`, `zip` and `bash` are not on my `PATH`, so the Helm chart, packaging and shell-script suites error out before they assert anything — the same `Executable not found in $PATH: "helm"` that #569's author reported — and running `tests/unit` as one process reproduces the `mock.module()` cross-contamination `CLAUDE.md` warns about (`tests/unit/db/factory.test.ts` then hangs in `pool-manager.test.ts`; that file passes 53/53 in isolation). None of those files import `mssql.ts` or `oracle.ts`. What I did run is above, including the A/B against unmodified `main`, so CI is the authority on the full gate and the 100% coverage merge.

### Test Environment
- **LibreDB Studio Version**: 0.13.7 (`main` @ `a59fb8b`)
- **Browser**: n/a — provider-level change, verified through the mock-based provider suites
- **OS**: Windows 11
- **Node.js/Bun Version**: Bun 1.3.5, Node 24.11.0
- **Database Type**: MSSQL and Oracle (mock-based; no server required)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Scope is MSSQL and Oracle only, per the issue — SQLite and LibreDB are #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
