### PR TITLE
fix(mssql,oracle): preserve absent overview sizes

### DIFF
--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -656,11 +656,11 @@ initialiser printed a confident `0 bytes` directly above *"No storage size infor
 was the odd one out; #569 (libSQL) and #517 (the search provider) merged the same
 pairing.
 
-A database that really measures `0` is a **reading** and is kept. `SUM(...)` over no row answers
-`NULL`, `Number(... || 0)` folds that to `0`, and the tab formats the `0 B` it was given. The absence
-is spelled `=== undefined` plus a conditional spread, never a falsy test: a falsy test would erase
-the very measurement it was meant to publish, which is the mistake §7.2 records for the connection
-count.
+A database that really measures `0` is a **reading** and is kept. `SUM(...)` over no input answers
+one row of `NULL`, which the provider maps to `0`; the tab then formats the `0 B` it was given. If
+the driver returns no row, no expected column, or a non-finite value, the measurement is absent and
+the string stays `N/A`. The shared `measuredNullableAggregate()` boundary preserves those states
+without a falsy test that would erase a genuine zero.
 
 ---
 

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -1000,11 +1000,11 @@ was the odd one out; #569 (libSQL) and #517 (the search provider) merged the sam
 pairing.
 
 A schema that really measures `0` is a **reading** and is kept, and here that case is ordinary rather
-than hypothetical: a freshly created user owns no segment, `SUM(BYTES)` over no row answers one row
-of `NULL`, `Number(... || 0)` folds that to `0`, and the tab formats the `0 B` it was given. The
-absence is therefore spelled `=== undefined` plus a conditional spread, never a falsy test - a falsy
-test would erase exactly that measurement, which is the mistake §7.2 records for the connection
-count.
+than hypothetical: a freshly created user owns no segment, so `SUM(BYTES)` answers one row of `NULL`,
+which the provider maps to `0`; the tab then formats the `0 B` it was given. If the driver returns no
+row, no expected column, or a non-finite value, the measurement is absent and the string stays `N/A`.
+The shared `measuredNullableAggregate()` boundary preserves those states without a falsy test that
+would erase a genuine zero.
 
 ---
 

--- a/src/lib/db/providers/sql/mssql.ts
+++ b/src/lib/db/providers/sql/mssql.ts
@@ -31,6 +31,7 @@ import {
 import { DatabaseConfigError, ConnectionError, QueryError, mapDatabaseError } from "../../errors";
 import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
+import { measuredNullableAggregate } from "../../utils/measured-aggregate";
 import { readLeadingKeyword } from "@/lib/sql/leading-keyword";
 import { resolveSqlGrammar, type SqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
@@ -1179,11 +1180,8 @@ export class MSSQLProvider extends SQLBaseProvider {
       // Database size
       try {
         const sizeRes = await this.pool!.request().query(OVERVIEW_DATABASE_SIZE_SQL);
-        // `|| 0`, not measuredNumber: SUM over no row answers NULL and that is a
-        // measured zero here, so unlike the count above this reading keeps its falsy
-        // fold. Only the catch below leaves the figure absent.
-        databaseSizeBytes = Number(sizeRes.recordset[0]?.size_bytes || 0);
-        databaseSize = formatBytes(databaseSizeBytes);
+        databaseSizeBytes = measuredNullableAggregate(sizeRes.recordset[0], "size_bytes");
+        if (databaseSizeBytes !== undefined) databaseSize = formatBytes(databaseSizeBytes);
       } catch {
         /* The size stays absent, never 0, and `databaseSize` keeps the "N/A" it was
            initialised with. */

--- a/src/lib/db/providers/sql/oracle.ts
+++ b/src/lib/db/providers/sql/oracle.ts
@@ -37,6 +37,7 @@ import {
 } from "../../errors";
 import { formatBytes } from "../../utils/pool-manager";
 import { analyzeQuery, DEFAULT_QUERY_LIMIT, MAX_UNLIMITED_ROWS } from "../../utils/query-limiter";
+import { measuredNullableAggregate } from "../../utils/measured-aggregate";
 import { resolveSqlGrammar } from "@/lib/sql/grammar";
 import { readStatementEnd } from "@/lib/sql/statement-end";
 import { CACHE_HIT_RATIO_UNAVAILABLE, formatCacheHitRatio, measuredNumber } from "@/lib/monitoring-cache-ratio";
@@ -1254,12 +1255,9 @@ export class OracleProvider extends SQLBaseProvider {
         const sizeRes = await conn.execute(`SELECT SUM(BYTES) AS TOTAL FROM USER_SEGMENTS`, [], {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
         });
-        // `|| 0`, not measuredNumber: a schema that owns no segment answers one row
-        // whose SUM is NULL, and that is a measured zero rather than an unknown - so
-        // unlike the count above this reading keeps its falsy fold, and only the catch
-        // below leaves the figure absent.
-        databaseSizeBytes = Number(((sizeRes.rows || []) as Record<string, unknown>[])[0]?.TOTAL || 0);
-        databaseSize = formatBytes(databaseSizeBytes);
+        const sizeRows = (sizeRes.rows || []) as Record<string, unknown>[];
+        databaseSizeBytes = measuredNullableAggregate(sizeRows[0], "TOTAL");
+        if (databaseSizeBytes !== undefined) databaseSize = formatBytes(databaseSizeBytes);
       } catch {
         /* The size stays absent, never 0, and `databaseSize` keeps the "N/A" it was
            initialised with. */

--- a/src/lib/db/utils/measured-aggregate.ts
+++ b/src/lib/db/utils/measured-aggregate.ts
@@ -1,0 +1,15 @@
+/**
+ * Read a nullable SQL aggregate without collapsing a missing result row into zero.
+ *
+ * Aggregate queries normally return one row whose value is `NULL` when there is
+ * nothing to aggregate. That is a measured zero. A missing row or column did not
+ * publish a measurement, and non-finite values cannot be displayed as one.
+ */
+export function measuredNullableAggregate(
+  row: Record<string, unknown> | undefined,
+  column: string,
+): number | undefined {
+  if (!row || !(column in row)) return undefined;
+  const parsed = Number(row[column] ?? 0);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -1580,6 +1580,36 @@ describe("MSSQLProvider", () => {
       expect(overview.databaseSize).toBe("0 B");
     });
 
+    test("a size read with no result row leaves overview size absent", async () => {
+      mockQueryFn = async (sql: string) => {
+        if (sql.toUpperCase().includes("SYS.DATABASE_FILES")) {
+          return { recordset: [], rowsAffected: [0] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(false);
+      expect(overview.databaseSize).toBe("N/A");
+    });
+
+    test("a non-finite size leaves overview size absent", async () => {
+      mockQueryFn = async (sql: string) => {
+        if (sql.toUpperCase().includes("SYS.DATABASE_FILES")) {
+          return { recordset: [{ size_bytes: Number.POSITIVE_INFINITY }], rowsAffected: [1] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(false);
+      expect(overview.databaseSize).toBe("N/A");
+    });
+
     test("Azure SQL detection from hostname", () => {
       const azureProvider = new MSSQLProvider({
         ...baseConfig,

--- a/tests/integration/db/mssql-provider.test.ts
+++ b/tests/integration/db/mssql-provider.test.ts
@@ -1561,8 +1561,8 @@ describe("MSSQLProvider", () => {
     test("a database that measures zero bytes keeps its measured zero size", async () => {
       // The anti-vacuity twin of the test above: absence must never be spelled with a
       // falsy test. `SUM(CAST(size AS BIGINT))` returns NULL when the aggregate has no
-      // row to sum, and `Number(... || 0)` reads that as 0 - a measurement, not a
-      // refusal - so the key stays present and the Storage tab formats the zero it was
+      // row to sum. The provider deliberately treats that returned null aggregate as
+      // a measured zero, so the key stays present and the Storage tab formats the zero it was
       // given rather than claiming it knows nothing.
       mockQueryFn = async (sql: string) => {
         const upper = sql.toUpperCase();
@@ -1584,6 +1584,21 @@ describe("MSSQLProvider", () => {
       mockQueryFn = async (sql: string) => {
         if (sql.toUpperCase().includes("SYS.DATABASE_FILES")) {
           return { recordset: [], rowsAffected: [0] };
+        }
+        return defaultQuery(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(false);
+      expect(overview.databaseSize).toBe("N/A");
+    });
+
+    test("a size result without the expected column leaves overview size absent", async () => {
+      mockQueryFn = async (sql: string) => {
+        if (sql.toUpperCase().includes("SYS.DATABASE_FILES")) {
+          return { recordset: [{ unrelated: 1 }], rowsAffected: [1] };
         }
         return defaultQuery(sql);
       };

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -1966,8 +1966,8 @@ describe("OracleProvider", () => {
       // The anti-vacuity twin of the absence pinned above, and why the guard is spelled
       // `=== undefined` rather than a falsy test. `SUM(BYTES) FROM USER_SEGMENTS` over a
       // schema that owns no segment is not a refusal: Oracle answers one row whose
-      // aggregate is NULL, and `Number(... || 0)` reads that as the measured 0 it is - a
-      // schema that really does hold nothing. A falsy test would erase exactly this
+      // aggregate is NULL. The provider deliberately treats that returned null aggregate
+      // as a measured 0 for a schema that really does hold nothing. A falsy test would erase exactly this
       // reading, and StorageTab.tsx would say "No storage size information available"
       // about a schema Oracle had just measured.
       mockExecuteFn = async (sql: string) => {
@@ -1994,6 +1994,22 @@ describe("OracleProvider", () => {
         const upper = sql.toUpperCase();
         if (upper.includes("USER_SEGMENTS") && upper.includes("SUM(BYTES)")) {
           return { rows: [], metaData: [{ name: "TOTAL" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(false);
+      expect(overview.databaseSize).toBe("N/A");
+    });
+
+    test("a size result without the expected column leaves overview size absent", async () => {
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_SEGMENTS") && upper.includes("SUM(BYTES)")) {
+          return { rows: [{ unrelated: 1 }], metaData: [{ name: "UNRELATED" }] };
         }
         return defaultExecute(sql);
       };

--- a/tests/integration/db/oracle-provider.test.ts
+++ b/tests/integration/db/oracle-provider.test.ts
@@ -1988,6 +1988,38 @@ describe("OracleProvider", () => {
       expect(overview.activeConnections).toBe(8);
       expect(overview.tableCount).toBe(10);
     });
+
+    test("a size read with no result row leaves overview size absent", async () => {
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_SEGMENTS") && upper.includes("SUM(BYTES)")) {
+          return { rows: [], metaData: [{ name: "TOTAL" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(false);
+      expect(overview.databaseSize).toBe("N/A");
+    });
+
+    test("a non-finite size leaves overview size absent", async () => {
+      mockExecuteFn = async (sql: string) => {
+        const upper = sql.toUpperCase();
+        if (upper.includes("USER_SEGMENTS") && upper.includes("SUM(BYTES)")) {
+          return { rows: [{ TOTAL: Number.POSITIVE_INFINITY }], metaData: [{ name: "TOTAL" }] };
+        }
+        return defaultExecute(sql);
+      };
+
+      await provider.connect();
+      const overview = await provider.getOverview();
+
+      expect("databaseSizeBytes" in overview).toBe(false);
+      expect(overview.databaseSize).toBe("N/A");
+    });
   });
 
   // =========================================================================


### PR DESCRIPTION
Closes #585.

Treats a missing aggregate row/column or non-finite value as unmeasured while preserving SQL `NULL` as a measured zero. The shared boundary is used by both MSSQL and Oracle, with provider tests and docs updated together.

Validation: `bun run format`, `lint`, `typecheck`, `knip`, `test`, `test:coverage`, `coverage:check` (100%), `build:lib`, `attw`, `build`, and Go launcher checks.
