### PR TITLE
docs: name the people who cleared the bar, without counting anything

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,33 @@ The repository keeps the `hacktoberfest` topic for discoverability. Note that Ha
 itself is organised around in-person and online events and no longer counts pull requests; the
 labels above are how this repository welcomes contributors in any month.
 
+### The contributor ladder
+
+Every change here lands with its tests in the same pull request, under a hard 100% line-coverage
+gate and six required checks. Clearing that bar says something about you, so we write down who
+cleared it and what it earns. Three rungs, and nothing on them is decorative.
+
+- **Contributor** — one merged pull request. You are listed in
+  [`CONTRIBUTORS.md`](CONTRIBUTORS.md) with a link to the change you made, so the entry is evidence
+  rather than a thank-you. Use it wherever you need to show what you have shipped.
+- **Trusted contributor** — three merged pull requests. You may assign yourself any open labeled
+  issue without asking first, and your review on someone else's pull request is read as a review
+  rather than a comment. Nothing to apply for; the third merge does it.
+- **Area owner** — you own one area: a database provider, or a subsystem such as the Helm chart or
+  the SQL editor. For a provider that means the triad the repository is built on — the code under
+  `src/lib/db/providers/`, the doc under `docs/providers/` and the tests under
+  `tests/integration/db/` move together, and a change to your area is reviewed with you. This rung
+  is offered by the maintainers, not applied for, and it is offered to people who have already been
+  answering questions about that area.
+
+Falling off a rung is not a thing. If you stop contributing, you keep what you earned.
+
+**Maintainers:** adding the contributor to `CONTRIBUTORS.md` is part of merging an external pull
+request, not a later sweep. `tests/unit/contributors-doc.test.ts` checks the page's shape and the
+ladder's two halves against each other, but it deliberately does not check that the list is
+complete — completeness cannot be measured in a shallow CI clone, so it stays a human step that is
+honest about being one.
+
 ## Development Setup
 
 ### Prerequisites

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,15 @@ maintainers and written down where you can read them and disagree.
   `src/lib/db/providers/`, the doc under `docs/providers/` and the tests under
   `tests/integration/db/` move together, and a change to your area is reviewed with you. Offered by
   the maintainers, and offered to people who have already been answering questions about that area.
+- **Maintainer** — carries the project: the releases, the review, and the decisions nobody else can
+  make. Not a rung you climb to from the ones above it, which is why it is listed separately rather
+  than at the top of the same ladder.
+
+Maintainers are on [`CONTRIBUTORS.md`](CONTRIBUTORS.md) alongside everyone else. Keeping their work
+off the page would make it read as a guest list rather than a record, and the standard the page holds
+people to is one they are held to as well. Bots and coding agents are not listed: `dependabot`,
+`Copilot` and `claude` all appear in the commit history, none of them is a person, and putting them
+beside people would blur the only thing the page is for.
 
 Falling off a rung is not a thing. If you stop contributing, you keep what you earned.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,20 +91,27 @@ labels above are how this repository welcomes contributors in any month.
 
 Every change here lands with its tests in the same pull request, under a hard 100% line-coverage
 gate and six required checks. Clearing that bar says something about you, so we write down who
-cleared it and what it earns. Three rungs, and nothing on them is decorative.
+cleared it and what it earns.
 
-- **Contributor** — one merged pull request. You are listed in
-  [`CONTRIBUTORS.md`](CONTRIBUTORS.md) with a link to the change you made, so the entry is evidence
-  rather than a thank-you. Use it wherever you need to show what you have shipped.
-- **Trusted contributor** — three merged pull requests. You may assign yourself any open labeled
-  issue without asking first, and your review on someone else's pull request is read as a review
-  rather than a comment. Nothing to apply for; the third merge does it.
+**There is no threshold on this page, and that is deliberate.** We do not count merged pull
+requests, changed lines, closed issues or anything else. A count measures how often somebody showed
+up; it cannot see the care they took, the bug nobody else found, or the question they answered for
+a stranger at midnight. Five small changes and one careful one are not the same thing in either
+direction, and a number cannot tell you which is which. So these rungs are judgements, made by the
+maintainers and written down where you can read them and disagree.
+
+- **Contributor** — you landed a change. You are listed in [`CONTRIBUTORS.md`](CONTRIBUTORS.md) with
+  a link to it, so the entry is evidence rather than a thank-you. Use it wherever you need to show
+  what you have shipped.
+- **Trusted contributor** — someone we would hand an issue to without a conversation first. In
+  practice: assign yourself any open labeled issue without asking, and your review on someone else's
+  pull request is read as a review rather than a comment. Nothing to apply for and nothing to reach;
+  we put you here, and the reason is written beside your name.
 - **Area owner** — you own one area: a database provider, or a subsystem such as the Helm chart or
   the SQL editor. For a provider that means the triad the repository is built on — the code under
   `src/lib/db/providers/`, the doc under `docs/providers/` and the tests under
-  `tests/integration/db/` move together, and a change to your area is reviewed with you. This rung
-  is offered by the maintainers, not applied for, and it is offered to people who have already been
-  answering questions about that area.
+  `tests/integration/db/` move together, and a change to your area is reviewed with you. Offered by
+  the maintainers, and offered to people who have already been answering questions about that area.
 
 Falling off a rung is not a thing. If you stop contributing, you keep what you earned.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,13 +4,49 @@ Every change in this repository lands with its tests in the same pull request, u
 
 So this is not a thank-you wall. Each entry links to the change itself, so a reader who does not know us can check the claim. If your name is here, the link is yours to use — a CV, a profile README, anywhere the question "what have you actually shipped" comes up.
 
-How the rungs work is written down in [CONTRIBUTING.md](CONTRIBUTING.md#the-contributor-ladder). The short version: one merged pull request puts you on this page, three lets you take an issue without asking, and owning an area is offered rather than applied for.
+Nothing here is counted. Not merged pull requests, not changed lines, not closed issues. A count sees how often somebody showed up and misses everything that matters about it: the care taken, the bug nobody else found, the answer written out for a stranger. So the rungs below are judgements rather than totals, and where one is not obvious the reason is written beside the name — [CONTRIBUTING.md](CONTRIBUTING.md#the-contributor-ladder) says what each rung means.
 
-Listed in the order people first landed a change. Maintainers and bots are not listed here; `git shortlog -sn` is the full record.
+Within each rung, people are in the order they first landed a change. Bots are not listed, and the maintainers' own day-to-day work belongs in `git shortlog -sn` rather than on this page.
 
 ## Trusted contributor
 
+### @harish18092002
+
+The first person outside the core team to send anything at all, on 2025-12-25, when there was no contributing guide, no labeled issue and no reason to believe anyone would answer. Being first is a different act from being second.
+
+- [Improved the query preview in the Save Query modal](https://github.com/libredb/libredb-studio/commit/ff22a5dd4f5b5a3fcd0c01339820ffa6035ae51f)
+
+### @omerfarukbolat
+
+The light theme rests on the shared token layer he built, and the export path escapes every field because of the pass he did over it. Both were the kind of change that moves the floor under everything else rather than fixing one thing.
+
+- [Fixed the auth flow, middleware redirects and hooks cleanup](https://github.com/libredb/libredb-studio/pull/10)
+- [Enforced the ESLint and TypeScript checks in CI, and fixed the component bugs they found](https://github.com/libredb/libredb-studio/pull/18)
+- [Built a light theme through a shared token layer, and fixed four silent query-execution defects](https://github.com/libredb/libredb-studio/pull/384)
+- [Escaped every field an export writes, and stopped a plan outliving its run](https://github.com/libredb/libredb-studio/pull/422)
+
+### @suleymansurucu
+
+Came the same day as the first, hours behind it, into the same empty repository. Two people decided this was worth their evening before there was anything here to promise them it would be.
+
+- [Handled SQL queries in the demo connection, with a mock fallback](https://github.com/libredb/libredb-studio/commit/c6d3e10c5d5076f674af12f58d2244e0208e6c5b)
+
+### @ugurpektas
+
+Built out the admin section: the routes, the interactive UI around them, and the tests that hold it. He did it in one careful pass rather than leaving it half-finished for someone else.
+
+- [Added the admin section routes and polished the interactive UI](https://github.com/libredb/libredb-studio/pull/231)
+
+### @koraysrn
+
+First into the agent layer, which nobody outside the core team had opened, and he has stayed in it since. Both of his changes are about a run behaving correctly when something goes wrong, which is the part nobody volunteers for.
+
+- [Enforced single-drive ownership in the agent, and refused post-close appends](https://github.com/libredb/libredb-studio/pull/419)
+- [Aggregated the PostgreSQL grounding column read per table](https://github.com/libredb/libredb-studio/pull/537)
+
 ### @hasnaintypes
+
+Went wherever the work was: the login page, the admin fleet view, a license notice nobody had stated, and the provider docs whose citations had quietly rotted. Each one arrived finished, with the reasoning written down.
 
 - [Closed the login hero's overflow at 1280x800](https://github.com/libredb/libredb-studio/pull/550)
 - [Stated elkjs's EPL-2.0 license alongside the MIT license](https://github.com/libredb/libredb-studio/pull/552)
@@ -28,10 +64,6 @@ Listed in the order people first landed a change. Maintainers and bots are not l
 
 - [Made Oracle Thick mode optional and mapped NJS-138 to an honest error](https://github.com/libredb/libredb-studio/pull/229)
 
-### @ugurpektas
-
-- [Added the admin section routes and polished the interactive UI](https://github.com/libredb/libredb-studio/pull/231)
-
 ### @yangchuansheng
 
 - [Added the Sealos deployment option](https://github.com/libredb/libredb-studio/pull/296)
@@ -43,11 +75,6 @@ Listed in the order people first landed a change. Maintainers and bots are not l
 ### @wjiec
 
 - [Used OIDC discovery for generic logout URLs](https://github.com/libredb/libredb-studio/pull/431)
-
-### @koraysrn
-
-- [Enforced single-drive ownership in the agent, and refused post-close appends](https://github.com/libredb/libredb-studio/pull/419)
-- [Aggregated the PostgreSQL grounding column read per table](https://github.com/libredb/libredb-studio/pull/537)
 
 ### @Matthew-Selvam
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,82 @@
+# Contributors
+
+Every change in this repository lands with its tests in the same pull request, under a hard 100% line-coverage gate and six required checks. That is an unusual bar for a project this size, and it means a merged pull request here is evidence about the person who wrote it, not only about the project.
+
+So this is not a thank-you wall. Each entry links to the change itself, so a reader who does not know us can check the claim. If your name is here, the link is yours to use — a CV, a profile README, anywhere the question "what have you actually shipped" comes up.
+
+How the rungs work is written down in [CONTRIBUTING.md](CONTRIBUTING.md#the-contributor-ladder). The short version: one merged pull request puts you on this page, three lets you take an issue without asking, and owning an area is offered rather than applied for.
+
+Listed in the order people first landed a change. Maintainers and bots are not listed here; `git shortlog -sn` is the full record.
+
+## Trusted contributor
+
+### @hasnaintypes
+
+- [Closed the login hero's overflow at 1280x800](https://github.com/libredb/libredb-studio/pull/550)
+- [Stated elkjs's EPL-2.0 license alongside the MIT license](https://github.com/libredb/libredb-studio/pull/552)
+- [Summed the fleet's own byte figure instead of re-parsing display strings](https://github.com/libredb/libredb-studio/pull/551)
+- [Replaced the stale line-number citations in `oracle.md` with named citations](https://github.com/libredb/libredb-studio/pull/563)
+- [Did the same for `mongodb.md`](https://github.com/libredb/libredb-studio/pull/581)
+
+## Contributor
+
+### @ucmazmehmet
+
+- [Updated the Windows native support documentation](https://github.com/libredb/libredb-studio/pull/209)
+
+### @sifaaraldevop
+
+- [Made Oracle Thick mode optional and mapped NJS-138 to an honest error](https://github.com/libredb/libredb-studio/pull/229)
+
+### @ugurpektas
+
+- [Added the admin section routes and polished the interactive UI](https://github.com/libredb/libredb-studio/pull/231)
+
+### @yangchuansheng
+
+- [Added the Sealos deployment option](https://github.com/libredb/libredb-studio/pull/296)
+
+### @ducminhle
+
+- [Added an HTTPRoute to the Helm chart](https://github.com/libredb/libredb-studio/pull/362)
+
+### @wjiec
+
+- [Used OIDC discovery for generic logout URLs](https://github.com/libredb/libredb-studio/pull/431)
+
+### @koraysrn
+
+- [Enforced single-drive ownership in the agent, and refused post-close appends](https://github.com/libredb/libredb-studio/pull/419)
+- [Aggregated the PostgreSQL grounding column read per table](https://github.com/libredb/libredb-studio/pull/537)
+
+### @Matthew-Selvam
+
+- [Capped chart series and pie slices at the palette size instead of repeating colours](https://github.com/libredb/libredb-studio/pull/501)
+- [Stopped schema-diff wrapping non-transactional dialects in `BEGIN;`/`COMMIT;`](https://github.com/libredb/libredb-studio/pull/521)
+
+### @mfatihdayan
+
+- [Updated the provider tri-sync rule to the shipped provider set](https://github.com/libredb/libredb-studio/pull/504)
+
+### @HasselNot7
+
+- [Normalized all text files to LF on checkout](https://github.com/libredb/libredb-studio/pull/555)
+- [Matched the `.gitattributes` rules as whole lines in the drift guard](https://github.com/libredb/libredb-studio/pull/562)
+
+### @v01dst
+
+- [Used `@theme inline` so the Geist font variables resolve](https://github.com/libredb/libredb-studio/pull/561)
+
+### @Akimbo92i
+
+- [Made libSQL omit an unknown overview size rather than reporting zero](https://github.com/libredb/libredb-studio/pull/569)
+
+### @cnYui
+
+- [Made MSSQL and Oracle do the same](https://github.com/libredb/libredb-studio/pull/579)
+
+## Getting on this page
+
+Take an issue labelled [good first issue](https://github.com/libredb/libredb-studio/labels/good%20first%20issue) — each one states what "done" looks like as a command you can run yourself, so you never have to ask whether you are finished. [CONTRIBUTING.md](CONTRIBUTING.md) has the setup and the gates.
+
+Reports count too. If you opened an issue that led to a fix, say so on the pull request that fixed it and we will list the report beside the change.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,26 +12,25 @@ Within each rung, people are in the order they first landed a change.
 
 ## Maintainer
 
-The people who carry the project: the releases, the review, and the decisions nobody else can make.
+The people who carry the project: the releases, the review, and the decisions nobody else can make. Their work is most of the history and is not itemised here; the links are a sample.
 
 ### @cevheri
 
-Wrote the thing. The engine set, the agent, the storage layer and the release machinery are his, and so is the standard the rest of this page is measured against.
+Organisation member. Wrote most of what is here.
 
-- [Brought libSQL in over the Hrana protocol, one type-id for sqld and Turso Cloud](https://github.com/libredb/libredb-studio/pull/511)
-- [Added DuckDB as an embedded file engine, with the boundary the engine itself enforces](https://github.com/libredb/libredb-studio/pull/516)
-- [Found that Oracle Thick mode had never once loaded in a built image](https://github.com/libredb/libredb-studio/pull/575)
+- [Brought libSQL in over the Hrana protocol](https://github.com/libredb/libredb-studio/pull/511)
+- [Added DuckDB as an embedded file engine](https://github.com/libredb/libredb-studio/pull/516)
 
 ### @yusuf-gundogdu
 
-Owns the question "which local model can actually drive an agent run", and answers it by running them rather than by reading their cards. Also keeps the distribution inventory honest about what is live.
+Organisation member. The agent model record, and the distribution inventory.
 
 - [Ran ten models across every agent surface, 300 for 300](https://github.com/libredb/libredb-studio/pull/465)
 - [Found two cloud marketplaces the inventory did not know about](https://github.com/libredb/libredb-studio/pull/577)
 
 ### @kaya-abdullah
 
-Lives where the wire-compatible engines disagree with the engine they claim to be, which is the least glamorous and most easily faked part of this product. The first localized READMEs are his too.
+Organisation member. The wire-compatible engines, and the first localized READMEs.
 
 - [Caught Trino handing back every bigint past 2^53 rounded](https://github.com/libredb/libredb-studio/pull/460)
 - [Added the Simplified Chinese and Japanese READMEs](https://github.com/libredb/libredb-studio/pull/317)
@@ -59,6 +58,13 @@ Came the same day as the first, hours behind it, into the same empty repository.
 
 - [Handled SQL queries in the demo connection, with a mock fallback](https://github.com/libredb/libredb-studio/commit/c6d3e10c5d5076f674af12f58d2244e0208e6c5b)
 
+### @hbasria
+
+Brought a fifth identity provider into the OIDC layer, and the branch he added is still what runs — `src/lib/oidc.ts` handles Zitadel's RP-initiated logout because of him. He arrived with the doc and the test in the same change, months before this repository wrote that down as a rule.
+
+- [Added Zitadel OIDC integration support](https://github.com/libredb/libredb-studio/commit/d8227cbc)
+- [Covered `OIDC_ROLE_CLAIM` in the Zitadel logout URL test](https://github.com/libredb/libredb-studio/commit/09d36a4d)
+
 ### @ugurpektas
 
 Built out the admin section: the routes, the interactive UI around them, and the tests that hold it. He did it in one careful pass rather than leaving it half-finished for someone else.
@@ -83,11 +89,6 @@ Went wherever the work was: the login page, the admin fleet view, a license noti
 - [Did the same for `mongodb.md`](https://github.com/libredb/libredb-studio/pull/581)
 
 ## Contributor
-
-### @hbasria
-
-- [Added Zitadel OIDC integration support](https://github.com/libredb/libredb-studio/commit/d8227cbc)
-- [Covered `OIDC_ROLE_CLAIM` in the Zitadel logout URL test](https://github.com/libredb/libredb-studio/commit/09d36a4d)
 
 ### @ucmazmehmet
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,35 @@ So this is not a thank-you wall. Each entry links to the change itself, so a rea
 
 Nothing here is counted. Not merged pull requests, not changed lines, not closed issues. A count sees how often somebody showed up and misses everything that matters about it: the care taken, the bug nobody else found, the answer written out for a stranger. So the rungs below are judgements rather than totals, and where one is not obvious the reason is written beside the name — [CONTRIBUTING.md](CONTRIBUTING.md#the-contributor-ladder) says what each rung means.
 
-Within each rung, people are in the order they first landed a change. Bots are not listed, and the maintainers' own day-to-day work belongs in `git shortlog -sn` rather than on this page.
+Everyone whose work is in `main` is here, maintainers included. Bots and coding agents are not — `dependabot`, `Copilot` and `claude` all appear in the repository's commit history and none of them is a person, so listing them beside people would blur the only thing this page is for. `git shortlog -sn` shows the whole history including theirs.
+
+Within each rung, people are in the order they first landed a change.
+
+## Maintainer
+
+The people who carry the project: the releases, the review, and the decisions nobody else can make.
+
+### @cevheri
+
+Wrote the thing. The engine set, the agent, the storage layer and the release machinery are his, and so is the standard the rest of this page is measured against.
+
+- [Brought libSQL in over the Hrana protocol, one type-id for sqld and Turso Cloud](https://github.com/libredb/libredb-studio/pull/511)
+- [Added DuckDB as an embedded file engine, with the boundary the engine itself enforces](https://github.com/libredb/libredb-studio/pull/516)
+- [Found that Oracle Thick mode had never once loaded in a built image](https://github.com/libredb/libredb-studio/pull/575)
+
+### @yusuf-gundogdu
+
+Owns the question "which local model can actually drive an agent run", and answers it by running them rather than by reading their cards. Also keeps the distribution inventory honest about what is live.
+
+- [Ran ten models across every agent surface, 300 for 300](https://github.com/libredb/libredb-studio/pull/465)
+- [Found two cloud marketplaces the inventory did not know about](https://github.com/libredb/libredb-studio/pull/577)
+
+### @kaya-abdullah
+
+Lives where the wire-compatible engines disagree with the engine they claim to be, which is the least glamorous and most easily faked part of this product. The first localized READMEs are his too.
+
+- [Caught Trino handing back every bigint past 2^53 rounded](https://github.com/libredb/libredb-studio/pull/460)
+- [Added the Simplified Chinese and Japanese READMEs](https://github.com/libredb/libredb-studio/pull/317)
 
 ## Trusted contributor
 
@@ -55,6 +83,11 @@ Went wherever the work was: the login page, the admin fleet view, a license noti
 - [Did the same for `mongodb.md`](https://github.com/libredb/libredb-studio/pull/581)
 
 ## Contributor
+
+### @hbasria
+
+- [Added Zitadel OIDC integration support](https://github.com/libredb/libredb-studio/commit/d8227cbc)
+- [Covered `OIDC_ROLE_CLAIM` in the Zitadel logout URL test](https://github.com/libredb/libredb-studio/commit/09d36a4d)
 
 ### @ucmazmehmet
 

--- a/README.md
+++ b/README.md
@@ -981,9 +981,10 @@ We welcome contributions from the community! Whether it's a bug fix, a new featu
 5. Open a Pull Request.
 
 Every change here lands with its tests in the same pull request, under a hard 100% line-coverage
-gate. Clearing that bar is worth something, so the people who have are named — with a link to the
-change they made — in [`CONTRIBUTORS.md`](CONTRIBUTORS.md), and what each rung earns is written down
-in [`CONTRIBUTING.md`](CONTRIBUTING.md#the-contributor-ladder). Start with a
+gate. Clearing that bar is worth something, so the people who have are named in
+[`CONTRIBUTORS.md`](CONTRIBUTORS.md) with a link to the change they made. Nothing on that page is
+counted — no merge totals, no line counts — and
+[`CONTRIBUTING.md`](CONTRIBUTING.md#the-contributor-ladder) says why. Start with a
 [`good first issue`](https://github.com/libredb/libredb-studio/labels/good%20first%20issue): each one
 states what "done" looks like as a command you can run yourself.
 

--- a/README.md
+++ b/README.md
@@ -980,6 +980,13 @@ We welcome contributions from the community! Whether it's a bug fix, a new featu
 4. Push to the Branch (`git push origin feature/AmazingFeature`).
 5. Open a Pull Request.
 
+Every change here lands with its tests in the same pull request, under a hard 100% line-coverage
+gate. Clearing that bar is worth something, so the people who have are named — with a link to the
+change they made — in [`CONTRIBUTORS.md`](CONTRIBUTORS.md), and what each rung earns is written down
+in [`CONTRIBUTING.md`](CONTRIBUTING.md#the-contributor-ladder). Start with a
+[`good first issue`](https://github.com/libredb/libredb-studio/labels/good%20first%20issue): each one
+states what "done" looks like as a command you can run yourself.
+
 ---
 
 ## License

--- a/tests/unit/contributors-doc.test.ts
+++ b/tests/unit/contributors-doc.test.ts
@@ -4,14 +4,21 @@
  * The page exists because a merged pull request here is evidence about the person who wrote it:
  * every change lands with its tests in the same PR, under a 100% line-coverage gate. A page making
  * that claim is only worth reading if each entry points at the change it is claiming, so these
- * tests pin the two things a reader would otherwise have to take on trust:
+ * tests pin the three things a reader would otherwise have to take on trust:
  *
- *   1. every person listed carries at least one link to a real merged pull request, written as a
- *      full URL rather than a bare `#123` - the page is read outside GitHub too, where a bare
- *      number links to nothing;
+ *   1. every person listed carries at least one link to the change itself, written as a full URL
+ *      rather than a bare `#123` - the page is read outside GitHub too, where a bare number links
+ *      to nothing;
  *   2. the rungs `CONTRIBUTORS.md` groups people under are exactly the rungs `CONTRIBUTING.md`
  *      defines. A ladder whose two halves drift is worse than no ladder: someone is told they are
- *      a "Trusted contributor" by one file and the other has never heard of the rung.
+ *      a "Trusted contributor" by one file and the other has never heard of the rung;
+ *   3. no rung is described as a number of merges. The page's premise is that nothing here is
+ *      counted, and a threshold creeping back into the prose would contradict it in the one place
+ *      a reader looks to find out how they are being judged.
+ *
+ * The rungs themselves are deliberately NOT testable, because they are judgements. There is no
+ * assertion that a person belongs where they are put; that is the maintainers' call and the reason
+ * is written beside the name so a reader can disagree with it.
  *
  * Deliberately NOT asserted: that the list is complete. Completeness can only be measured against
  * the GitHub API or a full `git log`, and CI clones shallowly, so a test claiming to check it would
@@ -27,7 +34,19 @@ const read = (relative: string): string => readFileSync(path.join(ROOT, relative
 
 const CONTRIBUTORS = "CONTRIBUTORS.md";
 const CONTRIBUTING = "CONTRIBUTING.md";
-const PULL_URL = "https://github.com/libredb/libredb-studio/pull/";
+
+/**
+ * Evidence is a pull request OR a commit, and the second is not a fallback.
+ *
+ * The two earliest outside changes reached `main` by rebase rather than through the merge button,
+ * so GitHub records pull requests 8 and 12 as closed with `mergedAt: null` even though the code has
+ * been in the tree since 2025-12-25. Linking those would show a stranger a rejected pull request as
+ * proof of a contribution. The commit is the honest citation there.
+ */
+const EVIDENCE_URLS = [
+  "https://github.com/libredb/libredb-studio/pull/",
+  "https://github.com/libredb/libredb-studio/commit/",
+];
 
 /**
  * The `## <rung>` headings people are actually grouped under.
@@ -75,11 +94,17 @@ describe("CONTRIBUTORS.md", () => {
     expect(entries(contributors).length).toBeGreaterThan(0);
   });
 
-  test("every person links to at least one merged pull request by full URL", () => {
+  test("every person links to a pull request or a commit by full URL", () => {
     const withoutEvidence = entries(contributors)
-      .filter(({ body }) => !body.includes(PULL_URL))
+      .filter(({ body }) => !EVIDENCE_URLS.some((prefix) => body.includes(prefix)))
       .map(({ login }) => login);
     expect(withoutEvidence).toEqual([]);
+  });
+
+  test("no rung is described as a number of anything", () => {
+    // The page states that nothing here is counted. A threshold creeping back into the prose is the
+    // one drift that would contradict the page's own premise, and it would read as policy.
+    expect(contributors).not.toMatch(/\b(?:one|two|three|four|five|\d+)\s+merged\b/i);
   });
 
   test("no bare #123 reference stands in for a link", () => {

--- a/tests/unit/contributors-doc.test.ts
+++ b/tests/unit/contributors-doc.test.ts
@@ -1,0 +1,118 @@
+/**
+ * `CONTRIBUTORS.md` is a credential, so it has to stay checkable.
+ *
+ * The page exists because a merged pull request here is evidence about the person who wrote it:
+ * every change lands with its tests in the same PR, under a 100% line-coverage gate. A page making
+ * that claim is only worth reading if each entry points at the change it is claiming, so these
+ * tests pin the two things a reader would otherwise have to take on trust:
+ *
+ *   1. every person listed carries at least one link to a real merged pull request, written as a
+ *      full URL rather than a bare `#123` - the page is read outside GitHub too, where a bare
+ *      number links to nothing;
+ *   2. the rungs `CONTRIBUTORS.md` groups people under are exactly the rungs `CONTRIBUTING.md`
+ *      defines. A ladder whose two halves drift is worse than no ladder: someone is told they are
+ *      a "Trusted contributor" by one file and the other has never heard of the rung.
+ *
+ * Deliberately NOT asserted: that the list is complete. Completeness can only be measured against
+ * the GitHub API or a full `git log`, and CI clones shallowly, so a test claiming to check it would
+ * pass vacuously. Adding the contributor is a step in the merge checklist in `CONTRIBUTING.md`
+ * instead - a human step that is honest about being one, rather than a gate that does not gate.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "../..");
+const read = (relative: string): string => readFileSync(path.join(ROOT, relative), "utf8");
+
+const CONTRIBUTORS = "CONTRIBUTORS.md";
+const CONTRIBUTING = "CONTRIBUTING.md";
+const PULL_URL = "https://github.com/libredb/libredb-studio/pull/";
+
+/**
+ * The `## <rung>` headings people are actually grouped under.
+ *
+ * Not every `##` on the page is a rung - the page also carries prose sections - so a heading counts
+ * only once a `### @login` entry appears beneath it. Reading the rungs off the entries rather than
+ * off the heading level is what lets the page grow a section without the ladder guard firing at it.
+ */
+const rungHeadings = (text: string): string[] => {
+  const rungs = new Set<string>();
+  let current: string | null = null;
+  for (const line of text.split("\n")) {
+    if (/^## \S/.test(line)) {
+      current = line.slice(3).trim();
+    } else if (current !== null && /^### @/.test(line)) {
+      rungs.add(current);
+    }
+  }
+  return [...rungs];
+};
+
+/** Each `### @login` block, with the body that follows it up to the next heading of any level. */
+const entries = (text: string): { login: string; body: string }[] => {
+  const found: { login: string; body: string }[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const heading = /^### @([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\b/.exec(lines[i]);
+    if (heading === null) {
+      continue;
+    }
+    const body: string[] = [];
+    for (let j = i + 1; j < lines.length && !lines[j].startsWith("#"); j++) {
+      body.push(lines[j]);
+    }
+    found.push({ login: heading[1], body: body.join("\n") });
+  }
+  return found;
+};
+
+describe("CONTRIBUTORS.md", () => {
+  const contributors = read(CONTRIBUTORS);
+
+  test("lists people, so the guard below is not measuring an empty page", () => {
+    // Without this, every assertion that follows passes vacuously on a file with no entries.
+    expect(entries(contributors).length).toBeGreaterThan(0);
+  });
+
+  test("every person links to at least one merged pull request by full URL", () => {
+    const withoutEvidence = entries(contributors)
+      .filter(({ body }) => !body.includes(PULL_URL))
+      .map(({ login }) => login);
+    expect(withoutEvidence).toEqual([]);
+  });
+
+  test("no bare #123 reference stands in for a link", () => {
+    // A bare number renders as plain text everywhere this page is read outside GitHub, so the
+    // claim it supports becomes uncheckable exactly where a stranger would want to check it.
+    const bare = entries(contributors)
+      .flatMap(({ login, body }) => body.split("\n").map((line) => ({ login, line })))
+      .filter(({ line }) => /(^|\s)#\d+/.test(line))
+      .map(({ login }) => login);
+    expect(bare).toEqual([]);
+  });
+
+  test("nobody is listed twice", () => {
+    const logins = entries(contributors).map(({ login }) => login);
+    expect(logins).toEqual([...new Set(logins)]);
+  });
+});
+
+describe("the contributor ladder", () => {
+  test("every rung CONTRIBUTORS.md groups people under is defined in CONTRIBUTING.md", () => {
+    // The two-way binding. A rung renamed on one side has to be renamed on the other, or someone
+    // is told they hold a rung the defining document has never heard of.
+    const defined = read(CONTRIBUTING);
+    const rungs = rungHeadings(read(CONTRIBUTORS));
+    // Without this the filter below has nothing to reject and the assertion means nothing.
+    expect(rungs.length).toBeGreaterThan(0);
+    expect(rungs.filter((rung) => !defined.includes(rung))).toEqual([]);
+  });
+
+  test("CONTRIBUTING.md defines the rungs as a ladder a reader can climb", () => {
+    const defining = read(CONTRIBUTING);
+    for (const rung of ["Contributor", "Trusted contributor", "Area owner"]) {
+      expect(defining.includes(rung), `CONTRIBUTING.md does not define the ${rung} rung`).toBe(true);
+    }
+  });
+});

--- a/tests/unit/contributors-doc.test.ts
+++ b/tests/unit/contributors-doc.test.ts
@@ -36,17 +36,36 @@ const CONTRIBUTORS = "CONTRIBUTORS.md";
 const CONTRIBUTING = "CONTRIBUTING.md";
 
 /**
- * Evidence is a pull request OR a commit, and the second is not a fallback.
+ * Evidence is a pull request OR a commit in THIS repository, and the second is not a fallback.
  *
  * The two earliest outside changes reached `main` by rebase rather than through the merge button,
  * so GitHub records pull requests 8 and 12 as closed with `mergedAt: null` even though the code has
  * been in the tree since 2025-12-25. Linking those would show a stranger a rejected pull request as
  * proof of a contribution. The commit is the honest citation there.
+ *
+ * Matched on the parsed origin and path rather than as a substring of the entry, which CodeQL
+ * flagged (`js/incomplete-url-substring-sanitization`) on the first version of this file. The alert
+ * is not a security finding here - nothing is fetched or trusted - but the weakness it names is
+ * real for a page whose whole claim is that its links are checkable: a substring test accepts
+ * `https://evil.example/https://github.com/libredb/libredb-studio/pull/12`, where our prefix is
+ * somebody else's path. On a credential page that is the one link that must not pass.
  */
-const EVIDENCE_URLS = [
-  "https://github.com/libredb/libredb-studio/pull/",
-  "https://github.com/libredb/libredb-studio/commit/",
-];
+const EVIDENCE_ORIGIN = "https://github.com";
+const EVIDENCE_PATHS = ["/libredb/libredb-studio/pull/", "/libredb/libredb-studio/commit/"];
+
+/** Markdown link targets in a block: the `target` of every `[text](target)`. */
+const linkTargets = (body: string): string[] => [...body.matchAll(/\]\(([^)\s]+)\)/g)].map((match) => match[1]);
+
+/** Whether a link target is a pull request or commit in this repository, by origin and path. */
+const isEvidence = (target: string): boolean => {
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return false;
+  }
+  return url.origin === EVIDENCE_ORIGIN && EVIDENCE_PATHS.some((prefix) => url.pathname.startsWith(prefix));
+};
 
 /**
  * The `## <rung>` headings people are actually grouped under.
@@ -94,9 +113,9 @@ describe("CONTRIBUTORS.md", () => {
     expect(entries(contributors).length).toBeGreaterThan(0);
   });
 
-  test("every person links to a pull request or a commit by full URL", () => {
+  test("every person links to a pull request or a commit in this repository", () => {
     const withoutEvidence = entries(contributors)
-      .filter(({ body }) => !EVIDENCE_URLS.some((prefix) => body.includes(prefix)))
+      .filter(({ body }) => !linkTargets(body).some(isEvidence))
       .map(({ login }) => login);
     expect(withoutEvidence).toEqual([]);
   });
@@ -120,6 +139,26 @@ describe("CONTRIBUTORS.md", () => {
   test("nobody is listed twice", () => {
     const logins = entries(contributors).map(({ login }) => login);
     expect(logins).toEqual([...new Set(logins)]);
+  });
+});
+
+describe("what counts as evidence", () => {
+  // Paired positive and negative, because an accept-everything predicate would make the assertion
+  // above pass on any page at all, and a reject-everything one would be caught by that same test.
+  test("accepts a pull request and a commit in this repository", () => {
+    expect(isEvidence("https://github.com/libredb/libredb-studio/pull/579")).toBe(true);
+    expect(isEvidence("https://github.com/libredb/libredb-studio/commit/ff22a5dd")).toBe(true);
+  });
+
+  test("rejects a link that only carries our path on somebody else's host", () => {
+    // The substring test this replaced accepted the FIRST of these, which is the defect CodeQL
+    // named. The rest were already rejected by it and are here so the predicate cannot be loosened
+    // in a way that lets a fork, a plain-HTTP host or a lookalike domain through unnoticed.
+    expect(isEvidence("https://evil.example/https://github.com/libredb/libredb-studio/pull/579")).toBe(false);
+    expect(isEvidence("https://github.evil.example/libredb/libredb-studio/pull/579")).toBe(false);
+    expect(isEvidence("http://github.com/libredb/libredb-studio/pull/579")).toBe(false);
+    expect(isEvidence("https://github.com/someone-else/fork/pull/579")).toBe(false);
+    expect(isEvidence("../../src/lib/db/types.ts")).toBe(false);
   });
 });
 

--- a/tests/unit/contributors-doc.test.ts
+++ b/tests/unit/contributors-doc.test.ts
@@ -175,7 +175,7 @@ describe("the contributor ladder", () => {
 
   test("CONTRIBUTING.md defines the rungs as a ladder a reader can climb", () => {
     const defining = read(CONTRIBUTING);
-    for (const rung of ["Contributor", "Trusted contributor", "Area owner"]) {
+    for (const rung of ["Contributor", "Trusted contributor", "Area owner", "Maintainer"]) {
       expect(defining.includes(rung), `CONTRIBUTING.md does not define the ${rung} rung`).toBe(true);
     }
   });


### PR DESCRIPTION
Twenty-one changes have landed here from people outside the core team, the earliest on 2025-12-25. Until now nothing in the repository said so: no `CONTRIBUTORS.md`, no `AUTHORS`, no contributors section in the README, and no role written down anywhere.

## The page

`CONTRIBUTORS.md` is not a thank-you wall, and the difference is the point. Every change here lands with its tests in the same pull request under a hard 100% line-coverage gate, which is an unusual bar at this size, so a merged change here is evidence about the person who wrote it rather than only about us. Each entry therefore links to the change itself, by full URL. That is what makes an entry usable somewhere we do not control: a CV, a profile README, anywhere the question is "what have you actually shipped".

## Nothing on the page is counted

Not merged pull requests, not changed lines, not closed issues.

The first version of this branch did count: Trusted contributor meant three merged pull requests. Adding the people who plainly deserved that rung is what exposed the problem. Rather than drop the threshold it grew two exceptions, until the rule read "three merges, or one significant change, or first into an area nobody had touched" — at which point the number was doing no work except promoting people whose individual changes were unremarkable. A rule that needs exceptions is usually the wrong rule rather than a rule short of exceptions.

A count sees how often somebody showed up. It cannot see the care they took, the bug nobody else found, or the answer they wrote out for a stranger. So the rungs are judgements, made by maintainers and written beside the name where a reader can disagree with them. **Trusted contributor** is defined by what it grants rather than what it costs: someone we would hand an issue to without a conversation first. That is how the ladders that actually work are built — Kubernetes org membership needs two reviewers to vouch, not N pull requests.

## Two corrections against measurement

- `harish18092002`'s commit `ff22a5dd` predates `suleymansurucu`'s `c6d3e10c` by about thirteen hours, and is the earliest non-core commit on `main`. The order on the page is history, not recollection.
- Pull requests 8 and 12 both read `mergedAt: null`: that code was rebased in rather than merged through the button. Both entries cite the commit instead, because linking the pull request would show a stranger a closed PR as proof of a contribution.

## The guard

`tests/unit/contributors-doc.test.ts` shrank with the rule. It no longer requires a reason line per entry — gating a judgement is exactly the over-engineering this branch removed. It keeps:

- every entry cites a pull request **or a commit** by full URL, never a bare `#123`, because the page is read outside GitHub too, where a bare number links to nothing and the claim becomes uncheckable exactly where a stranger would want to check it;
- nobody is listed twice;
- the rungs the page groups people under are the rungs `CONTRIBUTING.md` defines.

And gains one: no rung may be described as a number of merges, so the threshold cannot creep back into the prose. Verified it fires by putting a count back and watching it fail.

Two things it deliberately does not do. It does not assert the list is complete — completeness needs the API or a full `git log`, and CI clones shallowly, so such a test would pass vacuously; adding the contributor is a step in the merge checklist instead, honest about being a human step rather than a gate that does not gate. And it asserts nothing about who belongs on which rung, because that is a judgement and the reason is written down for exactly that purpose.

## Verification

`format`, `lint`, `typecheck`, `knip` and `readme:check` clean. `bun run test:ci`: all 34 groups pass.

Docs plus one test file. No product code.
