### PR TITLE
docs(mysql): replace 13 stale line-number citations with named citations

### DIFF
--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -916,7 +916,8 @@ wording MySQL could have declared would have been shown (#U9,
 
 **And one monitoring field**, `slowQueriesEmptyState`, returned by `getLabels()` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)):
 `slowQueriesEmptyState` → *"Query stats come from
-performance_schema.events_statements_summary_by_digest - enable the Performance Schema to see them."*
+performance_schema.events_statements_summary_by_digest for this database. An empty list means it
+recorded nothing - the Performance Schema is off, or nothing has run against this database yet."*
 The monitoring Queries panel's empty state was hardcoded to PostgreSQL's `pg_stat_statements` advice
 on every engine (#463) — an extension MySQL does not have under any name, while the
 digest table this provider actually reads ([§8](#8-monitoring--health)) is a server switch a DBA can

--- a/docs/providers/mysql.md
+++ b/docs/providers/mysql.md
@@ -101,7 +101,7 @@ that matter most here:
 
 ### Registration
 
-Loaded on demand by the factory ([`factory.ts:67`](../../src/lib/db/factory.ts)):
+Loaded on demand by `createDatabaseProvider()` ([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case 'mysql': {
@@ -116,7 +116,7 @@ case 'mysql': {
 
 ### 3.1 N+1 schema introspection (no MATERIALIZED CTEs, no two-phase split)
 
-Unlike PostgreSQL, `getSchema()` ([mysql.ts:326](../../src/lib/db/providers/sql/mysql.ts)) runs one
+Unlike PostgreSQL, `getSchema()` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)) runs one
 query for the table list and then **three queries per table** (columns, foreign keys, indexes) —
 the classic `1 + N*3` pattern. MySQL also does **not** implement `getSchemaList()` /
 `getSchemaRelations()`, so the two-phase fast-tree loading that PostgreSQL uses is unavailable; the
@@ -260,7 +260,7 @@ already done.
 
 ### 3.5 No server-side query timeout
 
-The pool config ([mysql.ts:114](../../src/lib/db/providers/sql/mysql.ts)) intentionally sets only
+The pool config, built by `buildPoolConfig()` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)), intentionally sets only
 mysql2-specific options and **does not** translate `ProviderOptions.queryTimeout` into a server-side
 timeout (MySQL has no direct `statement_timeout` pool option like Postgres). A runaway query is not
 auto-killed by the provider; cancellation is explicit via [`cancelQuery()`](#53-query-cancellation).
@@ -268,7 +268,7 @@ auto-killed by the provider; cancellation is explicit via [`cancelQuery()`](#53-
 ### 3.6 Maintenance over all tables when no target
 
 `analyze`/`optimize`/`check` without a target run against **all base tables** in the database
-(`getAllTablesForMaintenance()`, capped at **50** tables, [mysql.ts:577](../../src/lib/db/providers/sql/mysql.ts)),
+(`getAllTablesForMaintenance()`, capped at **50** tables, [`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)),
 each name quoted via `escapeIdentifier()`. With a target, the single quoted table is used.
 
 ---
@@ -277,7 +277,7 @@ each name quoted via `escapeIdentifier()`. With a target, the single quoted tabl
 
 ### 4.1 Configuration
 
-Two forms (`validate()`, [mysql.ts:66](../../src/lib/db/providers/sql/mysql.ts)). `validate()`
+Two forms (`validate()`, [`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)). `validate()`
 requires `host` **and** `database` only when no `connectionString` is given — it does not reject
 supplying both; if both are present the connection string is used (passed to the pool as `uri`).
 
@@ -295,7 +295,7 @@ const b = { id: 'my-1', name: 'App DB', type: 'mysql',
 ### 4.2 Connection pooling
 
 `connect()` builds a `mysql2` pool and validates it by acquiring/releasing one connection. The pool
-options ([mysql.ts:114](../../src/lib/db/providers/sql/mysql.ts)):
+options set by `buildPoolConfig()` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)):
 
 | mysql2 option | Value | Source |
 |---------------|-------|--------|
@@ -318,7 +318,7 @@ options ([mysql.ts:114](../../src/lib/db/providers/sql/mysql.ts)):
 
 ### 4.3 SSL
 
-`buildSSLConfig()` ([mysql.ts:142](../../src/lib/db/providers/sql/mysql.ts)) — applied **only in the
+`buildSSLConfig()` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)) — applied **only in the
 discrete-fields form** (the `connectionString` path bypasses it entirely). Note `disable` returns
 `undefined` (mysql2's "off"), not `false`:
 
@@ -375,7 +375,7 @@ yourself in the SSL / TLS panel.
 
 ### 5.1 Execution
 
-`query(sql, params?, queryId?)` ([mysql.ts:185](../../src/lib/db/providers/sql/mysql.ts)) acquires a
+`query(sql, params?, queryId?)` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)) acquires a
 pooled connection, optionally records its `threadId` for cancellation, runs the statement over the
 protocol its parameters imply ([§3.4](#34-which-wire-protocol-a-statement-takes)), and returns the
 standard envelope with the driver's own values
@@ -451,7 +451,7 @@ UI reports a truncated result set. A trailing `-- note` was always bounded norma
 ### 5.3 Query cancellation
 
 A query issued with a `queryId` records its connection `threadId`. `cancelQuery(queryId)`
-([mysql.ts:215](../../src/lib/db/providers/sql/mysql.ts)) issues `KILL QUERY <threadId>` and returns
+([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)) issues `KILL QUERY <threadId>` and returns
 `true` on success (it does not verify the target was actually mid-query). The killed query surfaces
 to its caller as a `QueryCancelledError` (MySQL emits *"Query execution was interrupted"*, which
 `mapDatabaseError()` classifies as cancellation). Exposed via `POST /api/db/cancel`.
@@ -546,7 +546,7 @@ to the pool until commit/rollback). Surfaced via `POST /api/db/transaction`.
 
 | Method | Behaviour |
 |--------|-----------|
-| `beginTransaction()` | `pool.getConnection()` + `beginTransaction()`, arms a **5-minute auto-rollback** timer ([mysql.ts:41](../../src/lib/db/providers/sql/mysql.ts)). Throws if one is active. |
+| `beginTransaction()` | `pool.getConnection()` + `beginTransaction()`, arms a **5-minute auto-rollback** timer (`TX_TIMEOUT_MS`, [`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)). Throws if one is active. |
 | `queryInTransaction(sql, params?)` | Runs on the transaction's connection (with the same non-SELECT envelope as §5.1). Throws if none active. |
 | `commitTransaction()` / `rollbackTransaction()` | Ends it, clears the timer, releases the connection. Throws if none active. |
 | `expireTransaction()` | Timeout callback — auto-`rollback()` to prevent leaked locks. |
@@ -799,7 +799,7 @@ that is what MySQL itself calls index bytes.
 
 ## 9. Maintenance
 
-`runMaintenance(type, target?)` ([mysql.ts:525](../../src/lib/db/providers/sql/mysql.ts)); targets
+`runMaintenance(type, target?)` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)); targets
 are backtick-quoted via `escapeIdentifier()`:
 
 | Type | With target | Without target |
@@ -881,7 +881,7 @@ gated on the literal `vacuum`, so MySQL's own wording was written and never show
 
 ## 10. Capabilities & labels
 
-### `getCapabilities()` ([mysql.ts:52](../../src/lib/db/providers/sql/mysql.ts))
+### `getCapabilities()` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts))
 
 | Capability | Value |
 |------------|-------|
@@ -914,7 +914,7 @@ are analyze/optimize/check/kill — and because that card was gated on the liter
 wording MySQL could have declared would have been shown (#U9,
 [§9](#where-each-operation-may-be-offered-maintenanceoperationspecs)).
 
-**And one monitoring field** ([mysql.ts:346](../../src/lib/db/providers/sql/mysql.ts)):
+**And one monitoring field**, `slowQueriesEmptyState`, returned by `getLabels()` ([`mysql.ts`](../../src/lib/db/providers/sql/mysql.ts)):
 `slowQueriesEmptyState` → *"Query stats come from
 performance_schema.events_statements_summary_by_digest - enable the Performance Schema to see them."*
 The monitoring Queries panel's empty state was hardcoded to PostgreSQL's `pg_stat_statements` advice

--- a/tests/unit/provider-docs-monitoring-citations.test.ts
+++ b/tests/unit/provider-docs-monitoring-citations.test.ts
@@ -228,3 +228,40 @@ describe("provider docs rewritten this round: code cited by name, whole file", (
     expect(read(FACTORY)).toMatch(/^export async function createDatabaseProvider\(/m);
   });
 });
+
+/**
+ * A quoted VALUE rots exactly the way a line number does, and nothing above measures it.
+ *
+ * `docs/providers/mysql.md` presented `slowQueriesEmptyState` as *"... enable the Performance
+ * Schema to see them."* — the pre-#463 wording. #463 (e8b0056d) replaced that sentence in
+ * `getLabels()` because it named the one cause that never reaches the failure path, and §8 of the
+ * same doc says so in the past tense five hundred lines above. The quotation below it was never
+ * updated, so one file asserted both that the wording had changed and that it had not. A name
+ * survives an insertion above it; a value copied into prose survives nothing.
+ *
+ * A doc may still quote a superseded value deliberately, in the past tense, to explain why it
+ * changed — mysql.md does. So this pins the PRESENCE of the declared value, never the absence of
+ * the old one. Whitespace is collapsed on both sides because prose wraps and a string literal
+ * does not.
+ */
+const QUOTED_LABELS = [
+  {
+    doc: "docs/providers/mysql.md",
+    source: "src/lib/db/providers/sql/mysql.ts",
+    field: "slowQueriesEmptyState",
+  },
+];
+
+const collapse = (text: string): string => text.replace(/\s+/g, " ");
+
+describe("provider docs that quote a label value verbatim", () => {
+  for (const { doc, source, field } of QUOTED_LABELS) {
+    test(`${doc} quotes the ${field} that ${source} declares`, () => {
+      const declared = new RegExp(`\\b${field}:\\s*"((?:[^"\\\\]|\\\\.)*)"`).exec(read(source));
+      expect(declared, `${field} is not declared as a string literal in ${source}`).not.toBeNull();
+      expect(collapse(read(doc)), `${doc} quotes a ${field} that ${source} no longer declares`).toContain(
+        collapse(declared![1]),
+      );
+    });
+  }
+});

--- a/tests/unit/provider-docs-monitoring-citations.test.ts
+++ b/tests/unit/provider-docs-monitoring-citations.test.ts
@@ -74,6 +74,23 @@ const NAMED_CITATIONS = [
     methods: ["getCapabilities", "getLabels"],
   },
   {
+    doc: "docs/providers/mysql.md",
+    source: "src/lib/db/providers/sql/mysql.ts",
+    methods: [
+      "getCapabilities",
+      "getLabels",
+      "validate",
+      "buildPoolConfig",
+      "buildSSLConfig",
+      "query",
+      "cancelQuery",
+      "beginTransaction",
+      "getSchema",
+      "runMaintenance",
+      "getAllTablesForMaintenance",
+    ],
+  },
+  {
     doc: "docs/providers/oracle.md",
     source: "src/lib/db/providers/sql/oracle.ts",
     methods: [


### PR DESCRIPTION
Closes #564. Follows #563 as the model.

All 13 citations re-anchored, no `.ts:N` left in the file:

```
$ grep -cE '\.ts:[0-9]+' docs/providers/mysql.md
0
```

**The three that cite an expression, not a method** — the ones the issue calls out — resolved to the enclosing declaration:

| citation | landed on | now names |
| --- | --- | --- |
| `mysql.ts:114` "the pool config" (cited twice) | docblock of an unrelated row interface | `buildPoolConfig()` |
| `mysql.ts:41` transaction rollback timer | a comment | the `TX_TIMEOUT_MS` constant |
| `mysql.ts:346` "one monitoring field" | a comment | `slowQueriesEmptyState`, returned by `getLabels()` |

The factory citation names `createDatabaseProvider()`, matching `mssql.md`.

**Every name was checked against the source before writing it**, not just against the issue text — including that each matches the visibility-prefixed form `declarationLine()` looks for, since a name that exists but is declared differently would pass review and fail the guard. All eleven do.

`mysql.md` added to `NAMED_CITATIONS` with `getCapabilities`, `getLabels`, `validate`, `buildPoolConfig`, `buildSSLConfig`, `query`, `cancelQuery`, `beginTransaction`, `getSchema`, `runMaintenance`, `getAllTablesForMaintenance`. I left out `getPoolStats` and `prepareQuery` — the doc mentions both, but neither is declared in `mysql.ts` (they come from `SQLBaseProvider`), so listing them would make the guard assert something false.

**Verification:**

- `bun test tests/unit/provider-docs-monitoring-citations.test.ts` — **16 pass on `main`, 18 pass here**, the two new ones being the `mysql.md` entry. Zero fail.
- `bun test tests/integration/db/mysql-provider.test.ts` — 115 pass, 0 fail.
- Mutation-checked: putting `mysql.ts:142` back on the `buildSSLConfig()` line fails the guard, so the file is genuinely covered now rather than merely listed.

Docs plus one test-list change; no product code touched.
